### PR TITLE
fix(ci): use cross tool for Linux ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,11 +119,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
+      - name: Install cross tool (Linux ARM64)
         if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
@@ -131,10 +129,13 @@ jobs:
           cache-on-failure: true
           shared-key: release-${{ matrix.target }}
 
-      - name: Build release binary
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - name: Build release binary (native)
+        if: ${{ !matrix.cross }}
         run: cargo build --manifest-path tools/nika/Cargo.toml --release --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: matrix.cross
+        run: cross build --manifest-path tools/nika/Cargo.toml --release --target ${{ matrix.target }}
 
       - name: Strip binary (Unix)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Summary
- Fix Linux ARM64 (aarch64-unknown-linux-gnu) cross-compilation failure
- Use `cross` tool instead of native cargo with manual gcc installation

## Problem
The v0.15.1 release workflow failed for Linux ARM64 with:
```
error: failed to run custom build command for `openssl-sys v0.9.111`
Could not find directory of OpenSSL installation
pkg-config has not been configured to support cross-compilation
```

## Solution
Use the [`cross`](https://github.com/cross-rs/cross) tool which provides Docker containers with pre-configured cross-compilation environments including all necessary dependencies (OpenSSL, etc.).

## Changes
- Install `cross` from git for Linux ARM64 builds (`matrix.cross: true`)
- Split build step into native and cross variants
- Remove manual gcc-aarch64-linux-gnu installation (cross handles this)

## Test plan
- [ ] PR CI passes (format, lint, tests)
- [ ] Merge and recreate v0.15.1 tag
- [ ] Verify all 5 platform builds succeed

🤖 Generated with [Claude Code](https://claude.ai/code)