### PR TITLE
feat(nika-schema): deep conformance tier + DAG-004 + the registry remaps

### DIFF
--- a/crates/nika-schema/src/analyzer/dag.rs
+++ b/crates/nika-schema/src/analyzer/dag.rs
@@ -7,14 +7,20 @@
 //! - `NIKA-DAG-001` · « The engine MUST reject any workflow with cyclic
 //!   dependencies at parse time with a clear error » (incl. 1-cycles ·
 //!   self-dependency).
+//! - `NIKA-DAG-004` · `on_error.recover` must not reference a task that
+//!   transitively depends on the declaring task — the recovery-time
+//!   await would deadlock (spec `05-errors.md` §recover resolution ·
+//!   the 03 carve-out exempts `recover:` from EDGES, not acyclicity).
 //! - Topological waves · « group tasks into parallel execution waves »
 //!   (steps 2-3 of the execution model).
 
 use std::collections::BTreeMap;
 
 use crate::error::SchemaError;
+use crate::expression::{NamespaceRef, expr_refs, scan_templates};
 use crate::raw::RawTask;
 use crate::source::Spanned;
+use crate::types::OnErrorAction;
 
 /// `NIKA-DAG-002` — collect unresolved `depends_on` references.
 pub(super) fn check_depends_on_resolve(
@@ -96,6 +102,95 @@ pub(super) fn check_cycles(
     }
 }
 
+/// `NIKA-DAG-004` — an `on_error.recover` reference to a task that
+/// transitively depends on the declaring task (spec `05-errors.md`
+/// §recover resolution · the await would deadlock · runs after
+/// DAG-001/002 so the walk is over a sane graph).
+pub(super) fn check_recover_acyclic(
+    tasks: &[Spanned<RawTask>],
+    ids: &BTreeMap<String, usize>,
+    errors: &mut Vec<SchemaError>,
+) {
+    for task in tasks {
+        let Some(on_error) = &task.value.on_error else {
+            continue;
+        };
+        let OnErrorAction::Recover(value) = &on_error.value.action else {
+            continue;
+        };
+        let declaring = task.value.id.value.as_str();
+        for target in recover_task_refs(&value.value) {
+            let Some(&start) = ids.get(&target) else {
+                continue; // unresolved · the scan layer reports it
+            };
+            if depends_transitively_on(tasks, ids, start, declaring) {
+                errors.push(SchemaError::RecoverAwaitDeadlock {
+                    task: declaring.to_owned(),
+                    target,
+                    span: Some(value.span),
+                });
+            }
+        }
+    }
+}
+
+/// Every `tasks.<id>` referenced inside the recover value's `${{ }}`
+/// islands (strings nested anywhere in the JSON value).
+fn recover_task_refs(value: &serde_json::Value) -> Vec<String> {
+    fn strings<'v>(v: &'v serde_json::Value, out: &mut Vec<&'v str>) {
+        match v {
+            serde_json::Value::String(s) => out.push(s),
+            serde_json::Value::Array(items) => items.iter().for_each(|i| strings(i, out)),
+            serde_json::Value::Object(map) => map.values().for_each(|i| strings(i, out)),
+            _ => {}
+        }
+    }
+    let mut raw = Vec::new();
+    strings(value, &mut raw);
+    let mut refs = Vec::new();
+    for s in raw {
+        let Ok(islands) = scan_templates(s) else {
+            continue; // malformed · the scan layer reports it
+        };
+        for island in islands {
+            for r in expr_refs(&island.expr) {
+                if let NamespaceRef::Tasks { id, .. } = r {
+                    refs.push(id);
+                }
+            }
+        }
+    }
+    refs.sort();
+    refs.dedup();
+    refs
+}
+
+/// Whether `start`'s transitive `depends_on` closure contains `needle`.
+fn depends_transitively_on(
+    tasks: &[Spanned<RawTask>],
+    ids: &BTreeMap<String, usize>,
+    start: usize,
+    needle: &str,
+) -> bool {
+    let mut seen = vec![false; tasks.len()];
+    let mut stack = vec![start];
+    while let Some(node) = stack.pop() {
+        if seen[node] {
+            continue;
+        }
+        seen[node] = true;
+        for dep in &tasks[node].value.depends_on {
+            if dep.value == needle {
+                return true;
+            }
+            if let Some(&next) = ids.get(&dep.value) {
+                stack.push(next);
+            }
+        }
+    }
+    false
+}
+
 /// Topological waves (Kahn levels) — wave N may run in parallel once
 /// wave N-1 completed (spec `03-dag.md` execution model steps 2-3).
 ///
@@ -147,6 +242,77 @@ mod tests {
     }
 
     const HEADER: &str = "nika: v1\nworkflow: t\n";
+
+    #[test]
+    fn recover_deadlock_direct_and_transitive() {
+        // 05 §recover resolution · DAG-004 — direct dependent AND a
+        // 2-hop transitive dependent both deadlock the recovery await.
+        let yaml = format!(
+            "{HEADER}tasks:
+  - id: fetch
+    invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
+    on_error:
+      recover: ${{{{ tasks.report.output }}}}
+  - id: mid
+    depends_on: [fetch]
+    exec: {{ command: echo }}
+  - id: report
+    depends_on: [mid]
+    exec: {{ command: echo }}
+"
+        );
+        let errors = analyze_yaml(&yaml).expect_err("deadlock");
+        assert!(
+            errors.iter().any(|e| matches!(
+                e,
+                SchemaError::RecoverAwaitDeadlock { task, target, .. }
+                    if task == "fetch" && target == "report"
+            )),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
+    fn recover_independent_source_is_legal() {
+        // 03 §carve-out · an independent recovery source needs NO edge
+        // and passes acyclicity (the example-22 fetch-chain shape).
+        let yaml = format!(
+            "{HEADER}tasks:
+  - id: cached
+    invoke: {{ tool: \"nika:read\", args: {{ path: \"./cache.json\" }} }}
+  - id: fetch
+    invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
+    on_error:
+      recover: ${{{{ tasks.cached.output }}}}
+"
+        );
+        analyze_yaml(&yaml).expect("independent recover is legal");
+    }
+
+    #[test]
+    fn recover_nested_value_refs_are_walked() {
+        // The recover value may be an object/array · refs nest anywhere.
+        let yaml = format!(
+            "{HEADER}tasks:
+  - id: fetch
+    invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
+    on_error:
+      recover:
+        stale: true
+        body: \"${{{{ tasks.consumer.output }}}}\"
+  - id: consumer
+    depends_on: [fetch]
+    exec: {{ command: echo }}
+"
+        );
+        let errors = analyze_yaml(&yaml).expect_err("nested ref deadlock");
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, SchemaError::RecoverAwaitDeadlock { .. })),
+            "{errors:?}"
+        );
+    }
 
     #[test]
     fn cycle_two_nodes() {

--- a/crates/nika-schema/src/analyzer/mod.rs
+++ b/crates/nika-schema/src/analyzer/mod.rs
@@ -57,6 +57,7 @@ pub fn analyze(wf: &RawWorkflow) -> Result<AnalyzedWorkflow, Vec<SchemaError>> {
     let ids = task_id_index(wf, &mut errors);
     dag::check_depends_on_resolve(&wf.tasks, &ids, &mut errors);
     dag::check_cycles(&wf.tasks, &ids, &mut errors);
+    dag::check_recover_acyclic(&wf.tasks, &ids, &mut errors);
     scan::scan_workflow(wf, &mut errors);
 
     if errors.is_empty() {

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -260,6 +260,23 @@ pub enum SchemaError {
         span: Option<Span>,
     },
 
+    /// `on_error.recover` references a task that transitively depends
+    /// on the declaring task — the recovery-time await would deadlock
+    /// (spec `05-errors.md` §recover resolution · `NIKA-DAG-004`).
+    #[error(
+        "task `{task}` on_error.recover reads tasks.{target} — `{target}` depends \
+         (transitively) on `{task}` · the recovery await would deadlock · recover \
+         from an upstream or independent source"
+    )]
+    RecoverAwaitDeadlock {
+        /// The task declaring the `on_error.recover`.
+        task: String,
+        /// The recovery source that loops back.
+        target: String,
+        /// The recover value's span.
+        span: Option<Span>,
+    },
+
     /// `when:` (or `for_each:`) is not a single CEL island of the
     /// required shape.
     ///
@@ -440,6 +457,7 @@ schema_code!(SCHEMA_304, 304, "unresolved-namespace-ref");
 schema_code!(SCHEMA_305, 305, "loop-local-outside-for-each");
 schema_code!(SCHEMA_306, 306, "unknown-task-field");
 schema_code!(SCHEMA_307, 307, "output-path-provably-invalid");
+schema_code!(SCHEMA_308, 308, "recover-await-deadlock");
 
 impl NikaErrorCode for SchemaError {
     fn nika_code(&self) -> NikaCode {
@@ -465,6 +483,7 @@ impl NikaErrorCode for SchemaError {
             Self::MissingField { .. } => SCHEMA_298,
             Self::Validation { .. } => SCHEMA_299,
             Self::WhenNotBoolean { .. } => SCHEMA_300,
+            Self::RecoverAwaitDeadlock { .. } => SCHEMA_308,
             Self::Cycle { .. } => SCHEMA_301,
             Self::UnknownDependency { .. } => SCHEMA_302,
             Self::MissingDependsOnEdge { .. } => SCHEMA_303,
@@ -599,6 +618,11 @@ fn analysis_level_variants() -> Vec<SchemaError> {
         SchemaError::MissingDependsOnEdge {
             task: String::new(),
             referenced: String::new(),
+            span: None,
+        },
+        SchemaError::RecoverAwaitDeadlock {
+            task: String::new(),
+            target: String::new(),
             span: None,
         },
         SchemaError::UnresolvedNamespaceRef {

--- a/crates/nika-schema/src/error/spec_code.rs
+++ b/crates/nika-schema/src/error/spec_code.rs
@@ -12,8 +12,8 @@
 //! Namespace allocation (per the Core conformance fixtures) ·
 //! - `PARSE` · structural/shape errors (YAML · envelope · task shape ·
 //!   verbs · the `workflow.schema.json`-checkable layer).
-//! - `PARSE-WHEN` · the `when:` static boolean-shape gate
-//!   (`NIKA-PARSE-WHEN-001` per spec `03-dag.md` §when).
+//! - (the former `PARSE-WHEN` sub-namespace is RETIRED — the spec
+//!   folded the static `when:` shape gate into `NIKA-VAR-005`).
 //! - `DAG` · topology (cycle · unresolved dep · missing edge).
 //! - `VAR` · the `${{ }}` substitution surface — both malformed
 //!   substitution syntax (fixture `variables/011` · « the YAML itself
@@ -134,16 +134,6 @@ const fn var(num: u16, category: SpecCategory) -> SpecCode {
     }
 }
 
-/// `NIKA-PARSE-WHEN-001` — the 4-segment sub-namespace (spec
-/// `03-dag.md` · « The engine rejects non-boolean `when:` expressions
-/// at parse time (`NIKA-PARSE-WHEN-001`) »).
-const PARSE_WHEN_001: SpecCode = SpecCode {
-    namespace: "PARSE-WHEN",
-    num: 1,
-    category: SpecCategory::ValidationError,
-    transient: false,
-};
-
 impl SchemaError {
     /// Map to the spec-facing code (spec `05-errors.md`).
     ///
@@ -172,18 +162,25 @@ impl SchemaError {
             Self::ReservedBindingName { .. } => parse(13, ValidationError),
             Self::BadSecretRef { .. } => parse(14, ValidationError),
             Self::BadTypedVar { .. } => parse(15, ValidationError),
-            Self::JqBindingContainsTemplate { .. } => parse(16, ValidationError),
+
             Self::DuplicateKey { .. } => parse(17, ValidationError),
             Self::MissingField { .. } => parse(18, ValidationError),
             Self::Validation { .. } => parse(19, ValidationError),
 
-            // ── NIKA-PARSE-WHEN · the when: boolean gate ────────────
-            Self::WhenNotBoolean { .. } => PARSE_WHEN_001,
+            // Spec 05 registry · NIKA-VAR-005 = « static expression
+            // violation » — the class spans the non-boolean `when:`
+            // shape gate (the retired NIKA-PARSE-WHEN-001 folded here)
+            // AND `${{ }}` inside an output binding (04 §binding
+            // rules · deep fixtures 003/007/008 expect NIKA-VAR).
+            Self::WhenNotBoolean { .. } | Self::JqBindingContainsTemplate { .. } => {
+                var(5, ValidationError)
+            }
 
             // ── NIKA-DAG · topology ─────────────────────────────────
             Self::Cycle { .. } => dag(1),
             Self::UnknownDependency { .. } => dag(2),
             Self::MissingDependsOnEdge { .. } => dag(3),
+            Self::RecoverAwaitDeadlock { .. } => dag(4),
 
             // ── NIKA-VAR · the ${{ }} surface ───────────────────────
             // NIKA-VAR-001 · reference resolution (fixtures 001-007 ·
@@ -192,10 +189,11 @@ impl SchemaError {
             Self::UnresolvedNamespaceRef { .. }
             | Self::LoopLocalOutsideForEach { .. }
             | Self::UnknownTaskField { .. } => var(1, VariableError),
-            // Fixture variables/011 · malformed substitution syntax is
-            // NIKA-VAR + validation_error (« the YAML itself parses
-            // fine ») — NOT NIKA-PARSE.
-            Self::TemplateSyntax { .. } => var(2, ValidationError),
+            // Spec 05 registry · NIKA-VAR-008 = unclosed/malformed
+            // `${{` opener (« the YAML itself parses fine » · fixture
+            // variables/011 matches on namespace) — VAR-002 is the
+            // RUNTIME binding-cardinality code · never static.
+            Self::TemplateSyntax { .. } => var(8, ValidationError),
             // NIKA-VAR-003 · static binding validation (04 §Static
             // binding validation · fixture variables/012) · the
             // category table's « invalid path » class.
@@ -216,7 +214,7 @@ mod tests {
             var(1, SpecCategory::VariableError).to_string(),
             "NIKA-VAR-001"
         );
-        assert_eq!(PARSE_WHEN_001.to_string(), "NIKA-PARSE-WHEN-001");
+        assert_eq!(dag(4).to_string(), "NIKA-DAG-004");
         assert_eq!(
             parse(17, SpecCategory::ValidationError).to_string(),
             "NIKA-PARSE-017"
@@ -302,8 +300,10 @@ mod tests {
             // variants (the spec defines ONE code for the class).
             seen.insert((code.namespace, code.num, code.category.as_str()));
         }
-        // 28 variants · 3 share VAR-001 → 26 distinct codes
-        // (VAR-003 static binding validation joined 2026-06-10).
+        // 29 variants · 3 share VAR-001 · 2 share VAR-005 → 26
+        // distinct codes (DAG-004 + the registry remaps of 2026-06-11 ·
+        // WhenNotBoolean/JqBindingContainsTemplate → VAR-005 ·
+        // TemplateSyntax → VAR-008).
         assert_eq!(seen.len(), 26, "{seen:?}");
     }
 }

--- a/crates/nika-schema/tests/common/mod.rs
+++ b/crates/nika-schema/tests/common/mod.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// NIKA_SPEC_DIR is a TEST-HARNESS path override (CI checkout layout) ·
+// not a secret — the SecretStore rule targets runtime secret lookup.
+#![allow(clippy::disallowed_methods)]
+// Each integration test binary compiles this module independently and
+// uses a subset of it — per-binary dead_code is expected, not rot.
+#![allow(dead_code)]
+
+//! Shared conformance-harness plumbing — the spec-checkout resolver,
+//! the `expected.json` contract, the engine runner and the
+//! runner-protocol matching rule (`conformance/runner-protocol.md`).
+
+use std::path::{Path, PathBuf};
+
+use nika_schema::{FileId, ParseMode, SchemaError, analyze, parse};
+
+/// Resolve the nika-spec checkout (env override · sibling default).
+pub(crate) fn spec_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("NIKA_SPEC_DIR") {
+        return PathBuf::from(dir);
+    }
+    // CARGO_MANIFEST_DIR = …/02-engineering/repos/engine/crates/nika-schema
+    // the spec checkout  = …/02-engineering/repos/spec
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../spec")
+        .canonicalize()
+        .expect("nika-spec checkout missing — set NIKA_SPEC_DIR or clone ../spec")
+}
+
+/// One expected-error entry (`code` XOR `namespace` per protocol).
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct ExpectedError {
+    pub(crate) code: Option<String>,
+    pub(crate) namespace: Option<String>,
+    pub(crate) category: Option<String>,
+}
+
+/// The `expected.json` contract.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct Expected {
+    pub(crate) valid: bool,
+    #[serde(default)]
+    pub(crate) errors: Vec<ExpectedError>,
+    #[serde(default)]
+    pub(crate) mode: Option<String>,
+    #[serde(default)]
+    pub(crate) note: Option<String>,
+}
+
+impl Expected {
+    /// « default: strict · the test default » per runner-protocol.md.
+    pub(crate) fn parse_mode(&self) -> ParseMode {
+        match self.mode.as_deref() {
+            Some("lenient") => ParseMode::Lenient,
+            _ => ParseMode::Strict,
+        }
+    }
+}
+
+/// Run parse + analyze · collect every emitted error.
+pub(crate) fn run_engine(yaml: &str, mode: ParseMode) -> Vec<SchemaError> {
+    match parse(yaml, FileId::new(0), mode) {
+        Ok(wf) => match analyze(&wf) {
+            Ok(_) => Vec::new(),
+            Err(errors) => errors,
+        },
+        Err(e) => vec![e],
+    }
+}
+
+/// Protocol matching · exact `code` OR `namespace`-prefix + `category`.
+pub(crate) fn matches_expected(emitted: &SchemaError, expected: &ExpectedError) -> bool {
+    let spec = emitted.spec_code();
+    let code = spec.to_string();
+    if let Some(exact) = &expected.code {
+        return &code == exact;
+    }
+    if let Some(namespace) = &expected.namespace {
+        if !code.starts_with(&format!("{namespace}-")) {
+            return false;
+        }
+        if let Some(category) = &expected.category {
+            return spec.category.as_str() == category;
+        }
+        return true;
+    }
+    false
+}
+
+/// One fixture's verdict against its `expected.json` (None = conformant).
+pub(crate) fn fixture_verdict(dir: &Path) -> Option<String> {
+    let yaml = std::fs::read_to_string(dir.join("input.yaml")).expect("read input.yaml");
+    let expected_raw =
+        std::fs::read_to_string(dir.join("expected.json")).expect("read expected.json");
+    let expected: Expected = serde_json::from_str(&expected_raw).expect("parse expected.json");
+    let emitted = run_engine(&yaml, expected.parse_mode());
+
+    if expected.valid {
+        if !emitted.is_empty() {
+            return Some(format!(
+                "expected VALID · engine emitted {} error(s) ·\n{}",
+                emitted.len(),
+                render(&emitted),
+            ));
+        }
+    } else if emitted.is_empty() {
+        return Some(format!(
+            "expected INVALID ({}) · engine accepted{}",
+            render_expected(&expected.errors),
+            expected
+                .note
+                .as_deref()
+                .map(|n| format!("\n  note · {n}"))
+                .unwrap_or_default(),
+        ));
+    } else {
+        let any_match = emitted
+            .iter()
+            .any(|e| expected.errors.iter().any(|x| matches_expected(e, x)));
+        if !any_match {
+            return Some(format!(
+                "expected one of [{}] · engine emitted ·\n{}",
+                render_expected(&expected.errors),
+                render(&emitted),
+            ));
+        }
+    }
+    None
+}
+
+/// Collect every fixture dir (any depth · a dir containing `input.yaml`).
+pub(crate) fn fixture_dirs(root: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        if dir.join("input.yaml").is_file() {
+            out.push(dir.to_path_buf());
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            }
+        }
+    }
+    let mut dirs = Vec::new();
+    walk(root, &mut dirs);
+    dirs.sort();
+    assert!(
+        !dirs.is_empty(),
+        "zero fixtures found under {} — the conformance gate must never be empty",
+        root.display()
+    );
+    dirs
+}
+
+/// Render emitted errors with their spec codes for diagnosis.
+pub(crate) fn render(errors: &[SchemaError]) -> String {
+    errors
+        .iter()
+        .map(|e| {
+            let spec = e.spec_code();
+            format!("  {} [{}] · {e}", spec, spec.category.as_str())
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render the expected entries compactly.
+pub(crate) fn render_expected(expected: &[ExpectedError]) -> String {
+    expected
+        .iter()
+        .map(|x| {
+            let id = x
+                .code
+                .clone()
+                .or_else(|| x.namespace.clone())
+                .unwrap_or_else(|| "<any>".to_owned());
+            match &x.category {
+                Some(category) => format!("{id}+{category}"),
+                None => id,
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/crates/nika-schema/tests/conformance_core.rs
+++ b/crates/nika-schema/tests/conformance_core.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 #![allow(clippy::expect_used, clippy::panic)]
-// NIKA_SPEC_DIR is a TEST-HARNESS path override (CI checkout layout) ·
-// not a secret — the SecretStore rule targets runtime secret lookup.
 #![allow(clippy::disallowed_methods)]
 
 //! Spec conformance · the FULL `core` suite.
@@ -19,99 +17,12 @@
 //!
 //! The spec dir resolves from `$NIKA_SPEC_DIR` or the sibling checkout
 //! (`<engine>/../spec`) — the suite HARD-FAILS when missing (the
-//! conformance gate must never silently skip).
+//! conformance gate must never silently skip). Harness plumbing is
+//! shared with the `deep` tier (`tests/common/mod.rs`).
 
-use std::path::{Path, PathBuf};
+mod common;
 
-use nika_schema::{FileId, ParseMode, SchemaError, analyze, parse};
-
-/// Resolve the nika-spec checkout (env override · sibling default).
-fn spec_dir() -> PathBuf {
-    if let Some(dir) = std::env::var_os("NIKA_SPEC_DIR") {
-        return PathBuf::from(dir);
-    }
-    // CARGO_MANIFEST_DIR = …/02-engineering/repos/engine/crates/nika-schema
-    // the spec checkout  = …/02-engineering/repos/spec
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../spec")
-        .canonicalize()
-        .expect("nika-spec checkout missing — set NIKA_SPEC_DIR or clone ../spec")
-}
-
-/// One expected-error entry (`code` XOR `namespace` per protocol).
-#[derive(Debug, serde::Deserialize)]
-struct ExpectedError {
-    code: Option<String>,
-    namespace: Option<String>,
-    category: Option<String>,
-}
-
-/// The `expected.json` contract.
-#[derive(Debug, serde::Deserialize)]
-struct Expected {
-    valid: bool,
-    #[serde(default)]
-    errors: Vec<ExpectedError>,
-    #[serde(default)]
-    mode: Option<String>,
-    #[serde(default)]
-    note: Option<String>,
-}
-
-/// Run parse + analyze · collect every emitted error.
-fn run_engine(yaml: &str, mode: ParseMode) -> Vec<SchemaError> {
-    match parse(yaml, FileId::new(0), mode) {
-        Ok(wf) => match analyze(&wf) {
-            Ok(_) => Vec::new(),
-            Err(errors) => errors,
-        },
-        Err(e) => vec![e],
-    }
-}
-
-/// Protocol matching · exact `code` OR `namespace`-prefix + `category`.
-fn matches_expected(emitted: &SchemaError, expected: &ExpectedError) -> bool {
-    let spec = emitted.spec_code();
-    let code = spec.to_string();
-    if let Some(exact) = &expected.code {
-        return &code == exact;
-    }
-    if let Some(namespace) = &expected.namespace {
-        if !code.starts_with(&format!("{namespace}-")) {
-            return false;
-        }
-        if let Some(category) = &expected.category {
-            return spec.category.as_str() == category;
-        }
-        return true;
-    }
-    false
-}
-
-/// Collect every fixture dir (a dir containing `input.yaml`).
-fn fixture_dirs(core: &Path) -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-    let groups = std::fs::read_dir(core).expect("read conformance/tests/core");
-    for group in groups {
-        let group = group.expect("dir entry").path();
-        if !group.is_dir() {
-            continue;
-        }
-        for fixture in std::fs::read_dir(&group).expect("read group dir") {
-            let fixture = fixture.expect("dir entry").path();
-            if fixture.join("input.yaml").is_file() {
-                dirs.push(fixture);
-            }
-        }
-    }
-    dirs.sort();
-    assert!(
-        !dirs.is_empty(),
-        "zero fixtures found under {} — the conformance gate must never be empty",
-        core.display()
-    );
-    dirs
-}
+use common::{fixture_dirs, fixture_verdict, spec_dir};
 
 #[test]
 fn core_conformance_suite() {
@@ -132,48 +43,8 @@ fn core_conformance_suite() {
             .unwrap_or(&dir)
             .display()
             .to_string();
-        let yaml = std::fs::read_to_string(dir.join("input.yaml")).expect("read input.yaml");
-        let expected_raw =
-            std::fs::read_to_string(dir.join("expected.json")).expect("read expected.json");
-        let expected: Expected = serde_json::from_str(&expected_raw).expect("parse expected.json");
-
-        // « default: strict · the test default » per runner-protocol.md.
-        let mode = match expected.mode.as_deref() {
-            Some("lenient") => ParseMode::Lenient,
-            _ => ParseMode::Strict,
-        };
-
-        let emitted = run_engine(&yaml, mode);
-
-        if expected.valid {
-            if !emitted.is_empty() {
-                failures.push(format!(
-                    "{label} · expected VALID · engine emitted {} error(s) ·\n{}",
-                    emitted.len(),
-                    render(&emitted),
-                ));
-            }
-        } else if emitted.is_empty() {
-            failures.push(format!(
-                "{label} · expected INVALID ({}) · engine accepted{}",
-                render_expected(&expected.errors),
-                expected
-                    .note
-                    .as_deref()
-                    .map(|n| format!("\n  note · {n}"))
-                    .unwrap_or_default(),
-            ));
-        } else {
-            let any_match = emitted
-                .iter()
-                .any(|e| expected.errors.iter().any(|x| matches_expected(e, x)));
-            if !any_match {
-                failures.push(format!(
-                    "{label} · expected one of [{}] · engine emitted ·\n{}",
-                    render_expected(&expected.errors),
-                    render(&emitted),
-                ));
-            }
+        if let Some(failure) = fixture_verdict(&dir) {
+            failures.push(format!("{label} · {failure}"));
         }
     }
 
@@ -185,35 +56,4 @@ fn core_conformance_suite() {
     );
     // Sanity floor — the suite ships 5 groups · 40+ fixtures.
     assert!(total >= 30, "only {total} fixtures walked — layout drift?");
-}
-
-/// Render emitted errors with their spec codes for diagnosis.
-fn render(errors: &[SchemaError]) -> String {
-    errors
-        .iter()
-        .map(|e| {
-            let spec = e.spec_code();
-            format!("  {} [{}] · {e}", spec, spec.category.as_str())
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-/// Render the expected entries compactly.
-fn render_expected(expected: &[ExpectedError]) -> String {
-    expected
-        .iter()
-        .map(|x| {
-            let id = x
-                .code
-                .clone()
-                .or_else(|| x.namespace.clone())
-                .unwrap_or_else(|| "<any>".to_owned());
-            match &x.category {
-                Some(category) => format!("{id}+{category}"),
-                None => id,
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
 }

--- a/crates/nika-schema/tests/conformance_deep.rs
+++ b/crates/nika-schema/tests/conformance_deep.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+#![allow(clippy::disallowed_methods)]
+
+//! Spec conformance · the `deep` static tier — the expression layer the
+//! JSON Schema cannot see (CEL EBNF parse · `when:` shape · binding
+//! purity · durations · builtin arg shapes · permits-fit).
+//!
+//! The `DEEP_GAPS` ledger is a RATCHET, not a skip list · every entry
+//! names an unimplemented check with its reason, and the suite asserts
+//! BOTH directions ·
+//!
+//! - a fixture NOT in the ledger MUST pass (a regression screams);
+//! - a fixture IN the ledger MUST still fail (an implemented check
+//!   forces removing its row — the ledger cannot go stale).
+
+mod common;
+
+use common::{fixture_dirs, fixture_verdict, spec_dir};
+
+/// The deep-tier gap ledger · fixture-name prefix → why the engine
+/// does not implement the check yet. Closing a gap = implement + DELETE
+/// the row (the suite fails on a stale row by design).
+const DEEP_GAPS: &[(&str, &str)] = &[
+    (
+        "005-invalid-schema",
+        "schema: blocks are not meta-validated (needs a Draft 2020-12 \
+         check_schema pass · jsonschema-class dep decision pending)",
+    ),
+    (
+        "006-jq-compile-error",
+        "jq compile-checking needs a jq engine in the validator (jaq \
+         dep decision pending · the Python oracle shells out to jq)",
+    ),
+    (
+        "009-write-without-content",
+        "builtin arg-shape checks (nika:write content:) not implemented",
+    ),
+    (
+        "010-done-standalone",
+        "nika:done placement check (agent-loop sentinel) not implemented",
+    ),
+    (
+        "011-jq-wrong-arg-name",
+        "builtin arg-shape checks (nika:jq expression:) not implemented",
+    ),
+    (
+        "012-wait-both-modes",
+        "builtin arg-shape checks (nika:wait duration XOR until) not \
+         implemented",
+    ),
+    (
+        "013-permits-fit-violation",
+        "PERMITS-FIT static check (body must fit the declared boundary \
+         · NIKA-SEC-004) not implemented",
+    ),
+];
+
+#[test]
+fn deep_conformance_suite() {
+    let deep = spec_dir().join("conformance/tests/deep");
+    assert!(
+        deep.is_dir(),
+        "conformance dir missing: {} — set NIKA_SPEC_DIR",
+        deep.display()
+    );
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut total = 0_usize;
+    let mut gaps_hit = 0_usize;
+
+    for dir in fixture_dirs(&deep) {
+        total += 1;
+        let label = dir
+            .strip_prefix(&deep)
+            .unwrap_or(&dir)
+            .display()
+            .to_string();
+        let gap = DEEP_GAPS.iter().find(|(name, _)| label.starts_with(name));
+        let verdict = fixture_verdict(&dir);
+
+        match (gap, verdict) {
+            // Not in the ledger · must pass.
+            (None, Some(failure)) => failures.push(format!("{label} · {failure}")),
+            (None, None) => {}
+            // In the ledger · must STILL fail (else the row is stale).
+            (Some((name, reason)), None) => failures.push(format!(
+                "{label} · PASSES but is in DEEP_GAPS (`{name}` · {reason}) — \
+                 the check landed · DELETE its ledger row"
+            )),
+            (Some(_), Some(_)) => gaps_hit += 1,
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {total} deep fixtures FAILED ·\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+    assert_eq!(
+        gaps_hit,
+        DEEP_GAPS.len(),
+        "ledger drift — {gaps_hit} gap fixtures hit vs {} ledger rows \
+         (a renamed/removed fixture leaves a dead row)",
+        DEEP_GAPS.len()
+    );
+    // Sanity floor — the deep tier ships 14+ fixtures.
+    assert!(total >= 12, "only {total} fixtures walked — layout drift?");
+}

--- a/crates/nika-schema/tests/examples_valid.rs
+++ b/crates/nika-schema/tests/examples_valid.rs
@@ -1,28 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 #![allow(clippy::expect_used, clippy::panic)]
-// NIKA_SPEC_DIR is a TEST-HARNESS path override (CI checkout layout) ·
-// not a secret — the SecretStore rule targets runtime secret lookup.
 #![allow(clippy::disallowed_methods)]
 
 //! Every published spec example (`nika-spec/examples/*.nika.yaml`)
 //! parses + analyzes VALID in strict mode — the examples are normative
 //! showcase code; an engine that rejects them is non-conformant.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use nika_schema::{FileId, ParseMode, analyze, parse};
 
-/// Resolve the nika-spec checkout (env override · sibling default).
-fn spec_dir() -> PathBuf {
-    if let Some(dir) = std::env::var_os("NIKA_SPEC_DIR") {
-        return PathBuf::from(dir);
-    }
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../spec")
-        .canonicalize()
-        .expect("nika-spec checkout missing — set NIKA_SPEC_DIR or clone ../spec")
-}
+mod common;
+use common::spec_dir;
 
 #[test]
 fn all_spec_examples_are_valid_strict() {


### PR DESCRIPTION
The socratic pass found three structural gaps:

- **A registered code implemented nowhere** — NIKA-DAG-004 (recover-await deadlock) existed in the spec registry and the playground TS port but neither canonical validator. The analyzer gains `check_recover_acyclic` (transitive walk over the recovery refs' dependency closure) + 3 unit tests + the engine now passes the 2 spec fixtures.
- **The engine never ran the deep tier** — `tests/conformance_deep.rs` lands with a two-way GAP LEDGER (a fixture off the ledger must pass · a fixture ON it must still fail — an implemented check forces deleting its row). **7/14 deep fixtures pass today**; the 7 honest gaps are schema-meta, jq-compile, four builtin arg shapes, permits-fit. Harness plumbing extracted to `tests/common` (core + examples suites reuse it · net LOC down, the 15k ratchet stays green).
- **Code drift hidden by namespace matching** — registry remaps: WhenNotBoolean + JqBindingContainsTemplate → NIKA-VAR-005 (the retired PARSE-WHEN sub-namespace dies), TemplateSyntax → NIKA-VAR-008 (VAR-002 is the runtime cardinality code, misassigned).

356 lib tests · core 59/59 · deep 7/14 + ledger · clippy -D clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)