### PR TITLE
fix(provider): use preamble() for system prompt in streaming path

### DIFF
--- a/tools/nika-core/Cargo.toml
+++ b/tools/nika-core/Cargo.toml
@@ -22,6 +22,8 @@ strsim = "0.11"
 smallvec = "1.13"
 semver = "1.0"
 jsonschema = "0.26"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/tools/nika-core/src/ast/agent_def.rs
+++ b/tools/nika-core/src/ast/agent_def.rs
@@ -1,0 +1,408 @@
+//! Agent definition types for workflow
+//!
+//! The `agents:` block in a workflow allows defining reusable agent configurations.
+//! Agents can be defined inline or loaded from external files.
+//!
+//! # Multi-format Support
+//!
+//! Agents and skills can be loaded from multiple formats:
+//! - `.agent.yaml` / `.agent.yml` - YAML format
+//! - `.skill.yaml` / `.skill.yml` - YAML format
+//! - `.md` files with YAML frontmatter (Claude Code style)
+//! - Folders containing the above
+//!
+//! # Example
+//!
+//! ```yaml
+//! agents:
+//!   researcher:
+//!     from: ./agents/researcher           # Auto-detect format (folder or file)
+//!   helper:
+//!     file: ./agents/helper.agent.yaml    # Explicit YAML
+//!   reviewer:
+//!     from: ./agents/reviewer.md          # Markdown with frontmatter
+//!   translator:
+//!     system: "You are a translator..."   # Inline definition
+//!     provider: claude
+//!     model: claude-sonnet-4-6
+//!     max_turns: 3
+//! ```
+
+use serde::Deserialize;
+
+/// Agent definition
+///
+/// Can be either an external file/folder reference or an inline definition.
+/// Adds support for `from:` which auto-detects format.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AgentDef {
+    /// External reference using `from:`
+    From {
+        /// Path to agent definition (file or folder, any supported format)
+        from: String,
+    },
+
+    /// External file reference using `file:`
+    External {
+        /// Path to the agent definition file (.agent.yaml)
+        file: String,
+    },
+
+    /// Inline definition
+    Inline {
+        /// System prompt for the agent
+        system: String,
+
+        /// Provider to use (claude, openai, etc.)
+        #[serde(default = "default_provider")]
+        provider: String,
+
+        /// Model to use (optional, uses provider default if not specified)
+        model: Option<String>,
+
+        /// Maximum turns for the agent (optional)
+        max_turns: Option<u32>,
+
+        /// Temperature for generation (optional)
+        temperature: Option<f32>,
+
+        /// Skills to load for this agent
+        ///
+        /// Skills can be:
+        /// - Relative paths: `./skills/my-skill.md`
+        /// - pkg: URIs: `pkg:@scope/name@version/path`
+        ///
+        /// Agent-level skills override workflow-level skills when both define
+        /// the same skill path.
+        #[serde(default)]
+        skills: Option<Vec<String>>,
+    },
+}
+
+fn default_provider() -> String {
+    "claude".to_string()
+}
+
+impl AgentDef {
+    /// Check if this is an external reference (file or from)
+    pub fn is_external(&self) -> bool {
+        matches!(self, AgentDef::External { .. } | AgentDef::From { .. })
+    }
+
+    /// Check if this is an inline definition
+    pub fn is_inline(&self) -> bool {
+        matches!(self, AgentDef::Inline { .. })
+    }
+
+    /// Check if this uses the new `from:` syntax
+    pub fn is_from(&self) -> bool {
+        matches!(self, AgentDef::From { .. })
+    }
+
+    /// Get the file/folder path if this is an external reference
+    pub fn file_path(&self) -> Option<&str> {
+        match self {
+            AgentDef::External { file } => Some(file),
+            AgentDef::From { from } => Some(from),
+            AgentDef::Inline { .. } => None,
+        }
+    }
+
+    /// Get the source path (alias for file_path)
+    pub fn source_path(&self) -> Option<&str> {
+        self.file_path()
+    }
+
+    /// Get the skills list if this is an inline definition
+    ///
+    /// Agent-level skills override workflow-level skills when both define
+    /// the same skill path.
+    pub fn skills(&self) -> Option<&Vec<String>> {
+        match self {
+            AgentDef::Inline { skills, .. } => skills.as_ref(),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn test_agent_def_from() {
+        let yaml = r#"
+from: ./agents/researcher
+"#;
+        let def: AgentDef = serde_yaml::from_str(yaml).unwrap();
+        assert!(def.is_external());
+        assert!(def.is_from());
+        assert_eq!(def.file_path(), Some("./agents/researcher"));
+    }
+
+    #[test]
+    fn test_agent_def_from_md() {
+        let yaml = r#"
+from: ./agents/reviewer.md
+"#;
+        let def: AgentDef = serde_yaml::from_str(yaml).unwrap();
+        assert!(def.is_from());
+        assert_eq!(def.source_path(), Some("./agents/reviewer.md"));
+    }
+
+    #[test]
+    fn test_agent_def_external() {
+        let yaml = r#"
+file: ./agents/researcher.agent.yaml
+"#;
+        let def: AgentDef = serde_yaml::from_str(yaml).unwrap();
+        assert!(def.is_external());
+        assert!(!def.is_from());
+        assert_eq!(def.file_path(), Some("./agents/researcher.agent.yaml"));
+    }
+
+    #[test]
+    fn test_agent_def_inline_minimal() {
+        let yaml = r#"
+system: "You are a helpful assistant."
+"#;
+        let def: AgentDef = serde_yaml::from_str(yaml).unwrap();
+        assert!(def.is_inline());
+        if let AgentDef::Inline {
+            system,
+            provider,
+            model,
+            max_turns,
+            temperature,
+            skills,
+        } = def
+        {
+            assert_eq!(system, "You are a helpful assistant.");
+            assert_eq!(provider, "claude"); // default
+            assert!(model.is_none());
+            assert!(max_turns.is_none());
+            assert!(temperature.is_none());
+            assert!(skills.is_none()); // no skills in minimal
+        }
+    }
+
+    #[test]
+    fn test_agent_def_inline_full() {
+        let yaml = r#"
+system: "You are a translator."
+provider: openai
+model: gpt-4o
+max_turns: 5
+temperature: 0.7
+"#;
+        let def: AgentDef = serde_yaml::from_str(yaml).unwrap();
+        assert!(def.is_inline());
+        if let AgentDef::Inline {
+            system,
+            provider,
+            model,
+            max_turns,
+            temperature,
+            skills,
+        } = def
+        {
+            assert_eq!(system, "You are a translator.");
+            assert_eq!(provider, "openai");
+            assert_eq!(model, Some("gpt-4o".to_string()));
+            assert_eq!(max_turns, Some(5));
+            assert_eq!(temperature, Some(0.7));
+            assert!(skills.is_none()); // no skills in this test
+        }
+    }
+
+    #[test]
+    fn test_agent_def_is_external() {
+        let external = AgentDef::External {
+            file: "test.yaml".to_string(),
+        };
+        let from = AgentDef::From {
+            from: "./agents/test".to_string(),
+        };
+        let inline = AgentDef::Inline {
+            system: "test".to_string(),
+            provider: "claude".to_string(),
+            model: None,
+            max_turns: None,
+            temperature: None,
+            skills: None,
+        };
+
+        assert!(external.is_external());
+        assert!(!external.is_inline());
+        assert!(!external.is_from());
+
+        assert!(from.is_external());
+        assert!(from.is_from());
+        assert!(!from.is_inline());
+
+        assert!(!inline.is_external());
+        assert!(inline.is_inline());
+        assert!(!inline.is_from());
+    }
+
+    #[test]
+    fn test_agent_def_file_path() {
+        let external = AgentDef::External {
+            file: "path/to/agent.yaml".to_string(),
+        };
+        let from = AgentDef::From {
+            from: "./agents/researcher".to_string(),
+        };
+        let inline = AgentDef::Inline {
+            system: "test".to_string(),
+            provider: "claude".to_string(),
+            model: None,
+            max_turns: None,
+            temperature: None,
+            skills: None,
+        };
+
+        assert_eq!(external.file_path(), Some("path/to/agent.yaml"));
+        assert_eq!(from.file_path(), Some("./agents/researcher"));
+        assert_eq!(from.source_path(), Some("./agents/researcher"));
+        assert_eq!(inline.file_path(), None);
+    }
+
+    // =========================================================================
+    // Skills Tests
+    // =========================================================================
+
+    #[test]
+    fn test_agent_def_inline_with_skills_array() {
+        let yaml = r#"
+            system: "You are a helpful assistant"
+            provider: claude
+            skills:
+              - ./skills/research.md
+              - ./skills/writing.md
+        "#;
+        let agent: AgentDef = serde_yaml::from_str(yaml).unwrap();
+
+        assert!(agent.is_inline());
+        let skills = agent.skills().expect("skills should be Some");
+        assert_eq!(skills.len(), 2);
+        assert_eq!(skills[0], "./skills/research.md");
+        assert_eq!(skills[1], "./skills/writing.md");
+    }
+
+    #[test]
+    fn test_agent_def_skills_helper_returns_some() {
+        let inline = AgentDef::Inline {
+            system: "test".to_string(),
+            provider: "claude".to_string(),
+            model: None,
+            max_turns: None,
+            temperature: None,
+            skills: Some(vec!["./skill.md".to_string()]),
+        };
+
+        assert!(inline.skills().is_some());
+        assert_eq!(inline.skills().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_agent_def_skills_helper_returns_none_for_no_skills() {
+        let inline = AgentDef::Inline {
+            system: "test".to_string(),
+            provider: "claude".to_string(),
+            model: None,
+            max_turns: None,
+            temperature: None,
+            skills: None,
+        };
+
+        assert!(inline.skills().is_none());
+    }
+
+    #[test]
+    fn test_agent_def_skills_helper_returns_none_for_external() {
+        let external = AgentDef::External {
+            file: "agent.yaml".to_string(),
+        };
+
+        // External agents don't have inline skills
+        assert!(external.skills().is_none());
+    }
+
+    #[test]
+    fn test_agent_def_empty_skills_array() {
+        let yaml = r#"
+            system: "You are a helpful assistant"
+            provider: claude
+            skills: []
+        "#;
+        let agent: AgentDef = serde_yaml::from_str(yaml).unwrap();
+
+        let skills = agent.skills().expect("empty array should still be Some");
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn test_agent_def_skills_with_pkg_uri() {
+        let yaml = r#"
+            system: "You are a helpful assistant"
+            provider: claude
+            skills:
+              - pkg:@supernovae/research@1.0.0/skills/deep-research.md
+              - pkg:@supernovae/writing@2.0.0/skills/technical-writing.md
+        "#;
+        let agent: AgentDef = serde_yaml::from_str(yaml).unwrap();
+
+        let skills = agent.skills().expect("skills should be Some");
+        assert_eq!(skills.len(), 2);
+        assert!(skills[0].starts_with("pkg:@"));
+        assert!(skills[1].starts_with("pkg:@"));
+        assert!(skills[0].contains("@1.0.0"));
+        assert!(skills[1].contains("@2.0.0"));
+    }
+
+    #[test]
+    fn test_agent_def_skills_with_relative_paths() {
+        let yaml = r#"
+            system: "You are a helpful assistant"
+            provider: claude
+            skills:
+              - ./skills/local-skill.md
+              - ../shared/common-skill.md
+              - skills/nested/deep-skill.md
+        "#;
+        let agent: AgentDef = serde_yaml::from_str(yaml).unwrap();
+
+        let skills = agent.skills().expect("skills should be Some");
+        assert_eq!(skills.len(), 3);
+        assert_eq!(skills[0], "./skills/local-skill.md");
+        assert_eq!(skills[1], "../shared/common-skill.md");
+        assert_eq!(skills[2], "skills/nested/deep-skill.md");
+    }
+
+    #[test]
+    fn test_agent_def_skills_mixed_pkg_and_relative() {
+        // Agent-level skills can mix pkg: URIs and relative paths
+        // This tests the intended behavior documented in ADR:
+        // - Agent-level skills override workflow-level skills
+        // - Skills are loaded and injected into the agent's system prompt
+        let yaml = r#"
+            system: "You are a helpful assistant"
+            provider: claude
+            skills:
+              - ./skills/project-specific.md
+              - pkg:@supernovae/research@1.0.0/skills/research.md
+        "#;
+        let agent: AgentDef = serde_yaml::from_str(yaml).unwrap();
+
+        let skills = agent.skills().expect("skills should be Some");
+        assert_eq!(skills.len(), 2);
+
+        // First is relative path
+        assert!(skills[0].starts_with("./"));
+        // Second is pkg: URI
+        assert!(skills[1].starts_with("pkg:"));
+    }
+}

--- a/tools/nika-core/src/ast/analyzed/ids.rs
+++ b/tools/nika-core/src/ast/analyzed/ids.rs
@@ -1,0 +1,196 @@
+//! Interned identifiers for the Analyzed AST.
+//!
+//! These are u32 indices that reference into lookup tables,
+//! providing O(1) comparison and hashing while keeping string
+//! data deduplicated.
+
+use rustc_hash::FxHashMap;
+use std::fmt;
+
+/// Interned task identifier.
+///
+/// Tasks are identified by a u32 index into the workflow's task table.
+/// This enables O(1) comparison and efficient storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TaskId(pub u32);
+
+impl TaskId {
+    /// Create a new task ID.
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Get the raw index.
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "task#{}", self.0)
+    }
+}
+
+/// Task name lookup table.
+///
+/// Bidirectional mapping between task names and TaskIds.
+/// Uses HashMap for O(1) name→id lookup.
+#[derive(Debug, Clone, Default)]
+pub struct TaskTable {
+    /// Task names indexed by TaskId.
+    names: Vec<String>,
+    /// Reverse lookup (name → TaskId) for O(1) lookup.
+    index: FxHashMap<String, TaskId>,
+}
+
+impl TaskTable {
+    /// Create a new empty task table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a task name, returning its ID.
+    ///
+    /// Does NOT check for duplicates - use `try_insert()` for safe insertion.
+    pub fn insert(&mut self, name: &str) -> TaskId {
+        let id = TaskId::new(self.names.len() as u32);
+        self.names.push(name.to_string());
+        self.index.insert(name.to_string(), id);
+        id
+    }
+
+    /// Try to insert a task name, returning None if duplicate.
+    ///
+    /// Returns `Some(TaskId)` on success, `None` if name already exists.
+    pub fn try_insert(&mut self, name: &str) -> Option<TaskId> {
+        if self.index.contains_key(name) {
+            None
+        } else {
+            Some(self.insert(name))
+        }
+    }
+
+    /// Check if a task name exists.
+    pub fn contains(&self, name: &str) -> bool {
+        self.index.contains_key(name)
+    }
+
+    /// Look up a task ID by name. O(1) operation.
+    pub fn get_id(&self, name: &str) -> Option<TaskId> {
+        self.index.get(name).copied()
+    }
+
+    /// Get a task name by ID.
+    pub fn get_name(&self, id: TaskId) -> Option<&str> {
+        self.names.get(id.0 as usize).map(|s| s.as_str())
+    }
+
+    /// Get the number of tasks.
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
+    /// Check if the table is empty.
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+
+    /// Iterate over all (TaskId, name) pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (TaskId, &str)> {
+        self.names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (TaskId::new(i as u32), name.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_task_id() {
+        let id = TaskId::new(42);
+        assert_eq!(id.index(), 42);
+        assert_eq!(format!("{}", id), "task#42");
+    }
+
+    #[test]
+    fn test_task_table() {
+        let mut table = TaskTable::new();
+        assert!(table.is_empty());
+
+        let id1 = table.insert("task1");
+        let id2 = table.insert("task2");
+
+        assert_eq!(id1.index(), 0);
+        assert_eq!(id2.index(), 1);
+
+        assert_eq!(table.get_id("task1"), Some(id1));
+        assert_eq!(table.get_id("task2"), Some(id2));
+        assert_eq!(table.get_id("unknown"), None);
+
+        assert_eq!(table.get_name(id1), Some("task1"));
+        assert_eq!(table.get_name(id2), Some("task2"));
+    }
+
+    #[test]
+    fn test_task_table_iter() {
+        let mut table = TaskTable::new();
+        table.insert("a");
+        table.insert("b");
+        table.insert("c");
+
+        let pairs: Vec<_> = table.iter().collect();
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[0].1, "a");
+        assert_eq!(pairs[1].1, "b");
+        assert_eq!(pairs[2].1, "c");
+    }
+
+    #[test]
+    fn test_task_table_try_insert() {
+        let mut table = TaskTable::new();
+
+        // First insert succeeds
+        let id1 = table.try_insert("task1");
+        assert!(id1.is_some());
+        assert_eq!(id1.unwrap().index(), 0);
+
+        // Second different insert succeeds
+        let id2 = table.try_insert("task2");
+        assert!(id2.is_some());
+        assert_eq!(id2.unwrap().index(), 1);
+
+        // Duplicate insert fails
+        let id3 = table.try_insert("task1");
+        assert!(id3.is_none());
+
+        // Table still has only 2 entries
+        assert_eq!(table.len(), 2);
+    }
+
+    #[test]
+    fn test_task_table_contains() {
+        let mut table = TaskTable::new();
+        table.insert("existing");
+
+        assert!(table.contains("existing"));
+        assert!(!table.contains("missing"));
+    }
+
+    #[test]
+    fn test_task_table_o1_lookup() {
+        let mut table = TaskTable::new();
+        // Insert many tasks to verify O(1) behavior
+        for i in 0..1000 {
+            table.insert(&format!("task_{}", i));
+        }
+
+        // Lookup should be O(1) with HashMap
+        assert_eq!(table.get_id("task_500").map(|id| id.index()), Some(500));
+        assert_eq!(table.get_id("task_999").map(|id| id.index()), Some(999));
+        assert_eq!(table.get_id("nonexistent"), None);
+    }
+}

--- a/tools/nika-core/src/ast/analyzed/mod.rs
+++ b/tools/nika-core/src/ast/analyzed/mod.rs
@@ -1,0 +1,108 @@
+//! Analyzed AST - Phase 2 of the Two-Phase IR Architecture.
+//!
+//! This module contains the validated, resolved AST types. All string
+//! references have been replaced with interned identifiers (TaskId, etc.),
+//! and all semantic validations have passed.
+//!
+//! # Two-Phase Architecture
+//!
+//! ```text
+//! ┌─────────────────┐
+//! │  YAML Source    │  workflow.nika.yaml
+//! └────────┬────────┘
+//!          │ marked_yaml
+//!          ▼
+//! ┌─────────────────┐
+//! │  raw::Workflow  │  (see ast/raw/)
+//! │  ├── Spanned<T> │  All nodes have line:col
+//! │  └── strings    │  Unresolved references
+//! └────────┬────────┘
+//!          │ analyze()  ← Phase 2 happens here
+//!          ▼
+//! ┌─────────────────────┐
+//! │ analyzed::Workflow  │  ← THIS MODULE
+//! │  ├── TaskId(u32)    │  Interned identifiers
+//! │  ├── resolved refs  │  All references validated
+//! │  └── validated      │  No cycles, unique IDs
+//! └─────────────────────┘
+//! ```
+//!
+//! # Benefits
+//!
+//! 1. **O(1) Comparison**: TaskId(u32) vs String comparison
+//! 2. **Memory Efficient**: Strings stored once in lookup tables
+//! 3. **Validated**: No cycles, no duplicate IDs, valid schema
+//! 4. **Ready for Execution**: Can be directly consumed by runtime
+//!
+//! # Example
+//!
+//! ```ignore
+//! use nika::ast::raw;
+//! use nika::ast::analyzed::{AnalyzedWorkflow, analyze};
+//! use nika::source::SourceRegistry;
+//!
+//! let mut sources = SourceRegistry::new();
+//! let file_id = sources.add_file("workflow.yaml", content);
+//!
+//! // Phase 1: Parse to raw AST
+//! let raw_workflow = raw::parse(&content, file_id)?;
+//!
+//! // Phase 2: Analyze to resolved AST
+//! let analyzed = analyze(&sources, raw_workflow)?;
+//!
+//! // Now use analyzed workflow
+//! for task in analyzed.iter_tasks() {
+//!     println!("Task {}: {:?}", task.name, task.action.verb_name());
+//! }
+//! ```
+
+mod ids;
+mod task;
+mod workflow;
+
+pub use ids::{TaskId, TaskTable};
+pub use task::{
+    AnalyzedAgentAction, AnalyzedExecAction, AnalyzedFetchAction, AnalyzedForEach,
+    AnalyzedInferAction, AnalyzedInvokeAction, AnalyzedOutput, AnalyzedRetry, AnalyzedTask,
+    AnalyzedTaskAction, HttpMethod, OutputFormat,
+};
+pub use workflow::{
+    AnalyzedContextFile, AnalyzedImportSpec, AnalyzedMcpServer, AnalyzedWorkflow, McpTransport,
+    SchemaVersion,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_exports() {
+        use crate::binding::WithSpec;
+
+        // Basic smoke test that all types are accessible
+        let _ = TaskId::new(0);
+        let _ = AnalyzedWorkflow::default();
+        let _ = SchemaVersion::latest();
+        let _ = AnalyzedTask {
+            id: TaskId::new(0),
+            name: String::new(),
+            description: None,
+            action: AnalyzedTaskAction::default(),
+            provider: None,
+            model: None,
+            with_spec: WithSpec::default(),
+            depends_on: Vec::new(),
+            implicit_deps: Vec::new(),
+            output: None,
+            for_each: None,
+            retry: None,
+            decompose: None,
+            concurrency: None,
+            fail_fast: None,
+            artifact: None,
+            log: None,
+            structured: None,
+            span: crate::source::Span::dummy(),
+        };
+    }
+}

--- a/tools/nika-core/src/ast/analyzed/task.rs
+++ b/tools/nika-core/src/ast/analyzed/task.rs
@@ -1,0 +1,598 @@
+//! Analyzed task AST.
+//!
+//! Tasks with resolved references - TaskId instead of String.
+//!
+
+use indexmap::IndexMap;
+
+use super::ids::TaskId;
+use crate::ast::artifact::ArtifactSpec;
+use crate::ast::decompose::DecomposeSpec;
+use crate::ast::logging::LogConfig;
+use crate::ast::structured::StructuredOutputSpec;
+use crate::binding::WithSpec;
+use crate::source::Span;
+
+/// An analyzed task - validated and resolved.
+///
+/// All string references are replaced with interned IDs.
+///
+#[derive(Debug, Clone)]
+pub struct AnalyzedTask {
+    /// Task ID (interned)
+    pub id: TaskId,
+
+    /// Task name (for display/debugging)
+    pub name: String,
+
+    /// Optional description
+    pub description: Option<String>,
+
+    /// The action this task performs
+    pub action: AnalyzedTaskAction,
+
+    /// Task-specific provider override
+    pub provider: Option<String>,
+
+    /// Task-specific model override
+    pub model: Option<String>,
+
+    /// Parsed `with:` bindings (alias → WithEntry with source, transforms, defaults)
+    ///
+    /// Phase 2 parses raw `Spanned<String>` values via `parse_with_entry()`.
+    /// Each entry has a `BindingPath` source, optional transforms, defaults, and type.
+    pub with_spec: WithSpec,
+
+    /// Explicit ordering dependencies: `depends_on: [task_id1, task_id2]`
+    ///
+    /// These are pure ordering edges — no data flows through them.
+    /// Resolved from raw string task names to interned `TaskId`.
+    pub depends_on: Vec<TaskId>,
+
+    /// Implicit dependencies auto-extracted from `with:` bindings.
+    ///
+    /// When a `WithEntry` source references a task (e.g., `step1.data`),
+    /// the analyzer extracts `step1` as an implicit dependency.
+    /// These are used by the DAG builder alongside `depends_on`.
+    pub implicit_deps: Vec<TaskId>,
+
+    /// Output configuration
+    pub output: Option<AnalyzedOutput>,
+
+    /// For-each iteration configuration
+    pub for_each: Option<AnalyzedForEach>,
+
+    /// Retry configuration
+    pub retry: Option<AnalyzedRetry>,
+
+    /// Decompose modifier for runtime DAG expansion
+    pub decompose: Option<DecomposeSpec>,
+
+    /// Standalone concurrency (used with decompose when no for_each)
+    pub concurrency: Option<u32>,
+
+    /// Standalone fail_fast (used with decompose when no for_each)
+    pub fail_fast: Option<bool>,
+
+    /// Artifact configuration for file persistence
+    pub artifact: Option<ArtifactSpec>,
+
+    /// Per-task log configuration
+    pub log: Option<LogConfig>,
+
+    /// Structured output specification (JSON schema enforcement)
+    pub structured: Option<StructuredOutputSpec>,
+
+    /// Span of the task
+    pub span: Span,
+}
+
+/// The action a task performs (analyzed).
+#[derive(Debug, Clone)]
+pub enum AnalyzedTaskAction {
+    /// LLM inference
+    Infer(AnalyzedInferAction),
+
+    /// Shell command execution
+    Exec(AnalyzedExecAction),
+
+    /// HTTP fetch
+    Fetch(AnalyzedFetchAction),
+
+    /// MCP tool invocation
+    Invoke(AnalyzedInvokeAction),
+
+    /// Autonomous agent
+    Agent(AnalyzedAgentAction),
+}
+
+impl Default for AnalyzedTaskAction {
+    fn default() -> Self {
+        AnalyzedTaskAction::Infer(AnalyzedInferAction::default())
+    }
+}
+
+impl AnalyzedTaskAction {
+    /// Get the verb name.
+    pub fn verb_name(&self) -> &'static str {
+        match self {
+            AnalyzedTaskAction::Infer(_) => "infer",
+            AnalyzedTaskAction::Exec(_) => "exec",
+            AnalyzedTaskAction::Fetch(_) => "fetch",
+            AnalyzedTaskAction::Invoke(_) => "invoke",
+            AnalyzedTaskAction::Agent(_) => "agent",
+        }
+    }
+}
+
+/// Analyzed infer action.
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzedInferAction {
+    /// The prompt to send to the LLM (may be empty when content is present)
+    pub prompt: String,
+
+    /// System prompt override
+    pub system: Option<String>,
+
+    /// Temperature (validated: 0.0 - 2.0)
+    pub temperature: Option<f64>,
+
+    /// Maximum tokens to generate
+    pub max_tokens: Option<u32>,
+
+    /// Enable extended thinking
+    pub thinking: Option<bool>,
+
+    /// Thinking budget tokens
+    pub thinking_budget: Option<u32>,
+
+    /// Multimodal content parts for vision (analyzed, spans stripped)
+    pub content: Option<Vec<crate::ast::content::AnalyzedContentPart>>,
+
+    /// Span of the action
+    pub span: Span,
+}
+
+/// Analyzed exec action.
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzedExecAction {
+    /// Command to execute
+    pub command: String,
+
+    /// Run through shell
+    pub shell: bool,
+
+    /// Working directory
+    pub working_dir: Option<String>,
+
+    /// Environment variables
+    pub env: IndexMap<String, String>,
+
+    /// Timeout in milliseconds
+    pub timeout_ms: Option<u64>,
+
+    /// Span of the action
+    pub span: Span,
+}
+
+/// Analyzed fetch action.
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzedFetchAction {
+    /// URL to fetch
+    pub url: String,
+
+    /// HTTP method
+    pub method: HttpMethod,
+
+    /// HTTP headers
+    pub headers: IndexMap<String, String>,
+
+    /// Request body
+    pub body: Option<String>,
+
+    /// Request body as JSON
+    pub json: Option<serde_json::Value>,
+
+    /// Timeout in milliseconds
+    pub timeout_ms: Option<u64>,
+
+    /// Follow redirects
+    pub follow_redirects: bool,
+
+    /// Span of the action
+    pub span: Span,
+}
+
+/// HTTP methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HttpMethod {
+    #[default]
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    /// Parse an HTTP method string.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_uppercase().as_str() {
+            "GET" => Some(Self::Get),
+            "POST" => Some(Self::Post),
+            "PUT" => Some(Self::Put),
+            "PATCH" => Some(Self::Patch),
+            "DELETE" => Some(Self::Delete),
+            "HEAD" => Some(Self::Head),
+            "OPTIONS" => Some(Self::Options),
+            _ => None,
+        }
+    }
+
+    /// Get the method as a string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
+        }
+    }
+}
+
+/// Analyzed invoke action.
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzedInvokeAction {
+    /// MCP server name (None = first available)
+    pub server: Option<String>,
+
+    /// Tool name
+    pub tool: String,
+
+    /// Tool parameters
+    pub params: Option<serde_json::Value>,
+
+    /// Timeout for tool execution
+    pub timeout_ms: Option<u64>,
+
+    /// Span of the action
+    pub span: Span,
+}
+
+/// Analyzed agent action.
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzedAgentAction {
+    /// The prompt for the agent
+    pub prompt: String,
+
+    /// Available tools
+    pub tools: Vec<String>,
+
+    /// Maximum iterations
+    pub max_iterations: Option<u32>,
+
+    /// Maximum tokens per response
+    pub max_tokens: Option<u32>,
+
+    /// Agent definition reference (resolved)
+    pub from: Option<String>,
+
+    /// Skills to inject
+    pub skills: Vec<String>,
+
+    /// MCP servers for tool access
+    pub mcp: Vec<String>,
+
+    /// System prompt (agent persona)
+    pub system: Option<String>,
+
+    /// Temperature for LLM sampling
+    pub temperature: Option<f64>,
+
+    /// Token budget for the agent
+    pub token_budget: Option<u32>,
+
+    /// Enable extended thinking (Claude)
+    pub extended_thinking: Option<bool>,
+
+    /// Thinking budget tokens
+    pub thinking_budget: Option<u32>,
+
+    /// Max spawn_agent recursion depth
+    pub depth_limit: Option<u32>,
+
+    /// Span of the action
+    pub span: Span,
+}
+
+/// Analyzed output configuration.
+#[derive(Debug, Clone)]
+pub struct AnalyzedOutput {
+    /// Output format
+    pub format: OutputFormat,
+
+    /// JSON Schema for validation (validated)
+    pub schema: Option<serde_json::Value>,
+
+    /// Span of the output config
+    pub span: Span,
+}
+
+/// Output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+    Yaml,
+}
+
+impl OutputFormat {
+    /// Parse an output format string.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "text" => Some(Self::Text),
+            "json" => Some(Self::Json),
+            "yaml" => Some(Self::Yaml),
+            _ => None,
+        }
+    }
+
+    /// Get the format as a string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Json => "json",
+            Self::Yaml => "yaml",
+        }
+    }
+}
+
+/// Analyzed for-each iteration configuration.
+#[derive(Debug, Clone)]
+pub struct AnalyzedForEach {
+    /// Items expression (binding expression or serialized array)
+    pub items: String,
+
+    /// Loop variable name (default: "item")
+    pub as_var: String,
+
+    /// Maximum concurrency (None = unlimited)
+    pub parallel: Option<u32>,
+
+    /// Fail fast on first error (default: true)
+    pub fail_fast: bool,
+
+    /// Span of the for_each config
+    pub span: Span,
+}
+
+impl Default for AnalyzedForEach {
+    fn default() -> Self {
+        Self {
+            items: String::new(),
+            as_var: "item".to_string(),
+            parallel: Some(1), // Default to sequential
+            fail_fast: true,
+            span: Span::dummy(),
+        }
+    }
+}
+
+impl AnalyzedForEach {
+    /// Check if this is a binding expression.
+    pub fn is_binding(&self) -> bool {
+        self.items.starts_with("{{") || self.items.starts_with("$")
+    }
+
+    /// Check if items is a literal array.
+    pub fn is_array(&self) -> bool {
+        self.items.starts_with('[')
+    }
+
+    /// Parse items as a JSON array if it's a literal.
+    pub fn parse_items(&self) -> Option<Vec<serde_json::Value>> {
+        if self.is_array() {
+            serde_json::from_str(&self.items).ok()
+        } else {
+            None
+        }
+    }
+}
+
+/// Analyzed retry configuration.
+#[derive(Debug, Clone)]
+pub struct AnalyzedRetry {
+    /// Maximum retry attempts (validated: 1-10)
+    pub max_attempts: u32,
+
+    /// Delay between retries in milliseconds (validated: 0-60000)
+    pub delay_ms: u64,
+
+    /// Exponential backoff multiplier (validated: 1.0-5.0)
+    pub backoff: Option<f64>,
+
+    /// Span of the retry config
+    pub span: Span,
+}
+
+impl Default for AnalyzedRetry {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            delay_ms: 1000,
+            backoff: None,
+            span: Span::dummy(),
+        }
+    }
+}
+
+impl AnalyzedRetry {
+    /// Calculate delay for a given attempt (0-indexed).
+    pub fn delay_for_attempt(&self, attempt: u32) -> u64 {
+        if attempt == 0 {
+            return 0; // No delay for first attempt
+        }
+        match self.backoff {
+            Some(multiplier) => {
+                let factor = multiplier.powi(attempt as i32 - 1);
+                (self.delay_ms as f64 * factor) as u64
+            }
+            None => self.delay_ms,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::FileId;
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    #[test]
+    fn test_http_method_parse() {
+        assert_eq!(HttpMethod::parse("GET"), Some(HttpMethod::Get));
+        assert_eq!(HttpMethod::parse("get"), Some(HttpMethod::Get));
+        assert_eq!(HttpMethod::parse("POST"), Some(HttpMethod::Post));
+        assert_eq!(HttpMethod::parse("UNKNOWN"), None);
+    }
+
+    #[test]
+    fn test_output_format_parse() {
+        assert_eq!(OutputFormat::parse("text"), Some(OutputFormat::Text));
+        assert_eq!(OutputFormat::parse("JSON"), Some(OutputFormat::Json));
+        assert_eq!(OutputFormat::parse("yaml"), Some(OutputFormat::Yaml));
+        assert_eq!(OutputFormat::parse("unknown"), None);
+    }
+
+    #[test]
+    fn test_analyzed_task_action_verb() {
+        let infer = AnalyzedTaskAction::Infer(AnalyzedInferAction::default());
+        assert_eq!(infer.verb_name(), "infer");
+
+        let exec = AnalyzedTaskAction::Exec(AnalyzedExecAction::default());
+        assert_eq!(exec.verb_name(), "exec");
+    }
+
+    #[test]
+    fn test_analyzed_task_with_spec() {
+        use crate::binding::types::{BindingPath, BindingSource, PathSegment};
+        use crate::binding::{WithEntry, WithSpec};
+
+        let mut with_spec = WithSpec::default();
+        with_spec.insert(
+            "data".to_string(),
+            WithEntry::simple(BindingPath {
+                source: BindingSource::Task("step1".into()),
+                segments: vec![PathSegment::Field("result".into())],
+            }),
+        );
+
+        assert_eq!(with_spec.len(), 1);
+        let entry = with_spec.get("data").unwrap();
+        assert_eq!(entry.task_id(), Some("step1"));
+    }
+
+    #[test]
+    fn test_analyzed_for_each_default() {
+        let for_each = AnalyzedForEach::default();
+        assert_eq!(for_each.as_var, "item");
+        assert_eq!(for_each.parallel, Some(1)); // Sequential by default
+        assert!(for_each.fail_fast);
+    }
+
+    #[test]
+    fn test_analyzed_for_each_is_binding() {
+        let for_each = AnalyzedForEach {
+            items: "{{with.items}}".to_string(),
+            ..Default::default()
+        };
+        assert!(for_each.is_binding());
+
+        let for_each = AnalyzedForEach {
+            items: "$items".to_string(),
+            ..Default::default()
+        };
+        assert!(for_each.is_binding());
+
+        let for_each = AnalyzedForEach {
+            items: r#"["a", "b", "c"]"#.to_string(),
+            ..Default::default()
+        };
+        assert!(!for_each.is_binding());
+    }
+
+    #[test]
+    fn test_analyzed_for_each_is_array() {
+        let for_each = AnalyzedForEach {
+            items: r#"["a", "b", "c"]"#.to_string(),
+            ..Default::default()
+        };
+        assert!(for_each.is_array());
+
+        let for_each = AnalyzedForEach {
+            items: "{{with.items}}".to_string(),
+            ..Default::default()
+        };
+        assert!(!for_each.is_array());
+    }
+
+    #[test]
+    fn test_analyzed_for_each_parse_items() {
+        let for_each = AnalyzedForEach {
+            items: r#"["a", "b", "c"]"#.to_string(),
+            ..Default::default()
+        };
+        let items = for_each.parse_items().unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0], serde_json::Value::String("a".to_string()));
+
+        let for_each = AnalyzedForEach {
+            items: "{{with.items}}".to_string(),
+            ..Default::default()
+        };
+        assert!(for_each.parse_items().is_none());
+    }
+
+    #[test]
+    fn test_analyzed_retry_default() {
+        let retry = AnalyzedRetry::default();
+        assert_eq!(retry.max_attempts, 3);
+        assert_eq!(retry.delay_ms, 1000);
+        assert!(retry.backoff.is_none());
+    }
+
+    #[test]
+    fn test_analyzed_retry_delay_for_attempt() {
+        // Without backoff
+        let retry = AnalyzedRetry {
+            max_attempts: 3,
+            delay_ms: 1000,
+            backoff: None,
+            span: make_span(0, 10),
+        };
+        assert_eq!(retry.delay_for_attempt(0), 0); // First attempt, no delay
+        assert_eq!(retry.delay_for_attempt(1), 1000); // Retry 1
+        assert_eq!(retry.delay_for_attempt(2), 1000); // Retry 2
+
+        // With exponential backoff
+        let retry = AnalyzedRetry {
+            max_attempts: 5,
+            delay_ms: 1000,
+            backoff: Some(2.0),
+            span: make_span(0, 10),
+        };
+        assert_eq!(retry.delay_for_attempt(0), 0); // No delay
+        assert_eq!(retry.delay_for_attempt(1), 1000); // 1000 * 2^0
+        assert_eq!(retry.delay_for_attempt(2), 2000); // 1000 * 2^1
+        assert_eq!(retry.delay_for_attempt(3), 4000); // 1000 * 2^2
+    }
+}

--- a/tools/nika-core/src/ast/analyzed/workflow.rs
+++ b/tools/nika-core/src/ast/analyzed/workflow.rs
@@ -1,0 +1,295 @@
+//! Analyzed workflow AST.
+//!
+//! This is the resolved, validated workflow structure with:
+//! - All task references resolved to TaskId
+//! - Dependency graph validated for cycles
+//! - Schema version validated
+
+use indexmap::IndexMap;
+
+use super::ids::{TaskId, TaskTable};
+use super::task::AnalyzedTask;
+use crate::ast::agent_def::AgentDef;
+use crate::ast::artifact::ArtifactsConfig;
+use crate::ast::logging::LogConfig;
+use crate::source::Span;
+
+/// An analyzed workflow - validated and ready for execution.
+///
+/// Unlike RawWorkflow, this has:
+/// - References resolved to interned IDs (TaskId)
+/// - Validated schema version
+/// - Validated dependency graph (no cycles)
+/// - Validated task IDs (no duplicates)
+#[derive(Debug, Clone)]
+pub struct AnalyzedWorkflow {
+    /// Schema version (validated)
+    pub schema_version: SchemaVersion,
+
+    /// Optional workflow name
+    pub name: Option<String>,
+
+    /// Optional description
+    pub description: Option<String>,
+
+    /// Default provider for the workflow
+    pub provider: Option<String>,
+
+    /// Default model for the workflow
+    pub model: Option<String>,
+
+    /// Task lookup table (TaskId → name)
+    pub task_table: TaskTable,
+
+    /// Tasks in execution order (topologically sorted)
+    pub tasks: Vec<AnalyzedTask>,
+
+    /// MCP server configurations (name → config)
+    pub mcp_servers: IndexMap<String, AnalyzedMcpServer>,
+
+    /// Context file configurations
+    pub context_files: Vec<AnalyzedContextFile>,
+
+    /// Import specifications
+    pub imports: Vec<AnalyzedImportSpec>,
+
+    /// Input parameters with defaults
+    pub inputs: IndexMap<String, serde_json::Value>,
+
+    /// Artifact configuration for file persistence
+    pub artifacts: Option<ArtifactsConfig>,
+
+    /// Log configuration
+    pub log: Option<LogConfig>,
+
+    /// Reusable agent definitions (name → config)
+    pub agents: Option<IndexMap<String, AgentDef>>,
+
+    /// Span of the entire workflow
+    pub span: Span,
+}
+
+impl Default for AnalyzedWorkflow {
+    fn default() -> Self {
+        Self {
+            schema_version: SchemaVersion::V12,
+            name: None,
+            description: None,
+            provider: None,
+            model: None,
+            task_table: TaskTable::new(),
+            tasks: Vec::new(),
+            mcp_servers: IndexMap::new(),
+            context_files: Vec::new(),
+            imports: Vec::new(),
+            inputs: IndexMap::new(),
+            artifacts: None,
+            log: None,
+            agents: None,
+            span: Span::dummy(),
+        }
+    }
+}
+
+impl AnalyzedWorkflow {
+    /// Get a task by its ID.
+    pub fn get_task(&self, id: TaskId) -> Option<&AnalyzedTask> {
+        self.tasks.iter().find(|t| t.id == id)
+    }
+
+    /// Get a task by name.
+    pub fn get_task_by_name(&self, name: &str) -> Option<&AnalyzedTask> {
+        let id = self.task_table.get_id(name)?;
+        self.get_task(id)
+    }
+
+    /// Get the number of tasks.
+    pub fn task_count(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// Iterate over all tasks.
+    pub fn iter_tasks(&self) -> impl Iterator<Item = &AnalyzedTask> {
+        self.tasks.iter()
+    }
+
+    /// Check if a task exists by name.
+    pub fn has_task(&self, name: &str) -> bool {
+        self.task_table.get_id(name).is_some()
+    }
+
+    /// Compute a hash of the workflow for trace identification.
+    ///
+    /// Uses xxhash3 for fast hashing. The hash is computed from:
+    /// - Schema version
+    /// - Provider + model
+    /// - Task count and task names
+    ///
+    /// Returns a 16-character hex string (64-bit hash).
+    pub fn compute_hash(&self) -> String {
+        use xxhash_rust::xxh3::xxh3_64;
+
+        let mut input = String::new();
+        input.push_str(self.schema_version.as_str());
+        if let Some(ref provider) = self.provider {
+            input.push_str(provider);
+        }
+        if let Some(ref model) = self.model {
+            input.push_str(model);
+        }
+        input.push_str(&self.tasks.len().to_string());
+        for task in &self.tasks {
+            input.push_str(&task.name);
+        }
+
+        let hash = xxh3_64(input.as_bytes());
+        format!("{:016x}", hash)
+    }
+}
+
+// SchemaVersion is defined in ast::schema and re-exported here.
+pub use super::super::schema::SchemaVersion;
+
+/// Analyzed MCP server configuration.
+#[derive(Debug, Clone)]
+pub struct AnalyzedMcpServer {
+    /// Server name
+    pub name: String,
+
+    /// Command to spawn (for stdio transport)
+    pub command: Option<String>,
+
+    /// Command arguments
+    pub args: Vec<String>,
+
+    /// Environment variables
+    pub env: IndexMap<String, String>,
+
+    /// Working directory
+    pub cwd: Option<String>,
+
+    /// URL (for SSE transport)
+    pub url: Option<String>,
+
+    /// Transport type (stdio or sse)
+    pub transport: McpTransport,
+
+    /// Span of the server config
+    pub span: Span,
+}
+
+/// MCP transport type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum McpTransport {
+    /// stdio transport (default)
+    #[default]
+    Stdio,
+    /// SSE transport
+    Sse,
+}
+
+/// Analyzed context file configuration.
+#[derive(Debug, Clone)]
+pub struct AnalyzedContextFile {
+    /// File path (may contain globs)
+    pub path: String,
+
+    /// Optional alias for the file in context
+    pub alias: Option<String>,
+
+    /// Maximum bytes to load
+    pub max_bytes: Option<u64>,
+
+    /// Span of the config
+    pub span: Span,
+}
+
+/// Analyzed import specification.
+#[derive(Debug, Clone)]
+pub struct AnalyzedImportSpec {
+    /// Path to the imported workflow or skill file.
+    pub path: String,
+
+    /// Optional task ID prefix for namespace isolation.
+    pub prefix: Option<String>,
+
+    /// Span of the import spec
+    pub span: Span,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_analyzed_workflow_default() {
+        let workflow = AnalyzedWorkflow::default();
+        assert_eq!(workflow.task_count(), 0);
+        assert!(workflow.name.is_none());
+        assert!(workflow.span.is_dummy());
+    }
+
+    #[test]
+    fn test_analyzed_workflow_task_lookup() {
+        use crate::binding::WithSpec;
+
+        let mut workflow = AnalyzedWorkflow::default();
+
+        // Insert some tasks
+        let id1 = workflow.task_table.insert("task1");
+        let id2 = workflow.task_table.insert("task2");
+
+        workflow.tasks.push(AnalyzedTask {
+            id: id1,
+            name: "task1".to_string(),
+            description: None,
+            action: super::super::task::AnalyzedTaskAction::default(),
+            provider: None,
+            model: None,
+            with_spec: WithSpec::default(),
+            depends_on: Vec::new(),
+            implicit_deps: Vec::new(),
+            output: None,
+            for_each: None,
+            retry: None,
+            decompose: None,
+            concurrency: None,
+            fail_fast: None,
+            artifact: None,
+            log: None,
+            structured: None,
+            span: Span::dummy(),
+        });
+
+        workflow.tasks.push(AnalyzedTask {
+            id: id2,
+            name: "task2".to_string(),
+            description: None,
+            action: super::super::task::AnalyzedTaskAction::default(),
+            provider: None,
+            model: None,
+            with_spec: WithSpec::default(),
+            depends_on: Vec::new(),
+            implicit_deps: Vec::new(),
+            output: None,
+            for_each: None,
+            retry: None,
+            decompose: None,
+            concurrency: None,
+            fail_fast: None,
+            artifact: None,
+            log: None,
+            structured: None,
+            span: Span::dummy(),
+        });
+
+        assert_eq!(workflow.task_count(), 2);
+        assert!(workflow.has_task("task1"));
+        assert!(workflow.has_task("task2"));
+        assert!(!workflow.has_task("unknown"));
+
+        assert!(workflow.get_task(id1).is_some());
+        assert_eq!(workflow.get_task(id1).unwrap().name, "task1");
+        assert!(workflow.get_task_by_name("task2").is_some());
+    }
+}

--- a/tools/nika-core/src/ast/analyzer/analyze.rs
+++ b/tools/nika-core/src/ast/analyzer/analyze.rs
@@ -1,0 +1,2618 @@
+//! Analyzer: raw::Workflow → analyzed::Workflow
+//!
+//! This is the core Phase 2 transformation that:
+//! 1. Validates schema version
+//! 2. Builds task table (interned IDs)
+//! 3. Resolves all task references (`with:` bindings → WithSpec, `depends_on:` → Vec<TaskId>)
+//! 4. Extracts implicit dependencies from WithEntry task references
+//! 5. Resolves `imports:` specifications
+//! 6. Detects cyclic dependencies
+//! 7. Collects all errors with precise spans
+
+use std::collections::{HashMap, HashSet};
+
+use super::errors::{AnalyzeError, AnalyzeErrorKind, AnalyzeResult};
+use super::suggestions::find_similar;
+use crate::ast::analyzed::{
+    AnalyzedAgentAction, AnalyzedContextFile, AnalyzedExecAction, AnalyzedFetchAction,
+    AnalyzedForEach, AnalyzedImportSpec, AnalyzedInferAction, AnalyzedInvokeAction,
+    AnalyzedMcpServer, AnalyzedOutput, AnalyzedRetry, AnalyzedTask, AnalyzedTaskAction,
+    AnalyzedWorkflow, HttpMethod, McpTransport, OutputFormat, TaskId, TaskTable,
+};
+use crate::ast::raw::{
+    RawAgentAction, RawExecAction, RawFetchAction, RawInferAction, RawInvokeAction, RawTask,
+    RawTaskAction, RawWorkflow,
+};
+use crate::ast::schema::SchemaVersion;
+use crate::binding::{parse_with_entry, WithSpec};
+use crate::source::{Span, Spanned};
+
+/// Analyzer context - holds state during analysis.
+struct AnalyzerContext {
+    /// Task name to ID mapping
+    task_table: TaskTable,
+    /// Task name to span mapping (for duplicate detection)
+    task_spans: HashMap<String, Span>,
+    /// Prefixes declared in `include:` — tasks matching these are resolved post-analysis
+    include_prefixes: Vec<String>,
+    /// Collected errors
+    errors: Vec<AnalyzeError>,
+    /// Collected warnings
+    warnings: Vec<AnalyzeError>,
+}
+
+impl AnalyzerContext {
+    fn new() -> Self {
+        Self {
+            task_table: TaskTable::new(),
+            task_spans: HashMap::new(),
+            include_prefixes: Vec::new(),
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    fn add_error(&mut self, error: AnalyzeError) {
+        self.errors.push(error);
+    }
+
+    fn add_warning(&mut self, warning: AnalyzeError) {
+        self.warnings.push(warning);
+    }
+
+    /// Check if a task name matches a declared include prefix.
+    ///
+    /// When `include:` declares `prefix: seo_`, references like `$seo_generate_title`
+    /// should not be flagged as unknown — they'll be resolved after DAG fusion.
+    fn is_included_task(&self, task_name: &str) -> bool {
+        self.include_prefixes
+            .iter()
+            .any(|prefix| task_name.starts_with(prefix))
+    }
+}
+
+/// Validate a raw workflow without producing an analyzed workflow.
+///
+/// Runs all validation checks (schema, feature gates, duplicate tasks,
+/// unknown task references, invalid bindings, cycle detection) and returns
+/// collected errors. This is cheaper than `analyze()` when you only need
+/// to check if a workflow is valid.
+///
+/// # Arguments
+///
+/// * `raw` - The raw workflow from Phase 1 parsing
+///
+/// # Returns
+///
+/// An `AnalyzeResult<()>` — `Ok(())` if valid, or errors if not.
+///
+/// # Example
+///
+/// ```ignore
+/// let raw = raw::parse(&source, file_id)?;
+/// let result = validate(&raw);
+/// if result.is_err() {
+///     for error in &result.errors {
+///         eprintln!("{}: {}", error.kind.code(), error);
+///     }
+/// }
+/// ```
+pub fn validate(raw: &RawWorkflow) -> AnalyzeResult<()> {
+    let mut ctx = AnalyzerContext::new();
+
+    // 1. Validate schema version
+    let version = analyze_schema(raw, &mut ctx).unwrap_or(SchemaVersion::V01);
+
+    // 2. Validate version-gated features
+    validate_feature_gates(raw, version, &mut ctx);
+
+    // 2.5. Collect include prefixes (tasks with these prefixes are resolved post-analysis)
+    collect_include_prefixes(raw, &mut ctx);
+
+    // 3. Build task table (detect duplicates)
+    build_task_table(&raw.tasks.value, &mut ctx);
+
+    // 4. Validate task references (unknown tasks in with:/depends_on:, invalid bindings)
+    let task_table = ctx.task_table.clone();
+    let task_names: Vec<String> = task_table.iter().map(|(_, n)| n.to_string()).collect();
+    for raw_task in raw.tasks.value.iter() {
+        validate_task_refs(&raw_task.value, &task_table, &task_names, &mut ctx);
+    }
+
+    // 5. Detect cyclic dependencies (requires building a lightweight dep graph)
+    detect_cycles_from_raw(&raw.tasks.value, &task_table, &mut ctx);
+
+    if ctx.errors.is_empty() {
+        let mut result = AnalyzeResult::ok(());
+        result.warnings = ctx.warnings;
+        result
+    } else {
+        let mut result = AnalyzeResult::err(ctx.errors);
+        result.warnings = ctx.warnings;
+        result
+    }
+}
+
+/// Analyze a raw workflow into a resolved, validated workflow.
+///
+/// This is the main entry point for Phase 2 analysis.
+///
+/// # Arguments
+///
+/// * `raw` - The raw workflow from Phase 1 parsing
+///
+/// # Returns
+///
+/// An AnalyzeResult containing either the analyzed workflow or collected errors.
+///
+/// # Example
+///
+/// ```ignore
+/// let raw = raw::parse(&source, file_id)?;
+/// let result = analyze(raw);
+/// if result.is_ok() {
+///     let workflow = result.value.unwrap();
+///     // Use analyzed workflow
+/// } else {
+///     for error in &result.errors {
+///         eprintln!("{}: {}", error.kind.code(), error);
+///     }
+/// }
+/// ```
+pub fn analyze(raw: RawWorkflow) -> AnalyzeResult<AnalyzedWorkflow> {
+    let mut ctx = AnalyzerContext::new();
+
+    // Collect include prefixes early (before raw fields are moved)
+    collect_include_prefixes(&raw, &mut ctx);
+
+    let mut workflow = AnalyzedWorkflow {
+        span: raw.span,
+        ..Default::default()
+    };
+
+    // 1. Validate schema version
+    if let Some(version) = analyze_schema(&raw, &mut ctx) {
+        workflow.schema_version = version;
+    }
+
+    // 2. Validate version-gated features
+    validate_feature_gates(&raw, workflow.schema_version, &mut ctx);
+
+    // 3. Extract metadata
+    workflow.name = raw.workflow.as_ref().map(|s| s.value.clone());
+    workflow.description = raw.description.map(|s| s.value);
+    workflow.provider = raw.provider.map(|s| s.value);
+    workflow.model = raw.model.map(|s| s.value);
+
+    // 4. Analyze MCP server configurations
+    if let Some(ref mcp) = raw.mcp {
+        for (name_spanned, server_spanned) in &mcp.value.servers {
+            let analyzed_server = analyze_mcp_server(
+                &name_spanned.value,
+                &server_spanned.value,
+                server_spanned.span,
+                &mut ctx,
+            );
+            workflow
+                .mcp_servers
+                .insert(name_spanned.value.clone(), analyzed_server);
+        }
+    }
+
+    // 5. Analyze imports
+    if let Some(ref imports) = raw.imports {
+        for import_spanned in &imports.value {
+            let import = &import_spanned.value;
+            workflow.imports.push(AnalyzedImportSpec {
+                path: import.path.value.clone(),
+                prefix: import.prefix.as_ref().map(|s| s.value.clone()),
+                span: import_spanned.span,
+            });
+        }
+    }
+
+    // 6. Analyze inputs
+    if let Some(ref inputs) = raw.inputs {
+        for (key_spanned, val_spanned) in &inputs.value {
+            workflow
+                .inputs
+                .insert(key_spanned.value.clone(), val_spanned.value.clone());
+        }
+    }
+
+    // 6a. Analyze context files
+    if let Some(ref context) = raw.context {
+        if let Some(ref files) = context.value.files {
+            for (alias_spanned, path_spanned) in files {
+                workflow.context_files.push(AnalyzedContextFile {
+                    path: path_spanned.value.clone(),
+                    alias: Some(alias_spanned.value.clone()),
+                    max_bytes: None,
+                    span: path_spanned.span,
+                });
+            }
+        }
+    }
+
+    // 6b. Parse workflow-level artifacts config
+    if let Some(ref artifacts_spanned) = raw.artifacts {
+        if let Ok(config) = serde_json::from_value(artifacts_spanned.value.clone()) {
+            workflow.artifacts = Some(config);
+        }
+    }
+
+    // 6c. Parse workflow-level log config
+    if let Some(ref log_spanned) = raw.log {
+        match serde_json::from_value(log_spanned.value.clone()) {
+            Ok(config) => workflow.log = Some(config),
+            Err(e) => tracing::warn!(error = %e, "Failed to parse workflow log: config"),
+        }
+    }
+
+    // 6d. Parse workflow-level agents config
+    if let Some(ref agents_spanned) = raw.agents {
+        if let serde_json::Value::Object(map) = &agents_spanned.value {
+            let mut agents = indexmap::IndexMap::new();
+            for (name, def_value) in map {
+                match serde_json::from_value(def_value.clone()) {
+                    Ok(def) => {
+                        agents.insert(name.clone(), def);
+                    }
+                    Err(e) => tracing::warn!(
+                        agent = %name,
+                        error = %e,
+                        "Failed to parse agent definition"
+                    ),
+                }
+            }
+            if !agents.is_empty() {
+                workflow.agents = Some(agents);
+            }
+        }
+    }
+
+    // 6e. Validate tasks array is non-empty
+    if raw.tasks.value.is_empty() {
+        ctx.errors.push(AnalyzeError::new(
+            AnalyzeErrorKind::InvalidValue,
+            raw.tasks.span,
+            "tasks array must not be empty; workflow requires at least one task",
+        ));
+    }
+
+    // 7. Build task table (first pass - collect all task IDs)
+    build_task_table(&raw.tasks.value, &mut ctx);
+
+    // 8. Analyze each task (second pass - resolve references)
+    // Clone task_table to avoid borrow checker issues
+    let task_table = ctx.task_table.clone();
+    let task_names: Vec<String> = task_table.iter().map(|(_, n)| n.to_string()).collect();
+    for raw_task in raw.tasks.value.iter() {
+        if let Some(analyzed_task) =
+            analyze_task(&raw_task.value, &task_table, &task_names, &mut ctx)
+        {
+            workflow.tasks.push(analyzed_task);
+        }
+    }
+
+    // 9. Detect cyclic dependencies
+    detect_cycles(&workflow, &mut ctx);
+
+    // Copy task table to workflow
+    workflow.task_table = ctx.task_table;
+
+    // Build result
+    if ctx.errors.is_empty() {
+        let mut result = AnalyzeResult::ok(workflow);
+        result.warnings = ctx.warnings;
+        result
+    } else {
+        let mut result = AnalyzeResult::err(ctx.errors);
+        result.warnings = ctx.warnings;
+        result
+    }
+}
+
+/// Analyze and validate the schema version.
+fn analyze_schema(raw: &RawWorkflow, ctx: &mut AnalyzerContext) -> Option<SchemaVersion> {
+    let schema_str = &raw.schema.value;
+
+    if let Some(version) = SchemaVersion::parse(schema_str) {
+        Some(version)
+    } else {
+        // Find similar schema version
+        let all_versions: Vec<&str> = SchemaVersion::all().iter().map(|v| v.as_str()).collect();
+        let suggestion = find_similar(schema_str, &all_versions, 0.6);
+
+        ctx.add_error(AnalyzeError::invalid_schema(
+            raw.schema.span,
+            schema_str,
+            suggestion.as_deref(),
+        ));
+        None
+    }
+}
+
+/// Validate version-gated features.
+///
+/// Checks that features used in the workflow are available in the declared schema version.
+fn validate_feature_gates(raw: &RawWorkflow, version: SchemaVersion, ctx: &mut AnalyzerContext) {
+    let version_str = version.as_str();
+
+    // Check MCP servers
+    if let Some(ref mcp) = raw.mcp {
+        if !version.supports_mcp() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                mcp.span,
+                "mcp",
+                version_str,
+                "nika/workflow@0.2",
+            ));
+        }
+    }
+
+    // Check context files
+    if let Some(ref context) = raw.context {
+        if !version.supports_context() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                context.span,
+                "context",
+                version_str,
+                "nika/workflow@0.9",
+            ));
+        }
+    }
+
+    // Check imports
+    if let Some(ref imports) = raw.imports {
+        if !version.supports_imports() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                imports.span,
+                "imports",
+                version_str,
+                "nika/workflow@0.12",
+            ));
+        }
+    }
+
+    // Check inputs
+    if let Some(ref inputs) = raw.inputs {
+        if !version.supports_inputs() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                inputs.span,
+                "inputs",
+                version_str,
+                "nika/workflow@0.10",
+            ));
+        }
+    }
+
+    // Check task-level features
+    for task in raw.tasks.value.iter() {
+        validate_task_feature_gates(&task.value, version, version_str, ctx);
+    }
+}
+
+/// Validate version-gated features in a task.
+fn validate_task_feature_gates(
+    task: &RawTask,
+    version: SchemaVersion,
+    version_str: &str,
+    ctx: &mut AnalyzerContext,
+) {
+    // Check for_each
+    if let Some(ref for_each) = task.for_each {
+        if !version.supports_for_each() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                for_each.span,
+                "for_each",
+                version_str,
+                "nika/workflow@0.3",
+            ));
+        }
+    }
+
+    // Check retry
+    if let Some(ref retry) = task.retry {
+        if !version.supports_retry() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                retry.span,
+                "retry",
+                version_str,
+                "nika/workflow@0.3",
+            ));
+        }
+
+        // retry: is only effective on fetch: tasks — warn on other verbs
+        if let Some(ref action) = task.action {
+            let verb_name = match action {
+                RawTaskAction::Fetch(_) => None,
+                RawTaskAction::Infer(_) => Some("infer"),
+                RawTaskAction::Exec(_) => Some("exec"),
+                RawTaskAction::Invoke(_) => Some("invoke"),
+                RawTaskAction::Agent(_) => Some("agent"),
+            };
+            if let Some(verb_name) = verb_name {
+                ctx.add_warning(
+                    AnalyzeError::new(
+                        AnalyzeErrorKind::InvalidValue,
+                        retry.span,
+                        format!(
+                            "'retry' has no effect on '{}' tasks (only 'fetch' supports retry)",
+                            verb_name
+                        ),
+                    )
+                    .with_suggestion("move retry to a fetch task, or remove it"),
+                );
+            }
+        }
+    }
+
+    // Check with: bindings
+    if let Some(ref with_refs) = task.with_refs {
+        if !version.supports_with() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                with_refs.span,
+                "with",
+                version_str,
+                "nika/workflow@0.12",
+            ));
+        }
+    }
+
+    // Check depends_on:
+    if let Some(ref depends_on) = task.depends_on {
+        if !version.supports_depends_on() {
+            ctx.add_error(AnalyzeError::unsupported_feature(
+                depends_on.span,
+                "depends_on",
+                version_str,
+                "nika/workflow@0.12",
+            ));
+        }
+    }
+
+    // Check invoke/agent verbs
+    if let Some(ref action) = task.action {
+        match action {
+            RawTaskAction::Invoke(invoke) => {
+                if !version.supports_invoke_agent() {
+                    ctx.add_error(AnalyzeError::unsupported_feature(
+                        invoke.span,
+                        "invoke verb",
+                        version_str,
+                        "nika/workflow@0.2",
+                    ));
+                }
+            }
+            RawTaskAction::Agent(agent) => {
+                if !version.supports_invoke_agent() {
+                    ctx.add_error(AnalyzeError::unsupported_feature(
+                        agent.span,
+                        "agent verb",
+                        version_str,
+                        "nika/workflow@0.2",
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Analyze a single task.
+///
+/// Parses `with:` binding expressions via `parse_with_entry()`, resolves `depends_on:`
+/// task names to `TaskId`, and auto-extracts implicit dependencies from task bindings.
+fn analyze_task(
+    raw: &RawTask,
+    task_table: &TaskTable,
+    all_task_names: &[String],
+    ctx: &mut AnalyzerContext,
+) -> Option<AnalyzedTask> {
+    let task_id = task_table.get_id(&raw.id.value)?;
+
+    let mut task = AnalyzedTask {
+        id: task_id,
+        name: raw.id.value.clone(),
+        description: raw.description.as_ref().map(|s| s.value.clone()),
+        action: AnalyzedTaskAction::default(),
+        provider: raw.provider.as_ref().map(|s| s.value.clone()),
+        model: raw.model.as_ref().map(|s| s.value.clone()),
+        with_spec: WithSpec::default(),
+        depends_on: Vec::new(),
+        implicit_deps: Vec::new(),
+        output: None,
+        for_each: raw
+            .for_each
+            .as_ref()
+            .map(|f| analyze_for_each(&f.value, f.span)),
+        retry: raw.retry.as_ref().map(|r| analyze_retry(&r.value, r.span)),
+        decompose: raw.decompose.as_ref().map(|d| d.value.clone()),
+        concurrency: raw.concurrency.as_ref().map(|s| s.value),
+        fail_fast: raw.fail_fast.as_ref().map(|s| s.value),
+        artifact: raw.artifact.as_ref().and_then(|s| {
+            match serde_json::from_value(s.value.clone()) {
+                Ok(spec) => Some(spec),
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %raw.id.value,
+                        error = %e,
+                        "Failed to parse artifact: config, ignoring"
+                    );
+                    None
+                }
+            }
+        }),
+        log: raw
+            .log
+            .as_ref()
+            .and_then(|s| match serde_json::from_value(s.value.clone()) {
+                Ok(config) => Some(config),
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %raw.id.value,
+                        error = %e,
+                        "Failed to parse log: config, ignoring"
+                    );
+                    None
+                }
+            }),
+        structured: raw.structured.clone(),
+        span: raw.span,
+    };
+
+    // Analyze action
+    if let Some(ref action) = raw.action {
+        task.action = analyze_action(action);
+
+        // Merge agent-block provider/model into task if not set at task level
+        if let RawTaskAction::Agent(ref agent_spanned) = action {
+            let agent = &agent_spanned.value;
+            if task.provider.is_none() {
+                task.provider = agent.provider.as_ref().map(|s| s.value.clone());
+            }
+            if task.model.is_none() {
+                task.model = agent.model.as_ref().map(|s| s.value.clone());
+            }
+        }
+    }
+
+    // Warn if retry: is used on non-fetch verbs (it only applies to fetch:)
+    if task.retry.is_some() {
+        if let Some(ref action) = raw.action {
+            let is_fetch = matches!(action, RawTaskAction::Fetch(_));
+            if !is_fetch {
+                tracing::warn!(
+                    task_id = %raw.id.value,
+                    "retry: config is only supported on fetch: tasks — ignored for this verb"
+                );
+            }
+        }
+    }
+
+    // Parse with: bindings
+    if let Some(ref with_refs) = raw.with_refs {
+        for (alias_spanned, value_spanned) in with_refs.value.iter() {
+            let alias = &alias_spanned.value;
+            let expr = &value_spanned.value;
+
+            match parse_with_entry(expr) {
+                Ok(entry) => {
+                    // Extract implicit dependency if this binding references a task
+                    if let Some(dep_task_name) = entry.task_id() {
+                        if let Some(dep_id) = task_table.get_id(dep_task_name) {
+                            // Deduplicate implicit deps
+                            if !task.implicit_deps.contains(&dep_id) {
+                                task.implicit_deps.push(dep_id);
+                            }
+                        } else if !ctx.is_included_task(dep_task_name) {
+                            // Unknown task reference in with: binding
+                            // (skip check for tasks matching include prefixes)
+                            let all_names: Vec<&str> =
+                                all_task_names.iter().map(|s| s.as_str()).collect();
+                            let suggestion = find_similar(dep_task_name, &all_names, 0.6);
+                            ctx.add_error(AnalyzeError::unknown_task(
+                                value_spanned.span,
+                                dep_task_name,
+                                suggestion.as_deref(),
+                            ));
+                        }
+                    }
+                    task.with_spec.insert(alias.clone(), entry);
+                }
+                Err(parse_err) => {
+                    ctx.add_error(AnalyzeError::invalid_binding(
+                        value_spanned.span,
+                        expr,
+                        &parse_err.reason,
+                    ));
+                }
+            }
+        }
+    }
+
+    // Resolve depends_on: task names to TaskId
+    if let Some(ref depends_on) = raw.depends_on {
+        for dep_spanned in &depends_on.value {
+            let dep_name = &dep_spanned.value;
+            if let Some(dep_id) = task_table.get_id(dep_name) {
+                task.depends_on.push(dep_id);
+            } else if !ctx.is_included_task(dep_name) {
+                // Unknown task in depends_on (skip for include-prefixed tasks)
+                let all_names: Vec<&str> = all_task_names.iter().map(|s| s.as_str()).collect();
+                let suggestion = find_similar(dep_name, &all_names, 0.6);
+                ctx.add_error(AnalyzeError::unknown_task(
+                    dep_spanned.span,
+                    dep_name,
+                    suggestion.as_deref(),
+                ));
+            }
+        }
+    }
+
+    // Analyze output config
+    if let Some(ref output) = raw.output {
+        task.output = Some(analyze_output(&output.value, ctx));
+    }
+
+    Some(task)
+}
+
+/// Analyze task action.
+fn analyze_action(raw: &RawTaskAction) -> AnalyzedTaskAction {
+    match raw {
+        RawTaskAction::Infer(s) => AnalyzedTaskAction::Infer(analyze_infer(&s.value)),
+        RawTaskAction::Exec(s) => AnalyzedTaskAction::Exec(analyze_shell_cmd(&s.value)),
+        RawTaskAction::Fetch(s) => AnalyzedTaskAction::Fetch(analyze_fetch(&s.value)),
+        RawTaskAction::Invoke(s) => AnalyzedTaskAction::Invoke(analyze_invoke(&s.value)),
+        RawTaskAction::Agent(s) => AnalyzedTaskAction::Agent(analyze_agent(&s.value)),
+    }
+}
+
+fn analyze_infer(raw: &RawInferAction) -> AnalyzedInferAction {
+    use crate::ast::content::analyze_content_part;
+
+    AnalyzedInferAction {
+        prompt: raw.prompt.value.clone(),
+        system: raw.system.as_ref().map(|s| s.value.clone()),
+        temperature: raw.temperature.as_ref().map(|s| s.value),
+        max_tokens: raw.max_tokens.as_ref().map(|s| s.value),
+        thinking: raw.thinking.as_ref().map(|s| s.value),
+        thinking_budget: raw.thinking_budget.as_ref().map(|s| s.value),
+        content: raw
+            .content
+            .as_ref()
+            .map(|spanned| spanned.value.iter().map(analyze_content_part).collect()),
+        span: raw.prompt.span,
+    }
+}
+
+fn analyze_shell_cmd(raw: &RawExecAction) -> AnalyzedExecAction {
+    AnalyzedExecAction {
+        command: raw.command.value.clone(),
+        shell: raw.shell.as_ref().map(|s| s.value).unwrap_or(false),
+        working_dir: raw.working_dir.as_ref().map(|s| s.value.clone()),
+        env: raw
+            .env
+            .as_ref()
+            .map(|s| {
+                s.value
+                    .iter()
+                    .map(|(k, v)| (k.value.clone(), v.value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        timeout_ms: raw.timeout_ms.as_ref().map(|s| s.value),
+        span: raw.command.span,
+    }
+}
+
+fn analyze_fetch(raw: &RawFetchAction) -> AnalyzedFetchAction {
+    let method = raw
+        .method
+        .as_ref()
+        .and_then(|s| HttpMethod::parse(&s.value))
+        .unwrap_or(HttpMethod::Get);
+
+    AnalyzedFetchAction {
+        url: raw.url.value.clone(),
+        method,
+        headers: raw
+            .headers
+            .as_ref()
+            .map(|s| {
+                s.value
+                    .iter()
+                    .map(|(k, v)| (k.value.clone(), v.value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        body: raw.body.as_ref().map(|s| s.value.clone()),
+        json: raw.json.as_ref().map(|s| s.value.clone()),
+        timeout_ms: raw.timeout_ms.as_ref().map(|s| s.value),
+        follow_redirects: raw
+            .follow_redirects
+            .as_ref()
+            .map(|s| s.value)
+            .unwrap_or(true),
+        span: raw.url.span,
+    }
+}
+
+fn analyze_invoke(raw: &RawInvokeAction) -> AnalyzedInvokeAction {
+    let (server, tool) = raw.parse_tool_name();
+
+    AnalyzedInvokeAction {
+        server: server
+            .map(|s| s.to_string())
+            .or_else(|| raw.mcp.as_ref().map(|s| s.value.clone())),
+        tool: tool.to_string(),
+        params: raw.params.as_ref().map(|s| s.value.clone()),
+        timeout_ms: raw.timeout_ms.as_ref().map(|s| s.value),
+        span: raw.tool.span,
+    }
+}
+
+fn analyze_agent(raw: &RawAgentAction) -> AnalyzedAgentAction {
+    AnalyzedAgentAction {
+        prompt: raw.prompt.value.clone(),
+        tools: raw
+            .tools
+            .as_ref()
+            .map(|s| s.value.iter().map(|v| v.value.clone()).collect())
+            .unwrap_or_default(),
+        max_iterations: raw.max_iterations.as_ref().map(|s| s.value),
+        max_tokens: raw.max_tokens.as_ref().map(|s| s.value),
+        from: raw.from.as_ref().map(|s| s.value.clone()),
+        skills: raw
+            .skills
+            .as_ref()
+            .map(|s| s.value.iter().map(|v| v.value.clone()).collect())
+            .unwrap_or_default(),
+        mcp: raw
+            .mcp
+            .as_ref()
+            .map(|s| s.value.iter().map(|v| v.value.clone()).collect())
+            .unwrap_or_default(),
+        system: raw.system.as_ref().map(|s| s.value.clone()),
+        temperature: raw.temperature.as_ref().map(|s| s.value),
+        token_budget: raw.token_budget.as_ref().map(|s| s.value),
+        extended_thinking: raw.extended_thinking.as_ref().map(|s| s.value),
+        thinking_budget: raw.thinking_budget.as_ref().map(|s| s.value),
+        depth_limit: raw.depth_limit.as_ref().map(|s| s.value),
+        span: raw.prompt.span,
+    }
+}
+
+fn analyze_output(
+    raw: &crate::ast::raw::RawOutputConfig,
+    _ctx: &mut AnalyzerContext,
+) -> AnalyzedOutput {
+    let format = raw
+        .format
+        .as_ref()
+        .and_then(|s| OutputFormat::parse(&s.value))
+        .unwrap_or(OutputFormat::Text);
+
+    AnalyzedOutput {
+        format,
+        schema: raw.schema.as_ref().map(|s| s.value.clone()),
+        span: raw.format.as_ref().map(|s| s.span).unwrap_or(Span::dummy()),
+    }
+}
+
+/// Analyze MCP server configuration.
+fn analyze_mcp_server(
+    name: &str,
+    raw: &crate::ast::raw::RawMcpServer,
+    span: Span,
+    ctx: &mut AnalyzerContext,
+) -> AnalyzedMcpServer {
+    let transport = if raw.is_sse() {
+        McpTransport::Sse
+    } else {
+        McpTransport::Stdio
+    };
+
+    // SSE servers are accepted by the analyzer but dropped during lowering
+    if transport == McpTransport::Sse {
+        ctx.add_warning(
+            AnalyzeError::new(
+                AnalyzeErrorKind::UnsupportedFeature,
+                span,
+                format!(
+                    "SSE MCP server '{}' will be dropped during execution (no runtime support)",
+                    name
+                ),
+            )
+            .with_suggestion("use a stdio-based MCP server instead"),
+        );
+    }
+
+    // Stdio servers require a non-empty command field
+    if transport == McpTransport::Stdio {
+        let has_command = raw
+            .command
+            .as_ref()
+            .map(|s| !s.value.trim().is_empty())
+            .unwrap_or(false);
+        if !has_command {
+            let error_span = raw.command.as_ref().map(|s| s.span).unwrap_or(span);
+            ctx.add_error(AnalyzeError::new(
+                AnalyzeErrorKind::MissingField,
+                error_span,
+                format!(
+                    "MCP server '{}' uses stdio transport but has no 'command' field",
+                    name
+                ),
+            ));
+        }
+    }
+
+    AnalyzedMcpServer {
+        name: name.to_string(),
+        command: raw.command.as_ref().map(|s| s.value.clone()),
+        args: raw
+            .args
+            .as_ref()
+            .map(|s| s.value.iter().map(|v| v.value.clone()).collect())
+            .unwrap_or_default(),
+        env: raw
+            .env
+            .as_ref()
+            .map(|s| {
+                s.value
+                    .iter()
+                    .map(|(k, v)| (k.value.clone(), v.value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        cwd: raw.cwd.as_ref().map(|s| s.value.clone()),
+        url: raw.url.as_ref().map(|s| s.value.clone()),
+        transport,
+        span,
+    }
+}
+
+/// Analyze for_each iteration configuration.
+fn analyze_for_each(raw: &crate::ast::raw::RawForEach, span: Span) -> AnalyzedForEach {
+    AnalyzedForEach {
+        items: raw.items.value.clone(),
+        as_var: raw
+            .as_var
+            .as_ref()
+            .map(|s| s.value.clone())
+            .unwrap_or_else(|| "item".to_string()),
+        parallel: Some(raw.parallel.as_ref().map(|s| s.value).unwrap_or(1)),
+        fail_fast: raw.fail_fast.as_ref().map(|s| s.value).unwrap_or(true),
+        span,
+    }
+}
+
+/// Analyze retry configuration.
+fn analyze_retry(raw: &crate::ast::raw::RawRetryConfig, span: Span) -> AnalyzedRetry {
+    AnalyzedRetry {
+        max_attempts: raw.max_attempts.as_ref().map(|s| s.value).unwrap_or(3),
+        delay_ms: raw.delay_ms.as_ref().map(|s| s.value).unwrap_or(1000),
+        backoff: raw.backoff.as_ref().map(|s| s.value),
+        span,
+    }
+}
+
+/// Build the task table from raw tasks, detecting duplicates.
+///
+/// Collect prefixes declared in `include:` entries.
+///
+/// When a workflow uses `include: [{ path: ./lib/seo.nika.yaml, prefix: seo_ }]`,
+/// task references like `$seo_generate_title` should not be flagged as unknown
+/// during analysis — they'll be resolved after `expand_includes()` merges the
+/// included tasks into the DAG.
+fn collect_include_prefixes(raw: &RawWorkflow, ctx: &mut AnalyzerContext) {
+    if let Some(ref imports) = raw.imports {
+        let mut seen = HashSet::new();
+        for import in &imports.value {
+            if let Some(ref prefix) = import.value.prefix {
+                if !seen.insert(prefix.value.clone()) {
+                    ctx.add_error(AnalyzeError::new(
+                        AnalyzeErrorKind::InvalidValue,
+                        prefix.span,
+                        format!("duplicate import prefix '{}'", prefix.value),
+                    ));
+                }
+                ctx.include_prefixes.push(prefix.value.clone());
+            }
+        }
+    }
+}
+
+/// Shared between `validate()` and `analyze()`.
+fn build_task_table(tasks: &[Spanned<RawTask>], ctx: &mut AnalyzerContext) {
+    for task in tasks.iter() {
+        let task_name = &task.value.id.value;
+        let task_span = task.value.id.span;
+
+        // Validate task ID format before inserting
+        if !validate_task_id(task_name, task_span, ctx) {
+            continue;
+        }
+
+        if let Some(first_span) = ctx.task_spans.get(task_name) {
+            ctx.add_error(AnalyzeError::duplicate_task(
+                task_span,
+                task_name,
+                *first_span,
+            ));
+        } else {
+            ctx.task_table.insert(task_name);
+            ctx.task_spans.insert(task_name.clone(), task_span);
+        }
+    }
+}
+
+/// Validate task ID format: non-empty, alphanumeric with hyphens/underscores/dots,
+/// must not start with `$` (reserved for binding references).
+fn validate_task_id(name: &str, span: Span, ctx: &mut AnalyzerContext) -> bool {
+    if name.is_empty() {
+        ctx.add_error(AnalyzeError::new(
+            AnalyzeErrorKind::InvalidValue,
+            span,
+            "task ID must not be empty",
+        ));
+        return false;
+    }
+    if name.starts_with('$') {
+        ctx.add_error(
+            AnalyzeError::new(
+                AnalyzeErrorKind::InvalidValue,
+                span,
+                format!(
+                    "task ID '{}' must not start with '$' (reserved for binding references)",
+                    name
+                ),
+            )
+            .with_suggestion("remove the leading '$' from the task ID"),
+        );
+        return false;
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
+    {
+        ctx.add_error(
+            AnalyzeError::new(
+                AnalyzeErrorKind::InvalidValue,
+                span,
+                format!("task ID '{}' contains invalid characters", name),
+            )
+            .with_suggestion("use only alphanumeric characters, hyphens, underscores, and dots"),
+        );
+        return false;
+    }
+    true
+}
+
+/// Validate task references without building analyzed tasks.
+///
+/// Checks `with:` bindings for unknown task references and invalid expressions,
+/// and `depends_on:` for unknown task references. Used by `validate()`.
+fn validate_task_refs(
+    raw: &RawTask,
+    task_table: &TaskTable,
+    all_task_names: &[String],
+    ctx: &mut AnalyzerContext,
+) {
+    // Validate with: bindings
+    if let Some(ref with_refs) = raw.with_refs {
+        for (_alias_spanned, value_spanned) in with_refs.value.iter() {
+            let expr = &value_spanned.value;
+
+            match parse_with_entry(expr) {
+                Ok(entry) => {
+                    // Check for unknown task references
+                    if let Some(dep_task_name) = entry.task_id() {
+                        if task_table.get_id(dep_task_name).is_none()
+                            && !ctx.is_included_task(dep_task_name)
+                        {
+                            let all_names: Vec<&str> =
+                                all_task_names.iter().map(|s| s.as_str()).collect();
+                            let suggestion = find_similar(dep_task_name, &all_names, 0.6);
+                            ctx.add_error(AnalyzeError::unknown_task(
+                                value_spanned.span,
+                                dep_task_name,
+                                suggestion.as_deref(),
+                            ));
+                        }
+                    }
+                }
+                Err(parse_err) => {
+                    ctx.add_error(AnalyzeError::invalid_binding(
+                        value_spanned.span,
+                        expr,
+                        &parse_err.reason,
+                    ));
+                }
+            }
+        }
+    }
+
+    // Validate depends_on: references
+    if let Some(ref depends_on) = raw.depends_on {
+        for dep_spanned in &depends_on.value {
+            let dep_name = &dep_spanned.value;
+            if task_table.get_id(dep_name).is_none() && !ctx.is_included_task(dep_name) {
+                let all_names: Vec<&str> = all_task_names.iter().map(|s| s.as_str()).collect();
+                let suggestion = find_similar(dep_name, &all_names, 0.6);
+                ctx.add_error(AnalyzeError::unknown_task(
+                    dep_spanned.span,
+                    dep_name,
+                    suggestion.as_deref(),
+                ));
+            }
+        }
+    }
+}
+
+/// Detect cyclic dependencies from raw workflow (without AnalyzedWorkflow).
+///
+/// Builds a lightweight dependency graph from raw task data and runs DFS cycle detection.
+/// Used by `validate()`.
+fn detect_cycles_from_raw(
+    tasks: &[Spanned<RawTask>],
+    task_table: &TaskTable,
+    ctx: &mut AnalyzerContext,
+) {
+    // Build adjacency list: TaskId → Vec<TaskId>
+    let mut adjacency: HashMap<TaskId, Vec<TaskId>> = HashMap::new();
+    let mut task_spans: HashMap<TaskId, Span> = HashMap::new();
+
+    for raw_task in tasks.iter() {
+        let task_name = &raw_task.value.id.value;
+        let Some(task_id) = task_table.get_id(task_name) else {
+            continue; // Skip tasks that failed duplicate detection
+        };
+        task_spans.insert(task_id, raw_task.value.span);
+        let deps = adjacency.entry(task_id).or_default();
+
+        // Collect depends_on edges
+        if let Some(ref depends_on) = raw_task.value.depends_on {
+            for dep_spanned in &depends_on.value {
+                if let Some(dep_id) = task_table.get_id(&dep_spanned.value) {
+                    deps.push(dep_id);
+                }
+            }
+        }
+
+        // Collect implicit deps from with: bindings
+        if let Some(ref with_refs) = raw_task.value.with_refs {
+            for (_alias, value_spanned) in with_refs.value.iter() {
+                if let Ok(entry) = parse_with_entry(&value_spanned.value) {
+                    if let Some(dep_task_name) = entry.task_id() {
+                        if let Some(dep_id) = task_table.get_id(dep_task_name) {
+                            if !deps.contains(&dep_id) {
+                                deps.push(dep_id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // DFS cycle detection
+    let graph = RawDepGraph {
+        adjacency,
+        task_table,
+        task_spans,
+    };
+    let mut visited = HashSet::new();
+    let mut rec_stack = HashSet::new();
+    let mut path = Vec::new();
+
+    for &task_id in graph.adjacency.keys() {
+        if !visited.contains(&task_id) {
+            detect_cycles_raw_dfs(
+                task_id,
+                &graph,
+                &mut visited,
+                &mut rec_stack,
+                &mut path,
+                ctx,
+            );
+        }
+    }
+}
+
+/// Read-only dependency graph context for raw cycle detection.
+struct RawDepGraph<'a> {
+    adjacency: HashMap<TaskId, Vec<TaskId>>,
+    task_table: &'a TaskTable,
+    task_spans: HashMap<TaskId, Span>,
+}
+
+/// DFS helper for raw cycle detection.
+fn detect_cycles_raw_dfs(
+    task_id: TaskId,
+    graph: &RawDepGraph<'_>,
+    visited: &mut HashSet<TaskId>,
+    rec_stack: &mut HashSet<TaskId>,
+    path: &mut Vec<TaskId>,
+    ctx: &mut AnalyzerContext,
+) {
+    visited.insert(task_id);
+    rec_stack.insert(task_id);
+    path.push(task_id);
+
+    if let Some(deps) = graph.adjacency.get(&task_id) {
+        for dep_id in deps {
+            if !visited.contains(dep_id) {
+                detect_cycles_raw_dfs(*dep_id, graph, visited, rec_stack, path, ctx);
+            } else if rec_stack.contains(dep_id) {
+                // Found cycle
+                let cycle_start = path.iter().position(|&id| id == *dep_id).unwrap();
+                let cycle_path: Vec<&str> = path[cycle_start..]
+                    .iter()
+                    .filter_map(|id| graph.task_table.get_name(*id))
+                    .collect();
+                let mut cycle_with_close = cycle_path.clone();
+                if let Some(name) = graph.task_table.get_name(*dep_id) {
+                    cycle_with_close.push(name);
+                }
+                let span = graph
+                    .task_spans
+                    .get(&task_id)
+                    .copied()
+                    .unwrap_or(Span::dummy());
+                ctx.add_error(AnalyzeError::cyclic_dependency(span, &cycle_with_close));
+            }
+        }
+    }
+
+    path.pop();
+    rec_stack.remove(&task_id);
+}
+
+/// Detect cyclic dependencies using DFS.
+///
+/// Checks both `depends_on` (explicit ordering) and `implicit_deps` (from with: bindings).
+fn detect_cycles(workflow: &AnalyzedWorkflow, ctx: &mut AnalyzerContext) {
+    let mut visited = HashSet::new();
+    let mut rec_stack = HashSet::new();
+    let mut path = Vec::new();
+
+    for task in &workflow.tasks {
+        if !visited.contains(&task.id) {
+            detect_cycles_dfs(
+                task.id,
+                workflow,
+                &mut visited,
+                &mut rec_stack,
+                &mut path,
+                ctx,
+            );
+        }
+    }
+}
+
+fn detect_cycles_dfs(
+    task_id: TaskId,
+    workflow: &AnalyzedWorkflow,
+    visited: &mut HashSet<TaskId>,
+    rec_stack: &mut HashSet<TaskId>,
+    path: &mut Vec<TaskId>,
+    ctx: &mut AnalyzerContext,
+) {
+    visited.insert(task_id);
+    rec_stack.insert(task_id);
+    path.push(task_id);
+
+    if let Some(task) = workflow.get_task(task_id) {
+        // Check explicit depends_on dependencies
+        for dep_id in &task.depends_on {
+            if !visited.contains(dep_id) {
+                detect_cycles_dfs(*dep_id, workflow, visited, rec_stack, path, ctx);
+            } else if rec_stack.contains(dep_id) {
+                // Found cycle
+                let cycle_start = path.iter().position(|&id| id == *dep_id).unwrap();
+                let cycle_path: Vec<&str> = path[cycle_start..]
+                    .iter()
+                    .filter_map(|id| workflow.task_table.get_name(*id))
+                    .collect();
+                let mut cycle_with_close = cycle_path.clone();
+                if let Some(name) = workflow.task_table.get_name(*dep_id) {
+                    cycle_with_close.push(name);
+                }
+                ctx.add_error(AnalyzeError::cyclic_dependency(
+                    task.span,
+                    &cycle_with_close,
+                ));
+            }
+        }
+
+        // Check implicit dependencies (from with: bindings)
+        for dep_id in &task.implicit_deps {
+            if !visited.contains(dep_id) {
+                detect_cycles_dfs(*dep_id, workflow, visited, rec_stack, path, ctx);
+            } else if rec_stack.contains(dep_id) {
+                // Found cycle via with: binding
+                let cycle_start = path.iter().position(|&id| id == *dep_id).unwrap();
+                let cycle_path: Vec<&str> = path[cycle_start..]
+                    .iter()
+                    .filter_map(|id| workflow.task_table.get_name(*id))
+                    .collect();
+                let mut cycle_with_close = cycle_path.clone();
+                if let Some(name) = workflow.task_table.get_name(*dep_id) {
+                    cycle_with_close.push(name);
+                }
+                ctx.add_error(AnalyzeError::cyclic_dependency(
+                    task.span,
+                    &cycle_with_close,
+                ));
+            }
+        }
+    }
+
+    path.pop();
+    rec_stack.remove(&task_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::raw::{
+        RawContextConfig, RawImportSpec, RawMcpConfig, RawMcpServer, RawTask, RawWorkflow,
+    };
+    use crate::source::{FileId, Spanned};
+    use indexmap::IndexMap;
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    fn make_raw_workflow(schema: &str, tasks: Vec<RawTask>) -> RawWorkflow {
+        RawWorkflow {
+            schema: Spanned::new(schema.to_string(), make_span(0, 20)),
+            tasks: Spanned::new(
+                tasks
+                    .into_iter()
+                    .map(|t| Spanned::new(t, make_span(0, 50)))
+                    .collect(),
+                make_span(0, 100),
+            ),
+            ..Default::default()
+        }
+    }
+
+    fn make_raw_task(id: &str) -> RawTask {
+        RawTask {
+            id: Spanned::new(id.to_string(), make_span(0, id.len() as u32)),
+            ..Default::default()
+        }
+    }
+
+    /// Helper: add a `with:` binding to a raw task.
+    fn add_with_ref(task: &mut RawTask, alias: &str, expr: &str) {
+        let with_refs = task
+            .with_refs
+            .get_or_insert_with(|| Spanned::new(IndexMap::new(), make_span(0, 50)));
+        with_refs.value.insert(
+            Spanned::new(alias.to_string(), make_span(0, alias.len() as u32)),
+            Spanned::new(expr.to_string(), make_span(0, expr.len() as u32)),
+        );
+    }
+
+    /// Helper: add `depends_on:` entries to a raw task.
+    fn add_depends_on(task: &mut RawTask, deps: &[&str]) {
+        let spanned_deps: Vec<Spanned<String>> = deps
+            .iter()
+            .map(|d| Spanned::new(d.to_string(), make_span(0, d.len() as u32)))
+            .collect();
+        task.depends_on = Some(Spanned::new(spanned_deps, make_span(0, 50)));
+    }
+
+    // ====================================================================
+    // Basic workflow analysis
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_valid_workflow() {
+        let raw = make_raw_workflow(
+            "nika/workflow@0.12",
+            vec![make_raw_task("task1"), make_raw_task("task2")],
+        );
+
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        assert_eq!(workflow.task_count(), 2);
+        assert!(workflow.has_task("task1"));
+        assert!(workflow.has_task("task2"));
+    }
+
+    #[test]
+    fn test_analyze_invalid_schema() {
+        let raw = make_raw_workflow("invalid", vec![]);
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::InvalidSchema);
+    }
+
+    #[test]
+    fn test_analyze_schema_suggestion() {
+        // Valid schema with at least one task
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("step1")]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_analyze_duplicate_task() {
+        let raw = make_raw_workflow(
+            "nika/workflow@0.12",
+            vec![make_raw_task("task1"), make_raw_task("task1")],
+        );
+
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::DuplicateTask);
+    }
+
+    // ====================================================================
+    // with: binding analysis
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_with_binding_simple() {
+        let mut task2 = make_raw_task("task2");
+        add_with_ref(&mut task2, "data", "$task1");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t2 = workflow.get_task_by_name("task2").unwrap();
+        assert_eq!(t2.with_spec.len(), 1);
+        assert!(t2.with_spec.contains_key("data"));
+        assert_eq!(t2.implicit_deps.len(), 1);
+    }
+
+    #[test]
+    fn test_analyze_with_binding_unknown_task() {
+        let mut task1 = make_raw_task("task1");
+        add_with_ref(&mut task1, "data", "$unknown_task");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::UnknownTask);
+    }
+
+    #[test]
+    fn test_analyze_with_binding_invalid_expr() {
+        let mut task1 = make_raw_task("task1");
+        // Empty expression should fail parse_with_entry
+        add_with_ref(&mut task1, "data", "");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::InvalidBinding);
+    }
+
+    #[test]
+    fn test_analyze_with_binding_env_source() {
+        // $env.API_KEY should NOT create an implicit dependency
+        let mut task1 = make_raw_task("task1");
+        add_with_ref(&mut task1, "key", "$env.API_KEY");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t1 = workflow.get_task_by_name("task1").unwrap();
+        assert_eq!(t1.with_spec.len(), 1);
+        assert!(t1.implicit_deps.is_empty()); // Env source, no task dep
+    }
+
+    #[test]
+    fn test_analyze_with_binding_deduplicates_implicit_deps() {
+        let mut task2 = make_raw_task("task2");
+        add_with_ref(&mut task2, "a", "$task1.field_a");
+        add_with_ref(&mut task2, "b", "$task1.field_b");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t2 = workflow.get_task_by_name("task2").unwrap();
+        // Both bindings reference task1, but implicit_deps should deduplicate
+        assert_eq!(t2.implicit_deps.len(), 1);
+    }
+
+    #[test]
+    fn test_analyze_with_binding_with_transforms() {
+        let mut task2 = make_raw_task("task2");
+        add_with_ref(&mut task2, "result", "$task1.data | upper | trim");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t2 = workflow.get_task_by_name("task2").unwrap();
+        let entry = t2.with_spec.get("result").unwrap();
+        assert!(entry.transform.is_some());
+        assert_eq!(entry.task_id(), Some("task1"));
+    }
+
+    #[test]
+    fn test_analyze_with_binding_with_default() {
+        let mut task2 = make_raw_task("task2");
+        add_with_ref(&mut task2, "val", "$task1.count ?? 0");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t2 = workflow.get_task_by_name("task2").unwrap();
+        let entry = t2.with_spec.get("val").unwrap();
+        assert!(entry.default.is_some());
+    }
+
+    // ====================================================================
+    // depends_on: analysis
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_depends_on_valid() {
+        let mut task2 = make_raw_task("task2");
+        add_depends_on(&mut task2, &["task1"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t2 = workflow.get_task_by_name("task2").unwrap();
+        assert_eq!(t2.depends_on.len(), 1);
+    }
+
+    #[test]
+    fn test_analyze_depends_on_unknown_task() {
+        let mut task1 = make_raw_task("task1");
+        add_depends_on(&mut task1, &["nonexistent"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::UnknownTask);
+    }
+
+    #[test]
+    fn test_analyze_depends_on_multiple() {
+        let mut task3 = make_raw_task("task3");
+        add_depends_on(&mut task3, &["task1", "task2"]);
+
+        let raw = make_raw_workflow(
+            "nika/workflow@0.12",
+            vec![make_raw_task("task1"), make_raw_task("task2"), task3],
+        );
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        let t3 = workflow.get_task_by_name("task3").unwrap();
+        assert_eq!(t3.depends_on.len(), 2);
+    }
+
+    // ====================================================================
+    // Cycle detection
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_cyclic_dependency_depends_on() {
+        let mut task1 = make_raw_task("task1");
+        let mut task2 = make_raw_task("task2");
+
+        add_depends_on(&mut task1, &["task2"]);
+        add_depends_on(&mut task2, &["task1"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1, task2]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency));
+    }
+
+    #[test]
+    fn test_analyze_cyclic_dependency_via_with() {
+        let mut task1 = make_raw_task("task1");
+        let mut task2 = make_raw_task("task2");
+
+        add_with_ref(&mut task1, "data", "$task2");
+        add_with_ref(&mut task2, "data", "$task1");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1, task2]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency));
+    }
+
+    #[test]
+    fn test_analyze_cyclic_dependency_mixed() {
+        // task1 depends_on task2 explicitly, task2 references task1 via with:
+        let mut task1 = make_raw_task("task1");
+        let mut task2 = make_raw_task("task2");
+
+        add_depends_on(&mut task1, &["task2"]);
+        add_with_ref(&mut task2, "data", "$task1");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1, task2]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency));
+    }
+
+    #[test]
+    fn test_analyze_cyclic_dependency_three_tasks_via_with() {
+        // A → B → C → A via with: bindings (transitive implicit cycle)
+        let mut a = make_raw_task("a");
+        add_with_ref(&mut a, "x", "$c.out");
+
+        let mut b = make_raw_task("b");
+        add_with_ref(&mut b, "x", "$a.out");
+
+        let mut c = make_raw_task("c");
+        add_with_ref(&mut c, "x", "$b.out");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![a, b, c]);
+        let result = analyze(raw);
+
+        assert!(result.is_err(), "3-task implicit cycle should be detected");
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency));
+    }
+
+    #[test]
+    fn test_analyze_complex_jsonpath_extracts_dep() {
+        // Deep JSONPath with transforms and default: $task1.data.items | sort | first(3) ?? []
+        let mut task2 = make_raw_task("task2");
+        add_with_ref(
+            &mut task2,
+            "items",
+            "$task1.data.items | sort | first(3) ?? []",
+        );
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let wf = result.value.unwrap();
+        let t2 = wf.get_task_by_name("task2").unwrap();
+        assert_eq!(
+            t2.implicit_deps.len(),
+            1,
+            "should extract dep from complex JSONPath expression"
+        );
+    }
+
+    // ====================================================================
+    // imports: analysis
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_imports() {
+        use crate::ast::raw::RawImportSpec;
+
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+        raw.imports = Some(Spanned::new(
+            vec![
+                Spanned::new(
+                    RawImportSpec {
+                        path: Spanned::new(
+                            "./partials/setup.nika.yaml".to_string(),
+                            make_span(0, 25),
+                        ),
+                        prefix: Some(Spanned::new("setup_".to_string(), make_span(30, 36))),
+                        span: make_span(0, 40),
+                    },
+                    make_span(0, 40),
+                ),
+                Spanned::new(
+                    RawImportSpec {
+                        path: Spanned::new("./tools.nika.yaml".to_string(), make_span(50, 67)),
+                        prefix: None,
+                        span: make_span(50, 70),
+                    },
+                    make_span(50, 70),
+                ),
+            ],
+            make_span(0, 80),
+        ));
+
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        assert_eq!(workflow.imports.len(), 2);
+        assert_eq!(workflow.imports[0].path, "./partials/setup.nika.yaml");
+        assert_eq!(workflow.imports[0].prefix.as_deref(), Some("setup_"));
+        assert_eq!(workflow.imports[1].path, "./tools.nika.yaml");
+        assert!(workflow.imports[1].prefix.is_none());
+    }
+
+    // ====================================================================
+    // Feature gating tests
+    // ====================================================================
+
+    #[test]
+    fn test_feature_gate_for_each_v01_fails() {
+        use crate::ast::raw::RawForEach;
+
+        let mut task = make_raw_task("task1");
+        task.for_each = Some(Spanned::new(
+            RawForEach {
+                items: Spanned::new("[\"a\", \"b\"]".to_string(), make_span(0, 10)),
+                as_var: None,
+                parallel: None,
+                fail_fast: None,
+            },
+            make_span(0, 50),
+        ));
+
+        // Using v0.1 which doesn't support for_each
+        let raw = make_raw_workflow("nika/workflow@0.1", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+        assert!(result.errors[0].message.contains("for_each"));
+    }
+
+    #[test]
+    fn test_feature_gate_for_each_v03_succeeds() {
+        use crate::ast::raw::RawForEach;
+
+        let mut task = make_raw_task("task1");
+        task.for_each = Some(Spanned::new(
+            RawForEach {
+                items: Spanned::new("[\"a\", \"b\"]".to_string(), make_span(0, 10)),
+                as_var: None,
+                parallel: None,
+                fail_fast: None,
+            },
+            make_span(0, 50),
+        ));
+
+        // Using v0.3 which supports for_each
+        let raw = make_raw_workflow("nika/workflow@0.3", vec![task]);
+        let result = analyze(raw);
+
+        // Should not have UnsupportedFeature errors
+        assert!(!result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+    }
+
+    #[test]
+    fn test_feature_gate_retry_v02_fails() {
+        use crate::ast::raw::RawRetryConfig;
+
+        let mut task = make_raw_task("task1");
+        task.retry = Some(Spanned::new(
+            RawRetryConfig {
+                max_attempts: Some(Spanned::new(3, make_span(0, 1))),
+                delay_ms: None,
+                backoff: None,
+            },
+            make_span(0, 30),
+        ));
+
+        // Using v0.2 which doesn't support retry
+        let raw = make_raw_workflow("nika/workflow@0.2", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+        assert!(result.errors[0].message.contains("retry"));
+    }
+
+    #[test]
+    fn test_feature_gate_invoke_v01_fails() {
+        use crate::ast::raw::RawInvokeAction;
+
+        let mut task = make_raw_task("task1");
+        task.action = Some(RawTaskAction::Invoke(Spanned::new(
+            RawInvokeAction {
+                tool: Spanned::new("novanet:search".to_string(), make_span(0, 14)),
+                mcp: None,
+                params: None,
+                timeout_ms: None,
+            },
+            make_span(0, 50),
+        )));
+
+        // Using v0.1 which doesn't support invoke
+        let raw = make_raw_workflow("nika/workflow@0.1", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+        assert!(result.errors[0].message.contains("invoke"));
+    }
+
+    #[test]
+    fn test_feature_gate_agent_v01_fails() {
+        use crate::ast::raw::RawAgentAction;
+
+        let mut task = make_raw_task("task1");
+        task.action = Some(RawTaskAction::Agent(Spanned::new(
+            RawAgentAction {
+                prompt: Spanned::new("Do something".to_string(), make_span(0, 12)),
+                tools: None,
+                max_iterations: None,
+                max_tokens: None,
+                from: None,
+                skills: None,
+                provider: None,
+                model: None,
+                mcp: None,
+                system: None,
+                temperature: None,
+                token_budget: None,
+                extended_thinking: None,
+                thinking_budget: None,
+                depth_limit: None,
+            },
+            make_span(0, 50),
+        )));
+
+        // Using v0.1 which doesn't support agent
+        let raw = make_raw_workflow("nika/workflow@0.1", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+        assert!(result.errors[0].message.contains("agent"));
+    }
+
+    #[test]
+    fn test_feature_gate_with_v11_fails() {
+        let mut task = make_raw_task("task1");
+        add_with_ref(&mut task, "data", "$other");
+
+        // Doesn't support with:
+        let raw = make_raw_workflow("nika/workflow@0.11", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+    }
+
+    #[test]
+    fn test_feature_gate_depends_on_v11_fails() {
+        let mut task = make_raw_task("task1");
+        add_depends_on(&mut task, &["other"]);
+
+        // Doesn't support depends_on:
+        let raw = make_raw_workflow("nika/workflow@0.11", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+    }
+
+    #[test]
+    fn test_feature_gate_imports_v11_fails() {
+        use crate::ast::raw::RawImportSpec;
+
+        let mut raw = make_raw_workflow("nika/workflow@0.11", vec![make_raw_task("task1")]);
+        raw.imports = Some(Spanned::new(
+            vec![Spanned::new(
+                RawImportSpec {
+                    path: Spanned::new("./setup.nika.yaml".to_string(), make_span(0, 17)),
+                    prefix: None,
+                    span: make_span(0, 20),
+                },
+                make_span(0, 20),
+            )],
+            make_span(0, 30),
+        ));
+
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+    }
+
+    #[test]
+    fn test_feature_gate_multiple_errors() {
+        use crate::ast::raw::{RawAgentAction, RawForEach};
+
+        let mut task = make_raw_task("task1");
+
+        // Add both for_each and agent action
+        task.for_each = Some(Spanned::new(
+            RawForEach {
+                items: Spanned::new("[\"a\"]".to_string(), make_span(0, 5)),
+                as_var: None,
+                parallel: None,
+                fail_fast: None,
+            },
+            make_span(0, 30),
+        ));
+        task.action = Some(RawTaskAction::Agent(Spanned::new(
+            RawAgentAction {
+                prompt: Spanned::new("Goal".to_string(), make_span(0, 4)),
+                tools: None,
+                max_iterations: None,
+                max_tokens: None,
+                from: None,
+                skills: None,
+                provider: None,
+                model: None,
+                mcp: None,
+                system: None,
+                temperature: None,
+                token_budget: None,
+                extended_thinking: None,
+                thinking_budget: None,
+                depth_limit: None,
+            },
+            make_span(0, 50),
+        )));
+
+        // Using v0.1 which doesn't support either
+        let raw = make_raw_workflow("nika/workflow@0.1", vec![task]);
+        let result = analyze(raw);
+
+        // Should have multiple UnsupportedFeature errors
+        let feature_errors: Vec<_> = result
+            .errors
+            .iter()
+            .filter(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature)
+            .collect();
+        assert_eq!(feature_errors.len(), 2);
+    }
+
+    #[test]
+    fn test_feature_gate_error_message_format() {
+        use crate::ast::raw::RawForEach;
+
+        let mut task = make_raw_task("task1");
+        task.for_each = Some(Spanned::new(
+            RawForEach {
+                items: Spanned::new("[\"x\"]".to_string(), make_span(0, 5)),
+                as_var: None,
+                parallel: None,
+                fail_fast: None,
+            },
+            make_span(0, 30),
+        ));
+
+        let raw = make_raw_workflow("nika/workflow@0.1", vec![task]);
+        let result = analyze(raw);
+
+        assert!(result.is_err());
+        let err = &result.errors[0];
+        assert!(err.message.contains("requires schema version"));
+        assert!(err.message.contains("nika/workflow@0.3"));
+        assert!(err.message.contains("nika/workflow@0.1"));
+        assert!(err.suggestion.as_ref().unwrap().contains("upgrade"));
+    }
+
+    // ====================================================================
+    // Metadata extraction
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_metadata() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+        raw.workflow = Some(Spanned::new("my-workflow".to_string(), make_span(0, 11)));
+        raw.description = Some(Spanned::new(
+            "A test workflow".to_string(),
+            make_span(0, 15),
+        ));
+        raw.provider = Some(Spanned::new("claude".to_string(), make_span(0, 6)));
+        raw.model = Some(Spanned::new(
+            "claude-sonnet-4-6".to_string(),
+            make_span(0, 15),
+        ));
+
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        assert_eq!(workflow.name.as_deref(), Some("my-workflow"));
+        assert_eq!(workflow.description.as_deref(), Some("A test workflow"));
+        assert_eq!(workflow.provider.as_deref(), Some("claude"));
+        assert_eq!(workflow.model.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    // ====================================================================
+    // Inputs analysis
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_inputs() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+
+        let mut inputs = IndexMap::new();
+        inputs.insert(
+            Spanned::new("topic".to_string(), make_span(0, 5)),
+            Spanned::new(serde_json::Value::String("AI".to_string()), make_span(0, 4)),
+        );
+        inputs.insert(
+            Spanned::new("count".to_string(), make_span(0, 5)),
+            Spanned::new(serde_json::json!(3), make_span(0, 1)),
+        );
+        raw.inputs = Some(Spanned::new(inputs, make_span(0, 50)));
+
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        assert_eq!(workflow.inputs.len(), 2);
+        assert_eq!(
+            workflow.inputs.get("topic"),
+            Some(&serde_json::Value::String("AI".to_string()))
+        );
+    }
+
+    // ====================================================================
+    // validate() tests
+    // ====================================================================
+
+    #[test]
+    fn test_validate_valid_workflow() {
+        let raw = make_raw_workflow(
+            "nika/workflow@0.12",
+            vec![make_raw_task("task1"), make_raw_task("task2")],
+        );
+
+        let result = validate(&raw);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_schema() {
+        let raw = make_raw_workflow("invalid", vec![]);
+        let result = validate(&raw);
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::InvalidSchema);
+    }
+
+    #[test]
+    fn test_validate_duplicate_task() {
+        let raw = make_raw_workflow(
+            "nika/workflow@0.12",
+            vec![make_raw_task("task1"), make_raw_task("task1")],
+        );
+
+        let result = validate(&raw);
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::DuplicateTask);
+    }
+
+    #[test]
+    fn test_validate_unknown_task_in_with() {
+        let mut task1 = make_raw_task("task1");
+        add_with_ref(&mut task1, "data", "$unknown_task");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = validate(&raw);
+
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::UnknownTask);
+    }
+
+    #[test]
+    fn test_validate_unknown_task_in_depends_on() {
+        let mut task1 = make_raw_task("task1");
+        add_depends_on(&mut task1, &["nonexistent"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = validate(&raw);
+
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::UnknownTask);
+    }
+
+    #[test]
+    fn test_validate_invalid_binding() {
+        let mut task1 = make_raw_task("task1");
+        add_with_ref(&mut task1, "data", "");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+        let result = validate(&raw);
+
+        assert!(result.is_err());
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::InvalidBinding);
+    }
+
+    #[test]
+    fn test_validate_cyclic_dependency_depends_on() {
+        let mut task1 = make_raw_task("task1");
+        let mut task2 = make_raw_task("task2");
+
+        add_depends_on(&mut task1, &["task2"]);
+        add_depends_on(&mut task2, &["task1"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1, task2]);
+        let result = validate(&raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency));
+    }
+
+    #[test]
+    fn test_validate_cyclic_dependency_via_with() {
+        let mut task1 = make_raw_task("task1");
+        let mut task2 = make_raw_task("task2");
+
+        add_with_ref(&mut task1, "data", "$task2");
+        add_with_ref(&mut task2, "data", "$task1");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1, task2]);
+        let result = validate(&raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency));
+    }
+
+    #[test]
+    fn test_validate_feature_gate() {
+        use crate::ast::raw::RawForEach;
+
+        let mut task = make_raw_task("task1");
+        task.for_each = Some(Spanned::new(
+            RawForEach {
+                items: Spanned::new("[\"a\"]".to_string(), make_span(0, 5)),
+                as_var: None,
+                parallel: None,
+                fail_fast: None,
+            },
+            make_span(0, 30),
+        ));
+
+        let raw = make_raw_workflow("nika/workflow@0.1", vec![task]);
+        let result = validate(&raw);
+
+        assert!(result.is_err());
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.kind == AnalyzeErrorKind::UnsupportedFeature));
+    }
+
+    #[test]
+    fn test_validate_agrees_with_analyze() {
+        // Ensure validate() and analyze() produce the same errors for invalid workflows
+        let mut task1 = make_raw_task("task1");
+        add_with_ref(&mut task1, "data", "$nonexistent");
+        add_depends_on(&mut task1, &["also_missing"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1]);
+
+        let validate_result = validate(&raw);
+        let analyze_result = analyze(raw.clone());
+
+        // Both should fail
+        assert!(validate_result.is_err());
+        assert!(analyze_result.is_err());
+
+        // Both should report the same error kinds
+        let validate_kinds: Vec<_> = validate_result.errors.iter().map(|e| &e.kind).collect();
+        let analyze_kinds: Vec<_> = analyze_result.errors.iter().map(|e| &e.kind).collect();
+        assert_eq!(validate_kinds, analyze_kinds);
+    }
+
+    #[test]
+    fn test_validate_valid_with_bindings() {
+        let mut task2 = make_raw_task("task2");
+        add_with_ref(&mut task2, "data", "$task1");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1"), task2]);
+        let result = validate(&raw);
+        assert!(result.is_ok());
+    }
+
+    // ====================================================================
+    // MCP server validation
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_mcp_stdio_server_requires_command() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+
+        // Create an MCP server with no command (stdio transport is default)
+        let mut mcp_config = RawMcpConfig::new();
+        mcp_config.servers.insert(
+            Spanned::new("broken".to_string(), make_span(10, 16)),
+            Spanned::new(RawMcpServer::default(), make_span(20, 30)),
+        );
+        raw.mcp = Some(Spanned::new(mcp_config, make_span(5, 35)));
+
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::MissingField);
+        let msg = result.errors[0].message.to_lowercase();
+        assert!(
+            msg.contains("command"),
+            "error message should mention command: {}",
+            msg
+        );
+        assert!(
+            msg.contains("broken"),
+            "error message should mention server name: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_analyze_mcp_stdio_server_with_command_ok() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+
+        let mut mcp_config = RawMcpConfig::new();
+        mcp_config.servers.insert(
+            Spanned::new("novanet".to_string(), make_span(10, 17)),
+            Spanned::new(
+                RawMcpServer::with_command("cargo run -p novanet-mcp"),
+                make_span(20, 60),
+            ),
+        );
+        raw.mcp = Some(Spanned::new(mcp_config, make_span(5, 65)));
+
+        let result = analyze(raw);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_analyze_mcp_sse_server_without_command_ok() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+
+        // SSE server does not need a command — it uses a URL
+        let mut mcp_config = RawMcpConfig::new();
+        mcp_config.servers.insert(
+            Spanned::new("remote".to_string(), make_span(10, 16)),
+            Spanned::new(
+                RawMcpServer::with_url("http://localhost:8080"),
+                make_span(20, 60),
+            ),
+        );
+        raw.mcp = Some(Spanned::new(mcp_config, make_span(5, 65)));
+
+        let result = analyze(raw);
+        assert!(result.is_ok(), "SSE server should not cause error");
+        // SSE server should produce a warning about being dropped
+        assert!(
+            !result.warnings.is_empty(),
+            "SSE server should produce a warning"
+        );
+        assert!(
+            result.warnings[0].message.contains("SSE"),
+            "warning should mention SSE, got: {}",
+            result.warnings[0].message
+        );
+    }
+
+    #[test]
+    fn test_analyze_mcp_stdio_server_empty_command() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("task1")]);
+
+        // A server with an empty command string should also fail
+        let mut mcp_config = RawMcpConfig::new();
+        let server = RawMcpServer {
+            command: Some(Spanned::new(String::new(), make_span(25, 25))),
+            ..Default::default()
+        };
+        mcp_config.servers.insert(
+            Spanned::new("empty_cmd".to_string(), make_span(10, 19)),
+            Spanned::new(server, make_span(20, 30)),
+        );
+        raw.mcp = Some(Spanned::new(mcp_config, make_span(5, 35)));
+
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::MissingField);
+    }
+
+    #[test]
+    fn test_analyze_rejects_empty_tasks_array() {
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![]);
+        let result = analyze(raw);
+        assert!(result.is_err(), "empty tasks array should be rejected");
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].kind, AnalyzeErrorKind::InvalidValue);
+        assert!(
+            result.errors[0].message.contains("empty"),
+            "error should mention empty, got: {}",
+            result.errors[0].message
+        );
+    }
+
+    #[test]
+    fn test_retry_on_infer_emits_warning() {
+        use crate::ast::raw::RawRetryConfig;
+
+        let mut task = make_raw_task("my_task");
+        task.action = Some(RawTaskAction::Infer(Spanned::new(
+            RawInferAction {
+                prompt: Spanned::new("Generate something".to_string(), make_span(0, 18)),
+                ..Default::default()
+            },
+            make_span(0, 50),
+        )));
+        task.retry = Some(Spanned::new(
+            RawRetryConfig {
+                max_attempts: Some(Spanned::new(3, make_span(0, 1))),
+                delay_ms: Some(Spanned::new(1000, make_span(0, 4))),
+                ..Default::default()
+            },
+            make_span(0, 30),
+        ));
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task]);
+        let result = analyze(raw);
+
+        // Should succeed (retry on infer is not an error)
+        assert!(
+            result.is_ok(),
+            "retry on infer should not be an error: {:?}",
+            result.errors
+        );
+        // But should emit a warning
+        assert!(
+            !result.warnings.is_empty(),
+            "retry on non-fetch verb should emit a warning"
+        );
+        assert!(
+            result.warnings[0].message.contains("retry"),
+            "Warning should mention retry, got: {}",
+            result.warnings[0].message
+        );
+    }
+
+    #[test]
+    fn test_retry_on_fetch_no_warning() {
+        use crate::ast::raw::RawRetryConfig;
+
+        let mut task = make_raw_task("my_fetch");
+        task.action = Some(RawTaskAction::Fetch(Spanned::new(
+            RawFetchAction {
+                url: Spanned::new("https://example.com".to_string(), make_span(0, 20)),
+                ..Default::default()
+            },
+            make_span(0, 50),
+        )));
+        task.retry = Some(Spanned::new(
+            RawRetryConfig {
+                max_attempts: Some(Spanned::new(3, make_span(0, 1))),
+                ..Default::default()
+            },
+            make_span(0, 30),
+        ));
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task]);
+        let result = analyze(raw);
+
+        // Should succeed with no warnings
+        assert!(
+            result.is_ok(),
+            "retry on fetch should succeed: {:?}",
+            result.errors
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "retry on fetch should NOT emit a warning, got: {:?}",
+            result.warnings
+        );
+    }
+
+    // ====================================================================
+    // Task ID format validation
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_empty_task_id() {
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("")]);
+        let result = analyze(raw);
+        assert!(result.is_err(), "empty task ID should be rejected");
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.kind == AnalyzeErrorKind::InvalidValue),
+            "expected InvalidValue for empty task ID, got: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_analyze_task_id_with_spaces() {
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("my task")]);
+        let result = analyze(raw);
+        assert!(result.is_err(), "task ID with spaces should be rejected");
+    }
+
+    #[test]
+    fn test_analyze_task_id_dollar_prefix() {
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("$reserved")]);
+        let result = analyze(raw);
+        assert!(
+            result.is_err(),
+            "task ID starting with $ should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_analyze_valid_task_id_with_hyphens_underscores() {
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("my-task_v2")]);
+        let result = analyze(raw);
+        assert!(
+            result.is_ok(),
+            "task ID with hyphens/underscores is valid: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_analyze_valid_task_id_with_dots() {
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("seo.keyword")]);
+        let result = analyze(raw);
+        assert!(
+            result.is_ok(),
+            "task ID with dots is valid: {:?}",
+            result.errors
+        );
+    }
+
+    // ====================================================================
+    // Duplicate import prefix detection
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_duplicate_import_prefix() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("main")]);
+        let imports = vec![
+            Spanned::new(
+                RawImportSpec {
+                    path: Spanned::new("./lib1.nika.yaml".to_string(), make_span(0, 20)),
+                    prefix: Some(Spanned::new("seo_".to_string(), make_span(0, 4))),
+                    span: make_span(0, 30),
+                },
+                make_span(0, 30),
+            ),
+            Spanned::new(
+                RawImportSpec {
+                    path: Spanned::new("./lib2.nika.yaml".to_string(), make_span(0, 20)),
+                    prefix: Some(Spanned::new("seo_".to_string(), make_span(0, 4))),
+                    span: make_span(0, 30),
+                },
+                make_span(0, 30),
+            ),
+        ];
+        raw.imports = Some(Spanned::new(imports, make_span(0, 100)));
+
+        let result = analyze(raw);
+        assert!(
+            result.is_err(),
+            "duplicate import prefix should be rejected"
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.message.contains("duplicate import prefix")),
+            "error should mention duplicate prefix: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_analyze_distinct_import_prefixes_ok() {
+        let mut raw = make_raw_workflow("nika/workflow@0.12", vec![make_raw_task("main")]);
+        let imports = vec![
+            Spanned::new(
+                RawImportSpec {
+                    path: Spanned::new("./lib1.nika.yaml".to_string(), make_span(0, 20)),
+                    prefix: Some(Spanned::new("seo_".to_string(), make_span(0, 4))),
+                    span: make_span(0, 30),
+                },
+                make_span(0, 30),
+            ),
+            Spanned::new(
+                RawImportSpec {
+                    path: Spanned::new("./lib2.nika.yaml".to_string(), make_span(0, 20)),
+                    prefix: Some(Spanned::new("content_".to_string(), make_span(0, 8))),
+                    span: make_span(0, 30),
+                },
+                make_span(0, 30),
+            ),
+        ];
+        raw.imports = Some(Spanned::new(imports, make_span(0, 100)));
+
+        let result = analyze(raw);
+        assert!(
+            result.is_ok(),
+            "distinct prefixes should be accepted: {:?}",
+            result.errors
+        );
+    }
+
+    // ====================================================================
+    // Multi-error collection and self-cycle
+    // ====================================================================
+
+    #[test]
+    fn test_analyze_collects_all_errors() {
+        // Workflow with 2 problems: duplicate task ID and unknown with: ref
+        let mut task1a = make_raw_task("task1");
+        add_with_ref(&mut task1a, "x", "$nonexistent");
+        let task1b = make_raw_task("task1"); // duplicate
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task1a, task1b]);
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert!(
+            result.errors.len() >= 2,
+            "analyzer should collect all errors, got {}: {:?}",
+            result.errors.len(),
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_analyze_self_cycle() {
+        let mut task = make_raw_task("loop_task");
+        add_depends_on(&mut task, &["loop_task"]);
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task]);
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency),
+            "self-cycle should be detected: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_analyze_self_cycle_via_with() {
+        // A task referencing itself via with: binding must be caught as a cycle
+        let mut task = make_raw_task("self_ref");
+        add_with_ref(&mut task, "data", "$self_ref");
+
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task]);
+        let result = analyze(raw);
+        assert!(result.is_err());
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.kind == AnalyzeErrorKind::CyclicDependency),
+            "self-cycle via with: should be detected: {:?}",
+            result.errors
+        );
+    }
+
+    // ── BUG-1: context.files must be transferred from raw to analyzed ──
+
+    #[test]
+    fn test_context_files_transferred_to_analyzed() {
+        let task = make_raw_task("greet");
+        let mut raw = make_raw_workflow("nika/workflow@0.9", vec![task]);
+
+        // Add context with two files
+        let mut files = IndexMap::new();
+        files.insert(
+            Spanned::new("brand".to_string(), make_span(0, 5)),
+            Spanned::new("./context/brand.md".to_string(), make_span(0, 18)),
+        );
+        files.insert(
+            Spanned::new("persona".to_string(), make_span(0, 7)),
+            Spanned::new("./context/persona.json".to_string(), make_span(0, 22)),
+        );
+        raw.context = Some(Spanned::new(
+            RawContextConfig { files: Some(files) },
+            make_span(0, 50),
+        ));
+
+        let result = analyze(raw);
+        assert!(result.is_ok(), "analyze failed: {:?}", result.errors);
+
+        let workflow = result.value.unwrap();
+        assert_eq!(
+            workflow.context_files.len(),
+            2,
+            "expected 2 context files, got {}",
+            workflow.context_files.len()
+        );
+
+        // Verify aliases and paths are preserved
+        let aliases: Vec<&str> = workflow
+            .context_files
+            .iter()
+            .filter_map(|cf| cf.alias.as_deref())
+            .collect();
+        assert!(aliases.contains(&"brand"), "missing 'brand' alias");
+        assert!(aliases.contains(&"persona"), "missing 'persona' alias");
+
+        let paths: Vec<&str> = workflow
+            .context_files
+            .iter()
+            .map(|cf| cf.path.as_str())
+            .collect();
+        assert!(paths.contains(&"./context/brand.md"));
+        assert!(paths.contains(&"./context/persona.json"));
+    }
+
+    #[test]
+    fn test_context_files_empty_when_no_context_block() {
+        let task = make_raw_task("greet");
+        let raw = make_raw_workflow("nika/workflow@0.12", vec![task]);
+
+        let result = analyze(raw);
+        assert!(result.is_ok());
+
+        let workflow = result.value.unwrap();
+        assert!(
+            workflow.context_files.is_empty(),
+            "context_files should be empty when no context: block"
+        );
+    }
+}

--- a/tools/nika-core/src/ast/analyzer/errors.rs
+++ b/tools/nika-core/src/ast/analyzer/errors.rs
@@ -1,0 +1,624 @@
+//! Analysis error types with span tracking.
+//!
+//! These errors are produced during Phase 2 analysis and include
+//! precise source locations for IDE integration.
+//!
+//! ## Rich Diagnostics
+//!
+//! For terminal display with source code snippets, wrap errors with
+//! [`RichAnalyzeError`] which carries the source content:
+//!
+//! ```ignore
+//! let rich = RichAnalyzeError::new(error, source_code, filename);
+//! eprintln!("{:?}", miette::Report::new(rich));
+//! ```
+
+use crate::source::Span;
+use miette::{Diagnostic, SourceSpan};
+
+/// An error that occurred during analysis.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnalyzeError {
+    /// The error kind
+    pub kind: AnalyzeErrorKind,
+    /// The span where the error occurred
+    pub span: Span,
+    /// Human-readable error message
+    pub message: String,
+    /// Optional suggestion (for "did you mean?" hints)
+    pub suggestion: Option<String>,
+    /// Optional note (additional context)
+    pub note: Option<String>,
+}
+
+impl AnalyzeError {
+    /// Create a new error.
+    pub fn new(kind: AnalyzeErrorKind, span: Span, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            span,
+            message: message.into(),
+            suggestion: None,
+            note: None,
+        }
+    }
+
+    /// Add a "did you mean?" suggestion.
+    pub fn with_suggestion(mut self, suggestion: impl Into<String>) -> Self {
+        self.suggestion = Some(suggestion.into());
+        self
+    }
+
+    /// Add a note.
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    /// Create an "unknown task" error with optional suggestion.
+    pub fn unknown_task(span: Span, name: &str, suggestion: Option<&str>) -> Self {
+        let mut err = Self::new(
+            AnalyzeErrorKind::UnknownTask,
+            span,
+            format!("unknown task '{}'", name),
+        );
+        if let Some(s) = suggestion {
+            err = err.with_suggestion(format!("did you mean '{}'?", s));
+        }
+        err
+    }
+
+    /// Create a "duplicate task" error.
+    pub fn duplicate_task(span: Span, name: &str, first_span: Span) -> Self {
+        Self::new(
+            AnalyzeErrorKind::DuplicateTask,
+            span,
+            format!("duplicate task id '{}'", name),
+        )
+        .with_note(format!("first defined at {:?}", first_span))
+    }
+
+    /// Create an "invalid schema" error.
+    pub fn invalid_schema(span: Span, schema: &str, suggestion: Option<&str>) -> Self {
+        let mut err = Self::new(
+            AnalyzeErrorKind::InvalidSchema,
+            span,
+            format!("invalid schema version '{}'", schema),
+        );
+        if let Some(s) = suggestion {
+            err = err.with_suggestion(format!("did you mean '{}'?", s));
+        }
+        err
+    }
+
+    /// Create a "cyclic dependency" error.
+    pub fn cyclic_dependency(span: Span, cycle: &[&str]) -> Self {
+        Self::new(
+            AnalyzeErrorKind::CyclicDependency,
+            span,
+            format!("cyclic dependency detected: {}", cycle.join(" → ")),
+        )
+    }
+
+    /// Create an "invalid value" error.
+    pub fn invalid_value(span: Span, field: &str, value: &str, expected: &str) -> Self {
+        Self::new(
+            AnalyzeErrorKind::InvalidValue,
+            span,
+            format!("invalid {} '{}', expected {}", field, value, expected),
+        )
+    }
+
+    /// Create a "missing field" error.
+    pub fn missing_field(span: Span, field: &str) -> Self {
+        Self::new(
+            AnalyzeErrorKind::MissingField,
+            span,
+            format!("missing required field '{}'", field),
+        )
+    }
+
+    /// Create an "unsupported feature" error for schema version gating.
+    pub fn unsupported_feature(
+        span: Span,
+        feature: &str,
+        current_version: &str,
+        required_version: &str,
+    ) -> Self {
+        Self::new(
+            AnalyzeErrorKind::UnsupportedFeature,
+            span,
+            format!(
+                "'{}' requires schema version {} or later, but workflow uses {}",
+                feature, required_version, current_version
+            ),
+        )
+        .with_suggestion(format!("upgrade to schema: {}", required_version))
+    }
+
+    /// Create an "invalid binding" error for malformed `with:` expressions.
+    pub fn invalid_binding(span: Span, input: &str, reason: &str) -> Self {
+        Self::new(
+            AnalyzeErrorKind::InvalidBinding,
+            span,
+            format!("invalid binding expression '{}': {}", input, reason),
+        )
+    }
+}
+
+impl std::fmt::Display for AnalyzeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)?;
+        if let Some(ref suggestion) = self.suggestion {
+            write!(f, " ({})", suggestion)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for AnalyzeError {}
+
+/// Kinds of analysis errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnalyzeErrorKind {
+    /// Unknown task reference (e.g., in `with:` or `depends_on:`)
+    UnknownTask,
+    /// Duplicate task ID
+    DuplicateTask,
+    /// Invalid schema version
+    InvalidSchema,
+    /// Cyclic dependency between tasks
+    CyclicDependency,
+    /// Invalid field value
+    InvalidValue,
+    /// Missing required field
+    MissingField,
+    /// Feature not available in this schema version
+    UnsupportedFeature,
+    /// Invalid binding expression in `with:` block
+    InvalidBinding,
+}
+
+impl AnalyzeErrorKind {
+    /// Get the error code in NIKA-XXX format.
+    ///
+    /// AST analysis errors use range NIKA-140-150:
+    /// - NIKA-140: Unknown task reference
+    /// - NIKA-141: Duplicate task ID
+    /// - NIKA-142: Invalid schema version
+    /// - NIKA-143: Cyclic dependency
+    /// - NIKA-144: Invalid field value
+    /// - NIKA-145: Missing required field
+    /// - NIKA-149: Feature not available in schema version
+    /// - NIKA-151: Invalid binding expression
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnknownTask => "NIKA-140",
+            Self::DuplicateTask => "NIKA-141",
+            Self::InvalidSchema => "NIKA-142",
+            Self::CyclicDependency => "NIKA-143",
+            Self::InvalidValue => "NIKA-144",
+            Self::MissingField => "NIKA-145",
+            Self::UnsupportedFeature => "NIKA-149",
+            Self::InvalidBinding => "NIKA-151",
+        }
+    }
+}
+
+/// Result of analysis - either an analyzed workflow or collected errors.
+#[derive(Debug)]
+pub struct AnalyzeResult<T> {
+    /// The result (if analysis succeeded)
+    pub value: Option<T>,
+    /// All errors encountered during analysis
+    pub errors: Vec<AnalyzeError>,
+    /// All warnings (non-fatal issues)
+    pub warnings: Vec<AnalyzeError>,
+}
+
+impl<T> AnalyzeResult<T> {
+    /// Create a successful result.
+    pub fn ok(value: T) -> Self {
+        Self {
+            value: Some(value),
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Create a failed result with errors.
+    pub fn err(errors: Vec<AnalyzeError>) -> Self {
+        Self {
+            value: None,
+            errors,
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Check if analysis succeeded (no errors).
+    pub fn is_ok(&self) -> bool {
+        self.errors.is_empty() && self.value.is_some()
+    }
+
+    /// Check if analysis failed.
+    pub fn is_err(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Get the value if successful.
+    pub fn into_result(self) -> Result<T, Vec<AnalyzeError>> {
+        if self.errors.is_empty() {
+            self.value.ok_or_else(Vec::new)
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    /// Add an error.
+    pub fn add_error(&mut self, error: AnalyzeError) {
+        self.errors.push(error);
+    }
+
+    /// Add a warning.
+    pub fn add_warning(&mut self, warning: AnalyzeError) {
+        self.warnings.push(warning);
+    }
+}
+
+// ============================================================================
+// Rich Diagnostic Wrapper for Terminal Display
+// ============================================================================
+
+/// A wrapper that combines [`AnalyzeError`] with source code for rich terminal display.
+///
+/// This implements [`miette::Diagnostic`] to show:
+/// - Error code (NIKA-140-151)
+/// - Source code snippet with highlighted span
+/// - "Did you mean?" suggestions
+/// - Additional notes
+///
+/// # Example
+///
+/// ```ignore
+/// use nika::ast::analyzer::errors::{AnalyzeError, RichAnalyzeError};
+///
+/// let error = AnalyzeError::unknown_task(span, "taks1", Some("task1"));
+/// let rich = RichAnalyzeError::new(error, source_code, "workflow.nika.yaml");
+///
+/// // Display with miette's fancy formatting
+/// eprintln!("{:?}", miette::Report::new(rich));
+/// ```
+#[derive(Debug)]
+pub struct RichAnalyzeError {
+    /// The underlying analysis error
+    error: AnalyzeError,
+    /// Source code content for display
+    source_code: String,
+    /// Filename for display
+    filename: String,
+    /// Miette source span (derived from error.span)
+    label_span: SourceSpan,
+}
+
+impl RichAnalyzeError {
+    /// Create a rich error from an [`AnalyzeError`] with source context.
+    pub fn new(
+        error: AnalyzeError,
+        source_code: impl Into<String>,
+        filename: impl Into<String>,
+    ) -> Self {
+        let source = source_code.into();
+        let label_span = SourceSpan::new(error.span.start.as_usize().into(), error.span.len());
+        Self {
+            error,
+            source_code: source,
+            filename: filename.into(),
+            label_span,
+        }
+    }
+
+    /// Get the underlying error.
+    pub fn error(&self) -> &AnalyzeError {
+        &self.error
+    }
+
+    /// Get the source code.
+    pub fn source(&self) -> &str {
+        &self.source_code
+    }
+
+    /// Get the filename.
+    pub fn filename(&self) -> &str {
+        &self.filename
+    }
+}
+
+impl std::fmt::Display for RichAnalyzeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.error.kind.code(), self.error.message)
+    }
+}
+
+impl std::error::Error for RichAnalyzeError {}
+
+impl Diagnostic for RichAnalyzeError {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(format!(
+            "nika::{}",
+            self.error.kind.code().to_lowercase().replace('-', "_")
+        )))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        self.error
+            .suggestion
+            .as_ref()
+            .map(|s| Box::new(s.clone()) as Box<dyn std::fmt::Display>)
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(format!(
+            "https://nika.sh/errors/{}",
+            self.error.kind.code()
+        )))
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source_code)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        let label =
+            miette::LabeledSpan::new_with_span(Some(self.error.message.clone()), self.label_span);
+        Some(Box::new(std::iter::once(label)))
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        None
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        None
+    }
+}
+
+/// Convert multiple [`AnalyzeError`]s to rich diagnostics.
+///
+/// # Example
+///
+/// ```ignore
+/// let rich_errors = to_rich_diagnostics(errors, &source_code, "workflow.nika.yaml");
+/// for err in rich_errors {
+///     eprintln!("{:?}", miette::Report::new(err));
+/// }
+/// ```
+pub fn to_rich_diagnostics(
+    errors: Vec<AnalyzeError>,
+    source_code: &str,
+    filename: &str,
+) -> Vec<RichAnalyzeError> {
+    errors
+        .into_iter()
+        .map(|e| RichAnalyzeError::new(e, source_code.to_string(), filename.to_string()))
+        .collect()
+}
+
+/// Format a single error for display using miette.
+///
+/// Returns a formatted string suitable for terminal output.
+pub fn format_error(error: &AnalyzeError, source_code: &str, filename: &str) -> String {
+    let rich = RichAnalyzeError::new(error.clone(), source_code, filename);
+    format!("{:?}", miette::Report::new(rich))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::FileId;
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    #[test]
+    fn test_analyze_error_display() {
+        let err = AnalyzeError::unknown_task(make_span(10, 20), "taks1", Some("task1"));
+        assert_eq!(
+            format!("{}", err),
+            "unknown task 'taks1' (did you mean 'task1'?)"
+        );
+    }
+
+    #[test]
+    fn test_analyze_error_duplicate() {
+        let err = AnalyzeError::duplicate_task(make_span(100, 110), "my-task", make_span(10, 20));
+        assert!(format!("{}", err).contains("duplicate task id 'my-task'"));
+    }
+
+    #[test]
+    fn test_analyze_error_cyclic() {
+        let err = AnalyzeError::cyclic_dependency(make_span(0, 10), &["a", "b", "c", "a"]);
+        assert!(format!("{}", err).contains("a → b → c → a"));
+    }
+
+    #[test]
+    fn test_error_kind_codes() {
+        // AST analysis errors use NIKA-140-150 range
+        assert_eq!(AnalyzeErrorKind::UnknownTask.code(), "NIKA-140");
+        assert_eq!(AnalyzeErrorKind::DuplicateTask.code(), "NIKA-141");
+        assert_eq!(AnalyzeErrorKind::InvalidSchema.code(), "NIKA-142");
+        assert_eq!(AnalyzeErrorKind::CyclicDependency.code(), "NIKA-143");
+        assert_eq!(AnalyzeErrorKind::InvalidValue.code(), "NIKA-144");
+        assert_eq!(AnalyzeErrorKind::MissingField.code(), "NIKA-145");
+        assert_eq!(AnalyzeErrorKind::UnsupportedFeature.code(), "NIKA-149");
+        assert_eq!(AnalyzeErrorKind::InvalidBinding.code(), "NIKA-151");
+    }
+
+    #[test]
+    fn test_analyze_result_ok() {
+        let result: AnalyzeResult<i32> = AnalyzeResult::ok(42);
+        assert!(result.is_ok());
+        assert!(!result.is_err());
+        assert_eq!(result.into_result(), Ok(42));
+    }
+
+    #[test]
+    fn test_analyze_result_err() {
+        let errors = vec![AnalyzeError::new(
+            AnalyzeErrorKind::UnknownTask,
+            make_span(0, 5),
+            "test error",
+        )];
+        let result: AnalyzeResult<i32> = AnalyzeResult::err(errors);
+        assert!(!result.is_ok());
+        assert!(result.is_err());
+        assert!(result.into_result().is_err());
+    }
+
+    // =========================================================================
+    // RichAnalyzeError Tests
+    // =========================================================================
+
+    #[test]
+    fn test_rich_error_creation() {
+        let source = "tasks:\n  - id: step1\n    with:\n      data: taks1\n";
+        let err = AnalyzeError::unknown_task(make_span(40, 45), "taks1", Some("task1"));
+        let rich = RichAnalyzeError::new(err, source, "test.nika.yaml");
+
+        assert_eq!(rich.filename(), "test.nika.yaml");
+        assert_eq!(rich.source(), source);
+        assert_eq!(rich.error().kind, AnalyzeErrorKind::UnknownTask);
+    }
+
+    #[test]
+    fn test_rich_error_display() {
+        let err = AnalyzeError::unknown_task(make_span(10, 15), "taks1", Some("task1"));
+        let rich = RichAnalyzeError::new(err, "some source", "test.yaml");
+
+        let display = format!("{}", rich);
+        assert!(display.contains("NIKA-140"));
+        assert!(display.contains("unknown task 'taks1'"));
+    }
+
+    #[test]
+    fn test_rich_error_diagnostic_code() {
+        let err = AnalyzeError::unknown_task(make_span(0, 5), "x", None);
+        let rich = RichAnalyzeError::new(err, "source", "file.yaml");
+
+        let code = Diagnostic::code(&rich).unwrap();
+        assert_eq!(format!("{}", code), "nika::nika_140");
+    }
+
+    #[test]
+    fn test_rich_error_diagnostic_help() {
+        let err = AnalyzeError::unknown_task(make_span(0, 5), "taks1", Some("task1"));
+        let rich = RichAnalyzeError::new(err, "source", "file.yaml");
+
+        let help = Diagnostic::help(&rich).unwrap();
+        assert_eq!(format!("{}", help), "did you mean 'task1'?");
+    }
+
+    #[test]
+    fn test_rich_error_diagnostic_no_help() {
+        let err = AnalyzeError::unknown_task(make_span(0, 5), "x", None);
+        let rich = RichAnalyzeError::new(err, "source", "file.yaml");
+
+        assert!(Diagnostic::help(&rich).is_none());
+    }
+
+    #[test]
+    fn test_rich_error_diagnostic_url() {
+        let err = AnalyzeError::new(AnalyzeErrorKind::CyclicDependency, make_span(0, 5), "cycle");
+        let rich = RichAnalyzeError::new(err, "source", "file.yaml");
+
+        let url = Diagnostic::url(&rich).unwrap();
+        assert_eq!(format!("{}", url), "https://nika.sh/errors/NIKA-143");
+    }
+
+    #[test]
+    fn test_rich_error_has_source_code() {
+        let source = "schema: nika/workflow@0.12\ntasks:\n  - id: test\n";
+        let err = AnalyzeError::missing_field(make_span(30, 40), "infer");
+        let rich = RichAnalyzeError::new(err, source, "test.yaml");
+
+        assert!(Diagnostic::source_code(&rich).is_some());
+    }
+
+    #[test]
+    fn test_rich_error_labels() {
+        let err = AnalyzeError::unknown_task(make_span(10, 20), "bad_task", None);
+        let rich = RichAnalyzeError::new(err, "0123456789bad_task90", "test.yaml");
+
+        let labels: Vec<_> = Diagnostic::labels(&rich).unwrap().collect();
+        assert_eq!(labels.len(), 1);
+
+        // The label span should match our error span
+        let span = labels[0].inner();
+        assert_eq!(span.offset(), 10);
+        assert_eq!(span.len(), 10);
+    }
+
+    #[test]
+    fn test_to_rich_diagnostics() {
+        let errors = vec![
+            AnalyzeError::unknown_task(make_span(10, 15), "a", None),
+            AnalyzeError::duplicate_task(make_span(20, 25), "b", make_span(0, 5)),
+        ];
+        let source = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+        let rich = to_rich_diagnostics(errors, source, "test.yaml");
+        assert_eq!(rich.len(), 2);
+        assert_eq!(rich[0].error().kind, AnalyzeErrorKind::UnknownTask);
+        assert_eq!(rich[1].error().kind, AnalyzeErrorKind::DuplicateTask);
+    }
+
+    #[test]
+    fn test_format_error_output() {
+        let source = r#"schema: "nika/workflow@0.12"
+tasks:
+  - id: step1
+    infer: "Hello"
+  - id: step2
+    with:
+      data: taks1
+    infer: "Process {{with.data}}"
+"#;
+        // "taks1" starts at byte ~96 in this source
+        let err = AnalyzeError::unknown_task(make_span(96, 101), "taks1", Some("task1"));
+        let output = format_error(&err, source, "workflow.nika.yaml");
+
+        // The output should contain the error code and message
+        assert!(output.contains("NIKA-140") || output.contains("nika_140"));
+        assert!(output.contains("unknown task"));
+    }
+
+    #[test]
+    fn test_rich_error_all_kinds() {
+        // Ensure all error kinds work with RichAnalyzeError
+        let kinds = [
+            (AnalyzeErrorKind::UnknownTask, "NIKA-140"),
+            (AnalyzeErrorKind::DuplicateTask, "NIKA-141"),
+            (AnalyzeErrorKind::InvalidSchema, "NIKA-142"),
+            (AnalyzeErrorKind::CyclicDependency, "NIKA-143"),
+            (AnalyzeErrorKind::InvalidValue, "NIKA-144"),
+            (AnalyzeErrorKind::MissingField, "NIKA-145"),
+            (AnalyzeErrorKind::UnsupportedFeature, "NIKA-149"),
+            (AnalyzeErrorKind::InvalidBinding, "NIKA-151"),
+        ];
+
+        for (kind, expected_code) in kinds {
+            let err = AnalyzeError::new(kind, make_span(0, 5), "test message");
+            let rich = RichAnalyzeError::new(err, "source", "file.yaml");
+
+            let code = Diagnostic::code(&rich).unwrap();
+            let code_str = format!("{}", code);
+            assert!(
+                code_str.contains(&expected_code.to_lowercase().replace('-', "_")),
+                "Expected code {} in {}, got {}",
+                expected_code,
+                kind.code(),
+                code_str
+            );
+        }
+    }
+}

--- a/tools/nika-core/src/ast/analyzer/mod.rs
+++ b/tools/nika-core/src/ast/analyzer/mod.rs
@@ -1,0 +1,90 @@
+//! Analyzer module - Phase 2 transformation.
+//!
+//! This module provides the core analysis functionality that transforms
+//! raw::Workflow (parsed from YAML) into analyzed::Workflow (validated,
+//! references resolved).
+//!
+//! # Two-Phase Architecture
+//!
+//! ```text
+//! ┌────────────────────────────────────────────────────────────────────┐
+//! │  Phase 1: Parsing (ast::raw)                                       │
+//! │  - marked_yaml parses YAML with Span tracking                      │
+//! │  - All values are strings, unresolved                              │
+//! │  - Output: raw::Workflow with Spanned<T> fields                    │
+//! └──────────────────────────┬─────────────────────────────────────────┘
+//!                            │
+//!                            │ analyze()
+//!                            │
+//!                            ▼
+//! ┌────────────────────────────────────────────────────────────────────┐
+//! │  Phase 2: Analysis (this module)                                   │
+//! │  - Validates schema version                                        │
+//! │  - Builds task table (TaskId interning)                            │
+//! │  - Resolves all references (with:, depends_on:)                     │
+//! │  - Detects cyclic dependencies                                     │
+//! │  - Collects errors with precise spans                              │
+//! │  - Output: analyzed::Workflow with TaskId fields                   │
+//! └────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Error Handling
+//!
+//! The analyzer collects ALL errors in a single pass (not fail-fast).
+//! This allows IDEs to show all problems at once.
+//!
+//! ```ignore
+//! let result = analyze(raw_workflow);
+//! if result.is_err() {
+//!     for error in &result.errors {
+//!         // error.span has precise location
+//!         // error.suggestion may have "did you mean?"
+//!         eprintln!("{}: {}", error.kind.code(), error);
+//!     }
+//! }
+//! ```
+//!
+//! # Suggestion Engine
+//!
+//! Uses Jaro-Winkler similarity (strsim) for "did you mean?" suggestions:
+//!
+//! - Unknown task "taks1" → did you mean "task1"?
+//! - Invalid schema "nika/workfow@0.10" → did you mean "nika/workflow@0.12"?
+
+mod analyze;
+mod errors;
+pub mod suggestions;
+
+pub use analyze::{analyze, validate};
+pub use errors::{
+    format_error, to_rich_diagnostics, AnalyzeError, AnalyzeErrorKind, AnalyzeResult,
+    RichAnalyzeError,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::raw::RawWorkflow;
+    use crate::source::{FileId, Span, Spanned};
+
+    #[test]
+    fn test_module_exports() {
+        // Smoke test that all types are accessible
+        let _ = AnalyzeErrorKind::UnknownTask;
+        let _ = AnalyzeError::new(AnalyzeErrorKind::UnknownTask, Span::dummy(), "test");
+    }
+
+    #[test]
+    fn test_analyze_empty_workflow_is_rejected() {
+        let raw = RawWorkflow {
+            schema: Spanned::new(
+                "nika/workflow@0.12".to_string(),
+                Span::new(FileId(0), 0, 18),
+            ),
+            ..Default::default()
+        };
+
+        let result = analyze(raw);
+        assert!(result.is_err(), "empty tasks array should be rejected");
+    }
+}

--- a/tools/nika-core/src/ast/analyzer/suggestions.rs
+++ b/tools/nika-core/src/ast/analyzer/suggestions.rs
@@ -1,0 +1,207 @@
+//! Suggestion engine using Levenshtein distance.
+//!
+//! Provides "did you mean?" suggestions for typos and near-misses.
+
+use strsim::jaro_winkler;
+
+/// Find the most similar string from a list of candidates.
+///
+/// Uses Jaro-Winkler similarity which works well for typos:
+/// - Gives extra weight to matching prefixes
+/// - Better for short strings like identifiers
+///
+/// # Arguments
+///
+/// * `input` - The input string (possibly with typo)
+/// * `candidates` - List of valid strings to match against
+/// * `threshold` - Minimum similarity score (0.0 - 1.0) to return a suggestion
+///
+/// # Returns
+///
+/// The best matching candidate if similarity >= threshold, None otherwise.
+///
+/// # Example
+///
+/// ```ignore
+/// let suggestion = find_similar("taks1", &["task1", "task2", "other"], 0.6);
+/// assert_eq!(suggestion, Some("task1".to_string()));
+/// ```
+pub fn find_similar(input: &str, candidates: &[&str], threshold: f64) -> Option<String> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let mut best_match: Option<(&str, f64)> = None;
+
+    for candidate in candidates {
+        let score = jaro_winkler(input, candidate);
+        if score >= threshold {
+            if let Some((_, best_score)) = best_match {
+                if score > best_score {
+                    best_match = Some((candidate, score));
+                }
+            } else {
+                best_match = Some((candidate, score));
+            }
+        }
+    }
+
+    best_match.map(|(s, _)| s.to_string())
+}
+
+/// Find all similar strings above a threshold, sorted by similarity.
+///
+/// # Arguments
+///
+/// * `input` - The input string
+/// * `candidates` - List of valid strings
+/// * `threshold` - Minimum similarity score
+/// * `max_results` - Maximum number of results to return
+///
+/// # Returns
+///
+/// Vec of similar strings, sorted by descending similarity.
+pub fn find_all_similar(
+    input: &str,
+    candidates: &[&str],
+    threshold: f64,
+    max_results: usize,
+) -> Vec<String> {
+    let mut matches: Vec<(&str, f64)> = candidates
+        .iter()
+        .map(|c| (*c, jaro_winkler(input, c)))
+        .filter(|(_, score)| *score >= threshold)
+        .collect();
+
+    // Sort by score descending
+    matches.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Take top N results
+    matches
+        .into_iter()
+        .take(max_results)
+        .map(|(s, _)| s.to_string())
+        .collect()
+}
+
+/// Get a formatted "did you mean?" message for a typo.
+///
+/// # Arguments
+///
+/// * `input` - The incorrect input
+/// * `candidates` - Valid options
+/// * `threshold` - Similarity threshold
+///
+/// # Returns
+///
+/// A formatted message like "did you mean 'task1'?" or None.
+pub fn did_you_mean(input: &str, candidates: &[&str], threshold: f64) -> Option<String> {
+    find_similar(input, candidates, threshold)
+        .map(|suggestion| format!("did you mean '{}'?", suggestion))
+}
+
+/// Check if two strings are similar enough to be considered a typo.
+pub fn is_typo(a: &str, b: &str, threshold: f64) -> bool {
+    jaro_winkler(a, b) >= threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_similar_exact_match() {
+        let suggestion = find_similar("task1", &["task1", "task2", "other"], 0.6);
+        assert_eq!(suggestion, Some("task1".to_string()));
+    }
+
+    #[test]
+    fn test_find_similar_typo() {
+        // Common typos
+        let suggestion = find_similar("taks1", &["task1", "task2", "other"], 0.6);
+        assert_eq!(suggestion, Some("task1".to_string()));
+
+        let suggestion = find_similar("tesk1", &["task1", "task2", "other"], 0.6);
+        assert_eq!(suggestion, Some("task1".to_string()));
+    }
+
+    #[test]
+    fn test_find_similar_no_match() {
+        let suggestion = find_similar("xyz", &["task1", "task2", "other"], 0.8);
+        assert_eq!(suggestion, None);
+    }
+
+    #[test]
+    fn test_find_similar_empty_candidates() {
+        let suggestion = find_similar("task1", &[], 0.6);
+        assert_eq!(suggestion, None);
+    }
+
+    #[test]
+    fn test_find_similar_case_sensitive() {
+        // Jaro-Winkler is case-sensitive, so exact case matches score higher
+        let suggestion = find_similar("task1", &["task1", "TASK1"], 0.6);
+        // Exact case match should be preferred
+        assert_eq!(suggestion, Some("task1".to_string()));
+
+        // Case difference significantly reduces score in Jaro-Winkler
+        // "TASK1" vs "task1" - only '1' matches exactly, score ~0.33
+        // This verifies Jaro-Winkler is case-sensitive
+        let suggestion = find_similar("TASK1", &["task1", "other"], 0.3);
+        // With low threshold, should still find "task1" over "other"
+        assert_eq!(suggestion, Some("task1".to_string()));
+    }
+
+    #[test]
+    fn test_find_similar_prefix_bonus() {
+        // Jaro-Winkler gives bonus for matching prefix
+        let suggestion = find_similar("task_one", &["task_two", "other_task"], 0.6);
+        assert_eq!(suggestion, Some("task_two".to_string()));
+    }
+
+    #[test]
+    fn test_find_all_similar() {
+        let results = find_all_similar("task", &["task1", "task2", "task3", "other"], 0.7, 3);
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|r| r.starts_with("task")));
+    }
+
+    #[test]
+    fn test_find_all_similar_limited() {
+        let results = find_all_similar("task", &["task1", "task2", "task3", "task4"], 0.5, 2);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_did_you_mean() {
+        let msg = did_you_mean("taks1", &["task1", "task2"], 0.6);
+        assert_eq!(msg, Some("did you mean 'task1'?".to_string()));
+
+        let msg = did_you_mean("xyz", &["task1", "task2"], 0.8);
+        assert_eq!(msg, None);
+    }
+
+    #[test]
+    fn test_is_typo() {
+        assert!(is_typo("taks1", "task1", 0.6));
+        assert!(!is_typo("xyz", "task1", 0.8));
+    }
+
+    #[test]
+    fn test_schema_version_typo() {
+        // Test with actual schema versions
+        let versions = [
+            "nika/workflow@0.1",
+            "nika/workflow@0.2",
+            "nika/workflow@0.10",
+        ];
+
+        // Typo: 0.01 instead of 0.1
+        let suggestion = find_similar("nika/workflow@0.01", &versions, 0.8);
+        assert!(suggestion.is_some());
+
+        // Typo: workflow misspelled
+        let suggestion = find_similar("nika/workfow@0.10", &versions, 0.8);
+        assert_eq!(suggestion, Some("nika/workflow@0.10".to_string()));
+    }
+}

--- a/tools/nika-core/src/ast/artifact.rs
+++ b/tools/nika-core/src/ast/artifact.rs
@@ -1,0 +1,396 @@
+//! Artifact configuration for file output
+//!
+//! Provides declarative file persistence for workflow task outputs.
+//! Artifacts are written atomically and tracked in a manifest.
+//!
+//! # YAML Syntax
+//!
+//! ```yaml
+//! # Workflow-level defaults
+//! artifacts:
+//!   dir: ./output/{{context.meta.date}}
+//!   format: json
+//!   mode: overwrite
+//!   manifest: true
+//!   max_size: 104857600  # 100MB
+//!
+//! tasks:
+//!   # Simple: use defaults
+//!   - id: task1
+//!     artifact: true
+//!
+//!   # Custom path
+//!   - id: task2
+//!     artifact:
+//!       path: ./data/{{context.meta.task_id}}.json
+//!
+//!   # Multiple outputs
+//!   - id: task3
+//!     artifact:
+//!       - path: ./raw.json
+//!         source: raw_data
+//!       - path: ./processed.json
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WORKFLOW-LEVEL CONFIG
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Default max artifact size: 100MB
+pub const DEFAULT_MAX_ARTIFACT_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Workflow-level artifact defaults
+///
+/// Configures default behavior for all task artifacts.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ArtifactsConfig {
+    /// Base directory for artifacts (supports context.meta.* templates)
+    #[serde(default)]
+    pub dir: Option<String>,
+
+    /// Default output format
+    #[serde(default)]
+    pub format: ArtifactFormat,
+
+    /// Default write mode
+    #[serde(default)]
+    pub mode: ArtifactMode,
+
+    /// Generate artifacts.json manifest at workflow end
+    #[serde(default)]
+    pub manifest: bool,
+
+    /// Maximum artifact size in bytes (default: 100MB)
+    #[serde(default = "default_max_size")]
+    pub max_size: u64,
+}
+
+fn default_max_size() -> u64 {
+    DEFAULT_MAX_ARTIFACT_SIZE
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TASK-LEVEL SPEC
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Task-level artifact specification
+///
+/// Supports three forms:
+/// - `artifact: true` — use workflow defaults
+/// - `artifact: { path: ... }` — single artifact with options
+/// - `artifact: [{ path: ... }, ...]` — multiple artifacts
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ArtifactSpec {
+    /// Simple boolean: use defaults
+    Enabled(bool),
+
+    /// Single artifact with options
+    Single(ArtifactOutput),
+
+    /// Multiple artifacts
+    Multiple(Vec<ArtifactOutput>),
+}
+
+impl Default for ArtifactSpec {
+    fn default() -> Self {
+        Self::Enabled(false)
+    }
+}
+
+/// Individual artifact output configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ArtifactOutput {
+    /// Output path (supports context.meta.* templates)
+    pub path: String,
+
+    /// Which binding to save (default: task result)
+    #[serde(default)]
+    pub source: Option<String>,
+
+    /// Template string to render (supports {{with.*}} bindings)
+    /// If set, this is used instead of task output
+    #[serde(default)]
+    pub template: Option<String>,
+
+    /// Output format override
+    #[serde(default)]
+    pub format: Option<ArtifactFormat>,
+
+    /// Write mode override
+    #[serde(default)]
+    pub mode: Option<ArtifactMode>,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ENUMS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Artifact output format
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactFormat {
+    /// Plain text (default)
+    #[default]
+    Text,
+
+    /// JSON (pretty-printed)
+    Json,
+
+    /// YAML format
+    Yaml,
+
+    /// Binary (raw bytes from CAS store)
+    Binary,
+}
+
+impl std::fmt::Display for ArtifactFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text => write!(f, "text"),
+            Self::Json => write!(f, "json"),
+            Self::Yaml => write!(f, "yaml"),
+            Self::Binary => write!(f, "binary"),
+        }
+    }
+}
+
+impl ArtifactFormat {
+    /// Get file extension for this format
+    pub fn extension(&self) -> &'static str {
+        match self {
+            Self::Text => "txt",
+            Self::Json => "json",
+            Self::Yaml => "yaml",
+            Self::Binary => "bin",
+        }
+    }
+}
+
+/// File write mode
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactMode {
+    /// Overwrite existing file (default)
+    #[default]
+    Overwrite,
+
+    /// Append to existing file
+    Append,
+
+    /// Create unique filename if exists (file.json → file-1.json)
+    Unique,
+
+    /// Fail if file already exists
+    Fail,
+}
+
+impl std::fmt::Display for ArtifactMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Overwrite => write!(f, "overwrite"),
+            Self::Append => write!(f, "append"),
+            Self::Unique => write!(f, "unique"),
+            Self::Fail => write!(f, "fail"),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MANIFEST ENTRY
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Artifact metadata for manifest and events
+///
+/// Returned by ArtifactWriter after successful write.
+/// Accumulated by Runner for manifest generation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactEntry {
+    /// Task that produced this artifact
+    pub task_id: String,
+
+    /// Absolute path where artifact was written
+    pub path: String,
+
+    /// File size in bytes
+    pub size: u64,
+
+    /// Format used (text, json, yaml)
+    pub format: String,
+
+    /// xxHash3 checksum (not cryptographic, for integrity)
+    pub checksum: String,
+
+    /// Creation timestamp (UTC)
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn test_parse_artifact_enabled() {
+        let yaml = r#"true"#;
+        let spec: ArtifactSpec = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(spec, ArtifactSpec::Enabled(true)));
+    }
+
+    #[test]
+    fn test_parse_artifact_disabled() {
+        let yaml = r#"false"#;
+        let spec: ArtifactSpec = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(spec, ArtifactSpec::Enabled(false)));
+    }
+
+    #[test]
+    fn test_parse_artifact_single() {
+        let yaml = r#"
+path: ./output/{{context.meta.task_id}}.json
+mode: unique
+"#;
+        let spec: ArtifactSpec = serde_yaml::from_str(yaml).unwrap();
+        match spec {
+            ArtifactSpec::Single(output) => {
+                assert!(output.path.contains("context.meta.task_id"));
+                assert_eq!(output.mode, Some(ArtifactMode::Unique));
+            }
+            _ => panic!("Expected Single artifact"),
+        }
+    }
+
+    #[test]
+    fn test_parse_artifact_multiple() {
+        let yaml = r#"
+- path: ./raw.json
+  source: raw_data
+- path: ./processed.json
+  format: json
+"#;
+        let spec: ArtifactSpec = serde_yaml::from_str(yaml).unwrap();
+        match spec {
+            ArtifactSpec::Multiple(outputs) => {
+                assert_eq!(outputs.len(), 2);
+                assert_eq!(outputs[0].source, Some("raw_data".to_string()));
+                assert_eq!(outputs[1].format, Some(ArtifactFormat::Json));
+            }
+            _ => panic!("Expected Multiple artifacts"),
+        }
+    }
+
+    #[test]
+    fn test_parse_artifacts_config() {
+        let yaml = r#"
+dir: ./output/{{context.meta.date}}
+format: json
+mode: overwrite
+manifest: true
+max_size: 52428800
+"#;
+        let config: ArtifactsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.dir,
+            Some("./output/{{context.meta.date}}".to_string())
+        );
+        assert_eq!(config.format, ArtifactFormat::Json);
+        assert_eq!(config.mode, ArtifactMode::Overwrite);
+        assert!(config.manifest);
+        assert_eq!(config.max_size, 50 * 1024 * 1024); // 50MB
+    }
+
+    #[test]
+    fn test_artifacts_config_defaults() {
+        let yaml = "{}";
+        let config: ArtifactsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.dir, None);
+        assert_eq!(config.format, ArtifactFormat::Text);
+        assert_eq!(config.mode, ArtifactMode::Overwrite);
+        assert!(!config.manifest);
+        assert_eq!(config.max_size, DEFAULT_MAX_ARTIFACT_SIZE);
+    }
+
+    #[test]
+    fn test_artifact_format_display() {
+        assert_eq!(ArtifactFormat::Text.to_string(), "text");
+        assert_eq!(ArtifactFormat::Json.to_string(), "json");
+        assert_eq!(ArtifactFormat::Yaml.to_string(), "yaml");
+        assert_eq!(ArtifactFormat::Binary.to_string(), "binary");
+    }
+
+    #[test]
+    fn test_artifact_format_extension() {
+        assert_eq!(ArtifactFormat::Text.extension(), "txt");
+        assert_eq!(ArtifactFormat::Json.extension(), "json");
+        assert_eq!(ArtifactFormat::Yaml.extension(), "yaml");
+        assert_eq!(ArtifactFormat::Binary.extension(), "bin");
+    }
+
+    #[test]
+    fn test_artifact_mode_display() {
+        assert_eq!(ArtifactMode::Overwrite.to_string(), "overwrite");
+        assert_eq!(ArtifactMode::Append.to_string(), "append");
+        assert_eq!(ArtifactMode::Unique.to_string(), "unique");
+        assert_eq!(ArtifactMode::Fail.to_string(), "fail");
+    }
+
+    #[test]
+    fn test_artifact_format_binary_serde() {
+        // Deserialize from YAML
+        let yaml = r#""binary""#;
+        let format: ArtifactFormat = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(format, ArtifactFormat::Binary);
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&format).unwrap();
+        assert_eq!(json, r#""binary""#);
+
+        // Deserialize from JSON
+        let back: ArtifactFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ArtifactFormat::Binary);
+
+        // Extension
+        assert_eq!(ArtifactFormat::Binary.extension(), "bin");
+
+        // Display
+        assert_eq!(ArtifactFormat::Binary.to_string(), "binary");
+    }
+
+    #[test]
+    fn test_artifact_format_binary_in_artifact_spec() {
+        let yaml = r#"
+path: ./output/image.bin
+format: binary
+"#;
+        let spec: ArtifactSpec = serde_yaml::from_str(yaml).unwrap();
+        match spec {
+            ArtifactSpec::Single(output) => {
+                assert_eq!(output.format, Some(ArtifactFormat::Binary));
+                assert_eq!(output.path, "./output/image.bin");
+            }
+            _ => panic!("Expected Single artifact"),
+        }
+    }
+
+    #[test]
+    fn test_artifact_entry_serialization() {
+        let entry = ArtifactEntry {
+            task_id: "test_task".to_string(),
+            path: "/tmp/output.json".to_string(),
+            size: 1234,
+            format: "json".to_string(),
+            checksum: "abc123".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("test_task"));
+        assert!(json.contains("1234"));
+    }
+}

--- a/tools/nika-core/src/ast/budget.rs
+++ b/tools/nika-core/src/ast/budget.rs
@@ -1,0 +1,461 @@
+//! YAML Bomb Protection via serde-saphyr Budget System
+//!
+//! This module provides protection against YAML bombs (deeply nested structures,
+//! alias expansion attacks, and oversized inputs) using serde-saphyr's Budget system.
+//!
+//! # Security
+//!
+//! YAML bombs are a class of denial-of-service attacks that exploit:
+//! - **Deep nesting**: Excessive recursion that can exhaust stack space
+//! - **Alias expansion**: Exponential expansion of anchors/aliases (the "billion laughs" attack)
+//! - **Large scalars**: Oversized string values that consume memory
+//!
+//! # Default Budget
+//!
+//! The default budget for Nika workflows is more restrictive than serde-saphyr's defaults:
+//!
+//! | Limit | Nika Default | serde-saphyr Default | Rationale |
+//! |-------|--------------|----------------------|-----------|
+//! | `max_depth` | 100 | 2,000 | Workflows rarely need >50 levels |
+//! | `max_anchors` | 200 | 50,000 | Workflows should use few anchors |
+//! | `max_aliases` | 500 | 50,000 | Limited alias usage expected |
+//! | `max_nodes` | 50,000 | 250,000 | Workflows are typically small |
+//! | `max_total_scalar_bytes` | 1 MiB | 64 MiB | Prevent memory exhaustion |
+//! | `max_events` | 100,000 | 1,000,000 | Limit parser event count |
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use nika::ast::budget::from_str_with_budget;
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize)]
+//! struct Workflow {
+//!     schema: String,
+//!     workflow: String,
+//! }
+//!
+//! let yaml = r#"
+//! schema: nika/workflow@0.12
+//! workflow: example
+//! "#;
+//!
+//! let workflow: Workflow = from_str_with_budget(yaml)?;
+//! ```
+
+use serde::de::{DeserializeOwned, Error as DeError};
+
+// Re-export Budget from serde_saphyr for external use
+pub use crate::serde_yaml::budget::{Budget, BudgetBreach, BudgetReport};
+pub use crate::serde_yaml::options::{AliasLimits, Options};
+
+/// Default budget for Nika workflows.
+///
+/// This budget is more restrictive than serde-saphyr defaults because
+/// Nika workflows are expected to be relatively small, well-structured
+/// YAML files rather than arbitrary user-generated content.
+pub fn default_budget() -> Budget {
+    Budget {
+        max_depth: 100,                          // Workflows rarely need > 50 levels
+        max_anchors: 200,                        // Few anchors expected in workflows
+        max_aliases: 500,                        // Limited alias usage
+        max_nodes: 50_000,                       // Workflows are typically small
+        max_total_scalar_bytes: 1_048_576,       // 1 MiB - prevent memory exhaustion
+        max_events: 100_000,                     // Limit parser event count
+        max_documents: 10,                       // Few multi-doc workflows
+        max_merge_keys: 100,                     // Limited merge key usage
+        max_reader_input_bytes: Some(2_097_152), // 2 MiB input cap
+        enforce_alias_anchor_ratio: true,        // Detect alias bombs
+        alias_anchor_min_aliases: 50,            // Lower threshold for detection
+        alias_anchor_ratio_multiplier: 5,        // Stricter ratio
+    }
+}
+
+/// Default alias limits for Nika workflows.
+///
+/// These limits restrict alias replay to prevent exponential expansion attacks.
+pub fn default_alias_limits() -> AliasLimits {
+    AliasLimits {
+        max_total_replayed_events: 100_000, // Total replayed events from all aliases
+        max_replay_stack_depth: 32,         // Nested alias depth
+        max_alias_expansions_per_anchor: 100, // How many times one anchor can be expanded
+    }
+}
+
+/// Default options combining budget and alias limits for Nika.
+pub fn default_options() -> Options {
+    Options {
+        budget: Some(default_budget()),
+        alias_limits: default_alias_limits(),
+        ..Options::default()
+    }
+}
+
+/// Parse YAML with Nika's default budget protection.
+///
+/// This function enforces:
+/// - Maximum nesting depth of 100
+/// - Maximum 200 anchors
+/// - Maximum 500 aliases
+/// - Maximum 1 MiB of scalar content
+/// - Alias/anchor ratio heuristic to detect alias bombs
+///
+/// # Errors
+///
+/// Returns `serde_saphyr::Error` if:
+/// - The YAML is malformed
+/// - Any budget limit is exceeded
+/// - Deserialization fails
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use nika::ast::budget::from_str_with_budget;
+///
+/// let yaml = "name: test\nversion: 1";
+/// let value: serde_json::Value = from_str_with_budget(yaml)?;
+/// ```
+pub fn from_str_with_budget<T: DeserializeOwned>(s: &str) -> Result<T, crate::serde_yaml::Error> {
+    crate::serde_yaml::from_str_with_options(s, default_options())
+}
+
+/// Parse YAML with custom budget settings.
+///
+/// Use this when the default budget is too restrictive or permissive
+/// for your specific use case.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use nika::ast::budget::{from_str_with_custom_budget, default_budget};
+///
+/// let mut budget = default_budget();
+/// budget.max_depth = 200;  // Allow deeper nesting
+///
+/// let yaml = "deeply: { nested: { content: true } }";
+/// let value: serde_json::Value = from_str_with_custom_budget(yaml, budget)?;
+/// ```
+pub fn from_str_with_custom_budget<T: DeserializeOwned>(
+    s: &str,
+    budget: Budget,
+) -> Result<T, crate::serde_yaml::Error> {
+    let options = Options {
+        budget: Some(budget),
+        alias_limits: default_alias_limits(),
+        ..Options::default()
+    };
+    crate::serde_yaml::from_str_with_options(s, options)
+}
+
+/// Check if YAML content exceeds budget limits without deserializing.
+///
+/// This is useful for pre-validation when you want to check budget
+/// compliance before attempting deserialization.
+///
+/// # Returns
+///
+/// - `Ok(report)` with `report.breached.is_none()` if within budget
+/// - `Ok(report)` with `report.breached.is_some()` if budget exceeded
+/// - `Err(error)` if YAML is malformed
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use nika::ast::budget::check_budget;
+///
+/// let yaml = "key: value";
+/// let report = check_budget(yaml)?;
+/// if report.breached.is_none() {
+///     println!("YAML is within budget limits");
+/// }
+/// ```
+pub fn check_budget(input: &str) -> Result<BudgetReport, crate::serde_yaml::Error> {
+    crate::serde_yaml::budget::check_yaml_budget(
+        input,
+        default_budget(),
+        crate::serde_yaml::budget::EnforcingPolicy::AllContent,
+    )
+    .map_err(|e| <crate::serde_yaml::Error as DeError>::custom(e.to_string()))
+}
+
+/// Check if YAML content exceeds custom budget limits.
+pub fn check_budget_with_custom(
+    input: &str,
+    budget: Budget,
+) -> Result<BudgetReport, crate::serde_yaml::Error> {
+    crate::serde_yaml::budget::check_yaml_budget(
+        input,
+        budget,
+        crate::serde_yaml::budget::EnforcingPolicy::AllContent,
+    )
+    .map_err(|e| <crate::serde_yaml::Error as DeError>::custom(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct SimpleConfig {
+        name: String,
+        enabled: bool,
+    }
+
+    #[test]
+    fn test_normal_yaml_parses_successfully() {
+        let yaml = r#"
+name: test-workflow
+enabled: true
+"#;
+
+        let config: SimpleConfig = from_str_with_budget(yaml).unwrap();
+        assert_eq!(config.name, "test-workflow");
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn test_nested_yaml_within_limits() {
+        let yaml = r#"
+level1:
+  level2:
+    level3:
+      level4:
+        value: "deep but acceptable"
+"#;
+
+        let result: serde_json::Value = from_str_with_budget(yaml).unwrap();
+        let value = &result["level1"]["level2"]["level3"]["level4"]["value"];
+        assert_eq!(value.as_str(), Some("deep but acceptable"));
+    }
+
+    #[test]
+    fn test_deep_nesting_rejected() {
+        // Generate YAML with nesting depth > 100
+        let mut yaml = String::new();
+        for _ in 0..110 {
+            yaml.push('[');
+        }
+        for _ in 0..110 {
+            yaml.push(']');
+        }
+
+        let result: Result<serde_json::Value, _> = from_str_with_budget(&yaml);
+        assert!(result.is_err(), "Deeply nested YAML should be rejected");
+
+        let err = result.unwrap_err();
+        let err_str = err.to_string();
+        // Should contain budget breach indication
+        assert!(
+            err_str.contains("depth") || err_str.contains("budget") || err_str.contains("Depth"),
+            "Error should mention depth limit: {err_str}"
+        );
+    }
+
+    #[test]
+    fn test_many_anchors_rejected() {
+        // Generate YAML with > 200 anchors
+        let mut yaml = String::new();
+        for i in 0..210 {
+            yaml.push_str(&format!("anchor_{i}: &a{i} value{i}\n"));
+        }
+
+        let result: Result<serde_json::Value, _> = from_str_with_budget(&yaml);
+        assert!(result.is_err(), "Too many anchors should be rejected");
+
+        let err = result.unwrap_err();
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("anchor") || err_str.contains("budget") || err_str.contains("Anchor"),
+            "Error should mention anchor limit: {err_str}"
+        );
+    }
+
+    #[test]
+    fn test_large_scalar_rejected() {
+        // Generate YAML with scalar content > 1 MiB
+        let large_value = "x".repeat(1_100_000); // 1.1 MiB
+        let yaml = format!("data: \"{large_value}\"");
+
+        let result: Result<serde_json::Value, _> = from_str_with_budget(&yaml);
+        assert!(result.is_err(), "Large scalar should be rejected");
+
+        let err = result.unwrap_err();
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("scalar")
+                || err_str.contains("budget")
+                || err_str.contains("Scalar")
+                || err_str.contains("bytes"),
+            "Error should mention scalar bytes limit: {err_str}"
+        );
+    }
+
+    #[test]
+    fn test_alias_bomb_rejected() {
+        // Classic "billion laughs" style alias bomb (simplified)
+        // Each level doubles the expansion
+        let yaml = r#"
+a: &a ["lol"]
+b: &b [*a, *a]
+c: &c [*b, *b]
+d: &d [*c, *c]
+e: &e [*d, *d]
+f: &f [*e, *e]
+g: &g [*f, *f]
+h: &h [*g, *g]
+i: &i [*h, *h]
+j: &j [*i, *i]
+k: &k [*j, *j]
+l: &l [*k, *k]
+m: &m [*l, *l]
+n: &n [*m, *m]
+o: &o [*n, *n]
+p: &p [*o, *o]
+q: &q [*p, *p]
+r: &r [*q, *q]
+s: &s [*r, *r]
+t: &t [*s, *s]
+result: *t
+"#;
+
+        let result: Result<serde_json::Value, _> = from_str_with_budget(yaml);
+        // This should fail due to alias limits or alias/anchor ratio
+        assert!(result.is_err(), "Alias bomb should be rejected");
+    }
+
+    #[test]
+    fn test_check_budget_valid_yaml() {
+        let yaml = "key: value\nlist:\n  - item1\n  - item2";
+        let report = check_budget(yaml).unwrap();
+        assert!(
+            report.breached.is_none(),
+            "Valid YAML should pass budget check"
+        );
+    }
+
+    #[test]
+    fn test_check_budget_deep_nesting() {
+        let mut yaml = String::new();
+        for _ in 0..110 {
+            yaml.push('[');
+        }
+        for _ in 0..110 {
+            yaml.push(']');
+        }
+
+        let report = check_budget(&yaml).unwrap();
+        assert!(
+            report.breached.is_some(),
+            "Deep nesting should breach budget"
+        );
+        if let Some(BudgetBreach::Depth { depth }) = report.breached {
+            assert!(depth > 100, "Should report depth > 100");
+        }
+    }
+
+    #[test]
+    fn test_custom_budget_allows_deeper_nesting() {
+        // 60 levels of nesting - exceeds default (100) but we'll allow more
+        let mut yaml = String::new();
+        for _ in 0..60 {
+            yaml.push('[');
+        }
+        for _ in 0..60 {
+            yaml.push(']');
+        }
+
+        // Default budget should pass (60 < 100)
+        let result: Result<serde_json::Value, _> = from_str_with_budget(&yaml);
+        assert!(result.is_ok(), "60 levels should pass default budget");
+
+        // Custom budget with lower depth should fail
+        let mut strict_budget = default_budget();
+        strict_budget.max_depth = 50;
+
+        let result: Result<serde_json::Value, _> =
+            from_str_with_custom_budget(&yaml, strict_budget);
+        assert!(result.is_err(), "60 levels should fail with max_depth=50");
+    }
+
+    #[test]
+    fn test_budget_report_statistics() {
+        let yaml = r#"
+root: &root
+  key1: value1
+  key2: value2
+ref1: *root
+ref2: *root
+"#;
+
+        let report = check_budget(yaml).unwrap();
+        assert!(report.breached.is_none());
+        assert!(report.nodes > 0, "Should count nodes");
+        assert_eq!(report.anchors, 1, "Should count one anchor");
+        assert_eq!(report.aliases, 2, "Should count two aliases");
+    }
+
+    #[test]
+    fn test_default_options_has_correct_values() {
+        let options = default_options();
+        let budget = options.budget.unwrap();
+
+        assert_eq!(budget.max_depth, 100);
+        assert_eq!(budget.max_anchors, 200);
+        assert_eq!(budget.max_aliases, 500);
+        assert_eq!(budget.max_nodes, 50_000);
+        assert_eq!(budget.max_total_scalar_bytes, 1_048_576);
+        assert_eq!(budget.max_events, 100_000);
+        assert!(budget.enforce_alias_anchor_ratio);
+
+        let alias_limits = options.alias_limits;
+        assert_eq!(alias_limits.max_total_replayed_events, 100_000);
+        assert_eq!(alias_limits.max_replay_stack_depth, 32);
+        assert_eq!(alias_limits.max_alias_expansions_per_anchor, 100);
+    }
+
+    #[test]
+    fn test_empty_yaml_parses() {
+        // Empty documents should work
+        let yaml = "";
+        let result: Result<Option<serde_json::Value>, _> = from_str_with_budget(yaml);
+        // Empty YAML is valid and deserializes to None/null
+        assert!(result.is_ok() || result.is_err()); // Either is acceptable
+    }
+
+    #[test]
+    fn test_typical_workflow_size() {
+        // A realistic Nika workflow should always pass
+        let yaml = r#"
+schema: nika/workflow@0.12
+workflow: test-workflow
+
+context:
+  files:
+    brand: ./context/brand.md
+    persona: ./context/persona.json
+
+tasks:
+  - id: step1
+    infer:
+      prompt: "Generate a headline for our product"
+      model: claude-sonnet-4-6
+      temperature: 0.7
+
+  - id: step2
+    with:
+      headline: step1
+    infer:
+      prompt: "Expand on this headline: {{with.headline}}"
+
+  - id: step3
+    exec:
+      command: "echo 'Done processing'"
+
+"#;
+
+        let result: serde_json::Value = from_str_with_budget(yaml).unwrap();
+        assert_eq!(result["schema"], "nika/workflow@0.12");
+        assert_eq!(result["workflow"], "test-workflow");
+    }
+}

--- a/tools/nika-core/src/ast/content.rs
+++ b/tools/nika-core/src/ast/content.rs
@@ -1,0 +1,353 @@
+//! Content parts for multimodal vision support.
+//!
+//! Three-phase types following the AST pipeline convention:
+//! - `RawContentPart` — parsed from YAML with span tracking
+//! - `AnalyzedContentPart` — validated, spans stripped
+//! - `ContentPart` — runtime type used in `InferParams`
+//!
+//! # YAML Syntax
+//!
+//! ```yaml
+//! content:
+//!   - type: text
+//!     text: "Describe this image"
+//!   - type: image
+//!     source: "{{with.photo.media[0].hash}}"
+//!     detail: high
+//!   - type: image_url
+//!     url: "https://example.com/photo.jpg"
+//!     detail: low
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use crate::source::{Span, Spanned};
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 1: Raw (from YAML parser, with spans)
+// ═══════════════════════════════════════════════════════════════
+
+/// Raw content part parsed from YAML with full span tracking.
+#[derive(Debug, Clone)]
+pub enum RawContentPart {
+    /// Text content: `{ type: text, text: "..." }`
+    Text { text: Spanned<String> },
+    /// CAS image reference: `{ type: image, source: "blake3:...", detail: auto }`
+    Image {
+        source: Spanned<String>,
+        detail: Option<Spanned<String>>,
+    },
+    /// External image URL: `{ type: image_url, url: "https://...", detail: low }`
+    ImageUrl {
+        url: Spanned<String>,
+        detail: Option<Spanned<String>>,
+    },
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 2: Analyzed (validated, spans stripped)
+// ═══════════════════════════════════════════════════════════════
+
+/// Analyzed content part — validated and span-free.
+#[derive(Debug, Clone)]
+pub enum AnalyzedContentPart {
+    Text { text: String },
+    Image { source: String, detail: ImageDetail },
+    ImageUrl { url: String, detail: ImageDetail },
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 3: Runtime (used in InferParams, serde-enabled)
+// ═══════════════════════════════════════════════════════════════
+
+/// Runtime content part for multimodal inference.
+///
+/// Used in `InferParams.content` to specify text + image parts
+/// sent to vision-capable LLMs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentPart {
+    /// Text content
+    Text { text: String },
+    /// CAS image reference (resolved to base64 at runtime)
+    Image {
+        source: String,
+        #[serde(default)]
+        detail: ImageDetail,
+    },
+    /// External image URL (passed directly to provider)
+    ImageUrl {
+        url: String,
+        #[serde(default)]
+        detail: ImageDetail,
+    },
+}
+
+/// Image detail level for vision models.
+///
+/// - `Auto`: Let the model decide (default)
+/// - `Low`: Faster, cheaper, lower resolution
+/// - `High`: Full resolution analysis
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ImageDetail {
+    #[default]
+    Auto,
+    Low,
+    High,
+}
+
+impl std::fmt::Display for ImageDetail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImageDetail::Auto => write!(f, "auto"),
+            ImageDetail::Low => write!(f, "low"),
+            ImageDetail::High => write!(f, "high"),
+        }
+    }
+}
+
+impl ImageDetail {
+    /// Parse from string, defaulting to Auto for unknown values.
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s {
+            "low" => ImageDetail::Low,
+            "high" => ImageDetail::High,
+            _ => ImageDetail::Auto,
+        }
+    }
+}
+
+impl std::fmt::Display for ContentPart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ContentPart::Text { text } => write!(f, "text({} chars)", text.len()),
+            ContentPart::Image { source, detail } => {
+                write!(f, "image(source={}, detail={})", source, detail)
+            }
+            ContentPart::ImageUrl { url, detail } => {
+                write!(f, "image_url(url={}, detail={})", url, detail)
+            }
+        }
+    }
+}
+
+/// Convert an analyzed content part to a runtime content part.
+impl From<AnalyzedContentPart> for ContentPart {
+    fn from(part: AnalyzedContentPart) -> Self {
+        match part {
+            AnalyzedContentPart::Text { text } => ContentPart::Text { text },
+            AnalyzedContentPart::Image { source, detail } => ContentPart::Image { source, detail },
+            AnalyzedContentPart::ImageUrl { url, detail } => ContentPart::ImageUrl { url, detail },
+        }
+    }
+}
+
+/// Convert a raw detail string to ImageDetail.
+pub(crate) fn parse_detail(detail: Option<&Spanned<String>>) -> ImageDetail {
+    detail
+        .map(|s| ImageDetail::from_str_lossy(&s.value))
+        .unwrap_or_default()
+}
+
+/// Analyze a raw content part into an analyzed content part.
+pub(crate) fn analyze_content_part(raw: &RawContentPart) -> AnalyzedContentPart {
+    match raw {
+        RawContentPart::Text { text } => AnalyzedContentPart::Text {
+            text: text.value.clone(),
+        },
+        RawContentPart::Image { source, detail } => AnalyzedContentPart::Image {
+            source: source.value.clone(),
+            detail: parse_detail(detail.as_ref()),
+        },
+        RawContentPart::ImageUrl { url, detail } => AnalyzedContentPart::ImageUrl {
+            url: url.value.clone(),
+            detail: parse_detail(detail.as_ref()),
+        },
+    }
+}
+
+/// Get the span of a raw content part (for error reporting).
+impl RawContentPart {
+    pub fn span(&self) -> Span {
+        match self {
+            RawContentPart::Text { text } => text.span,
+            RawContentPart::Image { source, .. } => source.span,
+            RawContentPart::ImageUrl { url, .. } => url.span,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_part_serde_text_round_trip() {
+        let part = ContentPart::Text {
+            text: "Hello world".to_string(),
+        };
+        let json = serde_json::to_string(&part).unwrap();
+        let parsed: ContentPart = serde_json::from_str(&json).unwrap();
+        assert_eq!(part, parsed);
+        assert!(json.contains(r#""type":"text""#));
+    }
+
+    #[test]
+    fn content_part_serde_image_round_trip() {
+        let part = ContentPart::Image {
+            source: "blake3:abc123".to_string(),
+            detail: ImageDetail::High,
+        };
+        let json = serde_json::to_string(&part).unwrap();
+        let parsed: ContentPart = serde_json::from_str(&json).unwrap();
+        assert_eq!(part, parsed);
+        assert!(json.contains(r#""type":"image""#));
+        assert!(json.contains(r#""detail":"high""#));
+    }
+
+    #[test]
+    fn content_part_serde_image_url_round_trip() {
+        let part = ContentPart::ImageUrl {
+            url: "https://example.com/photo.jpg".to_string(),
+            detail: ImageDetail::Low,
+        };
+        let json = serde_json::to_string(&part).unwrap();
+        let parsed: ContentPart = serde_json::from_str(&json).unwrap();
+        assert_eq!(part, parsed);
+        assert!(json.contains(r#""type":"image_url""#));
+    }
+
+    #[test]
+    fn content_part_serde_default_detail() {
+        let json = r#"{"type":"image","source":"blake3:xyz"}"#;
+        let part: ContentPart = serde_json::from_str(json).unwrap();
+        match part {
+            ContentPart::Image { detail, .. } => assert_eq!(detail, ImageDetail::Auto),
+            _ => panic!("expected Image"),
+        }
+    }
+
+    #[test]
+    fn image_detail_display() {
+        assert_eq!(ImageDetail::Auto.to_string(), "auto");
+        assert_eq!(ImageDetail::Low.to_string(), "low");
+        assert_eq!(ImageDetail::High.to_string(), "high");
+    }
+
+    #[test]
+    fn image_detail_from_str_lossy() {
+        assert_eq!(ImageDetail::from_str_lossy("low"), ImageDetail::Low);
+        assert_eq!(ImageDetail::from_str_lossy("high"), ImageDetail::High);
+        assert_eq!(ImageDetail::from_str_lossy("auto"), ImageDetail::Auto);
+        assert_eq!(ImageDetail::from_str_lossy("unknown"), ImageDetail::Auto);
+        assert_eq!(ImageDetail::from_str_lossy(""), ImageDetail::Auto);
+    }
+
+    #[test]
+    fn image_detail_default_is_auto() {
+        assert_eq!(ImageDetail::default(), ImageDetail::Auto);
+    }
+
+    #[test]
+    fn content_part_display() {
+        let text = ContentPart::Text {
+            text: "hello".to_string(),
+        };
+        assert_eq!(text.to_string(), "text(5 chars)");
+
+        let img = ContentPart::Image {
+            source: "blake3:abc".to_string(),
+            detail: ImageDetail::High,
+        };
+        assert_eq!(img.to_string(), "image(source=blake3:abc, detail=high)");
+    }
+
+    #[test]
+    fn content_part_serde_vec_round_trip() {
+        let parts = vec![
+            ContentPart::Text {
+                text: "Describe this:".to_string(),
+            },
+            ContentPart::Image {
+                source: "blake3:deadbeef".to_string(),
+                detail: ImageDetail::High,
+            },
+            ContentPart::ImageUrl {
+                url: "https://example.com/img.png".to_string(),
+                detail: ImageDetail::Auto,
+            },
+        ];
+        let json = serde_json::to_string(&parts).unwrap();
+        let parsed: Vec<ContentPart> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parts, parsed);
+    }
+
+    #[test]
+    fn analyze_content_part_text() {
+        let raw = RawContentPart::Text {
+            text: Spanned::dummy("hello".to_string()),
+        };
+        let analyzed = analyze_content_part(&raw);
+        match analyzed {
+            AnalyzedContentPart::Text { text } => assert_eq!(text, "hello"),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn analyze_content_part_image_with_detail() {
+        let raw = RawContentPart::Image {
+            source: Spanned::dummy("blake3:abc".to_string()),
+            detail: Some(Spanned::dummy("high".to_string())),
+        };
+        let analyzed = analyze_content_part(&raw);
+        match analyzed {
+            AnalyzedContentPart::Image { source, detail } => {
+                assert_eq!(source, "blake3:abc");
+                assert_eq!(detail, ImageDetail::High);
+            }
+            _ => panic!("expected Image"),
+        }
+    }
+
+    #[test]
+    fn analyze_content_part_image_no_detail_defaults_auto() {
+        let raw = RawContentPart::Image {
+            source: Spanned::dummy("blake3:xyz".to_string()),
+            detail: None,
+        };
+        let analyzed = analyze_content_part(&raw);
+        match analyzed {
+            AnalyzedContentPart::Image { detail, .. } => {
+                assert_eq!(detail, ImageDetail::Auto);
+            }
+            _ => panic!("expected Image"),
+        }
+    }
+
+    #[test]
+    fn analyzed_to_runtime_conversion() {
+        let analyzed = AnalyzedContentPart::Image {
+            source: "blake3:test".to_string(),
+            detail: ImageDetail::Low,
+        };
+        let runtime: ContentPart = analyzed.into();
+        assert_eq!(
+            runtime,
+            ContentPart::Image {
+                source: "blake3:test".to_string(),
+                detail: ImageDetail::Low,
+            }
+        );
+    }
+
+    #[test]
+    fn raw_content_part_span() {
+        let span = Span::new(crate::source::FileId(0), 10, 20);
+        let raw = RawContentPart::Text {
+            text: Spanned::new("test".to_string(), span),
+        };
+        assert_eq!(raw.span(), span);
+    }
+}

--- a/tools/nika-core/src/ast/context.rs
+++ b/tools/nika-core/src/ast/context.rs
@@ -1,0 +1,111 @@
+//! Context configuration for workflow
+//!
+//! The `context:` block in a workflow allows loading files at workflow start.
+//! Files are loaded into the RunContext and accessible via `{{context.files.alias}}` bindings.
+//!
+//! # Example
+//!
+//! ```yaml
+//! context:
+//!   files:
+//!     brand: ./context/brand.md        # Markdown → string
+//!     persona: ./context/persona.json  # JSON → parsed object
+//!     examples: ./context/*.md         # Glob → array of strings
+//!   session: .nika/sessions/prev.json  # Session restore
+//! ```
+
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+
+/// Context configuration for workflow
+///
+/// Defines files to load at workflow start and optional session restoration.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ContextConfig {
+    /// Files to load at workflow start
+    ///
+    /// Key is the alias, value is the file path (supports glob patterns).
+    /// - Single files: loaded as string (markdown, txt) or parsed (json, yaml)
+    /// - Glob patterns: loaded as array of strings
+    #[serde(default)]
+    pub files: FxHashMap<String, String>,
+
+    /// Session file to restore
+    ///
+    /// Path to a JSON file containing previous session data.
+    /// Accessible via `{{context.session.key}}` bindings.
+    pub session: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn test_context_config_default() {
+        let config = ContextConfig::default();
+        assert!(config.files.is_empty());
+        assert!(config.session.is_none());
+    }
+
+    #[test]
+    fn test_context_config_deserialize_empty() {
+        let yaml = "";
+        let config: ContextConfig = serde_yaml::from_str(yaml).unwrap_or_default();
+        assert!(config.files.is_empty());
+    }
+
+    #[test]
+    fn test_context_config_deserialize_files() {
+        let yaml = r#"
+files:
+  brand: ./context/brand.md
+  persona: ./context/persona.json
+"#;
+        let config: ContextConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.files.len(), 2);
+        assert_eq!(
+            config.files.get("brand"),
+            Some(&"./context/brand.md".to_string())
+        );
+        assert_eq!(
+            config.files.get("persona"),
+            Some(&"./context/persona.json".to_string())
+        );
+    }
+
+    #[test]
+    fn test_context_config_deserialize_session() {
+        let yaml = r#"
+session: .nika/sessions/prev.json
+"#;
+        let config: ContextConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.session, Some(".nika/sessions/prev.json".to_string()));
+    }
+
+    #[test]
+    fn test_context_config_deserialize_full() {
+        let yaml = r#"
+files:
+  brand: ./context/brand.md
+  examples: ./context/*.md
+session: .nika/sessions/prev.json
+"#;
+        let config: ContextConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.files.len(), 2);
+        assert!(config.files.contains_key("brand"));
+        assert!(config.files.contains_key("examples"));
+        assert!(config.session.is_some());
+    }
+
+    #[test]
+    fn test_context_config_glob_pattern() {
+        let yaml = r#"
+files:
+  examples: ./context/*.md
+"#;
+        let config: ContextConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.files.get("examples").unwrap().contains('*'));
+    }
+}

--- a/tools/nika-core/src/ast/decompose.rs
+++ b/tools/nika-core/src/ast/decompose.rs
@@ -1,0 +1,133 @@
+//! Decompose Module - Runtime DAG expansion via MCP traversal
+//!
+//! The `decompose:` modifier enables dynamic task expansion based on
+//! semantic graph traversal. Instead of static `for_each` arrays,
+//! decompose queries NovaNet to discover iteration items at runtime.
+//!
+//! # Example
+//!
+//! ```yaml
+//! tasks:
+//!   - id: generate_all
+//!     decompose:
+//!       strategy: semantic
+//!       traverse: HAS_CHILD
+//!       source: $entity
+//!     infer: "Generate for {{with.item}}"
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Decomposition strategy for runtime DAG expansion
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DecomposeStrategy {
+    /// Use novanet_traverse with arc to discover items
+    #[default]
+    Semantic,
+    /// Use literal array from source binding
+    Static,
+    /// Recursive decomposition (nested traversal)
+    Nested,
+}
+
+/// Specification for runtime decomposition
+///
+/// Decompose expands a task at runtime into multiple iterations
+/// based on graph traversal or static arrays.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DecomposeSpec {
+    /// Strategy for discovering iteration items
+    #[serde(default)]
+    pub strategy: DecomposeStrategy,
+    /// Arc name to traverse (e.g., "HAS_CHILD", "HAS_NATIVE")
+    pub traverse: String,
+    /// Source binding expression (e.g., "$entity", "{{with.entity_key}}")
+    pub source: String,
+    /// MCP server to use for traversal (defaults to "novanet")
+    #[serde(default)]
+    pub mcp_server: Option<String>,
+    /// Maximum items to expand (optional limit)
+    #[serde(default)]
+    pub max_items: Option<usize>,
+    /// Maximum recursion depth for nested strategy (default: 3)
+    #[serde(default)]
+    pub max_depth: Option<usize>,
+}
+
+impl DecomposeSpec {
+    /// Get the MCP server name (defaults to "novanet")
+    pub fn mcp_server(&self) -> &str {
+        self.mcp_server.as_deref().unwrap_or("novanet")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn test_decompose_strategy_default_is_semantic() {
+        let strategy = DecomposeStrategy::default();
+        assert_eq!(strategy, DecomposeStrategy::Semantic);
+    }
+
+    #[test]
+    fn test_decompose_spec_parses_minimal() {
+        let yaml = r#"
+traverse: HAS_CHILD
+source: $entity
+"#;
+        let spec: DecomposeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.strategy, DecomposeStrategy::Semantic);
+        assert_eq!(spec.traverse, "HAS_CHILD");
+        assert_eq!(spec.source, "$entity");
+        assert_eq!(spec.mcp_server(), "novanet");
+        assert!(spec.max_items.is_none());
+    }
+
+    #[test]
+    fn test_decompose_spec_parses_full() {
+        let yaml = r#"
+strategy: nested
+traverse: HAS_NATIVE
+source: "{{with.entity_key}}"
+mcp_server: custom_mcp
+max_items: 10
+"#;
+        let spec: DecomposeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.strategy, DecomposeStrategy::Nested);
+        assert_eq!(spec.traverse, "HAS_NATIVE");
+        assert_eq!(spec.source, "{{with.entity_key}}");
+        assert_eq!(spec.mcp_server(), "custom_mcp");
+        assert_eq!(spec.max_items, Some(10));
+    }
+
+    #[test]
+    fn test_decompose_spec_static_strategy() {
+        let yaml = r#"
+strategy: static
+traverse: DUMMY
+source: $locales
+"#;
+        let spec: DecomposeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.strategy, DecomposeStrategy::Static);
+    }
+
+    #[test]
+    fn test_decompose_spec_serializes() {
+        let spec = DecomposeSpec {
+            strategy: DecomposeStrategy::Semantic,
+            traverse: "HAS_CHILD".to_string(),
+            source: "$entity".to_string(),
+            mcp_server: None,
+            max_items: Some(5),
+            max_depth: None,
+        };
+        let yaml = serde_yaml::to_string(&spec).unwrap();
+        assert!(yaml.contains("traverse: HAS_CHILD"));
+        assert!(yaml.contains("source: $entity"));
+        assert!(yaml.contains("max_items: 5"));
+    }
+}

--- a/tools/nika-core/src/ast/include.rs
+++ b/tools/nika-core/src/ast/include.rs
@@ -1,0 +1,146 @@
+//! Include specification for DAG fusion
+//!
+//! The `include:` block merges tasks from external workflows into the main DAG.
+//! Included tasks share the same RunContext as the parent workflow.
+//!
+//! # Example
+//!
+//! ```yaml
+//! include:
+//!   # Filesystem path
+//!   - path: ./lib/seo-tasks.nika.yaml
+//!     prefix: seo_
+//!   # Package reference
+//!   - pkg: "@workflows/common"
+//!     prefix: common_
+//! ```
+
+use serde::Deserialize;
+
+use crate::error::CoreError;
+
+/// Include specification for DAG fusion
+///
+/// Merges tasks from an external workflow into the main DAG at parse time.
+/// Supports both filesystem paths and package references.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IncludeSpec {
+    /// Path to the workflow file to include (relative to parent workflow)
+    /// Mutually exclusive with `pkg`
+    #[serde(default)]
+    pub path: Option<String>,
+
+    /// Package reference to include (e.g., "@workflows/seo-audit")
+    /// Mutually exclusive with `path`
+    #[serde(default)]
+    pub pkg: Option<String>,
+
+    /// Optional prefix for all task IDs from this include
+    ///
+    /// Prevents ID collisions when including multiple workflows.
+    /// Example: prefix "seo_" transforms task "analyze" to "seo_analyze"
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+impl IncludeSpec {
+    /// Validate that exactly one of `path` or `pkg` is specified
+    pub fn validate(&self) -> Result<(), CoreError> {
+        match (&self.path, &self.pkg) {
+            (None, None) => Err(CoreError::ValidationError {
+                reason: "Include spec must have either 'path' or 'pkg'".into(),
+            }),
+            (Some(_), Some(_)) => Err(CoreError::ValidationError {
+                reason: "Include spec cannot have both 'path' and 'pkg'".into(),
+            }),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn test_include_spec_parse_minimal() {
+        let yaml = r#"
+path: ./lib/tasks.nika.yaml
+"#;
+        let spec: IncludeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.path, Some("./lib/tasks.nika.yaml".to_string()));
+        assert!(spec.pkg.is_none());
+        assert!(spec.prefix.is_none());
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn test_include_spec_parse_with_prefix() {
+        let yaml = r#"
+path: ./lib/seo-tasks.nika.yaml
+prefix: seo_
+"#;
+        let spec: IncludeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.path, Some("./lib/seo-tasks.nika.yaml".to_string()));
+        assert_eq!(spec.prefix, Some("seo_".to_string()));
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn test_include_spec_parse_array() {
+        let yaml = r#"
+- path: ./lib/seo.nika.yaml
+  prefix: seo_
+- path: ./lib/common.nika.yaml
+"#;
+        let specs: Vec<IncludeSpec> = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].prefix, Some("seo_".to_string()));
+        assert!(specs[1].prefix.is_none());
+    }
+
+    #[test]
+    fn test_include_spec_empty_prefix() {
+        let yaml = r#"
+path: ./lib/tasks.nika.yaml
+prefix: ""
+"#;
+        let spec: IncludeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.prefix, Some(String::new()));
+    }
+
+    // Package reference support
+    #[test]
+    fn test_include_spec_parse_pkg() {
+        let yaml = r#"
+pkg: "@workflows/seo-audit"
+prefix: seo_
+"#;
+        let spec: IncludeSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.pkg, Some("@workflows/seo-audit".to_string()));
+        assert!(spec.path.is_none());
+        assert_eq!(spec.prefix, Some("seo_".to_string()));
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn test_include_spec_validate_missing_both() {
+        let spec = IncludeSpec {
+            path: None,
+            pkg: None,
+            prefix: None,
+        };
+        assert!(spec.validate().is_err());
+    }
+
+    #[test]
+    fn test_include_spec_validate_both_present() {
+        let spec = IncludeSpec {
+            path: Some("./lib/tasks.yaml".to_string()),
+            pkg: Some("@workflows/seo".to_string()),
+            prefix: None,
+        };
+        assert!(spec.validate().is_err());
+    }
+}

--- a/tools/nika-core/src/ast/limits.rs
+++ b/tools/nika-core/src/ast/limits.rs
@@ -1,0 +1,515 @@
+//! Agent Limits Configuration
+//!
+//! Defines resource limits for agent execution including turns, tokens,
+//! cost, and duration constraints with configurable actions on limit reach.
+//!
+//! ## Features
+//!
+//! - **max_turns**: Maximum agentic loop iterations
+//! - **max_tokens**: Total token budget (input + output)
+//! - **max_cost_usd**: Cost ceiling per execution
+//! - **max_duration_secs**: Wall-clock timeout
+//!
+//! ## Example
+//!
+//! ```yaml
+//! agent:
+//!   prompt: "Research {{topic}}"
+//!   limits:
+//!     max_turns: 20
+//!     max_tokens: 50000
+//!     max_cost_usd: 2.00
+//!     max_duration_secs: 300
+//!     on_limit_reached:
+//!       action: complete_partial
+//!       save_progress: true
+//! ```
+
+use serde::Deserialize;
+
+use crate::error::CoreError;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LimitsConfig
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Configuration for agent execution limits.
+///
+/// Defines resource constraints that prevent runaway execution
+/// and enable cost control for LLM-based agents.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct LimitsConfig {
+    /// Maximum number of agentic loop turns (0 = unlimited)
+    #[serde(default)]
+    pub max_turns: u32,
+
+    /// Maximum total tokens (input + output) (0 = unlimited)
+    #[serde(default)]
+    pub max_tokens: u64,
+
+    /// Maximum cost in USD (0.0 = unlimited)
+    #[serde(default)]
+    pub max_cost_usd: f64,
+
+    /// Maximum execution duration in seconds (0 = unlimited)
+    #[serde(default)]
+    pub max_duration_secs: u64,
+
+    /// Action to take when a limit is reached
+    #[serde(default)]
+    pub on_limit_reached: OnLimitReachedConfig,
+}
+
+impl LimitsConfig {
+    /// Check if any limits are configured.
+    pub fn has_limits(&self) -> bool {
+        self.max_turns > 0
+            || self.max_tokens > 0
+            || self.max_cost_usd > 0.0
+            || self.max_duration_secs > 0
+    }
+
+    /// Check if turns limit is configured.
+    pub fn has_turns_limit(&self) -> bool {
+        self.max_turns > 0
+    }
+
+    /// Check if tokens limit is configured.
+    pub fn has_tokens_limit(&self) -> bool {
+        self.max_tokens > 0
+    }
+
+    /// Check if cost limit is configured.
+    pub fn has_cost_limit(&self) -> bool {
+        self.max_cost_usd > 0.0
+    }
+
+    /// Check if duration limit is configured.
+    pub fn has_duration_limit(&self) -> bool {
+        self.max_duration_secs > 0
+    }
+
+    /// Validate the limits configuration.
+    pub fn validate(&self) -> Result<(), CoreError> {
+        // Cost must be non-negative
+        if self.max_cost_usd < 0.0 {
+            return Err(CoreError::ValidationError {
+                reason: format!(
+                    "limits.max_cost_usd must be non-negative, got {}",
+                    self.max_cost_usd
+                ),
+            });
+        }
+
+        // Validate on_limit_reached
+        self.on_limit_reached.validate()?;
+
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OnLimitReachedConfig
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Configuration for behavior when a limit is reached.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OnLimitReachedConfig {
+    /// Action to take when limit is reached
+    #[serde(default)]
+    pub action: LimitAction,
+
+    /// Whether to save partial progress
+    #[serde(default = "default_save_progress")]
+    pub save_progress: bool,
+
+    /// Custom message for partial completion
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+impl Default for OnLimitReachedConfig {
+    fn default() -> Self {
+        Self {
+            action: LimitAction::default(),
+            save_progress: default_save_progress(),
+            message: None,
+        }
+    }
+}
+
+impl OnLimitReachedConfig {
+    /// Validate the on_limit_reached configuration.
+    pub fn validate(&self) -> Result<(), CoreError> {
+        // Escalate action requires save_progress to be useful
+        if self.action == LimitAction::Escalate && !self.save_progress {
+            // Just a warning, not an error
+        }
+        Ok(())
+    }
+}
+
+fn default_save_progress() -> bool {
+    true
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LimitAction
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Action to take when a limit is reached.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LimitAction {
+    /// Complete with partial results (recommended)
+    #[default]
+    CompletePartial,
+
+    /// Fail the task with an error
+    Fail,
+
+    /// Escalate to human or supervisor agent
+    Escalate,
+}
+
+impl LimitAction {
+    /// Get a human-readable description of the action.
+    pub fn description(&self) -> &'static str {
+        match self {
+            LimitAction::CompletePartial => "complete with partial results",
+            LimitAction::Fail => "fail the task",
+            LimitAction::Escalate => "escalate to human/supervisor",
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LimitType
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Type of limit that was reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LimitType {
+    /// Maximum turns exceeded
+    Turns,
+    /// Maximum tokens exceeded
+    Tokens,
+    /// Maximum cost exceeded
+    Cost,
+    /// Maximum duration exceeded
+    Duration,
+}
+
+impl LimitType {
+    /// Get a human-readable name for the limit type.
+    pub fn name(&self) -> &'static str {
+        match self {
+            LimitType::Turns => "turns",
+            LimitType::Tokens => "tokens",
+            LimitType::Cost => "cost",
+            LimitType::Duration => "duration",
+        }
+    }
+}
+
+impl std::fmt::Display for LimitType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LimitStatus
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Current status of a limit check.
+#[derive(Debug, Clone)]
+pub struct LimitStatus {
+    /// Type of limit
+    pub limit_type: LimitType,
+    /// Current value
+    pub current: f64,
+    /// Maximum allowed value
+    pub maximum: f64,
+    /// Percentage used (0.0-1.0)
+    pub usage_pct: f64,
+    /// Whether the limit has been exceeded
+    pub exceeded: bool,
+}
+
+impl LimitStatus {
+    /// Create a new limit status.
+    pub fn new(limit_type: LimitType, current: f64, maximum: f64) -> Self {
+        let usage_pct = if maximum > 0.0 {
+            (current / maximum).min(1.0)
+        } else {
+            0.0
+        };
+        Self {
+            limit_type,
+            current,
+            maximum,
+            usage_pct,
+            exceeded: maximum > 0.0 && current >= maximum,
+        }
+    }
+
+    /// Get remaining capacity.
+    pub fn remaining(&self) -> f64 {
+        if self.maximum > 0.0 {
+            (self.maximum - self.current).max(0.0)
+        } else {
+            f64::INFINITY
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    // ========================================================================
+    // LimitsConfig parsing tests
+    // ========================================================================
+
+    #[test]
+    fn parse_limits_config_full() {
+        let yaml = r#"
+max_turns: 20
+max_tokens: 50000
+max_cost_usd: 2.00
+max_duration_secs: 300
+on_limit_reached:
+  action: complete_partial
+  save_progress: true
+  message: "Limit reached, returning partial results"
+"#;
+        let config: LimitsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.max_turns, 20);
+        assert_eq!(config.max_tokens, 50000);
+        assert_eq!(config.max_cost_usd, 2.00);
+        assert_eq!(config.max_duration_secs, 300);
+        assert_eq!(config.on_limit_reached.action, LimitAction::CompletePartial);
+        assert!(config.on_limit_reached.save_progress);
+        assert!(config.on_limit_reached.message.is_some());
+    }
+
+    #[test]
+    fn parse_limits_config_defaults() {
+        let yaml = "";
+        let config: LimitsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.max_turns, 0); // 0 = unlimited
+        assert_eq!(config.max_tokens, 0); // 0 = unlimited
+        assert!((config.max_cost_usd - 0.0).abs() < f64::EPSILON); // 0.0 = unlimited
+        assert_eq!(config.max_duration_secs, 0); // 0 = unlimited
+        assert_eq!(config.on_limit_reached.action, LimitAction::CompletePartial);
+        assert!(config.on_limit_reached.save_progress);
+    }
+
+    #[test]
+    fn parse_limits_config_partial() {
+        let yaml = r#"
+max_turns: 10
+max_cost_usd: 1.50
+"#;
+        let config: LimitsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.max_turns, 10);
+        assert_eq!(config.max_cost_usd, 1.50);
+        assert_eq!(config.max_tokens, 0); // default
+        assert_eq!(config.max_duration_secs, 0); // default
+    }
+
+    // ========================================================================
+    // LimitAction parsing tests
+    // ========================================================================
+
+    #[test]
+    fn parse_limit_action_complete_partial() {
+        let yaml = r#"
+on_limit_reached:
+  action: complete_partial
+"#;
+        let config: LimitsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.on_limit_reached.action, LimitAction::CompletePartial);
+    }
+
+    #[test]
+    fn parse_limit_action_fail() {
+        let yaml = r#"
+on_limit_reached:
+  action: fail
+"#;
+        let config: LimitsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.on_limit_reached.action, LimitAction::Fail);
+    }
+
+    #[test]
+    fn parse_limit_action_escalate() {
+        let yaml = r#"
+on_limit_reached:
+  action: escalate
+"#;
+        let config: LimitsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.on_limit_reached.action, LimitAction::Escalate);
+    }
+
+    // ========================================================================
+    // has_limits tests
+    // ========================================================================
+
+    #[test]
+    fn has_limits_false_when_all_zero() {
+        let config = LimitsConfig::default();
+        assert!(!config.has_limits());
+    }
+
+    #[test]
+    fn has_limits_true_when_turns_set() {
+        let config = LimitsConfig {
+            max_turns: 10,
+            ..Default::default()
+        };
+        assert!(config.has_limits());
+        assert!(config.has_turns_limit());
+        assert!(!config.has_tokens_limit());
+    }
+
+    #[test]
+    fn has_limits_true_when_tokens_set() {
+        let config = LimitsConfig {
+            max_tokens: 50000,
+            ..Default::default()
+        };
+        assert!(config.has_limits());
+        assert!(config.has_tokens_limit());
+    }
+
+    #[test]
+    fn has_limits_true_when_cost_set() {
+        let config = LimitsConfig {
+            max_cost_usd: 2.00,
+            ..Default::default()
+        };
+        assert!(config.has_limits());
+        assert!(config.has_cost_limit());
+    }
+
+    #[test]
+    fn has_limits_true_when_duration_set() {
+        let config = LimitsConfig {
+            max_duration_secs: 300,
+            ..Default::default()
+        };
+        assert!(config.has_limits());
+        assert!(config.has_duration_limit());
+    }
+
+    // ========================================================================
+    // Validation tests
+    // ========================================================================
+
+    #[test]
+    fn validate_config_valid() {
+        let config = LimitsConfig {
+            max_turns: 20,
+            max_tokens: 50000,
+            max_cost_usd: 2.00,
+            max_duration_secs: 300,
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_negative_cost_invalid() {
+        let config = LimitsConfig {
+            max_cost_usd: -1.00,
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("max_cost_usd"));
+        assert!(err.to_string().contains("non-negative"));
+    }
+
+    #[test]
+    fn validate_zero_values_valid() {
+        let config = LimitsConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    // ========================================================================
+    // LimitStatus tests
+    // ========================================================================
+
+    #[test]
+    fn limit_status_not_exceeded() {
+        let status = LimitStatus::new(LimitType::Turns, 5.0, 20.0);
+        assert!(!status.exceeded);
+        assert_eq!(status.usage_pct, 0.25);
+        assert_eq!(status.remaining(), 15.0);
+    }
+
+    #[test]
+    fn limit_status_exceeded() {
+        let status = LimitStatus::new(LimitType::Tokens, 50000.0, 50000.0);
+        assert!(status.exceeded);
+        assert_eq!(status.usage_pct, 1.0);
+        assert_eq!(status.remaining(), 0.0);
+    }
+
+    #[test]
+    fn limit_status_over_exceeded() {
+        let status = LimitStatus::new(LimitType::Cost, 3.50, 2.00);
+        assert!(status.exceeded);
+        assert_eq!(status.usage_pct, 1.0); // Capped at 1.0
+        assert_eq!(status.remaining(), 0.0);
+    }
+
+    #[test]
+    fn limit_status_unlimited() {
+        let status = LimitStatus::new(LimitType::Duration, 100.0, 0.0);
+        assert!(!status.exceeded);
+        assert_eq!(status.usage_pct, 0.0);
+        assert!(status.remaining().is_infinite());
+    }
+
+    // ========================================================================
+    // LimitType tests
+    // ========================================================================
+
+    #[test]
+    fn limit_type_names() {
+        assert_eq!(LimitType::Turns.name(), "turns");
+        assert_eq!(LimitType::Tokens.name(), "tokens");
+        assert_eq!(LimitType::Cost.name(), "cost");
+        assert_eq!(LimitType::Duration.name(), "duration");
+    }
+
+    #[test]
+    fn limit_type_display() {
+        assert_eq!(format!("{}", LimitType::Turns), "turns");
+        assert_eq!(format!("{}", LimitType::Cost), "cost");
+    }
+
+    // ========================================================================
+    // LimitAction description tests
+    // ========================================================================
+
+    #[test]
+    fn limit_action_descriptions() {
+        assert_eq!(
+            LimitAction::CompletePartial.description(),
+            "complete with partial results"
+        );
+        assert_eq!(LimitAction::Fail.description(), "fail the task");
+        assert_eq!(
+            LimitAction::Escalate.description(),
+            "escalate to human/supervisor"
+        );
+    }
+}

--- a/tools/nika-core/src/ast/logging.rs
+++ b/tools/nika-core/src/ast/logging.rs
@@ -1,0 +1,260 @@
+//! Logging configuration
+//!
+//! Provides level-filtered logging for workflows and tasks.
+//!
+//! # YAML Syntax
+//!
+//! ```yaml
+//! # Workflow-level defaults
+//! log:
+//!   level: info
+//!   console: true
+//!   file: ./logs/{{context.meta.workflow}}.log
+//!
+//! tasks:
+//!   # Task-specific override
+//!   - id: verbose_task
+//!     log:
+//!       level: debug
+//!       console: false
+//!       file: ./logs/verbose.log
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LOG FORMAT
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Log output format
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    /// Plain text output (default)
+    #[default]
+    Text,
+
+    /// JSON structured output
+    Json,
+}
+
+impl std::fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text => write!(f, "text"),
+            Self::Json => write!(f, "json"),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LOG CONFIG
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Logging configuration for workflow or task
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LogConfig {
+    /// Minimum log level
+    #[serde(default)]
+    pub level: LogLevel,
+
+    /// Log output format (text or json)
+    #[serde(default)]
+    pub format: LogFormat,
+
+    /// Show in console output
+    #[serde(default = "default_true")]
+    pub console: bool,
+
+    /// Optional log file path (supports context.meta.* templates)
+    #[serde(default)]
+    pub file: Option<String>,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            level: LogLevel::default(),
+            format: LogFormat::default(),
+            console: true,
+            file: None,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LOG LEVEL
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Log levels
+///
+/// Ordered from most verbose to least:
+/// Trace < Debug < Info < Warn < Error
+#[derive(
+    Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Trace messages (most verbose)
+    Trace,
+
+    /// Debug messages
+    Debug,
+
+    /// Informational messages (default)
+    #[default]
+    Info,
+
+    /// Warning messages
+    Warn,
+
+    /// Error messages (least verbose)
+    Error,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Trace => write!(f, "trace"),
+            Self::Debug => write!(f, "debug"),
+            Self::Info => write!(f, "info"),
+            Self::Warn => write!(f, "warn"),
+            Self::Error => write!(f, "error"),
+        }
+    }
+}
+
+impl LogLevel {
+    /// Check if this level should be logged given a minimum level
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let min = LogLevel::Warn;
+    /// assert!(!LogLevel::Debug.should_log(min)); // Debug < Warn
+    /// assert!(!LogLevel::Info.should_log(min));  // Info < Warn
+    /// assert!(LogLevel::Warn.should_log(min));   // Warn >= Warn
+    /// assert!(LogLevel::Error.should_log(min));  // Error > Warn
+    /// ```
+    pub fn should_log(&self, min_level: LogLevel) -> bool {
+        *self >= min_level
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn test_parse_log_config_full() {
+        let yaml = r#"
+level: debug
+console: false
+file: ./logs/workflow.log
+"#;
+        let config: LogConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.level, LogLevel::Debug);
+        assert!(!config.console);
+        assert_eq!(config.file, Some("./logs/workflow.log".to_string()));
+    }
+
+    #[test]
+    fn test_parse_log_config_minimal() {
+        let yaml = "level: warn";
+        let config: LogConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.level, LogLevel::Warn);
+        assert!(config.console); // default true
+        assert_eq!(config.file, None);
+    }
+
+    #[test]
+    fn test_log_config_defaults() {
+        let config = LogConfig::default();
+        assert_eq!(config.level, LogLevel::Info);
+        assert_eq!(config.format, LogFormat::Text);
+        assert!(config.console);
+        assert_eq!(config.file, None);
+    }
+
+    #[test]
+    fn test_log_level_ordering() {
+        assert!(LogLevel::Debug < LogLevel::Info);
+        assert!(LogLevel::Info < LogLevel::Warn);
+        assert!(LogLevel::Warn < LogLevel::Error);
+    }
+
+    #[test]
+    fn test_log_level_should_log() {
+        let min = LogLevel::Warn;
+
+        assert!(!LogLevel::Debug.should_log(min));
+        assert!(!LogLevel::Info.should_log(min));
+        assert!(LogLevel::Warn.should_log(min));
+        assert!(LogLevel::Error.should_log(min));
+    }
+
+    #[test]
+    fn test_log_level_display() {
+        assert_eq!(LogLevel::Trace.to_string(), "trace");
+        assert_eq!(LogLevel::Debug.to_string(), "debug");
+        assert_eq!(LogLevel::Info.to_string(), "info");
+        assert_eq!(LogLevel::Warn.to_string(), "warn");
+        assert_eq!(LogLevel::Error.to_string(), "error");
+    }
+
+    #[test]
+    fn test_log_format_display() {
+        assert_eq!(LogFormat::Text.to_string(), "text");
+        assert_eq!(LogFormat::Json.to_string(), "json");
+    }
+
+    #[test]
+    fn test_parse_log_format_json() {
+        let yaml = r#"
+level: debug
+format: json
+console: true
+"#;
+        let config: LogConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.format, LogFormat::Json);
+    }
+
+    #[test]
+    fn test_parse_log_level_trace() {
+        let yaml = "level: trace";
+        let config: LogConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.level, LogLevel::Trace);
+    }
+
+    #[test]
+    fn test_trace_should_log() {
+        // Trace is most verbose, should log at all levels
+        assert!(LogLevel::Trace.should_log(LogLevel::Trace));
+        assert!(!LogLevel::Trace.should_log(LogLevel::Debug));
+        assert!(!LogLevel::Trace.should_log(LogLevel::Info));
+    }
+
+    #[test]
+    fn test_log_config_with_template() {
+        let yaml = r#"
+level: info
+file: ./logs/{{context.meta.workflow}}-{{context.meta.date}}.log
+"#;
+        let config: LogConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config
+            .file
+            .as_ref()
+            .unwrap()
+            .contains("context.meta.workflow"));
+        assert!(config.file.as_ref().unwrap().contains("context.meta.date"));
+    }
+}

--- a/tools/nika-core/src/ast/mod.rs
+++ b/tools/nika-core/src/ast/mod.rs
@@ -1,0 +1,104 @@
+//! AST Module - Abstract Syntax Tree for YAML workflows
+//!
+//! # Three-Phase Pipeline
+//!
+//! ```text
+//! YAML -> raw::parse -> analyzer::analyze -> AnalyzedWorkflow
+//! ```
+//!
+//! 1. **raw** -- Parsed from YAML with full span tracking (line:col)
+//! 2. **analyzed** -- Validated, references resolved, TaskId interning
+//!
+//! The lowering step (analyzed -> runtime types) lives in the `nika` crate,
+//! since it depends on runtime types not available here.
+//!
+//! # Modules
+//!
+//! ## Pipeline
+//! - `raw`: Raw AST with `Spanned<T>` fields for precise error locations
+//! - `analyzed`: Validated AST with TaskId interning and semantic checks
+//! - `analyzer`: Validation and transformation (raw -> analyzed)
+//!
+//! ## Type Modules
+//! - `schema`: SchemaVersion enum
+//! - `budget`: YAML bomb protection (Budget, from_str_with_budget)
+//! - `output`: OutputPolicy, OutputFormat, SchemaRef
+//! - `decompose`: DecomposeSpec, DecomposeStrategy
+//! - `context`: ContextConfig (file loading at workflow start)
+//! - `logging`: LogConfig, LogLevel, LogFormat
+//! - `structured`: StructuredOutputSpec (JSON schema enforcement)
+//! - `agent_def`: AgentDef (reusable agent configurations)
+//! - `artifact`: ArtifactsConfig, ArtifactSpec (file persistence)
+//! - `content`: ContentPart types (multimodal vision support)
+//! - `limits`: LimitsConfig (agent resource limits)
+//! - `include`: IncludeSpec (DAG fusion)
+
+// Pipeline stages
+pub mod analyzed;
+pub mod analyzer;
+pub mod raw;
+pub mod schema;
+
+// Security - YAML bomb protection
+pub mod budget;
+
+// Vision/multimodal content parts
+pub mod content;
+
+// Type modules
+pub mod agent_def;
+pub mod artifact;
+pub mod context;
+pub mod decompose;
+pub mod include;
+pub mod limits;
+pub mod logging;
+pub mod output;
+pub mod structured;
+
+// Re-export key types for convenient access
+pub use agent_def::AgentDef;
+pub use context::ContextConfig;
+pub use decompose::{DecomposeSpec, DecomposeStrategy};
+pub use include::IncludeSpec;
+pub use limits::{LimitAction, LimitStatus, LimitType, LimitsConfig, OnLimitReachedConfig};
+pub use logging::{LogConfig, LogFormat, LogLevel};
+pub use output::{OutputFormat, OutputPolicy, SchemaRef};
+pub use schema::SchemaVersion;
+pub use structured::StructuredOutputSpec;
+
+// ============================================================================
+// Unified Pipeline: YAML -> Raw -> Analyzed
+// ============================================================================
+
+use crate::ast::analyzed::AnalyzedWorkflow;
+use crate::error::CoreError;
+use crate::source::FileId;
+
+/// Parse a YAML workflow and return the AnalyzedWorkflow directly.
+///
+/// Pipeline: `YAML -> raw::parse -> analyzer::analyze -> AnalyzedWorkflow`
+///
+/// # Errors
+///
+/// - `CoreError::ValidationError` -- YAML syntax or structural errors (Phase 1)
+/// - `CoreError::ValidationError` -- Semantic validation errors (Phase 2)
+pub fn parse_analyzed(yaml: &str) -> Result<AnalyzedWorkflow, CoreError> {
+    // Phase 1: YAML -> Raw AST (with span tracking)
+    let raw = raw::parse(yaml, FileId(0)).map_err(|e| CoreError::ValidationError {
+        reason: format!("[{}] {}", e.kind.code(), e.message),
+    })?;
+
+    // Phase 2: Raw -> Analyzed (validation, reference resolution)
+    analyzer::analyze(raw)
+        .into_result()
+        .map_err(|errors| {
+            let messages: Vec<String> = errors
+                .iter()
+                .map(|e| format!("[{}] {}", e.kind.code(), e))
+                .collect();
+            CoreError::ValidationError {
+                reason: messages.join("; "),
+            }
+        })
+}

--- a/tools/nika-core/src/ast/output.rs
+++ b/tools/nika-core/src/ast/output.rs
@@ -1,0 +1,294 @@
+//! Output Policy - format and validation configuration
+//!
+//! Defines how task output should be formatted and validated:
+//! - `OutputFormat`: Text (default) or JSON
+//! - `SchemaRef`: Inline JSON Schema object or file path
+//! - `OutputPolicy`: Format + optional schema validation + retry config
+
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::fmt;
+
+/// Reference to a JSON Schema - either inline or file path
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum SchemaRef {
+    /// Inline JSON Schema object
+    Inline(JsonValue),
+    /// Path to JSON Schema file
+    File(String),
+}
+
+impl<'de> Deserialize<'de> for SchemaRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SchemaRefVisitor;
+
+        impl<'de> Visitor<'de> for SchemaRefVisitor {
+            type Value = SchemaRef;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a JSON Schema object or a file path string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(SchemaRef::File(v.to_string()))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(SchemaRef::File(v))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let value = JsonValue::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                Ok(SchemaRef::Inline(value))
+            }
+        }
+
+        deserializer.deserialize_any(SchemaRefVisitor)
+    }
+}
+
+/// Output policy configuration
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct OutputPolicy {
+    /// Output format (text or json)
+    #[serde(default)]
+    pub format: OutputFormat,
+
+    /// JSON Schema for output validation (inline object or file path)
+    #[serde(default)]
+    pub schema: Option<SchemaRef>,
+
+    /// Maximum retry attempts on validation failure (default: 2)
+    #[serde(default)]
+    pub max_retries: Option<u8>,
+
+    /// Original StructuredOutputSpec when this policy was bridged from `structured:`.
+    /// Preserves user's layer toggle config (enable_tool_injection, enable_repair, etc.)
+    /// that would otherwise be lost in the OutputPolicy→StructuredOutputSpec roundtrip.
+    #[serde(skip)]
+    pub source_structured_spec: Option<super::structured::StructuredOutputSpec>,
+}
+
+impl OutputPolicy {
+    /// Check if this policy requires structured output validation.
+    ///
+    /// Returns true when format is JSON and a schema is provided.
+    /// This is used by the executor to decide whether to use StructuredOutputEngine.
+    pub fn is_structured(&self) -> bool {
+        self.format == OutputFormat::Json && self.schema.is_some()
+    }
+
+    /// Convert to StructuredOutputSpec for use with StructuredOutputEngine.
+    ///
+    /// Returns None if this policy doesn't require structured output.
+    /// If this policy was bridged from a `structured:` config (via `to_output_policy()`),
+    /// returns the original spec with all user-configured layer toggles preserved.
+    /// Otherwise, constructs a spec with permissive defaults (all layers enabled).
+    pub fn to_structured_spec(&self) -> Option<super::structured::StructuredOutputSpec> {
+        if !self.is_structured() {
+            return None;
+        }
+
+        // Return original spec if available (preserves user's layer toggles)
+        if let Some(ref spec) = self.source_structured_spec {
+            return Some(spec.clone());
+        }
+
+        // Fallback: construct spec from OutputPolicy fields (output: block path)
+        let schema = self.schema.clone().unwrap();
+        Some(super::structured::StructuredOutputSpec {
+            schema,
+            enable_extractor: None,
+            enable_tool_injection: None,
+            enable_retry: Some(true),
+            enable_repair: Some(true),
+            max_retries: self.max_retries,
+            repair_model: None,
+        })
+    }
+}
+
+/// Output format enum
+#[derive(Debug, Clone, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    /// Raw text output (default)
+    #[default]
+    Text,
+
+    /// JSON parsed output
+    Json,
+
+    /// YAML formatted output
+    Yaml,
+
+    /// Markdown formatted output
+    Markdown,
+
+    /// Binary (raw bytes, not text content)
+    Binary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn parse_text_format() {
+        let yaml = "format: text";
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(policy.format, OutputFormat::Text);
+        assert!(policy.schema.is_none());
+    }
+
+    #[test]
+    fn parse_json_with_schema_file() {
+        let yaml = r#"
+            format: json
+            schema: .nika/schemas/result.json
+        "#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(policy.format, OutputFormat::Json);
+        assert!(
+            matches!(policy.schema, Some(SchemaRef::File(ref p)) if p == ".nika/schemas/result.json")
+        );
+    }
+
+    #[test]
+    fn parse_json_with_inline_schema() {
+        let yaml = r#"
+format: json
+schema:
+  type: object
+  properties:
+    name:
+      type: string
+  required:
+    - name
+"#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(policy.format, OutputFormat::Json);
+        assert!(matches!(policy.schema, Some(SchemaRef::Inline(_))));
+
+        // Verify schema content
+        if let Some(SchemaRef::Inline(schema)) = &policy.schema {
+            assert_eq!(schema["type"], "object");
+            assert!(schema["properties"]["name"].is_object());
+        }
+    }
+
+    #[test]
+    fn parse_max_retries() {
+        let yaml = r#"
+format: json
+max_retries: 3
+"#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(policy.max_retries, Some(3));
+    }
+
+    #[test]
+    fn default_is_text() {
+        let policy = OutputPolicy::default();
+        assert_eq!(policy.format, OutputFormat::Text);
+        assert!(policy.schema.is_none());
+        assert!(policy.max_retries.is_none());
+    }
+
+    // ========== is_structured() tests ==========
+
+    #[test]
+    fn is_structured_true_when_json_with_schema() {
+        let yaml = r#"
+format: json
+schema:
+  type: object
+"#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert!(policy.is_structured());
+    }
+
+    #[test]
+    fn is_structured_false_when_text() {
+        let policy = OutputPolicy::default();
+        assert!(!policy.is_structured());
+    }
+
+    #[test]
+    fn is_structured_false_when_json_without_schema() {
+        let yaml = "format: json";
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert!(!policy.is_structured());
+    }
+
+    #[test]
+    fn is_structured_false_when_text_with_schema() {
+        // Edge case: text format with schema should NOT be structured
+        let yaml = r#"
+format: text
+schema:
+  type: object
+"#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert!(!policy.is_structured());
+    }
+
+    // ========== to_structured_spec() tests ==========
+
+    #[test]
+    fn to_structured_spec_returns_spec_when_structured() {
+        let yaml = r#"
+format: json
+schema:
+  type: object
+  properties:
+    name:
+      type: string
+max_retries: 5
+"#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        let spec = policy.to_structured_spec();
+        assert!(spec.is_some());
+
+        let spec = spec.unwrap();
+        assert!(matches!(spec.schema, SchemaRef::Inline(_)));
+        assert_eq!(spec.max_retries, Some(5));
+        assert_eq!(spec.enable_retry, Some(true));
+        assert_eq!(spec.enable_repair, Some(true));
+    }
+
+    #[test]
+    fn to_structured_spec_returns_none_when_not_structured() {
+        let policy = OutputPolicy::default();
+        assert!(policy.to_structured_spec().is_none());
+    }
+
+    #[test]
+    fn to_structured_spec_with_file_schema() {
+        let yaml = r#"
+format: json
+schema: ./schemas/user.json
+"#;
+        let policy: OutputPolicy = serde_yaml::from_str(yaml).unwrap();
+        let spec = policy.to_structured_spec();
+        assert!(spec.is_some());
+
+        let spec = spec.unwrap();
+        assert!(matches!(spec.schema, SchemaRef::File(ref p) if p == "./schemas/user.json"));
+    }
+}

--- a/tools/nika-core/src/ast/raw/action.rs
+++ b/tools/nika-core/src/ast/raw/action.rs
@@ -1,0 +1,267 @@
+//! Raw task action variants (verbs).
+//!
+//! Each verb (infer, exec, fetch, invoke, agent) has its own params struct
+//! with full span tracking for error reporting.
+
+use indexmap::IndexMap;
+
+use crate::source::{Span, Spanned};
+
+/// The action a task performs - one of the 5 verbs.
+#[derive(Debug, Clone)]
+pub enum RawTaskAction {
+    /// LLM inference: infer: { prompt: "..." }
+    Infer(Spanned<RawInferAction>),
+
+    /// Shell command: exec: { command: "..." }
+    Exec(Spanned<RawExecAction>),
+
+    /// HTTP fetch: fetch: { url: "..." }
+    Fetch(Spanned<RawFetchAction>),
+
+    /// MCP tool invocation: invoke: tool_name or invoke: { tool: name, params: {...} }
+    Invoke(Spanned<RawInvokeAction>),
+
+    /// Autonomous agent: agent: { prompt: "..." }
+    Agent(Spanned<RawAgentAction>),
+}
+
+impl Default for RawTaskAction {
+    fn default() -> Self {
+        RawTaskAction::Infer(Spanned::dummy(RawInferAction::default()))
+    }
+}
+
+impl RawTaskAction {
+    /// Get the verb name as a string.
+    pub fn verb_name(&self) -> &'static str {
+        match self {
+            RawTaskAction::Infer(_) => "infer",
+            RawTaskAction::Exec(_) => "exec",
+            RawTaskAction::Fetch(_) => "fetch",
+            RawTaskAction::Invoke(_) => "invoke",
+            RawTaskAction::Agent(_) => "agent",
+        }
+    }
+
+    /// Get the span of the action.
+    pub fn span(&self) -> Span {
+        match self {
+            RawTaskAction::Infer(a) => a.span,
+            RawTaskAction::Exec(a) => a.span,
+            RawTaskAction::Fetch(a) => a.span,
+            RawTaskAction::Invoke(a) => a.span,
+            RawTaskAction::Agent(a) => a.span,
+        }
+    }
+}
+
+/// Parameters for the `infer` verb (LLM inference).
+#[derive(Debug, Clone, Default)]
+pub struct RawInferAction {
+    /// The prompt to send to the LLM (optional when `content` is present)
+    pub prompt: Spanned<String>,
+
+    /// System prompt override
+    pub system: Option<Spanned<String>>,
+
+    /// Temperature (0.0 - 2.0)
+    pub temperature: Option<Spanned<f64>>,
+
+    /// Maximum tokens to generate
+    pub max_tokens: Option<Spanned<u32>>,
+
+    /// Enable extended thinking (Claude)
+    pub thinking: Option<Spanned<bool>>,
+
+    /// Thinking budget tokens
+    pub thinking_budget: Option<Spanned<u32>>,
+
+    /// Multimodal content parts (text + images) for vision models
+    pub content: Option<Spanned<Vec<crate::ast::content::RawContentPart>>>,
+}
+
+/// Parameters for the `exec` verb (shell command execution).
+#[derive(Debug, Clone, Default)]
+pub struct RawExecAction {
+    /// Command to execute (string or array)
+    pub command: Spanned<String>,
+
+    /// Run through shell (sh -c) - defaults to false for security
+    pub shell: Option<Spanned<bool>>,
+
+    /// Working directory
+    pub working_dir: Option<Spanned<String>>,
+
+    /// Environment variables
+    pub env: Option<Spanned<IndexMap<Spanned<String>, Spanned<String>>>>,
+
+    /// Timeout in milliseconds
+    pub timeout_ms: Option<Spanned<u64>>,
+}
+
+/// Parameters for the `fetch` verb (HTTP requests).
+#[derive(Debug, Clone, Default)]
+pub struct RawFetchAction {
+    /// URL to fetch
+    pub url: Spanned<String>,
+
+    /// HTTP method (GET, POST, PUT, DELETE, etc.)
+    pub method: Option<Spanned<String>>,
+
+    /// HTTP headers
+    pub headers: Option<Spanned<IndexMap<Spanned<String>, Spanned<String>>>>,
+
+    /// Request body (for POST/PUT)
+    pub body: Option<Spanned<String>>,
+
+    /// Request body as JSON
+    pub json: Option<Spanned<serde_json::Value>>,
+
+    /// Timeout in milliseconds
+    pub timeout_ms: Option<Spanned<u64>>,
+
+    /// Follow redirects
+    pub follow_redirects: Option<Spanned<bool>>,
+}
+
+/// Parameters for the `invoke` verb (MCP tool invocation).
+#[derive(Debug, Clone, Default)]
+pub struct RawInvokeAction {
+    /// MCP tool name: "tool_name" or "server::tool_name"
+    pub tool: Spanned<String>,
+
+    /// Tool parameters (validated against MCP schema)
+    pub params: Option<Spanned<serde_json::Value>>,
+
+    /// Optional MCP server to use (if not in tool name)
+    pub mcp: Option<Spanned<String>>,
+
+    /// Timeout for tool execution
+    pub timeout_ms: Option<Spanned<u64>>,
+}
+
+impl RawInvokeAction {
+    /// Parse server and tool name from the tool field.
+    /// Returns (server, tool_name) where server may be None.
+    pub fn parse_tool_name(&self) -> (Option<&str>, &str) {
+        let tool = &self.tool.value;
+        if let Some((server, name)) = tool.split_once("::") {
+            (Some(server), name)
+        } else {
+            (None, tool.as_str())
+        }
+    }
+}
+
+/// Parameters for the `agent` verb (autonomous agent execution).
+#[derive(Debug, Clone, Default)]
+pub struct RawAgentAction {
+    /// The prompt for the agent to execute
+    pub prompt: Spanned<String>,
+
+    /// Available tools for the agent
+    pub tools: Option<Spanned<Vec<Spanned<String>>>>,
+
+    /// Maximum iterations before stopping
+    pub max_iterations: Option<Spanned<u32>>,
+
+    /// Maximum tokens per response
+    pub max_tokens: Option<Spanned<u32>>,
+
+    /// Agent definition reference (agents: section)
+    pub from: Option<Spanned<String>>,
+
+    /// Skills to inject into system prompt
+    pub skills: Option<Spanned<Vec<Spanned<String>>>>,
+
+    /// Provider override (inside agent: block)
+    pub provider: Option<Spanned<String>>,
+
+    /// Model override (inside agent: block)
+    pub model: Option<Spanned<String>>,
+
+    /// MCP servers for tool access
+    pub mcp: Option<Spanned<Vec<Spanned<String>>>>,
+
+    /// Temperature for LLM sampling
+    pub temperature: Option<Spanned<f64>>,
+
+    /// Token budget for the agent
+    pub token_budget: Option<Spanned<u32>>,
+
+    /// System prompt (agent persona)
+    pub system: Option<Spanned<String>>,
+
+    /// Enable extended thinking (Claude)
+    pub extended_thinking: Option<Spanned<bool>>,
+
+    /// Thinking budget tokens
+    pub thinking_budget: Option<Spanned<u32>>,
+
+    /// Max spawn_agent recursion depth
+    pub depth_limit: Option<Spanned<u32>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::FileId;
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    #[test]
+    fn test_action_verb_names() {
+        let infer = RawTaskAction::Infer(Spanned::dummy(RawInferAction::default()));
+        assert_eq!(infer.verb_name(), "infer");
+
+        let exec = RawTaskAction::Exec(Spanned::dummy(RawExecAction::default()));
+        assert_eq!(exec.verb_name(), "exec");
+
+        let fetch = RawTaskAction::Fetch(Spanned::dummy(RawFetchAction::default()));
+        assert_eq!(fetch.verb_name(), "fetch");
+
+        let invoke = RawTaskAction::Invoke(Spanned::dummy(RawInvokeAction::default()));
+        assert_eq!(invoke.verb_name(), "invoke");
+
+        let agent = RawTaskAction::Agent(Spanned::dummy(RawAgentAction::default()));
+        assert_eq!(agent.verb_name(), "agent");
+    }
+
+    #[test]
+    fn test_invoke_parse_tool_name() {
+        // Simple tool name
+        let simple = RawInvokeAction {
+            tool: Spanned::new("my_tool".to_string(), make_span(0, 7)),
+            ..Default::default()
+        };
+        let (server, name) = simple.parse_tool_name();
+        assert_eq!(server, None);
+        assert_eq!(name, "my_tool");
+
+        // Server-qualified name
+        let qualified = RawInvokeAction {
+            tool: Spanned::new("novanet::query".to_string(), make_span(0, 14)),
+            ..Default::default()
+        };
+        let (server, name) = qualified.parse_tool_name();
+        assert_eq!(server, Some("novanet"));
+        assert_eq!(name, "query");
+    }
+
+    #[test]
+    fn test_infer_action_fields() {
+        let infer = RawInferAction {
+            prompt: Spanned::new("Hello, world!".to_string(), make_span(0, 13)),
+            temperature: Some(Spanned::new(0.7, make_span(20, 23))),
+            max_tokens: Some(Spanned::new(1000, make_span(30, 34))),
+            ..Default::default()
+        };
+
+        assert_eq!(infer.prompt.value, "Hello, world!");
+        assert_eq!(infer.temperature.as_ref().unwrap().value, 0.7);
+        assert_eq!(infer.max_tokens.as_ref().unwrap().value, 1000);
+    }
+}

--- a/tools/nika-core/src/ast/raw/mcp.rs
+++ b/tools/nika-core/src/ast/raw/mcp.rs
@@ -1,0 +1,149 @@
+//! Raw MCP configuration AST.
+
+use indexmap::IndexMap;
+
+use crate::source::Spanned;
+
+/// Raw MCP configuration block.
+#[derive(Debug, Clone, Default)]
+pub struct RawMcpConfig {
+    /// Server definitions: name -> config
+    pub servers: IndexMap<Spanned<String>, Spanned<RawMcpServer>>,
+}
+
+/// Raw MCP server configuration.
+#[derive(Debug, Clone, Default)]
+pub struct RawMcpServer {
+    /// Command to spawn the server
+    pub command: Option<Spanned<String>>,
+
+    /// Arguments for the command
+    pub args: Option<Spanned<Vec<Spanned<String>>>>,
+
+    /// Environment variables
+    pub env: Option<Spanned<IndexMap<Spanned<String>, Spanned<String>>>>,
+
+    /// Working directory
+    pub cwd: Option<Spanned<String>>,
+
+    /// URL for SSE transport
+    pub url: Option<Spanned<String>>,
+
+    /// Transport type: stdio (default) or sse
+    pub transport: Option<Spanned<String>>,
+}
+
+impl RawMcpConfig {
+    /// Create a new empty MCP configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get the number of configured servers.
+    pub fn server_count(&self) -> usize {
+        self.servers.len()
+    }
+
+    /// Get a server by name.
+    pub fn get_server(&self, name: &str) -> Option<&Spanned<RawMcpServer>> {
+        self.servers
+            .iter()
+            .find(|(k, _)| k.value == name)
+            .map(|(_, v)| v)
+    }
+
+    /// Check if a server is configured.
+    pub fn has_server(&self, name: &str) -> bool {
+        self.get_server(name).is_some()
+    }
+
+    /// Iterate over server names.
+    pub fn server_names(&self) -> impl Iterator<Item = &str> {
+        self.servers.keys().map(|k| k.value.as_str())
+    }
+}
+
+impl RawMcpServer {
+    /// Create a new server config with a command.
+    pub fn with_command(command: impl Into<String>) -> Self {
+        Self {
+            command: Some(Spanned::dummy(command.into())),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new server config with a URL (SSE transport).
+    pub fn with_url(url: impl Into<String>) -> Self {
+        Self {
+            url: Some(Spanned::dummy(url.into())),
+            transport: Some(Spanned::dummy("sse".to_string())),
+            ..Default::default()
+        }
+    }
+
+    /// Check if this is an SSE server.
+    pub fn is_sse(&self) -> bool {
+        self.url.is_some()
+            || self
+                .transport
+                .as_ref()
+                .map(|t| t.value == "sse")
+                .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::{FileId, Span};
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    #[test]
+    fn test_mcp_config_empty() {
+        let config = RawMcpConfig::new();
+        assert_eq!(config.server_count(), 0);
+        assert!(!config.has_server("novanet"));
+    }
+
+    #[test]
+    fn test_mcp_config_with_servers() {
+        let mut config = RawMcpConfig::new();
+
+        config.servers.insert(
+            Spanned::new("novanet".to_string(), make_span(0, 7)),
+            Spanned::new(
+                RawMcpServer::with_command("cargo run -p novanet-mcp"),
+                make_span(10, 50),
+            ),
+        );
+
+        config.servers.insert(
+            Spanned::new("external".to_string(), make_span(60, 68)),
+            Spanned::new(
+                RawMcpServer::with_url("http://localhost:8080"),
+                make_span(70, 100),
+            ),
+        );
+
+        assert_eq!(config.server_count(), 2);
+        assert!(config.has_server("novanet"));
+        assert!(config.has_server("external"));
+        assert!(!config.has_server("unknown"));
+
+        let names: Vec<&str> = config.server_names().collect();
+        assert!(names.contains(&"novanet"));
+        assert!(names.contains(&"external"));
+    }
+
+    #[test]
+    fn test_mcp_server_sse() {
+        let stdio_server = RawMcpServer::with_command("cargo run");
+        assert!(!stdio_server.is_sse());
+
+        let sse_server = RawMcpServer::with_url("http://localhost:8080");
+        assert!(sse_server.is_sse());
+    }
+}

--- a/tools/nika-core/src/ast/raw/mod.rs
+++ b/tools/nika-core/src/ast/raw/mod.rs
@@ -1,0 +1,77 @@
+//! Raw AST - Phase 1 of the Two-Phase IR Architecture.
+//!
+//! This module contains AST types that are directly parsed from YAML with
+//! full span tracking. All string values are preserved as-is, and all nodes
+//! carry their source location for precise error reporting.
+//!
+//! # Two-Phase Architecture
+//!
+//! ```text
+//! ┌─────────────────┐
+//! │  YAML Source    │  workflow.nika.yaml
+//! └────────┬────────┘
+//!          │ marked_yaml
+//!          ▼
+//! ┌─────────────────┐
+//! │  raw::Workflow  │  ← THIS MODULE
+//! │  ├── Spanned<T> │  All nodes have line:col
+//! │  └── strings    │  Unresolved references
+//! └────────┬────────┘
+//!          │ analyze()
+//!          ▼
+//! ┌─────────────────┐
+//! │ analyzed::Workflow │  (see ast/analyzed/)
+//! │  ├── TaskId(u32)   │  Interned identifiers
+//! │  └── resolved refs │  All references validated
+//! └─────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```ignore
+//! use nika::ast::raw;
+//! use nika::source::SourceRegistry;
+//!
+//! let mut sources = SourceRegistry::new();
+//! let file_id = sources.add_file("workflow.yaml", content);
+//!
+//! // Phase 1: Parse to raw AST
+//! let raw_workflow = raw::parse(&content, file_id)?;
+//!
+//! // Phase 2: Analyze to resolved AST
+//! let analyzed = analyze(&sources, raw_workflow)?;
+//! ```
+//!
+//! # Design Principles
+//!
+//! 1. **Every node has a span** - For precise error locations
+//! 2. **Strings are unresolved** - Task IDs are strings, not interned
+//! 3. **No validation** - Structure only, semantics checked in Phase 2
+//! 4. **Preserves YAML order** - Uses indexmap for key ordering
+
+mod action;
+mod mcp;
+mod parser;
+mod task;
+mod workflow;
+
+pub use action::{
+    RawAgentAction, RawExecAction, RawFetchAction, RawInferAction, RawInvokeAction, RawTaskAction,
+};
+pub use mcp::{RawMcpConfig, RawMcpServer};
+pub use parser::{parse, ParseError, ParseErrorKind};
+pub use task::{RawForEach, RawOutputConfig, RawRetryConfig, RawTask};
+pub use workflow::{RawContextConfig, RawImportSpec, RawPkgConfig, RawWorkflow};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_structure() {
+        // Basic smoke test that all types are accessible
+        let _ = RawWorkflow::default();
+        let _ = RawTask::default();
+        let _ = RawMcpConfig::default();
+    }
+}

--- a/tools/nika-core/src/ast/raw/parser.rs
+++ b/tools/nika-core/src/ast/raw/parser.rs
@@ -1,0 +1,2547 @@
+//! YAML parser with span tracking using marked_yaml.
+//!
+//! This module provides the entry point for parsing YAML workflows
+//! into the raw AST with full source position tracking.
+
+use indexmap::IndexMap;
+use marked_yaml::{parse_yaml, LoadError, Marker, Node, Span as MarkedSpan};
+
+use super::action::{
+    RawAgentAction, RawExecAction, RawFetchAction, RawInferAction, RawInvokeAction, RawTaskAction,
+};
+use super::mcp::{RawMcpConfig, RawMcpServer};
+use super::task::{RawForEach, RawOutputConfig, RawRetryConfig, RawTask};
+use super::workflow::{RawContextConfig, RawImportSpec, RawPkgConfig, RawWorkflow};
+use crate::ast::decompose::{DecomposeSpec, DecomposeStrategy};
+use crate::ast::structured::StructuredOutputSpec;
+use crate::source::{ByteOffset, FileId, Span, Spanned};
+
+/// Errors that can occur during parsing.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    /// The error kind
+    pub kind: ParseErrorKind,
+    /// Location of the error (if available)
+    pub span: Span,
+    /// Error message
+    pub message: String,
+}
+
+/// Kinds of parse errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseErrorKind {
+    /// YAML syntax error
+    Syntax,
+    /// Missing required field
+    MissingField,
+    /// Invalid field type
+    InvalidType,
+    /// Unknown field
+    UnknownField,
+    /// Invalid schema version
+    InvalidSchema,
+}
+
+impl ParseErrorKind {
+    /// Get the error code for this kind.
+    ///
+    /// Parse-phase errors use NIKA-160..164 to avoid collision with
+    /// the top-level NikaError workflow codes (NIKA-001..005).
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Syntax => "NIKA-160",
+            Self::MissingField => "NIKA-161",
+            Self::InvalidType => "NIKA-162",
+            Self::UnknownField => "NIKA-163",
+            Self::InvalidSchema => "NIKA-164",
+        }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Convert a marked_yaml Marker to our ByteOffset.
+fn marker_to_offset(marker: &Marker) -> ByteOffset {
+    // marked_yaml uses character() for byte offset
+    ByteOffset::new(marker.character() as u32)
+}
+
+/// Convert a marked_yaml Marker to a point Span.
+fn marker_to_span(file: FileId, marker: &Marker) -> Span {
+    let offset = marker_to_offset(marker);
+    Span {
+        file,
+        start: offset,
+        end: offset,
+    }
+}
+
+/// Extract span from a LoadError if it carries a Marker.
+///
+/// Most LoadError variants include position information:
+/// - TopLevelMustBeMapping(Marker)
+/// - TopLevelMustBeSequence(Marker)
+/// - UnexpectedAnchor(Marker)
+/// - MappingKeyMustBeScalar(Marker)
+/// - UnexpectedTag(Marker)
+/// - ScanError(Marker, _)
+/// - DuplicateKey(Box<DuplicateKeyInner>)
+fn extract_span_from_load_error(file: FileId, error: &LoadError) -> Span {
+    match error {
+        LoadError::TopLevelMustBeMapping(marker)
+        | LoadError::TopLevelMustBeSequence(marker)
+        | LoadError::UnexpectedAnchor(marker)
+        | LoadError::MappingKeyMustBeScalar(marker)
+        | LoadError::UnexpectedTag(marker) => marker_to_span(file, marker),
+        LoadError::ScanError(marker, _) => marker_to_span(file, marker),
+        LoadError::DuplicateKey(inner) => {
+            // DuplicateKeyInner has key: MarkedScalarNode, use its span
+            marked_span_to_span(file, inner.key.span())
+        }
+    }
+}
+
+/// Convert a marked_yaml Span to our Span.
+fn marked_span_to_span(file: FileId, span: &MarkedSpan) -> Span {
+    match (span.start(), span.end()) {
+        (Some(start), Some(end)) => Span {
+            file,
+            start: marker_to_offset(start),
+            end: marker_to_offset(end),
+        },
+        (Some(start), None) => Span {
+            file,
+            start: marker_to_offset(start),
+            end: marker_to_offset(start), // Point span
+        },
+        _ => Span::dummy(),
+    }
+}
+
+/// Convert a marked_yaml Node span to our Span.
+fn node_to_span(file: FileId, node: &Node) -> Span {
+    marked_span_to_span(file, node.span())
+}
+
+/// Extract a spanned string from a YAML scalar node.
+fn extract_string(file: FileId, node: &Node) -> Result<Spanned<String>, ParseError> {
+    let span = node_to_span(file, node);
+    match node {
+        Node::Scalar(s) => Ok(Spanned::new(s.to_string(), span)),
+        _ => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span,
+            message: "expected string".to_string(),
+        }),
+    }
+}
+
+/// Get an optional string field from a mapping by key.
+fn get_string_field(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<String>>, ParseError> {
+    match map.get_node(key) {
+        Some(node) => extract_string(file, node).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Get an optional f64 field from a mapping.
+fn get_f64_field(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<f64>>, ParseError> {
+    match map.get_node(key) {
+        Some(Node::Scalar(s)) => {
+            let span = marked_span_to_span(file, s.span());
+            let value: f64 = s.as_str().parse().map_err(|_| ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: format!("'{}' must be a number", key),
+            })?;
+            if !value.is_finite() {
+                return Err(ParseError {
+                    kind: ParseErrorKind::InvalidType,
+                    span,
+                    message: format!("'{}' must be a finite number (got {})", key, s.as_str()),
+                });
+            }
+            Ok(Some(Spanned::new(value, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: format!("'{}' must be a number", key),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Get an optional u32 field from a mapping.
+fn get_u32_field(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<u32>>, ParseError> {
+    match map.get_node(key) {
+        Some(Node::Scalar(s)) => {
+            let span = marked_span_to_span(file, s.span());
+            let value: u32 = s.as_str().parse().map_err(|_| ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: format!("'{}' must be a positive integer", key),
+            })?;
+            Ok(Some(Spanned::new(value, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: format!("'{}' must be a positive integer", key),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Get an optional u64 field from a mapping.
+fn get_u64_field(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<u64>>, ParseError> {
+    match map.get_node(key) {
+        Some(Node::Scalar(s)) => {
+            let span = marked_span_to_span(file, s.span());
+            let value: u64 = s.as_str().parse().map_err(|_| ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: format!("'{}' must be a positive integer", key),
+            })?;
+            Ok(Some(Spanned::new(value, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: format!("'{}' must be a positive integer", key),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Get an optional bool field from a mapping.
+fn get_bool_field(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<bool>>, ParseError> {
+    match map.get_node(key) {
+        Some(Node::Scalar(s)) => {
+            let span = marked_span_to_span(file, s.span());
+            let value = match s.as_str().to_lowercase().as_str() {
+                "true" | "yes" | "on" | "1" => true,
+                "false" | "no" | "off" | "0" => false,
+                _ => {
+                    return Err(ParseError {
+                        kind: ParseErrorKind::InvalidType,
+                        span,
+                        message: format!("'{}' must be a boolean", key),
+                    });
+                }
+            };
+            Ok(Some(Spanned::new(value, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: format!("'{}' must be a boolean", key),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse a string-to-string mapping (for headers, env vars).
+#[allow(clippy::type_complexity)]
+fn parse_string_map(
+    file: FileId,
+    parent: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<IndexMap<Spanned<String>, Spanned<String>>>>, ParseError> {
+    match parent.get_node(key) {
+        Some(Node::Mapping(m)) => {
+            let span = marked_span_to_span(file, m.span());
+            let mut result = IndexMap::new();
+
+            for (k, v) in m.iter() {
+                let key_span = marked_span_to_span(file, k.span());
+                let key_str = Spanned::new(k.as_str().to_string(), key_span);
+                let val = extract_string(file, v)?;
+                result.insert(key_str, val);
+            }
+
+            Ok(Some(Spanned::new(result, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: format!("'{}' must be a mapping", key),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse an array of strings.
+fn parse_string_array(
+    file: FileId,
+    parent: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<Vec<Spanned<String>>>>, ParseError> {
+    match parent.get_node(key) {
+        Some(Node::Sequence(seq)) => {
+            let span = marked_span_to_span(file, seq.span());
+            let items: Result<Vec<_>, _> =
+                seq.iter().map(|node| extract_string(file, node)).collect();
+            Ok(Some(Spanned::new(items?, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: format!("'{}' must be an array", key),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse a JSON value from a node.
+fn parse_json_value(
+    file: FileId,
+    parent: &marked_yaml::types::MarkedMappingNode,
+    key: &str,
+) -> Result<Option<Spanned<serde_json::Value>>, ParseError> {
+    match parent.get_node(key) {
+        Some(node) => {
+            let span = node_to_span(file, node);
+            let value = node_to_json(node);
+            Ok(Some(Spanned::new(value, span)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Convert a YAML node to a JSON value.
+fn node_to_json(node: &Node) -> serde_json::Value {
+    match node {
+        Node::Scalar(s) => {
+            let str_val = s.as_str();
+            // Try parsing as different types
+            if let Ok(n) = str_val.parse::<i64>() {
+                serde_json::Value::Number(n.into())
+            } else if let Ok(n) = str_val.parse::<f64>() {
+                serde_json::Number::from_f64(n)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::String(str_val.to_string()))
+            } else if str_val == "true" {
+                serde_json::Value::Bool(true)
+            } else if str_val == "false" {
+                serde_json::Value::Bool(false)
+            } else if str_val == "null" || str_val == "~" {
+                serde_json::Value::Null
+            } else {
+                serde_json::Value::String(str_val.to_string())
+            }
+        }
+        Node::Mapping(m) => {
+            let obj: serde_json::Map<String, serde_json::Value> = m
+                .iter()
+                .map(|(k, v)| (k.as_str().to_string(), node_to_json(v)))
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        Node::Sequence(s) => {
+            let arr: Vec<serde_json::Value> = s.iter().map(node_to_json).collect();
+            serde_json::Value::Array(arr)
+        }
+    }
+}
+
+// ============================================================================
+// Action Parsing (5 Verbs)
+// ============================================================================
+
+/// Parse the task action from the mapping (dispatches to verb-specific parsers).
+fn parse_action(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<RawTaskAction>, ParseError> {
+    // Reject tasks with multiple verbs (must have exactly 0 or 1)
+    let verb_keys = ["infer", "exec", "fetch", "invoke", "agent"];
+    let found: Vec<&str> = verb_keys
+        .iter()
+        .filter(|k| map.get_node(k).is_some())
+        .copied()
+        .collect();
+    if found.len() > 1 {
+        let span = marked_span_to_span(file, map.span());
+        return Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span,
+            message: format!(
+                "task has multiple verbs ({}); each task must have exactly one",
+                found.join(", ")
+            ),
+        });
+    }
+
+    // Check for infer verb
+    if let Some(node) = map.get_node("infer") {
+        let action = parse_infer_action(file, node)?;
+        let span = node_to_span(file, node);
+        return Ok(Some(RawTaskAction::Infer(Spanned::new(action, span))));
+    }
+    // Check for exec verb
+    if let Some(node) = map.get_node("exec") {
+        let action = parse_exec_action(file, node)?;
+        let span = node_to_span(file, node);
+        return Ok(Some(RawTaskAction::Exec(Spanned::new(action, span))));
+    }
+    // Check for fetch verb
+    if let Some(node) = map.get_node("fetch") {
+        let action = parse_fetch_action(file, node)?;
+        let span = node_to_span(file, node);
+        return Ok(Some(RawTaskAction::Fetch(Spanned::new(action, span))));
+    }
+    // Check for invoke verb
+    if let Some(node) = map.get_node("invoke") {
+        let action = parse_invoke_action(file, node)?;
+        let span = node_to_span(file, node);
+        return Ok(Some(RawTaskAction::Invoke(Spanned::new(action, span))));
+    }
+    // Check for agent verb
+    if let Some(node) = map.get_node("agent") {
+        let action = parse_agent_action(file, node)?;
+        let span = node_to_span(file, node);
+        return Ok(Some(RawTaskAction::Agent(Spanned::new(action, span))));
+    }
+
+    Ok(None)
+}
+
+/// Parse infer action - supports both shorthand (string) and full form (mapping).
+///
+/// # Content / Prompt Rules
+///
+/// - `infer: "prompt"` — shorthand, text-only
+/// - `infer: { prompt: "..." }` — full form, text-only
+/// - `infer: { content: [...] }` — vision mode, prompt optional
+/// - `infer: { prompt: "...", content: [...] }` — prompt prepended as first Text part
+/// - Error if neither `prompt` nor `content` is present
+fn parse_infer_action(file: FileId, node: &Node) -> Result<RawInferAction, ParseError> {
+    let span = node_to_span(file, node);
+
+    match node {
+        // Shorthand: infer: "prompt string"
+        Node::Scalar(s) => Ok(RawInferAction {
+            prompt: Spanned::new(s.as_str().to_string(), span),
+            system: None,
+            temperature: None,
+            max_tokens: None,
+            thinking: None,
+            thinking_budget: None,
+            content: None,
+        }),
+        // Full form: infer: { prompt: "...", temperature: ..., content: [...] }
+        Node::Mapping(m) => {
+            let prompt = get_string_field(file, m, "prompt")?;
+            let content = parse_content_field(file, m)?;
+
+            // Require at least one of prompt or content
+            if prompt.is_none() && content.is_none() {
+                return Err(ParseError {
+                    kind: ParseErrorKind::MissingField,
+                    span,
+                    message: "infer action requires 'prompt' or 'content' field".to_string(),
+                });
+            }
+
+            // If content is present but no prompt, use empty prompt (validated later)
+            let prompt = prompt.unwrap_or_else(|| Spanned::new(String::new(), span));
+
+            Ok(RawInferAction {
+                prompt,
+                system: get_string_field(file, m, "system")?,
+                temperature: get_f64_field(file, m, "temperature")?,
+                max_tokens: get_u32_field(file, m, "max_tokens")?,
+                thinking: get_bool_field(file, m, "thinking")?.or(get_bool_field(
+                    file,
+                    m,
+                    "extended_thinking",
+                )?),
+                thinking_budget: get_u32_field(file, m, "thinking_budget")?,
+                content,
+            })
+        }
+        _ => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span,
+            message: "infer must be a string or mapping".to_string(),
+        }),
+    }
+}
+
+/// Parse the `content:` field from an infer mapping.
+///
+/// Returns `None` if the field is absent. Parses a YAML sequence where each
+/// element is a mapping with `type`, and type-specific fields.
+fn parse_content_field(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<Vec<crate::ast::content::RawContentPart>>>, ParseError> {
+    use crate::ast::content::RawContentPart;
+
+    let node = match map.get_node("content") {
+        Some(n) => n,
+        None => return Ok(None),
+    };
+
+    let span = node_to_span(file, node);
+
+    let seq = match node {
+        Node::Sequence(s) => s,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: "content must be a sequence".to_string(),
+            });
+        }
+    };
+
+    if seq.is_empty() {
+        return Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span,
+            message: "content must not be empty".to_string(),
+        });
+    }
+
+    let mut parts = Vec::with_capacity(seq.len());
+
+    for item in seq.iter() {
+        let item_span = node_to_span(file, item);
+        let m = match item {
+            Node::Mapping(m) => m,
+            _ => {
+                return Err(ParseError {
+                    kind: ParseErrorKind::InvalidType,
+                    span: item_span,
+                    message: "each content part must be a mapping with 'type' field".to_string(),
+                });
+            }
+        };
+
+        let type_field = get_string_field(file, m, "type")?.ok_or_else(|| ParseError {
+            kind: ParseErrorKind::MissingField,
+            span: item_span,
+            message: "content part requires 'type' field".to_string(),
+        })?;
+
+        let part = match type_field.value.as_str() {
+            "text" => {
+                let text = get_string_field(file, m, "text")?.ok_or_else(|| ParseError {
+                    kind: ParseErrorKind::MissingField,
+                    span: item_span,
+                    message: "text content part requires 'text' field".to_string(),
+                })?;
+                RawContentPart::Text { text }
+            }
+            "image" => {
+                let source = get_string_field(file, m, "source")?.ok_or_else(|| ParseError {
+                    kind: ParseErrorKind::MissingField,
+                    span: item_span,
+                    message: "image content part requires 'source' field".to_string(),
+                })?;
+                let detail = get_string_field(file, m, "detail")?;
+                RawContentPart::Image { source, detail }
+            }
+            "image_url" => {
+                let url = get_string_field(file, m, "url")?.ok_or_else(|| ParseError {
+                    kind: ParseErrorKind::MissingField,
+                    span: item_span,
+                    message: "image_url content part requires 'url' field".to_string(),
+                })?;
+                let detail = get_string_field(file, m, "detail")?;
+                RawContentPart::ImageUrl { url, detail }
+            }
+            other => {
+                return Err(ParseError {
+                    kind: ParseErrorKind::InvalidType,
+                    span: type_field.span,
+                    message: format!(
+                        "unknown content part type '{}', expected: text, image, image_url",
+                        other
+                    ),
+                });
+            }
+        };
+
+        parts.push(part);
+    }
+
+    Ok(Some(Spanned::new(parts, span)))
+}
+
+/// Parse exec action - supports both shorthand (string) and full form (mapping).
+fn parse_exec_action(file: FileId, node: &Node) -> Result<RawExecAction, ParseError> {
+    let span = node_to_span(file, node);
+
+    match node {
+        // Shorthand: exec: "command string"
+        Node::Scalar(s) => Ok(RawExecAction {
+            command: Spanned::new(s.as_str().to_string(), span),
+            shell: None,
+            working_dir: None,
+            env: None,
+            timeout_ms: None,
+        }),
+        // Full form
+        Node::Mapping(m) => {
+            let command = get_string_field(file, m, "command")?.ok_or_else(|| ParseError {
+                kind: ParseErrorKind::MissingField,
+                span,
+                message: "exec action requires 'command' field".to_string(),
+            })?;
+
+            Ok(RawExecAction {
+                command,
+                shell: get_bool_field(file, m, "shell")?,
+                working_dir: get_string_field(file, m, "working_dir")?
+                    .or(get_string_field(file, m, "cwd")?),
+                env: parse_string_map(file, m, "env")?,
+                // timeout_ms is the primary field (milliseconds).
+                // timeout is the schema alias (seconds) — convert to ms.
+                timeout_ms: match get_u64_field(file, m, "timeout_ms")? {
+                    Some(v) => Some(v),
+                    None => get_u64_field(file, m, "timeout")?
+                        .map(|s| Spanned::new(s.value * 1000, s.span)),
+                },
+            })
+        }
+        _ => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span,
+            message: "exec must be a string or mapping".to_string(),
+        }),
+    }
+}
+
+/// Parse fetch action - always requires a mapping.
+fn parse_fetch_action(file: FileId, node: &Node) -> Result<RawFetchAction, ParseError> {
+    let span = node_to_span(file, node);
+
+    let m = match node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: "fetch must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let url = get_string_field(file, m, "url")?.ok_or_else(|| ParseError {
+        kind: ParseErrorKind::MissingField,
+        span,
+        message: "fetch action requires 'url' field".to_string(),
+    })?;
+
+    Ok(RawFetchAction {
+        url,
+        method: get_string_field(file, m, "method")?,
+        headers: parse_string_map(file, m, "headers")?,
+        body: get_string_field(file, m, "body")?,
+        json: parse_json_value(file, m, "json")?,
+        timeout_ms: match get_u64_field(file, m, "timeout_ms")? {
+            Some(v) => Some(v),
+            None => {
+                get_u64_field(file, m, "timeout")?.map(|s| Spanned::new(s.value * 1000, s.span))
+            }
+        },
+        follow_redirects: get_bool_field(file, m, "follow_redirects")?,
+    })
+}
+
+/// Parse invoke action - always requires a mapping.
+fn parse_invoke_action(file: FileId, node: &Node) -> Result<RawInvokeAction, ParseError> {
+    let span = node_to_span(file, node);
+
+    let m = match node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: "invoke must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let tool = get_string_field(file, m, "tool")?.ok_or_else(|| ParseError {
+        kind: ParseErrorKind::MissingField,
+        span,
+        message: "invoke action requires 'tool' field".to_string(),
+    })?;
+
+    Ok(RawInvokeAction {
+        tool,
+        params: parse_json_value(file, m, "params")?,
+        mcp: get_string_field(file, m, "mcp")?.or(get_string_field(file, m, "server")?),
+        timeout_ms: match get_u64_field(file, m, "timeout_ms")? {
+            Some(v) => Some(v),
+            None => {
+                get_u64_field(file, m, "timeout")?.map(|s| Spanned::new(s.value * 1000, s.span))
+            }
+        },
+    })
+}
+
+/// Parse agent action - always requires a mapping.
+fn parse_agent_action(file: FileId, node: &Node) -> Result<RawAgentAction, ParseError> {
+    let span = node_to_span(file, node);
+
+    let m = match node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: "agent must be a mapping".to_string(),
+            });
+        }
+    };
+
+    // Agent uses 'prompt' as primary field, 'goal' as legacy fallback
+    let prompt = get_string_field(file, m, "prompt")?
+        .or(get_string_field(file, m, "goal")?)
+        .ok_or_else(|| ParseError {
+            kind: ParseErrorKind::MissingField,
+            span,
+            message: "agent action requires 'prompt' field (or legacy 'goal')".to_string(),
+        })?;
+
+    Ok(RawAgentAction {
+        prompt,
+        tools: parse_string_array(file, m, "tools")?,
+        max_iterations: get_u32_field(file, m, "max_iterations")?.or(get_u32_field(
+            file,
+            m,
+            "max_turns",
+        )?),
+        max_tokens: get_u32_field(file, m, "max_tokens")?,
+        from: get_string_field(file, m, "from")?,
+        skills: parse_string_array(file, m, "skills")?,
+        provider: get_string_field(file, m, "provider")?,
+        model: get_string_field(file, m, "model")?,
+        mcp: parse_string_array(file, m, "mcp")?,
+        system: get_string_field(file, m, "system")?,
+        temperature: get_f64_field(file, m, "temperature")?,
+        token_budget: get_u32_field(file, m, "token_budget")?,
+        extended_thinking: get_bool_field(file, m, "extended_thinking")?,
+        thinking_budget: get_u32_field(file, m, "thinking_budget")?,
+        depth_limit: get_u32_field(file, m, "depth_limit")?,
+    })
+}
+
+// ============================================================================
+// with:/depends_on:/for_each:/retry:/output: Parsing
+// ============================================================================
+
+/// Parse with: bindings.
+///
+/// Values are raw strings parsed by `parse_with_entry()` in Phase 2 (analyzer).
+/// Examples:
+///   - `data: step1` — simple task reference
+///   - `temp: step1.data.temp ?? 20` — path + default
+///   - `cfg: $env.API_KEY` — environment binding
+///   - `val: step1.output | upper | trim` — with transforms
+#[allow(clippy::type_complexity)]
+fn parse_with_refs(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<IndexMap<Spanned<String>, Spanned<String>>>>, ParseError> {
+    parse_string_map(file, map, "with")
+}
+
+/// Parse depends_on: ordering dependencies.
+///
+/// Pure ordering edges — no data flows through them.
+/// Data dependencies are expressed via `with:` bindings.
+fn parse_depends_on(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<Vec<Spanned<String>>>>, ParseError> {
+    match map.get_node("depends_on") {
+        Some(Node::Scalar(s)) => {
+            let span = marked_span_to_span(file, s.span());
+            Ok(Some(Spanned::new(
+                vec![Spanned::new(s.as_str().to_string(), span)],
+                span,
+            )))
+        }
+        Some(Node::Sequence(seq)) => {
+            let span = marked_span_to_span(file, seq.span());
+            let ids: Result<Vec<_>, _> = seq.iter().map(|n| extract_string(file, n)).collect();
+            Ok(Some(Spanned::new(ids?, span)))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: "depends_on/flow must be a string or array of strings".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse for_each: iteration.
+fn parse_for_each(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<RawForEach>>, ParseError> {
+    match map.get_node("for_each") {
+        Some(Node::Sequence(seq)) => {
+            let span = marked_span_to_span(file, seq.span());
+            // Array literal - serialize to JSON string for storage
+            let arr: Vec<serde_json::Value> = seq.iter().map(node_to_json).collect();
+            let items_str = serde_json::to_string(&arr).map_err(|e| ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: format!("failed to serialize for_each items: {}", e),
+            })?;
+
+            Ok(Some(Spanned::new(
+                RawForEach {
+                    items: Spanned::new(items_str, span),
+                    as_var: get_string_field(file, map, "as")?,
+                    parallel: get_u32_field(file, map, "concurrency")?
+                        .or(get_u32_field(file, map, "parallel")?),
+                    fail_fast: get_bool_field(file, map, "fail_fast")?,
+                },
+                span,
+            )))
+        }
+        Some(Node::Scalar(s)) => {
+            let span = marked_span_to_span(file, s.span());
+            Ok(Some(Spanned::new(
+                RawForEach {
+                    items: Spanned::new(s.as_str().to_string(), span),
+                    as_var: get_string_field(file, map, "as")?,
+                    parallel: get_u32_field(file, map, "concurrency")?
+                        .or(get_u32_field(file, map, "parallel")?),
+                    fail_fast: get_bool_field(file, map, "fail_fast")?,
+                },
+                span,
+            )))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: "for_each must be array or string".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse retry: configuration.
+fn parse_retry(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<RawRetryConfig>>, ParseError> {
+    match map.get_node("retry") {
+        Some(Node::Mapping(m)) => {
+            let span = marked_span_to_span(file, m.span());
+            Ok(Some(Spanned::new(
+                RawRetryConfig {
+                    max_attempts: get_u32_field(file, m, "max_attempts")?
+                        .or(get_u32_field(file, m, "max")?),
+                    delay_ms: get_u64_field(file, m, "delay_ms")?
+                        .or(get_u64_field(file, m, "delay")?),
+                    backoff: get_f64_field(file, m, "backoff")?.or(get_f64_field(
+                        file,
+                        m,
+                        "backoff_multiplier",
+                    )?),
+                },
+                span,
+            )))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: "retry must be a mapping".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse decompose: configuration.
+fn parse_decompose(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<DecomposeSpec>>, ParseError> {
+    match map.get_node("decompose") {
+        Some(Node::Mapping(m)) => {
+            let span = marked_span_to_span(file, m.span());
+
+            let traverse = get_string_field(file, m, "traverse")?
+                .ok_or_else(|| ParseError {
+                    kind: ParseErrorKind::MissingField,
+                    span,
+                    message: "decompose missing required field 'traverse'".to_string(),
+                })?
+                .value;
+
+            let source = get_string_field(file, m, "source")?
+                .ok_or_else(|| ParseError {
+                    kind: ParseErrorKind::MissingField,
+                    span,
+                    message: "decompose missing required field 'source'".to_string(),
+                })?
+                .value;
+
+            let strategy = match get_string_field(file, m, "strategy")? {
+                Some(s) => match s.value.as_str() {
+                    "semantic" => DecomposeStrategy::Semantic,
+                    "static" => DecomposeStrategy::Static,
+                    "nested" => DecomposeStrategy::Nested,
+                    other => {
+                        return Err(ParseError {
+                            kind: ParseErrorKind::InvalidType,
+                            span: s.span,
+                            message: format!(
+                                "invalid decompose strategy '{}': expected semantic, static, or nested",
+                                other
+                            ),
+                        });
+                    }
+                },
+                None => DecomposeStrategy::default(),
+            };
+
+            let mcp_server = get_string_field(file, m, "mcp_server")?.map(|s| s.value);
+
+            let max_items = get_u32_field(file, m, "max_items")?.map(|s| s.value as usize);
+
+            let max_depth = get_u32_field(file, m, "max_depth")?.map(|s| s.value as usize);
+
+            Ok(Some(Spanned::new(
+                DecomposeSpec {
+                    strategy,
+                    traverse,
+                    source,
+                    mcp_server,
+                    max_items,
+                    max_depth,
+                },
+                span,
+            )))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: "decompose must be a mapping".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse output: configuration.
+fn parse_output(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<RawOutputConfig>>, ParseError> {
+    match map.get_node("output") {
+        Some(Node::Mapping(m)) => {
+            let span = marked_span_to_span(file, m.span());
+            Ok(Some(Spanned::new(
+                RawOutputConfig {
+                    format: get_string_field(file, m, "format")?,
+                    schema: parse_json_value(file, m, "schema")?,
+                    schema_ref: get_string_field(file, m, "schema_ref")?
+                        .or(get_string_field(file, m, "$ref")?),
+                },
+                span,
+            )))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file, node),
+            message: "output must be a mapping".to_string(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// Parse structured: configuration (StructuredOutputSpec).
+///
+/// Supports shorthand (string path) or full mapping form:
+/// ```yaml
+/// structured: ./schemas/user.json          # shorthand
+/// structured:                               # full form
+///   schema: ./schemas/user.json
+///   max_retries: 3
+/// ```
+fn parse_structured(
+    file: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<StructuredOutputSpec>, ParseError> {
+    match map.get_node("structured") {
+        Some(node) => {
+            let span = node_to_span(file, node);
+            // Convert YAML node to JSON value, then deserialize via serde_json.
+            // StructuredOutputSpec's custom Deserialize handles both string and map forms.
+            let json_value = node_to_json(node);
+            let spec: StructuredOutputSpec =
+                serde_json::from_value(json_value).map_err(|e| ParseError {
+                    kind: ParseErrorKind::InvalidType,
+                    span,
+                    message: format!("invalid structured output config: {e}"),
+                })?;
+            Ok(Some(spec))
+        }
+        None => Ok(None),
+    }
+}
+
+// ============================================================================
+// Main Parser
+// ============================================================================
+
+/// Parse a YAML source string into a RawWorkflow.
+///
+/// This is the main entry point for Phase 1 parsing. The returned
+/// RawWorkflow contains full span information for all nodes.
+///
+/// # Arguments
+///
+/// * `source` - The YAML source content
+/// * `file_id` - The FileId from the SourceRegistry
+///
+/// # Returns
+///
+/// A RawWorkflow with span tracking, or a ParseError with location.
+///
+/// # Example
+///
+/// ```ignore
+/// use nika::ast::raw;
+/// use nika::source::SourceRegistry;
+///
+/// let mut sources = SourceRegistry::new();
+/// let file_id = sources.add_file("workflow.yaml", content.clone());
+/// let workflow = raw::parse(&content, file_id)?;
+/// ```
+pub fn parse(source: &str, file_id: FileId) -> Result<RawWorkflow, ParseError> {
+    // Parse YAML with marked_yaml
+    // The first argument is a source ID (we use file_id.0)
+    let node = parse_yaml(file_id.0 as usize, source).map_err(|e| {
+        // Extract span from LoadError variants that carry a Marker
+        let span = extract_span_from_load_error(file_id, &e);
+        ParseError {
+            kind: ParseErrorKind::Syntax,
+            span,
+            message: format!("YAML syntax error: {}", e),
+        }
+    })?;
+
+    // The root must be a mapping
+    let map = match &node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span: node_to_span(file_id, &node),
+                message: "workflow must be a YAML mapping".to_string(),
+            });
+        }
+    };
+
+    // Parse workflow fields
+    let mut workflow = RawWorkflow::default();
+    workflow.span = node_to_span(file_id, &node);
+
+    // Extract schema (required)
+    workflow.schema = get_string_field(file_id, map, "schema")?.ok_or_else(|| ParseError {
+        kind: ParseErrorKind::MissingField,
+        span: workflow.span,
+        message: "missing required field 'schema'".to_string(),
+    })?;
+
+    // Extract optional fields
+    workflow.workflow = get_string_field(file_id, map, "workflow")?;
+    workflow.description = get_string_field(file_id, map, "description")?;
+    workflow.provider = get_string_field(file_id, map, "provider")?;
+    workflow.model = get_string_field(file_id, map, "model")?;
+
+    // Parse MCP server configurations
+    workflow.mcp = parse_mcp_config(file_id, map)?;
+
+    // Parse pkg configuration
+    workflow.pkg = parse_pkg_config(file_id, map)?;
+
+    // Parse context configuration
+    workflow.context = parse_context_config(file_id, map)?;
+
+    // Parse imports
+    workflow.imports = parse_imports(file_id, map)?;
+
+    // Parse inputs
+    workflow.inputs = parse_inputs(file_id, map)?;
+
+    // Parse artifacts config
+    workflow.artifacts = match map.get_node("artifacts") {
+        Some(node) => {
+            let span = node_to_span(file_id, node);
+            Some(Spanned::new(node_to_json(node), span))
+        }
+        None => None,
+    };
+
+    // Parse log config
+    workflow.log = match map.get_node("log") {
+        Some(node) => {
+            let span = node_to_span(file_id, node);
+            Some(Spanned::new(node_to_json(node), span))
+        }
+        None => None,
+    };
+
+    // Parse agents config
+    workflow.agents = match map.get_node("agents") {
+        Some(node) => {
+            let span = node_to_span(file_id, node);
+            Some(Spanned::new(node_to_json(node), span))
+        }
+        None => None,
+    };
+
+    // Parse tasks
+    workflow.tasks = parse_tasks(file_id, map)?;
+
+    Ok(workflow)
+}
+
+/// Parse the MCP configuration block from a workflow mapping.
+fn parse_mcp_config(
+    file_id: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<RawMcpConfig>>, ParseError> {
+    // Look for "mcp:" mapping
+    let mcp_node = match map.get_node("mcp") {
+        Some(node) => node,
+        None => return Ok(None),
+    };
+
+    let mcp_map = match mcp_node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span: node_to_span(file_id, mcp_node),
+                message: "mcp must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let mcp_span = marked_span_to_span(file_id, mcp_map.span());
+    let mut config = RawMcpConfig::default();
+
+    // Support both formats:
+    //   Nested: mcp: { servers: { novanet: { command: ... } } }
+    //   Flat:   mcp: { novanet: { command: ... } }
+    let servers_map = if let Some(servers_node) = mcp_map.get_node("servers") {
+        match servers_node {
+            Node::Mapping(m) => m,
+            _ => {
+                return Err(ParseError {
+                    kind: ParseErrorKind::InvalidType,
+                    span: node_to_span(file_id, servers_node),
+                    message: "mcp.servers must be a mapping".to_string(),
+                });
+            }
+        }
+    } else {
+        // Flat format: entries directly under mcp:
+        mcp_map
+    };
+
+    for (key, value) in servers_map.iter() {
+        let server_name = Spanned::new(
+            key.as_str().to_string(),
+            marked_span_to_span(file_id, key.span()),
+        );
+
+        let server = parse_mcp_server(file_id, value)?;
+        config.servers.insert(server_name, server);
+    }
+
+    Ok(Some(Spanned::new(config, mcp_span)))
+}
+
+/// Parse a single MCP server configuration.
+fn parse_mcp_server(file_id: FileId, node: &Node) -> Result<Spanned<RawMcpServer>, ParseError> {
+    let span = node_to_span(file_id, node);
+
+    let map = match node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: "MCP server config must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let server = RawMcpServer {
+        command: get_string_field(file_id, map, "command")?,
+        args: parse_string_array(file_id, map, "args")?,
+        env: parse_string_map(file_id, map, "env")?,
+        cwd: get_string_field(file_id, map, "cwd")?,
+        url: get_string_field(file_id, map, "url")?,
+        transport: get_string_field(file_id, map, "transport")?,
+    };
+
+    Ok(Spanned::new(server, span))
+}
+
+/// Parse pkg: configuration.
+fn parse_pkg_config(
+    file_id: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<RawPkgConfig>>, ParseError> {
+    let pkg_node = match map.get_node("pkg") {
+        Some(node) => node,
+        None => return Ok(None),
+    };
+
+    let pkg_map = match pkg_node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span: node_to_span(file_id, pkg_node),
+                message: "pkg must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let span = marked_span_to_span(file_id, pkg_map.span());
+    let include = match parse_string_array(file_id, pkg_map, "include")? {
+        Some(arr) => arr.value,
+        None => Vec::new(),
+    };
+
+    Ok(Some(Spanned::new(RawPkgConfig { include }, span)))
+}
+
+/// Parse context: configuration.
+fn parse_context_config(
+    file_id: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<RawContextConfig>>, ParseError> {
+    let ctx_node = match map.get_node("context") {
+        Some(node) => node,
+        None => return Ok(None),
+    };
+
+    let ctx_map = match ctx_node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span: node_to_span(file_id, ctx_node),
+                message: "context must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let span = marked_span_to_span(file_id, ctx_map.span());
+    let files = parse_string_map(file_id, ctx_map, "files")?.map(|s| s.value);
+
+    Ok(Some(Spanned::new(RawContextConfig { files }, span)))
+}
+
+/// Parse imports: specification.
+///
+/// ```yaml
+/// imports:
+///   - path: ./partials/setup.nika.yaml
+///     prefix: setup_
+///   - path: pkg:@spn/core@1.0/seo.nika.yaml
+/// ```
+fn parse_imports(
+    file_id: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<Vec<Spanned<RawImportSpec>>>>, ParseError> {
+    // Accept both "imports:" (canonical) and "include:" (legacy alias)
+    let imports_node = match map.get_node("imports").or_else(|| map.get_node("include")) {
+        Some(node) => node,
+        None => return Ok(None),
+    };
+
+    let seq = match imports_node {
+        Node::Sequence(s) => s,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span: node_to_span(file_id, imports_node),
+                message: "imports must be a sequence".to_string(),
+            });
+        }
+    };
+
+    let outer_span = marked_span_to_span(file_id, seq.span());
+    let mut specs = Vec::new();
+
+    for item_node in seq.iter() {
+        let item_span = node_to_span(file_id, item_node);
+
+        let item_map = match item_node {
+            Node::Mapping(m) => m,
+            _ => {
+                return Err(ParseError {
+                    kind: ParseErrorKind::InvalidType,
+                    span: item_span,
+                    message: "import entry must be a mapping with 'path' field".to_string(),
+                });
+            }
+        };
+
+        let path = get_string_field(file_id, item_map, "path")?.ok_or_else(|| ParseError {
+            kind: ParseErrorKind::MissingField,
+            span: item_span,
+            message: "import entry requires 'path' field".to_string(),
+        })?;
+
+        let prefix = get_string_field(file_id, item_map, "prefix")?;
+
+        specs.push(Spanned::new(
+            RawImportSpec {
+                path,
+                prefix,
+                span: item_span,
+            },
+            item_span,
+        ));
+    }
+
+    Ok(Some(Spanned::new(specs, outer_span)))
+}
+
+/// Parse inputs: parameters with defaults.
+///
+/// ```yaml
+/// inputs:
+///   locale: "fr-FR"
+///   max_items: 10
+/// ```
+#[allow(clippy::type_complexity)]
+fn parse_inputs(
+    file_id: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Option<Spanned<IndexMap<Spanned<String>, Spanned<serde_json::Value>>>>, ParseError> {
+    let inputs_node = match map.get_node("inputs") {
+        Some(node) => node,
+        None => return Ok(None),
+    };
+
+    let inputs_map = match inputs_node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span: node_to_span(file_id, inputs_node),
+                message: "inputs must be a mapping".to_string(),
+            });
+        }
+    };
+
+    let span = marked_span_to_span(file_id, inputs_map.span());
+    let mut result = IndexMap::new();
+
+    for (k, v) in inputs_map.iter() {
+        let key_span = marked_span_to_span(file_id, k.span());
+        let key = Spanned::new(k.as_str().to_string(), key_span);
+        let val_span = node_to_span(file_id, v);
+        let val = Spanned::new(node_to_json(v), val_span);
+        result.insert(key, val);
+    }
+
+    Ok(Some(Spanned::new(result, span)))
+}
+
+/// Parse the tasks array from a workflow mapping.
+fn parse_tasks(
+    file_id: FileId,
+    map: &marked_yaml::types::MarkedMappingNode,
+) -> Result<Spanned<Vec<Spanned<RawTask>>>, ParseError> {
+    match map.get_node("tasks") {
+        Some(Node::Sequence(seq)) => {
+            let span = marked_span_to_span(file_id, seq.span());
+            let tasks = seq
+                .iter()
+                .map(|task_node| parse_task(file_id, task_node))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Spanned::new(tasks, span))
+        }
+        Some(node) => Err(ParseError {
+            kind: ParseErrorKind::InvalidType,
+            span: node_to_span(file_id, node),
+            message: "tasks must be a sequence".to_string(),
+        }),
+        None => {
+            // No tasks field - return empty array with dummy span
+            Ok(Spanned::dummy(Vec::new()))
+        }
+    }
+}
+
+/// Parse a single task from a YAML node.
+fn parse_task(file_id: FileId, node: &Node) -> Result<Spanned<RawTask>, ParseError> {
+    let span = node_to_span(file_id, node);
+
+    let map = match node {
+        Node::Mapping(m) => m,
+        _ => {
+            return Err(ParseError {
+                kind: ParseErrorKind::InvalidType,
+                span,
+                message: "task must be a mapping".to_string(),
+            });
+        }
+    };
+
+    // Extract task id (required)
+    let id = get_string_field(file_id, map, "id")?.ok_or_else(|| ParseError {
+        kind: ParseErrorKind::MissingField,
+        span,
+        message: "task missing required field 'id'".to_string(),
+    })?;
+
+    // Extract optional fields
+    let description = get_string_field(file_id, map, "description")?;
+    let provider = get_string_field(file_id, map, "provider")?;
+    let model = get_string_field(file_id, map, "model")?;
+
+    // Parse all task fields
+    let action = parse_action(file_id, map)?;
+    let with_refs = parse_with_refs(file_id, map)?;
+    let depends_on = parse_depends_on(file_id, map)?;
+    let output = parse_output(file_id, map)?;
+    let for_each = parse_for_each(file_id, map)?;
+    let retry = parse_retry(file_id, map)?;
+    let decompose = parse_decompose(file_id, map)?;
+    let structured = parse_structured(file_id, map)?;
+
+    // Parse artifact: config (task-level artifact output)
+    let artifact = match map.get_node("artifact") {
+        Some(node) => {
+            let span = node_to_span(file_id, node);
+            let value = node_to_json(node);
+            Some(Spanned::new(value, span))
+        }
+        None => None,
+    };
+
+    // Parse log: config (task-level log override)
+    let log = match map.get_node("log") {
+        Some(node) => {
+            let span = node_to_span(file_id, node);
+            let value = node_to_json(node);
+            Some(Spanned::new(value, span))
+        }
+        None => None,
+    };
+
+    // Parse standalone concurrency/fail_fast (used with decompose when no for_each)
+    let standalone_concurrency = if for_each.is_none() {
+        get_u32_field(file_id, map, "concurrency")?
+    } else {
+        None
+    };
+    let standalone_fail_fast = if for_each.is_none() {
+        get_bool_field(file_id, map, "fail_fast")?
+    } else {
+        None
+    };
+
+    let task = RawTask {
+        span,
+        id,
+        description,
+        provider,
+        model,
+        action,
+        with_refs,
+        depends_on,
+        output,
+        for_each,
+        retry,
+        decompose,
+        concurrency: standalone_concurrency,
+        fail_fast: standalone_fail_fast,
+        structured,
+        artifact,
+        log,
+    };
+
+    Ok(Spanned::new(task, span))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIMPLE_WORKFLOW: &str = r#"
+schema: "nika/workflow@0.12"
+workflow: test-workflow
+description: "A test workflow"
+provider: claude
+model: claude-sonnet-4-6
+
+tasks:
+  - id: task1
+    description: "First task"
+
+  - id: task2
+    description: "Second task"
+"#;
+
+    #[test]
+    fn test_parse_simple_workflow() {
+        let file_id = FileId(0);
+        let result = parse(SIMPLE_WORKFLOW, file_id);
+
+        assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+        let workflow = result.unwrap();
+
+        assert_eq!(workflow.schema.value, "nika/workflow@0.12");
+        assert_eq!(workflow.name(), "test-workflow");
+        assert_eq!(
+            workflow.description.as_ref().unwrap().value,
+            "A test workflow"
+        );
+        assert_eq!(workflow.provider.as_ref().unwrap().value, "claude");
+        assert_eq!(workflow.model.as_ref().unwrap().value, "claude-sonnet-4-6");
+        assert_eq!(workflow.task_count(), 2);
+
+        // Check spans are not dummy
+        assert!(!workflow.schema.span.is_dummy());
+        assert!(!workflow.tasks.span.is_dummy());
+    }
+
+    #[test]
+    fn test_parse_task_ids() {
+        let file_id = FileId(0);
+        let workflow = parse(SIMPLE_WORKFLOW, file_id).unwrap();
+
+        let task1 = workflow.get_task("task1");
+        assert!(task1.is_some());
+        assert_eq!(task1.unwrap().value.id.value, "task1");
+
+        let task2 = workflow.get_task("task2");
+        assert!(task2.is_some());
+        assert_eq!(task2.unwrap().value.id.value, "task2");
+    }
+
+    #[test]
+    fn test_parse_missing_schema() {
+        let yaml = r#"
+workflow: test
+tasks: []
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::MissingField);
+        assert!(err.message.contains("schema"));
+    }
+
+    #[test]
+    fn test_parse_invalid_yaml() {
+        let yaml = "invalid: yaml: syntax: [";
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::Syntax);
+    }
+
+    #[test]
+    fn test_span_tracking() {
+        let yaml = r#"schema: "nika/workflow@0.12"
+workflow: my-workflow
+tasks:
+  - id: hello
+"#;
+        let file_id = FileId(0);
+        let workflow = parse(yaml, file_id).unwrap();
+
+        // Check that schema has correct span
+        let schema_span = workflow.schema.span;
+        assert!(!schema_span.is_dummy());
+
+        // Check span bounds are reasonable
+        assert!(schema_span.start.0 <= schema_span.end.0);
+    }
+
+    // =========================================================================
+    // Verb Parsing Tests (5 Verbs)
+    // =========================================================================
+
+    #[test]
+    fn test_parse_infer_shorthand() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: generate
+    infer: "Generate a headline"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("generate").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Infer(action)) => {
+                assert_eq!(action.value.prompt.value, "Generate a headline");
+                assert!(action.value.temperature.is_none());
+                assert!(action.value.system.is_none());
+            }
+            _ => panic!("Expected Infer action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_infer_full_form() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: generate
+    infer:
+      prompt: "Generate content"
+      system: "You are a helpful assistant"
+      temperature: 0.7
+      max_tokens: 1000
+      thinking: true
+      thinking_budget: 8000
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("generate").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Infer(action)) => {
+                assert_eq!(action.value.prompt.value, "Generate content");
+                assert_eq!(
+                    action.value.system.as_ref().unwrap().value,
+                    "You are a helpful assistant"
+                );
+                assert!((action.value.temperature.as_ref().unwrap().value - 0.7).abs() < 0.001);
+                assert_eq!(action.value.max_tokens.as_ref().unwrap().value, 1000);
+                assert!(action.value.thinking.as_ref().unwrap().value);
+                assert_eq!(action.value.thinking_budget.as_ref().unwrap().value, 8000);
+            }
+            _ => panic!("Expected Infer action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_exec_shorthand() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: build
+    exec: "npm run build"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("build").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Exec(action)) => {
+                assert_eq!(action.value.command.value, "npm run build");
+                assert!(action.value.shell.is_none());
+            }
+            _ => panic!("Expected Exec action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_exec_full_form() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: build
+    exec:
+      command: "npm run build"
+      shell: true
+      cwd: "/app"
+      timeout: 30
+      env:
+        NODE_ENV: production
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("build").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Exec(action)) => {
+                assert_eq!(action.value.command.value, "npm run build");
+                assert!(action.value.shell.as_ref().unwrap().value);
+                assert_eq!(action.value.working_dir.as_ref().unwrap().value, "/app");
+                assert_eq!(action.value.timeout_ms.as_ref().unwrap().value, 30000);
+                let env = action.value.env.as_ref().unwrap();
+                assert!(env.value.values().any(|v| v.value == "production"));
+            }
+            _ => panic!("Expected Exec action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_fetch_action() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: api_call
+    fetch:
+      url: "https://api.example.com/data"
+      method: POST
+      headers:
+        Authorization: "Bearer token"
+      timeout: 5
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("api_call").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Fetch(action)) => {
+                assert_eq!(action.value.url.value, "https://api.example.com/data");
+                assert_eq!(action.value.method.as_ref().unwrap().value, "POST");
+                assert_eq!(action.value.timeout_ms.as_ref().unwrap().value, 5000); // 5 seconds * 1000
+                let headers = action.value.headers.as_ref().unwrap();
+                assert!(headers.value.values().any(|v| v.value.contains("Bearer")));
+            }
+            _ => panic!("Expected Fetch action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_invoke_action() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: mcp_call
+    invoke:
+      tool: novanet_generate
+      mcp: novanet
+      params:
+        entity: "qr-code"
+        locale: "fr-FR"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("mcp_call").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Invoke(action)) => {
+                assert_eq!(action.value.tool.value, "novanet_generate");
+                assert_eq!(action.value.mcp.as_ref().unwrap().value, "novanet");
+                assert!(action.value.params.is_some());
+            }
+            _ => panic!("Expected Invoke action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_agent_action() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: research
+    agent:
+      prompt: "Research AI trends"
+      tools:
+        - nika:read
+        - nika:write
+      max_turns: 10
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("research").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Agent(action)) => {
+                assert_eq!(action.value.prompt.value, "Research AI trends");
+                let tools = action.value.tools.as_ref().unwrap();
+                assert_eq!(tools.value.len(), 2);
+                assert_eq!(tools.value[0].value, "nika:read");
+                assert_eq!(action.value.max_iterations.as_ref().unwrap().value, 10);
+            }
+            _ => panic!("Expected Agent action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_agent_prompt_is_primary_field() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: research
+    agent:
+      prompt: "Research AI trends"
+      max_turns: 10
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("research").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Agent(action)) => {
+                // Field must be named `prompt`, not `goal`
+                assert_eq!(action.value.prompt.value, "Research AI trends");
+            }
+            _ => panic!("Expected Agent action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_agent_goal_legacy_fallback() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: research
+    agent:
+      goal: "Legacy goal syntax"
+      max_turns: 5
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("research").unwrap();
+
+        match &task.value.action {
+            Some(RawTaskAction::Agent(action)) => {
+                // Legacy `goal:` should still work as fallback
+                assert_eq!(action.value.prompt.value, "Legacy goal syntax");
+            }
+            _ => panic!("Expected Agent action"),
+        }
+    }
+
+    // =========================================================================
+    // Task Configuration Parsing Tests
+    // =========================================================================
+
+    #[test]
+    fn test_parse_with_refs_simple() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: step1
+    infer: "Generate"
+  - id: step2
+    with:
+      data: step1
+    infer: "Process {{with.data}}"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("step2").unwrap();
+
+        let with_refs = task.value.with_refs.as_ref().unwrap();
+        assert_eq!(with_refs.value.len(), 1);
+
+        let (alias, value) = with_refs.value.iter().next().unwrap();
+        assert_eq!(alias.value, "data");
+        assert_eq!(value.value, "step1");
+    }
+
+    #[test]
+    fn test_parse_with_refs_binding_expr() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: step1
+    infer: "Generate"
+  - id: step2
+    with:
+      data: "step1"
+      temp: "step1.data.temp ?? 20"
+      cfg: "$env.API_KEY"
+      val: "step1.output | upper | trim"
+    infer: "Process"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("step2").unwrap();
+
+        let with_refs = task.value.with_refs.as_ref().unwrap();
+        assert_eq!(with_refs.value.len(), 4);
+
+        let vals: Vec<&str> = with_refs.value.values().map(|v| v.value.as_str()).collect();
+        assert_eq!(vals[0], "step1");
+        assert_eq!(vals[1], "step1.data.temp ?? 20");
+        assert_eq!(vals[2], "$env.API_KEY");
+        assert_eq!(vals[3], "step1.output | upper | trim");
+    }
+
+    #[test]
+    fn test_parse_depends_on_single() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: step1
+    infer: "Generate"
+  - id: step2
+    depends_on: step1
+    infer: "Process"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("step2").unwrap();
+
+        let deps = task.value.depends_on.as_ref().unwrap();
+        assert_eq!(deps.value.len(), 1);
+        assert_eq!(deps.value[0].value, "step1");
+    }
+
+    #[test]
+    fn test_parse_depends_on_multiple() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: step1
+    infer: "Step 1"
+  - id: step2
+    infer: "Step 2"
+  - id: step3
+    depends_on: [step1, step2]
+    infer: "Process"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("step3").unwrap();
+
+        let deps = task.value.depends_on.as_ref().unwrap();
+        assert_eq!(deps.value.len(), 2);
+        assert_eq!(deps.value[0].value, "step1");
+        assert_eq!(deps.value[1].value, "step2");
+    }
+
+    #[test]
+    fn test_parse_imports() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+imports:
+  - path: ./partials/setup.nika.yaml
+    prefix: setup_
+  - path: "pkg:@spn/core@1.0/seo.nika.yaml"
+tasks:
+  - id: main_task
+    infer: "Main logic"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+
+        let imports = workflow.imports.as_ref().unwrap();
+        assert_eq!(imports.value.len(), 2);
+
+        assert_eq!(
+            imports.value[0].value.path.value,
+            "./partials/setup.nika.yaml"
+        );
+        assert_eq!(
+            imports.value[0].value.prefix.as_ref().unwrap().value,
+            "setup_"
+        );
+
+        assert_eq!(
+            imports.value[1].value.path.value,
+            "pkg:@spn/core@1.0/seo.nika.yaml"
+        );
+        assert!(imports.value[1].value.prefix.is_none());
+    }
+
+    #[test]
+    fn test_parse_inputs() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+inputs:
+  locale: "fr-FR"
+  max_items: 10
+  debug: true
+tasks:
+  - id: main_task
+    infer: "Main"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+
+        let inputs = workflow.inputs.as_ref().unwrap();
+        assert_eq!(inputs.value.len(), 3);
+
+        let keys: Vec<&str> = inputs.value.keys().map(|k| k.value.as_str()).collect();
+        assert_eq!(keys, vec!["locale", "max_items", "debug"]);
+
+        assert_eq!(
+            inputs.value.values().next().unwrap().value,
+            serde_json::Value::String("fr-FR".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_context_config() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+context:
+  files:
+    brand: ./context/brand.md
+    data: ./context/data.json
+tasks:
+  - id: main
+    infer: "Use brand: {{context.files.brand}}"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+
+        let ctx = workflow.context.as_ref().unwrap();
+        let files = ctx.value.files.as_ref().unwrap();
+        assert_eq!(files.len(), 2);
+        assert!(files.values().any(|v| v.value == "./context/brand.md"));
+    }
+
+    #[test]
+    fn test_parse_pkg_config() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+pkg:
+  include:
+    - "github:user/repo"
+    - "local:./path"
+tasks:
+  - id: main
+    infer: "Main"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+
+        let pkg = workflow.pkg.as_ref().unwrap();
+        assert_eq!(pkg.value.include.len(), 2);
+        assert_eq!(pkg.value.include[0].value, "github:user/repo");
+    }
+
+    #[test]
+    fn test_parse_for_each_array() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: parallel
+    for_each: ["a", "b", "c"]
+    as: item
+    concurrency: 3
+    infer: "Process {{with.item}}"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("parallel").unwrap();
+
+        let for_each = task.value.for_each.as_ref().unwrap();
+        assert!(for_each.value.items.value.contains("["));
+        assert_eq!(for_each.value.as_var.as_ref().unwrap().value, "item");
+        assert_eq!(for_each.value.parallel.as_ref().unwrap().value, 3);
+    }
+
+    #[test]
+    fn test_parse_for_each_binding() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: parallel
+    for_each: "{{with.items}}"
+    infer: "Process"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("parallel").unwrap();
+
+        let for_each = task.value.for_each.as_ref().unwrap();
+        assert_eq!(for_each.value.items.value, "{{with.items}}");
+    }
+
+    #[test]
+    fn test_parse_retry_config() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: resilient
+    retry:
+      max_attempts: 3
+      delay_ms: 1000
+      backoff: 2.0
+    infer: "Generate"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("resilient").unwrap();
+
+        let retry = task.value.retry.as_ref().unwrap();
+        assert_eq!(retry.value.max_attempts.as_ref().unwrap().value, 3);
+        assert_eq!(retry.value.delay_ms.as_ref().unwrap().value, 1000);
+        assert!((retry.value.backoff.as_ref().unwrap().value - 2.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_parse_output_config() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: structured
+    output:
+      format: json
+      schema:
+        type: object
+        properties:
+          name:
+            type: string
+    infer: "Generate JSON"
+"#;
+        let workflow = parse(yaml, FileId(0)).unwrap();
+        let task = workflow.get_task("structured").unwrap();
+
+        let output = task.value.output.as_ref().unwrap();
+        assert_eq!(output.value.format.as_ref().unwrap().value, "json");
+        assert!(output.value.schema.is_some());
+    }
+
+    // =========================================================================
+    // Error Cases
+    // =========================================================================
+
+    #[test]
+    fn test_parse_infer_missing_prompt() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: generate
+    infer:
+      temperature: 0.7
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::MissingField);
+        assert!(err.message.contains("prompt"));
+    }
+
+    #[test]
+    fn test_parse_fetch_missing_url() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: api_call
+    fetch:
+      method: GET
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::MissingField);
+        assert!(err.message.contains("url"));
+    }
+
+    #[test]
+    fn test_parse_invoke_missing_tool() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: mcp_call
+    invoke:
+      mcp: novanet
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::MissingField);
+        assert!(err.message.contains("tool"));
+    }
+
+    #[test]
+    fn test_parse_agent_missing_prompt() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: research
+    agent:
+      tools: [nika:read]
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::MissingField);
+        assert!(err.message.contains("prompt"));
+    }
+
+    #[test]
+    fn test_parse_rejects_multiple_verbs_in_task() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: ambiguous
+    infer: "Generate something"
+    exec: "echo hello"
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(
+            result.is_err(),
+            "task with multiple verbs should be rejected"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::InvalidType);
+        assert!(
+            err.message.contains("multiple verbs"),
+            "error should mention multiple verbs, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_temperature() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: generate
+    infer:
+      prompt: "Test"
+      temperature: not_a_number
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, ParseErrorKind::InvalidType);
+    }
+
+    #[test]
+    fn parse_rejects_yaml_nan_temperature() {
+        // YAML .nan is rendered as ".nan" by marked_yaml, rejected by Rust's parse::<f64>()
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: test
+    infer:
+      prompt: "hello"
+      temperature: .nan
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "YAML .nan temperature should be rejected");
+    }
+
+    #[test]
+    fn parse_rejects_nan_string_temperature() {
+        // "NaN" parses as f64::NaN successfully — caught by is_finite() check
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: test
+    infer:
+      prompt: "hello"
+      temperature: NaN
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "NaN temperature should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("finite") || err.message.contains("number"),
+            "Error should mention finite or number: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn parse_rejects_infinity_temperature() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: test
+    infer:
+      prompt: "hello"
+      temperature: .inf
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "Infinity temperature should be rejected");
+    }
+
+    #[test]
+    fn parse_rejects_inf_string_temperature() {
+        // "inf" parses as f64::INFINITY — caught by is_finite() check
+        let yaml = "schema: \"nika/workflow@0.12\"\ntasks:\n  - id: test\n    infer:\n      prompt: \"hello\"\n      temperature: inf\n";
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "inf temperature should be rejected");
+    }
+
+    #[test]
+    fn parse_rejects_negative_infinity_temperature() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: test
+    infer:
+      prompt: "hello"
+      temperature: -.inf
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "Negative infinity should be rejected");
+    }
+
+    // --- Edge cases: empty/malformed input ---
+
+    #[test]
+    fn parse_empty_string_errors() {
+        let result = parse("", FileId(0));
+        assert!(result.is_err(), "empty string should fail to parse");
+    }
+
+    #[test]
+    fn parse_yaml_array_instead_of_map() {
+        let result = parse("- item1\n- item2", FileId(0));
+        assert!(result.is_err(), "YAML array root should be rejected");
+    }
+
+    #[test]
+    fn parse_temperature_zero_is_valid() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: t
+    infer:
+      prompt: "hi"
+      temperature: 0.0
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_ok(), "temperature 0.0 should be valid");
+    }
+
+    #[test]
+    fn parse_temperature_one_is_valid() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+tasks:
+  - id: t
+    infer:
+      prompt: "hi"
+      temperature: 1.0
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_ok(), "temperature 1.0 should be valid");
+    }
+
+    #[test]
+    fn parse_whitespace_only_errors() {
+        let result = parse("   \n\n  \t  ", FileId(0));
+        assert!(result.is_err(), "whitespace-only input should fail");
+    }
+
+    // =========================================================================
+    // Vision / Content Parsing Tests
+    // =========================================================================
+
+    #[test]
+    fn parse_infer_with_content_text_and_image() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: vision-test
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: describe
+    infer:
+      content:
+        - type: text
+          text: "Describe this image"
+        - type: image
+          source: "blake3:abc123"
+          detail: high
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(
+            result.is_ok(),
+            "vision content should parse: {:?}",
+            result.err()
+        );
+        let wf = result.unwrap();
+        let task = &wf.tasks.value[0];
+        match &task.value.action {
+            Some(RawTaskAction::Infer(s)) => {
+                let content = s.value.content.as_ref().expect("content should be Some");
+                assert_eq!(content.value.len(), 2);
+            }
+            other => panic!("expected Some(Infer), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_infer_content_only_no_prompt() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: vision-no-prompt
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: t
+    infer:
+      content:
+        - type: text
+          text: "What is this?"
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(
+            result.is_ok(),
+            "content without prompt should parse: {:?}",
+            result.err()
+        );
+        let wf = result.unwrap();
+        let task = &wf.tasks.value[0];
+        match &task.value.action {
+            Some(RawTaskAction::Infer(s)) => {
+                assert!(
+                    s.value.prompt.value.is_empty(),
+                    "prompt should be empty string"
+                );
+                assert!(s.value.content.is_some(), "content should be present");
+            }
+            other => panic!("expected Some(Infer), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_infer_prompt_and_content() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: both
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: t
+    infer:
+      prompt: "Analyze carefully"
+      content:
+        - type: image
+          source: "blake3:xyz"
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(
+            result.is_ok(),
+            "prompt+content should parse: {:?}",
+            result.err()
+        );
+        let wf = result.unwrap();
+        let task = &wf.tasks.value[0];
+        match &task.value.action {
+            Some(RawTaskAction::Infer(s)) => {
+                assert_eq!(s.value.prompt.value, "Analyze carefully");
+                assert!(s.value.content.is_some());
+            }
+            other => panic!("expected Some(Infer), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_infer_shorthand_still_works() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: shorthand
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: t
+    infer: "Just a simple prompt"
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_ok());
+        let wf = result.unwrap();
+        match &wf.tasks.value[0].value.action {
+            Some(RawTaskAction::Infer(s)) => {
+                assert_eq!(s.value.prompt.value, "Just a simple prompt");
+                assert!(s.value.content.is_none());
+            }
+            other => panic!("expected Some(Infer), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_infer_neither_prompt_nor_content_errors() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: err
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: t
+    infer:
+      temperature: 0.5
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "neither prompt nor content should fail");
+        let err = result.unwrap_err();
+        assert!(err.message.contains("prompt") || err.message.contains("content"));
+    }
+
+    #[test]
+    fn parse_infer_content_invalid_type_errors() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: err
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: t
+    infer:
+      content:
+        - type: video
+          url: "https://example.com"
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "unknown content type should fail");
+        let err = result.unwrap_err();
+        assert!(err.message.contains("unknown content part type"));
+    }
+
+    #[test]
+    fn parse_infer_content_empty_sequence_errors() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: err
+provider: claude
+model: claude-sonnet-4-6
+tasks:
+  - id: t
+    infer:
+      content: []
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_err(), "empty content should fail");
+    }
+
+    #[test]
+    fn parse_infer_content_image_url_part() {
+        let yaml = r#"
+schema: "nika/workflow@0.12"
+workflow: url
+provider: openai
+model: gpt-4o
+tasks:
+  - id: t
+    infer:
+      content:
+        - type: image_url
+          url: "https://example.com/photo.jpg"
+          detail: low
+        - type: text
+          text: "What is in this photo?"
+"#;
+        let result = parse(yaml, FileId(0));
+        assert!(result.is_ok(), "image_url should parse: {:?}", result.err());
+    }
+}

--- a/tools/nika-core/src/ast/raw/task.rs
+++ b/tools/nika-core/src/ast/raw/task.rs
@@ -1,0 +1,197 @@
+//! Raw task AST with all fields as Spanned.
+
+use indexmap::IndexMap;
+
+use super::action::RawTaskAction;
+use crate::ast::decompose::DecomposeSpec;
+use crate::ast::structured::StructuredOutputSpec;
+use crate::source::{Span, Spanned};
+
+/// A raw task as parsed from YAML.
+///
+/// All string references (task IDs, aliases) are unresolved.
+/// Resolution happens in Phase 2 (analyzed AST).
+///
+#[derive(Debug, Clone, Default)]
+pub struct RawTask {
+    /// Task identifier (must be unique within workflow)
+    pub id: Spanned<String>,
+
+    /// Human-readable description
+    pub description: Option<Spanned<String>>,
+
+    /// The action this task performs (infer, exec, fetch, invoke, agent)
+    pub action: Option<RawTaskAction>,
+
+    /// Task-specific provider override
+    pub provider: Option<Spanned<String>>,
+
+    /// Task-specific model override
+    pub model: Option<Spanned<String>>,
+
+    /// Binding declarations: `with: { alias: "expression" }`
+    ///
+    /// Values are raw strings that get parsed by `parse_with_entry()` in Phase 2.
+    /// Examples:
+    ///   - `data: step1` — simple task reference
+    ///   - `temp: step1.data.temp ?? 20` — path + default
+    ///   - `cfg: $env.API_KEY` — environment binding
+    ///   - `val: step1.output | upper | trim` — with transforms
+    pub with_refs: Option<Spanned<IndexMap<Spanned<String>, Spanned<String>>>>,
+
+    /// Explicit ordering dependencies: `depends_on: [task_id1, task_id2]`
+    ///
+    /// These are pure ordering edges — no data flows through them.
+    /// Data dependencies are expressed via `with:` bindings.
+    pub depends_on: Option<Spanned<Vec<Spanned<String>>>>,
+
+    /// Output configuration
+    pub output: Option<Spanned<RawOutputConfig>>,
+
+    /// For-each iteration
+    pub for_each: Option<Spanned<RawForEach>>,
+
+    /// Retry configuration
+    pub retry: Option<Spanned<RawRetryConfig>>,
+
+    /// Decompose modifier for runtime DAG expansion
+    pub decompose: Option<Spanned<DecomposeSpec>>,
+
+    /// Standalone concurrency (used with decompose when no for_each)
+    pub concurrency: Option<Spanned<u32>>,
+
+    /// Standalone fail_fast (used with decompose when no for_each)
+    pub fail_fast: Option<Spanned<bool>>,
+
+    /// Structured output specification (JSON schema enforcement)
+    pub structured: Option<StructuredOutputSpec>,
+
+    /// Artifact output configuration (persists task output to files)
+    pub artifact: Option<Spanned<serde_json::Value>>,
+
+    /// Log configuration override for this task
+    pub log: Option<Spanned<serde_json::Value>>,
+
+    /// The span of the entire task block
+    pub span: Span,
+}
+
+/// Output configuration for a task.
+#[derive(Debug, Clone, Default)]
+pub struct RawOutputConfig {
+    /// Output format: text, json, yaml
+    pub format: Option<Spanned<String>>,
+    /// JSON Schema for validation
+    pub schema: Option<Spanned<serde_json::Value>>,
+    /// Schema reference: file path or inline
+    pub schema_ref: Option<Spanned<String>>,
+}
+
+/// For-each iteration configuration.
+#[derive(Debug, Clone, Default)]
+pub struct RawForEach {
+    /// Items expression: "$task_id" or "{{...}}"
+    pub items: Spanned<String>,
+    /// Loop variable name (default: "item")
+    pub as_var: Option<Spanned<String>>,
+    /// Maximum parallelism
+    pub parallel: Option<Spanned<u32>>,
+    /// Stop all iterations on first error (default: true)
+    pub fail_fast: Option<Spanned<bool>>,
+}
+
+/// Retry configuration.
+#[derive(Debug, Clone, Default)]
+pub struct RawRetryConfig {
+    /// Maximum retry attempts
+    pub max_attempts: Option<Spanned<u32>>,
+    /// Delay between retries in milliseconds
+    pub delay_ms: Option<Spanned<u64>>,
+    /// Exponential backoff multiplier
+    pub backoff: Option<Spanned<f64>>,
+}
+
+impl RawTask {
+    /// Create a new raw task with the given ID.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: Spanned::dummy(id.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Check if this task has any dependencies (with: or depends_on:).
+    pub fn has_dependencies(&self) -> bool {
+        self.with_refs
+            .as_ref()
+            .map(|w| !w.value.is_empty())
+            .unwrap_or(false)
+            || self
+                .depends_on
+                .as_ref()
+                .map(|d| !d.value.is_empty())
+                .unwrap_or(false)
+    }
+
+    /// Get all explicit depends_on task IDs.
+    pub fn depends_on_ids(&self) -> Vec<&str> {
+        match &self.depends_on {
+            Some(deps) => deps.value.iter().map(|s| s.value.as_str()).collect(),
+            None => vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::FileId;
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    #[test]
+    fn test_raw_task_new() {
+        let task = RawTask::new("my-task");
+        assert_eq!(task.id.value, "my-task");
+        assert!(!task.has_dependencies());
+    }
+
+    #[test]
+    fn test_task_has_dependencies_with() {
+        let mut task = RawTask::new("consumer");
+
+        let mut with_refs = IndexMap::new();
+        with_refs.insert(
+            Spanned::new("data".to_string(), make_span(0, 4)),
+            Spanned::new("producer".to_string(), make_span(6, 14)),
+        );
+        task.with_refs = Some(Spanned::new(with_refs, make_span(0, 20)));
+
+        assert!(task.has_dependencies());
+    }
+
+    #[test]
+    fn test_task_has_dependencies_depends_on() {
+        let mut task = RawTask::new("consumer");
+
+        task.depends_on = Some(Spanned::new(
+            vec![
+                Spanned::new("setup".to_string(), make_span(0, 5)),
+                Spanned::new("init".to_string(), make_span(7, 11)),
+            ],
+            make_span(0, 15),
+        ));
+
+        assert!(task.has_dependencies());
+        assert_eq!(task.depends_on_ids(), vec!["setup", "init"]);
+    }
+
+    #[test]
+    fn test_task_depends_on_empty() {
+        let task = RawTask::new("standalone");
+        assert!(task.depends_on_ids().is_empty());
+        assert!(!task.has_dependencies());
+    }
+}

--- a/tools/nika-core/src/ast/raw/workflow.rs
+++ b/tools/nika-core/src/ast/raw/workflow.rs
@@ -1,0 +1,189 @@
+//! Raw workflow AST - directly parsed from YAML with spans.
+
+use indexmap::IndexMap;
+
+use super::mcp::RawMcpConfig;
+use super::task::RawTask;
+use crate::source::{Span, Spanned};
+
+/// Raw workflow as parsed from YAML.
+///
+/// All fields preserve source positions via `Spanned<T>`.
+/// This is Phase 1 of the Two-Phase IR - no validation, just structure.
+#[derive(Debug, Clone, Default)]
+pub struct RawWorkflow {
+    /// Schema version: "nika/workflow@0.12"
+    pub schema: Spanned<String>,
+
+    /// Workflow identifier (optional in YAML, defaults to filename)
+    pub workflow: Option<Spanned<String>>,
+
+    /// Optional description
+    pub description: Option<Spanned<String>>,
+
+    /// Default provider (e.g., "claude", "openai")
+    pub provider: Option<Spanned<String>>,
+
+    /// Default model (e.g., "claude-sonnet-4-6")
+    pub model: Option<Spanned<String>>,
+
+    /// MCP server configuration
+    pub mcp: Option<Spanned<RawMcpConfig>>,
+
+    /// Package includes: pkg: { include: [...] }
+    pub pkg: Option<Spanned<RawPkgConfig>>,
+
+    /// Context files configuration
+    pub context: Option<Spanned<RawContextConfig>>,
+
+    /// Import external workflows/modules
+    ///
+    /// ```yaml
+    /// imports:
+    ///   - path: ./partials/setup.nika.yaml
+    ///     prefix: setup_
+    ///   - path: pkg:@spn/core@1.0/seo.nika.yaml
+    /// ```
+    pub imports: Option<Spanned<Vec<Spanned<RawImportSpec>>>>,
+
+    /// Input parameters with defaults
+    pub inputs: Option<Spanned<IndexMap<Spanned<String>, Spanned<serde_json::Value>>>>,
+
+    /// Artifact output configuration
+    pub artifacts: Option<Spanned<serde_json::Value>>,
+
+    /// Log configuration
+    pub log: Option<Spanned<serde_json::Value>>,
+
+    /// Reusable agent definitions
+    pub agents: Option<Spanned<serde_json::Value>>,
+
+    /// Task definitions (order matters for implicit flow)
+    pub tasks: Spanned<Vec<Spanned<RawTask>>>,
+
+    /// The span of the entire workflow document
+    pub span: Span,
+}
+
+/// Raw package configuration.
+#[derive(Debug, Clone, Default)]
+pub struct RawPkgConfig {
+    /// Included package specs: ["github:user/repo", "local:./path"]
+    pub include: Vec<Spanned<String>>,
+}
+
+/// Raw context configuration for file loading.
+#[derive(Debug, Clone, Default)]
+pub struct RawContextConfig {
+    /// File bindings: alias -> path
+    pub files: Option<IndexMap<Spanned<String>, Spanned<String>>>,
+}
+
+/// Raw import specification.
+///
+/// Replaces both `include:` (DAG fusion) and `skills:` (prompt injection).
+#[derive(Debug, Clone, Default)]
+pub struct RawImportSpec {
+    /// Path to the imported workflow or skill file.
+    /// Supports local paths and `pkg:` URIs.
+    pub path: Spanned<String>,
+
+    /// Optional task ID prefix for namespace isolation.
+    /// When set, all imported task IDs get this prefix.
+    pub prefix: Option<Spanned<String>>,
+
+    /// Span of the entire import spec
+    pub span: Span,
+}
+
+impl RawWorkflow {
+    /// Create a new empty raw workflow.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get the workflow name, falling back to "unnamed".
+    pub fn name(&self) -> &str {
+        self.workflow
+            .as_ref()
+            .map(|s| s.value.as_str())
+            .unwrap_or("unnamed")
+    }
+
+    /// Get the number of tasks.
+    pub fn task_count(&self) -> usize {
+        self.tasks.value.len()
+    }
+
+    /// Iterate over tasks.
+    pub fn iter_tasks(&self) -> impl Iterator<Item = &Spanned<RawTask>> {
+        self.tasks.value.iter()
+    }
+
+    /// Get a task by ID (linear search - Phase 2 uses interned IDs).
+    pub fn get_task(&self, id: &str) -> Option<&Spanned<RawTask>> {
+        self.tasks.value.iter().find(|t| t.value.id.value == id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::{FileId, Span};
+
+    fn make_span(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end)
+    }
+
+    #[test]
+    fn test_raw_workflow_default() {
+        let workflow = RawWorkflow::default();
+        assert_eq!(workflow.task_count(), 0);
+        assert_eq!(workflow.name(), "unnamed");
+    }
+
+    #[test]
+    fn test_raw_workflow_with_tasks() {
+        use super::super::task::RawTask;
+
+        let mut workflow = RawWorkflow::new();
+        workflow.workflow = Some(Spanned::new("test-workflow".to_string(), make_span(0, 13)));
+        workflow.tasks = Spanned::new(
+            vec![
+                Spanned::new(
+                    RawTask {
+                        id: Spanned::new("task1".to_string(), make_span(20, 25)),
+                        ..Default::default()
+                    },
+                    make_span(18, 50),
+                ),
+                Spanned::new(
+                    RawTask {
+                        id: Spanned::new("task2".to_string(), make_span(60, 65)),
+                        ..Default::default()
+                    },
+                    make_span(58, 90),
+                ),
+            ],
+            make_span(15, 95),
+        );
+
+        assert_eq!(workflow.task_count(), 2);
+        assert_eq!(workflow.name(), "test-workflow");
+        assert!(workflow.get_task("task1").is_some());
+        assert!(workflow.get_task("task2").is_some());
+        assert!(workflow.get_task("task3").is_none());
+    }
+
+    #[test]
+    fn test_raw_import_spec() {
+        let import = RawImportSpec {
+            path: Spanned::new("./partials/setup.nika.yaml".to_string(), make_span(0, 25)),
+            prefix: Some(Spanned::new("setup_".to_string(), make_span(30, 36))),
+            span: make_span(0, 40),
+        };
+
+        assert_eq!(import.path.value, "./partials/setup.nika.yaml");
+        assert_eq!(import.prefix.as_ref().unwrap().value, "setup_");
+    }
+}

--- a/tools/nika-core/src/ast/schema.rs
+++ b/tools/nika-core/src/ast/schema.rs
@@ -1,0 +1,292 @@
+//! Schema version definitions for Nika workflows.
+//!
+//! This module owns the `SchemaVersion` enum which is shared across
+//! the AST pipeline — used by both the analyzer (Phase 2) and the
+//! analyzed AST types.
+//!
+//! Extracted from `analyzed/workflow.rs` so that it can be imported
+//! without pulling in the full analyzed AST.
+
+/// Validated schema version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaVersion {
+    /// nika/workflow@0.1
+    V01,
+    /// nika/workflow@0.2
+    V02,
+    /// nika/workflow@0.3
+    V03,
+    /// nika/workflow@0.4
+    V04,
+    /// nika/workflow@0.5
+    V05,
+    /// nika/workflow@0.6
+    V06,
+    /// nika/workflow@0.7
+    V07,
+    /// nika/workflow@0.8
+    V08,
+    /// nika/workflow@0.9
+    V09,
+    /// nika/workflow@0.10
+    V10,
+    /// nika/workflow@0.11
+    V11,
+    /// nika/workflow@0.12
+    V12,
+}
+
+impl SchemaVersion {
+    /// Parse a schema version string.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "nika/workflow@0.1" => Some(Self::V01),
+            "nika/workflow@0.2" => Some(Self::V02),
+            "nika/workflow@0.3" => Some(Self::V03),
+            "nika/workflow@0.4" => Some(Self::V04),
+            "nika/workflow@0.5" => Some(Self::V05),
+            "nika/workflow@0.6" => Some(Self::V06),
+            "nika/workflow@0.7" => Some(Self::V07),
+            "nika/workflow@0.8" => Some(Self::V08),
+            "nika/workflow@0.9" => Some(Self::V09),
+            "nika/workflow@0.10" => Some(Self::V10),
+            "nika/workflow@0.11" => Some(Self::V11),
+            "nika/workflow@0.12" => Some(Self::V12),
+            _ => None,
+        }
+    }
+
+    /// Get the string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::V01 => "nika/workflow@0.1",
+            Self::V02 => "nika/workflow@0.2",
+            Self::V03 => "nika/workflow@0.3",
+            Self::V04 => "nika/workflow@0.4",
+            Self::V05 => "nika/workflow@0.5",
+            Self::V06 => "nika/workflow@0.6",
+            Self::V07 => "nika/workflow@0.7",
+            Self::V08 => "nika/workflow@0.8",
+            Self::V09 => "nika/workflow@0.9",
+            Self::V10 => "nika/workflow@0.10",
+            Self::V11 => "nika/workflow@0.11",
+            Self::V12 => "nika/workflow@0.12",
+        }
+    }
+
+    /// Get all valid schema versions.
+    pub fn all() -> &'static [Self] {
+        &[
+            Self::V01,
+            Self::V02,
+            Self::V03,
+            Self::V04,
+            Self::V05,
+            Self::V06,
+            Self::V07,
+            Self::V08,
+            Self::V09,
+            Self::V10,
+            Self::V11,
+            Self::V12,
+        ]
+    }
+
+    /// Get the latest schema version.
+    pub fn latest() -> Self {
+        Self::V12
+    }
+
+    /// Get the numeric version for comparison (e.g., V03 returns 3).
+    pub fn version_number(&self) -> u32 {
+        match self {
+            Self::V01 => 1,
+            Self::V02 => 2,
+            Self::V03 => 3,
+            Self::V04 => 4,
+            Self::V05 => 5,
+            Self::V06 => 6,
+            Self::V07 => 7,
+            Self::V08 => 8,
+            Self::V09 => 9,
+            Self::V10 => 10,
+            Self::V11 => 11,
+            Self::V12 => 12,
+        }
+    }
+
+    /// Check if a version supports a minimum required version.
+    pub fn supports(&self, min_version: Self) -> bool {
+        self.version_number() >= min_version.version_number()
+    }
+
+    /// Get a migration hint for upgrading from this schema version.
+    ///
+    /// Returns None for the latest version.
+    pub fn migration_hint(&self) -> Option<&'static str> {
+        match self {
+            Self::V01 => Some("@0.2 adds MCP servers, invoke: and agent: verbs"),
+            Self::V02 => Some("@0.3 adds for_each iteration and retry config"),
+            Self::V03 => Some("@0.4 adds decompose and structured output"),
+            Self::V04 => Some("@0.5 adds extended thinking and output format"),
+            Self::V05 => Some("@0.6 adds agents: definitions and skills:"),
+            Self::V06 => Some("@0.7 adds log: config and catch: error handling"),
+            Self::V07 => Some("@0.8 adds fetch: verb improvements"),
+            Self::V08 => Some("@0.9 adds context: files and imports:"),
+            Self::V09 => Some("@0.10 adds inputs: with defaults and artifacts:"),
+            Self::V10 => Some("@0.11 adds with: bindings replacing include:"),
+            Self::V11 => Some("@0.12 adds depends_on:, imports:, and ?? fallback operator"),
+            Self::V12 => None,
+        }
+    }
+
+    /// Check if MCP servers are supported.
+    pub fn supports_mcp(&self) -> bool {
+        self.supports(Self::V02)
+    }
+
+    /// Check if invoke/agent verbs are supported.
+    pub fn supports_invoke_agent(&self) -> bool {
+        self.supports(Self::V02)
+    }
+
+    /// Check if for_each is supported.
+    pub fn supports_for_each(&self) -> bool {
+        self.supports(Self::V03)
+    }
+
+    /// Check if skills are supported.
+    pub fn supports_skills(&self) -> bool {
+        self.supports(Self::V06)
+    }
+
+    /// Check if agent definitions are supported.
+    pub fn supports_agent_defs(&self) -> bool {
+        self.supports(Self::V06)
+    }
+
+    /// Check if context files are supported.
+    pub fn supports_context(&self) -> bool {
+        self.supports(Self::V09)
+    }
+
+    /// Check if include/DAG fusion is supported.
+    pub fn supports_include(&self) -> bool {
+        self.supports(Self::V09)
+    }
+
+    /// Check if inputs are supported.
+    pub fn supports_inputs(&self) -> bool {
+        self.supports(Self::V10)
+    }
+
+    /// Check if artifacts are supported.
+    pub fn supports_artifacts(&self) -> bool {
+        self.supports(Self::V10)
+    }
+
+    /// Check if retry configuration is supported.
+    pub fn supports_retry(&self) -> bool {
+        self.supports(Self::V03)
+    }
+
+    /// Check if with: binding syntax is supported.
+    pub fn supports_with(&self) -> bool {
+        self.supports(Self::V12)
+    }
+
+    /// Check if imports: syntax is supported.
+    pub fn supports_imports(&self) -> bool {
+        self.supports(Self::V12)
+    }
+
+    /// Check if depends_on: syntax is supported.
+    pub fn supports_depends_on(&self) -> bool {
+        self.supports(Self::V12)
+    }
+}
+
+impl std::fmt::Display for SchemaVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_schema_version_parse() {
+        assert_eq!(
+            SchemaVersion::parse("nika/workflow@0.1"),
+            Some(SchemaVersion::V01)
+        );
+        assert_eq!(
+            SchemaVersion::parse("nika/workflow@0.12"),
+            Some(SchemaVersion::V12)
+        );
+        assert_eq!(SchemaVersion::parse("invalid"), None);
+        assert_eq!(SchemaVersion::parse("nika/workflow@0.99"), None);
+    }
+
+    #[test]
+    fn test_schema_version_latest() {
+        assert_eq!(SchemaVersion::latest(), SchemaVersion::V12);
+        assert_eq!(SchemaVersion::latest().as_str(), "nika/workflow@0.12");
+    }
+
+    #[test]
+    fn test_schema_version_number() {
+        assert_eq!(SchemaVersion::V01.version_number(), 1);
+        assert_eq!(SchemaVersion::V05.version_number(), 5);
+        assert_eq!(SchemaVersion::V12.version_number(), 12);
+    }
+
+    #[test]
+    fn test_schema_version_supports() {
+        // V01 only supports V01
+        assert!(SchemaVersion::V01.supports(SchemaVersion::V01));
+        assert!(!SchemaVersion::V01.supports(SchemaVersion::V02));
+
+        // V12 supports all versions
+        assert!(SchemaVersion::V12.supports(SchemaVersion::V01));
+        assert!(SchemaVersion::V12.supports(SchemaVersion::V12));
+    }
+
+    #[test]
+    fn test_schema_version_feature_gates() {
+        // MCP requires v0.2+
+        assert!(!SchemaVersion::V01.supports_mcp());
+        assert!(SchemaVersion::V02.supports_mcp());
+        assert!(SchemaVersion::V12.supports_mcp());
+
+        // for_each requires v0.3+
+        assert!(!SchemaVersion::V01.supports_for_each());
+        assert!(!SchemaVersion::V02.supports_for_each());
+        assert!(SchemaVersion::V03.supports_for_each());
+        assert!(SchemaVersion::V12.supports_for_each());
+
+        // skills requires v0.6+
+        assert!(!SchemaVersion::V05.supports_skills());
+        assert!(SchemaVersion::V06.supports_skills());
+        assert!(SchemaVersion::V12.supports_skills());
+
+        // context requires v0.9+
+        assert!(!SchemaVersion::V08.supports_context());
+        assert!(SchemaVersion::V09.supports_context());
+        assert!(SchemaVersion::V12.supports_context());
+
+        // inputs requires v0.10+
+        assert!(!SchemaVersion::V09.supports_inputs());
+        assert!(SchemaVersion::V10.supports_inputs());
+
+        // with:/imports:/depends_on: require v0.12+
+        assert!(!SchemaVersion::V11.supports_with());
+        assert!(SchemaVersion::V12.supports_with());
+        assert!(!SchemaVersion::V11.supports_imports());
+        assert!(SchemaVersion::V12.supports_imports());
+        assert!(!SchemaVersion::V11.supports_depends_on());
+        assert!(SchemaVersion::V12.supports_depends_on());
+    }
+}

--- a/tools/nika-core/src/ast/structured.rs
+++ b/tools/nika-core/src/ast/structured.rs
@@ -1,0 +1,340 @@
+//! Structured Output Configuration
+//!
+//! Defines task-level configuration for JSON Schema validation:
+//! - `StructuredOutputSpec`: Schema + layer enables + retry config
+//!
+//! Works with the `StructuredOutputEngine` for ~99.99% compliance.
+
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use super::output::SchemaRef;
+
+/// Structured output configuration for a task
+///
+/// Controls how the StructuredOutputEngine validates and repairs output.
+/// Supports shorthand (just schema path) or full configuration.
+///
+/// # Examples
+///
+/// Shorthand (schema file path):
+/// ```yaml
+/// structured: ./schemas/user.json
+/// ```
+///
+/// Full configuration:
+/// ```yaml
+/// structured:
+///   schema: ./schemas/user.json
+///   max_retries: 3
+///   enable_repair: true
+///   repair_model: claude-sonnet-4-6
+/// ```
+///
+/// Inline schema:
+/// ```yaml
+/// structured:
+///   schema:
+///     type: object
+///     properties:
+///       name:
+///         type: string
+///     required: [name]
+/// ```
+#[derive(Debug, Clone, Serialize)]
+pub struct StructuredOutputSpec {
+    /// JSON Schema reference (inline or file path)
+    pub schema: SchemaRef,
+
+    /// Enable Layer 1: rig Extractor (Rust type extraction)
+    /// Default: true
+    #[serde(default)]
+    pub enable_extractor: Option<bool>,
+
+    /// Enable Layer 0: Tool injection (DynamicSubmitTool)
+    /// When true, injects a synthetic submit_result tool for provider-side
+    /// schema enforcement before falling through to post-processing layers.
+    /// Default: true
+    #[serde(default)]
+    pub enable_tool_injection: Option<bool>,
+
+    /// Enable Layer 3: Retry with feedback
+    /// Default: true
+    #[serde(default)]
+    pub enable_retry: Option<bool>,
+
+    /// Enable Layer 4: LLM repair
+    /// Default: true
+    #[serde(default)]
+    pub enable_repair: Option<bool>,
+
+    /// Maximum retry attempts (Layer 3)
+    /// Default: 2
+    #[serde(default)]
+    pub max_retries: Option<u8>,
+
+    /// Model to use for repair (Layer 4)
+    /// Default: same as task model
+    #[serde(default)]
+    pub repair_model: Option<String>,
+}
+
+impl StructuredOutputSpec {
+    /// Create with a schema reference
+    pub fn with_schema(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            enable_extractor: None,
+            enable_tool_injection: None,
+            enable_retry: None,
+            enable_repair: None,
+            max_retries: None,
+            repair_model: None,
+        }
+    }
+
+    /// Create with an inline JSON schema
+    pub fn with_inline_schema(schema: serde_json::Value) -> Self {
+        Self::with_schema(SchemaRef::Inline(schema))
+    }
+
+    /// Create with a file path
+    pub fn with_file_schema(path: impl Into<String>) -> Self {
+        Self::with_schema(SchemaRef::File(path.into()))
+    }
+
+    /// Get max_retries with default
+    pub fn max_retries_or_default(&self) -> u8 {
+        self.max_retries.unwrap_or(2)
+    }
+
+    /// Check if Layer 2 (tool_use) is enabled
+    pub fn enable_tool_injection_or_default(&self) -> bool {
+        self.enable_tool_injection.unwrap_or(true)
+    }
+
+    /// Check if Layer 3 (retry) is enabled
+    pub fn enable_retry_or_default(&self) -> bool {
+        self.enable_retry.unwrap_or(true)
+    }
+
+    /// Check if Layer 4 (repair) is enabled
+    pub fn enable_repair_or_default(&self) -> bool {
+        self.enable_repair.unwrap_or(true)
+    }
+
+    /// Convert to OutputPolicy for executor Layer 0 dispatch.
+    ///
+    /// The executor's `run_infer()` uses `OutputPolicy` to trigger Layer 0 tool injection
+    /// and prompt schema instructions. This bridges `structured:` config to that path.
+    /// The original spec is preserved in `source_structured_spec` so that
+    /// `to_structured_spec()` can roundtrip without losing layer toggle config.
+    pub fn to_output_policy(&self) -> super::output::OutputPolicy {
+        super::output::OutputPolicy {
+            format: super::output::OutputFormat::Json,
+            schema: Some(self.schema.clone()),
+            max_retries: self.max_retries,
+            source_structured_spec: Some(self.clone()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StructuredOutputSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StructuredOutputSpecVisitor;
+
+        impl<'de> Visitor<'de> for StructuredOutputSpecVisitor {
+            type Value = StructuredOutputSpec;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter
+                    .write_str("a schema path string or structured output configuration object")
+            }
+
+            // Shorthand: `structured: ./schema.json`
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StructuredOutputSpec::with_file_schema(v))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StructuredOutputSpec::with_file_schema(v))
+            }
+
+            // Full form: `structured: { schema: ..., max_retries: ... }`
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut schema: Option<SchemaRef> = None;
+                let mut enable_extractor: Option<bool> = None;
+                let mut enable_tool_injection: Option<bool> = None;
+                let mut enable_retry: Option<bool> = None;
+                let mut enable_repair: Option<bool> = None;
+                let mut max_retries: Option<u8> = None;
+                let mut repair_model: Option<String> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "schema" => {
+                            schema = Some(map.next_value()?);
+                        }
+                        "enable_extractor" => {
+                            enable_extractor = Some(map.next_value()?);
+                        }
+                        // Accept both new and legacy field names
+                        "enable_tool_injection" | "enable_tool_use" => {
+                            enable_tool_injection = Some(map.next_value()?);
+                        }
+                        "enable_retry" => {
+                            enable_retry = Some(map.next_value()?);
+                        }
+                        "enable_repair" => {
+                            enable_repair = Some(map.next_value()?);
+                        }
+                        "max_retries" => {
+                            max_retries = Some(map.next_value()?);
+                        }
+                        "repair_model" => {
+                            repair_model = Some(map.next_value()?);
+                        }
+                        _ => {
+                            // Ignore unknown fields
+                            let _: serde_json::Value = map.next_value()?;
+                        }
+                    }
+                }
+
+                let schema = schema.ok_or_else(|| de::Error::missing_field("schema"))?;
+
+                Ok(StructuredOutputSpec {
+                    schema,
+                    enable_extractor,
+                    enable_tool_injection,
+                    enable_retry,
+                    enable_repair,
+                    max_retries,
+                    repair_model,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(StructuredOutputSpecVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde_yaml;
+
+    #[test]
+    fn parse_shorthand_file_path() {
+        let yaml = "structured: ./schemas/user.json";
+        let spec: StructuredOutputSpec =
+            serde_yaml::from_str(&yaml.replace("structured: ", "")).unwrap();
+        assert!(matches!(spec.schema, SchemaRef::File(ref p) if p == "./schemas/user.json"));
+    }
+
+    #[test]
+    fn parse_full_form_with_file() {
+        let yaml = r#"
+schema: ./schemas/user.json
+max_retries: 3
+enable_repair: false
+"#;
+        let spec: StructuredOutputSpec = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(spec.schema, SchemaRef::File(ref p) if p == "./schemas/user.json"));
+        assert_eq!(spec.max_retries, Some(3));
+        assert_eq!(spec.enable_repair, Some(false));
+    }
+
+    #[test]
+    fn parse_full_form_with_inline_schema() {
+        let yaml = r#"
+schema:
+  type: object
+  properties:
+    name:
+      type: string
+  required:
+    - name
+max_retries: 2
+"#;
+        let spec: StructuredOutputSpec = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(spec.schema, SchemaRef::Inline(_)));
+        assert_eq!(spec.max_retries, Some(2));
+    }
+
+    #[test]
+    fn defaults_are_applied() {
+        let spec = StructuredOutputSpec::with_file_schema("./test.json");
+        assert_eq!(spec.max_retries_or_default(), 2);
+        assert!(spec.enable_tool_injection_or_default());
+        assert!(spec.enable_retry_or_default());
+        assert!(spec.enable_repair_or_default());
+    }
+
+    #[test]
+    fn constructors_work() {
+        let file_spec = StructuredOutputSpec::with_file_schema("./test.json");
+        assert!(matches!(file_spec.schema, SchemaRef::File(_)));
+
+        let inline_spec = StructuredOutputSpec::with_inline_schema(serde_json::json!({
+            "type": "object"
+        }));
+        assert!(matches!(inline_spec.schema, SchemaRef::Inline(_)));
+    }
+
+    #[test]
+    fn parse_with_repair_model() {
+        let yaml = r#"
+schema: ./test.json
+repair_model: claude-sonnet-4-6
+"#;
+        let spec: StructuredOutputSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.repair_model, Some("claude-sonnet-4-6".to_string()));
+    }
+
+    #[test]
+    fn parse_all_layer_toggles() {
+        let yaml = r#"
+schema: ./test.json
+enable_extractor: false
+enable_tool_injection: false
+enable_retry: true
+enable_repair: false
+"#;
+        let spec: StructuredOutputSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.enable_extractor, Some(false));
+        assert_eq!(spec.enable_tool_injection, Some(false));
+        assert_eq!(spec.enable_retry, Some(true));
+        assert_eq!(spec.enable_repair, Some(false));
+    }
+
+    #[test]
+    fn legacy_enable_tool_use_still_works() {
+        let yaml = r#"
+schema: ./test.json
+enable_tool_use: false
+"#;
+        let spec: StructuredOutputSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(spec.enable_tool_injection, Some(false));
+    }
+
+    #[test]
+    fn serialize_to_json() {
+        let spec = StructuredOutputSpec::with_file_schema("./test.json");
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(json.contains("./test.json"));
+    }
+}

--- a/tools/nika-core/src/error.rs
+++ b/tools/nika-core/src/error.rs
@@ -19,4 +19,10 @@ pub enum CoreError {
     /// NIKA-056: Invalid default value in a binding expression.
     #[error("[NIKA-056] Invalid default value '{raw}': {reason}")]
     InvalidDefault { raw: String, reason: String },
+
+    /// Validation error (generic).
+    ///
+    /// Used by AST modules (limits, include) for semantic validation failures.
+    #[error("{reason}")]
+    ValidationError { reason: String },
 }

--- a/tools/nika/docs/plans/LSP-PROGRESS.md
+++ b/tools/nika/docs/plans/LSP-PROGRESS.md
@@ -2,29 +2,34 @@
 
 > Updated by Claude Code after each session.
 
-## Status: BATCH 0 COMPLETE — Starting Batch 1
+## Status: BATCH 1 IN PROGRESS — nika-core extraction done
 
 | Batch | PR | Status | Tests Before | Tests After | Notes |
 |-------|-----|--------|:------------:|:-----------:|-------|
-| **0** | Pre-flight | **DONE** | 6,093 | 6,093 | Docs committed, clippy fixed, nika-lsp synced to v0.34.0 |
-| **0** | PR:vscode-polish | - | - | - | |
-| **0** | PR:benchmarks | - | - | - | |
-| **0** | PR:context-inputs | - | - | - | |
-| **1** | PR:extract-ast | **IN PROGRESS** | 6,093 | - | CRITICAL PATH |
-| **2** | PR:tower-lsp-upgrade | - | - | - | |
-| **2** | PR:foundation | - | - | - | |
-| **3** | PR:error-recovery | - | - | - | |
-| **4** | PR:wire-completion | - | - | - | |
-| **4** | PR:wire-hover | - | - | - | |
-| **4** | PR:wire-definition | - | - | - | |
-| **4** | PR:wire-code-action | - | - | - | |
-| **4** | PR:wire-semantic-tokens | - | - | - | |
-| **4** | PR:wire-symbols | - | - | - | |
-| **5** | PR:handler-migration-delete | - | - | - | |
-| **5** | PR:error-coverage | - | - | - | |
-| **6** | PR:standard-trivial | - | - | - | |
-| **6** | PR:standard-medium | - | - | - | |
-| **6** | PR:standard-hard | - | - | - | |
+| **0** | Pre-flight | **DONE** | 6,093 | 6,093 | Docs, clippy, nika-lsp v0.34.0 sync |
+| **1** | PR:extract-ast | **DONE** | 6,093 | 6,637 | nika-core: 597 tests, nika: 6,040 |
+| **1** | PR:tower-lsp-upgrade | **NEXT** | - | - | tower-lsp 0.20 → tower-lsp-server 0.23 |
+| **2** | PR:foundation | - | - | - | nika-lsp-core + WorldDatabase |
+| **3** | PR:error-recovery | - | - | - | tree-sitter bridge |
+| **4** | PR:wire-* (6 sub-PRs) | - | - | - | Handler migration |
+| **5** | PR:cleanup + errors | - | - | - | Delete old + error coverage |
+| **6** | PR:standard-features | - | - | - | 14 new handlers |
+
+## nika-core Crate Structure
+
+```
+nika-core v0.34.0 (15 deps, zero heavy deps)
+├── source/        — FileId, Span, Spanned<T>, SourceRegistry (12 tests)
+├── catalogs/      — providers (19), models (15), mcp_aliases (48) (41 tests)
+├── binding/       — types, entry (WithSpec), transform (27 ops) (239 tests)
+├── error.rs       — CoreError (InvalidPath, InvalidDefault, ValidationError)
+└── ast/           — Full 3-phase pipeline (305 tests)
+    ├── raw/       — parser, task, workflow, action, mcp
+    ├── analyzed/  — workflow, task, ids
+    ├── analyzer/  — analyze, errors, suggestions
+    └── schema, content, budget, output, decompose, context,
+        logging, limits, include, structured, agent_def, artifact
+```
 
 ## Blockers
 
@@ -34,4 +39,5 @@ None.
 
 | Date | Session | PR | Commits | Duration | Notes |
 |------|---------|-----|---------|----------|-------|
-| 2026-03-19 | S0.0 | Pre-flight | 3 | ~45min | Docs, cargo fmt + 49 clippy fixes, nika-lsp sync to v0.34.0 |
+| 2026-03-19 | S0.0 | Pre-flight | 4 | ~45min | Docs, cargo fmt + 49 clippy fixes, nika-lsp sync |
+| 2026-03-19 | S1.1 | extract-ast | 5 | ~3h | nika-core skeleton, source/, catalogs/, binding/, AST |

--- a/tools/nika/src/provider/rig.rs
+++ b/tools/nika/src/provider/rig.rs
@@ -1334,20 +1334,18 @@ impl RigProvider {
         let mut response_parts: Vec<String> = Vec::new();
         let mut result = StreamResult::default();
 
-        // Build prompt with system message if provided
-        let full_prompt = if let Some(system) = &options.system {
-            format!("{}\n\n{}", system, prompt)
-        } else {
-            prompt.to_string()
-        };
-
         // Helper: build request with options and start streaming
+        // Uses preamble() for system prompt (not string concatenation) to ensure
+        // providers treat it as a system message, not user text.
         macro_rules! build_request_with_options {
             ($client:expr) => {{
                 let model = $client.completion_model(model_id);
                 let mut rb = model
-                    .completion_request(&full_prompt)
+                    .completion_request(prompt)
                     .max_tokens(max_tokens as u64);
+                if let Some(ref system) = options.system {
+                    rb = rb.preamble(system.clone());
+                }
                 if let Some(temp) = options.temperature {
                     rb = rb.temperature(temp);
                 }
@@ -1400,14 +1398,19 @@ impl RigProvider {
                 use futures::StreamExt;
                 use std::pin::pin;
 
-                // Native inference now supports streaming via mistral.rs
+                // Native doesn't support preamble — concatenate system prompt for native only
+                let native_prompt = if let Some(ref system) = options.system {
+                    format!("{}\n\n{}", system, prompt)
+                } else {
+                    prompt.to_string()
+                };
                 let chat_options = super::native::ChatOptions {
                     temperature: options.temperature.map(|t| t as f32),
                     max_tokens: options.max_tokens,
                     ..Default::default()
                 };
                 let stream = runtime
-                    .infer_stream(&full_prompt, chat_options)
+                    .infer_stream(&native_prompt, chat_options)
                     .await
                     .map_err(|e: super::native::NativeError| {
                         RigInferError::PromptError(e.to_string())


### PR DESCRIPTION
## Summary

`infer_stream_with_options` was concatenating system prompt into user prompt via `format!("{}\n\n{}", system, prompt)`, while all other inference methods correctly use `builder.preamble()`. This demoted system instructions to user text, reducing their authority with providers like Claude and OpenAI.

## Found by

Socratic security audit (168 verdicts across 7 files, F4 finding)

## Test plan

- [x] `cargo test --lib -q` — 6040 passed
- [x] Pre-commit hooks passed (fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)