### PR TITLE
docs: update README versions to v0.16.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <sup>✨ Transform YAML into intelligent AI workflows ✨</sup>
 
 <!-- Primary Badges -->
-[![Version](https://img.shields.io/badge/v0.16.1-7c3aed?style=for-the-badge&logo=semver&logoColor=white)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/v0.16.5-7c3aed?style=for-the-badge&logo=semver&logoColor=white)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/rust_1.86+-f97316?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/AGPL--3.0-22c55e?style=for-the-badge&logo=gnu&logoColor=white)](LICENSE)
 [![Website](https://img.shields.io/badge/🦋_nika.sh-8b5cf6?style=for-the-badge)](https://nika.sh)
@@ -68,7 +68,7 @@ Connect LLMs, shell commands, HTTP APIs, and MCP tools in a single declarative f
 <!-- TUI Screenshot as ASCII Art -->
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────────┐
-│  🦋 Nika Studio                                                v0.16.0  ⌘K  ?  │
+│  🦋 Nika Studio                                                v0.16.5  ⌘K  ?  │
 ├─────────────────────────────────────────────────────────────────────────────────────┤
 │ ┌─ 📁 Files ───────────┐ ┌─ 📝 Editor ──────────────────────────────────────────┐  │
 │ │ ▸ workflows/         │ │  1 │ schema: "nika/workflow@0.9"                    │  │
@@ -97,7 +97,7 @@ Connect LLMs, shell commands, HTTP APIs, and MCP tools in a single declarative f
 
 <br>
 
-## ✨ What's New in v0.16.0
+## ✨ What's New in v0.16.5
 
 <table>
 <tr>
@@ -371,7 +371,7 @@ cd nika && cargo install --path tools/nika
 
 # ✅ Verify installation
 nika --version
-# nika 0.16.0
+# nika 0.16.5
 ```
 
 ### 👋 Hello World (30 seconds)
@@ -1640,7 +1640,7 @@ flows:
 ```
 ╔═════════════════════════════════════════════════════════════════════════════════╗
 ║                                                                                 ║
-║                           🦋 NIKA v0.16.0 STATS                                 ║
+║                           🦋 NIKA v0.16.5 STATS                                 ║
 ║                                                                                 ║
 ╠═════════════════════════════════════════════════════════════════════════════════╣
 ║                                                                                 ║


### PR DESCRIPTION
Updates all version references in README.md from v0.16.0/v0.16.1 to v0.16.5

## Changes
- Version badge: v0.16.1 → v0.16.5  
- TUI ASCII art header: v0.16.0 → v0.16.5
- 'What's New' section header: v0.16.0 → v0.16.5
- `--version` example output: 0.16.0 → 0.16.5
- Stats box header: v0.16.0 → v0.16.5

## Impact
Ensures README documentation accurately reflects the current release version.

## Related
- Addresses findings from documentation audit (Agent 3)
- Prepares for v0.16.6 release