### PR TITLE
fix(release): add working-directory for tools/nika to all jobs

### DIFF
--- a/tools/nika/.github/workflows/release.yml
+++ b/tools/nika/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  WORKING_DIR: tools/nika
 
 jobs:
   # ============================================================================
@@ -20,10 +21,15 @@ jobs:
   verify:
     name: Pre-release Verification
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/nika
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/nika -> target
       - uses: taiki-e/install-action@nextest
 
       - name: Run all tests
@@ -47,6 +53,9 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: verify
+    defaults:
+      run:
+        working-directory: tools/nika
 
     services:
       neo4j:
@@ -72,6 +81,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/nika -> target
       - uses: taiki-e/install-action@nextest
 
       - name: Wait for Neo4j
@@ -106,11 +117,16 @@ jobs:
     name: MVP 8 Verification
     runs-on: ubuntu-latest
     needs: verify
+    defaults:
+      run:
+        working-directory: tools/nika
 
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/nika -> target
       - uses: taiki-e/install-action@nextest
 
       - name: Phase 1 - Reasoning Capture
@@ -136,11 +152,16 @@ jobs:
     name: Chat UX v2 Verification
     runs-on: ubuntu-latest
     needs: verify
+    defaults:
+      run:
+        working-directory: tools/nika
 
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/nika -> target
       - uses: taiki-e/install-action@nextest
 
       - name: Run Chat UX widget tests
@@ -164,6 +185,9 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     needs: [verify, integration, mvp8, chat-ux]  # Require all verification to pass
+    defaults:
+      run:
+        working-directory: tools/nika
 
     strategy:
       matrix:
@@ -187,6 +211,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/nika -> target
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

The release workflow was failing because cargo commands run from the repo root, but `Cargo.toml` is located at `tools/nika/Cargo.toml`.

### Changes
- Add `defaults: run: working-directory: tools/nika` to all 5 jobs (verify, integration, mvp8, chat-ux, build)
- Update rust-cache with `workspaces: tools/nika -> target` for proper cache paths
- Add global `WORKING_DIR` env var for reference

### Fixes
Release workflow error:
```
cp: cannot stat 'target/x86_64-unknown-linux-gnu/release/nika': No such file or directory
```

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, recreate v0.15.1 tag and verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)