### PR TITLE
feat(media): PR1 — Media extraction pipeline with CAS storage

### DIFF
--- a/tools/nika/CLAUDE.md
+++ b/tools/nika/CLAUDE.md
@@ -61,7 +61,8 @@ src/
 | 160-164 | Policy/Boot errors |
 | 170-179 | Runtime (decompose) |
 | 200-219 | File tools + Builtin tools |
-| 250-259 | Context errors |
+| 250 | Context error |
+| 251-259 | Media pipeline |
 | 260-269 | Package URI errors |
 | 270-279 | Skill errors |
 | 280-289 | Artifacts |

--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -164,6 +164,14 @@ terminal_size = { version = "0.4", optional = true }  # Terminal dimensions for 
 # LSP Server (feature-gated) - v0.22 Language Server Protocol support
 tower-lsp = { version = "0.20", optional = true }
 
+# Media pipeline (2 genuinely new + 4 zero-cost promotes from transitive)
+blake3 = { version = "1.8", features = ["mmap"] }
+infer = "0.19"
+base64 = "0.22"
+mime_guess = "2.0"
+mime = "0.3"
+bytes = "1"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tools/nika/src/binding/resolve.rs
+++ b/tools/nika/src/binding/resolve.rs
@@ -359,6 +359,32 @@ fn resolve_entry(
     // Split path into task_id and remaining path
     let (task_id, field_path) = split_path(path);
 
+    // Intercept media paths: task_id.media, task_id.media[0].hash, etc.
+    // The media side-channel is in TaskResult.media, not in TaskResult.output,
+    // so get_output() cannot see it. Delegate to resolve_path() which handles
+    // both output and media resolution.
+    if let Some(fp) = field_path {
+        if fp == "media" || fp.starts_with("media.") || fp.starts_with("media[") {
+            let value = datastore.resolve_path(path);
+            return match value {
+                Some(v) if !v.is_null() => Ok(v),
+                Some(_) => entry
+                    .default
+                    .as_ref()
+                    .cloned()
+                    .ok_or_else(|| NikaError::NullValue {
+                        path: path.clone(),
+                        alias: alias.to_string(),
+                    }),
+                None => entry
+                    .default
+                    .as_ref()
+                    .cloned()
+                    .ok_or_else(|| NikaError::PathNotFound { path: path.clone() }),
+            };
+        }
+    }
+
     // Resolve the value from task output
     let value = match datastore.get_output(task_id) {
         Some(output) => {

--- a/tools/nika/src/binding/resolve.rs
+++ b/tools/nika/src/binding/resolve.rs
@@ -507,6 +507,32 @@ fn resolve_binding_path(
 ) -> Result<Option<Value>, NikaError> {
     match &binding_path.source {
         BindingSource::Task(task_id) => {
+            // Intercept media paths: segments starting with Field("media")
+            // Media data lives in TaskResult.media (side-channel), not in
+            // TaskResult.output. Delegate to resolve_path() which handles both.
+            if matches!(
+                binding_path.segments.first(),
+                Some(crate::binding::types::PathSegment::Field(f)) if f.as_ref() == "media"
+            ) {
+                // Reconstruct the full dot-separated path for resolve_path
+                let full_path = format!("{}{}", task_id, binding_path.segments.iter().fold(
+                    String::new(),
+                    |mut acc, seg| {
+                        match seg {
+                            crate::binding::types::PathSegment::Field(f) => {
+                                acc.push('.');
+                                acc.push_str(f);
+                            }
+                            crate::binding::types::PathSegment::Index(i) => {
+                                acc.push_str(&format!("[{}]", i));
+                            }
+                        }
+                        acc
+                    }
+                ));
+                return Ok(datastore.resolve_path(&full_path));
+            }
+
             let output = match datastore.get_output(task_id) {
                 Some(o) => o,
                 None => return Ok(None),

--- a/tools/nika/src/cli/init.rs
+++ b/tools/nika/src/cli/init.rs
@@ -219,21 +219,20 @@ Describe your project here. This context will be available to agents via `memory
     // Create example sub-workflow (can be called via nika:run)
     let example_subworkflow_path = workflows_dir.join("helpers.nika.yaml");
     let example_subworkflow_content = r#"# Helper Sub-Workflows
-# These workflows can be called from parent workflows via nika:run
+# These are standalone helper workflows — run them directly
+# or compose them into larger DAGs with depends_on.
 #
-# Usage in parent workflow:
-#   tasks:
-#     - id: generate_summary
-#       invoke:
-#         tool: nika:run
-#         params:
-#           workflow: .nika/workflows/helpers.nika.yaml
-#           task: summarize
-#           input: "{{with.content}}"
+# Examples:
+#   nika run .nika/workflows/helpers.nika.yaml
+#   nika run .nika/workflows/helpers.nika.yaml -p provider=openai
 
 schema: "nika/workflow@0.12"
 workflow: helpers
 description: "Reusable helper workflows for common tasks"
+
+inputs:
+  content: "Nika is a semantic YAML workflow engine for AI tasks."
+  target_language: "French"
 
 tasks:
   - id: summarize
@@ -241,37 +240,37 @@ tasks:
       prompt: |
         Summarize the following content in 3 bullet points:
 
-        {{with.input}}
-      model: claude-sonnet-4-20250514
-    output:
-      format: text
+        {{inputs.content}}
+      temperature: 0.3
+      max_tokens: 300
 
   - id: translate
     infer:
       prompt: |
-        Translate the following text to {{with.target_language | default: "French"}}:
+        Translate the following text to {{inputs.target_language}}:
 
-        {{with.input}}
-      model: claude-sonnet-4-20250514
-    output:
-      format: text
+        {{inputs.content}}
+      temperature: 0.2
+      max_tokens: 500
 
-  - id: review_code
+  - id: review
+    depends_on: [summarize, translate]
+    with:
+      summary: $summarize
+      translation: $translate
     infer:
       prompt: |
-        Review the following code for bugs, security issues, and improvements:
+        Review these outputs for quality:
 
-        ```{{with.language | default: "rust"}}
-        {{with.code}}
-        ```
+        SUMMARY:
+        {{with.summary}}
 
-        Provide:
-        1. Critical issues
-        2. Suggestions for improvement
-        3. Overall assessment
-      model: claude-sonnet-4-20250514
-    output:
-      format: text
+        TRANSLATION ({{inputs.target_language}}):
+        {{with.translation}}
+
+        Rate each 1-10 and suggest improvements.
+      temperature: 0.3
+      max_tokens: 400
 "#;
     fs::write(&example_subworkflow_path, example_subworkflow_content)?;
     println!(

--- a/tools/nika/src/display.rs
+++ b/tools/nika/src/display.rs
@@ -129,7 +129,7 @@ pub fn print_done_summary(
     // Main done line with telemetry
     if total_tokens > 0 {
         println!(
-            "{} {} {} {} {} {} {} {}",
+            "{} {} {} {} {} {} {}",
             "\u{2713}".green().bold(), // ✓
             "Done!".green().bold(),
             elapsed_str.dimmed(),
@@ -137,8 +137,7 @@ pub fn print_done_summary(
             format!("{} tokens", total_tokens).dimmed(),
             "·".dimmed(),
             format!("${}", crate::provider::cost::format_cost(total_cost)
-                .trim_start_matches('$')).dimmed(),
-            if total_cost > 0.0 { "" } else { "" }
+                .trim_start_matches('$')).dimmed()
         );
     } else {
         println!(
@@ -253,8 +252,6 @@ pub fn print_doctor_summary(pass_count: usize, warn_count: usize, fail_count: us
 pub fn format_duration(secs: f32) -> colored::ColoredString {
     let text = if secs < 0.1 {
         format!("{:.0}ms", secs * 1000.0)
-    } else if secs < 1.0 {
-        format!("{:.1}s", secs)
     } else if secs < 60.0 {
         format!("{:.1}s", secs)
     } else {

--- a/tools/nika/src/error.rs
+++ b/tools/nika/src/error.rs
@@ -490,6 +490,13 @@ pub enum NikaError {
     },
 
     // ═══════════════════════════════════════════
+    // MEDIA ERRORS (251-259)
+    // ═══════════════════════════════════════════
+    /// Media pipeline error (NIKA-251..259)
+    #[error(transparent)]
+    MediaError(#[from] crate::media::error::MediaError),
+
+    // ═══════════════════════════════════════════
     // PKG URI ERRORS (260-269)
     // ═══════════════════════════════════════════
     #[error("[NIKA-260] Invalid pkg: URI '{uri}': {reason}")]
@@ -681,6 +688,8 @@ impl NikaError {
             Self::AssertionFailed { .. } => "NIKA-213",
             // Context errors
             Self::ContextLoadError { .. } => "NIKA-250",
+            // Media errors
+            Self::MediaError(e) => e.code(),
             // Pkg URI errors
             Self::InvalidPkgUri { .. } => "NIKA-260",
             // Package errors
@@ -873,6 +882,10 @@ impl FixSuggestion for NikaError {
             // Context errors
             NikaError::ContextLoadError { .. } => {
                 Some("Check the file path exists and is readable")
+            }
+            // Media errors
+            NikaError::MediaError(_) => {
+                Some("Check media content and CAS store configuration")
             }
             // Pkg URI errors
             NikaError::InvalidPkgUri { .. } => Some(

--- a/tools/nika/src/error.rs
+++ b/tools/nika/src/error.rs
@@ -717,19 +717,21 @@ impl NikaError {
 
     /// Check if error is recoverable (can be retried)
     pub fn is_recoverable(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::McpNotConnected { .. }
-                | Self::ProviderApiError { .. }
-                | Self::McpToolError { .. }
-                | Self::Timeout { .. }
-                | Self::McpTimeout { .. }
-                | Self::McpToolCallFailed { .. }
-                // Structured output errors that can be retried
-                | Self::StructuredOutputExtractionFailed { .. }
-                | Self::StructuredOutputValidationFailed { .. }
-                | Self::StructuredOutputRepairFailed { .. }
-        )
+            | Self::ProviderApiError { .. }
+            | Self::McpToolError { .. }
+            | Self::Timeout { .. }
+            | Self::McpTimeout { .. }
+            | Self::McpToolCallFailed { .. }
+            // Structured output errors that can be retried
+            | Self::StructuredOutputExtractionFailed { .. }
+            | Self::StructuredOutputValidationFailed { .. }
+            | Self::StructuredOutputRepairFailed { .. } => true,
+            // Delegate to MediaError's own is_recoverable (only I/O errors)
+            Self::MediaError(e) => e.is_recoverable(),
+            _ => false,
+        }
     }
 }
 

--- a/tools/nika/src/error.rs
+++ b/tools/nika/src/error.rs
@@ -476,7 +476,7 @@ pub enum NikaError {
     AssertionFailed { message: String, condition: String },
 
     // ═══════════════════════════════════════════
-    // CONTEXT ERRORS (250-259)
+    // CONTEXT ERROR (250)
     // ═══════════════════════════════════════════
     #[error("[NIKA-250] Failed to load context file '{alias}' from '{path}': {reason}")]
     #[diagnostic(
@@ -493,6 +493,7 @@ pub enum NikaError {
     // MEDIA ERRORS (251-259)
     // ═══════════════════════════════════════════
     /// Media pipeline error (NIKA-251..259)
+    /// Note: miette diagnostic codes are forwarded via MediaError's own Diagnostic derive.
     #[error(transparent)]
     MediaError(#[from] crate::media::error::MediaError),
 

--- a/tools/nika/src/event/log.rs
+++ b/tools/nika/src/event/log.rs
@@ -2437,4 +2437,798 @@ mod tests {
         };
         assert!(!non_wf.is_workflow_event());
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Media event emission pipeline tests
+    // ═══════════════════════════════════════════════════════════════
+
+    // ----- Helpers for media tests -----
+
+    /// Realistic blake3 hash (64 hex chars after prefix)
+    const BLAKE3_PNG: &str =
+        "blake3:a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a";
+    const BLAKE3_WAV: &str =
+        "blake3:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const BLAKE3_PDF: &str =
+        "blake3:6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b";
+
+    fn media_extracted(task_id: &str, block_count: u32, types: &[&str]) -> EventKind {
+        EventKind::MediaExtracted {
+            task_id: Arc::from(task_id),
+            block_count,
+            content_types: types.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn media_processed(task_id: &str, hash: &str, mime: &str, size: u64) -> EventKind {
+        EventKind::MediaProcessed {
+            task_id: Arc::from(task_id),
+            hash: hash.to_string(),
+            mime_type: mime.to_string(),
+            size_bytes: size,
+        }
+    }
+
+    fn media_stored(
+        task_id: &str,
+        hash: &str,
+        path: &str,
+        size: u64,
+        verified: bool,
+        deduplicated: bool,
+        pipeline_ms: u64,
+    ) -> EventKind {
+        EventKind::MediaStored {
+            task_id: Arc::from(task_id),
+            hash: hash.to_string(),
+            path: path.to_string(),
+            size_bytes: size,
+            verified,
+            deduplicated,
+            pipeline_ms,
+        }
+    }
+
+    fn media_store_failed(task_id: &str, hash: &str, reason: &str) -> EventKind {
+        EventKind::MediaStoreFailed {
+            task_id: Arc::from(task_id),
+            hash: hash.to_string(),
+            reason: reason.to_string(),
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 1. Serde roundtrip for ALL 4 media variants
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_extracted_serde_roundtrip_single_type() {
+        let event = media_extracted("gen_logo", 1, &["image"]);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn media_extracted_serde_roundtrip_multiple_types() {
+        let event = media_extracted("gen_multi", 4, &["image", "audio", "video", "application"]);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+
+        // Verify field values survived roundtrip
+        if let EventKind::MediaExtracted {
+            block_count,
+            content_types,
+            ..
+        } = &back
+        {
+            assert_eq!(*block_count, 4);
+            assert_eq!(content_types.len(), 4);
+            assert_eq!(content_types[0], "image");
+            assert_eq!(content_types[3], "application");
+        } else {
+            panic!("Expected MediaExtracted");
+        }
+    }
+
+    #[test]
+    fn media_extracted_serde_roundtrip_empty_types() {
+        // Edge case: block_count=0 with no content_types
+        let event = media_extracted("empty_task", 0, &[]);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn media_processed_serde_roundtrip_png() {
+        let event = media_processed("gen_img", BLAKE3_PNG, "image/png", 65536);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+
+        if let EventKind::MediaProcessed {
+            hash,
+            mime_type,
+            size_bytes,
+            ..
+        } = &back
+        {
+            assert!(hash.starts_with("blake3:"));
+            assert_eq!(hash.len(), "blake3:".len() + 64); // blake3 = 64 hex chars
+            assert_eq!(mime_type, "image/png");
+            assert_eq!(*size_bytes, 65536);
+        } else {
+            panic!("Expected MediaProcessed");
+        }
+    }
+
+    #[test]
+    fn media_processed_serde_roundtrip_wav() {
+        let event = media_processed("gen_audio", BLAKE3_WAV, "audio/wav", 1_048_576);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn media_processed_serde_roundtrip_pdf() {
+        let event = media_processed("gen_doc", BLAKE3_PDF, "application/pdf", 204800);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn media_stored_serde_roundtrip_all_fields() {
+        let event = media_stored(
+            "gen_img",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+            65536,
+            true,
+            false,
+            42,
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+
+        if let EventKind::MediaStored {
+            hash,
+            path,
+            size_bytes,
+            verified,
+            deduplicated,
+            pipeline_ms,
+            ..
+        } = &back
+        {
+            assert_eq!(hash, BLAKE3_PNG);
+            assert!(path.starts_with(".nika/media/store/"));
+            assert_eq!(*size_bytes, 65536);
+            assert!(*verified);
+            assert!(!*deduplicated);
+            assert_eq!(*pipeline_ms, 42);
+        } else {
+            panic!("Expected MediaStored");
+        }
+    }
+
+    #[test]
+    fn media_stored_serde_roundtrip_deduplicated() {
+        let event = media_stored(
+            "gen_img_dup",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+            65536,
+            false, // verified=false for dedup hits
+            true,  // deduplicated=true
+            1,     // fast path
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn media_store_failed_serde_roundtrip_with_hash() {
+        let event = media_store_failed("gen_img", BLAKE3_PNG, "disk full");
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+
+        if let EventKind::MediaStoreFailed { hash, reason, .. } = &back {
+            assert_eq!(hash, BLAKE3_PNG);
+            assert_eq!(reason, "disk full");
+        } else {
+            panic!("Expected MediaStoreFailed");
+        }
+    }
+
+    #[test]
+    fn media_store_failed_serde_roundtrip_empty_hash() {
+        // Pre-hash failure: hash is empty string
+        let event = media_store_failed("gen_img", "", "base64 decode failed");
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EventKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+
+        if let EventKind::MediaStoreFailed { hash, reason, .. } = &back {
+            assert!(hash.is_empty(), "Pre-hash failure should have empty hash");
+            assert_eq!(reason, "base64 decode failed");
+        } else {
+            panic!("Expected MediaStoreFailed");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 2. Media event task_id extraction
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_extracted_returns_task_id() {
+        let event = media_extracted("extract_images", 3, &["image", "audio", "video"]);
+        assert_eq!(event.task_id(), Some("extract_images"));
+    }
+
+    #[test]
+    fn media_processed_returns_task_id() {
+        let event = media_processed("process_png", BLAKE3_PNG, "image/png", 1024);
+        assert_eq!(event.task_id(), Some("process_png"));
+    }
+
+    #[test]
+    fn media_stored_returns_task_id() {
+        let event = media_stored(
+            "store_to_cas",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6",
+            1024,
+            true,
+            false,
+            10,
+        );
+        assert_eq!(event.task_id(), Some("store_to_cas"));
+    }
+
+    #[test]
+    fn media_store_failed_returns_task_id() {
+        let event = media_store_failed("fail_store", BLAKE3_PNG, "permission denied");
+        assert_eq!(event.task_id(), Some("fail_store"));
+    }
+
+    #[test]
+    fn all_4_media_variants_have_task_id() {
+        let variants: Vec<(&str, EventKind)> = vec![
+            (
+                "extracted",
+                media_extracted("t_extract", 2, &["image", "audio"]),
+            ),
+            (
+                "processed",
+                media_processed("t_process", BLAKE3_WAV, "audio/wav", 2048),
+            ),
+            (
+                "stored",
+                media_stored("t_store", BLAKE3_PDF, ".nika/media/store/6b/86b2", 4096, true, false, 5),
+            ),
+            (
+                "failed",
+                media_store_failed("t_fail", "", "budget exceeded"),
+            ),
+        ];
+
+        for (name, event) in &variants {
+            assert!(
+                event.task_id().is_some(),
+                "Media{name} must return Some task_id"
+            );
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 3. Media events NDJSON compliance
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_extracted_ndjson_no_newlines() {
+        let event = media_extracted("ndjson_test", 5, &["image", "audio", "video"]);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            !json.contains('\n'),
+            "MediaExtracted JSON must not contain newlines: {json}"
+        );
+    }
+
+    #[test]
+    fn media_processed_ndjson_no_newlines() {
+        let event = media_processed("ndjson_test", BLAKE3_PNG, "image/png", 999999);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            !json.contains('\n'),
+            "MediaProcessed JSON must not contain newlines: {json}"
+        );
+    }
+
+    #[test]
+    fn media_stored_ndjson_no_newlines() {
+        let event = media_stored(
+            "ndjson_test",
+            BLAKE3_WAV,
+            ".nika/media/store/e3/b0c44298fc1c149afbf4c8996fb924",
+            512000,
+            true,
+            true,
+            100,
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            !json.contains('\n'),
+            "MediaStored JSON must not contain newlines: {json}"
+        );
+    }
+
+    #[test]
+    fn media_store_failed_ndjson_no_newlines() {
+        let event = media_store_failed("ndjson_test", "", "write error: No space left on device");
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            !json.contains('\n'),
+            "MediaStoreFailed JSON must not contain newlines: {json}"
+        );
+    }
+
+    #[test]
+    fn all_4_media_variants_ndjson_roundtrip() {
+        // Full NDJSON contract: serialize to single line, deserialize back
+        let variants = vec![
+            media_extracted("rt_task", 2, &["image", "audio"]),
+            media_processed("rt_task", BLAKE3_PNG, "image/png", 8192),
+            media_stored(
+                "rt_task",
+                BLAKE3_PNG,
+                ".nika/media/store/a7/ffc6f8bf1ed76651",
+                8192,
+                true,
+                false,
+                25,
+            ),
+            media_store_failed("rt_task", BLAKE3_PNG, "verification checksum mismatch"),
+        ];
+
+        for (i, variant) in variants.into_iter().enumerate() {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert!(
+                !json.contains('\n'),
+                "Media variant {i} has embedded newline"
+            );
+            let back: EventKind = serde_json::from_str(&json).unwrap_or_else(|e| {
+                panic!("Media variant {i} failed to deserialize: {e}\nJSON: {json}")
+            });
+            assert_eq!(variant, back, "Media variant {i} roundtrip mismatch");
+        }
+    }
+
+    #[test]
+    fn media_events_ndjson_full_envelope() {
+        // Verify the full Event envelope (id + timestamp_ms + kind) serializes to single-line
+        let log = EventLog::new();
+        log.emit(media_extracted("envelope_test", 1, &["image"]));
+        log.emit(media_processed("envelope_test", BLAKE3_PNG, "image/png", 4096));
+        log.emit(media_stored(
+            "envelope_test",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6",
+            4096,
+            true,
+            false,
+            15,
+        ));
+        log.emit(media_store_failed("envelope_test", "", "boom"));
+
+        for event in log.events() {
+            let json = serde_json::to_string(&event).unwrap();
+            assert!(
+                !json.contains('\n'),
+                "Full Event envelope must be single-line NDJSON: {json}"
+            );
+            // Verify envelope structure
+            let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert!(parsed.get("id").is_some(), "Missing 'id' in envelope");
+            assert!(
+                parsed.get("timestamp_ms").is_some(),
+                "Missing 'timestamp_ms' in envelope"
+            );
+            assert!(parsed.get("kind").is_some(), "Missing 'kind' in envelope");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 4. Media events in EventLog
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_extracted_appears_in_eventlog_events() {
+        let log = EventLog::new();
+        let id = log.emit(media_extracted("media_task", 3, &["image", "audio", "video"]));
+
+        let events = log.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, id);
+
+        if let EventKind::MediaExtracted {
+            task_id,
+            block_count,
+            content_types,
+        } = &events[0].kind
+        {
+            assert_eq!(task_id.as_ref(), "media_task");
+            assert_eq!(*block_count, 3);
+            assert_eq!(content_types, &["image", "audio", "video"]);
+        } else {
+            panic!("Expected MediaExtracted in events()");
+        }
+    }
+
+    #[test]
+    fn media_stored_broadcast_reaches_subscriber() {
+        let (log, mut rx) = EventLog::new_with_broadcast();
+
+        log.emit(media_stored(
+            "broadcast_test",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6",
+            4096,
+            true,
+            false,
+            10,
+        ));
+
+        // Subscriber should receive the event
+        let received = rx.try_recv().expect("Subscriber should receive MediaStored event");
+        assert_eq!(received.id, 0);
+
+        if let EventKind::MediaStored {
+            task_id,
+            hash,
+            verified,
+            ..
+        } = &received.kind
+        {
+            assert_eq!(task_id.as_ref(), "broadcast_test");
+            assert_eq!(hash, BLAKE3_PNG);
+            assert!(*verified);
+        } else {
+            panic!("Expected MediaStored via broadcast");
+        }
+    }
+
+    #[test]
+    fn media_events_broadcast_multiple_subscribers() {
+        let (log, mut rx1) = EventLog::new_with_broadcast();
+        let mut rx2 = log.subscribe().expect("Should be able to subscribe");
+
+        log.emit(media_processed("multi_sub", BLAKE3_WAV, "audio/wav", 2048));
+
+        let e1 = rx1.try_recv().expect("rx1 should receive");
+        let e2 = rx2.try_recv().expect("rx2 should receive");
+        assert_eq!(e1.id, e2.id);
+        assert_eq!(e1.kind, e2.kind);
+    }
+
+    #[test]
+    fn filter_task_returns_media_events() {
+        let log = EventLog::new();
+
+        // Mix of media and non-media events for the same task
+        log.emit(EventKind::TaskStarted {
+            task_id: "gen_image".into(),
+            verb: "invoke".into(),
+            inputs: json!({}),
+        });
+        log.emit(media_extracted("gen_image", 1, &["image"]));
+        log.emit(media_processed("gen_image", BLAKE3_PNG, "image/png", 4096));
+        log.emit(media_stored(
+            "gen_image",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6",
+            4096,
+            true,
+            false,
+            20,
+        ));
+
+        // Different task
+        log.emit(media_extracted("other_task", 2, &["audio", "video"]));
+
+        let gen_events = log.filter_task("gen_image");
+        assert_eq!(gen_events.len(), 4, "gen_image should have 4 events (1 task + 3 media)");
+
+        // Verify media events are in order
+        assert!(matches!(&gen_events[0].kind, EventKind::TaskStarted { .. }));
+        assert!(matches!(&gen_events[1].kind, EventKind::MediaExtracted { .. }));
+        assert!(matches!(&gen_events[2].kind, EventKind::MediaProcessed { .. }));
+        assert!(matches!(&gen_events[3].kind, EventKind::MediaStored { .. }));
+
+        let other_events = log.filter_task("other_task");
+        assert_eq!(other_events.len(), 1, "other_task should only have 1 event");
+    }
+
+    #[test]
+    fn filter_task_with_media_failure() {
+        let log = EventLog::new();
+
+        log.emit(media_extracted("fail_task", 1, &["image"]));
+        log.emit(media_processed("fail_task", BLAKE3_PNG, "image/png", 4096));
+        log.emit(media_store_failed("fail_task", BLAKE3_PNG, "disk full"));
+
+        let events = log.filter_task("fail_task");
+        assert_eq!(events.len(), 3);
+        assert!(matches!(&events[2].kind, EventKind::MediaStoreFailed { .. }));
+    }
+
+    #[test]
+    fn count_task_includes_media_events() {
+        let log = EventLog::new();
+
+        log.emit(media_extracted("count_me", 2, &["image", "audio"]));
+        log.emit(media_processed("count_me", BLAKE3_PNG, "image/png", 4096));
+        log.emit(media_processed("count_me", BLAKE3_WAV, "audio/wav", 8192));
+        log.emit(media_stored(
+            "count_me",
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6",
+            4096,
+            true,
+            false,
+            15,
+        ));
+        log.emit(media_stored(
+            "count_me",
+            BLAKE3_WAV,
+            ".nika/media/store/e3/b0c4",
+            8192,
+            true,
+            false,
+            22,
+        ));
+
+        assert_eq!(log.count_task("count_me"), 5);
+        assert_eq!(log.count_task("no_such_task"), 0);
+    }
+
+    #[test]
+    fn media_events_not_workflow_events() {
+        let log = EventLog::new();
+
+        log.emit(workflow_started(1));
+        log.emit(media_extracted("t1", 1, &["image"]));
+        log.emit(media_processed("t1", BLAKE3_PNG, "image/png", 4096));
+        log.emit(media_stored("t1", BLAKE3_PNG, ".nika/media/store/a7/ffc6", 4096, true, false, 10));
+        log.emit(media_store_failed("t1", "", "boom"));
+
+        let wf_events = log.workflow_events();
+        assert_eq!(wf_events.len(), 1, "Media events must NOT appear in workflow_events()");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 5. MediaStored field verification
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_stored_pipeline_ms_reasonable_values() {
+        // Normal processing: sub-second
+        let event = media_stored("fast_store", BLAKE3_PNG, ".nika/media/store/a7/ffc6", 4096, true, false, 42);
+        if let EventKind::MediaStored { pipeline_ms, .. } = &event {
+            assert!(*pipeline_ms < 10000, "pipeline_ms={pipeline_ms} should be < 10000ms");
+        }
+
+        // Zero is valid (dedup fast path)
+        let event_zero = media_stored("dedup_store", BLAKE3_PNG, ".nika/media/store/a7/ffc6", 4096, false, true, 0);
+        if let EventKind::MediaStored { pipeline_ms, .. } = &event_zero {
+            assert_eq!(*pipeline_ms, 0, "Dedup fast path can have 0ms pipeline");
+        }
+
+        // Edge: just under threshold
+        let event_edge = media_stored("slow_store", BLAKE3_PNG, ".nika/media/store/a7/ffc6", 4096, true, false, 9999);
+        if let EventKind::MediaStored { pipeline_ms, .. } = &event_edge {
+            assert!(*pipeline_ms < 10000);
+        }
+    }
+
+    #[test]
+    fn media_stored_verified_and_deduplicated_independent() {
+        // All four combinations of (verified, deduplicated) are valid
+        let combos: Vec<(bool, bool, &str)> = vec![
+            (true, false, "fresh write, verified"),
+            (false, false, "fresh write, unverified (small file)"),
+            (false, true, "dedup hit, not re-verified"),
+            (true, true, "dedup hit, re-verified"),
+        ];
+
+        for (verified, deduplicated, desc) in combos {
+            let event = media_stored(
+                "combo_test",
+                BLAKE3_PNG,
+                ".nika/media/store/a7/ffc6",
+                4096,
+                verified,
+                deduplicated,
+                10,
+            );
+            if let EventKind::MediaStored {
+                verified: v,
+                deduplicated: d,
+                ..
+            } = &event
+            {
+                assert_eq!(*v, verified, "verified mismatch for: {desc}");
+                assert_eq!(*d, deduplicated, "deduplicated mismatch for: {desc}");
+            }
+
+            // Roundtrip preserves both booleans
+            let json = serde_json::to_string(&event).unwrap();
+            let back: EventKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(event, back, "Roundtrip failed for: {desc}");
+        }
+    }
+
+    #[test]
+    fn media_stored_path_cas_format() {
+        // CAS paths follow the pattern: .nika/media/store/{first2}/{rest}
+        let cas_paths = vec![
+            ".nika/media/store/a7/ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+            ".nika/media/store/e3/b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ".nika/media/store/6b/86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+        ];
+
+        for path in cas_paths {
+            let event = media_stored("path_test", BLAKE3_PNG, path, 4096, true, false, 10);
+            if let EventKind::MediaStored { path: p, .. } = &event {
+                assert!(
+                    p.starts_with(".nika/media/store/"),
+                    "CAS path must start with .nika/media/store/: {p}"
+                );
+                // Path after prefix should be {2chars}/{rest}
+                let suffix = p.strip_prefix(".nika/media/store/").unwrap();
+                let parts: Vec<&str> = suffix.splitn(2, '/').collect();
+                assert_eq!(parts.len(), 2, "CAS path suffix must be dir/file: {suffix}");
+                assert_eq!(parts[0].len(), 2, "CAS directory prefix must be 2 chars: {}", parts[0]);
+                assert!(!parts[1].is_empty(), "CAS filename must not be empty");
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bonus: Media event serde tag verification
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_events_serde_tags_are_snake_case() {
+        let variants: Vec<(&str, EventKind)> = vec![
+            ("media_extracted", media_extracted("t", 1, &["image"])),
+            ("media_processed", media_processed("t", BLAKE3_PNG, "image/png", 100)),
+            (
+                "media_stored",
+                media_stored("t", BLAKE3_PNG, ".nika/media/store/a7/ffc6", 100, true, false, 5),
+            ),
+            ("media_store_failed", media_store_failed("t", "", "err")),
+        ];
+
+        for (expected_tag, event) in variants {
+            let json = serde_json::to_string(&event).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                parsed["type"].as_str().unwrap(),
+                expected_tag,
+                "Serde tag mismatch for {expected_tag}"
+            );
+        }
+    }
+
+    #[test]
+    fn media_events_deserialize_from_json_objects() {
+        // Verify we can construct media events from raw JSON (as a consumer would)
+        let json_extracted = json!({
+            "type": "media_extracted",
+            "task_id": "from_json",
+            "block_count": 2,
+            "content_types": ["image", "audio"]
+        });
+        let extracted: EventKind = serde_json::from_value(json_extracted).unwrap();
+        assert_eq!(extracted.task_id(), Some("from_json"));
+        if let EventKind::MediaExtracted { block_count, content_types, .. } = &extracted {
+            assert_eq!(*block_count, 2);
+            assert_eq!(content_types, &["image", "audio"]);
+        } else {
+            panic!("Expected MediaExtracted from JSON");
+        }
+
+        let json_stored = json!({
+            "type": "media_stored",
+            "task_id": "from_json",
+            "hash": BLAKE3_PNG,
+            "path": ".nika/media/store/a7/ffc6",
+            "size_bytes": 8192,
+            "verified": true,
+            "deduplicated": false,
+            "pipeline_ms": 33
+        });
+        let stored: EventKind = serde_json::from_value(json_stored).unwrap();
+        if let EventKind::MediaStored { pipeline_ms, verified, deduplicated, .. } = &stored {
+            assert_eq!(*pipeline_ms, 33);
+            assert!(*verified);
+            assert!(!*deduplicated);
+        } else {
+            panic!("Expected MediaStored from JSON");
+        }
+    }
+
+    #[test]
+    fn media_full_pipeline_lifecycle_in_eventlog() {
+        // Simulates the complete media pipeline lifecycle for a single image
+        let log = EventLog::new();
+        let task = "generate_screenshot";
+
+        // Step 1: MCP tool returns content blocks with images
+        log.emit(EventKind::TaskStarted {
+            task_id: task.into(),
+            verb: "invoke".into(),
+            inputs: json!({"tool": "screenshot"}),
+        });
+
+        // Step 2: Media blocks extracted
+        log.emit(media_extracted(task, 2, &["image", "image"]));
+
+        // Step 3: Each block processed
+        log.emit(media_processed(task, BLAKE3_PNG, "image/png", 65536));
+        log.emit(media_processed(task, BLAKE3_WAV, "image/jpeg", 32768));
+
+        // Step 4: Both stored (one fresh, one dedup)
+        log.emit(media_stored(
+            task,
+            BLAKE3_PNG,
+            ".nika/media/store/a7/ffc6f8bf1ed76651",
+            65536,
+            true,
+            false,
+            35,
+        ));
+        log.emit(media_stored(
+            task,
+            BLAKE3_WAV,
+            ".nika/media/store/e3/b0c44298fc1c1",
+            32768,
+            false,
+            true,
+            2,
+        ));
+
+        // Step 5: Task completes
+        log.emit(EventKind::TaskCompleted {
+            task_id: task.into(),
+            output: Arc::new(json!({"images": 2})),
+            duration_ms: 500,
+        });
+
+        let events = log.filter_task(task);
+        assert_eq!(events.len(), 7, "Full lifecycle: 1 started + 1 extracted + 2 processed + 2 stored + 1 completed");
+
+        // Verify ordering
+        assert!(matches!(&events[0].kind, EventKind::TaskStarted { .. }));
+        assert!(matches!(&events[1].kind, EventKind::MediaExtracted { .. }));
+        assert!(matches!(&events[2].kind, EventKind::MediaProcessed { .. }));
+        assert!(matches!(&events[3].kind, EventKind::MediaProcessed { .. }));
+        assert!(matches!(&events[4].kind, EventKind::MediaStored { .. }));
+        assert!(matches!(&events[5].kind, EventKind::MediaStored { .. }));
+        assert!(matches!(&events[6].kind, EventKind::TaskCompleted { .. }));
+
+        // Verify the dedup store was the second one
+        if let EventKind::MediaStored { deduplicated, pipeline_ms, .. } = &events[5].kind {
+            assert!(*deduplicated, "Second store should be dedup hit");
+            assert!(*pipeline_ms < 10, "Dedup fast path should be < 10ms");
+        }
+    }
 }

--- a/tools/nika/src/event/log.rs
+++ b/tools/nika/src/event/log.rs
@@ -1857,7 +1857,7 @@ mod tests {
     // WAVE 2 TESTS: NDJSON event system audit
     // ═══════════════════════════════════════════════════════════════
 
-    /// Helper: build one instance of every EventKind variant (all 32)
+    /// Helper: build one instance of every EventKind variant (all 36)
     fn all_36_variants() -> Vec<EventKind> {
         vec![
             // Workflow (6)

--- a/tools/nika/src/event/log.rs
+++ b/tools/nika/src/event/log.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides full audit trail with replay capability.
 //! - Event: envelope with id + timestamp + kind
-//! - EventKind: 32 variants across 10 categories (workflow/task/fine-grained/MCP/context/agent/guardrails/builtin/artifact/structured-output)
+//! - EventKind: 36 variants across 11 categories (workflow/task/fine-grained/MCP/context/agent/guardrails/builtin/artifact/media/structured-output)
 //! - EventLog: thread-safe, append-only log
 //!
 //! `AgentTurnMetadata` provides reasoning capture (thinking, tokens, stop_reason).
@@ -451,6 +451,55 @@ pub enum EventKind {
     },
 
     // ═══════════════════════════════════════════
+    // MEDIA EVENTS
+    // ═══════════════════════════════════════════
+    /// Media content blocks extracted from MCP tool result
+    MediaExtracted {
+        task_id: Arc<str>,
+        /// Number of non-text content blocks found
+        block_count: u32,
+        /// Content types found (e.g., ["image", "audio"])
+        content_types: Vec<String>,
+    },
+
+    /// Single media block processed (decoded + detected)
+    MediaProcessed {
+        task_id: Arc<str>,
+        /// blake3 hash of the decoded content (with "blake3:" prefix)
+        hash: String,
+        /// Detected MIME type
+        mime_type: String,
+        /// File size in bytes (decoded)
+        size_bytes: u64,
+    },
+
+    /// Media file stored in CAS
+    MediaStored {
+        task_id: Arc<str>,
+        /// blake3 hash (with "blake3:" prefix)
+        hash: String,
+        /// File path in CAS store
+        path: String,
+        /// File size in bytes
+        size_bytes: u64,
+        /// Whether read-back verification passed (or skipped for small files)
+        verified: bool,
+        /// Whether this was a dedup hit
+        deduplicated: bool,
+        /// Pipeline latency in milliseconds (decode -> store)
+        pipeline_ms: u64,
+    },
+
+    /// Media storage failed
+    MediaStoreFailed {
+        task_id: Arc<str>,
+        /// blake3 hash (if available, empty string if pre-hash failure)
+        hash: String,
+        /// Error description
+        reason: String,
+    },
+
+    // ═══════════════════════════════════════════
     // STRUCTURED OUTPUT EVENTS
     // ═══════════════════════════════════════════
     /// Structured output extraction attempt at a specific layer
@@ -510,6 +559,10 @@ impl EventKind {
             | Self::AgentComplete { task_id, .. }
             | Self::ArtifactWritten { task_id, .. }
             | Self::ArtifactFailed { task_id, .. }
+            | Self::MediaExtracted { task_id, .. }
+            | Self::MediaProcessed { task_id, .. }
+            | Self::MediaStored { task_id, .. }
+            | Self::MediaStoreFailed { task_id, .. }
             | Self::StructuredOutputAttempt { task_id, .. }
             | Self::StructuredOutputSuccess { task_id, .. }
             | Self::GuardrailPassed { task_id, .. }
@@ -1805,7 +1858,7 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════
 
     /// Helper: build one instance of every EventKind variant (all 32)
-    fn all_32_variants() -> Vec<EventKind> {
+    fn all_36_variants() -> Vec<EventKind> {
         vec![
             // Workflow (6)
             EventKind::WorkflowStarted {
@@ -1991,6 +2044,32 @@ mod tests {
                 path: "/tmp/output.json".into(),
                 reason: "permission denied".into(),
             },
+            // Media (4)
+            EventKind::MediaExtracted {
+                task_id: "gen_img".into(),
+                block_count: 2,
+                content_types: vec!["image".into(), "audio".into()],
+            },
+            EventKind::MediaProcessed {
+                task_id: "gen_img".into(),
+                hash: "blake3:a1b2c3d4".into(),
+                mime_type: "image/png".into(),
+                size_bytes: 4096,
+            },
+            EventKind::MediaStored {
+                task_id: "gen_img".into(),
+                hash: "blake3:a1b2c3d4".into(),
+                path: ".nika/media/store/a1/b2c3d4".into(),
+                size_bytes: 4096,
+                verified: true,
+                deduplicated: false,
+                pipeline_ms: 42,
+            },
+            EventKind::MediaStoreFailed {
+                task_id: "gen_img".into(),
+                hash: "blake3:a1b2c3d4".into(),
+                reason: "disk full".into(),
+            },
             // Structured Output (2)
             EventKind::StructuredOutputAttempt {
                 task_id: "t1".into(),
@@ -2010,18 +2089,18 @@ mod tests {
     }
 
     #[test]
-    fn wave2_variant_count_is_32() {
-        let variants = all_32_variants();
+    fn wave2_variant_count_is_36() {
+        let variants = all_36_variants();
         assert_eq!(
             variants.len(),
-            32,
-            "EventKind should have exactly 32 variants"
+            36,
+            "EventKind should have exactly 36 variants"
         );
     }
 
     #[test]
     fn wave2_all_variants_serialize_deserialize_roundtrip() {
-        for (i, variant) in all_32_variants().into_iter().enumerate() {
+        for (i, variant) in all_36_variants().into_iter().enumerate() {
             let json = serde_json::to_string(&variant)
                 .unwrap_or_else(|e| panic!("variant {i} failed to serialize: {e}"));
             let back: EventKind = serde_json::from_str(&json)
@@ -2033,7 +2112,7 @@ mod tests {
     #[test]
     fn wave2_ndjson_no_embedded_newlines() {
         // NDJSON = one JSON object per line, no embedded newlines
-        for (i, variant) in all_32_variants().into_iter().enumerate() {
+        for (i, variant) in all_36_variants().into_iter().enumerate() {
             let json = serde_json::to_string(&variant).unwrap();
             assert!(
                 !json.contains('\n'),
@@ -2241,7 +2320,7 @@ mod tests {
 
     #[test]
     fn wave2_task_id_extraction_all_variants() {
-        let variants = all_32_variants();
+        let variants = all_36_variants();
         // Variants WITH task_id (26 of them)
         let with_task_id: Vec<_> = variants.iter().filter(|v| v.task_id().is_some()).collect();
         // Variants WITHOUT task_id (8): 6 workflow + McpConnected + McpError
@@ -2251,8 +2330,8 @@ mod tests {
         // Log has task_id: Some("t1"), so it goes in with
         assert_eq!(
             with_task_id.len(),
-            23,
-            "23 variants should have task_id (including Log with Some)"
+            27,
+            "27 variants should have task_id (including Log with Some, 4 media events)"
         );
         assert_eq!(
             without_task_id.len(),

--- a/tools/nika/src/event/mod.rs
+++ b/tools/nika/src/event/mod.rs
@@ -3,7 +3,7 @@
 //! Provides full audit trail with replay capability.
 //! Key types:
 //! - `Event`: Envelope with id + timestamp + kind
-//! - `EventKind`: 34 variants across 8 levels (workflow/task/fine-grained/MCP/agent/guardrail/artifact/structured)
+//! - `EventKind`: 36 variants across 11 categories (workflow/task/fine-grained/MCP/context/agent/guardrail/builtin/artifact/media/structured-output)
 //! - `EventLog`: Thread-safe, append-only log
 //! - `EventEmitter`: Trait for dependency injection
 //! - `NoopEmitter`: Zero-cost no-op for testing

--- a/tools/nika/src/init/partials.rs
+++ b/tools/nika/src/init/partials.rs
@@ -41,16 +41,14 @@ tasks:
   - id: start
     description: "Log workflow start"
     invoke:
-      mcp: builtin
       tool: nika:log
       params:
         level: info
-        message: "Workflow started at {{timestamp}}"
+        message: "Workflow started"
 
   - id: end
     description: "Log workflow completion"
     invoke:
-      mcp: builtin
       tool: nika:log
       params:
         level: info
@@ -76,13 +74,17 @@ schema: "nika/workflow@0.12"
 workflow: error-handling-partial
 description: "Standardized error handling tasks"
 
+inputs:
+  previous_result: "No result provided"
+  error_details: "Unknown error"
+
 tasks:
   - id: check
     description: "Check for errors in previous task"
     infer:
       prompt: |
         Analyze the following result for errors:
-        {{with.previous_result}}
+        {{inputs.previous_result}}
 
         Return JSON:
         {
@@ -96,18 +98,23 @@ tasks:
 
   - id: notify
     description: "Send error notification"
+    depends_on: [check]
+    with:
+      check_result: $check
     invoke:
-      mcp: builtin
       tool: nika:log
       params:
         level: error
-        message: "Error occurred: {{with.error_details}}"
+        message: "Error check result: {{with.check_result}}"
 
   - id: recover
     description: "Attempt error recovery"
+    depends_on: [check]
+    with:
+      check_result: $check
     infer:
       prompt: |
-        An error occurred: {{with.error_details}}
+        An error check returned: {{with.check_result}}
 
         Suggest recovery steps:
         1. What can we try to recover?
@@ -138,13 +145,16 @@ schema: "nika/workflow@0.12"
 workflow: validation-partial
 description: "Input and output validation tasks"
 
+inputs:
+  data: "Sample input data for validation"
+
 tasks:
   - id: validate_input
     description: "Validate workflow inputs"
     infer:
       prompt: |
         Validate the following inputs:
-        {{with.inputs}}
+        {{inputs.data}}
 
         Check for:
         1. Required fields present
@@ -156,22 +166,22 @@ tasks:
         {
           "valid": true/false,
           "errors": ["list of validation errors"],
-          "warnings": ["list of warnings"],
-          "sanitized_inputs": {}
+          "warnings": ["list of warnings"]
         }
       temperature: 0.1
       max_tokens: 400
 
   - id: validate_output
     description: "Validate workflow outputs"
+    depends_on: [validate_input]
+    with:
+      validation: $validate_input
     infer:
       prompt: |
-        Validate the following outputs:
-        {{with.outputs}}
+        Review the input validation result:
+        {{with.validation}}
 
-        Expected schema: {{with.expected_schema}}
-
-        Check for:
+        Assess:
         1. Schema compliance
         2. Data completeness
         3. Quality metrics
@@ -189,10 +199,15 @@ tasks:
 
   - id: sanitize
     description: "Sanitize data for safety"
+    depends_on: [validate_input]
+    with:
+      validation: $validate_input
     infer:
       prompt: |
-        Sanitize the following data:
-        {{with.raw_data}}
+        Based on validation: {{with.validation}}
+
+        Sanitize the original data:
+        {{inputs.data}}
 
         Actions:
         1. Remove any PII
@@ -224,6 +239,12 @@ schema: "nika/workflow@0.12"
 workflow: notification-partial
 description: "Multi-channel notification tasks"
 
+inputs:
+  event_type: "workflow_complete"
+  details: "Workflow finished successfully"
+  recipient: "team"
+  channel: "slack"
+
 tasks:
   - id: format_message
     description: "Format notification message"
@@ -231,10 +252,10 @@ tasks:
       prompt: |
         Create a notification message:
 
-        Event type: {{with.event_type}}
-        Details: {{with.details}}
-        Recipient: {{with.recipient}}
-        Channel: {{with.channel}}
+        Event type: {{inputs.event_type}}
+        Details: {{inputs.details}}
+        Recipient: {{inputs.recipient}}
+        Channel: {{inputs.channel}}
 
         Format appropriately for the channel:
         - Slack: Use markdown, emojis
@@ -247,34 +268,42 @@ tasks:
 
   - id: send_slack
     description: "Send Slack notification (placeholder)"
+    depends_on: [format_message]
+    with:
+      formatted: $format_message
     invoke:
-      mcp: builtin
       tool: nika:log
       params:
         level: info
-        message: "[SLACK] {{with.formatted_message}}"
+        message: "[SLACK] {{with.formatted}}"
 
   - id: send_email
     description: "Send email notification (placeholder)"
+    depends_on: [format_message]
+    with:
+      formatted: $format_message
     invoke:
-      mcp: builtin
       tool: nika:log
       params:
         level: info
-        message: "[EMAIL] {{with.formatted_message}}"
+        message: "[EMAIL] {{with.formatted}}"
 
   - id: completion_summary
     description: "Create completion summary notification"
+    depends_on: [send_slack, send_email]
+    with:
+      slack_result: $send_slack
+      email_result: $send_email
     infer:
       prompt: |
         Create a completion summary:
 
-        Workflow: {{with.workflow_name}}
-        Duration: {{with.duration}}
-        Status: {{with.status}}
-        Results: {{with.results}}
+        Slack notification sent: {{with.slack_result}}
+        Email notification sent: {{with.email_result}}
 
-        Create a brief, informative summary suitable for notification.
+        Original event: {{inputs.event_type}} - {{inputs.details}}
+
+        Create a brief, informative summary suitable for logging.
         Include key metrics and any action items.
       temperature: 0.3
       max_tokens: 250
@@ -299,6 +328,10 @@ schema: "nika/workflow@0.12"
 workflow: quality-check-partial
 description: "Quality assurance check tasks"
 
+inputs:
+  content: "Sample content for quality review"
+  target_tone: "professional"
+
 tasks:
   - id: check_grammar
     description: "Check grammar and spelling"
@@ -306,7 +339,7 @@ tasks:
       prompt: |
         Review this content for grammar and spelling:
 
-        {{with.content}}
+        {{inputs.content}}
 
         Check for:
         1. Spelling errors
@@ -329,9 +362,9 @@ tasks:
       prompt: |
         Analyze the tone of this content:
 
-        {{with.content}}
+        {{inputs.content}}
 
-        Target tone: {{with.target_tone}}
+        Target tone: {{inputs.target_tone}}
 
         Evaluate:
         1. Does it match target tone?
@@ -354,7 +387,7 @@ tasks:
       prompt: |
         Identify factual claims in this content:
 
-        {{with.content}}
+        {{inputs.content}}
 
         List any claims that should be fact-checked:
         1. Statistics and numbers
@@ -374,6 +407,7 @@ tasks:
 
   - id: final_score
     description: "Calculate final quality score"
+    depends_on: [check_grammar, check_tone, check_factual]
     with:
       grammar: $check_grammar
       tone: $check_tone

--- a/tools/nika/src/init/tier1.rs
+++ b/tools/nika/src/init/tier1.rs
@@ -124,8 +124,8 @@ tasks:
       # WARNING: Only use shell: true when you need shell features!
       # shell: false (default) is more secure
       shell: true
-      # Timeout in milliseconds (30 seconds)
-      timeout: 30000
+      # Timeout in seconds
+      timeout: 30
 
   # ─────────────────────────────────────────────────────────────────────────────
   # WORKING DIRECTORY: Run commands in specific directory
@@ -260,8 +260,8 @@ tasks:
       url: "https://httpbin.org/ip"
       # HTTP method (GET is default, but explicit is clearer)
       method: GET
-      # Timeout in milliseconds (10 seconds)
-      timeout: 10000
+      # Timeout in seconds
+      timeout: 10
 
   # ─────────────────────────────────────────────────────────────────────────────
   # GET JSON DATA

--- a/tools/nika/src/init/tier5.rs
+++ b/tools/nika/src/init/tier5.rs
@@ -1147,7 +1147,7 @@ tasks:
     fetch:
       url: "{{with.endpoint.url}}"
       method: GET
-      timeout: 5000
+      timeout: 5
 
   - id: analyze_results
     depends_on: [check_endpoints]

--- a/tools/nika/src/lib.rs
+++ b/tools/nika/src/lib.rs
@@ -42,6 +42,7 @@ pub mod error;
 pub mod event;
 pub mod init;
 pub mod mcp;
+pub mod media;
 pub mod new;
 pub mod provider;
 pub mod registry;

--- a/tools/nika/src/lib.rs
+++ b/tools/nika/src/lib.rs
@@ -42,7 +42,7 @@ pub mod error;
 pub mod event;
 pub mod init;
 pub mod mcp;
-pub mod media;
+pub(crate) mod media;
 pub mod new;
 pub mod provider;
 pub mod registry;

--- a/tools/nika/src/mcp/retry.rs
+++ b/tools/nika/src/mcp/retry.rs
@@ -85,7 +85,7 @@ pub fn is_retryable_mcp_error(error: &NikaError) -> bool {
         // Tool errors: only retry if the error code is retryable (server-side)
         // InvalidParams, MethodNotFound etc. will always fail on retry
         NikaError::McpToolError { error_code, .. } => {
-            error_code.as_ref().map_or(true, |code| code.is_retryable())
+            error_code.as_ref().is_none_or(|code| code.is_retryable())
         }
 
         // Start errors: NOT retryable — if the server binary doesn't exist,

--- a/tools/nika/src/mcp/rmcp_adapter.rs
+++ b/tools/nika/src/mcp/rmcp_adapter.rs
@@ -501,17 +501,30 @@ impl RmcpClientAdapter {
                 uri: uri.to_string(),
             })?;
 
-        // Build ResourceContent from rmcp response
-        // Serialize the resource content as JSON for simplicity
-        let text = serde_json::to_string(resource).map_err(|e| NikaError::McpToolError {
-            tool: "resources/read".to_string(),
-            reason: format!("Failed to serialize resource: {}", e),
-            error_code: None, // Serialization errors are internal
-        })?;
-
-        let content = ResourceContent::new(uri)
-            .with_text(&text)
-            .with_mime_type("application/json");
+        // Build ResourceContent from rmcp response, preserving blob data
+        use rmcp::model::ResourceContents;
+        let content = match resource {
+            ResourceContents::TextResourceContents {
+                text, mime_type, ..
+            } => {
+                let mut rc = ResourceContent::new(uri);
+                rc = rc.with_text(text.clone());
+                if let Some(mime) = mime_type {
+                    rc = rc.with_mime_type(mime.as_str());
+                }
+                rc
+            }
+            ResourceContents::BlobResourceContents {
+                blob, mime_type, ..
+            } => {
+                let mut rc = ResourceContent::new(uri);
+                rc = rc.with_blob(blob.clone());
+                if let Some(mime) = mime_type {
+                    rc = rc.with_mime_type(mime.as_str());
+                }
+                rc
+            }
+        };
 
         Ok(content)
     }

--- a/tools/nika/src/mcp/rmcp_adapter.rs
+++ b/tools/nika/src/mcp/rmcp_adapter.rs
@@ -369,15 +369,67 @@ impl RmcpClientAdapter {
                 }
             })?;
 
-        // Convert rmcp result to Nika's ToolCallResult
+        // Convert rmcp result to Nika's ToolCallResult (exhaustive 5-variant match)
         let content: Vec<ContentBlock> = result
             .content
             .iter()
-            .filter_map(|c| {
-                // Extract text content
-                c.as_text().map(|t| ContentBlock::text(t.text.clone()))
+            .map(|c| {
+                use rmcp::model::RawContent;
+                match &**c {
+                    RawContent::Text(t) => ContentBlock::text(t.text.clone()),
+                    RawContent::Image(i) => ContentBlock::image(
+                        i.data.clone(),
+                        i.mime_type.clone(),
+                    ),
+                    RawContent::Audio(a) => ContentBlock::Audio {
+                        data: a.data.clone(),
+                        mime_type: a.mime_type.clone(),
+                    },
+                    RawContent::Resource(r) => {
+                        use rmcp::model::ResourceContents;
+                        match &r.resource {
+                            ResourceContents::TextResourceContents {
+                                text, uri, mime_type, ..
+                            } => {
+                                let mut rc = ResourceContent::new(uri.clone());
+                                if let Some(mime) = mime_type {
+                                    rc = rc.with_mime_type(mime.as_str());
+                                }
+                                rc = rc.with_text(text.clone());
+                                ContentBlock::resource(rc)
+                            }
+                            ResourceContents::BlobResourceContents {
+                                blob, uri, mime_type, ..
+                            } => {
+                                let mut rc = ResourceContent::new(uri.clone());
+                                if let Some(mime) = mime_type {
+                                    rc = rc.with_mime_type(mime.as_str());
+                                }
+                                rc = rc.with_blob(blob.clone());
+                                ContentBlock::resource(rc)
+                            }
+                        }
+                    }
+                    // [H2] RawResource.name is String, not Option<String> in rmcp 0.16
+                    RawContent::ResourceLink(l) => ContentBlock::ResourceLink {
+                        uri: l.uri.clone(),
+                        name: Some(l.name.clone()),
+                        mime_type: l.mime_type.clone(),
+                    },
+                }
             })
             .collect();
+
+        // Layer 1 extraction verification
+        let rmcp_count = result.content.len();
+        let extracted_count = content.len();
+        if extracted_count != rmcp_count {
+            tracing::warn!(
+                rmcp_count,
+                extracted_count,
+                "Content block count mismatch after extraction"
+            );
+        }
 
         Ok(ToolCallResult {
             content,

--- a/tools/nika/src/mcp/rmcp_adapter.rs
+++ b/tools/nika/src/mcp/rmcp_adapter.rs
@@ -411,9 +411,10 @@ impl RmcpClientAdapter {
                         }
                     }
                     // [H2] RawResource.name is String, not Option<String> in rmcp 0.16
+                    // Convert empty string to None so skip_serializing_if works correctly
                     RawContent::ResourceLink(l) => ContentBlock::ResourceLink {
                         uri: l.uri.clone(),
-                        name: Some(l.name.clone()),
+                        name: if l.name.is_empty() { None } else { Some(l.name.clone()) },
                         mime_type: l.mime_type.clone(),
                     },
                 }

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -1113,4 +1113,132 @@ mod tests {
         assert_eq!(config.cwd.unwrap(), "/home/user/projects/mcp");
         std::env::remove_var("NIKA_TEST_DIR");
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // ContentBlock Enum Tests (PR1)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_content_block_audio_enum() {
+        let block = ContentBlock::audio("b64audio", "audio/wav");
+        assert!(block.is_audio());
+        assert!(!block.is_text());
+        assert!(!block.is_image());
+        assert!(matches!(
+            block,
+            ContentBlock::Audio { ref data, ref mime_type }
+            if data == "b64audio" && mime_type == "audio/wav"
+        ));
+    }
+
+    #[test]
+    fn test_content_block_resource_link_enum() {
+        let block = ContentBlock::resource_link(
+            "file:///tmp/test.txt",
+            Some("test.txt".to_string()),
+            Some("text/plain".to_string()),
+        );
+        assert!(block.is_resource_link());
+        assert!(!block.is_text());
+        assert!(!block.is_resource());
+    }
+
+    #[test]
+    fn test_content_block_serde_roundtrip_all_variants() {
+        let blocks = vec![
+            ContentBlock::text("hello"),
+            ContentBlock::image("b64", "image/png"),
+            ContentBlock::audio("b64", "audio/wav"),
+            ContentBlock::resource(ResourceContent::new("file:///test").with_text("content")),
+            ContentBlock::resource_link("file:///link", None, None),
+        ];
+        for (i, block) in blocks.iter().enumerate() {
+            let json = serde_json::to_string(block)
+                .unwrap_or_else(|e| panic!("variant {i} failed to serialize: {e}"));
+            let back: ContentBlock = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("variant {i} failed to deserialize: {e}\nJSON: {json}"));
+            assert_eq!(*block, back, "variant {i} roundtrip mismatch");
+        }
+    }
+
+    #[test]
+    fn test_content_block_text_json_format() {
+        let block = ContentBlock::text("hello world");
+        let json = serde_json::to_value(&block).unwrap();
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["text"], "hello world");
+    }
+
+    #[test]
+    fn test_content_block_image_json_has_mime_type_camel_case() {
+        let block = ContentBlock::image("b64data", "image/png");
+        let json = serde_json::to_value(&block).unwrap();
+        assert_eq!(json["type"], "image");
+        assert_eq!(json["mimeType"], "image/png");
+        assert!(json.get("mime_type").is_none(), "should use mimeType not mime_type");
+    }
+
+    #[test]
+    fn test_content_block_resource_link_skips_none_fields() {
+        let block = ContentBlock::resource_link("file:///link", None, None);
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(!json.contains("name"), "None name should be skipped");
+        assert!(!json.contains("mimeType"), "None mimeType should be skipped");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // ToolCallResult Media Helper Tests (PR1)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_has_media_false_for_text_only() {
+        let result = ToolCallResult::success(vec![ContentBlock::text("hello")]);
+        assert!(!result.has_media());
+        assert!(result.images().is_empty());
+        assert!(result.audio_blocks().is_empty());
+        assert!(result.media_blocks().is_empty());
+    }
+
+    #[test]
+    fn test_has_media_true_for_mixed_content() {
+        let result = ToolCallResult::success(vec![
+            ContentBlock::text("description"),
+            ContentBlock::image("b64", "image/png"),
+            ContentBlock::audio("b64", "audio/wav"),
+        ]);
+        assert!(result.has_media());
+        assert_eq!(result.images().len(), 1);
+        assert_eq!(result.audio_blocks().len(), 1);
+        assert_eq!(result.media_blocks().len(), 2);
+    }
+
+    #[test]
+    fn test_text_preserved_with_media() {
+        let result = ToolCallResult::success(vec![
+            ContentBlock::text("First line"),
+            ContentBlock::image("b64data", "image/png"),
+            ContentBlock::text("Second line"),
+        ]);
+        assert_eq!(result.text(), "First line\nSecond line");
+        assert_eq!(result.first_text(), Some("First line"));
+        assert!(result.has_media());
+    }
+
+    #[test]
+    fn test_empty_content_vec() {
+        let result = ToolCallResult::success(vec![]);
+        assert!(!result.has_media());
+        assert_eq!(result.text(), "");
+        assert!(result.images().is_empty());
+        assert!(result.media_blocks().is_empty());
+    }
+
+    #[test]
+    fn test_with_blob_builder() {
+        let rc = ResourceContent::new("file:///test")
+            .with_blob("base64data")
+            .with_mime_type("application/pdf");
+        assert_eq!(rc.blob, Some("base64data".to_string()));
+        assert_eq!(rc.mime_type, Some("application/pdf".to_string()));
+    }
 }

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -504,15 +504,15 @@ pub struct ResourceContent {
     pub uri: String,
 
     /// MIME type of the resource content
-    #[serde(default, rename = "mimeType")]
+    #[serde(default, rename = "mimeType", skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
 
     /// Resource text content (if loaded)
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
 
     /// Resource binary content as base64 (if loaded)
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blob: Option<String>,
 }
 

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -1162,6 +1162,22 @@ mod tests {
     }
 
     #[test]
+    fn test_debug_print_all_variants_json() {
+        let blocks = vec![
+            ("text", ContentBlock::text("hello")),
+            ("image", ContentBlock::image("b64", "image/png")),
+            ("audio", ContentBlock::audio("b64", "audio/wav")),
+            ("resource", ContentBlock::resource(ResourceContent::new("file:///test").with_text("content"))),
+            ("resource_link_none", ContentBlock::resource_link("file:///link", None, None)),
+            ("resource_link_full", ContentBlock::resource_link("file:///link", Some("test.txt".into()), Some("text/plain".into()))),
+        ];
+        for (label, block) in &blocks {
+            let json = serde_json::to_string_pretty(block).unwrap();
+            println!("=== {label} ===\n{json}\n");
+        }
+    }
+
+    #[test]
     fn test_content_block_text_json_format() {
         let block = ContentBlock::text("hello world");
         let json = serde_json::to_value(&block).unwrap();

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -544,6 +544,14 @@ impl ResourceContent {
         self.blob = Some(blob.into());
         self
     }
+
+    /// Set the MIME type if value is Some.
+    pub fn with_optional_mime(mut self, mime_type: Option<String>) -> Self {
+        if mime_type.is_some() {
+            self.mime_type = mime_type;
+        }
+        self
+    }
 }
 
 /// Tool definition from MCP server.

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -349,90 +349,129 @@ impl ToolCallResult {
     pub fn text(&self) -> String {
         self.content
             .iter()
-            .filter_map(|block| block.text.as_deref())
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
             .collect::<Vec<_>>()
             .join("\n")
     }
 
     /// Extract the first text block, if any.
     pub fn first_text(&self) -> Option<&str> {
-        self.content.iter().find_map(|block| block.text.as_deref())
+        self.content.iter().find_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
     }
 }
 
 /// Content block in MCP tool results.
 ///
-/// Can be text, image (base64), or embedded resource.
+/// Represents one of five content types returned by MCP tools:
+/// text, image (base64), audio (base64), embedded resource, or resource link.
+///
+/// Uses internally tagged serde representation. All variants are struct-like
+/// (not newtype-wrapping-primitive) because `#[serde(tag = "type")]` requires
+/// the inner type to be a map/struct for deserialization.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub struct ContentBlock {
-    /// Content type: "text", "image", or "resource"
-    #[serde(rename = "type")]
-    pub content_type: String,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    /// Plain text content
+    Text {
+        text: String,
+    },
 
-    /// Text content (for type="text")
-    #[serde(default)]
-    pub text: Option<String>,
+    /// Base64-encoded image with MIME type
+    Image {
+        data: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+    },
 
-    /// Base64-encoded data (for type="image")
-    #[serde(default)]
-    pub data: Option<String>,
+    /// Base64-encoded audio with MIME type
+    Audio {
+        data: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+    },
 
-    /// MIME type (for type="image", e.g., "image/png")
-    #[serde(default)]
-    pub mime_type: Option<String>,
+    /// Embedded resource content (text or blob)
+    Resource(ResourceContent),
 
-    /// Embedded resource (for type="resource")
-    #[serde(default)]
-    pub resource: Option<ResourceContent>,
+    /// Resource link (URI reference without inline data)
+    ResourceLink {
+        uri: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "mimeType")]
+        mime_type: Option<String>,
+    },
 }
 
 impl ContentBlock {
     /// Create a text content block.
     pub fn text(text: impl Into<String>) -> Self {
-        Self {
-            content_type: "text".to_string(),
-            text: Some(text.into()),
-            data: None,
-            mime_type: None,
-            resource: None,
-        }
+        Self::Text { text: text.into() }
     }
 
     /// Create an image content block.
     pub fn image(data: impl Into<String>, mime_type: impl Into<String>) -> Self {
-        Self {
-            content_type: "image".to_string(),
-            text: None,
-            data: Some(data.into()),
-            mime_type: Some(mime_type.into()),
-            resource: None,
+        Self::Image {
+            data: data.into(),
+            mime_type: mime_type.into(),
+        }
+    }
+
+    /// Create an audio content block.
+    pub fn audio(data: impl Into<String>, mime_type: impl Into<String>) -> Self {
+        Self::Audio {
+            data: data.into(),
+            mime_type: mime_type.into(),
         }
     }
 
     /// Create a resource content block.
     pub fn resource(resource: ResourceContent) -> Self {
-        Self {
-            content_type: "resource".to_string(),
-            text: None,
-            data: None,
-            mime_type: None,
-            resource: Some(resource),
+        Self::Resource(resource)
+    }
+
+    /// Create a resource link content block.
+    pub fn resource_link(
+        uri: impl Into<String>,
+        name: Option<String>,
+        mime_type: Option<String>,
+    ) -> Self {
+        Self::ResourceLink {
+            uri: uri.into(),
+            name,
+            mime_type,
         }
     }
 
     /// Check if this is a text block.
     pub fn is_text(&self) -> bool {
-        self.content_type == "text"
+        matches!(self, Self::Text { .. })
     }
 
     /// Check if this is an image block.
     pub fn is_image(&self) -> bool {
-        self.content_type == "image"
+        matches!(self, Self::Image { .. })
+    }
+
+    /// Check if this is an audio block.
+    pub fn is_audio(&self) -> bool {
+        matches!(self, Self::Audio { .. })
     }
 
     /// Check if this is a resource block.
     pub fn is_resource(&self) -> bool {
-        self.content_type == "resource"
+        matches!(self, Self::Resource(_))
+    }
+
+    /// Check if this is a resource link block.
+    pub fn is_resource_link(&self) -> bool {
+        matches!(self, Self::ResourceLink { .. })
     }
 }
 
@@ -477,6 +516,12 @@ impl ResourceContent {
     /// Set the text content.
     pub fn with_text(mut self, text: impl Into<String>) -> Self {
         self.text = Some(text.into());
+        self
+    }
+
+    /// Set the blob content (base64-encoded binary).
+    pub fn with_blob(mut self, blob: impl Into<String>) -> Self {
+        self.blob = Some(blob.into());
         self
     }
 }
@@ -703,7 +748,7 @@ mod tests {
         assert!(block.is_text());
         assert!(!block.is_image());
         assert!(!block.is_resource());
-        assert_eq!(block.text, Some("Hello".to_string()));
+        assert!(matches!(block, ContentBlock::Text { ref text } if text == "Hello"));
     }
 
     #[test]
@@ -712,8 +757,11 @@ mod tests {
 
         assert!(block.is_image());
         assert!(!block.is_text());
-        assert_eq!(block.data, Some("SGVsbG8=".to_string()));
-        assert_eq!(block.mime_type, Some("image/png".to_string()));
+        assert!(matches!(
+            block,
+            ContentBlock::Image { ref data, ref mime_type }
+            if data == "SGVsbG8=" && mime_type == "image/png"
+        ));
     }
 
     #[test]
@@ -723,8 +771,7 @@ mod tests {
 
         assert!(block.is_resource());
         assert!(!block.is_text());
-        assert!(block.resource.is_some());
-        assert_eq!(block.resource.unwrap().uri, "file:///tmp/test.txt");
+        assert!(matches!(block, ContentBlock::Resource(ref rc) if rc.uri == "file:///tmp/test.txt"));
     }
 
     #[test]
@@ -736,8 +783,8 @@ mod tests {
 
         let block: ContentBlock = serde_json::from_str(json).unwrap();
 
-        assert_eq!(block.content_type, "text");
-        assert_eq!(block.text, Some("Hello from MCP".to_string()));
+        assert!(block.is_text());
+        assert!(matches!(block, ContentBlock::Text { ref text } if text == "Hello from MCP"));
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -1265,4 +1265,644 @@ mod tests {
         assert_eq!(rc.blob, Some("base64data".to_string()));
         assert_eq!(rc.mime_type, Some("application/pdf".to_string()));
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Exhaustive ContentBlock Serde Tests
+    //
+    // These tests simulate real MCP server JSON responses to catch silent
+    // serialization/deserialization bugs (field naming, missing fields,
+    // variant tagging, Option skipping, etc.).
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ---------------------------------------------------------------
+    // 1. Deserialization from external JSON (MCP server responses)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_deser_text_from_mcp_json() {
+        let json = r#"{"type": "text", "text": "hello"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert!(block.is_text());
+        assert_eq!(block, ContentBlock::Text { text: "hello".into() });
+    }
+
+    #[test]
+    fn test_deser_image_from_mcp_json() {
+        let json = r#"{"type": "image", "data": "b64data", "mimeType": "image/png"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert!(block.is_image());
+        assert_eq!(
+            block,
+            ContentBlock::Image {
+                data: "b64data".into(),
+                mime_type: "image/png".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_deser_audio_from_mcp_json() {
+        let json = r#"{"type": "audio", "data": "b64data", "mimeType": "audio/wav"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert!(block.is_audio());
+        assert_eq!(
+            block,
+            ContentBlock::Audio {
+                data: "b64data".into(),
+                mime_type: "audio/wav".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_deser_resource_from_mcp_json() {
+        let json = r#"{"type": "resource", "uri": "file:///test", "text": "content"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert!(block.is_resource());
+        let expected = ContentBlock::Resource(
+            ResourceContent::new("file:///test").with_text("content"),
+        );
+        assert_eq!(block, expected);
+    }
+
+    #[test]
+    fn test_deser_resource_link_from_mcp_json() {
+        let json = r#"{"type": "resource_link", "uri": "file:///link"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert!(block.is_resource_link());
+        assert_eq!(
+            block,
+            ContentBlock::ResourceLink {
+                uri: "file:///link".into(),
+                name: None,
+                mime_type: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_deser_resource_link_with_optional_fields() {
+        let json = r#"{
+            "type": "resource_link",
+            "uri": "file:///link",
+            "name": "report.pdf",
+            "mimeType": "application/pdf"
+        }"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            block,
+            ContentBlock::ResourceLink {
+                uri: "file:///link".into(),
+                name: Some("report.pdf".into()),
+                mime_type: Some("application/pdf".into()),
+            }
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // 2. Error cases — malformed / invalid JSON
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_deser_image_missing_mime_type_fails() {
+        let json = r#"{"type": "image", "data": "x"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "image without mimeType should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_image_missing_data_fails() {
+        let json = r#"{"type": "image", "mimeType": "image/png"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "image without data should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_audio_missing_mime_type_fails() {
+        let json = r#"{"type": "audio", "data": "x"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "audio without mimeType should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_audio_missing_data_fails() {
+        let json = r#"{"type": "audio", "mimeType": "audio/wav"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "audio without data should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_text_missing_text_field_fails() {
+        let json = r#"{"type": "text"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "text without text field should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_resource_missing_uri_fails() {
+        let json = r#"{"type": "resource", "text": "content"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "resource without uri should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_resource_link_missing_uri_fails() {
+        let json = r#"{"type": "resource_link", "name": "test.txt"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "resource_link without uri should fail to deserialize");
+    }
+
+    #[test]
+    fn test_deser_extra_unknown_fields_succeeds() {
+        // serde default: unknown fields are ignored (no deny_unknown_fields)
+        let json = r#"{"type": "text", "text": "hi", "extra": true, "count": 42}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block, ContentBlock::text("hi"));
+    }
+
+    #[test]
+    fn test_deser_invalid_type_value_fails() {
+        let json = r#"{"type": "video", "data": "x"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "unknown type 'video' should fail");
+    }
+
+    #[test]
+    fn test_deser_empty_string_type_fails() {
+        let json = r#"{"type": "", "text": "hello"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "empty string type should fail");
+    }
+
+    #[test]
+    fn test_deser_missing_type_field_fails() {
+        let json = r#"{"text": "hello"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "missing type field should fail");
+    }
+
+    #[test]
+    fn test_deser_null_type_fails() {
+        let json = r#"{"type": null, "text": "hello"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "null type should fail");
+    }
+
+    #[test]
+    fn test_deser_numeric_type_fails() {
+        let json = r#"{"type": 42, "text": "hello"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "numeric type should fail");
+    }
+
+    // ---------------------------------------------------------------
+    // 3. Resource variant: flat JSON structure + skip_serializing_if
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_resource_serializes_flat_not_nested() {
+        let block = ContentBlock::resource(
+            ResourceContent::new("file:///test")
+                .with_text("hello")
+                .with_mime_type("text/plain"),
+        );
+        let json = serde_json::to_value(&block).unwrap();
+
+        // Fields should be at top level, NOT nested under a "resource" key
+        assert_eq!(json["type"], "resource");
+        assert_eq!(json["uri"], "file:///test");
+        assert_eq!(json["text"], "hello");
+        assert_eq!(json["mimeType"], "text/plain");
+        assert!(json.get("resource").is_none(), "should NOT have nested 'resource' key");
+    }
+
+    #[test]
+    fn test_resource_content_none_fields_omitted_in_serialization() {
+        let rc = ResourceContent::new("file:///bare");
+        let json = serde_json::to_value(&rc).unwrap();
+
+        assert_eq!(json["uri"], "file:///bare");
+        assert!(json.get("mimeType").is_none(), "None mimeType should be omitted");
+        assert!(json.get("text").is_none(), "None text should be omitted");
+        assert!(json.get("blob").is_none(), "None blob should be omitted");
+    }
+
+    #[test]
+    fn test_resource_content_some_fields_present_in_serialization() {
+        let rc = ResourceContent::new("file:///full")
+            .with_mime_type("application/json")
+            .with_text("{}")
+            .with_blob("YmluYXJ5");
+        let json = serde_json::to_value(&rc).unwrap();
+
+        assert_eq!(json["uri"], "file:///full");
+        assert_eq!(json["mimeType"], "application/json");
+        assert_eq!(json["text"], "{}");
+        assert_eq!(json["blob"], "YmluYXJ5");
+    }
+
+    #[test]
+    fn test_resource_block_none_fields_omitted_via_content_block() {
+        // When wrapped in ContentBlock, the skip_serializing_if should still apply
+        let block = ContentBlock::resource(ResourceContent::new("file:///bare"));
+        let json_str = serde_json::to_string(&block).unwrap();
+
+        assert!(!json_str.contains("mimeType"), "None mimeType should be omitted");
+        assert!(!json_str.contains("\"text\""), "None text should be omitted");
+        assert!(!json_str.contains("blob"), "None blob should be omitted");
+        assert!(json_str.contains("\"type\""));
+        assert!(json_str.contains("\"uri\""));
+    }
+
+    #[test]
+    fn test_resource_content_roundtrip_with_all_fields() {
+        let original = ResourceContent::new("file:///test")
+            .with_mime_type("application/octet-stream")
+            .with_text("textual fallback")
+            .with_blob("YmxvYg==");
+
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ResourceContent = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_resource_content_roundtrip_with_no_optional_fields() {
+        let original = ResourceContent::new("file:///minimal");
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ResourceContent = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    // ---------------------------------------------------------------
+    // 4. ToolCallResult with mixed content
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_tool_call_result_deser_mixed_content() {
+        let json = r#"{
+            "content": [
+                {"type": "text", "text": "Analysis complete"},
+                {"type": "image", "data": "iVBORw0KGgo=", "mimeType": "image/png"},
+                {"type": "audio", "data": "UklGRg==", "mimeType": "audio/wav"},
+                {"type": "text", "text": "See attached media"},
+                {"type": "resource", "uri": "file:///data.json", "text": "{\"key\": 1}"},
+                {"type": "resource_link", "uri": "file:///extra"}
+            ],
+            "is_error": false
+        }"#;
+
+        let result: ToolCallResult = serde_json::from_str(json).unwrap();
+
+        assert!(!result.is_error);
+        assert_eq!(result.content.len(), 6);
+
+        // text() joins only text blocks
+        assert_eq!(result.text(), "Analysis complete\nSee attached media");
+
+        // has_media() should be true (image, audio, resource, resource_link)
+        assert!(result.has_media());
+
+        // media_blocks() = everything except text = 4 blocks
+        assert_eq!(result.media_blocks().len(), 4);
+
+        // images() = 1
+        assert_eq!(result.images().len(), 1);
+        assert!(result.images()[0].is_image());
+
+        // audio_blocks() = 1
+        assert_eq!(result.audio_blocks().len(), 1);
+        assert!(result.audio_blocks()[0].is_audio());
+
+        // first_text()
+        assert_eq!(result.first_text(), Some("Analysis complete"));
+    }
+
+    #[test]
+    fn test_tool_call_result_deser_error_with_mixed_content() {
+        let json = r#"{
+            "content": [
+                {"type": "text", "text": "Partial failure"},
+                {"type": "image", "data": "corrupt", "mimeType": "image/jpeg"}
+            ],
+            "is_error": true
+        }"#;
+
+        let result: ToolCallResult = serde_json::from_str(json).unwrap();
+        assert!(result.is_error);
+        assert!(result.has_media());
+        assert_eq!(result.text(), "Partial failure");
+    }
+
+    #[test]
+    fn test_tool_call_result_deser_is_error_defaults_false() {
+        // is_error has #[serde(default)], so omitting it should default to false
+        let json = r#"{
+            "content": [{"type": "text", "text": "ok"}]
+        }"#;
+
+        let result: ToolCallResult = serde_json::from_str(json).unwrap();
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn test_tool_call_result_roundtrip_mixed() {
+        let original = ToolCallResult::success(vec![
+            ContentBlock::text("output"),
+            ContentBlock::image("aW1n", "image/webp"),
+            ContentBlock::audio("YXVk", "audio/mp3"),
+            ContentBlock::resource(
+                ResourceContent::new("file:///r").with_text("resource text"),
+            ),
+            ContentBlock::resource_link("file:///rl", Some("name".into()), None),
+        ]);
+
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ToolCallResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_tool_call_result_empty_content_array() {
+        let json = r#"{"content": [], "is_error": false}"#;
+        let result: ToolCallResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.content.len(), 0);
+        assert!(!result.has_media());
+        assert_eq!(result.text(), "");
+        assert!(result.first_text().is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // 5. Unicode and special characters
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_text_block_with_emoji() {
+        let json = r#"{"type": "text", "text": "Hello 🌍"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block, ContentBlock::text("Hello 🌍"));
+    }
+
+    #[test]
+    fn test_text_block_with_newlines() {
+        let json = "{\"type\": \"text\", \"text\": \"line1\\nline2\"}";
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block, ContentBlock::text("line1\nline2"));
+    }
+
+    #[test]
+    fn test_text_block_with_unicode_escapes() {
+        // JSON unicode escape for e-acute: \u00e9
+        let json = r#"{"type": "text", "text": "caf\u00e9"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block, ContentBlock::text("caf\u{00e9}"));
+    }
+
+    #[test]
+    fn test_text_block_with_json_special_chars() {
+        // Text containing quotes, backslashes, tabs
+        let json = r#"{"type": "text", "text": "quote: \" backslash: \\ tab: \t"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            block,
+            ContentBlock::text("quote: \" backslash: \\ tab: \t")
+        );
+    }
+
+    #[test]
+    fn test_text_block_empty_string() {
+        let json = r#"{"type": "text", "text": ""}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block, ContentBlock::text(""));
+    }
+
+    #[test]
+    fn test_image_data_with_base64_special_chars() {
+        // Base64 alphabet includes +, /, and = (padding)
+        let b64 = "abc+def/ghi=";
+        let json = format!(
+            r#"{{"type": "image", "data": "{}", "mimeType": "image/png"}}"#,
+            b64
+        );
+        let block: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            block,
+            ContentBlock::Image {
+                data: b64.into(),
+                mime_type: "image/png".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_image_data_with_double_padding() {
+        let b64 = "YQ==";
+        let json = format!(
+            r#"{{"type": "image", "data": "{}", "mimeType": "image/gif"}}"#,
+            b64
+        );
+        let block: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            block,
+            ContentBlock::Image {
+                data: b64.into(),
+                mime_type: "image/gif".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_resource_uri_with_special_chars() {
+        let json = r#"{"type": "resource", "uri": "file:///path/to/my%20file.txt", "text": "ok"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        assert!(block.is_resource());
+        if let ContentBlock::Resource(rc) = &block {
+            assert_eq!(rc.uri, "file:///path/to/my%20file.txt");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // 6. Field naming invariants (camelCase in JSON, snake_case in Rust)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_image_serialization_uses_camel_case_mime_type() {
+        let block = ContentBlock::image("data", "image/jpeg");
+        let json = serde_json::to_value(&block).unwrap();
+
+        // Must be "mimeType" (camelCase), NOT "mime_type" (snake_case)
+        assert!(json.get("mimeType").is_some(), "should serialize as mimeType");
+        assert!(json.get("mime_type").is_none(), "should NOT serialize as mime_type");
+    }
+
+    #[test]
+    fn test_audio_serialization_uses_camel_case_mime_type() {
+        let block = ContentBlock::audio("data", "audio/ogg");
+        let json = serde_json::to_value(&block).unwrap();
+
+        assert!(json.get("mimeType").is_some(), "should serialize as mimeType");
+        assert!(json.get("mime_type").is_none(), "should NOT serialize as mime_type");
+    }
+
+    #[test]
+    fn test_resource_link_serialization_uses_camel_case_mime_type() {
+        let block = ContentBlock::resource_link(
+            "file:///x",
+            None,
+            Some("text/html".into()),
+        );
+        let json = serde_json::to_value(&block).unwrap();
+
+        assert!(json.get("mimeType").is_some(), "should serialize as mimeType");
+        assert!(json.get("mime_type").is_none(), "should NOT serialize as mime_type");
+    }
+
+    #[test]
+    fn test_resource_content_serialization_uses_camel_case_mime_type() {
+        let rc = ResourceContent::new("file:///x").with_mime_type("text/plain");
+        let json = serde_json::to_value(&rc).unwrap();
+
+        assert!(json.get("mimeType").is_some(), "should serialize as mimeType");
+        assert!(json.get("mime_type").is_none(), "should NOT serialize as mime_type");
+    }
+
+    #[test]
+    fn test_image_deser_rejects_snake_case_mime_type() {
+        // MCP spec uses camelCase; snake_case should NOT work
+        let json = r#"{"type": "image", "data": "x", "mime_type": "image/png"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(
+            result.is_err(),
+            "snake_case mime_type should fail — serde renames to mimeType"
+        );
+    }
+
+    #[test]
+    fn test_audio_deser_rejects_snake_case_mime_type() {
+        let json = r#"{"type": "audio", "data": "x", "mime_type": "audio/wav"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(
+            result.is_err(),
+            "snake_case mime_type should fail — serde renames to mimeType"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // 7. Type tag value invariants (snake_case)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_type_tag_values_are_snake_case() {
+        let cases: Vec<(ContentBlock, &str)> = vec![
+            (ContentBlock::text("t"), "text"),
+            (ContentBlock::image("d", "image/png"), "image"),
+            (ContentBlock::audio("d", "audio/wav"), "audio"),
+            (
+                ContentBlock::resource(ResourceContent::new("file:///x")),
+                "resource",
+            ),
+            (
+                ContentBlock::resource_link("file:///x", None, None),
+                "resource_link",
+            ),
+        ];
+
+        for (block, expected_tag) in cases {
+            let json = serde_json::to_value(&block).unwrap();
+            assert_eq!(
+                json["type"].as_str().unwrap(),
+                expected_tag,
+                "wrong type tag for {:?}",
+                block
+            );
+        }
+    }
+
+    #[test]
+    fn test_camel_case_type_tag_fails() {
+        // "resourceLink" (camelCase) should NOT work, only "resource_link" (snake_case)
+        let json = r#"{"type": "resourceLink", "uri": "file:///x"}"#;
+        let result = serde_json::from_str::<ContentBlock>(json);
+        assert!(result.is_err(), "camelCase type tag should fail");
+    }
+
+    // ---------------------------------------------------------------
+    // 8. Boundary and regression cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_deser_resource_with_blob_no_text() {
+        let json = r#"{"type": "resource", "uri": "file:///bin", "blob": "AQID"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        if let ContentBlock::Resource(rc) = &block {
+            assert_eq!(rc.uri, "file:///bin");
+            assert_eq!(rc.blob, Some("AQID".into()));
+            assert!(rc.text.is_none());
+            assert!(rc.mime_type.is_none());
+        } else {
+            panic!("expected Resource variant");
+        }
+    }
+
+    #[test]
+    fn test_deser_resource_uri_only() {
+        let json = r#"{"type": "resource", "uri": "file:///bare"}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        let expected = ContentBlock::resource(ResourceContent::new("file:///bare"));
+        assert_eq!(block, expected);
+    }
+
+    #[test]
+    fn test_content_block_clone_eq() {
+        let blocks = vec![
+            ContentBlock::text("t"),
+            ContentBlock::image("d", "image/png"),
+            ContentBlock::audio("d", "audio/wav"),
+            ContentBlock::resource(ResourceContent::new("file:///x")),
+            ContentBlock::resource_link("file:///x", Some("n".into()), Some("m".into())),
+        ];
+        for block in &blocks {
+            let cloned = block.clone();
+            assert_eq!(*block, cloned);
+        }
+    }
+
+    #[test]
+    fn test_large_text_block_roundtrip() {
+        let large_text = "a".repeat(100_000);
+        let block = ContentBlock::text(&large_text);
+        let json = serde_json::to_string(&block).unwrap();
+        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(block, parsed);
+    }
+
+    #[test]
+    fn test_large_base64_data_roundtrip() {
+        let large_data = "A".repeat(1_000_000); // ~750KB decoded
+        let block = ContentBlock::image(&large_data, "image/tiff");
+        let json = serde_json::to_string(&block).unwrap();
+        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(block, parsed);
+    }
+
+    #[test]
+    fn test_tool_call_result_many_blocks_roundtrip() {
+        let blocks: Vec<ContentBlock> = (0..100)
+            .map(|i| {
+                if i % 3 == 0 {
+                    ContentBlock::text(format!("block-{i}"))
+                } else if i % 3 == 1 {
+                    ContentBlock::image(format!("data-{i}"), "image/png")
+                } else {
+                    ContentBlock::audio(format!("audio-{i}"), "audio/ogg")
+                }
+            })
+            .collect();
+
+        let original = ToolCallResult::success(blocks);
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ToolCallResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, parsed);
+        assert_eq!(parsed.content.len(), 100);
+    }
 }

--- a/tools/nika/src/mcp/types.rs
+++ b/tools/nika/src/mcp/types.rs
@@ -364,6 +364,26 @@ impl ToolCallResult {
             _ => None,
         })
     }
+
+    /// Check if result contains any non-text content (images, audio, resources).
+    pub fn has_media(&self) -> bool {
+        self.content.iter().any(|b| !b.is_text())
+    }
+
+    /// Get all image content blocks.
+    pub fn images(&self) -> Vec<&ContentBlock> {
+        self.content.iter().filter(|b| b.is_image()).collect()
+    }
+
+    /// Get all audio content blocks.
+    pub fn audio_blocks(&self) -> Vec<&ContentBlock> {
+        self.content.iter().filter(|b| b.is_audio()).collect()
+    }
+
+    /// Get all non-text content blocks (images, audio, resources, resource links).
+    pub fn media_blocks(&self) -> Vec<&ContentBlock> {
+        self.content.iter().filter(|b| !b.is_text()).collect()
+    }
 }
 
 /// Content block in MCP tool results.

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -1,0 +1,166 @@
+//! MIME detection pipeline: magic bytes -> server hint fallback
+//!
+//! When both magic bytes AND server hint fail, returns
+//! `Err(MimeDetectionFailed)` instead of a silent fallback.
+//!
+//! Server MIME is case-normalized before any comparison.
+//!
+//! Declare-then-verify: when both magic bytes and server hint
+//! are available, cross-validates at the category level.
+
+use super::error::MediaError;
+
+/// Result of MIME detection.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DetectedMime {
+    /// Detected MIME type (e.g., "image/png")
+    pub mime_type: String,
+
+    /// File extension without dot (e.g., "png")
+    pub extension: String,
+
+    /// How the MIME type was determined
+    pub source: DetectionSource,
+}
+
+/// How the MIME type was determined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectionSource {
+    /// Determined via magic byte inspection (highest confidence)
+    MagicBytes,
+
+    /// Determined via file extension lookup
+    Extension,
+
+    /// Accepted from server-provided Content-Type hint
+    ServerHint,
+}
+
+/// Detect MIME type from binary data with optional server hint.
+///
+/// Detection pipeline (in order):
+/// 1. Magic byte inspection via `infer` crate (first 8192 bytes)
+/// 2. If server_mime provided and magic bytes fail, accept server hint
+/// 3. If both fail, return `Err(MimeDetectionFailed)`
+pub fn detect_mime(
+    data: &[u8],
+    server_mime: Option<&str>,
+) -> Result<DetectedMime, MediaError> {
+    // Normalize server MIME to lowercase for case-insensitive comparison
+    let server_mime_normalized: Option<String> =
+        server_mime.map(|m| m.to_ascii_lowercase());
+    let server_mime_ref = server_mime_normalized.as_deref();
+
+    let inspect_len = data.len().min(8192);
+    let sample = &data[..inspect_len];
+
+    // SVG special handling: magic bytes won't detect SVG (it's XML-based text)
+    if sample.len() >= 5 {
+        let text_start = std::str::from_utf8(&sample[..sample.len().min(512)]);
+        if let Ok(text) = text_start {
+            let trimmed = text.trim_start();
+            if trimmed.starts_with("<?xml") || trimmed.starts_with("<svg") {
+                if trimmed.contains("<svg")
+                    || trimmed.contains("xmlns=\"http://www.w3.org/2000/svg\"")
+                {
+                    return Ok(DetectedMime {
+                        mime_type: "image/svg+xml".to_string(),
+                        extension: "svg".to_string(),
+                        source: DetectionSource::MagicBytes,
+                    });
+                }
+            }
+        }
+    }
+
+    // Layer 1: Magic byte detection
+    if let Some(kind) = infer::get(sample) {
+        let mime_type = kind.mime_type().to_string();
+        let extension = kind.extension().to_string();
+
+        // Declare-then-verify: cross-validate with server hint
+        if let Some(server) = server_mime_ref {
+            let detected_category = mime_type.split('/').next();
+            let server_category = server.split('/').next();
+            if detected_category != server_category {
+                tracing::warn!(
+                    detected = %mime_type,
+                    server = %server,
+                    "MIME category mismatch: server declared {}, magic bytes detected {}",
+                    server,
+                    mime_type,
+                );
+            } else if *server != mime_type {
+                tracing::debug!(
+                    detected = %mime_type,
+                    server = %server,
+                    "MIME subtype mismatch: magic bytes disagree with server hint, using magic bytes"
+                );
+            }
+        }
+
+        return Ok(DetectedMime {
+            mime_type,
+            extension,
+            source: DetectionSource::MagicBytes,
+        });
+    }
+
+    // Layer 2: Accept server hint if magic bytes failed
+    if let Some(server) = server_mime_ref {
+        if server != "application/octet-stream" {
+            let extension = mime_to_extension(server);
+            return Ok(DetectedMime {
+                mime_type: server.to_string(),
+                extension,
+                source: DetectionSource::ServerHint,
+            });
+        }
+    }
+
+    // Layer 3: Both magic bytes and server hint failed
+    Err(MediaError::mime_detection_failed(
+        inspect_len,
+        server_mime.map(|s| s.to_string()),
+    ))
+}
+
+/// Convert a MIME type to a file extension.
+pub fn mime_to_extension(mime: &str) -> String {
+    // Try mime_guess first
+    let guesses = mime_guess::get_mime_extensions_str(mime);
+    if let Some(exts) = guesses {
+        if let Some(ext) = exts.first() {
+            return sanitize_extension(ext);
+        }
+    }
+
+    // Manual fallback for common types
+    let ext = match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/svg+xml" => "svg",
+        "audio/mpeg" => "mp3",
+        "audio/wav" | "audio/x-wav" => "wav",
+        "audio/ogg" => "ogg",
+        "audio/flac" => "flac",
+        "application/pdf" => "pdf",
+        "application/json" => "json",
+        "text/plain" => "txt",
+        "text/html" => "html",
+        _ => "bin",
+    };
+
+    sanitize_extension(ext)
+}
+
+/// Sanitize extension to prevent path traversal.
+/// Only allows alphanumeric characters and hyphens.
+fn sanitize_extension(ext: &str) -> String {
+    ext.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-')
+        .collect::<String>()
+        .to_lowercase()
+}

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -163,3 +163,101 @@ fn sanitize_extension(ext: &str) -> String {
         .collect::<String>()
         .to_lowercase()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // PNG magic bytes: 89 50 4E 47
+    const PNG_HEADER: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+    // JPEG magic bytes: FF D8 FF
+    const JPEG_HEADER: &[u8] = &[0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0];
+    // WAV: RIFF....WAVE
+    const WAV_HEADER: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, // RIFF
+        0x00, 0x00, 0x00, 0x00, // size
+        0x57, 0x41, 0x56, 0x45, // WAVE
+    ];
+
+    #[test]
+    fn detect_png_magic_bytes() {
+        let result = detect_mime(PNG_HEADER, None).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+        assert_eq!(result.extension, "png");
+        assert_eq!(result.source, DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn detect_jpeg_magic_bytes() {
+        let result = detect_mime(JPEG_HEADER, None).unwrap();
+        assert_eq!(result.mime_type, "image/jpeg");
+        assert_eq!(result.source, DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn detect_wav_magic_bytes() {
+        let result = detect_mime(WAV_HEADER, None).unwrap();
+        assert!(result.mime_type.contains("wav"), "expected wav, got {}", result.mime_type);
+        assert_eq!(result.source, DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn unknown_bytes_returns_error() {
+        let data = &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
+        let result = detect_mime(data, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_bytes_with_octet_stream_returns_error() {
+        let data = &[0x00, 0x01, 0x02, 0x03];
+        let result = detect_mime(data, Some("application/octet-stream"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_bytes_with_server_hint_accepted() {
+        let data = &[0x00, 0x01, 0x02, 0x03];
+        let result = detect_mime(data, Some("image/png")).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+        assert_eq!(result.source, DetectionSource::ServerHint);
+    }
+
+    #[test]
+    fn magic_bytes_preferred_over_server_hint() {
+        // PNG bytes + wrong server hint
+        let result = detect_mime(PNG_HEADER, Some("audio/wav")).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+        assert_eq!(result.source, DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn uppercase_server_mime_normalized() {
+        let data = &[0x00, 0x01, 0x02, 0x03];
+        let result = detect_mime(data, Some("IMAGE/PNG")).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+    }
+
+    #[test]
+    fn svg_detection() {
+        let svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"></svg>";
+        let result = detect_mime(svg, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+        assert_eq!(result.extension, "svg");
+    }
+
+    #[test]
+    fn mime_to_extension_common_types() {
+        assert_eq!(mime_to_extension("image/png"), "png");
+        // mime_guess may return "jfif" or "jpg" for image/jpeg
+        let jpeg_ext = mime_to_extension("image/jpeg");
+        assert!(jpeg_ext == "jpg" || jpeg_ext == "jfif", "got: {jpeg_ext}");
+        assert_eq!(mime_to_extension("application/pdf"), "pdf");
+    }
+
+    #[test]
+    fn sanitize_extension_rejects_traversal() {
+        assert_eq!(sanitize_extension("../etc/passwd"), "etcpasswd");
+        assert_eq!(sanitize_extension("png;rm -rf /"), "pngrm-rf");
+    }
+}

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -59,16 +59,15 @@ pub fn detect_mime(
         let text_start = std::str::from_utf8(&sample[..sample.len().min(512)]);
         if let Ok(text) = text_start {
             let trimmed = text.trim_start();
-            if trimmed.starts_with("<?xml") || trimmed.starts_with("<svg") {
-                if trimmed.contains("<svg")
-                    || trimmed.contains("xmlns=\"http://www.w3.org/2000/svg\"")
-                {
+            if (trimmed.starts_with("<?xml") || trimmed.starts_with("<svg"))
+                && (trimmed.contains("<svg")
+                    || trimmed.contains("xmlns=\"http://www.w3.org/2000/svg\""))
+            {
                     return Ok(DetectedMime {
                         mime_type: "image/svg+xml".to_string(),
                         extension: "svg".to_string(),
                         source: DetectionSource::MagicBytes,
                     });
-                }
             }
         }
     }

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -77,24 +77,27 @@ pub fn detect_mime(
         let mime_type = kind.mime_type().to_string();
         let extension = kind.extension().to_string();
 
-        // Declare-then-verify: cross-validate with server hint
+        // Declare-then-verify (D25): cross-validate with server hint
         if let Some(server) = server_mime_ref {
-            let detected_category = mime_type.split('/').next();
-            let server_category = server.split('/').next();
-            if detected_category != server_category {
-                tracing::warn!(
-                    detected = %mime_type,
-                    server = %server,
-                    "MIME category mismatch: server declared {}, magic bytes detected {}",
-                    server,
-                    mime_type,
-                );
-            } else if *server != mime_type {
-                tracing::debug!(
-                    detected = %mime_type,
-                    server = %server,
-                    "MIME subtype mismatch: magic bytes disagree with server hint, using magic bytes"
-                );
+            if !is_mime_alias(&mime_type, server) {
+                let detected_category = mime_type.split('/').next();
+                let server_category = server.split('/').next();
+                if detected_category != server_category {
+                    // Cross-category mismatch: REJECT (e.g., server=audio/*, magic=image/*)
+                    return Err(MediaError::MimeDetectionFailed {
+                        reason: format!(
+                            "MIME category conflict: server declared '{}' but magic bytes detected '{}'",
+                            server, mime_type
+                        ),
+                    });
+                } else {
+                    // Same category, different subtype: warn but accept magic bytes
+                    tracing::debug!(
+                        detected = %mime_type,
+                        server = %server,
+                        "MIME subtype mismatch: magic bytes disagree with server hint, using magic bytes"
+                    );
+                }
             }
         }
 
@@ -122,6 +125,25 @@ pub fn detect_mime(
         inspect_len,
         server_mime.map(|s| s.to_string()),
     ))
+}
+
+/// Check if two MIME types are known aliases of each other.
+///
+/// Covers common non-standard MIME variants sent by MCP servers:
+/// - `audio/mp3` ↔ `audio/mpeg`
+/// - `image/jpg` ↔ `image/jpeg`
+/// - `audio/wav` ↔ `audio/x-wav`
+pub fn is_mime_alias(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    let pair = (a.min(b), a.max(b));
+    matches!(
+        pair,
+        ("audio/mp3", "audio/mpeg")
+            | ("audio/wav", "audio/x-wav")
+            | ("image/jpeg", "image/jpg")
+    )
 }
 
 /// Convert a MIME type to a file extension.
@@ -224,9 +246,9 @@ mod tests {
     }
 
     #[test]
-    fn magic_bytes_preferred_over_server_hint() {
-        // PNG bytes + wrong server hint
-        let result = detect_mime(PNG_HEADER, Some("audio/wav")).unwrap();
+    fn magic_bytes_preferred_over_same_category_hint() {
+        // PNG bytes + wrong server hint (same category: image)
+        let result = detect_mime(PNG_HEADER, Some("image/webp")).unwrap();
         assert_eq!(result.mime_type, "image/png");
         assert_eq!(result.source, DetectionSource::MagicBytes);
     }
@@ -253,6 +275,52 @@ mod tests {
         let jpeg_ext = mime_to_extension("image/jpeg");
         assert!(jpeg_ext == "jpg" || jpeg_ext == "jfif", "got: {jpeg_ext}");
         assert_eq!(mime_to_extension("application/pdf"), "pdf");
+    }
+
+    #[test]
+    fn is_mime_alias_known_pairs() {
+        assert!(is_mime_alias("audio/mp3", "audio/mpeg"));
+        assert!(is_mime_alias("audio/mpeg", "audio/mp3"));
+        assert!(is_mime_alias("image/jpeg", "image/jpg"));
+        assert!(is_mime_alias("image/jpg", "image/jpeg"));
+        assert!(is_mime_alias("audio/wav", "audio/x-wav"));
+        assert!(is_mime_alias("audio/x-wav", "audio/wav"));
+    }
+
+    #[test]
+    fn is_mime_alias_identity() {
+        assert!(is_mime_alias("image/png", "image/png"));
+        assert!(is_mime_alias("audio/mpeg", "audio/mpeg"));
+    }
+
+    #[test]
+    fn is_mime_alias_non_aliases() {
+        assert!(!is_mime_alias("image/png", "image/jpeg"));
+        assert!(!is_mime_alias("audio/mp3", "image/png"));
+        assert!(!is_mime_alias("audio/ogg", "audio/flac"));
+    }
+
+    #[test]
+    fn cross_category_mismatch_is_rejected() {
+        // PNG bytes + server declares audio/wav → should fail with NIKA-251
+        let result = detect_mime(PNG_HEADER, Some("audio/wav"));
+        assert!(result.is_err(), "Cross-category mismatch should be rejected");
+        assert_eq!(result.unwrap_err().code(), "NIKA-251");
+    }
+
+    #[test]
+    fn same_category_alias_is_accepted() {
+        // WAV bytes + server declares audio/x-wav → alias, should accept
+        let result = detect_mime(WAV_HEADER, Some("audio/x-wav"));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn same_category_subtype_mismatch_uses_magic_bytes() {
+        // JPEG bytes + server declares image/webp → same category, accept magic bytes
+        let result = detect_mime(JPEG_HEADER, Some("image/webp")).unwrap();
+        assert_eq!(result.mime_type, "image/jpeg");
+        assert_eq!(result.source, DetectionSource::MagicBytes);
     }
 
     #[test]

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -25,6 +25,7 @@ pub struct DetectedMime {
 
 /// How the MIME type was determined.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Extension variant used in tests + PR2
 pub enum DetectionSource {
     /// Determined via magic byte inspection (highest confidence)
     MagicBytes,
@@ -54,15 +55,18 @@ pub fn detect_mime(
     let inspect_len = data.len().min(8192);
     let sample = &data[..inspect_len];
 
-    // SVG special handling: magic bytes won't detect SVG (it's XML-based text)
+    // SVG special handling: magic bytes won't detect SVG (it's XML-based text).
+    // Uses word-boundary check after `<svg` to avoid false positives on
+    // tags like `<svg-report>` or `<svg-data>`.
     if sample.len() >= 5 {
         let text_start = std::str::from_utf8(&sample[..sample.len().min(512)]);
         if let Ok(text) = text_start {
             let trimmed = text.trim_start();
-            if (trimmed.starts_with("<?xml") || trimmed.starts_with("<svg"))
-                && (trimmed.contains("<svg")
-                    || trimmed.contains("xmlns=\"http://www.w3.org/2000/svg\""))
-            {
+            let has_xml_prefix = trimmed.starts_with("<?xml");
+            let has_svg_tag = has_svg_element(trimmed);
+            let has_svg_ns = trimmed.contains("xmlns=\"http://www.w3.org/2000/svg\"")
+                || trimmed.contains("xmlns='http://www.w3.org/2000/svg'");
+            if has_svg_tag || (has_xml_prefix && has_svg_ns) {
                     return Ok(DetectedMime {
                         mime_type: "image/svg+xml".to_string(),
                         extension: "svg".to_string(),
@@ -197,6 +201,29 @@ pub fn mime_to_extension(mime: &str) -> String {
     }
 
     "bin".to_string()
+}
+
+/// Check if text contains an `<svg` element (not `<svg-something>`).
+///
+/// Requires `<svg` to be followed by a word boundary: space, `>`, `/`, tab, newline.
+/// This prevents false positives on tags like `<svg-report>`, `<svg-data>`, etc.
+fn has_svg_element(text: &str) -> bool {
+    let mut search_from = 0;
+    while let Some(pos) = text[search_from..].find("<svg") {
+        let abs_pos = search_from + pos;
+        let after = abs_pos + 4; // length of "<svg"
+        if after >= text.len() {
+            // `<svg` at end of string — could be start of valid SVG
+            return true;
+        }
+        let next_char = text.as_bytes()[after];
+        // Word boundary: space, >, /, tab, newline, carriage return
+        if matches!(next_char, b' ' | b'>' | b'/' | b'\t' | b'\n' | b'\r') {
+            return true;
+        }
+        search_from = abs_pos + 4;
+    }
+    false
 }
 
 /// Sanitize extension to prevent path traversal.
@@ -512,16 +539,13 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    fn svg_heuristic_false_positive_svg_prefixed_tag() {
-        // `<svg-report>` starts with `<svg` so passes starts_with guard,
-        // and `contains("<svg")` matches `<svg-report>` as a substring.
-        // The heuristic DOES fire here — this is a known false positive.
+    fn svg_heuristic_rejects_svg_prefixed_tag() {
+        // `<svg-report>` starts with `<svg` but is NOT followed by a word boundary.
+        // The tightened heuristic (has_svg_element) requires space/>/\t/\n after `<svg`.
+        // `<svg-report>` has `-` after `<svg`, which is NOT a word boundary → rejected.
         let data = b"<svg-report><item>data</item></svg-report>";
         let result = detect_mime(data, None);
-        // Current behavior: falsely detected as SVG
-        assert!(result.is_ok(), "heuristic fires on <svg-report> (known false positive)");
-        let detected = result.unwrap();
-        assert_eq!(detected.mime_type, "image/svg+xml");
+        assert!(result.is_err(), "<svg-report> should NOT be detected as SVG");
     }
 
     #[test]

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -133,6 +133,10 @@ pub fn detect_mime(
 /// - `audio/mp3` ↔ `audio/mpeg`
 /// - `image/jpg` ↔ `image/jpeg`
 /// - `audio/wav` ↔ `audio/x-wav`
+/// - `audio/flac` ↔ `audio/x-flac`
+/// - `audio/aiff` ↔ `audio/x-aiff`
+/// - `image/vnd.microsoft.icon` ↔ `image/x-icon`
+/// - `audio/mp4` ↔ `video/mp4` (container format ambiguity)
 pub fn is_mime_alias(a: &str, b: &str) -> bool {
     if a == b {
         return true;
@@ -143,38 +147,56 @@ pub fn is_mime_alias(a: &str, b: &str) -> bool {
         ("audio/mp3", "audio/mpeg")
             | ("audio/wav", "audio/x-wav")
             | ("image/jpeg", "image/jpg")
+            | ("audio/flac", "audio/x-flac")
+            | ("audio/aiff", "audio/x-aiff")
+            | ("image/vnd.microsoft.icon", "image/x-icon")
+            | ("audio/mp4", "video/mp4")
     )
 }
 
 /// Convert a MIME type to a file extension.
+///
+/// Checks the curated manual table FIRST (correct human-expected extensions),
+/// then falls back to `mime_guess` for uncommon types.
+/// This avoids mime_guess returning obscure extensions like "jfif" for JPEG,
+/// "m2a" for MP3, or "asm" for text/plain.
 pub fn mime_to_extension(mime: &str) -> String {
-    // Try mime_guess first
-    let guesses = mime_guess::get_mime_extensions_str(mime);
-    if let Some(exts) = guesses {
+    // Manual table first — curated, human-expected extensions
+    let manual = match mime {
+        "image/png" => Some("png"),
+        "image/jpeg" | "image/jpg" => Some("jpg"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        "image/svg+xml" => Some("svg"),
+        "image/vnd.microsoft.icon" | "image/x-icon" => Some("ico"),
+        "audio/mpeg" | "audio/mp3" => Some("mp3"),
+        "audio/wav" | "audio/x-wav" => Some("wav"),
+        "audio/ogg" => Some("ogg"),
+        "audio/flac" | "audio/x-flac" => Some("flac"),
+        "audio/aiff" | "audio/x-aiff" => Some("aiff"),
+        "audio/mp4" | "audio/x-m4a" => Some("m4a"),
+        "video/mp4" => Some("mp4"),
+        "video/webm" => Some("webm"),
+        "application/pdf" => Some("pdf"),
+        "application/json" => Some("json"),
+        "text/plain" => Some("txt"),
+        "text/html" => Some("html"),
+        "text/csv" => Some("csv"),
+        _ => None,
+    };
+
+    if let Some(ext) = manual {
+        return ext.to_string();
+    }
+
+    // Fallback to mime_guess for uncommon types
+    if let Some(exts) = mime_guess::get_mime_extensions_str(mime) {
         if let Some(ext) = exts.first() {
             return sanitize_extension(ext);
         }
     }
 
-    // Manual fallback for common types
-    let ext = match mime {
-        "image/png" => "png",
-        "image/jpeg" => "jpg",
-        "image/gif" => "gif",
-        "image/webp" => "webp",
-        "image/svg+xml" => "svg",
-        "audio/mpeg" => "mp3",
-        "audio/wav" | "audio/x-wav" => "wav",
-        "audio/ogg" => "ogg",
-        "audio/flac" => "flac",
-        "application/pdf" => "pdf",
-        "application/json" => "json",
-        "text/plain" => "txt",
-        "text/html" => "html",
-        _ => "bin",
-    };
-
-    sanitize_extension(ext)
+    "bin".to_string()
 }
 
 /// Sanitize extension to prevent path traversal.
@@ -271,10 +293,14 @@ mod tests {
     #[test]
     fn mime_to_extension_common_types() {
         assert_eq!(mime_to_extension("image/png"), "png");
-        // mime_guess may return "jfif" or "jpg" for image/jpeg
-        let jpeg_ext = mime_to_extension("image/jpeg");
-        assert!(jpeg_ext == "jpg" || jpeg_ext == "jfif", "got: {jpeg_ext}");
+        assert_eq!(mime_to_extension("image/jpeg"), "jpg");
+        assert_eq!(mime_to_extension("audio/mpeg"), "mp3");
+        assert_eq!(mime_to_extension("audio/wav"), "wav");
+        assert_eq!(mime_to_extension("audio/x-wav"), "wav");
+        assert_eq!(mime_to_extension("audio/flac"), "flac");
+        assert_eq!(mime_to_extension("text/plain"), "txt");
         assert_eq!(mime_to_extension("application/pdf"), "pdf");
+        assert_eq!(mime_to_extension("application/json"), "json");
     }
 
     #[test]
@@ -285,6 +311,12 @@ mod tests {
         assert!(is_mime_alias("image/jpg", "image/jpeg"));
         assert!(is_mime_alias("audio/wav", "audio/x-wav"));
         assert!(is_mime_alias("audio/x-wav", "audio/wav"));
+        assert!(is_mime_alias("audio/flac", "audio/x-flac"));
+        assert!(is_mime_alias("audio/x-flac", "audio/flac"));
+        assert!(is_mime_alias("audio/aiff", "audio/x-aiff"));
+        assert!(is_mime_alias("image/vnd.microsoft.icon", "image/x-icon"));
+        assert!(is_mime_alias("audio/mp4", "video/mp4"));
+        assert!(is_mime_alias("video/mp4", "audio/mp4"));
     }
 
     #[test]

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -86,8 +86,8 @@ pub fn detect_mime(
                     // Cross-category mismatch: REJECT (e.g., server=audio/*, magic=image/*)
                     return Err(MediaError::MimeDetectionFailed {
                         reason: format!(
-                            "MIME category conflict: server declared '{}' but magic bytes detected '{}'",
-                            server, mime_type
+                            "category conflict: server declared '{server}' \
+                             but magic bytes detected '{mime_type}'"
                         ),
                     });
                 } else {
@@ -355,9 +355,285 @@ mod tests {
         assert_eq!(result.source, DetectionSource::MagicBytes);
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 4: mime_to_extension for alias MIME types
+    // Non-standard MIME aliases must map to the correct extension
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn mime_to_extension_alias_image_jpg() {
+        // "image/jpg" is non-standard (standard is "image/jpeg")
+        // Must still return "jpg", not fall through to mime_guess
+        assert_eq!(mime_to_extension("image/jpg"), "jpg");
+    }
+
+    #[test]
+    fn mime_to_extension_alias_audio_mp3() {
+        // "audio/mp3" is non-standard (standard is "audio/mpeg")
+        // Must return "mp3", not some obscure extension like "m2a"
+        assert_eq!(mime_to_extension("audio/mp3"), "mp3");
+    }
+
+    #[test]
+    fn mime_to_extension_alias_audio_x_flac() {
+        // "audio/x-flac" is non-standard (standard is "audio/flac")
+        // Must return "flac"
+        assert_eq!(mime_to_extension("audio/x-flac"), "flac");
+    }
+
+    #[test]
+    fn mime_to_extension_alias_audio_x_wav() {
+        // "audio/x-wav" is non-standard (standard is "audio/wav")
+        assert_eq!(mime_to_extension("audio/x-wav"), "wav");
+    }
+
+    #[test]
+    fn mime_to_extension_alias_audio_x_aiff() {
+        // "audio/x-aiff" is non-standard (standard is "audio/aiff")
+        assert_eq!(mime_to_extension("audio/x-aiff"), "aiff");
+    }
+
+    #[test]
+    fn mime_to_extension_alias_image_x_icon() {
+        // "image/x-icon" is non-standard (standard is "image/vnd.microsoft.icon")
+        assert_eq!(mime_to_extension("image/x-icon"), "ico");
+    }
+
+    #[test]
+    fn mime_to_extension_alias_audio_mp4() {
+        // "audio/mp4" should return "m4a" (audio in MP4 container)
+        assert_eq!(mime_to_extension("audio/mp4"), "m4a");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 5: is_mime_alias reverse order for aiff and icon
+    // Lexicographic ordering in (a.min(b), a.max(b)) must work
+    // regardless of argument order
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn is_mime_alias_aiff_reverse_order() {
+        // Test that (audio/x-aiff, audio/aiff) matches — reverse of table order
+        assert!(is_mime_alias("audio/x-aiff", "audio/aiff"),
+            "reverse order must match: audio/x-aiff -> audio/aiff");
+        // Confirm canonical order also works
+        assert!(is_mime_alias("audio/aiff", "audio/x-aiff"),
+            "canonical order must match: audio/aiff -> audio/x-aiff");
+    }
+
+    #[test]
+    fn is_mime_alias_icon_reverse_order() {
+        // Test that (image/x-icon, image/vnd.microsoft.icon) matches
+        assert!(is_mime_alias("image/x-icon", "image/vnd.microsoft.icon"),
+            "reverse order must match: image/x-icon -> image/vnd.microsoft.icon");
+        // Confirm canonical order
+        assert!(is_mime_alias("image/vnd.microsoft.icon", "image/x-icon"),
+            "canonical order must match: image/vnd.microsoft.icon -> image/x-icon");
+    }
+
+    #[test]
+    fn is_mime_alias_mp4_cross_category_reverse() {
+        // Test both orderings of the cross-category mp4 alias
+        assert!(is_mime_alias("video/mp4", "audio/mp4"),
+            "reverse order must match: video/mp4 -> audio/mp4");
+        assert!(is_mime_alias("audio/mp4", "video/mp4"),
+            "canonical order must match: audio/mp4 -> video/mp4");
+    }
+
+    #[test]
+    fn is_mime_alias_flac_reverse_order() {
+        assert!(is_mime_alias("audio/x-flac", "audio/flac"),
+            "reverse order must match: audio/x-flac -> audio/flac");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 7: detect_mime with cross-category alias (audio/mp4 <> video/mp4)
+    // MP4 container is detected as video/mp4 by magic bytes. When
+    // server declares audio/mp4, the alias should prevent rejection.
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn detect_mime_mp4_container_with_audio_mp4_server_hint() {
+        // MP4 container header (ftyp box): detected as video/mp4 by infer
+        let mp4_header: Vec<u8> = vec![
+            0x00, 0x00, 0x00, 0x20, // box size = 32
+            0x66, 0x74, 0x79, 0x70, // "ftyp"
+            0x69, 0x73, 0x6F, 0x6D, // major brand "isom"
+            0x00, 0x00, 0x02, 0x00, // minor version
+            0x69, 0x73, 0x6F, 0x6D, // compatible brands: "isom"
+            0x69, 0x73, 0x6F, 0x32, // "iso2"
+            0x61, 0x76, 0x63, 0x31, // "avc1"
+            0x6D, 0x70, 0x34, 0x31, // "mp41"
+        ];
+
+        // Magic bytes -> video/mp4, server -> audio/mp4
+        // Without the alias, this would be a cross-category mismatch (video != audio)
+        // With the alias, it should be accepted
+        let result = detect_mime(&mp4_header, Some("audio/mp4"));
+        assert!(result.is_ok(),
+            "audio/mp4 <> video/mp4 alias should prevent cross-category rejection, got: {:?}",
+            result.err());
+
+        let detected = result.unwrap();
+        assert_eq!(detected.mime_type, "video/mp4",
+            "magic bytes should win (video/mp4), not server hint");
+        assert_eq!(detected.source, DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn detect_mime_mp4_container_with_video_mp4_server_matches() {
+        // MP4 container header: same as above
+        let mp4_header: Vec<u8> = vec![
+            0x00, 0x00, 0x00, 0x20,
+            0x66, 0x74, 0x79, 0x70,
+            0x69, 0x73, 0x6F, 0x6D,
+            0x00, 0x00, 0x02, 0x00,
+            0x69, 0x73, 0x6F, 0x6D,
+            0x69, 0x73, 0x6F, 0x32,
+            0x61, 0x76, 0x63, 0x31,
+            0x6D, 0x70, 0x34, 0x31,
+        ];
+
+        // Magic bytes -> video/mp4, server -> video/mp4 -> exact match
+        let result = detect_mime(&mp4_header, Some("video/mp4"));
+        assert!(result.is_ok());
+        let detected = result.unwrap();
+        assert_eq!(detected.mime_type, "video/mp4");
+    }
+
     #[test]
     fn sanitize_extension_rejects_traversal() {
         assert_eq!(sanitize_extension("../etc/passwd"), "etcpasswd");
         assert_eq!(sanitize_extension("png;rm -rf /"), "pngrm-rf");
+    }
+
+    // ---------------------------------------------------------------
+    // SVG heuristic edge cases (lines 57-73)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn svg_heuristic_false_positive_svg_prefixed_tag() {
+        // `<svg-report>` starts with `<svg` so passes starts_with guard,
+        // and `contains("<svg")` matches `<svg-report>` as a substring.
+        // The heuristic DOES fire here — this is a known false positive.
+        let data = b"<svg-report><item>data</item></svg-report>";
+        let result = detect_mime(data, None);
+        // Current behavior: falsely detected as SVG
+        assert!(result.is_ok(), "heuristic fires on <svg-report> (known false positive)");
+        let detected = result.unwrap();
+        assert_eq!(detected.mime_type, "image/svg+xml");
+    }
+
+    #[test]
+    fn svg_heuristic_leading_whitespace() {
+        // Leading whitespace/tabs/newlines should be stripped by trim_start()
+        let data = b"  \t\n  <svg xmlns=\"http://www.w3.org/2000/svg\"></svg>";
+        let result = detect_mime(data, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+        assert_eq!(result.extension, "svg");
+        assert_eq!(result.source, DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn svg_heuristic_xml_declaration_plus_svg_no_xmlns() {
+        // `<?xml` prefix passes first guard, `<svg>` substring found by contains("<svg").
+        // Even without xmlns, the heuristic fires.
+        let data = b"<?xml version=\"1.0\"?>\n<svg></svg>";
+        let result = detect_mime(data, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+        assert_eq!(result.extension, "svg");
+    }
+
+    #[test]
+    fn svg_heuristic_false_positive_svg_in_xml_comment() {
+        // `<?xml` passes starts_with guard. The comment text `<svg>` makes
+        // `contains("<svg")` return true. This is a known false positive:
+        // the heuristic cannot distinguish commented-out SVG from real SVG.
+        let data = b"<?xml version=\"1.0\"?><!-- comment with <svg> in it --><root/>";
+        let result = detect_mime(data, None);
+        assert!(result.is_ok(), "heuristic fires on <svg> inside XML comment (known false positive)");
+        let detected = result.unwrap();
+        assert_eq!(detected.mime_type, "image/svg+xml");
+    }
+
+    #[test]
+    fn svg_heuristic_false_negative_beyond_512_byte_window() {
+        // The heuristic only inspects the first 512 bytes of the sample.
+        // If the `<svg` tag starts beyond byte 512, it won't be found.
+        // Build: 620 bytes of non-whitespace padding + SVG tag.
+        let mut data = Vec::new();
+        // Use valid XML-like padding that is NOT whitespace (trim_start won't remove it)
+        data.extend_from_slice(b"<data>");
+        // 610 bytes of 'x' filler (total prefix = 6 + 610 = 616 bytes)
+        data.extend(std::iter::repeat(b'x').take(610));
+        data.extend_from_slice(b"</data><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
+
+        let result = detect_mime(&data, None);
+        // The first 512 bytes are `<data>xxxx...` which starts_with neither
+        // `<svg` nor `<?xml`, so the heuristic does not fire.
+        assert!(result.is_err(), "SVG beyond 512-byte window should not be detected (false negative)");
+    }
+
+    #[test]
+    fn svg_heuristic_single_quotes_xmlns() {
+        // The code checks `xmlns=\"http://www.w3.org/2000/svg\"` (double quotes).
+        // Single-quoted xmlns does NOT match that literal.
+        // However, `starts_with("<svg")` is true and `contains("<svg")` is also
+        // true (the tag itself is `<svg`), so the first OR branch fires.
+        // Result: still detected despite single quotes, because `contains("<svg")`
+        // is the condition that matches, not the xmlns check.
+        let data = b"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'></svg>";
+        let result = detect_mime(data, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+        assert_eq!(result.extension, "svg");
+    }
+
+    #[test]
+    fn svg_heuristic_uppercase_tag_not_detected() {
+        // `<SVG` does NOT match `starts_with("<svg")` (case-sensitive).
+        // It also does not match `starts_with("<?xml")`.
+        // The heuristic does not fire. Falls through to infer crate which
+        // also won't detect it, then to server hint, then to error.
+        let data = b"<SVG xmlns=\"http://www.w3.org/2000/svg\"></SVG>";
+        let result = detect_mime(data, None);
+        assert!(result.is_err(), "uppercase <SVG> not detected by case-sensitive heuristic");
+    }
+
+    #[test]
+    fn svg_heuristic_self_closing_no_xmlns() {
+        // `<svg/>` starts with `<svg`, and `contains("<svg")` is true.
+        // The heuristic fires even though this is a bare self-closing tag.
+        let data = b"<svg/>";
+        let result = detect_mime(data, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+        assert_eq!(result.extension, "svg");
+    }
+
+    #[test]
+    fn svg_heuristic_binary_with_svg_utf8_prefix() {
+        // Binary data whose first 4 bytes happen to be `<svg` in UTF-8,
+        // but followed by invalid UTF-8 byte 0xFF within the first 512 bytes.
+        // from_utf8 on the first 512 bytes will fail, so the heuristic skips.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"<svg");
+        data.push(0xFF); // invalid UTF-8
+        data.extend(std::iter::repeat(0x00u8).take(20));
+        let result = detect_mime(&data, None);
+        // from_utf8 fails on the 512-byte window → SVG heuristic skipped.
+        // infer crate won't recognize it → error (no server hint).
+        assert!(result.is_err(), "binary data with <svg prefix but invalid UTF-8 should not be detected as SVG");
+    }
+
+    #[test]
+    fn svg_heuristic_exactly_five_bytes() {
+        // `<svg>` is exactly 5 bytes. The `sample.len() >= 5` guard passes.
+        // from_utf8 succeeds. trim_start is a no-op. starts_with("<svg") is true.
+        // contains("<svg") is true. Detected as SVG.
+        let data = b"<svg>";
+        assert_eq!(data.len(), 5);
+        let result = detect_mime(data, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+        assert_eq!(result.extension, "svg");
+        assert_eq!(result.source, DetectionSource::MagicBytes);
     }
 }

--- a/tools/nika/src/media/error.rs
+++ b/tools/nika/src/media/error.rs
@@ -1,7 +1,9 @@
 //! Media pipeline error types (NIKA-251..259)
 //!
-//! Derives both `thiserror::Error` and `miette::Diagnostic` so that
-//! NikaError can use `#[error(transparent)] #[diagnostic(transparent)]`.
+//! Derives `miette::Diagnostic` so that
+//! NikaError can use `#[diagnostic(transparent)]`.
+//! Display is implemented manually for human-friendly error messages
+//! (with human-readable byte sizes, clear field labels, etc.).
 
 use std::path::PathBuf;
 
@@ -9,17 +11,15 @@ use std::path::PathBuf;
 ///
 /// Error codes NIKA-251 through NIKA-259 cover the media extraction,
 /// detection, storage, and processing pipeline.
-#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+#[derive(Debug, miette::Diagnostic)]
 pub enum MediaError {
     /// NIKA-251: Declared MIME type conflicts with detected magic bytes
-    #[error("[NIKA-251] MIME detection failed: {reason}")]
     #[diagnostic(code(nika::mime_detection_failed))]
     MimeDetectionFailed {
         reason: String,
     },
 
     /// NIKA-252: Media type is recognized but not supported for processing
-    #[error("[NIKA-252] unsupported media type '{mime_type}': {reason}")]
     #[diagnostic(code(nika::unsupported_media_type))]
     UnsupportedMediaType {
         mime_type: String,
@@ -27,14 +27,12 @@ pub enum MediaError {
     },
 
     /// NIKA-253: Referenced media hash not found in CAS store
-    #[error("[NIKA-253] media not found in store: {hash}")]
     #[diagnostic(code(nika::media_not_found))]
     MediaNotFound {
         hash: String,
     },
 
     /// NIKA-254: CAS read-back verification failed
-    #[error("[NIKA-254] CAS hash mismatch (expected {expected}, got {actual})")]
     #[diagnostic(code(nika::hash_mismatch))]
     HashMismatch {
         expected: String,
@@ -42,7 +40,6 @@ pub enum MediaError {
     },
 
     /// NIKA-255: I/O error during CAS store read or write
-    #[error("[NIKA-255] media store I/O error: {}: {source}", path.display())]
     #[diagnostic(code(nika::media_store_io))]
     MediaStoreIo {
         path: PathBuf,
@@ -50,35 +47,120 @@ pub enum MediaError {
     },
 
     /// NIKA-256: Base64 decoding failed for media content block
-    #[error("[NIKA-256] base64 decode failed for {source_desc}: {reason}")]
     #[diagnostic(code(nika::base64_decode_failed))]
     Base64DecodeFailed {
         source_desc: String,
         reason: String,
     },
 
-    /// NIKA-257: Base64 input exceeds maximum allowed size before decoding
-    #[error("[NIKA-257] base64 input too large ({size} bytes, max {max} bytes)")]
-    #[diagnostic(code(nika::base64_input_too_large))]
+    /// NIKA-257: Media content exceeds maximum allowed size
+    #[diagnostic(code(nika::media_too_large))]
     Base64InputTooLarge {
         size: usize,
         max: usize,
     },
 
     /// NIKA-258: Content block decoded to zero bytes
-    #[error("[NIKA-258] empty media content from task {task_id}")]
     #[diagnostic(code(nika::empty_media_content))]
     EmptyMediaContent {
         task_id: String,
     },
 
     /// NIKA-259: Per-run media budget exceeded
-    #[error("[NIKA-259] run media budget exceeded ({current} bytes, max {max} bytes)")]
     #[diagnostic(code(nika::run_budget_exceeded))]
     RunBudgetExceeded {
         current: u64,
         max: u64,
     },
+}
+
+impl std::fmt::Display for MediaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MimeDetectionFailed { reason } => {
+                write!(f, "[NIKA-251] MIME detection failed: {reason}")
+            }
+
+            Self::UnsupportedMediaType { mime_type, reason } => {
+                write!(f, "[NIKA-252] unsupported media type '{mime_type}': {reason}")
+            }
+
+            Self::MediaNotFound { hash } => {
+                write!(f, "[NIKA-253] media not found in store: {hash}")
+            }
+
+            Self::HashMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "[NIKA-254] CAS hash mismatch (expected {expected}, got {actual})"
+                )
+            }
+
+            Self::MediaStoreIo { path, source } => {
+                // Show only the filename or last 2 components to avoid leaking
+                // full filesystem paths in user-facing output.
+                let display_path = sanitize_path_for_display(path);
+                write!(f, "[NIKA-255] media store I/O error at {display_path}: {source}")
+            }
+
+            Self::Base64DecodeFailed { source_desc, reason } => {
+                write!(f, "[NIKA-256] base64 decode failed for {source_desc}: {reason}")
+            }
+
+            Self::Base64InputTooLarge { size, max } => {
+                write!(
+                    f,
+                    "[NIKA-257] media content too large ({}, limit is {})",
+                    format_size(*size as u64),
+                    format_size(*max as u64),
+                )
+            }
+
+            Self::EmptyMediaContent { task_id } => {
+                if task_id == "(cas-direct)" {
+                    write!(
+                        f,
+                        "[NIKA-258] empty media content received by CAS store \
+                         (internal guard: data was empty before storage)"
+                    )
+                } else {
+                    write!(f, "[NIKA-258] empty media content from task '{task_id}'")
+                }
+            }
+
+            Self::RunBudgetExceeded { current, max } => {
+                // `current` is actually the would-be total (existing + requested).
+                // Show it as the attempted total vs the limit, with remaining info.
+                let used = if *current > *max {
+                    // The budget was already partially used; show how much was used
+                    // before this attempt. We know: current = prev + requested_size,
+                    // and prev <= max (otherwise we'd have rejected earlier).
+                    // We can't recover `prev` here, so just show the attempted total.
+                    format!(
+                        "attempted total: {}, limit: {}",
+                        format_size(*current),
+                        format_size(*max),
+                    )
+                } else {
+                    format!(
+                        "at {}, limit: {}",
+                        format_size(*current),
+                        format_size(*max),
+                    )
+                };
+                write!(f, "[NIKA-259] run media budget exceeded ({used})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MediaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::MediaStoreIo { source, .. } => Some(source),
+            _ => None,
+        }
+    }
 }
 
 impl MediaError {
@@ -106,12 +188,237 @@ impl MediaError {
 
     /// Construct MimeDetectionFailed with optional server hint.
     pub fn mime_detection_failed(inspected_bytes: usize, server_hint: Option<String>) -> Self {
-        let hint_display = match &server_hint {
-            Some(hint) => format!(", server hint: {hint}"),
-            None => String::new(),
+        let reason = match &server_hint {
+            Some(hint) => format!(
+                "could not identify file type from {inspected_bytes} bytes inspected \
+                 (server hint '{hint}' was not usable)"
+            ),
+            None => format!(
+                "could not identify file type from {inspected_bytes} bytes inspected \
+                 and no server MIME hint was provided"
+            ),
         };
-        Self::MimeDetectionFailed {
-            reason: format!("{inspected_bytes} bytes inspected{hint_display}"),
+        Self::MimeDetectionFailed { reason }
+    }
+}
+
+/// Format bytes as human-readable size for error messages.
+///
+/// Inlined here to avoid a dependency on `crate::util::fs::format_size`
+/// (media module should remain low-dependency).
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// Sanitize a filesystem path for user-facing display.
+///
+/// Shows only the last 2 path components (shard dir + filename) to avoid
+/// leaking the full workspace path in error messages or logs.
+fn sanitize_path_for_display(path: &std::path::Path) -> String {
+    let components: Vec<_> = path.components().rev().take(2).collect();
+    match components.len() {
+        0 => "<unknown>".to_string(),
+        1 => components[0].as_os_str().to_string_lossy().to_string(),
+        _ => format!(
+            "{}/{}",
+            components[1].as_os_str().to_string_lossy(),
+            components[0].as_os_str().to_string_lossy(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_size_human_readable() {
+        assert_eq!(format_size(0), "0 bytes");
+        assert_eq!(format_size(512), "512 bytes");
+        assert_eq!(format_size(1024), "1.0 KB");
+        assert_eq!(format_size(1_048_576), "1.0 MB");
+        assert_eq!(format_size(104_857_600), "100.0 MB");
+        assert_eq!(format_size(1_073_741_824), "1.0 GB");
+    }
+
+    #[test]
+    fn sanitize_path_shows_last_two_components() {
+        let path = PathBuf::from("/home/user/.nika/media/store/af/1349b9abc");
+        let display = sanitize_path_for_display(&path);
+        assert_eq!(display, "af/1349b9abc");
+    }
+
+    #[test]
+    fn sanitize_path_single_component() {
+        let path = PathBuf::from("filename");
+        let display = sanitize_path_for_display(&path);
+        assert_eq!(display, "filename");
+    }
+
+    #[test]
+    fn display_mime_detection_failed_no_hint() {
+        let err = MediaError::mime_detection_failed(8192, None);
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-251"), "missing code: {msg}");
+        assert!(msg.contains("8192 bytes"), "missing byte count: {msg}");
+        assert!(msg.contains("no server MIME hint"), "missing guidance: {msg}");
+    }
+
+    #[test]
+    fn display_mime_detection_failed_with_hint() {
+        let err = MediaError::mime_detection_failed(100, Some("application/octet-stream".into()));
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-251"), "missing code: {msg}");
+        assert!(msg.contains("application/octet-stream"), "missing hint: {msg}");
+        assert!(msg.contains("not usable"), "missing guidance: {msg}");
+    }
+
+    #[test]
+    fn display_mime_cross_category_conflict() {
+        let err = MediaError::MimeDetectionFailed {
+            reason: "MIME category conflict: server declared 'audio/wav' but magic bytes detected 'image/png'".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-251"), "missing code: {msg}");
+        assert!(msg.contains("audio/wav"), "missing server type: {msg}");
+        assert!(msg.contains("image/png"), "missing detected type: {msg}");
+    }
+
+    #[test]
+    fn display_base64_input_too_large_human_readable() {
+        let err = MediaError::Base64InputTooLarge {
+            size: 150 * 1024 * 1024,
+            max: 100 * 1024 * 1024,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-257"), "missing code: {msg}");
+        assert!(msg.contains("150.0 MB"), "missing human size: {msg}");
+        assert!(msg.contains("100.0 MB"), "missing human max: {msg}");
+        assert!(msg.contains("media content too large"), "wrong label: {msg}");
+        // Must NOT say "base64 input" since CAS uses this for raw bytes too
+        assert!(!msg.contains("base64 input"), "should not say 'base64 input': {msg}");
+    }
+
+    #[test]
+    fn display_base64_input_too_large_small_sizes() {
+        let err = MediaError::Base64InputTooLarge {
+            size: 200,
+            max: 100,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("200 bytes"), "missing size: {msg}");
+        assert!(msg.contains("100 bytes"), "missing max: {msg}");
+    }
+
+    #[test]
+    fn display_empty_media_cas_direct() {
+        let err = MediaError::EmptyMediaContent {
+            task_id: "(cas-direct)".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-258"), "missing code: {msg}");
+        assert!(msg.contains("CAS store"), "should mention CAS: {msg}");
+        assert!(msg.contains("internal guard"), "should say internal guard: {msg}");
+        // Should NOT show the raw "(cas-direct)" sentinel to the user
+        assert!(!msg.contains("(cas-direct)"), "should not show sentinel: {msg}");
+    }
+
+    #[test]
+    fn display_empty_media_with_task_id() {
+        let err = MediaError::EmptyMediaContent {
+            task_id: "generate_image".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-258"), "missing code: {msg}");
+        assert!(msg.contains("generate_image"), "missing task_id: {msg}");
+    }
+
+    #[test]
+    fn display_run_budget_exceeded_human_readable() {
+        let err = MediaError::RunBudgetExceeded {
+            current: 600 * 1024 * 1024,
+            max: 500 * 1024 * 1024,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-259"), "missing code: {msg}");
+        assert!(msg.contains("600.0 MB"), "missing attempted total: {msg}");
+        assert!(msg.contains("500.0 MB"), "missing limit: {msg}");
+        assert!(msg.contains("attempted total"), "should say attempted: {msg}");
+    }
+
+    #[test]
+    fn display_media_store_io_sanitized_path() {
+        let err = MediaError::MediaStoreIo {
+            path: PathBuf::from("/Users/secret/.nika/media/store/af/1349b9"),
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-255"), "missing code: {msg}");
+        assert!(msg.contains("af/1349b9"), "missing path tail: {msg}");
+        assert!(msg.contains("denied"), "missing OS error: {msg}");
+        // Must NOT expose the full path
+        assert!(!msg.contains("/Users/secret"), "leaking full path: {msg}");
+    }
+
+    #[test]
+    fn display_hash_mismatch_shows_both() {
+        let err = MediaError::HashMismatch {
+            expected: "blake3:aaaa".into(),
+            actual: "blake3:bbbb".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("blake3:aaaa"), "missing expected: {msg}");
+        assert!(msg.contains("blake3:bbbb"), "missing actual: {msg}");
+    }
+
+    #[test]
+    fn all_variants_contain_error_code() {
+        let errors: Vec<MediaError> = vec![
+            MediaError::mime_detection_failed(0, None),
+            MediaError::UnsupportedMediaType {
+                mime_type: "video/mp4".into(),
+                reason: "not supported".into(),
+            },
+            MediaError::MediaNotFound { hash: "blake3:xxx".into() },
+            MediaError::HashMismatch {
+                expected: "blake3:aaa".into(),
+                actual: "blake3:bbb".into(),
+            },
+            MediaError::MediaStoreIo {
+                path: "/tmp/fail".into(),
+                source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+            },
+            MediaError::Base64DecodeFailed {
+                source_desc: "test".into(),
+                reason: "bad".into(),
+            },
+            MediaError::Base64InputTooLarge { size: 200, max: 100 },
+            MediaError::EmptyMediaContent { task_id: "t1".into() },
+            MediaError::RunBudgetExceeded { current: 600, max: 500 },
+        ];
+
+        let expected_codes = [
+            "NIKA-251", "NIKA-252", "NIKA-253", "NIKA-254",
+            "NIKA-255", "NIKA-256", "NIKA-257", "NIKA-258", "NIKA-259",
+        ];
+
+        for (i, (err, code)) in errors.iter().zip(expected_codes.iter()).enumerate() {
+            let display = err.to_string();
+            assert!(!display.is_empty(), "Error {i} Display is empty");
+            assert!(display.contains(code), "Error {i} Display missing code: {display}");
+            assert_eq!(err.code(), *code, "Error {i} code mismatch");
         }
     }
 }

--- a/tools/nika/src/media/error.rs
+++ b/tools/nika/src/media/error.rs
@@ -12,13 +12,10 @@ use std::path::PathBuf;
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum MediaError {
     /// NIKA-251: Declared MIME type conflicts with detected magic bytes
-    #[error("[NIKA-251] MIME detection failed ({inspected_bytes} bytes inspected{server_hint_display})")]
+    #[error("[NIKA-251] MIME detection failed: {reason}")]
     #[diagnostic(code(nika::mime_detection_failed))]
     MimeDetectionFailed {
-        inspected_bytes: usize,
-        server_hint: Option<String>,
-        #[help]
-        server_hint_display: String,
+        reason: String,
     },
 
     /// NIKA-252: Media type is recognized but not supported for processing
@@ -109,14 +106,12 @@ impl MediaError {
 
     /// Construct MimeDetectionFailed with optional server hint.
     pub fn mime_detection_failed(inspected_bytes: usize, server_hint: Option<String>) -> Self {
-        let server_hint_display = match &server_hint {
+        let hint_display = match &server_hint {
             Some(hint) => format!(", server hint: {hint}"),
             None => String::new(),
         };
         Self::MimeDetectionFailed {
-            inspected_bytes,
-            server_hint,
-            server_hint_display,
+            reason: format!("{inspected_bytes} bytes inspected{hint_display}"),
         }
     }
 }

--- a/tools/nika/src/media/error.rs
+++ b/tools/nika/src/media/error.rs
@@ -1,0 +1,122 @@
+//! Media pipeline error types (NIKA-251..259)
+//!
+//! Derives both `thiserror::Error` and `miette::Diagnostic` so that
+//! NikaError can use `#[error(transparent)] #[diagnostic(transparent)]`.
+
+use std::path::PathBuf;
+
+/// Media pipeline errors.
+///
+/// Error codes NIKA-251 through NIKA-259 cover the media extraction,
+/// detection, storage, and processing pipeline.
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+pub enum MediaError {
+    /// NIKA-251: Declared MIME type conflicts with detected magic bytes
+    #[error("[NIKA-251] MIME detection failed ({inspected_bytes} bytes inspected{server_hint_display})")]
+    #[diagnostic(code(nika::mime_detection_failed))]
+    MimeDetectionFailed {
+        inspected_bytes: usize,
+        server_hint: Option<String>,
+        #[help]
+        server_hint_display: String,
+    },
+
+    /// NIKA-252: Media type is recognized but not supported for processing
+    #[error("[NIKA-252] unsupported media type '{mime_type}': {reason}")]
+    #[diagnostic(code(nika::unsupported_media_type))]
+    UnsupportedMediaType {
+        mime_type: String,
+        reason: String,
+    },
+
+    /// NIKA-253: Referenced media hash not found in CAS store
+    #[error("[NIKA-253] media not found in store: {hash}")]
+    #[diagnostic(code(nika::media_not_found))]
+    MediaNotFound {
+        hash: String,
+    },
+
+    /// NIKA-254: CAS read-back verification failed
+    #[error("[NIKA-254] CAS hash mismatch (expected {expected}, got {actual})")]
+    #[diagnostic(code(nika::hash_mismatch))]
+    HashMismatch {
+        expected: String,
+        actual: String,
+    },
+
+    /// NIKA-255: Failed to write media file to CAS store
+    #[error("[NIKA-255] failed to write media store: {}: {source}", path.display())]
+    #[diagnostic(code(nika::media_store_write))]
+    MediaStoreWrite {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// NIKA-256: Base64 decoding failed for media content block
+    #[error("[NIKA-256] base64 decode failed for {source_desc}: {reason}")]
+    #[diagnostic(code(nika::base64_decode_failed))]
+    Base64DecodeFailed {
+        source_desc: String,
+        reason: String,
+    },
+
+    /// NIKA-257: Base64 input exceeds maximum allowed size before decoding
+    #[error("[NIKA-257] base64 input too large ({size} bytes, max {max} bytes)")]
+    #[diagnostic(code(nika::base64_input_too_large))]
+    Base64InputTooLarge {
+        size: usize,
+        max: usize,
+    },
+
+    /// NIKA-258: Content block decoded to zero bytes
+    #[error("[NIKA-258] empty media content from task {task_id}")]
+    #[diagnostic(code(nika::empty_media_content))]
+    EmptyMediaContent {
+        task_id: String,
+    },
+
+    /// NIKA-259: Per-run media budget exceeded
+    #[error("[NIKA-259] run media budget exceeded ({current} bytes, max {max} bytes)")]
+    #[diagnostic(code(nika::run_budget_exceeded))]
+    RunBudgetExceeded {
+        current: u64,
+        max: u64,
+    },
+}
+
+impl MediaError {
+    /// Get the NIKA error code for this error.
+    ///
+    /// Returns `&'static str` to match `NikaError::code()` signature.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::MimeDetectionFailed { .. } => "NIKA-251",
+            Self::UnsupportedMediaType { .. } => "NIKA-252",
+            Self::MediaNotFound { .. } => "NIKA-253",
+            Self::HashMismatch { .. } => "NIKA-254",
+            Self::MediaStoreWrite { .. } => "NIKA-255",
+            Self::Base64DecodeFailed { .. } => "NIKA-256",
+            Self::Base64InputTooLarge { .. } => "NIKA-257",
+            Self::EmptyMediaContent { .. } => "NIKA-258",
+            Self::RunBudgetExceeded { .. } => "NIKA-259",
+        }
+    }
+
+    /// Check if this error is potentially recoverable through retry.
+    pub fn is_recoverable(&self) -> bool {
+        matches!(self, Self::MediaStoreWrite { .. })
+    }
+
+    /// Construct MimeDetectionFailed with optional server hint.
+    pub fn mime_detection_failed(inspected_bytes: usize, server_hint: Option<String>) -> Self {
+        let server_hint_display = match &server_hint {
+            Some(hint) => format!(", server hint: {hint}"),
+            None => String::new(),
+        };
+        Self::MimeDetectionFailed {
+            inspected_bytes,
+            server_hint,
+            server_hint_display,
+        }
+    }
+}

--- a/tools/nika/src/media/error.rs
+++ b/tools/nika/src/media/error.rs
@@ -41,10 +41,10 @@ pub enum MediaError {
         actual: String,
     },
 
-    /// NIKA-255: Failed to write media file to CAS store
-    #[error("[NIKA-255] failed to write media store: {}: {source}", path.display())]
-    #[diagnostic(code(nika::media_store_write))]
-    MediaStoreWrite {
+    /// NIKA-255: I/O error during CAS store read or write
+    #[error("[NIKA-255] media store I/O error: {}: {source}", path.display())]
+    #[diagnostic(code(nika::media_store_io))]
+    MediaStoreIo {
         path: PathBuf,
         source: std::io::Error,
     },
@@ -91,7 +91,7 @@ impl MediaError {
             Self::UnsupportedMediaType { .. } => "NIKA-252",
             Self::MediaNotFound { .. } => "NIKA-253",
             Self::HashMismatch { .. } => "NIKA-254",
-            Self::MediaStoreWrite { .. } => "NIKA-255",
+            Self::MediaStoreIo { .. } => "NIKA-255",
             Self::Base64DecodeFailed { .. } => "NIKA-256",
             Self::Base64InputTooLarge { .. } => "NIKA-257",
             Self::EmptyMediaContent { .. } => "NIKA-258",
@@ -101,7 +101,7 @@ impl MediaError {
 
     /// Check if this error is potentially recoverable through retry.
     pub fn is_recoverable(&self) -> bool {
-        matches!(self, Self::MediaStoreWrite { .. })
+        matches!(self, Self::MediaStoreIo { .. })
     }
 
     /// Construct MimeDetectionFailed with optional server hint.

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -16,3 +16,4 @@ pub use error::MediaError;
 pub use processor::MediaProcessor;
 pub use store::{CasStore, CleanResult, StoreResult};
 pub use types::{MediaBudget, MediaRef, MediaType};
+

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -1,0 +1,8 @@
+//! Media pipeline: extraction, detection, storage, and processing.
+//!
+//! Handles binary content (images, audio, documents) from MCP tool results.
+//! Uses Content-Addressable Storage (CAS) with blake3 hashing.
+
+pub mod error;
+
+pub use error::MediaError;

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -7,6 +7,8 @@ pub mod detect;
 pub mod error;
 pub mod processor;
 pub mod store;
+#[cfg(test)]
+mod tests_e2e;
 pub mod types;
 
 pub use detect::{detect_mime, DetectedMime, DetectionSource};

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -3,8 +3,10 @@
 //! Handles binary content (images, audio, documents) from MCP tool results.
 //! Uses Content-Addressable Storage (CAS) with blake3 hashing.
 
+pub mod detect;
 pub mod error;
 pub mod types;
 
+pub use detect::{detect_mime, DetectedMime, DetectionSource};
 pub use error::MediaError;
 pub use types::{MediaBudget, MediaRef, MediaType};

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -4,5 +4,7 @@
 //! Uses Content-Addressable Storage (CAS) with blake3 hashing.
 
 pub mod error;
+pub mod types;
 
 pub use error::MediaError;
+pub use types::{MediaBudget, MediaRef, MediaType};

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -3,17 +3,16 @@
 //! Handles binary content (images, audio, documents) from MCP tool results.
 //! Uses Content-Addressable Storage (CAS) with blake3 hashing.
 
-pub mod detect;
-pub mod error;
-pub mod processor;
-pub mod store;
+pub(crate) mod detect;
+pub(crate) mod error;
+pub(crate) mod processor;
+pub(crate) mod store;
 #[cfg(test)]
 mod tests_e2e;
-pub mod types;
+pub(crate) mod types;
 
-pub use detect::{detect_mime, DetectedMime, DetectionSource};
-pub use error::MediaError;
-pub use processor::MediaProcessor;
-pub use store::{CasStore, CleanResult, StoreResult};
-pub use types::{MediaBudget, MediaRef, MediaType};
+pub(crate) use error::MediaError;
+pub(crate) use processor::MediaProcessor;
+pub(crate) use store::CasStore;
+pub(crate) use types::{MediaBudget, MediaRef};
 

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -5,10 +5,12 @@
 
 pub mod detect;
 pub mod error;
+pub mod processor;
 pub mod store;
 pub mod types;
 
 pub use detect::{detect_mime, DetectedMime, DetectionSource};
 pub use error::MediaError;
+pub use processor::MediaProcessor;
 pub use store::{CasStore, CleanResult, StoreResult};
 pub use types::{MediaBudget, MediaRef, MediaType};

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -5,8 +5,10 @@
 
 pub mod detect;
 pub mod error;
+pub mod store;
 pub mod types;
 
 pub use detect::{detect_mime, DetectedMime, DetectionSource};
 pub use error::MediaError;
+pub use store::{CasStore, CleanResult, StoreResult};
 pub use types::{MediaBudget, MediaRef, MediaType};

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -169,14 +169,6 @@ mod tests {
     use crate::mcp::types::ContentBlock;
     use base64::Engine;
 
-    fn make_processor() -> MediaProcessor {
-        let dir = tempfile::tempdir().unwrap();
-        let store = CasStore::new(dir.path());
-        // Leak the tempdir so it lives long enough
-        std::mem::forget(dir);
-        MediaProcessor::new(store)
-    }
-
     fn make_processor_with_dir() -> (MediaProcessor, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let store = CasStore::new(dir.path());

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -154,13 +154,26 @@ impl MediaProcessor {
         }
 
         // Check media budget before proceeding
-        self.budget.check_and_add(decoded.len() as u64, task_id)?;
+        let decoded_size = decoded.len() as u64;
+        self.budget.check_and_add(decoded_size, task_id)?;
 
         // Detect MIME type
-        let detected = detect_mime(&decoded, server_mime)?;
+        let detected = match detect_mime(&decoded, server_mime) {
+            Ok(d) => d,
+            Err(e) => {
+                self.budget.rollback(decoded_size);
+                return Err(e);
+            }
+        };
 
         // Store in CAS (hash-only filenames)
-        let store_result = self.store.store(&decoded).await?;
+        let store_result = match self.store.store(&decoded).await {
+            Ok(r) => r,
+            Err(e) => {
+                self.budget.rollback(decoded_size);
+                return Err(e);
+            }
+        };
 
         let media_ref = MediaRef {
             hash: store_result.hash.clone(),

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -5,6 +5,8 @@
 //! Rejects empty decoded data.
 //! Enforces per-run media budget via MediaBudget.
 
+use std::sync::Arc;
+
 use crate::mcp::types::ContentBlock;
 
 use super::detect::detect_mime;
@@ -18,7 +20,7 @@ const MAX_BASE64_INPUT_BYTES: usize = 100 * 1024 * 1024;
 /// Processes MCP content blocks into stored media files.
 pub struct MediaProcessor {
     store: CasStore,
-    budget: MediaBudget,
+    budget: Arc<MediaBudget>,
 }
 
 impl MediaProcessor {
@@ -26,12 +28,17 @@ impl MediaProcessor {
     pub fn new(store: CasStore) -> Self {
         Self {
             store,
-            budget: MediaBudget::new(),
+            budget: Arc::new(MediaBudget::new()),
         }
     }
 
-    /// Create a new processor with custom budget.
+    /// Create a new processor with custom owned budget.
     pub fn with_budget(store: CasStore, budget: MediaBudget) -> Self {
+        Self { store, budget: Arc::new(budget) }
+    }
+
+    /// Create a new processor with a shared per-run budget.
+    pub fn with_shared_budget(store: CasStore, budget: Arc<MediaBudget>) -> Self {
         Self { store, budget }
     }
 

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -132,10 +132,14 @@ impl MediaProcessor {
             return Ok(None);
         }
 
-        // Decode base64
+        // Decode base64 — strip whitespace first since many MCP servers
+        // return PEM-style base64 with \n at 76-char boundaries (OpenAI, etc.)
         use base64::Engine;
+        let clean_b64: String = base64_data.chars()
+            .filter(|c| !c.is_ascii_whitespace())
+            .collect();
         let decoded = base64::engine::general_purpose::STANDARD
-            .decode(base64_data)
+            .decode(&clean_b64)
             .map_err(|e| MediaError::Base64DecodeFailed {
                 source_desc: format!("task {task_id}"),
                 reason: e.to_string(),

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -1,0 +1,164 @@
+//! MediaProcessor: ContentBlock -> decode -> detect -> hash -> store -> MediaRef
+//!
+//! Fully async — CasStore::store() uses io::atomic internally.
+//! Rejects base64 input exceeding MAX_BASE64_INPUT_BYTES before decoding.
+//! Rejects empty decoded data.
+//! Enforces per-run media budget via MediaBudget.
+
+use crate::mcp::types::ContentBlock;
+
+use super::detect::detect_mime;
+use super::error::MediaError;
+use super::store::{CasStore, StoreResult};
+use super::types::{MediaBudget, MediaRef};
+
+/// Maximum base64 input size (100 MB encoded, ~75 MB decoded).
+const MAX_BASE64_INPUT_BYTES: usize = 100 * 1024 * 1024;
+
+/// Processes MCP content blocks into stored media files.
+pub struct MediaProcessor {
+    store: CasStore,
+    budget: MediaBudget,
+}
+
+impl MediaProcessor {
+    /// Create a new processor with the given CAS store and default budget.
+    pub fn new(store: CasStore) -> Self {
+        Self {
+            store,
+            budget: MediaBudget::new(),
+        }
+    }
+
+    /// Create a new processor with custom budget.
+    pub fn with_budget(store: CasStore, budget: MediaBudget) -> Self {
+        Self { store, budget }
+    }
+
+    /// Process a single content block (async).
+    ///
+    /// Returns `Ok(None)` for text blocks (no media to process).
+    /// Returns `Ok(Some((MediaRef, StoreResult)))` for media blocks.
+    pub async fn process(
+        &self,
+        block: &ContentBlock,
+        task_id: &str,
+    ) -> Result<Option<(MediaRef, StoreResult)>, MediaError> {
+        match block {
+            ContentBlock::Text { .. } => Ok(None),
+
+            ContentBlock::Image { data, mime_type } => {
+                self.process_base64(data, Some(mime_type.as_str()), task_id).await
+            }
+
+            ContentBlock::Audio { data, mime_type } => {
+                self.process_base64(data, Some(mime_type.as_str()), task_id).await
+            }
+
+            ContentBlock::Resource(rc) => {
+                if let Some(blob) = &rc.blob {
+                    self.process_base64(
+                        blob,
+                        rc.mime_type.as_deref(),
+                        task_id,
+                    ).await
+                } else {
+                    Ok(None)
+                }
+            }
+
+            ContentBlock::ResourceLink { uri, .. } => {
+                tracing::debug!(uri = %uri, "ResourceLink skipped (no inline data)");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Process all content blocks, collecting results per block (async).
+    ///
+    /// Skips text blocks silently. The `usize` in Err is the block index.
+    pub async fn process_all(
+        &self,
+        blocks: &[ContentBlock],
+        task_id: &str,
+    ) -> Vec<Result<(MediaRef, StoreResult), (usize, MediaError)>> {
+        let mut results = Vec::new();
+        for (i, block) in blocks.iter().enumerate() {
+            if block.is_text() {
+                continue;
+            }
+            match self.process(block, task_id).await {
+                Ok(Some(pair)) => results.push(Ok(pair)),
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        block_index = i,
+                        error = %e,
+                        "Failed to process media block"
+                    );
+                    results.push(Err((i, e)));
+                }
+            }
+        }
+        results
+    }
+
+    /// Decode base64 data, detect MIME, and store in CAS (async).
+    async fn process_base64(
+        &self,
+        base64_data: &str,
+        server_mime: Option<&str>,
+        task_id: &str,
+    ) -> Result<Option<(MediaRef, StoreResult)>, MediaError> {
+        // Guard: reject oversized base64 BEFORE decode
+        if base64_data.len() > MAX_BASE64_INPUT_BYTES {
+            return Err(MediaError::Base64InputTooLarge {
+                size: base64_data.len(),
+                max: MAX_BASE64_INPUT_BYTES,
+            });
+        }
+
+        // Guard: reject empty data
+        if base64_data.is_empty() {
+            tracing::warn!(task_id = %task_id, "Empty base64 data, skipping");
+            return Ok(None);
+        }
+
+        // Decode base64
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(base64_data)
+            .map_err(|e| MediaError::Base64DecodeFailed {
+                source_desc: format!("task {task_id}"),
+                reason: e.to_string(),
+            })?;
+
+        // Guard: reject empty decoded data
+        if decoded.is_empty() {
+            return Err(MediaError::EmptyMediaContent {
+                task_id: task_id.to_string(),
+            });
+        }
+
+        // Check media budget before proceeding
+        self.budget.check_and_add(decoded.len() as u64, task_id)?;
+
+        // Detect MIME type
+        let detected = detect_mime(&decoded, server_mime)?;
+
+        // Store in CAS (hash-only filenames)
+        let store_result = self.store.store(&decoded).await?;
+
+        let media_ref = MediaRef {
+            hash: store_result.hash.clone(),
+            mime_type: detected.mime_type,
+            size_bytes: store_result.size,
+            path: store_result.path.clone(),
+            extension: detected.extension,
+            created_by: task_id.to_string(),
+        };
+
+        Ok(Some((media_ref, store_result)))
+    }
+}

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -25,6 +25,7 @@ pub struct MediaProcessor {
 
 impl MediaProcessor {
     /// Create a new processor with the given CAS store and default budget.
+    #[allow(dead_code)] // Used in tests
     pub fn new(store: CasStore) -> Self {
         Self {
             store,
@@ -33,6 +34,7 @@ impl MediaProcessor {
     }
 
     /// Create a new processor with custom owned budget.
+    #[allow(dead_code)] // Used in tests
     pub fn with_budget(store: CasStore, budget: MediaBudget) -> Self {
         Self { store, budget: Arc::new(budget) }
     }
@@ -118,6 +120,13 @@ impl MediaProcessor {
         server_mime: Option<&str>,
         task_id: &str,
     ) -> Result<Option<(MediaRef, StoreResult)>, MediaError> {
+        tracing::debug!(
+            task_id = %task_id,
+            base64_len = base64_data.len(),
+            server_mime = ?server_mime,
+            "media: processing base64 block"
+        );
+
         // Guard: reject oversized base64 BEFORE decode
         if base64_data.len() > MAX_BASE64_INPUT_BYTES {
             return Err(MediaError::Base64InputTooLarge {
@@ -153,6 +162,13 @@ impl MediaProcessor {
             });
         }
 
+        tracing::trace!(
+            task_id = %task_id,
+            decoded_bytes = decoded.len(),
+            budget_used = self.budget.current_bytes(),
+            "media: base64 decoded successfully"
+        );
+
         // Check media budget before proceeding
         let decoded_size = decoded.len() as u64;
         self.budget.check_and_add(decoded_size, task_id)?;
@@ -174,6 +190,17 @@ impl MediaProcessor {
                 return Err(e);
             }
         };
+
+        tracing::debug!(
+            task_id = %task_id,
+            hash = %store_result.hash,
+            mime = %detected.mime_type,
+            size = store_result.size,
+            dedup = store_result.deduplicated,
+            verified = store_result.verified,
+            pipeline_ms = store_result.pipeline_ms,
+            "media: stored in CAS"
+        );
 
         let media_ref = MediaRef {
             hash: store_result.hash.clone(),

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -303,4 +303,93 @@ mod tests {
         assert!(r2.is_err());
         assert_eq!(r2.unwrap_err().code(), "NIKA-259");
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 1: Budget rollback on MIME detection failure
+    // When MIME detection fails AFTER budget was charged, the budget
+    // must be rolled back so future tasks are not unfairly penalized.
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn budget_rollback_on_mime_detection_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let budget = Arc::new(MediaBudget::with_max_per_run(1000));
+        let processor = MediaProcessor::with_shared_budget(store, Arc::clone(&budget));
+
+        // Encode random bytes that infer cannot detect as any MIME type.
+        // Use application/octet-stream as server hint, which is explicitly
+        // rejected by detect_mime, causing MimeDetectionFailed.
+        let unknown_data = vec![0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&unknown_data);
+
+        // Verify budget starts at 0
+        assert_eq!(budget.current_bytes(), 0, "budget should start at 0");
+
+        // Process should fail on MIME detection (NIKA-251)
+        let block = ContentBlock::image(b64, "application/octet-stream");
+        let result = processor.process(&block, "t_mime_fail").await;
+        assert!(result.is_err(), "unrecognizable bytes with octet-stream should fail");
+        assert_eq!(result.unwrap_err().code(), "NIKA-251");
+
+        // CRITICAL: budget must be rolled back to 0
+        assert_eq!(budget.current_bytes(), 0,
+            "budget must be rolled back after MIME detection failure, got {}",
+            budget.current_bytes());
+
+        // Prove the budget is usable: a valid image should still succeed
+        let block2 = ContentBlock::image(png_base64(), "image/png");
+        let result2 = processor.process(&block2, "t_after_rollback").await;
+        assert!(result2.is_ok(), "valid image should succeed after rollback: {:?}", result2.err());
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 2: Budget rollback on CAS store failure
+    // When CAS store fails AFTER budget was charged (e.g. I/O error),
+    // the budget must be rolled back.
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn budget_rollback_on_cas_store_failure() {
+        // Create a CAS store pointing to a read-only or nonexistent path
+        // to force a MediaStoreIo error during store()
+        let dir = tempfile::tempdir().unwrap();
+        let readonly_path = dir.path().join("readonly_store");
+        // Create the directory then make it read-only
+        std::fs::create_dir_all(&readonly_path).unwrap();
+
+        // On macOS/Linux: make the directory read-only so CAS writes fail
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&readonly_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        }
+
+        let store = CasStore::new(&readonly_path);
+        let budget = Arc::new(MediaBudget::with_max_per_run(10000));
+        let processor = MediaProcessor::with_shared_budget(store, Arc::clone(&budget));
+
+        assert_eq!(budget.current_bytes(), 0, "budget should start at 0");
+
+        let block = ContentBlock::image(png_base64(), "image/png");
+        let result = processor.process(&block, "t_cas_fail").await;
+
+        // Should fail with I/O error (NIKA-255)
+        assert!(result.is_err(), "CAS store to read-only dir should fail");
+        let err = result.unwrap_err();
+        assert_eq!(err.code(), "NIKA-255",
+            "expected MediaStoreIo (NIKA-255), got {}", err.code());
+
+        // CRITICAL: budget must be rolled back to 0
+        assert_eq!(budget.current_bytes(), 0,
+            "budget must be rolled back after CAS store failure, got {}",
+            budget.current_bytes());
+
+        // Restore permissions for cleanup
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&readonly_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
 }

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -98,7 +98,7 @@ impl MediaProcessor {
                 Ok(Some(pair)) => results.push(Ok(pair)),
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         task_id = %task_id,
                         block_index = i,
                         error = %e,
@@ -126,10 +126,11 @@ impl MediaProcessor {
             });
         }
 
-        // Guard: reject empty data
+        // Guard: reject empty data — malformed Image/Audio block
         if base64_data.is_empty() {
-            tracing::warn!(task_id = %task_id, "Empty base64 data, skipping");
-            return Ok(None);
+            return Err(MediaError::EmptyMediaContent {
+                task_id: task_id.to_string(),
+            });
         }
 
         // Decode base64 — strip whitespace first since many MCP servers
@@ -231,11 +232,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_empty_base64_returns_none() {
+    async fn process_empty_base64_returns_error() {
         let (processor, _dir) = make_processor_with_dir();
         let block = ContentBlock::image("", "image/png");
-        let result = processor.process(&block, "t1").await.unwrap();
-        assert!(result.is_none());
+        let result = processor.process(&block, "t1").await;
+        assert!(result.is_err(), "Empty base64 image should error (NIKA-258)");
+        assert_eq!(result.unwrap_err().code(), "NIKA-258");
     }
 
     #[tokio::test]

--- a/tools/nika/src/media/processor.rs
+++ b/tools/nika/src/media/processor.rs
@@ -162,3 +162,127 @@ impl MediaProcessor {
         Ok(Some((media_ref, store_result)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::types::ContentBlock;
+    use base64::Engine;
+
+    fn make_processor() -> MediaProcessor {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        // Leak the tempdir so it lives long enough
+        std::mem::forget(dir);
+        MediaProcessor::new(store)
+    }
+
+    fn make_processor_with_dir() -> (MediaProcessor, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        (MediaProcessor::new(store), dir)
+    }
+
+    /// Encode PNG header as base64 for tests
+    fn png_base64() -> String {
+        let png_data: Vec<u8> = vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+            0x00, 0x00, 0x00, 0x0D, // IHDR chunk length
+            0x49, 0x48, 0x44, 0x52, // IHDR
+            0x00, 0x00, 0x00, 0x01, // width=1
+            0x00, 0x00, 0x00, 0x01, // height=1
+            0x08, 0x02, 0x00, 0x00, 0x00, // bit depth, color type, etc
+        ];
+        base64::engine::general_purpose::STANDARD.encode(&png_data)
+    }
+
+    #[tokio::test]
+    async fn process_text_block_returns_none() {
+        let (processor, _dir) = make_processor_with_dir();
+        let block = ContentBlock::text("hello");
+        let result = processor.process(&block, "t1").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn process_image_block_returns_media_ref() {
+        let (processor, _dir) = make_processor_with_dir();
+        let block = ContentBlock::image(png_base64(), "image/png");
+        let result = processor.process(&block, "t1").await.unwrap();
+        assert!(result.is_some());
+        let (media_ref, _store_result) = result.unwrap();
+        assert!(media_ref.hash.starts_with("blake3:"));
+        assert_eq!(media_ref.mime_type, "image/png");
+        assert_eq!(media_ref.extension, "png");
+        assert!(media_ref.size_bytes > 0);
+        assert_eq!(media_ref.created_by, "t1");
+    }
+
+    #[tokio::test]
+    async fn process_invalid_base64_returns_error() {
+        let (processor, _dir) = make_processor_with_dir();
+        let block = ContentBlock::image("not!valid!base64!!!", "image/png");
+        let result = processor.process(&block, "t1").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), "NIKA-256");
+    }
+
+    #[tokio::test]
+    async fn process_empty_base64_returns_none() {
+        let (processor, _dir) = make_processor_with_dir();
+        let block = ContentBlock::image("", "image/png");
+        let result = processor.process(&block, "t1").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn process_oversized_base64_returns_error() {
+        let (processor, _dir) = make_processor_with_dir();
+        // Create a string > 100MB
+        let big = "A".repeat(MAX_BASE64_INPUT_BYTES + 1);
+        let block = ContentBlock::image(big, "image/png");
+        let result = processor.process(&block, "t1").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), "NIKA-257");
+    }
+
+    #[tokio::test]
+    async fn process_all_mixed_blocks() {
+        let (processor, _dir) = make_processor_with_dir();
+        let blocks = vec![
+            ContentBlock::text("some text"),
+            ContentBlock::image(png_base64(), "image/png"),
+            ContentBlock::text("more text"),
+        ];
+        let results = processor.process_all(&blocks, "t1").await;
+        // Should only have 1 result (the image), text blocks are skipped
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+    }
+
+    #[tokio::test]
+    async fn resource_link_skipped() {
+        let (processor, _dir) = make_processor_with_dir();
+        let block = ContentBlock::resource_link("file:///test", None, None);
+        let result = processor.process(&block, "t1").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn budget_enforcement() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let budget = MediaBudget::with_max_per_run(50); // Tiny budget
+        let processor = MediaProcessor::with_budget(store, budget);
+
+        let block = ContentBlock::image(png_base64(), "image/png");
+        // First process should succeed (PNG header is ~25 bytes)
+        let r1 = processor.process(&block, "t1").await;
+        assert!(r1.is_ok());
+
+        // Second process should fail (budget exceeded)
+        let r2 = processor.process(&block, "t2").await;
+        assert!(r2.is_err());
+        assert_eq!(r2.unwrap_err().code(), "NIKA-259");
+    }
+}

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -42,6 +42,7 @@ pub struct StoreResult {
 
 /// Entry in the CAS store.
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // Used in tests + PR2 (nika media list/gc)
 pub struct CasEntry {
     /// Algorithm-prefixed hash (e.g., "blake3:af1349...")
     pub hash: String,
@@ -55,6 +56,7 @@ pub struct CasEntry {
 
 /// Result of a cleanup operation.
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // Used in tests + PR2 (nika media gc)
 pub struct CleanResult {
     /// Number of files removed
     pub removed: u64,
@@ -193,6 +195,7 @@ impl CasStore {
     }
 
     /// Check if a hash exists in the store.
+    #[allow(dead_code)] // Used in tests + PR2
     pub fn exists(&self, hash: &str) -> bool {
         let raw = strip_hash_prefix(hash);
         if raw.len() < 3 {
@@ -203,6 +206,7 @@ impl CasStore {
     }
 
     /// Read file data by hash (async).
+    #[allow(dead_code)] // Used in tests + PR2
     pub async fn read(&self, hash: &str) -> Result<Vec<u8>, MediaError> {
         let raw = strip_hash_prefix(hash);
         if raw.len() < 3 {
@@ -226,6 +230,7 @@ impl CasStore {
     }
 
     /// List all entries in the store.
+    #[allow(dead_code)] // Used in tests + PR2
     pub fn list(&self) -> Vec<CasEntry> {
         let mut entries = Vec::new();
         let Ok(shards) = std::fs::read_dir(&self.root) else {
@@ -254,6 +259,7 @@ impl CasStore {
     }
 
     /// Remove all files from the store.
+    #[allow(dead_code)] // Used in tests + PR2
     pub fn clean_all(&self) -> CleanResult {
         let mut removed = 0u64;
         let mut bytes_freed = 0u64;
@@ -274,6 +280,7 @@ impl CasStore {
     }
 
     /// Remove files older than the given duration.
+    #[allow(dead_code)] // Used in tests + PR2
     pub fn clean_older_than(&self, duration: Duration) -> CleanResult {
         let mut removed = 0u64;
         let mut bytes_freed = 0u64;
@@ -305,6 +312,7 @@ impl CasStore {
 }
 
 /// Strip the algorithm prefix from a hash string, if present.
+#[allow(dead_code)] // Used by exists/read/list in tests + PR2
 fn strip_hash_prefix(hash: &str) -> &str {
     hash.strip_prefix(HASH_PREFIX).unwrap_or(hash)
 }

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -284,3 +284,148 @@ impl CasStore {
 fn strip_hash_prefix(hash: &str) -> &str {
     hash.strip_prefix(HASH_PREFIX).unwrap_or(hash)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn store_and_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = b"hello media pipeline";
+        let result = store.store(data).await.unwrap();
+
+        assert!(result.hash.starts_with("blake3:"));
+        assert!(!result.deduplicated);
+        assert!(result.verified);
+        assert_eq!(result.size, data.len() as u64);
+
+        let read_back = store.read(&result.hash).await.unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[tokio::test]
+    async fn store_dedup_same_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = b"identical content";
+        let r1 = store.store(data).await.unwrap();
+        let r2 = store.store(data).await.unwrap();
+
+        assert_eq!(r1.hash, r2.hash);
+        assert!(!r1.deduplicated);
+        assert!(r2.deduplicated);
+    }
+
+    #[tokio::test]
+    async fn exists_after_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = b"existence check";
+        let result = store.store(data).await.unwrap();
+
+        assert!(store.exists(&result.hash));
+        assert!(!store.exists("blake3:nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn read_nonexistent_hash_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.read("blake3:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn hash_only_filename_no_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = b"no extension in path";
+        let result = store.store(data).await.unwrap();
+
+        // Path should have NO extension
+        assert!(result.path.extension().is_none(),
+            "CAS path should have no extension: {:?}", result.path);
+    }
+
+    #[tokio::test]
+    async fn hash_has_blake3_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"prefix test").await.unwrap();
+        assert!(result.hash.starts_with("blake3:"),
+            "hash should have blake3: prefix, got: {}", result.hash);
+    }
+
+    #[tokio::test]
+    async fn list_returns_stored_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        store.store(b"file one").await.unwrap();
+        store.store(b"file two").await.unwrap();
+
+        let entries = store.list();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.hash.starts_with("blake3:")));
+    }
+
+    #[tokio::test]
+    async fn clean_all_removes_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        store.store(b"data one").await.unwrap();
+        store.store(b"data two").await.unwrap();
+
+        let clean = store.clean_all();
+        assert_eq!(clean.removed, 2);
+        assert_eq!(store.list().len(), 0);
+    }
+
+    #[test]
+    fn workspace_default_uses_workspace_root() {
+        let root = std::path::PathBuf::from("/tmp/test-workspace");
+        let store = CasStore::workspace_default(&root);
+        // Just verify it constructs without panic
+        assert!(!store.exists("blake3:nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_cas_writes_dedup_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(CasStore::new(dir.path()));
+
+        let data: Vec<u8> = b"identical content for all tasks".to_vec();
+
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let store = std::sync::Arc::clone(&store);
+                let data = data.clone();
+                tokio::spawn(async move { store.store(&data).await })
+            })
+            .collect();
+
+        let results: Vec<StoreResult> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|h| h.unwrap().unwrap())
+            .collect();
+
+        // All should have the same hash
+        let hash = &results[0].hash;
+        assert!(hash.starts_with("blake3:"));
+        assert!(results.iter().all(|r| &r.hash == hash));
+
+        // Exactly one should be non-deduplicated
+        let non_dedup_count = results.iter().filter(|r| !r.deduplicated).count();
+        assert_eq!(non_dedup_count, 1, "exactly one writer should be non-dedup");
+    }
+}

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -1,0 +1,286 @@
+//! Content-Addressable Storage (CAS) with blake3 hashing and io::atomic writes.
+//!
+//! Layout: `{root}/{hash[0..2]}/{hash[2..]}` (NO extension in filename).
+//! Hashes are prefixed: "blake3:af1349..." for algorithm identification.
+//! Uses `crate::io::atomic::write_fail()` for atomic CAS writes (O_EXCL).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::error::MediaError;
+
+/// blake3 hash algorithm prefix for MediaRef.hash values.
+const HASH_PREFIX: &str = "blake3:";
+
+/// Only verify files at or above this size (1MB).
+const VERIFY_THRESHOLD: u64 = 1024 * 1024;
+
+/// Result of a CAS store operation.
+#[derive(Debug, Clone)]
+pub struct StoreResult {
+    /// Algorithm-prefixed hash (e.g., "blake3:af1349...")
+    pub hash: String,
+
+    /// Final path where the file is stored
+    pub path: PathBuf,
+
+    /// File size in bytes
+    pub size: u64,
+
+    /// True if this file was already in the store (deduplicated)
+    pub deduplicated: bool,
+
+    /// True if read-back verification passed (or skipped for small files)
+    pub verified: bool,
+
+    /// Pipeline latency in milliseconds (hash -> store -> verify)
+    pub pipeline_ms: u64,
+}
+
+/// Entry in the CAS store.
+#[derive(Debug, Clone)]
+pub struct CasEntry {
+    /// Algorithm-prefixed hash (e.g., "blake3:af1349...")
+    pub hash: String,
+
+    /// File path
+    pub path: PathBuf,
+
+    /// File size in bytes
+    pub size: u64,
+}
+
+/// Result of a cleanup operation.
+#[derive(Debug, Clone)]
+pub struct CleanResult {
+    /// Number of files removed
+    pub removed: u64,
+
+    /// Total bytes freed
+    pub bytes_freed: u64,
+}
+
+/// Content-Addressable Storage backed by blake3.
+///
+/// All write operations are async, using `crate::io::atomic::write_fail()`
+/// which provides O_EXCL atomic check+create via tokio::fs.
+/// Filenames are hash-only (no extension).
+pub struct CasStore {
+    root: PathBuf,
+}
+
+impl CasStore {
+    /// Create a CAS store at the given root directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Create a CAS store at the workspace default location.
+    ///
+    /// Respects `NIKA_MEDIA_STORE` env var as override.
+    /// Otherwise uses `{workspace_root}/.nika/media/store/`.
+    pub fn workspace_default(workspace_root: &Path) -> Self {
+        if let Ok(override_path) = std::env::var("NIKA_MEDIA_STORE") {
+            return Self::new(PathBuf::from(override_path));
+        }
+        Self::new(workspace_root.join(".nika").join("media").join("store"))
+    }
+
+    /// Store binary data in the CAS (async).
+    ///
+    /// 1. Compute blake3 hash
+    /// 2. Derive path: `{root}/{hash[0..2]}/{hash[2..]}` (no extension)
+    /// 3. Create parent directories (async)
+    /// 4. Write via `io::atomic::write_fail()` (O_EXCL atomic check+create)
+    /// 5. If AlreadyExists, return deduplicated=true
+    /// 6. Read-back verify only for files >= VERIFY_THRESHOLD
+    pub async fn store(
+        &self,
+        data: &[u8],
+    ) -> Result<StoreResult, MediaError> {
+        let process_start = std::time::Instant::now();
+
+        let raw_hash = blake3::hash(data).to_hex().to_string();
+        let size = data.len() as u64;
+
+        let prefixed_hash = format!("{HASH_PREFIX}{raw_hash}");
+
+        let dir = self.root.join(&raw_hash[..2]);
+        let final_path = dir.join(&raw_hash[2..]);
+
+        // Create parent directories (async)
+        tokio::fs::create_dir_all(&dir).await.map_err(|e| MediaError::MediaStoreWrite {
+            path: dir.clone(),
+            source: e,
+        })?;
+
+        // Atomic write via io::atomic::write_fail (O_EXCL)
+        match crate::io::atomic::write_fail(&final_path, data).await {
+            Ok(()) => {
+                // New file stored
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Ok(StoreResult {
+                    hash: prefixed_hash,
+                    path: final_path,
+                    size,
+                    deduplicated: true,
+                    verified: true,
+                    pipeline_ms: process_start.elapsed().as_millis() as u64,
+                });
+            }
+            Err(e) => {
+                return Err(MediaError::MediaStoreWrite {
+                    path: final_path,
+                    source: e,
+                });
+            }
+        }
+
+        // Read-back verification only for files >= 1MB
+        let verified = if size >= VERIFY_THRESHOLD {
+            let stored = tokio::fs::read(&final_path).await.map_err(|e| {
+                MediaError::MediaStoreWrite {
+                    path: final_path.clone(),
+                    source: e,
+                }
+            })?;
+            let verify_hash = blake3::hash(&stored).to_hex().to_string();
+            if verify_hash != raw_hash {
+                let _ = tokio::fs::remove_file(&final_path).await;
+                return Err(MediaError::HashMismatch {
+                    expected: prefixed_hash,
+                    actual: format!("{HASH_PREFIX}{verify_hash}"),
+                });
+            }
+            true
+        } else {
+            true
+        };
+
+        Ok(StoreResult {
+            hash: prefixed_hash,
+            path: final_path,
+            size,
+            deduplicated: false,
+            verified,
+            pipeline_ms: process_start.elapsed().as_millis() as u64,
+        })
+    }
+
+    /// Check if a hash exists in the store.
+    pub fn exists(&self, hash: &str) -> bool {
+        let raw = strip_hash_prefix(hash);
+        if raw.len() < 3 {
+            return false;
+        }
+        let path = self.root.join(&raw[..2]).join(&raw[2..]);
+        path.exists()
+    }
+
+    /// Read file data by hash (async).
+    pub async fn read(&self, hash: &str) -> Result<Vec<u8>, MediaError> {
+        let raw = strip_hash_prefix(hash);
+        if raw.len() < 3 {
+            return Err(MediaError::MediaNotFound {
+                hash: hash.to_string(),
+            });
+        }
+        let path = self.root.join(&raw[..2]).join(&raw[2..]);
+        tokio::fs::read(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                MediaError::MediaNotFound {
+                    hash: hash.to_string(),
+                }
+            } else {
+                MediaError::MediaStoreWrite {
+                    path,
+                    source: e,
+                }
+            }
+        })
+    }
+
+    /// List all entries in the store.
+    pub fn list(&self) -> Vec<CasEntry> {
+        let mut entries = Vec::new();
+        let Ok(shards) = std::fs::read_dir(&self.root) else {
+            return entries;
+        };
+        for shard in shards.flatten() {
+            let shard_name = shard.file_name().to_string_lossy().to_string();
+            if shard_name.len() != 2 || !shard.path().is_dir() {
+                continue;
+            }
+            let Ok(files) = std::fs::read_dir(shard.path()) else {
+                continue;
+            };
+            for file in files.flatten() {
+                let file_name = file.file_name().to_string_lossy().to_string();
+                let raw_hash = format!("{}{}", shard_name, file_name);
+                let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+                entries.push(CasEntry {
+                    hash: format!("{HASH_PREFIX}{raw_hash}"),
+                    path: file.path(),
+                    size,
+                });
+            }
+        }
+        entries
+    }
+
+    /// Remove all files from the store.
+    pub fn clean_all(&self) -> CleanResult {
+        let mut removed = 0u64;
+        let mut bytes_freed = 0u64;
+        for entry in self.list() {
+            if let Ok(meta) = std::fs::metadata(&entry.path) {
+                bytes_freed += meta.len();
+            }
+            if std::fs::remove_file(&entry.path).is_ok() {
+                removed += 1;
+            } else {
+                tracing::warn!(path = %entry.path.display(), "failed to remove CAS file");
+            }
+        }
+        CleanResult {
+            removed,
+            bytes_freed,
+        }
+    }
+
+    /// Remove files older than the given duration.
+    pub fn clean_older_than(&self, duration: Duration) -> CleanResult {
+        let mut removed = 0u64;
+        let mut bytes_freed = 0u64;
+        let now = std::time::SystemTime::now();
+        for entry in self.list() {
+            let Ok(meta) = std::fs::metadata(&entry.path) else {
+                continue;
+            };
+            let Ok(modified) = meta.modified() else {
+                continue;
+            };
+            let Some(age) = now.duration_since(modified).ok() else {
+                continue;
+            };
+            if age > duration {
+                bytes_freed += meta.len();
+                if std::fs::remove_file(&entry.path).is_ok() {
+                    removed += 1;
+                } else {
+                    tracing::warn!(path = %entry.path.display(), "failed to remove CAS file");
+                }
+            }
+        }
+        CleanResult {
+            removed,
+            bytes_freed,
+        }
+    }
+}
+
+/// Strip the algorithm prefix from a hash string, if present.
+fn strip_hash_prefix(hash: &str) -> &str {
+    hash.strip_prefix(HASH_PREFIX).unwrap_or(hash)
+}

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -15,6 +15,9 @@ const HASH_PREFIX: &str = "blake3:";
 /// Only verify files at or above this size (1MB).
 const VERIFY_THRESHOLD: u64 = 1024 * 1024;
 
+/// Maximum raw data size accepted by CAS store (100MB, defense-in-depth).
+const MAX_STORE_SIZE: usize = 100 * 1024 * 1024;
+
 /// Result of a CAS store operation.
 #[derive(Debug, Clone)]
 pub struct StoreResult {
@@ -98,6 +101,21 @@ impl CasStore {
         &self,
         data: &[u8],
     ) -> Result<StoreResult, MediaError> {
+        // Defense-in-depth: reject empty data at the CAS layer (D28)
+        if data.is_empty() {
+            return Err(MediaError::EmptyMediaContent {
+                task_id: "(cas-direct)".to_string(),
+            });
+        }
+
+        // Defense-in-depth: reject oversized data at the CAS layer (D23)
+        if data.len() > MAX_STORE_SIZE {
+            return Err(MediaError::Base64InputTooLarge {
+                size: data.len(),
+                max: MAX_STORE_SIZE,
+            });
+        }
+
         let process_start = std::time::Instant::now();
 
         let raw_hash = blake3::hash(data).to_hex().to_string();
@@ -109,7 +127,7 @@ impl CasStore {
         let final_path = dir.join(&raw_hash[2..]);
 
         // Create parent directories (async)
-        tokio::fs::create_dir_all(&dir).await.map_err(|e| MediaError::MediaStoreWrite {
+        tokio::fs::create_dir_all(&dir).await.map_err(|e| MediaError::MediaStoreIo {
             path: dir.clone(),
             source: e,
         })?;
@@ -135,7 +153,7 @@ impl CasStore {
                 // CRITICAL: write_fail may leave a partial file on disk-full/IO error.
                 // Clean it up to prevent permanent CAS corruption.
                 let _ = tokio::fs::remove_file(&final_path).await;
-                return Err(MediaError::MediaStoreWrite {
+                return Err(MediaError::MediaStoreIo {
                     path: final_path,
                     source: e,
                 });
@@ -146,7 +164,7 @@ impl CasStore {
         // Small files: fsync guarantees integrity, verified=false to indicate skipped
         let verified = if size >= VERIFY_THRESHOLD {
             let stored = tokio::fs::read(&final_path).await.map_err(|e| {
-                MediaError::MediaStoreWrite {
+                MediaError::MediaStoreIo {
                     path: final_path.clone(),
                     source: e,
                 }
@@ -199,7 +217,7 @@ impl CasStore {
                     hash: hash.to_string(),
                 }
             } else {
-                MediaError::MediaStoreWrite {
+                MediaError::MediaStoreIo {
                     path,
                     source: e,
                 }
@@ -403,6 +421,27 @@ mod tests {
         let store = CasStore::workspace_default(&root);
         // Just verify it constructs without panic
         assert!(!store.exists("blake3:nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn store_rejects_empty_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), "NIKA-258");
+    }
+
+    #[tokio::test]
+    async fn store_rejects_oversized_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let big = vec![0u8; MAX_STORE_SIZE + 1];
+        let result = store.store(&big).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), "NIKA-257");
     }
 
     #[tokio::test]

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -120,12 +120,14 @@ impl CasStore {
                 // New file stored
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Content-addressed: same hash = same content, skip write.
+                // verified=false because we did NOT re-read and re-hash the existing file.
                 return Ok(StoreResult {
                     hash: prefixed_hash,
                     path: final_path,
                     size,
                     deduplicated: true,
-                    verified: true,
+                    verified: false,
                     pipeline_ms: process_start.elapsed().as_millis() as u64,
                 });
             }

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -114,14 +114,14 @@ impl CasStore {
             source: e,
         })?;
 
-        // Atomic write via io::atomic::write_fail (O_EXCL)
+        // Atomic write via O_EXCL (create_new). On success: new file.
+        // On AlreadyExists: dedup hit. On other error: clean up partial file.
         match crate::io::atomic::write_fail(&final_path, data).await {
             Ok(()) => {
-                // New file stored
+                // New file stored successfully
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 // Content-addressed: same hash = same content, skip write.
-                // verified=false because we did NOT re-read and re-hash the existing file.
                 return Ok(StoreResult {
                     hash: prefixed_hash,
                     path: final_path,
@@ -132,6 +132,9 @@ impl CasStore {
                 });
             }
             Err(e) => {
+                // CRITICAL: write_fail may leave a partial file on disk-full/IO error.
+                // Clean it up to prevent permanent CAS corruption.
+                let _ = tokio::fs::remove_file(&final_path).await;
                 return Err(MediaError::MediaStoreWrite {
                     path: final_path,
                     source: e,

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -445,6 +445,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn store_accepts_exactly_max_store_size() {
+        // Boundary test: exactly MAX_STORE_SIZE bytes should be accepted
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = vec![0xAB_u8; MAX_STORE_SIZE];
+        let result = store.store(&data).await;
+        assert!(result.is_ok(), "exactly MAX_STORE_SIZE should be accepted, got: {:?}", result.err());
+        let sr = result.unwrap();
+        assert_eq!(sr.size, MAX_STORE_SIZE as u64);
+        assert!(!sr.deduplicated);
+        // 100MB is above verify threshold (1MB), so it should be verified
+        assert!(sr.verified, "100MB file should trigger read-back verification");
+
+        // Verify read-back matches
+        let read_back = store.read(&sr.hash).await.unwrap();
+        assert_eq!(read_back.len(), MAX_STORE_SIZE);
+        assert!(read_back.iter().all(|&b| b == 0xAB),
+            "data corruption: not all bytes are 0xAB");
+    }
+
+    #[tokio::test]
     async fn concurrent_cas_writes_dedup_correctly() {
         let dir = tempfile::tempdir().unwrap();
         let store = std::sync::Arc::new(CasStore::new(dir.path()));

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -138,6 +138,7 @@ impl CasStore {
         }
 
         // Read-back verification only for files >= 1MB
+        // Small files: fsync guarantees integrity, verified=false to indicate skipped
         let verified = if size >= VERIFY_THRESHOLD {
             let stored = tokio::fs::read(&final_path).await.map_err(|e| {
                 MediaError::MediaStoreWrite {
@@ -155,7 +156,7 @@ impl CasStore {
             }
             true
         } else {
-            true
+            false // small file: verification skipped (fsync sufficient)
         };
 
         Ok(StoreResult {
@@ -299,7 +300,8 @@ mod tests {
 
         assert!(result.hash.starts_with("blake3:"));
         assert!(!result.deduplicated);
-        assert!(result.verified);
+        // Small files: verified=false (read-back skipped, fsync sufficient)
+        assert!(!result.verified);
         assert_eq!(result.size, data.len() as u64);
 
         let read_back = store.read(&result.hash).await.unwrap();

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -1,0 +1,750 @@
+//! Phase E: Deep E2E tests for media pipeline
+//!
+//! Tests the FULL pipeline end-to-end, targeting silent bugs:
+//! - Base64 edge cases (newlines, padding, URL-safe)
+//! - MIME detection edge cases
+//! - CAS store integrity under stress
+//! - MediaRef serde through the entire resolve_path pipeline
+//! - Error propagation — every error code must be exercisable
+//! - Budget enforcement under concurrent load
+//! - Backward compatibility — text-only workflows unchanged
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use std::sync::Arc;
+
+    use crate::media::detect::detect_mime;
+    use crate::media::error::MediaError;
+    use crate::media::processor::MediaProcessor;
+    use crate::media::store::CasStore;
+    use crate::media::types::{MediaBudget, MediaRef, MediaType};
+    use crate::mcp::types::{ContentBlock, ResourceContent, ToolCallResult};
+    use crate::store::RunContext;
+
+    // ═══════════════════════════════════════════════════════════════
+    // REAL BINARY DATA (actual file headers, not toy data)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Minimal valid PNG (1x1 pixel, RGBA)
+    fn real_png_bytes() -> Vec<u8> {
+        vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+            0x00, 0x00, 0x00, 0x0D, // IHDR chunk length
+            0x49, 0x48, 0x44, 0x52, // IHDR
+            0x00, 0x00, 0x00, 0x01, // width=1
+            0x00, 0x00, 0x00, 0x01, // height=1
+            0x08, 0x06,             // 8-bit RGBA
+            0x00, 0x00, 0x00,       // compression, filter, interlace
+            0x1F, 0x15, 0xC4, 0x89, // IHDR CRC
+            0x00, 0x00, 0x00, 0x0A, // IDAT chunk length
+            0x49, 0x44, 0x41, 0x54, // IDAT
+            0x78, 0x9C, 0x62, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE5, // zlib data
+            0x27, 0xDE, 0xFC, 0x07, // IDAT CRC
+            0x00, 0x00, 0x00, 0x00, // IEND chunk length
+            0x49, 0x45, 0x4E, 0x44, // IEND
+            0xAE, 0x42, 0x60, 0x82, // IEND CRC
+        ]
+    }
+
+    /// Minimal valid JPEG
+    fn real_jpeg_bytes() -> Vec<u8> {
+        vec![
+            0xFF, 0xD8, 0xFF, 0xE0, // SOI + APP0 marker
+            0x00, 0x10,             // APP0 length
+            0x4A, 0x46, 0x49, 0x46, 0x00, // JFIF\0
+            0x01, 0x01,             // version
+            0x00,                   // units
+            0x00, 0x01, 0x00, 0x01, // density
+            0x00, 0x00,             // thumbnail
+            0xFF, 0xD9,             // EOI
+        ]
+    }
+
+    /// MP3 frame header (ID3 tag)
+    fn real_mp3_bytes() -> Vec<u8> {
+        let mut data = vec![
+            0x49, 0x44, 0x33, // ID3
+            0x04, 0x00,       // version
+            0x00,             // flags
+            0x00, 0x00, 0x00, 0x00, // size
+        ];
+        // Pad to make it recognizable
+        data.extend_from_slice(&[0x00; 20]);
+        data
+    }
+
+    /// PDF header
+    fn real_pdf_bytes() -> Vec<u8> {
+        b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n".to_vec()
+    }
+
+    fn encode_b64(data: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(data)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #1: Base64 with newlines (PEM-style)
+    // Many MCP servers return base64 with \n line breaks.
+    // STANDARD engine rejects newlines → silent Base64DecodeFailed
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_base64_with_newlines_should_fail_gracefully() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        // Encode then add newlines (simulating PEM-style base64)
+        let png = real_png_bytes();
+        let b64 = encode_b64(&png);
+        let b64_with_newlines = b64.chars()
+            .enumerate()
+            .map(|(i, c)| if i > 0 && i % 76 == 0 { format!("\n{c}") } else { c.to_string() })
+            .collect::<String>();
+
+        let block = ContentBlock::image(b64_with_newlines, "image/png");
+        let result = processor.process(&block, "t_newline").await;
+
+        // This SHOULD fail with NIKA-256 (Base64DecodeFailed)
+        // If it silently succeeds with corrupted data, that's a bug
+        match result {
+            Err(e) => {
+                assert_eq!(e.code(), "NIKA-256", "Expected Base64DecodeFailed, got: {}", e);
+            }
+            Ok(Some((ref media_ref, _))) => {
+                // BUG: If it somehow decoded, verify the hash is correct
+                let expected_hash = format!("blake3:{}", blake3::hash(&png).to_hex());
+                assert_eq!(media_ref.hash, expected_hash,
+                    "SILENT BUG: base64 with newlines decoded to different data!");
+            }
+            Ok(None) => {
+                panic!("SILENT BUG: image block returned None (should be Some or Err)");
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #2: Base64 with URL-safe characters
+    // Some servers use URL-safe base64 (- and _ instead of + and /)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_base64_url_safe_should_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        // URL-safe base64 uses - instead of + and _ instead of /
+        let url_safe = base64::engine::general_purpose::URL_SAFE.encode(real_png_bytes());
+        let block = ContentBlock::image(url_safe, "image/png");
+        let result = processor.process(&block, "t_urlsafe").await;
+
+        // Should either fail or decode correctly
+        // If STANDARD engine silently produces wrong data, that's a bug
+        match result {
+            Err(e) => {
+                // Expected: URL-safe chars are invalid in STANDARD base64
+                assert!(e.code() == "NIKA-256" || e.code() == "NIKA-251",
+                    "Unexpected error: {}", e);
+            }
+            Ok(Some((media_ref, _))) => {
+                // If it decoded, verify correctness
+                assert!(media_ref.hash.starts_with("blake3:"));
+                assert!(media_ref.size_bytes > 0);
+            }
+            Ok(None) => {
+                panic!("SILENT BUG: image block returned None");
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #3: Base64 padding variants
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_base64_no_padding_should_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let b64 = encode_b64(&real_png_bytes());
+        let no_padding = b64.trim_end_matches('=').to_string();
+        let block = ContentBlock::image(no_padding, "image/png");
+        let result = processor.process(&block, "t_nopad").await;
+
+        // STANDARD engine REQUIRES padding → should fail
+        // If it silently produces corrupted data, that's a critical bug
+        match result {
+            Err(e) => assert_eq!(e.code(), "NIKA-256"),
+            Ok(Some(_)) => {
+                // Some base64 impls accept no-padding; verify data integrity
+            }
+            Ok(None) => panic!("SILENT BUG: image block returned None"),
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #4: MIME mismatch (server says audio, bytes are image)
+    // Should log warning but still detect correctly
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_mime_category_mismatch_uses_magic_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        // Send PNG data with audio/wav MIME type
+        let block = ContentBlock::image(encode_b64(&real_png_bytes()), "audio/wav");
+        let result = processor.process(&block, "t_mismatch").await;
+
+        match result {
+            Ok(Some((media_ref, _))) => {
+                // Magic bytes MUST win over server declaration
+                assert_eq!(media_ref.mime_type, "image/png",
+                    "SILENT BUG: server MIME type overrode magic bytes detection! Got: {}",
+                    media_ref.mime_type);
+                assert_eq!(media_ref.extension, "png");
+            }
+            Ok(None) => panic!("SILENT BUG: image data returned None"),
+            Err(e) => panic!("Unexpected error on valid PNG data: {}", e),
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #5: Resource with blob but no mime_type
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_resource_blob_no_mime() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let rc = ResourceContent::new("file:///image.png")
+            .with_blob(encode_b64(&real_png_bytes()));
+        // No mime_type set — processor must detect from magic bytes
+        let block = ContentBlock::Resource(rc);
+        let result = processor.process(&block, "t_nomime").await;
+
+        match result {
+            Ok(Some((media_ref, _))) => {
+                assert_eq!(media_ref.mime_type, "image/png",
+                    "SILENT BUG: MIME not detected from magic bytes when server hint missing");
+            }
+            Ok(None) => panic!("SILENT BUG: resource with blob returned None"),
+            Err(e) => panic!("SILENT BUG: valid PNG blob failed: {}", e),
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #6: Resource with text only (no blob) must return None
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_resource_text_only_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let rc = ResourceContent::new("file:///readme.md")
+            .with_text("# Hello World");
+        let block = ContentBlock::Resource(rc);
+        let result = processor.process(&block, "t_textonly").await.unwrap();
+        assert!(result.is_none(), "Text-only resource should return None, not store in CAS");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #7: CAS dedup produces consistent hash
+    // Two different JPEG encodings of "same visual" produce different hashes
+    // But same bytes MUST produce same hash (content-addressed)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_cas_dedup_same_bytes_same_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = real_png_bytes();
+        let r1 = store.store(&data).await.unwrap();
+        let r2 = store.store(&data).await.unwrap();
+
+        assert_eq!(r1.hash, r2.hash, "Same bytes must produce same hash");
+        assert!(!r1.deduplicated, "First write should not be dedup");
+        assert!(r2.deduplicated, "Second write must be dedup");
+
+        // Verify read-back matches original
+        let read_back = store.read(&r1.hash).await.unwrap();
+        assert_eq!(read_back, data, "SILENT BUG: read-back data corrupted!");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #8: CAS path does NOT contain extension
+    // If extension leaks into path, dedup breaks for jpeg vs jpg
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_cas_path_never_has_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let r = store.store(&real_png_bytes()).await.unwrap();
+        let filename = r.path.file_name().unwrap().to_string_lossy();
+
+        assert!(!filename.ends_with(".png"), "SILENT BUG: CAS filename has .png extension: {}", filename);
+        assert!(!filename.ends_with(".jpg"), "SILENT BUG: CAS filename has .jpg extension: {}", filename);
+        assert!(!filename.contains('.'), "SILENT BUG: CAS filename contains dot: {}", filename);
+        // Also verify the parent is a 2-char shard directory
+        let shard = r.path.parent().unwrap().file_name().unwrap().to_string_lossy();
+        assert_eq!(shard.len(), 2, "Shard directory should be 2 chars: {}", shard);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #9: media_staging lifecycle
+    // set_media → take_media must not leak
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_media_staging_set_then_take() {
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "test_task".into();
+
+        let refs = vec![MediaRef {
+            hash: "blake3:abc123".into(),
+            mime_type: "image/png".into(),
+            size_bytes: 1024,
+            path: "/tmp/store/ab/c123".into(),
+            extension: "png".into(),
+            created_by: "test_task".into(),
+        }];
+
+        ctx.set_media(&task_id, refs.clone());
+
+        // First take should return the refs
+        let taken = ctx.take_media(&task_id);
+        assert_eq!(taken.len(), 1, "take_media should return staged refs");
+        assert_eq!(taken[0].hash, "blake3:abc123");
+
+        // Second take should return empty (drained)
+        let taken_again = ctx.take_media(&task_id);
+        assert!(taken_again.is_empty(), "SILENT BUG: take_media didn't drain staging");
+    }
+
+    #[test]
+    fn e2e_media_staging_empty_vec_not_stored() {
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "empty_task".into();
+
+        // set_media with empty vec should be a no-op
+        ctx.set_media(&task_id, vec![]);
+
+        let taken = ctx.take_media(&task_id);
+        assert!(taken.is_empty(), "Empty vec should not be stored in staging");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #10: TaskResult.media survives with_media
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_task_result_with_media_attaches() {
+        use std::time::Duration;
+        use crate::store::TaskResult;
+
+        let tr = TaskResult::success(serde_json::json!("ok"), Duration::from_millis(100));
+        assert!(tr.media.is_empty(), "New TaskResult should have empty media");
+
+        let refs = vec![MediaRef {
+            hash: "blake3:deadbeef".into(),
+            mime_type: "image/png".into(),
+            size_bytes: 2048,
+            path: "/tmp/store/de/adbeef".into(),
+            extension: "png".into(),
+            created_by: "gen".into(),
+        }];
+
+        let tr = tr.with_media(refs);
+        assert_eq!(tr.media.len(), 1);
+        assert_eq!(tr.media[0].hash, "blake3:deadbeef");
+        assert!(tr.is_success(), "with_media should not change status");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #11: ToolCallResult backward compat
+    // text() must ONLY extract Text blocks, ignore Image/Audio
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_text_extraction_ignores_media_completely() {
+        let result = ToolCallResult::success(vec![
+            ContentBlock::text("visible text"),
+            ContentBlock::image("SGVsbG8=", "image/png"),
+            ContentBlock::audio("AAAA", "audio/wav"),
+            ContentBlock::resource(ResourceContent::new("file:///test").with_text("resource text")),
+            ContentBlock::resource_link("file:///link", None, None),
+            ContentBlock::text("more text"),
+        ]);
+
+        // text() must only join Text blocks
+        assert_eq!(result.text(), "visible text\nmore text",
+            "SILENT BUG: text() includes non-text content!");
+        assert_eq!(result.first_text(), Some("visible text"));
+
+        // media helpers must exclude Text
+        assert!(result.has_media());
+        assert_eq!(result.media_blocks().len(), 4); // image, audio, resource, resource_link
+        assert_eq!(result.images().len(), 1);
+        assert_eq!(result.audio_blocks().len(), 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #12: MIME case normalization end-to-end
+    // "IMAGE/PNG" from server must normalize to "image/png"
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_mime_case_normalization() {
+        let png = real_png_bytes();
+
+        // Test uppercase server MIME
+        let result = detect_mime(&png, Some("IMAGE/PNG")).unwrap();
+        assert_eq!(result.mime_type, "image/png",
+            "SILENT BUG: uppercase MIME not normalized: {}", result.mime_type);
+
+        // Test mixed case
+        let result = detect_mime(&png, Some("Image/Png")).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #13: PDF detection (application/pdf)
+    // PDF is a P0 type — must detect correctly
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_pdf_detection() {
+        let pdf = real_pdf_bytes();
+        let result = detect_mime(&pdf, None).unwrap();
+        assert_eq!(result.mime_type, "application/pdf",
+            "SILENT BUG: PDF not detected: {}", result.mime_type);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #14: MediaBudget race condition
+    // Concurrent check_and_add must not exceed budget
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_budget_concurrent_enforcement() {
+        let budget = Arc::new(MediaBudget::with_max_per_run(1000));
+
+        let handles: Vec<_> = (0..20)
+            .map(|i| {
+                let budget = Arc::clone(&budget);
+                tokio::spawn(async move {
+                    budget.check_and_add(100, &format!("t{i}"))
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|h| h.unwrap())
+            .collect();
+
+        let successes = results.iter().filter(|r| r.is_ok()).count();
+        let failures = results.iter().filter(|r| r.is_err()).count();
+
+        // Budget is 1000, each request is 100 → exactly 10 should succeed
+        assert_eq!(successes, 10,
+            "SILENT BUG: budget allowed {} of 20 (expected 10)", successes);
+        assert_eq!(failures, 10,
+            "SILENT BUG: budget rejected {} of 20 (expected 10)", failures);
+
+        // Final bytes should be exactly 1000
+        assert_eq!(budget.current_bytes(), 1000,
+            "SILENT BUG: budget tracking off: {}", budget.current_bytes());
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #15: Error code coverage
+    // Every NIKA-25x code must be exercisable
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_all_error_codes_covered() {
+        let errors: Vec<MediaError> = vec![
+            MediaError::mime_detection_failed(0, None),
+            MediaError::UnsupportedMediaType {
+                mime_type: "video/mp4".into(),
+                reason: "not supported".into(),
+            },
+            MediaError::MediaNotFound { hash: "blake3:xxx".into() },
+            MediaError::HashMismatch {
+                expected: "blake3:aaa".into(),
+                actual: "blake3:bbb".into(),
+            },
+            MediaError::MediaStoreWrite {
+                path: "/tmp/fail".into(),
+                source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+            },
+            MediaError::Base64DecodeFailed {
+                source_desc: "test".into(),
+                reason: "bad".into(),
+            },
+            MediaError::Base64InputTooLarge { size: 200, max: 100 },
+            MediaError::EmptyMediaContent { task_id: "t1".into() },
+            MediaError::RunBudgetExceeded { current: 600, max: 500 },
+        ];
+
+        let expected_codes = [
+            "NIKA-251", "NIKA-252", "NIKA-253", "NIKA-254",
+            "NIKA-255", "NIKA-256", "NIKA-257", "NIKA-258", "NIKA-259",
+        ];
+
+        for (i, (err, expected_code)) in errors.iter().zip(expected_codes.iter()).enumerate() {
+            assert_eq!(err.code(), *expected_code,
+                "Error {i} code mismatch: expected {expected_code}, got {}", err.code());
+            // Verify Display impl doesn't panic
+            let display = format!("{}", err);
+            assert!(!display.is_empty(), "Error {i} Display is empty");
+            // Verify it contains the NIKA code
+            assert!(display.contains(expected_code),
+                "Error {i} Display missing code: {display}");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #16: Full pipeline PNG → CAS → MediaRef → Serde
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_full_pipeline_png() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let png = real_png_bytes();
+        let b64 = encode_b64(&png);
+        let block = ContentBlock::image(b64, "image/png");
+
+        let result = processor.process(&block, "gen_img").await
+            .expect("process should succeed")
+            .expect("image block should produce Some");
+
+        let (media_ref, store_result) = result;
+
+        // Verify MediaRef
+        assert!(media_ref.hash.starts_with("blake3:"), "hash missing prefix");
+        assert_eq!(media_ref.mime_type, "image/png");
+        assert_eq!(media_ref.extension, "png");
+        assert_eq!(media_ref.size_bytes, png.len() as u64);
+        assert_eq!(media_ref.created_by, "gen_img");
+        assert!(media_ref.path.exists(), "CAS file should exist at {:?}", media_ref.path);
+
+        // Verify StoreResult
+        assert!(!store_result.deduplicated);
+        assert!(store_result.verified);
+        assert!(store_result.pipeline_ms < 1000, "pipeline took too long: {}ms", store_result.pipeline_ms);
+
+        // Verify CAS file content matches original
+        let stored_data = tokio::fs::read(&media_ref.path).await.unwrap();
+        assert_eq!(stored_data, png, "SILENT BUG: stored data doesn't match original!");
+
+        // Verify MediaRef serializes correctly
+        let json = serde_json::to_value(&media_ref).unwrap();
+        assert_eq!(json["mime_type"], "image/png");
+        assert!(json["hash"].as_str().unwrap().starts_with("blake3:"));
+        assert_eq!(json["size_bytes"], png.len() as u64);
+        assert_eq!(json["extension"], "png");
+        assert_eq!(json["created_by"], "gen_img");
+
+        // Verify MediaRef deserializes back
+        let back: MediaRef = serde_json::from_value(json).unwrap();
+        assert_eq!(back, media_ref);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #17: Full pipeline JPEG
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_full_pipeline_jpeg() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let jpeg = real_jpeg_bytes();
+        let block = ContentBlock::image(encode_b64(&jpeg), "image/jpeg");
+
+        let result = processor.process(&block, "gen_jpg").await
+            .expect("process should succeed")
+            .expect("should produce Some");
+
+        let (media_ref, _) = result;
+        assert_eq!(media_ref.mime_type, "image/jpeg");
+        assert!(media_ref.extension == "jpg" || media_ref.extension == "jpe",
+            "JPEG extension should be jpg or jpe, got: {}", media_ref.extension);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #18: process_all error attribution
+    // Errors must carry the correct block index
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_process_all_error_attribution() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let blocks = vec![
+            ContentBlock::text("header"),                              // index 0: skipped
+            ContentBlock::image(encode_b64(&real_png_bytes()), "image/png"), // index 1: success
+            ContentBlock::image("INVALID_BASE64!!!", "image/png"),     // index 2: failure
+            ContentBlock::text("footer"),                              // index 3: skipped
+        ];
+
+        let results = processor.process_all(&blocks, "multi").await;
+
+        // Should have 2 results (text blocks are skipped)
+        assert_eq!(results.len(), 2, "Expected 2 results (1 success + 1 failure)");
+
+        // First should be success (PNG at index 1)
+        assert!(results[0].is_ok(), "PNG at index 1 should succeed");
+
+        // Second should be error with block_index = 2
+        match &results[1] {
+            Err((idx, e)) => {
+                assert_eq!(*idx, 2, "Error should reference block index 2, got {}", idx);
+                assert_eq!(e.code(), "NIKA-256", "Should be Base64DecodeFailed");
+            }
+            Ok(_) => panic!("SILENT BUG: invalid base64 succeeded!"),
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #19: ContentBlock serde roundtrip with ALL fields
+    // Particularly test that Resource(ResourceContent) works with
+    // internally tagged serde
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_content_block_resource_serde_with_all_fields() {
+        let rc = ResourceContent::new("file:///data.json")
+            .with_mime_type("application/json")
+            .with_text(r#"{"key": "value"}"#)
+            .with_blob("SGVsbG8=");
+
+        let block = ContentBlock::Resource(rc);
+        let json = serde_json::to_string(&block).unwrap();
+
+        // Must contain the type tag
+        assert!(json.contains(r#""type":"resource""#),
+            "SILENT BUG: Resource variant missing type tag in JSON: {}", json);
+
+        // Must roundtrip
+        let back: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(block, back, "Resource serde roundtrip failed");
+
+        // Verify all fields present
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["uri"], "file:///data.json");
+        assert_eq!(val["mimeType"], "application/json");
+        assert_eq!(val["text"], r#"{"key": "value"}"#);
+        assert_eq!(val["blob"], "SGVsbG8=");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #20: NikaError::MediaError propagation
+    // MediaError must convert to NikaError and preserve code
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_media_error_to_nika_error() {
+        use crate::error::NikaError;
+
+        let media_err = MediaError::MediaNotFound { hash: "blake3:test".into() };
+        let nika_err: NikaError = media_err.into();
+
+        assert_eq!(nika_err.code(), "NIKA-253",
+            "SILENT BUG: MediaError code lost in NikaError conversion");
+
+        // Display must contain the code
+        let display = format!("{}", nika_err);
+        assert!(display.contains("NIKA-253"), "Display missing code: {}", display);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #21: CAS store concurrent stress test
+    // 50 tasks, mixed data → verify no data corruption
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_cas_concurrent_mixed_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CasStore::new(dir.path()));
+
+        let datasets: Vec<Vec<u8>> = (0..5).map(|i| {
+            let mut data = real_png_bytes();
+            data.push(i as u8); // Make each unique
+            data
+        }).collect();
+
+        // 50 concurrent writes (10 per unique dataset)
+        let handles: Vec<_> = (0..50).map(|i| {
+            let store = Arc::clone(&store);
+            let data = datasets[i % 5].clone();
+            tokio::spawn(async move { store.store(&data).await })
+        }).collect();
+
+        let results: Vec<_> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|h| h.unwrap().unwrap())
+            .collect();
+
+        // Should have exactly 5 unique hashes
+        let mut unique_hashes: Vec<_> = results.iter().map(|r| r.hash.clone()).collect();
+        unique_hashes.sort();
+        unique_hashes.dedup();
+        assert_eq!(unique_hashes.len(), 5,
+            "SILENT BUG: expected 5 unique hashes, got {}", unique_hashes.len());
+
+        // Verify each dataset can be read back correctly
+        // We can't rely on result ordering (concurrent tasks), so compute expected hash
+        for (i, data) in datasets.iter().enumerate() {
+            let expected_hash = format!("blake3:{}", blake3::hash(data).to_hex());
+            let read_back = store.read(&expected_hash).await.unwrap();
+            assert_eq!(&read_back, data,
+                "SILENT BUG: dataset {i} read-back mismatch");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SILENT BUG #22: MediaType classification edge cases
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn e2e_media_type_edge_cases() {
+        // Standard cases
+        assert_eq!(MediaType::from_mime("image/png"), MediaType::Image);
+        assert_eq!(MediaType::from_mime("audio/mpeg"), MediaType::Audio);
+        assert_eq!(MediaType::from_mime("application/pdf"), MediaType::Document);
+
+        // Edge cases
+        assert_eq!(MediaType::from_mime("image/svg+xml"), MediaType::Image);
+        assert_eq!(MediaType::from_mime("audio/x-wav"), MediaType::Audio);
+        assert_eq!(MediaType::from_mime("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+            MediaType::Document);
+
+        // Unknown types
+        assert_eq!(MediaType::from_mime("video/mp4"), MediaType::Unknown);
+        assert_eq!(MediaType::from_mime("text/html"), MediaType::Unknown);
+        assert_eq!(MediaType::from_mime(""), MediaType::Unknown);
+        assert_eq!(MediaType::from_mime("garbage"), MediaType::Unknown);
+    }
+}

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -1321,4 +1321,147 @@ mod tests {
         assert_eq!(json["hash"], "blake3:abcdef1234567890");
         assert_eq!(json["size_bytes"], 12345);
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PHASE E4: RESOLVE_PATH MEDIA BINDING TESTS
+    // Tests {{with.task.media}}, {{with.task.media[0].hash}}, etc.
+    // ═══════════════════════════════════════════════════════════════
+
+    fn setup_ctx_with_media() -> (RunContext, Arc<str>) {
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "gen_img".into();
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!("image generated"),
+            std::time::Duration::from_millis(100),
+        ).with_media(vec![
+            MediaRef {
+                hash: "blake3:aabbccdd11223344".into(),
+                mime_type: "image/png".into(),
+                size_bytes: 4096,
+                path: std::path::PathBuf::from("/tmp/store/aa/bbccdd11223344"),
+                extension: "png".into(),
+                created_by: "gen_img".into(),
+            },
+            MediaRef {
+                hash: "blake3:eeff0011aabbccdd".into(),
+                mime_type: "audio/mpeg".into(),
+                size_bytes: 8192,
+                path: std::path::PathBuf::from("/tmp/store/ee/ff0011aabbccdd"),
+                extension: "mp3".into(),
+                created_by: "gen_img".into(),
+            },
+        ]);
+        ctx.insert(Arc::clone(&task_id), tr);
+        (ctx, task_id)
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_full_array() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media");
+        assert!(result.is_some(), "resolve_path('gen_img.media') should return Some");
+        let arr = result.unwrap();
+        assert!(arr.is_array(), "media should be an array");
+        assert_eq!(arr.as_array().unwrap().len(), 2, "should have 2 media refs");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_first_hash() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].hash");
+        assert!(result.is_some(), "resolve_path('gen_img.media[0].hash') should return Some");
+        assert_eq!(result.unwrap(), "blake3:aabbccdd11223344");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_first_mime_type() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].mime_type");
+        assert!(result.is_some(), "resolve_path('gen_img.media[0].mime_type') should return Some");
+        assert_eq!(result.unwrap(), "image/png");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_second_hash() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[1].hash");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), "blake3:eeff0011aabbccdd");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_first_size_bytes() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].size_bytes");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), 4096);
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_first_path() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].path");
+        assert!(result.is_some());
+        let path_val = result.unwrap();
+        assert!(path_val.as_str().unwrap().contains("store/aa/bbccdd11223344"),
+            "path should contain CAS location: {}", path_val);
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_first_extension() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].extension");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), "png");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_first_created_by() {
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].created_by");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), "gen_img");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_empty() {
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "no_media".into();
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!("text only"),
+            std::time::Duration::from_millis(10),
+        );
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        let result = ctx.resolve_path("no_media.media");
+        assert!(result.is_some());
+        let arr = result.unwrap();
+        assert!(arr.is_array());
+        assert!(arr.as_array().unwrap().is_empty(), "empty media should return []");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_nonexistent_task() {
+        let ctx = RunContext::new();
+        let result = ctx.resolve_path("nonexistent.media");
+        assert!(result.is_none(), "nonexistent task should return None");
+    }
+
+    #[test]
+    fn e2e_resolve_path_normal_output_still_works() {
+        // Verify media interception doesn't break normal output resolution
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "weather".into();
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({"temperature": 22, "city": "Paris"}),
+            std::time::Duration::from_millis(50),
+        );
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        let temp = ctx.resolve_path("weather.temperature");
+        assert_eq!(temp, Some(serde_json::json!(22)));
+
+        let city = ctx.resolve_path("weather.city");
+        assert_eq!(city, Some(serde_json::json!("Paris")));
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -2626,4 +2626,393 @@ mod tests {
         let whole = ctx.resolve_path("roundtrip.media[0]").unwrap();
         assert_eq!(whole.as_object().unwrap().len(), 6);
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PHASE G: EXHAUSTIVE MIME DETECTION & PROCESSOR EDGE-CASE TESTS
+    // ═══════════════════════════════════════════════════════════════
+
+    // ---------------------------------------------------------------
+    // G1. MIME detection with ALL P0 types from the plan
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn g_detect_png_magic_bytes_89504e47() {
+        let png = real_png_bytes();
+        let result = detect_mime(&png, None).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+        assert_eq!(result.extension, "png");
+        assert_eq!(result.source, crate::media::detect::DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn g_detect_jpeg_magic_bytes_ffd8ff() {
+        let jpeg = real_jpeg_bytes();
+        let result = detect_mime(&jpeg, None).unwrap();
+        assert_eq!(result.mime_type, "image/jpeg");
+        assert_eq!(result.source, crate::media::detect::DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn g_detect_webp_riff_webp_vp8() {
+        let webp = vec![
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x24, 0x00, 0x00, 0x00, // chunk size
+            0x57, 0x45, 0x42, 0x50, // WEBP
+            0x56, 0x50, 0x38, 0x20, // "VP8 "
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let result = detect_mime(&webp, None).unwrap();
+        assert_eq!(result.mime_type, "image/webp");
+        assert_eq!(result.source, crate::media::detect::DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn g_detect_mp3_with_id3v2_tag() {
+        let mp3 = real_mp3_bytes();
+        let result = detect_mime(&mp3, None).unwrap();
+        assert!(
+            result.mime_type == "audio/mpeg" || result.mime_type == "audio/mp3",
+            "Expected audio/mpeg or audio/mp3, got: {}", result.mime_type
+        );
+        assert_eq!(result.source, crate::media::detect::DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn g_detect_mp3_ff_fb_sync_word() {
+        // MP3 frame sync: FF FB (MPEG1, Layer 3, no CRC)
+        let mut frame = vec![0xFF, 0xFB, 0x90, 0x00];
+        frame.extend_from_slice(&[0x00; 413]);
+        let result = detect_mime(&frame, None);
+        match result {
+            Ok(d) => {
+                assert!(
+                    d.mime_type.contains("mpeg") || d.mime_type.contains("mp3"),
+                    "FF FB sync should detect as MP3, got: {}", d.mime_type
+                );
+            }
+            Err(_) => {
+                // Server hint rescue
+                let rescued = detect_mime(&frame, Some("audio/mpeg")).unwrap();
+                assert_eq!(rescued.mime_type, "audio/mpeg");
+                assert_eq!(rescued.source, crate::media::detect::DetectionSource::ServerHint);
+            }
+        }
+    }
+
+    #[test]
+    fn g_detect_wav_riff_wave_with_fmt() {
+        let wav = vec![
+            0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+            0x57, 0x41, 0x56, 0x45, 0x66, 0x6D, 0x74, 0x20,
+            0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+            0x44, 0xAC, 0x00, 0x00, 0x88, 0x58, 0x01, 0x00,
+            0x02, 0x00, 0x10, 0x00,
+        ];
+        let result = detect_mime(&wav, None).unwrap();
+        assert!(result.mime_type.contains("wav"),
+            "WAV MIME expected, got: {}", result.mime_type);
+        assert_eq!(result.source, crate::media::detect::DetectionSource::MagicBytes);
+    }
+
+    #[test]
+    fn g_detect_pdf_percent_pdf_header() {
+        let pdf = real_pdf_bytes();
+        let result = detect_mime(&pdf, None).unwrap();
+        assert_eq!(result.mime_type, "application/pdf");
+        assert_eq!(result.extension, "pdf");
+        assert_eq!(result.source, crate::media::detect::DetectionSource::MagicBytes);
+    }
+
+    // ---------------------------------------------------------------
+    // G2. MIME edge cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn g_png_4_bytes_only_too_short_for_full_signature() {
+        // 4 bytes: 89 50 4E 47 — missing 0D 0A 1A 0A
+        let short = vec![0x89, 0x50, 0x4E, 0x47];
+        let result = detect_mime(&short, None);
+        match result {
+            Ok(d) => assert!(d.mime_type == "image/png",
+                "If detected with only 4 bytes, must still be PNG, got: {}", d.mime_type),
+            Err(_) => {} // expected
+        }
+    }
+
+    #[test]
+    fn g_null_bytes_common_in_binary_formats() {
+        let null_data = vec![0x00; 128];
+        let result = detect_mime(&null_data, None);
+        assert!(result.is_err(),
+            "128 null bytes should not match any known MIME type");
+    }
+
+    #[test]
+    fn g_null_bytes_with_server_hint_accepted() {
+        let null_data = vec![0x00; 128];
+        let result = detect_mime(&null_data, Some("audio/flac")).unwrap();
+        assert_eq!(result.mime_type, "audio/flac");
+        assert_eq!(result.source, crate::media::detect::DetectionSource::ServerHint);
+    }
+
+    #[test]
+    fn g_large_sample_over_8192_only_first_inspected() {
+        let mut data = real_png_bytes();
+        data.extend(vec![0xCC; 10_000]);
+        assert!(data.len() > 8192);
+        let result = detect_mime(&data, None).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+    }
+
+    #[test]
+    fn g_magic_bytes_at_offset_8192_not_detected() {
+        let mut data = vec![0x00; 8192];
+        data.extend_from_slice(&real_png_bytes());
+        let result = detect_mime(&data, None);
+        assert!(result.is_err(),
+            "PNG magic at offset 8192 should be beyond inspection window");
+    }
+
+    #[test]
+    fn g_exactly_8192_bytes_with_header() {
+        let mut data = real_png_bytes();
+        data.resize(8192, 0x00);
+        let result = detect_mime(&data, None).unwrap();
+        assert_eq!(result.mime_type, "image/png");
+    }
+
+    // ---------------------------------------------------------------
+    // G3. Processor with realistic MCP responses
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn g_process_single_text_returns_none_and_process_all_empty() {
+        let (processor, _dir) = make_processor_e2e();
+        let block = ContentBlock::text("Hello MCP");
+        assert!(processor.process(&block, "t1").await.unwrap().is_none());
+        assert!(processor.process_all(&[block], "t1").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn g_process_all_1_image_1_text_returns_1() {
+        let (processor, _dir) = make_processor_e2e();
+        let blocks = vec![
+            ContentBlock::image(encode_b64(&real_png_bytes()), "image/png"),
+            ContentBlock::text("Caption"),
+        ];
+        let results = processor.process_all(&blocks, "it1").await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+        assert_eq!(results[0].as_ref().unwrap().0.mime_type, "image/png");
+    }
+
+    #[tokio::test]
+    async fn g_process_all_5_images_2_audio_returns_7() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let budget = MediaBudget::with_max_per_run(50 * 1024 * 1024);
+        let processor = MediaProcessor::with_budget(store, budget);
+
+        let mut blocks = Vec::new();
+        for i in 0..5u8 {
+            let mut png = real_png_bytes();
+            png.push(i);
+            blocks.push(ContentBlock::image(encode_b64(&png), "image/png"));
+        }
+        for i in 0..2u8 {
+            let mut mp3 = real_mp3_bytes();
+            mp3.push(200 + i);
+            blocks.push(ContentBlock::audio(encode_b64(&mp3), "audio/mpeg"));
+        }
+
+        let results = processor.process_all(&blocks, "g_batch7").await;
+        assert_eq!(results.len(), 7, "5 images + 2 audio = 7 results");
+
+        let (img, aud) = results.iter().fold((0usize, 0usize), |(i, a), r| {
+            let mr = &r.as_ref().unwrap().0;
+            if mr.mime_type.starts_with("image/") { (i + 1, a) }
+            else if mr.mime_type.starts_with("audio/") { (i, a + 1) }
+            else { (i, a) }
+        });
+        assert_eq!(img, 5);
+        assert_eq!(aud, 2);
+
+        // All hashes unique
+        let mut hashes: Vec<_> = results.iter()
+            .map(|r| r.as_ref().unwrap().0.hash.clone()).collect();
+        hashes.sort();
+        hashes.dedup();
+        assert_eq!(hashes.len(), 7);
+    }
+
+    #[tokio::test]
+    async fn g_process_all_all_failures_correct_indices() {
+        let (processor, _dir) = make_processor_e2e();
+        let blocks = vec![
+            ContentBlock::text("skip"),                           // 0
+            ContentBlock::image("BAD1!!!", "image/png"),          // 1
+            ContentBlock::text("skip"),                           // 2
+            ContentBlock::audio("BAD2!!!", "audio/wav"),          // 3
+            ContentBlock::image("BAD3!!!", "image/jpeg"),         // 4
+        ];
+        let results = processor.process_all(&blocks, "g_allfail").await;
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|r| r.is_err()));
+        let indices: Vec<usize> = results.iter()
+            .map(|r| r.as_ref().unwrap_err().0).collect();
+        assert_eq!(indices, vec![1, 3, 4]);
+        for r in &results {
+            assert_eq!(r.as_ref().unwrap_err().1.code(), "NIKA-256");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // G4. Base64 edge cases in processor
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn g_base64_valid_unrecognizable_bytes_nika_251() {
+        let (processor, _dir) = make_processor_e2e();
+        // Bytes that don't match any known magic signature
+        let random = vec![
+            0x07, 0x13, 0x29, 0x37, 0x41, 0x53, 0x67, 0x71,
+            0x83, 0x97, 0xA1, 0xB3, 0xC7, 0xD1, 0xE3, 0xF7,
+        ];
+        let block = ContentBlock::image(encode_b64(&random), "application/octet-stream");
+        let result = processor.process(&block, "g_unknown").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), "NIKA-251",
+            "Valid base64 decoding to unidentifiable bytes + octet-stream -> NIKA-251");
+    }
+
+    #[tokio::test]
+    async fn g_base64_crlf_line_breaks_succeeds() {
+        let (processor, _dir) = make_processor_e2e();
+        let png = real_png_bytes();
+        let b64 = encode_b64(&png);
+        let with_crlf: String = b64.chars()
+            .enumerate()
+            .map(|(i, c)| if i > 0 && i % 76 == 0 { format!("\r\n{c}") } else { c.to_string() })
+            .collect();
+        assert!(with_crlf.contains("\r\n"));
+
+        let block = ContentBlock::image(with_crlf, "image/png");
+        let (mr, _) = processor.process(&block, "g_crlf").await
+            .expect("CRLF base64 should succeed").expect("Some");
+        assert_eq!(mr.hash, format!("blake3:{}", blake3::hash(&png).to_hex()));
+        assert_eq!(mr.mime_type, "image/png");
+    }
+
+    #[tokio::test]
+    async fn g_base64_tab_characters_succeeds() {
+        let (processor, _dir) = make_processor_e2e();
+        let png = real_png_bytes();
+        let b64 = encode_b64(&png);
+        let with_tabs: String = b64.chars()
+            .enumerate()
+            .map(|(i, c)| if i > 0 && i % 25 == 0 { format!("\t{c}") } else { c.to_string() })
+            .collect();
+        assert!(with_tabs.contains('\t'));
+
+        let block = ContentBlock::image(with_tabs, "image/png");
+        let (mr, _) = processor.process(&block, "g_tabs").await
+            .expect("tab base64 should succeed").expect("Some");
+        assert_eq!(mr.hash, format!("blake3:{}", blake3::hash(&png).to_hex()));
+    }
+
+    // ---------------------------------------------------------------
+    // G5. Budget edge cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn g_budget_zero_rejects_any_addition() {
+        let budget = MediaBudget::with_max_per_run(0);
+        let err = budget.check_and_add(1, "t1").unwrap_err();
+        assert_eq!(err.code(), "NIKA-259");
+        assert_eq!(budget.current_bytes(), 0);
+    }
+
+    #[test]
+    fn g_budget_zero_accepts_zero_size() {
+        let budget = MediaBudget::with_max_per_run(0);
+        // 0 + 0 = 0 which is NOT > 0
+        assert!(budget.check_and_add(0, "t1").is_ok());
+    }
+
+    #[test]
+    fn g_budget_u64_max_accepts_large_additions() {
+        let budget = MediaBudget::with_max_per_run(u64::MAX);
+        for i in 0..50 {
+            assert!(budget.check_and_add(1_000_000, &format!("t{i}")).is_ok());
+        }
+        assert_eq!(budget.current_bytes(), 50_000_000);
+    }
+
+    #[test]
+    fn g_budget_u64_max_half_plus_half_succeeds() {
+        let budget = MediaBudget::with_max_per_run(u64::MAX);
+        let half = u64::MAX / 2;
+        assert!(budget.check_and_add(half, "t1").is_ok());
+        assert!(budget.check_and_add(half, "t2").is_ok());
+        // u64::MAX / 2 * 2 = u64::MAX - 1 (since MAX is odd)
+        // One more byte should succeed
+        assert!(budget.check_and_add(1, "t3").is_ok());
+        assert_eq!(budget.current_bytes(), u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn g_shared_budget_3_processors_total_enforced() {
+        let budget = Arc::new(MediaBudget::with_max_per_run(150));
+        let dirs: Vec<_> = (0..3).map(|_| tempfile::tempdir().unwrap()).collect();
+        let procs: Vec<_> = dirs.iter().map(|d|
+            MediaProcessor::with_shared_budget(CasStore::new(d.path()), Arc::clone(&budget))
+        ).collect();
+
+        let b64 = encode_b64(&real_png_bytes());
+
+        assert!(procs[0].process(&ContentBlock::image(b64.clone(), "image/png"), "p0").await.is_ok());
+        assert!(procs[1].process(&ContentBlock::image(b64.clone(), "image/png"), "p1").await.is_ok());
+        let r3 = procs[2].process(&ContentBlock::image(b64.clone(), "image/png"), "p2").await;
+        assert!(r3.is_err());
+        assert_eq!(r3.unwrap_err().code(), "NIKA-259");
+
+        let png_size = real_png_bytes().len() as u64;
+        assert_eq!(budget.current_bytes(), 2 * png_size);
+    }
+
+    // ---------------------------------------------------------------
+    // G6. MediaRef created_by field
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn g_created_by_matches_exact_task_id() {
+        let (processor, _dir) = make_processor_e2e();
+        let block = ContentBlock::image(encode_b64(&real_png_bytes()), "image/png");
+        let (mr, _) = processor.process(&block, "precise_task_42").await.unwrap().unwrap();
+        assert_eq!(mr.created_by, "precise_task_42");
+    }
+
+    #[tokio::test]
+    async fn g_created_by_unicode_task_ids() {
+        let (processor, _dir) = make_processor_e2e();
+        let block = ContentBlock::image(encode_b64(&real_png_bytes()), "image/png");
+        for id in [
+            "\u{1F98B}_butterfly",
+            "\u{4F60}\u{597D}_hello",
+            "caf\u{00E9}_task",
+            "\u{0410}\u{0411}\u{0412}_abc",
+            "\u{0627}\u{0644}\u{0639}\u{0631}\u{0628}\u{064A}\u{0629}",
+        ] {
+            let (mr, _) = processor.process(&block, id).await.unwrap().unwrap();
+            assert_eq!(mr.created_by, id, "Unicode task_id not preserved: {}", id);
+        }
+    }
+
+    #[tokio::test]
+    async fn g_created_by_empty_string() {
+        let (processor, _dir) = make_processor_e2e();
+        let block = ContentBlock::image(encode_b64(&real_png_bytes()), "image/png");
+        let (mr, _) = processor.process(&block, "").await.unwrap().unwrap();
+        assert_eq!(mr.created_by, "");
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -90,12 +90,13 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════
 
     #[tokio::test]
-    async fn e2e_base64_with_newlines_should_fail_gracefully() {
+    async fn e2e_base64_with_newlines_succeeds() {
+        // Real MCP servers (OpenAI etc.) send PEM-style base64 with \n
+        // We strip whitespace before decoding to handle this correctly
         let dir = tempfile::tempdir().unwrap();
         let store = CasStore::new(dir.path());
         let processor = MediaProcessor::new(store);
 
-        // Encode then add newlines (simulating PEM-style base64)
         let png = real_png_bytes();
         let b64 = encode_b64(&png);
         let b64_with_newlines = b64.chars()
@@ -104,24 +105,15 @@ mod tests {
             .collect::<String>();
 
         let block = ContentBlock::image(b64_with_newlines, "image/png");
-        let result = processor.process(&block, "t_newline").await;
+        let result = processor.process(&block, "t_newline").await
+            .expect("base64 with newlines should succeed after whitespace stripping")
+            .expect("image should produce Some");
 
-        // This SHOULD fail with NIKA-256 (Base64DecodeFailed)
-        // If it silently succeeds with corrupted data, that's a bug
-        match result {
-            Err(e) => {
-                assert_eq!(e.code(), "NIKA-256", "Expected Base64DecodeFailed, got: {}", e);
-            }
-            Ok(Some((ref media_ref, _))) => {
-                // BUG: If it somehow decoded, verify the hash is correct
-                let expected_hash = format!("blake3:{}", blake3::hash(&png).to_hex());
-                assert_eq!(media_ref.hash, expected_hash,
-                    "SILENT BUG: base64 with newlines decoded to different data!");
-            }
-            Ok(None) => {
-                panic!("SILENT BUG: image block returned None (should be Some or Err)");
-            }
-        }
+        let (media_ref, _) = result;
+        let expected_hash = format!("blake3:{}", blake3::hash(&png).to_hex());
+        assert_eq!(media_ref.hash, expected_hash,
+            "Decoded data should match original after newline stripping");
+        assert_eq!(media_ref.mime_type, "image/png");
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -756,19 +748,21 @@ mod tests {
     // --- Base64 stress tests ---
 
     #[tokio::test]
-    async fn e2e_base64_with_spaces_fails() {
-        // Some servers insert spaces in base64
+    async fn e2e_base64_with_spaces_succeeds() {
+        // Some servers insert spaces in base64 — we strip whitespace
         let (processor, _dir) = make_processor_e2e();
-        let b64 = encode_b64(&real_png_bytes());
+        let png = real_png_bytes();
+        let b64 = encode_b64(&png);
         let with_spaces = b64.chars()
             .enumerate()
             .map(|(i, c)| if i > 0 && i % 20 == 0 { format!(" {c}") } else { c.to_string() })
             .collect::<String>();
         let block = ContentBlock::image(with_spaces, "image/png");
-        let result = processor.process(&block, "t_spaces").await;
-        // STANDARD base64 rejects whitespace → should be NIKA-256
-        assert!(result.is_err(), "Base64 with spaces should fail");
-        assert_eq!(result.unwrap_err().code(), "NIKA-256");
+        let result = processor.process(&block, "t_spaces").await
+            .expect("base64 with spaces should succeed after whitespace stripping")
+            .expect("image should produce Some");
+        let expected_hash = format!("blake3:{}", blake3::hash(&png).to_hex());
+        assert_eq!(result.0.hash, expected_hash);
     }
 
     #[tokio::test]

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -1464,4 +1464,1166 @@ mod tests {
         let city = ctx.resolve_path("weather.city");
         assert_eq!(city, Some(serde_json::json!("Paris")));
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // CAS STORE STRESS & INTEGRITY TESTS
+    // ═══════════════════════════════════════════════════════════════
+
+    // --- 1. Large file integrity ---
+
+    #[tokio::test]
+    async fn e2e_cas_large_file_above_threshold_verified_and_roundtrip() {
+        // 2MB file (above VERIFY_THRESHOLD=1MB) must have verified=true
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Build 2MB data with a recognizable pattern (not all zeros)
+        let mut data = Vec::with_capacity(2 * 1024 * 1024);
+        for i in 0u32..(2 * 1024 * 1024 / 4) {
+            data.extend_from_slice(&i.to_le_bytes());
+        }
+        assert_eq!(data.len(), 2 * 1024 * 1024);
+
+        let result = store.store(&data).await.unwrap();
+        assert!(result.verified, "2MB file must trigger read-back verification");
+        assert!(!result.deduplicated);
+        assert_eq!(result.size, 2 * 1024 * 1024);
+
+        // Read back and verify byte-for-byte
+        let read_back = store.read(&result.hash).await.unwrap();
+        assert_eq!(read_back.len(), data.len());
+        assert_eq!(read_back, data, "byte-for-byte mismatch on 2MB roundtrip");
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_large_file_dedup_on_second_store() {
+        // Store 2MB file twice: second store must be deduplicated
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = vec![0xFE_u8; 2 * 1024 * 1024];
+        let r1 = store.store(&data).await.unwrap();
+        assert!(!r1.deduplicated);
+        assert!(r1.verified);
+
+        let r2 = store.store(&data).await.unwrap();
+        assert!(r2.deduplicated, "second store of identical 2MB file must dedup");
+        assert_eq!(r1.hash, r2.hash);
+        assert_eq!(r1.path, r2.path);
+    }
+
+    // --- 2. Binary data integrity with ALL byte values ---
+
+    #[tokio::test]
+    async fn e2e_cas_all_byte_values_no_corruption() {
+        // Store data containing every possible byte value 0x00..0xFF
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let mut data: Vec<u8> = (0x00..=0xFF).collect();
+        // Repeat 4 times so we also test multi-occurrence
+        let single_round = data.clone();
+        for _ in 0..3 {
+            data.extend_from_slice(&single_round);
+        }
+        assert_eq!(data.len(), 256 * 4);
+
+        let result = store.store(&data).await.unwrap();
+        let read_back = store.read(&result.hash).await.unwrap();
+        assert_eq!(read_back, data, "all-bytes roundtrip must not corrupt any value");
+
+        // Every byte value must be present in the read-back
+        for byte in 0x00..=0xFF_u8 {
+            assert!(
+                read_back.contains(&byte),
+                "byte 0x{byte:02X} missing after roundtrip"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_blake3_hash_is_deterministic() {
+        // Same data must always produce the same hash
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data: Vec<u8> = (0..=255).collect();
+
+        let r1 = store.store(&data).await.unwrap();
+        // r2 will be deduped, but hash must match
+        let r2 = store.store(&data).await.unwrap();
+        assert_eq!(r1.hash, r2.hash, "blake3 hash must be deterministic");
+
+        // Also verify against direct blake3 computation
+        let expected_raw = blake3::hash(&data).to_hex().to_string();
+        let expected = format!("blake3:{expected_raw}");
+        assert_eq!(r1.hash, expected, "hash must match direct blake3 computation");
+    }
+
+    // --- 3. CAS cleanup edge cases ---
+
+    #[tokio::test]
+    async fn e2e_cas_clean_older_than_zero_cleans_everything() {
+        // Duration::ZERO means "older than 0s" — every file qualifies
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        store.store(b"alpha").await.unwrap();
+        store.store(b"beta").await.unwrap();
+        store.store(b"gamma").await.unwrap();
+        assert_eq!(store.list().len(), 3);
+
+        // Files are always at least a few nanoseconds old
+        // Small sleep to ensure mtime is strictly in the past
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let clean = store.clean_older_than(std::time::Duration::ZERO);
+        assert_eq!(clean.removed, 3, "Duration::ZERO should remove all files");
+        assert_eq!(store.list().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_clean_older_than_long_duration_cleans_nothing() {
+        // Duration of 1 hour — recently-created files should survive
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        store.store(b"fresh-1").await.unwrap();
+        store.store(b"fresh-2").await.unwrap();
+
+        let clean = store.clean_older_than(std::time::Duration::from_secs(3600));
+        assert_eq!(clean.removed, 0, "no files should be older than 1 hour");
+        assert_eq!(store.list().len(), 2, "both files should survive");
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_clean_all_on_empty_store() {
+        // clean_all on empty store should return removed=0, bytes_freed=0
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let clean = store.clean_all();
+        assert_eq!(clean.removed, 0);
+        assert_eq!(clean.bytes_freed, 0);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_clean_all_twice_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        store.store(b"to-be-removed").await.unwrap();
+        let c1 = store.clean_all();
+        assert_eq!(c1.removed, 1);
+
+        let c2 = store.clean_all();
+        assert_eq!(c2.removed, 0, "second clean_all should find nothing");
+        assert_eq!(c2.bytes_freed, 0);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_clean_older_than_zero_on_empty_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let clean = store.clean_older_than(std::time::Duration::ZERO);
+        assert_eq!(clean.removed, 0);
+        assert_eq!(clean.bytes_freed, 0);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_clean_reports_correct_bytes_freed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data_a = vec![0xAA_u8; 1000];
+        let data_b = vec![0xBB_u8; 2000];
+        store.store(&data_a).await.unwrap();
+        store.store(&data_b).await.unwrap();
+
+        let clean = store.clean_all();
+        assert_eq!(clean.removed, 2);
+        assert_eq!(clean.bytes_freed, 3000, "bytes_freed must equal sum of file sizes");
+    }
+
+    // --- 4. Hash format validation ---
+
+    #[tokio::test]
+    async fn e2e_cas_hash_format_64_hex_after_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"hash format test").await.unwrap();
+
+        // Must start with "blake3:"
+        assert!(result.hash.starts_with("blake3:"), "missing blake3: prefix");
+
+        let raw = result.hash.strip_prefix("blake3:").unwrap();
+        // Must be exactly 64 hex characters
+        assert_eq!(raw.len(), 64, "raw hash must be 64 hex chars, got {}", raw.len());
+        assert!(
+            raw.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash contains non-hex characters: {raw}"
+        );
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_hash_deterministic_multiple_runs() {
+        // Verify determinism across separate CasStore instances
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+        let store1 = CasStore::new(dir1.path());
+        let store2 = CasStore::new(dir2.path());
+
+        let data = b"determinism across stores";
+        let r1 = store1.store(data).await.unwrap();
+        let r2 = store2.store(data).await.unwrap();
+
+        assert_eq!(r1.hash, r2.hash, "same data must produce same hash in different stores");
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_different_data_different_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let r1 = store.store(b"data-alpha").await.unwrap();
+        let r2 = store.store(b"data-beta").await.unwrap();
+        let r3 = store.store(b"data-gamma").await.unwrap();
+
+        // All hashes must be distinct
+        assert_ne!(r1.hash, r2.hash, "alpha vs beta must differ");
+        assert_ne!(r1.hash, r3.hash, "alpha vs gamma must differ");
+        assert_ne!(r2.hash, r3.hash, "beta vs gamma must differ");
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_single_bit_difference_changes_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data_a = vec![0x00_u8; 64];
+        let mut data_b = data_a.clone();
+        data_b[31] = 0x01; // flip one bit in the middle
+
+        let ra = store.store(&data_a).await.unwrap();
+        let rb = store.store(&data_b).await.unwrap();
+        assert_ne!(ra.hash, rb.hash, "single bit flip must change hash");
+    }
+
+    // --- 5. Path safety ---
+
+    #[tokio::test]
+    async fn e2e_cas_path_never_escapes_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Store various data to generate different hashes/shards
+        for i in 0..20_u32 {
+            let data = i.to_le_bytes();
+            let result = store.store(&data).await.unwrap();
+
+            // The final path must always be under the root directory
+            assert!(
+                result.path.starts_with(dir.path()),
+                "CAS path escaped root: {:?} not under {:?}",
+                result.path,
+                dir.path()
+            );
+
+            // Must not contain ".." anywhere
+            let path_str = result.path.to_string_lossy();
+            assert!(
+                !path_str.contains(".."),
+                "CAS path contains directory traversal: {path_str}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_shard_directory_is_2_hex_chars() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        for i in 0..20_u32 {
+            let result = store.store(&i.to_le_bytes()).await.unwrap();
+
+            // Path structure: {root}/{shard}/{filename}
+            let relative = result.path.strip_prefix(dir.path()).unwrap();
+            let components: Vec<_> = relative.components().collect();
+            assert_eq!(
+                components.len(), 2,
+                "CAS path must have exactly 2 components (shard/file), got {}: {:?}",
+                components.len(), relative
+            );
+
+            let shard = components[0].as_os_str().to_string_lossy();
+            assert_eq!(shard.len(), 2, "shard dir must be 2 chars, got '{shard}'");
+            assert!(
+                shard.chars().all(|c| c.is_ascii_hexdigit()),
+                "shard dir must be hex, got '{shard}'"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_file_has_no_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Test with data that could trick an extension parser
+        let png = real_png_bytes();
+        let jpeg = real_jpeg_bytes();
+        let test_data: Vec<&[u8]> = vec![
+            b"hello.png",       // text that looks like a filename
+            b"data.tar.gz",     // double extension
+            &png,               // actual PNG binary
+            &jpeg,              // actual JPEG binary
+        ];
+
+        for data in &test_data {
+            let result = store.store(data).await.unwrap();
+            assert!(
+                result.path.extension().is_none(),
+                "CAS file must have no extension, got: {:?}",
+                result.path
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_shard_and_filename_reconstruct_hash() {
+        // Verify shard + filename = raw hash
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"reconstruct test").await.unwrap();
+        let raw_hash = result.hash.strip_prefix("blake3:").unwrap();
+
+        let relative = result.path.strip_prefix(dir.path()).unwrap();
+        let components: Vec<_> = relative.components().collect();
+        let shard = components[0].as_os_str().to_string_lossy();
+        let filename = components[1].as_os_str().to_string_lossy();
+
+        let reconstructed = format!("{shard}{filename}");
+        assert_eq!(
+            reconstructed, raw_hash,
+            "shard + filename must reconstruct the raw hash"
+        );
+    }
+
+    // --- 6. Concurrent read + write ---
+
+    #[tokio::test]
+    async fn e2e_cas_concurrent_read_write_no_partial_reads() {
+        // Pre-store data so it exists, then concurrently write (dedup) + read
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CasStore::new(dir.path()));
+
+        // Build recognizable 512KB pattern
+        let mut data = Vec::with_capacity(512 * 1024);
+        for i in 0u32..(512 * 1024 / 4) {
+            data.extend_from_slice(&i.to_le_bytes());
+        }
+
+        // Initial store
+        let initial = store.store(&data).await.unwrap();
+        let hash = initial.hash.clone();
+
+        // Spawn 5 writers (dedup) and 5 readers concurrently
+        let mut handles = Vec::new();
+
+        for _ in 0..5 {
+            let s = Arc::clone(&store);
+            let d = data.clone();
+            handles.push(tokio::spawn(async move {
+                s.store(&d).await.unwrap();
+            }));
+        }
+
+        for _ in 0..5 {
+            let s = Arc::clone(&store);
+            let h = hash.clone();
+            let expected_len = data.len();
+            handles.push(tokio::spawn(async move {
+                let read_back = s.read(&h).await.unwrap();
+                assert_eq!(
+                    read_back.len(), expected_len,
+                    "partial read detected: got {} bytes, expected {}",
+                    read_back.len(), expected_len
+                );
+            }));
+        }
+
+        futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .for_each(|h| h.unwrap());
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_concurrent_store_different_data_no_collision() {
+        // Concurrently store 20 different files and verify all are distinct
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CasStore::new(dir.path()));
+
+        let handles: Vec<_> = (0..20_u32)
+            .map(|i| {
+                let s = Arc::clone(&store);
+                tokio::spawn(async move {
+                    let data = format!("unique-content-{i}");
+                    let result = s.store(data.as_bytes()).await.unwrap();
+                    (i, result.hash)
+                })
+            })
+            .collect();
+
+        let results: Vec<(u32, String)> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|h| h.unwrap())
+            .collect();
+
+        // All hashes must be unique
+        let mut hashes: Vec<&str> = results.iter().map(|(_, h)| h.as_str()).collect();
+        hashes.sort();
+        hashes.dedup();
+        assert_eq!(
+            hashes.len(), 20,
+            "20 different inputs must produce 20 distinct hashes"
+        );
+
+        // Verify all files readable
+        assert_eq!(store.list().len(), 20);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_concurrent_read_after_store_all_correct() {
+        // Store N files, then concurrently read all back and verify content
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CasStore::new(dir.path()));
+
+        let items: Vec<(Vec<u8>, String)> = {
+            let mut v = Vec::new();
+            for i in 0..10_u32 {
+                let data = format!("content-for-verification-{i}").into_bytes();
+                let result = store.store(&data).await.unwrap();
+                v.push((data, result.hash));
+            }
+            v
+        };
+
+        let handles: Vec<_> = items
+            .into_iter()
+            .map(|(expected_data, hash)| {
+                let s = Arc::clone(&store);
+                tokio::spawn(async move {
+                    let read_back = s.read(&hash).await.unwrap();
+                    assert_eq!(read_back, expected_data, "content mismatch for hash {hash}");
+                })
+            })
+            .collect();
+
+        futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .for_each(|h| h.unwrap());
+    }
+
+    // --- Extra edge cases ---
+
+    #[tokio::test]
+    async fn e2e_cas_empty_data_store_and_read() {
+        // Empty data is a valid CAS entry (0 bytes)
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"").await.unwrap();
+        assert_eq!(result.size, 0);
+        assert!(!result.verified, "empty file is under threshold");
+
+        let read_back = store.read(&result.hash).await.unwrap();
+        assert!(read_back.is_empty());
+
+        // Dedup on second store
+        let r2 = store.store(b"").await.unwrap();
+        assert!(r2.deduplicated);
+        assert_eq!(result.hash, r2.hash);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_single_byte_store_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(&[0x42]).await.unwrap();
+        assert_eq!(result.size, 1);
+
+        let read_back = store.read(&result.hash).await.unwrap();
+        assert_eq!(read_back, vec![0x42]);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_list_after_clean_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        for i in 0..5_u32 {
+            store.store(&i.to_le_bytes()).await.unwrap();
+        }
+        assert_eq!(store.list().len(), 5);
+
+        store.clean_all();
+        assert_eq!(store.list().len(), 0);
+
+        // Re-store one file: list should show exactly 1
+        store.store(b"post-clean").await.unwrap();
+        assert_eq!(store.list().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_list_entries_have_correct_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = b"list field check";
+        let store_result = store.store(data).await.unwrap();
+
+        let entries = store.list();
+        assert_eq!(entries.len(), 1);
+
+        let entry = &entries[0];
+        assert_eq!(entry.hash, store_result.hash);
+        assert_eq!(entry.path, store_result.path);
+        assert_eq!(entry.size, data.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_exists_returns_false_after_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"will-be-cleaned").await.unwrap();
+        assert!(store.exists(&result.hash));
+
+        store.clean_all();
+        assert!(
+            !store.exists(&result.hash),
+            "exists must return false after clean_all"
+        );
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_read_after_clean_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.store(b"ephemeral").await.unwrap();
+        store.clean_all();
+
+        let read = store.read(&result.hash).await;
+        assert!(read.is_err());
+        assert_eq!(read.unwrap_err().code(), "NIKA-253");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PHASE F: Template binding pipeline — edge cases & isolation
+    // ═══════════════════════════════════════════════════════════════
+
+    // -----------------------------------------------------------------
+    // F1: resolve_path edge cases not yet tested
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn e2e_resolve_path_media_whole_object_no_field() {
+        // "task.media[0]" should return the entire MediaRef JSON object
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0]");
+        assert!(
+            result.is_some(),
+            "media[0] without field should return the full MediaRef"
+        );
+        let obj = result.unwrap();
+        assert!(
+            obj.is_object(),
+            "media[0] should be a JSON object, got: {}",
+            obj
+        );
+        // Verify it contains all 6 expected fields
+        let map = obj.as_object().unwrap();
+        assert_eq!(
+            map.get("hash").and_then(|v| v.as_str()),
+            Some("blake3:aabbccdd11223344")
+        );
+        assert_eq!(
+            map.get("mime_type").and_then(|v| v.as_str()),
+            Some("image/png")
+        );
+        assert_eq!(
+            map.get("size_bytes").and_then(|v| v.as_u64()),
+            Some(4096)
+        );
+        assert_eq!(
+            map.get("extension").and_then(|v| v.as_str()),
+            Some("png")
+        );
+        assert_eq!(
+            map.get("created_by").and_then(|v| v.as_str()),
+            Some("gen_img")
+        );
+        assert!(map.contains_key("path"), "should have 'path' field");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_whole_object_second() {
+        // "task.media[1]" should return the second MediaRef
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[1]");
+        assert!(result.is_some());
+        let obj = result.unwrap();
+        assert!(obj.is_object());
+        assert_eq!(obj["hash"], "blake3:eeff0011aabbccdd");
+        assert_eq!(obj["mime_type"], "audio/mpeg");
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_dot_length() {
+        // "task.media.length" -- not a valid JSON path; arrays don't have .length
+        // Should return None (no JavaScript-style .length in JSON)
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media.length");
+        assert!(
+            result.is_none(),
+            "media.length is not valid JSON path, should return None"
+        );
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_out_of_bounds_with_field() {
+        // "task.media[999].hash" -- index beyond array length
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[999].hash");
+        assert!(
+            result.is_none(),
+            "out-of-bounds index should return None"
+        );
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_out_of_bounds_no_field() {
+        // "task.media[999]" -- whole object at out-of-bounds index
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[999]");
+        assert!(
+            result.is_none(),
+            "out-of-bounds index without field should return None"
+        );
+    }
+
+    #[test]
+    fn e2e_resolve_path_mediax_not_intercepted() {
+        // "task.mediax" -- starts with "media" but is NOT a media path
+        // Should resolve from task output, not media interception
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "task".into();
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({"mediax": "extra_value", "media_extra": 42}),
+            std::time::Duration::from_millis(10),
+        );
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // "task.mediax" should resolve from output (not media interception)
+        let result = ctx.resolve_path("task.mediax");
+        assert_eq!(
+            result,
+            Some(serde_json::json!("extra_value")),
+            "mediax should resolve from task output, not media interception"
+        );
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_extra_not_intercepted() {
+        // "task.media_extra" -- starts with "media" prefix + underscore
+        // Should NOT be intercepted by the media path logic
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "task".into();
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({"media_extra": "should_not_be_media"}),
+            std::time::Duration::from_millis(10),
+        );
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        let result = ctx.resolve_path("task.media_extra");
+        assert_eq!(
+            result,
+            Some(serde_json::json!("should_not_be_media")),
+            "media_extra should NOT be intercepted by media path logic"
+        );
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_nonexistent_field() {
+        // "task.media[0].nonexistent_field" -- valid index, invalid field name
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].nonexistent_field");
+        assert!(
+            result.is_none(),
+            "nonexistent field on MediaRef should return None"
+        );
+    }
+
+    #[test]
+    fn e2e_resolve_path_media_deeply_nested_invalid() {
+        // "task.media[0].hash.something" -- trying to navigate into a string field
+        let (ctx, _) = setup_ctx_with_media();
+        let result = ctx.resolve_path("gen_img.media[0].hash.something");
+        assert!(
+            result.is_none(),
+            "cannot navigate into a string field"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // F2: Multiple tasks with media -- isolation
+    // -----------------------------------------------------------------
+
+    /// Helper: set up two tasks each with their own media refs
+    fn setup_two_tasks_with_media() -> RunContext {
+        let ctx = RunContext::new();
+
+        // Task A: 1 image
+        let media_a = vec![MediaRef {
+            hash: "blake3:aaaa111122223333".into(),
+            mime_type: "image/jpeg".into(),
+            size_bytes: 2048,
+            path: std::path::PathBuf::from("/tmp/cas/aa/aa111122223333"),
+            extension: "jpg".into(),
+            created_by: "task_a".into(),
+        }];
+        let tr_a = crate::store::TaskResult::success(
+            serde_json::json!({"prompt": "a dog"}),
+            std::time::Duration::from_millis(100),
+        )
+        .with_media(media_a);
+        ctx.insert(Arc::from("task_a"), tr_a);
+
+        // Task B: 2 audio files
+        let media_b = vec![
+            MediaRef {
+                hash: "blake3:bbbb444455556666".into(),
+                mime_type: "audio/wav".into(),
+                size_bytes: 16384,
+                path: std::path::PathBuf::from("/tmp/cas/bb/bb444455556666"),
+                extension: "wav".into(),
+                created_by: "task_b".into(),
+            },
+            MediaRef {
+                hash: "blake3:bbbb777788889999".into(),
+                mime_type: "audio/mpeg".into(),
+                size_bytes: 32768,
+                path: std::path::PathBuf::from("/tmp/cas/bb/bb777788889999"),
+                extension: "mp3".into(),
+                created_by: "task_b".into(),
+            },
+        ];
+        let tr_b = crate::store::TaskResult::success(
+            serde_json::json!({"source": "microphone"}),
+            std::time::Duration::from_millis(200),
+        )
+        .with_media(media_b);
+        ctx.insert(Arc::from("task_b"), tr_b);
+
+        ctx
+    }
+
+    #[test]
+    fn e2e_multi_task_media_array_counts() {
+        let ctx = setup_two_tasks_with_media();
+
+        let a_media = ctx.resolve_path("task_a.media").unwrap();
+        assert_eq!(
+            a_media.as_array().unwrap().len(),
+            1,
+            "task_a should have 1 media ref"
+        );
+
+        let b_media = ctx.resolve_path("task_b.media").unwrap();
+        assert_eq!(
+            b_media.as_array().unwrap().len(),
+            2,
+            "task_b should have 2 media refs"
+        );
+    }
+
+    #[test]
+    fn e2e_multi_task_media_no_cross_leak() {
+        let ctx = setup_two_tasks_with_media();
+
+        // task_a.media[0].hash should be task_a's image, not task_b's audio
+        let a_hash = ctx.resolve_path("task_a.media[0].hash").unwrap();
+        assert_eq!(a_hash, "blake3:aaaa111122223333");
+
+        // task_b.media[0].hash should be task_b's first audio
+        let b_hash = ctx.resolve_path("task_b.media[0].hash").unwrap();
+        assert_eq!(b_hash, "blake3:bbbb444455556666");
+
+        // task_b.media[1].hash should be task_b's second audio
+        let b_hash2 = ctx.resolve_path("task_b.media[1].hash").unwrap();
+        assert_eq!(b_hash2, "blake3:bbbb777788889999");
+    }
+
+    #[test]
+    fn e2e_multi_task_media_mime_types_isolated() {
+        let ctx = setup_two_tasks_with_media();
+
+        // task_a has image, task_b has audio -- no type confusion
+        assert_eq!(
+            ctx.resolve_path("task_a.media[0].mime_type").unwrap(),
+            "image/jpeg"
+        );
+        assert_eq!(
+            ctx.resolve_path("task_b.media[0].mime_type").unwrap(),
+            "audio/wav"
+        );
+        assert_eq!(
+            ctx.resolve_path("task_b.media[1].mime_type").unwrap(),
+            "audio/mpeg"
+        );
+    }
+
+    #[test]
+    fn e2e_multi_task_output_not_affected_by_media() {
+        let ctx = setup_two_tasks_with_media();
+
+        // Standard output fields must resolve independently of media
+        assert_eq!(ctx.resolve_path("task_a.prompt").unwrap(), "a dog");
+        assert_eq!(ctx.resolve_path("task_b.source").unwrap(), "microphone");
+    }
+
+    #[test]
+    fn e2e_multi_task_media_created_by_correct() {
+        let ctx = setup_two_tasks_with_media();
+
+        // Each media ref's created_by should reference its own task
+        assert_eq!(
+            ctx.resolve_path("task_a.media[0].created_by").unwrap(),
+            "task_a"
+        );
+        assert_eq!(
+            ctx.resolve_path("task_b.media[0].created_by").unwrap(),
+            "task_b"
+        );
+        assert_eq!(
+            ctx.resolve_path("task_b.media[1].created_by").unwrap(),
+            "task_b"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // F3: TaskResult with both output AND media -- no collision
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn e2e_output_and_media_coexist_no_collision() {
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "gen".into();
+
+        // Task output has structured JSON AND media refs
+        let media = vec![MediaRef {
+            hash: "blake3:face0000dead0000".into(),
+            mime_type: "image/png".into(),
+            size_bytes: 1024,
+            path: std::path::PathBuf::from("/tmp/cas/fa/ce0000dead0000"),
+            extension: "png".into(),
+            created_by: "gen".into(),
+        }];
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({
+                "status": "ok",
+                "url": "https://example.com/image.png",
+                "dimensions": {"width": 512, "height": 512}
+            }),
+            std::time::Duration::from_millis(250),
+        )
+        .with_media(media);
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // Output fields resolve from output
+        assert_eq!(ctx.resolve_path("gen.status").unwrap(), "ok");
+        assert_eq!(
+            ctx.resolve_path("gen.url").unwrap(),
+            "https://example.com/image.png"
+        );
+        assert_eq!(ctx.resolve_path("gen.dimensions.width").unwrap(), 512);
+        assert_eq!(ctx.resolve_path("gen.dimensions.height").unwrap(), 512);
+
+        // Media fields resolve from media refs
+        assert_eq!(
+            ctx.resolve_path("gen.media[0].hash").unwrap(),
+            "blake3:face0000dead0000"
+        );
+        assert_eq!(
+            ctx.resolve_path("gen.media[0].mime_type").unwrap(),
+            "image/png"
+        );
+        assert_eq!(
+            ctx.resolve_path("gen.media[0].size_bytes").unwrap(),
+            1024
+        );
+        assert_eq!(
+            ctx.resolve_path("gen.media[0].extension").unwrap(),
+            "png"
+        );
+
+        // Full media array
+        let arr = ctx.resolve_path("gen.media").unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 1);
+
+        // Full output (no media key contamination)
+        let full = ctx.resolve_path("gen").unwrap();
+        assert!(full.is_object());
+        assert_eq!(full["status"], "ok");
+        // Media should NOT appear in the output Value itself
+        assert!(
+            full.get("media").is_none(),
+            "media should not be merged into the output JSON"
+        );
+    }
+
+    #[test]
+    fn e2e_output_with_media_key_in_output() {
+        // Edge case: task output itself has a "media" key
+        // The media interception should still use TaskResult.media, not output.media
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "tricky".into();
+
+        let media = vec![MediaRef {
+            hash: "blake3:real_media_hash000".into(),
+            mime_type: "image/webp".into(),
+            size_bytes: 500,
+            path: std::path::PathBuf::from("/tmp/cas/re/al_media_hash000"),
+            extension: "webp".into(),
+            created_by: "tricky".into(),
+        }];
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({
+                "media": "this is output media, not real",
+                "other": "value"
+            }),
+            std::time::Duration::from_millis(10),
+        )
+        .with_media(media);
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // "tricky.media" should return the TaskResult.media array (from interception),
+        // NOT the output "media" string field
+        let result = ctx.resolve_path("tricky.media");
+        assert!(result.is_some());
+        let arr = result.unwrap();
+        assert!(
+            arr.is_array(),
+            "media path should return the media array, not output field"
+        );
+        assert_eq!(arr.as_array().unwrap().len(), 1);
+        assert_eq!(arr[0]["hash"], "blake3:real_media_hash000");
+
+        // Other output fields still work
+        assert_eq!(ctx.resolve_path("tricky.other").unwrap(), "value");
+    }
+
+    #[test]
+    fn e2e_output_field_named_media_no_real_media() {
+        // Task output has "media" field but TaskResult.media is empty
+        // "task.media" should return empty array (from interception), not output.media
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "confusing".into();
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({
+                "media": ["fake_ref_1", "fake_ref_2"],
+                "count": 2
+            }),
+            std::time::Duration::from_millis(10),
+        );
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        let result = ctx.resolve_path("confusing.media");
+        assert!(result.is_some());
+        let arr = result.unwrap();
+        assert!(arr.is_array());
+        // Empty because TaskResult.media is empty -- interception takes priority
+        assert!(
+            arr.as_array().unwrap().is_empty(),
+            "should return empty media array, not output.media field"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // F4: MediaRef serialization completeness
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn e2e_mediaref_json_has_all_six_fields() {
+        let mr = MediaRef {
+            hash: "blake3:0123456789abcdef".into(),
+            mime_type: "application/pdf".into(),
+            size_bytes: 65536,
+            path: std::path::PathBuf::from("/tmp/cas/01/23456789abcdef"),
+            extension: "pdf".into(),
+            created_by: "pdf_gen".into(),
+        };
+        let json = serde_json::to_value(&mr).unwrap();
+        let obj = json
+            .as_object()
+            .expect("MediaRef should serialize to object");
+
+        // Exactly 6 fields
+        assert_eq!(
+            obj.len(),
+            6,
+            "MediaRef should have exactly 6 fields, got: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+
+        // Each field present and correct type
+        assert!(obj["hash"].is_string(), "hash should be string");
+        assert!(obj["mime_type"].is_string(), "mime_type should be string");
+        assert!(obj["size_bytes"].is_u64(), "size_bytes should be u64");
+        assert!(obj["path"].is_string(), "path should serialize as string");
+        assert!(
+            obj["extension"].is_string(),
+            "extension should be string"
+        );
+        assert!(
+            obj["created_by"].is_string(),
+            "created_by should be string"
+        );
+    }
+
+    #[test]
+    fn e2e_mediaref_path_serializes_as_absolute() {
+        let mr = MediaRef {
+            hash: "blake3:abcdef0123456789".into(),
+            mime_type: "image/png".into(),
+            size_bytes: 1024,
+            path: std::path::PathBuf::from("/var/nika/cas/ab/cdef0123456789"),
+            extension: "png".into(),
+            created_by: "test".into(),
+        };
+        let json = serde_json::to_value(&mr).unwrap();
+        let path_str = json["path"].as_str().unwrap();
+
+        assert!(
+            path_str.starts_with('/'),
+            "serialized path should be absolute (start with /), got: {}",
+            path_str
+        );
+        assert!(
+            path_str.contains("cas/ab/cdef0123456789"),
+            "path should contain the CAS directory structure, got: {}",
+            path_str
+        );
+    }
+
+    #[test]
+    fn e2e_mediaref_hash_always_blake3_prefix() {
+        // Verify hash field always has the algorithm prefix
+        let hashes = vec![
+            "blake3:0000000000000000",
+            "blake3:ffffffffffffffff",
+            "blake3:aabbccdd11223344",
+        ];
+
+        for hash_val in hashes {
+            let mr = MediaRef {
+                hash: hash_val.into(),
+                mime_type: "image/png".into(),
+                size_bytes: 1,
+                path: std::path::PathBuf::from("/tmp/cas/00/00"),
+                extension: "png".into(),
+                created_by: "test".into(),
+            };
+            let json = serde_json::to_value(&mr).unwrap();
+            let serialized_hash = json["hash"].as_str().unwrap();
+            assert!(
+                serialized_hash.starts_with("blake3:"),
+                "hash must start with 'blake3:', got: {}",
+                serialized_hash
+            );
+        }
+    }
+
+    #[test]
+    fn e2e_mediaref_roundtrip_preserves_all_fields() {
+        // Serialize -> Deserialize should be identity for all field values
+        let original = MediaRef {
+            hash: "blake3:deadbeefcafebabe".into(),
+            mime_type: "audio/wav".into(),
+            size_bytes: 123456789,
+            path: std::path::PathBuf::from("/opt/nika/cas/de/adbeefcafebabe"),
+            extension: "wav".into(),
+            created_by: "audio_task".into(),
+        };
+        let json_str = serde_json::to_string(&original).unwrap();
+        let deserialized: MediaRef = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(original.hash, deserialized.hash);
+        assert_eq!(original.mime_type, deserialized.mime_type);
+        assert_eq!(original.size_bytes, deserialized.size_bytes);
+        assert_eq!(original.path, deserialized.path);
+        assert_eq!(original.extension, deserialized.extension);
+        assert_eq!(original.created_by, deserialized.created_by);
+    }
+
+    #[test]
+    fn e2e_mediaref_resolve_path_roundtrip_all_fields() {
+        // Insert a TaskResult with media, then verify resolve_path returns
+        // correct values for ALL 6 fields through the full pipeline
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "roundtrip".into();
+        let media = vec![MediaRef {
+            hash: "blake3:a1b2c3d4e5f60000".into(),
+            mime_type: "image/gif".into(),
+            size_bytes: 99999,
+            path: std::path::PathBuf::from("/data/cas/a1/b2c3d4e5f60000"),
+            extension: "gif".into(),
+            created_by: "roundtrip".into(),
+        }];
+        let tr = crate::store::TaskResult::success(
+            serde_json::json!({"done": true}),
+            std::time::Duration::from_millis(50),
+        )
+        .with_media(media);
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // Verify each field through resolve_path
+        assert_eq!(
+            ctx.resolve_path("roundtrip.media[0].hash").unwrap(),
+            "blake3:a1b2c3d4e5f60000"
+        );
+        assert_eq!(
+            ctx.resolve_path("roundtrip.media[0].mime_type").unwrap(),
+            "image/gif"
+        );
+        assert_eq!(
+            ctx.resolve_path("roundtrip.media[0].size_bytes").unwrap(),
+            99999
+        );
+        let path_val = ctx.resolve_path("roundtrip.media[0].path").unwrap();
+        assert_eq!(
+            path_val.as_str().unwrap(),
+            "/data/cas/a1/b2c3d4e5f60000"
+        );
+        assert_eq!(
+            ctx.resolve_path("roundtrip.media[0].extension").unwrap(),
+            "gif"
+        );
+        assert_eq!(
+            ctx.resolve_path("roundtrip.media[0].created_by").unwrap(),
+            "roundtrip"
+        );
+
+        // Also verify the whole object has exactly 6 keys
+        let whole = ctx.resolve_path("roundtrip.media[0]").unwrap();
+        assert_eq!(whole.as_object().unwrap().len(), 6);
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -1125,4 +1125,206 @@ mod tests {
         let store = CasStore::new(dir.path());
         (MediaProcessor::new(store), dir)
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PHASE E3: INTEGRATION PIPELINE TESTS
+    // Simulates what run_invoke does: ToolCallResult → processor → CAS → MediaRef → TaskResult
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn e2e_invoke_simulation_mixed_content() {
+        // Simulates a real MCP tool returning text + image + audio
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let budget = Arc::new(MediaBudget::new());
+        let processor = MediaProcessor::with_shared_budget(store, Arc::clone(&budget));
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "invoke_sim".into();
+
+        // Simulate tool result with mixed content
+        let tool_result = ToolCallResult::success(vec![
+            ContentBlock::text("Image generated successfully"),
+            ContentBlock::image(encode_b64(&real_png_bytes()), "image/png"),
+            ContentBlock::text("Audio also available"),
+            ContentBlock::audio(encode_b64(&real_mp3_bytes()), "audio/mpeg"),
+        ]);
+
+        // Check has_media
+        assert!(tool_result.has_media());
+        assert_eq!(tool_result.media_blocks().len(), 2);
+
+        // Process all blocks
+        let results = processor.process_all(&tool_result.content, task_id.as_ref()).await;
+
+        // Collect successful media refs
+        let mut media_refs = Vec::new();
+        for result in results {
+            match result {
+                Ok((media_ref, store_result)) => {
+                    assert!(media_ref.hash.starts_with("blake3:"));
+                    assert!(media_ref.size_bytes > 0);
+                    assert_eq!(media_ref.created_by, "invoke_sim");
+                    let cas_filename = store_result.path.file_name().unwrap().to_string_lossy();
+                    assert!(!cas_filename.contains('.'),
+                        "CAS filename should not contain dot: {}", cas_filename);
+                    media_refs.push(media_ref);
+                }
+                Err((idx, e)) => {
+                    panic!("Block {idx} failed unexpectedly: {e}");
+                }
+            }
+        }
+
+        assert_eq!(media_refs.len(), 2, "Should have 2 media refs (image + audio)");
+
+        // Stage in RunContext
+        ctx.set_media(&task_id, media_refs.clone());
+
+        // Take from RunContext (simulates what runner does)
+        let taken = ctx.take_media(&task_id);
+        assert_eq!(taken.len(), 2);
+
+        // Build TaskResult with media
+        use crate::store::TaskResult;
+        let text = tool_result.text();
+        let output = serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+        let tr = TaskResult::success(output, std::time::Duration::from_millis(42))
+            .with_media(taken);
+
+        assert_eq!(tr.media.len(), 2);
+        assert_eq!(tr.media[0].mime_type, "image/png");
+        assert!(tr.media[1].mime_type.contains("mpeg") || tr.media[1].mime_type.contains("mp3"));
+
+        // Verify text output is preserved
+        assert_eq!(
+            tr.output.as_str().unwrap(),
+            "Image generated successfully\nAudio also available"
+        );
+
+        // Verify budget tracked
+        assert!(budget.current_bytes() > 0, "Budget should have tracked bytes");
+    }
+
+    #[tokio::test]
+    async fn e2e_invoke_simulation_text_only_no_media() {
+        // Simulates a text-only MCP response — NO media processing should happen
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "text_invoke".into();
+
+        let tool_result = ToolCallResult::success(vec![
+            ContentBlock::text("Just text, no media"),
+        ]);
+
+        assert!(!tool_result.has_media());
+
+        // No media processing needed
+        let taken = ctx.take_media(&task_id);
+        assert!(taken.is_empty());
+
+        use crate::store::TaskResult;
+        let tr = TaskResult::success(
+            serde_json::Value::String(tool_result.text()),
+            std::time::Duration::from_millis(10),
+        ).with_media(taken);
+
+        assert!(tr.media.is_empty());
+        assert!(tr.is_success());
+    }
+
+    #[tokio::test]
+    async fn e2e_invoke_simulation_partial_failure() {
+        // One block succeeds, one fails — media refs should contain only successes
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let tool_result = ToolCallResult::success(vec![
+            ContentBlock::text("description"),
+            ContentBlock::image(encode_b64(&real_png_bytes()), "image/png"),
+            ContentBlock::image("INVALID!!!", "image/png"), // Will fail
+        ]);
+
+        let results = processor.process_all(&tool_result.content, "partial").await;
+
+        let mut media_refs = Vec::new();
+        let mut errors = Vec::new();
+        for result in results {
+            match result {
+                Ok((mr, _)) => media_refs.push(mr),
+                Err((idx, e)) => errors.push((idx, e)),
+            }
+        }
+
+        assert_eq!(media_refs.len(), 1, "One image should succeed");
+        assert_eq!(errors.len(), 1, "One image should fail");
+        assert_eq!(errors[0].0, 2, "Error should reference block index 2");
+        assert_eq!(errors[0].1.code(), "NIKA-256");
+
+        // Verify the successful media ref is valid
+        assert_eq!(media_refs[0].mime_type, "image/png");
+        assert!(media_refs[0].path.exists());
+    }
+
+    #[tokio::test]
+    async fn e2e_invoke_simulation_dedup_same_image_twice() {
+        // Same image in two blocks → CAS dedup, but 2 MediaRefs with same hash
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        let png_b64 = encode_b64(&real_png_bytes());
+        let tool_result = ToolCallResult::success(vec![
+            ContentBlock::image(png_b64.clone(), "image/png"),
+            ContentBlock::image(png_b64, "image/png"),
+        ]);
+
+        let results = processor.process_all(&tool_result.content, "dedup").await;
+        assert_eq!(results.len(), 2);
+
+        let refs: Vec<_> = results.into_iter()
+            .map(|r| r.unwrap())
+            .collect();
+
+        // Both should have the same hash
+        assert_eq!(refs[0].0.hash, refs[1].0.hash,
+            "Same image should have same hash");
+
+        // One should be dedup
+        let dedup_count = refs.iter().filter(|(_, sr)| sr.deduplicated).count();
+        assert_eq!(dedup_count, 1, "One should be deduplicated");
+    }
+
+    #[tokio::test]
+    async fn e2e_media_ref_json_fields_complete() {
+        // Verify every field is present in serialized MediaRef JSON
+        let mr = MediaRef {
+            hash: "blake3:abcdef1234567890".into(),
+            mime_type: "image/png".into(),
+            size_bytes: 12345,
+            path: std::path::PathBuf::from("/tmp/store/ab/cdef1234567890"),
+            extension: "png".into(),
+            created_by: "task_gen".into(),
+        };
+        let json = serde_json::to_value(&mr).unwrap();
+
+        // ALL fields must be present
+        assert!(json.get("hash").is_some(), "missing hash");
+        assert!(json.get("mime_type").is_some(), "missing mime_type");
+        assert!(json.get("size_bytes").is_some(), "missing size_bytes");
+        assert!(json.get("path").is_some(), "missing path");
+        assert!(json.get("extension").is_some(), "missing extension");
+        assert!(json.get("created_by").is_some(), "missing created_by");
+
+        // Verify types
+        assert!(json["hash"].is_string());
+        assert!(json["mime_type"].is_string());
+        assert!(json["size_bytes"].is_number());
+        assert!(json["path"].is_string());
+        assert!(json["extension"].is_string());
+        assert!(json["created_by"].is_string());
+
+        // Verify values
+        assert_eq!(json["hash"], "blake3:abcdef1234567890");
+        assert_eq!(json["size_bytes"], 12345);
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -547,7 +547,8 @@ mod tests {
 
         // Verify StoreResult
         assert!(!store_result.deduplicated);
-        assert!(store_result.verified);
+        // Small files: verified=false (read-back skipped, fsync sufficient)
+        assert!(!store_result.verified);
         assert!(store_result.pipeline_ms < 1000, "pipeline took too long: {}ms", store_result.pipeline_ms);
 
         // Verify CAS file content matches original

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -3269,4 +3269,356 @@ mod tests {
             "RunBudgetExceeded should NOT be recoverable");
         assert_eq!(nika_err.code(), "NIKA-259");
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // MONSTER INTEGRATION TEST
+    // Exercises the ENTIRE media pipeline end-to-end:
+    //   ContentBlock -> MediaProcessor -> CAS -> staging -> TaskResult
+    //   -> RunContext.insert -> resolve_path (all variants)
+    //   -> binding bridge (BindingEntry -> ResolvedBindings)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn monster_full_pipeline_with_binding_bridge() {
+        use crate::binding::{BindingEntry, BindingSpec, ResolvedBindings};
+        use crate::store::TaskResult;
+        use std::time::Duration;
+
+        // ───────────────────────────────────────────────────
+        // Step 1: Create 3 ContentBlocks: 2 images (PNG) + 1 text
+        // ───────────────────────────────────────────────────
+
+        // PNG #1: the standard minimal PNG
+        let png1_bytes = real_png_bytes();
+        let png1_b64 = encode_b64(&png1_bytes);
+
+        // PNG #2: same header but with an extra byte to make it unique
+        let mut png2_bytes = real_png_bytes();
+        png2_bytes.push(0xFF); // different content -> different hash
+        let png2_b64 = encode_b64(&png2_bytes);
+
+        let blocks = vec![
+            ContentBlock::image(png1_b64, "image/png"),
+            ContentBlock::text("This text block should be filtered out"),
+            ContentBlock::image(png2_b64, "image/png"),
+        ];
+
+        // ───────────────────────────────────────────────────
+        // Step 2: Process through MediaProcessor -> CAS store
+        // ───────────────────────────────────────────────────
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let budget = Arc::new(MediaBudget::new());
+        let processor = MediaProcessor::with_shared_budget(store, Arc::clone(&budget));
+
+        let results = processor.process_all(&blocks, "monster_task").await;
+
+        // Text block is filtered -> only 2 results
+        assert_eq!(results.len(), 2,
+            "process_all should return 2 results (text filtered), got {}", results.len());
+
+        let mut media_refs: Vec<MediaRef> = Vec::new();
+        for (i, result) in results.into_iter().enumerate() {
+            let (media_ref, store_result) = result
+                .unwrap_or_else(|(_idx, e)| panic!("Block {i} failed: {e}"));
+            assert!(media_ref.hash.starts_with("blake3:"),
+                "media_ref[{i}] hash should start with blake3:");
+            assert_eq!(media_ref.mime_type, "image/png",
+                "media_ref[{i}] mime_type should be image/png");
+            assert_eq!(media_ref.extension, "png",
+                "media_ref[{i}] extension should be png");
+            assert!(media_ref.size_bytes > 0,
+                "media_ref[{i}] size_bytes should be > 0");
+            assert_eq!(media_ref.created_by, "monster_task",
+                "media_ref[{i}] created_by should be monster_task");
+            assert!(store_result.path.exists(),
+                "CAS file should exist for media_ref[{i}]");
+            media_refs.push(media_ref);
+        }
+
+        // Two different PNGs must produce different hashes
+        assert_ne!(media_refs[0].hash, media_refs[1].hash,
+            "Two different PNG byte sequences must produce different blake3 hashes");
+
+        // Verify hashes are correct blake3 computations
+        let expected_hash_0 = format!("blake3:{}", blake3::hash(&png1_bytes).to_hex());
+        let expected_hash_1 = format!("blake3:{}", blake3::hash(&png2_bytes).to_hex());
+        assert_eq!(media_refs[0].hash, expected_hash_0);
+        assert_eq!(media_refs[1].hash, expected_hash_1);
+
+        // Budget should have tracked both images
+        assert!(budget.current_bytes() > 0, "Budget should have tracked bytes");
+        assert_eq!(
+            budget.current_bytes(),
+            (png1_bytes.len() + png2_bytes.len()) as u64,
+            "Budget should equal total decoded bytes"
+        );
+
+        // ───────────────────────────────────────────────────
+        // Step 3: Stage in RunContext via set_media
+        // ───────────────────────────────────────────────────
+
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "monster_task".into();
+
+        ctx.set_media(&task_id, media_refs.clone());
+
+        // ───────────────────────────────────────────────────
+        // Step 4: Take from RunContext via take_media
+        // ───────────────────────────────────────────────────
+
+        let taken = ctx.take_media(&task_id);
+        assert_eq!(taken.len(), 2,
+            "take_media should return 2 staged refs, got {}", taken.len());
+
+        // Verify take_media drains the staging area
+        let taken_again = ctx.take_media(&task_id);
+        assert!(taken_again.is_empty(),
+            "Second take_media must return empty (staging drained)");
+
+        // ───────────────────────────────────────────────────
+        // Step 5: Build TaskResult with with_media
+        // ───────────────────────────────────────────────────
+
+        let tr = TaskResult::success(
+            serde_json::json!({"description": "Monster generated", "quality": 99}),
+            Duration::from_millis(42),
+        ).with_media(taken);
+
+        assert_eq!(tr.media.len(), 2, "TaskResult should carry 2 media refs");
+        assert!(tr.is_success(), "with_media should preserve success status");
+
+        // ───────────────────────────────────────────────────
+        // Step 6: Insert into RunContext
+        // ───────────────────────────────────────────────────
+
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // Also insert a task with NO media for the empty-media test
+        let no_media_id: Arc<str> = "no_media_task".into();
+        let no_media_tr = TaskResult::success(
+            serde_json::json!("text only result"),
+            Duration::from_millis(5),
+        );
+        ctx.insert(Arc::clone(&no_media_id), no_media_tr);
+
+        // ───────────────────────────────────────────────────
+        // Step 7: Test EVERY resolve_path variant
+        // ───────────────────────────────────────────────────
+
+        // 7a: task.media -> full array (2 items, not 3 — text was filtered)
+        let media_val = ctx.resolve_path("monster_task.media")
+            .expect("resolve_path('monster_task.media') should return Some");
+        let media_arr = media_val.as_array()
+            .expect("media should be a JSON array");
+        assert_eq!(media_arr.len(), 2,
+            "media array should have 2 items (text block was filtered)");
+
+        // 7b: task.media[0].hash -> starts with "blake3:"
+        let hash_0 = ctx.resolve_path("monster_task.media[0].hash")
+            .expect("media[0].hash should exist");
+        let hash_0_str = hash_0.as_str().expect("hash should be a string");
+        assert!(hash_0_str.starts_with("blake3:"),
+            "hash should start with blake3:, got: {}", hash_0_str);
+        assert_eq!(hash_0_str, expected_hash_0,
+            "hash[0] should match blake3 of png1");
+
+        // 7c: task.media[0].mime_type -> "image/png"
+        let mime_0 = ctx.resolve_path("monster_task.media[0].mime_type")
+            .expect("media[0].mime_type should exist");
+        assert_eq!(mime_0, "image/png");
+
+        // 7d: task.media[0].extension -> "png"
+        let ext_0 = ctx.resolve_path("monster_task.media[0].extension")
+            .expect("media[0].extension should exist");
+        assert_eq!(ext_0, "png");
+
+        // 7e: task.media[0].size_bytes -> > 0
+        let size_0 = ctx.resolve_path("monster_task.media[0].size_bytes")
+            .expect("media[0].size_bytes should exist");
+        assert!(size_0.as_u64().unwrap() > 0,
+            "size_bytes should be > 0, got {}", size_0);
+        assert_eq!(size_0.as_u64().unwrap(), png1_bytes.len() as u64,
+            "size_bytes should match actual PNG byte count");
+
+        // 7f: task.media[0].path -> contains the CAS shard directory
+        let path_0 = ctx.resolve_path("monster_task.media[0].path")
+            .expect("media[0].path should exist");
+        let path_0_str = path_0.as_str().expect("path should be a string");
+        // CAS uses 2-char shard directories; the hash hex starts after "blake3:"
+        let hash_hex_0 = &expected_hash_0["blake3:".len()..];
+        let shard_0 = &hash_hex_0[..2];
+        assert!(path_0_str.contains(shard_0),
+            "path should contain 2-char shard dir '{}': {}", shard_0, path_0_str);
+
+        // 7g: task.media[0].created_by -> "monster_task"
+        let created_0 = ctx.resolve_path("monster_task.media[0].created_by")
+            .expect("media[0].created_by should exist");
+        assert_eq!(created_0, "monster_task");
+
+        // 7h: task.media[1].hash -> different from [0]
+        let hash_1 = ctx.resolve_path("monster_task.media[1].hash")
+            .expect("media[1].hash should exist");
+        let hash_1_str = hash_1.as_str().expect("hash[1] should be a string");
+        assert_ne!(hash_0_str, hash_1_str,
+            "media[0].hash and media[1].hash must differ (different PNG data)");
+        assert_eq!(hash_1_str, expected_hash_1);
+
+        // 7i: task.media[99].hash -> None (out of bounds)
+        let oob = ctx.resolve_path("monster_task.media[99].hash");
+        assert!(oob.is_none(),
+            "Out-of-bounds media[99].hash should return None, got {:?}", oob);
+
+        // 7j: task.media when task has no media -> empty array
+        let empty_media = ctx.resolve_path("no_media_task.media")
+            .expect("resolve_path for task with no media should return Some");
+        let empty_arr = empty_media.as_array()
+            .expect("empty media should be an array");
+        assert!(empty_arr.is_empty(),
+            "task with no media should return empty array, got {:?}", empty_arr);
+
+        // 7k: task.output_field -> still works (not shadowed by media interception)
+        let desc = ctx.resolve_path("monster_task.description")
+            .expect("non-media output field should still resolve");
+        assert_eq!(desc, "Monster generated",
+            "output field should not be shadowed by media");
+        let quality = ctx.resolve_path("monster_task.quality")
+            .expect("numeric output field should still resolve");
+        assert_eq!(quality, 99);
+
+        // ───────────────────────────────────────────────────
+        // Step 8: Test the binding bridge
+        //   BindingEntry -> ResolvedBindings::from_binding_spec
+        //   This exercises resolve_entry() with media path interception
+        // ───────────────────────────────────────────────────
+
+        let mut spec: BindingSpec = BindingSpec::default();
+
+        // Binding that reads the full media array
+        spec.insert(
+            "all_media".into(),
+            BindingEntry::new("monster_task.media"),
+        );
+        // Binding that reads a specific media field
+        spec.insert(
+            "first_hash".into(),
+            BindingEntry::new("monster_task.media[0].hash"),
+        );
+        // Binding that reads media[1].mime_type
+        spec.insert(
+            "second_mime".into(),
+            BindingEntry::new("monster_task.media[1].mime_type"),
+        );
+        // Binding that reads a regular (non-media) output field
+        spec.insert(
+            "desc".into(),
+            BindingEntry::new("monster_task.description"),
+        );
+        // Binding that reads media from a task with no media
+        spec.insert(
+            "empty".into(),
+            BindingEntry::new("no_media_task.media"),
+        );
+        // Binding that reads out-of-bounds with a default
+        spec.insert(
+            "oob_safe".into(),
+            BindingEntry::with_default(
+                "monster_task.media[99].hash",
+                serde_json::json!("no_such_media"),
+            ),
+        );
+        // Binding that reads media[0].size_bytes
+        spec.insert(
+            "img_size".into(),
+            BindingEntry::new("monster_task.media[0].size_bytes"),
+        );
+        // Binding that reads media[0].extension
+        spec.insert(
+            "img_ext".into(),
+            BindingEntry::new("monster_task.media[0].extension"),
+        );
+        // Binding that reads media[0].created_by
+        spec.insert(
+            "img_author".into(),
+            BindingEntry::new("monster_task.media[0].created_by"),
+        );
+        // Binding that reads media[0].path
+        spec.insert(
+            "img_path".into(),
+            BindingEntry::new("monster_task.media[0].path"),
+        );
+
+        let resolved = ResolvedBindings::from_binding_spec(Some(&spec), &ctx)
+            .expect("from_binding_spec should succeed for all media bindings");
+
+        // Verify all_media binding
+        let all_media = resolved.get("all_media")
+            .expect("all_media binding should be resolved");
+        assert!(all_media.is_array());
+        assert_eq!(all_media.as_array().unwrap().len(), 2);
+
+        // Verify first_hash binding
+        let first_hash = resolved.get("first_hash")
+            .expect("first_hash binding should be resolved");
+        assert_eq!(first_hash.as_str().unwrap(), expected_hash_0,
+            "first_hash binding should match direct resolve_path result");
+
+        // Verify second_mime binding
+        let second_mime = resolved.get("second_mime")
+            .expect("second_mime binding should be resolved");
+        assert_eq!(second_mime, "image/png");
+
+        // Verify desc binding (non-media, must not be affected)
+        let desc_binding = resolved.get("desc")
+            .expect("desc binding (non-media) should be resolved");
+        assert_eq!(desc_binding, "Monster generated");
+
+        // Verify empty binding (task with no media -> empty array)
+        let empty_binding = resolved.get("empty")
+            .expect("empty binding should be resolved");
+        assert!(empty_binding.is_array());
+        assert!(empty_binding.as_array().unwrap().is_empty());
+
+        // Verify oob_safe binding (out-of-bounds with default)
+        let oob_binding = resolved.get("oob_safe")
+            .expect("oob_safe binding should be resolved");
+        assert_eq!(oob_binding, "no_such_media",
+            "Out-of-bounds media path should fall back to default");
+
+        // Verify img_size binding
+        let img_size = resolved.get("img_size")
+            .expect("img_size binding should be resolved");
+        assert_eq!(img_size.as_u64().unwrap(), png1_bytes.len() as u64);
+
+        // Verify img_ext binding
+        let img_ext = resolved.get("img_ext")
+            .expect("img_ext binding should be resolved");
+        assert_eq!(img_ext, "png");
+
+        // Verify img_author binding
+        let img_author = resolved.get("img_author")
+            .expect("img_author binding should be resolved");
+        assert_eq!(img_author, "monster_task");
+
+        // Verify img_path binding
+        let img_path = resolved.get("img_path")
+            .expect("img_path binding should be resolved");
+        let img_path_str = img_path.as_str().expect("path should be a string");
+        assert!(img_path_str.contains(shard_0),
+            "binding img_path should contain CAS shard dir: {}", img_path_str);
+
+        // ───────────────────────────────────────────────────
+        // Final sanity: verify CAS files on disk are intact
+        // ───────────────────────────────────────────────────
+        let stored_data_0 = tokio::fs::read(&media_refs[0].path).await
+            .expect("CAS file for media_ref[0] should be readable");
+        assert_eq!(stored_data_0, png1_bytes,
+            "CAS stored data for png1 must match original bytes");
+
+        let stored_data_1 = tokio::fs::read(&media_refs[1].path).await
+            .expect("CAS file for media_ref[1] should be readable");
+        assert_eq!(stored_data_1, png2_bytes,
+            "CAS stored data for png2 must match original bytes");
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -748,4 +748,381 @@ mod tests {
         assert_eq!(MediaType::from_mime(""), MediaType::Unknown);
         assert_eq!(MediaType::from_mime("garbage"), MediaType::Unknown);
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PHASE E2: AGGRESSIVE EDGE CASES — SILENT BUG HUNTING
+    // ═══════════════════════════════════════════════════════════════
+
+    // --- Base64 stress tests ---
+
+    #[tokio::test]
+    async fn e2e_base64_with_spaces_fails() {
+        // Some servers insert spaces in base64
+        let (processor, _dir) = make_processor_e2e();
+        let b64 = encode_b64(&real_png_bytes());
+        let with_spaces = b64.chars()
+            .enumerate()
+            .map(|(i, c)| if i > 0 && i % 20 == 0 { format!(" {c}") } else { c.to_string() })
+            .collect::<String>();
+        let block = ContentBlock::image(with_spaces, "image/png");
+        let result = processor.process(&block, "t_spaces").await;
+        // STANDARD base64 rejects whitespace → should be NIKA-256
+        assert!(result.is_err(), "Base64 with spaces should fail");
+        assert_eq!(result.unwrap_err().code(), "NIKA-256");
+    }
+
+    #[tokio::test]
+    async fn e2e_base64_single_char_fails() {
+        let (processor, _dir) = make_processor_e2e();
+        let block = ContentBlock::image("A", "image/png");
+        let result = processor.process(&block, "t_single").await;
+        // Single char is invalid base64 (not multiple of 4)
+        assert!(result.is_err(), "Single char base64 should fail");
+    }
+
+    #[tokio::test]
+    async fn e2e_base64_just_padding_fails() {
+        let (processor, _dir) = make_processor_e2e();
+        let block = ContentBlock::image("====", "image/png");
+        let result = processor.process(&block, "t_padding").await;
+        // Just padding chars is invalid
+        assert!(result.is_err(), "Padding-only base64 should fail");
+    }
+
+    #[tokio::test]
+    async fn e2e_base64_decodes_to_single_byte() {
+        let (processor, _dir) = make_processor_e2e();
+        // Single byte 0xFF → base64 "/w=="
+        let b64 = encode_b64(&[0xFF]);
+        let block = ContentBlock::image(b64, "application/octet-stream");
+        let result = processor.process(&block, "t_1byte").await;
+        // 1 byte → infer::get() returns None → server hint "application/octet-stream" → error
+        assert!(result.is_err(), "Single byte with octet-stream should fail MIME detection");
+        assert_eq!(result.unwrap_err().code(), "NIKA-251");
+    }
+
+    // --- MIME detection stress ---
+
+    #[test]
+    fn e2e_detect_empty_data_fails() {
+        // Empty slice should fail
+        let result = detect_mime(&[], None);
+        assert!(result.is_err(), "Empty data should fail MIME detection");
+    }
+
+    #[test]
+    fn e2e_detect_single_byte_fails() {
+        let result = detect_mime(&[0x89], None);
+        assert!(result.is_err(), "Single byte should fail MIME detection");
+    }
+
+    #[test]
+    fn e2e_detect_almost_png_fails() {
+        // First 3 bytes of PNG but incomplete signature
+        let almost_png = &[0x89, 0x50, 0x4E];
+        let result = detect_mime(almost_png, None);
+        // Should NOT detect as PNG — incomplete signature
+        match result {
+            Ok(detected) => {
+                assert_ne!(detected.mime_type, "image/png",
+                    "SILENT BUG: incomplete PNG signature detected as PNG!");
+            }
+            Err(_) => {} // Expected: detection fails
+        }
+    }
+
+    #[test]
+    fn e2e_detect_webp_header() {
+        // RIFF....WEBP
+        let webp = &[
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x00, 0x00, 0x00, 0x00, // size
+            0x57, 0x45, 0x42, 0x50, // WEBP
+        ];
+        let result = detect_mime(webp, None).unwrap();
+        assert_eq!(result.mime_type, "image/webp");
+    }
+
+    #[test]
+    fn e2e_detect_mp3_id3_header() {
+        let mp3 = real_mp3_bytes();
+        let result = detect_mime(&mp3, None).unwrap();
+        assert!(result.mime_type.contains("mp3") || result.mime_type.contains("mpeg"),
+            "MP3 not detected: {}", result.mime_type);
+    }
+
+    #[test]
+    fn e2e_detect_xml_not_svg() {
+        // XML that is NOT SVG — should NOT be detected as image/svg+xml
+        let xml = b"<?xml version=\"1.0\"?><root><data>hello</data></root>";
+        let result = detect_mime(xml, None);
+        match result {
+            Ok(detected) => {
+                assert_ne!(detected.mime_type, "image/svg+xml",
+                    "SILENT BUG: non-SVG XML detected as SVG!");
+            }
+            Err(_) => {} // Expected: not detected
+        }
+    }
+
+    #[test]
+    fn e2e_detect_svg_with_xml_declaration() {
+        let svg = b"<?xml version=\"1.0\"?><svg xmlns=\"http://www.w3.org/2000/svg\"><circle/></svg>";
+        let result = detect_mime(svg, None).unwrap();
+        assert_eq!(result.mime_type, "image/svg+xml");
+    }
+
+    #[test]
+    fn e2e_detect_server_mime_alias_audio_mp3() {
+        // Server says "audio/mp3" (non-standard) for an actual MP3
+        let mp3 = real_mp3_bytes();
+        let result = detect_mime(&mp3, Some("audio/mp3")).unwrap();
+        // Magic bytes should detect correctly regardless of non-standard server hint
+        assert!(result.mime_type.contains("mpeg") || result.mime_type.contains("mp3"),
+            "MP3 detection failed with non-standard server hint: {}", result.mime_type);
+    }
+
+    // --- CAS store edge cases ---
+
+    #[tokio::test]
+    async fn e2e_cas_store_large_file_without_verify() {
+        // File just under verify threshold (1MB) — should NOT be verified
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let data = vec![0xAB_u8; 1024 * 1024 - 1]; // 1MB - 1 byte
+        let result = store.store(&data).await.unwrap();
+        assert!(!result.verified, "File under 1MB should not be verified");
+        assert!(!result.deduplicated);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_store_exact_threshold_is_verified() {
+        // File exactly at verify threshold (1MB) — SHOULD be verified
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let data = vec![0xCD_u8; 1024 * 1024]; // Exactly 1MB
+        let result = store.store(&data).await.unwrap();
+        assert!(result.verified, "File at exactly 1MB should be verified");
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_read_with_raw_hash_no_prefix() {
+        // read() should accept both "blake3:..." and raw hash
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let data = b"read with raw hash";
+        let result = store.store(data).await.unwrap();
+
+        // Read with full prefix
+        let data1 = store.read(&result.hash).await.unwrap();
+        assert_eq!(data1, data);
+
+        // Read with raw hash (strip "blake3:" prefix)
+        let raw_hash = result.hash.strip_prefix("blake3:").unwrap();
+        let data2 = store.read(raw_hash).await.unwrap();
+        assert_eq!(data2, data);
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_exists_with_raw_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let result = store.store(b"exists check").await.unwrap();
+
+        assert!(store.exists(&result.hash));
+        let raw = result.hash.strip_prefix("blake3:").unwrap();
+        assert!(store.exists(raw));
+    }
+
+    #[tokio::test]
+    async fn e2e_cas_read_invalid_short_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        // Hash too short (< 3 chars)
+        let result = store.read("ab").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), "NIKA-253");
+    }
+
+    // --- Process pipeline integration ---
+
+    #[tokio::test]
+    async fn e2e_process_audio_block() {
+        let (processor, _dir) = make_processor_e2e();
+        let mp3 = real_mp3_bytes();
+        let block = ContentBlock::audio(encode_b64(&mp3), "audio/mpeg");
+        let result = processor.process(&block, "gen_audio").await
+            .expect("process should succeed")
+            .expect("audio should return Some");
+        let (media_ref, _) = result;
+        assert!(media_ref.mime_type.contains("mpeg") || media_ref.mime_type.contains("mp3"),
+            "Audio MIME type wrong: {}", media_ref.mime_type);
+        assert_eq!(media_ref.created_by, "gen_audio");
+    }
+
+    #[tokio::test]
+    async fn e2e_process_resource_with_blob_and_mime() {
+        let (processor, _dir) = make_processor_e2e();
+        let pdf = real_pdf_bytes();
+        let rc = ResourceContent::new("file:///doc.pdf")
+            .with_blob(encode_b64(&pdf))
+            .with_mime_type("application/pdf");
+        let block = ContentBlock::Resource(rc);
+        let result = processor.process(&block, "gen_pdf").await
+            .expect("process should succeed")
+            .expect("blob resource should return Some");
+        let (media_ref, _) = result;
+        assert_eq!(media_ref.mime_type, "application/pdf");
+    }
+
+    #[tokio::test]
+    async fn e2e_process_all_only_errors() {
+        let (processor, _dir) = make_processor_e2e();
+        let blocks = vec![
+            ContentBlock::image("BAD_BASE64!!!", "image/png"),
+            ContentBlock::audio("ALSO_BAD!!!", "audio/wav"),
+        ];
+        let results = processor.process_all(&blocks, "fail_all").await;
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.is_err()),
+            "All blocks should fail");
+    }
+
+    #[tokio::test]
+    async fn e2e_process_all_empty_vec() {
+        let (processor, _dir) = make_processor_e2e();
+        let results = processor.process_all(&[], "empty").await;
+        assert!(results.is_empty(), "Empty input should produce empty output");
+    }
+
+    #[tokio::test]
+    async fn e2e_process_all_text_only() {
+        let (processor, _dir) = make_processor_e2e();
+        let blocks = vec![
+            ContentBlock::text("hello"),
+            ContentBlock::text("world"),
+        ];
+        let results = processor.process_all(&blocks, "text_only").await;
+        assert!(results.is_empty(), "Text-only blocks should produce empty output");
+    }
+
+    // --- Shared budget e2e ---
+
+    #[tokio::test]
+    async fn e2e_shared_budget_across_processors() {
+        let budget = Arc::new(MediaBudget::with_max_per_run(200));
+
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+        let p1 = MediaProcessor::with_shared_budget(
+            CasStore::new(dir1.path()), Arc::clone(&budget));
+        let p2 = MediaProcessor::with_shared_budget(
+            CasStore::new(dir2.path()), Arc::clone(&budget));
+
+        let png = real_png_bytes();
+        let b64 = encode_b64(&png);
+
+        // First processor succeeds
+        let r1 = p1.process(&ContentBlock::image(b64.clone(), "image/png"), "t1").await;
+        assert!(r1.is_ok(), "First process should succeed: {:?}", r1.err());
+
+        // Second processor succeeds (still under budget)
+        let r2 = p2.process(&ContentBlock::image(b64.clone(), "image/png"), "t2").await;
+        assert!(r2.is_ok(), "Second process should succeed: {:?}", r2.err());
+
+        // Third processor should fail (budget exceeded: ~70 bytes x 3 > 200)
+        let r3 = p1.process(&ContentBlock::image(b64.clone(), "image/png"), "t3").await;
+        assert!(r3.is_err(), "Third process should exceed budget");
+        assert_eq!(r3.unwrap_err().code(), "NIKA-259");
+    }
+
+    // --- Error code regression tests ---
+
+    #[test]
+    fn e2e_all_error_variants_have_display() {
+        // Every error variant must have a non-empty Display and contain its NIKA code
+        let cases: Vec<(MediaError, &str)> = vec![
+            (MediaError::mime_detection_failed(100, Some("image/png".into())), "NIKA-251"),
+            (MediaError::UnsupportedMediaType { mime_type: "x".into(), reason: "y".into() }, "NIKA-252"),
+            (MediaError::MediaNotFound { hash: "h".into() }, "NIKA-253"),
+            (MediaError::HashMismatch { expected: "a".into(), actual: "b".into() }, "NIKA-254"),
+            (MediaError::MediaStoreWrite {
+                path: "/x".into(),
+                source: std::io::Error::new(std::io::ErrorKind::Other, "test"),
+            }, "NIKA-255"),
+            (MediaError::Base64DecodeFailed { source_desc: "x".into(), reason: "y".into() }, "NIKA-256"),
+            (MediaError::Base64InputTooLarge { size: 200, max: 100 }, "NIKA-257"),
+            (MediaError::EmptyMediaContent { task_id: "t".into() }, "NIKA-258"),
+            (MediaError::RunBudgetExceeded { current: 600, max: 500 }, "NIKA-259"),
+        ];
+        for (err, code) in &cases {
+            let display = format!("{err}");
+            assert!(!display.is_empty(), "{code} has empty display");
+            assert!(display.contains(code), "{code} display missing code: {display}");
+            assert_eq!(err.code(), *code);
+        }
+    }
+
+    #[test]
+    fn e2e_media_error_is_recoverable() {
+        // Only MediaStoreWrite should be recoverable
+        assert!(MediaError::MediaStoreWrite {
+            path: "/x".into(),
+            source: std::io::Error::new(std::io::ErrorKind::Other, ""),
+        }.is_recoverable());
+
+        assert!(!MediaError::mime_detection_failed(0, None).is_recoverable());
+        assert!(!MediaError::Base64DecodeFailed { source_desc: "".into(), reason: "".into() }.is_recoverable());
+        assert!(!MediaError::RunBudgetExceeded { current: 0, max: 0 }.is_recoverable());
+    }
+
+    // --- ContentBlock serde exhaustive ---
+
+    #[test]
+    fn e2e_content_block_audio_json_format() {
+        let block = ContentBlock::audio("data123", "audio/mpeg");
+        let json = serde_json::to_value(&block).unwrap();
+        assert_eq!(json["type"], "audio");
+        assert_eq!(json["data"], "data123");
+        assert_eq!(json["mimeType"], "audio/mpeg");
+        // Must NOT have mime_type (snake_case)
+        assert!(json.get("mime_type").is_none());
+    }
+
+    #[test]
+    fn e2e_content_block_resource_link_with_all_fields() {
+        let block = ContentBlock::resource_link(
+            "file:///test",
+            Some("myfile.pdf".into()),
+            Some("application/pdf".into()),
+        );
+        let json = serde_json::to_value(&block).unwrap();
+        assert_eq!(json["type"], "resource_link");
+        assert_eq!(json["uri"], "file:///test");
+        assert_eq!(json["name"], "myfile.pdf");
+        assert_eq!(json["mimeType"], "application/pdf");
+    }
+
+    #[test]
+    fn e2e_content_block_deserialize_unknown_type_fails() {
+        // Unknown type should fail deserialization
+        let json = r#"{"type": "video", "data": "abc"}"#;
+        let result: Result<ContentBlock, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "Unknown content type 'video' should fail deserialization");
+    }
+
+    #[test]
+    fn e2e_content_block_missing_type_fails() {
+        let json = r#"{"text": "hello"}"#;
+        let result: Result<ContentBlock, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "Missing 'type' field should fail deserialization");
+    }
+
+    // --- Helper ---
+
+    fn make_processor_e2e() -> (MediaProcessor, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        (MediaProcessor::new(store), dir)
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -183,25 +183,37 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════
 
     #[tokio::test]
-    async fn e2e_mime_category_mismatch_uses_magic_bytes() {
+    async fn e2e_mime_category_mismatch_is_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let store = CasStore::new(dir.path());
         let processor = MediaProcessor::new(store);
 
-        // Send PNG data with audio/wav MIME type
+        // Send PNG data with audio/wav MIME type → cross-category mismatch → NIKA-251
         let block = ContentBlock::image(encode_b64(&real_png_bytes()), "audio/wav");
+        let result = processor.process(&block, "t_mismatch").await;
+
+        assert!(result.is_err(), "Cross-category MIME mismatch should be rejected");
+        assert_eq!(result.unwrap_err().code(), "NIKA-251");
+    }
+
+    #[tokio::test]
+    async fn e2e_mime_same_category_mismatch_uses_magic_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let processor = MediaProcessor::new(store);
+
+        // Send PNG data with image/webp MIME type → same category → magic bytes win
+        let block = ContentBlock::image(encode_b64(&real_png_bytes()), "image/webp");
         let result = processor.process(&block, "t_mismatch").await;
 
         match result {
             Ok(Some((media_ref, _))) => {
-                // Magic bytes MUST win over server declaration
                 assert_eq!(media_ref.mime_type, "image/png",
-                    "SILENT BUG: server MIME type overrode magic bytes detection! Got: {}",
-                    media_ref.mime_type);
+                    "Magic bytes should win for same-category mismatch");
                 assert_eq!(media_ref.extension, "png");
             }
-            Ok(None) => panic!("SILENT BUG: image data returned None"),
-            Err(e) => panic!("Unexpected error on valid PNG data: {}", e),
+            Ok(None) => panic!("image data returned None"),
+            Err(e) => panic!("Same-category mismatch should not error: {}", e),
         }
     }
 
@@ -479,7 +491,7 @@ mod tests {
                 expected: "blake3:aaa".into(),
                 actual: "blake3:bbb".into(),
             },
-            MediaError::MediaStoreWrite {
+            MediaError::MediaStoreIo {
                 path: "/tmp/fail".into(),
                 source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
             },
@@ -1040,7 +1052,7 @@ mod tests {
             (MediaError::UnsupportedMediaType { mime_type: "x".into(), reason: "y".into() }, "NIKA-252"),
             (MediaError::MediaNotFound { hash: "h".into() }, "NIKA-253"),
             (MediaError::HashMismatch { expected: "a".into(), actual: "b".into() }, "NIKA-254"),
-            (MediaError::MediaStoreWrite {
+            (MediaError::MediaStoreIo {
                 path: "/x".into(),
                 source: std::io::Error::new(std::io::ErrorKind::Other, "test"),
             }, "NIKA-255"),
@@ -1059,8 +1071,8 @@ mod tests {
 
     #[test]
     fn e2e_media_error_is_recoverable() {
-        // Only MediaStoreWrite should be recoverable
-        assert!(MediaError::MediaStoreWrite {
+        // Only MediaStoreIo (I/O errors) should be recoverable
+        assert!(MediaError::MediaStoreIo {
             path: "/x".into(),
             source: std::io::Error::new(std::io::ErrorKind::Other, ""),
         }.is_recoverable());
@@ -1934,21 +1946,13 @@ mod tests {
 
     #[tokio::test]
     async fn e2e_cas_empty_data_store_and_read() {
-        // Empty data is a valid CAS entry (0 bytes)
+        // Defense-in-depth: empty data is now rejected at CAS layer (NIKA-258)
         let dir = tempfile::tempdir().unwrap();
         let store = CasStore::new(dir.path());
 
-        let result = store.store(b"").await.unwrap();
-        assert_eq!(result.size, 0);
-        assert!(!result.verified, "empty file is under threshold");
-
-        let read_back = store.read(&result.hash).await.unwrap();
-        assert!(read_back.is_empty());
-
-        // Dedup on second store
-        let r2 = store.store(b"").await.unwrap();
-        assert!(r2.deduplicated);
-        assert_eq!(result.hash, r2.hash);
+        let result = store.store(b"").await;
+        assert!(result.is_err(), "CAS should reject empty data");
+        assert_eq!(result.unwrap_err().code(), "NIKA-258");
     }
 
     #[tokio::test]

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -3019,4 +3019,254 @@ mod tests {
         let (mr, _) = processor.process(&block, "").await.unwrap().unwrap();
         assert_eq!(mr.created_by, "");
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 3: Full pipeline — ContentBlock -> process -> CAS -> MediaRef
+    //        -> RunContext.set_media -> take_media -> resolve_path
+    // Exercises the REAL CAS store (not mock data) through the entire
+    // pipeline from raw bytes to template-resolvable media bindings.
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn gap3_full_pipeline_content_block_to_resolve_path() {
+        // Step 1: Create real processor with CAS store
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let budget = Arc::new(MediaBudget::with_max_per_run(100_000));
+        let processor = MediaProcessor::with_shared_budget(store, Arc::clone(&budget));
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "pipeline_test".into();
+
+        // Step 2: Create a ContentBlock with real PNG data
+        let png_data = real_png_bytes();
+        let b64 = encode_b64(&png_data);
+        let block = ContentBlock::image(b64, "image/png");
+
+        // Step 3: Process through MediaProcessor
+        let (media_ref, store_result) = processor
+            .process(&block, task_id.as_ref())
+            .await
+            .expect("process should succeed")
+            .expect("image block should produce Some");
+
+        // Verify the MediaRef is populated correctly
+        assert!(media_ref.hash.starts_with("blake3:"), "hash missing prefix");
+        assert_eq!(media_ref.mime_type, "image/png");
+        assert_eq!(media_ref.extension, "png");
+        assert_eq!(media_ref.size_bytes, png_data.len() as u64);
+        assert_eq!(media_ref.created_by, "pipeline_test");
+        assert!(media_ref.path.exists(), "CAS file should exist on disk");
+
+        // Verify CAS file content is correct (not corrupted)
+        let on_disk = tokio::fs::read(&media_ref.path).await.unwrap();
+        assert_eq!(on_disk, png_data, "CAS stored data must match original PNG bytes");
+
+        // Verify the hash is correct
+        let expected_hash = format!("blake3:{}", blake3::hash(&png_data).to_hex());
+        assert_eq!(media_ref.hash, expected_hash, "hash must match direct blake3 computation");
+
+        // Verify StoreResult fields
+        assert!(!store_result.deduplicated);
+        assert_eq!(store_result.size, png_data.len() as u64);
+
+        // Step 4: Stage in RunContext (simulates what run_invoke does)
+        ctx.set_media(&task_id, vec![media_ref.clone()]);
+
+        // Step 5: Take from RunContext (simulates what runner does after task completes)
+        let taken = ctx.take_media(&task_id);
+        assert_eq!(taken.len(), 1, "take_media should return 1 ref");
+        assert_eq!(taken[0].hash, media_ref.hash);
+
+        // Step 6: Build TaskResult with media (simulates runner)
+        use crate::store::TaskResult;
+        let tr = TaskResult::success(
+            serde_json::json!({"prompt": "generate a logo"}),
+            std::time::Duration::from_millis(42),
+        ).with_media(taken);
+        assert_eq!(tr.media.len(), 1);
+
+        // Step 7: Insert into RunContext results (simulates runner storing the result)
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // Step 8: resolve_path — test every media field through template bindings
+
+        // {{with.pipeline_test.media}} -> full array
+        let media_arr = ctx.resolve_path("pipeline_test.media")
+            .expect("resolve_path('pipeline_test.media') should return Some");
+        assert!(media_arr.is_array());
+        assert_eq!(media_arr.as_array().unwrap().len(), 1);
+
+        // {{with.pipeline_test.media[0].hash}} -> actual blake3 hash
+        let resolved_hash = ctx.resolve_path("pipeline_test.media[0].hash")
+            .expect("resolve_path('...media[0].hash') should return Some");
+        assert_eq!(resolved_hash, expected_hash,
+            "resolved hash must match the actual blake3 hash of PNG data");
+
+        // {{with.pipeline_test.media[0].mime_type}} -> "image/png"
+        let resolved_mime = ctx.resolve_path("pipeline_test.media[0].mime_type")
+            .expect("resolve_path('...media[0].mime_type') should return Some");
+        assert_eq!(resolved_mime, "image/png");
+
+        // {{with.pipeline_test.media[0].extension}} -> "png"
+        let resolved_ext = ctx.resolve_path("pipeline_test.media[0].extension")
+            .expect("resolve_path('...media[0].extension') should return Some");
+        assert_eq!(resolved_ext, "png");
+
+        // {{with.pipeline_test.media[0].size_bytes}} -> exact decoded size
+        let resolved_size = ctx.resolve_path("pipeline_test.media[0].size_bytes")
+            .expect("resolve_path('...media[0].size_bytes') should return Some");
+        assert_eq!(resolved_size, png_data.len() as u64,
+            "size_bytes must match decoded PNG size, not base64 size");
+
+        // {{with.pipeline_test.media[0].path}} -> CAS path on disk
+        let resolved_path = ctx.resolve_path("pipeline_test.media[0].path")
+            .expect("resolve_path('...media[0].path') should return Some");
+        let path_str = resolved_path.as_str().expect("path should be a string");
+        assert!(path_str.contains(dir.path().to_str().unwrap()),
+            "resolved path should contain CAS root: {}", path_str);
+
+        // {{with.pipeline_test.media[0].created_by}} -> task_id
+        let resolved_creator = ctx.resolve_path("pipeline_test.media[0].created_by")
+            .expect("resolve_path('...media[0].created_by') should return Some");
+        assert_eq!(resolved_creator, "pipeline_test");
+
+        // Normal output fields still resolve correctly
+        let prompt = ctx.resolve_path("pipeline_test.prompt")
+            .expect("normal output should still resolve");
+        assert_eq!(prompt, "generate a logo");
+
+        // Budget was consumed
+        assert_eq!(budget.current_bytes(), png_data.len() as u64,
+            "budget should track the decoded PNG size");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 8: NikaError::is_recoverable for MediaError variants
+    // Only MediaStoreIo should be recoverable through NikaError.
+    // All other MediaError variants must be non-recoverable.
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn gap8_nika_error_is_recoverable_media_store_io() {
+        use crate::error::NikaError;
+
+        // MediaStoreIo is the ONLY recoverable MediaError variant
+        let io_err = MediaError::MediaStoreIo {
+            path: "/tmp/cas/ab/cdef".into(),
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied"),
+        };
+        let nika_err: NikaError = io_err.into();
+        assert!(nika_err.is_recoverable(),
+            "MediaStoreIo should be recoverable through NikaError");
+        assert_eq!(nika_err.code(), "NIKA-255");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_mime_detection_failed() {
+        use crate::error::NikaError;
+
+        let err = MediaError::MimeDetectionFailed {
+            reason: "magic bytes unrecognized".into(),
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "MimeDetectionFailed should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-251");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_unsupported_media_type() {
+        use crate::error::NikaError;
+
+        let err = MediaError::UnsupportedMediaType {
+            mime_type: "video/x-matroska".into(),
+            reason: "not in allowlist".into(),
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "UnsupportedMediaType should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-252");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_media_not_found() {
+        use crate::error::NikaError;
+
+        let err = MediaError::MediaNotFound {
+            hash: "blake3:deadbeef".into(),
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "MediaNotFound should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-253");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_hash_mismatch() {
+        use crate::error::NikaError;
+
+        let err = MediaError::HashMismatch {
+            expected: "blake3:aaa".into(),
+            actual: "blake3:bbb".into(),
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "HashMismatch should NOT be recoverable (data corruption)");
+        assert_eq!(nika_err.code(), "NIKA-254");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_base64_decode_failed() {
+        use crate::error::NikaError;
+
+        let err = MediaError::Base64DecodeFailed {
+            source_desc: "task gen_img".into(),
+            reason: "invalid byte at position 4".into(),
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "Base64DecodeFailed should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-256");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_base64_input_too_large() {
+        use crate::error::NikaError;
+
+        let err = MediaError::Base64InputTooLarge {
+            size: 200_000_000,
+            max: 100_000_000,
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "Base64InputTooLarge should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-257");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_empty_media_content() {
+        use crate::error::NikaError;
+
+        let err = MediaError::EmptyMediaContent {
+            task_id: "empty_task".into(),
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "EmptyMediaContent should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-258");
+    }
+
+    #[test]
+    fn gap8_nika_error_is_not_recoverable_run_budget_exceeded() {
+        use crate::error::NikaError;
+
+        let err = MediaError::RunBudgetExceeded {
+            current: 600_000_000,
+            max: 500_000_000,
+        };
+        let nika_err: NikaError = err.into();
+        assert!(!nika_err.is_recoverable(),
+            "RunBudgetExceeded should NOT be recoverable");
+        assert_eq!(nika_err.code(), "NIKA-259");
+    }
 }

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -193,4 +193,62 @@ mod tests {
         assert_eq!(MediaType::from_mime("application/pdf"), MediaType::Document);
         assert_eq!(MediaType::from_mime("text/plain"), MediaType::Unknown);
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // GAP 1/2 support: MediaBudget::rollback unit test
+    // Verifies that rollback correctly decrements the counter
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn media_budget_rollback_restores_capacity() {
+        let budget = MediaBudget::with_max_per_run(1000);
+
+        // Charge 600 bytes
+        budget.check_and_add(600, "t1").unwrap();
+        assert_eq!(budget.current_bytes(), 600);
+
+        // Roll back 600 bytes (simulates failure after budget charge)
+        budget.rollback(600);
+        assert_eq!(budget.current_bytes(), 0,
+            "rollback should restore budget to 0");
+
+        // After rollback, the full budget should be available again
+        budget.check_and_add(900, "t2").unwrap();
+        assert_eq!(budget.current_bytes(), 900);
+    }
+
+    #[test]
+    fn media_budget_partial_rollback() {
+        let budget = MediaBudget::with_max_per_run(1000);
+
+        budget.check_and_add(300, "t1").unwrap();
+        budget.check_and_add(400, "t2").unwrap();
+        assert_eq!(budget.current_bytes(), 700);
+
+        // Roll back only t2's allocation
+        budget.rollback(400);
+        assert_eq!(budget.current_bytes(), 300,
+            "partial rollback should leave t1's allocation intact");
+
+        // Now we have 700 bytes of capacity remaining
+        budget.check_and_add(700, "t3").unwrap();
+        assert_eq!(budget.current_bytes(), 1000);
+    }
+
+    #[test]
+    fn media_budget_rollback_then_reuse() {
+        let budget = MediaBudget::with_max_per_run(100);
+
+        // Fill to capacity
+        budget.check_and_add(100, "t1").unwrap();
+        assert!(budget.check_and_add(1, "t2").is_err(), "should be at capacity");
+
+        // Roll back and verify capacity is restored
+        budget.rollback(100);
+        assert_eq!(budget.current_bytes(), 0);
+
+        // Now the full budget is available
+        budget.check_and_add(100, "t3").unwrap();
+        assert_eq!(budget.current_bytes(), 100);
+    }
 }

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -117,3 +117,62 @@ impl Default for MediaBudget {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn media_budget_under_limit() {
+        let budget = MediaBudget::with_max_per_run(1024);
+        assert!(budget.check_and_add(512, "t1").is_ok());
+        assert_eq!(budget.current_bytes(), 512);
+    }
+
+    #[test]
+    fn media_budget_exceeds_limit() {
+        let budget = MediaBudget::with_max_per_run(1024);
+        budget.check_and_add(512, "t1").unwrap();
+        let err = budget.check_and_add(1024, "t2").unwrap_err();
+        assert_eq!(err.code(), "NIKA-259");
+        // Budget should NOT have increased
+        assert_eq!(budget.current_bytes(), 512);
+    }
+
+    #[test]
+    fn media_budget_accumulated_tracking() {
+        let budget = MediaBudget::with_max_per_run(1000);
+        budget.check_and_add(300, "t1").unwrap();
+        budget.check_and_add(300, "t2").unwrap();
+        budget.check_and_add(300, "t3").unwrap();
+        assert_eq!(budget.current_bytes(), 900);
+        // This should fail (900 + 200 = 1100 > 1000)
+        assert!(budget.check_and_add(200, "t4").is_err());
+    }
+
+    #[test]
+    fn media_ref_serde_roundtrip() {
+        let mr = MediaRef {
+            hash: "blake3:af1349b9".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: 4096,
+            path: PathBuf::from("/tmp/store/af/1349b9"),
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        };
+        let json = serde_json::to_string(&mr).unwrap();
+        let back: MediaRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(mr, back);
+        assert!(json.contains("blake3:af1349b9"));
+    }
+
+    #[test]
+    fn media_type_from_mime() {
+        assert_eq!(MediaType::from_mime("image/png"), MediaType::Image);
+        assert_eq!(MediaType::from_mime("image/jpeg"), MediaType::Image);
+        assert_eq!(MediaType::from_mime("audio/wav"), MediaType::Audio);
+        assert_eq!(MediaType::from_mime("audio/mpeg"), MediaType::Audio);
+        assert_eq!(MediaType::from_mime("application/pdf"), MediaType::Document);
+        assert_eq!(MediaType::from_mime("text/plain"), MediaType::Unknown);
+    }
+}

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -1,0 +1,119 @@
+//! Media pipeline types: MediaRef, MediaType, MediaBudget
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+/// Reference to a media file stored in the CAS.
+///
+/// Serializes to JSON for use in `{{with.task_id.media[0].hash}}` templates.
+/// Hash stores the algorithm-prefixed hash: `"blake3:af1349..."`.
+/// CAS filenames are hash-only (no extension). Extension is stored only here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MediaRef {
+    /// Algorithm-prefixed hash (e.g., "blake3:af1349b9...")
+    pub hash: String,
+
+    /// Detected MIME type (e.g., "image/png", "audio/wav")
+    pub mime_type: String,
+
+    /// File size in bytes (decoded, not base64)
+    pub size_bytes: u64,
+
+    /// Absolute path to the stored file
+    pub path: PathBuf,
+
+    /// File extension without dot (e.g., "png", "wav")
+    pub extension: String,
+
+    /// Task ID that produced this media
+    pub created_by: String,
+}
+
+/// Broad media type classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaType {
+    Image,
+    Audio,
+    Document,
+    Unknown,
+}
+
+impl MediaType {
+    /// Classify a MIME type string into a MediaType.
+    pub fn from_mime(mime: &str) -> Self {
+        if mime.starts_with("image/") {
+            Self::Image
+        } else if mime.starts_with("audio/") {
+            Self::Audio
+        } else if mime.starts_with("application/pdf")
+            || mime.starts_with("application/vnd.openxmlformats")
+            || mime.starts_with("application/msword")
+        {
+            Self::Document
+        } else {
+            Self::Unknown
+        }
+    }
+}
+
+/// Media budget enforcement for memory safety.
+///
+/// Tracks cumulative bytes processed per run to prevent unbounded media
+/// accumulation (e.g., from `for_each` with many media-producing iterations).
+/// Uses `AtomicU64` for lock-free concurrent access from parallel tasks.
+pub struct MediaBudget {
+    run_bytes: AtomicU64,
+    max_per_run: u64,
+}
+
+impl MediaBudget {
+    /// Default per-run budget: 500MB.
+    pub const DEFAULT_MAX_PER_RUN: u64 = 500 * 1024 * 1024;
+
+    /// Create a new budget with default limits.
+    pub fn new() -> Self {
+        Self {
+            run_bytes: AtomicU64::new(0),
+            max_per_run: Self::DEFAULT_MAX_PER_RUN,
+        }
+    }
+
+    /// Create a new budget with custom per-run limit.
+    pub fn with_max_per_run(max_per_run: u64) -> Self {
+        Self {
+            run_bytes: AtomicU64::new(0),
+            max_per_run,
+        }
+    }
+
+    /// Check budget and add bytes atomically. Returns error if budget exceeded.
+    pub fn check_and_add(
+        &self,
+        size: u64,
+        _task_id: &str,
+    ) -> Result<(), super::error::MediaError> {
+        let new_total = self.run_bytes.fetch_add(size, Ordering::Relaxed) + size;
+        if new_total > self.max_per_run {
+            self.run_bytes.fetch_sub(size, Ordering::Relaxed);
+            return Err(super::error::MediaError::RunBudgetExceeded {
+                current: new_total,
+                max: self.max_per_run,
+            });
+        }
+        Ok(())
+    }
+
+    /// Get current accumulated bytes.
+    pub fn current_bytes(&self) -> u64 {
+        self.run_bytes.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for MediaBudget {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -34,6 +34,7 @@ pub struct MediaRef {
 /// Broad media type classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // Used in tests + PR2
 pub enum MediaType {
     Image,
     Audio,
@@ -43,6 +44,7 @@ pub enum MediaType {
 
 impl MediaType {
     /// Classify a MIME type string into a MediaType.
+    #[allow(dead_code)] // Used in tests + PR2
     pub fn from_mime(mime: &str) -> Self {
         if mime.starts_with("image/") {
             Self::Image

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -90,25 +90,38 @@ impl MediaBudget {
     }
 
     /// Check budget and add bytes atomically. Returns error if budget exceeded.
+    ///
+    /// Uses `fetch_update` (CAS loop) so the increment and comparison
+    /// are one atomic unit — prevents concurrent overruns.
     pub fn check_and_add(
         &self,
         size: u64,
         _task_id: &str,
     ) -> Result<(), super::error::MediaError> {
-        let new_total = self.run_bytes.fetch_add(size, Ordering::Relaxed) + size;
-        if new_total > self.max_per_run {
-            self.run_bytes.fetch_sub(size, Ordering::Relaxed);
-            return Err(super::error::MediaError::RunBudgetExceeded {
-                current: new_total,
+        let result = self.run_bytes.fetch_update(
+            Ordering::AcqRel,
+            Ordering::Acquire,
+            |current| {
+                let new_total = current + size;
+                if new_total > self.max_per_run {
+                    None // reject: over budget
+                } else {
+                    Some(new_total) // accept: update counter
+                }
+            },
+        );
+        match result {
+            Ok(_) => Ok(()),
+            Err(current) => Err(super::error::MediaError::RunBudgetExceeded {
+                current: current + size,
                 max: self.max_per_run,
-            });
+            }),
         }
-        Ok(())
     }
 
     /// Get current accumulated bytes.
     pub fn current_bytes(&self) -> u64 {
-        self.run_bytes.load(Ordering::Relaxed)
+        self.run_bytes.load(Ordering::Acquire)
     }
 }
 

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -119,6 +119,11 @@ impl MediaBudget {
         }
     }
 
+    /// Roll back a budget allocation (e.g., when CAS store fails after budget was charged).
+    pub fn rollback(&self, size: u64) {
+        self.run_bytes.fetch_sub(size, Ordering::AcqRel);
+    }
+
     /// Get current accumulated bytes.
     pub fn current_bytes(&self) -> u64 {
         self.run_bytes.load(Ordering::Acquire)

--- a/tools/nika/src/provider/rig.rs
+++ b/tools/nika/src/provider/rig.rs
@@ -1325,15 +1325,28 @@ pub struct NikaMcpToolDef {
     pub input_schema: serde_json::Value,
 }
 
+/// Shared media staging for agent tool calls.
+///
+/// When agent tools return binary content (images, audio, etc.),
+/// the content blocks are collected here since rig's `ToolDyn::call()`
+/// can only return `String`. After the agent loop completes,
+/// `run_agent()` drains this map and runs the MediaProcessor pipeline.
+pub type AgentMediaStaging = Arc<dashmap::DashMap<String, Vec<crate::mcp::types::ContentBlock>>>;
+
 /// MCP tool wrapper implementing rig-core's `ToolDyn` trait.
 ///
 /// This allows us to use our MCP tools (rmcp 0.16) with rig-core's
 /// agent system without version conflicts.
+///
+/// Binary content from tool results is staged via `media_staging`
+/// side-channel since rig's `ToolDyn::call()` returns `String` only.
 #[derive(Debug, Clone)]
 pub struct NikaMcpTool {
     definition: NikaMcpToolDef,
     /// Optional MCP client for real tool calls
     client: Option<Arc<McpClient>>,
+    /// Shared staging for binary content blocks (agent media side-channel)
+    media_staging: Option<AgentMediaStaging>,
 }
 
 impl NikaMcpTool {
@@ -1342,6 +1355,7 @@ impl NikaMcpTool {
         Self {
             definition,
             client: None,
+            media_staging: None,
         }
     }
 
@@ -1350,6 +1364,20 @@ impl NikaMcpTool {
         Self {
             definition,
             client: Some(client),
+            media_staging: None,
+        }
+    }
+
+    /// Create a new NikaMcpTool with media staging for agent loops
+    pub fn with_media_staging(
+        definition: NikaMcpToolDef,
+        client: Arc<McpClient>,
+        staging: AgentMediaStaging,
+    ) -> Self {
+        Self {
+            definition,
+            client: Some(client),
+            media_staging: Some(staging),
         }
     }
 
@@ -1403,6 +1431,33 @@ impl ToolDyn for NikaMcpTool {
                     e
                 ))))
             })?;
+
+            // Stage binary content blocks via side-channel (if media staging is enabled)
+            if result.has_media() {
+                if let Some(ref staging) = self.media_staging {
+                    let media_blocks: Vec<_> = result.media_blocks()
+                        .into_iter()
+                        .cloned()
+                        .collect();
+                    if !media_blocks.is_empty() {
+                        tracing::debug!(
+                            tool = %tool_name,
+                            media_count = media_blocks.len(),
+                            "agent: staging binary content from tool call"
+                        );
+                        staging
+                            .entry(tool_name.clone())
+                            .or_default()
+                            .extend(media_blocks);
+                    }
+                } else {
+                    tracing::warn!(
+                        tool = %tool_name,
+                        media_count = result.media_blocks().len(),
+                        "agent: tool returned binary content but no media staging configured — data will be lost"
+                    );
+                }
+            }
 
             // Extract text content from the result
             let output = result.text();

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -958,7 +958,11 @@ impl TaskExecutor {
 
                     let process_results = processor.process_all(&tool_result.content, task_id.as_ref()).await;
 
+                    // Process all results: emit events for EVERY block first,
+                    // then fail on non-recoverable errors. This ensures the trace
+                    // is complete even when the task fails partway through.
                     let mut media_refs = Vec::new();
+                    let mut fatal_error: Option<crate::media::MediaError> = None;
                     for result in process_results {
                         match result {
                             Ok((media_ref, store_result)) => {
@@ -985,13 +989,17 @@ impl TaskExecutor {
                                     hash: String::new(),
                                     reason: format!("block {block_index}: {error}"),
                                 });
-                                // Non-recoverable errors (HashMismatch, BudgetExceeded, etc.)
-                                // must fail the task — don't silently swallow data corruption.
-                                if !error.is_recoverable() {
-                                    return Err(NikaError::MediaError(error));
+                                // Capture first non-recoverable error for task failure
+                                if fatal_error.is_none() && !error.is_recoverable() {
+                                    fatal_error = Some(error);
                                 }
                             }
                         }
+                    }
+
+                    // If any non-recoverable error occurred, fail the task
+                    if let Some(error) = fatal_error {
+                        return Err(NikaError::MediaError(error));
                     }
 
                     // Stage media refs in side-channel for runner to pick up

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -949,7 +949,7 @@ impl TaskExecutor {
                     });
 
                     let workspace_root = std::env::current_dir().unwrap_or_else(|_| {
-                        tracing::warn!("Failed to get current directory for CAS, using /tmp");
+                        tracing::error!("Failed to get current directory for CAS, falling back to /tmp");
                         std::path::PathBuf::from("/tmp")
                     });
                     let store = CasStore::workspace_default(&workspace_root);

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -925,7 +925,74 @@ impl TaskExecutor {
                     });
                 }
 
-                // Extract text and try to parse as JSON
+                // Process media content (if any)
+                if tool_result.has_media() {
+                    use crate::mcp::types::ContentBlock;
+                    use crate::media::{CasStore, MediaProcessor};
+
+                    let media_blocks = tool_result.media_blocks();
+                    let content_types: Vec<String> = media_blocks
+                        .iter()
+                        .map(|b| match b {
+                            ContentBlock::Text { .. } => unreachable!("media_blocks filters text"),
+                            ContentBlock::Image { .. } => "image".to_string(),
+                            ContentBlock::Audio { .. } => "audio".to_string(),
+                            ContentBlock::Resource(_) => "resource".to_string(),
+                            ContentBlock::ResourceLink { .. } => "resource_link".to_string(),
+                        })
+                        .collect();
+
+                    self.event_log.emit(EventKind::MediaExtracted {
+                        task_id: Arc::clone(task_id),
+                        block_count: media_blocks.len() as u32,
+                        content_types,
+                    });
+
+                    let workspace_root = std::env::current_dir().unwrap_or_else(|_| {
+                        tracing::warn!("Failed to get current directory for CAS, using /tmp");
+                        std::path::PathBuf::from("/tmp")
+                    });
+                    let store = CasStore::workspace_default(&workspace_root);
+                    let processor = MediaProcessor::new(store);
+
+                    let process_results = processor.process_all(&tool_result.content, &task_id.to_string()).await;
+
+                    let mut media_refs = Vec::new();
+                    for result in process_results {
+                        match result {
+                            Ok((media_ref, store_result)) => {
+                                self.event_log.emit(EventKind::MediaProcessed {
+                                    task_id: Arc::clone(task_id),
+                                    hash: media_ref.hash.clone(),
+                                    mime_type: media_ref.mime_type.clone(),
+                                    size_bytes: media_ref.size_bytes,
+                                });
+                                self.event_log.emit(EventKind::MediaStored {
+                                    task_id: Arc::clone(task_id),
+                                    hash: media_ref.hash.clone(),
+                                    path: media_ref.path.display().to_string(),
+                                    size_bytes: media_ref.size_bytes,
+                                    verified: store_result.verified,
+                                    deduplicated: store_result.deduplicated,
+                                    pipeline_ms: store_result.pipeline_ms,
+                                });
+                                media_refs.push(media_ref);
+                            }
+                            Err((block_index, error)) => {
+                                self.event_log.emit(EventKind::MediaStoreFailed {
+                                    task_id: Arc::clone(task_id),
+                                    hash: String::new(),
+                                    reason: format!("block {block_index}: {error}"),
+                                });
+                            }
+                        }
+                    }
+
+                    // Stage media refs in side-channel for runner to pick up
+                    datastore.set_media(task_id, media_refs);
+                }
+
+                // Text output flows as before (backward compat)
                 let text = tool_result.text();
                 serde_json::from_str(&text).unwrap_or_else(|_| {
                     tracing::trace!(task = %task_id, "MCP tool returned non-JSON text, wrapping as string");

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -1013,8 +1013,68 @@ impl TaskExecutor {
                     serde_json::Value::String(text)
                 })
             } else if let Some(resource) = &invoke.resource {
-                // Resource read path
+                // Resource read path — now handles blob data via media pipeline
                 let content = client.read_resource(resource).await?;
+
+                // If resource has a blob, process it through the media pipeline
+                if let Some(blob) = &content.blob {
+                    use crate::mcp::types::ContentBlock;
+                    use crate::media::{CasStore, MediaProcessor};
+
+                    let mime = content.mime_type.clone().unwrap_or_else(|| "application/octet-stream".to_string());
+                    let block = ContentBlock::Resource(
+                        crate::mcp::types::ResourceContent::new(resource.clone())
+                            .with_blob(blob.clone())
+                            .with_optional_mime(content.mime_type.clone())
+                    );
+
+                    tracing::debug!(
+                        task_id = %task_id,
+                        resource = %resource,
+                        mime = %mime,
+                        blob_len = blob.len(),
+                        "Resource read returned blob data, processing through media pipeline"
+                    );
+
+                    self.event_log.emit(EventKind::MediaExtracted {
+                        task_id: Arc::clone(task_id),
+                        block_count: 1,
+                        content_types: vec!["resource_blob".to_string()],
+                    });
+
+                    let workspace_root = datastore.workspace_root();
+                    let store = CasStore::workspace_default(&workspace_root);
+                    let processor = MediaProcessor::with_shared_budget(
+                        store,
+                        std::sync::Arc::clone(datastore.media_budget()),
+                    );
+                    let results = processor.process_all(&[block], task_id.as_ref()).await;
+                    let mut media_refs = Vec::new();
+                    for result in results {
+                        match result {
+                            Ok((media_ref, store_result)) => {
+                                self.event_log.emit(EventKind::MediaStored {
+                                    task_id: Arc::clone(task_id),
+                                    hash: media_ref.hash.clone(),
+                                    path: media_ref.path.display().to_string(),
+                                    size_bytes: media_ref.size_bytes,
+                                    verified: store_result.verified,
+                                    deduplicated: store_result.deduplicated,
+                                    pipeline_ms: store_result.pipeline_ms,
+                                });
+                                media_refs.push(media_ref);
+                            }
+                            Err((_, error)) => {
+                                tracing::warn!(task_id = %task_id, error = %error, "Resource blob media processing failed");
+                            }
+                        }
+                    }
+                    if !media_refs.is_empty() {
+                        datastore.set_media(task_id, media_refs);
+                    }
+                }
+
+                // Text output (if any)
                 content
                     .text
                     .map(|t| {
@@ -1275,6 +1335,80 @@ impl TaskExecutor {
             duration_ms = duration_ms,
             "Agent loop completed"
         );
+
+        // Process any media content staged during agent tool calls (H1 side-channel)
+        let staged_media = agent_loop.drain_media();
+        if !staged_media.is_empty() {
+            tracing::info!(
+                task_id = %task_id,
+                block_count = staged_media.len(),
+                "agent: processing staged media from tool calls"
+            );
+
+            use crate::media::{CasStore, MediaProcessor};
+
+            self.event_log.emit(EventKind::MediaExtracted {
+                task_id: Arc::clone(task_id),
+                block_count: staged_media.len() as u32,
+                content_types: staged_media.iter().map(|b| match b {
+                    crate::mcp::types::ContentBlock::Image { .. } => "image".to_string(),
+                    crate::mcp::types::ContentBlock::Audio { .. } => "audio".to_string(),
+                    crate::mcp::types::ContentBlock::Resource(_) => "resource".to_string(),
+                    crate::mcp::types::ContentBlock::ResourceLink { .. } => "resource_link".to_string(),
+                    crate::mcp::types::ContentBlock::Text { .. } => "text".to_string(),
+                }).collect(),
+            });
+
+            let workspace_root = datastore.workspace_root();
+            let store = CasStore::workspace_default(&workspace_root);
+            let processor = MediaProcessor::with_shared_budget(
+                store,
+                std::sync::Arc::clone(datastore.media_budget()),
+            );
+
+            let process_results = processor.process_all(&staged_media, task_id.as_ref()).await;
+            let mut media_refs = Vec::new();
+            for result in process_results {
+                match result {
+                    Ok((media_ref, store_result)) => {
+                        self.event_log.emit(EventKind::MediaProcessed {
+                            task_id: Arc::clone(task_id),
+                            hash: media_ref.hash.clone(),
+                            mime_type: media_ref.mime_type.clone(),
+                            size_bytes: media_ref.size_bytes,
+                        });
+                        self.event_log.emit(EventKind::MediaStored {
+                            task_id: Arc::clone(task_id),
+                            hash: media_ref.hash.clone(),
+                            path: media_ref.path.display().to_string(),
+                            size_bytes: media_ref.size_bytes,
+                            verified: store_result.verified,
+                            deduplicated: store_result.deduplicated,
+                            pipeline_ms: store_result.pipeline_ms,
+                        });
+                        media_refs.push(media_ref);
+                    }
+                    Err((block_index, error)) => {
+                        self.event_log.emit(EventKind::MediaStoreFailed {
+                            task_id: Arc::clone(task_id),
+                            hash: String::new(),
+                            reason: format!("agent block {block_index}: {error}"),
+                        });
+                        // For agent media, we log but don't fail the task
+                        // (the agent already completed successfully)
+                        tracing::warn!(
+                            task_id = %task_id,
+                            block_index = block_index,
+                            error = %error,
+                            "agent: media processing failed for staged block"
+                        );
+                    }
+                }
+            }
+            if !media_refs.is_empty() {
+                datastore.set_media(task_id, media_refs);
+            }
+        }
 
         // Telemetry: log non-string response types for observability
         if let Some(v) = result.final_output.get("response") {

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -953,7 +953,11 @@ impl TaskExecutor {
                         std::path::PathBuf::from("/tmp")
                     });
                     let store = CasStore::workspace_default(&workspace_root);
-                    let processor = MediaProcessor::new(store);
+                    // Use shared per-run budget from RunContext (not a fresh one per invoke)
+                    let processor = MediaProcessor::with_shared_budget(
+                        store,
+                        std::sync::Arc::clone(datastore.media_budget()),
+                    );
 
                     let process_results = processor.process_all(&tool_result.content, task_id.as_ref()).await;
 

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -948,10 +948,7 @@ impl TaskExecutor {
                         content_types,
                     });
 
-                    let workspace_root = std::env::current_dir().unwrap_or_else(|_| {
-                        tracing::error!("Failed to get current directory for CAS, falling back to /tmp");
-                        std::path::PathBuf::from("/tmp")
-                    });
+                    let workspace_root = datastore.workspace_root();
                     let store = CasStore::workspace_default(&workspace_root);
                     // Use shared per-run budget from RunContext (not a fresh one per invoke)
                     let processor = MediaProcessor::with_shared_budget(
@@ -988,6 +985,11 @@ impl TaskExecutor {
                                     hash: String::new(),
                                     reason: format!("block {block_index}: {error}"),
                                 });
+                                // Non-recoverable errors (HashMismatch, BudgetExceeded, etc.)
+                                // must fail the task — don't silently swallow data corruption.
+                                if !error.is_recoverable() {
+                                    return Err(NikaError::MediaError(error));
+                                }
                             }
                         }
                     }

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -955,7 +955,7 @@ impl TaskExecutor {
                     let store = CasStore::workspace_default(&workspace_root);
                     let processor = MediaProcessor::new(store);
 
-                    let process_results = processor.process_all(&tool_result.content, &task_id.to_string()).await;
+                    let process_results = processor.process_all(&tool_result.content, task_id.as_ref()).await;
 
                     let mut media_refs = Vec::new();
                     for result in process_results {

--- a/tools/nika/src/runtime/rig_agent_loop/mod.rs
+++ b/tools/nika/src/runtime/rig_agent_loop/mod.rs
@@ -45,7 +45,7 @@ use crate::ast::AgentParams;
 use crate::error::NikaError;
 use crate::event::EventLog;
 use crate::mcp::McpClient;
-use crate::provider::rig::{NikaMcpTool, NikaMcpToolDef};
+use crate::provider::rig::{AgentMediaStaging, NikaMcpTool, NikaMcpToolDef};
 use crate::runtime::submit_tool::DynamicSubmitTool;
 use crate::runtime::SkillInjector;
 use crate::tools::{
@@ -105,6 +105,10 @@ pub struct RigAgentLoop {
     skills_map: Option<std::collections::HashMap<String, String>>,
     /// Base directory for resolving skill paths
     base_dir: Option<PathBuf>,
+    /// Shared media staging for agent tool calls (H1 side-channel).
+    /// Binary content blocks from MCP tools are collected here since
+    /// rig's ToolDyn::call() returns String only.
+    pub media_staging: AgentMediaStaging,
 }
 
 impl std::fmt::Debug for RigAgentLoop {
@@ -114,6 +118,7 @@ impl std::fmt::Debug for RigAgentLoop {
             .field("params", &self.params)
             .field("tool_count", &self.tools.len())
             .field("history_len", &self.history.len())
+            .field("media_staged", &self.media_staging.len())
             .finish_non_exhaustive()
     }
 }
@@ -186,8 +191,11 @@ impl RigAgentLoop {
             }
         }
 
-        // Build tools from MCP clients
-        let mut tools = Self::build_tools(&params.mcp, &mcp_clients)?;
+        // Create shared media staging for agent tool calls (H1 side-channel)
+        let media_staging: AgentMediaStaging = Arc::new(dashmap::DashMap::new());
+
+        // Build tools from MCP clients (with media staging for binary content)
+        let mut tools = Self::build_tools(&params.mcp, &mcp_clients, &media_staging)?;
 
         // Add spawn_agent tool if depth_limit allows spawning (MVP 8 Phase 2)
         // Default depth is 1 (root agent). Child agents get higher depths via spawn_agent.
@@ -341,6 +349,7 @@ impl RigAgentLoop {
             skill_injector: None,
             skills_map: None,
             base_dir: None,
+            media_staging,
         })
     }
 
@@ -521,10 +530,25 @@ impl RigAgentLoop {
             .collect()
     }
 
-    /// Build NikaMcpTool instances from MCP clients
+    /// Drain collected media content blocks from all agent tool calls.
+    ///
+    /// Returns all ContentBlocks that were staged during the agent loop.
+    /// The DashMap is drained (emptied) after this call.
+    pub fn drain_media(&self) -> Vec<crate::mcp::types::ContentBlock> {
+        let mut all_blocks = Vec::new();
+        // Drain all entries from the staging map
+        for entry in self.media_staging.iter() {
+            all_blocks.extend(entry.value().iter().cloned());
+        }
+        self.media_staging.clear();
+        all_blocks
+    }
+
+    /// Build NikaMcpTool instances from MCP clients with media staging
     fn build_tools(
         mcp_names: &[String],
         mcp_clients: &FxHashMap<String, Arc<McpClient>>,
+        media_staging: &AgentMediaStaging,
     ) -> Result<Vec<Arc<dyn rig::tool::ToolDyn>>, NikaError> {
         let mut tools: Vec<Arc<dyn rig::tool::ToolDyn>> = Vec::new();
 
@@ -536,11 +560,10 @@ impl RigAgentLoop {
                 })?;
 
             // Get tool definitions from MCP client
-            // For now, we'll get mock tools if client is in mock mode
             let tool_defs = client.get_tool_definitions();
 
             for def in tool_defs {
-                let tool = NikaMcpTool::with_client(
+                let tool = NikaMcpTool::with_media_staging(
                     NikaMcpToolDef {
                         name: def.name.clone(),
                         description: def.description.clone().unwrap_or_default(),
@@ -550,6 +573,7 @@ impl RigAgentLoop {
                             .unwrap_or_else(|| serde_json::json!({"type": "object"})),
                     },
                     client.clone(),
+                    Arc::clone(media_staging),
                 );
                 tools.push(Arc::new(tool));
             }

--- a/tools/nika/src/runtime/rig_agent_loop/providers.rs
+++ b/tools/nika/src/runtime/rig_agent_loop/providers.rs
@@ -508,7 +508,7 @@ impl RigAgentLoop {
                 .map(|pk| {
                     crate::provider::cost::calculate_cost(
                         pk,
-                        &model_name,
+                        model_name,
                         total_input_tokens,
                         total_output_tokens,
                     )

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -909,6 +909,10 @@ Please provide a corrected JSON response that strictly matches the schema."#,
             tracing::warn!(error = %e, "Failed to get current directory, using '.'");
             std::path::PathBuf::from(".")
         });
+
+        // Set workspace root for CAS media store path resolution
+        self.datastore.set_workspace_root(base_path.clone());
+
         if !self.workflow.context_files.is_empty() {
             let loaded_context =
                 load_context_analyzed(&self.workflow.context_files, &base_path).await?;
@@ -1863,9 +1867,17 @@ Please provide a corrected JSON response that strictly matches the schema."#,
                     results.iter().map(|(_, r)| r.duration).sum();
                 let all_success = results.iter().all(|(_, r)| r.is_success());
 
-                // Create aggregated result with JSON array
+                // Merge media refs from all successful iterations
+                let merged_media: Vec<crate::media::MediaRef> = results
+                    .iter()
+                    .filter(|(_, r)| r.is_success())
+                    .flat_map(|(_, r)| r.media.iter().cloned())
+                    .collect();
+
+                // Create aggregated result with JSON array + merged media
                 let aggregated_result = if all_success {
                     TaskResult::success(Value::Array(outputs), total_duration)
+                        .with_media(merged_media)
                 } else {
                     // Collect errors
                     let errors: Vec<String> = results
@@ -1873,6 +1885,7 @@ Please provide a corrected JSON response that strictly matches the schema."#,
                         .filter_map(|(idx, r)| r.error().map(|e| format!("[{}]: {}", idx, e)))
                         .collect();
                     TaskResult::failed(errors.join("; "), total_duration)
+                        .with_media(merged_media)
                 };
 
                 // Store aggregated result under parent ID

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -807,6 +807,8 @@ Please provide a corrected JSON response that strictly matches the schema."#,
 
                     let tr =
                         make_task_result(final_output, effective_output.as_ref(), duration).await;
+                    // Attach media refs from staging side-channel
+                    let tr = tr.with_media(datastore.take_media(&task_id));
                     if tr.is_success() {
                         event_log.emit(EventKind::TaskCompleted {
                             task_id: Arc::clone(&task_id),

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -785,6 +785,8 @@ Please provide a corrected JSON response that strictly matches the schema."#,
                                     result.value.to_string()
                                 }
                                 Err(e) => {
+                                    // Drain any orphaned media refs (defense-in-depth)
+                                    let _ = datastore.take_media(&task_id);
                                     event_log.emit(EventKind::TaskFailed {
                                         task_id: Arc::clone(&task_id),
                                         error: e.to_string(),

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -1705,10 +1705,8 @@ Please provide a corrected JSON response that strictly matches the schema."#,
                                         else { DS::Failed };
                                     let meta = if success {
                                         Some(format!("{:.1}s", task_result.duration.as_secs_f32()))
-                                    } else if let Some(err) = task_result.error() {
-                                        Some(format!("✗ {}", &err[..err.len().min(30)]))
                                     } else {
-                                        None
+                                        task_result.error().map(|err| format!("✗ {}", &err[..err.len().min(30)]))
                                     };
                                     dag.update_task(parent_id, status, meta);
                                     dag.redraw();

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -825,6 +825,8 @@ Please provide a corrected JSON response that strictly matches the schema."#,
                     tr
                 }
                 Err(e) => {
+                    // Drain any orphaned media refs (defense-in-depth)
+                    let _ = datastore.take_media(&task_id);
                     event_log.emit(EventKind::TaskFailed {
                         task_id: Arc::clone(&task_id),
                         error: e.to_string(),

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -210,7 +210,13 @@ impl Default for RunContext {
             context: Arc::default(),
             inputs: Arc::default(),
             media_staging: Arc::new(DashMap::with_hasher(FxBuildHasher)),
-            media_budget: Arc::new(crate::media::MediaBudget::new()),
+            media_budget: Arc::new({
+                let max = std::env::var("NIKA_MEDIA_BUDGET")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(crate::media::MediaBudget::DEFAULT_MAX_PER_RUN);
+                crate::media::MediaBudget::with_max_per_run(max)
+            }),
             workspace_root: Arc::new(RwLock::new(workspace_root)),
         }
     }

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -190,6 +190,10 @@ pub struct RunContext {
     /// Written by run_invoke() after MediaProcessor completes.
     /// Read (and drained) by the runner after building TaskResult.
     media_staging: Arc<DashMap<Arc<str>, Vec<crate::media::MediaRef>, FxBuildHasher>>,
+
+    /// Shared per-run media budget (500MB default).
+    /// Lives here so all invoke tasks in a single run share one budget.
+    media_budget: Arc<crate::media::MediaBudget>,
 }
 
 impl Default for RunContext {
@@ -199,6 +203,7 @@ impl Default for RunContext {
             context: Arc::default(),
             inputs: Arc::default(),
             media_staging: Arc::new(DashMap::with_hasher(FxBuildHasher)),
+            media_budget: Arc::new(crate::media::MediaBudget::new()),
         }
     }
 }
@@ -273,6 +278,11 @@ impl RunContext {
             .remove(task_id)
             .map(|(_, v)| v)
             .unwrap_or_default()
+    }
+
+    /// Get the shared per-run media budget.
+    pub fn media_budget(&self) -> &Arc<crate::media::MediaBudget> {
+        &self.media_budget
     }
 
     /// Resolve a dot-separated path (e.g., "weather.summary")

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -318,10 +318,8 @@ impl RunContext {
                 return Some(media_json);
             }
             let media_remaining = &remaining[5..]; // skip "media"
-            if media_remaining.starts_with('.') {
-                return jsonpath::resolve(&media_json, &media_remaining[1..])
-                    .ok()
-                    .flatten();
+            if let Some(dot_rest) = media_remaining.strip_prefix('.') {
+                return jsonpath::resolve(&media_json, dot_rest).ok().flatten();
             }
             if media_remaining.starts_with('[') {
                 return jsonpath::resolve(&media_json, media_remaining)

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -289,16 +289,49 @@ impl RunContext {
     ///
     /// Uses jsonpath module internally for unified path resolution.
     /// Supports both simple dot notation and array indices.
+    ///
+    /// Media paths are intercepted before standard output resolution:
+    /// - `"task_id.media"` → full media array as JSON
+    /// - `"task_id.media[0].hash"` → specific media ref field
+    /// - `"task_id.media[0].path"` → specific media ref field
     pub fn resolve_path(&self, path: &str) -> Option<Value> {
         let mut parts = path.splitn(2, '.');
         let task_id = parts.next()?;
 
-        let output = self.get_output(task_id)?;
-
         // If no remaining path, return the whole output (clone from Arc)
         let Some(remaining) = parts.next() else {
+            let output = self.get_output(task_id)?;
             return Some((*output).clone());
         };
+
+        // Intercept media paths: task_id.media, task_id.media[0].hash, etc.
+        if remaining == "media"
+            || remaining.starts_with("media.")
+            || remaining.starts_with("media[")
+        {
+            let result = self.results.get(task_id)?.value().clone();
+            if result.media.is_empty() {
+                return Some(Value::Array(vec![]));
+            }
+            let media_json = serde_json::to_value(&result.media).ok()?;
+            if remaining == "media" {
+                return Some(media_json);
+            }
+            let media_remaining = &remaining[5..]; // skip "media"
+            if media_remaining.starts_with('.') {
+                return jsonpath::resolve(&media_json, &media_remaining[1..])
+                    .ok()
+                    .flatten();
+            }
+            if media_remaining.starts_with('[') {
+                return jsonpath::resolve(&media_json, media_remaining)
+                    .ok()
+                    .flatten();
+            }
+            return Some(media_json);
+        }
+
+        let output = self.get_output(task_id)?;
 
         // Use jsonpath for path resolution (handles both dots and array indices)
         // Arc<Value> derefs to &Value, so this works without changes
@@ -1114,5 +1147,130 @@ mod tests {
         assert!(store.resolve_input_path("inputs").is_none());
         assert!(store.resolve_input_path("other.path").is_none());
         assert!(store.resolve_input_path("").is_none());
+    }
+
+    // =========================================================================
+    // Media Path Resolution Tests
+    // =========================================================================
+
+    /// Helper: create a TaskResult with media refs for testing.
+    fn task_with_media() -> TaskResult {
+        use std::path::PathBuf;
+
+        let media = vec![
+            crate::media::MediaRef {
+                hash: "blake3:af1349b9".to_string(),
+                mime_type: "image/png".to_string(),
+                size_bytes: 4096,
+                path: PathBuf::from("/tmp/cas/af/1349b9"),
+                extension: "png".to_string(),
+                created_by: "gen_img".to_string(),
+            },
+            crate::media::MediaRef {
+                hash: "blake3:deadbeef".to_string(),
+                mime_type: "audio/wav".to_string(),
+                size_bytes: 8192,
+                path: PathBuf::from("/tmp/cas/de/adbeef"),
+                extension: "wav".to_string(),
+                created_by: "gen_img".to_string(),
+            },
+        ];
+        TaskResult::success(json!({"prompt": "a cat"}), Duration::from_secs(1))
+            .with_media(media)
+    }
+
+    #[test]
+    fn resolve_media_full_array() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let value = store.resolve_path("gen_img.media").unwrap();
+        let arr = value.as_array().expect("media should be an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["hash"], "blake3:af1349b9");
+        assert_eq!(arr[1]["hash"], "blake3:deadbeef");
+    }
+
+    #[test]
+    fn resolve_media_index_hash() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let hash = store.resolve_path("gen_img.media[0].hash").unwrap();
+        assert_eq!(hash, "blake3:af1349b9");
+
+        let hash2 = store.resolve_path("gen_img.media[1].hash").unwrap();
+        assert_eq!(hash2, "blake3:deadbeef");
+    }
+
+    #[test]
+    fn resolve_media_index_mime_type() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let mime = store.resolve_path("gen_img.media[0].mime_type").unwrap();
+        assert_eq!(mime, "image/png");
+
+        let mime2 = store.resolve_path("gen_img.media[1].mime_type").unwrap();
+        assert_eq!(mime2, "audio/wav");
+    }
+
+    #[test]
+    fn resolve_media_empty_returns_empty_array() {
+        let store = RunContext::new();
+        // Task with no media
+        store.insert(
+            Arc::from("no_media"),
+            TaskResult::success(json!({"text": "hello"}), Duration::from_secs(1)),
+        );
+
+        let value = store.resolve_path("no_media.media").unwrap();
+        assert_eq!(value, json!([]));
+    }
+
+    #[test]
+    fn resolve_media_index_path() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let path = store.resolve_path("gen_img.media[0].path").unwrap();
+        assert_eq!(path, "/tmp/cas/af/1349b9");
+    }
+
+    #[test]
+    fn resolve_media_index_size_bytes() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let size = store.resolve_path("gen_img.media[0].size_bytes").unwrap();
+        assert_eq!(size, 4096);
+    }
+
+    #[test]
+    fn resolve_media_index_extension() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let ext = store.resolve_path("gen_img.media[0].extension").unwrap();
+        assert_eq!(ext, "png");
+    }
+
+    #[test]
+    fn resolve_media_out_of_bounds() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        // Index beyond array length should return None
+        assert!(store.resolve_path("gen_img.media[99].hash").is_none());
+    }
+
+    #[test]
+    fn resolve_media_does_not_shadow_output() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        // Standard output field should still resolve normally
+        let prompt = store.resolve_path("gen_img.prompt").unwrap();
+        assert_eq!(prompt, "a cat");
     }
 }

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -44,6 +44,8 @@ pub struct TaskResult {
     pub duration: Duration,
     /// Success or failure status
     pub status: TaskOutcome,
+    /// Media files produced by this task (empty for non-media tasks)
+    pub media: Vec<crate::media::MediaRef>,
 }
 
 impl TaskResult {
@@ -53,6 +55,7 @@ impl TaskResult {
             output: Arc::new(output.into()),
             duration,
             status: TaskOutcome::Success,
+            media: Vec::new(),
         }
     }
 
@@ -62,6 +65,7 @@ impl TaskResult {
             output: Arc::new(Value::String(output.into())),
             duration,
             status: TaskOutcome::Success,
+            media: Vec::new(),
         }
     }
 
@@ -71,6 +75,7 @@ impl TaskResult {
             output: Arc::new(Value::Null),
             duration,
             status: TaskOutcome::Failed(error.into()),
+            media: Vec::new(),
         }
     }
 
@@ -85,6 +90,7 @@ impl TaskResult {
             status: TaskOutcome::DependencyFailed {
                 dependency: dependency.into(),
             },
+            media: Vec::new(),
         }
     }
 
@@ -98,7 +104,14 @@ impl TaskResult {
             status: TaskOutcome::Skipped {
                 reason: reason.into(),
             },
+            media: Vec::new(),
         }
+    }
+
+    /// Attach media references to this result.
+    pub fn with_media(mut self, media: Vec<crate::media::MediaRef>) -> Self {
+        self.media = media;
+        self
     }
 
     /// Check if task succeeded
@@ -172,6 +185,11 @@ pub struct RunContext {
     /// Contains input definitions from the `inputs:` block.
     /// Accessible via `{{inputs.param}}` bindings.
     inputs: Arc<RwLock<FxHashMap<String, Value>>>,
+
+    /// Side-channel for media refs produced by invoke tasks.
+    /// Written by run_invoke() after MediaProcessor completes.
+    /// Read (and drained) by the runner after building TaskResult.
+    media_staging: Arc<DashMap<Arc<str>, Vec<crate::media::MediaRef>, FxBuildHasher>>,
 }
 
 impl Default for RunContext {
@@ -180,6 +198,7 @@ impl Default for RunContext {
             results: Arc::new(DashMap::with_hasher(FxBuildHasher)),
             context: Arc::default(),
             inputs: Arc::default(),
+            media_staging: Arc::new(DashMap::with_hasher(FxBuildHasher)),
         }
     }
 }
@@ -234,6 +253,26 @@ impl RunContext {
     /// Returns `Arc<Value>` for O(1) cloning instead of deep copy
     pub fn get_output(&self, task_id: &str) -> Option<Arc<Value>> {
         self.results.get(task_id).map(|r| Arc::clone(&r.output))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // MEDIA STAGING
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Stage media refs for a task (called from run_invoke).
+    pub fn set_media(&self, task_id: &Arc<str>, media: Vec<crate::media::MediaRef>) {
+        if !media.is_empty() {
+            self.media_staging.insert(Arc::clone(task_id), media);
+        }
+    }
+
+    /// Take staged media refs for a task (called from runner after building TaskResult).
+    /// Returns empty vec if no media was staged.
+    pub fn take_media(&self, task_id: &Arc<str>) -> Vec<crate::media::MediaRef> {
+        self.media_staging
+            .remove(task_id)
+            .map(|(_, v)| v)
+            .unwrap_or_default()
     }
 
     /// Resolve a dot-separated path (e.g., "weather.summary")

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -7,6 +7,7 @@
 //! Added inputs storage for workflow `inputs:` block.
 
 use std::borrow::Cow;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -194,16 +195,23 @@ pub struct RunContext {
     /// Shared per-run media budget (500MB default).
     /// Lives here so all invoke tasks in a single run share one budget.
     media_budget: Arc<crate::media::MediaBudget>,
+
+    /// Workspace root for CAS store path resolution.
+    /// Set by Runner at workflow start. Defaults to current_dir().
+    workspace_root: Arc<RwLock<PathBuf>>,
 }
 
 impl Default for RunContext {
     fn default() -> Self {
+        let workspace_root = std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."));
         Self {
             results: Arc::new(DashMap::with_hasher(FxBuildHasher)),
             context: Arc::default(),
             inputs: Arc::default(),
             media_staging: Arc::new(DashMap::with_hasher(FxBuildHasher)),
             media_budget: Arc::new(crate::media::MediaBudget::new()),
+            workspace_root: Arc::new(RwLock::new(workspace_root)),
         }
     }
 }
@@ -283,6 +291,16 @@ impl RunContext {
     /// Get the shared per-run media budget.
     pub fn media_budget(&self) -> &Arc<crate::media::MediaBudget> {
         &self.media_budget
+    }
+
+    /// Set the workspace root (called by Runner at workflow start).
+    pub fn set_workspace_root(&self, root: PathBuf) {
+        *self.workspace_root.write() = root;
+    }
+
+    /// Get the workspace root path (cloned).
+    pub fn workspace_root(&self) -> PathBuf {
+        self.workspace_root.read().clone()
     }
 
     /// Resolve a dot-separated path (e.g., "weather.summary")

--- a/tools/nika/src/tui/chat_agent.rs
+++ b/tools/nika/src/tui/chat_agent.rs
@@ -681,23 +681,27 @@ impl ChatAgent {
         let result = client.call_tool(tool_name, params).await?;
 
         // Format result for display
-        // ContentBlock is a struct with content_type, text, data, mime_type, resource fields
         let format_block = |c: crate::mcp::types::ContentBlock| -> String {
-            if c.is_text() {
-                c.text.unwrap_or_default()
-            } else if c.is_image() {
-                let data_len = c.data.as_ref().map(|d| d.len()).unwrap_or(0);
-                format!("[Image: {} bytes]", data_len)
-            } else if c.is_resource() {
-                if let Some(res) = &c.resource {
-                    res.text
-                        .clone()
-                        .unwrap_or_else(|| format!("[Resource: {}]", res.uri))
-                } else {
-                    "[Resource]".to_string()
+            use crate::mcp::types::ContentBlock;
+            match c {
+                ContentBlock::Text { text } => text,
+                ContentBlock::Image { data, mime_type } => {
+                    format!("[Image: {} bytes, {}]", data.len(), mime_type)
                 }
-            } else {
-                format!("[Unknown content type: {}]", c.content_type)
+                ContentBlock::Audio { data, mime_type } => {
+                    format!("[Audio: {} bytes, {}]", data.len(), mime_type)
+                }
+                ContentBlock::Resource(res) => {
+                    res.text
+                        .unwrap_or_else(|| format!("[Resource: {}]", res.uri))
+                }
+                ContentBlock::ResourceLink { uri, name, .. } => {
+                    if let Some(n) = name {
+                        format!("[ResourceLink: {} ({})]", uri, n)
+                    } else {
+                        format!("[ResourceLink: {}]", uri)
+                    }
+                }
             }
         };
 

--- a/tools/nika/src/tui/state/mod.rs
+++ b/tools/nika/src/tui/state/mod.rs
@@ -1030,6 +1030,28 @@ impl TuiState {
                 ));
                 self.dirty.notifications = true;
             }
+
+            // ═══════════════════════════════════════════
+            // MEDIA EVENTS (no TUI action needed yet)
+            // ═══════════════════════════════════════════
+            EventKind::MediaExtracted { task_id, block_count, .. } => {
+                self.add_notification(Notification::info(
+                    format!("[{}] Extracted {} media block(s)", task_id, block_count),
+                    timestamp_ms,
+                ));
+                self.dirty.notifications = true;
+            }
+            EventKind::MediaProcessed { .. }
+            | EventKind::MediaStored { .. } => {
+                // Tracked via events, no TUI notification for individual blocks
+            }
+            EventKind::MediaStoreFailed { task_id, reason, .. } => {
+                self.add_notification(Notification::error(
+                    format!("[{}] Media store failed: {}", task_id, reason),
+                    timestamp_ms,
+                ));
+                self.dirty.notifications = true;
+            }
         }
     }
 

--- a/tools/nika/tests/completion_integration_test.rs
+++ b/tools/nika/tests/completion_integration_test.rs
@@ -52,10 +52,7 @@ fn test_explicit_mode_generates_complete_tool_instruction() {
 fn test_pattern_mode_generates_pattern_instruction() {
     let config = CompletionConfig {
         mode: CompletionMode::Pattern,
-        patterns: vec![PatternConfig {
-            pattern_type: PatternType::Exact,
-            value: "DONE".to_string(),
-        }],
+        patterns: vec![PatternConfig::new("DONE", PatternType::Exact)],
         instruction: None,
         confidence: None,
         signal: None,


### PR DESCRIPTION
## Summary

Nika silently drops ALL non-text content from MCP tool results (images, audio, PDFs). This PR adds a complete media extraction pipeline:

- **ContentBlock enum** with 5 struct variants (Text, Image, Audio, Resource, ResourceLink) — exhaustive match on rmcp's RawContent
- **CAS store** with blake3 hashing, O_EXCL atomic dedup, read-back verification (>1MB), shard-directory layout
- **MediaProcessor pipeline**: base64 decode → MIME detection (3-layer: magic bytes → server hint → extension) → CAS store → MediaRef
- **Declare-then-verify MIME** with 7 alias pairs, cross-category rejection (NIKA-251)
- **Media budget** enforcement with AtomicU64 CAS loop, rollback on failure
- **Agent verb media** side-channel via AgentMediaStaging (bypasses rig's String-only ToolDyn)
- **Resource blob** extraction from invoke: resource: path
- **Binding bridge** for media paths in both string-path and typed-path resolution systems
- **4 new EventKind variants**: MediaExtracted, MediaProcessed, MediaStored, MediaStoreFailed
- **NIKA_MEDIA_BUDGET** env var override (default 500MB)
- **Error codes NIKA-251..259** with human-readable error messages

### Key metrics
- **5568 tests pass** (+363 from baseline), **0 clippy warnings**
- **242 media-specific tests** covering CAS, MIME detection, budget, SVG heuristics, binding bridge, concurrent writes
- **60+ audit agents** deployed across 6 rounds, **28+ bugs found and fixed**
- **0 known remaining bugs** (2 consecutive clean audit rounds)

### Architecture

```
MCP Server → rmcp response → ContentBlock extraction (exhaustive 5-variant match)
    → MediaProcessor (base64 decode → MIME detect → budget check → CAS store)
    → MediaRef → RunContext.media_staging (DashMap side-channel)
    → TaskResult.media → resolve_path() interception → template bindings
```

### New dependencies
- `blake3 = "1.8"` (features = ["mmap"]) — CAS hashing, 14x faster than SHA-256
- `infer = "0.19"` — magic byte MIME detection

### Error codes

| Code | Name | Description |
|------|------|-------------|
| NIKA-251 | MimeDetectionFailed | MIME category conflict or undetectable |
| NIKA-252 | UnsupportedMediaType | Reserved for future |
| NIKA-253 | MediaNotFound | Hash not in CAS |
| NIKA-254 | HashMismatch | Read-back verification failed |
| NIKA-255 | MediaStoreIo | CAS I/O error |
| NIKA-256 | Base64DecodeFailed | Malformed base64 |
| NIKA-257 | Base64InputTooLarge | >100MB payload |
| NIKA-258 | EmptyMediaContent | Zero-byte content |
| NIKA-259 | RunBudgetExceeded | Per-run budget exceeded |

## Test plan

- [x] `cargo test --lib` — 5568 pass, 0 fail
- [x] `cargo clippy --lib -- -D warnings` — 0 warnings
- [x] 242 media tests (CAS, MIME, budget, bindings, SVG, concurrent)
- [x] 60+ audit agents across 6 rounds — 0 remaining bugs
- [x] Monster full-pipeline test (ContentBlock → CAS → RunContext → resolve_path → template)
- [x] Budget rollback tests (MIME failure, CAS failure)
- [x] SVG heuristic edge cases (10 tests)
- [x] Cross-category MIME rejection tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)