### PR TITLE
ADR index generator: tolerate missing optional frontmatter fields

### DIFF
--- a/docs/adr/index.json
+++ b/docs/adr/index.json
@@ -961,3 +961,37 @@
       "requires": ["ADR-003"],
       "enables": []
     }
+    ,
+    {
+      "id": "ADR-096",
+      "title": "The agent-loop intelligence layer — routing, stall guard, compose, telemetry",
+      "status": "accepted",
+      "date": "2026-06-12",
+      "filename": "adr-096-agent-loop-intelligence.md",
+      "tags": ["nika-verb-agent","agent-loop","react","stall-guard","tool-routing","sota-2040"],
+      "affects_crates": ["nika-verb-agent","nika-event"],
+      "affects_layers": ["L2","L0"],
+      "supersedes": [],
+      "superseded_by": [],
+      "related": ["ADR-092"],
+      "requires": [],
+      "enables": []
+    }
+    ,
+    {
+      "id": "ADR-097",
+      "title": "Parallel intra-turn tool dispatch — concurrent resolve, request-order fold",
+      "status": "accepted",
+      "date": "2026-06-12",
+      "filename": "adr-097-parallel-intra-turn-dispatch.md",
+      "tags": ["nika-verb-agent","agent-loop","parallel-function-calling","determinism"],
+      "affects_crates": ["nika-verb-agent"],
+      "affects_layers": ["L2"],
+      "supersedes": [],
+      "superseded_by": [],
+      "related": ["ADR-096"],
+      "requires": [],
+      "enables": []
+    }
+  ]
+}

--- a/scripts/adr/generate-index.sh
+++ b/scripts/adr/generate-index.sh
@@ -20,7 +20,7 @@ json_escape() {
 # Usage: extract_scalar "field_name" "$frontmatter"
 extract_scalar() {
   local field="$1" fm="$2"
-  printf '%s\n' "$fm" | grep -E "^${field}:" | head -1 \
+  printf '%s\n' "$fm" | { grep -E "^${field}:" || true; } | head -1 \
     | sed -E "s/^${field}:[[:space:]]*//" \
     | sed -E 's/^"//; s/"$//' \
     | sed -E "s/^'//; s/'$//"
@@ -31,7 +31,7 @@ extract_scalar() {
 # Returns one element per line, stripped of quotes and brackets.
 extract_array() {
   local field="$1" fm="$2"
-  printf '%s\n' "$fm" | grep -E "^${field}:" | head -1 \
+  printf '%s\n' "$fm" | { grep -E "^${field}:" || true; } | head -1 \
     | sed -E "s/^${field}:[[:space:]]*//" \
     | tr -d '[]' \
     | tr ',' '\n' \


### PR DESCRIPTION
Independent fix. `docs/adr/index.json` has been invalid at HEAD since the ADR-096/097 renumbering: a missing optional field (`enables:`) made grep exit 1 inside the extract helpers' command-substitution pipelines — pipefail propagated, set -e killed the run mid-JSON (truncated after ADR-095). Both helpers now wrap the field grep in `{ grep || true; }`. Regenerated: valid JSON · 62 ADRs · 095-097 present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)