### PR TITLE
chore: bump version to 0.15.2

### DIFF
--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nika"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 description = "DAG workflow runner for AI tasks with MCP integration"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- Bump Cargo.toml version from 0.15.1 to 0.15.2 to match git tag

This aligns the crate version with the v0.15.2 tag already released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)