### PR TITLE
fix(runtime): mock provider vision awareness + ProviderCalled telemetry

### DIFF
--- a/tools/nika-core/src/binding/entry.rs
+++ b/tools/nika-core/src/binding/entry.rs
@@ -1,0 +1,1750 @@
+//! Binding Spec — YAML types for explicit data binding
+//!
+//! Unified syntax: `alias: task.path [?? default]`
+//!
+//! Examples:
+//! - `forecast: weather.summary` -> simple path (eager)
+//! - `temp: weather.data.temp ?? 20` -> with numeric default
+//! - `name: user.profile ?? "Anonymous"` -> with string default (quoted)
+//! - `cfg: x ?? {"a": 1}` -> with object default
+//!
+//! Extended syntax for lazy bindings:
+//! - `alias: { path: task.result, lazy: true }` -> deferred resolution
+//! - `alias: { path: task.result, lazy: true, default: "fallback" }` -> lazy with default
+
+use rustc_hash::FxHashMap;
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::Deserialize;
+use serde_json::Value;
+use std::fmt;
+
+use crate::error::CoreError;
+
+use super::transform::TransformExpr;
+use super::types::{BindingPath, BindingType};
+
+/// Binding spec - map of alias to entry (YAML `with:` block)
+pub type BindingSpec = FxHashMap<String, BindingEntry>;
+
+/// Unified with entry - supports both string and extended object syntax
+///
+/// String syntax: `task.path [?? default]`
+/// - path: "task.field.subfield" or "task" for entire output
+/// - default: Optional JSON literal after ??
+///
+/// Extended syntax (YAML object):
+/// - path: "task.field" (required)
+/// - lazy: bool (optional, default false)
+/// - default: JSON value (optional)
+#[derive(Debug, Clone, PartialEq)]
+pub struct BindingEntry {
+    /// Full path: "task.field.subfield" or "task" for entire output
+    pub path: String,
+    /// Optional default value (JSON literal)
+    pub default: Option<Value>,
+    /// Lazy flag - if true, resolution is deferred until first access
+    pub lazy: bool,
+}
+
+impl BindingEntry {
+    /// Create a new BindingEntry with just a path (eager resolution)
+    pub fn new(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            default: None,
+            lazy: false,
+        }
+    }
+
+    /// Create a new BindingEntry with path and default (eager resolution)
+    pub fn with_default(path: impl Into<String>, default: Value) -> Self {
+        Self {
+            path: path.into(),
+            default: Some(default),
+            lazy: false,
+        }
+    }
+
+    /// Create a new lazy BindingEntry (deferred resolution)
+    pub fn new_lazy(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            default: None,
+            lazy: true,
+        }
+    }
+
+    /// Create a new lazy BindingEntry with default (deferred resolution)
+    pub fn lazy_with_default(path: impl Into<String>, default: Value) -> Self {
+        Self {
+            path: path.into(),
+            default: Some(default),
+            lazy: true,
+        }
+    }
+
+    /// Check if this binding is lazy (deferred resolution)
+    pub fn is_lazy(&self) -> bool {
+        self.lazy
+    }
+
+    /// Extract the task ID from the path (first segment before '.')
+    pub fn task_id(&self) -> &str {
+        self.path.split('.').next().unwrap_or(&self.path)
+    }
+
+    /// Normalize a binding path by stripping the `$` prefix if present.
+    ///
+    /// This enables implicit output reference syntax where `$task` is
+    /// syntactic sugar for `task`. The RunContext.resolve_path() function
+    /// already handles resolving bare task IDs to their full output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nika_core::binding::BindingEntry;
+    ///
+    /// assert_eq!(BindingEntry::normalize_path("$task1"), "task1");
+    /// assert_eq!(BindingEntry::normalize_path("task1"), "task1");
+    /// assert_eq!(BindingEntry::normalize_path("$my_task"), "my_task");
+    /// assert_eq!(BindingEntry::normalize_path("task.field"), "task.field");
+    /// assert_eq!(BindingEntry::normalize_path("$task.field"), "task.field");
+    /// ```
+    #[inline]
+    pub fn normalize_path(path: &str) -> &str {
+        path.strip_prefix('$').unwrap_or(path)
+    }
+}
+
+/// Parse a binding entry string into BindingEntry (eager resolution)
+///
+/// Syntax: `task.path [?? default]`
+/// - If `??` found outside quotes, splits into path and default
+/// - Default is parsed as JSON literal (strings must be quoted)
+/// - String syntax always produces eager bindings (lazy=false)
+pub fn parse_binding_entry(s: &str) -> Result<BindingEntry, CoreError> {
+    let s = s.trim();
+
+    if s.is_empty() {
+        return Err(CoreError::InvalidPath {
+            path: String::new(),
+        });
+    }
+
+    match find_operator_outside_quotes(s, "??") {
+        Some(idx) => {
+            let path = s[..idx].trim();
+
+            if path.is_empty() {
+                return Err(CoreError::InvalidPath {
+                    path: s.to_string(),
+                });
+            }
+
+            let default_str = s[idx + 2..].trim();
+            let default =
+                serde_json::from_str(default_str).map_err(|e| CoreError::InvalidDefault {
+                    raw: default_str.to_string(),
+                    reason: e.to_string(),
+                })?;
+
+            Ok(BindingEntry {
+                path: path.to_string(),
+                default: Some(default),
+                lazy: false,
+            })
+        }
+        None => Ok(BindingEntry {
+            path: s.to_string(),
+            default: None,
+            lazy: false,
+        }),
+    }
+}
+
+/// Find the position of an operator outside of quoted strings
+///
+/// Handles double-quoted strings ("...") and ignores operator inside quotes.
+/// Example: `x ?? "What?? Really??"` -> finds first ?? at position 2
+fn find_operator_outside_quotes(s: &str, op: &str) -> Option<usize> {
+    let mut in_quotes = false;
+    let mut escape_next = false;
+    let mut byte_pos = 0;
+
+    for ch in s.chars() {
+        if escape_next {
+            escape_next = false;
+        } else if ch == '\\' {
+            escape_next = true;
+        } else if ch == '"' {
+            in_quotes = !in_quotes;
+        } else if !in_quotes && s[byte_pos..].starts_with(op) {
+            return Some(byte_pos);
+        }
+
+        byte_pos += ch.len_utf8();
+    }
+
+    None
+}
+
+/// Custom deserializer for BindingEntry
+///
+/// Accepts two formats:
+/// 1. String: `task.path [?? default]` → eager binding
+/// 2. Object: `{path: "task.path", lazy: true, default: ...}` → lazy binding
+impl<'de> Deserialize<'de> for BindingEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(BindingEntryVisitor)
+    }
+}
+
+struct BindingEntryVisitor;
+
+impl<'de> Visitor<'de> for BindingEntryVisitor {
+    type Value = BindingEntry;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .write_str("a string 'task.path [?? default]' or an object {path, lazy?, default?}")
+    }
+
+    /// Handle string format: "task.path [?? default]" (eager)
+    /// Applies normalize_path() to strip $ prefix from implicit output syntax ($task → task)
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let mut entry = parse_binding_entry(value).map_err(|e| de::Error::custom(e.to_string()))?;
+        entry.path = BindingEntry::normalize_path(&entry.path).to_string();
+        Ok(entry)
+    }
+
+    /// Handle object format: {path, lazy?, default?}
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut path: Option<String> = None;
+        let mut lazy: Option<bool> = None;
+        let mut default: Option<Value> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "path" => {
+                    if path.is_some() {
+                        return Err(de::Error::duplicate_field("path"));
+                    }
+                    path = Some(map.next_value()?);
+                }
+                "lazy" => {
+                    if lazy.is_some() {
+                        return Err(de::Error::duplicate_field("lazy"));
+                    }
+                    lazy = Some(map.next_value()?);
+                }
+                "default" => {
+                    if default.is_some() {
+                        return Err(de::Error::duplicate_field("default"));
+                    }
+                    default = Some(map.next_value()?);
+                }
+                _ => {
+                    // Ignore unknown fields for forward compatibility
+                    let _ = map.next_value::<de::IgnoredAny>()?;
+                }
+            }
+        }
+
+        let path = path.ok_or_else(|| de::Error::missing_field("path"))?;
+        let path = BindingEntry::normalize_path(&path).to_string();
+
+        Ok(BindingEntry {
+            path,
+            default,
+            lazy: lazy.unwrap_or(false),
+        })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// WithEntry -- new binding system
+// ═══════════════════════════════════════════════════════════════
+
+/// A single binding entry in the `with:` block
+///
+/// Supports two YAML forms:
+///
+/// **String form** (most common):
+/// ```yaml
+/// with:
+///   result: $step1
+///   title: $step1.title | upper
+///   count: $step1.items | length ?? 0
+/// ```
+///
+/// **Object form** (for complex cases):
+/// ```yaml
+/// with:
+///   summary:
+///     from: $step1.abstract
+///     type: string
+///     transform: lower | trim
+///     default: "No abstract"
+///     lazy: true
+/// ```
+#[derive(Debug, Clone)]
+pub struct WithEntry {
+    /// Parsed source path (e.g., $step1.data.items)
+    pub source: BindingPath,
+    /// Type constraint (default: Any)
+    pub binding_type: BindingType,
+    /// Default value if source is null/missing (applied AFTER transforms)
+    pub default: Option<Value>,
+    /// Defer resolution until first access
+    pub lazy: bool,
+    /// Transform pipeline to apply after resolution
+    pub transform: Option<TransformExpr>,
+}
+
+/// Map of alias -> WithEntry (YAML `with:` block)
+pub type WithSpec = FxHashMap<String, WithEntry>;
+
+/// Error parsing a WithEntry string (NIKA-155)
+#[derive(Debug, Clone, PartialEq)]
+pub struct WithEntryParseError {
+    pub input: String,
+    pub reason: String,
+}
+
+impl fmt::Display for WithEntryParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[NIKA-155] WithEntry parse error in '{}': {}",
+            self.input, self.reason
+        )
+    }
+}
+
+impl std::error::Error for WithEntryParseError {}
+
+impl WithEntry {
+    /// Create a simple WithEntry from a BindingPath (no transforms, no default)
+    pub fn simple(source: BindingPath) -> Self {
+        Self {
+            source,
+            binding_type: BindingType::default(),
+            default: None,
+            lazy: false,
+            transform: None,
+        }
+    }
+
+    /// Create a WithEntry with a default value
+    pub fn with_default(source: BindingPath, default: Value) -> Self {
+        Self {
+            source,
+            binding_type: BindingType::default(),
+            default: Some(default),
+            lazy: false,
+            transform: None,
+        }
+    }
+
+    /// Extract the task ID if this binding references a task output.
+    ///
+    /// Returns `Some(task_id)` for Task sources, `None` for Context/Input/Env/LoopVar.
+    pub fn task_id(&self) -> Option<&str> {
+        use super::types::BindingSource;
+        match &self.source.source {
+            BindingSource::Task(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Check if this binding is lazy (deferred resolution)
+    pub fn is_lazy(&self) -> bool {
+        self.lazy
+    }
+}
+
+/// Parse a with-entry from its string form
+///
+/// Grammar:
+/// ```text
+///   entry     := path ("|" transform)* ("??" default)?
+///   path      := "$" identifier ("." identifier | "[" index "]")*
+///   transform := name | name "(" args ")"
+///   default   := json_value
+/// ```
+///
+/// Examples:
+/// ```text
+///   "$step1"                          → simple task ref
+///   "$step1.data"                     → task ref with field access
+///   "$step1.data ?? fallback"         → with JSON default
+///   "$step1.data | upper"             → with transform
+///   "$step1.data | sort | unique"     → transform chain
+///   "$step1.data | sort | first(3) ?? []"  → chain + default
+/// ```
+pub fn parse_with_entry(input: &str) -> Result<WithEntry, WithEntryParseError> {
+    let input_trimmed = input.trim();
+
+    if input_trimmed.is_empty() {
+        return Err(WithEntryParseError {
+            input: input.to_string(),
+            reason: "empty input".to_string(),
+        });
+    }
+
+    // Step 1: Split off the default (" ?? ") -- must be outside quotes
+    let (path_and_transforms, default_value) = split_default(input_trimmed)?;
+
+    if path_and_transforms.is_empty() {
+        return Err(WithEntryParseError {
+            input: input.to_string(),
+            reason: "empty path before '??'".to_string(),
+        });
+    }
+
+    // Step 2: Split path from transforms by "|"
+    let (path_str, transform_str) = split_transforms(path_and_transforms);
+
+    let path_str = path_str.trim();
+    if path_str.is_empty() {
+        return Err(WithEntryParseError {
+            input: input.to_string(),
+            reason: "empty path".to_string(),
+        });
+    }
+
+    // Step 3: Parse the path as a BindingPath
+    let source = BindingPath::parse(path_str).map_err(|e| WithEntryParseError {
+        input: input.to_string(),
+        reason: e.reason,
+    })?;
+
+    // Step 4: Parse transforms (if any)
+    let transform = if let Some(t_str) = transform_str {
+        let t_str = t_str.trim();
+        if t_str.is_empty() {
+            return Err(WithEntryParseError {
+                input: input.to_string(),
+                reason: "empty transform after '|'".to_string(),
+            });
+        }
+        Some(
+            TransformExpr::parse(t_str).map_err(|e| WithEntryParseError {
+                input: input.to_string(),
+                reason: e.reason,
+            })?,
+        )
+    } else {
+        None
+    };
+
+    // Step 5: Parse default value (if any) -- must be valid JSON
+    let default = match default_value {
+        Some(d_str) => {
+            let d_str = d_str.trim();
+            if d_str.is_empty() {
+                return Err(WithEntryParseError {
+                    input: input.to_string(),
+                    reason: "empty default value after '??'".to_string(),
+                });
+            }
+            let val: Value = serde_json::from_str(d_str).map_err(|e| WithEntryParseError {
+                input: input.to_string(),
+                reason: format!("invalid default JSON: {e}"),
+            })?;
+            Some(val)
+        }
+        None => None,
+    };
+
+    Ok(WithEntry {
+        source,
+        binding_type: BindingType::default(),
+        default,
+        lazy: false,
+        transform,
+    })
+}
+
+/// Split the input at " ?? " to separate the path+transforms from the default value.
+///
+/// Respects double-quoted strings: `$x | default("a ?? b") ?? "fallback"`
+/// would split at the final `??`, not the one inside `default()`.
+fn split_default(s: &str) -> Result<(&str, Option<&str>), WithEntryParseError> {
+    // Find the LAST " ?? " outside of quotes and parens
+    // We scan left-to-right tracking quote/paren state, recording each valid `??` position.
+    // The rightmost `??` outside quotes becomes the split point.
+    let mut in_quotes = false;
+    let mut escape_next = false;
+    let mut paren_depth: u32 = 0;
+    let mut last_default_pos: Option<usize> = None;
+    let bytes = s.as_bytes();
+
+    let mut i = 0;
+    while i < bytes.len() {
+        if escape_next {
+            escape_next = false;
+            i += 1;
+            continue;
+        }
+
+        match bytes[i] {
+            b'\\' => {
+                escape_next = true;
+            }
+            b'"' => {
+                in_quotes = !in_quotes;
+            }
+            b'(' if !in_quotes => {
+                paren_depth = paren_depth.saturating_add(1);
+            }
+            b')' if !in_quotes => {
+                paren_depth = paren_depth.saturating_sub(1);
+            }
+            b'?' if !in_quotes && paren_depth == 0 => {
+                // Check for `??`
+                if i + 1 < bytes.len() && bytes[i + 1] == b'?' {
+                    last_default_pos = Some(i);
+                    i += 2; // skip both `?`
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    match last_default_pos {
+        Some(pos) => {
+            let path_part = &s[..pos].trim_end();
+            let default_part = &s[pos + 2..].trim_start();
+            Ok((path_part, Some(default_part)))
+        }
+        None => Ok((s, None)),
+    }
+}
+
+/// Split the path+transforms at the FIRST `|` outside quotes and parens.
+///
+/// Returns `(path, Some(transforms))` or `(path, None)`.
+fn split_transforms(s: &str) -> (&str, Option<&str>) {
+    let mut in_quotes = false;
+    let mut escape_next = false;
+    let mut paren_depth: u32 = 0;
+    let bytes = s.as_bytes();
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+
+        match b {
+            b'\\' => escape_next = true,
+            b'"' => in_quotes = !in_quotes,
+            b'(' if !in_quotes => paren_depth = paren_depth.saturating_add(1),
+            b')' if !in_quotes => paren_depth = paren_depth.saturating_sub(1),
+            b'|' if !in_quotes && paren_depth == 0 => {
+                return (&s[..i], Some(&s[i + 1..]));
+            }
+            _ => {}
+        }
+    }
+
+    (s, None)
+}
+
+/// Custom deserializer for WithEntry
+///
+/// Accepts two YAML formats:
+/// 1. String: `"$step1.data | upper ?? fallback"` → parsed by `parse_with_entry`
+/// 2. Object: `{ from: "$step1", type: string, transform: "upper", default: "x", lazy: true }`
+impl<'de> Deserialize<'de> for WithEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(WithEntryVisitor)
+    }
+}
+
+struct WithEntryVisitor;
+
+impl<'de> Visitor<'de> for WithEntryVisitor {
+    type Value = WithEntry;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(
+            "a string '$path | transform ?? default' or an object \
+             { from, type?, transform?, default?, lazy? }",
+        )
+    }
+
+    /// Handle string form: "$step1.data | upper ?? fallback"
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        parse_with_entry(value).map_err(|e| de::Error::custom(e.to_string()))
+    }
+
+    /// Handle object form: { from, type?, transform?, default?, lazy? }
+    fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        // Use a helper struct for the object form
+        #[derive(Deserialize)]
+        struct WithEntryObject {
+            from: String,
+            #[serde(rename = "type", default)]
+            binding_type: BindingType,
+            #[serde(default)]
+            transform: Option<String>,
+            #[serde(default)]
+            default: Option<Value>,
+            #[serde(default)]
+            lazy: bool,
+        }
+
+        let obj = WithEntryObject::deserialize(de::value::MapAccessDeserializer::new(map))?;
+
+        // Parse `from:` as BindingPath
+        let source = BindingPath::parse(&obj.from)
+            .map_err(|e| de::Error::custom(format!("[NIKA-155] invalid 'from' path: {e}")))?;
+
+        // Parse `transform:` as TransformExpr (if present)
+        let transform = match obj.transform {
+            Some(ref t_str) if !t_str.trim().is_empty() => Some(
+                TransformExpr::parse(t_str.trim())
+                    .map_err(|e| de::Error::custom(format!("[NIKA-155] invalid transform: {e}")))?,
+            ),
+            _ => None,
+        };
+
+        Ok(WithEntry {
+            source,
+            binding_type: obj.binding_type,
+            default: obj.default,
+            lazy: obj.lazy,
+            transform,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::transform::TransformOp;
+    use super::super::types::BindingSource;
+    use serde_saphyr as serde_yaml;
+    use serde_json::json;
+
+    // ═══════════════════════════════════════════════════════════════
+    // parse_binding_entry() tests - TDD: write these first
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn parse_simple_path() {
+        let entry = parse_binding_entry("weather.summary").unwrap();
+        assert_eq!(entry.path, "weather.summary");
+        assert_eq!(entry.default, None);
+    }
+
+    #[test]
+    fn parse_simple_task_only() {
+        let entry = parse_binding_entry("weather").unwrap();
+        assert_eq!(entry.path, "weather");
+        assert_eq!(entry.default, None);
+    }
+
+    #[test]
+    fn parse_nested_path() {
+        let entry = parse_binding_entry("weather.data.temperature.celsius").unwrap();
+        assert_eq!(entry.path, "weather.data.temperature.celsius");
+        assert_eq!(entry.default, None);
+    }
+
+    #[test]
+    fn parse_with_default_number() {
+        let entry = parse_binding_entry("x.y ?? 0").unwrap();
+        assert_eq!(entry.path, "x.y");
+        assert_eq!(entry.default, Some(json!(0)));
+    }
+
+    #[test]
+    fn parse_with_default_negative_number() {
+        let entry = parse_binding_entry("score ?? -1").unwrap();
+        assert_eq!(entry.path, "score");
+        assert_eq!(entry.default, Some(json!(-1)));
+    }
+
+    #[test]
+    fn parse_with_default_float() {
+        let entry = parse_binding_entry("rate ?? 0.5").unwrap();
+        assert_eq!(entry.path, "rate");
+        assert_eq!(entry.default, Some(json!(0.5)));
+    }
+
+    #[test]
+    fn parse_with_default_string() {
+        let entry = parse_binding_entry(r#"x.y ?? "Anon""#).unwrap();
+        assert_eq!(entry.path, "x.y");
+        assert_eq!(entry.default, Some(json!("Anon")));
+    }
+
+    #[test]
+    fn parse_with_default_empty_string() {
+        let entry = parse_binding_entry(r#"name ?? """#).unwrap();
+        assert_eq!(entry.path, "name");
+        assert_eq!(entry.default, Some(json!("")));
+    }
+
+    #[test]
+    fn parse_with_default_bool_true() {
+        let entry = parse_binding_entry("enabled ?? true").unwrap();
+        assert_eq!(entry.path, "enabled");
+        assert_eq!(entry.default, Some(json!(true)));
+    }
+
+    #[test]
+    fn parse_with_default_bool_false() {
+        let entry = parse_binding_entry("enabled ?? false").unwrap();
+        assert_eq!(entry.path, "enabled");
+        assert_eq!(entry.default, Some(json!(false)));
+    }
+
+    #[test]
+    fn parse_with_default_null() {
+        let entry = parse_binding_entry("value ?? null").unwrap();
+        assert_eq!(entry.path, "value");
+        assert_eq!(entry.default, Some(json!(null)));
+    }
+
+    #[test]
+    fn parse_with_default_object() {
+        let entry = parse_binding_entry(r#"x ?? {"a": 1, "b": 2}"#).unwrap();
+        assert_eq!(entry.path, "x");
+        assert_eq!(entry.default, Some(json!({"a": 1, "b": 2})));
+    }
+
+    #[test]
+    fn parse_with_default_array() {
+        let entry = parse_binding_entry(r#"tags ?? ["untagged"]"#).unwrap();
+        assert_eq!(entry.path, "tags");
+        assert_eq!(entry.default, Some(json!(["untagged"])));
+    }
+
+    #[test]
+    fn parse_with_default_nested_object() {
+        let entry = parse_binding_entry(r#"cfg ?? {"debug": false, "nested": {"a": 1}}"#).unwrap();
+        assert_eq!(entry.path, "cfg");
+        assert_eq!(
+            entry.default,
+            Some(json!({"debug": false, "nested": {"a": 1}}))
+        );
+    }
+
+    #[test]
+    fn parse_quotes_in_default() {
+        // The ?? inside quotes should be ignored
+        let entry = parse_binding_entry(r#"x ?? "What?? Really??""#).unwrap();
+        assert_eq!(entry.path, "x");
+        assert_eq!(entry.default, Some(json!("What?? Really??")));
+    }
+
+    #[test]
+    fn parse_escaped_quotes_in_default() {
+        let entry = parse_binding_entry(r#"x ?? "He said \"hello\"""#).unwrap();
+        assert_eq!(entry.path, "x");
+        assert_eq!(entry.default, Some(json!("He said \"hello\"")));
+    }
+
+    #[test]
+    fn parse_with_whitespace() {
+        let entry = parse_binding_entry("  weather.summary  ").unwrap();
+        assert_eq!(entry.path, "weather.summary");
+    }
+
+    #[test]
+    fn parse_with_whitespace_around_operator() {
+        let entry = parse_binding_entry("x  ??  0").unwrap();
+        assert_eq!(entry.path, "x");
+        assert_eq!(entry.default, Some(json!(0)));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Error cases - TDD: these should fail appropriately
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn parse_reject_unquoted_string() {
+        // "Anonymous" without quotes is invalid JSON
+        let result = parse_binding_entry("x ?? Anonymous");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("NIKA-056"));
+    }
+
+    #[test]
+    fn parse_reject_empty_path() {
+        let result = parse_binding_entry("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_reject_only_operator() {
+        let result = parse_binding_entry("??");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_reject_empty_path_with_default() {
+        let result = parse_binding_entry("?? 0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_reject_invalid_json_default() {
+        // Missing closing brace
+        let result = parse_binding_entry(r#"x ?? {"a": 1"#);
+        assert!(result.is_err());
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // task_id() extraction tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn task_id_simple() {
+        let entry = BindingEntry::new("weather");
+        assert_eq!(entry.task_id(), "weather");
+    }
+
+    #[test]
+    fn task_id_with_path() {
+        let entry = BindingEntry::new("weather.summary");
+        assert_eq!(entry.task_id(), "weather");
+    }
+
+    #[test]
+    fn task_id_with_nested_path() {
+        let entry = BindingEntry::new("weather.data.temp.celsius");
+        assert_eq!(entry.task_id(), "weather");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // YAML deserialization tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn yaml_parse_simple() {
+        let yaml = "forecast: weather.summary";
+        let spec: BindingSpec = serde_yaml::from_str(yaml).unwrap();
+        let entry = spec.get("forecast").unwrap();
+        assert_eq!(entry.path, "weather.summary");
+        assert_eq!(entry.default, None);
+    }
+
+    #[test]
+    fn yaml_parse_with_default() {
+        let yaml = r#"temp: weather.temp ?? 20"#;
+        let spec: BindingSpec = serde_yaml::from_str(yaml).unwrap();
+        let entry = spec.get("temp").unwrap();
+        assert_eq!(entry.path, "weather.temp");
+        assert_eq!(entry.default, Some(json!(20)));
+    }
+
+    #[test]
+    fn yaml_parse_multiple_entries() {
+        let yaml = r#"
+forecast: weather.summary
+temp: weather.temp ?? 20
+name: user.name ?? "Anonymous"
+"#;
+        let spec: BindingSpec = serde_yaml::from_str(yaml).unwrap();
+
+        let forecast = spec.get("forecast").unwrap();
+        assert_eq!(forecast.path, "weather.summary");
+        assert_eq!(forecast.default, None);
+
+        let temp = spec.get("temp").unwrap();
+        assert_eq!(temp.path, "weather.temp");
+        assert_eq!(temp.default, Some(json!(20)));
+
+        let name = spec.get("name").unwrap();
+        assert_eq!(name.path, "user.name");
+        assert_eq!(name.default, Some(json!("Anonymous")));
+    }
+
+    #[test]
+    fn yaml_parse_complex_defaults() {
+        // Note: Complex JSON defaults need to be quoted in YAML
+        // because {} and [] have special meaning in YAML
+        let yaml = r#"
+cfg: 'settings ?? {"debug": false}'
+tags: 'meta.tags ?? ["default"]'
+"#;
+        let spec: BindingSpec = serde_yaml::from_str(yaml).unwrap();
+
+        let cfg = spec.get("cfg").unwrap();
+        assert_eq!(cfg.default, Some(json!({"debug": false})));
+
+        let tags = spec.get("tags").unwrap();
+        assert_eq!(tags.default, Some(json!(["default"])));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // find_operator_outside_quotes() tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn find_op_simple() {
+        assert_eq!(find_operator_outside_quotes("a ?? b", "??"), Some(2));
+    }
+
+    #[test]
+    fn find_op_no_match() {
+        assert_eq!(find_operator_outside_quotes("a.b.c", "??"), None);
+    }
+
+    #[test]
+    fn find_op_inside_quotes_ignored() {
+        // The ?? inside quotes should be ignored
+        let s = r#"x ?? "What?? Really??""#;
+        assert_eq!(find_operator_outside_quotes(s, "??"), Some(2));
+    }
+
+    #[test]
+    fn find_op_only_inside_quotes() {
+        let s = r#""a ?? b""#;
+        assert_eq!(find_operator_outside_quotes(s, "??"), None);
+    }
+
+    #[test]
+    fn find_op_multiple_operators() {
+        // Should find first one outside quotes
+        let s = "a ?? b ?? c";
+        assert_eq!(find_operator_outside_quotes(s, "??"), Some(2));
+    }
+
+    #[test]
+    fn find_op_with_escaped_quote() {
+        let s = r#"x ?? "He said \"??\"""#;
+        assert_eq!(find_operator_outside_quotes(s, "??"), Some(2));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // normalize_path() tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_normalize_path_strips_dollar_prefix() {
+        assert_eq!(BindingEntry::normalize_path("$task1"), "task1");
+        assert_eq!(BindingEntry::normalize_path("task1"), "task1");
+        assert_eq!(BindingEntry::normalize_path("$my_task"), "my_task");
+        assert_eq!(BindingEntry::normalize_path("task.field"), "task.field");
+        assert_eq!(BindingEntry::normalize_path("$task.field"), "task.field");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Deserialization normalization tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_binding_entry_deserialize_normalizes_dollar_prefix_shorthand() {
+        // Shorthand: "$task1" → BindingEntry { path: "task1", ... }
+        let entry: BindingEntry = serde_yaml::from_str("\"$task1\"").unwrap();
+        assert_eq!(entry.path, "task1");
+
+        // Without prefix should also work
+        let entry: BindingEntry = serde_yaml::from_str("\"task1\"").unwrap();
+        assert_eq!(entry.path, "task1");
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_normalizes_dollar_prefix_full_form() {
+        // Full form with $ prefix in path field
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "$my_task"
+            default: "fallback"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "my_task");
+        assert_eq!(
+            entry.default.as_ref().map(|v| v.as_str()),
+            Some(Some("fallback"))
+        );
+
+        // Without prefix should also work
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "my_task"
+            lazy: true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "my_task");
+        assert!(entry.lazy);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Comprehensive edge case tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_normalize_path_edge_cases() {
+        // Multiple $ prefixes - only strip first
+        assert_eq!(BindingEntry::normalize_path("$$task"), "$task");
+        assert_eq!(BindingEntry::normalize_path("$$$task"), "$$task");
+
+        // $ in middle or end - should NOT be stripped
+        assert_eq!(BindingEntry::normalize_path("ta$sk"), "ta$sk");
+        assert_eq!(BindingEntry::normalize_path("task$"), "task$");
+        assert_eq!(BindingEntry::normalize_path("ta$sk$"), "ta$sk$");
+
+        // Nested field access with $ prefix
+        assert_eq!(
+            BindingEntry::normalize_path("$task.field.subfield"),
+            "task.field.subfield"
+        );
+        assert_eq!(
+            BindingEntry::normalize_path("$task.nested.deep.path"),
+            "task.nested.deep.path"
+        );
+
+        // Empty string and edge cases
+        assert_eq!(BindingEntry::normalize_path(""), "");
+        assert_eq!(BindingEntry::normalize_path("$"), "");
+        assert_eq!(BindingEntry::normalize_path("$$"), "$");
+
+        // Just dots
+        assert_eq!(BindingEntry::normalize_path("$."), ".");
+        assert_eq!(BindingEntry::normalize_path("$.."), "..");
+        assert_eq!(BindingEntry::normalize_path(".task"), ".task");
+        assert_eq!(BindingEntry::normalize_path("$.task"), ".task");
+
+        // Unicode paths (should work fine)
+        assert_eq!(BindingEntry::normalize_path("$résultat"), "résultat");
+        assert_eq!(BindingEntry::normalize_path("$задача"), "задача");
+
+        // Whitespace handling (normalize_path doesn't trim)
+        assert_eq!(BindingEntry::normalize_path("$ task"), " task");
+        assert_eq!(BindingEntry::normalize_path("$task "), "task ");
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_nested_field_access() {
+        // Shorthand form with nested field access
+        let entry: BindingEntry = serde_yaml::from_str("\"$research.summary.title\"").unwrap();
+        assert_eq!(entry.path, "research.summary.title");
+
+        // Full form with nested field access
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "$agent_result.response.data.items"
+            lazy: true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "agent_result.response.data.items");
+        assert!(entry.lazy);
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_multiple_dollar_signs() {
+        // Multiple $ at start - only first stripped
+        let entry: BindingEntry = serde_yaml::from_str("\"$$task\"").unwrap();
+        assert_eq!(entry.path, "$task");
+
+        let entry: BindingEntry = serde_yaml::from_str("\"$$$triple\"").unwrap();
+        assert_eq!(entry.path, "$$triple");
+
+        // Full form with multiple $
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "$$escaped_var"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "$escaped_var");
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_dollar_in_middle() {
+        // $ in middle should be preserved
+        let entry: BindingEntry = serde_yaml::from_str("\"task$name\"").unwrap();
+        assert_eq!(entry.path, "task$name");
+
+        let entry: BindingEntry = serde_yaml::from_str("\"$task$name\"").unwrap();
+        assert_eq!(entry.path, "task$name");
+
+        // Full form
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "result$2"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "result$2");
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_special_characters() {
+        // Underscores and numbers (common in task IDs)
+        let entry: BindingEntry = serde_yaml::from_str("\"$task_123\"").unwrap();
+        assert_eq!(entry.path, "task_123");
+
+        let entry: BindingEntry = serde_yaml::from_str("\"$_private_task\"").unwrap();
+        assert_eq!(entry.path, "_private_task");
+
+        // Hyphens
+        let entry: BindingEntry = serde_yaml::from_str("\"$task-name\"").unwrap();
+        assert_eq!(entry.path, "task-name");
+
+        // Mixed
+        let entry: BindingEntry = serde_yaml::from_str("\"$task_1-result.field_2\"").unwrap();
+        assert_eq!(entry.path, "task_1-result.field_2");
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_with_all_options() {
+        // Full form with $ prefix and all options set
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "$complex_task.nested.value"
+            default: "default_value"
+            lazy: true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "complex_task.nested.value");
+        assert_eq!(
+            entry.default.as_ref().map(|v| v.as_str()),
+            Some(Some("default_value"))
+        );
+        assert!(entry.lazy);
+    }
+
+    #[test]
+    fn test_binding_entry_equivalence_with_and_without_dollar() {
+        // These should produce identical BindingEntry instances
+        let with_dollar: BindingEntry = serde_yaml::from_str("\"$my_task\"").unwrap();
+        let without_dollar: BindingEntry = serde_yaml::from_str("\"my_task\"").unwrap();
+
+        assert_eq!(with_dollar.path, without_dollar.path);
+        assert_eq!(with_dollar.default, without_dollar.default);
+        assert_eq!(with_dollar.lazy, without_dollar.lazy);
+    }
+
+    #[test]
+    fn test_binding_entry_deserialize_real_workflow_patterns() {
+        // Pattern: Simple task reference
+        let entry: BindingEntry = serde_yaml::from_str("\"$get_context\"").unwrap();
+        assert_eq!(entry.path, "get_context");
+
+        // Pattern: Output field access
+        let entry: BindingEntry = serde_yaml::from_str("\"$generate.content\"").unwrap();
+        assert_eq!(entry.path, "generate.content");
+
+        // Pattern: Agent result access
+        let entry: BindingEntry =
+            serde_yaml::from_str("\"$research_agent.findings.summary\"").unwrap();
+        assert_eq!(entry.path, "research_agent.findings.summary");
+
+        // Pattern: Lazy binding with default for optional task output
+        let entry: BindingEntry = serde_yaml::from_str(
+            r#"
+            path: "$optional_step.result"
+            default: null
+            lazy: true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "optional_step.result");
+        assert_eq!(entry.default, Some(serde_json::Value::Null));
+        assert!(entry.lazy);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry -- parse_with_entry() tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_parse_simple() {
+        let entry = parse_with_entry("$step1").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+        assert_eq!(entry.default, None);
+        assert_eq!(entry.transform, None);
+        assert!(!entry.lazy);
+        assert_eq!(entry.binding_type, BindingType::Any);
+    }
+
+    #[test]
+    fn with_parse_field_access() {
+        let entry = parse_with_entry("$step1.output").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1.output").unwrap());
+        assert_eq!(entry.default, None);
+        assert_eq!(entry.transform, None);
+    }
+
+    #[test]
+    fn with_parse_deep_path() {
+        let entry = parse_with_entry("$step1.data.items[0].name").unwrap();
+        assert_eq!(
+            entry.source,
+            BindingPath::parse("$step1.data.items[0].name").unwrap()
+        );
+    }
+
+    #[test]
+    fn with_parse_default_string() {
+        let entry = parse_with_entry(r#"$step1 ?? "fallback""#).unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+        assert_eq!(entry.default, Some(json!("fallback")));
+        assert_eq!(entry.transform, None);
+    }
+
+    #[test]
+    fn with_parse_default_number() {
+        let entry = parse_with_entry("$step1 ?? 42").unwrap();
+        assert_eq!(entry.default, Some(json!(42)));
+    }
+
+    #[test]
+    fn with_parse_default_float() {
+        let entry = parse_with_entry("$step1.score ?? 0.5").unwrap();
+        assert_eq!(entry.default, Some(json!(0.5)));
+    }
+
+    #[test]
+    fn with_parse_default_bool() {
+        let entry = parse_with_entry("$step1.enabled ?? true").unwrap();
+        assert_eq!(entry.default, Some(json!(true)));
+    }
+
+    #[test]
+    fn with_parse_default_null() {
+        let entry = parse_with_entry("$step1.val ?? null").unwrap();
+        assert_eq!(entry.default, Some(json!(null)));
+    }
+
+    #[test]
+    fn with_parse_default_array() {
+        let entry = parse_with_entry("$step1 ?? []").unwrap();
+        assert_eq!(entry.default, Some(json!([])));
+    }
+
+    #[test]
+    fn with_parse_default_object() {
+        let entry = parse_with_entry(r#"$step1 ?? {"key": "val"}"#).unwrap();
+        assert_eq!(entry.default, Some(json!({"key": "val"})));
+    }
+
+    #[test]
+    fn with_parse_transform_single() {
+        let entry = parse_with_entry("$step1 | upper").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+        assert!(entry.transform.is_some());
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops.len(), 1);
+        assert_eq!(t.ops[0], TransformOp::Upper);
+    }
+
+    #[test]
+    fn with_parse_transform_chain() {
+        let entry = parse_with_entry("$step1.items | sort | unique").unwrap();
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops.len(), 2);
+        assert_eq!(t.ops[0], TransformOp::Sort);
+        assert_eq!(t.ops[1], TransformOp::Unique);
+    }
+
+    #[test]
+    fn with_parse_transform_with_args() {
+        let entry = parse_with_entry("$step1.items | first(3)").unwrap();
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops.len(), 1);
+        assert_eq!(t.ops[0], TransformOp::FirstN(3));
+    }
+
+    #[test]
+    fn with_parse_transform_and_default() {
+        let entry = parse_with_entry("$step1.items | length ?? 0").unwrap();
+        assert!(entry.transform.is_some());
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops.len(), 1);
+        assert_eq!(t.ops[0], TransformOp::Length);
+        assert_eq!(entry.default, Some(json!(0)));
+    }
+
+    #[test]
+    fn with_parse_full_chain_and_default() {
+        let entry = parse_with_entry(r#"$step1.items | sort | first(3) ?? []"#).unwrap();
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops.len(), 2);
+        assert_eq!(t.ops[0], TransformOp::Sort);
+        assert_eq!(t.ops[1], TransformOp::FirstN(3));
+        assert_eq!(entry.default, Some(json!([])));
+    }
+
+    #[test]
+    fn with_parse_context_ref() {
+        let entry = parse_with_entry("$context.files.brand").unwrap();
+        match &entry.source.source {
+            BindingSource::Context(path) => assert_eq!(path.as_ref(), "files.brand"),
+            _ => panic!("expected Context source"),
+        }
+    }
+
+    #[test]
+    fn with_parse_input_ref() {
+        let entry = parse_with_entry("$inputs.locale").unwrap();
+        match &entry.source.source {
+            BindingSource::Input(path) => assert_eq!(path.as_ref(), "locale"),
+            _ => panic!("expected Input source"),
+        }
+    }
+
+    #[test]
+    fn with_parse_env_ref() {
+        let entry = parse_with_entry("$env.API_URL").unwrap();
+        match &entry.source.source {
+            BindingSource::Env(path) => assert_eq!(path.as_ref(), "API_URL"),
+            _ => panic!("expected Env source"),
+        }
+    }
+
+    #[test]
+    fn with_parse_whitespace_tolerance() {
+        let entry = parse_with_entry("  $step1  |  upper  ").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops[0], TransformOp::Upper);
+    }
+
+    #[test]
+    fn with_parse_whitespace_around_default() {
+        let entry = parse_with_entry("$step1  ??  42").unwrap();
+        assert_eq!(entry.default, Some(json!(42)));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry error cases
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_parse_empty_string_error() {
+        let result = parse_with_entry("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().reason.contains("empty"));
+    }
+
+    #[test]
+    fn with_parse_no_dollar_error() {
+        let result = parse_with_entry("step1");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.reason.contains("must start with '$'"));
+    }
+
+    #[test]
+    fn with_parse_pipe_only_error() {
+        let result = parse_with_entry("| upper");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn with_parse_default_only_error() {
+        let result = parse_with_entry("?? 42");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn with_parse_trailing_pipe_error() {
+        let result = parse_with_entry("$step1 |");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().reason.contains("empty transform"));
+    }
+
+    #[test]
+    fn with_parse_invalid_json_default_error() {
+        let result = parse_with_entry(r#"$step1 ?? {broken"#);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().reason.contains("invalid default JSON"));
+    }
+
+    #[test]
+    fn with_parse_unquoted_string_default_error() {
+        let result = parse_with_entry("$step1 ?? Anonymous");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn with_parse_empty_default_error() {
+        // "$step1 ??" with nothing after
+        let result = parse_with_entry("$step1 ??");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().reason.contains("empty default"));
+    }
+
+    #[test]
+    fn with_parse_unknown_transform_error() {
+        let result = parse_with_entry("$step1 | nonexistent_transform");
+        assert!(result.is_err());
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry: default inside transform parens (edge case)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_parse_default_inside_parens_ignored() {
+        // The ?? inside default() should NOT be treated as the default separator
+        let entry = parse_with_entry(r#"$step1 | default("a ?? b")"#).unwrap();
+        assert!(entry.transform.is_some());
+        assert_eq!(entry.default, None); // No ?? outside parens
+    }
+
+    #[test]
+    fn with_parse_default_after_transform_with_inner_qq() {
+        // default("a ?? b") ?? "fallback"
+        let entry = parse_with_entry(r#"$step1 | default("a ?? b") ?? "fallback""#).unwrap();
+        assert!(entry.transform.is_some());
+        assert_eq!(entry.default, Some(json!("fallback")));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry helpers
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_entry_task_id() {
+        let entry = parse_with_entry("$step1.data.name").unwrap();
+        assert_eq!(entry.task_id(), Some("step1"));
+    }
+
+    #[test]
+    fn with_entry_task_id_context() {
+        let entry = parse_with_entry("$context.files.brand").unwrap();
+        assert_eq!(entry.task_id(), None);
+    }
+
+    #[test]
+    fn with_entry_simple_constructor() {
+        let path = BindingPath::parse("$step1.data").unwrap();
+        let entry = WithEntry::simple(path.clone());
+        assert_eq!(entry.source, path);
+        assert_eq!(entry.default, None);
+        assert!(!entry.lazy);
+        assert_eq!(entry.transform, None);
+    }
+
+    #[test]
+    fn with_entry_with_default_constructor() {
+        let path = BindingPath::parse("$step1").unwrap();
+        let entry = WithEntry::with_default(path.clone(), json!(42));
+        assert_eq!(entry.source, path);
+        assert_eq!(entry.default, Some(json!(42)));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry YAML deserialization (string form)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_deser_string_simple() {
+        let entry: WithEntry = serde_yaml::from_str("\"$step1\"").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+    }
+
+    #[test]
+    fn with_deser_string_with_transform() {
+        let entry: WithEntry = serde_yaml::from_str("\"$step1.name | upper\"").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1.name").unwrap());
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops[0], TransformOp::Upper);
+    }
+
+    #[test]
+    fn with_deser_string_with_default() {
+        let entry: WithEntry = serde_yaml::from_str(r#""$step1 ?? 42""#).unwrap();
+        assert_eq!(entry.default, Some(json!(42)));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry YAML deserialization (object form)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_deser_object_minimal() {
+        let entry: WithEntry = serde_yaml::from_str(
+            r#"
+            from: "$step1"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+        assert_eq!(entry.binding_type, BindingType::Any);
+        assert_eq!(entry.default, None);
+        assert!(!entry.lazy);
+        assert_eq!(entry.transform, None);
+    }
+
+    #[test]
+    fn with_deser_object_typed() {
+        let entry: WithEntry = serde_yaml::from_str(
+            r#"
+            from: "$step1.name"
+            type: string
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.binding_type, BindingType::String);
+    }
+
+    #[test]
+    fn with_deser_object_with_transform() {
+        let entry: WithEntry = serde_yaml::from_str(
+            r#"
+            from: "$step1.text"
+            transform: "upper | trim"
+            "#,
+        )
+        .unwrap();
+        let t = entry.transform.unwrap();
+        assert_eq!(t.ops.len(), 2);
+        assert_eq!(t.ops[0], TransformOp::Upper);
+        assert_eq!(t.ops[1], TransformOp::Trim);
+    }
+
+    #[test]
+    fn with_deser_object_full() {
+        let entry: WithEntry = serde_yaml::from_str(
+            r#"
+            from: "$step1.abstract"
+            type: string
+            transform: "lower | trim"
+            default: "No abstract"
+            lazy: true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1.abstract").unwrap());
+        assert_eq!(entry.binding_type, BindingType::String);
+        assert!(entry.transform.is_some());
+        assert_eq!(entry.default, Some(json!("No abstract")));
+        assert!(entry.lazy);
+    }
+
+    #[test]
+    fn with_deser_object_lazy() {
+        let entry: WithEntry = serde_yaml::from_str(
+            r#"
+            from: "$step1.result"
+            lazy: true
+            "#,
+        )
+        .unwrap();
+        assert!(entry.lazy);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithSpec deserialization (YAML map)
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_deser_spec_empty() {
+        let spec: WithSpec = serde_yaml::from_str("{}").unwrap();
+        assert!(spec.is_empty());
+    }
+
+    #[test]
+    fn with_deser_spec_single() {
+        let spec: WithSpec = serde_yaml::from_str(r#"result: "$step1""#).unwrap();
+        assert_eq!(spec.len(), 1);
+        let entry = spec.get("result").unwrap();
+        assert_eq!(entry.source, BindingPath::parse("$step1").unwrap());
+    }
+
+    #[test]
+    fn with_deser_spec_mixed() {
+        let yaml = r#"
+result: "$step1"
+title: "$step1.title | upper"
+summary:
+  from: "$step1.abstract"
+  type: string
+  transform: "lower | trim"
+  default: "N/A"
+  lazy: true
+"#;
+        let spec: WithSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.len(), 3);
+
+        // String form: simple ref
+        let result = spec.get("result").unwrap();
+        assert_eq!(result.source, BindingPath::parse("$step1").unwrap());
+        assert_eq!(result.transform, None);
+
+        // String form: with transform
+        let title = spec.get("title").unwrap();
+        assert_eq!(title.source, BindingPath::parse("$step1.title").unwrap());
+        let t = title.transform.as_ref().unwrap();
+        assert_eq!(t.ops[0], TransformOp::Upper);
+
+        // Object form: full
+        let summary = spec.get("summary").unwrap();
+        assert_eq!(
+            summary.source,
+            BindingPath::parse("$step1.abstract").unwrap()
+        );
+        assert_eq!(summary.binding_type, BindingType::String);
+        assert!(summary.lazy);
+        assert_eq!(summary.default, Some(json!("N/A")));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry object form error cases
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_deser_object_missing_from_error() {
+        let result: Result<WithEntry, _> = serde_yaml::from_str(
+            r#"
+            type: string
+            "#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn with_deser_object_invalid_path_error() {
+        let result: Result<WithEntry, _> = serde_yaml::from_str(
+            r#"
+            from: "step1"
+            "#,
+        );
+        // No $ prefix -> error
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn with_deser_object_invalid_transform_error() {
+        let result: Result<WithEntry, _> = serde_yaml::from_str(
+            r#"
+            from: "$step1"
+            transform: "nonexistent_op"
+            "#,
+        );
+        assert!(result.is_err());
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // split_default() edge cases
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn split_default_no_default() {
+        let (path, def) = split_default("$step1 | upper").unwrap();
+        assert_eq!(path, "$step1 | upper");
+        assert_eq!(def, None);
+    }
+
+    #[test]
+    fn split_default_simple() {
+        let (path, def) = split_default("$step1 ?? 42").unwrap();
+        assert_eq!(path, "$step1");
+        assert_eq!(def, Some("42"));
+    }
+
+    #[test]
+    fn split_default_inside_parens_ignored() {
+        let (path, def) = split_default(r#"$step1 | default("a ?? b")"#).unwrap();
+        assert_eq!(path, r#"$step1 | default("a ?? b")"#);
+        assert_eq!(def, None);
+    }
+
+    #[test]
+    fn split_default_after_parens() {
+        let (path, def) = split_default(r#"$step1 | default("inner") ?? "outer""#).unwrap();
+        assert_eq!(path, r#"$step1 | default("inner")"#);
+        assert_eq!(def, Some(r#""outer""#));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // split_transforms() edge cases
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn split_transforms_no_pipe() {
+        let (path, t) = split_transforms("$step1");
+        assert_eq!(path, "$step1");
+        assert_eq!(t, None);
+    }
+
+    #[test]
+    fn split_transforms_single() {
+        let (path, t) = split_transforms("$step1 | upper");
+        assert_eq!(path, "$step1 ");
+        assert_eq!(t, Some(" upper"));
+    }
+
+    #[test]
+    fn split_transforms_chain() {
+        // First pipe splits path from rest of transforms
+        let (path, t) = split_transforms("$step1 | sort | unique");
+        assert_eq!(path, "$step1 ");
+        assert_eq!(t, Some(" sort | unique"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntryParseError display
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_entry_parse_error_display() {
+        let err = WithEntryParseError {
+            input: "$bad".to_string(),
+            reason: "test error".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NIKA-155"));
+        assert!(msg.contains("$bad"));
+        assert!(msg.contains("test error"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // WithEntry: binding pattern tests
+    // ═══════════════════════════════════════════════════════════════
+
+    #[test]
+    fn with_simple_path() {
+        let entry = parse_with_entry("$step1").unwrap();
+        assert_eq!(entry.task_id(), Some("step1"));
+    }
+
+    #[test]
+    fn with_deep_path() {
+        let entry = parse_with_entry("$step1.data.name").unwrap();
+        assert_eq!(entry.task_id(), Some("step1"));
+        assert_eq!(entry.source.segments.len(), 2);
+    }
+
+    #[test]
+    fn with_default_string() {
+        let entry = parse_with_entry(r#"$step1 ?? "N/A""#).unwrap();
+        assert_eq!(entry.default, Some(json!("N/A")));
+    }
+}

--- a/tools/nika-core/src/binding/mod.rs
+++ b/tools/nika-core/src/binding/mod.rs
@@ -1,0 +1,22 @@
+//! Core Binding Types
+//!
+//! Pure type definitions for the binding system, with no runtime dependencies.
+//!
+//! - `types`: BindingPath, BindingSource, PathSegment, BindingType
+//! - `entry`: BindingSpec, BindingEntry, WithSpec, WithEntry, parse_with_entry
+//! - `transform`: TransformOp, TransformExpr, 27 built-in transforms
+//!
+//! Runtime-dependent modules (resolve, template, jsonpath, validate, mention)
+//! remain in the `nika` crate.
+
+mod entry;
+pub mod transform;
+pub mod types;
+
+// Re-export public types
+pub use entry::{
+    parse_binding_entry, parse_with_entry, BindingEntry, BindingSpec, WithEntry,
+    WithEntryParseError, WithSpec,
+};
+pub use transform::{TransformError, TransformExpr, TransformOp, TransformParseError};
+pub use types::{BindingPath, BindingPathError, BindingSource, BindingType, PathSegment};

--- a/tools/nika-core/src/binding/transform.rs
+++ b/tools/nika-core/src/binding/transform.rs
@@ -1,0 +1,1356 @@
+//! Transform Engine
+//!
+//! Pipeline transforms applied to binding values.
+//! Transforms are chained with `|` pipes: `sort | unique | first(3)`
+//!
+//! # Categories
+//!
+//! | Category | Ops |
+//! |----------|-----|
+//! | String | `upper`, `lower`, `trim`, `trim_start`, `trim_end` |
+//! | Collection | `length`, `first`, `last`, `first(N)`, `last(N)`, `keys`, `values`, `flatten`, `reverse`, `sort`, `unique`, `compact` |
+//! | Type conversion | `to_string`, `to_number`, `to_bool`, `to_json`, `parse_json` |
+//! | Numeric | `round(N)`, `abs`, `ceil`, `floor` |
+//! | Utility | `default(V)`, `type_of`, `join(S)`, `split(S)`, `shell` |
+//!
+//! # Null Handling
+//!
+//! - **Propagating**: null in → null out (`length`, `keys`, `type_of`, `to_string`, `to_json`)
+//! - **Failing**: null in → NIKA-153 error (`upper`, `lower`, `sort`, etc.)
+//! - Use `default()` or `??` to handle nulls safely
+
+use serde_json::Value;
+use smallvec::SmallVec;
+use std::fmt;
+
+/// A single transform operation
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransformOp {
+    // -- String --
+    Upper,
+    Lower,
+    Trim,
+    TrimStart,
+    TrimEnd,
+
+    // -- Collection --
+    Length,
+    First,
+    Last,
+    FirstN(usize),
+    LastN(usize),
+    Keys,
+    Values,
+    Flatten,
+    Reverse,
+    Sort,
+    Unique,
+    Compact, // remove nulls
+
+    // -- Type conversion --
+    ToString,
+    ToNumber,
+    ToBool,
+    ToJson,
+    ParseJson,
+
+    // -- Numeric --
+    Round(Option<u32>),
+    Abs,
+    Ceil,
+    Floor,
+
+    // -- Utility --
+    Default(Value),
+    TypeOf,
+    Join(String),
+    Split(String),
+    Shell,
+}
+
+/// A chain of transform operations: `sort | unique | first(3)`
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransformExpr {
+    pub ops: SmallVec<[TransformOp; 2]>,
+}
+
+/// Error parsing a transform expression (NIKA-151)
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransformParseError {
+    pub input: String,
+    pub reason: String,
+}
+
+impl fmt::Display for TransformParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[NIKA-151] Transform parse error in '{}': {}",
+            self.input, self.reason
+        )
+    }
+}
+
+impl std::error::Error for TransformParseError {}
+
+/// Error applying a transform (NIKA-152 type mismatch, NIKA-153 null input)
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransformError {
+    /// NIKA-152: Type mismatch
+    TypeMismatch {
+        op: &'static str,
+        expected: &'static str,
+        got: String,
+    },
+    /// NIKA-153: Null input on a failing transform
+    NullInput { op: &'static str },
+}
+
+impl fmt::Display for TransformError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransformError::TypeMismatch { op, expected, got } => {
+                write!(
+                    f,
+                    "[NIKA-152] Transform '{}' failed: expected {}, got {}",
+                    op, expected, got
+                )
+            }
+            TransformError::NullInput { op } => {
+                write!(
+                    f,
+                    "[NIKA-153] Transform '{}' received null — use default() to handle",
+                    op
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TransformError {}
+
+// ═══════════════════════════════════════════════════════════════
+// TransformExpr
+// ═══════════════════════════════════════════════════════════════
+
+impl TransformExpr {
+    /// Parse a pipe-separated transform expression.
+    ///
+    /// Examples: `"sort | unique | first(3)"`, `"upper"`, `""`
+    pub fn parse(input: &str) -> Result<Self, TransformParseError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Ok(TransformExpr {
+                ops: SmallVec::new(),
+            });
+        }
+
+        let ops: SmallVec<[TransformOp; 2]> = trimmed
+            .split('|')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| parse_single_op(s, input))
+            .collect::<Result<_, _>>()?;
+
+        Ok(TransformExpr { ops })
+    }
+
+    /// Apply all transforms in sequence to a value.
+    pub fn apply(&self, value: &Value) -> Result<Value, TransformError> {
+        let mut current = value.clone();
+        for op in &self.ops {
+            current = op.apply(&current)?;
+        }
+        Ok(current)
+    }
+
+    /// Returns true if this expression is empty (no-op).
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// TransformOp::apply
+// ═══════════════════════════════════════════════════════════════
+
+impl TransformOp {
+    /// Apply this single transform to a JSON value.
+    pub fn apply(&self, value: &Value) -> Result<Value, TransformError> {
+        match self {
+            // ── String ───────────────────────────────────────
+            TransformOp::Upper => match value {
+                Value::Null => Err(TransformError::NullInput { op: "upper" }),
+                Value::String(s) => Ok(Value::String(s.to_uppercase())),
+                _ => Err(type_mismatch("upper", "string", value)),
+            },
+            TransformOp::Lower => match value {
+                Value::Null => Err(TransformError::NullInput { op: "lower" }),
+                Value::String(s) => Ok(Value::String(s.to_lowercase())),
+                _ => Err(type_mismatch("lower", "string", value)),
+            },
+            TransformOp::Trim => match value {
+                Value::Null => Err(TransformError::NullInput { op: "trim" }),
+                Value::String(s) => Ok(Value::String(s.trim().to_string())),
+                _ => Err(type_mismatch("trim", "string", value)),
+            },
+            TransformOp::TrimStart => match value {
+                Value::Null => Err(TransformError::NullInput { op: "trim_start" }),
+                Value::String(s) => Ok(Value::String(s.trim_start().to_string())),
+                _ => Err(type_mismatch("trim_start", "string", value)),
+            },
+            TransformOp::TrimEnd => match value {
+                Value::Null => Err(TransformError::NullInput { op: "trim_end" }),
+                Value::String(s) => Ok(Value::String(s.trim_end().to_string())),
+                _ => Err(type_mismatch("trim_end", "string", value)),
+            },
+
+            // ── Collection ───────────────────────────────────
+            TransformOp::Length => match value {
+                Value::Null => Ok(Value::Null), // propagating
+                Value::Array(arr) => Ok(Value::Number(arr.len().into())),
+                Value::String(s) => Ok(Value::Number(s.len().into())),
+                Value::Object(obj) => Ok(Value::Number(obj.len().into())),
+                _ => Err(type_mismatch("length", "array, string, or object", value)),
+            },
+            TransformOp::First => match value {
+                Value::Null => Err(TransformError::NullInput { op: "first" }),
+                Value::Array(arr) => Ok(arr.first().cloned().unwrap_or(Value::Null)),
+                _ => Err(type_mismatch("first", "array", value)),
+            },
+            TransformOp::Last => match value {
+                Value::Null => Err(TransformError::NullInput { op: "last" }),
+                Value::Array(arr) => Ok(arr.last().cloned().unwrap_or(Value::Null)),
+                _ => Err(type_mismatch("last", "array", value)),
+            },
+            TransformOp::FirstN(n) => match value {
+                Value::Null => Err(TransformError::NullInput { op: "first" }),
+                Value::Array(arr) => {
+                    let taken: Vec<Value> = arr.iter().take(*n).cloned().collect();
+                    Ok(Value::Array(taken))
+                }
+                _ => Err(type_mismatch("first", "array", value)),
+            },
+            TransformOp::LastN(n) => match value {
+                Value::Null => Err(TransformError::NullInput { op: "last" }),
+                Value::Array(arr) => {
+                    let skip = arr.len().saturating_sub(*n);
+                    let taken: Vec<Value> = arr.iter().skip(skip).cloned().collect();
+                    Ok(Value::Array(taken))
+                }
+                _ => Err(type_mismatch("last", "array", value)),
+            },
+            TransformOp::Keys => match value {
+                Value::Null => Ok(Value::Null), // propagating
+                Value::Object(obj) => {
+                    let keys: Vec<Value> = obj.keys().map(|k| Value::String(k.clone())).collect();
+                    Ok(Value::Array(keys))
+                }
+                _ => Err(type_mismatch("keys", "object", value)),
+            },
+            TransformOp::Values => match value {
+                Value::Null => Err(TransformError::NullInput { op: "values" }),
+                Value::Object(obj) => {
+                    let vals: Vec<Value> = obj.values().cloned().collect();
+                    Ok(Value::Array(vals))
+                }
+                _ => Err(type_mismatch("values", "object", value)),
+            },
+            TransformOp::Flatten => match value {
+                Value::Null => Err(TransformError::NullInput { op: "flatten" }),
+                Value::Array(arr) => {
+                    let mut flat = Vec::new();
+                    for item in arr {
+                        match item {
+                            Value::Array(inner) => flat.extend(inner.iter().cloned()),
+                            other => flat.push(other.clone()),
+                        }
+                    }
+                    Ok(Value::Array(flat))
+                }
+                _ => Err(type_mismatch("flatten", "array", value)),
+            },
+            TransformOp::Reverse => match value {
+                Value::Null => Err(TransformError::NullInput { op: "reverse" }),
+                Value::Array(arr) => {
+                    let mut rev = arr.clone();
+                    rev.reverse();
+                    Ok(Value::Array(rev))
+                }
+                _ => Err(type_mismatch("reverse", "array", value)),
+            },
+            TransformOp::Sort => match value {
+                Value::Null => Err(TransformError::NullInput { op: "sort" }),
+                Value::Array(arr) => {
+                    let mut sorted = arr.clone();
+                    sorted.sort_by_key(|a| a.to_string());
+                    Ok(Value::Array(sorted))
+                }
+                _ => Err(type_mismatch("sort", "array", value)),
+            },
+            TransformOp::Unique => match value {
+                Value::Null => Err(TransformError::NullInput { op: "unique" }),
+                Value::Array(arr) => {
+                    let mut seen = Vec::new();
+                    let mut unique = Vec::new();
+                    for item in arr {
+                        let s = item.to_string();
+                        if !seen.contains(&s) {
+                            seen.push(s);
+                            unique.push(item.clone());
+                        }
+                    }
+                    Ok(Value::Array(unique))
+                }
+                _ => Err(type_mismatch("unique", "array", value)),
+            },
+            TransformOp::Compact => match value {
+                Value::Null => Err(TransformError::NullInput { op: "compact" }),
+                Value::Array(arr) => {
+                    let compacted: Vec<Value> =
+                        arr.iter().filter(|v| !v.is_null()).cloned().collect();
+                    Ok(Value::Array(compacted))
+                }
+                _ => Err(type_mismatch("compact", "array", value)),
+            },
+
+            // ── Type conversion ──────────────────────────────
+            TransformOp::ToString => match value {
+                Value::Null => Ok(Value::Null), // propagating
+                Value::String(_) => Ok(value.clone()),
+                Value::Number(n) => Ok(Value::String(n.to_string())),
+                Value::Bool(b) => Ok(Value::String(b.to_string())),
+                _ => Ok(Value::String(value.to_string())),
+            },
+            TransformOp::ToNumber => match value {
+                Value::Null => Err(TransformError::NullInput { op: "to_number" }),
+                Value::Number(_) => Ok(value.clone()),
+                Value::String(s) => {
+                    if let Ok(n) = s.parse::<i64>() {
+                        Ok(Value::Number(n.into()))
+                    } else if let Ok(f) = s.parse::<f64>() {
+                        Ok(serde_json::Number::from_f64(f)
+                            .map(Value::Number)
+                            .unwrap_or(Value::Null))
+                    } else {
+                        Err(TransformError::TypeMismatch {
+                            op: "to_number",
+                            expected: "numeric string",
+                            got: format!("\"{}\"", s),
+                        })
+                    }
+                }
+                Value::Bool(b) => Ok(Value::Number(if *b { 1 } else { 0 }.into())),
+                _ => Err(type_mismatch("to_number", "string, number, or bool", value)),
+            },
+            TransformOp::ToBool => match value {
+                Value::Null => Err(TransformError::NullInput { op: "to_bool" }),
+                Value::Bool(_) => Ok(value.clone()),
+                Value::Number(n) => Ok(Value::Bool(n.as_f64().map(|f| f != 0.0).unwrap_or(false))),
+                Value::String(s) => match s.as_str() {
+                    "true" | "1" | "yes" => Ok(Value::Bool(true)),
+                    "false" | "0" | "no" | "" => Ok(Value::Bool(false)),
+                    _ => Err(TransformError::TypeMismatch {
+                        op: "to_bool",
+                        expected: "truthy/falsy value",
+                        got: format!("\"{}\"", s),
+                    }),
+                },
+                _ => Err(type_mismatch("to_bool", "string, number, or bool", value)),
+            },
+            TransformOp::ToJson => match value {
+                Value::Null => Ok(Value::Null), // propagating
+                _ => Ok(Value::String(
+                    serde_json::to_string(value).unwrap_or_default(),
+                )),
+            },
+            TransformOp::ParseJson => match value {
+                Value::Null => Err(TransformError::NullInput { op: "parse_json" }),
+                Value::String(s) => {
+                    serde_json::from_str(s).map_err(|_| TransformError::TypeMismatch {
+                        op: "parse_json",
+                        expected: "valid JSON string",
+                        got: format!("\"{}\"", truncate(s, 50)),
+                    })
+                }
+                _ => Err(type_mismatch("parse_json", "string", value)),
+            },
+
+            // ── Numeric ──────────────────────────────────────
+            TransformOp::Round(decimals) => match value {
+                Value::Null => Err(TransformError::NullInput { op: "round" }),
+                Value::Number(n) => {
+                    let f = n.as_f64().unwrap_or(0.0);
+                    let d = decimals.unwrap_or(0);
+                    let factor = 10f64.powi(d as i32);
+                    let rounded = (f * factor).round() / factor;
+                    Ok(serde_json::Number::from_f64(rounded)
+                        .map(Value::Number)
+                        .unwrap_or(Value::Null))
+                }
+                _ => Err(type_mismatch("round", "number", value)),
+            },
+            TransformOp::Abs => match value {
+                Value::Null => Err(TransformError::NullInput { op: "abs" }),
+                Value::Number(n) => {
+                    if let Some(i) = n.as_i64() {
+                        Ok(Value::Number(i.unsigned_abs().into()))
+                    } else if let Some(f) = n.as_f64() {
+                        Ok(serde_json::Number::from_f64(f.abs())
+                            .map(Value::Number)
+                            .unwrap_or(Value::Null))
+                    } else {
+                        Ok(value.clone())
+                    }
+                }
+                _ => Err(type_mismatch("abs", "number", value)),
+            },
+            TransformOp::Ceil => match value {
+                Value::Null => Err(TransformError::NullInput { op: "ceil" }),
+                Value::Number(n) => {
+                    let f = n.as_f64().unwrap_or(0.0);
+                    Ok(Value::Number((f.ceil() as i64).into()))
+                }
+                _ => Err(type_mismatch("ceil", "number", value)),
+            },
+            TransformOp::Floor => match value {
+                Value::Null => Err(TransformError::NullInput { op: "floor" }),
+                Value::Number(n) => {
+                    let f = n.as_f64().unwrap_or(0.0);
+                    Ok(Value::Number((f.floor() as i64).into()))
+                }
+                _ => Err(type_mismatch("floor", "number", value)),
+            },
+
+            // ── Utility ──────────────────────────────────────
+            TransformOp::Default(default_val) => {
+                if value.is_null() {
+                    Ok(default_val.clone())
+                } else {
+                    Ok(value.clone())
+                }
+            }
+            TransformOp::TypeOf => {
+                let name = value_type_name(value);
+                Ok(Value::String(name.to_string()))
+            }
+            TransformOp::Join(sep) => match value {
+                Value::Null => Err(TransformError::NullInput { op: "join" }),
+                Value::Array(arr) => {
+                    let strings: Vec<String> = arr
+                        .iter()
+                        .map(|v| match v {
+                            Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        })
+                        .collect();
+                    Ok(Value::String(strings.join(sep)))
+                }
+                _ => Err(type_mismatch("join", "array", value)),
+            },
+            TransformOp::Split(sep) => match value {
+                Value::Null => Err(TransformError::NullInput { op: "split" }),
+                Value::String(s) => {
+                    let parts: Vec<Value> = s
+                        .split(sep.as_str())
+                        .map(|p| Value::String(p.to_string()))
+                        .collect();
+                    Ok(Value::Array(parts))
+                }
+                _ => Err(type_mismatch("split", "string", value)),
+            },
+            TransformOp::Shell => {
+                // Shell escaping — delegate to existing template::escape_for_shell logic
+                match value {
+                    Value::String(s) => Ok(Value::String(shell_escape(s))),
+                    _ => Ok(Value::String(value.to_string())),
+                }
+            }
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Pipe Parser
+// ═══════════════════════════════════════════════════════════════
+
+/// Parse a single transform op from string.
+///
+/// Examples: `"upper"`, `"first(3)"`, `"join(', ')"`, `"default('N/A')"`, `"round(2)"`
+fn parse_single_op(input: &str, full_input: &str) -> Result<TransformOp, TransformParseError> {
+    let trimmed = input.trim();
+
+    // Check for parameterized form: name(arg)
+    if let Some(paren_pos) = trimmed.find('(') {
+        let name = trimmed[..paren_pos].trim();
+        let rest = &trimmed[paren_pos + 1..];
+        let arg = rest
+            .strip_suffix(')')
+            .ok_or_else(|| TransformParseError {
+                input: full_input.to_string(),
+                reason: format!("unclosed parenthesis in '{}'", trimmed),
+            })?
+            .trim();
+
+        match name {
+            "first" => {
+                let n: usize = arg.parse().map_err(|_| TransformParseError {
+                    input: full_input.to_string(),
+                    reason: format!("invalid argument for first(): '{}'", arg),
+                })?;
+                Ok(TransformOp::FirstN(n))
+            }
+            "last" => {
+                let n: usize = arg.parse().map_err(|_| TransformParseError {
+                    input: full_input.to_string(),
+                    reason: format!("invalid argument for last(): '{}'", arg),
+                })?;
+                Ok(TransformOp::LastN(n))
+            }
+            "round" => {
+                let d: u32 = arg.parse().map_err(|_| TransformParseError {
+                    input: full_input.to_string(),
+                    reason: format!("invalid argument for round(): '{}'", arg),
+                })?;
+                Ok(TransformOp::Round(Some(d)))
+            }
+            "join" => {
+                let sep = strip_quotes(arg);
+                Ok(TransformOp::Join(sep.to_string()))
+            }
+            "split" => {
+                let sep = strip_quotes(arg);
+                Ok(TransformOp::Split(sep.to_string()))
+            }
+            "default" => {
+                let val = parse_default_value(arg).map_err(|reason| TransformParseError {
+                    input: full_input.to_string(),
+                    reason,
+                })?;
+                Ok(TransformOp::Default(val))
+            }
+            _ => Err(TransformParseError {
+                input: full_input.to_string(),
+                reason: format!("unknown transform: '{}'", name),
+            }),
+        }
+    } else {
+        // Simple name (no args)
+        match trimmed {
+            "upper" => Ok(TransformOp::Upper),
+            "lower" => Ok(TransformOp::Lower),
+            "trim" => Ok(TransformOp::Trim),
+            "trim_start" => Ok(TransformOp::TrimStart),
+            "trim_end" => Ok(TransformOp::TrimEnd),
+            "length" => Ok(TransformOp::Length),
+            "first" => Ok(TransformOp::First),
+            "last" => Ok(TransformOp::Last),
+            "keys" => Ok(TransformOp::Keys),
+            "values" => Ok(TransformOp::Values),
+            "flatten" => Ok(TransformOp::Flatten),
+            "reverse" => Ok(TransformOp::Reverse),
+            "sort" => Ok(TransformOp::Sort),
+            "unique" => Ok(TransformOp::Unique),
+            "compact" => Ok(TransformOp::Compact),
+            "to_string" => Ok(TransformOp::ToString),
+            "to_number" => Ok(TransformOp::ToNumber),
+            "to_bool" => Ok(TransformOp::ToBool),
+            "to_json" => Ok(TransformOp::ToJson),
+            "parse_json" => Ok(TransformOp::ParseJson),
+            "round" => Ok(TransformOp::Round(None)),
+            "abs" => Ok(TransformOp::Abs),
+            "ceil" => Ok(TransformOp::Ceil),
+            "floor" => Ok(TransformOp::Floor),
+            "type_of" => Ok(TransformOp::TypeOf),
+            "shell" => Ok(TransformOp::Shell),
+            _ => Err(TransformParseError {
+                input: full_input.to_string(),
+                reason: format!("unknown transform: '{}'", trimmed),
+            }),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════
+
+/// Get a human-readable type name for a JSON value.
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Helper to create TypeMismatch errors.
+fn type_mismatch(op: &'static str, expected: &'static str, got: &Value) -> TransformError {
+    TransformError::TypeMismatch {
+        op,
+        expected,
+        got: value_type_name(got).to_string(),
+    }
+}
+
+/// Strip surrounding quotes (single or double) from a string argument.
+fn strip_quotes(s: &str) -> &str {
+    let trimmed = s.trim();
+    if (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+        || (trimmed.starts_with('"') && trimmed.ends_with('"'))
+    {
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    }
+}
+
+/// Parse a default value argument: string, number, bool, null, or JSON.
+fn parse_default_value(arg: &str) -> Result<Value, String> {
+    let trimmed = arg.trim();
+
+    // Quoted string
+    if (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+        || (trimmed.starts_with('"') && trimmed.ends_with('"'))
+    {
+        return Ok(Value::String(trimmed[1..trimmed.len() - 1].to_string()));
+    }
+
+    // null
+    if trimmed == "null" {
+        return Ok(Value::Null);
+    }
+
+    // boolean
+    if trimmed == "true" {
+        return Ok(Value::Bool(true));
+    }
+    if trimmed == "false" {
+        return Ok(Value::Bool(false));
+    }
+
+    // integer
+    if let Ok(n) = trimmed.parse::<i64>() {
+        return Ok(Value::Number(n.into()));
+    }
+
+    // float
+    if let Ok(f) = trimmed.parse::<f64>() {
+        if let Some(n) = serde_json::Number::from_f64(f) {
+            return Ok(Value::Number(n));
+        }
+    }
+
+    // JSON object or array
+    if (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+    {
+        return serde_json::from_str(trimmed).map_err(|e| format!("invalid JSON default: {}", e));
+    }
+
+    // Bare string (unquoted) — treat as string
+    Ok(Value::String(trimmed.to_string()))
+}
+
+/// Truncate a string for error messages (UTF-8 safe).
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        // Find a valid UTF-8 char boundary at or before `max`
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
+    }
+}
+
+/// Shell-escape a string (single-quote wrapping).
+fn shell_escape(s: &str) -> String {
+    // Wrap in single quotes, escaping any internal single quotes
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+impl fmt::Display for TransformOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransformOp::Upper => write!(f, "upper"),
+            TransformOp::Lower => write!(f, "lower"),
+            TransformOp::Trim => write!(f, "trim"),
+            TransformOp::TrimStart => write!(f, "trim_start"),
+            TransformOp::TrimEnd => write!(f, "trim_end"),
+            TransformOp::Length => write!(f, "length"),
+            TransformOp::First => write!(f, "first"),
+            TransformOp::Last => write!(f, "last"),
+            TransformOp::FirstN(n) => write!(f, "first({})", n),
+            TransformOp::LastN(n) => write!(f, "last({})", n),
+            TransformOp::Keys => write!(f, "keys"),
+            TransformOp::Values => write!(f, "values"),
+            TransformOp::Flatten => write!(f, "flatten"),
+            TransformOp::Reverse => write!(f, "reverse"),
+            TransformOp::Sort => write!(f, "sort"),
+            TransformOp::Unique => write!(f, "unique"),
+            TransformOp::Compact => write!(f, "compact"),
+            TransformOp::ToString => write!(f, "to_string"),
+            TransformOp::ToNumber => write!(f, "to_number"),
+            TransformOp::ToBool => write!(f, "to_bool"),
+            TransformOp::ToJson => write!(f, "to_json"),
+            TransformOp::ParseJson => write!(f, "parse_json"),
+            TransformOp::Round(None) => write!(f, "round"),
+            TransformOp::Round(Some(d)) => write!(f, "round({})", d),
+            TransformOp::Abs => write!(f, "abs"),
+            TransformOp::Ceil => write!(f, "ceil"),
+            TransformOp::Floor => write!(f, "floor"),
+            TransformOp::Default(v) => write!(f, "default({})", v),
+            TransformOp::TypeOf => write!(f, "type_of"),
+            TransformOp::Join(sep) => write!(f, "join('{}')", sep),
+            TransformOp::Split(sep) => write!(f, "split('{}')", sep),
+            TransformOp::Shell => write!(f, "shell"),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ─────────────────────────────────────────────────────────────
+    // Parse tests
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_upper() {
+        let expr = TransformExpr::parse("upper").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Upper]);
+    }
+
+    #[test]
+    fn parse_lower() {
+        let expr = TransformExpr::parse("lower").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Lower]);
+    }
+
+    #[test]
+    fn parse_trim() {
+        let expr = TransformExpr::parse("trim").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Trim]);
+    }
+
+    #[test]
+    fn parse_length() {
+        let expr = TransformExpr::parse("length").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Length]);
+    }
+
+    #[test]
+    fn parse_first() {
+        let expr = TransformExpr::parse("first").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::First]);
+    }
+
+    #[test]
+    fn parse_first_n() {
+        let expr = TransformExpr::parse("first(3)").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::FirstN(3)]);
+    }
+
+    #[test]
+    fn parse_last_n() {
+        let expr = TransformExpr::parse("last(5)").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::LastN(5)]);
+    }
+
+    #[test]
+    fn parse_join() {
+        let expr = TransformExpr::parse("join(', ')").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Join(", ".to_string())]);
+    }
+
+    #[test]
+    fn parse_split() {
+        let expr = TransformExpr::parse("split('/')").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Split("/".to_string())]);
+    }
+
+    #[test]
+    fn parse_default_string() {
+        let expr = TransformExpr::parse("default('N/A')").unwrap();
+        assert_eq!(
+            expr.ops.as_slice(),
+            &[TransformOp::Default(Value::String("N/A".to_string()))]
+        );
+    }
+
+    #[test]
+    fn parse_default_number() {
+        let expr = TransformExpr::parse("default(42)").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Default(json!(42))]);
+    }
+
+    #[test]
+    fn parse_round() {
+        let expr = TransformExpr::parse("round(2)").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Round(Some(2))]);
+    }
+
+    #[test]
+    fn parse_round_no_arg() {
+        let expr = TransformExpr::parse("round").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Round(None)]);
+    }
+
+    #[test]
+    fn parse_shell() {
+        let expr = TransformExpr::parse("shell").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Shell]);
+    }
+
+    #[test]
+    fn parse_to_json() {
+        let expr = TransformExpr::parse("to_json").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::ToJson]);
+    }
+
+    #[test]
+    fn parse_parse_json() {
+        let expr = TransformExpr::parse("parse_json").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::ParseJson]);
+    }
+
+    #[test]
+    fn parse_unknown() {
+        let err = TransformExpr::parse("bogus").unwrap_err();
+        assert!(err.reason.contains("unknown transform"));
+    }
+
+    #[test]
+    fn parse_pipeline() {
+        let expr = TransformExpr::parse("sort | unique | first(3)").unwrap();
+        assert_eq!(
+            expr.ops.as_slice(),
+            &[
+                TransformOp::Sort,
+                TransformOp::Unique,
+                TransformOp::FirstN(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_empty() {
+        let expr = TransformExpr::parse("").unwrap();
+        assert!(expr.is_empty());
+    }
+
+    #[test]
+    fn parse_single() {
+        let expr = TransformExpr::parse("upper").unwrap();
+        assert_eq!(expr.ops.len(), 1);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Apply tests — String
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_upper_string() {
+        let result = TransformOp::Upper.apply(&json!("hello")).unwrap();
+        assert_eq!(result, json!("HELLO"));
+    }
+
+    #[test]
+    fn apply_upper_non_string() {
+        let err = TransformOp::Upper.apply(&json!(42)).unwrap_err();
+        assert!(matches!(err, TransformError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn apply_upper_null() {
+        let err = TransformOp::Upper.apply(&Value::Null).unwrap_err();
+        assert!(matches!(err, TransformError::NullInput { .. }));
+    }
+
+    #[test]
+    fn apply_lower_string() {
+        let result = TransformOp::Lower.apply(&json!("HELLO")).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn apply_trim() {
+        let result = TransformOp::Trim.apply(&json!(" hello ")).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn apply_trim_start() {
+        let result = TransformOp::TrimStart.apply(&json!("  hello  ")).unwrap();
+        assert_eq!(result, json!("hello  "));
+    }
+
+    #[test]
+    fn apply_trim_end() {
+        let result = TransformOp::TrimEnd.apply(&json!("  hello  ")).unwrap();
+        assert_eq!(result, json!("  hello"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Apply tests — Collection
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_length_array() {
+        let result = TransformOp::Length.apply(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!(3));
+    }
+
+    #[test]
+    fn apply_length_string() {
+        let result = TransformOp::Length.apply(&json!("abc")).unwrap();
+        assert_eq!(result, json!(3));
+    }
+
+    #[test]
+    fn apply_length_object() {
+        let result = TransformOp::Length.apply(&json!({"a": 1, "b": 2})).unwrap();
+        assert_eq!(result, json!(2));
+    }
+
+    #[test]
+    fn apply_length_null() {
+        let result = TransformOp::Length.apply(&Value::Null).unwrap();
+        assert_eq!(result, Value::Null); // propagating
+    }
+
+    #[test]
+    fn apply_first_array() {
+        let result = TransformOp::First.apply(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!(1));
+    }
+
+    #[test]
+    fn apply_first_empty() {
+        let result = TransformOp::First.apply(&json!([])).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn apply_last_array() {
+        let result = TransformOp::Last.apply(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!(3));
+    }
+
+    #[test]
+    fn apply_first_n() {
+        let result = TransformOp::FirstN(3)
+            .apply(&json!([1, 2, 3, 4, 5]))
+            .unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn apply_last_n() {
+        let result = TransformOp::LastN(2)
+            .apply(&json!([1, 2, 3, 4, 5]))
+            .unwrap();
+        assert_eq!(result, json!([4, 5]));
+    }
+
+    #[test]
+    fn apply_keys() {
+        let result = TransformOp::Keys.apply(&json!({"a": 1, "b": 2})).unwrap();
+        // serde_json::Map preserves insertion order
+        assert_eq!(result, json!(["a", "b"]));
+    }
+
+    #[test]
+    fn apply_keys_null() {
+        let result = TransformOp::Keys.apply(&Value::Null).unwrap();
+        assert_eq!(result, Value::Null); // propagating
+    }
+
+    #[test]
+    fn apply_values() {
+        let result = TransformOp::Values.apply(&json!({"a": 1, "b": 2})).unwrap();
+        assert_eq!(result, json!([1, 2]));
+    }
+
+    #[test]
+    fn apply_sort() {
+        let result = TransformOp::Sort.apply(&json!([3, 1, 2])).unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn apply_unique() {
+        let result = TransformOp::Unique.apply(&json!([1, 2, 2, 3])).unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn apply_compact() {
+        let result = TransformOp::Compact
+            .apply(&json!([1, null, 2, null]))
+            .unwrap();
+        assert_eq!(result, json!([1, 2]));
+    }
+
+    #[test]
+    fn apply_flatten() {
+        let result = TransformOp::Flatten.apply(&json!([[1, 2], [3]])).unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn apply_reverse() {
+        let result = TransformOp::Reverse.apply(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!([3, 2, 1]));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Apply tests — Type conversion
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_to_string() {
+        let result = TransformOp::ToString.apply(&json!(42)).unwrap();
+        assert_eq!(result, json!("42"));
+    }
+
+    #[test]
+    fn apply_to_string_null() {
+        let result = TransformOp::ToString.apply(&Value::Null).unwrap();
+        assert_eq!(result, Value::Null); // propagating
+    }
+
+    #[test]
+    fn apply_to_number() {
+        let result = TransformOp::ToNumber.apply(&json!("42")).unwrap();
+        assert_eq!(result, json!(42));
+    }
+
+    #[test]
+    fn apply_to_number_float() {
+        let result = TransformOp::ToNumber.apply(&json!("3.12")).unwrap();
+        assert_eq!(result, json!(3.12));
+    }
+
+    #[test]
+    fn apply_to_bool_number() {
+        assert_eq!(TransformOp::ToBool.apply(&json!(1)).unwrap(), json!(true));
+        assert_eq!(TransformOp::ToBool.apply(&json!(0)).unwrap(), json!(false));
+    }
+
+    #[test]
+    fn apply_to_bool_string() {
+        assert_eq!(
+            TransformOp::ToBool.apply(&json!("true")).unwrap(),
+            json!(true)
+        );
+        assert_eq!(
+            TransformOp::ToBool.apply(&json!("false")).unwrap(),
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn apply_to_json() {
+        let result = TransformOp::ToJson.apply(&json!([1, 2])).unwrap();
+        assert_eq!(result, json!("[1,2]"));
+    }
+
+    #[test]
+    fn apply_parse_json() {
+        let result = TransformOp::ParseJson.apply(&json!(r#"{"a":1}"#)).unwrap();
+        assert_eq!(result, json!({"a": 1}));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Apply tests — Numeric
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_round() {
+        let result = TransformOp::Round(Some(2)).apply(&json!(4.56789)).unwrap();
+        assert_eq!(result, json!(4.57));
+    }
+
+    #[test]
+    fn apply_round_no_decimals() {
+        let result = TransformOp::Round(None).apply(&json!(3.7)).unwrap();
+        assert_eq!(result, json!(4.0));
+    }
+
+    #[test]
+    fn apply_abs() {
+        let result = TransformOp::Abs.apply(&json!(-5)).unwrap();
+        assert_eq!(result, json!(5));
+    }
+
+    #[test]
+    fn apply_abs_float() {
+        let result = TransformOp::Abs.apply(&json!(-3.12)).unwrap();
+        assert_eq!(result, json!(3.12));
+    }
+
+    #[test]
+    fn apply_ceil() {
+        let result = TransformOp::Ceil.apply(&json!(3.2)).unwrap();
+        assert_eq!(result, json!(4));
+    }
+
+    #[test]
+    fn apply_floor() {
+        let result = TransformOp::Floor.apply(&json!(3.8)).unwrap();
+        assert_eq!(result, json!(3));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Apply tests — Utility
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_join() {
+        let result = TransformOp::Join(", ".to_string())
+            .apply(&json!(["a", "b"]))
+            .unwrap();
+        assert_eq!(result, json!("a, b"));
+    }
+
+    #[test]
+    fn apply_split() {
+        let result = TransformOp::Split("/".to_string())
+            .apply(&json!("a/b/c"))
+            .unwrap();
+        assert_eq!(result, json!(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn apply_default_with_null() {
+        let result = TransformOp::Default(json!("N/A"))
+            .apply(&Value::Null)
+            .unwrap();
+        assert_eq!(result, json!("N/A"));
+    }
+
+    #[test]
+    fn apply_default_with_value() {
+        let result = TransformOp::Default(json!("N/A"))
+            .apply(&json!("hello"))
+            .unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn apply_typeof() {
+        assert_eq!(
+            TransformOp::TypeOf.apply(&json!(42)).unwrap(),
+            json!("number")
+        );
+        assert_eq!(
+            TransformOp::TypeOf.apply(&json!("x")).unwrap(),
+            json!("string")
+        );
+        assert_eq!(
+            TransformOp::TypeOf.apply(&Value::Null).unwrap(),
+            json!("null")
+        );
+        assert_eq!(
+            TransformOp::TypeOf.apply(&json!(true)).unwrap(),
+            json!("boolean")
+        );
+        assert_eq!(
+            TransformOp::TypeOf.apply(&json!([1])).unwrap(),
+            json!("array")
+        );
+        assert_eq!(
+            TransformOp::TypeOf.apply(&json!({"a": 1})).unwrap(),
+            json!("object")
+        );
+    }
+
+    #[test]
+    fn apply_shell() {
+        let result = TransformOp::Shell.apply(&json!("hello world")).unwrap();
+        assert_eq!(result, json!("'hello world'"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Pipeline tests
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn pipeline_sort_unique() {
+        let expr = TransformExpr::parse("sort | unique").unwrap();
+        let result = expr.apply(&json!([3, 1, 2, 1])).unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn pipeline_sort_first_n() {
+        let expr = TransformExpr::parse("sort | first(2)").unwrap();
+        let result = expr.apply(&json!([3, 1, 2])).unwrap();
+        assert_eq!(result, json!([1, 2]));
+    }
+
+    #[test]
+    fn pipeline_upper_trim() {
+        let expr = TransformExpr::parse("trim | upper").unwrap();
+        let result = expr.apply(&json!(" hello ")).unwrap();
+        assert_eq!(result, json!("HELLO"));
+    }
+
+    #[test]
+    fn pipeline_empty() {
+        let expr = TransformExpr::parse("").unwrap();
+        let result = expr.apply(&json!("unchanged")).unwrap();
+        assert_eq!(result, json!("unchanged"));
+    }
+
+    #[test]
+    fn pipeline_single() {
+        let expr = TransformExpr::parse("upper").unwrap();
+        assert_eq!(expr.ops.len(), 1);
+    }
+
+    #[test]
+    fn pipeline_default_then_upper() {
+        let expr = TransformExpr::parse("default('unknown') | upper").unwrap();
+        let result = expr.apply(&Value::Null).unwrap();
+        assert_eq!(result, json!("UNKNOWN"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Display
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn display_ops() {
+        assert_eq!(TransformOp::Upper.to_string(), "upper");
+        assert_eq!(TransformOp::FirstN(3).to_string(), "first(3)");
+        assert_eq!(
+            TransformOp::Join(", ".to_string()).to_string(),
+            "join(', ')"
+        );
+        assert_eq!(TransformOp::Round(Some(2)).to_string(), "round(2)");
+        assert_eq!(TransformOp::Round(None).to_string(), "round");
+        assert_eq!(
+            TransformOp::Default(json!("N/A")).to_string(),
+            "default(\"N/A\")"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Error display
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn error_display_parse() {
+        let err = TransformParseError {
+            input: "bogus".to_string(),
+            reason: "unknown transform: 'bogus'".to_string(),
+        };
+        assert!(err.to_string().contains("NIKA-151"));
+    }
+
+    #[test]
+    fn error_display_type_mismatch() {
+        let err = TransformError::TypeMismatch {
+            op: "upper",
+            expected: "string",
+            got: "number".to_string(),
+        };
+        assert!(err.to_string().contains("NIKA-152"));
+    }
+
+    #[test]
+    fn error_display_null_input() {
+        let err = TransformError::NullInput { op: "sort" };
+        assert!(err.to_string().contains("NIKA-153"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Edge cases
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_default_bool() {
+        let expr = TransformExpr::parse("default(true)").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Default(json!(true))]);
+    }
+
+    #[test]
+    fn parse_default_null() {
+        let expr = TransformExpr::parse("default(null)").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Default(Value::Null)]);
+    }
+
+    #[test]
+    fn parse_default_array() {
+        let expr = TransformExpr::parse("default([])").unwrap();
+        assert_eq!(expr.ops.as_slice(), &[TransformOp::Default(json!([]))]);
+    }
+
+    #[test]
+    fn first_n_larger_than_array() {
+        let result = TransformOp::FirstN(10).apply(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!([1, 2, 3])); // takes what's available
+    }
+
+    #[test]
+    fn last_n_larger_than_array() {
+        let result = TransformOp::LastN(10).apply(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn flatten_mixed() {
+        let result = TransformOp::Flatten
+            .apply(&json!([[1, 2], 3, [4]]))
+            .unwrap();
+        assert_eq!(result, json!([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn unclosed_paren() {
+        let err = TransformExpr::parse("first(3").unwrap_err();
+        assert!(err.reason.contains("unclosed parenthesis"));
+    }
+
+    #[test]
+    fn join_mixed_types() {
+        let result = TransformOp::Join(", ".to_string())
+            .apply(&json!(["a", 1, true]))
+            .unwrap();
+        assert_eq!(result, json!("a, 1, true"));
+    }
+
+    #[test]
+    fn parse_json_invalid() {
+        let err = TransformOp::ParseJson
+            .apply(&json!("not json"))
+            .unwrap_err();
+        assert!(matches!(err, TransformError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn to_number_invalid() {
+        let err = TransformOp::ToNumber.apply(&json!("abc")).unwrap_err();
+        assert!(matches!(err, TransformError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn to_bool_invalid_string() {
+        let err = TransformOp::ToBool.apply(&json!("maybe")).unwrap_err();
+        assert!(matches!(err, TransformError::TypeMismatch { .. }));
+    }
+}

--- a/tools/nika-core/src/binding/types.rs
+++ b/tools/nika-core/src/binding/types.rs
@@ -1,0 +1,816 @@
+//! Core Binding Types
+//!
+//! Foundational types for the binding system redesign:
+//! - `BindingPath`: Parsed path like `$step1.data.items[0].name`
+//! - `BindingSource`: Where data comes from (Task, Context, Input, Env, LoopVar)
+//! - `PathSegment`: Individual path segment (field name or array index)
+//! - `BindingType`: Type constraint on binding values (7 variants)
+//!
+//! # Path Syntax
+//!
+//! All binding paths start with `$`:
+//!
+//! | Pattern | Source | Example |
+//! |---------|--------|---------|
+//! | `$task_id` | Task output | `$step1`, `$step1.data.name` |
+//! | `$context.*` | Context file/session | `$context.files.brand` |
+//! | `$inputs.*` | Workflow inputs | `$inputs.locale` |
+//! | `$env.*` | Environment variable | `$env.API_URL` |
+//! | `$item` | Loop variable (for_each) | `$item`, `$item.name` |
+//!
+//! Array indexing uses brackets: `$data.items[0].name`
+//!
+//! # Design Notes
+//!
+//! - `Arc<str>` for identifiers: cheap clones, no lifetime issues
+//! - `BindingPath` is `Hash + Eq` for use as map keys
+//! - `BindingType` has serde support for YAML deserialization
+//! - Parse errors use NIKA-150 error code
+
+use std::fmt;
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+/// Source path for a binding -- parsed from "$task_id.field.path"
+///
+/// Combines a source (where data comes from) with optional property
+/// access segments for nested data traversal.
+///
+/// # Examples
+///
+/// ```text
+/// $step1           → Task("step1"), segments: []
+/// $step1.name      → Task("step1"), segments: [Field("name")]
+/// $data[0].name    → Task("data"), segments: [Index(0), Field("name")]
+/// $context.files.x → Context("files.x"), segments: []
+/// $inputs.locale   → Input("locale"), segments: []
+/// $env.API_URL     → Env("API_URL"), segments: []
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BindingPath {
+    /// Where the data comes from
+    pub source: BindingSource,
+    /// Property access segments after the source
+    pub segments: Vec<PathSegment>,
+}
+
+/// Where data originates
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BindingSource {
+    /// Task output: $task_id
+    Task(Arc<str>),
+    /// Context file/session: $context.files.brand or $context.session
+    Context(Arc<str>),
+    /// Workflow input: $inputs.locale
+    Input(Arc<str>),
+    /// Environment variable: $env.API_URL
+    Env(Arc<str>),
+    /// Loop variable: $item (from for_each as:)
+    LoopVar(Arc<str>),
+}
+
+/// Single segment in a property path
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PathSegment {
+    /// Named field: .name
+    Field(Arc<str>),
+    /// Array index: [0]
+    Index(usize),
+}
+
+/// Type constraint on a binding value (optional, defaults to Any)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BindingType {
+    /// No type constraint (default)
+    #[default]
+    Any,
+    /// JSON string
+    String,
+    /// JSON number (integer or float)
+    Number,
+    /// JSON integer only
+    Integer,
+    /// JSON boolean
+    Boolean,
+    /// JSON array
+    Array,
+    /// JSON object
+    Object,
+}
+
+/// Error type for binding path parsing (NIKA-150)
+#[derive(Debug, Clone, PartialEq)]
+pub struct BindingPathError {
+    pub input: String,
+    pub reason: String,
+}
+
+impl fmt::Display for BindingPathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[NIKA-150] Invalid binding path '{}': {}",
+            self.input, self.reason
+        )
+    }
+}
+
+impl std::error::Error for BindingPathError {}
+
+// ═══════════════════════════════════════════════════════════════
+// Reserved namespace prefixes
+// ═══════════════════════════════════════════════════════════════
+
+const RESERVED_CONTEXT: &str = "context";
+const RESERVED_INPUTS: &str = "inputs";
+const RESERVED_ENV: &str = "env";
+
+impl BindingPath {
+    /// Parse a binding path string like "$task_id.field[0].name"
+    ///
+    /// Reserved namespaces: context, inputs, env
+    /// Everything else is a task reference or loop variable.
+    ///
+    /// Loop variables (from `for_each as: item`) are resolved by the caller
+    /// providing a `loop_vars` hint set. Without that hint, ambiguous single-segment
+    /// paths like `$item` are treated as Task references by default. Callers can
+    /// use `parse_with_loop_vars` for disambiguation.
+    pub fn parse(input: &str) -> Result<Self, BindingPathError> {
+        Self::parse_inner(input, None)
+    }
+
+    /// Parse with loop variable hints for disambiguation.
+    ///
+    /// Any top-level identifier matching `loop_vars` becomes `BindingSource::LoopVar`.
+    pub fn parse_with_loop_vars(input: &str, loop_vars: &[&str]) -> Result<Self, BindingPathError> {
+        Self::parse_inner(input, Some(loop_vars))
+    }
+
+    fn parse_inner(input: &str, loop_vars: Option<&[&str]>) -> Result<Self, BindingPathError> {
+        let trimmed = input.trim();
+
+        // Must start with $
+        let rest = trimmed.strip_prefix('$').ok_or_else(|| BindingPathError {
+            input: trimmed.to_string(),
+            reason: "binding paths must start with '$'".to_string(),
+        })?;
+
+        if rest.is_empty() {
+            return Err(BindingPathError {
+                input: trimmed.to_string(),
+                reason: "empty path after '$'".to_string(),
+            });
+        }
+
+        // Tokenize: split on '.' and '[', preserving bracket content
+        let tokens = tokenize_path(rest).map_err(|reason| BindingPathError {
+            input: trimmed.to_string(),
+            reason,
+        })?;
+
+        if tokens.is_empty() {
+            return Err(BindingPathError {
+                input: trimmed.to_string(),
+                reason: "empty path after '$'".to_string(),
+            });
+        }
+
+        // First token is the root identifier
+        let root = match &tokens[0] {
+            PathToken::Field(name) => name.as_str(),
+            PathToken::Index(_) => {
+                return Err(BindingPathError {
+                    input: trimmed.to_string(),
+                    reason: "path cannot start with an array index".to_string(),
+                });
+            }
+        };
+
+        // Check reserved namespaces
+        match root {
+            RESERVED_CONTEXT => {
+                // $context.files.brand → Context("files.brand")
+                // Everything after "context." becomes the context sub-path
+                if tokens.len() < 2 {
+                    return Err(BindingPathError {
+                        input: trimmed.to_string(),
+                        reason: "'$context' requires a sub-path (e.g., '$context.files.brand')"
+                            .to_string(),
+                    });
+                }
+                let sub_path = tokens_to_dotted_string(&tokens[1..]);
+                Ok(BindingPath {
+                    source: BindingSource::Context(Arc::from(sub_path.as_str())),
+                    segments: vec![],
+                })
+            }
+            RESERVED_INPUTS => {
+                // $inputs.locale → Input("locale")
+                if tokens.len() < 2 {
+                    return Err(BindingPathError {
+                        input: trimmed.to_string(),
+                        reason: "'$inputs' requires a sub-path (e.g., '$inputs.locale')"
+                            .to_string(),
+                    });
+                }
+                let sub_path = tokens_to_dotted_string(&tokens[1..]);
+                Ok(BindingPath {
+                    source: BindingSource::Input(Arc::from(sub_path.as_str())),
+                    segments: vec![],
+                })
+            }
+            RESERVED_ENV => {
+                // $env.API_URL → Env("API_URL")
+                if tokens.len() < 2 {
+                    return Err(BindingPathError {
+                        input: trimmed.to_string(),
+                        reason: "'$env' requires a variable name (e.g., '$env.API_URL')"
+                            .to_string(),
+                    });
+                }
+                let var_name = tokens_to_dotted_string(&tokens[1..]);
+                Ok(BindingPath {
+                    source: BindingSource::Env(Arc::from(var_name.as_str())),
+                    segments: vec![],
+                })
+            }
+            _ => {
+                // Check if this is a loop variable
+                let is_loop_var = loop_vars.map(|vars| vars.contains(&root)).unwrap_or(false);
+
+                let source = if is_loop_var {
+                    BindingSource::LoopVar(Arc::from(root))
+                } else {
+                    BindingSource::Task(Arc::from(root))
+                };
+
+                // Remaining tokens become path segments
+                let segments = tokens[1..]
+                    .iter()
+                    .map(|t| match t {
+                        PathToken::Field(name) => PathSegment::Field(Arc::from(name.as_str())),
+                        PathToken::Index(idx) => PathSegment::Index(*idx),
+                    })
+                    .collect();
+
+                Ok(BindingPath { source, segments })
+            }
+        }
+    }
+
+    /// Extract the task ID if this is a Task source
+    pub fn task_id(&self) -> Option<&Arc<str>> {
+        match &self.source {
+            BindingSource::Task(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Returns true if this binding references a task output
+    pub fn is_task_ref(&self) -> bool {
+        matches!(self.source, BindingSource::Task(_))
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Internal tokenizer
+// ═══════════════════════════════════════════════════════════════
+
+#[derive(Debug, Clone)]
+enum PathToken {
+    Field(String),
+    Index(usize),
+}
+
+/// Tokenize a path string (after stripping $) into fields and indices.
+///
+/// "step1.data.items[0].name" → [Field("step1"), Field("data"), Field("items"), Index(0), Field("name")]
+fn tokenize_path(input: &str) -> Result<Vec<PathToken>, String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(&ch) = chars.peek() {
+        match ch {
+            '.' => {
+                chars.next();
+                if !current.is_empty() {
+                    tokens.push(PathToken::Field(std::mem::take(&mut current)));
+                }
+                // Leading dot or double dot check
+                if tokens.is_empty() && current.is_empty() {
+                    return Err("path cannot start with '.'".to_string());
+                }
+            }
+            '[' => {
+                chars.next();
+                if !current.is_empty() {
+                    tokens.push(PathToken::Field(std::mem::take(&mut current)));
+                }
+                // Parse index content until ']'
+                let mut idx_str = String::new();
+                loop {
+                    match chars.next() {
+                        Some(']') => break,
+                        Some(c) => idx_str.push(c),
+                        None => return Err("unclosed bracket in path".to_string()),
+                    }
+                }
+                let idx: usize = idx_str
+                    .parse()
+                    .map_err(|_| format!("invalid array index: '{}'", idx_str))?;
+                tokens.push(PathToken::Index(idx));
+            }
+            ']' => {
+                return Err("unexpected ']' without matching '['".to_string());
+            }
+            _ => {
+                chars.next();
+                current.push(ch);
+            }
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(PathToken::Field(current));
+    }
+
+    Ok(tokens)
+}
+
+/// Convert tokens back to a dotted string (for Context/Input/Env sub-paths)
+fn tokens_to_dotted_string(tokens: &[PathToken]) -> String {
+    tokens
+        .iter()
+        .map(|t| match t {
+            PathToken::Field(name) => name.clone(),
+            PathToken::Index(idx) => idx.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Display implementations
+// ═══════════════════════════════════════════════════════════════
+
+impl fmt::Display for BindingPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "${}", self.source)?;
+        for seg in &self.segments {
+            write!(f, "{}", seg)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for BindingSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BindingSource::Task(id) => write!(f, "{}", id),
+            BindingSource::Context(path) => write!(f, "context.{}", path),
+            BindingSource::Input(path) => write!(f, "inputs.{}", path),
+            BindingSource::Env(var) => write!(f, "env.{}", var),
+            BindingSource::LoopVar(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+impl fmt::Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathSegment::Field(name) => write!(f, ".{}", name),
+            PathSegment::Index(idx) => write!(f, "[{}]", idx),
+        }
+    }
+}
+
+impl fmt::Display for BindingType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BindingType::Any => write!(f, "any"),
+            BindingType::String => write!(f, "string"),
+            BindingType::Number => write!(f, "number"),
+            BindingType::Integer => write!(f, "integer"),
+            BindingType::Boolean => write!(f, "boolean"),
+            BindingType::Array => write!(f, "array"),
+            BindingType::Object => write!(f, "object"),
+        }
+    }
+}
+
+impl BindingSource {
+    /// Returns true if this is a task reference
+    pub fn is_task(&self) -> bool {
+        matches!(self, BindingSource::Task(_))
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingPath::parse — Task references
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_simple_task_ref() {
+        let bp = BindingPath::parse("$step1").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("step1")));
+        assert!(bp.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_task_with_field() {
+        let bp = BindingPath::parse("$step1.output").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("step1")));
+        assert_eq!(bp.segments, vec![PathSegment::Field(Arc::from("output"))]);
+    }
+
+    #[test]
+    fn parse_task_deep_path() {
+        let bp = BindingPath::parse("$step1.data.items[0].name").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("step1")));
+        assert_eq!(
+            bp.segments,
+            vec![
+                PathSegment::Field(Arc::from("data")),
+                PathSegment::Field(Arc::from("items")),
+                PathSegment::Index(0),
+                PathSegment::Field(Arc::from("name")),
+            ]
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingPath::parse — Reserved namespaces
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_context_file() {
+        let bp = BindingPath::parse("$context.files.brand").unwrap();
+        assert_eq!(bp.source, BindingSource::Context(Arc::from("files.brand")));
+        assert!(bp.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_context_session() {
+        let bp = BindingPath::parse("$context.session").unwrap();
+        assert_eq!(bp.source, BindingSource::Context(Arc::from("session")));
+        assert!(bp.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_input() {
+        let bp = BindingPath::parse("$inputs.locale").unwrap();
+        assert_eq!(bp.source, BindingSource::Input(Arc::from("locale")));
+        assert!(bp.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_input_nested() {
+        let bp = BindingPath::parse("$inputs.config.theme").unwrap();
+        assert_eq!(bp.source, BindingSource::Input(Arc::from("config.theme")));
+        assert!(bp.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_env() {
+        let bp = BindingPath::parse("$env.API_URL").unwrap();
+        assert_eq!(bp.source, BindingSource::Env(Arc::from("API_URL")));
+        assert!(bp.segments.is_empty());
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingPath::parse — Loop variables
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_loop_var() {
+        let bp = BindingPath::parse_with_loop_vars("$item", &["item"]).unwrap();
+        assert_eq!(bp.source, BindingSource::LoopVar(Arc::from("item")));
+        assert!(bp.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_loop_var_with_field() {
+        let bp = BindingPath::parse_with_loop_vars("$item.name", &["item"]).unwrap();
+        assert_eq!(bp.source, BindingSource::LoopVar(Arc::from("item")));
+        assert_eq!(bp.segments, vec![PathSegment::Field(Arc::from("name"))]);
+    }
+
+    #[test]
+    fn parse_without_loop_hint_is_task() {
+        // Without loop_vars hint, $item is treated as a Task reference
+        let bp = BindingPath::parse("$item").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("item")));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingPath::parse — Array indexing
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_index_segment() {
+        let bp = BindingPath::parse("$data[0]").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("data")));
+        assert_eq!(bp.segments, vec![PathSegment::Index(0)]);
+    }
+
+    #[test]
+    fn parse_multiple_indexes() {
+        let bp = BindingPath::parse("$data[0].items[1]").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("data")));
+        assert_eq!(
+            bp.segments,
+            vec![
+                PathSegment::Index(0),
+                PathSegment::Field(Arc::from("items")),
+                PathSegment::Index(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_consecutive_indexes() {
+        let bp = BindingPath::parse("$matrix[0][1]").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("matrix")));
+        assert_eq!(
+            bp.segments,
+            vec![PathSegment::Index(0), PathSegment::Index(1)]
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingPath::parse — Error cases
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_missing_dollar() {
+        let err = BindingPath::parse("step1").unwrap_err();
+        assert!(err.reason.contains("must start with '$'"));
+    }
+
+    #[test]
+    fn parse_empty() {
+        let err = BindingPath::parse("$").unwrap_err();
+        assert!(err.reason.contains("empty path"));
+    }
+
+    #[test]
+    fn parse_empty_string() {
+        let err = BindingPath::parse("").unwrap_err();
+        assert!(err.reason.contains("must start with '$'"));
+    }
+
+    #[test]
+    fn parse_unclosed_bracket() {
+        let err = BindingPath::parse("$data[0").unwrap_err();
+        assert!(err.reason.contains("unclosed bracket"));
+    }
+
+    #[test]
+    fn parse_invalid_index() {
+        let err = BindingPath::parse("$data[abc]").unwrap_err();
+        assert!(err.reason.contains("invalid array index"));
+    }
+
+    #[test]
+    fn parse_context_without_subpath() {
+        let err = BindingPath::parse("$context").unwrap_err();
+        assert!(err.reason.contains("requires a sub-path"));
+    }
+
+    #[test]
+    fn parse_inputs_without_subpath() {
+        let err = BindingPath::parse("$inputs").unwrap_err();
+        assert!(err.reason.contains("requires a sub-path"));
+    }
+
+    #[test]
+    fn parse_env_without_var() {
+        let err = BindingPath::parse("$env").unwrap_err();
+        assert!(err.reason.contains("requires a variable name"));
+    }
+
+    #[test]
+    fn parse_unexpected_close_bracket() {
+        let err = BindingPath::parse("$data]0[").unwrap_err();
+        assert!(err.reason.contains("unexpected ']'"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingPath::parse — Whitespace handling
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_with_leading_whitespace() {
+        let bp = BindingPath::parse("  $step1.name  ").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("step1")));
+        assert_eq!(bp.segments, vec![PathSegment::Field(Arc::from("name"))]);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Display roundtrip
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn display_roundtrip_task() {
+        let original = "$step1.data.items[0].name";
+        let bp = BindingPath::parse(original).unwrap();
+        let displayed = bp.to_string();
+        let reparsed = BindingPath::parse(&displayed).unwrap();
+        assert_eq!(bp, reparsed);
+    }
+
+    #[test]
+    fn display_roundtrip_context() {
+        let original = "$context.files.brand";
+        let bp = BindingPath::parse(original).unwrap();
+        let displayed = bp.to_string();
+        let reparsed = BindingPath::parse(&displayed).unwrap();
+        assert_eq!(bp, reparsed);
+    }
+
+    #[test]
+    fn display_roundtrip_inputs() {
+        let original = "$inputs.config.theme";
+        let bp = BindingPath::parse(original).unwrap();
+        let displayed = bp.to_string();
+        let reparsed = BindingPath::parse(&displayed).unwrap();
+        assert_eq!(bp, reparsed);
+    }
+
+    #[test]
+    fn display_roundtrip_env() {
+        let original = "$env.API_URL";
+        let bp = BindingPath::parse(original).unwrap();
+        let displayed = bp.to_string();
+        let reparsed = BindingPath::parse(&displayed).unwrap();
+        assert_eq!(bp, reparsed);
+    }
+
+    #[test]
+    fn display_simple_task() {
+        let bp = BindingPath::parse("$step1").unwrap();
+        assert_eq!(bp.to_string(), "$step1");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Helper methods
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn task_id_extraction() {
+        let bp = BindingPath::parse("$step1.field").unwrap();
+        assert_eq!(bp.task_id().map(|s| s.as_ref()), Some("step1"));
+    }
+
+    #[test]
+    fn task_id_none_for_context() {
+        let bp = BindingPath::parse("$context.files.brand").unwrap();
+        assert!(bp.task_id().is_none());
+    }
+
+    #[test]
+    fn is_task_ref_true() {
+        let bp = BindingPath::parse("$step1").unwrap();
+        assert!(bp.is_task_ref());
+    }
+
+    #[test]
+    fn is_task_ref_false_for_context() {
+        let bp = BindingPath::parse("$context.files.brand").unwrap();
+        assert!(!bp.is_task_ref());
+    }
+
+    #[test]
+    fn is_task_ref_false_for_input() {
+        let bp = BindingPath::parse("$inputs.locale").unwrap();
+        assert!(!bp.is_task_ref());
+    }
+
+    #[test]
+    fn is_task_ref_false_for_env() {
+        let bp = BindingPath::parse("$env.HOME").unwrap();
+        assert!(!bp.is_task_ref());
+    }
+
+    #[test]
+    fn source_is_task() {
+        assert!(BindingSource::Task(Arc::from("x")).is_task());
+        assert!(!BindingSource::Context(Arc::from("x")).is_task());
+        assert!(!BindingSource::Input(Arc::from("x")).is_task());
+        assert!(!BindingSource::Env(Arc::from("x")).is_task());
+        assert!(!BindingSource::LoopVar(Arc::from("x")).is_task());
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // BindingType
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn binding_type_default() {
+        assert_eq!(BindingType::default(), BindingType::Any);
+    }
+
+    #[test]
+    fn binding_type_deserialize() {
+        let t: BindingType = serde_json::from_str(r#""string""#).unwrap();
+        assert_eq!(t, BindingType::String);
+    }
+
+    #[test]
+    fn binding_type_all_variants() {
+        let cases = [
+            (r#""any""#, BindingType::Any),
+            (r#""string""#, BindingType::String),
+            (r#""number""#, BindingType::Number),
+            (r#""integer""#, BindingType::Integer),
+            (r#""boolean""#, BindingType::Boolean),
+            (r#""array""#, BindingType::Array),
+            (r#""object""#, BindingType::Object),
+        ];
+        for (json, expected) in cases {
+            let t: BindingType = serde_json::from_str(json).unwrap();
+            assert_eq!(t, expected, "Failed for JSON: {}", json);
+        }
+    }
+
+    #[test]
+    fn binding_type_display() {
+        assert_eq!(BindingType::Any.to_string(), "any");
+        assert_eq!(BindingType::String.to_string(), "string");
+        assert_eq!(BindingType::Number.to_string(), "number");
+        assert_eq!(BindingType::Integer.to_string(), "integer");
+        assert_eq!(BindingType::Boolean.to_string(), "boolean");
+        assert_eq!(BindingType::Array.to_string(), "array");
+        assert_eq!(BindingType::Object.to_string(), "object");
+    }
+
+    #[test]
+    fn binding_type_invalid_deserialize() {
+        let result = serde_json::from_str::<BindingType>(r#""unknown""#);
+        assert!(result.is_err());
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Edge cases
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_underscore_task_id() {
+        let bp = BindingPath::parse("$my_step_1.result").unwrap();
+        assert_eq!(bp.source, BindingSource::Task(Arc::from("my_step_1")));
+    }
+
+    #[test]
+    fn parse_context_deep_path() {
+        let bp = BindingPath::parse("$context.files.config.nested.deep").unwrap();
+        assert_eq!(
+            bp.source,
+            BindingSource::Context(Arc::from("files.config.nested.deep"))
+        );
+    }
+
+    #[test]
+    fn parse_env_with_numbers() {
+        let bp = BindingPath::parse("$env.AWS_REGION_1").unwrap();
+        assert_eq!(bp.source, BindingSource::Env(Arc::from("AWS_REGION_1")));
+    }
+
+    #[test]
+    fn binding_path_error_display() {
+        let err = BindingPathError {
+            input: "step1".to_string(),
+            reason: "must start with '$'".to_string(),
+        };
+        assert!(err.to_string().contains("NIKA-150"));
+        assert!(err.to_string().contains("step1"));
+    }
+
+    #[test]
+    fn clone_and_eq() {
+        let bp1 = BindingPath::parse("$step1.name").unwrap();
+        let bp2 = bp1.clone();
+        assert_eq!(bp1, bp2);
+    }
+
+    #[test]
+    fn hash_consistency() {
+        use std::collections::HashSet;
+        let bp1 = BindingPath::parse("$step1.name").unwrap();
+        let bp2 = BindingPath::parse("$step1.name").unwrap();
+        let mut set = HashSet::new();
+        set.insert(bp1);
+        set.insert(bp2);
+        assert_eq!(set.len(), 1); // Same path = same hash
+    }
+}

--- a/tools/nika-core/src/error.rs
+++ b/tools/nika-core/src/error.rs
@@ -1,0 +1,22 @@
+//! Minimal error types for nika-core.
+//!
+//! Contains only the error variants needed by core binding modules.
+//! The full NikaError enum lives in the `nika` crate and implements
+//! `From<CoreError>` for seamless interop.
+
+use thiserror::Error;
+
+/// Core error type for nika-core modules.
+///
+/// Kept intentionally minimal -- only variants required by pure-type
+/// modules (binding/entry.rs) that were extracted from the main crate.
+#[derive(Debug, Error)]
+pub enum CoreError {
+    /// NIKA-050: Invalid binding path syntax.
+    #[error("[NIKA-050] Invalid path syntax: {path}")]
+    InvalidPath { path: String },
+
+    /// NIKA-056: Invalid default value in a binding expression.
+    #[error("[NIKA-056] Invalid default value '{raw}': {reason}")]
+    InvalidDefault { raw: String, reason: String },
+}

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -131,13 +131,46 @@ impl TaskExecutor {
         // Mock provider support for testing (no API call)
         // Generates a generic JSON response with common test fields
         if provider_name == "mock" {
-            // Generate a response that satisfies common test schemas
-            // Includes: name, value, result, status, message, items, keywords, key_phrases, user, metadata
+            // For vision content, include content metadata in mock response
+            let vision_info = if has_content {
+                let parts = infer.content.as_ref().unwrap();
+                let image_count = parts
+                    .iter()
+                    .filter(|p| {
+                        matches!(
+                            p,
+                            crate::ast::content::ContentPart::Image { .. }
+                                | crate::ast::content::ContentPart::ImageUrl { .. }
+                        )
+                    })
+                    .count();
+                let text_count = parts
+                    .iter()
+                    .filter(|p| matches!(p, crate::ast::content::ContentPart::Text { .. }))
+                    .count();
+                serde_json::json!({
+                    "vision": true,
+                    "image_count": image_count,
+                    "text_count": text_count,
+                    "total_parts": parts.len(),
+                })
+            } else {
+                serde_json::json!({ "vision": false })
+            };
+
+            // EMIT: ProviderCalled for mock (consistent with non-mock path)
+            self.event_log.emit(EventKind::ProviderCalled {
+                task_id: Arc::clone(task_id),
+                provider: "mock".to_string(),
+                model: infer.model.as_deref().unwrap_or("mock-model").to_string(),
+                prompt_len: prompt.len(),
+            });
+
             let mock_response = serde_json::json!({
                 "mock": true,
                 "task_id": task_id.as_ref(),
                 "name": "mock_value",
-                "age": 25,  // For validation tests requiring age field
+                "age": 25,
                 "value": 42,
                 "result": "mock_result",
                 "status": "success",
@@ -147,7 +180,7 @@ impl TaskExecutor {
                 "key_phrases": ["mock response", "test workflow"],
                 "content": format!("Mock content for task {}", task_id),
                 "prompt_len": prompt.len(),
-                // Structured output fields for complex schema tests
+                "vision_info": vision_info,
                 "user": {
                     "name": "Mock User",
                     "email": "mock@example.com",


### PR DESCRIPTION
## Summary

Two telemetry gaps found via Socratic questioning of the mock provider path:

1. **Mock ignores vision content** — returns same canned JSON for text and vision infer. Now includes `vision_info` with image/text counts so tests can verify vision content reaches the provider.

2. **Mock skips ProviderCalled event** — traces from mock runs were missing this event while non-mock runs had it. Now consistent.

## Bug found

The mock provider check (`if provider_name == "mock"`) runs BEFORE the vision dispatch. This means mock-based tests with `content:` never exercise the vision path — they return early with canned JSON. This is a testing blind spot, not a production bug (real providers go through the vision path).

## Test plan

- [x] `cargo test --lib -q` — 6040 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)