### PR TITLE
feat(nika-schema): spec catch-up — the four static-validator gaps close

### DIFF
--- a/crates/nika-schema/src/analyzer/scan.rs
+++ b/crates/nika-schema/src/analyzer/scan.rs
@@ -21,6 +21,7 @@ use crate::error::SchemaError;
 use crate::expression::{ExprError, NamespaceRef, expr_refs, is_boolean_shaped, scan_templates};
 use crate::raw::{ForEachValue, RawAction, RawTask, RawWorkflow};
 use crate::source::{Span, Spanned};
+use crate::types::WhenGate;
 
 /// The reserved result-record fields (spec `04-variables.md` §result
 /// record) — valid `tasks.<id>.<field>` accessors + forbidden
@@ -137,10 +138,15 @@ fn scan_task(task: &RawTask, index: &WorkflowIndex<'_>, errors: &mut Vec<SchemaE
         allow_loop_locals: has_for_each,
     };
 
-    // `when:` — single boolean-shaped island (NIKA-PARSE-WHEN-001).
-    if let Some(when) = &task.when {
-        check_single_island(when, "when", id, true, errors);
-        scan_string(when, &body_ctx, index, errors);
+    // `when:` — the expression form is a single boolean-shaped island ·
+    // the YAML boolean literal (`when: true` · the always-pattern ·
+    // spec 03 §when shape rules) has nothing to scan.
+    if let Some(when) = &task.when
+        && let WhenGate::Expr(expr) = &when.value
+    {
+        let spanned = Spanned::new(expr.clone(), when.span);
+        check_single_island(&spanned, "when", id, true, errors);
+        scan_string(&spanned, &body_ctx, index, errors);
     }
     // `for_each:` — expression form is a single island (no boolean
     // requirement) · literal-list form scans element strings.
@@ -176,7 +182,7 @@ fn scan_task(task: &RawTask, index: &WorkflowIndex<'_>, errors: &mut Vec<SchemaE
         allow_loop_locals: has_for_each,
     };
     if let Some(on_error) = &task.on_error
-        && let crate::types::OnError::Recover(value) = &on_error.value
+        && let crate::types::OnErrorAction::Recover(value) = &on_error.value.action
     {
         scan_json(value, &no_edge_ctx, index, errors);
     }
@@ -190,9 +196,12 @@ fn scan_task(task: &RawTask, index: &WorkflowIndex<'_>, errors: &mut Vec<SchemaE
         allow_loop_locals: has_for_each,
     };
     for cleanup in &task.on_finally {
-        if let Some(when) = &cleanup.value.when {
-            check_single_island(when, "when", id, true, errors);
-            scan_string(when, &finally_ctx, index, errors);
+        if let Some(when) = &cleanup.value.when
+            && let WhenGate::Expr(expr) = &when.value
+        {
+            let spanned = Spanned::new(expr.clone(), when.span);
+            check_single_island(&spanned, "when", id, true, errors);
+            scan_string(&spanned, &finally_ctx, index, errors);
         }
         scan_action(&cleanup.value.action, &finally_ctx, index, errors);
     }

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -263,8 +263,11 @@ pub enum SchemaError {
     /// `when:` (or `for_each:`) is not a single CEL island of the
     /// required shape.
     ///
-    /// Spec `03-dag.md` · « The engine **rejects non-boolean `when:`
-    /// expressions at parse time** (`NIKA-PARSE-WHEN-001`). »
+    /// Spec `03-dag.md` §when shape rules · statically-non-boolean-shaped
+    /// roots are rejected at parse time (the spec's `NIKA-VAR-005` class ·
+    /// the retired `NIKA-PARSE-WHEN-001` name was folded there) — the
+    /// YAML boolean literal (`when: true` · the always-pattern) is the
+    /// OTHER legal form and never reaches this error.
     #[error("invalid `{field}:` in task `{task}` — {reason}")]
     WhenNotBoolean {
         /// The field (`when` or `for_each`).

--- a/crates/nika-schema/src/expression/refs.rs
+++ b/crates/nika-schema/src/expression/refs.rs
@@ -10,7 +10,7 @@
 //!
 //! `is_boolean_shaped` is the static `when:` gate (spec `03-dag.md`
 //! §when · « an engine MAY additionally reject statically-non-boolean-
-//! shaped roots » · we DO · `NIKA-PARSE-WHEN-001`).
+//! shaped roots » · we DO · the spec NIKA-VAR-005 class).
 
 use super::ast::{Expr, Literal, NamespaceRef};
 

--- a/crates/nika-schema/src/lints/preference_rules.rs
+++ b/crates/nika-schema/src/lints/preference_rules.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 use crate::expression::{Expr, Literal, NamespaceRef, RelOp, expr_refs, scan_templates};
 use crate::raw::{RawAction, RawTask, RawWorkflow};
 use crate::source::Span;
-use crate::types::OnError;
+use crate::types::OnErrorAction;
 
 /// One advisory finding from a lint pass.
 ///
@@ -97,7 +97,8 @@ pub fn one_obvious_way(wf: &RawWorkflow) -> Vec<Lint> {
 /// (the analyzer owns those errors · lints stay silent).
 fn when_expr(task: &RawTask) -> Option<Expr> {
     let w = task.when.as_ref()?;
-    let islands = scan_templates(&w.value).ok()?;
+    let src = w.value.as_expr()?; // boolean literals carry no expression
+    let islands = scan_templates(src).ok()?;
     let mut it = islands.into_iter();
     let island = it.next()?;
     if it.next().is_some() {
@@ -311,8 +312,8 @@ fn rule_001_redundant_success_when(
         // Skip-able dependency → the status check is NOT redundant.
         let dep_skippable = index.get(dep).is_some_and(|&i| {
             matches!(
-                tasks[i].on_error.as_ref().map(|o| &o.value),
-                Some(OnError::Skip)
+                tasks[i].on_error.as_ref().map(|o| &o.value.action),
+                Some(OnErrorAction::Skip)
             )
         });
         if dep_skippable {
@@ -338,8 +339,8 @@ fn rule_001_redundant_success_when(
 fn rule_002_skip_for_dependents(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
     for task in tasks {
         if !matches!(
-            task.on_error.as_ref().map(|o| &o.value),
-            Some(OnError::Skip)
+            task.on_error.as_ref().map(|o| &o.value.action),
+            Some(OnErrorAction::Skip)
         ) {
             continue;
         }

--- a/crates/nika-schema/src/parser/envelope.rs
+++ b/crates/nika-schema/src/parser/envelope.rs
@@ -19,8 +19,9 @@ use super::{Cx, value::node_to_json};
 /// Keys of the typed `vars:` form (spec 01 §vars).
 const TYPED_VAR_KEYS: &[&str] = &["type", "required", "default", "description"];
 
-/// Keys of a `secrets:` entry (spec 01 §secrets).
-const SECRET_KEYS: &[&str] = &["source", "key"];
+/// Keys of a `secrets:` entry (spec 01 §secrets · `key` XOR `path` ·
+/// discriminated by `source`).
+const SECRET_KEYS: &[&str] = &["source", "key", "path"];
 
 /// Keys of the typed `outputs:` form (spec 01 §outputs).
 const TYPED_OUTPUT_KEYS: &[&str] = &["value", "type", "description"];
@@ -131,10 +132,13 @@ pub(super) fn parse_env(
     parse_string_map(cx, node, "env")
 }
 
-/// Parse `secrets:` — each entry MUST be a `{ source, key }` reference.
+/// Parse `secrets:` — each entry MUST be a reference to a store,
+/// **discriminated by `source`** · `vault`/`env` require `key:` ·
+/// `file` requires `path:` (spec 01 §secrets).
 ///
-/// Spec 01 §secrets · « A secret is always a **reference to a store** —
-/// never an inline literal. » A scalar value is therefore a parse error.
+/// « A secret is always a **reference to a store** — never an inline
+/// literal. » A scalar value is therefore a parse error, and so is the
+/// wrong field for the source (`file` + `key:` · `vault` + `path:`).
 pub(super) fn parse_secrets(
     cx: &Cx<'_>,
     workflow: &MarkedMappingNode,
@@ -181,17 +185,37 @@ pub(super) fn parse_secrets(
             }
         };
 
-        let key_scalar = entry
-            .get_scalar("key")
+        // The reference field is discriminated by `source` (spec 01) ·
+        // vault/env read `key:` · file reads `path:` · the OTHER field
+        // present is a shape error (never silently accepted).
+        let (want, reject) = match source {
+            SecretSource::File => ("path", "key"),
+            SecretSource::Vault | SecretSource::Env => ("key", "path"),
+        };
+        if entry.get_node(reject).is_some() {
+            return Err(SchemaError::BadSecretRef {
+                reason: format!(
+                    "secret `{}` with `source: {source}` takes `{want}:`, not `{reject}:` \
+                     (spec 01 §secrets · the shape is discriminated by source)",
+                    name.value
+                ),
+                span: cx.span(entry.span()),
+            });
+        }
+        let reference = entry
+            .get_scalar(want)
             .ok_or_else(|| SchemaError::BadSecretRef {
-                reason: format!("secret `{}` is missing its `key`", name.value),
+                reason: format!(
+                    "secret `{}` with `source: {source}` is missing its `{want}:`",
+                    name.value
+                ),
                 span: cx.span(entry.span()),
             })?;
 
         let span = cx.span_or_zero(entry.span());
         out.push((
             name,
-            Spanned::new(SecretRef::new(source, key_scalar.as_str()), span),
+            Spanned::new(SecretRef::new(source, reference.as_str()), span),
         ));
     }
     Ok(out)
@@ -435,6 +459,50 @@ secrets:
 ";
         let err = parse_strict(yaml).expect_err("unknown source");
         assert!(matches!(err, SchemaError::BadSecretRef { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn secrets_file_source_takes_path() {
+        // Spec 01 §secrets · the shape is discriminated by source ·
+        // `file` requires `path:` (k8s/Docker mounted secrets).
+        let yaml = "\
+secrets:
+  signing_pem:
+    source: file
+    path: ~/.keys/signing.pem
+";
+        let wf = parse_strict(yaml).expect("parse");
+        assert_eq!(wf.secrets[0].1.value.source, SecretSource::File);
+        assert_eq!(wf.secrets[0].1.value.key, "~/.keys/signing.pem");
+    }
+
+    #[test]
+    fn secrets_wrong_field_for_source_errors() {
+        // `file` + `key:` and `vault` + `path:` are both shape errors —
+        // the wrong field is never silently accepted.
+        let file_with_key = "\
+secrets:
+  pem:
+    source: file
+    key: ~/.keys/signing.pem
+";
+        let err = parse_strict(file_with_key).expect_err("file takes path");
+        assert!(
+            matches!(&err, SchemaError::BadSecretRef { reason, .. } if reason.contains("`path:`")),
+            "{err:?}"
+        );
+
+        let vault_with_path = "\
+secrets:
+  api_key:
+    source: vault
+    path: prod/key
+";
+        let err = parse_strict(vault_with_path).expect_err("vault takes key");
+        assert!(
+            matches!(&err, SchemaError::BadSecretRef { reason, .. } if reason.contains("`key:`")),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -15,7 +15,10 @@ use marked_yaml::types::MarkedMappingNode;
 use crate::error::SchemaError;
 use crate::raw::{ForEachValue, RawFinallyTask, RawTask};
 use crate::source::Spanned;
-use crate::types::{BackoffStrategy, OnError, RetryConfig, is_valid_error_code, parse_go_duration};
+use crate::types::{
+    BackoffStrategy, OnError, OnErrorAction, RetryConfig, WhenGate, is_valid_error_code,
+    parse_go_duration,
+};
 
 use super::value::node_to_json;
 use super::verbs::{VERB_KEYS, parse_verb};
@@ -51,8 +54,12 @@ const RETRY_KEYS: &[&str] = &[
     "on_codes",
 ];
 
-/// Keys of an `on_error:` block (spec 05 §`on_error`).
-const ON_ERROR_KEYS: &[&str] = &["recover", "skip", "fail_workflow"];
+/// Keys of an `on_error:` block (spec 05 §`on_error` · exactly one
+/// ACTION + the optional `on_codes` filter).
+const ON_ERROR_KEYS: &[&str] = &["recover", "skip", "fail_workflow", "on_codes"];
+
+/// The `on_error:` ACTION keys (mutually exclusive · exactly one).
+const ON_ERROR_ACTION_KEYS: &[&str] = &["recover", "skip", "fail_workflow"];
 
 /// Parse the top-level `tasks:` sequence into `Vec<Spanned<RawTask>>`.
 ///
@@ -110,7 +117,7 @@ fn parse_task(cx: &Cx<'_>, mapping: &MarkedMappingNode) -> Result<RawTask, Schem
     let mut task = RawTask::new(id, action);
 
     task.depends_on = parse_string_list(cx, mapping, "depends_on")?;
-    task.when = cx.opt_scalar(mapping, "when")?;
+    task.when = parse_when(cx, mapping)?;
     task.for_each = parse_for_each(cx, mapping)?;
     task.max_parallel = parse_max_parallel(cx, mapping)?;
     task.fail_fast = parse_bool_field(cx, mapping, "fail_fast")?;
@@ -122,6 +129,34 @@ fn parse_task(cx: &Cx<'_>, mapping: &MarkedMappingNode) -> Result<RawTask, Schem
     task.on_finally = parse_on_finally(cx, mapping, &task_label)?;
 
     Ok(task)
+}
+
+/// `when:` — a `${{ … }}` CEL string OR the YAML boolean literal
+/// (spec 03 §when shape rules · `when: true` = the always-pattern).
+///
+/// marked-yaml coerces booleans for PLAIN-style scalars only, so a
+/// quoted `"true"` stays a string — exactly the spec's split (the
+/// literal form is the YAML boolean · a quoted "true" is a bare string
+/// the analyzer rejects).
+fn parse_when(
+    cx: &Cx<'_>,
+    mapping: &MarkedMappingNode,
+) -> Result<Option<Spanned<WhenGate>>, SchemaError> {
+    let Some(node) = mapping.get_node("when") else {
+        return Ok(None);
+    };
+    if let Some(b) = node
+        .as_scalar()
+        .and_then(marked_yaml::types::MarkedScalarNode::as_bool)
+    {
+        return Ok(Some(Spanned::new(
+            WhenGate::Literal(b),
+            cx.span_or_zero(node.span()),
+        )));
+    }
+    Ok(cx
+        .opt_scalar(mapping, "when")?
+        .map(|s| Spanned::new(WhenGate::Expr(s.value), s.span)))
 }
 
 /// Extract an optional list of string scalars under `key`.
@@ -349,7 +384,7 @@ fn parse_retry(
     }
     for code in parse_string_list(cx, retry_map, "on_codes")? {
         // Spec 05 · on_codes lists canonical codes matching
-        // ^NIKA-[A-Z]{2,9}(-[A-Z]{2,9})?-[0-9]{3}$ — not HTTP statuses.
+        // ^NIKA-[A-Z]{2,9}(-[A-Z][A-Z0-9_]{1,15})?-[0-9]{3}$ — not HTTP statuses.
         if !is_valid_error_code(&code.value) {
             return Err(SchemaError::BadRetry {
                 reason: format!(
@@ -365,8 +400,9 @@ fn parse_retry(
     Ok(Some(Spanned::new(config, cx.span_or_zero(node.span()))))
 }
 
-/// `on_error:` — exactly one of `recover` | `skip: true` |
-/// `fail_workflow: true` (spec 05 §`on_error` · mutually exclusive).
+/// `on_error:` — exactly one ACTION (`recover` | `skip: true` |
+/// `fail_workflow: true`) + the optional `on_codes:` filter (spec 05
+/// §`on_error` · the catch-side mirror of `retry.on_codes`).
 fn parse_on_error(
     cx: &Cx<'_>,
     mapping: &MarkedMappingNode,
@@ -382,7 +418,7 @@ fn parse_on_error(
     };
     cx.check_unknown_keys(on_error_map, ON_ERROR_KEYS, "`on_error:`")?;
 
-    let present: Vec<&str> = ON_ERROR_KEYS
+    let present: Vec<&str> = ON_ERROR_ACTION_KEYS
         .iter()
         .copied()
         .filter(|k| on_error_map.get_node(k).is_some())
@@ -391,20 +427,24 @@ fn parse_on_error(
         [one] => *one,
         [] => {
             return Err(SchemaError::BadOnError {
-                reason: "exactly one of `recover`, `skip`, `fail_workflow` required (none found)"
+                reason: "exactly one of `recover`, `skip`, `fail_workflow` required (none found \
+                         — `on_codes` alone is a filter with nothing to filter)"
                     .to_owned(),
                 span: cx.span(on_error_map.span()),
             });
         }
         many => {
             return Err(SchemaError::BadOnError {
-                reason: format!("fields are mutually exclusive — found {}", many.join(" + ")),
+                reason: format!(
+                    "actions are mutually exclusive — found {}",
+                    many.join(" + ")
+                ),
                 span: cx.span(on_error_map.span()),
             });
         }
     };
 
-    let on_error = match mode {
+    let action = match mode {
         "recover" => {
             let value_node =
                 on_error_map
@@ -413,21 +453,37 @@ fn parse_on_error(
                         reason: "`recover` value missing".to_owned(),
                         span: cx.span(on_error_map.span()),
                     })?;
-            OnError::Recover(Spanned::new(
+            OnErrorAction::Recover(Spanned::new(
                 node_to_json(value_node),
                 cx.span_or_zero(value_node.span()),
             ))
         }
         "skip" => {
             require_true_flag(cx, on_error_map, "skip")?;
-            OnError::Skip
+            OnErrorAction::Skip
         }
         _ => {
             require_true_flag(cx, on_error_map, "fail_workflow")?;
-            OnError::FailWorkflow
+            OnErrorAction::FailWorkflow
         }
     };
-    Ok(Some(Spanned::new(on_error, cx.span_or_zero(node.span()))))
+
+    let mut policy = OnError::new(action);
+    for code in parse_string_list(cx, on_error_map, "on_codes")? {
+        // Same canonical regex as retry.on_codes (spec 05) — exact
+        // codes route the catch · never HTTP statuses.
+        if !is_valid_error_code(&code.value) {
+            return Err(SchemaError::BadOnError {
+                reason: format!(
+                    "`on_codes` entry `{}` is not a canonical NIKA-<NS>-<NNN> code",
+                    code.value
+                ),
+                span: Some(code.span),
+            });
+        }
+        policy.on_codes.push(code);
+    }
+    Ok(Some(Spanned::new(policy, cx.span_or_zero(node.span()))))
 }
 
 /// `skip:` / `fail_workflow:` carry the literal `true` (spec 05 syntax ·
@@ -548,7 +604,7 @@ fn parse_on_finally(
 
         let action = parse_verb(cx, cleanup_map, &format!("{task_label}.on_finally"))?;
         let mut finally = RawFinallyTask::new(action);
-        finally.when = cx.opt_scalar(cleanup_map, "when")?;
+        finally.when = parse_when(cx, cleanup_map)?;
         finally.timeout = parse_timeout(cx, cleanup_map, "timeout")?;
         out.push(Spanned::new(finally, cx.span_or_zero(item.span())));
     }
@@ -563,7 +619,7 @@ mod tests {
     use crate::parser::{ParseMode, parse};
     use crate::raw::{RawAction, RawWorkflow};
     use crate::source::FileId;
-    use crate::types::{BackoffStrategy, OnError};
+    use crate::types::{BackoffStrategy, OnErrorAction, WhenGate};
 
     fn parse_strict(yaml: &str) -> Result<RawWorkflow, SchemaError> {
         parse(yaml, FileId::new(0), ParseMode::Strict)
@@ -684,7 +740,7 @@ tasks:
         assert_eq!(b.depends_on[0].value, "a");
         assert_eq!(
             b.when.as_ref().expect("when").value,
-            "${{ tasks.a.status == 'success' }}"
+            WhenGate::Expr("${{ tasks.a.status == 'success' }}".into())
         );
         assert_eq!(
             b.for_each.as_ref().expect("for_each").value,
@@ -870,10 +926,12 @@ tasks:
       recover: ${{ tasks.cached.output }}
 ";
         let task = one_task(yaml);
-        let OnError::Recover(value) = task.on_error.expect("on_error").value else {
+        let policy = task.on_error.expect("on_error").value;
+        let OnErrorAction::Recover(value) = policy.action else {
             panic!("expected Recover");
         };
         assert_eq!(value.value, "${{ tasks.cached.output }}");
+        assert!(policy.on_codes.is_empty(), "no filter declared");
     }
 
     #[test]
@@ -886,7 +944,7 @@ tasks:
       recover: 0
 ";
         let task = one_task(yaml);
-        let OnError::Recover(value) = task.on_error.expect("on_error").value else {
+        let OnErrorAction::Recover(value) = task.on_error.expect("on_error").value.action else {
             panic!("expected Recover");
         };
         assert_eq!(value.value, 0);
@@ -905,12 +963,12 @@ tasks:
 ";
         let wf = parse_strict(yaml).expect("parse");
         assert!(matches!(
-            wf.tasks[0].value.on_error.as_ref().expect("a").value,
-            OnError::Skip
+            wf.tasks[0].value.on_error.as_ref().expect("a").value.action,
+            OnErrorAction::Skip
         ));
         assert!(matches!(
-            wf.tasks[1].value.on_error.as_ref().expect("b").value,
-            OnError::FailWorkflow
+            wf.tasks[1].value.on_error.as_ref().expect("b").value.action,
+            OnErrorAction::FailWorkflow
         ));
     }
 
@@ -927,6 +985,100 @@ tasks:
 ";
         let err = parse_strict(yaml).expect_err("two fields");
         assert!(matches!(err, SchemaError::BadOnError { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn on_error_on_codes_filter() {
+        // Spec 05 · on_codes = catch-side filter beside exactly one action.
+        let yaml = "\
+tasks:
+  - id: slow_fetch
+    invoke: { tool: \"nika:fetch\", args: { url: \"https://slow.example.com\" } }
+    on_error:
+      on_codes: [NIKA-TIMEOUT-001, NIKA-BUILTIN-JSON_MERGE_PATCH-001]
+      recover: { stale: true }
+";
+        let policy = one_task(yaml).on_error.expect("on_error").value;
+        assert!(matches!(policy.action, OnErrorAction::Recover(_)));
+        assert_eq!(policy.on_codes.len(), 2);
+        assert_eq!(
+            policy.on_codes[1].value,
+            "NIKA-BUILTIN-JSON_MERGE_PATCH-001"
+        );
+    }
+
+    #[test]
+    fn on_error_on_codes_alone_errors() {
+        // A filter with nothing to filter (spec 05 · one action required).
+        let yaml = "\
+tasks:
+  - id: t
+    exec: { command: echo }
+    on_error:
+      on_codes: [NIKA-TIMEOUT-001]
+";
+        let err = parse_strict(yaml).expect_err("filter alone");
+        assert!(matches!(err, SchemaError::BadOnError { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn when_boolean_literal_forms() {
+        // Spec 03 §when shape rules · the YAML boolean literal is legal
+        // (`when: true` = the always-pattern) · a QUOTED \"true\" stays a
+        // bare string (marked-yaml coerces plain style only).
+        let yaml = "\
+tasks:
+  - id: work
+    exec: { command: echo }
+  - id: record
+    depends_on: [work]
+    when: true
+    exec: { command: echo }
+  - id: never
+    depends_on: [work]
+    when: false
+    exec: { command: echo }
+  - id: quoted
+    depends_on: [work]
+    when: \"true\"
+    exec: { command: echo }
+";
+        let wf = parse_strict(yaml).expect("parse");
+        assert_eq!(
+            wf.tasks[1].value.when.as_ref().expect("record").value,
+            WhenGate::Literal(true)
+        );
+        assert_eq!(
+            wf.tasks[2].value.when.as_ref().expect("never").value,
+            WhenGate::Literal(false)
+        );
+        assert_eq!(
+            wf.tasks[3].value.when.as_ref().expect("quoted").value,
+            WhenGate::Expr("true".into()),
+            "a quoted \"true\" is a bare string · the analyzer rejects it"
+        );
+    }
+
+    #[test]
+    fn when_yaml11_bool_aliases_stay_strings() {
+        // marked-yaml's as_bool accepts true/True/TRUE + false forms ONLY —
+        // the YAML 1.1 aliases (`yes` · `on`) stay strings, exactly the
+        // spec's split (03 §when · the literal form is true/false).
+        let yaml = "\
+tasks:
+  - id: work
+    exec: { command: echo }
+  - id: legacy
+    depends_on: [work]
+    when: yes
+    exec: { command: echo }
+";
+        let wf = parse_strict(yaml).expect("parse");
+        assert_eq!(
+            wf.tasks[1].value.when.as_ref().expect("legacy").value,
+            WhenGate::Expr("yes".into()),
+            "`when: yes` is NOT a boolean literal · the analyzer rejects it as a bare string"
+        );
     }
 
     #[test]

--- a/crates/nika-schema/src/raw/task.rs
+++ b/crates/nika-schema/src/raw/task.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use crate::source::Spanned;
-use crate::types::{OnError, RetryConfig};
+use crate::types::{OnError, RetryConfig, WhenGate};
 
 use super::action::RawAction;
 
@@ -27,8 +27,10 @@ pub struct RawTask {
     pub id: Spanned<String>,
     /// `depends_on:` — task ids this task waits on (default `[]`).
     pub depends_on: Vec<Spanned<String>>,
-    /// `when:` — conditional execution · a single boolean CEL island.
-    pub when: Option<Spanned<String>>,
+    /// `when:` — conditional execution · a single boolean CEL island OR
+    /// the YAML boolean literal (`when: true` = the always-pattern ·
+    /// spec 03 §when shape rules).
+    pub when: Option<Spanned<WhenGate>>,
     /// `for_each:` — map this task over a collection (spec `03-dag.md`
     /// · « The collection is either a literal list or a reference to
     /// an upstream task's array output »).
@@ -93,8 +95,9 @@ pub enum ForEachValue {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct RawFinallyTask {
-    /// `when:` — conditional cleanup (sees the parent's status/error).
-    pub when: Option<Spanned<String>>,
+    /// `when:` — conditional cleanup (sees the parent's status/error) ·
+    /// same two forms as the task-level gate.
+    pub when: Option<Spanned<WhenGate>>,
     /// `timeout:` — per-cleanup-task override (default 30s · engine).
     pub timeout: Option<Spanned<Duration>>,
     /// The cleanup verb.

--- a/crates/nika-schema/src/types/mod.rs
+++ b/crates/nika-schema/src/types/mod.rs
@@ -18,15 +18,17 @@ pub mod retry;
 pub mod schema_version;
 pub mod secret;
 pub mod var_decl;
+pub mod when_gate;
 
 // Re-exports for convenience.
 pub use capture::CaptureMode;
 pub use duration::{GoDurationError, parse_go_duration};
 pub use extract::{ExtractMode, ResponseMode};
-pub use on_error::OnError;
+pub use on_error::{OnError, OnErrorAction};
 pub use output_decl::OutputDecl;
 pub use permits::{ExecPermit, FsPermits, NetPermits, Permits};
 pub use retry::{BackoffStrategy, RetryConfig, is_valid_error_code};
 pub use schema_version::SchemaVersion;
 pub use secret::{SecretRef, SecretSource};
 pub use var_decl::{VarDecl, VarType};
+pub use when_gate::WhenGate;

--- a/crates/nika-schema/src/types/on_error.rs
+++ b/crates/nika-schema/src/types/on_error.rs
@@ -3,31 +3,63 @@
 
 //! Error recovery — the task-level `on_error:` block.
 //!
-//! Per spec `05-errors.md` §`on_error` · the three fields are **mutually
-//! exclusive** ·
+//! Per spec `05-errors.md` §`on_error` · exactly ONE action + an
+//! optional code filter ·
 //!
 //! | Field | Effect | Downstream sees |
 //! |---|---|---|
 //! | `recover: <value>` | a `${{ }}` ref OR a literal | `status: success` |
-//! | `skip: true` | skip on error | `status: skipped` |
+//! | `skip: true` | skip on error · **the original error stays readable** at `tasks.X.error` | `status: skipped` |
 //! | `fail_workflow: true` | fail the workflow (default behavior) | n/a |
+//! | `on_codes: [NIKA-…]` | **filter** · the action applies ONLY when the final error's code is listed · an unlisted code falls through to the default fail — the catch-side mirror of `retry.on_codes` |
 //!
-//! Two-or-zero fields = a parse error — exactly one must be present.
+//! Two-or-zero actions = a parse error — exactly one must be present.
+//! `on_codes` combines with any one action; alone it is a parse error
+//! (a filter with nothing to filter).
 
 use crate::source::Spanned;
 
-/// A task's `on_error:` recovery policy — exactly one of the three modes.
+/// The `on_error:` action — exactly one of the three modes.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
-pub enum OnError {
+pub enum OnErrorAction {
     /// `recover: <value>` — use a recovery output (a `${{ }}` ref like
     /// `${{ tasks.cached.output }}` OR any literal). Downstream sees
-    /// `status: success` with the recover value as output.
+    /// `status: success` with the recover value as output · the value
+    /// substitutes the raw output BEFORE `output:` binding extraction
+    /// (spec 05 §recovery × bindings).
     Recover(Spanned<serde_json::Value>),
-    /// `skip: true` — downstream sees `status: skipped`.
+    /// `skip: true` — downstream sees `status: skipped` · the original
+    /// typed error stays readable at `tasks.X.error` (spec 05 · the one
+    /// state where both coexist · enables per-code routing).
     Skip,
     /// `fail_workflow: true` — explicit form of the default behavior.
     FailWorkflow,
+}
+
+/// A task's `on_error:` recovery policy — one action + optional filter.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct OnError {
+    /// The recovery action (exactly one · parser-enforced).
+    pub action: OnErrorAction,
+    /// `on_codes:` — when non-empty, the action applies ONLY to the
+    /// listed canonical codes (`NIKA-<NS>[-<SUB>]-<NNN>` · validated
+    /// against [`is_valid_error_code`](crate::types::is_valid_error_code))
+    /// · an unlisted code falls through to the default fail.
+    pub on_codes: Vec<Spanned<String>>,
+}
+
+impl OnError {
+    /// A policy with the given action and no code filter (applies to
+    /// every error · the pre-filter spec shape).
+    #[must_use]
+    pub fn new(action: OnErrorAction) -> Self {
+        Self {
+            action,
+            on_codes: Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -37,13 +69,23 @@ mod tests {
 
     #[test]
     fn recover_carries_value() {
-        let v = OnError::Recover(Spanned::new(serde_json::json!(0), Span::default()));
-        assert!(matches!(v, OnError::Recover(ref s) if s.value == 0));
+        let v = OnError::new(OnErrorAction::Recover(Spanned::new(
+            serde_json::json!(0),
+            Span::default(),
+        )));
+        assert!(matches!(v.action, OnErrorAction::Recover(ref s) if s.value == 0));
+        assert!(v.on_codes.is_empty(), "new() = no filter · applies to all");
     }
 
     #[test]
     fn unit_variants_exist() {
-        assert!(matches!(OnError::Skip, OnError::Skip));
-        assert!(matches!(OnError::FailWorkflow, OnError::FailWorkflow));
+        assert!(matches!(
+            OnError::new(OnErrorAction::Skip).action,
+            OnErrorAction::Skip
+        ));
+        assert!(matches!(
+            OnError::new(OnErrorAction::FailWorkflow).action,
+            OnErrorAction::FailWorkflow
+        ));
     }
 }

--- a/crates/nika-schema/src/types/retry.rs
+++ b/crates/nika-schema/src/types/retry.rs
@@ -92,23 +92,33 @@ impl RetryConfig {
     }
 }
 
-/// Validate a `retry.on_codes` entry against the canonical error-code
-/// regex (spec `05-errors.md` §namespaces) ·
-/// `^NIKA-[A-Z]{2,9}(-[A-Z]{2,9})?-[0-9]{3}$`.
+/// Validate a `retry.on_codes` / `on_error.on_codes` entry against the
+/// canonical error-code regex (spec `05-errors.md` §namespaces) ·
+/// `^NIKA-[A-Z]{2,9}(-[A-Z][A-Z0-9_]{1,15})?-[0-9]{3}$`.
 ///
-/// Hand-rolled (no regex dep in L0) · segments split on `-` ·
-/// `NIKA` · 1-2 uppercase namespace segments of 2-9 letters · 3 digits.
+/// Hand-rolled (no regex dep in L0) · segments split on `-` · `NIKA` ·
+/// a primary namespace of 2-9 uppercase letters · an optional
+/// sub-namespace (a leading letter then 1-15 of `[A-Z0-9_]` — the
+/// underscore admits underscore-named builtins ·
+/// `NIKA-BUILTIN-JSON_MERGE_PATCH-001`) · exactly 3 digits.
 #[must_use]
 pub fn is_valid_error_code(code: &str) -> bool {
     let segments: Vec<&str> = code.split('-').collect();
-    let (ns_segments, digits) = match segments.as_slice() {
-        ["NIKA", ns, digits] => (vec![*ns], *digits),
-        ["NIKA", ns1, ns2, digits] => (vec![*ns1, *ns2], *digits),
+    let (ns, sub, digits) = match segments.as_slice() {
+        ["NIKA", ns, digits] => (*ns, None, *digits),
+        ["NIKA", ns, sub, digits] => (*ns, Some(*sub), *digits),
         _ => return false,
     };
-    for ns in ns_segments {
-        let len = ns.len();
-        if !(2..=9).contains(&len) || !ns.chars().all(|c| c.is_ascii_uppercase()) {
+    if !(2..=9).contains(&ns.len()) || !ns.chars().all(|c| c.is_ascii_uppercase()) {
+        return false;
+    }
+    if let Some(sub) = sub {
+        let mut chars = sub.chars();
+        let first_is_letter = chars.next().is_some_and(|c| c.is_ascii_uppercase());
+        if !first_is_letter
+            || !(2..=16).contains(&sub.len())
+            || !chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        {
             return false;
         }
     }
@@ -128,6 +138,18 @@ mod tests {
         assert_eq!(r.backoff_max_ms, 60_000);
         assert!(r.jitter, "jitter defaults true · anti-thundering-herd");
         assert!(r.on_codes.is_empty());
+    }
+
+    #[test]
+    fn backoff_strategy_display_round_trips() {
+        // pins the Display impl (a mutant replaced fmt with Ok(()) unseen)
+        for (v, txt) in [
+            (BackoffStrategy::Fixed, "fixed"),
+            (BackoffStrategy::Linear, "linear"),
+            (BackoffStrategy::Exponential, "exponential"),
+        ] {
+            assert_eq!(v.to_string(), txt);
+        }
     }
 
     #[test]
@@ -153,6 +175,11 @@ mod tests {
         assert!(is_valid_error_code("NIKA-DAG-001"));
         assert!(is_valid_error_code("NIKA-BUILTIN-FETCH-001"));
         assert!(is_valid_error_code("NIKA-PARSE-WHEN-001"));
+        // underscore sub-namespaces (spec 05 · underscore-named builtins)
+        assert!(is_valid_error_code("NIKA-BUILTIN-JSON_MERGE_PATCH-001"));
+        assert!(is_valid_error_code("NIKA-BUILTIN-JSON_DIFF-001"));
+        // digits inside a sub-namespace (leading char stays a letter)
+        assert!(is_valid_error_code("NIKA-BUILTIN-BASE64-001"));
     }
 
     #[test]
@@ -166,5 +193,11 @@ mod tests {
         assert!(!is_valid_error_code("OLY-DAG-001")); // wrong prefix
         assert!(!is_valid_error_code("NIKA-A-B-C-001")); // 3 sub-namespaces
         assert!(!is_valid_error_code("503")); // HTTP status · not a code
+        // underscore rules · sub-namespace ONLY · never the primary ·
+        // never leading · ≤16 chars total
+        assert!(!is_valid_error_code("NIKA-BUIL_TIN-001")); // _ in primary ns
+        assert!(!is_valid_error_code("NIKA-BUILTIN-_MERGE-001")); // leading _
+        assert!(!is_valid_error_code("NIKA-BUILTIN-1MERGE-001")); // leading digit
+        assert!(!is_valid_error_code("NIKA-BUILTIN-JSON_MERGE_PATCHX2-001")); // sub 17 > 16
     }
 }

--- a/crates/nika-schema/src/types/secret.rs
+++ b/crates/nika-schema/src/types/secret.rs
@@ -5,13 +5,19 @@
 //!
 //! Per spec `01-envelope.md` §secrets · « A secret is always a **reference
 //! to a store** — never an inline literal. » The `source` field is a closed
-//! enum (« the only three v0.1 values ») ·
+//! enum, and the entry shape is **discriminated by it** (spec 01 ·
+//! `vault`/`env` require `key:` · `file` requires `path:`) ·
 //!
-//! | `source` | `key` means |
-//! |---|---|
-//! | `vault` (default) | path in the local `nika-vault` |
-//! | `env` | name of an OS environment variable |
-//! | `file` | path to a file holding the value |
+//! | `source` | YAML field | the reference means |
+//! |---|---|---|
+//! | `vault` (default) | `key:` | path in the local `nika-vault` |
+//! | `env` | `key:` | name of an OS environment variable |
+//! | `file` | `path:` | path to a file holding the value |
+//!
+//! The model stores the reference uniformly in [`SecretRef::key`] — the
+//! parser owns the field-name discrimination (a `file` entry written
+//! with `key:`, or a `vault`/`env` entry written with `path:`, is a
+//! parse error).
 
 use std::fmt;
 

--- a/crates/nika-schema/src/types/when_gate.rs
+++ b/crates/nika-schema/src/types/when_gate.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `when:` gate — a `${{ … }}` CEL boolean OR a YAML boolean literal.
+//!
+//! Per spec `03-dag.md` §when shape rules · `when:` accepts exactly two
+//! forms ·
+//!
+//! | Form | Meaning |
+//! |---|---|
+//! | `when: ${{ … }}` | a CEL boolean expression · evaluated over terminal deps |
+//! | `when: true` / `when: false` | the YAML **boolean literal** · the always/never pattern (`true` replaces the default success-gate · the task runs even when an upstream failed) |
+//!
+//! A bare string (`when: "tasks.a.status == 'success'"` · no `${{ }}`)
+//! is never evaluated and is rejected by the analyzer. A *quoted*
+//! `"true"` is a bare string, not a boolean literal — marked-yaml keeps
+//! the distinction (`as_bool` coerces plain-style scalars only), so the
+//! parser sees exactly what the spec means.
+
+/// A task's `when:` value — boolean literal or expression source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WhenGate {
+    /// `when: true` / `when: false` — the YAML boolean literal.
+    /// `true` is the **always-pattern** (runs whatever happened
+    /// upstream — the record/notify shape) · `false` never runs.
+    Literal(bool),
+    /// `when: ${{ … }}` — the raw string body · the analyzer enforces
+    /// the single-island boolean shape (spec 03 · `NIKA-VAR-005` class).
+    Expr(String),
+}
+
+impl WhenGate {
+    /// The expression source, when this gate is the expression form.
+    #[must_use]
+    pub fn as_expr(&self) -> Option<&str> {
+        match self {
+            Self::Expr(s) => Some(s),
+            Self::Literal(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_carries_bool() {
+        assert_eq!(WhenGate::Literal(true), WhenGate::Literal(true));
+        assert_ne!(WhenGate::Literal(true), WhenGate::Literal(false));
+    }
+
+    #[test]
+    fn as_expr_splits_the_forms() {
+        assert_eq!(
+            WhenGate::Expr("${{ x > 0 }}".into()).as_expr(),
+            Some("${{ x > 0 }}")
+        );
+        assert_eq!(WhenGate::Literal(true).as_expr(), None);
+    }
+}


### PR DESCRIPTION
Closes #115. The spec hardening rounds moved the static contract; all four gaps land spec-derived:

- **WhenGate** — `when:` accepts the YAML boolean literal (`when: true` = the always-pattern) OR a `${{ }}` CEL expression. Quoted `"true"` and YAML 1.1 aliases (`yes`) stay strings the analyzer rejects — both pinned by tests.
- **Secrets discrimination** — `vault`/`env` take `key:`, `file` takes `path:`; the wrong field is a prescriptive parse error.
- **`on_error.on_codes`** — catch-side filter beside exactly one action (mirror of `retry.on_codes`); `OnError` becomes `{action, on_codes}` with spans preserved.
- **Error-code regex** — underscore sub-namespaces (`NIKA-BUILTIN-JSON_MERGE_PATCH-001`), boundaries pinned.

**conformance_core: 57/57** (was 53/57) · 353 lib tests · clippy -D clean · mutation 25/26 + the Display gap killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)