### PR TITLE
fix(media): add required field to extract_metadata + readability + html_to_md schemas

### DIFF
--- a/tools/nika/src/runtime/builtin/media/extract_metadata.rs
+++ b/tools/nika/src/runtime/builtin/media/extract_metadata.rs
@@ -38,6 +38,7 @@ impl MediaOp for ExtractMetadataOp {
               "description": "Raw HTML string to extract metadata from"
             }
           },
+          "required": ["hash"],
           "additionalProperties": false
         })
     }

--- a/tools/nika/src/runtime/builtin/media/html_to_md.rs
+++ b/tools/nika/src/runtime/builtin/media/html_to_md.rs
@@ -38,6 +38,7 @@ impl MediaOp for HtmlToMdOp {
               "description": "Raw HTML string to convert"
             }
           },
+          "required": ["hash"],
           "additionalProperties": false
         })
     }

--- a/tools/nika/src/runtime/builtin/media/readability.rs
+++ b/tools/nika/src/runtime/builtin/media/readability.rs
@@ -43,6 +43,7 @@ impl MediaOp for ReadabilityOp {
               "description": "URL of the page (for resolving relative links)"
             }
           },
+          "required": ["hash"],
           "additionalProperties": false
         })
     }


### PR DESCRIPTION
Fix paranoid schema test — 3 tools needed 'required' in parameters_schema(). 6389 tests pass, 0 failures across all feature combos.