### PR TITLE
fix(fetch): address 3 security findings — size guards + validation sync

### DIFF
--- a/tools/nika/src/ast/action.rs
+++ b/tools/nika/src/ast/action.rs
@@ -369,7 +369,7 @@ pub struct FetchParams {
     /// Response mode: "full" (status + headers + body JSON) or "binary" (CAS store)
     #[serde(default)]
     pub response: Option<String>,
-    /// Extraction mode: markdown, article, text, selector, metadata, links, feed, jsonpath, llm_txt
+    /// Extraction mode: markdown, text, selector, metadata, links, jsonpath
     #[serde(default)]
     pub extract: Option<String>,
     /// CSS selector or JSONPath expression (used with extract: selector, text, jsonpath)
@@ -417,8 +417,7 @@ impl FetchParams {
         }
         if let Some(ref extract) = self.extract {
             let valid = [
-                "markdown", "article", "text", "selector", "metadata", "links", "feed", "jsonpath",
-                "llm_txt",
+                "markdown", "text", "selector", "metadata", "links", "jsonpath",
             ];
             if !valid.contains(&extract.as_str()) {
                 return Err(NikaError::ValidationError {
@@ -1634,8 +1633,7 @@ fetch:
     #[test]
     fn test_fetch_validate_valid_extract_modes() {
         let valid_modes = [
-            "markdown", "article", "text", "selector", "metadata", "links", "feed", "jsonpath",
-            "llm_txt",
+            "markdown", "text", "selector", "metadata", "links", "jsonpath",
         ];
         for mode in &valid_modes {
             let params = FetchParams {

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -1051,6 +1051,13 @@ impl TaskExecutor {
                         let body = response.text().await.map_err(|e| {
                             NikaError::Execution(format!("Failed to read response: {}", e))
                         })?;
+                        if body.len() as u64 > FULL_MAX_RESPONSE_SIZE {
+                            return Err(NikaError::Execution(format!(
+                                "Response body too large ({} bytes, max {} bytes)",
+                                body.len(),
+                                FULL_MAX_RESPONSE_SIZE
+                            )));
+                        }
                         return Ok(serde_json::json!({
                             "status": status,
                             "headers": headers,
@@ -1067,6 +1074,15 @@ impl TaskExecutor {
                             .and_then(|v| v.to_str().ok())
                             .unwrap_or("application/octet-stream")
                             .to_string();
+                        const BINARY_MAX_RESPONSE_SIZE: u64 = 100 * 1024 * 1024; // 100 MB (CAS limit)
+                        if let Some(len) = response.content_length() {
+                            if len > BINARY_MAX_RESPONSE_SIZE {
+                                return Err(NikaError::Execution(format!(
+                                    "Binary response too large ({} bytes, max {} bytes)",
+                                    len, BINARY_MAX_RESPONSE_SIZE
+                                )));
+                            }
+                        }
                         let bytes = response.bytes().await.map_err(|e| {
                             NikaError::Execution(format!("Failed to read binary response: {}", e))
                         })?;


### PR DESCRIPTION
3 fixes from Socratic audit (192 verdicts): H1 post-read size guard on full, H2 remove unimplemented extract modes, M1 pre-read size check on binary. 6287 tests pass.