### PR TITLE
Field fixes: local-model timeouts, mock-from-schema, --var, sitemap examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,7 @@ version = "0.93.0-dev"
 dependencies = [
  "bytes",
  "futures-core",
+ "jsonschema",
  "nika-catalog",
  "nika-kernel",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,6 +3953,7 @@ dependencies = [
 name = "nika-runtime"
 version = "0.93.0-dev"
 dependencies = [
+ "bytes",
  "futures-util",
  "insta",
  "jaq-core",

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -682,7 +682,7 @@ pub fn nika_cli::verbs::run::example(slug: &str, model_override: core::option::O
 pub fn nika_cli::verbs::run::fs_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_builtin::permits::FsBoundary
 pub fn nika_cli::verbs::run::net_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_http::NetBoundary
 pub fn nika_cli::verbs::run::production_runtime(default_model: &str, caps: nika_cli::verbs::run::RuntimeCapabilities) -> core::result::Result<nika_cli::verbs::run::ProdRuntime, nika_kernel_core::io::http::HttpError>
-pub fn nika_cli::verbs::run::run(file: &str, json: bool, output: core::option::Option<&str>, theme: nika_cli::display::theme::Theme, mode: nika_cli::verbs::run::RenderMode, dry_run: bool, model_override: core::option::Option<&str>) -> u8
+pub fn nika_cli::verbs::run::run(file: &str, json: bool, output: core::option::Option<&str>, theme: nika_cli::display::theme::Theme, mode: nika_cli::verbs::run::RenderMode, dry_run: bool, model_override: core::option::Option<&str>, vars: &[alloc::string::String]) -> u8
 pub type nika_cli::verbs::run::ProdRuntime = nika_runtime::Runtime<nika_exec_runner::TokioShell, nika_builtin::BuiltinDispatcher<nika_fs::TokioFs, nika_http::ReqwestHttp, nika_clock::SystemClock, nika_cli::verbs::run::compose::StderrEmitter, nika_builtin::NonInteractive, nika_builtin::NoWorkflow>, nika_http::ReqwestHttp, nika_cli::verbs::run::compose::RegistryProvider<nika_http::ReqwestHttp>, nika_builtin::BuiltinDispatcher<nika_fs::TokioFs, nika_http::ReqwestHttp, nika_clock::SystemClock, nika_cli::verbs::run::compose::StderrEmitter, nika_builtin::NonInteractive, nika_builtin::NoWorkflow>, nika_clock::SystemClock>
 pub mod nika_cli::verbs::wire
 pub enum nika_cli::verbs::wire::WireTarget

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -97,6 +97,12 @@ enum Command {
         /// mock/echo` previews any workflow offline (zero key · zero network).
         #[arg(long, value_name = "PROVIDER/NAME")]
         model: Option<String>,
+        /// Set a workflow `vars:` value (repeatable). Overrides a declared
+        /// `default:` and satisfies a `required: true` var. The value is
+        /// parsed as JSON when it parses (numbers · booleans · arrays),
+        /// else taken as a string. Unknown keys are refused.
+        #[arg(long = "var", value_name = "KEY=VALUE")]
+        var: Vec<String>,
     },
     /// Static anatomy: tasks · verbs · DAG tree · cost · permits.
     Inspect {
@@ -295,6 +301,7 @@ fn main() -> std::process::ExitCode {
             quiet,
             dry_run,
             model,
+            var,
         } => verbs::run::run(
             &file,
             json,
@@ -303,6 +310,7 @@ fn main() -> std::process::ExitCode {
             resolve_run_mode(quiet, no_progress),
             dry_run,
             model.as_deref(),
+            &var,
         ),
         Command::Inspect { file } => emit(&verbs::inspect::run(&file)),
         Command::Graph { file, format } => {

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -86,14 +86,32 @@ fn canon_row(code: &str) -> Option<String> {
     let row = nika_pack::error_codes()
         .into_iter()
         .find(|r| r.code == code)?;
+    let fix = cli_fix_hint(code)
+        .map(|h| format!("  fix: {h}\n\n"))
+        .unwrap_or_default();
     Some(format!(
-        "{code} · {category} · transient: {transient}\n\n  {failure}\n\n\
+        "{code} · {category} · transient: {transient}\n\n  {failure}\n\n{fix}\
          spec conformance code — emitted by `nika check`; prose home: \
          spec/05-errors.md (embedded canon `error_codes` is the SSOT row).\n",
         category = row.category,
         transient = row.transient,
         failure = row.failure,
     ))
+}
+
+/// The ENGINE-side actionable fix for a spec code, when this binary
+/// ships one (the canon row states the FAILURE — the SSOT never carries
+/// per-CLI affordances, so the flag lives here with the flag itself).
+fn cli_fix_hint(code: &str) -> Option<&'static str> {
+    match code {
+        // F4: the unresolved-vars class is fixable from the CLI.
+        "NIKA-VAR-001" => Some(
+            "an unbound workflow var is supplied on the CLI — `nika run <file> \
+             --var <key>=<value>` (repeatable) — or given a `default:` in the \
+             workflow `vars:` block",
+        ),
+        _ => None,
+    }
 }
 
 /// Parse a per-builtin runtime code `NIKA-BUILTIN-<NAME>-<NNN>` to the builtin
@@ -141,6 +159,20 @@ mod tests {
         assert!(out.text.contains("NIKA-DAG-003"));
         assert!(out.text.contains("validation_error"));
         assert!(out.text.contains("spec/05-errors.md"));
+    }
+
+    #[test]
+    fn var001_teaches_the_var_flag() {
+        // F4: `nika explain NIKA-VAR-001` must say HOW to supply a var
+        // from the CLI, not just that the reference is unresolved.
+        let out = run("NIKA-VAR-001");
+        assert_eq!(out.code, exit::OK);
+        assert!(out.text.contains("--var"), "names the flag:\n{}", out.text);
+        assert!(
+            out.text.contains("default:"),
+            "names the workflow-side fix too:\n{}",
+            out.text
+        );
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/run/compose.rs
+++ b/crates/nika-cli/src/verbs/run/compose.rs
@@ -324,6 +324,21 @@ pub fn capabilities_of(wf: &nika_schema::raw::RawWorkflow) -> RuntimeCapabilitie
     }
 }
 
+/// The provider client's transport ceiling — `HttpConfig::timeout` on the
+/// PROVIDER client, which reqwest applies as the client-level idle-read
+/// guard (armed even while AWAITING RESPONSE HEADERS) and as the fallback
+/// total deadline for a request without an explicit one.
+///
+/// Every buffered provider call sets its OWN total deadline (the task
+/// `timeout:` · else the wire layer's per-provider default — 30s cloud ·
+/// 300s local), so this ceiling never governs a well-formed call; it only
+/// reaps sockets that stopped delivering. It MUST comfortably exceed the
+/// longest silent local-model wait (a non-streaming completion delivers
+/// ZERO bytes while the model computes — the default 30s guard killed every
+/// `timeout: 7m` ollama task at 30s · F1). A task `timeout:` beyond this
+/// ceiling is capped by it on a fully-silent connection.
+const PROVIDER_TRANSPORT_CEILING: std::time::Duration = std::time::Duration::from_secs(600);
+
 /// The HTTP client for the PROVIDER path (LLM inference), distinct from
 /// the fetch/builtin client.
 ///
@@ -338,6 +353,11 @@ pub fn capabilities_of(wf: &nika_schema::raw::RawWorkflow) -> RuntimeCapabilitie
 /// contradicts the local-first raison. `Disabled` is exactly the
 /// "trusted internal networks" opt-out the `nika-http` docs sanction.
 ///
+/// The config `timeout` is raised to [`PROVIDER_TRANSPORT_CEILING`]: the
+/// per-REQUEST deadline is owned by the wire layer (task `timeout:` else
+/// the per-provider default), and the 30s client default would undercut
+/// any longer budget via the idle-read guard (see the ceiling's doc).
+///
 /// # Errors
 ///
 /// [`nika_kernel::HttpError`] when the TLS backend won't initialize.
@@ -348,6 +368,7 @@ pub fn capabilities_of(wf: &nika_schema::raw::RawWorkflow) -> RuntimeCapabilitie
 fn provider_http() -> Result<ReqwestHttp, nika_kernel::HttpError> {
     let mut config = HttpConfig::default();
     config.ssrf = SsrfMode::Disabled;
+    config.timeout = PROVIDER_TRANSPORT_CEILING;
     ReqwestHttp::with_config(config)
 }
 

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -74,17 +74,11 @@ pub fn run(
     model_override: Option<&str>,
     vars: &[String],
 ) -> u8 {
-    // `--output json` selects the machine-result mode (spec 01 §"What
-    // leaves a run"): the resolved `outputs:` object as one JSON object on
-    // stdout · diagnostics/progress on stderr. Absent → the live human
-    // render. Validated up front so an unknown format fails before any work.
-    let output_json = match output {
-        None => false,
-        Some("json") => true,
-        Some(other) => {
-            eprintln!("nika run: unknown --output format `{other}` (expected `json`)");
-            return exit::ENV;
-        }
+    // `--output` validated up front so an unknown format fails before any
+    // work (machine-result mode · see `output_mode`).
+    let output_json = match output_mode(output) {
+        Ok(flag) => flag,
+        Err(code) => return code,
     };
 
     // ── Audit BEFORE run (spec §3 · INV the runtime also enforces) ──
@@ -120,16 +114,8 @@ pub fn run(
     };
 
     // ── Dry-run (spec §10 · "plan only · zero effects") ─────────────
-    // The audit passed; STOP here and show the static plan (the same anatomy
-    // `nika inspect` renders) without composing any production seam. No fs,
-    // no http, no subprocess, no provider call — the run is never reached.
     if dry_run {
-        let plan = crate::verbs::inspect::run(file);
-        if !plan.text.is_empty() {
-            println!("{}", plan.text.trim_end());
-        }
-        println!("\n  dry-run · plan only · no effects executed");
-        return exit::OK;
+        return render_dry_run(file);
     }
 
     // ── Compose the production runtime (real seams · env keys) ──────
@@ -245,6 +231,34 @@ fn example_model(yaml: &str) -> String {
     .ok()
     .and_then(|wf| wf.model.map(|m| m.value))
     .unwrap_or_default()
+}
+
+/// Validate `--output` up front — `Ok(true)` selects the machine-result
+/// mode (spec 01 §"What leaves a run": the resolved `outputs:` object as
+/// ONE JSON object on stdout · diagnostics/progress on stderr) · `Ok(false)`
+/// the live human render · `Err(exit)` an unknown format (already printed).
+fn output_mode(output: Option<&str>) -> Result<bool, u8> {
+    match output {
+        None => Ok(false),
+        Some("json") => Ok(true),
+        Some(other) => {
+            eprintln!("nika run: unknown --output format `{other}` (expected `json`)");
+            Err(exit::ENV)
+        }
+    }
+}
+
+/// `--dry-run` (spec §10 · "plan only · zero effects"): the audit passed —
+/// render the static plan (the same anatomy `nika inspect` renders) without
+/// composing any production seam. No fs, no http, no subprocess, no
+/// provider call — the run is never reached.
+fn render_dry_run(file: &str) -> u8 {
+    let plan = crate::verbs::inspect::run(file);
+    if !plan.text.is_empty() {
+        println!("{}", plan.text.trim_end());
+    }
+    println!("\n  dry-run · plan only · no effects executed");
+    exit::OK
 }
 
 /// Parse the repeatable `--var KEY=VALUE` overrides and validate every

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -56,6 +56,13 @@ use crate::verbs::exit;
 /// previews offline). It travels the SAME composition path as an envelope
 /// model, so a bad id fails loud identically (the registry surfaces its
 /// typed error when an infer/agent task actually resolves it).
+///
+/// `vars` — the repeatable `--var KEY=VALUE` overrides (F4): each key must
+/// be a declared workflow var (unknown keys are refused · exit 3); values
+/// override a `default:` and satisfy a `required: true` var.
+// Eight independent CLI parameters ARE the clap surface — the same idiom
+// as TraceArgs' four bools, not a state machine to encode in a struct.
+#[allow(clippy::too_many_arguments)]
 #[must_use]
 pub fn run(
     file: &str,
@@ -65,6 +72,7 @@ pub fn run(
     mode: RenderMode,
     dry_run: bool,
     model_override: Option<&str>,
+    vars: &[String],
 ) -> u8 {
     // `--output json` selects the machine-result mode (spec 01 §"What
     // leaves a run"): the resolved `outputs:` object as one JSON object on
@@ -99,6 +107,18 @@ pub fn run(
         return out.code;
     }
 
+    // ── `--var` overrides (F4) — parse + validate BEFORE any work ────
+    // An unknown key is refused loudly (a typo'd override silently doing
+    // nothing would be the worst outcome) · same exit class as an unknown
+    // `--output` format (operator input · exit 3).
+    let overrides = match parse_var_overrides(vars, &wf) {
+        Ok(map) => map,
+        Err(message) => {
+            eprintln!("nika run: {message}");
+            return exit::ENV;
+        }
+    };
+
     // ── Dry-run (spec §10 · "plan only · zero effects") ─────────────
     // The audit passed; STOP here and show the static plan (the same anatomy
     // `nika inspect` renders) without composing any production seam. No fs,
@@ -128,7 +148,9 @@ pub fn run(
     // static check cannot see). The static check is the other half of each.
     let caps = capabilities_of(&wf);
     let runtime = match production_runtime(default_model, caps) {
-        Ok(rt) => rt,
+        // The validated `--var` overrides ride the runtime builder — they
+        // merge OVER the envelope defaults at run start (F4).
+        Ok(rt) => rt.with_var_overrides(overrides),
         Err(e) => {
             eprintln!("nika run: environment: {e}");
             return exit::ENV;
@@ -197,6 +219,7 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         mode,
         false,
         model_override,
+        &[],
     );
     // The example's own envelope model — what we suggest overriding when a
     // run fails offline. A parse miss leaves it empty (the tip then never
@@ -222,6 +245,41 @@ fn example_model(yaml: &str) -> String {
     .ok()
     .and_then(|wf| wf.model.map(|m| m.value))
     .unwrap_or_default()
+}
+
+/// Parse the repeatable `--var KEY=VALUE` overrides and validate every
+/// key against the workflow's declared `vars:` — an unknown key is
+/// refused with the declared set (a typo'd override silently doing
+/// nothing would be the worst outcome). Values parse as JSON when they
+/// parse (numbers · booleans · arrays · quoted strings), else ride as
+/// plain strings: `--var topic=news` is the string `"news"`,
+/// `--var limit=5` the number `5`.
+fn parse_var_overrides(
+    pairs: &[String],
+    wf: &RawWorkflow,
+) -> Result<BTreeMap<String, Value>, String> {
+    let declared: Vec<&str> = wf.vars.iter().map(|(k, _)| k.value.as_str()).collect();
+    let mut overrides = BTreeMap::new();
+    for pair in pairs {
+        let (key, raw) = match pair.split_once('=') {
+            Some((k, v)) if !k.trim().is_empty() => (k.trim(), v),
+            _ => return Err(format!("--var expects KEY=VALUE, got `{pair}`")),
+        };
+        if !declared.contains(&key) {
+            return Err(if declared.is_empty() {
+                format!("--var {key}: this workflow declares no `vars:`")
+            } else {
+                format!(
+                    "--var {key}: unknown var — the workflow declares: {}",
+                    declared.join(" · ")
+                )
+            });
+        }
+        let value =
+            serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()));
+        overrides.insert(key.to_owned(), value);
+    }
+    Ok(overrides)
 }
 
 /// Should the offline-preview tip fire after an example run?
@@ -442,6 +500,7 @@ mod tests {
             RenderMode::Plain,
             false,
             Some("mock/echo"),
+            &[],
         );
         assert_eq!(
             code,
@@ -469,11 +528,100 @@ mod tests {
             RenderMode::Plain,
             false,
             Some("mock/echo"),
+            &[],
         );
         assert_eq!(
             overridden,
             exit::OK,
             "the override resolved mock/echo, not the envelope's ollama model"
         );
+    }
+
+    // ── `--var` (F4) — the required-var class was UNRUNNABLE from the CLI ──
+
+    /// The workflow of the field repro: a `required: true` var with no
+    /// default. Before F4 there was NO way to run it from the CLI.
+    const REQUIRED_VAR_WF: &str = "nika: v1\nworkflow: needs-var\nmodel: mock/echo\nvars:\n  topic:\n    type: string\n    required: true\ntasks:\n  - id: ask\n    infer: { prompt: \"about ${{ vars.topic }}\" }\n";
+
+    fn run_with_vars(name: &str, vars: &[String]) -> u8 {
+        let wf = stage(name, REQUIRED_VAR_WF);
+        run(
+            &wf.to_string_lossy(),
+            false,
+            None,
+            plain_theme(),
+            RenderMode::Plain,
+            false,
+            None,
+            vars,
+        )
+    }
+
+    #[test]
+    fn var_flag_satisfies_a_required_var() {
+        // Without the flag the first `${{ vars.topic }}` reference fails
+        // the task (NIKA-VAR-001) → workflow failed.
+        assert_eq!(
+            run_with_vars("var-missing.nika.yaml", &[]),
+            exit::WORKFLOW,
+            "an unbound required var still fails the run"
+        );
+        // With `--var topic=rust` the SAME workflow runs green.
+        assert_eq!(
+            run_with_vars("var-provided.nika.yaml", &["topic=rust".to_owned()]),
+            exit::OK,
+            "--var makes the required-var workflow runnable"
+        );
+    }
+
+    #[test]
+    fn var_flag_refuses_unknown_keys_and_bad_shapes() {
+        // A typo'd key must refuse LOUDLY (exit 3 · never silently ignored).
+        assert_eq!(
+            run_with_vars("var-unknown.nika.yaml", &["topik=rust".to_owned()]),
+            exit::ENV,
+            "unknown --var key is refused"
+        );
+        // A pair without `=` is an operator input error, same class.
+        assert_eq!(
+            run_with_vars("var-shape.nika.yaml", &["topic".to_owned()]),
+            exit::ENV,
+            "malformed --var pair is refused"
+        );
+    }
+
+    #[test]
+    fn parse_var_overrides_types_json_else_string() {
+        let wf = nika_schema::parse(
+            "nika: v1\nworkflow: t\nvars:\n  topic: { type: string, required: true }\n  limit: { type: integer, default: 3 }\n  flags: [\"a\"]\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+
+        // JSON-if-parses: numbers · arrays land typed; bare words as strings.
+        let overrides = super::parse_var_overrides(
+            &[
+                "topic=quantum news".to_owned(),
+                "limit=5".to_owned(),
+                "flags=[\"x\",\"y\"]".to_owned(),
+            ],
+            &wf,
+        )
+        .expect("valid overrides");
+        assert_eq!(overrides["topic"], json!("quantum news"));
+        assert_eq!(overrides["limit"], json!(5));
+        assert_eq!(overrides["flags"], json!(["x", "y"]));
+
+        // The unknown-key refusal NAMES the declared set (actionable).
+        let err = super::parse_var_overrides(&["ghost=1".to_owned()], &wf)
+            .expect_err("unknown key refused");
+        assert!(err.contains("ghost"), "{err}");
+        assert!(err.contains("topic"), "lists the declared vars: {err}");
+
+        // `=` in the VALUE is preserved (split_once · key=v=w).
+        let eq = super::parse_var_overrides(&["topic=a=b".to_owned()], &wf)
+            .expect("value may carry '='");
+        assert_eq!(eq["topic"], json!("a=b"));
     }
 }

--- a/crates/nika-cli/tests/e2e_pipeline.rs
+++ b/crates/nika-cli/tests/e2e_pipeline.rs
@@ -381,8 +381,10 @@ async fn e2e_structured_output_validates_real_dataflow() {
     let (wf, report) = parse_and_check(WORKFLOW_OK);
     assert!(report.is_clean());
 
-    // Drive ONLY the extract lane: gather's mocked JSON rides the echo
-    // provider's reply and must come back schema-validated and typed.
+    // Drive ONLY the extract lane: the prompt carries gather's mocked
+    // JSON through real interpolation, and the schema'd mock SYNTHESIZES
+    // a conformant instance (F3 · mock-from-schema) that must come back
+    // schema-validated and typed.
     let shell = MockShell::new().enqueue_ok("42\n");
     let tools = MockToolExecutor::new()
         .enqueue_ok(ToolResult::success("call-gather", GATHER_JSON))
@@ -415,8 +417,10 @@ async fn e2e_structured_output_validates_real_dataflow() {
             out.output
         );
     };
-    assert_eq!(value["headline"], "Rust 2.0");
-    assert_eq!(value["score"], 9);
+    // The synthesized minimal instance of the extract schema (F3): the
+    // required string sits on "mock", the bounded integer on its floor.
+    assert_eq!(value["headline"], "mock");
+    assert_eq!(value["score"], 0);
     assert_eq!(out.model_resolved, "mock/echo");
     assert!(out.usage.output_tokens > 0, "usage flows back");
 }

--- a/crates/nika-kernel-ai/public-api.txt
+++ b/crates/nika-kernel-ai/public-api.txt
@@ -1079,6 +1079,7 @@ pub nika_kernel_ai::provider::InferRequest::stop_sequences: alloc::vec::Vec<allo
 pub nika_kernel_ai::provider::InferRequest::temperature: core::option::Option<f32>
 pub nika_kernel_ai::provider::InferRequest::tenant: core::option::Option<nika_types::id::TenantId>
 pub nika_kernel_ai::provider::InferRequest::thinking_budget: core::option::Option<u32>
+pub nika_kernel_ai::provider::InferRequest::timeout: core::option::Option<core::time::Duration>
 pub nika_kernel_ai::provider::InferRequest::tool_choice: nika_kernel_ai::provider::ToolChoice
 pub nika_kernel_ai::provider::InferRequest::tools: alloc::vec::Vec<nika_kernel_ai::provider::ToolDef>
 impl nika_kernel_ai::provider::InferRequest

--- a/crates/nika-kernel-ai/src/provider.rs
+++ b/crates/nika-kernel-ai/src/provider.rs
@@ -220,6 +220,12 @@ pub struct InferRequest {
     /// use this seed for any randomized behavior (temperature sampling).
     /// Reserved for content-addressed replay (v0.90 `EventLog`).
     pub replay_seed: Option<u64>,
+    /// Transport deadline for ONE provider round-trip — the task-level
+    /// `timeout:` plumbed down so the HTTP effect's fixed default cannot
+    /// undercut a longer task budget (a local model routinely needs
+    /// minutes for one completion). `None` → the adapter's per-provider
+    /// default governs (the caller declared no budget).
+    pub timeout: Option<std::time::Duration>,
     /// `OTel` `GenAI` semconv bridge (Q13). Populated by the provider impl;
     /// default is `GenAiSystem::Unknown` + `GenAiOperation::Chat`.
     pub gen_ai: crate::genai::GenAiAttrs,
@@ -246,6 +252,7 @@ impl InferRequest {
             baggage: None,
             tenant: None,
             replay_seed: None,
+            timeout: None,
             gen_ai: crate::genai::GenAiAttrs::new(),
         }
     }

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -93,7 +93,7 @@ showcase:
     tier: T2
     description: "Competitor sitemap \u2192 top page \u2192 gap analysis \u2192 typed brief"
     constructs: [output, outputs, schema, typed_vars]
-    sha256_16: a208959c135fe202
+    sha256_16: 4ff7531ce45449f3
   - file: examples/showcase/t2-support-triage.nika.yaml
     workflow: support-triage
     tier: T2
@@ -105,7 +105,7 @@ showcase:
     tier: T3
     description: "Sitemap \u2192 parallel page reads \u2192 one competitive brief + ping"
     constructs: [fail_fast, for_each, max_parallel, on_error, output, outputs, retry, secrets, timeout]
-    sha256_16: 104f7e45765c172a
+    sha256_16: d8b565ab15a06491
   - file: examples/showcase/t3-config-drift-sentinel.nika.yaml
     workflow: config-drift-sentinel
     tier: T3

--- a/crates/nika-pack/pack/examples/showcase/t2-seo-content-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-seo-content-brief.nika.yaml
@@ -9,9 +9,11 @@
 #
 # Demonstrates ·
 #   - `mode: sitemap` then `mode: article` · two fetch extractions chained
-#   - `output:` jq slice · `.urls[:5]` — bind just the top of a list
+#     (sitemap yields the ROOT ARRAY `[{loc, changefreq, priority}, …]`)
+#   - `output:` jq · `.[:5] | map(.loc)` — slice the array, keep the URLs
 #   - CEL indexing · `${{ tasks.map.top[0] }}` reaches into a binding
 #   - `infer.schema:` · the brief is typed, not a blob
+#     (mock/echo synthesizes schema-conformant output · offline-runnable)
 #
 # Run · nika run examples/showcase/t2-seo-content-brief.nika.yaml
 nika: v1
@@ -35,7 +37,7 @@ tasks:
         url: "${{ vars.competitor_sitemap }}"
         mode: sitemap
     output:
-      top: ".urls[:5]"
+      top: ".[:5] | map(.loc)"
 
   - id: top_page
     depends_on: [map]

--- a/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
@@ -39,7 +39,7 @@ tasks:
         url: "${{ vars.competitor_sitemap }}"
         mode: sitemap
     output:
-      recent: ".urls[:8]"             # cap the radar at the 8 freshest pages
+      recent: ".[:8] | map(.loc)"     # sitemap = the root array of {loc, …} · cap at 8, keep the URLs
 
   - id: pages
     depends_on: [map]

--- a/crates/nika-pack/pack/spec/03-dag.md
+++ b/crates/nika-pack/pack/spec/03-dag.md
@@ -644,7 +644,7 @@ tasks:
         url: "https://example.com/sitemap.xml"
         mode: sitemap
     output:
-      pages: ".urls[]"
+      pages: "map(.loc)"   # sitemap output IS the root array of {loc, …} · a binding is single-valued, so collect the URLs into one array
 
   - id: summarize
     depends_on: [discover]

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -18,8 +18,9 @@ bytes        = { workspace = true }
 futures-core = { workspace = true }
 
 [dev-dependencies]
-tokio    = { workspace = true }
-proptest = { workspace = true }
+tokio      = { workspace = true }
+proptest   = { workspace = true }
+jsonschema = { workspace = true }   # mock_schema tests validate the synthesized instance with the SAME crate the verb's floor uses
 
 [package.metadata.lore]
 daemon        = "messager"

--- a/crates/nika-providers/src/parity_tests.rs
+++ b/crates/nika-providers/src/parity_tests.rs
@@ -389,3 +389,85 @@ async fn every_wired_profile_parses_a_tool_call_consistently() {
         );
     }
 }
+
+#[tokio::test]
+async fn every_wired_profile_carries_the_transport_deadline() {
+    // F1 parity (field report 2026-07-04): the task `timeout:` must govern
+    // the provider HTTP deadline on EVERY wire — and when the task declares
+    // none, the default is per provider CLASS: local servers get minutes
+    // (a 14B model cannot answer a real prompt in 30s · the sovereignty
+    // story), cloud keeps the historical 30s.
+    use crate::wire::{CLOUD_DEFAULT_TIMEOUT, LOCAL_DEFAULT_TIMEOUT};
+    use std::time::Duration;
+
+    let task_budget = Duration::from_secs(420); // the `timeout: "7m"` repro
+
+    for (id, wire, requires_key) in wired_http_profiles() {
+        let is_local = matches!(id, "ollama" | "lmstudio" | "llamacpp" | "localai" | "vllm");
+
+        // (a) no task timeout → the per-class default rides the request.
+        let fake = FakeHttp::with_json(200, ok_fixture(wire));
+        let rp = resolve_on(&fake, id, requires_key);
+        rp.infer(request())
+            .await
+            .unwrap_or_else(|e| panic!("[{id}] infer must succeed: {e}"));
+        let expected = if is_local {
+            LOCAL_DEFAULT_TIMEOUT
+        } else {
+            CLOUD_DEFAULT_TIMEOUT
+        };
+        assert_eq!(
+            fake.captured()[0].timeout,
+            Some(expected),
+            "[{id}] class default rides the buffered request"
+        );
+
+        // (b) task timeout declared → it WINS on every wire (the 408-at-30s
+        // class: a `timeout: "7m"` task must never die at the transport).
+        let fake = FakeHttp::with_json(200, ok_fixture(wire));
+        let rp = resolve_on(&fake, id, requires_key);
+        let mut req = request();
+        req.timeout = Some(task_budget);
+        rp.infer(req)
+            .await
+            .unwrap_or_else(|e| panic!("[{id}] infer must succeed: {e}"));
+        assert_eq!(
+            fake.captured()[0].timeout,
+            Some(task_budget),
+            "[{id}] the task budget governs the transport deadline"
+        );
+
+        // (c) STREAMING carries only an EXPLICIT budget (a generation
+        // legitimately outlives any fixed total · the idle-read guard
+        // reaps stalls) — None when the task declares none.
+        let fake = FakeHttp::with_stream(200, sse_fixture(wire), 16);
+        let rp = resolve_on(&fake, id, requires_key);
+        let _ = collect(
+            rp.infer_stream(request())
+                .await
+                .unwrap_or_else(|e| panic!("[{id}] stream must open: {e}")),
+        )
+        .await;
+        assert_eq!(
+            fake.captured()[0].timeout,
+            None,
+            "[{id}] streaming without a task budget carries no total deadline"
+        );
+
+        let fake = FakeHttp::with_stream(200, sse_fixture(wire), 16);
+        let rp = resolve_on(&fake, id, requires_key);
+        let mut req = request();
+        req.timeout = Some(task_budget);
+        let _ = collect(
+            rp.infer_stream(req)
+                .await
+                .unwrap_or_else(|e| panic!("[{id}] stream must open: {e}")),
+        )
+        .await;
+        assert_eq!(
+            fake.captured()[0].timeout,
+            Some(task_budget),
+            "[{id}] an explicit task budget rides the streaming request too"
+        );
+    }
+}

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -87,6 +87,17 @@ impl Profile {
         v
     }
 
+    /// Whether this profile is one of the 5 LOCAL servers (`ollama` ·
+    /// `lmstudio` · `llamacpp` · `localai` · `vllm`) — keyed on the
+    /// canonical id (the [`LOCAL`] seed rows), so an operator
+    /// `with_base_url` override never flips the classification. Local
+    /// servers get the generous transport-deadline default (a local
+    /// model routinely needs minutes for one completion — see
+    /// `wire::transport_deadline`).
+    pub(crate) fn is_local(&self) -> bool {
+        LOCAL.iter().any(|(id, _)| *id == self.id)
+    }
+
     /// Resolve a model nickname through the catalog row (`"sonnet"` →
     /// `"claude-sonnet-4-20250514"`). Unknown names pass through verbatim —
     /// the wire model namespace is the provider's, not ours.
@@ -257,6 +268,17 @@ mod tests {
                 assert_eq!(p.wire, WireFormat::OpenAiCompat);
                 assert!(p.base_url.starts_with("http://127.0.0.1"), "{}", p.id);
             }
+        }
+    }
+
+    #[test]
+    fn is_local_classifies_exactly_the_five_local_servers() {
+        // F1: the classification drives the transport-deadline default
+        // (local ≫ cloud) — keyed on the id so a base_url override can
+        // never flip it.
+        for p in seed() {
+            let expected = ["ollama", "lmstudio", "llamacpp", "localai", "vllm"].contains(&p.id);
+            assert_eq!(p.is_local(), expected, "{} classification", p.id);
         }
     }
 

--- a/crates/nika-providers/src/wire/anthropic.rs
+++ b/crates/nika-providers/src/wire/anthropic.rs
@@ -107,6 +107,9 @@ fn build_request(
     let mut http_req = HttpRequest::post(rp.base_url.clone());
     http_req.headers = headers;
     http_req.body = Some(Bytes::from(bytes));
+    // The task `timeout:` governs the transport deadline (F1) — see
+    // `wire::transport_deadline` for the buffered-vs-streaming split.
+    http_req.timeout = super::transport_deadline(&rp.profile, req, stream);
     Ok(http_req)
 }
 

--- a/crates/nika-providers/src/wire/gemini.rs
+++ b/crates/nika-providers/src/wire/gemini.rs
@@ -113,6 +113,9 @@ fn build_request(
     let mut http_req = HttpRequest::post(endpoint(&rp.base_url, &rp.wire_model, stream));
     http_req.headers = headers;
     http_req.body = Some(Bytes::from(bytes));
+    // The task `timeout:` governs the transport deadline (F1) — see
+    // `wire::transport_deadline` for the buffered-vs-streaming split.
+    http_req.timeout = super::transport_deadline(&rp.profile, req, stream);
     Ok(http_req)
 }
 

--- a/crates/nika-providers/src/wire/mock.rs
+++ b/crates/nika-providers/src/wire/mock.rs
@@ -8,6 +8,11 @@
 //! usage arithmetic, and a 3-delta synthetic stream. Determinism is the
 //! contract — engine tests and conformance fixtures rely on byte-stable
 //! output for identical input.
+//!
+//! A request carrying `response_format: JsonSchema` does NOT echo — it
+//! returns a SYNTHESIZED schema-conformant instance (`mock_schema` · F3),
+//! so every structured workflow dry-runs offline instead of dying
+//! NIKA-INFER-002 after burning its retry budget.
 
 use std::collections::VecDeque;
 use std::pin::Pin;
@@ -15,16 +20,23 @@ use std::task::{Context, Poll};
 
 use futures_core::Stream;
 use nika_kernel::ai::provider::{
-    ContentBlock, InferEvent, InferEventStream, InferRequest, InferResponse, ProviderError, Role,
-    StopReason, TokenUsage,
+    ContentBlock, InferEvent, InferEventStream, InferRequest, InferResponse, ProviderError,
+    ResponseFormat, Role, StopReason, TokenUsage,
 };
 
+use super::mock_schema;
 use crate::registry::ResolvedProvider;
 
-/// Deterministic single-shot response.
+/// Deterministic single-shot response — the echo, or (schema attached) a
+/// synthesized conformant instance as PURE JSON (no prefix noise: the
+/// schema instruction demands "ONLY a JSON value", and the mock complies
+/// exactly like a well-behaved model).
 pub(crate) fn infer<H>(rp: &ResolvedProvider<H>, request: &InferRequest) -> InferResponse {
     let echo = last_user_text(request);
-    let text = format!("mock({model}) · {echo}", model = rp.wire_model());
+    let text = match &request.response_format {
+        ResponseFormat::JsonSchema(schema) => mock_schema::synthesize(schema).to_string(),
+        _ => format!("mock({model}) · {echo}", model = rp.wire_model()),
+    };
     let usage = usage_for(&echo, &text);
 
     let mut resp = InferResponse::new(
@@ -129,6 +141,41 @@ mod tests {
 
     fn req(text: &str) -> InferRequest {
         InferRequest::new("echo", vec![Message::text(Role::User, text)])
+    }
+
+    #[test]
+    fn schema_request_synthesizes_pure_json() {
+        // F3: a JsonSchema request returns ONLY a conformant JSON value —
+        // no `mock(model) ·` prefix (the schema instruction says "ONLY a
+        // JSON value" and the mock behaves like a well-behaved model).
+        let rp = resolved();
+        let mut request = req("extract the fields");
+        request.response_format =
+            nika_kernel::ai::provider::ResponseFormat::JsonSchema(serde_json::json!({
+                "type": "object",
+                "required": ["headline", "score"],
+                "properties": {
+                    "headline": { "type": "string" },
+                    "score": { "type": "integer", "minimum": 0 }
+                }
+            }));
+        let a = infer(&rp, &request);
+        let b = infer(&rp, &request);
+        let (ContentBlock::Text { text: ta }, ContentBlock::Text { text: tb }) =
+            (&a.content[0], &b.content[0])
+        else {
+            panic!("expected text blocks");
+        };
+        assert_eq!(ta, tb, "byte-stable under a schema too");
+        let parsed: serde_json::Value = serde_json::from_str(ta).expect("pure JSON · no prefix");
+        assert_eq!(parsed["headline"], "mock");
+        assert_eq!(parsed["score"], 0);
+        // the plain-echo contract is untouched
+        let plain = infer(&rp, &req("hello"));
+        let ContentBlock::Text { text } = &plain.content[0] else {
+            panic!("expected text");
+        };
+        assert!(text.starts_with("mock(echo) · "), "{text}");
     }
 
     #[test]

--- a/crates/nika-providers/src/wire/mock_schema.rs
+++ b/crates/nika-providers/src/wire/mock_schema.rs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Schema-driven synthesis for the `mock` provider — the offline-CI story.
+//!
+//! When a request carries `response_format: JsonSchema`, the mock stops
+//! echoing and SYNTHESIZES a minimal instance of the schema (F3 · field
+//! report 2026-07-04): the echo can never satisfy a schema, so every
+//! structured workflow on `mock/echo` burned its retry budget and died
+//! NIKA-INFER-002 — there was no offline story for exactly the workflows
+//! that need CI most. With synthesis, `nika run --model mock/echo`
+//! dry-runs ANY structured workflow offline (zero key · zero network).
+//!
+//! The generator is TOTAL and deterministic (byte-stable output for the
+//! same schema — the mock contract) but deliberately MINIMAL: it honors
+//! the keywords workflow authors actually write (`type` · `enum` ·
+//! `const` · `default` · `required`/`properties` · `items` · numeric and
+//! length bounds · first-branch `oneOf`/`anyOf`/`allOf`) and degrades to
+//! `null` elsewhere. A schema it cannot satisfy (e.g. `pattern` ·
+//! unresolved `$ref`) simply fails the verb's validation — the honest
+//! signal, never a panic.
+
+use serde_json::{Map, Value};
+
+/// Recursion ceiling — a pathological/deeply-nested schema degrades to
+/// `null` leaves instead of unbounded descent (`$ref` is NOT resolved,
+/// so a cyclic schema cannot trap the generator).
+const MAX_DEPTH: u8 = 16;
+
+/// Ceiling on generated array length — a hostile `minItems: 10_000_000`
+/// must not buy an allocation (the instance then honestly fails the
+/// verb's validation instead).
+const MAX_ITEMS: usize = 64;
+
+/// Synthesize a minimal, deterministic instance of `schema`.
+pub(crate) fn synthesize(schema: &Value) -> Value {
+    instance(schema, 0)
+}
+
+fn instance(schema: &Value, depth: u8) -> Value {
+    if depth >= MAX_DEPTH {
+        return Value::Null;
+    }
+    let Some(obj) = schema.as_object() else {
+        // `true` (anything) · `false` (unsatisfiable) · non-object form —
+        // null is the minimal candidate either way.
+        return Value::Null;
+    };
+    // Authored fixed points win over type synthesis.
+    if let Some(c) = obj.get("const") {
+        return c.clone();
+    }
+    if let Some(first) = obj
+        .get("enum")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+    {
+        return first.clone();
+    }
+    if let Some(d) = obj.get("default") {
+        return d.clone();
+    }
+    // Composition — the FIRST branch is the minimal instance (allOf with
+    // genuinely conflicting branches then fails validation · honest).
+    for key in ["oneOf", "anyOf", "allOf"] {
+        if let Some(branch) = obj
+            .get(key)
+            .and_then(Value::as_array)
+            .and_then(|a| a.first())
+        {
+            return instance(branch, depth + 1);
+        }
+    }
+    match type_of(obj) {
+        Some("string") => Value::String(string_within(obj)),
+        Some("integer") => integer_within(obj),
+        Some("number") => number_within(obj),
+        Some("boolean") => Value::Bool(false),
+        Some("array") => array_within(obj, depth),
+        Some("object") => object_within(obj, depth),
+        // "null" · unknown/future types · no type and no structural
+        // hint → null (validates against an unconstrained schema).
+        _ => Value::Null,
+    }
+}
+
+/// The effective `type` — a bare string, the FIRST entry of a type
+/// array (`["string","null"]`), or inferred from structural keywords
+/// when absent (an author writing `properties:` means an object).
+fn type_of(obj: &Map<String, Value>) -> Option<&str> {
+    match obj.get("type") {
+        Some(Value::String(t)) => Some(t.as_str()),
+        Some(Value::Array(ts)) => ts.iter().find_map(Value::as_str),
+        _ => {
+            if obj.contains_key("properties") || obj.contains_key("required") {
+                Some("object")
+            } else if obj.contains_key("items") {
+                Some("array")
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// `"mock"`, padded up to `minLength` / truncated to `maxLength` (the
+/// base is ASCII so byte truncation is char-safe). Contradictory bounds
+/// (`maxLength < minLength`) are unsatisfiable — the instance then fails
+/// validation, honestly.
+fn string_within(obj: &Map<String, Value>) -> String {
+    let mut s = String::from("mock");
+    if let Some(min) = obj.get("minLength").and_then(Value::as_u64) {
+        while (s.len() as u64) < min {
+            s.push_str("mock");
+        }
+        s.truncate(usize::try_from(min).unwrap_or(s.len()).max(4));
+    }
+    if let Some(max) = obj.get("maxLength").and_then(Value::as_u64) {
+        let max = usize::try_from(max).unwrap_or(usize::MAX);
+        if s.len() > max {
+            s.truncate(max);
+        }
+    }
+    s
+}
+
+/// `minimum` ?? `exclusiveMinimum`+1 ?? (`maximum` when negative) ?? 0.
+fn integer_within(obj: &Map<String, Value>) -> Value {
+    if let Some(min) = int_bound(obj.get("minimum")) {
+        return Value::from(min);
+    }
+    if let Some(xmin) = int_bound(obj.get("exclusiveMinimum")) {
+        return Value::from(xmin.saturating_add(1));
+    }
+    if let Some(max) = int_bound(obj.get("maximum"))
+        && max < 0
+    {
+        return Value::from(max);
+    }
+    Value::from(0)
+}
+
+/// An integer bound that may be authored as a float (`minimum: 1.0` on
+/// an integer type is legal JSON Schema) — ceil so the bound holds.
+fn int_bound(v: Option<&Value>) -> Option<i64> {
+    let v = v?;
+    #[allow(clippy::cast_possible_truncation)] // ceil'd bound · schema-authored magnitudes
+    v.as_i64().or_else(|| v.as_f64().map(|f| f.ceil() as i64))
+}
+
+/// `minimum` ?? `exclusiveMinimum`+1 ?? (`maximum` when negative) ?? 0.0.
+fn number_within(obj: &Map<String, Value>) -> Value {
+    let bound = |key: &str| obj.get(key).and_then(Value::as_f64);
+    let candidate = bound("minimum")
+        .or_else(|| bound("exclusiveMinimum").map(|x| x + 1.0))
+        .or_else(|| bound("maximum").filter(|m| *m < 0.0))
+        .unwrap_or(0.0);
+    serde_json::Number::from_f64(candidate).map_or(Value::Null, Value::Number)
+}
+
+/// One representative item (per the F3 contract) unless `minItems`
+/// demands more, capped at [`MAX_ITEMS`] and clamped to `maxItems`.
+fn array_within(obj: &Map<String, Value>, depth: u8) -> Value {
+    let min = obj.get("minItems").and_then(Value::as_u64).unwrap_or(0);
+    let max = obj
+        .get("maxItems")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    let n = usize::try_from(min.max(1).min(max))
+        .unwrap_or(1)
+        .min(MAX_ITEMS);
+    let item = obj
+        .get("items")
+        .map_or(Value::Null, |items| instance(items, depth + 1));
+    Value::Array(std::iter::repeat_with(|| item.clone()).take(n).collect())
+}
+
+/// Exactly the `required` keys, each synthesized from its `properties`
+/// schema (a required key WITHOUT a property schema is unconstrained →
+/// null). Optional properties are omitted — minimal instance.
+fn object_within(obj: &Map<String, Value>, depth: u8) -> Value {
+    let empty = Map::new();
+    let props = obj
+        .get("properties")
+        .and_then(Value::as_object)
+        .unwrap_or(&empty);
+    let mut out = Map::new();
+    if let Some(required) = obj.get("required").and_then(Value::as_array) {
+        for key in required.iter().filter_map(Value::as_str) {
+            let value = props
+                .get(key)
+                .map_or(Value::Null, |s| instance(s, depth + 1));
+            out.insert(key.to_owned(), value);
+        }
+    }
+    Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The instance must VALIDATE against its own schema — the whole
+    /// point of synthesis (asserted with the same `jsonschema` crate the
+    /// verb's validation floor uses).
+    fn assert_conformant(schema: &Value) -> Value {
+        let v = synthesize(schema);
+        let validator = jsonschema::validator_for(schema).expect("test schema compiles");
+        let errors: Vec<String> = validator.iter_errors(&v).map(|e| e.to_string()).collect();
+        assert!(
+            errors.is_empty(),
+            "synthesized instance must validate:\n  schema: {schema}\n  instance: {v}\n  errors: {errors:?}"
+        );
+        v
+    }
+
+    #[test]
+    fn atlas_style_review_schema_validates() {
+        // The exact class the field report hit (payload-review): enum
+        // severity + bounded integer + required arrays of typed objects.
+        let schema = json!({
+            "type": "object",
+            "required": ["verdict", "score", "findings"],
+            "properties": {
+                "verdict": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
+                "score": { "type": "integer", "minimum": 0, "maximum": 12 },
+                "findings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["severity", "detail"],
+                        "properties": {
+                            "severity": { "type": "string", "enum": ["P0", "P1"] },
+                            "detail": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        });
+        let v = assert_conformant(&schema);
+        assert_eq!(v["verdict"], "P0", "enum honors its first entry");
+        assert_eq!(v["score"], 0, "bounded integer sits on its minimum");
+        assert_eq!(v["findings"][0]["severity"], "P0");
+        assert_eq!(v["findings"][0]["detail"], "mock");
+    }
+
+    #[test]
+    fn scalar_defaults_per_type() {
+        assert_eq!(synthesize(&json!({ "type": "string" })), json!("mock"));
+        assert_eq!(synthesize(&json!({ "type": "integer" })), json!(0));
+        assert_eq!(synthesize(&json!({ "type": "number" })), json!(0.0));
+        assert_eq!(synthesize(&json!({ "type": "boolean" })), json!(false));
+        assert_eq!(synthesize(&json!({ "type": "null" })), Value::Null);
+    }
+
+    #[test]
+    fn numeric_bounds_are_honored() {
+        assert_conformant(&json!({ "type": "integer", "minimum": 5 }));
+        assert_eq!(
+            synthesize(&json!({ "type": "integer", "minimum": 5 })),
+            json!(5)
+        );
+        // float-authored bound on an integer type → ceil'd
+        assert_eq!(
+            synthesize(&json!({ "type": "integer", "minimum": 4.2 })),
+            json!(5)
+        );
+        assert_eq!(
+            synthesize(&json!({ "type": "integer", "exclusiveMinimum": 3 })),
+            json!(4)
+        );
+        // negative-only range: 0 would violate → the maximum is the instance
+        assert_conformant(&json!({ "type": "integer", "maximum": -3 }));
+        assert_eq!(
+            synthesize(&json!({ "type": "integer", "maximum": -3 })),
+            json!(-3)
+        );
+        assert_conformant(&json!({ "type": "number", "minimum": 1.5 }));
+    }
+
+    #[test]
+    fn string_length_bounds_are_honored() {
+        let long = assert_conformant(&json!({ "type": "string", "minLength": 10 }));
+        assert!(long.as_str().expect("string").len() >= 10);
+        let short = assert_conformant(&json!({ "type": "string", "maxLength": 2 }));
+        assert_eq!(short, json!("mo"));
+    }
+
+    #[test]
+    fn fixed_points_win_over_type_synthesis() {
+        assert_eq!(
+            synthesize(&json!({ "type": "integer", "const": 42 })),
+            json!(42)
+        );
+        assert_eq!(
+            synthesize(&json!({ "type": "string", "default": "hi" })),
+            json!("hi")
+        );
+        // enum of any type — first entry verbatim
+        assert_eq!(
+            synthesize(&json!({ "enum": [{ "k": 1 }, "x"] })),
+            json!({ "k": 1 })
+        );
+    }
+
+    #[test]
+    fn type_arrays_and_inferred_shapes() {
+        assert_eq!(
+            synthesize(&json!({ "type": ["string", "null"] })),
+            json!("mock")
+        );
+        // no `type` but `properties`/`required` → object inferred
+        let v = assert_conformant(&json!({
+            "required": ["name"],
+            "properties": { "name": { "type": "string" } }
+        }));
+        assert_eq!(v, json!({ "name": "mock" }));
+        // no `type` but `items` → array inferred
+        assert_eq!(
+            synthesize(&json!({ "items": { "type": "integer" } })),
+            json!([0])
+        );
+    }
+
+    #[test]
+    fn composition_takes_the_first_branch() {
+        assert_eq!(
+            synthesize(&json!({ "oneOf": [{ "type": "integer" }, { "type": "string" }] })),
+            json!(0)
+        );
+        assert_eq!(
+            synthesize(&json!({ "anyOf": [{ "const": "a" }, { "const": "b" }] })),
+            json!("a")
+        );
+    }
+
+    #[test]
+    fn min_items_replicates_within_the_ceiling() {
+        let v = assert_conformant(&json!({
+            "type": "array", "minItems": 3, "items": { "type": "string" }
+        }));
+        assert_eq!(v, json!(["mock", "mock", "mock"]));
+        // maxItems: 0 → the empty array (min.max(1) clamped down)
+        assert_eq!(
+            synthesize(&json!({ "type": "array", "maxItems": 0 })),
+            json!([])
+        );
+        // hostile minItems is capped — allocation-bounded, honestly invalid
+        let huge = synthesize(&json!({ "type": "array", "minItems": 1_000_000 }));
+        assert_eq!(huge.as_array().expect("array").len(), MAX_ITEMS);
+    }
+
+    #[test]
+    fn deterministic_byte_stable() {
+        let schema = json!({
+            "type": "object",
+            "required": ["b", "a"],
+            "properties": { "a": { "type": "integer" }, "b": { "type": "string" } }
+        });
+        assert_eq!(
+            synthesize(&schema).to_string(),
+            synthesize(&schema).to_string(),
+            "the mock contract: byte-stable output for identical input"
+        );
+    }
+
+    #[test]
+    fn total_on_degenerate_schemas() {
+        // Non-object forms · unresolved $ref · unknown types — total, null.
+        assert_eq!(synthesize(&json!(true)), Value::Null);
+        assert_eq!(synthesize(&json!(false)), Value::Null);
+        assert_eq!(synthesize(&json!({ "$ref": "#/defs/x" })), Value::Null);
+        assert_eq!(synthesize(&json!({ "type": "wormhole" })), Value::Null);
+        // deep nesting degrades to null leaves instead of unbounded descent
+        let mut deep = json!({ "type": "string" });
+        for _ in 0..40 {
+            deep = json!({ "type": "object", "required": ["k"], "properties": { "k": deep } });
+        }
+        let _ = synthesize(&deep); // must terminate
+    }
+}

--- a/crates/nika-providers/src/wire/mod.rs
+++ b/crates/nika-providers/src/wire/mod.rs
@@ -23,7 +23,44 @@ use nika_kernel::ai::provider::{InferEvent, ProviderError};
 use nika_kernel::genai::GenAiSystem;
 use nika_kernel::http::HttpError;
 
+use crate::profile::Profile;
 use crate::sse::SseParser;
+
+/// Default transport deadline for CLOUD providers when the task declares
+/// no `timeout:` — matches the HTTP effect's historical 30s default (the
+/// pre-plumb behavior · cloud completions comfortably fit it).
+pub(crate) const CLOUD_DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Default transport deadline for the 5 LOCAL servers (`ollama` ·
+/// `lmstudio` · `llamacpp` · `localai` · `vllm`) when the task declares
+/// no `timeout:` — a local model routinely needs minutes for one
+/// completion on consumer hardware; the 30s cloud default killed every
+/// serious local-first workflow with a 408 (F1 field report 2026-07-04).
+pub(crate) const LOCAL_DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// The per-request transport deadline for one provider round-trip.
+///
+/// BUFFERED calls always get a total deadline: the task-level `timeout:`
+/// (plumbed via `InferRequest::timeout`) when declared, else the
+/// per-provider default (local ≫ cloud — the sovereignty story breaks
+/// when a 14B model gets 30s). STREAMING requests carry only an EXPLICIT
+/// task timeout (else `None`): an SSE generation legitimately outlives
+/// any fixed total budget — the http effect's idle-read guard reaps a
+/// STALLED stream instead (`nika-http` streaming timeout semantics).
+pub(crate) fn transport_deadline(
+    profile: &Profile,
+    req: &nika_kernel::ai::provider::InferRequest,
+    stream: bool,
+) -> Option<std::time::Duration> {
+    if stream {
+        return req.timeout;
+    }
+    Some(req.timeout.unwrap_or(if profile.is_local() {
+        LOCAL_DEFAULT_TIMEOUT
+    } else {
+        CLOUD_DEFAULT_TIMEOUT
+    }))
+}
 
 /// Transport-layer failure → provider error (no HTTP status yet).
 pub(crate) fn map_http_err(e: &HttpError) -> ProviderError {
@@ -396,6 +433,42 @@ mod tests {
             }
             other => panic!("expected Api, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn transport_deadline_matrix() {
+        use nika_kernel::ai::provider::{InferRequest, Message, Role};
+        use std::time::Duration;
+
+        let profiles = crate::profile::seed();
+        let ollama = profiles.iter().find(|p| p.id == "ollama").expect("ollama");
+        let openai = profiles.iter().find(|p| p.id == "openai").expect("openai");
+        let req = |t: Option<Duration>| {
+            let mut r = InferRequest::new("m", vec![Message::text(Role::User, "q")]);
+            r.timeout = t;
+            r
+        };
+
+        // Buffered · no task budget → the per-class default.
+        assert_eq!(
+            transport_deadline(ollama, &req(None), false),
+            Some(LOCAL_DEFAULT_TIMEOUT),
+            "local default is the generous one"
+        );
+        assert_eq!(
+            transport_deadline(openai, &req(None), false),
+            Some(CLOUD_DEFAULT_TIMEOUT),
+            "cloud keeps the historical 30s"
+        );
+        // Buffered · task budget → it wins on BOTH classes.
+        let budget = Some(Duration::from_secs(420));
+        assert_eq!(transport_deadline(ollama, &req(budget), false), budget);
+        assert_eq!(transport_deadline(openai, &req(budget), false), budget);
+        // Streaming → explicit-only (None = idle guard governs).
+        assert_eq!(transport_deadline(openai, &req(None), true), None);
+        assert_eq!(transport_deadline(openai, &req(budget), true), budget);
+        // The local default honours the ≥300s floor (F1 acceptance).
+        assert!(LOCAL_DEFAULT_TIMEOUT >= Duration::from_secs(300));
     }
 
     #[test]

--- a/crates/nika-providers/src/wire/mod.rs
+++ b/crates/nika-providers/src/wire/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod anthropic;
 pub(crate) mod gemini;
 mod gemini_schema;
 pub(crate) mod mock;
+mod mock_schema;
 pub(crate) mod openai_compat;
 
 use std::collections::VecDeque;

--- a/crates/nika-providers/src/wire/openai_compat.rs
+++ b/crates/nika-providers/src/wire/openai_compat.rs
@@ -113,6 +113,11 @@ fn build_request(
     let mut http_req = HttpRequest::post(rp.base_url.clone());
     http_req.headers = headers;
     http_req.body = Some(Bytes::from(bytes));
+    // The task `timeout:` governs the transport deadline (F1) — buffered
+    // calls always get one (per-provider default when undeclared · local
+    // servers get minutes, not the 30s cloud default); streaming carries
+    // only an explicit budget (the idle-read guard reaps stalls).
+    http_req.timeout = super::transport_deadline(&rp.profile, req, stream);
     Ok(http_req)
 }
 

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -34,6 +34,7 @@ uuid             = { workspace = true }
 nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0-dev" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
 nika-providers   = { path = "../nika-providers", version = "0.93.0-dev" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
 nika-pack        = { path = "../nika-pack", version = "0.93.0-dev" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }
 tokio            = { workspace = true }

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -200,6 +200,7 @@ pub async fn nika_runtime::Runtime<S, T, H, P, D, C>::run(&self, wf: &nika_schem
 impl<S, T, H, P, D, C> nika_runtime::Runtime<S, T, H, P, D, C>
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::new(shell: nika_verb_exec::ExecVerb<S>, invoke: alloc::sync::Arc<nika_verb_invoke::InvokeVerb<T>>, infer: nika_verb_infer::InferVerb<H>, agent: nika_verb_agent::AgentVerb<P, T, D>, clock: C, config: nika_runtime::RuntimeConfig) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_secret_resolver(self, resolver: alloc::sync::Arc<dyn nika_runtime::WorkflowSecretResolver>) -> Self
+pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_var_overrides(self, overrides: alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>) -> Self
 impl<D> owo_colors::OwoColorize for nika_runtime::Runtime<S, T, H, P, D, C>
 impl<T, U> core::convert::Into<U> for nika_runtime::Runtime<S, T, H, P, D, C> where U: core::convert::From<T>
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::into(self) -> U

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -143,16 +143,23 @@ where
     D: ToolDefinitionProviderDyn,
 {
     /// Dispatch one action through its verb (see module docs).
+    ///
+    /// `deadline` — the task-level `timeout:` budget (spec 03). The
+    /// attempt loop enforces it as the TOTAL budget; it is ALSO handed
+    /// to the infer path so the provider transport deadline cannot
+    /// undercut it (F1 · a 30s HTTP default killed every `timeout: 7m`
+    /// local-model task at 30s).
     pub(crate) async fn dispatch(
         &self,
         action: &RawAction,
         scope: &Scope<'_>,
         agent_buffer: &crate::agent_events::BufferingObserver,
+        deadline: Option<std::time::Duration>,
     ) -> Dispatched {
         match action {
             RawAction::Invoke(inner) => self.dispatch_invoke(inner, scope).await,
             RawAction::Exec(inner) => self.dispatch_shell(inner, scope).await,
-            RawAction::Infer(inner) => self.dispatch_infer(inner, scope).await,
+            RawAction::Infer(inner) => self.dispatch_infer(inner, scope, deadline).await,
             RawAction::Agent(inner) => self.dispatch_agent(inner, scope, agent_buffer).await,
             // #[non_exhaustive] · a future verb must land HERE loudly ·
             // the runtime refuses rather than silently no-ops.
@@ -300,12 +307,16 @@ where
         &self,
         action: &nika_schema::raw::RawInferAction,
         scope: &Scope<'_>,
+        deadline: Option<std::time::Duration>,
     ) -> Dispatched {
         let prompt = match expr::render(&action.prompt.value, scope) {
             Ok(p) => p,
             Err(err) => return Dispatched::template_err("infer · ?", &err),
         };
         let mut input = InferInput::new(prompt);
+        // The task `timeout:` flows to the provider transport deadline —
+        // the outer attempt-loop select still enforces the total budget.
+        input.timeout = deadline;
         input.system = match render_opt(action.system.as_ref(), scope) {
             Ok(v) => v,
             Err(err) => return Dispatched::template_err("infer · ?", &err),
@@ -731,5 +742,143 @@ mod tests {
         assert!(!value_is_blank(&serde_json::json!([1])));
         assert!(!value_is_blank(&Value::Bool(false)));
         assert!(!value_is_blank(&serde_json::json!(0)));
+    }
+}
+
+/// F1 (field report 2026-07-04) — the task `timeout:` must arrive on the
+/// provider HTTP request through the REAL parse → check → run chain: the
+/// 30s transport default killed every `timeout: "7m"` local-model task
+/// with a 408 at 30s. Asserted at the http seam (a capturing effect
+/// under a real `ProviderRegistry` · `ollama` profile · zero network).
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod infer_deadline_tests {
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use nika_kernel::http::{
+        HttpError, HttpPostDyn, HttpRequest, HttpResponse, HttpStreamResponse,
+    };
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+    use nika_verb_agent::AgentVerb;
+    use nika_verb_exec::ExecVerb;
+    use nika_verb_invoke::InvokeVerb;
+
+    use crate::{DeterministicStamper, Runtime, RuntimeConfig, VecSink};
+
+    /// Captures every provider request · answers a minimal
+    /// openai-compat success so the run settles green.
+    #[derive(Default)]
+    struct CapturingHttp {
+        captured: Mutex<Vec<HttpRequest>>,
+    }
+
+    impl CapturingHttp {
+        fn captured(&self) -> Vec<HttpRequest> {
+            self.captured.lock().expect("test mutex").clone()
+        }
+    }
+
+    const OPENAI_OK: &str = r#"{"id":"cc","model":"m",
+        "choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],
+        "usage":{"prompt_tokens":1,"completion_tokens":1}}"#;
+
+    impl HttpPostDyn for CapturingHttp {
+        async fn post(&self, request: HttpRequest) -> Result<HttpResponse, HttpError> {
+            self.captured
+                .lock()
+                .expect("test mutex")
+                .push(request.clone());
+            Ok(HttpResponse::new(
+                200,
+                BTreeMap::new(),
+                Bytes::from_static(OPENAI_OK.as_bytes()),
+                request.url,
+            ))
+        }
+
+        async fn send_streaming(
+            &self,
+            _request: HttpRequest,
+        ) -> Result<HttpStreamResponse, HttpError> {
+            Err(HttpError::Unsupported {
+                reason: "streaming not exercised here".to_owned(),
+            })
+        }
+    }
+
+    async fn run_and_capture(yaml: &str) -> Vec<HttpRequest> {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(report.is_clean(), "fixture passes the ladder");
+
+        let http = Arc::new(CapturingHttp::default());
+        let registry = Arc::new(ProviderRegistry::new(
+            Arc::clone(&http),
+            ProvidersConfig::new(),
+        ));
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+        let runtime = Runtime::new(
+            ExecVerb::new(Arc::new(MockShell::new())),
+            Arc::clone(&invoke),
+            nika_verb_infer::InferVerb::new(registry, "ollama/llama3.2"),
+            AgentVerb::new(
+                Arc::new(MockProvider::new("mock")),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default(),
+        );
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let outcome = runtime
+            .run(&wf, &report, &mut stamper, &mut sink)
+            .await
+            .expect("clean run");
+        assert!(outcome.ok, "the canned success settles green");
+        http.captured()
+    }
+
+    #[tokio::test]
+    async fn task_timeout_governs_the_provider_http_deadline() {
+        // The exact field repro: `timeout: "7m"` on a local-model infer.
+        let captured = run_and_capture(
+            "nika: v1\nworkflow: w\nmodel: ollama/llama3.2\ntasks:\n  - id: ask\n    timeout: \"7m\"\n    infer: { prompt: \"hello\" }\n",
+        )
+        .await;
+        assert_eq!(captured.len(), 1, "one provider round-trip");
+        assert_eq!(
+            captured[0].timeout,
+            Some(Duration::from_secs(420)),
+            "the task budget rides the provider HTTP request"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_provider_without_task_timeout_gets_the_generous_default() {
+        let captured = run_and_capture(
+            "nika: v1\nworkflow: w\nmodel: ollama/llama3.2\ntasks:\n  - id: ask\n    infer: { prompt: \"hello\" }\n",
+        )
+        .await;
+        assert_eq!(captured.len(), 1, "one provider round-trip");
+        // 300s — nika-providers' LOCAL_DEFAULT_TIMEOUT (pub(crate) there ·
+        // the ≥300s F1 acceptance floor pinned at the consumer seam).
+        assert_eq!(
+            captured[0].timeout,
+            Some(Duration::from_secs(300)),
+            "a local provider defaults to minutes, never the 30s cloud default"
+        );
     }
 }

--- a/crates/nika-runtime/src/errors.rs
+++ b/crates/nika-runtime/src/errors.rs
@@ -39,7 +39,12 @@ pub enum RuntimeError {
     /// class · spec 05) · engine-internal [`codes::NIKA_1702`] via
     /// [`NikaErrorCode::nika_code`] for diagnostics. The wire code is what
     /// `tasks.X.error.code` exposes — never the 1702 (spec 05 §142).
-    #[error("NIKA-VAR-001 · unresolved template reference `{reference}`")]
+    /// A `vars.*` reference carries the CLI fix (`--var key=value` · F4)
+    /// — the first thing a user with an unbound required var needs.
+    #[error(
+        "NIKA-VAR-001 · unresolved template reference `{reference}`{}",
+        var_cli_hint(.reference)
+    )]
     #[diagnostic(code(nika::runtime::unresolved_template))]
     UnresolvedTemplate {
         /// The reference inside the island (e.g. `tasks.ghost.output`).
@@ -97,6 +102,18 @@ pub enum RuntimeError {
         /// The binding-relative message (which `<name>` · the jq cause).
         message: String,
     },
+}
+
+/// The actionable suffix for an unresolved `vars.*` reference — the CLI
+/// is the fix a user can apply WITHOUT editing the workflow (`--var` ·
+/// F4). Non-`vars` references (tasks · secrets · env) get no suffix:
+/// their fixes are different classes.
+fn var_cli_hint(reference: &str) -> &'static str {
+    if reference.trim_start().starts_with("vars.") {
+        " — supply it with `nika run <file> --var <key>=<value>` or declare a `default:`"
+    } else {
+        ""
+    }
 }
 
 impl RuntimeError {
@@ -268,6 +285,24 @@ mod tests {
                 "{code} must resolve in the embedded spec table"
             );
         }
+    }
+
+    #[test]
+    fn vars_reference_carries_the_cli_fix_hint() {
+        // F4: an unbound `vars.*` reference must TEACH the fix the user
+        // can apply without editing the workflow (`--var key=value`).
+        let err = RuntimeError::UnresolvedTemplate {
+            reference: "vars.topic".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.starts_with("NIKA-VAR-001"), "{msg}");
+        assert!(msg.contains("--var"), "the CLI fix is named: {msg}");
+        // Non-vars references get no suffix — their fixes are different
+        // classes (a ghost task id is a workflow bug, not a CLI miss).
+        let task = RuntimeError::UnresolvedTemplate {
+            reference: "tasks.ghost.output".into(),
+        };
+        assert!(!task.to_string().contains("--var"), "{task}");
     }
 
     #[test]

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -154,6 +154,11 @@ pub struct Runtime<S, T, H, P, D, C> {
     /// the prior behavior); the composer injects an env/file resolver via
     /// [`Self::with_secret_resolver`].
     secrets: Arc<dyn WorkflowSecretResolver>,
+    /// Operator-supplied `vars:` values (`nika run --var key=value` · F4)
+    /// — merged OVER the envelope defaults at run start, so an override
+    /// wins and a `required: true` var without a default becomes
+    /// runnable. Empty by default (envelope defaults only).
+    var_overrides: BTreeMap<String, Value>,
 }
 
 impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
@@ -178,6 +183,7 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
             clock,
             config,
             secrets: Arc::new(secret::NoSecrets),
+            var_overrides: BTreeMap::new(),
         }
     }
 
@@ -187,6 +193,18 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
     #[must_use]
     pub fn with_secret_resolver(mut self, resolver: Arc<dyn WorkflowSecretResolver>) -> Self {
         self.secrets = resolver;
+        self
+    }
+
+    /// Inject operator-supplied `vars:` values (`nika run --var key=value`
+    /// · F4). Builder form — merged OVER the envelope defaults at run
+    /// start: an override wins against a declared `default:`, and a
+    /// `required: true` var without one becomes runnable from the CLI.
+    /// Keys are the composer's concern (the CLI validates them against
+    /// the workflow's declared `vars:` before composing).
+    #[must_use]
+    pub fn with_var_overrides(mut self, overrides: BTreeMap<String, Value>) -> Self {
+        self.var_overrides = overrides;
         self
     }
 }
@@ -304,7 +322,12 @@ where
         if !report.is_clean() {
             return Err(RuntimeError::DirtyReport);
         }
-        let (vars, workflow_name) = envelope_values(wf);
+        let (mut vars, workflow_name) = envelope_values(wf);
+        // Operator `--var` overrides win over the envelope defaults (F4) —
+        // and give a `required: true` var without a default its value.
+        for (key, value) in &self.var_overrides {
+            vars.insert(key.clone(), value.clone());
+        }
         // Resolve the `secrets:` namespace ONCE at run start (MINOR-B · the
         // injected composer resolver reads env/file). A miss leaves that
         // secret unbound → its `${{ secrets.X }}` reference raises NIKA-1702
@@ -842,6 +865,110 @@ outputs:
         assert!(
             !completed.fields.iter().any(|f| f.key == "warning"),
             "no warning on a clean success"
+        );
+    }
+}
+
+/// F4 — operator `--var` overrides through the REAL parse → check → run
+/// chain: an override wins over a declared `default:`, and a
+/// `required: true` var without one becomes runnable (before: the run
+/// could only die NIKA-VAR-001 at first reference).
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod var_override_tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+    use nika_verb_agent::AgentVerb;
+    use nika_verb_exec::ExecVerb;
+    use nika_verb_infer::InferVerb;
+    use nika_verb_invoke::InvokeVerb;
+    use serde_json::Value;
+
+    use crate::{DeterministicStamper, RunOutcome, Runtime, RuntimeConfig, VecSink};
+
+    const WORKFLOW: &str = r#"
+nika: v1
+workflow: var-override
+vars:
+  topic:
+    type: string
+    required: true
+  lang: { type: string, default: "en" }
+tasks:
+  - id: say
+    exec: { command: "echo ${{ vars.topic }}" }
+outputs:
+  topic_out: ${{ vars.topic }}
+  lang_out: ${{ vars.lang }}
+"#;
+
+    async fn run_with(overrides: BTreeMap<String, Value>) -> RunOutcome {
+        let wf = nika_schema::parse(
+            WORKFLOW,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(report.is_clean(), "fixture passes the ladder");
+
+        let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+        let runtime = Runtime::new(
+            ExecVerb::new(Arc::new(MockShell::new().enqueue_ok("said\n"))),
+            Arc::clone(&invoke),
+            InferVerb::new(registry, "mock/echo"),
+            AgentVerb::new(
+                Arc::new(MockProvider::new("mock")),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default(),
+        )
+        .with_var_overrides(overrides);
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        runtime
+            .run(&wf, &report, &mut stamper, &mut sink)
+            .await
+            .expect("clean run")
+    }
+
+    #[tokio::test]
+    async fn override_satisfies_a_required_var_and_beats_the_default() {
+        let overrides = BTreeMap::from([
+            ("topic".to_owned(), Value::String("rust".to_owned())),
+            ("lang".to_owned(), Value::String("fr".to_owned())),
+        ]);
+        let outcome = run_with(overrides).await;
+        assert!(outcome.ok, "the required var is satisfied → green run");
+        assert_eq!(outcome.outputs["topic_out"], "rust");
+        assert_eq!(
+            outcome.outputs["lang_out"], "fr",
+            "an override wins over the declared default"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_required_var_still_fails_var001_at_reference() {
+        // No override → the pre-F4 behavior is intact: the task's
+        // `${{ vars.topic }}` fails NIKA-VAR-001 (with the --var hint).
+        let outcome = run_with(BTreeMap::new()).await;
+        assert!(!outcome.ok, "unbound required var fails the task");
+        let record = &outcome.records["say"];
+        let error = record.error.as_ref().expect("task carries its error");
+        assert_eq!(error.code, "NIKA-VAR-001");
+        assert!(
+            error.message.contains("--var"),
+            "the message teaches the CLI fix: {}",
+            error.message
         );
     }
 }

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -397,9 +397,8 @@ where
         let outcome = {
             // The attempt loop borrows the accumulators; the borrow ends
             // when the loop future is consumed/dropped (both arms below).
-            // The task's ONE `timeout:` budget — enforced below as the
-            // attempt-loop total AND handed to the dispatch so the infer
-            // transport deadline cannot undercut it (F1).
+            // `budget` = the task's ONE `timeout:` — the total enforced
+            // below AND handed to dispatch (the infer transport · F1).
             let budget = task.timeout.as_ref().map(|t| t.value);
             let attempts = async {
                 let mut attempt = 1_u32;

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -397,10 +397,16 @@ where
         let outcome = {
             // The attempt loop borrows the accumulators; the borrow ends
             // when the loop future is consumed/dropped (both arms below).
+            // The task's ONE `timeout:` budget — enforced below as the
+            // attempt-loop total AND handed to the dispatch so the infer
+            // transport deadline cannot undercut it (F1).
+            let budget = task.timeout.as_ref().map(|t| t.value);
             let attempts = async {
                 let mut attempt = 1_u32;
                 loop {
-                    let dispatched = self.dispatch(&task.action, scope, &agent_buffer).await;
+                    let dispatched = self
+                        .dispatch(&task.action, scope, &agent_buffer, budget)
+                        .await;
                     note.clone_from(&dispatched.note);
                     attempt_marks.push(agent_buffer.len());
                     match dispatched.result {
@@ -432,7 +438,7 @@ where
                 }
             };
 
-            match task.timeout.as_ref().map(|t| t.value) {
+            match budget {
                 None => attempts.await,
                 Some(limit) => {
                     let attempts = std::pin::pin!(attempts);
@@ -522,7 +528,8 @@ where
         // outcome dropped by design) — a throwaway buffer satisfies the
         // dispatch seam; collecting it is a trigger-gated ratchet.
         let cleanup_buffer = crate::agent_events::BufferingObserver::new();
-        let attempt = std::pin::pin!(self.dispatch(&mini.action, scope, &cleanup_buffer));
+        let attempt =
+            std::pin::pin!(self.dispatch(&mini.action, scope, &cleanup_buffer, Some(limit)));
         let timer = std::pin::pin!(self.clock.sleep(limit));
         // Either way the outcome is dropped — cleanup observability is
         // the cleanup's own effects (e.g. `nika:emit` · spec 03).

--- a/crates/nika-verb-infer/public-api.txt
+++ b/crates/nika-verb-infer/public-api.txt
@@ -87,6 +87,7 @@ pub nika_verb_infer::InferInput::schema: core::option::Option<serde_json::value:
 pub nika_verb_infer::InferInput::system: core::option::Option<alloc::string::String>
 pub nika_verb_infer::InferInput::temperature: core::option::Option<f32>
 pub nika_verb_infer::InferInput::thinking_budget: core::option::Option<u32>
+pub nika_verb_infer::InferInput::timeout: core::option::Option<core::time::Duration>
 impl nika_verb_infer::InferInput
 pub fn nika_verb_infer::InferInput::new(prompt: impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for nika_verb_infer::InferInput

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -83,6 +83,12 @@ pub struct InferInput {
     pub schema: Option<serde_json::Value>,
     /// Extended-thinking token budget (spec `thinking.budget_tokens`).
     pub thinking_budget: Option<u32>,
+    /// The task-level `timeout:` budget (spec 03) — plumbed to the
+    /// provider transport deadline so the HTTP effect's fixed default
+    /// cannot undercut a longer task budget (F1 · a local model
+    /// routinely needs minutes). `None` → the adapter's per-provider
+    /// default governs.
+    pub timeout: Option<std::time::Duration>,
 }
 
 impl InferInput {
@@ -97,6 +103,7 @@ impl InferInput {
             max_tokens: None,
             schema: None,
             thinking_budget: None,
+            timeout: None,
         }
     }
 }
@@ -309,6 +316,10 @@ fn build_request(
     request.temperature = input.temperature;
     request.max_tokens = input.max_tokens;
     request.thinking_budget = input.thinking_budget;
+    // The task `timeout:` rides every round-trip of this task (schema
+    // retries included) — the OUTER attempt-loop budget still enforces
+    // the real total; this only stops the transport from undercutting it.
+    request.timeout = input.timeout;
     if let Some(schema) = &input.schema
         && native_schema
     {
@@ -561,6 +572,22 @@ mod tests {
             InferValue::Text(t) => assert!(t.contains("capital of France")),
             other => panic!("expected text, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn request_carries_the_task_timeout() {
+        // F1: the task `timeout:` must reach the provider transport
+        // deadline — unset stays None (the adapter's per-provider
+        // default governs).
+        let budget = std::time::Duration::from_secs(420);
+        let mut input = InferInput::new("q");
+        input.timeout = Some(budget);
+        let req = build_request(&input, "m", base_messages(&input, true), true);
+        assert_eq!(req.timeout, Some(budget));
+
+        let unset = InferInput::new("q");
+        let req = build_request(&unset, "m", base_messages(&unset, true), true);
+        assert_eq!(req.timeout, None, "no budget → adapter default governs");
     }
 
     #[test]

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -418,30 +418,72 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn structured_happy_path_through_the_noisy_echo() {
-        // mock echoes `mock(echo) · {prompt}` — the prompt IS the JSON, the
-        // balanced-span extraction digs it out of the prefix noise.
-        let mut input = InferInput::new(r#"{"name":"Ada","age":36}"#);
+    async fn structured_mock_synthesizes_a_conformant_instance() {
+        // F3: mock + `schema:` returns a SYNTHESIZED conformant instance
+        // (the echo could never satisfy a schema — every structured
+        // workflow on mock/echo died NIKA-INFER-002 · no offline CI).
+        let mut input = InferInput::new("extract the person");
         input.schema = Some(json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
-                "age": { "type": "integer" }
+                "age": { "type": "integer", "minimum": 0 }
             },
             "required": ["name", "age"]
         }));
         let out = mock_verb().run(input).await.expect("valid structured");
         match out.output {
-            InferValue::Structured(v) => assert_eq!(v["age"], 36),
+            InferValue::Structured(v) => {
+                assert_eq!(v["name"], "mock");
+                assert_eq!(v["age"], 0);
+            }
+            other => panic!("expected structured, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn structured_mock_handles_atlas_style_schemas() {
+        // The field-report class (payload-review · geo-audit): enum
+        // severity + bounded integers + arrays of typed objects must
+        // dry-run green offline — the F3 acceptance shape.
+        let mut input = InferInput::new("review the payload");
+        input.schema = Some(json!({
+            "type": "object",
+            "required": ["verdict", "score", "findings"],
+            "properties": {
+                "verdict": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
+                "score": { "type": "integer", "minimum": 0, "maximum": 12 },
+                "findings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["severity", "detail"],
+                        "properties": {
+                            "severity": { "type": "string", "enum": ["P0", "P1"] },
+                            "detail": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }));
+        let out = mock_verb().run(input).await.expect("dry-runs offline");
+        match out.output {
+            InferValue::Structured(v) => {
+                assert_eq!(v["verdict"], "P0", "enum → first entry");
+                assert_eq!(v["score"], 0, "bounded integer → minimum");
+                assert_eq!(v["findings"][0]["severity"], "P0");
+            }
             other => panic!("expected structured, got {other:?}"),
         }
     }
 
     #[tokio::test]
     async fn schema_retry_exhaustion_reports_attempts() {
-        // The echo of a prose prompt never validates → budget exhausted.
-        let mut input = InferInput::new("just prose, no json here");
-        input.schema = Some(json!({ "type": "object", "required": ["x"] }));
+        // A `pattern` is outside the mock generator's vocabulary — the
+        // synthesized "mock" never validates → budget exhausted (the
+        // retry loop itself stays covered post-F3).
+        let mut input = InferInput::new("give me a year");
+        input.schema = Some(json!({ "type": "string", "pattern": "^\\d{4}$" }));
         let err = mock_verb().run(input).await.expect_err("never validates");
         match err {
             VerbInferError::SchemaValidation { attempts, .. } => {
@@ -454,8 +496,8 @@ mod tests {
 
     #[tokio::test]
     async fn zero_retry_budget_is_single_shot() {
-        let mut input = InferInput::new("prose");
-        input.schema = Some(json!({ "type": "object", "required": ["x"] }));
+        let mut input = InferInput::new("give me a year");
+        input.schema = Some(json!({ "type": "string", "pattern": "^\\d{4}$" }));
         let err = mock_verb()
             .with_schema_retry_budget(0)
             .run(input)

--- a/crates/nika-verb-infer/src/structured.rs
+++ b/crates/nika-verb-infer/src/structured.rs
@@ -186,8 +186,10 @@ mod tests {
 
     #[test]
     fn json_embedded_in_prose_is_extracted() {
-        // The mock provider echoes `mock(model) · {prompt}` — the balanced-span
-        // layer is what makes the deterministic happy path work end-to-end.
+        // Real models wrap JSON in prose (`Here's the data: {...}`) — the
+        // balanced-span layer digs it out. (The mock provider synthesizes
+        // pure JSON for schema requests since F3; this layer serves the
+        // REAL providers' noisy replies.)
         let text = r#"mock(echo) · {"name":"Ada","age":36}"#;
         assert!(matches!(
             extract_and_validate(text, &validator(&person_schema())),


### PR DESCRIPTION
First external-style dogfooding of nika 0.92 (4 production workflows in the atlas repo · real e2e). 5 commits, full gates green (3069 lib tests · pre-push suite).

- **F1** task `timeout:` governs the provider HTTP deadline · local provider classes default ≥300s · proof: ollama qwen2.5:14b green in 46.8s past the old 30s 408
- **F3** mock synthesizes schema-conformant output → every schema workflow runs offline (the CI story) · proof: 4/4 atlas workflows green under mock
- **F4** repeatable `nika run --var key=value` · unknown-key refused pre-run · VAR-001 hint names the flag
- **F5** embedded sitemap examples bind the root array (`map(.loc)`) · manifest hashes recomputed 27/27

Field report: `ventures/nika/01-product/strategy/2026-07-04-nika-next-version-field-improvements.md` (private monorepo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)