### PR TITLE
fix(security): replace unwrap/unreachable + llm_txt size/timeout limits

### DIFF
--- a/tools/nika/src/runtime/builtin/media/extract_metadata.rs
+++ b/tools/nika/src/runtime/builtin/media/extract_metadata.rs
@@ -80,7 +80,9 @@ fn extract_all_metadata(html: &str) -> Result<serde_json::Value, NikaError> {
     let feeds = extract_feeds(&document);
 
     let mut result = serde_json::json!({});
-    let obj = result.as_object_mut().unwrap();
+    let obj = result
+        .as_object_mut()
+        .expect("json!({}) is always an object");
 
     if let Some(t) = title {
         obj.insert("title".to_string(), serde_json::Value::String(t));

--- a/tools/nika/src/runtime/executor/extract.rs
+++ b/tools/nika/src/runtime/executor/extract.rs
@@ -128,7 +128,7 @@ fn extract_metadata_json(html: &str) -> Result<String, NikaError> {
     let mut meta = serde_json::Map::new();
 
     // <title>
-    let title_sel = scraper::Selector::parse("title").unwrap();
+    let title_sel = scraper::Selector::parse("title").expect("static CSS selector");
     if let Some(el) = document.select(&title_sel).next() {
         meta.insert(
             "title".into(),
@@ -137,7 +137,7 @@ fn extract_metadata_json(html: &str) -> Result<String, NikaError> {
     }
 
     // meta name="description"
-    let meta_sel = scraper::Selector::parse("meta[name=description]").unwrap();
+    let meta_sel = scraper::Selector::parse("meta[name=description]").expect("static CSS selector");
     if let Some(el) = document.select(&meta_sel).next() {
         if let Some(content) = el.value().attr("content") {
             meta.insert("description".into(), content.into());
@@ -181,7 +181,8 @@ fn extract_metadata_json(html: &str) -> Result<String, NikaError> {
     }
 
     // JSON-LD
-    let jsonld_sel = scraper::Selector::parse("script[type=\"application/ld+json\"]").unwrap();
+    let jsonld_sel = scraper::Selector::parse("script[type=\"application/ld+json\"]")
+        .expect("static CSS selector");
     let json_ld: Vec<serde_json::Value> = document
         .select(&jsonld_sel)
         .filter_map(|el| serde_json::from_str(&el.text().collect::<String>()).ok())
@@ -191,7 +192,7 @@ fn extract_metadata_json(html: &str) -> Result<String, NikaError> {
     }
 
     // Canonical
-    let canon_sel = scraper::Selector::parse("link[rel=canonical]").unwrap();
+    let canon_sel = scraper::Selector::parse("link[rel=canonical]").expect("static CSS selector");
     if let Some(el) = document.select(&canon_sel).next() {
         if let Some(href) = el.value().attr("href") {
             meta.insert("canonical".into(), href.into());
@@ -204,7 +205,7 @@ fn extract_metadata_json(html: &str) -> Result<String, NikaError> {
 #[cfg(feature = "fetch-html")]
 fn extract_links_json(html: &str, _base_url: Option<&str>) -> Result<String, NikaError> {
     let document = scraper::Html::parse_document(html);
-    let a_sel = scraper::Selector::parse("a[href]").unwrap();
+    let a_sel = scraper::Selector::parse("a[href]").expect("static CSS selector");
     let links: Vec<serde_json::Value> = document
         .select(&a_sel)
         .map(|el| {

--- a/tools/nika/src/runtime/executor/verbs.rs
+++ b/tools/nika/src/runtime/executor/verbs.rs
@@ -1150,7 +1150,16 @@ impl TaskExecutor {
                             "/llms-full.txt",
                         ] {
                             let llm_url = format!("{}{}", origin, path);
-                            if let Ok(resp) = http_client.get(&llm_url).send().await {
+                            if let Ok(resp) = http_client
+                                .get(&llm_url)
+                                .timeout(std::time::Duration::from_secs(5))
+                                .send()
+                                .await
+                            {
+                                // Size limit on llm.txt response (1 MB max -- these are text files)
+                                if resp.content_length().unwrap_or(0) > 1_048_576 {
+                                    continue;
+                                }
                                 if resp.status().is_success() {
                                     if let Ok(body) = resp.text().await {
                                         if !body.trim().is_empty() {
@@ -1368,12 +1377,17 @@ impl TaskExecutor {
                     let media_blocks = tool_result.media_blocks();
                     let content_types: Vec<String> = media_blocks
                         .iter()
-                        .map(|b| match b {
-                            ContentBlock::Text { .. } => unreachable!("media_blocks filters text"),
-                            ContentBlock::Image { .. } => "image".to_string(),
-                            ContentBlock::Audio { .. } => "audio".to_string(),
-                            ContentBlock::Resource(_) => "resource".to_string(),
-                            ContentBlock::ResourceLink { .. } => "resource_link".to_string(),
+                        .filter_map(|b| match b {
+                            ContentBlock::Text { .. } => {
+                                tracing::warn!(
+                                    "Unexpected text block in media processing, skipping"
+                                );
+                                None
+                            }
+                            ContentBlock::Image { .. } => Some("image".to_string()),
+                            ContentBlock::Audio { .. } => Some("audio".to_string()),
+                            ContentBlock::Resource(_) => Some("resource".to_string()),
+                            ContentBlock::ResourceLink { .. } => Some("resource_link".to_string()),
                         })
                         .collect();
 


### PR DESCRIPTION
5 fixes from security scan: H1-H3 (unwrap→expect, unreachable→warn+skip), M3-M4 (llm_txt 1MB limit + 5s timeout per sub-request). 6616 tests pass.