### PR TITLE
fix(version): bump Cargo.toml to 0.15.1

### DIFF
--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nika"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "DAG workflow runner for AI tasks with MCP integration"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- Fixes Cargo.toml version mismatch that caused release workflow failure
- Bumps version from 0.15.0 to 0.15.1 to match the git tag

## Context

PR #38 was merged with skill merging features but the Cargo.toml version wasn't bumped. This caused the release workflow to fail on all 5 platforms with:

```
Cargo.toml version (0.15.0) does not match release version (0.15.1)
```

## After Merge

1. Delete v0.15.1 tag (already done)
2. Recreate v0.15.1 tag on merge commit
3. Push tag to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Co-Authored-By: Nika <agent@nika.sh>