### PR TITLE
feat(media): PR2 — Binary artifacts, nika media CLI, E2E integrity

### DIFF
--- a/tools/nika/CLAUDE.md
+++ b/tools/nika/CLAUDE.md
@@ -65,7 +65,7 @@ src/
 | 251-259 | Media pipeline |
 | 260-269 | Package URI errors |
 | 270-279 | Skill errors |
-| 280-289 | Artifacts |
+| 280-285 | Artifacts + Media (path, write, size, integrity, cleanup, lock) |
 | 300-309 | Structured output |
 
 ## Testing

--- a/tools/nika/Cargo.lock
+++ b/tools/nika/Cargo.lock
@@ -221,6 +221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +492,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+ "memmap2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +712,17 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid 1.22.0",
+]
 
 [[package]]
 name = "cfg-if"
@@ -899,6 +931,12 @@ dependencies = [
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2868,6 +2906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3810,6 +3857,9 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backon",
+ "base64 0.22.1",
+ "blake3",
+ "bytes",
  "camino",
  "chrono",
  "clap",
@@ -3827,11 +3877,14 @@ dependencies = [
  "humantime",
  "ignore",
  "indexmap 2.13.0",
+ "infer",
  "insta",
  "jsonschema",
  "keyring",
  "marked-yaml",
  "miette",
+ "mime",
+ "mime_guess",
  "mistralrs",
  "nix 0.29.0",
  "nucleo",
@@ -3842,6 +3895,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ratatui",
+ "reflink-copy",
  "regex",
  "reqwest 0.12.28",
  "rig-core",
@@ -5266,6 +5320,18 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "serde_json",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -166,6 +166,7 @@ tower-lsp = { version = "0.20", optional = true }
 
 # Media pipeline (2 genuinely new + 4 zero-cost promotes from transitive)
 blake3 = { version = "1.8", features = ["mmap"] }
+reflink-copy = "0.1"  # Cross-platform reflink (instant on APFS/btrfs, fallback copy on ext4)
 infer = "0.19"
 base64 = "0.22"
 mime_guess = "2.0"

--- a/tools/nika/schemas/nika-workflow.schema.json
+++ b/tools/nika/schemas/nika-workflow.schema.json
@@ -780,7 +780,7 @@
         },
         "format": {
           "type": "string",
-          "enum": ["text", "json", "yaml"],
+          "enum": ["text", "json", "yaml", "binary"],
           "default": "text",
           "description": "Default output format"
         },
@@ -829,7 +829,7 @@
             },
             "format": {
               "type": "string",
-              "enum": ["text", "json", "yaml"],
+              "enum": ["text", "json", "yaml", "binary"],
               "description": "Output format override"
             },
             "mode": {
@@ -849,7 +849,7 @@
               "path": { "type": "string" },
               "source": { "type": "string" },
               "template": { "type": "string", "description": "Template string (v0.22+)" },
-              "format": { "type": "string", "enum": ["text", "json", "yaml"] },
+              "format": { "type": "string", "enum": ["text", "json", "yaml", "binary"] },
               "mode": { "type": "string", "enum": ["overwrite", "append", "unique", "fail"] }
             }
           }

--- a/tools/nika/src/ast/artifact.rs
+++ b/tools/nika/src/ast/artifact.rs
@@ -141,6 +141,9 @@ pub enum ArtifactFormat {
 
     /// YAML format
     Yaml,
+
+    /// Binary (raw bytes from CAS store)
+    Binary,
 }
 
 impl std::fmt::Display for ArtifactFormat {
@@ -149,6 +152,7 @@ impl std::fmt::Display for ArtifactFormat {
             Self::Text => write!(f, "text"),
             Self::Json => write!(f, "json"),
             Self::Yaml => write!(f, "yaml"),
+            Self::Binary => write!(f, "binary"),
         }
     }
 }
@@ -160,6 +164,7 @@ impl ArtifactFormat {
             Self::Text => "txt",
             Self::Json => "json",
             Self::Yaml => "yaml",
+            Self::Binary => "bin",
         }
     }
 }
@@ -331,6 +336,44 @@ max_size: 52428800
         assert_eq!(ArtifactMode::Append.to_string(), "append");
         assert_eq!(ArtifactMode::Unique.to_string(), "unique");
         assert_eq!(ArtifactMode::Fail.to_string(), "fail");
+    }
+
+    #[test]
+    fn test_artifact_format_binary_serde() {
+        // Deserialize from YAML
+        let yaml = r#""binary""#;
+        let format: ArtifactFormat = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(format, ArtifactFormat::Binary);
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&format).unwrap();
+        assert_eq!(json, r#""binary""#);
+
+        // Deserialize from JSON
+        let back: ArtifactFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ArtifactFormat::Binary);
+
+        // Extension
+        assert_eq!(ArtifactFormat::Binary.extension(), "bin");
+
+        // Display
+        assert_eq!(ArtifactFormat::Binary.to_string(), "binary");
+    }
+
+    #[test]
+    fn test_artifact_format_binary_in_artifact_spec() {
+        let yaml = r#"
+path: ./output/image.bin
+format: binary
+"#;
+        let spec: ArtifactSpec = serde_yaml::from_str(yaml).unwrap();
+        match spec {
+            ArtifactSpec::Single(output) => {
+                assert_eq!(output.format, Some(ArtifactFormat::Binary));
+                assert_eq!(output.path, "./output/image.bin");
+            }
+            _ => panic!("Expected Single artifact"),
+        }
     }
 
     #[test]

--- a/tools/nika/src/ast/artifact.rs
+++ b/tools/nika/src/ast/artifact.rs
@@ -321,6 +321,7 @@ max_size: 52428800
         assert_eq!(ArtifactFormat::Text.to_string(), "text");
         assert_eq!(ArtifactFormat::Json.to_string(), "json");
         assert_eq!(ArtifactFormat::Yaml.to_string(), "yaml");
+        assert_eq!(ArtifactFormat::Binary.to_string(), "binary");
     }
 
     #[test]
@@ -328,6 +329,7 @@ max_size: 52428800
         assert_eq!(ArtifactFormat::Text.extension(), "txt");
         assert_eq!(ArtifactFormat::Json.extension(), "json");
         assert_eq!(ArtifactFormat::Yaml.extension(), "yaml");
+        assert_eq!(ArtifactFormat::Binary.extension(), "bin");
     }
 
     #[test]

--- a/tools/nika/src/ast/lower.rs
+++ b/tools/nika/src/ast/lower.rs
@@ -662,6 +662,7 @@ fn unlower_output(output: &OutputPolicy) -> AnalyzedOutput {
         OutputFormat::Json => AnalyzedOutputFormat::Json,
         OutputFormat::Yaml => AnalyzedOutputFormat::Yaml,
         OutputFormat::Markdown => AnalyzedOutputFormat::Text,
+        OutputFormat::Binary => AnalyzedOutputFormat::Text, // Binary bypasses text formatting
     };
     AnalyzedOutput {
         format,

--- a/tools/nika/src/ast/output.rs
+++ b/tools/nika/src/ast/output.rs
@@ -138,6 +138,9 @@ pub enum OutputFormat {
 
     /// Markdown formatted output
     Markdown,
+
+    /// Binary (raw bytes, not text content)
+    Binary,
 }
 
 #[cfg(test)]

--- a/tools/nika/src/ast/schema_validator.rs
+++ b/tools/nika/src/ast/schema_validator.rs
@@ -640,6 +640,69 @@ tasks:
         let result = validator.validate_value(&value);
         assert!(result.is_ok(), "JSON value validation should work");
     }
+
+    // ========================================================================
+    // Test: Artifact format: binary passes schema validation
+    // Binary format was added for CAS media pipeline support
+    // ========================================================================
+    #[test]
+    fn test_artifact_format_binary_passes_schema() {
+        let validator = WorkflowSchemaValidator::new().unwrap();
+
+        // Task-level artifact with format: binary
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: download_image
+    exec: "curl -o /tmp/img.png https://example.com/img.png"
+    artifact:
+      path: ./output/image.bin
+      format: binary
+"#;
+        let result = validator.validate_yaml(yaml);
+        assert!(
+            result.is_ok(),
+            "Artifact format: binary should pass schema validation: {:?}",
+            result
+        );
+
+        // Workflow-level artifacts config with format: binary
+        let yaml2 = r#"
+schema: "nika/workflow@0.12"
+artifacts:
+  dir: ./output
+  format: binary
+tasks:
+  - id: step1
+    exec: "echo hello"
+    artifact: true
+"#;
+        let result2 = validator.validate_yaml(yaml2);
+        assert!(
+            result2.is_ok(),
+            "Workflow-level artifacts format: binary should pass: {:?}",
+            result2
+        );
+
+        // Multiple artifacts array with format: binary
+        let yaml3 = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: multi_output
+    exec: "echo done"
+    artifact:
+      - path: ./output/data.json
+        format: json
+      - path: ./output/image.bin
+        format: binary
+"#;
+        let result3 = validator.validate_yaml(yaml3);
+        assert!(
+            result3.is_ok(),
+            "Multiple artifacts with format: binary should pass: {:?}",
+            result3
+        );
+    }
 }
 
 // ========================================================================

--- a/tools/nika/src/binding/resolve.rs
+++ b/tools/nika/src/binding/resolve.rs
@@ -100,6 +100,14 @@ impl LazyBinding {
 pub struct ResolvedBindings {
     /// Alias -> binding mappings (resolved or pending)
     bindings: FxHashMap<String, LazyBinding>,
+    /// Alias -> source task ID (for media path resolution)
+    ///
+    /// When a binding like `img: $gen_img` is created, this maps
+    /// `"img"` -> `"gen_img"`. This is needed because media refs live
+    /// in the TaskResult side-channel, not in the task output value.
+    /// Without this, templates like `{{with.img.media[0].hash}}` and
+    /// binary artifact `source: img` cannot resolve media paths.
+    source_tasks: FxHashMap<String, String>,
 }
 
 impl ResolvedBindings {
@@ -133,6 +141,17 @@ impl ResolvedBindings {
         let mut resolved = Self::new();
 
         for (alias, entry) in spec {
+            // Track source task ID for media path resolution
+            let (task_id, _) = split_path(&entry.path);
+            if !task_id.starts_with("inputs.")
+                && !task_id.starts_with("context.")
+                && !task_id.starts_with("env.")
+            {
+                resolved
+                    .source_tasks
+                    .insert(alias.clone(), task_id.to_string());
+            }
+
             if entry.is_lazy() {
                 // Lazy binding - defer resolution
                 resolved.bindings.insert(
@@ -179,6 +198,13 @@ impl ResolvedBindings {
         let mut bindings = Self::new();
 
         for (alias, entry) in spec {
+            // Track source task ID for media path resolution
+            if let Some(task_id) = entry.source.task_id() {
+                bindings
+                    .source_tasks
+                    .insert(alias.clone(), task_id.to_string());
+            }
+
             if entry.is_lazy() {
                 bindings.bindings.insert(
                     alias.clone(),
@@ -208,6 +234,32 @@ impl ResolvedBindings {
     pub fn set(&mut self, alias: impl Into<String>, value: Value) {
         self.bindings
             .insert(alias.into(), LazyBinding::Resolved(value));
+    }
+
+    /// Set a resolved value with source task ID tracking.
+    ///
+    /// Use this when the binding originates from a task output, so that
+    /// media path resolution (e.g., `{{with.alias.media[0].hash}}`) can
+    /// trace back to the correct task's media refs.
+    pub fn set_with_source(
+        &mut self,
+        alias: impl Into<String>,
+        value: Value,
+        source_task_id: impl Into<String>,
+    ) {
+        let alias = alias.into();
+        self.source_tasks
+            .insert(alias.clone(), source_task_id.into());
+        self.bindings
+            .insert(alias, LazyBinding::Resolved(value));
+    }
+
+    /// Get the source task ID for a binding alias.
+    ///
+    /// Returns `Some("gen_img")` when the binding was `img: $gen_img`.
+    /// Used by artifact processor to resolve media paths and binary artifact sources.
+    pub fn source_task_id(&self, alias: &str) -> Option<&str> {
+        self.source_tasks.get(alias).map(|s| s.as_str())
     }
 
     /// Get a resolved value (only works for already-resolved bindings)
@@ -2533,5 +2585,50 @@ mod tests {
         assert_eq!(json_type_name(&json!("str")), "string");
         assert_eq!(json_type_name(&json!([])), "array");
         assert_eq!(json_type_name(&json!({})), "object");
+    }
+
+    // ========== source_task_id tracking ==========
+
+    #[test]
+    fn source_task_id_set_with_source() {
+        let mut bindings = ResolvedBindings::new();
+        bindings.set_with_source("img", json!("output text"), "gen_img");
+
+        assert_eq!(bindings.source_task_id("img"), Some("gen_img"));
+        assert_eq!(bindings.source_task_id("nonexistent"), None);
+
+        // The value should still be accessible
+        assert_eq!(bindings.get("img"), Some(&json!("output text")));
+    }
+
+    #[test]
+    fn source_task_id_plain_set_has_no_tracking() {
+        let mut bindings = ResolvedBindings::new();
+        bindings.set("img", json!("output text"));
+
+        // Plain set() does not track source task ID
+        assert_eq!(bindings.source_task_id("img"), None);
+    }
+
+    #[test]
+    fn source_task_id_from_binding_spec() {
+        use crate::binding::entry::BindingEntry;
+
+        let mut spec = BindingSpec::default();
+        spec.insert("forecast".to_string(), BindingEntry::new("weather.summary"));
+
+        let store = RunContext::new();
+        store.insert(
+            std::sync::Arc::from("weather"),
+            crate::store::TaskResult::success(
+                json!({"summary": "Sunny"}),
+                std::time::Duration::from_secs(1),
+            ),
+        );
+
+        let bindings = ResolvedBindings::from_binding_spec(Some(&spec), &store).unwrap();
+
+        // "forecast" binding came from $weather -> source task ID is "weather"
+        assert_eq!(bindings.source_task_id("forecast"), Some("weather"));
     }
 }

--- a/tools/nika/src/cli/media.rs
+++ b/tools/nika/src/cli/media.rs
@@ -48,7 +48,9 @@ pub enum MediaAction {
 pub async fn handle_media_command(action: MediaAction, quiet: bool) -> Result<(), NikaError> {
     let workspace_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let store = CasStore::workspace_default(&workspace_root);
-    let store_root = workspace_root.join(".nika").join("media").join("store");
+    // Derive store_root from the actual CasStore root, NOT hardcoded.
+    // This ensures NIKA_MEDIA_STORE overrides are respected for lockfile checks.
+    let store_root = store.root().to_path_buf();
 
     match action {
         MediaAction::List => handle_list(&store, quiet),
@@ -176,9 +178,9 @@ fn handle_clean(
     if !force {
         let lockfile = store_root.join(LOCKFILE_NAME);
         if lockfile.exists() {
-            return Err(NikaError::ConfigError {
+            return Err(NikaError::MediaStoreLocked {
                 reason: format!(
-                    "Media store is locked by a running workflow ({}). \
+                    "Locked by a running workflow ({}). \
                      Use --force to override or wait for the workflow to complete.",
                     lockfile.display()
                 ),
@@ -224,6 +226,11 @@ fn handle_clean(
         }
     } else {
         let result = store.clean_older_than(duration);
+        // TODO(PR2): Emit EventKind::MediaCleanup here. The CLI has no EventLog
+        // because it runs outside the workflow runner context. Options: accept an
+        // optional EventLog param, write one-shot NDJSON to trace dir, or defer
+        // until `nika media clean` integrates with the TUI. The MediaCleanup
+        // variant exists in EventKind but is never emitted.
         if !quiet {
             println!(
                 "{} Removed {} file(s), freed {}",
@@ -323,4 +330,170 @@ mod tests {
         let result = handle_clean(&store, dir.path(), "1h", true, true, true);
         assert!(result.is_ok());
     }
+
+    // ── Functional tests with actual CAS data ──────────────────────────
+
+    /// Backdate a file's mtime by the given duration.
+    fn backdate_mtime(path: &std::path::Path, age: Duration) {
+        let old_time = std::time::SystemTime::now() - age;
+        let file = std::fs::File::open(path).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(old_time))
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_with_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        store.store(b"alpha").await.unwrap();
+        store.store(b"bravo").await.unwrap();
+        store.store(b"charlie").await.unwrap();
+
+        // handle_list with quiet=true prints entries to stdout but should not error
+        let result = handle_list(&store, true);
+        assert!(result.is_ok());
+
+        let entries = store.list();
+        assert_eq!(entries.len(), 3, "expected 3 entries, got {}", entries.len());
+    }
+
+    #[tokio::test]
+    async fn test_stats_with_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let blob_a = b"stats-blob-alpha";
+        let blob_b = b"stats-blob-bravo!!";
+
+        store.store(blob_a).await.unwrap();
+        store.store(blob_b).await.unwrap();
+
+        // handle_stats with quiet=false prints table to stdout but should not error
+        let result = handle_stats(&store, false);
+        assert!(result.is_ok());
+
+        let entries = store.list();
+        assert_eq!(entries.len(), 2);
+
+        let total_size: u64 = entries.iter().map(|e| e.size).sum();
+        assert_eq!(
+            total_size,
+            (blob_a.len() + blob_b.len()) as u64,
+            "total size mismatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clean_removes_old_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Store a blob and backdate its mtime to 2 hours ago
+        let sr = store.store(b"old-file-content").await.unwrap();
+        backdate_mtime(&sr.path, Duration::from_secs(7200));
+
+        assert_eq!(store.list().len(), 1, "precondition: 1 file before clean");
+
+        // Clean with older_than=1h, dry_run=false, force=false
+        let clean = handle_clean(&store, dir.path(), "1h", false, false, true);
+        assert!(clean.is_ok());
+
+        // File backdated 2h ago exceeds the 1h threshold; it should be gone
+        assert_eq!(
+            store.list().len(),
+            0,
+            "file backdated 2h should have been removed by 1h threshold"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clean_dry_run_preserves_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Store and backdate to 2 hours ago
+        let sr = store.store(b"dry-run-content").await.unwrap();
+        backdate_mtime(&sr.path, Duration::from_secs(7200));
+
+        assert_eq!(store.list().len(), 1, "precondition: 1 file before dry-run");
+
+        // dry_run=true: report what would be deleted, but don't actually delete
+        let clean = handle_clean(&store, dir.path(), "1h", true, false, true);
+        assert!(clean.is_ok());
+
+        assert_eq!(store.list().len(), 1, "dry-run must not delete files");
+    }
+
+    #[tokio::test]
+    async fn test_clean_min_age_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Store a blob and backdate to only 3 minutes ago
+        let sr = store.store(b"young-file").await.unwrap();
+        backdate_mtime(&sr.path, Duration::from_secs(180));
+
+        assert_eq!(store.list().len(), 1, "precondition: 1 file");
+
+        // Request older_than="1m" -- the 5-minute safety floor clamps this to 5m.
+        // The file is only 3 minutes old (< 5m floor), so it must survive.
+        let clean = handle_clean(&store, dir.path(), "1m", false, false, true);
+        assert!(clean.is_ok());
+
+        assert_eq!(
+            store.list().len(),
+            1,
+            "file aged 3m must survive when floor clamps 1m to 5m"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stats_shard_distribution() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Store 20 distinct blobs for hash diversity across shards
+        for i in 0u32..20 {
+            let blob = format!("shard-test-blob-{i:04}");
+            store.store(blob.as_bytes()).await.unwrap();
+        }
+
+        let entries = store.list();
+        assert_eq!(entries.len(), 20, "should have 20 unique entries");
+
+        // Count distinct shards (first 2 hex chars of hash after "blake3:")
+        let mut shards = std::collections::BTreeSet::new();
+        for entry in &entries {
+            let raw = entry.hash.strip_prefix("blake3:").unwrap();
+            shards.insert(raw[..2].to_string());
+        }
+
+        // 20 random-ish blake3 hashes across 256 possible shards: P(all same) ~ 1e-46
+        assert!(
+            shards.len() >= 2,
+            "expected >= 2 distinct shards from 20 files, got {}",
+            shards.len()
+        );
+
+        // Verify the shard distribution logic matches handle_stats internals
+        let mut shard_map: std::collections::BTreeMap<String, (usize, u64)> =
+            std::collections::BTreeMap::new();
+        for entry in &entries {
+            let shard = entry
+                .hash
+                .strip_prefix("blake3:")
+                .map(|h| h[..2].to_string())
+                .unwrap();
+            let counter = shard_map.entry(shard).or_insert((0, 0));
+            counter.0 += 1;
+            counter.1 += entry.size;
+        }
+        assert_eq!(shard_map.len(), shards.len());
+
+        // handle_stats itself should not error
+        let result = handle_stats(&store, false);
+        assert!(result.is_ok());
+    }
+
 }

--- a/tools/nika/src/cli/media.rs
+++ b/tools/nika/src/cli/media.rs
@@ -1,0 +1,326 @@
+//! `nika media` subcommand — list, stats, and GC for CAS media store.
+//!
+//! Commands:
+//! - `nika media list` — Table output: HASH | SIZE | PATH
+//! - `nika media stats` — Count, total size, shard distribution
+//! - `nika media clean` — Remove old files with GC safety
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Subcommand;
+use colored::Colorize;
+
+use nika::error::NikaError;
+use nika::media::CasStore;
+
+/// Minimum GC age floor: 5 minutes (safety: prevent deleting in-flight media)
+const MIN_GC_AGE_SECS: u64 = 300;
+
+/// Lockfile name written by runner during workflow execution
+const LOCKFILE_NAME: &str = ".nika-run.lock";
+
+#[derive(Subcommand, Debug)]
+pub enum MediaAction {
+    /// List all files in the media store
+    List,
+
+    /// Show store statistics (count, size, shard distribution)
+    Stats,
+
+    /// Remove old media files from the store
+    Clean {
+        /// Minimum age for deletion (e.g., "1h", "7d", "30m"). Default: 1h
+        #[arg(long, default_value = "1h")]
+        older_than: String,
+
+        /// Show what would be deleted without actually deleting
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Force cleanup even if a workflow is running (bypass lockfile check)
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+/// Handle `nika media` subcommand
+pub async fn handle_media_command(action: MediaAction, quiet: bool) -> Result<(), NikaError> {
+    let workspace_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let store = CasStore::workspace_default(&workspace_root);
+    let store_root = workspace_root.join(".nika").join("media").join("store");
+
+    match action {
+        MediaAction::List => handle_list(&store, quiet),
+        MediaAction::Stats => handle_stats(&store, quiet),
+        MediaAction::Clean {
+            older_than,
+            dry_run,
+            force,
+        } => handle_clean(&store, &store_root, &older_than, dry_run, force, quiet),
+    }
+}
+
+fn handle_list(store: &CasStore, quiet: bool) -> Result<(), NikaError> {
+    let entries = store.list();
+
+    if entries.is_empty() {
+        if !quiet {
+            println!("{}", "Media store is empty.".dimmed());
+        }
+        return Ok(());
+    }
+
+    if !quiet {
+        println!(
+            "{:<68}  {:>10}  {}",
+            "HASH".bold(),
+            "SIZE".bold(),
+            "PATH".bold()
+        );
+    }
+
+    for entry in &entries {
+        println!(
+            "{:<68}  {:>10}  {}",
+            entry.hash.dimmed(),
+            format_bytes(entry.size),
+            entry.path.display(),
+        );
+    }
+
+    if !quiet {
+        println!(
+            "\n{} file(s), {} total",
+            entries.len(),
+            format_bytes(entries.iter().map(|e| e.size).sum())
+        );
+    }
+
+    Ok(())
+}
+
+fn handle_stats(store: &CasStore, quiet: bool) -> Result<(), NikaError> {
+    let entries = store.list();
+
+    let total_size: u64 = entries.iter().map(|e| e.size).sum();
+    let count = entries.len();
+
+    // Shard distribution
+    let mut shards: std::collections::BTreeMap<String, (usize, u64)> = std::collections::BTreeMap::new();
+    for entry in &entries {
+        // Extract shard prefix (first 2 chars of hash after "blake3:")
+        let shard = entry
+            .hash
+            .strip_prefix("blake3:")
+            .map(|h: &str| h[..2.min(h.len())].to_string())
+            .unwrap_or_else(|| "??".to_string());
+        let counter = shards.entry(shard).or_insert((0, 0));
+        counter.0 += 1;
+        counter.1 += entry.size;
+    }
+
+    if quiet {
+        println!("{count}");
+        return Ok(());
+    }
+
+    println!("{}", "Media Store Statistics".bold());
+    println!("  Files:      {}", count);
+    println!("  Total size: {}", format_bytes(total_size));
+    println!("  Shards:     {}", shards.len());
+
+    if !shards.is_empty() {
+        println!("\n{}", "Shard Distribution:".bold());
+        for (shard, (shard_count, shard_size)) in &shards {
+            println!(
+                "  {}/  {:>4} files  {:>10}",
+                shard,
+                shard_count,
+                format_bytes(*shard_size)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_clean(
+    store: &CasStore,
+    store_root: &std::path::Path,
+    older_than: &str,
+    dry_run: bool,
+    force: bool,
+    quiet: bool,
+) -> Result<(), NikaError> {
+    // Parse duration
+    let duration = humantime::parse_duration(older_than).map_err(|e| NikaError::ConfigError {
+        reason: format!("Invalid duration '{}': {}. Examples: 1h, 30m, 7d", older_than, e),
+    })?;
+
+    // Enforce minimum GC age (5 minutes)
+    let duration = if duration.as_secs() < MIN_GC_AGE_SECS {
+        if !quiet {
+            println!(
+                "{} Minimum GC age is 5 minutes, using 5m instead of '{}'",
+                "⚠".yellow(),
+                older_than
+            );
+        }
+        Duration::from_secs(MIN_GC_AGE_SECS)
+    } else {
+        duration
+    };
+
+    // Check lockfile (unless --force)
+    if !force {
+        let lockfile = store_root.join(LOCKFILE_NAME);
+        if lockfile.exists() {
+            return Err(NikaError::ConfigError {
+                reason: format!(
+                    "Media store is locked by a running workflow ({}). \
+                     Use --force to override or wait for the workflow to complete.",
+                    lockfile.display()
+                ),
+            });
+        }
+    }
+
+    if dry_run {
+        // Count what would be deleted
+        let entries = store.list();
+        let now = std::time::SystemTime::now();
+        let mut would_delete = 0u64;
+        let mut would_free = 0u64;
+
+        for entry in &entries {
+            if let Ok(meta) = std::fs::metadata(&entry.path) {
+                if let Ok(modified) = meta.modified() {
+                    if let Ok(age) = now.duration_since(modified) {
+                        if age > duration {
+                            would_delete += 1;
+                            would_free += entry.size;
+                            if !quiet {
+                                println!(
+                                    "  {} {} ({})",
+                                    "would delete:".yellow(),
+                                    entry.hash.dimmed(),
+                                    format_bytes(entry.size)
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !quiet {
+            println!(
+                "\n{} Would delete {} file(s), freeing {}",
+                "dry-run:".cyan().bold(),
+                would_delete,
+                format_bytes(would_free)
+            );
+        }
+    } else {
+        let result = store.clean_older_than(duration);
+        if !quiet {
+            println!(
+                "{} Removed {} file(s), freed {}",
+                "✓".green(),
+                result.removed,
+                format_bytes(result.bytes_freed)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Format bytes as human-readable size
+pub(crate) fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1024), "1.0 KB");
+        assert_eq!(format_bytes(1_048_576), "1.0 MB");
+        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+    }
+
+    #[test]
+    fn test_parse_duration_valid() {
+        assert!(humantime::parse_duration("1h").is_ok());
+        assert!(humantime::parse_duration("30m").is_ok());
+        assert!(humantime::parse_duration("7d").is_ok());
+        assert!(humantime::parse_duration("5m").is_ok());
+    }
+
+    #[test]
+    fn test_min_gc_age_enforced() {
+        // Durations under 5 minutes should be clamped
+        let short = humantime::parse_duration("1m").unwrap();
+        assert!(short.as_secs() < MIN_GC_AGE_SECS);
+    }
+
+    #[tokio::test]
+    async fn test_list_empty_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        // Should not panic on empty store
+        let result = handle_list(&store, true);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_stats_empty_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let result = handle_stats(&store, true);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_clean_dry_run_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let result = handle_clean(&store, dir.path(), "1h", true, false, true);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_clean_lockfile_blocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        // Create lockfile
+        let lockfile = dir.path().join(LOCKFILE_NAME);
+        std::fs::write(&lockfile, "locked").unwrap();
+
+        let result = handle_clean(&store, dir.path(), "1h", false, false, true);
+        assert!(result.is_err());
+
+        // With --force should work
+        let result = handle_clean(&store, dir.path(), "1h", true, true, true);
+        assert!(result.is_ok());
+    }
+}

--- a/tools/nika/src/cli/mod.rs
+++ b/tools/nika/src/cli/mod.rs
@@ -16,6 +16,7 @@ pub mod model;
 
 pub mod config;
 pub mod doctor;
+pub mod media;
 pub mod schema;
 pub mod workflow;
 

--- a/tools/nika/src/error.rs
+++ b/tools/nika/src/error.rs
@@ -28,7 +28,7 @@
 //! - NIKA-220-229: Reserved (DAG Panel - not implemented)
 //! - NIKA-230-239: Reserved (Session persistence - not implemented)
 //! - NIKA-240-249: Reserved (Animation/Export - not implemented)
-//! - NIKA-280-289: Artifact errors (path validation, write, size limits)
+//! - NIKA-280-285: Artifact/media errors (path validation, write, size, integrity, cleanup, lock)
 //! - NIKA-300-309: Structured Output errors (JSON Schema validation, extraction, repair)
 
 use crate::mcp::types::McpErrorCode;
@@ -552,6 +552,27 @@ pub enum NikaError {
         max_size: u64,
     },
 
+    #[error("[NIKA-283] Media integrity warning: {reason}")]
+    #[diagnostic(
+        code(nika::media_integrity_warning),
+        help("CAS file may have been deleted or corrupted during workflow execution")
+    )]
+    MediaIntegrityWarning { reason: String },
+
+    #[error("[NIKA-284] Media cleanup failed: {reason}")]
+    #[diagnostic(
+        code(nika::media_cleanup_error),
+        help("Check file permissions and disk space in .nika/media/store/")
+    )]
+    MediaCleanupError { reason: String },
+
+    #[error("[NIKA-285] Media store is locked: {reason}")]
+    #[diagnostic(
+        code(nika::media_store_locked),
+        help("A workflow is currently running. Use --force to override or wait for completion")
+    )]
+    MediaStoreLocked { reason: String },
+
     // ═══════════════════════════════════════════
     // STRUCTURED OUTPUT ERRORS (300-309)
     // ═══════════════════════════════════════════
@@ -702,6 +723,9 @@ impl NikaError {
             Self::ArtifactPathError { .. } => "NIKA-280",
             Self::ArtifactWriteError { .. } => "NIKA-281",
             Self::ArtifactSizeExceeded { .. } => "NIKA-282",
+            Self::MediaIntegrityWarning { .. } => "NIKA-283",
+            Self::MediaCleanupError { .. } => "NIKA-284",
+            Self::MediaStoreLocked { .. } => "NIKA-285",
             // Structured Output errors
             Self::StructuredOutputExtractionFailed { .. } => "NIKA-300",
             Self::StructuredOutputValidationFailed { .. } => "NIKA-301",
@@ -922,6 +946,15 @@ impl FixSuggestion for NikaError {
             }
             NikaError::ArtifactSizeExceeded { .. } => {
                 Some("Increase artifacts.max_size in workflow or reduce output size")
+            }
+            NikaError::MediaIntegrityWarning { .. } => {
+                Some("CAS file may have been deleted or corrupted during workflow execution")
+            }
+            NikaError::MediaCleanupError { .. } => {
+                Some("Check file permissions and disk space in .nika/media/store/")
+            }
+            NikaError::MediaStoreLocked { .. } => {
+                Some("A workflow is currently running. Use --force to override or wait for completion")
             }
             // Structured Output errors
             NikaError::StructuredOutputExtractionFailed { .. } => {

--- a/tools/nika/src/event/log.rs
+++ b/tools/nika/src/event/log.rs
@@ -437,8 +437,11 @@ pub enum EventKind {
         path: String,
         /// Size in bytes
         size: u64,
-        /// Output format (text, json)
+        /// Output format (text, json, binary)
         format: String,
+        /// Blake3 checksum from CAS (binary artifacts only)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        checksum: Option<String>,
     },
     /// Artifact write failed
     ArtifactFailed {
@@ -497,6 +500,14 @@ pub enum EventKind {
         hash: String,
         /// Error description
         reason: String,
+    },
+
+    /// Media integrity check completed (emitted after all tasks finish)
+    MediaIntegrityCheck {
+        /// Number of media refs checked
+        checked: u64,
+        /// Number of integrity warnings (missing files, size mismatches)
+        warnings: u64,
     },
 
     // ═══════════════════════════════════════════
@@ -595,7 +606,8 @@ impl EventKind {
             | Self::WorkflowResumed
             | Self::McpConnected { .. }
             | Self::McpError { .. }
-            | Self::MediaCleanup { .. } => None,
+            | Self::MediaCleanup { .. }
+            | Self::MediaIntegrityCheck { .. } => None,
         }
     }
 
@@ -1872,7 +1884,7 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════
 
     /// Helper: build one instance of every EventKind variant (all 37)
-    fn all_37_variants() -> Vec<EventKind> {
+    fn all_38_variants() -> Vec<EventKind> {
         vec![
             // Workflow (6)
             EventKind::WorkflowStarted {
@@ -2052,6 +2064,7 @@ mod tests {
                 path: "/tmp/output.json".into(),
                 size: 1024,
                 format: "json".into(),
+                checksum: None,
             },
             EventKind::ArtifactFailed {
                 task_id: "t1".into(),
@@ -2105,22 +2118,27 @@ mod tests {
                 bytes_freed: 10240,
                 dry_run: false,
             },
+            // Media Integrity Check (1)
+            EventKind::MediaIntegrityCheck {
+                checked: 10,
+                warnings: 0,
+            },
         ]
     }
 
     #[test]
-    fn wave2_variant_count_is_37() {
-        let variants = all_37_variants();
+    fn wave2_variant_count_is_38() {
+        let variants = all_38_variants();
         assert_eq!(
             variants.len(),
-            37,
-            "EventKind should have exactly 37 variants"
+            38,
+            "EventKind should have exactly 38 variants"
         );
     }
 
     #[test]
     fn wave2_all_variants_serialize_deserialize_roundtrip() {
-        for (i, variant) in all_37_variants().into_iter().enumerate() {
+        for (i, variant) in all_38_variants().into_iter().enumerate() {
             let json = serde_json::to_string(&variant)
                 .unwrap_or_else(|e| panic!("variant {i} failed to serialize: {e}"));
             let back: EventKind = serde_json::from_str(&json)
@@ -2132,7 +2150,7 @@ mod tests {
     #[test]
     fn wave2_ndjson_no_embedded_newlines() {
         // NDJSON = one JSON object per line, no embedded newlines
-        for (i, variant) in all_37_variants().into_iter().enumerate() {
+        for (i, variant) in all_38_variants().into_iter().enumerate() {
             let json = serde_json::to_string(&variant).unwrap();
             assert!(
                 !json.contains('\n'),
@@ -2340,10 +2358,10 @@ mod tests {
 
     #[test]
     fn wave2_task_id_extraction_all_variants() {
-        let variants = all_37_variants();
+        let variants = all_38_variants();
         // Variants WITH task_id (27 of them)
         let with_task_id: Vec<_> = variants.iter().filter(|v| v.task_id().is_some()).collect();
-        // Variants WITHOUT task_id (10): 6 workflow + McpConnected + McpError + Custom(None) + MediaCleanup
+        // Variants WITHOUT task_id (11): 6 workflow + McpConnected + McpError + Custom(None) + MediaCleanup + MediaIntegrityCheck
         let without_task_id: Vec<_> = variants.iter().filter(|v| v.task_id().is_none()).collect();
 
         // Custom has task_id: None in our test data, so it goes in without
@@ -2355,8 +2373,8 @@ mod tests {
         );
         assert_eq!(
             without_task_id.len(),
-            10,
-            "10 variants should lack task_id (workflow-level + McpConnected + McpError + Custom with None + MediaCleanup)"
+            11,
+            "11 variants should lack task_id (workflow-level + McpConnected + McpError + Custom with None + MediaCleanup + MediaIntegrityCheck)"
         );
     }
 

--- a/tools/nika/src/event/log.rs
+++ b/tools/nika/src/event/log.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides full audit trail with replay capability.
 //! - Event: envelope with id + timestamp + kind
-//! - EventKind: 36 variants across 11 categories (workflow/task/fine-grained/MCP/context/agent/guardrails/builtin/artifact/media/structured-output)
+//! - EventKind: 37 variants across 12 categories (workflow/task/fine-grained/MCP/context/agent/guardrails/builtin/artifact/media/structured-output/media-cleanup)
 //! - EventLog: thread-safe, append-only log
 //!
 //! `AgentTurnMetadata` provides reasoning capture (thinking, tokens, stop_reason).
@@ -537,6 +537,19 @@ pub enum EventKind {
         /// Total attempts across all layers before success
         total_attempts: u32,
     },
+
+    // ═══════════════════════════════════════════
+    // MEDIA CLEANUP EVENTS
+    // ═══════════════════════════════════════════
+    /// Media store cleanup (GC) operation completed
+    MediaCleanup {
+        /// Number of files removed
+        removed: u64,
+        /// Total bytes freed
+        bytes_freed: u64,
+        /// Whether this was a dry-run (no files actually deleted)
+        dry_run: bool,
+    },
 }
 
 impl EventKind {
@@ -581,7 +594,8 @@ impl EventKind {
             | Self::WorkflowPaused
             | Self::WorkflowResumed
             | Self::McpConnected { .. }
-            | Self::McpError { .. } => None,
+            | Self::McpError { .. }
+            | Self::MediaCleanup { .. } => None,
         }
     }
 
@@ -1857,8 +1871,8 @@ mod tests {
     // WAVE 2 TESTS: NDJSON event system audit
     // ═══════════════════════════════════════════════════════════════
 
-    /// Helper: build one instance of every EventKind variant (all 36)
-    fn all_36_variants() -> Vec<EventKind> {
+    /// Helper: build one instance of every EventKind variant (all 37)
+    fn all_37_variants() -> Vec<EventKind> {
         vec![
             // Workflow (6)
             EventKind::WorkflowStarted {
@@ -2085,22 +2099,28 @@ mod tests {
                 layer_name: "rig_extractor".into(),
                 total_attempts: 1,
             },
+            // Media Cleanup (1)
+            EventKind::MediaCleanup {
+                removed: 5,
+                bytes_freed: 10240,
+                dry_run: false,
+            },
         ]
     }
 
     #[test]
-    fn wave2_variant_count_is_36() {
-        let variants = all_36_variants();
+    fn wave2_variant_count_is_37() {
+        let variants = all_37_variants();
         assert_eq!(
             variants.len(),
-            36,
-            "EventKind should have exactly 36 variants"
+            37,
+            "EventKind should have exactly 37 variants"
         );
     }
 
     #[test]
     fn wave2_all_variants_serialize_deserialize_roundtrip() {
-        for (i, variant) in all_36_variants().into_iter().enumerate() {
+        for (i, variant) in all_37_variants().into_iter().enumerate() {
             let json = serde_json::to_string(&variant)
                 .unwrap_or_else(|e| panic!("variant {i} failed to serialize: {e}"));
             let back: EventKind = serde_json::from_str(&json)
@@ -2112,7 +2132,7 @@ mod tests {
     #[test]
     fn wave2_ndjson_no_embedded_newlines() {
         // NDJSON = one JSON object per line, no embedded newlines
-        for (i, variant) in all_36_variants().into_iter().enumerate() {
+        for (i, variant) in all_37_variants().into_iter().enumerate() {
             let json = serde_json::to_string(&variant).unwrap();
             assert!(
                 !json.contains('\n'),
@@ -2320,10 +2340,10 @@ mod tests {
 
     #[test]
     fn wave2_task_id_extraction_all_variants() {
-        let variants = all_36_variants();
-        // Variants WITH task_id (26 of them)
+        let variants = all_37_variants();
+        // Variants WITH task_id (27 of them)
         let with_task_id: Vec<_> = variants.iter().filter(|v| v.task_id().is_some()).collect();
-        // Variants WITHOUT task_id (8): 6 workflow + McpConnected + McpError
+        // Variants WITHOUT task_id (10): 6 workflow + McpConnected + McpError + Custom(None) + MediaCleanup
         let without_task_id: Vec<_> = variants.iter().filter(|v| v.task_id().is_none()).collect();
 
         // Custom has task_id: None in our test data, so it goes in without
@@ -2335,8 +2355,8 @@ mod tests {
         );
         assert_eq!(
             without_task_id.len(),
-            9,
-            "9 variants should lack task_id (workflow-level + McpConnected + McpError + Custom with None)"
+            10,
+            "10 variants should lack task_id (workflow-level + McpConnected + McpError + Custom with None + MediaCleanup)"
         );
     }
 

--- a/tools/nika/src/event/mod.rs
+++ b/tools/nika/src/event/mod.rs
@@ -3,7 +3,7 @@
 //! Provides full audit trail with replay capability.
 //! Key types:
 //! - `Event`: Envelope with id + timestamp + kind
-//! - `EventKind`: 36 variants across 11 categories (workflow/task/fine-grained/MCP/context/agent/guardrail/builtin/artifact/media/structured-output)
+//! - `EventKind`: 37 variants across 12 categories (workflow/task/fine-grained/MCP/context/agent/guardrail/builtin/artifact/media/structured-output/media-cleanup)
 //! - `EventLog`: Thread-safe, append-only log
 //! - `EventEmitter`: Trait for dependency injection
 //! - `NoopEmitter`: Zero-cost no-op for testing

--- a/tools/nika/src/io/security.rs
+++ b/tools/nika/src/io/security.rs
@@ -405,6 +405,96 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // SECURITY: Symlink attack detection tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_canonicalized_boundary_detects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let base_dir = temp.path().join("artifacts");
+        fs::create_dir_all(&base_dir).unwrap();
+
+        let escape_target = temp.path().join("outside");
+        fs::create_dir_all(&escape_target).unwrap();
+        let secret_file = escape_target.join("secret.txt");
+        fs::write(&secret_file, "sensitive data").unwrap();
+
+        let symlink_path = base_dir.join("evil");
+        symlink(&escape_target, &symlink_path).unwrap();
+
+        let result = validate_canonicalized_boundary(
+            &base_dir,
+            &symlink_path.join("secret.txt"),
+        );
+        assert!(result.is_err(),
+            "validate_canonicalized_boundary must detect symlink-based escape");
+        assert!(result.unwrap_err().reason.contains("traversal"),
+            "Error should mention path traversal");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_artifact_path_does_not_resolve_symlinks() {
+        // validate_artifact_path uses normalize_path (logical) not canonicalize.
+        // This documents the known limitation: symlinks inside the artifact dir
+        // that point outside are NOT detected by this function.
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+
+        let escape_target = temp.path().join("outside");
+        fs::create_dir_all(&escape_target).unwrap();
+        let symlink_dir = canonical_dir.join("escape_link");
+        symlink(&escape_target, &symlink_dir).unwrap();
+
+        let result = validate_artifact_path(
+            &canonical_dir,
+            Path::new("escape_link/file.txt"),
+        );
+        assert!(result.is_ok(),
+            "validate_artifact_path does not resolve symlinks (known limitation)");
+    }
+
+    #[test]
+    fn test_validate_artifact_path_dot_dot_in_middle() {
+        let artifact_dir = PathBuf::from("/project/artifacts");
+        let result = validate_artifact_path(
+            &artifact_dir,
+            Path::new("subdir/../../escape"),
+        );
+        assert!(result.is_err(),
+            "Path with .. escaping via subdirectory must be blocked");
+    }
+
+    #[test]
+    fn test_validate_artifact_path_deep_traversal() {
+        let artifact_dir = PathBuf::from("/project/artifacts");
+        let result = validate_artifact_path(
+            &artifact_dir,
+            Path::new("a/b/c/d/../../../../../../../../etc/passwd"),
+        );
+        assert!(result.is_err(),
+            "Deep path traversal must be blocked");
+    }
+
+    #[test]
+    fn test_validate_artifact_path_control_chars_blocked() {
+        let artifact_dir = PathBuf::from("/project/artifacts");
+        let result = validate_artifact_path(
+            &artifact_dir,
+            Path::new("file\r\ninjection"),
+        );
+        assert!(result.is_err(),
+            "Control characters in path must be blocked");
+    }
+
     #[test]
     fn test_normalize_path_preserves_unresolvable_parent() {
         // Relative path with leading `..` — should be preserved, not swallowed

--- a/tools/nika/src/io/writer.rs
+++ b/tools/nika/src/io/writer.rs
@@ -40,7 +40,6 @@ pub const DEFAULT_MAX_SIZE: u64 = 10 * 1024 * 1024;
 
 /// Source for binary artifact data
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Used in commit 3 (artifact_processor binary dispatch)
 pub(crate) enum BinarySource {
     /// Copy from a CAS store path
     CasPath(PathBuf),
@@ -48,7 +47,6 @@ pub(crate) enum BinarySource {
 
 /// Request to write a binary artifact
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Used in commit 3 (artifact_processor binary dispatch)
 pub(crate) struct BinaryWriteRequest {
     /// Task ID that produced this binary
     pub task_id: String,
@@ -257,7 +255,6 @@ impl ArtifactWriter {
     /// - `NikaError::ArtifactSizeExceeded` if source exceeds max_size
     /// - `NikaError::ArtifactWriteError` if copy fails or source missing
     /// - `NikaError::ArtifactPathError` if output path validation fails
-    #[allow(dead_code)] // Used in commit 3 (artifact_processor binary dispatch)
     pub(crate) async fn write_binary(
         &self,
         request: BinaryWriteRequest,

--- a/tools/nika/src/io/writer.rs
+++ b/tools/nika/src/io/writer.rs
@@ -552,8 +552,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_binary_rejects_append_mode() {
-        // Binary artifacts with append mode should fail
+    async fn test_write_binary_always_overwrites() {
+        // Binary artifacts always use overwrite semantics (no append mode)
         let temp = tempdir().unwrap();
         let artifact_dir = temp.path().join("artifacts");
         std::fs::create_dir_all(&artifact_dir).unwrap();
@@ -570,9 +570,9 @@ mod tests {
             expected_size: 4,
         };
 
-        // write_binary should not support append — it always overwrites
+        // write_binary always overwrites — append is not supported for binary
         let result = writer.write_binary(request).await;
-        assert!(result.is_ok()); // Binary always does overwrite, not append
+        assert!(result.is_ok(), "Binary write should succeed (overwrite mode)");
     }
 
     #[tokio::test]

--- a/tools/nika/src/io/writer.rs
+++ b/tools/nika/src/io/writer.rs
@@ -291,6 +291,10 @@ impl ArtifactWriter {
         // Copy binary from source
         let size = match request.source {
             BinarySource::CasPath(ref src) => {
+                // reflink_or_copy uses create_new semantics — remove existing file first
+                // to support overwrite mode (the default for artifacts)
+                let _ = fs::remove_file(&final_path).await;
+
                 // Use reflink_or_copy: instant on APFS/btrfs, fallback on ext4/NTFS
                 // This is a sync operation, so we spawn_blocking to avoid blocking the runtime
                 let src = src.clone();
@@ -323,7 +327,7 @@ impl ArtifactWriter {
         Ok(WriteResult {
             path: final_path,
             size,
-            format: OutputFormat::Text, // Binary doesn't have a text format; use Text as placeholder
+            format: OutputFormat::Binary,
         })
     }
 
@@ -613,5 +617,68 @@ mod tests {
 
         let result = writer.write_binary(request).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_overwrite_existing() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        // Create CAS files with different content
+        let cas_dir = temp.path().join("cas");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file_v1 = cas_dir.join("v1");
+        let cas_file_v2 = cas_dir.join("v2");
+        std::fs::write(&cas_file_v1, b"version 1 data").unwrap();
+        std::fs::write(&cas_file_v2, b"version 2 data -- longer").unwrap();
+
+        // First write
+        let request1 = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file_v1),
+            expected_size: 14,
+        };
+        let result1 = writer.write_binary(request1).await.unwrap();
+        assert_eq!(std::fs::read(&result1.path).unwrap(), b"version 1 data");
+
+        // Second write to same path (overwrite) — must succeed
+        let request2 = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file_v2),
+            expected_size: 24,
+        };
+        let result2 = writer.write_binary(request2).await.unwrap();
+        assert_eq!(
+            std::fs::read(&result2.path).unwrap(),
+            b"version 2 data -- longer",
+            "Overwrite should replace file content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_format_is_binary() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("data");
+        std::fs::write(&cas_file, b"test").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 4,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        assert_eq!(result.format, OutputFormat::Binary, "Binary write should report Binary format");
     }
 }

--- a/tools/nika/src/io/writer.rs
+++ b/tools/nika/src/io/writer.rs
@@ -38,6 +38,28 @@ use crate::io::template::TemplateResolver;
 /// Default maximum artifact size (10 MB)
 pub const DEFAULT_MAX_SIZE: u64 = 10 * 1024 * 1024;
 
+/// Source for binary artifact data
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Used in commit 3 (artifact_processor binary dispatch)
+pub(crate) enum BinarySource {
+    /// Copy from a CAS store path
+    CasPath(PathBuf),
+}
+
+/// Request to write a binary artifact
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Used in commit 3 (artifact_processor binary dispatch)
+pub(crate) struct BinaryWriteRequest {
+    /// Task ID that produced this binary
+    pub task_id: String,
+    /// Output path template (may contain `{{var}}` placeholders)
+    pub output_path: String,
+    /// Source of binary data
+    pub source: BinarySource,
+    /// Expected file size (for size limit check before copy)
+    pub expected_size: u64,
+}
+
 /// Result of a successful write operation
 #[derive(Debug, Clone)]
 pub struct WriteResult {
@@ -218,6 +240,93 @@ impl ArtifactWriter {
             path: final_path,
             size: content_size,
             format: request.format,
+        })
+    }
+
+    /// Write a binary artifact by copying from CAS store path.
+    ///
+    /// Uses reflink_or_copy for instant copy-on-write on APFS/btrfs,
+    /// with automatic fallback to regular copy on other filesystems.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - Binary write request with source path and metadata
+    ///
+    /// # Errors
+    ///
+    /// - `NikaError::ArtifactSizeExceeded` if source exceeds max_size
+    /// - `NikaError::ArtifactWriteError` if copy fails or source missing
+    /// - `NikaError::ArtifactPathError` if output path validation fails
+    #[allow(dead_code)] // Used in commit 3 (artifact_processor binary dispatch)
+    pub(crate) async fn write_binary(
+        &self,
+        request: BinaryWriteRequest,
+    ) -> Result<WriteResult, NikaError> {
+        // Check size limit before copy
+        if request.expected_size > self.max_size {
+            return Err(NikaError::ArtifactSizeExceeded {
+                path: request.output_path.clone(),
+                size: request.expected_size,
+                max_size: self.max_size,
+            });
+        }
+
+        // Resolve template variables in output path
+        let resolver = TemplateResolver::new(&request.task_id, &self.workflow_name);
+        let resolved_path = resolver.resolve(&request.output_path)?;
+
+        // Validate path stays within artifact directory
+        let full_path = validate_artifact_path(&self.artifact_dir, Path::new(&resolved_path))?;
+
+        // Create parent directories
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|e| NikaError::ArtifactWriteError {
+                    path: parent.display().to_string(),
+                    reason: format!("Failed to create parent directories: {}", e),
+                })?;
+        }
+
+        // Final path validation after directory creation (mitigates TOCTOU)
+        let final_path = validate_artifact_path(&self.artifact_dir, Path::new(&resolved_path))?;
+
+        // Copy binary from source
+        let size = match request.source {
+            BinarySource::CasPath(ref src) => {
+                // Use reflink_or_copy: instant on APFS/btrfs, fallback on ext4/NTFS
+                // This is a sync operation, so we spawn_blocking to avoid blocking the runtime
+                let src = src.clone();
+                let dst = final_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    reflink_copy::reflink_or_copy(&src, &dst)
+                })
+                .await
+                .map_err(|e| NikaError::ArtifactWriteError {
+                    path: final_path.display().to_string(),
+                    reason: format!("Task join error: {}", e),
+                })?
+                .map_err(|e| NikaError::ArtifactWriteError {
+                    path: final_path.display().to_string(),
+                    reason: format!("Binary copy failed: {}", e),
+                })?;
+
+                // reflink_or_copy returns Option<u64> — None means reflink (0-cost), Some(n) means n bytes copied
+                // Either way, the file is now at final_path. Get actual size.
+                fs::metadata(&final_path)
+                    .await
+                    .map(|m| m.len())
+                    .map_err(|e| NikaError::ArtifactWriteError {
+                        path: final_path.display().to_string(),
+                        reason: format!("Failed to stat written file: {}", e),
+                    })?
+            }
+        };
+
+        Ok(WriteResult {
+            path: final_path,
+            size,
+            format: OutputFormat::Text, // Binary doesn't have a text format; use Text as placeholder
         })
     }
 
@@ -408,5 +517,104 @@ mod tests {
         assert_eq!(request.content, "content");
         assert!(matches!(request.format, OutputFormat::Json));
         assert_eq!(request.vars.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_from_cas_path() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        // Create a fake CAS file
+        let cas_dir = temp.path().join("cas");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file = cas_dir.join("testfile");
+        let data = b"binary image data here";
+        std::fs::write(&cas_file, data).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "gen_img".to_string(),
+            output_path: "images/result.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: data.len() as u64,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        assert!(result.path.ends_with("images/result.bin"));
+        assert_eq!(result.size, data.len() as u64);
+
+        // Verify file content
+        let written = std::fs::read(&result.path).unwrap();
+        assert_eq!(written, data);
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_rejects_append_mode() {
+        // Binary artifacts with append mode should fail
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("dummy");
+        std::fs::write(&cas_file, b"test").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 4,
+        };
+
+        // write_binary should not support append — it always overwrites
+        let result = writer.write_binary(request).await;
+        assert!(result.is_ok()); // Binary always does overwrite, not append
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_size_limit() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow").with_max_size(10);
+
+        let cas_file = temp.path().join("bigfile");
+        let data = vec![0u8; 100];
+        std::fs::write(&cas_file, &data).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 100,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, NikaError::ArtifactSizeExceeded { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_missing_source() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(PathBuf::from("/nonexistent/cas/file")),
+            expected_size: 42,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err());
     }
 }

--- a/tools/nika/src/io/writer.rs
+++ b/tools/nika/src/io/writer.rs
@@ -288,39 +288,61 @@ impl ArtifactWriter {
         // Final path validation after directory creation (mitigates TOCTOU)
         let final_path = validate_artifact_path(&self.artifact_dir, Path::new(&resolved_path))?;
 
-        // Copy binary from source
+        // Copy binary from source using atomic temp+rename pattern.
+        //
+        // reflink_or_copy uses O_EXCL (create_new) semantics -- it fails if the
+        // destination exists. A remove+copy approach (even with retries) has a
+        // fundamental TOCTOU race under high concurrency. The correct fix is the
+        // same pattern write_atomic uses: copy to a unique temp file, then
+        // atomically rename. POSIX rename() on the same filesystem is atomic --
+        // concurrent renames to the same path all succeed, last writer wins.
         let size = match request.source {
             BinarySource::CasPath(ref src) => {
-                // reflink_or_copy uses create_new semantics — remove existing file first
-                // to support overwrite mode (the default for artifacts)
-                let _ = fs::remove_file(&final_path).await;
+                let parent = final_path.parent().unwrap_or(Path::new("."));
+                let temp_path = parent.join(format!(
+                    ".nika-tmp-{}-{}",
+                    std::process::id(),
+                    uuid::Uuid::new_v4().simple()
+                ));
 
-                // Use reflink_or_copy: instant on APFS/btrfs, fallback on ext4/NTFS
-                // This is a sync operation, so we spawn_blocking to avoid blocking the runtime
                 let src = src.clone();
-                let dst = final_path.clone();
+                let tmp = temp_path.clone();
                 tokio::task::spawn_blocking(move || {
-                    reflink_copy::reflink_or_copy(&src, &dst)
+                    reflink_copy::reflink_or_copy(&src, &tmp)
                 })
                 .await
                 .map_err(|e| NikaError::ArtifactWriteError {
                     path: final_path.display().to_string(),
                     reason: format!("Task join error: {}", e),
                 })?
-                .map_err(|e| NikaError::ArtifactWriteError {
-                    path: final_path.display().to_string(),
-                    reason: format!("Binary copy failed: {}", e),
+                .map_err(|e| {
+                    let _ = std::fs::remove_file(&temp_path);
+                    NikaError::ArtifactWriteError {
+                        path: final_path.display().to_string(),
+                        reason: format!("Binary copy failed: {}", e),
+                    }
                 })?;
 
-                // reflink_or_copy returns Option<u64> — None means reflink (0-cost), Some(n) means n bytes copied
-                // Either way, the file is now at final_path. Get actual size.
-                fs::metadata(&final_path)
+                let size = fs::metadata(&temp_path)
                     .await
                     .map(|m| m.len())
                     .map_err(|e| NikaError::ArtifactWriteError {
                         path: final_path.display().to_string(),
-                        reason: format!("Failed to stat written file: {}", e),
-                    })?
+                        reason: format!("Failed to stat temp file: {}", e),
+                    })?;
+
+                match fs::rename(&temp_path, &final_path).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        let _ = fs::remove_file(&temp_path).await;
+                        return Err(NikaError::ArtifactWriteError {
+                            path: final_path.display().to_string(),
+                            reason: format!("Atomic rename failed: {}", e),
+                        });
+                    }
+                }
+
+                size
             }
         };
 
@@ -680,5 +702,446 @@ mod tests {
 
         let result = writer.write_binary(request).await.unwrap();
         assert_eq!(result.format, OutputFormat::Binary, "Binary write should report Binary format");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SECURITY: Binary artifact output path traversal tests
+    // Verify that write_binary blocks output paths containing ".."
+    // or absolute paths, matching the same protections as text write.
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn test_write_binary_output_path_traversal_blocked() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("data");
+        std::fs::write(&cas_file, b"secret").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "../../../etc/shadow".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 6,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err(), "Path traversal in binary output must be blocked");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, NikaError::ArtifactPathError { .. }),
+            "Expected ArtifactPathError, got: {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_output_absolute_path_blocked() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("data");
+        std::fs::write(&cas_file, b"test").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "/tmp/escape.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 4,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err(), "Absolute output path in binary write must be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_output_hidden_traversal_blocked() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("data");
+        std::fs::write(&cas_file, b"test").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "a/../../escape.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 4,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err(), "Hidden traversal in binary output path must be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_output_null_byte_blocked() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("data");
+        std::fs::write(&cas_file, b"test").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output\0.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 4,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err(), "Null bytes in binary output path must be blocked");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SECURITY: Binary artifact source path validation tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn test_write_binary_source_outside_cas_fails_gracefully() {
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(PathBuf::from("/nonexistent/fake/cas/ab/cdef")),
+            expected_size: 42,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err(), "Missing CAS source file must produce an error");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_write_binary_symlink_source_reads_target() {
+        // Verify behavior when CAS path is a symlink: reflink_or_copy follows
+        // symlinks by default. This test documents the behavior.
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let real_file = temp.path().join("real_data");
+        std::fs::write(&real_file, b"real content").unwrap();
+        let symlink_path = temp.path().join("cas_symlink");
+        symlink(&real_file, &symlink_path).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(symlink_path),
+            expected_size: 12,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        let written = std::fs::read(&result.path).unwrap();
+        assert_eq!(written, b"real content",
+            "Symlink source is followed by reflink_or_copy (documented behavior)");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_write_binary_symlink_in_output_parent_dir() {
+        // Security test: if a parent directory in the output path is a symlink
+        // that points outside the artifact directory, validate_artifact_path
+        // uses normalize_path (logical, not filesystem), so it cannot detect this.
+        // This test documents the known limitation.
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(&canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("data");
+        std::fs::write(&cas_file, b"test data").unwrap();
+
+        // Create a symlink inside the artifact dir that points outside
+        let escape_target = temp.path().join("escape_target");
+        std::fs::create_dir_all(&escape_target).unwrap();
+        let symlink_dir = canonical_dir.join("evil_link");
+        symlink(&escape_target, &symlink_dir).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "evil_link/file.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 9,
+        };
+
+        // This currently SUCCEEDS because normalize_path doesn't resolve symlinks.
+        // Documented as a known limitation -- defense relies on the artifact_dir
+        // being created by nika itself (not user-controlled).
+        let result = writer.write_binary(request).await;
+        assert!(result.is_ok(),
+            "Symlink-in-parent currently passes logical validation (known limitation)");
+
+        let escaped_file = escape_target.join("file.bin");
+        assert!(escaped_file.exists(),
+            "File was written through symlink to escape target (known limitation)");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Edge case tests for reflink-copy behavior
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn test_write_binary_empty_source_file() {
+        // Edge case: source file is 0 bytes
+        // reflink_or_copy should handle this gracefully
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("empty");
+        std::fs::write(&cas_file, b"").unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 0,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        assert_eq!(result.size, 0, "Empty source should produce empty output");
+
+        let content = std::fs::read(&result.path).unwrap();
+        assert!(content.is_empty(), "Output file should be empty");
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_source_is_symlink() {
+        // Edge case: source file is a symlink — reflink should follow it
+        // On macOS, clonefile handles symlinks. The fallback fs::copy also follows symlinks.
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        // Create real file and a symlink to it
+        let real_file = temp.path().join("real_data");
+        std::fs::write(&real_file, b"symlink target data").unwrap();
+
+        let symlink_path = temp.path().join("link_to_real");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_file, &symlink_path).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&real_file, &symlink_path).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "from_symlink.bin".to_string(),
+            source: BinarySource::CasPath(symlink_path),
+            expected_size: 19,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        let content = std::fs::read(&result.path).unwrap();
+        assert_eq!(content, b"symlink target data", "Should copy the symlink target content");
+        assert_eq!(result.size, 19);
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_source_deleted_before_copy() {
+        // Edge case: CAS file deleted between request creation and copy execution
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        // Create then immediately delete the source file
+        let cas_file = temp.path().join("ephemeral");
+        std::fs::write(&cas_file, b"will be deleted").unwrap();
+        std::fs::remove_file(&cas_file).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file),
+            expected_size: 15,
+        };
+
+        let result = writer.write_binary(request).await;
+        assert!(result.is_err(), "Should fail when source file is missing");
+
+        let err = result.unwrap_err();
+        if let NikaError::ArtifactWriteError { reason, .. } = &err {
+            assert!(
+                reason.contains("Binary copy failed"),
+                "Error should mention copy failure: {}",
+                reason
+            );
+        } else {
+            panic!("Expected ArtifactWriteError, got: {:?}", err);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_read_only_source_works() {
+        // Edge case: source file is read-only — copy should still work
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(canonical_dir, "test-workflow");
+
+        let cas_file = temp.path().join("readonly");
+        std::fs::write(&cas_file, b"read-only content").unwrap();
+
+        // Make the source file read-only
+        let mut perms = std::fs::metadata(&cas_file).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&cas_file, perms).unwrap();
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: BinarySource::CasPath(cas_file.clone()),
+            expected_size: 17,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        assert_eq!(result.size, 17);
+        let content = std::fs::read(&result.path).unwrap();
+        assert_eq!(content, b"read-only content");
+
+        // Restore permissions for cleanup
+        let mut perms = std::fs::metadata(&cas_file).unwrap().permissions();
+        perms.set_readonly(false);
+        std::fs::set_permissions(&cas_file, perms).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_binary_no_partial_file_on_missing_source() {
+        // Verify that when reflink_or_copy fails, no partial destination file is left
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = ArtifactWriter::new(&canonical_dir, "test-workflow");
+
+        let request = BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "should_not_exist.bin".to_string(),
+            source: BinarySource::CasPath(PathBuf::from("/nonexistent/path/file")),
+            expected_size: 100,
+        };
+
+        let _ = writer.write_binary(request).await;
+
+        // Verify no partial file was left at the destination
+        let ghost = canonical_dir.join("should_not_exist.bin");
+        assert!(
+            !ghost.exists(),
+            "Failed copy should not leave a partial file at: {}",
+            ghost.display()
+        );
+    }
+
+    /// Stress test: 10 concurrent binary writes to the SAME output path.
+    ///
+    /// Verifies the retry loop handles the TOCTOU race between remove_file
+    /// and reflink_or_copy (which uses create_new / O_EXCL internally).
+    /// All writes must succeed and the final file must be consistent.
+    #[tokio::test]
+    async fn test_write_binary_concurrent_same_path() {
+        use std::sync::Arc as StdArc;
+        use tokio::task::JoinSet;
+
+        let temp = tempdir().unwrap();
+        let artifact_dir = temp.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let canonical_dir = artifact_dir.canonicalize().unwrap();
+        let writer = StdArc::new(ArtifactWriter::new(&canonical_dir, "test-workflow"));
+
+        // Create 10 distinct CAS source files with identifiable content
+        let cas_dir = temp.path().join("cas");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+
+        let mut cas_files = Vec::new();
+        for i in 0..10u8 {
+            let cas_file = cas_dir.join(format!("source_{}", i));
+            // Each file has unique content: 1KB of repeated byte value
+            let data = vec![i; 1024];
+            std::fs::write(&cas_file, &data).unwrap();
+            cas_files.push(cas_file);
+        }
+
+        // Spawn 10 concurrent write_binary calls to the SAME output path
+        let mut join_set = JoinSet::new();
+        for (i, cas_file) in cas_files.into_iter().enumerate() {
+            let writer = StdArc::clone(&writer);
+            join_set.spawn(async move {
+                let request = BinaryWriteRequest {
+                    task_id: format!("task_{}", i),
+                    output_path: "shared_output.bin".to_string(),
+                    source: BinarySource::CasPath(cas_file),
+                    expected_size: 1024,
+                };
+                (i, writer.write_binary(request).await)
+            });
+        }
+
+        // Collect results — all should succeed (no errors)
+        let mut successes = 0;
+        let mut errors = 0;
+        while let Some(join_result) = join_set.join_next().await {
+            let (idx, write_result) = join_result.expect("task should not panic");
+            match write_result {
+                Ok(result) => {
+                    assert_eq!(result.size, 1024, "task_{} wrote wrong size", idx);
+                    successes += 1;
+                }
+                Err(e) => {
+                    eprintln!("task_{} failed: {}", idx, e);
+                    errors += 1;
+                }
+            }
+        }
+
+        // ALL writes must succeed — no TOCTOU errors
+        assert_eq!(
+            errors, 0,
+            "All concurrent binary writes should succeed, but {} failed", errors
+        );
+        assert_eq!(successes, 10, "All 10 writes should succeed");
+
+        // The final file must contain valid data (1024 bytes of a single repeated value)
+        let final_path = canonical_dir.join("shared_output.bin");
+        let content = std::fs::read(&final_path).unwrap();
+        assert_eq!(content.len(), 1024, "File should be exactly 1024 bytes");
+
+        // All bytes should be the same value (from one consistent writer)
+        let first_byte = content[0];
+        assert!(
+            content.iter().all(|&b| b == first_byte),
+            "File content should be consistent (all bytes from one writer), \
+             but found mixed data — indicates corruption from concurrent writes"
+        );
     }
 }

--- a/tools/nika/src/lib.rs
+++ b/tools/nika/src/lib.rs
@@ -42,7 +42,7 @@ pub mod error;
 pub mod event;
 pub mod init;
 pub mod mcp;
-pub(crate) mod media;
+pub mod media;
 pub mod new;
 pub mod provider;
 pub mod registry;

--- a/tools/nika/src/main.rs
+++ b/tools/nika/src/main.rs
@@ -260,6 +260,15 @@ enum Commands {
         action: cli::pkg::PkgAction,
     },
 
+    /// Manage media store (list, stats, clean)
+    ///
+    /// List, inspect, and garbage-collect binary files stored in the
+    /// Content-Addressable Store (CAS) at .nika/media/store/
+    Media {
+        #[command(subcommand)]
+        action: cli::media::MediaAction,
+    },
+
     /// Generate shell completions
     Completion {
         /// Shell to generate completions for
@@ -496,6 +505,8 @@ async fn main() {
         Some(Commands::Provider { action }) => cli::provider::handle_provider_command(action).await,
 
         Some(Commands::Mcp { action }) => cli::mcp::handle_mcp_command(action).await,
+
+        Some(Commands::Media { action }) => cli::media::handle_media_command(action, quiet).await,
 
         #[cfg(feature = "native-inference")]
         Some(Commands::Model { action }) => cli::model::handle_model_command(action, quiet).await,

--- a/tools/nika/src/media/detect.rs
+++ b/tools/nika/src/media/detect.rs
@@ -25,7 +25,7 @@ pub struct DetectedMime {
 
 /// How the MIME type was determined.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // Extension variant used in tests + PR2
+#[allow(dead_code)] // Extension variant reserved for future use
 pub enum DetectionSource {
     /// Determined via magic byte inspection (highest confidence)
     MagicBytes,

--- a/tools/nika/src/media/mod.rs
+++ b/tools/nika/src/media/mod.rs
@@ -11,8 +11,8 @@ pub(crate) mod store;
 mod tests_e2e;
 pub(crate) mod types;
 
-pub(crate) use error::MediaError;
+pub use error::MediaError;
 pub(crate) use processor::MediaProcessor;
-pub(crate) use store::CasStore;
-pub(crate) use types::{MediaBudget, MediaRef};
+pub use store::CasStore;
+pub use types::{MediaBudget, MediaRef};
 

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -80,13 +80,26 @@ impl CasStore {
 
     /// Create a CAS store at the workspace default location.
     ///
-    /// Respects `NIKA_MEDIA_STORE` env var as override.
+    /// Respects `NIKA_MEDIA_STORE` env var as override (canonicalized).
     /// Otherwise uses `{workspace_root}/.nika/media/store/`.
     pub fn workspace_default(workspace_root: &Path) -> Self {
         if let Ok(override_path) = std::env::var("NIKA_MEDIA_STORE") {
-            return Self::new(PathBuf::from(override_path));
+            let path = PathBuf::from(&override_path);
+            // Canonicalize if the path exists (resolves symlinks, `..`, etc.).
+            // If it doesn't exist yet, use the raw path -- store() will create it.
+            let resolved = path.canonicalize().unwrap_or(path);
+            return Self::new(resolved);
         }
         Self::new(workspace_root.join(".nika").join("media").join("store"))
+    }
+
+    /// The root directory of this CAS store.
+    ///
+    /// Used by the runner for lockfile placement and by the CLI for GC checks.
+    /// The lockfile MUST be placed inside the actual store root so that
+    /// `NIKA_MEDIA_STORE` overrides are respected.
+    pub fn root(&self) -> &Path {
+        &self.root
     }
 
     /// Store binary data in the CAS (async).
@@ -495,5 +508,239 @@ mod tests {
         // Exactly one should be non-deduplicated
         let non_dedup_count = results.iter().filter(|r| !r.deduplicated).count();
         assert_eq!(non_dedup_count, 1, "exactly one writer should be non-dedup");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // NIKA_MEDIA_STORE env var + root() accessor + path validation
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn root_accessor_returns_store_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        assert_eq!(store.root(), dir.path());
+    }
+
+    #[test]
+    fn workspace_default_without_env_uses_nika_media_store_path() {
+        // Ensure NIKA_MEDIA_STORE is NOT set for this test
+        let saved = std::env::var("NIKA_MEDIA_STORE").ok();
+        std::env::remove_var("NIKA_MEDIA_STORE");
+
+        let workspace = PathBuf::from("/tmp/test-workspace");
+        let store = CasStore::workspace_default(&workspace);
+        let expected = workspace.join(".nika").join("media").join("store");
+        assert_eq!(store.root(), expected.as_path());
+
+        // Restore env var if it was set
+        if let Some(val) = saved {
+            std::env::set_var("NIKA_MEDIA_STORE", val);
+        }
+    }
+
+    #[test]
+    fn workspace_default_respects_nika_media_store_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join("custom-store");
+
+        let saved = std::env::var("NIKA_MEDIA_STORE").ok();
+        std::env::set_var("NIKA_MEDIA_STORE", override_path.to_str().unwrap());
+
+        let store = CasStore::workspace_default(Path::new("/ignored/workspace"));
+
+        // The override path doesn't exist yet, so canonicalize falls back to raw path
+        assert_eq!(store.root(), override_path.as_path());
+
+        match saved {
+            Some(val) => std::env::set_var("NIKA_MEDIA_STORE", val),
+            None => std::env::remove_var("NIKA_MEDIA_STORE"),
+        }
+    }
+
+    #[test]
+    fn workspace_default_canonicalizes_existing_override_path() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a subdirectory so canonicalize has something to resolve
+        let actual = dir.path().join("store");
+        std::fs::create_dir_all(&actual).unwrap();
+
+        // Construct a path with `..` that resolves to the same place
+        let dotdot_path = dir.path().join("store").join("..").join("store");
+
+        let saved = std::env::var("NIKA_MEDIA_STORE").ok();
+        std::env::set_var("NIKA_MEDIA_STORE", dotdot_path.to_str().unwrap());
+
+        let store = CasStore::workspace_default(Path::new("/ignored"));
+
+        // After canonicalization, the `..` should be resolved
+        let resolved = store.root().to_path_buf();
+        assert!(
+            !resolved.to_str().unwrap().contains(".."),
+            "path should be canonicalized, got: {}",
+            resolved.display()
+        );
+        // The canonical paths should match
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            actual.canonicalize().unwrap(),
+            "resolved path should point to the same directory"
+        );
+
+        match saved {
+            Some(val) => std::env::set_var("NIKA_MEDIA_STORE", val),
+            None => std::env::remove_var("NIKA_MEDIA_STORE"),
+        }
+    }
+
+    #[tokio::test]
+    async fn env_override_store_is_fully_functional() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join("custom-cas");
+
+        let saved = std::env::var("NIKA_MEDIA_STORE").ok();
+        std::env::set_var("NIKA_MEDIA_STORE", override_path.to_str().unwrap());
+
+        let store = CasStore::workspace_default(Path::new("/ignored/workspace"));
+
+        // Store data -- should create directories inside the custom path
+        let data = b"env override test data";
+        let result = store.store(data).await.unwrap();
+
+        assert!(result.hash.starts_with("blake3:"));
+        assert!(
+            result.path.starts_with(&override_path),
+            "stored file should be inside override path, got: {}",
+            result.path.display()
+        );
+
+        // Read back
+        let read_back = store.read(&result.hash).await.unwrap();
+        assert_eq!(read_back, data);
+
+        // List
+        let entries = store.list();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].path.starts_with(&override_path));
+
+        // Exists
+        assert!(store.exists(&result.hash));
+
+        // Clean
+        let clean = store.clean_all();
+        assert_eq!(clean.removed, 1);
+        assert_eq!(store.list().len(), 0);
+
+        match saved {
+            Some(val) => std::env::set_var("NIKA_MEDIA_STORE", val),
+            None => std::env::remove_var("NIKA_MEDIA_STORE"),
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SECURITY: CAS hash-to-path safety tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn cas_path_is_always_within_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let payloads: Vec<&[u8]> = vec![
+            b"payload one",
+            b"payload two",
+            b"\x00\x01\x02\xff\xfe\xfd",
+            b"../../../etc/passwd",
+        ];
+
+        let canonical_root = dir.path().canonicalize().unwrap();
+
+        for payload in payloads {
+            let result = store.store(payload).await.unwrap();
+
+            let canonical_path = result.path.canonicalize().unwrap();
+            assert!(
+                canonical_path.starts_with(&canonical_root),
+                "CAS file {:?} escapes root {:?}",
+                canonical_path,
+                canonical_root,
+            );
+
+            let shard = result
+                .path
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_string_lossy();
+            let filename = result.path.file_name().unwrap().to_string_lossy();
+
+            assert_eq!(shard.len(), 2, "Shard directory must be 2 hex chars");
+            assert!(
+                shard.chars().all(|c| c.is_ascii_hexdigit()),
+                "Shard '{}' contains non-hex chars",
+                shard
+            );
+            assert!(
+                filename.chars().all(|c| c.is_ascii_hexdigit()),
+                "Filename '{}' contains non-hex chars",
+                filename
+            );
+        }
+    }
+
+    #[test]
+    fn cas_hash_prefix_strip_safety() {
+        assert_eq!(strip_hash_prefix("blake3:abcdef"), "abcdef");
+        assert_eq!(strip_hash_prefix("abcdef"), "abcdef");
+        // Theoretical adversarial input -- in practice blake3 only outputs hex
+        assert_eq!(strip_hash_prefix("blake3:../../etc"), "../../etc");
+    }
+
+    #[test]
+    fn cas_exists_rejects_short_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        assert!(!store.exists("ab"));
+        assert!(!store.exists("a"));
+        assert!(!store.exists(""));
+        assert!(!store.exists("blake3:ab"));
+        assert!(!store.exists("blake3:a"));
+    }
+
+    #[tokio::test]
+    async fn cas_read_rejects_short_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let result = store.read("ab").await;
+        assert!(result.is_err());
+        let result = store.read("blake3:ab").await;
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cas_store_uses_o_excl_prevents_symlink_attack() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let data = b"symlink attack test data";
+        let raw_hash = blake3::hash(data).to_hex().to_string();
+        let shard_dir = dir.path().join(&raw_hash[..2]);
+        std::fs::create_dir_all(&shard_dir).unwrap();
+        let final_path = shard_dir.join(&raw_hash[2..]);
+
+        let decoy = dir.path().join("decoy");
+        std::fs::write(&decoy, b"decoy content").unwrap();
+        symlink(&decoy, &final_path).unwrap();
+
+        let result = store.store(data).await.unwrap();
+        assert!(
+            result.deduplicated,
+            "Symlink at CAS path must be treated as existing file (O_EXCL semantics)"
+        );
     }
 }

--- a/tools/nika/src/media/store.rs
+++ b/tools/nika/src/media/store.rs
@@ -42,7 +42,6 @@ pub struct StoreResult {
 
 /// Entry in the CAS store.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Used in tests + PR2 (nika media list/gc)
 pub struct CasEntry {
     /// Algorithm-prefixed hash (e.g., "blake3:af1349...")
     pub hash: String,
@@ -56,7 +55,6 @@ pub struct CasEntry {
 
 /// Result of a cleanup operation.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Used in tests + PR2 (nika media gc)
 pub struct CleanResult {
     /// Number of files removed
     pub removed: u64,
@@ -195,7 +193,6 @@ impl CasStore {
     }
 
     /// Check if a hash exists in the store.
-    #[allow(dead_code)] // Used in tests + PR2
     pub fn exists(&self, hash: &str) -> bool {
         let raw = strip_hash_prefix(hash);
         if raw.len() < 3 {
@@ -206,7 +203,6 @@ impl CasStore {
     }
 
     /// Read file data by hash (async).
-    #[allow(dead_code)] // Used in tests + PR2
     pub async fn read(&self, hash: &str) -> Result<Vec<u8>, MediaError> {
         let raw = strip_hash_prefix(hash);
         if raw.len() < 3 {
@@ -230,7 +226,6 @@ impl CasStore {
     }
 
     /// List all entries in the store.
-    #[allow(dead_code)] // Used in tests + PR2
     pub fn list(&self) -> Vec<CasEntry> {
         let mut entries = Vec::new();
         let Ok(shards) = std::fs::read_dir(&self.root) else {
@@ -259,7 +254,6 @@ impl CasStore {
     }
 
     /// Remove all files from the store.
-    #[allow(dead_code)] // Used in tests + PR2
     pub fn clean_all(&self) -> CleanResult {
         let mut removed = 0u64;
         let mut bytes_freed = 0u64;
@@ -280,7 +274,6 @@ impl CasStore {
     }
 
     /// Remove files older than the given duration.
-    #[allow(dead_code)] // Used in tests + PR2
     pub fn clean_older_than(&self, duration: Duration) -> CleanResult {
         let mut removed = 0u64;
         let mut bytes_freed = 0u64;
@@ -312,7 +305,6 @@ impl CasStore {
 }
 
 /// Strip the algorithm prefix from a hash string, if present.
-#[allow(dead_code)] // Used by exists/read/list in tests + PR2
 fn strip_hash_prefix(hash: &str) -> &str {
     hash.strip_prefix(HASH_PREFIX).unwrap_or(hash)
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -3621,4 +3621,174 @@ mod tests {
         assert_eq!(stored_data_1, png2_bytes,
             "CAS stored data for png2 must match original bytes");
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PR2: Binary Artifact + CAS Integration Tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn pr2_full_pipeline_binary_artifact_cas_to_disk() {
+        // Monster test: CAS store → MediaRef → binary artifact → disk → verify
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // Store binary data in CAS
+        let binary_data = b"\x89PNG\r\n\x1a\nfake image bytes for test 12345";
+        let store_result = store.store(binary_data).await.unwrap();
+
+        // Create MediaRef from store result
+        let media_ref = crate::media::types::MediaRef {
+            hash: store_result.hash.clone(),
+            mime_type: "image/png".to_string(),
+            size_bytes: store_result.size,
+            path: store_result.path.clone(),
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        };
+
+        // Verify CAS file exists and is readable
+        assert!(media_ref.path.exists(), "CAS file should exist");
+        let cas_data = tokio::fs::read(&media_ref.path).await.unwrap();
+        assert_eq!(cas_data, binary_data, "CAS data should match original");
+
+        // Create artifact writer
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "test-workflow");
+
+        // Write binary artifact from CAS path
+        let request = crate::io::writer::BinaryWriteRequest {
+            task_id: "gen_img".to_string(),
+            output_path: "output/image.bin".to_string(),
+            source: crate::io::writer::BinarySource::CasPath(media_ref.path.clone()),
+            expected_size: media_ref.size_bytes,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        assert!(result.path.ends_with("output/image.bin"));
+        assert_eq!(result.size, binary_data.len() as u64);
+
+        // Verify artifact content matches original
+        let artifact_data = tokio::fs::read(&result.path).await.unwrap();
+        assert_eq!(artifact_data, binary_data, "Artifact data should match original binary");
+    }
+
+    #[tokio::test]
+    async fn pr2_integrity_check_detects_missing_cas_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // Store and then delete the file
+        let data = b"test data for deletion";
+        let result = store.store(data).await.unwrap();
+        tokio::fs::remove_file(&result.path).await.unwrap();
+
+        // MediaRef points to deleted file
+        let media_ref = crate::media::types::MediaRef {
+            hash: result.hash,
+            mime_type: "image/png".to_string(),
+            size_bytes: result.size,
+            path: result.path.clone(),
+            extension: "png".to_string(),
+            created_by: "task1".to_string(),
+        };
+
+        // Integrity check should detect missing file
+        assert!(!media_ref.path.exists(), "CAS file should be deleted");
+    }
+
+    #[tokio::test]
+    async fn pr2_binary_artifact_size_limit_respected() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        let data = vec![0xAB_u8; 1024]; // 1KB
+        let result = store.store(&data).await.unwrap();
+
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        // Writer with 512-byte limit
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "test-workflow")
+            .with_max_size(512);
+
+        let request = crate::io::writer::BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "output.bin".to_string(),
+            source: crate::io::writer::BinarySource::CasPath(result.path),
+            expected_size: 1024, // Exceeds 512 limit
+        };
+
+        let write_result = writer.write_binary(request).await;
+        assert!(write_result.is_err(), "Should reject binary exceeding size limit");
+        let err = write_result.unwrap_err();
+        assert!(matches!(err, crate::error::NikaError::ArtifactSizeExceeded { .. }));
+    }
+
+    #[tokio::test]
+    async fn pr2_cas_gc_respects_age() {
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // Store a file
+        store.store(b"old data").await.unwrap();
+
+        // Clean with 0-second age should remove it (file is already "old enough")
+        let result = store.clean_older_than(Duration::from_secs(0));
+        assert_eq!(result.removed, 1);
+        assert!(store.list().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pr2_cas_gc_preserves_recent_files() {
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // Store a file (just created, so very recent)
+        store.store(b"fresh data").await.unwrap();
+
+        // Clean with 1-hour age should preserve it
+        let result = store.clean_older_than(Duration::from_secs(3600));
+        assert_eq!(result.removed, 0);
+        assert_eq!(store.list().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pr2_cas_dedup_consistency_with_binary_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        let data = b"identical binary content";
+
+        // Store same data twice — should dedup
+        let r1 = store.store(data).await.unwrap();
+        let r2 = store.store(data).await.unwrap();
+
+        assert_eq!(r1.hash, r2.hash);
+        assert!(!r1.deduplicated);
+        assert!(r2.deduplicated);
+        assert_eq!(r1.path, r2.path);
+
+        // Binary artifact from either should work
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "test");
+
+        let request = crate::io::writer::BinaryWriteRequest {
+            task_id: "task1".to_string(),
+            output_path: "dedup_test.bin".to_string(),
+            source: crate::io::writer::BinarySource::CasPath(r1.path),
+            expected_size: r1.size,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+        let written = tokio::fs::read(&result.path).await.unwrap();
+        assert_eq!(written, data);
+    }
 }

--- a/tools/nika/src/media/tests_e2e.rs
+++ b/tools/nika/src/media/tests_e2e.rs
@@ -3791,4 +3791,503 @@ mod tests {
         let written = tokio::fs::read(&result.path).await.unwrap();
         assert_eq!(written, data);
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // PR2 STRESS TESTS: Comprehensive binary artifact pipeline
+    // ═══════════════════════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn pr2_stress_concurrent_binary_artifacts() {
+        // 10 different binary blobs (various sizes: 1B, 1KB, 1MB) stored in CAS,
+        // then 10 binary artifacts written in parallel to different output paths.
+        // Verify ALL 10 artifacts written correctly with NO corruption.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CasStore::new(dir.path().join("store")));
+
+        // Create 10 different binary blobs with varied sizes
+        let blobs: Vec<Vec<u8>> = vec![
+            vec![0x42],                                         // 1 byte
+            vec![0xAA; 100],                                    // 100 bytes
+            vec![0xBB; 512],                                    // 512 bytes
+            (0..=255).collect(),                                // 256 bytes (all byte values)
+            vec![0xCC; 1024],                                   // 1 KB
+            vec![0xDD; 4096],                                   // 4 KB
+            vec![0xEE; 10_000],                                 // 10 KB
+            vec![0xFF; 65_536],                                 // 64 KB
+            vec![0x11; 100_000],                                // 100 KB
+            vec![0x22; 1024 * 1024],                            // 1 MB
+        ];
+
+        // Store all 10 in CAS
+        let mut store_results = Vec::new();
+        for blob in &blobs {
+            let result = store.store(blob).await.unwrap();
+            store_results.push(result);
+        }
+
+        // Create 10 MediaRefs pointing to these CAS files
+        let media_refs: Vec<MediaRef> = store_results
+            .iter()
+            .enumerate()
+            .map(|(i, sr)| MediaRef {
+                hash: sr.hash.clone(),
+                mime_type: "application/octet-stream".to_string(),
+                size_bytes: sr.size,
+                path: sr.path.clone(),
+                extension: "bin".to_string(),
+                created_by: format!("task_{i}"),
+            })
+            .collect();
+
+        // Create artifact writer
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+
+        // Process 10 binary artifact writes in parallel
+        let handles: Vec<_> = media_refs
+            .iter()
+            .enumerate()
+            .map(|(i, mr)| {
+                let writer = crate::io::writer::ArtifactWriter::new(
+                    canonical.clone(),
+                    "stress-test",
+                );
+                let request = crate::io::writer::BinaryWriteRequest {
+                    task_id: format!("task_{i}"),
+                    output_path: format!("out_{i}.bin"),
+                    source: crate::io::writer::BinarySource::CasPath(mr.path.clone()),
+                    expected_size: mr.size_bytes,
+                };
+                tokio::spawn(async move { writer.write_binary(request).await })
+            })
+            .collect();
+
+        let results: Vec<_> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|h| h.unwrap().unwrap())
+            .collect();
+
+        // Verify ALL 10 artifacts were written correctly with NO corruption
+        assert_eq!(results.len(), 10, "all 10 artifacts should be written");
+        for (i, result) in results.iter().enumerate() {
+            let written = tokio::fs::read(&result.path).await.unwrap();
+            assert_eq!(
+                written.len(),
+                blobs[i].len(),
+                "artifact {i} size mismatch: expected {}, got {}",
+                blobs[i].len(),
+                written.len()
+            );
+            assert_eq!(
+                written, blobs[i],
+                "artifact {i} content corruption detected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn pr2_binary_artifact_with_real_png_data() {
+        // Use a real PNG header followed by valid IHDR chunk.
+        // Store in CAS, create MediaRef, write binary artifact.
+        // Verify the output file starts with PNG magic bytes and size matches exactly.
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        let png_data = real_png_bytes();
+
+        // Store in CAS
+        let sr = store.store(&png_data).await.unwrap();
+
+        // Create MediaRef
+        let media_ref = MediaRef {
+            hash: sr.hash.clone(),
+            mime_type: "image/png".to_string(),
+            size_bytes: sr.size,
+            path: sr.path.clone(),
+            extension: "png".to_string(),
+            created_by: "png_task".to_string(),
+        };
+
+        // Write binary artifact
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "png-test");
+
+        let request = crate::io::writer::BinaryWriteRequest {
+            task_id: "png_task".to_string(),
+            output_path: "image.png".to_string(),
+            source: crate::io::writer::BinarySource::CasPath(media_ref.path.clone()),
+            expected_size: media_ref.size_bytes,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+
+        // Verify the output file starts with PNG magic bytes
+        let written = tokio::fs::read(&result.path).await.unwrap();
+        assert!(
+            written.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+            "output file must start with PNG magic bytes"
+        );
+
+        // Verify file size matches exactly
+        assert_eq!(
+            written.len(),
+            png_data.len(),
+            "output file size must match original PNG data exactly"
+        );
+        assert_eq!(
+            result.size, png_data.len() as u64,
+            "WriteResult size must match original"
+        );
+
+        // Verify byte-for-byte identity
+        assert_eq!(written, png_data, "output file must be identical to original PNG");
+    }
+
+    #[tokio::test]
+    async fn pr2_binary_artifact_large_file() {
+        // Create a 5MB binary blob, store in CAS (should pass 100MB limit),
+        // write binary artifact, verify blake3 hash of output matches MediaRef.hash.
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        let data = vec![0xAB_u8; 5 * 1024 * 1024]; // 5MB
+        let sr = store.store(&data).await.unwrap();
+
+        // 5MB is above the 1MB verify threshold, so verified should be true
+        assert!(sr.verified, "5MB file should trigger read-back verification");
+        assert_eq!(sr.size, 5 * 1024 * 1024);
+
+        let media_ref = MediaRef {
+            hash: sr.hash.clone(),
+            mime_type: "application/octet-stream".to_string(),
+            size_bytes: sr.size,
+            path: sr.path.clone(),
+            extension: "bin".to_string(),
+            created_by: "large_task".to_string(),
+        };
+
+        // Write binary artifact
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "large-test");
+
+        let request = crate::io::writer::BinaryWriteRequest {
+            task_id: "large_task".to_string(),
+            output_path: "large.bin".to_string(),
+            source: crate::io::writer::BinarySource::CasPath(media_ref.path.clone()),
+            expected_size: media_ref.size_bytes,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+
+        // Verify blake3 hash of output matches MediaRef.hash
+        let written = tokio::fs::read(&result.path).await.unwrap();
+        let output_hash = format!("blake3:{}", blake3::hash(&written).to_hex());
+        assert_eq!(
+            output_hash, media_ref.hash,
+            "blake3 hash of artifact output must match MediaRef.hash"
+        );
+        assert_eq!(written.len(), 5 * 1024 * 1024, "artifact must be exactly 5MB");
+    }
+
+    #[tokio::test]
+    async fn pr2_binary_artifact_then_integrity_check() {
+        // Store a CAS file, create MediaRef, verify integrity (path + size),
+        // then delete CAS file and verify integrity fails.
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        let data = b"integrity check data payload";
+        let sr = store.store(data).await.unwrap();
+
+        let media_ref = MediaRef {
+            hash: sr.hash.clone(),
+            mime_type: "application/octet-stream".to_string(),
+            size_bytes: sr.size,
+            path: sr.path.clone(),
+            extension: "bin".to_string(),
+            created_by: "integrity_task".to_string(),
+        };
+
+        // Store MediaRef in a TaskResult and insert into RunContext
+        use crate::store::TaskResult;
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "integrity_task".into();
+        let tr = TaskResult::success(
+            serde_json::json!("done"),
+            std::time::Duration::from_millis(50),
+        )
+        .with_media(vec![media_ref.clone()]);
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // Verify media ref is accessible from RunContext
+        let resolved = ctx.resolve_path("integrity_task.media[0].hash");
+        assert_eq!(resolved.unwrap().as_str().unwrap(), sr.hash);
+
+        // Integrity check: path exists and size matches
+        assert!(media_ref.path.exists(), "CAS file should exist");
+        let meta = std::fs::metadata(&media_ref.path).unwrap();
+        assert_eq!(
+            meta.len(),
+            media_ref.size_bytes,
+            "file size must match MediaRef.size_bytes"
+        );
+
+        // Delete CAS file
+        tokio::fs::remove_file(&media_ref.path).await.unwrap();
+
+        // Integrity check fails: path missing
+        assert!(
+            !media_ref.path.exists(),
+            "CAS file should be gone after deletion"
+        );
+
+        // CAS read should also fail
+        let read_result = store.read(&media_ref.hash).await;
+        assert!(read_result.is_err(), "read should fail for deleted CAS file");
+        assert_eq!(read_result.unwrap_err().code(), "NIKA-253");
+    }
+
+    #[tokio::test]
+    async fn pr2_cas_gc_preserves_active_media() {
+        // Store 2 CAS files, backdate file 1 mtime to 2 hours ago,
+        // keep file 2 recent, call clean_older_than(1h).
+        // Verify: file 1 deleted, file 2 preserved, correct bytes_freed count.
+        use std::fs::FileTimes;
+        use std::time::{Duration, SystemTime};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // Store 2 files
+        let data_old = vec![0xAA_u8; 500];
+        let data_new = vec![0xBB_u8; 300];
+        let r_old = store.store(&data_old).await.unwrap();
+        let r_new = store.store(&data_new).await.unwrap();
+
+        // Backdate file 1 mtime to 2 hours ago
+        let two_hours_ago = SystemTime::now() - Duration::from_secs(2 * 3600);
+        let file = std::fs::File::open(&r_old.path).unwrap();
+        file.set_times(FileTimes::new().set_modified(two_hours_ago))
+            .unwrap();
+
+        // Keep file 2 recent (just created, mtime is now)
+
+        // Clean files older than 1 hour
+        let clean = store.clean_older_than(Duration::from_secs(3600));
+
+        // File 1 should be deleted
+        assert_eq!(clean.removed, 1, "only the old file should be removed");
+        assert!(
+            !r_old.path.exists(),
+            "old file should be deleted by GC"
+        );
+
+        // File 2 should be preserved
+        assert!(
+            r_new.path.exists(),
+            "recent file should be preserved by GC"
+        );
+
+        // Correct bytes_freed count
+        assert_eq!(
+            clean.bytes_freed, 500,
+            "bytes_freed should equal the old file's size (500)"
+        );
+
+        // Verify store still lists 1 file
+        assert_eq!(store.list().len(), 1, "only the recent file should remain");
+    }
+
+    #[tokio::test]
+    async fn pr2_binary_artifact_checksum_is_blake3() {
+        // Store data in CAS, create MediaRef with blake3 hash from StoreResult,
+        // write binary artifact, re-hash the artifact output with blake3,
+        // verify hash matches MediaRef.hash (strip "blake3:" prefix).
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // Use a non-trivial data pattern to ensure hash is meaningful
+        let mut data = Vec::with_capacity(8192);
+        for i in 0u32..2048 {
+            data.extend_from_slice(&i.to_le_bytes());
+        }
+        assert_eq!(data.len(), 8192);
+
+        let sr = store.store(&data).await.unwrap();
+
+        let media_ref = MediaRef {
+            hash: sr.hash.clone(),
+            mime_type: "application/octet-stream".to_string(),
+            size_bytes: sr.size,
+            path: sr.path.clone(),
+            extension: "bin".to_string(),
+            created_by: "checksum_task".to_string(),
+        };
+
+        // Write binary artifact
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "checksum-test");
+
+        let request = crate::io::writer::BinaryWriteRequest {
+            task_id: "checksum_task".to_string(),
+            output_path: "verified.bin".to_string(),
+            source: crate::io::writer::BinarySource::CasPath(media_ref.path.clone()),
+            expected_size: media_ref.size_bytes,
+        };
+
+        let result = writer.write_binary(request).await.unwrap();
+
+        // Re-hash the artifact output with blake3
+        let written = tokio::fs::read(&result.path).await.unwrap();
+        let artifact_raw_hash = blake3::hash(&written).to_hex().to_string();
+        let artifact_prefixed_hash = format!("blake3:{artifact_raw_hash}");
+
+        // Verify: artifact hash matches MediaRef.hash
+        assert_eq!(
+            artifact_prefixed_hash, media_ref.hash,
+            "blake3 hash of artifact must match MediaRef.hash (no corruption in copy)"
+        );
+
+        // Also verify by stripping prefix
+        let expected_raw = media_ref.hash.strip_prefix("blake3:").unwrap();
+        assert_eq!(
+            artifact_raw_hash, expected_raw,
+            "raw hash comparison must match after prefix stripping"
+        );
+
+        // And verify against direct blake3 of the original data
+        let original_hash = blake3::hash(&data).to_hex().to_string();
+        assert_eq!(
+            artifact_raw_hash, original_hash,
+            "artifact hash must match hash of original data"
+        );
+    }
+
+    #[tokio::test]
+    async fn pr2_multiple_artifacts_from_single_task() {
+        // One task produces 3 media files (image, audio, document).
+        // 3 binary artifacts each with different source, process all 3,
+        // verify all 3 written correctly with correct content.
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path().join("store"));
+
+        // 3 different content types
+        let image_data = real_png_bytes();
+        let audio_data = real_mp3_bytes();
+        let document_data = real_pdf_bytes();
+
+        // Store all 3 in CAS
+        let sr_img = store.store(&image_data).await.unwrap();
+        let sr_aud = store.store(&audio_data).await.unwrap();
+        let sr_doc = store.store(&document_data).await.unwrap();
+
+        // Create 3 MediaRefs, all from the same task
+        let media_refs = vec![
+            MediaRef {
+                hash: sr_img.hash.clone(),
+                mime_type: "image/png".to_string(),
+                size_bytes: sr_img.size,
+                path: sr_img.path.clone(),
+                extension: "png".to_string(),
+                created_by: "multi_task".to_string(),
+            },
+            MediaRef {
+                hash: sr_aud.hash.clone(),
+                mime_type: "audio/mpeg".to_string(),
+                size_bytes: sr_aud.size,
+                path: sr_aud.path.clone(),
+                extension: "mp3".to_string(),
+                created_by: "multi_task".to_string(),
+            },
+            MediaRef {
+                hash: sr_doc.hash.clone(),
+                mime_type: "application/pdf".to_string(),
+                size_bytes: sr_doc.size,
+                path: sr_doc.path.clone(),
+                extension: "pdf".to_string(),
+                created_by: "multi_task".to_string(),
+            },
+        ];
+
+        // Verify all 3 have different hashes
+        assert_ne!(media_refs[0].hash, media_refs[1].hash);
+        assert_ne!(media_refs[0].hash, media_refs[2].hash);
+        assert_ne!(media_refs[1].hash, media_refs[2].hash);
+
+        // Create artifact writer
+        let artifact_dir = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&artifact_dir).await.unwrap();
+        let canonical = artifact_dir.canonicalize().unwrap();
+        let writer = crate::io::writer::ArtifactWriter::new(canonical, "multi-test");
+
+        // Write all 3 binary artifacts
+        let output_specs = vec![
+            ("output/image.png", &media_refs[0]),
+            ("output/audio.mp3", &media_refs[1]),
+            ("output/doc.pdf", &media_refs[2]),
+        ];
+
+        let expected_data = vec![&image_data, &audio_data, &document_data];
+
+        for (i, (path, mr)) in output_specs.iter().enumerate() {
+            let request = crate::io::writer::BinaryWriteRequest {
+                task_id: "multi_task".to_string(),
+                output_path: path.to_string(),
+                source: crate::io::writer::BinarySource::CasPath(mr.path.clone()),
+                expected_size: mr.size_bytes,
+            };
+
+            let result = writer.write_binary(request).await.unwrap();
+
+            // Verify written content matches original
+            let written = tokio::fs::read(&result.path).await.unwrap();
+            assert_eq!(
+                written, *expected_data[i],
+                "artifact {i} ({}) content mismatch",
+                path
+            );
+            assert_eq!(result.size, mr.size_bytes, "artifact {i} size mismatch");
+        }
+
+        // Verify CAS still has all 3 (artifacts are copies, not moves)
+        assert!(store.exists(&media_refs[0].hash));
+        assert!(store.exists(&media_refs[1].hash));
+        assert!(store.exists(&media_refs[2].hash));
+
+        // Verify TaskResult with all 3 media refs resolves correctly
+        use crate::store::TaskResult;
+        let ctx = RunContext::new();
+        let task_id: Arc<str> = "multi_task".into();
+        let tr = TaskResult::success(
+            serde_json::json!("multi-output task"),
+            std::time::Duration::from_millis(100),
+        )
+        .with_media(media_refs);
+        ctx.insert(Arc::clone(&task_id), tr);
+
+        // Verify all 3 media refs are accessible through resolve_path
+        let arr = ctx.resolve_path("multi_task.media").unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 3);
+
+        assert_eq!(
+            ctx.resolve_path("multi_task.media[0].mime_type").unwrap(),
+            "image/png"
+        );
+        assert_eq!(
+            ctx.resolve_path("multi_task.media[1].mime_type").unwrap(),
+            "audio/mpeg"
+        );
+        assert_eq!(
+            ctx.resolve_path("multi_task.media[2].mime_type").unwrap(),
+            "application/pdf"
+        );
+    }
 }

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -34,7 +34,7 @@ pub struct MediaRef {
 /// Broad media type classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[allow(dead_code)] // Used in tests + PR2
+#[allow(dead_code)] // Used in tests
 pub enum MediaType {
     Image,
     Audio,
@@ -44,7 +44,7 @@ pub enum MediaType {
 
 impl MediaType {
     /// Classify a MIME type string into a MediaType.
-    #[allow(dead_code)] // Used in tests + PR2
+    #[allow(dead_code)] // Used in tests
     pub fn from_mime(mime: &str) -> Self {
         if mime.starts_with("image/") {
             Self::Image

--- a/tools/nika/src/media/types.rs
+++ b/tools/nika/src/media/types.rs
@@ -122,8 +122,16 @@ impl MediaBudget {
     }
 
     /// Roll back a budget allocation (e.g., when CAS store fails after budget was charged).
+    ///
+    /// Uses `fetch_update` with `saturating_sub` to prevent underflow.
+    /// Without this, a rollback larger than the current value would wrap to `u64::MAX`,
+    /// effectively disabling budget enforcement for the rest of the run.
     pub fn rollback(&self, size: u64) {
-        self.run_bytes.fetch_sub(size, Ordering::AcqRel);
+        let _ = self.run_bytes.fetch_update(
+            Ordering::AcqRel,
+            Ordering::Acquire,
+            |current| Some(current.saturating_sub(size)),
+        );
     }
 
     /// Get current accumulated bytes.

--- a/tools/nika/src/runtime/artifact_processor.rs
+++ b/tools/nika/src/runtime/artifact_processor.rs
@@ -131,11 +131,17 @@ pub async fn process_task_artifacts(
 
                 // Emit ArtifactWritten event if event_log provided
                 if let Some(log) = event_log {
+                    let checksum = if write_result.format == OutputFormat::Binary {
+                        resolve_binary_checksum(&output_spec, media_refs)
+                    } else {
+                        None
+                    };
                     log.emit(EventKind::ArtifactWritten {
                         task_id: Arc::from(task_id),
                         path: write_result.path.display().to_string(),
                         size: write_result.size,
                         format: format!("{:?}", write_result.format).to_lowercase(),
+                        checksum,
                     });
                 }
 
@@ -188,16 +194,17 @@ async fn write_single_artifact(
         .or(workflow_config.map(|c| c.format))
         .unwrap_or(ArtifactFormat::Text);
 
-    // Binary format: resolve source to CAS path and copy
-    if format == ArtifactFormat::Binary {
-        return write_binary_artifact(task_id, output_spec, writer, bindings, datastore, media_refs).await;
-    }
-
-    // Determine mode (task spec > workflow default)
+    // Determine mode (task spec > workflow default) — computed before binary
+    // branch so that binary artifacts can validate and reject unsupported modes.
     let mode = output_spec
         .mode
         .or(workflow_config.map(|c| c.mode))
         .unwrap_or(ArtifactMode::Overwrite);
+
+    // Binary format: resolve source to CAS path and copy
+    if format == ArtifactFormat::Binary {
+        return write_binary_artifact(task_id, output_spec, mode, writer, bindings, datastore, media_refs).await;
+    }
 
     // Determine content source: source binding > template > task output
     let raw_content: String = if let Some(ref source_alias) = output_spec.source {
@@ -339,58 +346,107 @@ async fn write_single_artifact(
 ///
 /// Resolves the `source` binding to a media hash or path, then copies from CAS store.
 /// Falls back to the first media ref if no explicit source is specified.
+///
+/// # Mode support
+///
+/// Binary artifacts only support `Overwrite` (default) and `Fail` modes.
+/// `Append` and `Unique` are rejected with NIKA-281 because binary data
+/// cannot be meaningfully appended or deduplicated by filename suffix.
 async fn write_binary_artifact(
     task_id: &str,
     output_spec: &ArtifactOutput,
+    mode: ArtifactMode,
     writer: &ArtifactWriter,
     bindings: &ResolvedBindings,
     datastore: &RunContext,
     media_refs: &[MediaRef],
 ) -> Result<WriteResult, NikaError> {
+    // Reject unsupported modes for binary artifacts
+    match mode {
+        ArtifactMode::Append => {
+            return Err(NikaError::ArtifactWriteError {
+                path: output_spec.path.clone(),
+                reason: "Binary artifacts do not support append mode".to_string(),
+            });
+        }
+        ArtifactMode::Unique => {
+            return Err(NikaError::ArtifactWriteError {
+                path: output_spec.path.clone(),
+                reason: "Binary artifacts do not support unique mode".to_string(),
+            });
+        }
+        ArtifactMode::Overwrite | ArtifactMode::Fail => {
+            // Supported -- continue
+        }
+    }
+
     // Resolve source to a MediaRef:
     // 1. If source is specified, look it up in bindings/media_refs
     // 2. Otherwise, use first media ref from the task
+    //
+    // Resolution order for `source: alias`:
+    //   a) Direct match: media_refs.created_by == alias || media_refs.hash == alias
+    //   b) Binding indirection: resolve alias -> source task ID -> media_refs.created_by
+    //   c) Hash indirection: binding value is a hash string -> media_refs.hash == hash
     let media_ref = if let Some(ref source_alias) = output_spec.source {
         // Try to find media by source alias (could be a task_id or hash)
         // First check if any media ref was created by a task matching the source alias
-        let from_media = media_refs.iter().find(|m| m.created_by == *source_alias || m.hash == *source_alias);
+        let from_media = media_refs
+            .iter()
+            .find(|m| m.created_by == *source_alias || m.hash == *source_alias);
         if let Some(mr) = from_media {
             mr.clone()
         } else {
-            // Try resolving from bindings — the value might contain a media hash
-            let hash_value = if let Some(value) = bindings.get(source_alias) {
-                match value {
-                    serde_json::Value::String(s) => Some(s.clone()),
-                    _ => None,
-                }
+            // Try binding indirection: source_alias is a with-binding alias
+            // that maps to a task (e.g., `source: img` where `with: { img: $gen_img }`)
+            // Resolve the source task ID and find media by created_by.
+            let from_binding_source = bindings
+                .source_task_id(source_alias)
+                .and_then(|task_id| {
+                    media_refs
+                        .iter()
+                        .find(|m| m.created_by == task_id)
+                        .cloned()
+                });
+
+            if let Some(mr) = from_binding_source {
+                mr
             } else {
-                datastore.get_output(source_alias).and_then(|v| {
-                    match v.as_ref() {
+                // Try resolving from bindings — the value might contain a media hash
+                let hash_value = if let Some(value) = bindings.get(source_alias) {
+                    match value {
                         serde_json::Value::String(s) => Some(s.clone()),
                         _ => None,
                     }
-                })
-            };
+                } else {
+                    datastore.get_output(source_alias).and_then(|v| match v.as_ref() {
+                        serde_json::Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                };
 
-            if let Some(hash) = hash_value {
-                // Find media ref by hash
-                media_refs.iter().find(|m| m.hash == hash).cloned().ok_or_else(|| {
-                    NikaError::ArtifactWriteError {
+                if let Some(hash) = hash_value {
+                    // Find media ref by hash
+                    media_refs
+                        .iter()
+                        .find(|m| m.hash == hash)
+                        .cloned()
+                        .ok_or_else(|| NikaError::ArtifactWriteError {
+                            path: output_spec.path.clone(),
+                            reason: format!(
+                                "Binary artifact source '{}' resolved to hash '{}' but no media ref matches",
+                                source_alias, hash
+                            ),
+                        })?
+                } else {
+                    return Err(NikaError::ArtifactWriteError {
                         path: output_spec.path.clone(),
                         reason: format!(
-                            "Binary artifact source '{}' resolved to hash '{}' but no media ref matches",
-                            source_alias, hash
+                            "Binary artifact source '{}' not found in media refs or bindings",
+                            source_alias
                         ),
-                    }
-                })?
-            } else {
-                return Err(NikaError::ArtifactWriteError {
-                    path: output_spec.path.clone(),
-                    reason: format!(
-                        "Binary artifact source '{}' not found in media refs or bindings",
-                        source_alias
-                    ),
-                });
+                    });
+                }
             }
         }
     } else {
@@ -417,6 +473,17 @@ async fn write_binary_artifact(
     let artifact_dir_str = ""; // Binary artifacts use the raw path
     let normalized_path = normalize_artifact_path(&resolved_path, artifact_dir_str);
 
+    // For Fail mode, check that the target does not already exist
+    if mode == ArtifactMode::Fail {
+        let resolved = writer.validate_path(task_id, &normalized_path)?;
+        if resolved.exists() {
+            return Err(NikaError::ArtifactWriteError {
+                path: resolved.display().to_string(),
+                reason: "File already exists and mode is 'fail'".to_string(),
+            });
+        }
+    }
+
     let request = BinaryWriteRequest {
         task_id: task_id.to_string(),
         output_path: normalized_path,
@@ -425,6 +492,23 @@ async fn write_binary_artifact(
     };
 
     writer.write_binary(request).await
+}
+
+/// Resolve the blake3 checksum for a binary artifact from media refs.
+///
+/// Looks up the matching MediaRef by source alias or falls back to the first ref.
+/// Returns `Some("blake3:...")` if found, `None` otherwise.
+fn resolve_binary_checksum(output_spec: &ArtifactOutput, media_refs: &[MediaRef]) -> Option<String> {
+    if let Some(ref source_alias) = output_spec.source {
+        // Match by creator task_id or by hash
+        media_refs
+            .iter()
+            .find(|m| m.created_by == *source_alias || m.hash == *source_alias)
+            .map(|m| m.hash.clone())
+    } else {
+        // No explicit source -- use first media ref (same logic as write_binary_artifact)
+        media_refs.first().map(|m| m.hash.clone())
+    }
 }
 
 /// Format output content based on artifact format
@@ -510,7 +594,7 @@ async fn resolve_artifact_dir(
 /// where user-controlled binding values enter the filesystem path context.
 fn sanitize_for_path(value: &str) -> String {
     value
-        .replace(['/', '\\'], "_")
+        .replace(['/', '\\', ':'], "_")
         .replace('\0', "")
         .replace("..", "_")
         .replace('~', "_")
@@ -553,7 +637,35 @@ fn resolve_artifact_path_bindings(path: &str, output: &str, bindings: &ResolvedB
         } else if let Some(alias) = var_name.strip_prefix("with.") {
             // Extract top-level alias (e.g., "with.timestamp" → "timestamp")
             let top_alias = alias.split('.').next().unwrap_or(alias);
-            if let Some(value) = bindings.get(top_alias) {
+
+            // Check for media paths: {{with.alias.media[N].field}}
+            // Media refs live in the TaskResult side-channel, not in the task
+            // output value, so we must resolve via datastore.resolve_path()
+            // using the original source task ID.
+            let nested_path = alias.split_once('.').map(|x| x.1).unwrap_or("");
+            let is_media_path = nested_path == "media"
+                || nested_path.starts_with("media.")
+                || nested_path.starts_with("media[");
+
+            if is_media_path {
+                // Resolve media path via datastore using source task ID
+                if let Some(source_task_id) = bindings.source_task_id(top_alias) {
+                    let full_path = format!("{}.{}", source_task_id, nested_path);
+                    if let Some(value) = datastore.resolve_path(&full_path) {
+                        let raw_value = match &value {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        let sanitized = sanitize_for_path(&raw_value);
+                        result.replace_range(start..end, &sanitized);
+                        pos = start + sanitized.len();
+                    } else {
+                        pos = end;
+                    }
+                } else {
+                    pos = end;
+                }
+            } else if let Some(value) = bindings.get(top_alias) {
                 // For nested paths like "with.data.name", do JSONPath-like access
                 let raw_value = if alias.contains('.') {
                     // Navigate into the JSON value
@@ -1527,5 +1639,359 @@ mod tests {
             "Error should mention no media: {}",
             result.errors[0]
         );
+    }
+
+    // ═══════════════════════════════════════════════════
+    // Binary artifact mode validation tests
+    // ═══════════════════════════════════════════════════
+
+    fn setup_binary_mode_fixtures() -> (
+        tempfile::TempDir,
+        Vec<crate::media::MediaRef>,
+        ResolvedBindings,
+        RunContext,
+    ) {
+        use crate::media::MediaRef;
+        let base = tempdir().unwrap();
+        std::fs::create_dir_all(base.path().join(".nika/artifacts")).unwrap();
+        let cas_dir = base.path().join(".nika/media/store/ab");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file = cas_dir.join("testbin");
+        std::fs::write(&cas_file, b"binary payload").unwrap();
+        let media_refs = vec![MediaRef {
+            hash: "blake3:testbin".to_string(),
+            mime_type: "application/octet-stream".to_string(),
+            size_bytes: 14,
+            path: cas_file,
+            extension: "bin".to_string(),
+            created_by: "producer".to_string(),
+        }];
+        (base, media_refs, ResolvedBindings::default(), RunContext::new())
+    }
+
+    #[tokio::test]
+    async fn test_binary_mode_append_is_rejected() {
+        let (base, media_refs, bindings, datastore) = setup_binary_mode_fixtures();
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output.bin".to_string(),
+            source: None,
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: Some(ArtifactMode::Append),
+        });
+        let result = process_task_artifacts(
+            "producer", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        ).await;
+        assert_eq!(result.written, 0, "Append mode must be rejected for binary");
+        assert_eq!(result.errors.len(), 1);
+        assert!(
+            result.errors[0].contains("Binary artifacts do not support append mode"),
+            "got: {}", result.errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_binary_mode_unique_is_rejected() {
+        let (base, media_refs, bindings, datastore) = setup_binary_mode_fixtures();
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output.bin".to_string(),
+            source: None,
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: Some(ArtifactMode::Unique),
+        });
+        let result = process_task_artifacts(
+            "producer", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        ).await;
+        assert_eq!(result.written, 0, "Unique mode must be rejected for binary");
+        assert_eq!(result.errors.len(), 1);
+        assert!(
+            result.errors[0].contains("Binary artifacts do not support unique mode"),
+            "got: {}", result.errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_binary_mode_overwrite_succeeds() {
+        let (base, media_refs, bindings, datastore) = setup_binary_mode_fixtures();
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output.bin".to_string(),
+            source: None,
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: Some(ArtifactMode::Overwrite),
+        });
+        let result = process_task_artifacts(
+            "producer", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        ).await;
+        assert_eq!(result.written, 1, "Overwrite should work, errors: {:?}", result.errors);
+        assert!(result.errors.is_empty());
+        assert_eq!(std::fs::read(&result.paths[0]).unwrap(), b"binary payload");
+    }
+
+    #[tokio::test]
+    async fn test_binary_mode_fail_rejects_existing_file() {
+        let (base, media_refs, bindings, datastore) = setup_binary_mode_fixtures();
+        // Pre-create the target so fail mode triggers
+        let target = base.path().join(".nika/artifacts/output.bin");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, b"existing data").unwrap();
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output.bin".to_string(),
+            source: None,
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: Some(ArtifactMode::Fail),
+        });
+        let result = process_task_artifacts(
+            "producer", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        ).await;
+        assert_eq!(result.written, 0, "Fail mode should reject existing file");
+        assert_eq!(result.errors.len(), 1);
+        assert!(
+            result.errors[0].contains("already exists"),
+            "got: {}", result.errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_binary_mode_fail_succeeds_for_new_file() {
+        let (base, media_refs, bindings, datastore) = setup_binary_mode_fixtures();
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "fresh_output.bin".to_string(),
+            source: None,
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: Some(ArtifactMode::Fail),
+        });
+        let result = process_task_artifacts(
+            "producer", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        ).await;
+        assert_eq!(result.written, 1, "Fail mode should succeed for new file, errors: {:?}", result.errors);
+        assert!(result.errors.is_empty());
+        assert_eq!(std::fs::read(&result.paths[0]).unwrap(), b"binary payload");
+    }
+
+    // ========== Media binding template tests (source_task_id tracking) ==========
+
+    #[test]
+    fn test_path_bindings_media_hash_via_source_task() {
+        use crate::media::MediaRef;
+        use crate::store::TaskResult;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let datastore = RunContext::new();
+        let mut task_result =
+            TaskResult::success_str("LLM text output".to_string(), Duration::from_millis(100));
+        task_result.media = vec![MediaRef {
+            hash: "blake3:af1349b9".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: 4096,
+            path: std::path::PathBuf::from("/tmp/cas/af/1349b9"),
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+        datastore.insert(Arc::from("gen_img"), task_result);
+
+        let mut bindings = ResolvedBindings::new();
+        bindings.set_with_source("img", serde_json::json!("LLM text output"), "gen_img");
+
+        let result = resolve_artifact_path_bindings(
+            "output/{{with.img.media[0].hash}}.bin",
+            "",
+            &bindings,
+            &datastore,
+        );
+        assert_eq!(
+            result, "output/blake3_af1349b9.bin",
+            "Media hash should resolve via source task ID, with : sanitized to _"
+        );
+    }
+
+    #[test]
+    fn test_path_bindings_media_extension_via_source_task() {
+        use crate::media::MediaRef;
+        use crate::store::TaskResult;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let datastore = RunContext::new();
+        let mut task_result =
+            TaskResult::success_str("output".to_string(), Duration::from_millis(50));
+        task_result.media = vec![MediaRef {
+            hash: "blake3:deadbeef".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: 1024,
+            path: std::path::PathBuf::from("/tmp/cas/de/adbeef"),
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+        datastore.insert(Arc::from("gen_img"), task_result);
+
+        let mut bindings = ResolvedBindings::new();
+        bindings.set_with_source("img", serde_json::json!("output"), "gen_img");
+
+        let result = resolve_artifact_path_bindings(
+            "output/{{with.img.media[0].extension}}/result.bin",
+            "",
+            &bindings,
+            &datastore,
+        );
+        assert_eq!(
+            result, "output/png/result.bin",
+            "Media extension should resolve via source task ID"
+        );
+    }
+
+    #[test]
+    fn test_path_bindings_media_without_source_task_unresolved() {
+        let bindings = ResolvedBindings::new();
+        let datastore = RunContext::new();
+
+        let result = resolve_artifact_path_bindings(
+            "output/{{with.img.media[0].hash}}.bin",
+            "",
+            &bindings,
+            &datastore,
+        );
+        assert_eq!(
+            result, "output/{{with.img.media[0].hash}}.bin",
+            "Without source task tracking, media path should remain unresolved"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_binary_artifact_source_via_binding_alias() {
+        use crate::media::MediaRef;
+        use crate::store::TaskResult;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let base = tempdir().unwrap();
+        let artifact_dir = base.path().join(".nika/artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+
+        let cas_dir = base.path().join(".nika/media/store/ab");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file = cas_dir.join("cdef1234");
+        let binary_data = b"\x89PNG fake image";
+        std::fs::write(&cas_file, binary_data).unwrap();
+
+        let datastore = RunContext::new();
+        let mut task_result =
+            TaskResult::success_str("generated image".to_string(), Duration::from_millis(100));
+        task_result.media = vec![MediaRef {
+            hash: "blake3:abcdef1234".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: binary_data.len() as u64,
+            path: cas_file.clone(),
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+        datastore.insert(Arc::from("gen_img"), task_result);
+
+        let mut bindings = ResolvedBindings::new();
+        bindings.set_with_source("img", serde_json::json!("generated image"), "gen_img");
+
+        let media_refs = vec![MediaRef {
+            hash: "blake3:abcdef1234".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: binary_data.len() as u64,
+            path: cas_file,
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output/image.bin".to_string(),
+            source: Some("img".to_string()),
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: None,
+        });
+
+        let result = process_task_artifacts(
+            "save_img", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        )
+        .await;
+
+        assert_eq!(
+            result.written, 1,
+            "Binary artifact should resolve via binding alias indirection, errors: {:?}",
+            result.errors
+        );
+        assert!(result.errors.is_empty(), "No errors expected: {:?}", result.errors);
+
+        let written = std::fs::read(&result.paths[0]).unwrap();
+        assert_eq!(written, binary_data, "Binary content should match CAS source");
+    }
+
+    #[tokio::test]
+    async fn test_binary_artifact_path_with_media_extension_template() {
+        use crate::media::MediaRef;
+        use crate::store::TaskResult;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let base = tempdir().unwrap();
+        let artifact_dir = base.path().join(".nika/artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+
+        let cas_dir = base.path().join(".nika/media/store/xx");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file = cas_dir.join("yy1234");
+        let binary_data = b"image bytes";
+        std::fs::write(&cas_file, binary_data).unwrap();
+
+        let datastore = RunContext::new();
+        let mut task_result =
+            TaskResult::success_str("done".to_string(), Duration::from_millis(50));
+        task_result.media = vec![MediaRef {
+            hash: "blake3:xxyy1234".to_string(),
+            mime_type: "image/jpeg".to_string(),
+            size_bytes: binary_data.len() as u64,
+            path: cas_file.clone(),
+            extension: "jpg".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+        datastore.insert(Arc::from("gen_img"), task_result);
+
+        let mut bindings = ResolvedBindings::new();
+        bindings.set_with_source("img", serde_json::json!("done"), "gen_img");
+
+        let media_refs = vec![MediaRef {
+            hash: "blake3:xxyy1234".to_string(),
+            mime_type: "image/jpeg".to_string(),
+            size_bytes: binary_data.len() as u64,
+            path: cas_file,
+            extension: "jpg".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output/result.{{with.img.media[0].extension}}".to_string(),
+            source: None,
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: None,
+        });
+
+        let result = process_task_artifacts(
+            "gen_img", "", &spec, None, base.path(), None, &bindings, &datastore, &media_refs,
+        )
+        .await;
+
+        assert_eq!(result.written, 1, "errors: {:?}", result.errors);
+
+        let path_str = result.paths[0].display().to_string();
+        assert!(
+            path_str.ends_with("result.jpg"),
+            "Path should end with resolved extension 'result.jpg', got: {}",
+            path_str
+        );
+
+        let written = std::fs::read(&result.paths[0]).unwrap();
+        assert_eq!(written, binary_data);
     }
 }

--- a/tools/nika/src/runtime/artifact_processor.rs
+++ b/tools/nika/src/runtime/artifact_processor.rs
@@ -1334,7 +1334,6 @@ mod tests {
     #[tokio::test]
     async fn test_process_binary_artifact_from_media_ref() {
         use crate::media::MediaRef;
-        use std::path::PathBuf;
 
         let base = tempdir().unwrap();
         let artifact_dir = base.path().join(".nika/artifacts");
@@ -1391,7 +1390,6 @@ mod tests {
     #[tokio::test]
     async fn test_process_binary_artifact_with_source() {
         use crate::media::MediaRef;
-        use std::path::PathBuf;
 
         let base = tempdir().unwrap();
         let artifact_dir = base.path().join(".nika/artifacts");

--- a/tools/nika/src/runtime/artifact_processor.rs
+++ b/tools/nika/src/runtime/artifact_processor.rs
@@ -254,6 +254,7 @@ async fn write_single_artifact(
         ArtifactFormat::Text => OutputFormat::Text,
         ArtifactFormat::Json => OutputFormat::Json,
         ArtifactFormat::Yaml => OutputFormat::Text, // YAML treated as text for validation
+        ArtifactFormat::Binary => OutputFormat::Text, // Binary bypasses format_output entirely
     };
 
     // Pre-resolve {{with.*}} and {{output}} binding references in the path
@@ -357,6 +358,14 @@ fn format_output(output: &str, format: ArtifactFormat) -> Result<String, NikaErr
                     Ok(output.to_string())
                 }
             }
+        }
+        ArtifactFormat::Binary => {
+            // Binary artifacts are handled separately via write_binary()
+            // This path should not be reached for binary format
+            Err(NikaError::ArtifactWriteError {
+                path: "".to_string(),
+                reason: "Binary format must be written via write_binary(), not format_output()".to_string(),
+            })
         }
     }
 }

--- a/tools/nika/src/runtime/artifact_processor.rs
+++ b/tools/nika/src/runtime/artifact_processor.rs
@@ -339,7 +339,6 @@ async fn write_single_artifact(
 ///
 /// Resolves the `source` binding to a media hash or path, then copies from CAS store.
 /// Falls back to the first media ref if no explicit source is specified.
-#[allow(clippy::too_many_arguments)]
 async fn write_binary_artifact(
     task_id: &str,
     output_spec: &ArtifactOutput,

--- a/tools/nika/src/runtime/artifact_processor.rs
+++ b/tools/nika/src/runtime/artifact_processor.rs
@@ -1453,4 +1453,82 @@ mod tests {
         let written = std::fs::read(&result.paths[0]).unwrap();
         assert_eq!(written, b"image data 2");
     }
+
+    // ========== Binary artifact edge cases ==========
+
+    #[tokio::test]
+    async fn test_binary_artifact_missing_source_binding_error() {
+        let base = tempdir().unwrap();
+        let artifact_dir = base.path().join(".nika/artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let bindings = ResolvedBindings::default();
+        let datastore = RunContext::new();
+
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output.bin".to_string(),
+            source: Some("nonexistent_source".to_string()),
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: None,
+        });
+
+        let result = process_task_artifacts(
+            "task1",
+            "",
+            &spec,
+            None,
+            base.path(),
+            None,
+            &bindings,
+            &datastore,
+            &[], // No media refs
+        )
+        .await;
+
+        assert_eq!(result.written, 0);
+        assert_eq!(result.errors.len(), 1);
+        assert!(
+            result.errors[0].contains("not found"),
+            "Error should mention source not found: {}",
+            result.errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_binary_artifact_no_media_no_source_error() {
+        let base = tempdir().unwrap();
+        let artifact_dir = base.path().join(".nika/artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let bindings = ResolvedBindings::default();
+        let datastore = RunContext::new();
+
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output.bin".to_string(),
+            source: None, // No source specified
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: None,
+        });
+
+        let result = process_task_artifacts(
+            "task1",
+            "text output",
+            &spec,
+            None,
+            base.path(),
+            None,
+            &bindings,
+            &datastore,
+            &[], // No media refs either
+        )
+        .await;
+
+        assert_eq!(result.written, 0);
+        assert_eq!(result.errors.len(), 1);
+        assert!(
+            result.errors[0].contains("no media"),
+            "Error should mention no media: {}",
+            result.errors[0]
+        );
+    }
 }

--- a/tools/nika/src/runtime/artifact_processor.rs
+++ b/tools/nika/src/runtime/artifact_processor.rs
@@ -20,7 +20,8 @@ use crate::error::NikaError;
 use crate::event::{EventKind, EventLog};
 use crate::io::atomic::{write_append, write_fail, write_unique};
 use crate::io::security::DEFAULT_ARTIFACT_DIR;
-use crate::io::writer::{ArtifactWriter, WriteRequest, WriteResult};
+use crate::io::writer::{ArtifactWriter, BinarySource, BinaryWriteRequest, WriteRequest, WriteResult};
+use crate::media::MediaRef;
 use crate::serde_yaml;
 use crate::store::RunContext;
 
@@ -47,6 +48,7 @@ pub struct ArtifactProcessResult {
 /// * `event_log` - Optional event log for emitting artifact events
 /// * `bindings` - Resolved bindings for template resolution
 /// * `datastore` - Data store for lazy binding resolution
+/// * `media_refs` - Media files produced by the task (for binary artifact source resolution)
 ///
 /// # Returns
 ///
@@ -61,6 +63,7 @@ pub async fn process_task_artifacts(
     event_log: Option<&EventLog>,
     bindings: &ResolvedBindings,
     datastore: &RunContext,
+    media_refs: &[MediaRef],
 ) -> ArtifactProcessResult {
     let mut result = ArtifactProcessResult {
         written: 0,
@@ -114,6 +117,7 @@ pub async fn process_task_artifacts(
             &writer,
             bindings,
             datastore,
+            media_refs,
         )
         .await
         {
@@ -167,6 +171,7 @@ pub async fn process_task_artifacts(
 ///
 /// Supports `template:` field - if set, resolves template with bindings
 /// instead of using task output directly.
+#[allow(clippy::too_many_arguments)]
 async fn write_single_artifact(
     task_id: &str,
     output: &str,
@@ -175,12 +180,18 @@ async fn write_single_artifact(
     writer: &ArtifactWriter,
     bindings: &ResolvedBindings,
     datastore: &RunContext,
+    media_refs: &[MediaRef],
 ) -> Result<WriteResult, NikaError> {
     // Determine format (task spec > workflow default)
     let format = output_spec
         .format
         .or(workflow_config.map(|c| c.format))
         .unwrap_or(ArtifactFormat::Text);
+
+    // Binary format: resolve source to CAS path and copy
+    if format == ArtifactFormat::Binary {
+        return write_binary_artifact(task_id, output_spec, writer, bindings, datastore, media_refs).await;
+    }
 
     // Determine mode (task spec > workflow default)
     let mode = output_spec
@@ -322,6 +333,99 @@ async fn write_single_artifact(
             })
         }
     }
+}
+
+/// Write a binary artifact from a media reference.
+///
+/// Resolves the `source` binding to a media hash or path, then copies from CAS store.
+/// Falls back to the first media ref if no explicit source is specified.
+#[allow(clippy::too_many_arguments)]
+async fn write_binary_artifact(
+    task_id: &str,
+    output_spec: &ArtifactOutput,
+    writer: &ArtifactWriter,
+    bindings: &ResolvedBindings,
+    datastore: &RunContext,
+    media_refs: &[MediaRef],
+) -> Result<WriteResult, NikaError> {
+    // Resolve source to a MediaRef:
+    // 1. If source is specified, look it up in bindings/media_refs
+    // 2. Otherwise, use first media ref from the task
+    let media_ref = if let Some(ref source_alias) = output_spec.source {
+        // Try to find media by source alias (could be a task_id or hash)
+        // First check if any media ref was created by a task matching the source alias
+        let from_media = media_refs.iter().find(|m| m.created_by == *source_alias || m.hash == *source_alias);
+        if let Some(mr) = from_media {
+            mr.clone()
+        } else {
+            // Try resolving from bindings — the value might contain a media hash
+            let hash_value = if let Some(value) = bindings.get(source_alias) {
+                match value {
+                    serde_json::Value::String(s) => Some(s.clone()),
+                    _ => None,
+                }
+            } else {
+                datastore.get_output(source_alias).and_then(|v| {
+                    match v.as_ref() {
+                        serde_json::Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    }
+                })
+            };
+
+            if let Some(hash) = hash_value {
+                // Find media ref by hash
+                media_refs.iter().find(|m| m.hash == hash).cloned().ok_or_else(|| {
+                    NikaError::ArtifactWriteError {
+                        path: output_spec.path.clone(),
+                        reason: format!(
+                            "Binary artifact source '{}' resolved to hash '{}' but no media ref matches",
+                            source_alias, hash
+                        ),
+                    }
+                })?
+            } else {
+                return Err(NikaError::ArtifactWriteError {
+                    path: output_spec.path.clone(),
+                    reason: format!(
+                        "Binary artifact source '{}' not found in media refs or bindings",
+                        source_alias
+                    ),
+                });
+            }
+        }
+    } else {
+        // No explicit source — use first media ref
+        media_refs.first().cloned().ok_or_else(|| {
+            NikaError::ArtifactWriteError {
+                path: output_spec.path.clone(),
+                reason: "Binary artifact requires media content but task produced no media".to_string(),
+            }
+        })?
+    };
+
+    debug!(
+        task_id = %task_id,
+        hash = %media_ref.hash,
+        path = %media_ref.path.display(),
+        "Writing binary artifact from CAS"
+    );
+
+    // Pre-resolve binding references in the path
+    let resolved_path = resolve_artifact_path_bindings(&output_spec.path, "", bindings, datastore);
+
+    // Normalize the artifact path
+    let artifact_dir_str = ""; // Binary artifacts use the raw path
+    let normalized_path = normalize_artifact_path(&resolved_path, artifact_dir_str);
+
+    let request = BinaryWriteRequest {
+        task_id: task_id.to_string(),
+        output_path: normalized_path,
+        source: BinarySource::CasPath(media_ref.path.clone()),
+        expected_size: media_ref.size_bytes,
+    };
+
+    writer.write_binary(request).await
 }
 
 /// Format output content based on artifact format
@@ -639,6 +743,7 @@ mod tests {
             None, // No event log for tests
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -664,6 +769,7 @@ mod tests {
             None, // No event log for tests
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -710,6 +816,7 @@ mod tests {
             None, // No event log for tests
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -751,6 +858,7 @@ mod tests {
             None, // No event log for tests
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -791,6 +899,7 @@ mod tests {
             None,
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -829,6 +938,7 @@ mod tests {
             None,
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -929,6 +1039,7 @@ mod tests {
             None,
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -974,6 +1085,7 @@ mod tests {
             None,
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -1010,6 +1122,7 @@ mod tests {
             None,
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -1159,6 +1272,7 @@ mod tests {
             None,
             &bindings,
             &datastore,
+            &[],
         )
         .await;
 
@@ -1213,5 +1327,130 @@ mod tests {
     fn test_sanitize_for_path_truncation() {
         let long = "x".repeat(300);
         assert_eq!(sanitize_for_path(&long).len(), 200);
+    }
+
+    // ========== Binary artifact tests ==========
+
+    #[tokio::test]
+    async fn test_process_binary_artifact_from_media_ref() {
+        use crate::media::MediaRef;
+        use std::path::PathBuf;
+
+        let base = tempdir().unwrap();
+        let artifact_dir = base.path().join(".nika/artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+
+        // Create a fake CAS file
+        let cas_dir = base.path().join(".nika/media/store/ab");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file = cas_dir.join("cdef1234");
+        let binary_data = b"\x89PNG\r\n\x1a\n fake image data";
+        std::fs::write(&cas_file, binary_data).unwrap();
+
+        let bindings = ResolvedBindings::default();
+        let datastore = RunContext::new();
+
+        let media_refs = vec![MediaRef {
+            hash: "blake3:abcdef1234".to_string(),
+            mime_type: "image/png".to_string(),
+            size_bytes: binary_data.len() as u64,
+            path: cas_file.clone(),
+            extension: "png".to_string(),
+            created_by: "gen_img".to_string(),
+        }];
+
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output/image.bin".to_string(),
+            source: None, // Use first media ref
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: None,
+        });
+
+        let result = process_task_artifacts(
+            "gen_img",
+            "text output (ignored for binary)",
+            &spec,
+            None,
+            base.path(),
+            None,
+            &bindings,
+            &datastore,
+            &media_refs,
+        )
+        .await;
+
+        assert_eq!(result.written, 1, "Expected 1 binary artifact, errors: {:?}", result.errors);
+        assert!(result.errors.is_empty(), "Unexpected errors: {:?}", result.errors);
+
+        // Verify file was copied correctly
+        let written = std::fs::read(&result.paths[0]).unwrap();
+        assert_eq!(written, binary_data);
+    }
+
+    #[tokio::test]
+    async fn test_process_binary_artifact_with_source() {
+        use crate::media::MediaRef;
+        use std::path::PathBuf;
+
+        let base = tempdir().unwrap();
+        let artifact_dir = base.path().join(".nika/artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+
+        // Create two fake CAS files
+        let cas_dir = base.path().join(".nika/media/store/ab");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let cas_file1 = cas_dir.join("file1");
+        let cas_file2 = cas_dir.join("file2");
+        std::fs::write(&cas_file1, b"image data 1").unwrap();
+        std::fs::write(&cas_file2, b"image data 2").unwrap();
+
+        let bindings = ResolvedBindings::default();
+        let datastore = RunContext::new();
+
+        let media_refs = vec![
+            MediaRef {
+                hash: "blake3:hash1".to_string(),
+                mime_type: "image/png".to_string(),
+                size_bytes: 12,
+                path: cas_file1,
+                extension: "png".to_string(),
+                created_by: "gen_img".to_string(),
+            },
+            MediaRef {
+                hash: "blake3:hash2".to_string(),
+                mime_type: "image/jpeg".to_string(),
+                size_bytes: 12,
+                path: cas_file2.clone(),
+                extension: "jpg".to_string(),
+                created_by: "gen_thumb".to_string(),
+            },
+        ];
+
+        // Specify source by creator task_id
+        let spec = ArtifactSpec::Single(ArtifactOutput {
+            path: "output/thumb.bin".to_string(),
+            source: Some("gen_thumb".to_string()),
+            template: None,
+            format: Some(ArtifactFormat::Binary),
+            mode: None,
+        });
+
+        let result = process_task_artifacts(
+            "save_thumb",
+            "",
+            &spec,
+            None,
+            base.path(),
+            None,
+            &bindings,
+            &datastore,
+            &media_refs,
+        )
+        .await;
+
+        assert_eq!(result.written, 1, "errors: {:?}", result.errors);
+        let written = std::fs::read(&result.paths[0]).unwrap();
+        assert_eq!(written, b"image data 2");
     }
 }

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -960,6 +960,17 @@ Please provide a corrected JSON response that strictly matches the schema."#,
         // Set workspace root for CAS media store path resolution
         self.datastore.set_workspace_root(base_path.clone());
 
+        // Create media store lockfile to prevent GC during workflow execution
+        let media_lockfile = base_path
+            .join(".nika")
+            .join("media")
+            .join("store")
+            .join(".nika-run.lock");
+        if let Some(parent) = media_lockfile.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&media_lockfile, format!("pid:{}", std::process::id()));
+
         if !self.workflow.context_files.is_empty() {
             let loaded_context =
                 load_context_analyzed(&self.workflow.context_files, &base_path).await?;
@@ -1942,6 +1953,9 @@ Please provide a corrected JSON response that strictly matches the schema."#,
 
         // Verify media integrity (warn-only, never fail successful workflows)
         let media_warnings = self.verify_media_integrity();
+
+        // Remove media store lockfile (GC is now safe)
+        let _ = std::fs::remove_file(&media_lockfile);
 
         // Get final output
         let output = self.get_final_output().unwrap_or_default();

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -44,6 +44,41 @@ use crate::ast::artifact::ArtifactsConfig;
 use std::path::PathBuf;
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// RAII Lockfile Guard
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// RAII guard that removes a lockfile on drop.
+///
+/// The media store lockfile (`.nika-run.lock`) prevents `nika media clean` from
+/// garbage-collecting blobs that are still in use by a running workflow. Without
+/// this guard, any early return via `?`, `return Err(...)`, or panic would leave
+/// a stale lockfile that permanently blocks GC until manually deleted.
+///
+/// The guard writes the lockfile on creation and removes it when dropped,
+/// covering **all** exit paths: normal completion, error propagation, and
+/// unwinding panics.
+struct LockfileGuard {
+    path: PathBuf,
+}
+
+impl LockfileGuard {
+    /// Create the lockfile and return a guard that will remove it on drop.
+    fn create(path: PathBuf) -> Self {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&path, format!("pid:{}", std::process::id()));
+        Self { path }
+    }
+}
+
+impl Drop for LockfileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // Helper Functions
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -410,11 +445,14 @@ impl Runner {
     /// Verify media integrity: check that all MediaRef paths exist and sizes match.
     ///
     /// Called after all tasks complete but before WorkflowCompleted event.
-    /// Returns warning count. Never fails the workflow — only warns.
+    /// Emits a `MediaIntegrityCheck` event with results.
+    /// Returns warning count. Never fails the workflow -- only warns.
     fn verify_media_integrity(&self) -> usize {
         let mut warnings = 0;
+        let mut checked: u64 = 0;
         for (task_id, result) in self.datastore.iter_results() {
             for media_ref in &result.media {
+                checked += 1;
                 if !media_ref.path.exists() {
                     tracing::warn!(
                         task_id = %task_id,
@@ -450,6 +488,15 @@ impl Runner {
                 }
             }
         }
+
+        // Emit structured event for telemetry consumers
+        if checked > 0 {
+            self.event_log.emit(EventKind::MediaIntegrityCheck {
+                checked,
+                warnings: warnings as u64,
+            });
+        }
+
         warnings
     }
 
@@ -960,16 +1007,14 @@ Please provide a corrected JSON response that strictly matches the schema."#,
         // Set workspace root for CAS media store path resolution
         self.datastore.set_workspace_root(base_path.clone());
 
-        // Create media store lockfile to prevent GC during workflow execution
-        let media_lockfile = base_path
-            .join(".nika")
-            .join("media")
-            .join("store")
-            .join(".nika-run.lock");
-        if let Some(parent) = media_lockfile.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let _ = std::fs::write(&media_lockfile, format!("pid:{}", std::process::id()));
+        // RAII lockfile: auto-removed on all exit paths (normal, error, panic)
+        let _lockfile_guard = LockfileGuard::create(
+            base_path
+                .join(".nika")
+                .join("media")
+                .join("store")
+                .join(".nika-run.lock"),
+        );
 
         if !self.workflow.context_files.is_empty() {
             let loaded_context =
@@ -1954,8 +1999,8 @@ Please provide a corrected JSON response that strictly matches the schema."#,
         // Verify media integrity (warn-only, never fail successful workflows)
         let media_warnings = self.verify_media_integrity();
 
-        // Remove media store lockfile (GC is now safe)
-        let _ = std::fs::remove_file(&media_lockfile);
+        // Lockfile is removed automatically when `_lockfile_guard` drops
+        // (at function exit -- normal return, error, or panic).
 
         // Get final output
         let output = self.get_final_output().unwrap_or_default();
@@ -4945,5 +4990,87 @@ mod tests {
         let roundtripped = policy.source_structured_spec.unwrap();
         assert_eq!(roundtripped.max_retries, Some(5));
         assert_eq!(roundtripped.enable_repair, Some(false));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // LOCKFILE GUARD RAII TESTS
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn lockfile_guard_creates_and_removes_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("store").join(".nika-run.lock");
+
+        {
+            let _guard = LockfileGuard::create(lock_path.clone());
+            assert!(lock_path.exists(), "Lockfile should exist while guard is alive");
+
+            let content = std::fs::read_to_string(&lock_path).unwrap();
+            assert!(
+                content.starts_with("pid:"),
+                "Lockfile should contain pid, got: {content}"
+            );
+        }
+
+        assert!(
+            !lock_path.exists(),
+            "Lockfile should be removed after guard is dropped"
+        );
+    }
+
+    #[test]
+    fn lockfile_guard_removes_on_panic_unwind() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("store").join(".nika-run.lock");
+
+        let result = std::panic::catch_unwind(|| {
+            let _guard = LockfileGuard::create(lock_path.clone());
+            assert!(lock_path.exists(), "Lockfile should exist before panic");
+            panic!("simulated runner panic");
+        });
+
+        assert!(result.is_err(), "Should have caught the panic");
+        assert!(
+            !lock_path.exists(),
+            "Lockfile should be removed even after panic unwind"
+        );
+    }
+
+    #[test]
+    fn lockfile_guard_removes_on_early_return() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("store").join(".nika-run.lock");
+
+        fn simulate_early_return(path: &std::path::Path) -> Result<(), &'static str> {
+            let _guard = LockfileGuard::create(path.to_path_buf());
+            assert!(path.exists(), "Lockfile should exist before early return");
+            Err("simulated ? operator bail-out")?;
+            unreachable!()
+        }
+
+        let result = simulate_early_return(&lock_path);
+        assert!(result.is_err());
+        assert!(
+            !lock_path.exists(),
+            "Lockfile should be removed after early return via ?"
+        );
+    }
+
+    #[test]
+    fn lockfile_guard_tolerates_missing_file() {
+        // If someone manually deletes the lockfile during a run,
+        // Drop should not panic.
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("store").join(".nika-run.lock");
+
+        let guard = LockfileGuard::create(lock_path.clone());
+        assert!(lock_path.exists());
+
+        // Simulate external deletion
+        std::fs::remove_file(&lock_path).unwrap();
+        assert!(!lock_path.exists());
+
+        // Drop should not panic
+        drop(guard);
     }
 }

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -854,6 +854,7 @@ Please provide a corrected JSON response that strictly matches the schema."#,
                     Some(&event_log),
                     &bindings,
                     &datastore,
+                    task_result.media.as_slice(),
                 )
                 .await;
 

--- a/tools/nika/src/runtime/runner.rs
+++ b/tools/nika/src/runtime/runner.rs
@@ -407,6 +407,52 @@ impl Runner {
         trace_path
     }
 
+    /// Verify media integrity: check that all MediaRef paths exist and sizes match.
+    ///
+    /// Called after all tasks complete but before WorkflowCompleted event.
+    /// Returns warning count. Never fails the workflow — only warns.
+    fn verify_media_integrity(&self) -> usize {
+        let mut warnings = 0;
+        for (task_id, result) in self.datastore.iter_results() {
+            for media_ref in &result.media {
+                if !media_ref.path.exists() {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        hash = %media_ref.hash,
+                        path = %media_ref.path.display(),
+                        "Media integrity: CAS file missing"
+                    );
+                    warnings += 1;
+                    continue;
+                }
+                match std::fs::metadata(&media_ref.path) {
+                    Ok(meta) => {
+                        if meta.len() != media_ref.size_bytes {
+                            tracing::warn!(
+                                task_id = %task_id,
+                                hash = %media_ref.hash,
+                                expected = media_ref.size_bytes,
+                                actual = meta.len(),
+                                "Media integrity: size mismatch"
+                            );
+                            warnings += 1;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            task_id = %task_id,
+                            hash = %media_ref.hash,
+                            error = %e,
+                            "Media integrity: failed to stat CAS file"
+                        );
+                        warnings += 1;
+                    }
+                }
+            }
+        }
+        warnings
+    }
+
     /// Check if a task qualifies for schema validation retry
     ///
     /// Returns Some((schema, max_retries, infer_params)) if:
@@ -1894,6 +1940,9 @@ Please provide a corrected JSON response that strictly matches the schema."#,
             }
         }
 
+        // Verify media integrity (warn-only, never fail successful workflows)
+        let media_warnings = self.verify_media_integrity();
+
         // Get final output
         let output = self.get_final_output().unwrap_or_default();
 
@@ -1902,6 +1951,13 @@ Please provide a corrected JSON response that strictly matches the schema."#,
             final_output: Arc::new(Value::String(output.clone())),
             total_duration_ms: workflow_start.elapsed().as_millis() as u64,
         });
+
+        if media_warnings > 0 {
+            tracing::warn!(
+                warnings = media_warnings,
+                "Media integrity check completed with warnings"
+            );
+        }
 
         // Write execution trace to .nika/traces/
         let trace_path = self.write_trace();

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -246,7 +246,11 @@ impl RunContext {
     ///
     /// Returns (task_id, TaskResult) pairs for all stored results.
     /// Used by integrity checks at workflow end.
-    pub fn iter_results(&self) -> Vec<(Arc<str>, TaskResult)> {
+    ///
+    /// Note: for_each tasks store both individual iteration entries (task[0], task[1], ...)
+    /// and an aggregated parent entry (task). Media refs appear in both, so callers
+    /// doing per-file checks may see duplicates. This is acceptable for warn-only checks.
+    pub(crate) fn iter_results(&self) -> Vec<(Arc<str>, TaskResult)> {
         self.results
             .iter()
             .map(|entry| (entry.key().clone(), entry.value().clone()))

--- a/tools/nika/src/store/run_context.rs
+++ b/tools/nika/src/store/run_context.rs
@@ -242,6 +242,17 @@ impl RunContext {
         self.results.contains_key(task_id)
     }
 
+    /// Iterate over all task results (cloned).
+    ///
+    /// Returns (task_id, TaskResult) pairs for all stored results.
+    /// Used by integrity checks at workflow end.
+    pub fn iter_results(&self) -> Vec<(Arc<str>, TaskResult)> {
+        self.results
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect()
+    }
+
     /// Check if task succeeded
     pub fn is_success(&self, task_id: &str) -> bool {
         self.get(task_id).is_some_and(|r| r.is_success())
@@ -1294,5 +1305,42 @@ mod tests {
         // Standard output field should still resolve normally
         let prompt = store.resolve_path("gen_img.prompt").unwrap();
         assert_eq!(prompt, "a cat");
+    }
+
+    #[test]
+    fn iter_results_returns_all_entries() {
+        let store = RunContext::new();
+        store.insert(
+            Arc::from("task1"),
+            TaskResult::success_str("out1", Duration::from_millis(10)),
+        );
+        store.insert(
+            Arc::from("task2"),
+            TaskResult::success_str("out2", Duration::from_millis(20)),
+        );
+        store.insert(
+            Arc::from("task3"),
+            TaskResult::failed("err", Duration::from_millis(5)),
+        );
+
+        let results = store.iter_results();
+        assert_eq!(results.len(), 3);
+
+        // All task IDs should be present
+        let ids: Vec<String> = results.iter().map(|(id, _)| id.to_string()).collect();
+        assert!(ids.contains(&"task1".to_string()));
+        assert!(ids.contains(&"task2".to_string()));
+        assert!(ids.contains(&"task3".to_string()));
+    }
+
+    #[test]
+    fn iter_results_includes_media_refs() {
+        let store = RunContext::new();
+        store.insert(Arc::from("gen_img"), task_with_media());
+
+        let results = store.iter_results();
+        let (_, result) = results.iter().find(|(id, _)| id.as_ref() == "gen_img").unwrap();
+        assert_eq!(result.media.len(), 2);
+        assert_eq!(result.media[0].hash, "blake3:af1349b9");
     }
 }

--- a/tools/nika/src/tui/state/mod.rs
+++ b/tools/nika/src/tui/state/mod.rs
@@ -1052,6 +1052,15 @@ impl TuiState {
                 ));
                 self.dirty.notifications = true;
             }
+            EventKind::MediaCleanup { removed, bytes_freed, dry_run } => {
+                if !dry_run {
+                    self.add_notification(Notification::info(
+                        format!("Media cleanup: removed {} files, freed {} bytes", removed, bytes_freed),
+                        timestamp_ms,
+                    ));
+                    self.dirty.notifications = true;
+                }
+            }
         }
     }
 

--- a/tools/nika/src/tui/state/mod.rs
+++ b/tools/nika/src/tui/state/mod.rs
@@ -1061,6 +1061,15 @@ impl TuiState {
                     self.dirty.notifications = true;
                 }
             }
+            EventKind::MediaIntegrityCheck { checked, warnings } => {
+                if *warnings > 0 {
+                    self.add_notification(Notification::warning(
+                        format!("Media integrity: {}/{} refs had warnings", warnings, checked),
+                        timestamp_ms,
+                    ));
+                    self.dirty.notifications = true;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Binary artifact format**: `ArtifactFormat::Binary` writes raw bytes from CAS store to disk via reflink_or_copy (instant on APFS/btrfs, fallback copy on ext4)
- **`nika media` CLI**: `list` (table output), `stats` (count/size/shards), `clean` (GC with 3-layer safety: lockfile + mtime + 5min floor)
- **E2E integrity check**: `verify_media_integrity()` runs at workflow end, warns on missing/corrupted CAS files (never fails workflow)
- **MediaCleanup event**: 37th EventKind variant for GC tracking in NDJSON traces

### Changes (18 files, +1307/-29)

| Commit | Scope | What |
|--------|-------|------|
| `feat(ast)` | artifact.rs, output.rs | `Binary` variant + `OutputFormat::Binary` |
| `feat(io)` | writer.rs | `write_binary()` with reflink_or_copy + overwrite fix |
| `feat(runtime)` | artifact_processor.rs | Binary dispatch: MediaRef → CAS → disk |
| `test(artifact)` | artifact_processor.rs | Edge cases: missing source, no media |
| `feat(runtime)` | runner.rs, run_context.rs | `iter_results()` + `verify_media_integrity()` |
| `feat(cli)` | media.rs, main.rs | `nika media list\|stats\|clean` |
| `feat(event)` | log.rs | `MediaCleanup` (36→37 variants) |
| `test(media)` | tests_e2e.rs | Monster pipeline, GC, dedup, size limit |
| `fix(io)` | writer.rs | Overwrite existing + correct format in traces |

### New dependency

- `reflink-copy = "0.1"` — cross-platform CoW with fallback

### Error codes

- NIKA-280..282 (existing artifact errors) — reused for binary path/write/size
- No new NIKA-283..285 needed (deferred to PR3 when GC gets event emission)

## Test plan

- [x] 5588 lib tests pass (`cargo test --lib -q`)
- [x] 7 CLI media tests pass (`cargo test --bin nika cli::media`)
- [x] 0 clippy warnings (`cargo clippy --lib -- -D warnings`)
- [x] Binary artifact E2E: CAS → MediaRef → reflink → disk → verify
- [x] Binary overwrite: second write to same path succeeds
- [x] GC safety: lockfile blocks, --force bypasses, 5min floor enforced
- [x] Integrity check: detects missing CAS files (warn-only)
- [x] Dedup consistency: deduplicated CAS files produce correct binary artifacts
- [x] Size limit: binary exceeding max_size rejected before copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)