### PR TITLE
chore(release): bump nika to v0.16.0

### DIFF
--- a/tools/nika/Cargo.lock
+++ b/tools/nika/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "nika"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nika"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 description = "DAG workflow runner for AI tasks with MCP integration"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

BREAKING CHANGE: Remove `nika pkg` commands in favor of the `spn` CLI.

### Changes
- Remove pkg module from CLI (~221 lines)
- Bump version from 0.15.2 to 0.16.0
- Migration guide: `docs/MIGRATION-PKG-TO-SPN.md`

### Migration

Users should migrate from `nika pkg` to `spn`:

| Old Command | New Command |
|-------------|-------------|
| `nika pkg install @scope/name` | `spn pkg install @scope/name` |
| `nika pkg list` | `spn pkg list` |
| `nika pkg search query` | `spn pkg search query` |
| `nika pkg update @scope/name` | `spn pkg update @scope/name` |
| `nika pkg remove @scope/name` | `spn pkg remove @scope/name` |

See full migration guide: [MIGRATION-PKG-TO-SPN.md](docs/MIGRATION-PKG-TO-SPN.md)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)