### PR TITLE
fix(release): correct target path for archive steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           BINARY: ${{ matrix.binary }}
         run: |
-          BINARY_PATH="target/${TARGET}/release/${BINARY}"
+          BINARY_PATH="tools/nika/target/${TARGET}/release/${BINARY}"
           if [ -f "$BINARY_PATH" ] && ! echo "$TARGET" | grep -q "aarch64-unknown-linux"; then
             strip "$BINARY_PATH" || true
           fi
@@ -157,7 +157,7 @@ jobs:
         run: |
           ARCHIVE_NAME="${ARTIFACT}-${VERSION}"
           mkdir -p "dist/${ARCHIVE_NAME}"
-          cp "target/${TARGET}/release/${BINARY}" "dist/${ARCHIVE_NAME}/"
+          cp "tools/nika/target/${TARGET}/release/${BINARY}" "dist/${ARCHIVE_NAME}/"
           cp README.md LICENSE CHANGELOG.md "dist/${ARCHIVE_NAME}/" 2>/dev/null || true
           cd dist
           tar -czvf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
@@ -174,7 +174,7 @@ jobs:
         run: |
           $ARCHIVE_NAME = "${env:ARTIFACT}-${env:VERSION}"
           New-Item -ItemType Directory -Force -Path "dist\$ARCHIVE_NAME"
-          Copy-Item "target\${env:TARGET}\release\${env:BINARY}" "dist\$ARCHIVE_NAME\"
+          Copy-Item "tools\nika\target\${env:TARGET}\release\${env:BINARY}" "dist\$ARCHIVE_NAME\"
           Copy-Item README.md, LICENSE, CHANGELOG.md "dist\$ARCHIVE_NAME\" -ErrorAction SilentlyContinue
           Compress-Archive -Path "dist\$ARCHIVE_NAME" -DestinationPath "dist\$ARCHIVE_NAME.zip"
           Get-FileHash "dist\$ARCHIVE_NAME.zip" -Algorithm SHA256 | ForEach-Object { "$($_.Hash.ToLower())  $ARCHIVE_NAME.zip" } | Out-File -Encoding ascii "dist\$ARCHIVE_NAME.zip.sha256"


### PR DESCRIPTION
## Summary
- Fix release workflow archive steps to use correct target path

## Problem
The cargo build uses `--manifest-path tools/nika/Cargo.toml` which outputs binaries to `tools/nika/target/`, but the archive steps were looking for binaries at `target/` (repo root).

This caused all 5 platform builds to fail with:
```
cp: target/x86_64-apple-darwin/release/nika: No such file or directory
```

## Changes
- Strip binary (Unix): `target/` → `tools/nika/target/`
- Create archive (Unix): `target/` → `tools/nika/target/`
- Create archive (Windows): `target\` → `tools\nika\target\`

## Test plan
- [ ] CI passes
- [ ] Merge this PR
- [ ] Delete v0.15.1 tag
- [ ] Recreate v0.15.1 tag to trigger release
- [ ] All 5 platform builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)