### PR TITLE
security(context): scrub strategic brand content from public example file

### DIFF
--- a/tools/nika/context/brand.md
+++ b/tools/nika/context/brand.md
@@ -1,192 +1,26 @@
-# Nika Brand Bible
+# Example Brand Guide
 
-> "They built walls around intelligence. We compiled a door."
+This file is a **placeholder example** for Nika's `context:` YAML feature. It shows how a Nika workflow can reference a markdown file as structured context.
 
----
+## Usage in a workflow
 
-## Mission
+```yaml
+context:
+  brand: ./context/brand.md      # loaded as string and passed to LLM context
+  style: ./context/style-guide.md
+  schema: ./context/schema.json  # parsed as JSON
+```
 
-The gap between "AI exists" and "I can use AI" should be zero.
+## What YOUR brand.md should contain
 
-AI is the new electricity. Six closed labs control it. Chips cost $6M per rack. Subscriptions
-run $20–$200/month. And even if you pay, you still need a software engineer to wire anything
-useful. Nika exists to end that.
+Replace this example with your own brand voice, tone, and guidelines. A good brand.md typically covers:
 
----
+- **Voice axioms** — 5-10 principles describing how your product sounds
+- **Anti-patterns** — phrases or tones to avoid
+- **Example artifacts** — 2-3 canonical pieces of copy for tone calibration
 
-## Voice Pillars
+Keep it under ~800 tokens for efficient LLM context usage.
 
-| Pillar | Means | Does NOT mean |
-|--------|-------|---------------|
-| **Honest** | No fluff, no hype, no "disruption". Say what it does. Show the numbers. | Not cynical. Not nihilistic. |
-| **Technical** | We speak to developers who read source code. Benchmarks > adjectives. | Not gatekeeping. Explain simply when needed. |
-| **Liberatory** | Anti-monopoly, anti-lock-in, pro-access. This is a tool for the 99%. | Not preachy. Not political lecturing. Let the code argue. |
-| **Simple** | 5 verbs > 500 SDK methods. One binary > Docker + Python + pip + prayer. | Not dumbed down. Simplicity is engineering, not marketing. |
+## About this placeholder
 
-### How We Sound
-
-- Like a hacker who ships, not a startup that pitches
-- Like @0xSero's manifesto: conviction backed by code
-- Like Mr. Robot's opening monologue: direct, honest, slightly uncomfortable
-- Like the best HackerNews Show HN post you've ever read
-
-### How We Do NOT Sound
-
-- Corporate: "We're excited to announce our innovative platform..."
-- Startup: "Disruptive AI-powered orchestration solution..."
-- Academic: "A novel approach to declarative workflow specification..."
-- Anime fan: "Just like Luffy's Gear 5, Nika liberates..."
-
----
-
-## Tagline Hierarchy
-
-Use the right tagline for the right context.
-
-| Level | Tagline | When to use |
-|-------|---------|-------------|
-| **Primary** | Automate AI. No code required. | README, homepage, first impression |
-| **Manifesto** | The Drums of Liberation. In Rust. | Community rallying, deep content, talks |
-| **Technical** | 5 verbs. 22 providers. Zero Python. | Developer marketing, comparisons, HN |
-| **Confrontational** | LangChain chains you. Nika frees you. | Twitter, competitive posts, spicy takes |
-| **Mission** | AI shouldn't have a subscription fee. | Press, manifesto, about page |
-| **Poetic** | Liberate your AI. | Video closers, swag, minimal contexts |
-
----
-
-## Punchlines Bank
-
-These are load-bearing quotes. Preserve verbatim. Use liberally.
-
-1. "AI is the new electricity. It should be accessible to everyone."
-2. "The gap between 'AI exists' and 'I can use AI' should be zero."
-3. "Performance is not a luxury. Performance is freedom."
-4. "When your tool is lightweight, it goes everywhere. That's reach. That's access. That's the mission."
-5. "The five verbs are not a limitation. They are a language."
-6. "Workflows are data, not code."
-7. "MIT and Apache are gifts to corporations. AGPL breaks that pattern."
-8. "Nika is not a product. It's a movement."
-9. "In 1984, they controlled the words. In 2026, they control the tokens. Not anymore."
-10. "They built walls around intelligence. We compiled a door."
-11. "Built for the 99% who can't afford a $6M rack."
-12. "One binary to free them all."
-13. "Nika appeared in times of need. This is that time."
-14. "Open Source must win. We wrote the weapon in Rust."
-
----
-
-## The Three Narrative Layers
-
-Every piece of Nika communication operates on three layers. The deeper you go, the more
-resonance. But always lead with Layer 1.
-
-### Layer 1 — Real World (primary, always lead with this)
-
-AI is gatekept. 6 labs, $6M racks, $49/mo platforms. 57% of internet content is AI-generated
-but most humans can't access the tools. Controlling access to LLMs is the new Newspeak —
-limiting what people can think at scale. Nika is the open-source weapon that breaks the wall.
-
-**References:** @0xSero manifesto, Peter Thiel/Palantir surveillance capitalism, Orwell's 1984,
-the actual benchmark data (5x RAM, 4ms cold start, 44% CrewAI failure rate).
-
-### Layer 2 — The Code (secondary, the proof)
-
-A single Rust binary. 451K lines. 10 crates. 7,800+ tests. 5 verbs. YAML in, DAG out.
-No Python, no Docker, no cloud. Runs on a Raspberry Pi. Runs in CI. Runs on a $5 VPS.
-The code IS the argument. Show benchmarks, not adjectives.
-
-### Layer 3 — The Myth (subtext only, never lead with this)
-
-The name "Nika" comes from the Sun God in One Piece — a mythical warrior who liberates slaves
-by bringing them joy, not violence. The project architecture mirrors Dr. Vegapunk's satellite
-system (distributed specialized intelligence). The course is called "Liberation." The symbol
-is a butterfly — transformation, courage, freedom.
-
-**One Piece Rule:** Never mention One Piece in an elevator pitch, README first paragraph,
-press release, or investor deck. It belongs in: deep technical docs, the course narrative,
-architecture inspiration sections, community content, and as easter eggs for fans who notice.
-
----
-
-## Symbol Guide
-
-### The Blue Butterfly
-
-- **Meaning:** Liberation, transformation, the impossible becoming possible
-- **Origin:** Nika the warrior brings freedom. Butterflies symbolize metamorphosis.
-- **Usage:** Sparingly. One butterfly is powerful. A swarm is a climax, not a default.
-- **Color:** Indigo blue (#6366f1) or electric blue (#3b82f6) on dark backgrounds
-- **Where:** Logo accent, course completion badges, video closers, subtle terminal Easter eggs
-- **Where NOT:** Every slide, every paragraph, every social media post. Restraint = impact.
-
-### The Five Verbs
-
-- **infer · exec · fetch · invoke · agent**
-- These are Nika's DNA. They appear carved, etched, stated — never decorated.
-- They are the answer to "what can it do?" in exactly 5 words.
-
----
-
-## Visual Identity
-
-| Element | Value | Notes |
-|---------|-------|-------|
-| **Primary background** | #002b36 (Solarized Dark) | Terminal-native aesthetic |
-| **Primary accent** | #3b82f6 (Electric Blue) | Links, highlights, the butterfly |
-| **Secondary accent** | #6366f1 (Indigo) | Depth, secondary elements |
-| **Tertiary accent** | #06b6d4 (Cyan) | Data flow, fetch verb |
-| **Text** | #f8fafc (Near White) | High contrast on dark |
-| **Warning/Action** | #f59e0b (Amber) | exec verb, alerts |
-| **Success** | #10b981 (Emerald) | Completions, passing tests |
-| **Aesthetic** | Terminal-first. Dark mode. Monospace. | Not glassmorphism. Not gradients. Not purple AI glow. |
-| **Photography style** | Hacker in garage. Terminal at 3am. Real dev environments. | Not stock photos. Not corporate office. Not anime. |
-
----
-
-## Content Rules
-
-### Every Major Document Must...
-
-1. **Open with WHY** (the problem) before WHAT (the solution)
-2. **Show benchmarks** within the first scroll — numbers argue better than words
-3. **Include one punchline** from the bank above
-4. **Pass the 30-second test** — can a non-technical person understand the mission?
-
-### One Piece Content Policy
-
-| Context | One Piece OK? | Example |
-|---------|--------------|---------|
-| Elevator pitch | No | "YAML workflow engine for AI" not "Sun God Nika" |
-| README first paragraph | No | Lead with problem/solution |
-| Deep technical docs | Yes, as metaphor | "Architecture inspired by Vegapunk's satellite system" |
-| Course level names | Yes | "Jailbreak", "Liberation", "SuperNovae" |
-| Community content | Yes | Memes, fan art, twitter threads for the crew |
-| Video prompts | Subtle only | A butterfly, not a full pirate fleet |
-| Architecture docs | Yes, credited | "The brain/body split mirrors Vegapunk's design" |
-
----
-
-## Competitor Framing
-
-Never attack competitors by name in docs. Let the code speak. In marketing:
-
-| Competitor | Our framing |
-|------------|------------|
-| LangChain | "Zero abstraction tax. YAML is the abstraction." |
-| CrewAI | "Deterministic DAG, not 44% failure rate." |
-| Zapier/Make | "Your workflows belong in git, not in a database." |
-| Dify/n8n | "CLI-native. No Docker. No database. No web UI required." |
-| All Python | "5x less RAM. 4ms cold start. Single binary." |
-
----
-
-## The North Star Test
-
-Before publishing any Nika content, ask:
-
-1. Would @0xSero retweet this? (conviction + code)
-2. Would it survive HackerNews comments? (technical honesty)
-3. Does it sound like a movement, not a product? (liberation > features)
-4. Could someone with zero tech background understand the mission? (accessibility)
-
-If all four: ship it.
+This file ships with Nika as a structural reference for users writing their first workflow. It contains no real brand content from any product.


### PR DESCRIPTION
## Summary

- Replace `tools/nika/context/brand.md` (192 LOC of real strategic brand content) with a generic 26-LOC placeholder explaining how to use `context:` in a Nika workflow
- The file is referenced by 5+ test fixtures, `showcase_infra.rs` templates, and AST context docs — so the path must remain, but the content MUST be generic
- Strategic content is preserved privately in the supernovae-hq monorepo at `nika/hq/brand/_legacy-engine-brand.md` for consolidation into the canonical Art Bible

## Why

The example file at `tools/nika/context/brand.md` shipped on the PUBLIC `main` branch but contained real strategic brand material — voice pillars, anti-monopoly mission, the "They built walls around intelligence. We compiled a door." tagline, positioning thesis.

Per the supernovae-hq privacy rule (enforced by `scripts/hygiene/check-privacy-boundary.sh`): strategic brand material lives in the private monorepo at `<product>/hq/brand/`, never in public submodules.

Note: the active Diamond work on `nika-diamond` does not contain this file (Diamond migrated `tools/` → `crates/` and dropped the outdated example), so the leak is only on the legacy `main` branch. This PR keeps main hygienic for any future visitor who lands on the default branch.

## Public vs private going forward

- **PRIVATE** (supernovae-hq): all brand strategy, voice, positioning, anti-patterns — stays in `<product>/hq/brand/`
- **PUBLIC** (later, deliberate): consumer-facing material (taglines, mission one-liners) will be crafted separately, never extracted from private

## Test plan

- [x] New content is 26 LOC, generic, references no product strategy
- [x] File path preserved (tests + showcase templates unaffected)
- [x] Strategic archive saved privately at `supernovae-hq/nika/hq/brand/_legacy-engine-brand.md`
- [ ] Reviewer confirms no strategic language remains in `tools/nika/context/brand.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)