### PR TITLE
docs(crate-specs): scaffold Connectome climb — 10 Gate-1 specs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,8 +129,8 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `feat/nika-pack`                                      |
-| HEAD             | `3215bdd4b` (`3215bdd4b650ded677070dab8a1f5c2f1c67ad62`)             |
+| branch           | `main`                                      |
+| HEAD             | `3176466f7` (`3176466f70e7f64c3b8203588612ba2ba7429314`)             |
 | workspace        | v0.80.0                                  |
 | crates (workspace)| 25                                              |
 | crates (admitted)| 23 / 42                                   |
@@ -141,8 +141,8 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | L2               | 0                                              |
 | L3               | 0                                              |
 | L4               | 1                                              |
-| lib tests        | 1394 passed, 0 failed                              |
-| clippy           | 0 warnings                              |
+| lib tests        | (skipped — pass --no-quick to compute)                              |
+| clippy           | (skipped)                              |
 
 Narrative context (manually maintained):
 

--- a/.claude/rules/nika-invariants.md
+++ b/.claude/rules/nika-invariants.md
@@ -2,12 +2,12 @@
 
 ## Crate structure
 
-- Total target : **42 crates diamond v0.90** (cap 100) + **10 memory crates** at v0.95 Cortex (1 L2 orchestrator `nika-memory` + **9 L1 satellite crates** · 8 algorithmic concerns · autodesc splits into `nika-autodesc-minimal` [W4] + `nika-autodesc-full` [Phase 2] per ADR-042) — separate count. Satellites · `hnsw, bm25, rrf, fsrs, rdfs-reasoner, temporal, graph-algos, autodesc-minimal, autodesc-full`. See ADR-004 + ADR-042 + `BLUEPRINT_2036.md`.
+- Total target : **42 crates diamond v0.90** (cap 100) + **11 Connectome crates** (1 L2 orchestrator `nika-connectome` [renamed from `nika-memory` per the Connectome lock 2026-05-22] + **10 L1 satellite crates** · autodesc splits into `nika-autodesc-minimal` [W4] + `nika-autodesc-full` [Phase 2] per ADR-042 · `nika-rerank` M13 added by the SOTA ratification 2026-06-11) — separate count. Satellites · `hnsw, bm25, rrf, rerank, fsrs, rdfs-reasoner, temporal, graph-algos, autodesc-minimal, autodesc-full`. Phase-M climb · recall floor at v0.85 · cognition at v0.90+ · specs at `docs/crate-specs/nika-<sat>.md`. See ADR-004 + ADR-042 + `BLUEPRINT_2036.md`.
 
 ## Collapse-vs-publish principle (LOCKED · post BLUEPRINT_2036 v1.0)
 
 - **Internal-only clusters → collapse to one crate** · `nika-effects` (was 5 effect crates · ADR-055 queued) · `nika-verbs` (was 4 verb crates · ADR-056 queued · 4-verb semantic lock preserved at module level · fetch is the `nika:fetch` builtin under invoke, not a verb crate) · `init+lints+catalog-verify` → `nika-cli` subcommands. Per ADR-006 monolithic-kernel-spirit applied across clusters.
-- **Externally-publishable clusters → preserve per-crate granularity** · memory satellites (9 crates · ADR-004 publishable standalone on crates.io · external Rust RDF/ML ecosystem value) · provider variants (rig · native · mock · 3 crates · heavy-dep isolation). Per ADR-004 + ADR-042.
+- **Externally-publishable clusters → preserve per-crate granularity** · Connectome satellites (10 crates · ADR-004 publishable standalone on crates.io · external Rust RDF/ML ecosystem value) · provider variants (rig · native · mock · 3 crates · heavy-dep isolation). Per ADR-004 + ADR-042.
 - **Decision rule** · « is there genuine external value to per-crate granularity? » YES → split · NO → collapse. Default is collapse (12-gate ceremony × N crates costs more than module discipline within 1 crate).
 - Max LOC per crate : **15,000** (strict, enforced by xtask/CI)
 - Max LOC per file : **1,500** (strict, CI blocks)
@@ -17,7 +17,7 @@
 
 - `nika-*` prefix for all workspace members
 - `nika-verb-<verb>` for verb executors (exec, invoke, infer, agent · fetch is the `nika:fetch` builtin reached via invoke, not a verb)
-- `nika-memory-*` for memory subsystem satellites
+- Connectome satellites keep pro names (`nika-hnsw`, `nika-bm25`, … — NO `nika-memory-` prefix · `nika-bm25` admitted proves the canon)
 - `nika-<noun>` for effect impls (fs, http, blob, process, etc.)
 - `nika-process` (not `nika-exec-runner`, not `nika-shell`)
 - `nika-daemon-db` (not `nika-storage`)
@@ -94,7 +94,7 @@ pub struct InferResponse {
 }
 ```
 
-These hooks allow Cortex + agent-v2 to land post-v0.90 **without breaking
+These hooks allow the Connectome + agent-v2 to land post-v0.90 **without breaking
 change** to the public API.
 
 ## 28+ sacred invariants (inherited)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,8 +64,8 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `feat/nika-pack`                                      |
-| HEAD             | `3215bdd4b` (`3215bdd4b650ded677070dab8a1f5c2f1c67ad62`)             |
+| branch           | `main`                                      |
+| HEAD             | `3176466f7` (`3176466f70e7f64c3b8203588612ba2ba7429314`)             |
 | workspace        | v0.80.0                                  |
 | crates (workspace)| 25                                              |
 | crates (admitted)| 23 / 42                                   |
@@ -76,8 +76,8 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | L2               | 0                                              |
 | L3               | 0                                              |
 | L4               | 1                                              |
-| lib tests        | 1394 passed, 0 failed                              |
-| clippy           | 0 warnings                              |
+| lib tests        | (skipped — pass --no-quick to compute)                              |
+| clippy           | (skipped)                              |
 
 Diamond foundation, **8 crates admitted** + **2 WIP** in workspace
 (8 total), orphan branch from scratch.

--- a/docs/crate-specs/nika-autodesc-full.md
+++ b/docs/crate-specs/nika-autodesc-full.md
@@ -1,0 +1,51 @@
+# Crate spec — `nika-autodesc-full`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — ingest satellite (M5 · ★ schema evolution) |
+| LOC budget | ≤6,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Schema induction + entity resolution + hierarchical summarization —
+the connectome grows its OWN ontology from what it ingests
+(AutoSchemaKG pattern · no predefined schema) · clusters duplicate
+entities (KGGen) · maintains RAPTOR-style hierarchical summaries and
+A-MEM Zettelkasten-style linked notes. LLM-enrich is OPT-IN
+(`feature = "llm-enrich"` per ADR-040) — the deterministic floor works
+without any model.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct SchemaEvolver { /* induction state */ }
+impl SchemaEvolver {
+    pub fn observe(&mut self, batch: &[Record]) -> SchemaDelta;
+    pub fn resolve_entities(&self, store: &ConnectomeStore) -> Vec<MergeCandidate>;
+    pub fn summarize(&self, community: &Community) -> Result<SummaryNode, NikaError>;
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+builds on autodesc-minimal + graph-algos (Leiden communities feed summaries).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- AutoSchemaKG · arXiv:2505.23628 (schema induction)
+- RAPTOR · arXiv:2401.18059 (hierarchical abstractive retrieval trees)
+- A-MEM · arXiv:2502.12110 (agentic Zettelkasten notes)
+
+## 5. Test strategy
+
+Schema-delta determinism on golden corpora · entity-resolution precision/recall fixtures · summary-tree shape invariants. Mutation ≥85% (Rule-2 exemption where llm-enrich gated).
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-autodesc-minimal.md
+++ b/docs/crate-specs/nika-autodesc-minimal.md
@@ -1,0 +1,52 @@
+# Crate spec — `nika-autodesc-minimal`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — ingest satellite (M9 · ★ THE MOAT) |
+| LOC budget | ≤4,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+The zero-LLM write path — deterministic ingest of records into the
+connectome with PROV-O provenance attached to every triple (source ·
+agent · activity · time · ed25519-signable). Write operations follow
+the Mem0-validated pipeline (ADD / MERGE / DELETE with entity-cluster
+matching per KGGen). **Ingest redaction guard (ADR-081-class)** ·
+secret/PII patterns are refused at the write path — the engine's
+Guard 1-2 lesson applied to memory. Embedding literals carry model
+provenance (embedding-provenance invariant) — migration-safe by schema.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct Ingestor { /* redaction rules · prov context */ }
+impl Ingestor {
+    pub fn add(&self, store: &mut ConnectomeStore, record: Record) -> Result<ProvenancedId, NikaError>;
+    pub fn merge(&self, store: &mut ConnectomeStore, a: RecordId, b: RecordId) -> Result<RecordId, NikaError>;
+    pub fn delete(&self, store: &mut ConnectomeStore, id: RecordId) -> Result<Tombstone, NikaError>;
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+PROV-O vocabulary over oxigraph · `ed25519-dalek@2.2` (pin 2.x · 3.0-rc breaking imminent).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- PROV-O · W3C 2013 (canonical)
+- Mem0 · arXiv:2504.19413 (ADD/MERGE/DELETE ops pipeline)
+- KGGen · arXiv:2502.09956 (entity-resolution clustering)
+
+## 5. Test strategy
+
+Provenance completeness invariant (NO triple without prov) · redaction guard negative tests (plant secrets · MUST refuse) · merge idempotence · signature round-trip. Mutation ≥90% · security-sensitive → proptest (Gate 6 MANDATORY here).
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-connectome.md
+++ b/docs/crate-specs/nika-connectome.md
@@ -1,0 +1,59 @@
+# Crate spec — `nika-connectome`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L2 — THE ORCHESTRATOR |
+| LOC budget | ≤10,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+The cognitive organ's conductor — owns the Oxigraph store (in-memory
++ N-Quads snapshot per the ratified-stack honesty note · `feature = \"rocksdb\"`
+opt-in later), composes the recall pipeline (BM25 ∥ HNSW → RRF →
+rerank M13 → **context assembly M15** · token-budgeted packing with
+dedup + diversity), routes ingest through autodesc, exposes the
+GraphRAG query path (M11 · LazyGraphRAG-style local-NLP index ·
+deferred summarization), and schedules FSRS review sweeps. Ships the
+**memory bench harness** (LongMemEval + LoCoMo · sister of the spec
+repo's eval/) at R2.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct Connectome { /* store + satellites */ }
+impl Connectome {
+    pub fn open(path: &Path) -> Result<Self, NikaError>;          // snapshot load
+    pub fn recall(&self, query: RecallQuery) -> Result<AssembledContext, NikaError>;
+    pub fn ingest(&mut self, record: Record) -> Result<ProvenancedId, NikaError>;
+    pub fn sparql(&self, q: &str) -> Result<QueryResults, NikaError>;
+    pub fn snapshot(&self) -> Result<PathBuf, NikaError>;          // N-Quads dump
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+`oxigraph@0.5.8` + all Phase-M satellites (downward deps only · L2→L1).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- GraphRAG · arXiv:2404.16130 · LazyGraphRAG (MSR blog 2024-11 · 0.1% index cost)
+- MemOS · arXiv:2507.03724 (lifecycle scheduling informs the sweep design)
+- Benchmarks · LongMemEval arXiv:2410.10813 · LoCoMo arXiv:2402.17753
+
+## 5. Test strategy
+
+End-to-end recall quality gates on bench corpora · snapshot round-trip (open→ingest→snapshot→open = identical SPARQL results) · context-assembly budget invariants (never exceeds token budget · dedup holds). Mutation ≥85%.
+
+## 6. Error prefix
+
+`NIKA-CNX-NNN` (Phase-M reservation) · allocated in the `nika_error::codes` registry at ceremony.
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-fsrs.md
+++ b/docs/crate-specs/nika-fsrs.md
@@ -1,0 +1,49 @@
+# Crate spec — `nika-fsrs`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — forgetting satellite (M10) |
+| LOC budget | ≤1,500 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Optimal forgetting — FSRS (Free Spaced Repetition Scheduler · the
+Anki 23.10+ algorithm) decides each record's retrievability and next
+review · memories decay honestly instead of accumulating forever. The
+recall pipeline weights results by retrievability; the consolidator
+(M14 · future) uses due-review sets as its work queue. Augmented by the
+Generative-Agents scoring triple (recency · importance · relevance).
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct MemoryScheduler { /* fsrs params */ }
+impl MemoryScheduler {
+    pub fn review(&mut self, id: RecordId, grade: Grade, at: Timestamp) -> NextReview;
+    pub fn retrievability(&self, id: RecordId, at: Timestamp) -> f32;
+    pub fn due(&self, at: Timestamp, limit: usize) -> Vec<RecordId>;
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+`fsrs@6.6` (BSD-3 · open-spaced-repetition official · burn is dev-dep only · runtime = ndarray/rayon · pin `priority-queue@=2.7.0` noted).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- FSRS · open-spaced-repetition (Anki 23.10+) · root model KDD 2022
+- Generative Agents recency·importance·relevance · arXiv:2304.03442
+
+## 5. Test strategy
+
+Determinism fixtures (same review history → same schedule) · retrievability monotonic-decay property tests · due-set ordering. Mutation ≥90%.
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-graph-algos.md
+++ b/docs/crate-specs/nika-graph-algos.md
@@ -1,0 +1,46 @@
+# Crate spec — `nika-graph-algos`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — reasoning satellite (M6) |
+| LOC budget | ≤4,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Graph cognition over the connectome — community detection (Leiden),
+centrality, shortest paths, and **Personalized PageRank** (the HippoRAG
+bridge: seed PPR from query-matched entities to surface associatively-
+linked memories — the single strongest memory↔graph result of 2024-25,
+portable pure-Rust).
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub fn leiden(g: &ConnectomeGraph, resolution: f64) -> Communities;
+pub fn personalized_pagerank(g: &ConnectomeGraph, seeds: &[NodeId], damping: f64)
+    -> Vec<(NodeId, f64)>;
+pub fn centrality(g: &ConnectomeGraph, kind: Centrality) -> Vec<(NodeId, f64)>;
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+`petgraph@0.8.3` (MIT/Apache) + `graphrs@0.11` (MIT · native Leiden/Louvain) · PPR = maison (~200 LOC power-iteration).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- Leiden · Traag et al. · arXiv:1810.08473
+- HippoRAG · arXiv:2405.14831 · HippoRAG 2 · arXiv:2502.14802 (ICML 2025 · the PPR memory pattern)
+
+## 5. Test strategy
+
+Golden fixtures vs NetworkX outputs (small graphs) · Leiden well-connectedness property · PPR convergence tolerance tests. Mutation ≥90%.
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-hnsw.md
+++ b/docs/crate-specs/nika-hnsw.md
@@ -1,0 +1,49 @@
+# Crate spec — `nika-hnsw`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — recall satellite (M2 · vector ANN) |
+| LOC budget | ≤2,500 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Approximate-nearest-neighbor vector recall over the connectome's
+embeddings — Pinecone-class, local, sovereign. Embeddings live IN the
+RDF graph as `xsd:base64Binary` literals (ADR-004 storage scenario); the
+HNSW index is an **ephemeral cache rebuilt at boot** — the graph is the
+truth, the index is derived. Each embedding literal carries its model
+provenance (embedding-provenance invariant) — no silent cross-model cosine.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct HnswIndex { /* hnsw_rs wrapper · M dims · ef params */ }
+impl HnswIndex {
+    pub fn build(records: impl Iterator<Item = (RecordId, Vec<f32>)>) -> Self;
+    pub fn search(&self, query: &[f32], k: usize) -> Vec<(RecordId, f32)>;
+    pub fn insert(&mut self, id: RecordId, vec: Vec<f32>);
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+`hnsw_rs@0.3.4` (MIT/Apache · pure-Rust · anndists/rayon). Matryoshka truncation + int8 quantization as feature-gated R2.
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- HNSW · Malkov & Yashunin · arXiv:1603.09320 (canonical)
+- Matryoshka Representation Learning · arXiv:2205.13147 (truncatable dims · R2)
+
+## 5. Test strategy
+
+Recall@k vs brute-force oracle on synthetic + real corpora (proptest dims) · boot-rebuild determinism · insert-after-build parity. Mutation ≥90%.
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-rdfs-reasoner.md
+++ b/docs/crate-specs/nika-rdfs-reasoner.md
@@ -1,0 +1,45 @@
+# Crate spec — `nika-rdfs-reasoner`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — reasoning satellite (M7) |
+| LOC budget | ≤3,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Deterministic inference over the graph — RDFS entailment + OWL 2 RL
+materialization (subclass/subproperty transitivity · domain/range ·
+inverse · transitive properties). Zero LLM. New triples land
+provenance-tagged as `prov:wasDerivedFrom` the rule + premises.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct Reasoner { /* ruleset */ }
+impl Reasoner {
+    pub fn materialize(&self, store: &mut ConnectomeStore) -> Result<DerivedCount, NikaError>;
+    pub fn explain(&self, triple: &Triple) -> Option<DerivationChain>;
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+`reasonable@0.4.4` (BSD-3 · OWL2-RL pure-Rust). horned-owl REJECTED (LGPL-3.0 · license wall).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- W3C OWL 2 RL profile + RDFS entailment (specs · not arXiv)
+
+## 5. Test strategy
+
+W3C entailment test-suite subset as golden fixtures · derivation-chain explainability round-trip · idempotence (re-materialize = no new triples). Mutation ≥90%.
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-rerank.md
+++ b/docs/crate-specs/nika-rerank.md
@@ -1,0 +1,52 @@
+# Crate spec — `nika-rerank`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — recall satellite (M13 · cross-encoder rerank · NEW · ratified 2026-06-11) |
+| LOC budget | ≤3,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+The precision tail — a LOCAL cross-encoder reranks the top-N fused
+candidates (+20-30% precision over RRF alone, the 2024-25 standard).
+Pure-candle (xlm-roberta arch · bge-reranker-v2-m3 weights · Qwen3-0.6B
+alternative) · quantized CPU inference · zero cloud, zero FFI.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct Reranker { /* candle model handle */ }
+impl Reranker {
+    pub fn load(model_dir: &Path) -> Result<Self, NikaError>;
+    pub fn rerank(&self, query: &str, candidates: Vec<Candidate>, top_k: usize)
+        -> Result<Vec<(Candidate, f32)>, NikaError>;
+}
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+`candle-core@0.10` + `candle-transformers` (xlm-roberta) · weights sovereign local-path load (the nika-ocr `with_models` precedent · no auto-download).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- BGE-M3 family · arXiv:2402.03216 (bge-reranker-v2-m3 weights)
+- Qwen3 Embedding/Reranker · arXiv:2506.05176 (Apache-2.0 · the 2025 local SOTA)
+
+## 5. Test strategy
+
+Golden score-parity fixtures vs reference implementation outputs · latency budget test (p95 ≤80ms/pair CPU quantized) · Rule-2 model-inference mutation exemption (the nika-ocr precedent).
+
+## 6. Note · why a 10th satellite
+
+The original 9-satellite pipeline stopped at RRF; every production retrieval stack 2024+
+carries a reranker tail. Formalized as mechanism M13 (operator-ratified 2026-06-11).
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-rrf.md
+++ b/docs/crate-specs/nika-rrf.md
@@ -1,0 +1,40 @@
+# Crate spec — `nika-rrf`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — recall satellite (M3 · rank fusion) |
+| LOC budget | ≤400 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Reciprocal Rank Fusion — merges the lexical (BM25) and vector (HNSW)
+result lists into one hybrid ranking. ~150 LOC of load-bearing
+simplicity; the canonical k=60 constant; deterministic, total, pure.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub fn fuse(lists: &[Vec<RecordId>], k: f32) -> Vec<(RecordId, f32)>;
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+none beyond std (pure function crate).
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- RRF · Cormack, Clarke & Buettcher · SIGIR 2009 (canonical · pre-arXiv)
+
+## 5. Test strategy
+
+Property tests (permutation invariance per-list · monotonicity · k sensitivity) · golden fixtures vs the paper's worked example. Mutation 100% target (tiny surface).
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/docs/crate-specs/nika-temporal.md
+++ b/docs/crate-specs/nika-temporal.md
@@ -1,0 +1,45 @@
+# Crate spec — `nika-temporal`
+
+| | |
+|---|---|
+| Status | **Phase M proposal** (Gate 1 · shipped 2026-06-11 · admission at its Phase-M step of the Connectome climb (ADR-004 + ADR-042 lineage)) |
+| Layer | L1 — time satellite (M8) |
+| LOC budget | ≤2,000 src |
+| Crate version | tracks workspace |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` initially · **publishable crates.io standalone** post-admission (per ADR-004 · external ecosystem value) |
+| NIKA codes | `NIKA-CNX-*` family · exact range allocated at ceremony via `nika_error::codes` registry (never invented here) |
+
+---
+
+## 1. Purpose
+
+Bitemporal layer — every assertion carries valid-time (when true in
+the world) and transaction-time (when recorded). « What did I believe
+on May 10th? » and « what was true on May 10th? » are different
+queries, and both work. Zep (2025) validates exactly this design for
+agent memory in production.
+
+## 2. Public API (sketch · Gate 1 level · final at ceremony)
+
+```rust
+pub struct TemporalQuery { /* as-of · between · valid vs tx */ }
+pub fn as_of(store: &ConnectomeStore, tx_time: Timestamp) -> SnapshotView;
+pub fn valid_during(store: &ConnectomeStore, interval: Interval) -> TripleSet;
+```
+
+## 3. Dependencies (LOCKED · Connectome stack ratification 2026-06-11 · crates.io-verified)
+
+RDF-star annotations over `oxigraph@0.5.8` (the locked store) · no extra deps.
+
+## 4. SOTA references (ratified 2026-06-11 · arXiv-API-verified)
+
+- Bitemporal model · Snodgrass 1995 (canonical DB time)
+- Zep · arXiv:2501.13956 (temporal KG for agent memory · prod validation)
+
+## 5. Test strategy
+
+Bitemporal truth-table fixtures (4 quadrants valid×tx) · retroactive-correction scenarios · as-of determinism. Mutation ≥90%.
+
+🦋 *Connectome satellite · « Memory is the function · the Connectome is the structure. »*

--- a/scripts/hygiene/check-status-claims-sync.sh
+++ b/scripts/hygiene/check-status-claims-sync.sh
@@ -59,11 +59,18 @@ fi
 #                         drift. HEAD parity for tracked docs is intentionally
 #                         left unenforced; vector 1 (memory-head-sha) handles
 #                         the out-of-tree MEMORY.md pointer separately.
-# What remains: branch, workspace version, crate counts, per-layer
+#   - branch            : tree-local, same class as HEAD. A PR branch that
+#                         splices the block then squash-merges poisons main's
+#                         embedded block with the feature-branch name, hard-
+#                         blocking every later push from main (fired twice,
+#                         2026-06-10/11 · feat/nika-pack). Committed docs on
+#                         main should cosmetically say `main`, but parity on
+#                         this row is structurally meaningless.
+# What remains: workspace version, crate counts, per-layer
 # distribution. These are the SLOWLY-changing fields where drift is
 # pathological (a wrong layer count = misleading architecture claim).
 strip_dynamic() {
-  grep -vE '^\| (lib tests|clippy|HEAD) '
+  grep -vE '^\| (lib tests|clippy|HEAD|branch) '
 }
 
 CANONICAL_STATIC=$(echo "$CANONICAL" | strip_dynamic)


### PR DESCRIPTION
Gate-1 surface for the Connectome admission sequence (Phase M): one spec per satellite + the L2 orchestrator. Stack locked per the 2026-06-11 SOTA ratification (crates.io-verified versions, arXiv-API-verified papers). `nika-rerank` joins as the 10th satellite (M13 cross-encoder tail after RRF).

Also:
- `nika-invariants.md` un-drifted — Cortex retired → Connectome, pro satellite names canonical (`nika-bm25` admitted proves it), 10-satellite count.
- vector 23 now strips the `branch` row (tree-local, same class as HEAD) — the squash-merge of #112 had poisoned main's embedded block with `feat/nika-pack`, which would hard-block every later push from main. Both whitelisted docs re-spliced with `branch=main`.

Docs + hygiene only — no Rust crate code touched (session B active on crates/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)