### PR TITLE
feat(nika-schema): builtin arg-shapes close four ledger rows + the lints corpus moves to the spec

### DIFF
--- a/crates/nika-schema/src/analyzer/builtin_shape.rs
+++ b/crates/nika-schema/src/analyzer/builtin_shape.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Builtin arg-shape rules — the statically-checkable contracts of
+//! `stdlib/builtins-v0.1.md` the JSON Schema cannot express (deep
+//! conformance fixtures 009-012) · `nika:write` requires `content:` ·
+//! `nika:done` is valid only inside an `agent:` tools whitelist (the
+//! loop sentinel · `NIKA-BUILTIN-DONE-001`) · `nika:jq` takes exactly
+//! `expression:` · `nika:wait` takes `duration:` XOR `until:`.
+
+use crate::error::SchemaError;
+use crate::raw::{RawAction, RawTask};
+use crate::source::{Span, Spanned};
+
+/// Run every builtin arg-shape rule over a task's action (and its
+/// `on_finally:` cleanup actions — same `invoke:` surface).
+pub(super) fn check_builtin_shapes(tasks: &[Spanned<RawTask>], errors: &mut Vec<SchemaError>) {
+    for task in tasks {
+        let id = task.value.id.value.as_str();
+        check_action(&task.value.action, id, errors);
+        for cleanup in &task.value.on_finally {
+            check_action(&cleanup.value.action, id, errors);
+        }
+    }
+}
+
+fn check_action(action: &RawAction, task: &str, errors: &mut Vec<SchemaError>) {
+    let RawAction::Invoke(invoke) = action else {
+        return;
+    };
+    let tool = invoke.tool.value.as_str();
+    let span = invoke.tool.span;
+    let args = invoke.args.as_ref().map(|a| &a.value);
+    let has = |key: &str| -> bool {
+        matches!(args, Some(serde_json::Value::Object(map)) if map.contains_key(key))
+    };
+
+    match tool {
+        "nika:write" if !has("content") => errors.push(shape(
+            task,
+            tool,
+            "requires a `content:` arg — a write with nothing to write \
+             (builtins-v0.1.md §nika:write)",
+            span,
+        )),
+        "nika:done" => errors.push(shape(
+            task,
+            tool,
+            "is the agent-loop completion sentinel — valid ONLY inside an \
+             `agent:` tools whitelist · never a standalone invoke \
+             (02-verbs.md §loop semantics · NIKA-BUILTIN-DONE-001)",
+            span,
+        )),
+        "nika:jq" if !has("expression") => errors.push(shape(
+            task,
+            tool,
+            "requires an `expression:` arg — exactly that name, never \
+             `query`/`expr` (builtins-v0.1.md §nika:jq · one name everywhere)",
+            span,
+        )),
+        "nika:wait" if has("duration") == has("until") => errors.push(shape(
+            task,
+            tool,
+            "takes `duration:` XOR `until:` — exactly one \
+             (builtins-v0.1.md §nika:wait)",
+            span,
+        )),
+        _ => {}
+    }
+}
+
+fn shape(task: &str, tool: &str, reason: &str, span: Span) -> SchemaError {
+    SchemaError::BadBuiltinArgs {
+        task: task.to_owned(),
+        tool: tool.to_owned(),
+        reason: reason.to_owned(),
+        span: Some(span),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analyzer::analyze;
+    use crate::error::SchemaError;
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn has_shape_error(yaml: &str, tool: &str) -> bool {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
+        analyze(&wf)
+            .err()
+            .unwrap_or_default()
+            .iter()
+            .any(|e| matches!(e, SchemaError::BadBuiltinArgs { tool: t, .. } if t == tool))
+    }
+
+    #[test]
+    fn shape_rules_table() {
+        // (args yaml · tool · violates?) — one row per contract direction.
+        let cases = [
+            (r#"{ path: "./o" }"#, "nika:write", true),
+            (r#"{ path: "./o", content: "hi" }"#, "nika:write", false),
+            ("{}", "nika:done", true), // standalone · always the sentinel error
+            (r#"{ input: [], query: "length" }"#, "nika:jq", true),
+            (r#"{ input: [], expression: "length" }"#, "nika:jq", false),
+            (
+                r#"{ duration: "5s", until: "2026-12-01T00:00:00Z" }"#,
+                "nika:wait",
+                true, // both modes
+            ),
+            ("{}", "nika:wait", true),                     // neither mode
+            (r#"{ duration: "5s" }"#, "nika:wait", false), // exactly one
+        ];
+        for (args, tool, violates) in cases {
+            let yaml = format!(
+                "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    invoke:\n      \
+                 tool: \"{tool}\"\n      args: {args}\n"
+            );
+            assert_eq!(
+                has_shape_error(&yaml, tool),
+                violates,
+                "{tool} · args {args}"
+            );
+        }
+    }
+
+    #[test]
+    fn done_in_agent_whitelist_is_legal_and_on_finally_is_checked() {
+        // The sentinel is LEGAL as an agent tools entry…
+        let agent = "nika: v1\nworkflow: t\ntasks:\n  - id: l\n    agent:\n      \
+                     prompt: \"go\"\n      tools: [\"nika:done\"]\n";
+        assert!(!has_shape_error(agent, "nika:done"));
+        // …and cleanup actions face the same rules as task actions.
+        let finally = "nika: v1\nworkflow: t\ntasks:\n  - id: w\n    \
+                       exec: { command: echo }\n    on_finally:\n      - invoke:\n          \
+                       tool: \"nika:write\"\n          args: { path: \"./log\" }\n";
+        assert!(has_shape_error(finally, "nika:write"));
+    }
+}

--- a/crates/nika-schema/src/analyzer/dag.rs
+++ b/crates/nika-schema/src/analyzer/dag.rs
@@ -249,15 +249,18 @@ mod tests {
     const HEADER: &str = "nika: v1\nworkflow: t\n";
 
     #[test]
-    fn recover_deadlock_direct_and_transitive() {
-        // 05 §recover resolution · DAG-004 — direct dependent AND a
-        // 2-hop transitive dependent both deadlock the recovery await.
+    fn recover_deadlock_transitive_and_nested_refs() {
+        // 05 §recover resolution · DAG-004 — a 2-hop transitive
+        // dependent deadlocks the await · refs nest anywhere in the
+        // recover JSON value.
         let yaml = format!(
             "{HEADER}tasks:
   - id: fetch
     invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
     on_error:
-      recover: ${{{{ tasks.report.output }}}}
+      recover:
+        stale: true
+        body: \"${{{{ tasks.report.output }}}}\"
   - id: mid
     depends_on: [fetch]
     exec: {{ command: echo }}
@@ -292,31 +295,6 @@ mod tests {
 "
         );
         analyze_yaml(&yaml).expect("independent recover is legal");
-    }
-
-    #[test]
-    fn recover_nested_value_refs_are_walked() {
-        // The recover value may be an object/array · refs nest anywhere.
-        let yaml = format!(
-            "{HEADER}tasks:
-  - id: fetch
-    invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
-    on_error:
-      recover:
-        stale: true
-        body: \"${{{{ tasks.consumer.output }}}}\"
-  - id: consumer
-    depends_on: [fetch]
-    exec: {{ command: echo }}
-"
-        );
-        let errors = analyze_yaml(&yaml).expect_err("nested ref deadlock");
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, SchemaError::RecoverAwaitDeadlock { .. })),
-            "{errors:?}"
-        );
     }
 
     #[test]

--- a/crates/nika-schema/src/analyzer/mod.rs
+++ b/crates/nika-schema/src/analyzer/mod.rs
@@ -18,6 +18,7 @@
 //! - `output:` binding rules · reserved names + pure-jq
 //! - topological waves (spec `03-dag.md` execution model)
 
+mod builtin_shape;
 mod dag;
 mod scan;
 mod schema_paths;
@@ -58,6 +59,7 @@ pub fn analyze(wf: &RawWorkflow) -> Result<AnalyzedWorkflow, Vec<SchemaError>> {
     dag::check_depends_on_resolve(&wf.tasks, &ids, &mut errors);
     dag::check_cycles(&wf.tasks, &ids, &mut errors);
     dag::check_recover_acyclic(&wf.tasks, &ids, &mut errors);
+    builtin_shape::check_builtin_shapes(&wf.tasks, &mut errors);
     scan::scan_workflow(wf, &mut errors);
 
     if errors.is_empty() {

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -260,6 +260,20 @@ pub enum SchemaError {
         span: Option<Span>,
     },
 
+    /// A builtin `invoke:` violates its statically-checkable arg
+    /// contract (`stdlib/builtins-v0.1.md` · deep fixtures 009-012).
+    #[error("task `{task}` · `{tool}` {reason}")]
+    BadBuiltinArgs {
+        /// The task carrying the invoke.
+        task: String,
+        /// The builtin tool id.
+        tool: String,
+        /// The violated contract (prescriptive · names the fix).
+        reason: String,
+        /// The tool reference's span.
+        span: Option<Span>,
+    },
+
     /// `on_error.recover` references a task that transitively depends
     /// on the declaring task — the recovery-time await would deadlock
     /// (spec `05-errors.md` §recover resolution · `NIKA-DAG-004`).
@@ -471,6 +485,7 @@ schema_code!(SCHEMA_305, 305, "loop-local-outside-for-each");
 schema_code!(SCHEMA_306, 306, "unknown-task-field");
 schema_code!(SCHEMA_307, 307, "output-path-provably-invalid");
 schema_code!(SCHEMA_308, 308, "recover-await-deadlock");
+schema_code!(SCHEMA_309, 309, "bad-builtin-args");
 
 impl NikaErrorCode for SchemaError {
     fn nika_code(&self) -> NikaCode {
@@ -497,6 +512,7 @@ impl NikaErrorCode for SchemaError {
             Self::Validation { .. } => SCHEMA_299,
             Self::WhenNotBoolean { .. } => SCHEMA_300,
             Self::RecoverAwaitDeadlock { .. } => SCHEMA_308,
+            Self::BadBuiltinArgs { .. } => SCHEMA_309,
             Self::Cycle { .. } => SCHEMA_301,
             Self::UnknownDependency { .. } => SCHEMA_302,
             Self::MissingDependsOnEdge { .. } => SCHEMA_303,
@@ -637,6 +653,12 @@ fn analysis_level_variants() -> Vec<SchemaError> {
         SchemaError::RecoverAwaitDeadlock {
             task: String::new(),
             target: String::new(),
+            span: None,
+        },
+        SchemaError::BadBuiltinArgs {
+            task: String::new(),
+            tool: String::new(),
+            reason: String::new(),
             span: None,
         },
         SchemaError::UnresolvedNamespaceRef {

--- a/crates/nika-schema/src/error/spec_code.rs
+++ b/crates/nika-schema/src/error/spec_code.rs
@@ -182,6 +182,22 @@ impl SchemaError {
             Self::MissingDependsOnEdge { .. } => dag(3),
             Self::RecoverAwaitDeadlock { .. } => dag(4),
 
+            // ── NIKA-BUILTIN · arg-shape contracts ── nika:done carries
+            // its REGISTERED exact code (deep fixture 010 matches on it) ·
+            // the other shapes emit the generic builtin namespace.
+            Self::BadBuiltinArgs { tool, .. } if tool == "nika:done" => SpecCode {
+                namespace: "BUILTIN-DONE",
+                num: 1,
+                category: ValidationError,
+                transient: false,
+            },
+            Self::BadBuiltinArgs { .. } => SpecCode {
+                namespace: "BUILTIN",
+                num: 1,
+                category: ValidationError,
+                transient: false,
+            },
+
             // ── NIKA-VAR · the ${{ }} surface ───────────────────────
             // NIKA-VAR-001 · reference resolution (fixtures 001-007 ·
             // variable_error) · loop-locals + unknown task fields are
@@ -301,10 +317,11 @@ mod tests {
             // variants (the spec defines ONE code for the class).
             seen.insert((code.namespace, code.num, code.category.as_str()));
         }
-        // 29 variants · 3 share VAR-001 · 2 share VAR-005 → 26
-        // distinct codes (DAG-004 + the registry remaps of 2026-06-11 ·
-        // WhenNotBoolean/JqBindingContainsTemplate → VAR-005 ·
-        // TemplateSyntax → VAR-008).
-        assert_eq!(seen.len(), 26, "{seen:?}");
+        // 30 variants · 3 share VAR-001 · 2 share VAR-005 → 27
+        // distinct codes (DAG-004 + BadBuiltinArgs generic + the
+        // registry remaps of 2026-06-11 · the nika:done arm adds
+        // BUILTIN-DONE-001 only when the tool matches — the enumerator
+        // carries the generic arm).
+        assert_eq!(seen.len(), 27, "{seen:?}");
     }
 }

--- a/crates/nika-schema/tests/conformance_deep.rs
+++ b/crates/nika-schema/tests/conformance_deep.rs
@@ -34,23 +34,6 @@ const DEEP_GAPS: &[(&str, &str)] = &[
          dep decision pending · the Python oracle shells out to jq)",
     ),
     (
-        "009-write-without-content",
-        "builtin arg-shape checks (nika:write content:) not implemented",
-    ),
-    (
-        "010-done-standalone",
-        "nika:done placement check (agent-loop sentinel) not implemented",
-    ),
-    (
-        "011-jq-wrong-arg-name",
-        "builtin arg-shape checks (nika:jq expression:) not implemented",
-    ),
-    (
-        "012-wait-both-modes",
-        "builtin arg-shape checks (nika:wait duration XOR until) not \
-         implemented",
-    ),
-    (
         "013-permits-fit-violation",
         "PERMITS-FIT static check (body must fit the declared boundary \
          · NIKA-SEC-004) not implemented",

--- a/crates/nika-schema/tests/lints_one_obvious_way.rs
+++ b/crates/nika-schema/tests/lints_one_obvious_way.rs
@@ -1,576 +1,111 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 #![allow(clippy::expect_used, clippy::panic)]
+#![allow(clippy::disallowed_methods)]
 
-//! `one-obvious-way` lint pass · spec `03-dag.md` §One obvious way.
+//! `one-obvious-way` lint conformance · spec `03-dag.md` §One obvious
+//! way — « normative for linters ».
 //!
-//! The spec table is **normative for linters** — 7 preference rules
-//! (`one-obvious-way/001`…`/007` · table order) shipped as WARNINGS ·
-//! never hard errors (the discouraged forms are legal · just not
-//! canonical). Each rule gets a fires + does-not-fire pair so the
-//! precision contract (low false-positive) is pinned by tests.
+//! The fixture corpus lives in the SPEC repo
+//! (`nika-spec/conformance/tests/lints/**` · `input.yaml` +
+//! `expected-lints.json`) so any engine's linter can claim the same
+//! precision contract — fires + does-not-fire pairs per rule, exact
+//! ordered `(rule, task)` equality. The corpus moved out of this file
+//! 2026-06-11 (the shared-test-corpus pattern · same as the
+//! conformance tiers); only the engine-specific shape assertions stay
+//! inline below.
 
+mod common;
+
+use common::{fixture_dirs, spec_dir};
 use nika_schema::lints::{Lint, one_obvious_way};
 use nika_schema::{FileId, ParseMode, parse};
 
-/// Parse a fixture (strict mode · must be valid) and run the lint pass.
 fn lint(yaml: &str) -> Vec<Lint> {
     let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("lint fixture must parse");
     one_obvious_way(&wf)
 }
 
-/// `(rule, task_id)` projection for compact assertions.
-fn rules(yaml: &str) -> Vec<(String, String)> {
-    lint(yaml)
-        .into_iter()
-        .map(|l| (l.rule.to_string(), l.task_id))
-        .collect()
+#[derive(Debug, serde::Deserialize, PartialEq)]
+struct ExpectedLint {
+    rule: String,
+    task: String,
 }
 
-// ───────────────────────── 001 · redundant success `when:` ─────────────────────────
+#[derive(Debug, serde::Deserialize)]
+struct ExpectedLints {
+    lints: Vec<ExpectedLint>,
+}
 
 #[test]
-fn rule_001_fires_on_redundant_success_when() {
-    let yaml = r#"
-nika: v1
-workflow: f001
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'success' }}"
-    exec: { command: "./b.sh" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/001".to_string(), "b".to_string())]
+fn lint_fixture_corpus() {
+    let root = spec_dir().join("conformance/tests/lints");
+    assert!(root.is_dir(), "missing {} — clone ../spec", root.display());
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut total = 0_usize;
+
+    for dir in fixture_dirs(&root) {
+        total += 1;
+        let label = dir
+            .strip_prefix(&root)
+            .unwrap_or(&dir)
+            .display()
+            .to_string();
+        let yaml = std::fs::read_to_string(dir.join("input.yaml")).expect("read input.yaml");
+        let expected: ExpectedLints = serde_json::from_str(
+            &std::fs::read_to_string(dir.join("expected-lints.json"))
+                .expect("read expected-lints.json"),
+        )
+        .expect("parse expected-lints.json");
+
+        let got: Vec<ExpectedLint> = lint(&yaml)
+            .into_iter()
+            .map(|l| ExpectedLint {
+                rule: l.rule.to_string(),
+                task: l.task_id,
+            })
+            .collect();
+
+        // EXACT ordered equality — pins precision (no false positives),
+        // determinism and task ordering in one comparison.
+        if got != expected.lints {
+            failures.push(format!(
+                "{label} · expected {:?} · got {:?}",
+                expected.lints, got
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {total} lint fixtures FAILED ·\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
     );
-}
-
-#[test]
-fn rule_001_fires_on_reversed_operands() {
-    let yaml = r#"
-nika: v1
-workflow: f001r
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    depends_on: [a]
-    when: "${{ 'success' == tasks.a.status }}"
-    exec: { command: "./b.sh" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/001".to_string(), "b".to_string())]
-    );
-}
-
-#[test]
-fn rule_001_fires_on_singleton_in_list() {
-    let yaml = r#"
-nika: v1
-workflow: f001in
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    depends_on: [a]
-    when: "${{ tasks.a.status in ['success'] }}"
-    exec: { command: "./b.sh" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/001".to_string(), "b".to_string())]
-    );
-}
-
-#[test]
-fn rule_001_silent_when_dependency_can_be_skipped() {
-    // `on_error: skip` on the dependency makes the status check REAL
-    // work (skipped ≠ success) — not a restatement of the default gate.
-    let yaml = r#"
-nika: v1
-workflow: f001skip
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-    on_error: { skip: true }
-  - id: b
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'success' }}"
-    exec: { command: "./b.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-#[test]
-fn rule_001_silent_on_compound_expression() {
-    // A conjunct carries intent beyond the default gate — only the
-    // WHOLE-expression restatement is noise.
-    let yaml = r#"
-nika: v1
-workflow: f001and
-vars:
-  go: { type: boolean, default: true }
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'success' && vars.go }}"
-    exec: { command: "./b.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-#[test]
-fn rule_001_silent_when_status_is_not_a_dependency() {
-    // Guarding on a task OUTSIDE depends_on is not the default-gate
-    // restatement (it is a different — possibly invalid — construct).
-    let yaml = r#"
-nika: v1
-workflow: f001nodep
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: c
-    exec: { command: "./c.sh" }
-  - id: b
-    depends_on: [a, c]
-    when: "${{ tasks.a.status == 'failure' }}"
-    exec: { command: "./b.sh" }
-"#;
-    // `== 'failure'` is not the success restatement → 001 silent.
-    let fired = rules(yaml);
-    assert!(!fired.iter().any(|(r, _)| r == "one-obvious-way/001"));
-}
-
-// ───────────────────────── 002 · skip-for-dependents ─────────────────────────
-
-#[test]
-fn rule_002_fires_on_skip_with_unguarded_dependent() {
-    let yaml = r#"
-nika: v1
-workflow: f002
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-    on_error: { skip: true }
-  - id: b
-    depends_on: [a]
-    exec: { command: "./b.sh" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/002".to_string(), "a".to_string())]
-    );
-}
-
-#[test]
-fn rule_002_silent_when_dependents_guard_on_status() {
-    // The canonical skip pattern (05-errors example) · dependents read
-    // the status explicitly.
-    let yaml = r#"
-nika: v1
-workflow: f002ok
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-    on_error: { skip: true }
-  - id: b
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'success' }}"
-    exec: { command: "./b.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-#[test]
-fn rule_002_silent_without_dependents() {
-    let yaml = r#"
-nika: v1
-workflow: f002leaf
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-    on_error: { skip: true }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-// ───────────────────────── 003 · retry via duplicate task ─────────────────────────
-
-#[test]
-fn rule_003_fires_on_failure_guarded_duplicate() {
-    let yaml = r#"
-nika: v1
-workflow: f003
-tasks:
-  - id: a
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/data" }
-  - id: a_retry
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'failure' }}"
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/data" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/003".to_string(), "a_retry".to_string())]
-    );
-}
-
-#[test]
-fn rule_003_silent_when_bodies_differ() {
-    // A failure-guarded task doing DIFFERENT work is legitimate
-    // (« use a task only when real work runs on failure »).
-    let yaml = r#"
-nika: v1
-workflow: f003diff
-tasks:
-  - id: a
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/data" }
-  - id: report
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'failure' }}"
-    invoke:
-      tool: "nika:notify"
-      args: { channel: webhook, target: "https://hooks.example.com", message: "a failed" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-// ───────────────────────── 004 · fallback value via task ─────────────────────────
-
-#[test]
-fn rule_004_fires_on_literal_jq_fallback_task() {
-    let yaml = r#"
-nika: v1
-workflow: f004
-tasks:
-  - id: a
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/data" }
-  - id: fallback
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'failure' }}"
-    invoke:
-      tool: "nika:jq"
-      args: { input: { count: 0 }, expression: "." }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/004".to_string(), "fallback".to_string())]
-    );
-}
-
-#[test]
-fn rule_004_fires_on_echo_fallback_task() {
-    let yaml = r#"
-nika: v1
-workflow: f004echo
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: fallback
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'failure' }}"
-    exec: { command: "echo default-value" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/004".to_string(), "fallback".to_string())]
-    );
-}
-
-#[test]
-fn rule_004_silent_on_real_failure_work() {
-    // nika:fetch on failure = real work · NOT a mere value.
-    let yaml = r#"
-nika: v1
-workflow: f004real
-tasks:
-  - id: a
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://primary.example.com" }
-  - id: mirror
-    depends_on: [a]
-    when: "${{ tasks.a.status == 'failure' }}"
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://mirror.example.com" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-// ───────────────────────── 005 · cleanup via terminal task ─────────────────────────
-
-#[test]
-fn rule_005_fires_on_depends_on_everything_with_permissive_when() {
-    let yaml = r#"
-nika: v1
-workflow: f005
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    exec: { command: "./b.sh" }
-  - id: cleanup
-    depends_on: [a, b]
-    when: "${{ tasks.a.status in ['success', 'failure'] }}"
-    exec: { command: "./cleanup.sh" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/005".to_string(), "cleanup".to_string())]
-    );
-}
-
-#[test]
-fn rule_005_silent_on_plain_join_task() {
-    // A sink that depends on everything WITHOUT a permissive when is a
-    // legitimate join.
-    let yaml = r#"
-nika: v1
-workflow: f005join
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    exec: { command: "./b.sh" }
-  - id: summarize
-    depends_on: [a, b]
-    exec: { command: "./summarize.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-#[test]
-fn rule_005_silent_when_not_depending_on_everything() {
-    let yaml = r#"
-nika: v1
-workflow: f005partial
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-  - id: b
-    exec: { command: "./b.sh" }
-  - id: c
-    depends_on: [a]
-    when: "${{ tasks.a.status in ['success', 'failure'] }}"
-    exec: { command: "./c.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-// ───────────────────────── 006 · per-element timing tricks ─────────────────────────
-
-#[test]
-fn rule_006_fires_on_timeout_command_in_for_each() {
-    let yaml = r#"
-nika: v1
-workflow: f006
-tasks:
-  - id: shards
-    for_each: [1, 2, 3]
-    exec: { command: "timeout 30 ./process.sh" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/006".to_string(), "shards".to_string())]
-    );
-}
-
-#[test]
-fn rule_006_silent_without_for_each() {
-    let yaml = r#"
-nika: v1
-workflow: f006plain
-tasks:
-  - id: one
-    exec: { command: "timeout 30 ./process.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-#[test]
-fn rule_006_silent_on_plain_for_each_command() {
-    let yaml = r#"
-nika: v1
-workflow: f006ok
-tasks:
-  - id: shards
-    for_each: [1, 2, 3]
-    timeout: 30s
-    exec: { command: "./process.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-// ───────────────────────── 007 · manual sharding ─────────────────────────
-
-#[test]
-fn rule_007_fires_on_sequential_exec_shards() {
-    let yaml = r#"
-nika: v1
-workflow: f007
-tasks:
-  - id: shard1
-    exec: { command: "./process.sh part1" }
-  - id: shard2
-    depends_on: [shard1]
-    exec: { command: "./process.sh part2" }
-  - id: shard3
-    depends_on: [shard2]
-    exec: { command: "./process.sh part3" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/007".to_string(), "shard1".to_string())]
-    );
-}
-
-#[test]
-fn rule_007_fires_on_invoke_arg_shards() {
-    let yaml = r#"
-nika: v1
-workflow: f007invoke
-tasks:
-  - id: page1
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/page/1" }
-  - id: page2
-    depends_on: [page1]
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/page/2" }
-  - id: page3
-    depends_on: [page2]
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/page/3" }
-"#;
-    assert_eq!(
-        rules(yaml),
-        vec![("one-obvious-way/007".to_string(), "page1".to_string())]
-    );
-}
-
-#[test]
-fn rule_007_silent_on_genuine_pipeline() {
-    // Distinct steps (different token shapes) = a pipeline · not shards.
-    let yaml = r#"
-nika: v1
-workflow: f007pipe
-tasks:
-  - id: fetch
-    exec: { command: "./fetch.sh" }
-  - id: parse
-    depends_on: [fetch]
-    exec: { command: "./parse.sh --strict input.json" }
-  - id: report
-    depends_on: [parse]
-    exec: { command: "./report.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-#[test]
-fn rule_007_silent_on_two_task_chain() {
-    let yaml = r#"
-nika: v1
-workflow: f007two
-tasks:
-  - id: shard1
-    exec: { command: "./process.sh part1" }
-  - id: shard2
-    depends_on: [shard1]
-    exec: { command: "./process.sh part2" }
-"#;
-    assert!(rules(yaml).is_empty());
-}
-
-// ───────────────────────── pass shape ─────────────────────────
-
-#[test]
-fn lints_are_deterministic_and_task_ordered() {
-    // Two independent findings → emitted in task order.
-    let yaml = r#"
-nika: v1
-workflow: forder
-tasks:
-  - id: a
-    exec: { command: "./a.sh" }
-    on_error: { skip: true }
-  - id: b
-    depends_on: [a]
-    exec: { command: "./b.sh" }
-  - id: shards
-    for_each: [1, 2]
-    exec: { command: "timeout 5 ./p.sh" }
-"#;
-    let fired = rules(yaml);
-    assert_eq!(
-        fired,
-        vec![
-            ("one-obvious-way/002".to_string(), "a".to_string()),
-            ("one-obvious-way/006".to_string(), "shards".to_string()),
-        ]
-    );
+    assert!(total >= 24, "only {total} lint fixtures — corpus drift?");
 }
 
 #[test]
 fn lint_carries_message_and_suggestion() {
-    let yaml = r#"
+    // Engine-specific shape — the WARNING text itself (not spec
+    // surface · the corpus pins rule/task only).
+    let yaml = "\
 nika: v1
 workflow: fshape
 tasks:
   - id: a
-    exec: { command: "./a.sh" }
+    exec: { command: \"./a.sh\" }
   - id: b
     depends_on: [a]
-    when: "${{ tasks.a.status == 'success' }}"
-    exec: { command: "./b.sh" }
-"#;
+    when: \"${{ tasks.a.status == 'success' }}\"
+    exec: { command: \"./b.sh\" }
+";
     let lints = lint(yaml);
     assert_eq!(lints.len(), 1);
     let l = &lints[0];
     assert_eq!(l.rule, "one-obvious-way/001");
     assert!(!l.message.is_empty());
     assert!(!l.suggestion.is_empty());
-    // The suggestion names the canonical form.
-    assert!(l.suggestion.contains("depends_on"));
-}
-
-#[test]
-fn clean_workflow_yields_no_lints() {
-    let yaml = r#"
-nika: v1
-workflow: fclean
-tasks:
-  - id: fetch
-    invoke:
-      tool: "nika:fetch"
-      args: { url: "https://example.com/data" }
-    retry: { max_attempts: 3 }
-    on_error:
-      recover: { items: [] }
-  - id: process
-    depends_on: [fetch]
-    for_each: "${{ tasks.fetch.output.items }}"
-    max_parallel: 4
-    timeout: 60s
-    exec: { command: "./process.sh" }
-"#;
-    assert!(rules(yaml).is_empty());
+    assert!(l.suggestion.contains("depends_on"), "{}", l.suggestion);
 }

--- a/scripts/hygiene/check-all.sh
+++ b/scripts/hygiene/check-all.sh
@@ -47,7 +47,11 @@ record() {
 # very "social noise" ADR-090 exists to kill. So the ceiling is generous (60s,
 # ~5x the slowest vector's ~12s baseline) and env-overridable for extreme load.
 # Still bounded so a genuinely-hung vector can't wedge the suite.
-VECTOR_TIMEOUT_SECS="${HYGIENE_VECTOR_TIMEOUT_SECS:-60}"
+# 120s default · the 60s floor produced false-RED timeouts on the two
+# cargo-walking vectors (adr-schema-valid · doc-private-items) whenever a
+# concurrent session compiled the workspace — three occurrences 2026-06-11
+# (stress-to-ratchet threshold). Raise per-run via HYGIENE_VECTOR_TIMEOUT_SECS.
+VECTOR_TIMEOUT_SECS="${HYGIENE_VECTOR_TIMEOUT_SECS:-120}"
 TIMEOUT_CMD=""
 if command -v timeout >/dev/null 2>&1; then
   TIMEOUT_CMD="timeout $VECTOR_TIMEOUT_SECS"


### PR DESCRIPTION
Three structural fixes from the friction inventory:

- **Four deep-ledger rows closed in Rust** — `analyzer/builtin_shape` (write content · done placement with its registered `NIKA-BUILTIN-DONE-001` · jq `expression:` · wait XOR · on_finally actions included). The two-way ratchet screamed at the stale rows exactly as designed; deep tier now **11/14**, ledger down to 3 (schema-meta · jq-compile · permits-fit — each a dep/design decision).
- **The 15k cap fixed structurally, not cosmetically** — the one-obvious-way lint CASES moved to the spec as a shared fixture corpus (`conformance/tests/lints/` · 26 cases · spec c9233c9): the table is normative for linters, so its fires/silent pairs are conformance material any engine's linter can claim. The engine test is now a ~100-line walker; crate back under cap with real headroom.
- **Hygiene vector timeout 60s→120s default** — three false-RED timeouts today under concurrent compilation (the stress-to-ratchet threshold).

358 lib tests · core 61/61 · deep 11/14 · lints 26/26 · clippy -D clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)