### PR TITLE
feat(media): PR5b — 5 Web Extraction Builtins

### DIFF
--- a/tools/nika/Cargo.lock
+++ b/tools/nika/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "futures-core",
  "mio 1.1.1",
@@ -1622,6 +1622,19 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf 0.11.3",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec 1.15.1",
 ]
 
 [[package]]
@@ -2023,6 +2036,17 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -2163,6 +2187,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e4c03f2421dab1870544d171d3db22bdab0da4015995ff0b2f23125bbda9fb"
+dependencies = [
+ "bit-set 0.8.0",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.38.0",
+ "nom 8.0.0",
+ "precomputed-hash",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
+]
+
+[[package]]
+name = "dom_smoothie"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc8a68d2cb540ae0f9d8602a15f7549cc7addf3b52614d950af1a59c5c8784f"
+dependencies = [
+ "dom_query",
+ "flagset",
+ "foldhash 0.2.0",
+ "gjson",
+ "html-escape",
+ "once_cell",
+ "phf 0.13.1",
+ "tendril 0.5.0",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2703,6 +2761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gjson"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "htmd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3283c6ef7b7af1e31cf13e9ce70ef2577c5a33a880bb80b3aaf791adfcc9a3"
+dependencies = [
+ "html5ever 0.36.1",
+ "markup5ever_rcdom",
+ "phf 0.13.1",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3518,18 @@ dependencies = [
  "tendril 0.5.0",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.1",
+ "match_token",
 ]
 
 [[package]]
@@ -4556,6 +4649,20 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
@@ -4574,6 +4681,29 @@ dependencies = [
  "log",
  "tendril 0.5.0",
  "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.36.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5fc8802e8797c0dfdd2ce5c21aa0aee21abbc7b3b18559100651b3352a7b63"
+dependencies = [
+ "html5ever 0.36.1",
+ "markup5ever 0.36.1",
+ "tendril 0.4.3",
+ "xml5ever",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4824,7 +4954,7 @@ dependencies = [
  "clap",
  "csv",
  "derive-new",
- "derive_more",
+ "derive_more 2.1.1",
  "dirs 6.0.0",
  "either",
  "float8",
@@ -4868,7 +4998,7 @@ dependencies = [
  "rustfft",
  "safetensors",
  "schemars 1.2.1",
- "scraper",
+ "scraper 0.25.0",
  "serde",
  "serde-big-array",
  "serde-saphyr 0.0.16",
@@ -5098,6 +5228,7 @@ dependencies = [
  "crossterm 0.29.0",
  "dashmap 6.1.0",
  "dirs 5.0.1",
+ "dom_smoothie",
  "dotenvy",
  "dssim-core",
  "fast_image_resize",
@@ -5106,6 +5237,7 @@ dependencies = [
  "futures",
  "git2",
  "globset",
+ "htmd",
  "humantime",
  "ignore",
  "image",
@@ -5133,6 +5265,7 @@ dependencies = [
  "petgraph",
  "pretty_assertions",
  "proptest",
+ "psl",
  "qrcode",
  "qrcode-ai-scanner-core",
  "rand 0.8.5",
@@ -5146,6 +5279,7 @@ dependencies = [
  "rig-core",
  "rmcp",
  "rustc-hash 2.1.1",
+ "scraper 0.22.0",
  "secrecy",
  "semver",
  "serde",
@@ -5191,6 +5325,7 @@ dependencies = [
 name = "nika-core"
 version = "0.34.0"
 dependencies = [
+ "chrono",
  "indexmap 2.13.0",
  "jsonschema",
  "marked-yaml",
@@ -5204,6 +5339,7 @@ dependencies = [
  "strsim 0.11.1",
  "thiserror 1.0.69",
  "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -6403,6 +6539,21 @@ dependencies = [
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b63978a2742d3f662188698ab45854156e7e34658f53fa951e9253a3dfd583"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pulp"
@@ -7729,16 +7880,31 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+dependencies = [
+ "cssparser 0.34.0",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.29.1",
+ "precomputed-hash",
+ "selectors 0.26.0",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "scraper"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
 dependencies = [
- "cssparser",
+ "cssparser 0.36.0",
  "ego-tree",
  "getopts",
  "html5ever 0.36.1",
  "precomputed-hash",
- "selectors",
+ "selectors 0.33.0",
  "tendril 0.4.3",
 ]
 
@@ -7810,13 +7976,51 @@ dependencies = [
 
 [[package]]
 name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.34.0",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec 1.15.1",
+]
+
+[[package]]
+name = "selectors"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
 dependencies = [
  "bitflags 2.11.0",
- "cssparser",
- "derive_more",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.1",
+ "servo_arc",
+ "smallvec 1.15.1",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
@@ -8519,6 +8723,19 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -8527,6 +8744,18 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -10307,8 +10536,8 @@ checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -11182,6 +11411,16 @@ name = "xml-no-std"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
+
+[[package]]
+name = "xml5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f57dd51b88a4b9f99f9b55b136abb86210629d61c48117ddb87f567e51e66be7"
+dependencies = [
+ "log",
+ "markup5ever 0.36.1",
+]
 
 [[package]]
 name = "xmlwriter"

--- a/tools/nika/Cargo.toml
+++ b/tools/nika/Cargo.toml
@@ -42,6 +42,11 @@ media-provenance = ["dep:c2pa"]
 media-qr = ["dep:qrcode-ai-scanner-core", "dep:image"]
 media-compression = ["dep:zstd"]
 media-iqa = ["dep:dssim-core", "dep:rgb", "dep:image"]
+# PR5b features — Web extraction builtins
+fetch-html = ["dep:scraper", "dep:psl"]
+fetch-markdown = ["dep:htmd"]
+fetch-article = ["dep:dom_smoothie", "dep:scraper"]
+fetch-extract = ["fetch-html", "fetch-markdown"]
 
 [dependencies]
 # Core AST and analysis (protocol-agnostic)
@@ -218,6 +223,12 @@ qrcode-ai-scanner-core = { version = "0.2", optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
 dssim-core = { version = "3.4", optional = true }
 rgb = { version = "0.8", optional = true }
+
+# Web extraction tools — PR5b
+scraper = { version = "0.22", optional = true, features = ["atomic"] }
+htmd = { version = "0.5", optional = true }
+dom_smoothie = { version = "0.16", optional = true }
+psl = { version = "2", optional = true }
 
 # Logging
 tracing = "0.1"

--- a/tools/nika/src/runtime/builtin/media/css_select.rs
+++ b/tools/nika/src/runtime/builtin/media/css_select.rs
@@ -1,0 +1,440 @@
+//! nika:css_select — CSS selector extraction from HTML content.
+//!
+//! Accepts a CAS hash or raw HTML string and a CSS selector.
+//! Returns matching elements as text or HTML fragments.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::context::MediaToolContext;
+use super::error::invalid_args;
+use super::{MediaOp, MediaOpResult};
+use crate::error::NikaError;
+
+/// Maximum HTML input size: 10 MB.
+const MAX_HTML_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum number of matches to return (prevents unbounded output).
+const MAX_MATCHES: usize = 1000;
+
+pub struct CssSelectOp;
+
+impl MediaOp for CssSelectOp {
+    fn name(&self) -> &'static str {
+        "css_select"
+    }
+
+    fn description(&self) -> &'static str {
+        "Extract elements from HTML using CSS selectors (returns text or HTML fragments)"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+          "type": "object",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "CAS hash of HTML content (blake3:...)"
+            },
+            "html": {
+              "type": "string",
+              "description": "Raw HTML string to query"
+            },
+            "selector": {
+              "type": "string",
+              "description": "CSS selector (e.g., 'div.product h2', '#main a')"
+            },
+            "output": {
+              "type": "string",
+              "enum": ["text", "html"],
+              "description": "Output mode: 'text' (default) extracts text content, 'html' returns HTML fragments",
+              "default": "text"
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of matches to return (default: 1000)",
+              "default": 1000
+            }
+          },
+          "required": ["selector"],
+          "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: &'a MediaToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<MediaOpResult, NikaError>> + Send + 'a>> {
+        Box::pin(async move {
+            ctx.check_cancelled()?;
+
+            let selector_str = args
+                .get("selector")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| invalid_args("css_select", "missing 'selector' parameter"))?
+                .to_string();
+
+            let output_mode = args
+                .get("output")
+                .and_then(|v| v.as_str())
+                .unwrap_or("text")
+                .to_string();
+
+            if output_mode != "text" && output_mode != "html" {
+                return Err(invalid_args(
+                    "css_select",
+                    format!("invalid output mode '{output_mode}', expected 'text' or 'html'"),
+                ));
+            }
+
+            let limit = args
+                .get("limit")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(MAX_MATCHES as u64)
+                .min(MAX_MATCHES as u64) as usize;
+
+            let html = resolve_html(&args, ctx).await?;
+
+            // Parse and select on the compute pool (can be CPU-intensive)
+            let matches = ctx
+                .compute
+                .compute(move || -> Result<Vec<String>, NikaError> {
+                    let document = scraper::Html::parse_document(&html);
+
+                    let selector = scraper::Selector::parse(&selector_str).map_err(|e| {
+                        invalid_args(
+                            "css_select",
+                            format!("invalid CSS selector '{selector_str}': {e}"),
+                        )
+                    })?;
+
+                    let results: Vec<String> = document
+                        .select(&selector)
+                        .take(limit)
+                        .map(|el| {
+                            if output_mode == "html" {
+                                el.html()
+                            } else {
+                                el.text().collect::<Vec<_>>().join("")
+                            }
+                        })
+                        .collect();
+
+                    Ok(results)
+                })
+                .await??;
+
+            let count = matches.len();
+
+            Ok(MediaOpResult::Metadata(serde_json::json!({
+              "matches": matches,
+              "count": count
+            })))
+        })
+    }
+}
+
+/// Resolve HTML content from either a CAS hash or raw HTML string.
+async fn resolve_html(
+    args: &serde_json::Value,
+    ctx: &MediaToolContext,
+) -> Result<String, NikaError> {
+    if let Some(hash) = args.get("hash").and_then(|v| v.as_str()) {
+        let data = ctx.read_media(hash).await?;
+        if data.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "css_select",
+                format!(
+                    "HTML content too large ({} bytes, max {} bytes)",
+                    data.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        String::from_utf8(data).map_err(|_| {
+            invalid_args(
+                "css_select",
+                "CAS content is not valid UTF-8 (expected HTML)",
+            )
+        })
+    } else if let Some(html) = args.get("html").and_then(|v| v.as_str()) {
+        if html.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "css_select",
+                format!(
+                    "HTML string too large ({} bytes, max {} bytes)",
+                    html.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        Ok(html.to_string())
+    } else {
+        Err(invalid_args(
+            "css_select",
+            "missing 'hash' or 'html' parameter",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::CasStore;
+    use std::sync::Arc;
+
+    async fn setup() -> (tempfile::TempDir, Arc<MediaToolContext>) {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = Arc::new(MediaToolContext::new(CasStore::new(dir.path())));
+        (dir, ctx)
+    }
+
+    const SAMPLE_HTML: &str = r#"
+        <html>
+        <body>
+            <h1 id="title">Main Title</h1>
+            <div class="product">
+                <h2>Product A</h2>
+                <p class="price">$10</p>
+            </div>
+            <div class="product">
+                <h2>Product B</h2>
+                <p class="price">$20</p>
+            </div>
+            <ul>
+                <li>Item 1</li>
+                <li>Item 2</li>
+            </ul>
+        </body>
+        </html>
+    "#;
+
+    #[tokio::test]
+    async fn select_by_tag() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": SAMPLE_HTML, "selector": "h2"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 2);
+            assert_eq!(matches[0], "Product A");
+            assert_eq!(matches[1], "Product B");
+            assert_eq!(v["count"], 2);
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_by_class() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": SAMPLE_HTML, "selector": ".price"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 2);
+            assert_eq!(matches[0], "$10");
+            assert_eq!(matches[1], "$20");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_by_id() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": SAMPLE_HTML, "selector": "#title"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 1);
+            assert_eq!(matches[0], "Main Title");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_nested() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": SAMPLE_HTML, "selector": "div.product h2"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 2);
+            assert_eq!(matches[0], "Product A");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_text_mode() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": SAMPLE_HTML,
+                    "selector": ".product",
+                    "output": "text"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 2);
+            let text = matches[0].as_str().unwrap();
+            assert!(
+                text.contains("Product A"),
+                "text should contain title: {text}"
+            );
+            assert!(text.contains("$10"), "text should contain price: {text}");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_html_mode() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": SAMPLE_HTML,
+                    "selector": "li",
+                    "output": "html"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 2);
+            let html = matches[0].as_str().unwrap();
+            assert!(
+                html.contains("<li>"),
+                "html mode should include tags: {html}"
+            );
+            assert!(html.contains("Item 1"), "html should contain text: {html}");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_invalid_selector() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": SAMPLE_HTML, "selector": "!!!invalid"}),
+                &ctx,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn select_no_matches() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": SAMPLE_HTML, "selector": "span.nonexistent"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert!(matches.is_empty());
+            assert_eq!(v["count"], 0);
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_missing_selector_param() {
+        let (_dir, ctx) = setup().await;
+        let op = CssSelectOp;
+        let result = op
+            .execute(serde_json::json!({"html": "<p>test</p>"}), &ctx)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn select_from_cas_hash() {
+        let (_dir, ctx) = setup().await;
+        let sr = ctx.cas.store(SAMPLE_HTML.as_bytes()).await.unwrap();
+
+        let op = CssSelectOp;
+        let result = op
+            .execute(serde_json::json!({"hash": sr.hash, "selector": "h1"}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let matches = v["matches"].as_array().unwrap();
+            assert_eq!(matches.len(), 1);
+            assert_eq!(matches[0], "Main Title");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn select_cancelled() {
+        let (_dir, ctx) = setup().await;
+        ctx.cancel.cancel();
+        let op = CssSelectOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": "<p>x</p>", "selector": "p"}),
+                &ctx,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+    }
+}

--- a/tools/nika/src/runtime/builtin/media/extract_links.rs
+++ b/tools/nika/src/runtime/builtin/media/extract_links.rs
@@ -1,0 +1,652 @@
+//! nika:extract_links — Rich SEO link classification from HTML.
+//!
+//! Classifies links by DOM context (nav, header, footer, content, sidebar),
+//! internal vs external (via eTLD+1 comparison), and extracts rel attributes,
+//! anchor text, dofollow/nofollow status.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::context::MediaToolContext;
+use super::error::{invalid_args, tool_error};
+use super::{MediaOp, MediaOpResult};
+use crate::error::NikaError;
+
+/// Maximum HTML input size: 10 MB.
+const MAX_HTML_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum number of links to return.
+const MAX_LINKS: usize = 5000;
+
+pub struct ExtractLinksOp;
+
+impl MediaOp for ExtractLinksOp {
+    fn name(&self) -> &'static str {
+        "extract_links"
+    }
+
+    fn description(&self) -> &'static str {
+        "Extract and classify links from HTML by context (nav/content/footer), internal/external, nofollow"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+          "type": "object",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "CAS hash of HTML content (blake3:...)"
+            },
+            "html": {
+              "type": "string",
+              "description": "Raw HTML string"
+            },
+            "base_url": {
+              "type": "string",
+              "description": "Base URL for resolving relative links and classifying internal/external"
+            }
+          },
+          "required": ["base_url"],
+          "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: &'a MediaToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<MediaOpResult, NikaError>> + Send + 'a>> {
+        Box::pin(async move {
+            ctx.check_cancelled()?;
+
+            let base_url_str = args
+                .get("base_url")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| invalid_args("extract_links", "missing 'base_url' parameter"))?
+                .to_string();
+
+            let html = resolve_html(&args, ctx).await?;
+
+            // Extract links on compute pool
+            let result = ctx
+                .compute
+                .compute(move || extract_links(&html, &base_url_str))
+                .await??;
+
+            Ok(MediaOpResult::Metadata(result))
+        })
+    }
+}
+
+/// A classified link.
+#[derive(Debug)]
+struct LinkInfo {
+    href: String,
+    text: String,
+    rel: String,
+    nofollow: bool,
+    context: String,
+}
+
+impl LinkInfo {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "href": self.href,
+            "text": self.text,
+            "rel": self.rel,
+            "nofollow": self.nofollow,
+            "context": self.context,
+        })
+    }
+}
+
+/// Extract and classify all links from HTML.
+fn extract_links(html: &str, base_url_str: &str) -> Result<serde_json::Value, NikaError> {
+    let base_url = url::Url::parse(base_url_str).map_err(|e| {
+        invalid_args(
+            "extract_links",
+            format!("invalid base_url '{base_url_str}': {e}"),
+        )
+    })?;
+
+    let base_domain = registrable_domain(base_url.host_str().unwrap_or(""));
+
+    let document = scraper::Html::parse_document(html);
+    let a_selector = scraper::Selector::parse("a[href]")
+        .map_err(|e| tool_error("extract_links", format!("selector error: {e}")))?;
+
+    let mut internal_links: Vec<serde_json::Value> = Vec::new();
+    let mut external_links: Vec<serde_json::Value> = Vec::new();
+
+    let mut total_count = 0usize;
+    let mut internal_count = 0usize;
+    let mut external_count = 0usize;
+    let mut nofollow_count = 0usize;
+
+    for element in document.select(&a_selector) {
+        if total_count >= MAX_LINKS {
+            break;
+        }
+
+        let el_val = element.value();
+        let raw_href = match el_val.attr("href") {
+            Some(h) => h.trim(),
+            None => continue,
+        };
+
+        // Skip anchors, javascript:, mailto:, tel:
+        if raw_href.is_empty()
+            || raw_href.starts_with('#')
+            || raw_href.starts_with("javascript:")
+            || raw_href.starts_with("mailto:")
+            || raw_href.starts_with("tel:")
+        {
+            continue;
+        }
+
+        // Resolve relative URLs
+        let resolved = match base_url.join(raw_href) {
+            Ok(u) => u.to_string(),
+            Err(_) => raw_href.to_string(),
+        };
+
+        let text: String = element
+            .text()
+            .collect::<Vec<_>>()
+            .join("")
+            .trim()
+            .to_string();
+        let rel = el_val.attr("rel").unwrap_or("").to_string();
+        let nofollow = rel.contains("nofollow");
+
+        // Classify context by walking ancestors
+        let context = classify_context(&element);
+
+        // Classify internal/external via eTLD+1
+        let link_url = url::Url::parse(&resolved);
+        let is_internal = match &link_url {
+            Ok(u) => {
+                let link_domain = registrable_domain(u.host_str().unwrap_or(""));
+                link_domain == base_domain
+            }
+            Err(_) => {
+                // If we can't parse, it's likely a relative URL (internal)
+                true
+            }
+        };
+
+        let info = LinkInfo {
+            href: resolved,
+            text,
+            rel,
+            nofollow,
+            context,
+        };
+
+        total_count += 1;
+        if nofollow {
+            nofollow_count += 1;
+        }
+
+        if is_internal {
+            internal_count += 1;
+            internal_links.push(info.to_json());
+        } else {
+            external_count += 1;
+            external_links.push(info.to_json());
+        }
+    }
+
+    Ok(serde_json::json!({
+        "internal": internal_links,
+        "external": external_links,
+        "summary": {
+            "total": total_count,
+            "internal": internal_count,
+            "external": external_count,
+            "nofollow": nofollow_count,
+        }
+    }))
+}
+
+/// Classify link context by walking ancestor elements.
+fn classify_context(element: &scraper::ElementRef) -> String {
+    use scraper::Node;
+
+    let mut current = element.parent();
+    while let Some(node) = current {
+        if let Node::Element(el) = node.value() {
+            let tag = el.name();
+            match tag {
+                "nav" => return "nav".to_string(),
+                "header" => return "header".to_string(),
+                "footer" => return "footer".to_string(),
+                "aside" => return "sidebar".to_string(),
+                "main" | "article" | "section" => return "content".to_string(),
+                _ => {}
+            }
+            // Check role attribute
+            if let Some(role) = el.attr("role") {
+                match role {
+                    "navigation" => return "nav".to_string(),
+                    "banner" => return "header".to_string(),
+                    "contentinfo" => return "footer".to_string(),
+                    "complementary" => return "sidebar".to_string(),
+                    "main" => return "content".to_string(),
+                    _ => {}
+                }
+            }
+        }
+        current = node.parent();
+    }
+
+    "content".to_string() // Default to content
+}
+
+/// Extract the registrable domain (eTLD+1) using the `psl` crate.
+fn registrable_domain(host: &str) -> String {
+    let host_bytes = host.as_bytes();
+    match psl::domain(host_bytes) {
+        Some(domain) => {
+            // psl::domain returns bytes, convert back
+            std::str::from_utf8(domain.as_bytes())
+                .unwrap_or(host)
+                .to_lowercase()
+        }
+        None => host.to_lowercase(),
+    }
+}
+
+/// Resolve HTML content from either a CAS hash or raw HTML string.
+async fn resolve_html(
+    args: &serde_json::Value,
+    ctx: &MediaToolContext,
+) -> Result<String, NikaError> {
+    if let Some(hash) = args.get("hash").and_then(|v| v.as_str()) {
+        let data = ctx.read_media(hash).await?;
+        if data.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "extract_links",
+                format!(
+                    "HTML content too large ({} bytes, max {} bytes)",
+                    data.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        String::from_utf8(data).map_err(|_| {
+            invalid_args(
+                "extract_links",
+                "CAS content is not valid UTF-8 (expected HTML)",
+            )
+        })
+    } else if let Some(html) = args.get("html").and_then(|v| v.as_str()) {
+        if html.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "extract_links",
+                format!(
+                    "HTML string too large ({} bytes, max {} bytes)",
+                    html.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        Ok(html.to_string())
+    } else {
+        Err(invalid_args(
+            "extract_links",
+            "missing 'hash' or 'html' parameter",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::CasStore;
+    use std::sync::Arc;
+
+    async fn setup() -> (tempfile::TempDir, Arc<MediaToolContext>) {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = Arc::new(MediaToolContext::new(CasStore::new(dir.path())));
+        (dir, ctx)
+    }
+
+    const LINKS_HTML: &str = r#"
+        <html>
+        <body>
+            <nav>
+                <a href="/about">About</a>
+                <a href="/contact">Contact</a>
+            </nav>
+            <header>
+                <a href="/">Home</a>
+            </header>
+            <main>
+                <article>
+                    <a href="https://example.com/article">Internal Article</a>
+                    <a href="https://other.com/page" rel="nofollow">External Link</a>
+                    <a href="https://blog.example.com/post">Subdomain Post</a>
+                </article>
+            </main>
+            <aside>
+                <a href="https://ads.com/click">Ad Link</a>
+            </aside>
+            <footer>
+                <a href="/privacy">Privacy</a>
+                <a href="https://twitter.com/example" rel="nofollow noopener">Twitter</a>
+            </footer>
+        </body>
+        </html>
+    "#;
+
+    #[tokio::test]
+    async fn extract_internal_links() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let internal = v["internal"].as_array().unwrap();
+            assert!(
+                internal.len() >= 4,
+                "should have internal links: {internal:?}"
+            );
+            // Check that relative links were resolved
+            let hrefs: Vec<&str> = internal.iter().filter_map(|l| l["href"].as_str()).collect();
+            assert!(
+                hrefs.iter().any(|h| h.contains("/about")),
+                "should resolve /about: {hrefs:?}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_external_links() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let external = v["external"].as_array().unwrap();
+            assert!(
+                !external.is_empty(),
+                "should have external links: {external:?}"
+            );
+            let hrefs: Vec<&str> = external.iter().filter_map(|l| l["href"].as_str()).collect();
+            assert!(
+                hrefs.iter().any(|h| h.contains("other.com")),
+                "should find other.com: {hrefs:?}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn classify_subdomain_as_internal() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let internal = v["internal"].as_array().unwrap();
+            let hrefs: Vec<&str> = internal.iter().filter_map(|l| l["href"].as_str()).collect();
+            assert!(
+                hrefs.iter().any(|h| h.contains("blog.example.com")),
+                "subdomain should be internal: {hrefs:?}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn detect_nofollow() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let summary = &v["summary"];
+            assert!(
+                summary["nofollow"].as_u64().unwrap() >= 2,
+                "should detect nofollow links: {summary}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn classify_nav_context() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let internal = v["internal"].as_array().unwrap();
+            let nav_links: Vec<&serde_json::Value> =
+                internal.iter().filter(|l| l["context"] == "nav").collect();
+            assert!(
+                !nav_links.is_empty(),
+                "should find nav context links: {internal:?}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn classify_footer_context() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            // Combine both internal and external
+            let all_links: Vec<&serde_json::Value> = v["internal"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .chain(v["external"].as_array().unwrap().iter())
+                .collect();
+            let footer_links: Vec<&&serde_json::Value> = all_links
+                .iter()
+                .filter(|l| l["context"] == "footer")
+                .collect();
+            assert!(
+                !footer_links.is_empty(),
+                "should find footer context links: {all_links:?}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn summary_counts() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let summary = &v["summary"];
+            let total = summary["total"].as_u64().unwrap();
+            let internal = summary["internal"].as_u64().unwrap();
+            let external = summary["external"].as_u64().unwrap();
+            assert_eq!(total, internal + external);
+            assert!(total > 0, "should have some links");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_from_cas_hash() {
+        let (_dir, ctx) = setup().await;
+        let sr = ctx.cas.store(LINKS_HTML.as_bytes()).await.unwrap();
+
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "hash": sr.hash,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert!(v["summary"]["total"].as_u64().unwrap() > 0);
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_base_url() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(serde_json::json!({"html": "<a href='/x'>x</a>"}), &ctx)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn invalid_base_url() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": "<a href='/x'>x</a>",
+                    "base_url": "not-a-url"
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn extract_cancelled() {
+        let (_dir, ctx) = setup().await;
+        ctx.cancel.cancel();
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": LINKS_HTML,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn skips_anchors_and_mailto() {
+        let (_dir, ctx) = setup().await;
+        let html = r##"
+            <a href="#section">Anchor</a>
+            <a href="mailto:test@example.com">Email</a>
+            <a href="tel:+1234567890">Phone</a>
+            <a href="javascript:void(0)">JS</a>
+            <a href="https://example.com/real">Real Link</a>
+        "##;
+        let op = ExtractLinksOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": html,
+                    "base_url": "https://example.com"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(
+                v["summary"]["total"].as_u64().unwrap(),
+                1,
+                "should only count the real link"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+}

--- a/tools/nika/src/runtime/builtin/media/extract_metadata.rs
+++ b/tools/nika/src/runtime/builtin/media/extract_metadata.rs
@@ -1,0 +1,579 @@
+//! nika:extract_metadata — Extract SEO metadata from HTML pages.
+//!
+//! Extracts title, description, Open Graph, Twitter Cards, JSON-LD,
+//! canonical URL, favicon, RSS/Atom feeds, robots directives, and author.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::context::MediaToolContext;
+use super::error::invalid_args;
+use super::{MediaOp, MediaOpResult};
+use crate::error::NikaError;
+
+/// Maximum HTML input size: 10 MB.
+const MAX_HTML_SIZE: usize = 10 * 1024 * 1024;
+
+pub struct ExtractMetadataOp;
+
+impl MediaOp for ExtractMetadataOp {
+    fn name(&self) -> &'static str {
+        "extract_metadata"
+    }
+
+    fn description(&self) -> &'static str {
+        "Extract SEO metadata from HTML: title, description, OG, Twitter, JSON-LD, canonical, favicon, feeds"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+          "type": "object",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "CAS hash of HTML content (blake3:...)"
+            },
+            "html": {
+              "type": "string",
+              "description": "Raw HTML string to extract metadata from"
+            }
+          },
+          "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: &'a MediaToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<MediaOpResult, NikaError>> + Send + 'a>> {
+        Box::pin(async move {
+            ctx.check_cancelled()?;
+
+            let html = resolve_html(&args, ctx).await?;
+
+            // Extract metadata on compute pool
+            let metadata = ctx
+                .compute
+                .compute(move || extract_all_metadata(&html))
+                .await??;
+
+            Ok(MediaOpResult::Metadata(metadata))
+        })
+    }
+}
+
+/// Extract all metadata from HTML.
+fn extract_all_metadata(html: &str) -> Result<serde_json::Value, NikaError> {
+    let document = scraper::Html::parse_document(html);
+
+    let title = extract_title(&document);
+    let description = extract_meta_content(&document, "description");
+    let author = extract_meta_content(&document, "author");
+    let robots = extract_meta_content(&document, "robots");
+    let canonical = extract_canonical(&document);
+    let favicon = extract_favicon(&document);
+    let og = extract_og_tags(&document);
+    let twitter = extract_twitter_tags(&document);
+    let json_ld = extract_json_ld(&document);
+    let feeds = extract_feeds(&document);
+
+    let mut result = serde_json::json!({});
+    let obj = result.as_object_mut().unwrap();
+
+    if let Some(t) = title {
+        obj.insert("title".to_string(), serde_json::Value::String(t));
+    }
+    if let Some(d) = description {
+        obj.insert("description".to_string(), serde_json::Value::String(d));
+    }
+    if let Some(a) = author {
+        obj.insert("author".to_string(), serde_json::Value::String(a));
+    }
+    if let Some(r) = robots {
+        obj.insert("robots".to_string(), serde_json::Value::String(r));
+    }
+    if let Some(c) = canonical {
+        obj.insert("canonical".to_string(), serde_json::Value::String(c));
+    }
+    if let Some(f) = favicon {
+        obj.insert("favicon".to_string(), serde_json::Value::String(f));
+    }
+    if !og.is_empty() {
+        obj.insert("og".to_string(), serde_json::json!(og));
+    }
+    if !twitter.is_empty() {
+        obj.insert("twitter".to_string(), serde_json::json!(twitter));
+    }
+    if !json_ld.is_empty() {
+        obj.insert("json_ld".to_string(), serde_json::Value::Array(json_ld));
+    }
+    if !feeds.is_empty() {
+        obj.insert("feeds".to_string(), serde_json::Value::Array(feeds));
+    }
+
+    Ok(result)
+}
+
+/// Extract the <title> tag content.
+fn extract_title(doc: &scraper::Html) -> Option<String> {
+    let selector = scraper::Selector::parse("title").ok()?;
+    doc.select(&selector)
+        .next()
+        .map(|el| el.text().collect::<Vec<_>>().join("").trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Extract a <meta name="..." content="..."> value.
+fn extract_meta_content(doc: &scraper::Html, name: &str) -> Option<String> {
+    let selector = scraper::Selector::parse("meta").ok()?;
+    for el in doc.select(&selector) {
+        let el_val = el.value();
+        if let Some(n) = el_val.attr("name") {
+            if n.eq_ignore_ascii_case(name) {
+                if let Some(content) = el_val.attr("content") {
+                    let trimmed = content.trim().to_string();
+                    if !trimmed.is_empty() {
+                        return Some(trimmed);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract <link rel="canonical" href="...">
+fn extract_canonical(doc: &scraper::Html) -> Option<String> {
+    let selector = scraper::Selector::parse(r#"link[rel="canonical"]"#).ok()?;
+    doc.select(&selector)
+        .next()
+        .and_then(|el| el.value().attr("href"))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Extract favicon from <link rel="icon"> or <link rel="shortcut icon">
+fn extract_favicon(doc: &scraper::Html) -> Option<String> {
+    // Try rel="icon" first, then "shortcut icon"
+    for rel_val in &["icon", "shortcut icon"] {
+        let selector_str = format!(r#"link[rel="{rel_val}"]"#);
+        let selector = match scraper::Selector::parse(&selector_str) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if let Some(el) = doc.select(&selector).next() {
+            if let Some(href) = el.value().attr("href") {
+                let trimmed = href.trim().to_string();
+                if !trimmed.is_empty() {
+                    return Some(trimmed);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract Open Graph meta tags (og:*).
+fn extract_og_tags(doc: &scraper::Html) -> std::collections::HashMap<String, String> {
+    let mut og = std::collections::HashMap::new();
+    let selector = match scraper::Selector::parse(r#"meta[property]"#) {
+        Ok(s) => s,
+        Err(_) => return og,
+    };
+
+    for el in doc.select(&selector) {
+        let el_val = el.value();
+        if let Some(property) = el_val.attr("property") {
+            if let Some(stripped) = property.strip_prefix("og:") {
+                if let Some(content) = el_val.attr("content") {
+                    let trimmed = content.trim().to_string();
+                    if !trimmed.is_empty() {
+                        og.insert(stripped.to_string(), trimmed);
+                    }
+                }
+            }
+        }
+    }
+    og
+}
+
+/// Extract Twitter Card meta tags (twitter:*).
+fn extract_twitter_tags(doc: &scraper::Html) -> std::collections::HashMap<String, String> {
+    let mut twitter = std::collections::HashMap::new();
+    let selector = match scraper::Selector::parse("meta") {
+        Ok(s) => s,
+        Err(_) => return twitter,
+    };
+
+    for el in doc.select(&selector) {
+        let el_val = el.value();
+        // Twitter uses both name="twitter:*" and property="twitter:*"
+        let key = el_val.attr("name").or_else(|| el_val.attr("property"));
+
+        if let Some(name) = key {
+            if let Some(stripped) = name.strip_prefix("twitter:") {
+                if let Some(content) = el_val.attr("content") {
+                    let trimmed = content.trim().to_string();
+                    if !trimmed.is_empty() {
+                        twitter.insert(stripped.to_string(), trimmed);
+                    }
+                }
+            }
+        }
+    }
+    twitter
+}
+
+/// Extract JSON-LD scripts.
+fn extract_json_ld(doc: &scraper::Html) -> Vec<serde_json::Value> {
+    let selector = match scraper::Selector::parse(r#"script[type="application/ld+json"]"#) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut results = Vec::new();
+    for el in doc.select(&selector) {
+        let text: String = el.text().collect();
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            // Try to parse as JSON; if valid, include it
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                results.push(parsed);
+            }
+        }
+    }
+    results
+}
+
+/// Extract RSS/Atom feed links.
+fn extract_feeds(doc: &scraper::Html) -> Vec<serde_json::Value> {
+    let mut feeds = Vec::new();
+
+    for feed_type in &["application/rss+xml", "application/atom+xml"] {
+        let selector_str = format!(r#"link[type="{feed_type}"]"#);
+        let selector = match scraper::Selector::parse(&selector_str) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for el in doc.select(&selector) {
+            let el_val = el.value();
+            let href = el_val.attr("href").unwrap_or("").trim().to_string();
+            let title = el_val.attr("title").unwrap_or("").trim().to_string();
+            if !href.is_empty() {
+                feeds.push(serde_json::json!({
+                    "type": feed_type,
+                    "href": href,
+                    "title": title
+                }));
+            }
+        }
+    }
+    feeds
+}
+
+/// Resolve HTML content from either a CAS hash or raw HTML string.
+async fn resolve_html(
+    args: &serde_json::Value,
+    ctx: &MediaToolContext,
+) -> Result<String, NikaError> {
+    if let Some(hash) = args.get("hash").and_then(|v| v.as_str()) {
+        let data = ctx.read_media(hash).await?;
+        if data.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "extract_metadata",
+                format!(
+                    "HTML content too large ({} bytes, max {} bytes)",
+                    data.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        String::from_utf8(data).map_err(|_| {
+            invalid_args(
+                "extract_metadata",
+                "CAS content is not valid UTF-8 (expected HTML)",
+            )
+        })
+    } else if let Some(html) = args.get("html").and_then(|v| v.as_str()) {
+        if html.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "extract_metadata",
+                format!(
+                    "HTML string too large ({} bytes, max {} bytes)",
+                    html.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        Ok(html.to_string())
+    } else {
+        Err(invalid_args(
+            "extract_metadata",
+            "missing 'hash' or 'html' parameter",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::CasStore;
+    use std::sync::Arc;
+
+    async fn setup() -> (tempfile::TempDir, Arc<MediaToolContext>) {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = Arc::new(MediaToolContext::new(CasStore::new(dir.path())));
+        (dir, ctx)
+    }
+
+    const FULL_HTML: &str = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <title>My Page Title</title>
+            <meta name="description" content="A great page about things">
+            <meta name="author" content="Jane Doe">
+            <meta name="robots" content="index, follow">
+            <meta property="og:title" content="OG Title">
+            <meta property="og:description" content="OG Description">
+            <meta property="og:image" content="https://example.com/image.jpg">
+            <meta property="og:type" content="article">
+            <meta name="twitter:card" content="summary_large_image">
+            <meta name="twitter:title" content="Twitter Title">
+            <meta name="twitter:image" content="https://example.com/tw-image.jpg">
+            <link rel="canonical" href="https://example.com/page">
+            <link rel="icon" href="/favicon.ico">
+            <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/feed.xml">
+            <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/atom.xml">
+            <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "Article",
+                "headline": "My Article"
+            }
+            </script>
+        </head>
+        <body><h1>Content</h1></body>
+        </html>
+    "#;
+
+    #[tokio::test]
+    async fn extract_title() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["title"], "My Page Title");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_description() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["description"], "A great page about things");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_og_tags() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["og"]["title"], "OG Title");
+            assert_eq!(v["og"]["description"], "OG Description");
+            assert_eq!(v["og"]["image"], "https://example.com/image.jpg");
+            assert_eq!(v["og"]["type"], "article");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_twitter_cards() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["twitter"]["card"], "summary_large_image");
+            assert_eq!(v["twitter"]["title"], "Twitter Title");
+            assert_eq!(v["twitter"]["image"], "https://example.com/tw-image.jpg");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_json_ld() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let json_ld = v["json_ld"].as_array().unwrap();
+            assert_eq!(json_ld.len(), 1);
+            assert_eq!(json_ld[0]["@type"], "Article");
+            assert_eq!(json_ld[0]["headline"], "My Article");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_canonical() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["canonical"], "https://example.com/page");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_favicon() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["favicon"], "/favicon.ico");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_feeds() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let feeds = v["feeds"].as_array().unwrap();
+            assert_eq!(feeds.len(), 2);
+            assert_eq!(feeds[0]["href"], "/feed.xml");
+            assert_eq!(feeds[0]["title"], "RSS Feed");
+            assert_eq!(feeds[1]["href"], "/atom.xml");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_empty_page() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": "<html><body></body></html>"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            // Empty page should return empty object with no fields
+            assert!(v.get("title").is_none());
+            assert!(v.get("og").is_none());
+            assert!(v.get("twitter").is_none());
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_author_and_robots() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": FULL_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["author"], "Jane Doe");
+            assert_eq!(v["robots"], "index, follow");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_from_cas_hash() {
+        let (_dir, ctx) = setup().await;
+        let sr = ctx.cas.store(FULL_HTML.as_bytes()).await.unwrap();
+
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"hash": sr.hash}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["title"], "My Page Title");
+            assert!(v["og"]["title"].is_string());
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_missing_params() {
+        let (_dir, ctx) = setup().await;
+        let op = ExtractMetadataOp;
+        let result = op.execute(serde_json::json!({}), &ctx).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn extract_cancelled() {
+        let (_dir, ctx) = setup().await;
+        ctx.cancel.cancel();
+        let op = ExtractMetadataOp;
+        let result = op
+            .execute(serde_json::json!({"html": "<html></html>"}), &ctx)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+    }
+}

--- a/tools/nika/src/runtime/builtin/media/html_to_md.rs
+++ b/tools/nika/src/runtime/builtin/media/html_to_md.rs
@@ -1,0 +1,282 @@
+//! nika:html_to_md — Convert HTML content to Markdown.
+//!
+//! Accepts either a CAS hash (reads HTML from store) or raw HTML string.
+//! Uses `htmd` (turndown.js-inspired) for high-fidelity conversion.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::context::MediaToolContext;
+use super::error::{invalid_args, tool_error};
+use super::{MediaOp, MediaOpResult};
+use crate::error::NikaError;
+
+/// Maximum HTML input size: 10 MB.
+const MAX_HTML_SIZE: usize = 10 * 1024 * 1024;
+
+pub struct HtmlToMdOp;
+
+impl MediaOp for HtmlToMdOp {
+    fn name(&self) -> &'static str {
+        "html_to_md"
+    }
+
+    fn description(&self) -> &'static str {
+        "Convert HTML content to Markdown (from CAS hash or raw HTML string)"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+          "type": "object",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "CAS hash of HTML content (blake3:...)"
+            },
+            "html": {
+              "type": "string",
+              "description": "Raw HTML string to convert"
+            }
+          },
+          "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: &'a MediaToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<MediaOpResult, NikaError>> + Send + 'a>> {
+        Box::pin(async move {
+            ctx.check_cancelled()?;
+
+            let html = resolve_html(&args, ctx).await?;
+
+            if html.is_empty() {
+                return Ok(MediaOpResult::Metadata(serde_json::json!({
+                  "markdown": "",
+                  "char_count": 0
+                })));
+            }
+
+            // Convert on the compute pool (htmd can be CPU-intensive for large docs)
+            let markdown = ctx
+                .compute
+                .compute(move || -> Result<String, NikaError> {
+                    htmd::convert(&html)
+                        .map_err(|e| tool_error("html_to_md", format!("conversion failed: {e}")))
+                })
+                .await??;
+
+            let char_count = markdown.len();
+
+            Ok(MediaOpResult::Metadata(serde_json::json!({
+              "markdown": markdown,
+              "char_count": char_count
+            })))
+        })
+    }
+}
+
+/// Resolve HTML content from either a CAS hash or raw HTML string.
+async fn resolve_html(
+    args: &serde_json::Value,
+    ctx: &MediaToolContext,
+) -> Result<String, NikaError> {
+    if let Some(hash) = args.get("hash").and_then(|v| v.as_str()) {
+        let data = ctx.read_media(hash).await?;
+        if data.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "html_to_md",
+                format!(
+                    "HTML content too large ({} bytes, max {} bytes)",
+                    data.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        String::from_utf8(data).map_err(|_| {
+            invalid_args(
+                "html_to_md",
+                "CAS content is not valid UTF-8 (expected HTML)",
+            )
+        })
+    } else if let Some(html) = args.get("html").and_then(|v| v.as_str()) {
+        if html.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "html_to_md",
+                format!(
+                    "HTML string too large ({} bytes, max {} bytes)",
+                    html.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        Ok(html.to_string())
+    } else {
+        Err(invalid_args(
+            "html_to_md",
+            "missing 'hash' or 'html' parameter",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::CasStore;
+    use std::sync::Arc;
+
+    async fn setup() -> (tempfile::TempDir, Arc<MediaToolContext>) {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = Arc::new(MediaToolContext::new(CasStore::new(dir.path())));
+        (dir, ctx)
+    }
+
+    #[tokio::test]
+    async fn convert_basic_html() {
+        let (_dir, ctx) = setup().await;
+        let op = HtmlToMdOp;
+        let result = op
+            .execute(
+                serde_json::json!({"html": "<h1>Hello</h1><p>World</p>"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let md = v["markdown"].as_str().unwrap();
+            assert!(md.contains("Hello"), "should contain heading text");
+            assert!(md.contains("World"), "should contain paragraph text");
+            assert!(v["char_count"].as_u64().unwrap() > 0);
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_html_with_tables() {
+        let (_dir, ctx) = setup().await;
+        let op = HtmlToMdOp;
+        let html =
+            "<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>";
+        let result = op
+            .execute(serde_json::json!({"html": html}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let md = v["markdown"].as_str().unwrap();
+            assert!(md.contains("Name"), "should contain table header");
+            assert!(md.contains("Alice"), "should contain table data");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_html_with_code_blocks() {
+        let (_dir, ctx) = setup().await;
+        let op = HtmlToMdOp;
+        let html = "<pre><code>fn main() { }</code></pre>";
+        let result = op
+            .execute(serde_json::json!({"html": html}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let md = v["markdown"].as_str().unwrap();
+            assert!(
+                md.contains("fn main()"),
+                "should contain code content: {md}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_html_with_links() {
+        let (_dir, ctx) = setup().await;
+        let op = HtmlToMdOp;
+        let html = r#"<a href="https://example.com">Example</a>"#;
+        let result = op
+            .execute(serde_json::json!({"html": html}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let md = v["markdown"].as_str().unwrap();
+            assert!(md.contains("[Example]"), "should contain link text: {md}");
+            assert!(
+                md.contains("https://example.com"),
+                "should contain link URL: {md}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_from_cas_hash() {
+        let (_dir, ctx) = setup().await;
+        let html = b"<h2>From CAS</h2><p>Stored content</p>";
+        let sr = ctx.cas.store(html).await.unwrap();
+
+        let op = HtmlToMdOp;
+        let result = op
+            .execute(serde_json::json!({"hash": sr.hash}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let md = v["markdown"].as_str().unwrap();
+            assert!(md.contains("From CAS"), "should convert CAS content: {md}");
+            assert!(
+                md.contains("Stored content"),
+                "should contain paragraph: {md}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_empty_html() {
+        let (_dir, ctx) = setup().await;
+        let op = HtmlToMdOp;
+        let result = op
+            .execute(serde_json::json!({"html": ""}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["markdown"], "");
+            assert_eq!(v["char_count"], 0);
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_missing_params() {
+        let (_dir, ctx) = setup().await;
+        let op = HtmlToMdOp;
+        let result = op.execute(serde_json::json!({}), &ctx).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn convert_cancelled() {
+        let (_dir, ctx) = setup().await;
+        ctx.cancel.cancel();
+        let op = HtmlToMdOp;
+        let result = op
+            .execute(serde_json::json!({"html": "<p>test</p>"}), &ctx)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+    }
+}

--- a/tools/nika/src/runtime/builtin/media/mod.rs
+++ b/tools/nika/src/runtime/builtin/media/mod.rs
@@ -53,6 +53,17 @@ mod provenance;
 mod qr;
 #[cfg(feature = "media-iqa")]
 mod quality;
+// PR5b tools — Web extraction builtins
+#[cfg(feature = "fetch-html")]
+mod css_select;
+#[cfg(feature = "fetch-html")]
+mod extract_links;
+#[cfg(feature = "fetch-html")]
+mod extract_metadata;
+#[cfg(feature = "fetch-markdown")]
+mod html_to_md;
+#[cfg(feature = "fetch-article")]
+mod readability;
 #[cfg(test)]
 mod tests_comprehensive;
 #[cfg(test)]
@@ -318,6 +329,39 @@ pub(crate) fn create_media_tool_adapters(ctx: Arc<MediaToolContext>) -> Vec<Box<
     {
         tools.push(Box::new(MediaToolAdapter::new(
             Arc::new(quality::QualityOp),
+            Arc::clone(&ctx),
+        )));
+    }
+
+    // PR5b — Web extraction builtins
+    #[cfg(feature = "fetch-html")]
+    {
+        tools.push(Box::new(MediaToolAdapter::new(
+            Arc::new(css_select::CssSelectOp),
+            Arc::clone(&ctx),
+        )));
+        tools.push(Box::new(MediaToolAdapter::new(
+            Arc::new(extract_metadata::ExtractMetadataOp),
+            Arc::clone(&ctx),
+        )));
+        tools.push(Box::new(MediaToolAdapter::new(
+            Arc::new(extract_links::ExtractLinksOp),
+            Arc::clone(&ctx),
+        )));
+    }
+
+    #[cfg(feature = "fetch-markdown")]
+    {
+        tools.push(Box::new(MediaToolAdapter::new(
+            Arc::new(html_to_md::HtmlToMdOp),
+            Arc::clone(&ctx),
+        )));
+    }
+
+    #[cfg(feature = "fetch-article")]
+    {
+        tools.push(Box::new(MediaToolAdapter::new(
+            Arc::new(readability::ReadabilityOp),
             Arc::clone(&ctx),
         )));
     }

--- a/tools/nika/src/runtime/builtin/media/readability.rs
+++ b/tools/nika/src/runtime/builtin/media/readability.rs
@@ -1,0 +1,350 @@
+//! nika:readability — Article content extraction (Mozilla Readability).
+//!
+//! Extracts the main article content from a web page, stripping
+//! navigation, footer, ads, and other non-content elements.
+//! Uses `dom_smoothie` (Rust port of Mozilla's Readability.js).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::context::MediaToolContext;
+use super::error::{invalid_args, tool_error};
+use super::{MediaOp, MediaOpResult};
+use crate::error::NikaError;
+
+/// Maximum HTML input size: 10 MB.
+const MAX_HTML_SIZE: usize = 10 * 1024 * 1024;
+
+pub struct ReadabilityOp;
+
+impl MediaOp for ReadabilityOp {
+    fn name(&self) -> &'static str {
+        "readability"
+    }
+
+    fn description(&self) -> &'static str {
+        "Extract main article content from HTML, stripping nav/footer/ads (Mozilla Readability)"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+          "type": "object",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "CAS hash of HTML content (blake3:...)"
+            },
+            "html": {
+              "type": "string",
+              "description": "Raw HTML string"
+            },
+            "url": {
+              "type": "string",
+              "description": "URL of the page (for resolving relative links)"
+            }
+          },
+          "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: &'a MediaToolContext,
+    ) -> Pin<Box<dyn Future<Output = Result<MediaOpResult, NikaError>> + Send + 'a>> {
+        Box::pin(async move {
+            ctx.check_cancelled()?;
+
+            let html = resolve_html(&args, ctx).await?;
+            let url = args
+                .get("url")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            if html.is_empty() {
+                return Ok(MediaOpResult::Metadata(serde_json::json!({
+                  "title": null,
+                  "content": "",
+                  "text_content": "",
+                  "excerpt": null,
+                  "char_count": 0
+                })));
+            }
+
+            // dom_smoothie is CPU-intensive — run on compute pool
+            let result = ctx
+                .compute
+                .compute(move || -> Result<serde_json::Value, NikaError> {
+                    let mut readability =
+                        dom_smoothie::Readability::new(html.as_str(), url.as_deref(), None)
+                            .map_err(|e| {
+                                tool_error("readability", format!("failed to initialize: {e}"))
+                            })?;
+
+                    let article = readability.parse().map_err(|e| {
+                        tool_error("readability", format!("extraction failed: {e}"))
+                    })?;
+
+                    let content_str = article.content.to_string();
+                    let text_content_str = article.text_content.to_string();
+                    let char_count = text_content_str.len();
+
+                    Ok(serde_json::json!({
+                        "title": article.title,
+                        "byline": article.byline,
+                        "content": content_str,
+                        "text_content": text_content_str,
+                        "excerpt": article.excerpt,
+                        "site_name": article.site_name,
+                        "lang": article.lang,
+                        "published_time": article.published_time,
+                        "char_count": char_count,
+                    }))
+                })
+                .await??;
+
+            Ok(MediaOpResult::Metadata(result))
+        })
+    }
+}
+
+/// Resolve HTML content from either a CAS hash or raw HTML string.
+async fn resolve_html(
+    args: &serde_json::Value,
+    ctx: &MediaToolContext,
+) -> Result<String, NikaError> {
+    if let Some(hash) = args.get("hash").and_then(|v| v.as_str()) {
+        let data = ctx.read_media(hash).await?;
+        if data.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "readability",
+                format!(
+                    "HTML content too large ({} bytes, max {} bytes)",
+                    data.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        String::from_utf8(data).map_err(|_| {
+            invalid_args(
+                "readability",
+                "CAS content is not valid UTF-8 (expected HTML)",
+            )
+        })
+    } else if let Some(html) = args.get("html").and_then(|v| v.as_str()) {
+        if html.len() > MAX_HTML_SIZE {
+            return Err(invalid_args(
+                "readability",
+                format!(
+                    "HTML string too large ({} bytes, max {} bytes)",
+                    html.len(),
+                    MAX_HTML_SIZE
+                ),
+            ));
+        }
+        Ok(html.to_string())
+    } else {
+        Err(invalid_args(
+            "readability",
+            "missing 'hash' or 'html' parameter",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::CasStore;
+    use std::sync::Arc;
+
+    async fn setup() -> (tempfile::TempDir, Arc<MediaToolContext>) {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = Arc::new(MediaToolContext::new(CasStore::new(dir.path())));
+        (dir, ctx)
+    }
+
+    /// A realistic article HTML for testing.
+    const ARTICLE_HTML: &str = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <title>The Future of Rust - A Deep Dive</title>
+            <meta name="author" content="Alice Smith">
+            <meta name="description" content="An in-depth look at Rust's future">
+        </head>
+        <body>
+            <nav>
+                <a href="/">Home</a>
+                <a href="/blog">Blog</a>
+            </nav>
+            <article>
+                <h1>The Future of Rust</h1>
+                <p>Rust has become one of the most loved programming languages in the world.
+                   Its focus on safety, performance, and concurrency makes it ideal for systems
+                   programming, web development, and more. In this article, we explore what
+                   the future holds for the Rust ecosystem.</p>
+                <p>The Rust community has been growing steadily. With the introduction of
+                   async/await, the language has become more accessible for network programming.
+                   The borrow checker, once seen as a barrier, is now appreciated as a powerful
+                   tool for preventing bugs at compile time.</p>
+                <p>Looking ahead, improvements to compile times, better IDE support, and
+                   expanding the standard library are key priorities. The Rust Foundation
+                   continues to invest in the language's infrastructure and community.</p>
+                <p>Many companies including Mozilla, Microsoft, Google, and Amazon are now
+                   using Rust in production. The language's adoption in safety-critical systems,
+                   embedded development, and WebAssembly is accelerating.</p>
+                <p>In conclusion, Rust's future looks bright. The combination of performance,
+                   safety, and a thriving community ensures that Rust will continue to grow
+                   and evolve for years to come.</p>
+            </article>
+            <footer>
+                <p>Copyright 2026 Example Corp</p>
+                <a href="/privacy">Privacy Policy</a>
+            </footer>
+        </body>
+        </html>
+    "#;
+
+    #[tokio::test]
+    async fn extract_article_content() {
+        let (_dir, ctx) = setup().await;
+        let op = ReadabilityOp;
+        let result = op
+            .execute(serde_json::json!({"html": ARTICLE_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let text = v["text_content"].as_str().unwrap();
+            assert!(text.contains("Rust"), "should extract article text: {text}");
+            assert!(
+                v["char_count"].as_u64().unwrap() > 100,
+                "should have substantial content"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_title() {
+        let (_dir, ctx) = setup().await;
+        let op = ReadabilityOp;
+        let result = op
+            .execute(serde_json::json!({"html": ARTICLE_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let title = v["title"].as_str().unwrap();
+            assert!(
+                title.contains("Rust"),
+                "should extract article title: {title}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn strips_navigation() {
+        let (_dir, ctx) = setup().await;
+        let op = ReadabilityOp;
+        let result = op
+            .execute(serde_json::json!({"html": ARTICLE_HTML}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            let content = v["content"].as_str().unwrap();
+            // Nav links should not appear in extracted content
+            assert!(
+                !content.contains("Privacy Policy"),
+                "should strip footer: {content}"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_from_cas_hash() {
+        let (_dir, ctx) = setup().await;
+        let sr = ctx.cas.store(ARTICLE_HTML.as_bytes()).await.unwrap();
+
+        let op = ReadabilityOp;
+        let result = op
+            .execute(serde_json::json!({"hash": sr.hash}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert!(v["char_count"].as_u64().unwrap() > 0);
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_with_url() {
+        let (_dir, ctx) = setup().await;
+        let op = ReadabilityOp;
+        let result = op
+            .execute(
+                serde_json::json!({
+                    "html": ARTICLE_HTML,
+                    "url": "https://example.com/article"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert!(
+                v["char_count"].as_u64().unwrap() > 0,
+                "should extract content with URL context"
+            );
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_empty_html() {
+        let (_dir, ctx) = setup().await;
+        let op = ReadabilityOp;
+        let result = op
+            .execute(serde_json::json!({"html": ""}), &ctx)
+            .await
+            .unwrap();
+
+        if let MediaOpResult::Metadata(v) = result {
+            assert_eq!(v["char_count"], 0);
+            assert_eq!(v["content"], "");
+        } else {
+            panic!("expected Metadata result");
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_missing_params() {
+        let (_dir, ctx) = setup().await;
+        let op = ReadabilityOp;
+        let result = op.execute(serde_json::json!({}), &ctx).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NIKA-294"));
+    }
+
+    #[tokio::test]
+    async fn extract_cancelled() {
+        let (_dir, ctx) = setup().await;
+        ctx.cancel.cancel();
+        let op = ReadabilityOp;
+        let result = op
+            .execute(serde_json::json!({"html": ARTICLE_HTML}), &ctx)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+    }
+}

--- a/tools/nika/src/runtime/builtin/media/tests_e2e_workflow.rs
+++ b/tools/nika/src/runtime/builtin/media/tests_e2e_workflow.rs
@@ -325,6 +325,18 @@ mod tests {
         {
             expected += 1; // quality
         }
+        #[cfg(feature = "fetch-html")]
+        {
+            expected += 3; // css_select, extract_metadata, extract_links
+        }
+        #[cfg(feature = "fetch-markdown")]
+        {
+            expected += 1; // html_to_md
+        }
+        #[cfg(feature = "fetch-article")]
+        {
+            expected += 1; // readability
+        }
 
         assert_eq!(
             total, expected,


### PR DESCRIPTION
## Summary

5 new builtin tools for web content extraction, composable with ANY content source (CAS, MCP, fetch):

| Tool | Feature | Tests | Description |
|------|---------|-------|-------------|
| `nika:html_to_md` | fetch-markdown | 8 | HTML → clean Markdown (htmd, turndown.js port) |
| `nika:css_select` | fetch-html | 11 | CSS selector extraction (text/html output modes) |
| `nika:extract_metadata` | fetch-html | 13 | OG, Twitter Cards, JSON-LD, SEO tags, feeds |
| `nika:extract_links` | fetch-html | 12 | Rich link classification (internal/external, nav/content/footer) |
| `nika:readability` | fetch-article | 8 | Article extraction (Mozilla Readability via dom_smoothie) |

### New deps (all feature-gated, NOT in defaults)
- scraper 0.22 (14.8M downloads)
- htmd 0.5 (248K downloads)
- dom_smoothie 0.16 (16K downloads)
- psl 2 (eTLD+1 for link classification)

### Feature flags
```toml
fetch-html = ["dep:scraper", "dep:psl"]
fetch-markdown = ["dep:htmd"]
fetch-article = ["dep:dom_smoothie", "dep:scraper"]
fetch-extract = ["fetch-html", "fetch-markdown"]
```

### Key differentiator
`nika:extract_metadata` does what Diffbot charges $299/mo for — deterministic structured data extraction at $0 per page. No LLM tokens needed.

## Test plan
- [x] `cargo test --lib --features fetch-extract` — 44 passed
- [x] `cargo test --lib --features fetch-article` — 8 passed
- [x] `cargo test --lib` — 6255 passed (default features, no regression)
- [x] `cargo clippy --features fetch-extract -- -D warnings` — 0 warnings
- [x] Pre-commit hooks passed on every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)