### PR TITLE
fix(event): add missing MediaProcessed + MediaStoreFailed for resource blobs

### DIFF
--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -1331,6 +1331,12 @@ impl TaskExecutor {
                     for result in results {
                         match result {
                             Ok((media_ref, store_result)) => {
+                                self.event_log.emit(EventKind::MediaProcessed {
+                                    task_id: Arc::clone(task_id),
+                                    hash: media_ref.hash.clone(),
+                                    mime_type: media_ref.mime_type.clone(),
+                                    size_bytes: media_ref.size_bytes,
+                                });
                                 self.event_log.emit(EventKind::MediaStored {
                                     task_id: Arc::clone(task_id),
                                     hash: media_ref.hash.clone(),
@@ -1342,8 +1348,13 @@ impl TaskExecutor {
                                 });
                                 media_refs.push(media_ref);
                             }
-                            Err((_, error)) => {
+                            Err((idx, error)) => {
                                 tracing::warn!(task_id = %task_id, error = %error, "Resource blob media processing failed");
+                                self.event_log.emit(EventKind::MediaStoreFailed {
+                                    task_id: Arc::clone(task_id),
+                                    hash: format!("blob_index:{}", idx),
+                                    reason: error.to_string(),
+                                });
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Two telemetry gaps in resource blob processing:
1. Success path: MediaStored without preceding MediaProcessed
2. Error path: only tracing::warn, no MediaStoreFailed event

Found by telemetry gap hunter agent (24 tests, 9 gaps across all verbs).

## Test plan
- [x] 6040 tests passed, pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)