### PR TITLE
fix(deps): switch reqwest to rustls-tls for cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,11 +119,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
+      - name: Install cross tool (Linux ARM64)
         if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
@@ -131,10 +129,13 @@ jobs:
           cache-on-failure: true
           shared-key: release-${{ matrix.target }}
 
-      - name: Build release binary
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - name: Build release binary (native)
+        if: ${{ !matrix.cross }}
         run: cargo build --manifest-path tools/nika/Cargo.toml --release --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: matrix.cross
+        run: cross build --manifest-path tools/nika/Cargo.toml --release --target ${{ matrix.target }}
 
       - name: Strip binary (Unix)
         if: matrix.os != 'windows-latest'

--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -46,7 +46,7 @@ thiserror = "1.0"
 miette = { version = "7.6", features = ["fancy"] }
 
 # HTTP
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 url = "2"  # URL parsing and validation
 
 # Secure credential storage


### PR DESCRIPTION
## Summary

- Switch reqwest from native-tls (OpenSSL) to rustls-tls (pure Rust) for ARM64 cross-compilation compatibility
- This eliminates the `openssl-sys` dependency that was causing Linux ARM64 builds to fail

## Problem

The Linux ARM64 build was failing with:
```
failed to run custom build command for `openssl-sys v0.9.111`
```

The `cross` tool's Docker container doesn't have ARM64 OpenSSL development libraries, making cross-compilation impossible with native-tls.

## Solution

Use `rustls-tls` feature instead of default `native-tls`:
```toml
reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
```

rustls is a pure Rust TLS implementation that requires no system dependencies.

## Test plan

- [ ] CI passes (cargo check, cargo test)
- [ ] Release workflow builds all 5 platforms successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Nika <agent@nika.sh>