### PR TITLE
chore(nika-pack): re-sync pack — rounds 2+3 (spec 6c18927)

### DIFF
--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -45,6 +45,8 @@ counts:
   providers: 14
   extract_modes: 9
   error_namespaces: 14
+  error_categories: 12
+  error_codes: 28
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -178,6 +180,64 @@ error_namespaces:
     - NIKA-SEC
     - NIKA-TIMEOUT
     - NIKA-VAR
+
+# ---------------------------------------------------- error categories (v1 closed enum)
+# spec/05-errors.md §Categories is the prose home · 10 original + 2 additive
+# (process_error · budget_error · divergence-audit 2026-06-11 · spec 44bf15f).
+error_categories:
+  count: 12
+  reference: spec/05-errors.md
+  items:
+    - parse_error
+    - validation_error
+    - variable_error
+    - provider_error
+    - network_error
+    - tool_error
+    - process_error
+    - budget_error
+    - security_error
+    - timeout_error
+    - cancelled
+    - internal_error
+
+# ---------------------------------------------------- concrete error codes (v0.1 normative floor)
+# spec/05-errors.md §Concrete v0.1 codes is the prose home · the projector
+# emits website public/errors/catalog.json from THIS block and the parity
+# check binds the prose table to it (same row set · same fields).
+# transient · false | engine-assessed
+error_codes:
+  count: 28
+  reference: spec/05-errors.md
+  items:
+    - { code: NIKA-DAG-001, category: validation_error, transient: "false", failure: "cycle in depends_on (incl. self-dependency)" }
+    - { code: NIKA-DAG-002, category: validation_error, transient: "false", failure: "depends_on references an undeclared task" }
+    - { code: NIKA-DAG-003, category: validation_error, transient: "false", failure: "a tasks.X reference with no declared edge" }
+    - { code: NIKA-DAG-004, category: validation_error, transient: "false", failure: "on_error.recover references a task downstream of the declaring task (await would deadlock)" }
+    - { code: NIKA-VAR-001, category: variable_error, transient: "false", failure: "unresolved reference (unknown namespace entry · undeclared env/vars key)" }
+    - { code: NIKA-VAR-002, category: variable_error, transient: "false", failure: "binding cardinality — a jq binding emitted zero or multiple values" }
+    - { code: NIKA-VAR-003, category: validation_error, transient: "false", failure: "provably-invalid path into a declared schema (static walk)" }
+    - { code: NIKA-VAR-004, category: variable_error, transient: "false", failure: "jq runtime error while evaluating a binding" }
+    - { code: NIKA-VAR-005, category: validation_error, transient: "false", failure: "static expression violation — outside cel-subset/0.1 · chained relation · unknown function · non-boolean when: root · jq compile error" }
+    - { code: NIKA-VAR-006, category: variable_error, transient: "false", failure: "expression type error at evaluation — cross-type compare · non-boolean when: value · for_each over a non-array" }
+    - { code: NIKA-VAR-007, category: variable_error, transient: "false", failure: "bytes value substituted into a string position" }
+    - { code: NIKA-VAR-008, category: validation_error, transient: "false", failure: "unclosed ${{ opener" }
+    - { code: NIKA-INFER-001, category: provider_error, transient: "engine-assessed", failure: "provider call failed (HTTP error · provider refusal)" }
+    - { code: NIKA-INFER-002, category: validation_error, transient: "false", failure: "structured output failed schema validation (after any engine-internal retries)" }
+    - { code: NIKA-EXEC-001, category: process_error, transient: "false", failure: "non-zero exit code (default capture modes)" }
+    - { code: NIKA-EXEC-002, category: process_error, transient: "false", failure: "spawn failure (command not found · permission)" }
+    - { code: NIKA-INVOKE-001, category: validation_error, transient: "false", failure: "unknown tool (unresolvable nika:/mcp: id)" }
+    - { code: NIKA-INVOKE-002, category: validation_error, transient: "false", failure: "tool args failed the tool's schema" }
+    - { code: NIKA-AGENT-001, category: budget_error, transient: "false", failure: "max_turns exhausted before completion" }
+    - { code: NIKA-AGENT-002, category: budget_error, transient: "false", failure: "max_tokens_total exhausted before completion" }
+    - { code: NIKA-MCP-001, category: tool_error, transient: "engine-assessed", failure: "MCP server not configured / not reachable at call time" }
+    - { code: NIKA-MCP-002, category: tool_error, transient: "engine-assessed", failure: "MCP tool call failed (transport · tool-side error)" }
+    - { code: NIKA-SEC-001, category: security_error, transient: "false", failure: "exec: blocklist hit" }
+    - { code: NIKA-SEC-002, category: security_error, transient: "false", failure: "agent tool call outside the tools: whitelist" }
+    - { code: NIKA-SEC-003, category: security_error, transient: "false", failure: "run-recursion bound — nested-run depth exceeded OR self-launching workflow" }
+    - { code: NIKA-TIMEOUT-001, category: timeout_error, transient: "false", failure: "task (or for_each iteration) exceeded timeout:" }
+    - { code: NIKA-CANCEL-001, category: cancelled, transient: "false", failure: "task cancelled (workflow failure gate · user cancellation)" }
+    - { code: NIKA-BUILTIN-DONE-001, category: validation_error, transient: "false", failure: "nika:done invoked outside an agent: loop" }
 
 # ---------------------------------------------------------------- pillars
 # 5 immutable pillars forever (spec/00-overview · the language backbone).

--- a/crates/nika-pack/pack/examples/22-fetch-chain.nika.yaml
+++ b/crates/nika-pack/pack/examples/22-fetch-chain.nika.yaml
@@ -17,6 +17,11 @@ vars:
 
 tasks:
   # A deterministic local fallback, in case the live fetch fails.
+  # SHAPE CONTRACT · the cached JSON mirrors the API response shape
+  # ({ data: { title, body } }) — on recovery the output: bindings below
+  # evaluate over THIS value (recover substitutes the raw output before
+  # extraction · 05-errors §recovery × bindings) · so tasks.fetch_article.title
+  # works on both paths.
   - id: cached
     invoke:
       tool: nika:read
@@ -34,7 +39,7 @@ tasks:
       title: ".data.title"
       body: ".data.body"
     on_error:
-      recover: ${{ tasks.cached.output }}    # degrade gracefully to the cached copy
+      recover: ${{ tasks.cached.output }}    # same shape as the live response · bindings still extract
 
   - id: summarize
     depends_on: [fetch_article]

--- a/crates/nika-pack/pack/examples/26-for-each-locales.nika.yaml
+++ b/crates/nika-pack/pack/examples/26-for-each-locales.nika.yaml
@@ -21,7 +21,9 @@ tasks:
   - id: translate
     for_each: ${{ vars.locales }}     # one iteration per locale
     max_parallel: 3                    # at most 3 concurrent translations
-    fail_fast: false                   # keep going · collect per-iteration errors
+    fail_fast: false                   # keep going · a failed locale yields null at its index
+    on_error:
+      recover: null                    # the batch lives · filter nulls at the fan-in
     with:
       locale: ${{ item }}              # current element
       n: ${{ index }}                  # 0-based position

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -15,24 +15,24 @@ foundation:
   - file: examples/19-schema-retry.nika.yaml
     sha256_16: c9d9a0f6e6dfb9c5
   - file: examples/22-fetch-chain.nika.yaml
-    sha256_16: 3b8140160f4720c0
+    sha256_16: 7f39d402ea41dcd5
   - file: examples/23-code-review.nika.yaml
     sha256_16: 1067f66757507178
   - file: examples/26-for-each-locales.nika.yaml
-    sha256_16: bfd6ec2a4df673dd
+    sha256_16: 187904d14bb2e430
 templates:
   - file: templates/agent-loop.nika.yaml
     sha256_16: 4de0e9cd94e9228a
   - file: templates/chain.nika.yaml
     sha256_16: 823f49b8fd3d3dbe
   - file: templates/etl-state.nika.yaml
-    sha256_16: c86244ce23f78dd4
+    sha256_16: d1b672d199505f56
   - file: templates/fanout.nika.yaml
-    sha256_16: 687d4fcc3b4defb1
+    sha256_16: 32a0c6a483339247
   - file: templates/gate-and-act.nika.yaml
     sha256_16: 1d51deb4424f24d6
   - file: templates/human-gated-ship.nika.yaml
-    sha256_16: 68ce68cfc2e2cc6b
+    sha256_16: c8e1bd7f0b0cd294
 showcase:
   - file: examples/showcase/t1-meeting-actions.nika.yaml
     workflow: meeting-actions
@@ -69,13 +69,13 @@ showcase:
     tier: T2
     description: "CSV batch \u2192 schema gate \u2192 quarantine the bad \u00b7 aggregate the good"
     constructs: [on_error, outputs, when]
-    sha256_16: c0a2910ef02e71b9
+    sha256_16: 23b955868d4c7621
   - file: examples/showcase/t2-invoice-chaser.nika.yaml
     workflow: invoice-chaser
     tier: T2
     description: "Ledger CSV \u2192 overdue filter \u2192 drafted reminders \u2192 human gate \u2192 drafts file"
     constructs: [outputs, when]
-    sha256_16: 82456ae10ac8ebc5
+    sha256_16: 129be0260b2bcd5c
   - file: examples/showcase/t2-release-notes.nika.yaml
     workflow: release-notes
     tier: T2
@@ -87,7 +87,7 @@ showcase:
     tier: T2
     description: "dependency release feed \u2192 diff vs last run \u2192 only the NEW ships"
     constructs: [on_error, output, outputs, when]
-    sha256_16: 02839e973deeb073
+    sha256_16: 4bcb33e1db4fffb1
   - file: examples/showcase/t2-seo-content-brief.nika.yaml
     workflow: seo-content-brief
     tier: T2
@@ -104,32 +104,32 @@ showcase:
     workflow: competitor-radar
     tier: T3
     description: "Sitemap \u2192 parallel page reads \u2192 one competitive brief + ping"
-    constructs: [fail_fast, for_each, max_parallel, output, outputs, retry, secrets, timeout]
-    sha256_16: a212d58a67b14abe
+    constructs: [fail_fast, for_each, max_parallel, on_error, output, outputs, retry, secrets, timeout]
+    sha256_16: 50c5803c438efc6b
   - file: examples/showcase/t3-config-drift-sentinel.nika.yaml
     workflow: config-drift-sentinel
     tier: T3
     description: "live config vs sanctioned baseline \u2192 typed drift \u2192 explained alert"
-    constructs: [outputs, retry, secrets, typed_vars, when]
-    sha256_16: 9de9191887f8dc0d
+    constructs: [on_error, outputs, retry, secrets, typed_vars, when]
+    sha256_16: 5ac8c0dffa4fdf87
   - file: examples/showcase/t3-localization-factory.nika.yaml
     workflow: localization-factory
     tier: T3
     description: "glob docs \u2192 parallel read \u2192 parallel translate \u2192 mirror tree"
-    constructs: [fail_fast, for_each, max_parallel, outputs]
-    sha256_16: efd97c32a3d4eb73
+    constructs: [fail_fast, for_each, max_parallel, on_error, outputs]
+    sha256_16: 2404e47d06aef766
   - file: examples/showcase/t3-pr-review-fanout.nika.yaml
     workflow: pr-review-fanout
     tier: T3
     description: "changed files \u2192 one read-only review agent each \u2192 merged REVIEW.md"
-    constructs: [agent_tools, fail_fast, for_each, max_parallel, outputs, schema]
-    sha256_16: 71311315b7addcaf
+    constructs: [agent_tools, fail_fast, for_each, max_parallel, on_error, outputs, schema]
+    sha256_16: 579638baa0cfd41a
   - file: examples/showcase/t3-resume-screener.nika.yaml
     workflow: resume-screener
     tier: T3
     description: "glob CVs \u2192 local-model rubric per candidate \u2192 deterministic shortlist"
-    constructs: [fail_fast, for_each, local_model, max_parallel, outputs, schema, when, with]
-    sha256_16: df21f7572f61cd8b
+    constructs: [fail_fast, for_each, local_model, max_parallel, on_error, outputs, schema, when, with]
+    sha256_16: a7b1ae4c65b76389
   - file: examples/showcase/t4-ceo-monday-brief.nika.yaml
     workflow: ceo-monday-brief
     tier: T4
@@ -146,11 +146,11 @@ showcase:
     workflow: incident-war-room
     tier: T4
     description: "parallel evidence \u2192 typed timeline \u2192 settle + recheck \u2192 postmortem draft"
-    constructs: [capture, on_finally, outputs, retry, schema, secrets, thinking]
-    sha256_16: e35a3f47b3019239
+    constructs: [capture, on_finally, outputs, retry, schema, secrets, thinking, when]
+    sha256_16: 63e0a14fe6376014
   - file: examples/showcase/t4-release-train.nika.yaml
     workflow: release-train
     tier: T4
     description: "parallel gates \u2192 human GO \u2192 hold until the window \u2192 ship \u00b7 verify \u00b7 record"
-    constructs: [capture, on_finally, outputs, retry, secrets, timeout, typed_vars]
-    sha256_16: 6049a8c793e4e407
+    constructs: [capture, on_finally, outputs, retry, secrets, timeout, typed_vars, when]
+    sha256_16: a95ba8b6b7123534

--- a/crates/nika-pack/pack/examples/showcase/t2-etl-quarantine.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-etl-quarantine.nika.yaml
@@ -84,7 +84,7 @@ tasks:
 
   - id: report
     depends_on: [good]
-    when: ${{ size(tasks.good.output) > 0 }}
+    when: ${{ tasks.good.output != null && size(tasks.good.output) > 0 }}   # good is SKIPPED (null) on the quarantine path · guard before size()
     invoke:
       tool: "nika:write"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t2-invoice-chaser.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-invoice-chaser.nika.yaml
@@ -58,6 +58,7 @@ tasks:
 
   - id: approve
     depends_on: [drafts]
+    when: ${{ tasks.drafts.output != null }}   # nothing drafted · nothing to approve
     invoke:
       tool: "nika:prompt"
       args:
@@ -66,7 +67,7 @@ tasks:
 
   - id: save
     depends_on: [approve, drafts]
-    when: ${{ tasks.approve.output == true }}
+    when: ${{ tasks.drafts.output != null && tasks.approve.output == true }}   # zero overdue → drafts skipped (null) · don't write nothing
     invoke:
       tool: "nika:write"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t2-release-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-radar.nika.yaml
@@ -36,6 +36,7 @@ tasks:
       tool: "nika:read"
       args: { path: "${{ vars.state_path }}" }
     on_error:
+      on_codes: [NIKA-BUILTIN-READ-001]   # not-found ONLY · a permission error still fails loudly
       recover: ${{ tasks.no_state.output }}
 
   - id: feed

--- a/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
@@ -43,6 +43,8 @@ tasks:
     for_each: ${{ tasks.map.recent }}
     max_parallel: 4                    # be polite · 4 fetches in flight max
     fail_fast: false                   # one dead page must not kill the radar
+    on_error:
+      recover: null                    # a dead page yields null at its index · the radar lives
     timeout: "30s"
     retry:
       max_attempts: 3

--- a/crates/nika-pack/pack/examples/showcase/t3-config-drift-sentinel.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-config-drift-sentinel.nika.yaml
@@ -78,6 +78,8 @@ tasks:
   - id: explain
     depends_on: [drift]
     when: ${{ size(tasks.drift.output) > 0 }}
+    on_error:
+      recover: "(explanation unavailable — model call failed · the raw patch is attached)"
     infer:
       prompt: |
         This RFC 6902 patch is UNSANCTIONED config drift in production ·

--- a/crates/nika-pack/pack/examples/showcase/t3-localization-factory.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-localization-factory.nika.yaml
@@ -52,7 +52,9 @@ tasks:
     depends_on: [pairs]
     for_each: ${{ tasks.pairs.output }}
     max_parallel: 3                    # rate-limit the provider
-    fail_fast: false                   # finish the batch · report stragglers
+    fail_fast: false                   # finish the batch · a failed file yields null at its index
+    on_error:
+      recover: null                    # null keeps the transpose zip aligned (order preserved)
     infer:
       prompt: |
         Translate to ${{ vars.lang }} · keep markdown structure, code blocks
@@ -65,7 +67,7 @@ tasks:
       tool: "nika:jq"
       args:
         input: ["${{ tasks.pairs.output }}", "${{ tasks.translated.output }}"]
-        expression: "transpose | map({path: .[0].path, text: .[1]})"
+        expression: "transpose | map(select(.[1] != null)) | map({path: .[0].path, text: .[1]})"
 
   - id: mirror
     depends_on: [bundle]

--- a/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
@@ -49,6 +49,8 @@ tasks:
     for_each: ${{ tasks.files.output }}
     max_parallel: 4
     fail_fast: false
+    on_error:
+      recover: null                    # a budget-exhausted review yields null · the swarm lives
     agent:
       system: "You are a precise code reviewer. Read the file, then report findings."
       prompt: "Review ${{ item }} · bugs first, then risky patterns. Read it before judging."
@@ -78,7 +80,7 @@ tasks:
       tool: "nika:jq"
       args:
         input: "${{ tasks.reviews.output }}"
-        expression: 'map(.findings[] + {file: .file}) | sort_by(.severity)'
+        expression: 'map(select(. != null)) | map(.findings[] + {file: .file}) | sort_by(.severity)'
 
   - id: summary
     depends_on: [merged, todo_sweep]

--- a/crates/nika-pack/pack/examples/showcase/t3-resume-screener.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-resume-screener.nika.yaml
@@ -37,6 +37,8 @@ tasks:
     for_each: ${{ tasks.pool.output }}
     max_parallel: 2                    # local model · don't thrash the GPU
     fail_fast: false                   # one unreadable CV must not stop the batch
+    on_error:
+      recover: null                    # it yields null at its index · filtered at the fan-in
     with:
       cv_path: ${{ item }}
     infer:
@@ -61,7 +63,7 @@ tasks:
       tool: "nika:jq"
       args:
         input: "${{ tasks.screened.output }}"
-        expression: 'map(select(.fit != "weak")) | sort_by(.fit != "strong", -(.years_relevant // 0))'
+        expression: 'map(select(. != null)) | map(select(.fit != "weak")) | sort_by(.fit != "strong", -(.years_relevant // 0))'
 
   - id: shortlist
     depends_on: [ranked]
@@ -83,6 +85,7 @@ tasks:
 
   - id: save
     depends_on: [brief]
+    when: ${{ tasks.brief.output != null }}    # skip cascades by VALUE · a skipped brief is null
     invoke:
       tool: "nika:write"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
@@ -12,7 +12,7 @@
 #   - 3-way parallel gather · exec + fetch (with retry) + read
 #   - `nika:wait` · the settle window before the confirmation re-poll
 #   - `nika:assert` · refuse to write « resolved » while prod still burns
-#   - `on_finally:` · the journal event + the ping fire EVEN IF a step fails
+#   - the always-pattern (`when: true`) · the ping fires EVEN IF a step fails
 #
 # Run · nika run examples/showcase/t4-incident-war-room.nika.yaml
 nika: v1
@@ -124,14 +124,22 @@ tasks:
         path: "./incidents/${{ vars.service }}-postmortem.md"
         content: "${{ tasks.postmortem.output }}"
         create_dirs: true
-    on_finally:                        # ALWAYS fires · success, fail, timeout, cancel
-      - invoke:
-          tool: "nika:emit"
-          args:
-            event_type: "incident.postmortem.drafted"
-            payload:
-              service: "${{ vars.service }}"
-              status: "${{ tasks.save.status }}"
+
+  # the always-pattern · the on-call ping fires on EVERY outcome —
+  # including the designed failure path (recovery NOT confirmed → the
+  # assert fails → save never starts → this still runs · when: true
+  # replaces the default gate · 03 §Task states).
+  - id: ping
+    depends_on: [save]
+    when: true
+    invoke:
+      tool: "nika:emit"
+      args:
+        event_type: "incident.postmortem.drafted"
+        payload:
+          service: "${{ vars.service }}"
+          status: "${{ tasks.save.status }}"
+    on_finally:
       - invoke:
           tool: "nika:notify"
           args:

--- a/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
@@ -13,7 +13,7 @@
 #   - `nika:date` `op: diff` · compute how long the gates took
 #   - `nika:prompt` · the conductor's GO is a human decision
 #   - parallel gate wave + `capture: structured` exit-code checks
-#   - `nika:emit` + `on_finally:` · the departure record always lands
+#   - the always-pattern (`when: true`) · the departure record always lands
 #
 # Run · nika run examples/showcase/t4-release-train.nika.yaml
 nika: v1
@@ -130,14 +130,22 @@ tasks:
       args:
         condition: "${{ tasks.verify.output == vars.version }}"
         message: "Prod does not report the shipped version — investigate before announcing"
-    on_finally:                        # the record lands · shipped OR aborted
-      - invoke:
-          tool: "nika:emit"
-          args:
-            event_type: "release.train.departed"
-            payload:
-              version: "${{ vars.version }}"
-              status: "${{ tasks.live.status }}"
+
+  # the always-pattern · `when: true` replaces the default success-gate ·
+  # this task runs whether `live` succeeded, failed, or never started
+  # (upstream abort) — a record that must land on EVERY outcome is a
+  # terminal task, not a cleanup hook (03 §Task states).
+  - id: record
+    depends_on: [live]
+    when: true
+    invoke:
+      tool: "nika:emit"
+      args:
+        event_type: "release.train.departed"
+        payload:
+          version: "${{ vars.version }}"
+          status: "${{ tasks.live.status }}"
+    on_finally:
       - invoke:
           tool: "nika:notify"
           args:

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -457,7 +457,7 @@
       "additionalProperties": false,
       "properties": {
         "tool": {
-          "description": "Tool ref · `nika:<name>` builtin (closed enum from stdlib v0.1 · LSP-perfect completion) OR `mcp:<server>/<tool>` (open · pattern) OR `x-<vendor>:<tool>` (engine-specific · explicitly non-portable · 06-stdlib-contract §Namespace ownership).",
+          "description": "Tool reference · nika:<path> (closed v0.1 builtin set) OR mcp:<server>/<tool> (requires the slash). The namespace set is CLOSED at v1 (spec/02-verbs.md) — an x-<vendor>: prefix is RESERVED, not valid (engine-specific tools route through mcp: · spec/06-stdlib-contract.md §Namespace ownership).",
           "oneOf": [
             {
               "type": "string",
@@ -491,11 +491,6 @@
               "type": "string",
               "description": "`mcp:<server>/<tool>` external MCP tool · open (pattern · `/` separates path). · mcp: requires the slash (mcp:<server>/<tool> · server kebab-case · spec/02-verbs.md §tool reference grammar)",
               "pattern": "^mcp:[a-z][a-z0-9-]*/[A-Za-z0-9_/-]+$"
-            },
-            {
-              "type": "string",
-              "description": "`x-<vendor>:<tool>` custom engine-specific tool · open (pattern) · workflows using `x-*` tools are explicitly NOT portable across engines (the OpenAPI `x-` extension pattern · per 06-stdlib-contract §Namespace ownership).",
-              "pattern": "^x-[a-z][a-z0-9-]*:[a-z][a-z0-9_]*(/[a-z][a-z0-9_]*)*$"
             }
           ]
         },

--- a/crates/nika-pack/pack/spec/02-verbs.md
+++ b/crates/nika-pack/pack/spec/02-verbs.md
@@ -219,6 +219,13 @@ spec minor — it never appears silently.
 
 See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) for the canonical builtin list (<!-- canon:builtins -->22<!-- /canon --> builtins in v0.1).
 
+> **Grouped paths are grammar-legal · v0.1 ships none.** The reference
+> grammar admits `nika:<group>/<tool>` (the `nika:connectome/recall`
+> illustration above is the reserved FUTURE shape) — but the v0.1 builtin
+> set contains only flat names · a grouped `nika:` path is rejected against
+> the closed 22 set today (`NIKA-INVOKE-001`). The seam exists so the
+> Connectome tools land additively · zero workflow-shape change.
+
 ### MCP call
 
 ```yaml

--- a/crates/nika-pack/pack/spec/03-dag.md
+++ b/crates/nika-pack/pack/spec/03-dag.md
@@ -677,7 +677,12 @@ completes · REGARDLESS of outcome (success · failure · timeout · cancel).
   per cleanup task via `timeout:` field).
 - **Failed parent task's `on_finally:` runs BEFORE** the error propagates
   upward in the DAG (gives cleanup a chance to undo side effects).
-- **Engine MUST execute** `on_finally:` on cancel (Ctrl+C) and timeout.
+- **Engine MUST execute** `on_finally:` on cancel (Ctrl+C) and timeout —
+  for a task that **started**. A task that never ran (`skipped` gate ·
+  cancelled-before-start) runs NO `on_finally:` (there is nothing to clean
+  up) — a record that must land on EVERY outcome is a **terminal
+  `when: true` task** (the always-pattern · §Task states), not a cleanup
+  hook.
 - **Engine MAY skip** `on_finally:` only if the workflow process itself
   crashes (SIGSEGV · OOM · hard kill).
 

--- a/crates/nika-pack/pack/spec/04-variables.md
+++ b/crates/nika-pack/pack/spec/04-variables.md
@@ -154,7 +154,7 @@ takes whichever ran ·
     tool: nika:jq
     args:
       input: [ "${{ tasks.build_prod.output }}", "${{ tasks.build_dev.output }}" ]
-      query: "[ .[] | select(. != null) ] | first"
+      expression: "[ .[] | select(. != null) ] | first"
 ```
 
 **One obvious way · no bare alias.** `${{ tasks.X }}` is the whole result

--- a/crates/nika-pack/pack/spec/05-errors.md
+++ b/crates/nika-pack/pack/spec/05-errors.md
@@ -264,6 +264,15 @@ Resolution happens at **recovery time** ·
    `skipped`), the reference is unresolved → `NIKA-VAR-001` → the recovery
    itself fails → the task fails as if `on_error:` were absent.
 
+**Recovery × `output:` bindings (normative)** · when `recover:` fires, the
+recovery value **substitutes the raw output BEFORE binding extraction** —
+the task's `output:` jq bindings evaluate over the recovered value exactly
+as they would over a verb response. Downstream consumers stay shape-stable
+(`tasks.X.title` works whether the live call or the fallback produced the
+data) — which is why a recovery source SHOULD match the raw output's shape.
+A binding that fails over the recovered shape errors as usual
+(`NIKA-VAR-002` / `NIKA-VAR-004`) · the recovery does not mask it.
+
 **Parse-time acyclicity rule (`NIKA-DAG-004` · `validation_error`)** · a
 `recover:` reference to a task that **transitively depends on the declaring
 task** is rejected at parse time. At recovery time such a task could never

--- a/crates/nika-pack/pack/spec/06-stdlib-contract.md
+++ b/crates/nika-pack/pack/spec/06-stdlib-contract.md
@@ -151,21 +151,31 @@ invoke:
 
 These are not stdlib · they depend on the engine's MCP server registry being configured.
 
-## Namespace ownership · `nika:` · `mcp:` · `x-`
+## Namespace ownership · `nika:` · `mcp:` (closed at v1)
 
-The three canonical tool namespaces ·
+The namespace set is **CLOSED at v1** — `nika:` and `mcp:` are the only two
+([02 §tool reference grammar](./02-verbs.md#tool-reference-grammar-canonical) ·
+any other prefix is rejected at parse time) ·
 
 | Namespace | Owner | Source of truth | Examples |
 |---|---|---|---|
 | `nika:*` | **Spec-owned** | `stdlib/builtins-v0.1.md` (this directory's sibling) | `nika:read` · `nika:jq` · `nika:done` |
 | `mcp:<server>/*` | Engine + user | Engine's MCP server registry config | `mcp:postgres/query` · `mcp:browser/navigate` |
-| `x-<vendor>:*` | **Custom · engine-specific** | Engine documentation (OUT of spec) | `x-superclever:research` · `x-myengine:custom_tool` |
 
-The `nika:*` namespace is **spec-owned**. A custom engine MUST NOT add tools to the `nika:*` namespace · it would violate portability (a workflow using a vendor's `nika:custom` builtin would not run on a different engine).
+The `nika:*` namespace is **spec-owned**. A custom engine MUST NOT add tools
+to the `nika:*` namespace · it would violate portability (a workflow using a
+vendor's `nika:custom` builtin would not run on a different engine).
 
-Custom engines that want to ship engine-specific builtins MUST use the `x-<vendor>:*` prefix. Workflows referencing `x-*` tools are explicitly NOT portable across engines · the workflow author acknowledges the vendor lock-in.
+**Engine-specific tools route through `mcp:`** — an engine that ships custom
+capabilities exposes them as an MCP server it hosts (`mcp:myengine/research`).
+That is exactly what the protocol is for · the tool is then *declared* in the
+engine's MCP registry like any other (portability semantics intact · any
+engine with that server configured runs the workflow) · and no third
+namespace appears silently.
 
-This is the OpenAPI `x-` extension pattern · industry canonical.
+(An OpenAPI-style `x-<vendor>:` prefix was considered and is **reserved as a
+possible future additive minor** — it does NOT exist in v0.1 · a parser that
+accepts `x-anything:tool` today is non-conformant.)
 
 ---
 
@@ -178,7 +188,7 @@ See [07-conformance.md](./07-conformance.md). In summary ·
 | Core | None · only parse + DAG + variable + error · no execution needed |
 | Runtime | Must execute the 4 verbs · provider/tool implementations engine's choice |
 | Stdlib v0.1 | Must ship the <!-- canon:providers -->14<!-- /canon --> providers + <!-- canon:extract_modes -->9<!-- /canon --> extract modes + <!-- canon:builtins -->22<!-- /canon --> builtins |
-| Stdlib v0.1+media | Stdlib v0.1 + 24 media builtins |
+| Stdlib v0.1+media | RESERVED · enumerated when the media set publishes (stdlib v0.x · the 24 names are not yet normative) |
 
 A v0.1-compliant engine for a workflow author depends on which level they need.
 

--- a/crates/nika-pack/pack/spec/07-conformance.md
+++ b/crates/nika-pack/pack/spec/07-conformance.md
@@ -45,6 +45,7 @@ An engine claims « Core v0.1-compliant » if it ·
    - Detects cycles · rejects with `NIKA-DAG-001`
    - Detects unresolved `depends_on` references · rejects with `NIKA-DAG-002`
    - Detects a `when:`/`with:` reference to an undeclared dependency · rejects with `NIKA-DAG-003`
+   - Detects an `on_error.recover` reference to a task downstream of the declaring task · rejects with `NIKA-DAG-004` (the await would deadlock · [05](./05-errors.md#recover-reference-resolution-normative))
    - Computes topological waves for parallel execution
 
 3. **Resolves variable references** correctly (static · reference-resolution · NOT runtime evaluation)
@@ -53,8 +54,8 @@ An engine claims « Core v0.1-compliant » if it ·
    - `${{ tasks.X.field }}` resolves to a declared upstream task + a valid field name
    - `${{ env.X }}` · `${{ secrets.X }}` resolve to declared namespaces
    - `when:` and `for_each:` expressions are valid **CEL** (the v0.1 subset · see 03-dag) and their references **resolve to known namespaces** — Core parses but does NOT *evaluate* them (no execution = no `tasks.X.status` to compare against · that is Runtime's job)
-   - `output:` bindings are valid **jq** expressions (the one data language · see 04-variables)
-   - Reports undefined references with `NIKA-VAR-001`
+   - `output:` bindings are valid **jq** expressions (the one data language · see 04-variables) · `${{ }}` never appears inside a binding
+   - Reports undefined references with `NIKA-VAR-001` · static expression violations with `NIKA-VAR-005` (the deep-static layer · CEL subset parse · jq compile · `when:` boolean shape)
 
 4. **Produces typed errors** matching the v0.1 spec
    - `code` follows `NIKA-<NAMESPACE>-<NNN>` format
@@ -143,6 +144,7 @@ What is populated TODAY vs what lands with the reference engine ·
 | Layer | Status | What it proves |
 |---|---|---|
 | **Core fixtures** (`tests/core/`) | ✅ populated · runner-executable | parse + validate + DAG + variables + errors · the full Level-1 static contract |
+| **Deep-static fixtures** (`tests/deep/`) | ✅ populated · runner-executable | the expression layer the schema cannot see · the normative CEL EBNF parsed for real · jq compile · duration grammar · schema-meta · `when:` shape · binding purity |
 | **Stdlib static surface** (`tests/stdlib/`) | ✅ populated · runner-executable | the stdlib **names + shapes** layer · provider prefixes · the closed `nika:*` builtin set · extract modes · checkable with zero execution (lists derive from [`canon.yaml`](../canon.yaml)) |
 | **Examples as conformance inputs** (`examples/`) | ✅ executed by the runner `all` gate | every shipped example MUST validate at the full static level |
 | **Runtime behavioral fixtures** (`tests/runtime/`) | ⏳ **post-announce** | verb execution · task fields · events · they require an executing engine · they land with the reference engine's vertical slice (v0.81.0) |
@@ -168,10 +170,12 @@ conformance/
 │   │   ├── variables/
 │   │   └── errors/
 │   │
+│   ├── deep/                  # deep-static layer · CEL subset parse · jq compile ·
+│   │                          # durations · schema-meta · when shape · binding purity
 │   ├── runtime/               # verb execution · task fields · events
 │   │   ├── infer/
 │   │   ├── exec/
-││   │   ├── invoke/
+│   │   ├── invoke/
 │   │   ├── agent/
 │   │   └── workflow-lifecycle/
 │   │

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -41,11 +41,15 @@ invoke: { tool: "nika:log", args: { level: info, message: "Processing ${{ vars.u
 ```
 Emit a log entry (`debug`/`info`/`warn`/`error`) to the workflow event stream (human-readable diagnostic).
 
+Returns `null` · best-effort (no failure codes · a log that cannot land never fails the task).
+
 ### `nika:emit`
 ```yaml
 invoke: { tool: "nika:emit", args: { event_type: custom.event, payload: { ... } } }
 ```
 Emit a custom machine event (consumed by subscribers · journal). Distinct from `log` · `log` = human diagnostic · `emit` = machine event.
+
+`event_type:` matches `^[a-z][a-z0-9_.-]*$` · `payload:` any JSON value. Returns `null`. Delivery is engine-side (journal · subscribers) · best-effort once shape-valid. Throws · `NIKA-BUILTIN-EMIT-001` (invalid event shape · `validation_error`).
 
 ### `nika:assert`
 ```yaml
@@ -53,11 +57,19 @@ invoke: { tool: "nika:assert", args: { condition: "${{ tasks.X.output.count > 0 
 ```
 Fail the task if `condition` (a **CEL `${{ }}` boolean**) is false · else no-op. The **fail-fast guard** (distinct from `when:` which is the **skip-guard**). `condition:` uses the canonical `${{ }}` CEL surface — never a legacy `$task` syntax.
 
+Returns `true` on pass. Throws · `NIKA-BUILTIN-ASSERT-001` (assertion failed · `tool_error` · `transient: false` · `message:` lands in the error message · retryable via `retry.on_codes` — the polling pattern's lever).
+
 ### `nika:prompt`
 ```yaml
 invoke: { tool: "nika:prompt", args: { message: "Approve deploy to production?", default: false } }
 ```
-Interactive human confirm · blocks until answered. v0.1 conformance · engines MAY use `default` in CI/non-interactive mode.
+Interactive human confirm · blocks until answered. **Returns a boolean**
+(`true` = confirmed · `false` = refused — a refusal is a VALUE, never an
+error · gate downstream with `when:`). Non-interactive contract (normative) ·
+when no human can answer (CI · daemon) the engine MUST use `default:` when
+present · and MUST fail `NIKA-BUILTIN-PROMPT-001` (`validation_error` ·
+non-interactive without a `default:`) when absent — never hang forever ·
+never silently pick an answer.
 
 ### `nika:done`
 ```yaml
@@ -89,7 +101,13 @@ Throws · `NIKA-BUILTIN-WAIT-001` on absolute timeout · `-002` if the timestamp
 ```yaml
 invoke: { tool: "nika:read", args: { path: "./config.yaml", encoding: utf-8 } }
 ```
-Read a file · returns string content.
+Read a file · returns **string** content (text mode · the default).
+`binary: true` (explicit · no content sniffing) returns **opaque bytes**
+([04 §value rendering](../spec/04-variables.md) · they flow tool→tool ·
+never into a string position). Throws · `NIKA-BUILTIN-READ-001` (file not
+found — the code the state-file first-run pattern scopes its recovery to) ·
+`-002` (IO failure · permission) · `-003` (text mode on non-UTF-8 content ·
+use `binary: true`). All `tool_error` · `transient: false`.
 
 ### `nika:write`
 ```yaml
@@ -97,23 +115,35 @@ invoke: { tool: "nika:write", args: { path: "./out.md", content: "...", create_d
 ```
 Write a file · returns the path. A binary `content` value (an opaque bytes output from an upstream tool · e.g. MCP image content) is written as-is · no `output_format` declaration needed (the value carries its own type).
 
+`overwrite:` defaults **true** · `create_dirs:` defaults **false**. Throws · `NIKA-BUILTIN-WRITE-001` (IO failure) · `-002` (`overwrite: false` and the path exists). Both `tool_error` · `transient: false`.
+
 ### `nika:edit`
 ```yaml
 invoke: { tool: "nika:edit", args: { path: "./file.md", find: "old", replace: "new" } }
 ```
-In-place find/replace · returns the modified path.
+In-place find/replace · returns the modified path. `find:` is a **literal
+string** (not a regex — use `nika:grep` to locate · jq to transform) ·
+replaces **all occurrences** · `count:` caps replacements when set. Throws ·
+`NIKA-BUILTIN-EDIT-001` (`find:` matched nothing — an edit that edits
+nothing is an authoring bug · `tool_error`) · `-002` (IO failure).
 
 ### `nika:glob`
 ```yaml
 invoke: { tool: "nika:glob", args: { pattern: "./src/**/*.rs", exclude: ["**/target/**"] } }
 ```
-Glob match · returns array of paths.
+Glob match · returns array of paths · **sorted lexicographically**
+(deterministic across engines · filesystems). Throws ·
+`NIKA-BUILTIN-GLOB-001` (invalid pattern · `validation_error`).
 
 ### `nika:grep`
 ```yaml
 invoke: { tool: "nika:grep", args: { pattern: "TODO:", path: "./src", case_insensitive: false } }
 ```
-Recursive grep · returns array of `{ path, line, match }`.
+Recursive grep · returns array of `{ path, line, match }` · `line` is the
+1-based line **number** (integer) · `match` the matched line text · results
+sorted by `(path, line)`. `pattern:` is a **Rust-regex-class** expression
+(RE2-compatible · no backreferences · the portable subset). Throws ·
+`NIKA-BUILTIN-GREP-001` (invalid pattern · `validation_error`).
 
 ---
 
@@ -135,26 +165,31 @@ invoke:
 ```
 Same shape combines / zips N inputs · build the array, index inside jq.
 
+**The arg is `expression:`** — exactly that name (not `query:` · not `expr:` ·
+one name everywhere · the conformance oracle gates it). Throws ·
+`NIKA-BUILTIN-JQ-001` (program error at runtime · `tool_error` — compile
+errors are caught statically · `NIKA-VAR-005`).
+
 **Implementation** · reference engine uses `jaq` (Rust jq).
 
 ### `nika:json_diff`
 ```yaml
 invoke: { tool: "nika:json_diff", args: { before: { ... }, after: { ... } } }
 ```
-JSON diff · returns **RFC 6902** JSON Patch. (jq can't diff.)
+JSON diff · returns **RFC 6902** JSON Patch. (jq can't diff.) Throws · `NIKA-BUILTIN-JSON_DIFF-001` (non-JSON input · `validation_error`).
 
 ### `nika:validate` · schema validation (json OR yaml)
 ```yaml
 invoke: { tool: "nika:validate", args: { data: { ... }, schema: { type: object, ... }, format: json } }
 # format: json (default · validate a value) | yaml (parse a YAML string first, then validate)
 ```
-Validate data against a **JSON Schema** · returns `{ valid: bool, errors: [...] }`. Merges the former `json_verify` + `yaml_validate` (`format:` arg · one validator).
+Validate data against a **JSON Schema** · returns `{ valid: bool, errors: [...] }` — invalid DATA is a **report, never a task failure** (gate on `.valid` downstream · or `nika:assert` it). Merges the former `json_verify` + `yaml_validate` (`format:` arg · one validator). Throws · `NIKA-BUILTIN-VALIDATE-001` (the `schema:` itself is not a valid JSON Schema · `validation_error`) · `-002` (`format: yaml` and the string does not parse as YAML).
 
 ### `nika:json_merge_patch`
 ```yaml
 invoke: { tool: "nika:json_merge_patch", args: { target: { ... }, patch: { ... } } }
 ```
-**RFC 7396** merge patch (`null` deletes a key) · the delete-on-null semantics jq's `*` recursive-merge does NOT provide (so this stays a genuine builtin). Plain recursive merge (no delete) is just `jq '.[0] * .[1]'` on a `[base, overlay]` input · no builtin needed.
+**RFC 7396** merge patch (`null` deletes a key) · the delete-on-null semantics jq's `*` recursive-merge does NOT provide (so this stays a genuine builtin). Plain recursive merge (no delete) is just `jq '.[0] * .[1]'` on a `[base, overlay]` input · no builtin needed. Throws · `NIKA-BUILTIN-JSON_MERGE_PATCH-001` (non-object target/patch · `validation_error`).
 
 ### `nika:convert` · universal multi-format conversion
 ```yaml
@@ -166,7 +201,7 @@ invoke:
     to: json                           # REQUIRED · enum · json | yaml | toml | csv
     has_header: true                   # OPTIONAL · CSV only · default true
 ```
-Universal format converter · 4 formats v0.1 (`json` · `yaml` · `toml` · `csv`) · 12 directions in scope (4×3 minus identity).
+Universal format converter · 4 formats v0.1 (`json` · `yaml` · `toml` · `csv`) · 12 directions in scope (4×3 minus identity) · `from == to` is rejected (`NIKA-BUILTIN-CONVERT-001` · `validation_error` · an identity conversion is an authoring bug). Throws · `-002` (the input does not parse as `from:` · `tool_error`).
 
 Pattern · `fetch+extract` symmetry · single super-powerful builtin · `from`/`to` mode parameters · all bidirectional pairs canonical · no per-direction builtin slot.
 
@@ -178,20 +213,20 @@ Reference implementation · `serde_transcode` 1.1+ orchestrator (zero-allocation
 ```yaml
 invoke: { tool: "nika:uuid", args: { version: v7 } }   # v7 default (timestamped/sortable · RFC 9562) | v4 (random)
 ```
-Generate a UUID. (Generators are not jq · jq is pure transform.)
+Generate a UUID. (Generators are not jq · jq is pure transform.) Returns the canonical lowercase-hyphenated string. No failure codes.
 
 ### `nika:date`
 ```yaml
 invoke: { tool: "nika:date", args: { op: now } }
 # op: now { tz } | add { base, duration } | subtract | format { input, format } | parse | diff { start, end, unit }
 ```
-Timestamp arithmetic · op-discriminated single builtin · timezone-aware (IANA · default UTC) · ISO 8601 out.
+Timestamp arithmetic · op-discriminated single builtin · timezone-aware (IANA · default UTC) · ISO 8601 out. `format:`/`parse` use the **strftime** field grammar (`%Y-%m-%d` · the one cross-language constant). Every op returns a string EXCEPT `diff` (integer · in `unit:`). Throws · `NIKA-BUILTIN-DATE-001` (unparseable input / unknown op / bad tz · `validation_error`).
 
 ### `nika:hash`
 ```yaml
 invoke: { tool: "nika:hash", args: { algo: blake3, content: "${{ tasks.X.output }}", encoding: hex } }
 ```
-Content hashing · default **blake3** (fastest modern cryptographic hash · parallel · secure) · or `sha256`/`sha512`. md5/sha1 NOT supported (cryptographically broken). Use cases · cache keys · content addressing · provenance.
+Content hashing · default **blake3** (fastest modern cryptographic hash · parallel · secure) · or `sha256`/`sha512`. md5/sha1 NOT supported (cryptographically broken · `NIKA-BUILTIN-HASH-001` `validation_error` on an unsupported algo). `encoding:` `hex` (default) | `base64`. Use cases · cache keys · content addressing · provenance.
 
 ---
 
@@ -210,13 +245,20 @@ invoke: { tool: "nika:fetch", args: { url: "https://example.com/article", mode: 
 | `mode` | extraction mode · see `extract-modes-v0.1.md` · default `markdown` |
 | `jq` | a jq expression · only with `mode: jq` (structured JSON extraction · replaces the former JSONPath mode) |
 
+**Non-2xx is failure (normative)** · a non-2xx response throws
+`NIKA-BUILTIN-FETCH-001` (`category: network_error` · `transient: true` for
+5xx/408/429 · `false` for other 4xx · `details.status_code` carries the
+status). To poll a pending resource · the jq-error pattern
+([08 H19](../spec/08-out-of-scope.md)) — not status-code inspection.
+Redirects follow up to an engine cap · the FINAL status decides.
+
 **Security (engine MUST)** · SSRF defense (reject private-net + cloud-metadata `169.254.169.254` unless configured) · honor task-level `timeout` · reject self-signed TLS by default.
 
 ### `nika:notify`
 ```yaml
 invoke: { tool: "nika:notify", args: { channel: webhook, target: "https://hooks.slack.com/...", message: "Done · ${{ tasks.X.status }}", severity: info } }
 ```
-Send notifications · `channel:` enum (`webhook`/`slack`/`email`/`discord`/`sms` · one builtin not 5). v0.81 engine MUST support `webhook` · others MAY be feature-gated (`NIKA-BUILTIN-NOTIFY-001` if unconfigured).
+Send notifications · `channel:` enum (`webhook`/`slack`/`email`/`discord`/`sms` · one builtin not 5). v0.81 engine MUST support `webhook` · others MAY be feature-gated. Returns `null` on accepted delivery. Throws · `NIKA-BUILTIN-NOTIFY-001` (channel unconfigured · `validation_error`) · `-002` (delivery failed · `network_error` · transient engine-assessed).
 
 ---
 
@@ -278,7 +320,7 @@ separate doc). Deliberate « less but better » (Rams 10).
 ## Cross-builtin invariants
 
 A v0.1-compliant builtin · takes a single `args` object · returns a
-JSON-serializable value · reports errors as typed `NIKA-BUILTIN-NNN` codes ·
+JSON-serializable value · reports errors as typed `NIKA-BUILTIN-<NAME>-NNN` codes (4-segment · per-builtin sub-namespace · [05](../spec/05-errors.md)) ·
 honors task-level `timeout` · respects engine security policies.
 
 ---

--- a/crates/nika-pack/pack/stdlib/extract-modes-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/extract-modes-v0.1.md
@@ -26,7 +26,7 @@ Plus an implicit ·
 
 | Mode | Output | Use case |
 |---|---|---|
-| `raw` | string (bytes as string) | Raw response body · no extraction (default if no body to extract) |
+| `raw` | string (text · UTF-8) | Raw response body · no extraction · **text only** (a non-UTF-8 body is `NIKA-BUILTIN-FETCH-001` · binary is file-mediated per [04 §value rendering](../spec/04-variables.md)) |
 
 ---
 
@@ -251,19 +251,13 @@ invoke:
 
 ---
 
-### `llm-txt` · (special) · llms.txt convention
+### `llm-txt` · RESERVED (not a v0.1 mode)
 
-```yaml
-invoke:
-  tool: "nika:fetch"
-  args:
-    url: "https://example.com/llms.txt"
-    mode: llm-txt
-```
-
-**Behavior** · fetches and parses an `llms.txt` file (the emerging convention for LLM-friendly site descriptions). Returns parsed structure.
-
-**Status** · experimental in v0.1 · MAY stabilize in stdlib v0.2.
+A future mode parsing the `llms.txt` convention (LLM-friendly site
+descriptions). **NOT in the v0.1 canonical set** — `mode: llm-txt` is
+rejected today (the canon list of 9 is closed · the conformance oracle
+enforces it). Until it stabilizes (stdlib v0.2 candidate) · fetch with
+`mode: text` and parse with `nika:jq` / an `infer:` step.
 
 ---
 

--- a/crates/nika-pack/pack/stdlib/providers-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/providers-v0.1.md
@@ -404,10 +404,23 @@ infer:
 **Backend** · deterministic test fixture · returns a configured response.
 
 **Models** ·
-- `mock-deterministic` · returns the prompt verbatim (echo)
+- **`echo` · THE canonical test model** (`model: mock/echo` — what every
+  canonical example uses) · returns the prompt text **verbatim** as the
+  output · zero network · zero entropy (bit-identical across runs/engines).
+  With a `schema:` declared · returns `{}` shaped to the schema's required
+  scalar defaults (string `""` · number `0` · boolean `false` · array `[]` ·
+  object recursed) — deterministic · validates · carries no meaning (test
+  the SHAPE of your DAG · not model quality).
+- `mock-deterministic` · returns the prompt verbatim (echo's long-form alias)
 - `mock-error` · returns a configured error
 - `mock-streaming` · streams a configured response
 - `mock-json` · returns structured JSON matching a configured schema
+
+The configured-response forms (`mock-error` · `mock-streaming` ·
+`mock-json`) read their fixture from **engine config** (NOT workflow YAML ·
+the workflow stays portable) — the behavioral conformance fixtures
+(post-announce) pin their exact contract. `mock/echo` is fully normative
+TODAY (the static + example gates rely on it).
 
 **Auth** · none.
 

--- a/crates/nika-pack/pack/templates/etl-state.nika.yaml
+++ b/crates/nika-pack/pack/templates/etl-state.nika.yaml
@@ -29,6 +29,7 @@ tasks:
       tool: "nika:read"
       args: { path: "${{ vars.state_path }}" }
     on_error:
+      on_codes: [NIKA-BUILTIN-READ-001]   # not-found ONLY · a permission error still fails loudly
       recover: ${{ tasks.empty.output }}
 
   - id: fresh

--- a/crates/nika-pack/pack/templates/fanout.nika.yaml
+++ b/crates/nika-pack/pack/templates/fanout.nika.yaml
@@ -8,7 +8,8 @@
 # Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
 # The leash (pattern 4 · ALWAYS set all three) ·
 #   max_parallel  cap concurrency (APIs rate-limit · GPUs thrash)
-#   fail_fast: false   collect errors · one bad item ≠ dead batch
+#   fail_fast: false + on_error recover: null — one bad item yields null
+#     at its index (order preserved) · the batch lives · filter downstream
 #   per-iteration retry/timeout · the flaky world is normal
 nika: v1
 workflow: fanout-template           # SLOT: kebab-case workflow id
@@ -35,16 +36,27 @@ tasks:
       max_attempts: 3
       backoff_strategy: exponential
       jitter: true
+    on_error:
+      recover: null                 # a failed item yields null at its index · the batch lives
     infer:                          # SLOT: the per-item job (any verb)
       prompt: |
         Process this item · ${{ item }}
 
-  - id: merge
+  - id: survivors
     depends_on: [process]
+    invoke:                         # the null-aware fan-in · order preserved
+      tool: "nika:jq"
+      args:
+        input: ${{ tasks.process.output }}
+        expression: "[ .[] | select(. != null) ]"
+
+
+  - id: merge
+    depends_on: [survivors]
     infer:
       prompt: |
-        # SLOT: the fan-in · tasks.process.output is the ARRAY (input order)
-        Merge these results into one report · ${{ tasks.process.output }}
+        # SLOT: the fan-in · the survivors array (failed items filtered)
+        Merge these results into one report · ${{ tasks.survivors.output }}
 
 outputs:
   report: ${{ tasks.merge.output }}

--- a/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
+++ b/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
@@ -8,7 +8,9 @@
 # Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
 # The contract (patterns 6 + 9) ·
 #   nothing irreversible happens before nika:prompt returns true
-#   the assert makes « no » terminal · on_finally records EITHER WAY
+#   the assert makes a RED gate terminal · the act fails LOUDLY (default
+#   capture) · a terminal `when: true` task records EVERY outcome
+#   (acted · refused · failed) — the always-pattern
 nika: v1
 workflow: human-gated-ship-template  # SLOT: kebab-case workflow id
 description: "verify in parallel · human GO · act · record"   # SLOT
@@ -51,15 +53,20 @@ tasks:
     when: ${{ tasks.human.output == true }}
     exec:
       command: "echo shipped"       # SLOT: the irreversible action
-      capture: structured
-    on_finally:                     # the record lands · acted OR refused
-      - invoke:
-          tool: "nika:notify"
-          args:
-            channel: webhook
-            target: "${{ secrets.webhook }}"
-            message: "Run finished · act=${{ tasks.act.status }}"   # SLOT
-            severity: info
+      # default capture · a failing ship fails LOUDLY (NIKA-EXEC-001) —
+      # never `capture: structured` on the irreversible step (exit codes
+      # would become data and a red ship would read as success)
+
+  - id: record
+    depends_on: [act]
+    when: true                      # the always-pattern · runs on success, failure, OR refusal
+    invoke:
+      tool: "nika:notify"
+      args:
+        channel: webhook
+        target: "${{ secrets.webhook }}"
+        message: "Run finished · act=${{ tasks.act.status }}"   # SLOT · success | failure | skipped
+        severity: info
 
 outputs:
   acted: ${{ tasks.act.status }}


### PR DESCRIPTION
Carries both hardening rounds: builtin failure codes + jq expression-arg + corpus A-H (round 2) and the x-vendor schema purge + entry-surface one-voice + eval routing arm (round 3). nika-schema conformance_core sees 53/57 with the flipped x-vendor fixture — the 4 gaps are #115. Pack data only. Supersedes feat/pack-round2 (stale base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)