### PR TITLE
ci(hygiene): stop nightly drift-issue spam + resync status block

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,8 +130,8 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | field            | value                                          |
 |------------------|------------------------------------------------|
 | branch           | `main`                                      |
-| HEAD             | `16b9ac480` (`16b9ac480d44f6ee110c4537eea87d07bf29a8c1`)             |
-| workspace        | v0.91.0-dev                                  |
+| HEAD             | `856b5717a` (`856b5717a5feda2fcad6a214a59a94ad30faa658`)             |
+| workspace        | v0.92.0-dev                                  |
 | crates (workspace)| 39                                              |
 | crates (admitted)| 39 / 42                                   |
 | crates (WIP)     | 0 —                                   |

--- a/.github/workflows/hygiene-nightly.yml
+++ b/.github/workflows/hygiene-nightly.yml
@@ -18,6 +18,15 @@ jobs:
           fetch-depth: 0
           ref: main   # explicit — always check main even if default branch differs (renamed from nika-diamond 2026-05-06)
 
+      # Vectors 34 (cargo-deny) + 36 (cargo-machete) hard-RED when the binary is
+      # absent. Installing them here makes the nightly actually run the
+      # supply-chain policy instead of false-RED-ing on a missing tool — one of
+      # the causes of the recurring drift-issue spam (2026-06).
+      - name: Install supply-chain tools (cargo-deny + cargo-machete)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny,cargo-machete
+
       - name: Run hygiene dashboard
         id: hygiene
         env:
@@ -50,12 +59,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TITLE="hygiene-drift: ecosystem out of sync"
+          # Self-heal the dedup label. Without it, `gh issue create --label`
+          # silently fell back to a label-less issue, so the list query below
+          # never matched and the nightly opened a NEW duplicate every run
+          # (18 dupes by 2026-06-28). Creating it idempotently makes dedup work.
+          gh label create hygiene-drift --color fbca04 \
+            --description "Auto-filed by the nightly hygiene drift dashboard" \
+            --force >/dev/null 2>&1 || true
           EXISTING=$(gh issue list --label hygiene-drift --state open --json number --jq '.[0].number' 2>/dev/null)
           if [ -n "$EXISTING" ]; then
             gh issue edit "$EXISTING" --body-file /tmp/issue-body.md
           else
-            gh issue create --title "$TITLE" --body-file /tmp/issue-body.md --label hygiene-drift 2>/dev/null || \
-              gh issue create --title "$TITLE" --body-file /tmp/issue-body.md
+            gh issue create --title "$TITLE" --body-file /tmp/issue-body.md --label hygiene-drift
           fi
 
       - name: Close drift issue if all green

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,8 +84,8 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | field            | value                                          |
 |------------------|------------------------------------------------|
 | branch           | `main`                                      |
-| HEAD             | `16b9ac480` (`16b9ac480d44f6ee110c4537eea87d07bf29a8c1`)             |
-| workspace        | v0.91.0-dev                                  |
+| HEAD             | `856b5717a` (`856b5717a5feda2fcad6a214a59a94ad30faa658`)             |
+| workspace        | v0.92.0-dev                                  |
 | crates (workspace)| 39                                              |
 | crates (admitted)| 39 / 42                                   |
 | crates (WIP)     | 0 —                                   |

--- a/scripts/hygiene/check-memory-head.sh
+++ b/scripts/hygiene/check-memory-head.sh
@@ -11,8 +11,12 @@ else
   MEMORY="$MEMORY_NEW" # will trigger the not-found error below
 fi
 [ -f "$MEMORY" ] || {
-  echo "MEMORY.md not found"
-  exit 2
+  # Local-only vector: MEMORY.md lives in the developer's ~/.claude tree, never
+  # in the repo. Absent ⇒ running in CI or a fresh clone, not a real drift —
+  # skip rather than false-RED (this was the dominant cause of the nightly
+  # hygiene-drift issue spam · 2026-06).
+  echo "SKIP (local-only check · MEMORY.md absent — run locally to verify the HEAD pointer)"
+  exit 0
 }
 
 actual="$(git rev-parse --short=9 HEAD 2>/dev/null)"


### PR DESCRIPTION
## Why

The `hygiene-nightly` workflow opened a **new duplicate issue every night** — 18 open `hygiene-drift: ecosystem out of sync` issues by 2026-06-28 (#117, #124–#142).

### Root cause of the spam
The workflow dedupes by the `hygiene-drift` label, but that label was never created in the repo. `gh issue create --label hygiene-drift` failed, the fallback filed a **label-less** issue, and the next run's `gh issue list --label hygiene-drift` matched nothing → a fresh duplicate every run.

### Why it RED-ed every night (the trigger)
Three vectors hard-RED **in the CI environment specifically**:

| Vector | RED because | Real? |
|---|---|---|
| `1 memory-head` | `~/.claude/.../MEMORY.md` is a **local** file, absent in CI | false-RED |
| `34 cargo-deny` | tool **not installed** in the runner | false-RED |
| `36 cargo-machete` | tool **not installed** in the runner | false-RED |
| `23 status-claims-sync` | status block stale (`0.91`→`0.92`-dev) | **real drift** |

## What

- **Self-heal the `hygiene-drift` label** before filing → dedup works, a single rolling issue is maintained instead of one per day.
- **Install `cargo-deny` + `cargo-machete`** in the runner → vectors 34/36 run the real supply-chain policy instead of false-RED. (PR enforcement unchanged — `diamond-ci` already runs both.)
- **Skip vector 1 (memory-head)** when `MEMORY.md` is absent — it points at the developer's out-of-tree `~/.claude` pointer, can never pass in CI; stays active locally.
- **Resync the status block** (`.claude/CLAUDE.md` + `ROADMAP.md`) to workspace `0.92.0-dev` → vector 23 green.

## Result
After merge the nightly is all-green-or-yellow (exit 1) → it stops filing, and if it ever RED-s again it **edits the one labelled issue** instead of spamming. The 18 existing duplicates are closed alongside this.

## Follow-up (separate PR, not blocking)
Two ADR id collisions remain — a hygiene **WARN**, not a RED, so not part of the spam: `ADR-093` and `ADR-094` each name two decisions. `index.toml` registers `093`=infer-local-http + `094`=pck; the unregistered agent-loop / parallel-dispatch ADRs squat the same ids. Renumbering them to 096/097 touches ~50 doc-comments across the agent crates, so it deserves its own focused PR.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
