### PR TITLE
CLI wow: wave-group inspect, live lanes + ms, waterfall, verdict card

### DIFF
--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -175,6 +175,168 @@ pub fn waterfall(view: &RunView, theme: &Theme) -> Vec<String> {
     lines
 }
 
+/// Widest the verdict card grows (inner cells) — 2-indent + corners keeps
+/// the line ≤ 64, comfortably shareable.
+const CARD_INNER_CAP: usize = 58;
+
+/// The wave sizes the shape glyph speaks: the injected plan when the run
+/// provided one (the scheduler's truth), else reconstructed by chaining
+/// overlapping intervals in start order (a replayed trace's best honest
+/// read — only tasks that RAN count).
+fn wave_sizes(view: &RunView) -> Vec<usize> {
+    if let Some(plan) = view.plan() {
+        return plan.iter().map(Vec::len).collect();
+    }
+    let now = view.last_ts_ms();
+    let mut ivs: Vec<Interval> = view
+        .rows()
+        .iter()
+        .filter_map(|r| interval_of(r, now))
+        .collect();
+    ivs.sort_by_key(|iv| (iv.start, iv.end));
+    let mut sizes = Vec::new();
+    let mut group_end: Option<i64> = None;
+    for iv in ivs {
+        match (group_end, sizes.last_mut()) {
+            (Some(end), Some(last)) if iv.start <= end => {
+                *last += 1;
+                group_end = Some(end.max(iv.end));
+            }
+            _ => {
+                sizes.push(1);
+                group_end = Some(iv.end);
+            }
+        }
+    }
+    sizes
+}
+
+/// The mini DAG-shape glyph (design §2d): wave sizes as diamond runs
+/// joined by flow arrows — `◆◆◆ ⇉ ◆` (`###` ` => ` `#` in ASCII).
+/// Unique per workflow shape, instantly recognizable. Wide waves cap at
+/// five diamonds (`◆◆◆◆◆+`), long chains at six waves (`… `-tailed).
+#[must_use]
+pub fn dag_shape(view: &RunView, theme: &Theme) -> String {
+    let (diamond, arrow, plus, tail) = if theme.ascii {
+        ("#", " => ", "+", "...")
+    } else {
+        ("◆", " ⇉ ", "+", "…")
+    };
+    let sizes = wave_sizes(view);
+    let mut runs: Vec<String> = sizes
+        .iter()
+        .take(6)
+        .map(|&n| {
+            let mut run = diamond.repeat(n.min(5));
+            if n > 5 {
+                run.push_str(plus);
+            }
+            run
+        })
+        .collect();
+    if sizes.len() > 6 {
+        runs.push(tail.to_owned());
+    }
+    runs.join(arrow)
+}
+
+/// The shareable verdict card (design §2d) — the run's signature frame:
+/// the DAG-shape glyph, the totals (tasks · waves · retries · wall ·
+/// spend · models), and the caller's outputs note when one applies.
+/// Renders nothing before a verdict (a card mid-run would lie).
+#[must_use]
+pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -> Vec<String> {
+    let Some(ok) = view.verdict else {
+        return Vec::new();
+    };
+    let (tl, tr, bl, br, h, v) = if theme.ascii {
+        ('+', '+', '+', '+', '-', '|')
+    } else {
+        ('╭', '╮', '╰', '╯', '─', '│')
+    };
+    let mark_raw = match (ok, theme.ascii) {
+        (true, false) => "✓",
+        (true, true) => "OK",
+        (false, false) => "✖",
+        (false, true) => "X",
+    };
+    let title_raw = format!("{h} nika {mark_raw} {} ", view.workflow);
+
+    let waves = wave_sizes(view).len();
+    let mut rows = vec![
+        format!(
+            "{}    {} tasks · {waves} waves · {} retries",
+            dag_shape(view, theme),
+            view.rows().len(),
+            view.retries,
+        ),
+        totals_row(view),
+    ];
+    if let Some(note) = outputs_note {
+        rows.push(note.to_owned());
+    }
+
+    let inner = rows
+        .iter()
+        .map(|r| r.chars().count() + 4)
+        .chain(std::iter::once(title_raw.chars().count() + 1))
+        .max()
+        .unwrap_or(0)
+        .min(CARD_INNER_CAP);
+    let ellipsis = if theme.ascii { "~" } else { "…" };
+    let fill: String =
+        std::iter::repeat_n(h, inner.saturating_sub(title_raw.chars().count())).collect();
+    let mark_role = if ok { Role::Good } else { Role::Bad };
+    let title = format!(
+        "{h} nika {} {} ",
+        theme.paint(mark_role, mark_raw),
+        theme.paint(Role::Strong, &view.workflow),
+    );
+    let mut lines = vec![format!("  {tl}{title}{fill}{tr}")];
+    for row in &rows {
+        let fitted = fit_cells(row, inner.saturating_sub(4), ellipsis);
+        let pad = inner
+            .saturating_sub(4)
+            .saturating_sub(fitted.chars().count());
+        lines.push(format!("  {v}  {fitted}{}  {v}", " ".repeat(pad)));
+    }
+    let bottom: String = std::iter::repeat_n(h, inner).collect();
+    lines.push(format!("  {bl}{bottom}{br}"));
+    lines
+}
+
+/// The card's totals row: wall time · spend · the models the stream
+/// named (the fold kept them off the `infer · <model>` / `agent ·
+/// <model>` notes — rendered only when the stream actually said them).
+fn totals_row(view: &RunView) -> String {
+    let mut row = format!("{} · ${:.4}", fmt_wall_ms(view.elapsed_ms), view.cost_usd);
+    let mut models: Vec<&str> = Vec::new();
+    for r in view.rows() {
+        if let Some(m) = r.model.as_deref()
+            && !models.contains(&m)
+        {
+            models.push(m);
+        }
+    }
+    for m in models.iter().take(2) {
+        row.push_str(" · ");
+        row.push_str(m);
+    }
+    row
+}
+
+/// Truncate to `width` display cells with a theme-true mark — the card
+/// border never breaks on an overlong outputs note.
+fn fit_cells(s: &str, width: usize, ellipsis: &str) -> String {
+    if s.chars().count() <= width {
+        return s.to_owned();
+    }
+    let keep = width.saturating_sub(ellipsis.chars().count());
+    let mut out: String = s.chars().take(keep).collect();
+    out.push_str(ellipsis);
+    out
+}
+
 /// A wall duration for humans: `12ms` · `3.2s` · `2m04s`. Sub-second
 /// stays in milliseconds (the mock-run scale), minutes keep the seconds.
 #[must_use]
@@ -399,6 +561,111 @@ mod tests {
             !lines.iter().any(|l| l.contains("late")),
             "cancelled never bars: {lines:?}"
         );
+    }
+
+    /// The card speaks the plan's shape when one was injected: wave sizes
+    /// become diamond runs joined by flow arrows — the signature glyph.
+    #[test]
+    fn dag_shape_reads_the_plan_first() {
+        let mut view = RunView::new();
+        for e in demo::success() {
+            view.apply(&e);
+        }
+        // Reconstructed (no plan): the demo ran strictly sequentially.
+        assert_eq!(dag_shape(&view, &PLAIN), "◆ ⇉ ◆ ⇉ ◆ ⇉ ◆");
+        // The scheduler's truth: 3 parallel sources then the join.
+        view.set_plan(vec![
+            vec!["a".into(), "b".into(), "c".into()],
+            vec!["join".into()],
+        ]);
+        assert_eq!(dag_shape(&view, &PLAIN), "◆◆◆ ⇉ ◆");
+        assert_eq!(dag_shape(&view, &ASCII), "### => #");
+    }
+
+    /// Wide waves cap at five diamonds (+), long chains at six waves (…).
+    #[test]
+    fn dag_shape_caps_width_and_length() {
+        let mut view = RunView::new();
+        view.apply(&ev(EventKind::WorkflowCompleted, 0, &[]));
+        view.set_plan(vec![vec!["t".into(); 8], vec!["x".into()]]);
+        assert_eq!(dag_shape(&view, &PLAIN), "◆◆◆◆◆+ ⇉ ◆");
+        view.set_plan(vec![vec!["t".into()]; 8]);
+        assert_eq!(dag_shape(&view, &PLAIN), "◆ ⇉ ◆ ⇉ ◆ ⇉ ◆ ⇉ ◆ ⇉ ◆ ⇉ …");
+    }
+
+    /// Golden verdict card — the shareable frame: shape glyph · totals ·
+    /// the models the stream named · the caller's outputs note. Borders
+    /// stay intact (padded to one inner width) in both themes.
+    #[test]
+    fn verdict_card_is_the_shareable_frame() {
+        let mut view = RunView::new();
+        for e in demo::success() {
+            view.apply(&e);
+        }
+        view.set_plan(vec![
+            vec!["fetch_top".into(), "extract_ai".into(), "summarize".into()],
+            vec!["write_md".into()],
+            vec!["notify_slack".into()],
+        ]);
+        let lines = verdict_card(&view, &PLAIN, Some("outputs → review (object)"));
+        assert_eq!(lines.len(), 5, "top + 3 rows + bottom: {lines:?}");
+        assert!(
+            lines[0].starts_with("  ╭─ nika ✓ veille-news ─"),
+            "{lines:?}"
+        );
+        assert!(lines[0].ends_with('╮'), "{lines:?}");
+        assert!(
+            lines[1].contains("◆◆◆ ⇉ ◆ ⇉ ◆") && lines[1].contains("5 tasks · 3 waves · 0 retries"),
+            "{lines:?}"
+        );
+        assert!(
+            lines[2].contains("4.7s · $0.0110 · claude-sonnet"),
+            "totals + the model the stream named: {lines:?}"
+        );
+        assert!(lines[3].contains("outputs → review (object)"), "{lines:?}");
+        assert!(
+            lines[4].starts_with("  ╰─") && lines[4].ends_with('╯'),
+            "{lines:?}"
+        );
+        // Every border row closes at the SAME column (the box holds).
+        let widths: Vec<usize> = lines.iter().map(|l| l.chars().count()).collect();
+        assert!(
+            widths.iter().all(|w| *w == widths[0]),
+            "aligned card: {widths:?} {lines:?}"
+        );
+
+        // ASCII parity: corners + mark + shape glyph, zero unicode leaks.
+        let ascii = verdict_card(&view, &ASCII, None);
+        assert!(
+            ascii[0].starts_with("  +- nika OK veille-news -"),
+            "{ascii:?}"
+        );
+        assert!(ascii[1].contains("### => # => #"), "{ascii:?}");
+        for glyph in ['╭', '╮', '╰', '╯', '─', '│', '◆', '⇉', '✓'] {
+            assert!(
+                !ascii.iter().any(|l| l.contains(glyph)),
+                "unicode {glyph} leaked into --ascii: {ascii:?}"
+            );
+        }
+    }
+
+    /// A failed run cards the ✖ mark; a run with no verdict cards nothing
+    /// (mid-run frames must never carry a verdict card).
+    #[test]
+    fn verdict_card_marks_failure_and_stays_silent_mid_run() {
+        let mut view = RunView::new();
+        for e in demo::failure() {
+            view.apply(&e);
+        }
+        let lines = verdict_card(&view, &PLAIN, None);
+        assert!(lines[0].contains("✖ veille-news"), "{lines:?}");
+
+        let mut mid = RunView::new();
+        for e in demo::retrying() {
+            mid.apply(&e);
+        }
+        assert!(mid.verdict.is_none());
+        assert!(verdict_card(&mid, &PLAIN, None).is_empty());
     }
 
     #[test]

--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -11,6 +11,11 @@
 //! from that one reconstruction.
 
 use crate::display::state::{RunView, TaskRow, TaskState};
+use crate::display::theme::{Role, Theme};
+
+/// Bar-region width of the waterfall (cells) — with the id + duration
+/// columns a typical frame stays graceful under 80 columns.
+const BAR_WIDTH: usize = 34;
 
 /// One task's reconstructed wall interval on the run's timeline (unix ms).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +89,90 @@ pub(crate) fn lane_marks(view: &RunView) -> Vec<bool> {
             })
         })
         .collect()
+}
+
+/// The post-run waterfall (design §2c): one wall-time-scaled bar per task
+/// that RAN, offsets showing the REAL overlap — a pure fold of the trace
+/// (the same interval reconstruction as the lane markers · zero new
+/// instrumentation). A time axis closes the chart. Fewer than two ran
+/// tasks render nothing (a solo bar is noise, same law as the anatomy's
+/// analysis footer).
+#[must_use]
+pub fn waterfall(view: &RunView, theme: &Theme) -> Vec<String> {
+    let now = view.last_ts_ms();
+    let ran: Vec<(&TaskRow, Interval)> = view
+        .rows()
+        .iter()
+        .filter_map(|r| interval_of(r, now).map(|iv| (r, iv)))
+        .collect();
+    if ran.len() < 2 {
+        return Vec::new();
+    }
+    let Some(t0) = ran.iter().map(|(_, iv)| iv.start).min() else {
+        return Vec::new();
+    };
+    let Some(t1) = ran.iter().map(|(_, iv)| iv.end).max() else {
+        return Vec::new();
+    };
+    let span = t1.saturating_sub(t0).max(1);
+    let (edge_l, edge_r, bar, dot) = if theme.ascii {
+        ('[', ']', '#', '.')
+    } else {
+        ('▕', '▏', '█', '·')
+    };
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    // display geometry — ±1 cell is invisible, the tests pin the rounding
+    let cell = |ts: i64| -> usize {
+        ((ts.saturating_sub(t0)) as f64 / span as f64 * BAR_WIDTH as f64).round() as usize
+    };
+
+    let id_w = ran
+        .iter()
+        .map(|(r, _)| r.id.chars().count())
+        .max()
+        .unwrap_or(0);
+    let durs: Vec<String> = ran
+        .iter()
+        .map(|(_, iv)| fmt_wall_ms(u64::try_from(iv.end.saturating_sub(iv.start)).unwrap_or(0)))
+        .collect();
+    let time_w = durs.iter().map(|d| d.chars().count()).max().unwrap_or(0);
+
+    let mut lines = Vec::with_capacity(ran.len() + 1);
+    for ((row, iv), dur) in ran.iter().zip(&durs) {
+        let off = cell(iv.start).min(BAR_WIDTH - 1);
+        let len = cell(iv.end).saturating_sub(off).clamp(1, BAR_WIDTH - off);
+        let role = match row.state {
+            TaskState::Failed => Role::Bad,
+            TaskState::Running | TaskState::Retrying => Role::Accent,
+            _ => Role::Good,
+        };
+        let mut line = format!(
+            "  {:<id_w$}  {edge_l}{}{}{edge_r}",
+            row.id,
+            " ".repeat(off),
+            theme.paint(role, &bar.to_string().repeat(len)),
+        );
+        line.push_str(&" ".repeat(BAR_WIDTH - off - len));
+        line.push_str("  ");
+        line.push_str(&theme.paint(Role::Dim, &format!("{dur:>time_w$}")));
+        if let Some(cost) = row.cost_usd {
+            line.push_str(&theme.paint(Role::Dim, &format!(" · ${cost:.4}")));
+        }
+        lines.push(line);
+    }
+    // The axis: `0s` under the id column, dots to the bar region's close,
+    // the run's total span at the end.
+    let total = fmt_wall_ms(u64::try_from(span).unwrap_or(0));
+    let dots = (id_w + BAR_WIDTH).saturating_sub(total.chars().count());
+    lines.push(theme.paint(
+        Role::Dim,
+        &format!("  0s {} {total}", dot.to_string().repeat(dots)),
+    ));
+    lines
 }
 
 /// A wall duration for humans: `12ms` · `3.2s` · `2m04s`. Sub-second
@@ -216,6 +305,100 @@ mod tests {
         );
         let marks = lane_marks(&view);
         assert!(marks[2] && marks[3], "running ∥ settled sibling: {marks:?}");
+    }
+
+    const PLAIN: Theme = Theme {
+        color: false,
+        ascii: false,
+        animate: false,
+    };
+    const ASCII: Theme = Theme {
+        color: false,
+        ascii: true,
+        animate: false,
+    };
+
+    /// Golden waterfall — bars scale to wall time, offsets carry the real
+    /// sequencing, the axis closes the chart (design §2c geometry pinned:
+    /// a mutated scale factor draws a wrong-but-plausible chart).
+    #[test]
+    fn waterfall_scales_bars_and_offsets() {
+        let mut view = RunView::new();
+        // a ran [0, 1000] (stamp span) · b ran [1000, 1500] after it.
+        view.apply(&ev(EventKind::TaskStarted, 0, &[("task", s("a"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 1000, &[("task", s("a"))]));
+        view.apply(&ev(EventKind::TaskStarted, 1000, &[("task", s("b"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 1500, &[("task", s("b"))]));
+
+        let lines = waterfall(&view, &PLAIN);
+        assert_eq!(lines.len(), 3, "two bars + the axis: {lines:?}");
+        // span 1500 over 34 cells: a = cells 0..23 · b = cells 23..34.
+        assert_eq!(
+            lines[0],
+            format!("  a  ▕{}▏{}   1.0s", "█".repeat(23), " ".repeat(11)),
+        );
+        assert_eq!(
+            lines[1],
+            format!("  b  ▕{}{}▏  500ms", " ".repeat(23), "█".repeat(11)),
+        );
+        assert_eq!(lines[2], format!("  0s {} 1.5s", "·".repeat(31)));
+    }
+
+    /// ASCII parity for every waterfall glyph (▕█▏ → [#] · axis dots → .)
+    /// and the solo-run silence (a single bar is noise, not insight).
+    #[test]
+    fn waterfall_ascii_parity_and_solo_silence() {
+        let mut view = RunView::new();
+        view.apply(&ev(EventKind::TaskStarted, 0, &[("task", s("only"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 100, &[("task", s("only"))]));
+        assert!(
+            waterfall(&view, &PLAIN).is_empty(),
+            "one ran task → no waterfall"
+        );
+
+        view.apply(&ev(EventKind::TaskStarted, 100, &[("task", s("next"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 400, &[("task", s("next"))]));
+        let lines = waterfall(&view, &ASCII);
+        assert_eq!(lines.len(), 3);
+        assert!(
+            lines[0].contains('[') && lines[0].contains('#'),
+            "{lines:?}"
+        );
+        assert!(lines[2].starts_with("  0s ."), "{lines:?}");
+        for line in &lines {
+            for glyph in ['▕', '▏', '█', '·'] {
+                assert!(
+                    !line.contains(glyph),
+                    "unicode {glyph} leaked into --ascii: {line}"
+                );
+            }
+        }
+    }
+
+    /// Skipped/cancelled rows never bar (they did not run) and a failed
+    /// row keeps its per-task spend on the chart.
+    #[test]
+    fn waterfall_charts_only_ran_rows() {
+        let mut view = RunView::new();
+        view.apply(&ev(EventKind::TaskStarted, 0, &[("task", s("work"))]));
+        view.apply(&ev(
+            EventKind::TaskFailed,
+            800,
+            &[("task", s("work")), ("cost_usd", Value::Float(0.002))],
+        ));
+        view.apply(&ev(EventKind::TaskStarted, 800, &[("task", s("more"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 900, &[("task", s("more"))]));
+        view.apply(&ev(EventKind::TaskCancelled, 900, &[("task", s("late"))]));
+        let lines = waterfall(&view, &PLAIN);
+        assert_eq!(lines.len(), 3, "two ran bars + axis (no cancelled bar)");
+        assert!(
+            lines[0].contains("work") && lines[0].ends_with("· $0.0020"),
+            "failed row bars + keeps its spend: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("late")),
+            "cancelled never bars: {lines:?}"
+        );
     }
 
     #[test]

--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Execution-flow reads over the folded [`RunView`] — pure functions of
+//! the event stream (the fold law), zero new instrumentation.
+//!
+//! The stream stamps task frames at SETTLE time while the runtime measures
+//! the REAL wall duration per task (`duration_ms`), so each task's
+//! interval is reconstructed as `[end − duration, end]`: real widths,
+//! honest overlap. Everything here (lane markers · durations) derives
+//! from that one reconstruction.
+
+use crate::display::state::{RunView, TaskRow, TaskState};
+
+/// One task's reconstructed wall interval on the run's timeline (unix ms).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Interval {
+    /// Reconstructed start (`end − duration` · else the started stamp).
+    pub start: i64,
+    /// The terminal stamp (or "now" for a still-running task).
+    pub end: i64,
+}
+
+impl Interval {
+    /// Inclusive overlap — zero-width intervals (sub-millisecond tasks)
+    /// at the same stamp still count as concurrent.
+    fn overlaps(self, other: Self) -> bool {
+        self.start <= other.end && other.start <= self.end
+    }
+}
+
+/// Reconstruct one row's interval. A terminal row anchors on its end
+/// stamp minus the measured duration; a RUNNING row spans its start
+/// stamp to `now` (the latest stamp the fold has seen). Rows that never
+/// ran (pending · skipped · cancelled-before-start) have no interval.
+pub(crate) fn interval_of(row: &TaskRow, now_ms: Option<i64>) -> Option<Interval> {
+    match row.state {
+        TaskState::Ok | TaskState::Failed => {
+            let end = row.ended_ms?;
+            let start = row
+                .wall_ms()
+                .and_then(|d| end.checked_sub(i64::try_from(d).ok()?))
+                .or(row.started_ms)?;
+            Some(Interval { start, end })
+        }
+        TaskState::Running | TaskState::Retrying => {
+            let start = row.started_ms?;
+            let end = now_ms.unwrap_or(start).max(start);
+            Some(Interval { start, end })
+        }
+        TaskState::Pending | TaskState::Skipped | TaskState::Cancelled => None,
+    }
+}
+
+/// The `∥` lane markers: for each row, did it ACTUALLY run concurrently
+/// with a sibling? With an injected wave plan, siblings = same-wave tasks
+/// (the scheduler's truth); without one (a replayed trace), any
+/// overlapping task counts. Marks derive from reconstructed intervals —
+/// a wave whose members happened to run sequentially earns no marker.
+pub(crate) fn lane_marks(view: &RunView) -> Vec<bool> {
+    let now = view.last_ts_ms();
+    let rows = view.rows();
+    let intervals: Vec<Option<Interval>> = rows.iter().map(|r| interval_of(r, now)).collect();
+    let wave_of = |id: &str| -> Option<usize> {
+        view.plan()?
+            .iter()
+            .position(|wave| wave.iter().any(|t| t == id))
+    };
+    rows.iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let Some(a) = intervals[i] else { return false };
+            let my_wave = wave_of(&row.id);
+            rows.iter().enumerate().any(|(j, other)| {
+                if i == j {
+                    return false;
+                }
+                let Some(b) = intervals[j] else { return false };
+                // Plan present on BOTH sides → same-wave siblings only.
+                match (my_wave, wave_of(&other.id)) {
+                    (Some(w1), Some(w2)) if w1 != w2 => false,
+                    _ => a.overlaps(b),
+                }
+            })
+        })
+        .collect()
+}
+
+/// A wall duration for humans: `12ms` · `3.2s` · `2m04s`. Sub-second
+/// stays in milliseconds (the mock-run scale), minutes keep the seconds.
+#[must_use]
+pub fn fmt_wall_ms(ms: u64) -> String {
+    if ms < 1_000 {
+        return format!("{ms}ms");
+    }
+    if ms < 60_000 {
+        #[allow(clippy::cast_precision_loss)] // display-only seconds
+        return format!("{:.1}s", ms as f64 / 1000.0);
+    }
+    format!("{}m{:02}s", ms / 60_000, (ms % 60_000) / 1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::demo;
+    use nika_event::EventKind;
+    use nika_types::resource::{KeyValue, Value};
+
+    fn ev(kind: EventKind, ms: u64, fields: &[(&str, Value)]) -> nika_event::Event {
+        let mut e = demo::bare_event(kind, ms);
+        for (k, v) in fields {
+            e = e.with_field(KeyValue::new(*k, v.clone()));
+        }
+        e
+    }
+
+    fn s(v: &str) -> Value {
+        Value::String(v.to_owned())
+    }
+
+    /// Two settle-stamped siblings with REAL durations reconstruct to
+    /// overlapping intervals (∥ both) while a downstream task that ran
+    /// after them stays unmarked — the ∥ law on the settle-time stream.
+    #[test]
+    fn lane_marks_flag_reconstructed_overlap_only() {
+        let mut view = RunView::new();
+        // Wave 1: a + b dispatched concurrently · both settle at ~1000ms
+        // with real durations 900/850 → intervals [100,1000] · [150,1000].
+        for (task, dur, end) in [("a", 900i64, 1000u64), ("b", 850, 1000)] {
+            view.apply(&ev(EventKind::TaskStarted, end, &[("task", s(task))]));
+            view.apply(&ev(
+                EventKind::TaskCompleted,
+                end,
+                &[("task", s(task)), ("duration_ms", Value::Int(dur))],
+            ));
+        }
+        // Wave 2: c ran strictly after · [1010, 1500].
+        view.apply(&ev(EventKind::TaskStarted, 1500, &[("task", s("c"))]));
+        view.apply(&ev(
+            EventKind::TaskCompleted,
+            1500,
+            &[("task", s("c")), ("duration_ms", Value::Int(490))],
+        ));
+        assert_eq!(lane_marks(&view), vec![true, true, false]);
+    }
+
+    /// The wave plan SCOPES the marker: tasks in different waves never
+    /// mark each other even when their reconstructed intervals touch
+    /// (the zero-width mock-run case: everything stamps the same ms).
+    #[test]
+    fn plan_scopes_marks_to_wave_siblings() {
+        let mut view = RunView::new();
+        for task in ["a", "b", "c"] {
+            view.apply(&ev(EventKind::TaskStarted, 100, &[("task", s(task))]));
+            view.apply(&ev(
+                EventKind::TaskCompleted,
+                100,
+                &[("task", s(task)), ("duration_ms", Value::Int(0))],
+            ));
+        }
+        // Without a plan every zero-width interval touches every other.
+        assert_eq!(lane_marks(&view), vec![true, true, true]);
+        // The plan says c runs alone in wave 2 → its touch is scheduling
+        // adjacency, not concurrency.
+        view.set_plan(vec![
+            vec!["a".to_owned(), "b".to_owned()],
+            vec!["c".to_owned()],
+        ]);
+        assert_eq!(lane_marks(&view), vec![true, true, false]);
+    }
+
+    /// The demo storyboard is strictly sequential — no row earns a mark
+    /// (golden frames stay marker-free by construction).
+    #[test]
+    fn demo_storyboard_has_no_concurrency() {
+        let mut view = RunView::new();
+        for e in demo::success() {
+            view.apply(&e);
+        }
+        assert!(lane_marks(&view).iter().all(|m| !m));
+    }
+
+    /// Rows that never ran reconstruct no interval — and a RUNNING row
+    /// spans to "now" so it can overlap an already-settled sibling.
+    #[test]
+    fn interval_reconstruction_covers_the_states() {
+        let mut view = RunView::new();
+        view.apply(&ev(EventKind::TaskScheduled, 0, &[("task", s("p"))]));
+        view.apply(&ev(EventKind::TaskSkipped, 5, &[("task", s("skip"))]));
+        view.apply(&ev(EventKind::TaskStarted, 10, &[("task", s("live"))]));
+        view.apply(&ev(EventKind::TaskStarted, 400, &[("task", s("done"))]));
+        view.apply(&ev(
+            EventKind::TaskCompleted,
+            400,
+            &[("task", s("done")), ("duration_ms", Value::Int(300))],
+        ));
+        let rows = view.rows();
+        let now = view.last_ts_ms();
+        assert!(interval_of(&rows[0], now).is_none(), "pending: no interval");
+        assert!(interval_of(&rows[1], now).is_none(), "skipped: no interval");
+        // live: [10, now=400] · done: [100, 400] → they overlap.
+        assert_eq!(
+            interval_of(&rows[2], now),
+            Some(Interval {
+                start: 10,
+                end: 400
+            })
+        );
+        assert_eq!(
+            interval_of(&rows[3], now),
+            Some(Interval {
+                start: 100,
+                end: 400
+            })
+        );
+        let marks = lane_marks(&view);
+        assert!(marks[2] && marks[3], "running ∥ settled sibling: {marks:?}");
+    }
+
+    #[test]
+    fn wall_format_scales() {
+        assert_eq!(fmt_wall_ms(0), "0ms");
+        assert_eq!(fmt_wall_ms(12), "12ms");
+        assert_eq!(fmt_wall_ms(999), "999ms");
+        assert_eq!(fmt_wall_ms(1_000), "1.0s");
+        assert_eq!(fmt_wall_ms(3_200), "3.2s");
+        assert_eq!(fmt_wall_ms(59_949), "59.9s");
+        assert_eq!(fmt_wall_ms(124_000), "2m04s");
+    }
+}

--- a/crates/nika-cli/src/display/mod.rs
+++ b/crates/nika-cli/src/display/mod.rs
@@ -2,8 +2,10 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
 //! The display module — fold (`state`) · glyphs/colour (`theme`) · frames
-//! (`render`). One truth in, text out; no I/O lives here.
+//! (`render`) · execution-flow reads (`flow`). One truth in, text out; no
+//! I/O lives here.
 
+pub mod flow;
 pub mod render;
 pub mod state;
 pub mod theme;

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -5,8 +5,13 @@
 //! lines`. No I/O here: the replay loop owns the terminal, this module owns
 //! the truth-to-text mapping. Snapshot tests pin BOTH glyph themes.
 
-use crate::display::state::{RunView, TaskState};
+use crate::display::flow::{fmt_wall_ms, lane_marks};
+use crate::display::state::{RunView, TaskRow, TaskState};
 use crate::display::theme::{Role, Theme};
+
+/// Widest the note column grows before the time column floats free —
+/// keeps a typical frame graceful under 80 columns.
+const NOTE_COL_CAP: usize = 40;
 
 /// Render one frame of the run card.
 #[must_use]
@@ -36,21 +41,36 @@ pub fn frame(view: &RunView, theme: &Theme, tick: usize) -> Vec<String> {
     }
     lines.push(String::new());
 
-    // Task rows — stable order, aligned ids, notes dimmed.
+    // Task rows — stable order, aligned ids, notes dimmed. Time and cost
+    // are first-class columns: a settled row carries its REAL wall time
+    // (+ per-task spend when the stream reported one), a running row its
+    // live elapsed, and `∥` marks wave-siblings that actually overlapped.
     let width = view.rows().iter().map(|r| r.id.len()).max().unwrap_or(8);
-    for row in view.rows() {
-        let mut note = row.note.clone();
-        if row.state == TaskState::Running && !view.token_samples.is_empty() {
-            let spark = theme.sparkline(&view.token_samples);
-            if !spark.is_empty() {
-                note = format!("{note} {spark}");
-            }
-        }
-        lines.push(format!(
-            "  {} {:<width$}  {}",
-            theme.glyph(row.state, tick),
-            row.id,
-            theme.paint(Role::Dim, &note),
+    let marks = lane_marks(view);
+    let times: Vec<Option<String>> = view.rows().iter().map(|r| row_wall(r, view)).collect();
+    let note_w = view
+        .rows()
+        .iter()
+        .map(|r| r.note.chars().count())
+        .max()
+        .unwrap_or(0)
+        .min(NOTE_COL_CAP);
+    let time_w = times
+        .iter()
+        .flatten()
+        .map(|t| t.chars().count())
+        .max()
+        .unwrap_or(0);
+    for (i, row) in view.rows().iter().enumerate() {
+        let mark = marks.get(i).copied().unwrap_or(false);
+        lines.push(task_line(
+            row,
+            view,
+            theme,
+            tick,
+            (width, note_w, time_w),
+            times[i].as_deref(),
+            mark,
         ));
     }
 
@@ -77,6 +97,70 @@ pub fn frame(view: &RunView, theme: &Theme, tick: usize) -> Vec<String> {
         append_failure_card(&mut lines, view, theme);
     }
     lines
+}
+
+/// The wall-time cell for one row: a settled row's REAL duration (the
+/// runtime-measured `duration_ms` · else the stamp span), a running or
+/// retrying row's LIVE elapsed against the latest stamp the fold has
+/// seen. Rows that never ran show nothing — never an invented number.
+fn row_wall(row: &TaskRow, view: &RunView) -> Option<String> {
+    match row.state {
+        TaskState::Ok | TaskState::Failed => row.wall_ms().map(fmt_wall_ms),
+        TaskState::Running | TaskState::Retrying => {
+            let start = row.started_ms?;
+            let now = view.last_ts_ms()?;
+            Some(fmt_wall_ms(u64::try_from(now.saturating_sub(start)).ok()?))
+        }
+        TaskState::Pending | TaskState::Skipped | TaskState::Cancelled => None,
+    }
+}
+
+/// Assemble one storyboard row: glyph · id · dimmed note · then the
+/// time/cost/lane suffix, column-aligned on RAW (pre-paint) widths so
+/// ANSI escapes never skew the layout. Rows with no suffix keep the
+/// legacy shape exactly (no trailing padding).
+// `&Theme` to match the `frame` borrow that threads it here — the same
+// one-calling-convention rationale as `append_failure_card`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn task_line(
+    row: &TaskRow,
+    view: &RunView,
+    theme: &Theme,
+    tick: usize,
+    (id_w, note_w, time_w): (usize, usize, usize),
+    time: Option<&str>,
+    mark: bool,
+) -> String {
+    let mut note = row.note.clone();
+    if row.state == TaskState::Running && !view.token_samples.is_empty() {
+        let spark = theme.sparkline(&view.token_samples);
+        if !spark.is_empty() {
+            note = format!("{note} {spark}");
+        }
+    }
+    let mut line = format!(
+        "  {} {:<id_w$}  {}",
+        theme.glyph(row.state, tick),
+        row.id,
+        theme.paint(Role::Dim, &note),
+    );
+    let cost = row.cost_usd.map(|c| format!(" · ${c:.4}"));
+    if time.is_none() && cost.is_none() && !mark {
+        return line;
+    }
+    // Column pad computed on the RAW note (paint added escapes, the
+    // sparkline may ride a running row — transient shift accepted).
+    let pad = note_w.saturating_sub(row.note.chars().count());
+    line.push_str(&" ".repeat(pad + 2));
+    let cell = format!("{:>time_w$}", time.unwrap_or(""));
+    line.push_str(&theme.paint(Role::Dim, cell.trim_end()));
+    if let Some(cost) = cost {
+        line.push_str(&theme.paint(Role::Dim, &cost));
+    }
+    if mark {
+        line.push_str(&theme.paint(Role::Accent, if theme.ascii { " ||" } else { " ∥" }));
+    }
+    line
 }
 
 /// Render the COMPACT final card (spec §3.5 `--quiet` · "final card only ·
@@ -186,6 +270,9 @@ mod tests {
     };
 
     /// Golden frame — the unicode theme, colour off (the exact spec story).
+    /// Time is a first-class column now: each settled row carries its wall
+    /// time right-aligned after the note column, per-task spend follows on
+    /// the rows whose completion reported one; the skipped row stays bare.
     #[test]
     fn golden_success_frame_unicode() {
         let lines = frame(&fold(&demo::success()), &UNICODE, 0);
@@ -193,10 +280,10 @@ mod tests {
             "  🦋 nika · veille-news · 5 tasks · ceiling ≤ $0.04",
             "     permits ✓ network:read(hn.algolia.com) · fs:write(./out)",
             "",
-            "  ✔  fetch_top     http 200 · 1.2s · 34 KB",
-            "  ✔  extract_ai    jq · 0.1s · 12 items",
-            "  ✔  summarize     claude-sonnet · 3.1s · $0.011",
-            "  ✔  write_md      2.1 KB written",
+            "  ✔  fetch_top     http 200 · 1.2s · 34 KB         1.2s",
+            "  ✔  extract_ai    jq · 0.1s · 12 items           130ms",
+            "  ✔  summarize     claude-sonnet · 3.1s · $0.011   3.0s · $0.0110",
+            "  ✔  write_md      2.1 KB written                 290ms",
             "  ⊘  notify_slack  when: env.CI != 'true'",
         ];
         assert_eq!(&lines[..8], &expected[..]);
@@ -217,7 +304,10 @@ mod tests {
             lines[0],
             "  [nika] nika · veille-news · 5 tasks · ceiling ≤ $0.04"
         );
-        assert_eq!(lines[3], "  ok fetch_top     http 200 · 1.2s · 34 KB");
+        assert_eq!(
+            lines[3],
+            "  ok fetch_top     http 200 · 1.2s · 34 KB         1.2s"
+        );
     }
 
     #[test]
@@ -341,6 +431,49 @@ mod tests {
     fn frame_is_stable_under_ticks_when_nothing_runs() {
         let view = fold(&demo::success());
         assert_eq!(frame(&view, &UNICODE, 0), frame(&view, &UNICODE, 9));
+    }
+
+    /// The running row shows a LIVE elapsed (now − started) and `∥` marks
+    /// the wave-siblings that actually overlapped — with `||` parity under
+    /// the ASCII theme (never a unicode leak).
+    #[test]
+    fn lanes_and_live_elapsed_render_in_both_themes() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+
+        let mut view = RunView::new();
+        let task = |name: &str| KeyValue::new("task", Value::String(name.to_owned()));
+        view.apply(&demo::bare_event(EventKind::TaskStarted, 100).with_field(task("a")));
+        view.apply(&demo::bare_event(EventKind::TaskStarted, 150).with_field(task("b")));
+        // a settles at 1000 with a REAL measured duration (900ms) → its
+        // reconstructed interval [100, 1000] overlaps b's [150, now].
+        view.apply(
+            &demo::bare_event(EventKind::TaskCompleted, 1000)
+                .with_field(task("a"))
+                .with_field(KeyValue::new("duration_ms", Value::Int(900))),
+        );
+
+        let lines = frame(&view, &UNICODE, 0);
+        let a = lines.iter().find(|l| l.contains(" a ")).expect("a row");
+        assert!(
+            a.contains("900ms") && a.ends_with('∥'),
+            "settled sibling: duration + lane marker: {a}"
+        );
+        let b = lines.iter().find(|l| l.contains(" b ")).expect("b row");
+        assert!(
+            b.contains("850ms") && b.ends_with('∥'),
+            "running sibling: LIVE elapsed (1000−150) + marker: {b}"
+        );
+
+        let ascii = frame(&view, &ASCII, 0);
+        assert!(
+            ascii.iter().any(|l| l.ends_with("900ms ||")),
+            "ascii parity ∥→||: {ascii:?}"
+        );
+        assert!(
+            !ascii.iter().any(|l| l.contains('∥')),
+            "no unicode leaks into --ascii: {ascii:?}"
+        );
     }
 
     /// The sparkline rides the RUNNING row exactly when samples exist —

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -57,6 +57,11 @@ pub struct TaskRow {
     pub duration_ms: Option<u64>,
     /// Per-task spend (`cost_usd` on the terminal frame).
     pub cost_usd: Option<f64>,
+    /// The model an inference note named (`infer · <model>` / `agent ·
+    /// <model>` — the runtime's note vocabulary), kept once seen: the
+    /// terminal note overwrites `note`, this survives for the verdict
+    /// surface.
+    pub model: Option<String>,
 }
 
 impl TaskRow {
@@ -255,6 +260,7 @@ impl RunView {
                 ended_ms: None,
                 duration_ms: None,
                 cost_usd: None,
+                model: None,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);
@@ -263,6 +269,17 @@ impl RunView {
         let row = &mut self.rows[idx];
         row.state = state;
         if let Some(note) = str_field(event, "note") {
+            // The runtime's inference notes name the model (`infer ·
+            // <model>`) — keep it once seen: the terminal note replaces
+            // `note`, the verdict surface still wants the model.
+            let model = note
+                .strip_prefix("infer · ")
+                .or_else(|| note.strip_prefix("agent · "));
+            if let Some(m) = model
+                && !m.is_empty()
+            {
+                row.model = Some(m.to_owned());
+            }
             note.clone_into(&mut row.note);
         }
         if let Some(detail) = str_field(event, "detail") {

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -48,6 +48,29 @@ pub struct TaskRow {
     pub note: String,
     /// Failure detail (`detail` field) — feeds the failure card.
     pub detail: String,
+    /// `task_started` stamp (unix ms) — feeds the live elapsed readout.
+    pub started_ms: Option<i64>,
+    /// Terminal stamp (unix ms) — completion · failure · skip · cancel.
+    pub ended_ms: Option<i64>,
+    /// The runtime-measured `duration_ms` field (the REAL wall time —
+    /// event stamps are settle-time, this one is measured at dispatch).
+    pub duration_ms: Option<u64>,
+    /// Per-task spend (`cost_usd` on the terminal frame).
+    pub cost_usd: Option<f64>,
+}
+
+impl TaskRow {
+    /// The task's best-known wall duration: the runtime-measured
+    /// `duration_ms` when the stream carried it, else the stamp span.
+    /// `None` for a task that never reached a terminal state.
+    #[must_use]
+    pub fn wall_ms(&self) -> Option<u64> {
+        if let Some(d) = self.duration_ms {
+            return Some(d);
+        }
+        let (start, end) = (self.started_ms?, self.ended_ms?);
+        u64::try_from(end.saturating_sub(start)).ok()
+    }
 }
 
 /// The folded view of one run — everything a frame needs, nothing more.
@@ -70,7 +93,13 @@ pub struct RunView {
     pub workflow_detail: Option<String>,
     /// Wall-clock span folded from event timestamps (ms).
     pub elapsed_ms: u64,
+    /// Retry attempts observed across the run (`task_retrying` count).
+    pub retries: u32,
     first_ts_ms: Option<i64>,
+    last_ts_ms: Option<i64>,
+    /// The static wave plan (task ids per wave · from the check report) —
+    /// side information the run verb injects; the fold never derives it.
+    plan_waves: Option<Vec<Vec<String>>>,
     rows: Vec<TaskRow>,
     index: BTreeMap<String, usize>,
 }
@@ -86,6 +115,27 @@ impl RunView {
     #[must_use]
     pub fn rows(&self) -> &[TaskRow] {
         &self.rows
+    }
+
+    /// The latest event stamp folded so far (unix ms) — "now" as the
+    /// stream knows it (feeds the running row's live elapsed).
+    #[must_use]
+    pub fn last_ts_ms(&self) -> Option<i64> {
+        self.last_ts_ms
+    }
+
+    /// Inject the static wave plan (task ids per wave · from the check
+    /// report). Side information for the lane markers + the DAG-shape
+    /// glyph — a replayed trace without it falls back to interval
+    /// reconstruction.
+    pub fn set_plan(&mut self, waves: Vec<Vec<String>>) {
+        self.plan_waves = Some(waves);
+    }
+
+    /// The injected wave plan, when the caller provided one.
+    #[must_use]
+    pub fn plan(&self) -> Option<&[Vec<String>]> {
+        self.plan_waves.as_deref()
     }
 
     /// How many rows reached a terminal state.
@@ -106,6 +156,7 @@ impl RunView {
     pub fn apply(&mut self, event: &Event) {
         let ts = event.timestamp.unix_ms();
         let first = *self.first_ts_ms.get_or_insert(ts);
+        self.last_ts_ms = Some(ts);
         self.elapsed_ms = u64::try_from(ts.saturating_sub(first)).unwrap_or(0);
 
         match event.kind {
@@ -116,24 +167,49 @@ impl RunView {
                 self.ceiling_usd = float_field(event, "ceiling_usd");
                 self.permits = str_field(event, "permits").map(str::to_owned);
             }
-            EventKind::TaskScheduled => self.touch(event, TaskState::Pending),
-            EventKind::TaskStarted => self.touch(event, TaskState::Running),
+            EventKind::TaskScheduled => {
+                self.touch(event, TaskState::Pending);
+            }
+            EventKind::TaskStarted => {
+                if let Some(i) = self.touch(event, TaskState::Running) {
+                    self.rows[i].started_ms = Some(ts);
+                }
+            }
             EventKind::TaskCompleted => {
-                self.touch(event, TaskState::Ok);
-                if let Some(usd) = float_field(event, "cost_usd") {
+                let usd = float_field(event, "cost_usd");
+                if let Some(i) = self.touch(event, TaskState::Ok) {
+                    self.stamp_terminal(i, ts, event, usd);
+                }
+                if let Some(usd) = usd {
                     self.cost_usd += usd;
                 }
                 if let Some(tokens) = int_field(event, "tokens") {
                     self.token_samples.push(u64::try_from(tokens).unwrap_or(0));
                 }
             }
-            EventKind::TaskFailed => self.touch(event, TaskState::Failed),
-            EventKind::TaskSkipped => self.touch(event, TaskState::Skipped),
+            EventKind::TaskFailed => {
+                let usd = float_field(event, "cost_usd");
+                if let Some(i) = self.touch(event, TaskState::Failed) {
+                    self.stamp_terminal(i, ts, event, usd);
+                }
+            }
+            EventKind::TaskSkipped => {
+                if let Some(i) = self.touch(event, TaskState::Skipped) {
+                    self.rows[i].ended_ms = Some(ts);
+                }
+            }
             // §3.1 `↻` — the attempt failed · the TASK has not · the row
             // holds yellow until the terminal frame replaces it.
-            EventKind::TaskRetrying => self.touch(event, TaskState::Retrying),
+            EventKind::TaskRetrying => {
+                self.retries = self.retries.saturating_add(1);
+                self.touch(event, TaskState::Retrying);
+            }
             // §3.1 `◼` — a decision, not a defect (dim · never red).
-            EventKind::TaskCancelled => self.touch(event, TaskState::Cancelled),
+            EventKind::TaskCancelled => {
+                if let Some(i) = self.touch(event, TaskState::Cancelled) {
+                    self.rows[i].ended_ms = Some(ts);
+                }
+            }
             EventKind::WorkflowCompleted => self.verdict = Some(true),
             EventKind::WorkflowFailed => {
                 self.verdict = Some(false);
@@ -148,10 +224,24 @@ impl RunView {
         }
     }
 
+    /// Stamp a ran-to-terminal row (completed · failed): the end stamp,
+    /// the runtime-measured duration, the per-task spend.
+    fn stamp_terminal(&mut self, i: usize, ts: i64, event: &Event, usd: Option<f64>) {
+        let row = &mut self.rows[i];
+        row.ended_ms = Some(ts);
+        if let Some(d) = int_field(event, "duration_ms") {
+            row.duration_ms = u64::try_from(d).ok();
+        }
+        if usd.is_some() {
+            row.cost_usd = usd;
+        }
+    }
+
     /// Upsert the row a task event addresses, updating state + notes.
-    fn touch(&mut self, event: &Event, state: TaskState) {
+    /// Returns the row index so the caller can stamp kind-specific facts.
+    fn touch(&mut self, event: &Event, state: TaskState) -> Option<usize> {
         let Some(task_id) = str_field(event, "task") else {
-            return; // a task event without a task field renders nothing
+            return None; // a task event without a task field renders nothing
         };
         let idx = if let Some(&i) = self.index.get(task_id) {
             i
@@ -161,6 +251,10 @@ impl RunView {
                 state: TaskState::Pending,
                 note: String::new(),
                 detail: String::new(),
+                started_ms: None,
+                ended_ms: None,
+                duration_ms: None,
+                cost_usd: None,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);
@@ -174,6 +268,7 @@ impl RunView {
         if let Some(detail) = str_field(event, "detail") {
             detail.clone_into(&mut row.detail);
         }
+        Some(idx)
     }
 }
 
@@ -318,5 +413,53 @@ mod tests {
         let ev = demo::bare_event(EventKind::TaskStarted, 100);
         view.apply(&ev);
         assert!(view.rows().is_empty());
+    }
+
+    /// Terminal rows stamp start/end + spend, and the runtime-measured
+    /// `duration_ms` field WINS over the stamp span (stamps are settle-
+    /// time; the measurement is the wall truth).
+    #[test]
+    fn terminal_rows_stamp_time_and_spend() {
+        use nika_types::resource::{KeyValue, Value};
+
+        let mut view = RunView::new();
+        for ev in demo::success() {
+            view.apply(&ev);
+        }
+        let fetch = &view.rows()[0];
+        assert_eq!(fetch.started_ms, Some(20));
+        assert_eq!(fetch.ended_ms, Some(1200));
+        assert_eq!(fetch.wall_ms(), Some(1180), "stamp-span fallback");
+        let summarize = view
+            .rows()
+            .iter()
+            .find(|r| r.id == "summarize")
+            .expect("row");
+        assert_eq!(summarize.cost_usd, Some(0.011), "per-task spend rides");
+
+        // An explicit duration_ms field wins over the (settle-time) span.
+        let mut measured = RunView::new();
+        let task = || KeyValue::new("task", Value::String("t".to_owned()));
+        measured.apply(&demo::bare_event(EventKind::TaskStarted, 0).with_field(task()));
+        measured.apply(
+            &demo::bare_event(EventKind::TaskCompleted, 5000)
+                .with_field(task())
+                .with_field(KeyValue::new("duration_ms", Value::Int(40))),
+        );
+        assert_eq!(measured.rows()[0].wall_ms(), Some(40), "measured wins");
+        assert_eq!(measured.last_ts_ms(), Some(5000), "now = latest stamp");
+    }
+
+    /// The retry counter folds every `task_retrying` frame (feeds the
+    /// verdict surface's `N retries`).
+    #[test]
+    fn retrying_frames_count_toward_the_retry_total() {
+        let mut view = RunView::new();
+        for ev in demo::retrying() {
+            view.apply(&ev);
+        }
+        assert_eq!(view.retries, 1);
+        let fresh = RunView::new();
+        assert_eq!(fresh.retries, 0);
     }
 }

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -458,6 +458,11 @@ fn trace_render(args: &TraceArgs, replay: bool) -> u8 {
         }
         print_lines(&frame(&view, &theme, 0));
     }
+    // The trace surface owns the run overlays (replay = re-render, never
+    // re-execute): the waterfall + the verdict card close the read, from
+    // any past trace — the same final frame a live TTY run ends on.
+    print_lines(&nika_cli::display::flow::waterfall(&view, &theme));
+    print_lines(&nika_cli::display::flow::verdict_card(&view, &theme, None));
     // The locked exit contract: 0 = run ok · 1 = workflow failed.
     u8::from(view.verdict != Some(true))
 }
@@ -503,6 +508,9 @@ fn redraw(view: &RunView, theme: Theme, tick: usize, drawn: usize) -> usize {
 }
 
 fn print_lines(lines: &[String]) {
+    if lines.is_empty() {
+        return; // an empty overlay (solo-task waterfall · no verdict) prints nothing
+    }
     let mut out = std::io::stdout().lock();
     let _ = writeln!(out, "{}", lines.join("\n"));
 }

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -75,10 +75,13 @@ enum Command {
         #[arg(long)]
         ascii: bool,
     },
-    /// Static anatomy: tasks · verbs · DAG tree · cost · permits.
+    /// Static anatomy: tasks · verbs · wave groups · cost · permits.
     Inspect {
         /// Workflow file (`*.nika.yaml`).
         file: String,
+        /// Force the ASCII glyph theme (CI logs · legacy terminals).
+        #[arg(long)]
+        ascii: bool,
     },
     /// The ONE graph projector (json canonical · mermaid/dot derived).
     Graph {
@@ -319,7 +322,7 @@ fn main() -> std::process::ExitCode {
             no_color,
             ascii,
         } => verbs::test::run(&file, update, term_theme(no_color, ascii)),
-        Command::Inspect { file } => emit(&verbs::inspect::run(&file)),
+        Command::Inspect { file, ascii } => emit(&verbs::inspect::run(&file, ascii)),
         Command::Graph { file, format } => {
             let format = match format {
                 GraphFormatArg::Json => verbs::graph::GraphFormat::Json,

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -4,19 +4,58 @@
 //! `nika inspect` — the static anatomy as a terminal DAG (spec §6).
 //!
 //! Derives from the SAME projection as `nika graph` (one projector · N
-//! renderers): a box-drawing tree in first-parent order, each task drawn
-//! once, the footer attesting the DAG check. Static facts only — run
-//! overlays belong to the trace surface.
+//! renderers): waves rendered as bordered visual groups ("N in parallel")
+//! joined by flow arrows — the parallelism the scheduler proved, made
+//! visible. Static facts only — run overlays belong to the trace surface.
 
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
-use crate::verbs::graph::{GraphDoc, project};
+use crate::verbs::graph::{GraphDoc, Node, project};
 use crate::verbs::{VerbOutput, load_checked};
 
-/// The `nika inspect <file>` verb.
+/// Widest a wave box may grow (2-indent + corners lands the line ≤ 78 —
+/// graceful under 80 columns).
+const BOX_INNER_CAP: usize = 74;
+
+/// The glyph column for the wave-group render — unicode default, ASCII
+/// parity first-class (the same two-theme law as the run storyboard).
+struct Glyphs {
+    /// Task marker (`◆` / `#`).
+    task: &'static str,
+    /// Box corners `(top-left, top-right, bottom-left, bottom-right)`.
+    corners: [char; 4],
+    /// Horizontal rule.
+    h: char,
+    /// Vertical rail.
+    v: char,
+    /// Inter-wave flow arrow (`↓` / `v`).
+    arrow: &'static str,
+    /// Truncation mark when a row outgrows the box cap.
+    ellipsis: &'static str,
+}
+
+const UNICODE_GLYPHS: Glyphs = Glyphs {
+    task: "◆",
+    corners: ['╭', '╮', '╰', '╯'],
+    h: '─',
+    v: '│',
+    arrow: "↓",
+    ellipsis: "…",
+};
+
+const ASCII_GLYPHS: Glyphs = Glyphs {
+    task: "#",
+    corners: ['+', '+', '+', '+'],
+    h: '-',
+    v: '|',
+    arrow: "v",
+    ellipsis: "~",
+};
+
+/// The `nika inspect <file>` verb. `ascii` selects the ASCII glyph theme
+/// (`--ascii` · CI logs · legacy terminals).
 #[must_use]
-pub fn run(path: &str) -> VerbOutput {
+pub fn run(path: &str, ascii: bool) -> VerbOutput {
     let (wf, report) = match load_checked(path) {
         Ok(pair) => pair,
         Err(out) => return out,
@@ -42,15 +81,16 @@ pub fn run(path: &str) -> VerbOutput {
     };
 
     let mut out = format!(
-        "{} · {} task(s) · {} wave(s) · {ceiling}\n",
+        "{} · {} tasks · {} waves · {ceiling}\n",
         doc.workflow,
         doc.nodes.len(),
         report.waves.len(),
     );
-    render_tree(&mut out, &doc);
+    let wave_sizes: Vec<usize> = report.waves.iter().map(Vec::len).collect();
+    render_waves(&mut out, &doc, &wave_sizes, ascii);
     // The spec §6 footer verbatim — NIKA-DAG-001 is the conformance code
     // the ladder proved clean to get here.
-    out.push_str("└─ (no orphans · DAG check NIKA-DAG-001 clean)\n");
+    out.push_str("  (no orphans · DAG check NIKA-DAG-001 clean)\n");
     render_analysis(&mut out, report.analysis.as_ref());
     VerbOutput::ok(out)
 }
@@ -104,59 +144,9 @@ fn render_analysis(out: &mut String, analysis: Option<&nika_schema::check::DagAn
     }
 }
 
-/// Box-drawing tree: roots at depth 0, children under their FIRST parent
-/// (a DAG joins; the tree shows one spine and the graph verb shows all
-/// edges). Every node printed exactly once, in projection (wave) order.
-fn render_tree(out: &mut String, doc: &GraphDoc) {
-    // first-parent map + root list, both in stable projection order.
-    let mut first_parent: BTreeMap<&str, &str> = BTreeMap::new();
-    for edge in &doc.edges {
-        first_parent.entry(edge.to.as_str()).or_insert(&edge.from);
-    }
-    let children = |id: &str| -> Vec<&str> {
-        doc.nodes
-            .iter()
-            .filter(|n| first_parent.get(n.id.as_str()) == Some(&id))
-            .map(|n| n.id.as_str())
-            .collect()
-    };
-    let mut printed: BTreeSet<&str> = BTreeSet::new();
-
-    let roots: Vec<&str> = doc
-        .nodes
-        .iter()
-        .filter(|n| !first_parent.contains_key(n.id.as_str()))
-        .map(|n| n.id.as_str())
-        .collect();
-    let id_width = doc.nodes.iter().map(|n| n.id.len()).max().unwrap_or(0);
-
-    for (i, root) in roots.iter().enumerate() {
-        let last = i + 1 == roots.len();
-        walk(out, doc, root, "", last, &children, &mut printed, id_width);
-    }
-}
-
-/// Recursive spine walk — `prefix` carries the rail glyphs of ancestors.
-#[allow(clippy::too_many_arguments)] // a local recursion, not an API
-fn walk<'a>(
-    out: &mut String,
-    doc: &'a GraphDoc,
-    id: &'a str,
-    prefix: &str,
-    last: bool,
-    children: &dyn Fn(&str) -> Vec<&'a str>,
-    printed: &mut BTreeSet<&'a str>,
-    id_width: usize,
-) {
-    if !printed.insert(id) {
-        return;
-    }
-    // Projection nodes cover every edge endpoint (same source data) —
-    // a miss would be a projector bug; render nothing rather than panic.
-    let Some(node) = doc.nodes.iter().find(|n| n.id == id) else {
-        return;
-    };
-
+/// The static facts one task row carries (verb · tool · model · cost ·
+/// fan-out · gate) — the SAME vocabulary the old tree drew, per node.
+fn node_meta(node: &Node) -> String {
     let mut meta: Vec<String> = vec![node.verb.to_owned()];
     if let Some(tool) = &node.tool {
         meta.push(tool.clone());
@@ -176,30 +166,92 @@ fn walk<'a>(
     if let Some(when) = &node.when {
         meta.push(format!("when: {when}"));
     }
+    meta.join(" · ")
+}
 
-    let branch = if last { "└─" } else { "├─" };
-    let _ = writeln!(
-        out,
-        "{prefix}{branch} {:<id_width$}  {}",
-        node.id,
-        meta.join(" · "),
-    );
+/// Waves as visual groups: a bordered box per parallel wave ("N in
+/// parallel"), a bare row for a single-task wave, flow arrows between
+/// waves. The projection's node order IS wave order (one projector law),
+/// so `wave_sizes` slices it without re-deriving anything.
+fn render_waves(out: &mut String, doc: &GraphDoc, wave_sizes: &[usize], ascii: bool) {
+    let g = if ascii {
+        &ASCII_GLYPHS
+    } else {
+        &UNICODE_GLYPHS
+    };
+    let id_width = doc
+        .nodes
+        .iter()
+        .map(|n| n.id.chars().count())
+        .max()
+        .unwrap_or(0);
+    let mut cursor = 0usize;
+    for (i, &size) in wave_sizes.iter().enumerate() {
+        let end = cursor.saturating_add(size).min(doc.nodes.len());
+        let members = &doc.nodes[cursor..end];
+        cursor = end;
+        if i > 0 {
+            let _ = writeln!(out, "    {}", g.arrow);
+        }
+        if members.len() > 1 {
+            render_wave_group(out, i + 1, members, id_width, g);
+        } else if let Some(node) = members.first() {
+            let _ = writeln!(
+                out,
+                "  {} {:<id_width$}  {}",
+                g.task,
+                node.id,
+                node_meta(node),
+            );
+        }
+    }
+}
 
-    let kids = children(id);
-    let child_prefix = format!("{prefix}{}", if last { "   " } else { "│  " });
-    for (i, kid) in kids.iter().enumerate() {
-        let kid_last = i + 1 == kids.len();
-        walk(
+/// One bordered wave group — header names the wave + its parallelism, each
+/// member row aligned on the shared id column, width capped so the box
+/// stays graceful under 80 columns (overlong rows truncate with a mark).
+fn render_wave_group(out: &mut String, n: usize, members: &[Node], id_width: usize, g: &Glyphs) {
+    let header = format!(" wave {n} {h}{h} {} in parallel ", members.len(), h = g.h);
+    let contents: Vec<String> = members
+        .iter()
+        .map(|node| format!("{} {:<id_width$}  {}", g.task, node.id, node_meta(node)))
+        .collect();
+    let inner = contents
+        .iter()
+        .map(|c| c.chars().count() + 2)
+        .chain(std::iter::once(header.chars().count() + 1))
+        .max()
+        .unwrap_or(0)
+        .min(BOX_INNER_CAP);
+    let rule: String =
+        std::iter::repeat_n(g.h, inner.saturating_sub(header.chars().count())).collect();
+    let _ = writeln!(out, "  {}{header}{rule}{}", g.corners[0], g.corners[1]);
+    for content in &contents {
+        let fitted = fit(content, inner.saturating_sub(2), g.ellipsis);
+        let pad = inner
+            .saturating_sub(2)
+            .saturating_sub(fitted.chars().count());
+        let _ = writeln!(
             out,
-            doc,
-            kid,
-            &child_prefix,
-            kid_last,
-            children,
-            printed,
-            id_width,
+            "  {v} {fitted}{blank} {v}",
+            v = g.v,
+            blank = " ".repeat(pad),
         );
     }
+    let bottom: String = std::iter::repeat_n(g.h, inner).collect();
+    let _ = writeln!(out, "  {}{bottom}{}", g.corners[2], g.corners[3]);
+}
+
+/// Truncate a row to `width` display cells, marking the cut — the box
+/// border stays intact when a meta string outgrows the cap.
+fn fit(s: &str, width: usize, ellipsis: &str) -> String {
+    if s.chars().count() <= width {
+        return s.to_owned();
+    }
+    let keep = width.saturating_sub(ellipsis.chars().count());
+    let mut out: String = s.chars().take(keep).collect();
+    out.push_str(ellipsis);
+    out
 }
 
 #[cfg(test)]
@@ -224,7 +276,7 @@ mod tests {
         let path = tmp(
             "nika: v1\nworkflow: anatomy\n\nmodel: mock/echo\n\ntasks:\n  - id: root\n    infer: { prompt: \"r\", max_tokens: 10 }\n  - id: left\n    depends_on: [root]\n    infer: { prompt: \"l\", max_tokens: 10 }\n  - id: right\n    depends_on: [root]\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: join\n    depends_on: [left, right]\n    infer: { prompt: \"j\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.join.output }}\n",
         );
-        let out = run(path.to_str().expect("utf-8 tmp path"));
+        let out = run(path.to_str().expect("utf-8 tmp path"), false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
         assert!(out.text.contains("parallelism  width 2"), "{}", out.text);
@@ -243,6 +295,25 @@ mod tests {
             "{}",
             out.text
         );
+        // The diamond's middle wave is a bordered group; the solo root
+        // and join render as bare rows joined by flow arrows.
+        assert!(
+            out.text.contains("╭ wave 2 ── 2 in parallel "),
+            "wave group header: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("│ ◆ left ") && out.text.contains("│ ◆ right"),
+            "boxed members: {}",
+            out.text
+        );
+        assert!(out.text.contains("  ◆ root "), "bare root: {}", out.text);
+        assert_eq!(
+            out.text.matches("    ↓").count(),
+            2,
+            "two flow arrows join three waves: {}",
+            out.text
+        );
     }
 
     #[test]
@@ -251,41 +322,51 @@ mod tests {
         let path = tmp(
             "nika: v1\nworkflow: solo\n\nmodel: mock/echo\n\ntasks:\n  - id: only\n    infer: { prompt: \"x\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.only.output }}\n",
         );
-        let out = run(path.to_str().expect("utf-8 tmp path"));
+        let out = run(path.to_str().expect("utf-8 tmp path"), false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
         assert!(!out.text.contains("parallelism"), "{}", out.text);
         assert!(!out.text.contains("blast"), "{}", out.text);
+        // One wave of one task: no box, no arrow — a bare row only.
+        assert!(
+            !out.text.contains('╭'),
+            "no box for a solo wave: {}",
+            out.text
+        );
+        assert!(
+            !out.text.contains('↓'),
+            "no arrow with one wave: {}",
+            out.text
+        );
+        assert!(out.text.contains("  ◆ only"), "{}", out.text);
     }
 
-    /// A fan-out of 5 nests every child under its first parent (the box-drawing
-    /// tree) and the witness antichain (width 5) truncates to 4 names + an
-    /// ellipsis. The exact rails pin the recursion (a mutated child-match or
-    /// last-detection breaks the nesting); the `· …` pins the `> 4` truncation.
+    /// A fan-out of 5 renders as ONE bordered wave group ("5 in parallel")
+    /// under the root's bare row, and the witness antichain (width 5)
+    /// truncates to 4 names + an ellipsis (the `> 4` truncation).
     #[test]
-    fn fan_out_nests_children_and_truncates_the_witness() {
+    fn fan_out_groups_the_wave_and_truncates_the_witness() {
         let path = tmp(
             "nika: v1\nworkflow: fan5\ntasks:\n  - id: root\n    exec: { command: \"echo r\" }\n  - id: c1\n    depends_on: [root]\n    exec: { command: \"echo 1\" }\n  - id: c2\n    depends_on: [root]\n    exec: { command: \"echo 2\" }\n  - id: c3\n    depends_on: [root]\n    exec: { command: \"echo 3\" }\n  - id: c4\n    depends_on: [root]\n    exec: { command: \"echo 4\" }\n  - id: c5\n    depends_on: [root]\n    exec: { command: \"echo 5\" }\n",
         );
-        let out = run(path.to_str().expect("utf-8 tmp path"));
+        let out = run(path.to_str().expect("utf-8 tmp path"), false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
-        // The tree: root on the spine, c1 the FIRST branch, c5 the LAST.
+        // Wave 1 = the bare root · arrow · wave 2 = the bordered fan of 5.
+        assert!(out.text.contains("  ◆ root"), "bare root: {}", out.text);
         assert!(
-            out.text.contains("└─ root"),
-            "root on the spine: {}",
+            out.text.contains("╭ wave 2 ── 5 in parallel "),
+            "fan group header: {}",
             out.text
         );
-        assert!(
-            out.text.contains("   ├─ c1"),
-            "c1 nested + branch rail: {}",
-            out.text
-        );
-        assert!(
-            out.text.contains("   └─ c5"),
-            "c5 nested + closing rail: {}",
-            out.text
-        );
+        for c in ["c1", "c2", "c3", "c4", "c5"] {
+            assert!(
+                out.text.contains(&format!("│ ◆ {c}")),
+                "{c} boxed: {}",
+                out.text
+            );
+        }
+        assert!(out.text.contains("    ↓"), "flow arrow: {}", out.text);
         // Width 5 → witness shows 4 names + the ellipsis.
         assert!(
             out.text
@@ -301,6 +382,37 @@ mod tests {
         );
     }
 
+    /// ASCII parity is first-class: every wave-group glyph has an ASCII
+    /// twin (`◆→#` · box → `+-|` · `↓→v`) and NO unicode leaks through.
+    #[test]
+    fn ascii_theme_draws_the_same_waves() {
+        let path = tmp(
+            "nika: v1\nworkflow: fanscii\ntasks:\n  - id: root\n    exec: { command: \"echo r\" }\n  - id: c1\n    depends_on: [root]\n    exec: { command: \"echo 1\" }\n  - id: c2\n    depends_on: [root]\n    exec: { command: \"echo 2\" }\n",
+        );
+        let out = run(path.to_str().expect("utf-8 tmp path"), true);
+        std::fs::remove_file(&path).ok();
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(
+            out.text.contains("+ wave 2 -- 2 in parallel "),
+            "ascii header: {}",
+            out.text
+        );
+        assert!(out.text.contains("| # c1"), "ascii member: {}", out.text);
+        assert!(
+            out.text.contains("  # root"),
+            "ascii bare row: {}",
+            out.text
+        );
+        assert!(out.text.contains("    v\n"), "ascii arrow: {}", out.text);
+        for glyph in ['◆', '╭', '╮', '╰', '╯', '│', '─', '↓'] {
+            assert!(
+                !out.text.contains(glyph),
+                "unicode {glyph} leaked into --ascii: {}",
+                out.text
+            );
+        }
+    }
+
     /// A wide diamond (4 middles · join) pins the truncation BOUNDARY: width 4
     /// shows all 4 witness names with NO ellipsis (`> 4` is false), and the
     /// blast report caps at 3 with a `+2 more` suffix (the `more > 0` guard).
@@ -309,7 +421,7 @@ mod tests {
         let path = tmp(
             "nika: v1\nworkflow: wide-diamond\ntasks:\n  - id: root\n    exec: { command: \"echo r\" }\n  - id: m1\n    depends_on: [root]\n    exec: { command: \"echo 1\" }\n  - id: m2\n    depends_on: [root]\n    exec: { command: \"echo 2\" }\n  - id: m3\n    depends_on: [root]\n    exec: { command: \"echo 3\" }\n  - id: m4\n    depends_on: [root]\n    exec: { command: \"echo 4\" }\n  - id: join\n    depends_on: [m1, m2, m3, m4]\n    exec: { command: \"echo j\" }\n",
         );
-        let out = run(path.to_str().expect("utf-8 tmp path"));
+        let out = run(path.to_str().expect("utf-8 tmp path"), false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
         assert!(

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -462,26 +462,34 @@ async fn execute(
 }
 
 /// The TTY final-frame epilogue: the post-run waterfall (real durations ·
-/// real overlap · pure fold of the run's own event stream) and the
-/// `outputs → key (type)` pointer.
+/// real overlap · pure fold of the run's own event stream) then the
+/// shareable verdict card, its outputs note naming what left the run.
 fn print_flow_epilogue(view: &crate::RunView, outputs: &BTreeMap<String, Value>, theme: Theme) {
     for line in crate::display::flow::waterfall(view, &theme) {
         println!("{line}");
     }
-    if outputs.is_empty() {
-        return;
+    let note = outputs_note(outputs);
+    for line in crate::display::flow::verdict_card(view, &theme, note.as_deref()) {
+        println!("{line}");
     }
-    let parts: Vec<String> = outputs
+}
+
+/// The card's outputs note: `outputs → key (type) · key2 (type)` — the
+/// export contract's shape at a glance (types only, never a data dump).
+/// Two keys shown, the rest counted.
+fn outputs_note(outputs: &BTreeMap<String, Value>) -> Option<String> {
+    if outputs.is_empty() {
+        return None;
+    }
+    let mut parts: Vec<String> = outputs
         .iter()
+        .take(2)
         .map(|(key, value)| format!("{key} ({})", json_type_name(value)))
         .collect();
-    println!(
-        "  {}",
-        theme.paint(
-            crate::Role::Dim,
-            &format!("outputs → {}", parts.join(" · "))
-        )
-    );
+    if outputs.len() > 2 {
+        parts.push(format!("+{} more", outputs.len() - 2));
+    }
+    Some(format!("outputs → {}", parts.join(" · ")))
 }
 
 /// The JSON type vocabulary for the outputs pointer — names only, never

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -116,7 +116,7 @@ pub fn run(
 
     // ── Dry-run (spec §10 · "plan only · zero effects") ─────────────
     if dry_run {
-        return render_dry_run(file);
+        return render_dry_run(file, theme.ascii);
     }
 
     // ── Compose the production runtime (real seams · env keys) ──────
@@ -236,8 +236,8 @@ fn output_mode(output: Option<&str>) -> Result<bool, u8> {
 /// render the static plan (the same anatomy `nika inspect` renders) without
 /// composing any production seam. No fs, no http, no subprocess, no
 /// provider call — the run is never reached.
-fn render_dry_run(file: &str) -> u8 {
-    let plan = crate::verbs::inspect::run(file);
+fn render_dry_run(file: &str, ascii: bool) -> u8 {
+    let plan = crate::verbs::inspect::run(file, ascii);
     if !plan.text.is_empty() {
         println!("{}", plan.text.trim_end());
     }

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -372,6 +372,21 @@ fn offline_tip_applies(exit_code: u8, override_given: bool, model: &str) -> bool
     exit_code != exit::OK && !override_given && !model.is_empty() && model != "mock/echo"
 }
 
+/// The static wave plan as task ids (the check report's schedule) —
+/// injected into the display fold so the ∥ lane markers and the DAG-shape
+/// glyph speak the scheduler's truth, not a reconstruction.
+fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
+    report
+        .waves
+        .iter()
+        .map(|wave| {
+            wave.iter()
+                .filter_map(|&i| wf.tasks.get(i).map(|t| t.value.id.value.clone()))
+                .collect()
+        })
+        .collect()
+}
+
 /// Drive the runtime through the chosen sink · return the exit code.
 async fn execute(
     runtime: &ProdRuntime,
@@ -393,6 +408,7 @@ async fn execute(
         // composition path · never the live TTY redraw); the one final
         // storyboard frame is what matters, not the animation.
         let mut sink = FoldSink::new(std::io::stderr().lock(), theme, RenderMode::Plain);
+        sink.set_plan(plan_waves(wf, report));
         let (code, outputs) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
         sink.print_final();
         // Built BEFORE the sink is consumed — the failure envelope reads
@@ -423,6 +439,7 @@ async fn execute(
         code
     } else {
         let mut sink = FoldSink::new(std::io::stdout().lock(), theme, mode);
+        sink.set_plan(plan_waves(wf, report));
         let (code, _outputs) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
         // `Live` painted in place during the run; `Plain`/`Quiet` folded
         // silently · print the ONE final frame now.

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -440,17 +440,60 @@ async fn execute(
     } else {
         let mut sink = FoldSink::new(std::io::stdout().lock(), theme, mode);
         sink.set_plan(plan_waves(wf, report));
-        let (code, _outputs) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
+        let (code, outputs) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
         // `Live` painted in place during the run; `Plain`/`Quiet` folded
         // silently · print the ONE final frame now.
         if mode != RenderMode::Live {
             sink.print_final();
+        }
+        // The Live (TTY) final frame carries the flow epilogue: the wall-
+        // time waterfall + the outputs pointer (design §2c). The sober
+        // registers (piped `Plain` · `--quiet` · machine modes) stay
+        // untouched — CI logs never grow chart art.
+        if mode == RenderMode::Live {
+            print_flow_epilogue(sink.view(), &outputs, theme);
         }
         if let Some(e) = sink.into_error() {
             eprintln!("nika run: render failed: {e}");
             return exit::ENV;
         }
         code
+    }
+}
+
+/// The TTY final-frame epilogue: the post-run waterfall (real durations ·
+/// real overlap · pure fold of the run's own event stream) and the
+/// `outputs → key (type)` pointer.
+fn print_flow_epilogue(view: &crate::RunView, outputs: &BTreeMap<String, Value>, theme: Theme) {
+    for line in crate::display::flow::waterfall(view, &theme) {
+        println!("{line}");
+    }
+    if outputs.is_empty() {
+        return;
+    }
+    let parts: Vec<String> = outputs
+        .iter()
+        .map(|(key, value)| format!("{key} ({})", json_type_name(value)))
+        .collect();
+    println!(
+        "  {}",
+        theme.paint(
+            crate::Role::Dim,
+            &format!("outputs → {}", parts.join(" · "))
+        )
+    );
+}
+
+/// The JSON type vocabulary for the outputs pointer — names only, never
+/// values (a summary line, not a data leak into the scrollback).
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
     }
 }
 

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -110,6 +110,13 @@ impl<W: Write> FoldSink<W> {
         &self.view
     }
 
+    /// Inject the static wave plan (task ids per wave · from the check
+    /// report) — feeds the ∥ lane markers + the DAG-shape glyph. Side
+    /// information only: the fold itself never changes.
+    pub fn set_plan(&mut self, waves: Vec<Vec<String>>) {
+        self.view.set_plan(waves);
+    }
+
     /// Print the final frame once (the `Plain`/`Quiet` lanes · the caller
     /// calls this after the run · a no-op buffered error stays buffered).
     /// `Quiet` paints the compact verdict card; `Plain` the full storyboard.

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -197,6 +197,12 @@ fn the_live_lane_paints_one_clean_frame_when_piped() {
         !stdout.contains('\x1b'),
         "piped (non-TTY) leaks no cursor escapes: {stdout:?}"
     );
+    // The sober register stays sober: the TTY-only flow epilogue (the
+    // waterfall chart + outputs pointer) never reaches a piped capture.
+    assert!(
+        !stdout.contains("\n  0s ") && !stdout.contains("outputs →"),
+        "piped (non-TTY) carries no waterfall/epilogue art: {stdout:?}"
+    );
 }
 
 // `examples run` EXECUTES (no longer refuses). 01-hello infers against

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -175,21 +175,36 @@ fn graph_refuses_a_dag_broken_file_with_exit_2() {
 // ─── inspect · the terminal anatomy ─────────────────────────────────────
 
 #[test]
-fn inspect_draws_the_box_tree_with_static_facts() {
+fn inspect_draws_the_wave_groups_with_static_facts() {
     let path = fixture_path("inspect.nika.yaml", WORKFLOW);
-    let out = inspect::run(&path);
+    let out = inspect::run(&path, false);
     assert_eq!(out.code, exit::OK, "{}", out.text);
 
     // Header: identity + counts + the honest cost bound.
     let header = out.text.lines().next().expect("header");
     assert!(
-        header.contains("static-suite · 5 task(s)"),
+        header.contains("static-suite · 5 tasks"),
         "header: {header}"
     );
     assert!(header.contains("floor"), "mock/echo is unpriced: {header}");
 
-    // Tree rows: box glyphs + verb facts + gate + fan-out.
-    assert!(out.text.contains("├─") || out.text.contains("└─"));
+    // Waves as bordered groups: {gather,probe} · {fan,think} · notify.
+    assert!(
+        out.text.contains("╭ wave 1 ── 2 in parallel "),
+        "{}",
+        out.text
+    );
+    assert!(
+        out.text.contains("╭ wave 2 ── 2 in parallel "),
+        "{}",
+        out.text
+    );
+    assert_eq!(
+        out.text.matches("    ↓").count(),
+        2,
+        "two flow arrows join three waves: {}",
+        out.text
+    );
     assert!(out.text.contains("invoke · nika:read"), "{}", out.text);
     assert!(out.text.contains("for_each ×3"), "{}", out.text);
     assert!(


### PR DESCRIPTION
Stacked on #150. 4 commits · 3085 workspace tests 0 fail · machine surfaces PROVEN byte-frozen (`--output json` cmp-identical BEFORE↔AFTER · NDJSON kind-sequence identical · nika test 4/4 on the after binary).

- `inspect`: waves become visible groups (`╭ wave 1 ── 3 in parallel ╮`) · `--ascii` parity leak-tested
- live run: per-task duration + `∥` lane markers (plan-sibling AND real interval overlap)
- final TTY frame: scaled waterfall (settle-time reconstruction · honest overlap) + shareable verdict card with the DAG-shape glyph (`◆◆◆ ⇉ ◆`)
- replay rides the EXISTING `nika trace show|replay` (zero new verbs · mini-ADR in commit body) · pipes/NO_COLOR stay sober

BEFORE/AFTER frames in the commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)