### PR TITLE
chore(pack): re-vendor spec snapshot + forward-compat clause anchors

### DIFF
--- a/crates/nika-pack/pack/QUICKSTART.md
+++ b/crates/nika-pack/pack/QUICKSTART.md
@@ -19,7 +19,7 @@ Two header lines + one task ·
 nika: v1
 workflow: hello
 
-model: anthropic/claude-haiku-4-5
+model: ollama/llama3.2:3b
 
 tasks:
   - id: greet
@@ -32,6 +32,14 @@ tasks:
 - `model:`: the default model · `<provider>/<name>` (the prefix picks the provider).
 - one task · `infer:` calls the model.
 
+> **Model note** · every step on this page runs local on
+> `ollama/llama3.2:3b` · zero key, nothing leaves your machine
+> (`ollama pull llama3.2:3b` first · or `lmstudio/…` · `llamacpp/…` ·
+> `vllm/…`). Prefer cloud? Swap the one `model:` line for any of the
+> <!-- canon:providers -->14<!-- /canon --> providers ·
+> `mistral/mistral-small` · `anthropic/claude-haiku-4-5` ·
+> `openai/gpt-5.2` · the rest of the file doesn't change.
+
 ---
 
 ## 2 · Chain two steps (a DAG)
@@ -43,7 +51,7 @@ graph · `${{ tasks.<id>.output }}` reads a prior task's result ·
 nika: v1
 workflow: summarize-and-translate
 
-model: anthropic/claude-haiku-4-5
+model: ollama/llama3.2:3b
 
 tasks:
   - id: summarize
@@ -75,7 +83,7 @@ vars:
   text: "Hello, world"
   target_lang: "French"
 
-model: anthropic/claude-haiku-4-5
+model: ollama/llama3.2:3b
 
 tasks:
   - id: translate
@@ -100,7 +108,7 @@ Everything else (fetching a URL, querying a DB, writing a file) is a
 nika: v1
 workflow: fetch-and-summarize
 
-model: anthropic/claude-haiku-4-5
+model: ollama/llama3.2:3b
 
 tasks:
   - id: fetch_page
@@ -183,15 +191,6 @@ return `NIKA-<NS>-<NNN>` codes · see [spec/05-errors.md](./spec/05-errors.md)) 
 plus the workflow's **`outputs:`** return contract (what `nika run` prints + what
 a caller receives).
 
-## Zero-cloud · local-first
-
-Swap the model prefix to run fully local · no API key, nothing leaves your
-machine ·
-
-```yaml
-model: ollama/llama3.1        # or lmstudio/... · llamacpp/... · vllm/...
-```
-
 ## Where to go next
 
 - **[spec/](./spec/)**: the full specification (~30 pages · the contract)
@@ -199,7 +198,7 @@ model: ollama/llama3.1        # or lmstudio/... · llamacpp/... · vllm/...
   skeleton (6 valid, slot-marked) instead of starting blank, the
   deterministic path agents follow ([protocol](AGENTS.md))
 - **[stdlib/](./stdlib/)**: the <!-- canon:providers -->14<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->23<!-- /canon --> builtins
-- **[examples/](./examples/)**: 7 foundation workflows (full v0.1 construct coverage · 19 more pending for GA)
+- **[examples/](./examples/)**: 7 foundation + 20 showcase workflows, all shipped and CI-gated
 - **[README.md](./README.md)**: why a language · repo layout · governance
 
 ---

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -8,7 +8,7 @@
 #
 # Projectors · scripts/canon-projectors.py (in-repo · counts → docs+website) ·
 #   scripts/showcase-projector.py (examples → docs+website) · monorepo gate ·
-#   supernovae scripts/audit/nika-showcase-parity.sh + nika-canon-project.sh
+#   supernovae plumbing/scripts/audit/nika-showcase-parity.sh + nika-canon-project.sh
 # Architecture · projection-by-default (edit here once → projectors update
 #   every surface · drift is caught structurally at commit time). The .ttl is currently parallel-authored · in Phase 3
 #   it gets generated from this file.
@@ -86,7 +86,7 @@ namespaces:
     - secrets
 
 # ---------------------------------------------------------------- builtins
-# Post atomic-language audit · 42→27→26→25→22 (-20 · -48% · zero functional loss) → 23 (compose added 2026-06-13 · ADR-096 · agent-loop self-check intrinsic, loop-only like done).
+# Post atomic-language audit · 42→27→26→25→22 (-20 · -48% · zero functional loss) → 23 (compose added 2026-06-13 · ADR-093 · agent-loop self-check intrinsic, loop-only like done).
 # stdlib/builtins-v0.1.md is the prose home (matches at 23 · cascade complete 2026-06-13).
 # Admission test · 3 razors · (1) NOT-expressible-in-jq+CEL+Schema · (2) canonical
 # interop format (RFC-6902/7396/9562 · etc.) · (3) cookbook-clarity.

--- a/crates/nika-pack/pack/examples/01-hello.nika.yaml
+++ b/crates/nika-pack/pack/examples/01-hello.nika.yaml
@@ -6,13 +6,13 @@
 # Demonstrates ·
 #   - the envelope · `nika: v1` (contract version) + `workflow:` (kebab-case id)
 #   - one task · the `infer:` verb (a single LLM call)
-#   - the `ollama/llama3.1` model · local · no API key (mock/echo for CI)
+#   - the `ollama/llama3.2:3b` model · local · no API key (mock/echo for CI)
 #
 # Run · nika run examples/01-hello.nika.yaml
 nika: v1
 workflow: hello
 
-model: ollama/llama3.1      # local · zero key · swap for any cloud provider in the catalog
+model: ollama/llama3.2:3b   # local · zero key · swap for any cloud provider in the catalog
 
 tasks:
   - id: greet

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -7,7 +7,7 @@ pack_version: 0.1.0-draft
 workflow_count: 27
 foundation:
   - file: examples/01-hello.nika.yaml
-    sha256_16: d9dc9ab842c6ef57
+    sha256_16: f2f6af40906bdfcf
   - file: examples/06-parallel-fanout.nika.yaml
     sha256_16: 728605e34575d6d4
   - file: examples/16-exec-pipeline.nika.yaml
@@ -22,24 +22,24 @@ foundation:
     sha256_16: 187904d14bb2e430
 templates:
   - file: templates/agent-loop.nika.yaml
-    sha256_16: 4de0e9cd94e9228a
+    sha256_16: 48976c5e6a0b7c6c
   - file: templates/chain.nika.yaml
-    sha256_16: 823f49b8fd3d3dbe
+    sha256_16: 850080f98e115a8b
   - file: templates/etl-state.nika.yaml
-    sha256_16: d1b672d199505f56
+    sha256_16: cba8dcdc952eedc0
   - file: templates/fanout.nika.yaml
-    sha256_16: 32a0c6a483339247
+    sha256_16: 11762d6f2a2d0f09
   - file: templates/gate-and-act.nika.yaml
     sha256_16: e8a0c5e7f60f5e60
   - file: templates/human-gated-ship.nika.yaml
-    sha256_16: 3b487f1da13cf918
+    sha256_16: 8a0675f074eecb75
 showcase:
   - file: examples/showcase/t1-meeting-actions.nika.yaml
     workflow: meeting-actions
     tier: T1
     description: "Transcript \u2192 typed action items {owner, task, due}"
-    constructs: [outputs, schema, typed_vars]
-    sha256_16: 7f552e5c4d5de071
+    constructs: [local_model, outputs, schema, typed_vars]
+    sha256_16: 379a7c308babd800
   - file: examples/showcase/t1-price-watch.nika.yaml
     workflow: price-watch
     tier: T1
@@ -50,20 +50,20 @@ showcase:
     workflow: social-repurpose
     tier: T1
     description: "One post \u2192 thread + LinkedIn + newsletter, in parallel"
-    constructs: [outputs, with]
-    sha256_16: db1c878b8622043c
+    constructs: [local_model, outputs, with]
+    sha256_16: 2dcf80168fe991dd
   - file: examples/showcase/t1-standup-digest.nika.yaml
     workflow: standup-digest
     tier: T1
     description: "Read yesterday's commits, write today's standup note"
-    constructs: [outputs]
-    sha256_16: 45c9aba08825db66
+    constructs: [local_model, outputs]
+    sha256_16: d5b3d3251cecd249
   - file: examples/showcase/t2-contract-guard.nika.yaml
     workflow: contract-guard
     tier: T2
     description: "Local-model clause extraction \u2192 schema gate \u2192 risk memo"
     constructs: [local_model, outputs, schema, typed_vars]
-    sha256_16: 15f402a1f2a0e3b5
+    sha256_16: 8e88657f06a10f13
   - file: examples/showcase/t2-etl-quarantine.nika.yaml
     workflow: etl-quarantine
     tier: T2
@@ -74,83 +74,83 @@ showcase:
     workflow: invoice-chaser
     tier: T2
     description: "Ledger CSV \u2192 overdue filter \u2192 drafted reminders \u2192 human gate \u2192 drafts file"
-    constructs: [outputs, when]
-    sha256_16: 129be0260b2bcd5c
+    constructs: [local_model, outputs, when]
+    sha256_16: 45c16e8d428551e0
   - file: examples/showcase/t2-release-notes.nika.yaml
     workflow: release-notes
     tier: T2
     description: "git log \u2192 typed release notes \u2192 CHANGELOG insert \u2192 team ping"
-    constructs: [outputs, schema, secrets]
-    sha256_16: 2719d3b25dd6bc17
+    constructs: [local_model, outputs, schema, secrets]
+    sha256_16: 977ec0d0c59235d1
   - file: examples/showcase/t2-release-radar.nika.yaml
     workflow: release-radar
     tier: T2
     description: "dependency release feed \u2192 diff vs last run \u2192 only the NEW ships"
-    constructs: [on_error, output, outputs, when]
-    sha256_16: 73a9558fc944e869
+    constructs: [local_model, on_error, output, outputs, when]
+    sha256_16: be07b2ce1defe966
   - file: examples/showcase/t2-seo-content-brief.nika.yaml
     workflow: seo-content-brief
     tier: T2
     description: "Competitor sitemap \u2192 top page \u2192 gap analysis \u2192 typed brief"
-    constructs: [output, outputs, schema, typed_vars]
-    sha256_16: a208959c135fe202
+    constructs: [local_model, output, outputs, schema, typed_vars]
+    sha256_16: 9f0178f6dfcb84c0
   - file: examples/showcase/t2-support-triage.nika.yaml
     workflow: support-triage
     tier: T2
     description: "Ticket queue \u2192 typed triage \u2192 urgent escalation \u2192 triage board"
-    constructs: [outputs, schema, secrets, when]
-    sha256_16: ce4f9cf6464cb952
+    constructs: [local_model, outputs, schema, secrets, when]
+    sha256_16: dc7cf4a0b94e3d81
   - file: examples/showcase/t3-competitor-radar.nika.yaml
     workflow: competitor-radar
     tier: T3
     description: "Sitemap \u2192 parallel page reads \u2192 one competitive brief + ping"
-    constructs: [fail_fast, for_each, max_parallel, on_error, output, outputs, retry, secrets, timeout]
-    sha256_16: 104f7e45765c172a
+    constructs: [fail_fast, for_each, local_model, max_parallel, on_error, output, outputs, retry, secrets, timeout]
+    sha256_16: d45263a21b26ca87
   - file: examples/showcase/t3-config-drift-sentinel.nika.yaml
     workflow: config-drift-sentinel
     tier: T3
     description: "live config vs sanctioned baseline \u2192 typed drift \u2192 explained alert"
-    constructs: [on_error, outputs, retry, secrets, typed_vars, when]
-    sha256_16: 284539f24ef96388
+    constructs: [local_model, on_error, outputs, retry, secrets, typed_vars, when]
+    sha256_16: 20c0ee73e8d42310
   - file: examples/showcase/t3-localization-factory.nika.yaml
     workflow: localization-factory
     tier: T3
     description: "glob docs \u2192 parallel read \u2192 parallel translate \u2192 mirror tree"
-    constructs: [fail_fast, for_each, max_parallel, on_error, outputs]
-    sha256_16: 2404e47d06aef766
+    constructs: [fail_fast, for_each, local_model, max_parallel, on_error, outputs]
+    sha256_16: 2f2d57a92eb2847f
   - file: examples/showcase/t3-pr-review-fanout.nika.yaml
     workflow: pr-review-fanout
     tier: T3
     description: "changed files \u2192 one read-only review agent each \u2192 merged REVIEW.md"
-    constructs: [agent_tools, fail_fast, for_each, max_parallel, on_error, outputs, schema]
-    sha256_16: 579638baa0cfd41a
+    constructs: [agent_tools, fail_fast, for_each, local_model, max_parallel, on_error, outputs, schema]
+    sha256_16: 190345ec10312ae7
   - file: examples/showcase/t3-resume-screener.nika.yaml
     workflow: resume-screener
     tier: T3
     description: "glob CVs \u2192 local-model rubric per candidate \u2192 deterministic shortlist"
     constructs: [fail_fast, for_each, local_model, max_parallel, on_error, outputs, schema, when, with]
-    sha256_16: ecdb3c05f653bef4
+    sha256_16: 524a09c40c8a95b2
   - file: examples/showcase/t4-ceo-monday-brief.nika.yaml
     workflow: ceo-monday-brief
     tier: T4
     description: "news + repo pulse + KPIs \u2192 thinking synthesis \u2192 dated brief + cost ping"
-    constructs: [on_finally, output, outputs, secrets, thinking]
-    sha256_16: 55c6abf63449452e
+    constructs: [local_model, on_finally, output, outputs, secrets, thinking]
+    sha256_16: 8f97593a3521570b
   - file: examples/showcase/t4-deep-research-brief.nika.yaml
     workflow: deep-research-brief
     tier: T4
     description: "plan \u2192 budgeted research agent \u2192 thinking synthesis \u2192 brief on disk"
-    constructs: [agent_tools, outputs, schema, thinking, typed_vars]
-    sha256_16: 627c79c8f2f46cb1
+    constructs: [agent_tools, local_model, outputs, schema, thinking, typed_vars]
+    sha256_16: 1c5bb32552234427
   - file: examples/showcase/t4-incident-war-room.nika.yaml
     workflow: incident-war-room
     tier: T4
     description: "parallel evidence \u2192 typed timeline \u2192 settle + recheck \u2192 postmortem draft"
-    constructs: [capture, on_finally, outputs, retry, schema, secrets, thinking, when]
-    sha256_16: ab7d0cbd45329e89
+    constructs: [capture, local_model, on_finally, outputs, retry, schema, secrets, thinking, when]
+    sha256_16: ea3838c93e19a3d8
   - file: examples/showcase/t4-release-train.nika.yaml
     workflow: release-train
     tier: T4
     description: "parallel gates \u2192 human GO \u2192 hold until the window \u2192 ship \u00b7 verify \u00b7 record"
     constructs: [capture, on_finally, outputs, retry, secrets, timeout, typed_vars, when]
-    sha256_16: b12de28f818a65af
+    sha256_16: 6c4324567481b8bb

--- a/crates/nika-pack/pack/examples/showcase/t1-meeting-actions.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-meeting-actions.nika.yaml
@@ -3,12 +3,12 @@
 #
 # showcase · T1 starter · every office job
 #
-# A meeting transcript goes in. Owners, tasks and deadlines come out —
+# A meeting transcript goes in. Owners, tasks and deadlines come out:
 # as typed JSON your task tracker can actually import.
 #
 # Demonstrates ·
 #   - typed `vars:` · `transcript_path` is required · the engine validates inputs
-#   - `infer.schema:` · structured output — the model MUST return this shape
+#   - `infer.schema:` · structured output: the model MUST return this shape
 #   - `${{ tasks.X.output.actions }}` · indexing into a schema-validated object
 #   - `nika:log` · human-readable diagnostics on the event stream
 #
@@ -17,7 +17,7 @@ nika: v1
 workflow: meeting-actions
 description: "Transcript → typed action items {owner, task, due}"
 
-model: mock/echo            # swap for openai/gpt-5.2 or any provider in the catalog
+model: ollama/llama3.2:3b   # local · zero key · swap for openai/gpt-5.2 or any provider in the catalog
 
 vars:
   transcript_path:

--- a/crates/nika-pack/pack/examples/showcase/t1-price-watch.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-price-watch.nika.yaml
@@ -3,7 +3,7 @@
 #
 # showcase · T1 starter · e-commerce / personal
 #
-# A price-drop alert in ~20 lines — and ZERO model calls. Not every
+# A price-drop alert in ~20 lines, and ZERO model calls. Not every
 # workflow needs an LLM · the DAG, the tools and one CEL comparison
 # do the whole job deterministically.
 #

--- a/crates/nika-pack/pack/examples/showcase/t1-social-repurpose.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-social-repurpose.nika.yaml
@@ -4,7 +4,7 @@
 # showcase · T1 starter · marketing / creators
 #
 # One blog post becomes a tweet thread, a LinkedIn post and a newsletter
-# blurb — three rewrites running IN PARALLEL, merged into one bundle.
+# blurb: three rewrites running IN PARALLEL, merged into one bundle.
 #
 # Demonstrates ·
 #   - the diamond DAG · read → 3 parallel infers → merge
@@ -16,7 +16,7 @@ nika: v1
 workflow: social-repurpose
 description: "One post → thread + LinkedIn + newsletter, in parallel"
 
-model: mock/echo            # swap for mistral/mistral-large or any provider
+model: ollama/llama3.2:3b   # local · zero key · swap for mistral/mistral-large or any provider
 
 vars:
   post_path: "./blog/launch-post.md"

--- a/crates/nika-pack/pack/examples/showcase/t1-standup-digest.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-standup-digest.nika.yaml
@@ -3,20 +3,20 @@
 #
 # showcase · T1 starter · engineering / any team
 #
-# Your standup note writes itself — from what you actually committed.
+# Your standup note writes itself, from what you actually committed.
 #
 # Demonstrates ·
 #   - implicit parallelism · `today` + `history` have no deps · they run together
 #   - `nika:date` · timestamps come from a builtin, not the model's imagination
 #   - `exec:` → `infer:` · the bread-and-butter chain (real data in, words out)
-#   - `nika:write` · ALWAYS pass `content:` — a write without content writes nothing
+#   - `nika:write` · ALWAYS pass `content:` (a write without content writes nothing)
 #
 # Run · nika run examples/showcase/t1-standup-digest.nika.yaml
 nika: v1
 workflow: standup-digest
 description: "Read yesterday's commits, write today's standup note"
 
-model: mock/echo            # deterministic · swap for ollama/llama3.1 (local · zero key)
+model: ollama/llama3.2:3b   # local · zero key · swap for anthropic/claude-haiku-4-5 (fast one-liner job)
 
 tasks:
   # No deps between these two → the engine runs them in parallel.

--- a/crates/nika-pack/pack/examples/showcase/t2-contract-guard.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-contract-guard.nika.yaml
@@ -8,7 +8,7 @@
 # validate + assert pair refuses to ship a memo built on bad data.
 #
 # Demonstrates ·
-#   - sovereignty · `model: ollama/llama3.1` — sensitive docs stay local
+#   - sovereignty · `model: ollama/llama3.2:3b`: sensitive docs stay local
 #   - `nika:validate` · re-check the extraction against a stricter schema
 #   - `nika:assert` · the fail-fast guard (vs `when:` · the skip-guard)
 #   - belt-and-braces · schema at infer time + validate + assert downstream
@@ -18,7 +18,7 @@ nika: v1
 workflow: contract-guard
 description: "Local-model clause extraction → schema gate → risk memo"
 
-model: ollama/llama3.1      # the whole review runs offline · zero cloud
+model: ollama/llama3.2:3b   # the whole review runs offline · zero cloud
 
 vars:
   contract_path:
@@ -74,7 +74,7 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ tasks.check.output.valid == true }}"
-        message: "Clause extraction failed the schema gate — refusing to write the memo"
+        message: "Clause extraction failed the schema gate: refusing to write the memo"
 
   - id: memo
     depends_on: [clauses, gate]

--- a/crates/nika-pack/pack/examples/showcase/t2-etl-quarantine.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-etl-quarantine.nika.yaml
@@ -10,7 +10,7 @@
 #
 # Demonstrates ·
 #   - `on_error: recover:` · graceful degradation to a fallback value ·
-#     the skipped branch reads as null — guard `size()` with `!= null`
+#     the skipped branch reads as null: guard `size()` with `!= null`
 #   - `nika:convert` CSV→JSON + `nika:validate` as the schema gate
 #   - jq `group_by` aggregation · stats without a model call
 #   - the quarantine pattern · bad data is DATA, not an exception

--- a/crates/nika-pack/pack/examples/showcase/t2-invoice-chaser.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-invoice-chaser.nika.yaml
@@ -4,12 +4,12 @@
 # showcase · T2 chain · finance / freelance
 #
 # Friday ritual, automated · the invoice ledger is filtered for overdue
-# rows, polite reminders are drafted — and NOTHING goes out until a
+# rows, polite reminders are drafted, and NOTHING goes out until a
 # human says yes. The approval gate is three lines.
 #
 # Demonstrates ·
 #   - `nika:convert` · CSV → JSON, one builtin, `from:`/`to:`
-#   - `nika:jq` · THE data language — filter rows, no LLM needed for data work
+#   - `nika:jq` · THE data language: filter rows, no LLM needed for data work
 #   - `size(...)` CEL · the canonical empty-check gates the whole tail
 #   - `nika:prompt` · the human-in-the-loop gate (blocks until answered)
 #
@@ -18,7 +18,7 @@ nika: v1
 workflow: invoice-chaser
 description: "Ledger CSV → overdue filter → drafted reminders → human gate → drafts file"
 
-model: mock/echo            # swap for groq/llama-3.3-70b — drafting is a fast-model job
+model: ollama/llama3.2:3b   # local · zero key · swap for groq/llama-3.3-70b (drafting is a fast-model job)
 
 vars:
   ledger_csv: "./finance/invoices.csv"

--- a/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
@@ -9,7 +9,7 @@
 # Demonstrates ·
 #   - `exec:` with vars · the git range is an input, not a hardcode
 #   - `infer.schema:` · highlights/breaking/body as a typed object
-#   - `nika:edit` · in-place find/replace — the changelog INSERT pattern
+#   - `nika:edit` · in-place find/replace: the changelog INSERT pattern
 #   - `nika:notify` · webhook ping with fields from the structured output
 #
 # Run · nika run examples/showcase/t2-release-notes.nika.yaml
@@ -17,7 +17,7 @@ nika: v1
 workflow: release-notes
 description: "git log → typed release notes → CHANGELOG insert → team ping"
 
-model: mock/echo            # swap for mistral/mistral-large
+model: ollama/llama3.2:3b   # local · zero key · swap for mistral/mistral-large
 
 vars:
   since_tag: "v0.80.0"

--- a/crates/nika-pack/pack/examples/showcase/t2-release-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-radar.nika.yaml
@@ -3,7 +3,7 @@
 #
 # showcase · T2 chain · devops / dependency hygiene
 #
-# « Did anything we depend on ship this week? » — answered from the
+# « Did anything we depend on ship this week? » · answered from the
 # project's own feeds. `mode: feed` parses RSS/Atom natively · the
 # diff against last run's state means you only hear about what's NEW.
 #
@@ -12,14 +12,14 @@
 #   - the state-file pattern · read last run → diff → write next state
 #   - `nika:json_diff` (RFC 6902) · NEW entries = additions in the patch
 #   - `on_error: on_codes + recover:` · first-run recovery scoped to
-#     not-found ONLY — a permission error still fails loudly
+#     not-found ONLY · a permission error still fails loudly
 #
 # Run · nika run examples/showcase/t2-release-radar.nika.yaml
 nika: v1
 workflow: release-radar
 description: "dependency release feed → diff vs last run → only the NEW ships"
 
-model: mock/echo            # swap for ollama/llama3.1 (local · zero key)
+model: ollama/llama3.2:3b   # local · zero key · swap for any of the 14 providers
 
 vars:
   releases_feed: "https://github.com/tokio-rs/tokio/releases.atom"

--- a/crates/nika-pack/pack/examples/showcase/t2-seo-content-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-seo-content-brief.nika.yaml
@@ -4,12 +4,12 @@
 # showcase · T2 chain · SEO / content marketing
 #
 # A competitor's sitemap goes in. A ready-to-write content brief comes
-# out · title, angle, outline, keywords — grounded in what they actually
+# out · title, angle, outline, keywords: grounded in what they actually
 # published, not vibes.
 #
 # Demonstrates ·
 #   - `mode: sitemap` then `mode: article` · two fetch extractions chained
-#   - `output:` jq slice · `.urls[:5]` — bind just the top of a list
+#   - `output:` jq slice · `.urls[:5]`: bind just the top of a list
 #   - CEL indexing · `${{ tasks.map.top[0] }}` reaches into a binding
 #   - `infer.schema:` · the brief is typed, not a blob
 #
@@ -18,7 +18,7 @@ nika: v1
 workflow: seo-content-brief
 description: "Competitor sitemap → top page → gap analysis → typed brief"
 
-model: mock/echo            # swap for openai/gpt-5.2
+model: ollama/llama3.2:3b   # local · zero key · swap for openai/gpt-5.2
 
 vars:
   competitor_sitemap: "https://competitor.example.com/sitemap.xml"

--- a/crates/nika-pack/pack/examples/showcase/t2-support-triage.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-support-triage.nika.yaml
@@ -8,7 +8,7 @@
 # webhook, the full board written to disk under a batch id.
 #
 # Demonstrates ·
-#   - `nika:uuid` · v7 batch ids — sortable, timestamped, no collisions
+#   - `nika:uuid` · v7 batch ids: sortable, timestamped, no collisions
 #   - `infer.schema:` over a LIST · classify the whole queue in one typed call
 #   - `nika:jq` post-filter · urgency slicing WITHOUT another model call
 #   - conditional `notify` · the escalation fires only when needed
@@ -18,7 +18,7 @@ nika: v1
 workflow: support-triage
 description: "Ticket queue → typed triage → urgent escalation → triage board"
 
-model: mock/echo            # swap for groq/llama-3.3-70b — triage wants speed
+model: ollama/llama3.2:3b   # local · zero key · swap for groq/llama-3.3-70b (triage wants speed)
 
 vars:
   queue_path: "./support/overnight-queue.json"

--- a/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
@@ -5,7 +5,7 @@
 #
 # Monday 8am · everything your competitor shipped last week, read in
 # parallel, digested into one brief on your desk. N pages is decided at
-# RUNTIME by their sitemap — not hardcoded.
+# RUNTIME by their sitemap, not hardcoded.
 #
 # Demonstrates ·
 #   - `for_each` over a runtime collection · the matrix / fan-out pattern
@@ -18,7 +18,7 @@ nika: v1
 workflow: competitor-radar
 description: "Sitemap → parallel page reads → one competitive brief + ping"
 
-model: mock/echo            # swap for anthropic/claude-sonnet-4-6
+model: ollama/llama3.2:3b   # local · zero key · swap for anthropic/claude-sonnet-4-6
 
 vars:
   competitor_sitemap: "https://competitor.example.com/sitemap.xml"

--- a/crates/nika-pack/pack/examples/showcase/t3-config-drift-sentinel.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-config-drift-sentinel.nika.yaml
@@ -3,7 +3,7 @@
 #
 # showcase · T3 fan-out · SRE / platform
 #
-# « Did anyone change prod config without telling us? » — answered
+# « Did anyone change prod config without telling us? » · answered
 # deterministically. Approved overrides are merged into the baseline
 # (RFC 7396), the live config is diffed against that (RFC 6902), and
 # ONLY unsanctioned drift wakes anyone up. The LLM explains; jq decides.
@@ -11,8 +11,8 @@
 # Demonstrates ·
 #   - `on_error: recover:` on the explain step · a model outage degrades the
 #     alert text, never silences the alert
-#   - `nika:json_merge_patch` · RFC 7396 — sanctioned overrides, null deletes
-#   - `nika:json_diff` · RFC 6902 patch — what ACTUALLY changed
+#   - `nika:json_merge_patch` · RFC 7396: sanctioned overrides, null deletes
+#   - `nika:json_diff` · RFC 6902 patch: what ACTUALLY changed
 #   - `nika:hash` (blake3) · provenance fingerprint in the alert
 #   - `size(...)` gate + `nika:emit` · machine event for the journal
 #
@@ -21,7 +21,7 @@ nika: v1
 workflow: config-drift-sentinel
 description: "live config vs sanctioned baseline → typed drift → explained alert"
 
-model: mock/echo            # swap for anthropic/claude-haiku-4-5 — explain is cheap
+model: ollama/llama3.2:3b   # local · zero key · swap for anthropic/claude-haiku-4-5 (explain is cheap)
 
 vars:
   config_url: "https://api.internal.example.com/v1/config"
@@ -84,7 +84,7 @@ tasks:
     depends_on: [drift]
     when: ${{ size(tasks.drift.output) > 0 }}
     on_error:
-      recover: "(explanation unavailable — model call failed · the raw patch is attached)"
+      recover: "(explanation unavailable · model call failed · the raw patch is attached)"
     infer:
       prompt: |
         This RFC 6902 patch is UNSANCTIONED config drift in production ·

--- a/crates/nika-pack/pack/examples/showcase/t3-localization-factory.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-localization-factory.nika.yaml
@@ -11,14 +11,14 @@
 #   - `nika:glob` · the collection comes from the filesystem at runtime
 #   - chained `for_each` stages · read-all → translate-all → write-all
 #   - `nika:jq` `transpose` · zip two parallel arrays into [{path, text}]
-#   - `${{ item.path }}` · loop-locals are objects too — field access works
+#   - `${{ item.path }}` · loop-locals are objects too: field access works
 #
 # Run · nika run examples/showcase/t3-localization-factory.nika.yaml
 nika: v1
 workflow: localization-factory
 description: "glob docs → parallel read → parallel translate → mirror tree"
 
-model: mistral/mistral-large    # EU model for EU locales · pick yours
+model: ollama/llama3.2:3b   # local default · swap for mistral/mistral-large (EU model for EU locales)
 
 vars:
   lang: "fr"

--- a/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
@@ -4,7 +4,7 @@
 # showcase · T3 fan-out · engineering
 #
 # A review SWARM · one mini-agent per changed file, each granted
-# read-only tools, all running in parallel — then jq flattens the
+# read-only tools, all running in parallel, then jq flattens the
 # findings and one model writes the summary a human actually reads.
 #
 # Demonstrates ·
@@ -19,7 +19,7 @@ nika: v1
 workflow: pr-review-fanout
 description: "changed files → one read-only review agent each → merged REVIEW.md"
 
-model: anthropic/claude-sonnet-4-6   # agent loops want a tool-calling model
+model: ollama/llama3.2:3b   # local tool-calling model · swap for anthropic/claude-sonnet-4-6 for depth
 
 vars:
   base_ref: "main"

--- a/crates/nika-pack/pack/examples/showcase/t3-resume-screener.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-resume-screener.nika.yaml
@@ -20,9 +20,9 @@ nika: v1
 workflow: resume-screener
 description: "glob CVs → local-model rubric per candidate → deterministic shortlist"
 
-model: ollama/llama3.1      # PII stays on the machine · the whole screen is offline
+model: ollama/llama3.2:3b   # PII stays on the machine · the whole screen is offline
 
-permits:                    # the file IS the blast radius · no net category at all —
+permits:                    # the file IS the blast radius · no net category at all:
   fs:                       # CVs cannot leave this machine even if a prompt is hijacked
     read: ["./hiring/inbox/**"]
     write: ["./hiring/out/**", "./hiring/shortlist-brief.md"]
@@ -74,7 +74,7 @@ tasks:
         CV ·
         ${{ item.text }}
         Score this candidate against the role. Quote evidence from the
-        CV for every rating — no rating without a quote.
+        CV for every rating: no rating without a quote.
       schema:
         type: object
         required: [file, fit, strengths, concerns]

--- a/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
@@ -5,7 +5,7 @@
 #
 # The Monday brief that assembles itself · market signal, engineering
 # pulse and the KPI sheet gathered in parallel · synthesized with a
-# thinking budget · saved, dated — and the ping tells you what the run
+# thinking budget · saved, dated, and the ping tells you what the run
 # COST. The workflow reports its own bill.
 #
 # Demonstrates ·
@@ -20,7 +20,7 @@ nika: v1
 workflow: ceo-monday-brief
 description: "news + repo pulse + KPIs → thinking synthesis → dated brief + cost ping"
 
-model: mistral/mistral-large
+model: ollama/llama3.2:3b   # local default · the synthesis task below overrides to a stronger model
 
 vars:
   watch_query: "AI workflow engines"

--- a/crates/nika-pack/pack/examples/showcase/t4-deep-research-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-deep-research-brief.nika.yaml
@@ -6,13 +6,13 @@
 # Plan → investigate → synthesize · a three-stage research pipeline.
 # A fast model plans the queries, an AGENT works the web under explicit
 # budgets, a thinking model writes the executive brief. Each stage is
-# auditable — the plan, the sources and the findings all land on disk.
+# auditable: the plan, the sources and the findings all land on disk.
 #
 # Demonstrates ·
 #   - plan-then-execute · `infer.schema:` plans · `agent:` executes the plan
-#   - budgets · `max_turns` + `max_tokens_total` — agents have a leash
+#   - budgets · `max_turns` + `max_tokens_total`: agents have a leash
 #   - `thinking:` · extended reasoning budget for the synthesis stage
-#   - typed `outputs:` · the workflow is CALLABLE — another workflow can
+#   - typed `outputs:` · the workflow is CALLABLE: another workflow can
 #     consume {brief, sources} as a contract
 #
 # Run · nika run examples/showcase/t4-deep-research-brief.nika.yaml
@@ -20,7 +20,7 @@ nika: v1
 workflow: deep-research-brief
 description: "plan → budgeted research agent → thinking synthesis → brief on disk"
 
-model: anthropic/claude-sonnet-4-6
+model: ollama/llama3.2:3b   # local default · per-task overrides below pick stronger models
 
 vars:
   topic:

--- a/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
@@ -19,7 +19,7 @@ nika: v1
 workflow: incident-war-room
 description: "parallel evidence → typed timeline → settle + recheck → postmortem draft"
 
-model: mistral/mistral-large
+model: ollama/llama3.2:3b   # local default · the synthesis task below overrides to a stronger model
 
 vars:
   service: "checkout-api"
@@ -105,7 +105,7 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ tasks.recheck.output == 'operational' }}"
-        message: "Service is NOT back to operational — postmortem draft blocked"
+        message: "Service is NOT back to operational: postmortem draft blocked"
 
   # ── the draft · only after recovery is proven ──
   - id: postmortem
@@ -129,7 +129,7 @@ tasks:
         content: "${{ tasks.postmortem.output }}"
         create_dirs: true
 
-  # the always-pattern · the on-call ping fires on EVERY outcome —
+  # the always-pattern · the on-call ping fires on EVERY outcome:
   # including the designed failure path (recovery NOT confirmed → the
   # assert fails → save never starts → this still runs · when: true
   # replaces the default gate · 03 §Task states).

--- a/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
@@ -5,7 +5,7 @@
 #
 # The release train · gates run in parallel, a human signs the
 # departure, the train WAITS until the scheduled window (absolute
-# `until:` — not a sleep), ships, verifies, and the journal gets the
+# `until:`, not a sleep), ships, verifies, and the journal gets the
 # full departure record. Time is a first-class citizen here.
 #
 # Demonstrates ·
@@ -68,7 +68,7 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ tasks.tests.output.exit_code == 0 && tasks.lint.output.exit_code == 0 && tasks.audit.output.exit_code == 0 }}"
-        message: "A release gate is RED — the train does not depart"
+        message: "A release gate is RED: the train does not depart"
 
   - id: gate_time
     depends_on: [t0, gates_green]
@@ -95,7 +95,7 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ tasks.conductor.output == true }}"
-        message: "Departure not signed — train cancelled"
+        message: "Departure not signed: train cancelled"
 
   # ── hold until the window · absolute time, not a sleep ──
   - id: hold
@@ -132,11 +132,11 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ tasks.verify.output == vars.version }}"
-        message: "Prod does not report the shipped version — investigate before announcing"
+        message: "Prod does not report the shipped version: investigate before announcing"
 
   # the always-pattern · `when: true` replaces the default success-gate ·
   # this task runs whether `live` succeeded, failed, or never started
-  # (upstream abort) — a record that must land on EVERY outcome is a
+  # (upstream abort) · a record that must land on EVERY outcome is a
   # terminal task, not a cleanup hook (03 §Task states).
   - id: record
     depends_on: [live]

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -12,7 +12,7 @@ It describes the **what** ·
 
 - which LLMs to call (`infer:`)
 - which commands to run (`exec:`)
-- which tools to call — including fetching a URL (`invoke:`)
+- which tools to call, including fetching a URL (`invoke:`)
 - which agentic loops to spawn (`agent:`)
 
 The **how** lives in conformant engines.
@@ -61,7 +61,7 @@ These 5 pillars are **locked forever** at `nika: v1`. Everything else (providers
 nika: v1
 workflow: hello
 
-model: ollama/llama3.1
+model: ollama/llama3.2:3b
 tasks:
   - id: greet
     infer:
@@ -106,7 +106,7 @@ outputs:                              # what the workflow returns · symmetric t
   summary: ${{ tasks.summarize.output }}
 ```
 
-3 tasks · DAG with deps · 2 verbs (`invoke:` ×2 incl `nika:fetch` · `infer:`) · variable substitution + task output reference · an `outputs:` return contract. Note each task that references `${{ tasks.X.output }}` also lists `X` in `depends_on:` — that pairing is **required** (`NIKA-DAG-003` · the engine never infers the edge). The 4th verb, `agent:` (an agentic loop · may declare a `schema:`), is shown in [examples/](../examples/).
+3 tasks · DAG with deps · 2 verbs (`invoke:` ×2 incl `nika:fetch` · `infer:`) · variable substitution + task output reference · an `outputs:` return contract. Note each task that references `${{ tasks.X.output }}` also lists `X` in `depends_on:`. That pairing is **required** (`NIKA-DAG-003` · the engine never infers the edge). The 4th verb, `agent:` (an agentic loop · may declare a `schema:`), is shown in [examples/](../examples/).
 
 ---
 
@@ -123,7 +123,7 @@ outputs:                              # what the workflow returns · symmetric t
 | [07 conformance](./07-conformance.md) | What « v0.1-compliant » means |
 | [08 out of scope](./08-out-of-scope.md) | Explicit defer list (memory · macros · etc.) |
 
-**Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/) — **<!-- canon:providers -->14<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->23<!-- /canon --> builtins** (6 core · 5 file · 8 data · 2 introspection · 2 network · post ADR-086/087/088 Rams sweep 2026-05-27).
+**Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/): **<!-- canon:providers -->14<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->23<!-- /canon --> builtins** (6 core · 5 file · 8 data · 1 introspection · 2 network · post ADR-086/087/088 Rams sweep 2026-05-27).
 
 ---
 
@@ -145,7 +145,7 @@ See [`08-out-of-scope.md`](./08-out-of-scope.md) for the explicit list.
 
 ## Frozen language envelope
 
-The **language** envelope is frozen at `nika: v1` forever. The 5 pillars are locked at the `nika: v1` contract · minor language additions are additive only (feature-detected · no minor version in the file) · breaking changes would ship as a new contract (`nika: v2`) with its own spec — and the envelope being frozen, that is effectively never. (This is the **language** version, independent of any engine version: the reference engine ships its own semver toward a 1.0 release, which does not touch `nika: v1`.)
+The **language** envelope is frozen at `nika: v1` forever. The 5 pillars are locked at the `nika: v1` contract · minor language additions are additive only (feature-detected · no minor version in the file) · breaking changes would ship as a new contract (`nika: v2`) with its own spec, and the envelope being frozen, that is effectively never. (This is the **language** version, independent of any engine version: the reference engine ships its own semver toward a 1.0 release, which does not touch `nika: v1`.)
 
 In practice · we expect `nika: v1` to last 10+ years.
 

--- a/crates/nika-pack/pack/spec/01-envelope.md
+++ b/crates/nika-pack/pack/spec/01-envelope.md
@@ -30,7 +30,7 @@ workflow: scrape-and-summarize          # required · kebab-case · unique withi
 description: "Fetch + summarize"         # optional · human-readable
 
 # Workflow-level default model · any task may override · <provider>/<name>
-model: ollama/llama3.1            # optional · anthropic/claude-sonnet-4-6 for cloud
+model: ollama/llama3.2:3b         # optional · anthropic/claude-sonnet-4-6 for cloud
 
 # Inputs · available as ${{ vars.<name> }} · untyped OR typed
 vars:
@@ -72,16 +72,16 @@ outputs:
 
 A workflow file is **YAML 1.2 · core schema**. Two consequences authors hit ·
 
-- **Anchors & aliases (`&x` / `*x`) are fully supported** — they are core
+- **Anchors & aliases (`&x` / `*x`) are fully supported**: they are core
   YAML · they resolve BEFORE validation (the schema sees the expanded
   document) · legitimate for de-duplicating repeated blocks (a shared
   `retry:` policy · a common `with:` shape).
-- **Merge keys (`<<:`) are NOT part of the contract** — YAML 1.2 dropped
+- **Merge keys (`<<:`) are NOT part of the contract**: YAML 1.2 dropped
   them (they were a 1.1 extension) · parser support varies · a portable
   workflow MUST NOT use them · the reference linter rejects them at check
   time (`NIKA-PARSE` · `validation_error`).
 
-(YAML 1.2 core also kills the 1.1 traps — `no` is a string, not `false` ·
+(YAML 1.2 core also kills the 1.1 traps: `no` is a string, not `false` ·
 `3:22` is a string, not sexagesimal. The quoted-duration rule of
 [03 §timeout](./03-dag.md#timeout--optional--task-level-timeout-go-duration-string)
 adds the belt to those suspenders.)
@@ -103,7 +103,7 @@ Nika workflow »; the value `v1` pins the **language contract version**.
 additions to the language (a new optional field, a new builtin) are
 **additive** and never change this value. A future `nika: v2` would be a
 deliberate breaking-change generation with its own spec, not
-backward-compatible with v1 — the language envelope is frozen, so that is
+backward-compatible with v1: the language envelope is frozen, so that is
 effectively never. (This is the **language** version, independent of any
 engine version.)
 
@@ -114,11 +114,11 @@ engine version.)
 > Kubernetes-style `apiVersion: nika.sh/v1` (the superseded ADR-021 form)
 > plus a separate `schema: nika/workflow@v1` (superseded too). That is two version-ish fields and
 > ceremony a workflow file does not need. Modern specs converge on a
-> single version marker — OpenAPI writes `openapi: 3.1.0`, Docker
+> single version marker: OpenAPI writes `openapi: 3.1.0`, Docker
 > Compose dropped its `version:` field entirely. Nika takes the
 > middle, proven path: **one field, the language name as the key, the
 > contract version as the value.** The engine's internal canonical URI
-> stays `https://nika.sh/spec/v1` for RDF / conformance tooling — but
+> stays `https://nika.sh/spec/v1` for RDF / conformance tooling, but
 > the author never types a URL.
 
 ### `workflow` · **required · kebab-case · unique within file**
@@ -130,7 +130,7 @@ workflow: scrape-and-summarize
 A stable identifier for the workflow. Kebab-case. Used in journal events,
 traces, and error messages.
 
-The presence of `workflow:` is also the **document-type discriminator** —
+The presence of `workflow:` is also the **document-type discriminator**:
 it marks this file as a workflow. Future Nika document types (if any ever
 ship) would use their own top-level key; there is no separate `kind:`
 field in v1.
@@ -149,12 +149,12 @@ listings + LSP hover hints.
 ### `model` · *optional · default model · `<provider>/<name>`*
 
 ```yaml
-model: ollama/llama3.1                  # local
+model: ollama/llama3.2:3b               # local
 # model: anthropic/claude-sonnet-4-6    # cloud · same shape
 ```
 
 Default model for any `infer:` or `agent:` verb in this workflow, as a single
-**`<provider>/<name>`** string (the LiteLLM / OpenRouter / Vercel convention —
+**`<provider>/<name>`** string (the LiteLLM / OpenRouter / Vercel convention:
 there is no separate `provider:` field). The provider prefix selects the
 backend and decides local-vs-cloud (`ollama/` · `lmstudio/` = local · the rest
 = cloud). See [stdlib/providers-v0.1.md](../stdlib/providers-v0.1.md) for the
@@ -181,10 +181,10 @@ vars:
 
 Inputs available in every task via `${{ vars.<name> }}` substitution.
 
-The **untyped form** (`name: value`) is the value's default — simplest for
+The **untyped form** (`name: value`) is the value's default, simplest for
 a workflow you run yourself. The **typed form** (`name: { type, required,
 default, description }`) lets the engine validate inputs and
-**generate a callable schema** — this is what powers `nika.run_workflow`
+**generate a callable schema**: this is what powers `nika.run_workflow`
 over MCP (a caller like an agent host sees the typed inputs and knows
 exactly what to pass) and UI generation. Simple stays simple; power is
 there when a workflow becomes a reusable, callable unit. Typed `vars:` are
@@ -192,7 +192,7 @@ the **input** half of that callable contract; typed [`outputs:`](#outputs--optio
 (below) are the **output** half.
 
 **The discriminator (normative)** · a var whose value is an **object
-carrying a string `type:` key** IS a typed declaration — `type:` must then be
+carrying a string `type:` key** IS a typed declaration: `type:` must then be
 one of the closed enum (`string` · `number` · `integer` · `boolean` · `array`
 · `object`) or the workflow is rejected (`NIKA-PARSE` · `validation_error`).
 An untyped object default that legitimately contains a `type` key
@@ -232,7 +232,7 @@ require `key:` · `file` requires `path:` · an entry with neither (or an
 inline literal value) is rejected (`NIKA-PARSE` · `validation_error`).
 
 Sensitive values available via `${{ secrets.<name> }}`. A secret is always
-a **reference to a store** — never an inline literal. The engine **masks**
+a **reference to a store**, never an inline literal. The engine **masks**
 resolved secret values in logs, traces, and journal events.
 
 **`source` · closed enum** (the only three v0.1 values) ·
@@ -245,17 +245,17 @@ resolved secret values in logs, traces, and journal events.
 
 The `env` / `secrets` split is the modern secure-workflow default: non-sensitive
 config in `env:` (appears in logs), masked references in `secrets:` (never
-logged) — note `source: env` reads a *secret* from an env var and still masks
+logged). Note `source: env` reads a *secret* from an env var and still masks
 it, which is different from the plain `env:` block.
 
 #### `egress` · *optional · sanctioned destinations (declassification)*
 
-By default, a `secrets.<name>` value reaching ANY effect — an `exec:` or
-`invoke:` sink, OR an `infer:`/`agent:` **prompt** (`prompt:` + `system:`) —
+By default, a `secrets.<name>` value reaching ANY effect, an `exec:` or
+`invoke:` sink, OR an `infer:`/`agent:` **prompt** (`prompt:` + `system:`),
 is a **blocking leak**: the engine masks its own output but cannot follow a
 secret a subprocess, a tool, or a third-party provider re-emits (`nika check`
 reports it · the workflow is refused). An `infer:`/`agent:` prompt is a
-provider-egress sink like any other — a secret in it LEAVES the run to the
+provider-egress sink like any other: a secret in it LEAVES the run to the
 provider, so it needs an explicit sanction (`egress: [{ to: "infer" }]` /
 `{ to: "agent" }`) exactly as a tool sink does.
 
@@ -264,7 +264,7 @@ response is not a verbatim echo of its prompt, so `tasks.<id>.output` of an
 `infer:`/`agent:` task is never tainted by a prompt secret (it does not
 re-leak downstream).
 
-But legitimate workflows MUST send a secret to other sinks — a webhook-URL
+But legitimate workflows MUST send a secret to other sinks: a webhook-URL
 secret to `nika:notify`, an API key in a `nika:fetch` header. The optional
 `egress:` list on a secret **sanctions** exactly those destinations · the
 author declassifies their OWN secret, in-file, statically checkable.
@@ -286,19 +286,19 @@ secrets:
 ```
 
 **Default-deny.** An absent / empty `egress:` is the current behavior,
-unchanged — NO sanctioned egress, every `exec:`/`invoke:` reach is a leak.
+unchanged: NO sanctioned egress, every `exec:`/`invoke:` reach is a leak.
 
 **Semantics (normative) · a secret→sink edge is sanctioned iff ALL hold** ·
 
 | Layer | Rule |
 |---|---|
-| **① confidentiality** | the sink's id equals an `egress[].to:` — a tool id (`nika:fetch` · `mcp:<server>/<tool>`), `exec`, or the provider-egress sinks `infer` / `agent` (an infer/agent prompt). `to:` is SPECIFIC — a clearance for `nika:fetch` never authorizes `exec` (no cross-tool laundering). |
+| **① confidentiality** | the sink's id equals an `egress[].to:`: a tool id (`nika:fetch` · `mcp:<server>/<tool>`), `exec`, or the provider-egress sinks `infer` / `agent` (an infer/agent prompt). `to:` is SPECIFIC: a clearance for `nika:fetch` never authorizes `exec` (no cross-tool laundering). |
 | **② integrity** | for a network sink, either `host:` equals the effect's **static-literal** destination host (a templated `${{ }}`-derived host does NOT sanction · it stays the runtime check), OR `host_from_self: true` AND the destination arg is **exactly** `${{ secrets.<this> }}` (not concatenated) AND **no other secret co-occurs** in the same effect payload. A sink with no addressable host (`{ to }` alone) clears this layer. |
-| **③ capability** | when a [`permits:`](#permits--optional--the-declared-capability-boundary) block is present and the host is statically known, the host MUST ALSO be in `permits.net.http` — `egress:` NARROWS the capability boundary, never widens it. `host_from_self` (host unknown statically) degrades to the runtime `permits` check. |
+| **③ capability** | when a [`permits:`](#permits--optional--the-declared-capability-boundary) block is present and the host is statically known, the host MUST ALSO be in `permits.net.http`: `egress:` NARROWS the capability boundary, never widens it. `host_from_self` (host unknown statically) degrades to the runtime `permits` check. |
 
 `to:` is required. `host:` and `host_from_self:` are mutually exclusive (a host
 is a literal you can check OR the secret itself, never both). Sanctioning the
-egress clears the **send**, not the **capture** — a sanctioned `exec:`/tool can
+egress clears the **send**, not the **capture**: a sanctioned `exec:`/tool can
 still embed the secret in its captured output, so that output stays tainted and
 re-leaks if it reaches an unsanctioned sink downstream.
 
@@ -316,7 +316,7 @@ permits:                          # the workflow's entire blast radius, declared
   tools: ["nika:read", "nika:write", "mcp:browser/*"]  # the builtin/MCP surface it may invoke
 ```
 
-`permits:` makes the **file itself the security boundary** — an auditable
+`permits:` makes the **file itself the security boundary**: an auditable
 property of the workflow, not a runtime flag. It is **optional and
 non-breaking**: a workflow with no `permits:` block runs exactly as today
 (bounded only by the engine's own SSRF + blocklist floor).
@@ -327,12 +327,12 @@ DEFAULT-DENY unless listed** ·
 | Category | When listed | When the `permits:` block is present but this category is omitted |
 |---|---|---|
 | `fs.read` / `fs.write` | only the matching path globs are allowed | **no** filesystem read / write |
-| `net.http` | only the listed hosts (globs ok) — tightens the engine SSRF floor, never loosens it | **no** outbound network |
-| `exec` | `false` = no shells · `true` = any (still blocklist-gated) · array = only those program names (argv `command[0]`) | treated as `false` — **no** `exec:` |
+| `net.http` | only the listed hosts (globs ok) · tightens the engine SSRF floor, never loosens it | **no** outbound network |
+| `exec` | `false` = no shells · `true` = any (still blocklist-gated) · array = only those program names (argv `command[0]`) | treated as `false` · **no** `exec:` |
 | `tools` | only the matching `nika:` / `mcp:` ids (globs ok) | **no** `invoke:` of any tool |
 
 So `permits: {}` is a workflow provably limited to pure compute (`infer:` +
-CEL + `nika:jq`) — zero fs, zero net, zero shell, zero tools. That property
+CEL + `nika:jq`): zero fs, zero net, zero shell, zero tools. That property
 is checkable BEFORE the run.
 
 **The engine MUST enforce `permits:` on BOTH surfaces** ·
@@ -341,7 +341,7 @@ is checkable BEFORE the run.
    `invoke:` of an unlisted tool → a **lint error** (the run is refused
    before it starts).
 2. **At runtime** · any effect escaping the declared set fails the task
-   `NIKA-SEC-004` (`security_error` · never fed back to an `agent:` model —
+   `NIKA-SEC-004` (`security_error` · never fed back to an `agent:` model:
    a capability boundary is not negotiation material). This catches the
    dynamic cases a static check cannot (a host computed at run time).
 
@@ -375,7 +375,7 @@ outputs:
     description: "The final markdown brief"
 ```
 
-`outputs:` declares **what the workflow returns** — the symmetric twin of
+`outputs:` declares **what the workflow returns**, the symmetric twin of
 `vars:` (what it takes in). Each entry is a name bound to a
 `${{ tasks.<id>.output }}` reference (or any `${{ ... }}` expression), in the
 **untyped form** (bare reference) or the **typed form**
@@ -383,12 +383,12 @@ outputs:
 
 This single block serves three consumers ·
 
-- **`nika run`** — prints this object as the workflow result (without `outputs:`,
+- **`nika run`**: prints this object as the workflow result (without `outputs:`,
   the CLI result is engine-defined and implicit).
-- **`nika.run_workflow` over MCP** — a caller (agent host · parent workflow)
+- **`nika.run_workflow` over MCP**: a caller (agent host · parent workflow)
   receives exactly this shape. Together with typed `vars:` it forms the
   **complete callable contract** · typed in, typed out.
-- **Schema generation** — typed outputs generate the *output half* of the
+- **Schema generation**: typed outputs generate the *output half* of the
   callable schema (typed `vars:` generate the input half).
 
 If `outputs:` is omitted, the workflow still runs; its result is
@@ -398,28 +398,28 @@ referenced task ids must exist (parse-time validated).
 > **`outputs:` (envelope · plural) ≠ `output:` (task · singular).** The
 > workflow-level `outputs:` is the *return contract*; the task-level `output:`
 > ([04-variables.md](./04-variables.md#output-binding--output)) defines *named
-> jq bindings* on one task. Plural-at-the-top, singular-per-task — the
+> jq bindings* on one task. Plural-at-the-top, singular-per-task: the
 > same split GitHub Actions uses for `workflow_call.outputs` vs step `outputs`.
 
 ### What leaves a run · the export contract (normative)
 
 Exactly **three** things cross the run boundary · nothing else is promised ·
 
-1. **The `outputs:` object** — when declared, a conformant engine's run
+1. **The `outputs:` object**: when declared, a conformant engine's run
    command prints it as a **single JSON object on stdout** (and returns the
    same shape over MCP). Diagnostics · progress · logs go to **stderr** ·
    never interleaved into the stdout JSON.
-2. **The exit code** — maps 1:1 to the workflow final state
+2. **The exit code**: maps 1:1 to the workflow final state
    ([05 §workflow-level semantics](./05-errors.md#workflow-level-error-semantics)) ·
    `success` → **0** · `failure` → **non-zero** · `cancelled` → **non-zero**
    (distinct from failure's code · engine-documented). Parse/validation
    rejection (the run never started) is also non-zero.
-3. **Tool side effects** — whatever the workflow's tools wrote (files ·
+3. **Tool side effects**: whatever the workflow's tools wrote (files ·
    notifications · MCP calls). The language does not track these; they are
    the workflow's business.
 
 A schema'd **machine run report** (per-task statuses · timings · costs ·
-ProofChain-compatible provenance) is deferred — see
+ProofChain-compatible provenance) is deferred: see
 [08 §Horizon postures H10](./08-out-of-scope.md#horizon-postures--the--did-you-think-of-x--table-2026-06-10) ·
 until then `nika:inspect` exposes run introspection *inside* the run, and
 the completion event (05) is the engine-side hook.
@@ -428,7 +428,7 @@ the completion event (05) is the engine-side hook.
 
 ## YAML conventions · no traps
 
-A Nika file is **YAML 1.2** (which is a strict superset of JSON — every Nika
+A Nika file is **YAML 1.2** (which is a strict superset of JSON: every Nika
 workflow can also be written as JSON). YAML 1.2 is mandated specifically to
 avoid the classic YAML 1.1 footguns that bite generated configs:
 
@@ -460,7 +460,7 @@ these files) should quote-by-default for the four ambiguous-scalar cases above.
 
 - It is NOT a place to inline credentials. Use `secrets:` with a `source` reference.
 - It is NOT a place for engine runtime config (global timeouts · concurrency limits). Those live in engine config files, out of scope of the spec.
-- It is NOT a place for imports / includes. v1 is single-file workflows. (Static composition is a candidate for a later additive minor — see [08-out-of-scope.md](./08-out-of-scope.md).)
+- It is NOT a place for imports / includes. v1 is single-file workflows. (Static composition is a candidate for a later additive minor: see [08-out-of-scope.md](./08-out-of-scope.md).)
 
 ---
 
@@ -523,9 +523,9 @@ A v0.1-compliant engine MUST ·
 3. Validate `workflow` identifier kebab-case format
 4. Make workflow-level `model`, `vars`, `env`, `secrets` available to all tasks as defaults
 5. Validate typed `vars` (type + required) before execution · reject missing required inputs
-6. Validate each typed `outputs` value against its declared `type:` at run end · a value that does not match its declared type fails the run (`NIKA-VAR-009` · `validation_error`) — the callable contract is enforced on BOTH halves (typed in via `vars`, typed out via `outputs`) · symmetric with rule 5
+6. Validate each typed `outputs` value against its declared `type:` at run end · a value that does not match its declared type fails the run (`NIKA-VAR-009` · `validation_error`): the callable contract is enforced on BOTH halves (typed in via `vars`, typed out via `outputs`) · symmetric with rule 5
 7. Mask resolved `secrets` values in all logs · traces · journal events
-8. Enforce a declared `permits:` block on both surfaces — refuse statically-detectable escapes at check time, and fail any runtime effect outside the boundary with `NIKA-SEC-004` · once `permits:` is present every category is default-deny unless listed
+8. Enforce a declared `permits:` block on both surfaces: refuse statically-detectable escapes at check time, and fail any runtime effect outside the boundary with `NIKA-SEC-004` · once `permits:` is present every category is default-deny unless listed
 
 ---
 

--- a/crates/nika-pack/pack/spec/02-verbs.md
+++ b/crates/nika-pack/pack/spec/02-verbs.md
@@ -2,12 +2,12 @@
 
 > Every task in a Nika workflow binds to **exactly one** of 4 verbs.
 > A verb is a **distinct native execution model** the engine itself
-> implements — call a model, run a process, dispatch a tool, drive an
+> implements: call a model, run a process, dispatch a tool, drive an
 > agentic loop. That is the whole operation space.
 >
-> Everything *callable* — fetching a URL, a database query, a file
-> write, cognitive recall — is a **tool** reached through `invoke:`.
-> Everything about *ordering* — iteration, branching — is a **DAG**
+> Everything *callable* (fetching a URL, a database query, a file
+> write, cognitive recall) is a **tool** reached through `invoke:`.
+> Everything about *ordering* (iteration, branching) is a **DAG**
 > construct (`for_each` · `when`). The 4 verbs never change; tools and
 > the stdlib grow freely.
 
@@ -25,7 +25,7 @@
 A task **must** specify exactly one of these. Multiple verbs on a single task is a validation error.
 
 > **Where did `fetch` go?** Fetching a URL is *calling a tool*, not a
-> distinct execution model — so it is the `nika:fetch` builtin, reached
+> distinct execution model, so it is the `nika:fetch` builtin, reached
 > through `invoke:` (the extract modes become its `mode` argument). Same
 > reason a DB query (`invoke: mcp:postgres/query`) or a file write
 > (`invoke: nika:write`) is not its own verb. See
@@ -142,35 +142,35 @@ Run a shell command. The result is the command's stdout (default) or a structure
 | `stdin` | no | string | Stdin data · may use `${{ ... }}` |
 | `capture` | no | enum | `stdout` (default) · `stderr` · `combined` · `structured` (= `{ stdout, stderr, exit_code }`) |
 
-> **`exec.env` ≠ the envelope `env:`** — different scopes, same word (the one
+> **`exec.env` ≠ the envelope `env:`**: different scopes, same word (the one
 > overlap to know). The envelope `env:` is *workflow config* read via
 > `${{ env.* }}`; `exec.env` is the *OS environment of this subprocess*. They
-> are NOT auto-connected — to pass a workflow value into the process, do it
+> are NOT auto-connected. To pass a workflow value into the process, do it
 > explicitly: `env: { API_BASE: "${{ env.API_BASE }}" }`.
 
-> `timeout` and `retry` are **task-level** fields (see [03-dag.md](./03-dag.md)) — they apply uniformly to every verb, so they are not repeated inside `exec:`.
+> `timeout` and `retry` are **task-level** fields (see [03-dag.md](./03-dag.md)): they apply uniformly to every verb, so they are not repeated inside `exec:`.
 
 ### Security
 
 A v0.1-compliant engine MUST ·
 
-- **Honor the two `command` forms** · a **string** runs through `/bin/sh -c` (the shell-feature path · pipes · redirects); an **array** runs through `execve` with NO shell — `command[0]` is the program, the rest are argv passed verbatim, each element substituted independently.
+- **Honor the two `command` forms** · a **string** runs through `/bin/sh -c` (the shell-feature path · pipes · redirects); an **array** runs through `execve` with NO shell: `command[0]` is the program, the rest are argv passed verbatim, each element substituted independently.
 - Implement a shell **blocklist** for dangerous commands on the STRING form (see reference impl `nika-policy` for canonical list · 100+ patterns including `rm -rf /` · `chmod 777` · `curl … | sh` · etc.)
 - Reject blocklist matches with a clear error
 - Honor `timeout` with a hard kill (Go-duration string · see 03-dag)
 - Sandbox `cwd` if configured (engine-specific)
 
-> **The argv form is the STRUCTURAL fix for command injection — prefer it.**
+> **The argv form is the STRUCTURAL fix for command injection: prefer it.**
 > A `${{ }}`-interpolated value in the STRING form is shell-parsed:
 > `command: "process ${{ item }}"` with `item == "; rm -rf /"` is a classic
 > injection, and the blocklist is a *detector* (best-effort), not a guarantee.
-> The ARRAY form removes the shell entirely — `command: ["process", "${{ item }}"]`
+> The ARRAY form removes the shell entirely: `command: ["process", "${{ item }}"]`
 > passes `item` as ONE argv element no matter what it contains; there is no
 > shell to parse it. **Rule of thumb · any command carrying a task output, a
 > `var`, or any value not authored inline → use the array form.** `nika check`
 > warns (`one-obvious-way`) when an interpolated value lands in a string
 > `command`. The string form stays first-class for genuine shell pipelines
-> (`"cat x | grep y > z"`) — that is what `/bin/sh -c` is for.
+> (`"cat x | grep y > z"`). That is what `/bin/sh -c` is for.
 
 ### Conformance
 
@@ -181,7 +181,7 @@ The engine MUST ·
 - Return exit code in `structured` capture mode
 - **Fail the task on non-zero exit** (`NIKA-EXEC-001` · `process_error`) in
   `stdout` / `stderr` / `combined` capture modes (unless `on_error:` recovers ·
-  [05](./05-errors.md)) — **EXCEPT `capture: structured`**, where a non-zero
+  [05](./05-errors.md)), **EXCEPT `capture: structured`**, where a non-zero
   exit is **data, not failure** · the task succeeds and `exit_code` is the
   workflow's to branch on (`when: ${{ tasks.test.output.exit_code != 0 }}`) ·
   the one-obvious-way split · default modes for « must succeed » · structured
@@ -206,7 +206,7 @@ mcp:postgres/query          MCP · server `postgres` · tool `query`
 mcp:my-server/do_thing      MCP · server names admit kebab-case · tools admit snake_case
 ```
 
-The `mcp:` form **requires the slash** — `mcp:postgres` alone (no tool) is a
+The `mcp:` form **requires the slash**: `mcp:postgres` alone (no tool) is a
 parse error (`NIKA-PARSE` · `validation_error`) · server segment
 `[a-z][a-z0-9-]*` · tool segment `[A-Za-z0-9_-]+` (tool names are the MCP
 server's to define).
@@ -218,7 +218,7 @@ clean · `nika:*` · `nika:connectome/*` · `mcp:browser/*`.
 **The namespace set is CLOSED at v1** · `nika:` and `mcp:` are the only two ·
 any other namespace (`custom:thing` · `x:tool`) is rejected at parse time
 (`NIKA-PARSE` · `validation_error`). A third namespace would be an additive
-spec minor — it never appears silently.
+spec minor. It never appears silently.
 
 ### Builtin call
 
@@ -234,7 +234,7 @@ See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) for the canonical buil
 
 > **Grouped paths are grammar-legal · v0.1 ships none.** The reference
 > grammar admits `nika:<group>/<tool>` (the `nika:connectome/recall`
-> illustration above is the reserved FUTURE shape) — but the v0.1 builtin
+> illustration above is the reserved FUTURE shape), but the v0.1 builtin
 > set contains only flat names · a grouped `nika:` path is rejected against
 > the closed 23 set today (`NIKA-INVOKE-001`). The seam exists so the
 > Connectome tools land additively · zero workflow-shape change.
@@ -328,7 +328,7 @@ The agent loops · model response → if tool calls present, execute tools → f
 3. `max_tokens_total` exhausted, OR
 4. A tool returns the canonical completion sentinel `nika:done` (the builtin tool · see [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md))
 
-`nika:done` is **valid only inside an `agent:` loop's tool whitelist** — it is
+`nika:done` is **valid only inside an `agent:` loop's tool whitelist**: it is
 the loop-completion sentinel. Calling `nika:done` from a standalone `invoke:`
 task (outside any agent loop) is an error (`NIKA-BUILTIN-DONE-001`). The
 sentinel has no meaning without a loop to terminate. `nika:done` accepts an
@@ -336,12 +336,12 @@ optional **`result:`** arg (any JSON value) · when present the task's
 `.output` is that value (and `schema:` validates IT) · when absent `.output`
 is the final assistant message (string).
 
-The agent may also grant itself **`nika:compose`** — a second loop-only
+The agent may also grant itself **`nika:compose`**, a second loop-only
 builtin (also valid ONLY inside an `agent:` whitelist · standalone is
 `NIKA-BUILTIN-COMPOSE-001`). It lets the model **self-check a workflow it is
 drafting**: pass a `workflow_yaml` string, get the full `nika check` verdict
 back (conformance + secret-flow + permits + the termination/cost certificate)
-as the tool result. It **never executes** the draft — verification yields an
+as the tool result. It **never executes** the draft: verification yields an
 artifact + its certificate, and running it stays a separate, gated decision.
 See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) §`nika:compose`.
 
@@ -351,16 +351,16 @@ See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) §`nika:compose`.
 - Case 2 (`max_turns` reached) → **`status: failure`** · `NIKA-AGENT-001` ·
   `budget_error` · the last assistant message is preserved at
   `error.details.partial_output` (a budget that runs out did NOT produce the
-  asked-for result — failing loudly beats returning an unfinished answer ·
+  asked-for result: failing loudly beats returning an unfinished answer ·
   recover the partial explicitly via `on_error:` if it is acceptable).
 - Case 3 (`max_tokens_total` exhausted) → same shape · `NIKA-AGENT-002`.
 
 **Tool-call errors inside the loop are fed back, not fatal** · a failing tool
 call returns its typed error to the MODEL as the tool result (the standard
-agentic convention — the model sees the failure and adapts) · the loop
+agentic convention: the model sees the failure and adapts) · the loop
 continues against its budgets. The ONE exception · a `security_error`
 (whitelist violation `NIKA-SEC-002` · blocklist) **fails the task
-immediately** — security boundaries are not negotiation material for a model.
+immediately**: security boundaries are not negotiation material for a model.
 
 ### Tool whitelist · glob semantics
 
@@ -399,34 +399,34 @@ The engine MUST ·
 
 ## Forward-compat
 
-The 4 verb names are **immutable forever** — and the count is **4, absolute**. The operation space is complete: call a model (`infer`), run a process (`exec`), call a tool (`invoke`), run an agentic loop (`agent`). Every other capability is either an **invoke-able tool** (an HTTP fetch → `invoke: nika:fetch` · a database query → `invoke: mcp:postgres/query` · a file write → `invoke: nika:write` · cognitive recall → `invoke: nika:connectome/recall`) or a **DAG control-flow construct** (iteration → `for_each` · branching → `when`). A new verb would require a `nika: v2` language contract — a frozen-forever envelope, so that is effectively never (this is about the **language** version, not the engine version).
+The 4 verb names are **immutable forever**, and the count is **4, absolute**. The operation space is complete: call a model (`infer`), run a process (`exec`), call a tool (`invoke`), run an agentic loop (`agent`). Every other capability is either an **invoke-able tool** (an HTTP fetch → `invoke: nika:fetch` · a database query → `invoke: mcp:postgres/query` · a file write → `invoke: nika:write` · cognitive recall → `invoke: nika:connectome/recall`) or a **DAG control-flow construct** (iteration → `for_each` · branching → `when`). A new verb would require a `nika: v2` language contract (a frozen-forever envelope), so that is effectively never (this is about the **language** version, not the engine version).
 
 ### The closure argument · why no case forces a 5th verb
 
 Every candidate operation decomposes along **two orthogonal axes** ·
 
-- **WHO executes** — the execution model. There are exactly four · model
+- **WHO executes**: the execution model. There are exactly four · model
   inference (`infer`) · OS process (`exec`) · dispatch-a-call-and-await-its-
   result (`invoke`) · model-driven loop over tools (`agent`). Anything with a
-  request/response shape — however exotic the backend — is by construction
+  request/response shape (however exotic the backend) is by construction
   the `invoke` model.
-- **WHEN it runs** — ordering. Edges (`depends_on`) · conditions (`when`) ·
+- **WHEN it runs**: ordering. Edges (`depends_on`) · conditions (`when`) ·
   iteration (`for_each`) · time-bounds (`timeout`) · recovery (`retry` ·
-  `on_error` · `on_finally`). Ordering never executes anything — it is
+  `on_error` · `on_finally`). Ordering never executes anything: it is
   DAG-side, or host-side when it concerns *starting* a run at all.
 
 The recurring « doesn't X need a verb? » cases, stress-tested ·
 
 | Candidate | Axis | Resolution |
 |---|---|---|
-| **wait-for-human** (approval gate) | WHO · a call that resolves when a human answers | a **tool** · request/response with a long latency · `invoke:` model — **already shipped** as `nika:prompt` (blocking confirm · [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md)) |
-| **sleep / delay** inside a run | WHO · a call that resolves after a duration | a **tool** — **already shipped** as `nika:wait` (relative `duration:` XOR absolute `until:`) · NOT a verb — nothing is executed, a result (elapsed) is awaited |
+| **wait-for-human** (approval gate) | WHO · a call that resolves when a human answers | a **tool** · request/response with a long latency · `invoke:` model · **already shipped** as `nika:prompt` (blocking confirm · [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md)) |
+| **sleep / delay** inside a run | WHO · a call that resolves after a duration | a **tool** · **already shipped** as `nika:wait` (relative `duration:` XOR absolute `until:`) · NOT a verb · nothing is executed, a result (elapsed) is awaited |
 | **cron / schedule** (start a run at time T) | neither · it precedes the run | **host concern** · a workflow describes a run, not its triggering · explicitly out-of-scope ([08](./08-out-of-scope.md)) |
 | **streaming between tasks** | WHEN · changes what an *edge* delivers | a **DAG-edge semantic**, not an execution model · out-of-scope v0.1 · an additive edge attribute later · never a verb |
 | **sub-workflow call** | WHO · dispatch-and-await a run | a **tool** (workflow-as-tool · see [08](./08-out-of-scope.md) §composition) · the `invoke` model again |
 
 A 5th verb would have to name an execution model that is none of
-call-with-result, process, inference, or loop — and every concrete candidate
+call-with-result, process, inference, or loop, and every concrete candidate
 inspected since the 4-verb lock (D-2026-05-22-N18) has resolved to a tool
 (WHO · request/response) or an ordering construct (WHEN). That is the
 closure: **the verb set is closed under decomposition into WHO × WHEN.**

--- a/crates/nika-pack/pack/spec/03-dag.md
+++ b/crates/nika-pack/pack/spec/03-dag.md
@@ -64,9 +64,9 @@ the workflow file.
 
 **Why snake_case, not kebab** · task ids are referenced in CEL expressions as
 `tasks.<id>.output`. In CEL (and almost every expression language) a hyphen is
-the **subtraction operator** — `tasks.research-topic.output` would parse as
+the **subtraction operator**: `tasks.research-topic.output` would parse as
 `tasks.research - topic.output`, a silent trap. Snake_case ids are always
-clean CEL identifiers. (The workflow-level `workflow:` id stays kebab-case —
+clean CEL identifiers. (The workflow-level `workflow:` id stays kebab-case:
 it is a resource name, never referenced inside an expression.)
 
 ### `depends_on` · *optional · default `[]`*
@@ -94,11 +94,11 @@ A list of task ids this task depends on. The engine MUST not start this task unt
 
 #### Expression language · a documented subset of CEL
 
-Everything inside `${{ ... }}` — both value substitution and `when:`
-conditions — is **[CEL](https://cel.dev) (Common Expression Language)**, the
+Everything inside `${{ ... }}` (both value substitution and `when:`
+conditions) is **[CEL](https://cel.dev) (Common Expression Language)**, the
 validated, non-Turing-complete, side-effect-free expression standard used by
 Kubernetes (ValidatingAdmissionPolicy), Kyverno, Envoy, and gRPC. Nika does
-**not** invent an expression DSL — it adopts the standard. (This supersedes the « custom minimal DSL » framing.)
+**not** invent an expression DSL: it adopts the standard. (This supersedes the « custom minimal DSL » framing.)
 
 **Why CEL** · it is *common* (millions of K8s users), *comprehensible*
 (reads like a boolean expression), *validated* (a published spec + multiple
@@ -119,10 +119,10 @@ literals                    true · false · 42 · 3.14 · 'str' · "str" · nul
 grouping                    ( … )
 ```
 
-`size()` (collection/string length) is the ONE function in the v0.1 subset —
+`size()` (collection/string length) is the ONE function in the v0.1 subset,
 the canonical empty/non-empty-check idiom (`size(items) > 0`). Everything else
 is **reserved** · arithmetic · CEL macros (`has()`, `all()`, `exists()`) · and
-string-manipulation functions (`startsWith`, `matches`, `contains`, …) — not in
+string-manipulation functions (`startsWith`, `matches`, `contains`, …): not in
 the v0.1 subset, addable in a later minor (CEL is a superset, so growth is
 additive and never breaking). If you need richer logic today, compute it in a
 `nika:assert` builtin or an `infer:` task.
@@ -131,7 +131,7 @@ additive and never breaking). If you need richer logic today, compute it in a
 
 Prose + examples are not re-implementable; this EBNF is. A conformant engine
 parses exactly this grammar inside `${{ }}` (it is a strict subset of
-[cel-spec](https://github.com/google/cel-spec) — any full CEL parser accepts
+[cel-spec](https://github.com/google/cel-spec): any full CEL parser accepts
 every expression below) ·
 
 ```ebnf
@@ -166,17 +166,17 @@ STRING   = /'([^'\\]|\\.)*'/ | /"([^"\\]|\\.)*"/ ;   (* escapes · \\ \' \" \n \
    (substring / prefix / suffix tests · case-sensitive · operands MUST be
    strings). `has(x)` is the presence macro · `true` iff the reference `x`
    resolves to a defined, non-`null` value (the safe way to test an optional
-   field before reading it · never raises `NIKA-VAR-001`). **No regex** —
+   field before reading it · never raises `NIKA-VAR-001`). **No regex**:
    `matches()` is reserved (ReDoS surface · a later minor). Any other call
    suffix is a parse error.
 2. **Precedence** (tightest → loosest) · postfix (`.` `[]`) → `!` → relational
    (`==` `!=` `<` `<=` `>` `>=` `in`) → `&&` → `||` → ternary (`?:`).
    Parentheses override. The ternary `cond ? a : b` requires a **boolean**
    `cond` (a non-boolean condition is `NIKA-VAR-006`) · `a` and `b` may be any
-   value and need not share a type — it is value-selection, not a relation, so
+   value and need not share a type: it is value-selection, not a relation, so
    it does NOT count against the one-relation rule.
 3. **Relations do not chain** · `rel` admits at most one `relop`
-   (non-associative) — `a == b == c` must be written `(a == b) == c` if that
+   (non-associative): `a == b == c` must be written `(a == b) == c` if that
    is really meant.
 4. **No implicit coercion** · the subset is strongly typed per CEL ·
    comparing values of different types (`42 == "42"`) is an evaluation error
@@ -194,7 +194,7 @@ STRING   = /'([^'\\]|\\.)*'/ | /"([^"\\]|\\.)*"/ ;   (* escapes · \\ \' \" \n \
    root is `NIKA-VAR-001`.
 
 The grammar is versioned (`cel-subset/0.1`) · later minors may only ADD
-productions (arithmetic · `matches()` regex · further macros) — never change
+productions (arithmetic · `matches()` regex · further macros), never change
 the meaning of an expression that parses today. The conditional `?:`, the
 `has()` macro, and the `contains`/`startsWith`/`endsWith` string tests are IN
 `cel-subset/0.1` (they are standard CEL · any full CEL parser accepts them).
@@ -213,15 +213,15 @@ when:   ${{ tasks.scan.output.contains('ERROR') }}      # branch on substring
 · `env` · `secrets`) are bound as top-level CEL variables. `tasks.<id>.status`
 etc. resolve against the live DAG state. **Inside a `for_each` task body, two
 more scoped CEL variables are bound** · `item` (the current element) and `index`
-(its 0-based position) — available ONLY within that task (the <!-- canon:namespaces -->5<!-- /canon --> namespaces are
+(its 0-based position), available ONLY within that task (the <!-- canon:namespaces -->5<!-- /canon --> namespaces are
 global · `item`/`index` are for_each-local · see `for_each` below).
 
 #### Referencing a task requires an explicit `depends_on`
 
-If a task references `tasks.<id>` inside a `${{ }}` expression — in `when:` ·
+If a task references `tasks.<id>` inside a `${{ }}` expression, in `when:` ·
 `with:` · `for_each:` · or any verb field (`prompt:` · `command:` · `args:` ·
-…) — that task **MUST** declare `<id>` in its `depends_on:`. The engine **rejects the workflow at parse
-time** otherwise (`NIKA-DAG-003` · `validation_error`) — it does **not** silently
+…), that task **MUST** declare `<id>` in its `depends_on:`. The engine **rejects the workflow at parse
+time** otherwise (`NIKA-DAG-003` · `validation_error`): it does **not** silently
 infer the edge (a verb-body reference is an edge too · no invisible edges).
 
 ```yaml
@@ -237,24 +237,24 @@ infer the edge (a verb-body reference is an edge too · no invisible edges).
   exec: { command: "./deploy.sh" }
 ```
 
-**Why explicit, not inferred** · an inferred edge is an invisible edge — it
+**Why explicit, not inferred** · an inferred edge is an invisible edge: it
 makes the DAG harder to read and lets a typo (`tasks.tset`) silently change
 ordering. Requiring the declaration keeps the graph honest: every dependency
 is visible in `depends_on`, and a dangling reference is a loud parse error, not
-a race. (This is the one rule an LLM most often gets wrong — so it fails fast.)
+a race. (This is the one rule an LLM most often gets wrong, so it fails fast.)
 
 **Two surfaces are deliberately NOT in this rule** ·
 
-- **`output:`** — its values are pure **jq** over the task's OWN raw output
+- **`output:`**: its values are pure **jq** over the task's OWN raw output
   ([04 §output binding](./04-variables.md#output-binding--output)) · they never
   contain `${{ }}` · `tasks.X` cannot legitimately appear there.
-- **`on_error:` / `on_finally:`** — a `recover:` reference reads a *fallback
+- **`on_error:` / `on_finally:`**: a `recover:` reference reads a *fallback
   source*, an `on_finally:` reads its *own parent* · neither is an
   execution-order edge ([05 §on_error](./05-errors.md#error-recovery--on_error)
   defines the recovery-time resolution semantics).
 
 **Implementation** · an engine MAY embed a CEL library (e.g. the Rust
-`cel-interpreter` crate) OR hand-roll the small v0.1 subset above — both are
+`cel-interpreter` crate) OR hand-roll the small v0.1 subset above: both are
 conformant because the subset is exactly CEL. The Core conformance suite tests
 the subset against the CEL spec.
 
@@ -287,7 +287,7 @@ case) or the **YAML boolean literal `true` / `false`** (the always/never
 pattern · `when: true` runs the task regardless of upstream outcome · see
 §Task states). Anything else is rejected.
 
-**Parse time (MUST · `NIKA-VAR-005` · `validation_error`)** — statically
+**Parse time (MUST · `NIKA-VAR-005` · `validation_error`)**: statically
 non-boolean-SHAPED roots are rejected before any execution ·
 ```yaml
 when: ${{ vars.threshold }}                    # ❌ bare reference · no relation/boolean operator
@@ -296,7 +296,7 @@ when: ${{ 'production' }}                      # ❌ bare literal
 when: "literal string"                          # ❌ neither ${{ }} nor a YAML boolean
 ```
 
-**Evaluation time (`NIKA-VAR-006` · `variable_error`)** — an expression whose
+**Evaluation time (`NIKA-VAR-006` · `variable_error`)**: an expression whose
 *shape* is boolean but whose runtime value is not (a typed comparison across
 types · a reference that resolves non-boolean through an operator the static
 pass could not see) fails when evaluated.
@@ -327,7 +327,7 @@ when: ${{ size(vars.items) > 0 }}              # collection size check
 `for_each` runs the task **once per element** of the collection. Inside the
 task body, `${{ item }}` resolves to the current element (and `${{ index }}`
 to its zero-based position). The collection is either a literal list or a
-reference to an upstream task's array output — this is the **matrix /
+reference to an upstream task's array output: this is the **matrix /
 fan-out** pattern familiar from GitHub Actions.
 
 #### ⚠️ Parallel by default
@@ -379,7 +379,7 @@ fail_fast: false                # default true · false = process all even if so
 #### Semantics (closed at v1)
 
 - **Every expression in the task body is re-evaluated PER ITERATION** with
-  `item`/`index` bound — `with:`, the verb fields (`prompt:` · `command:` ·
+  `item`/`index` bound: `with:`, the verb fields (`prompt:` · `command:` ·
   `args:` · …), `when:`, AND the `output:` bindings. (The canonical
   `with: { page: ${{ item }} }` shape above relies on this: `with:` is NOT
   evaluated once at dispatch, it is evaluated once per element.) The only
@@ -387,22 +387,22 @@ fail_fast: false                # default true · false = process all even if so
 - The task's output is the **array of per-iteration outputs**, in input
   order · referenced downstream as `${{ tasks.scrape_all.output }}`
   (an array) · `${{ tasks.scrape_all.output[0] }}` for one element.
-- **`output:` bindings apply per iteration** — each binding's jq runs over
+- **`output:` bindings apply per iteration**: each binding's jq runs over
   that iteration's raw response · downstream `tasks.X.<name>` is the
   **array of that binding's per-iteration values**, input order (so
   `tasks.X.output` = array of raw outputs · `tasks.X.title` = array of
   titles · positions align).
 - **A failed iteration contributes `null`** at its index (in `.output`
-  AND in every named binding) — positional alignment survives partial
+  AND in every named binding): positional alignment survives partial
   failure (the zip patterns stay sound). Per-iteration
   `on_error: { recover: … }` substitutes its recovery value instead.
 - **Where `.output` is observable** · the positional array is the
-  task's `.output` only when the **parent settles `success`** — i.e.
+  task's `.output` only when the **parent settles `success`**, i.e.
   every element either succeeded, was `on_error: skip`-ped (→ `null` at
   its index) or `on_error: recover`-ed (→ the recovery value). That is
   the zip-sound surface a downstream task reads. An **UNRECOVERED**
   iteration error transitions the parent to `failure` (per `fail_fast`),
-  and the failed parent's `.output` is **`null`** — NOT a partial array ·
+  and the failed parent's `.output` is **`null`**: NOT a partial array ·
   the per-iteration errors surface in the failure detail, not as output
   (a downstream task gated on the failed parent is cancelled · the
   positional array is observable only on a `success` settle). To keep the
@@ -416,13 +416,13 @@ fail_fast: false                # default true · false = process all even if so
   `for_each` over its own output. The DAG stays acyclic.
 - If the collection is empty · the task is `skipped` (status `skipped`).
 - `when:` is evaluated **once** before the fan-out · `retry:` /
-  `on_error:` / **`timeout:`** apply **per iteration** — the timeout
+  `on_error:` / **`timeout:`** apply **per iteration**: the timeout
   clock covers one element's execution including its own retries (and
   backoff sleeps · wall-clock). There is **no whole-fan-out timer** in
   v0.1 (bound total work via `max_parallel:` + the per-iteration cap).
 - `max_parallel:` + `fail_fast:` apply uniformly across all iterations.
 - `on_finally:` (see below) runs **once** after all iterations complete
-  (success OR failure) — `item` / `index` are NOT in scope there (there
+  (success OR failure): `item` / `index` are NOT in scope there (there
   is no current element after the fan-out).
 
 This is the one construct that lets a v1 workflow process a
@@ -543,12 +543,12 @@ A v0.1-compliant engine MUST ·
 
 A downstream task sees an upstream's status via `${{ tasks.task_id.status }}`.
 **Only the four terminal states are observable from expressions** (the closed
-enum of [04](./04-variables.md#-taskxoutput--task-output-reference)) —
+enum of [04](./04-variables.md#-taskxoutput--task-output-reference)):
 `pending` / `running` exist in run reports and events, never inside `${{ }}`
 (a dependent's expressions evaluate only once all its deps are terminal).
 
 **The gate.** The default `depends_on` behavior (no `when:`) is to run only
-when all deps are `success` or `skipped` — any dep ending `failure` or
+when all deps are `success` or `skipped`: any dep ending `failure` or
 `cancelled` makes the default gate unsatisfiable and the task is `cancelled`.
 An **explicit `when:`** REPLACES the default gate · it is evaluated once all
 deps are terminal, whatever their status · `true` → run (the always-pattern ·
@@ -556,7 +556,7 @@ deps are terminal, whatever their status · `true` → run (the always-pattern �
 [05 §workflow-level semantics](./05-errors.md#workflow-level-error-semantics).
 
 > **`depends_on` IS the success-gate.** Do NOT write
-> `when: ${{ tasks.X.status == 'success' }}` as a plain gate — it is **redundant**
+> `when: ${{ tasks.X.status == 'success' }}` as a plain gate: it is **redundant**
 > (`depends_on` already requires success). Use `when:` ONLY for conditions BEYOND
 > the default gate · a value check (`tasks.X.output.coverage > 80`) · an env check
 > · or to **exclude a skipped** upstream (`when: status == 'success'` is meaningful
@@ -667,12 +667,12 @@ tasks:
 
 `discover` finds N pages · `summarize` runs once per page (parallel,
 bounded) · `digest` consumes the array of all summaries. N is computed at
-runtime — no static enumeration.
+runtime: no static enumeration.
 
 ### Output shape · *no `output_format` field · shape is per-verb*
 
 There is **no `output_format` task field**. The raw output shape is determined
-**per verb** — the single source of truth is the `.output` table in
+**per verb**: the single source of truth is the `.output` table in
 [02-verbs.md](./02-verbs.md#what--tasksidoutput--holds--per-verb) ·
 
 - `infer:` → string · or the schema object when `schema:` is set
@@ -682,7 +682,7 @@ There is **no `output_format` task field**. The raw output shape is determined
 
 To **force JSON validation** of a raw output, use the per-verb mechanism that
 already owns it (`infer`/`agent` `schema:` · `exec` `capture: structured`) or
-the `nika:validate` builtin — never a duplicate task-level type enum (a single
+the `nika:validate` builtin, never a duplicate task-level type enum (a single
 source of truth · Rams 4 understandable). A `output_format` field was drafted
 in pre-public hardening and **removed** · it duplicated `capture`/`schema` and
 its default table had drifted out of sync with 02-verbs (the very drift a
@@ -721,10 +721,10 @@ completes · REGARDLESS of outcome (success · failure · timeout · cancel).
   per cleanup task via `timeout:` field).
 - **Failed parent task's `on_finally:` runs BEFORE** the error propagates
   upward in the DAG (gives cleanup a chance to undo side effects).
-- **Engine MUST execute** `on_finally:` on cancel (Ctrl+C) and timeout —
+- **Engine MUST execute** `on_finally:` on cancel (Ctrl+C) and timeout,
   for a task that **started**. A task that never ran (`skipped` gate ·
   cancelled-before-start) runs NO `on_finally:` (there is nothing to clean
-  up) — a record that must land on EVERY outcome is a **terminal
+  up). A record that must land on EVERY outcome is a **terminal
   `when: true` task** (the always-pattern · §Task states), not a cleanup
   hook.
 - **Engine MAY skip** `on_finally:` only if the workflow process itself
@@ -759,18 +759,18 @@ on_finally:
 ## One obvious way · control-flow preference rules (normative for lints)
 
 Several intents are *expressible* two ways; the spec names ONE as canonical.
-These rules are informative for authors and **normative for linters** — a
+These rules are informative for authors and **normative for linters**: a
 conformant linter (the reference `one-obvious-way` rule set) warns on the
 discouraged form ·
 
 | Intent | ✅ The one way | ❌ Discouraged · why |
 |---|---|---|
-| « run B only if A succeeded » | `depends_on: [a]` alone — success-gating is the **default edge semantic** (a failed dependency cancels dependents · §Task states) | `depends_on: [a]` + `when: ${{ tasks.a.status == 'success' }}` — redundant restatement of the default |
-| « run B even if A failed » | an explicit `when:` (it replaces the default gate · §Task states « to run regardless ») — `when: ${{ tasks.a.status in ['success','failure'] }}` reads the intent precisely | encoding it via `on_error: { skip: true }` on A — that changes A's contract for B's benefit |
-| « retry on transient failure » | `retry:` — the ONE retry shape (`max_attempts` · `backoff_*` · `on_codes`) | a `when:`-guarded duplicate task · a self-referencing recovery chain |
-| « provide a fallback value » | `on_error: { recover: … }` — the route stays *in the failing task* | a second task `when: ${{ tasks.a.status == 'failure' }}` for a mere value — use a task only when real *work* runs on failure |
+| « run B only if A succeeded » | `depends_on: [a]` alone · success-gating is the **default edge semantic** (a failed dependency cancels dependents · §Task states) | `depends_on: [a]` + `when: ${{ tasks.a.status == 'success' }}` · redundant restatement of the default |
+| « run B even if A failed » | an explicit `when:` (it replaces the default gate · §Task states « to run regardless ») · `when: ${{ tasks.a.status in ['success','failure'] }}` reads the intent precisely | encoding it via `on_error: { skip: true }` on A · that changes A's contract for B's benefit |
+| « retry on transient failure » | `retry:` · the ONE retry shape (`max_attempts` · `backoff_*` · `on_codes`) | a `when:`-guarded duplicate task · a self-referencing recovery chain |
+| « provide a fallback value » | `on_error: { recover: … }` · the route stays *in the failing task* | a second task `when: ${{ tasks.a.status == 'failure' }}` for a mere value · use a task only when real *work* runs on failure |
 | « cleanup that always runs » | `on_finally:` | a terminal task depending on everything with a permissive `when:` |
-| « time-bound an iteration » | `timeout:` on the `for_each` task — it applies **per iteration** (§for_each semantics) | per-element timing tricks inside the body · a whole-fan-out timer (none exists in v0.1) |
+| « time-bound an iteration » | `timeout:` on the `for_each` task · it applies **per iteration** (§for_each semantics) | per-element timing tricks inside the body · a whole-fan-out timer (none exists in v0.1) |
 | « cap fan-out concurrency » | `max_parallel:` | manual sharding into N sequential tasks |
 
 The dividing line, stated once · **`when:` reads state to decide *whether* a
@@ -778,7 +778,7 @@ task runs · `on_error:`/`retry:` decide *what happens inside* a task's own
 failure · `depends_on` is pure ordering.** A construct that restates another
 construct's default is noise; a construct that smuggles another's job is a
 trap. The reference validator ships these as warnings (`one-obvious-way/001`
-…`/007` · table order) — never hard errors (the discouraged forms are legal ·
+…`/007` · table order), never hard errors (the discouraged forms are legal ·
 just not canonical).
 
 ## Forward-compat

--- a/crates/nika-pack/pack/spec/04-variables.md
+++ b/crates/nika-pack/pack/spec/04-variables.md
@@ -32,7 +32,7 @@ If you have used GitHub Actions, this is the same. If you have not, the rule is 
 Language · the validated, non-Turing-complete standard used by Kubernetes,
 Envoy, and gRPC). A bare reference like `${{ vars.topic }}` is a CEL identifier
 path that evaluates to its value; a condition like `${{ tasks.test.coverage > 80 }}`
-is a CEL boolean. One expression language, everywhere — Nika does not invent a
+is a CEL boolean. One expression language, everywhere: Nika does not invent a
 DSL. See [03-dag.md](./03-dag.md#expression-language--a-documented-subset-of-cel) for the v0.1 CEL subset.
 
 ---
@@ -50,18 +50,18 @@ ${{ secrets.X }}          masked secret reference        (vault-backed · never 
 Five namespaces. That's it.
 
 > **Loop-locals are not a 6th namespace.** Inside a `for_each` task body, two
-> extra identifiers are in scope — `${{ item }}` (the current element) and
+> extra identifiers are in scope: `${{ item }}` (the current element) and
 > `${{ index }}` (its 0-based position). They are **loop-scoped locals**, alive
-> only within that task's body — not global namespaces. So the count stays
+> only within that task's body, not global namespaces. So the count stays
 > « <!-- canon:namespaces -->5<!-- /canon --> namespaces » + the for-each locals where a loop is present.
 
 **Shadowing is structurally impossible.** Every namespace is reached
 through its explicit prefix (`vars.` · `with.` · `tasks.` · `env.` ·
-`secrets.`) — a `vars.item` and the loop-local `item` never collide
+`secrets.`): a `vars.item` and the loop-local `item` never collide
 (one is `vars.item` · the other is bare `item`), a task may be named
 `item` (`tasks.item.output` is unambiguous), and `with.X` never hides a
 `vars.X`. The only bare identifiers in the language are the two
-loop-locals, and `for_each` does not nest within a task — so there is no
+loop-locals, and `for_each` does not nest within a task, so there is no
 scope chain · no resolution-order subtleties · nothing to shadow. This
 is by construction, not by rule.
 
@@ -117,7 +117,7 @@ Reference any upstream task's output (or status · error · duration_ms) ·
     command: "./deploy.sh ${{ tasks.build.output.artifact_path }}"
 ```
 
-`tasks.X` is the task **result record** — a CEL object, NOT the bare output
+`tasks.X` is the task **result record**: a CEL object, NOT the bare output
 value. Always write `.output` for the value · the record's fields are ·
 
 ```
@@ -132,7 +132,7 @@ ${{ tasks.X.<name> }}                a named output: binding (jq · see below)
 
 #### Defined-null reads (normative · the branch-join unlock)
 
-Reading a field of a task that reached a terminal state **never errors** —
+Reading a field of a task that reached a terminal state **never errors**:
 absent values are **`null`**, deterministically ·
 
 ```
@@ -158,7 +158,7 @@ takes whichever ran ·
 ```
 
 **One obvious way · no bare alias.** `${{ tasks.X }}` is the whole result
-object · the output is ALWAYS `${{ tasks.X.output }}` — there is no `tasks.X`
+object · the output is ALWAYS `${{ tasks.X.output }}`: there is no `tasks.X`
 == output shortcut (it would make `tasks.X` both a scalar and a record · which
 CEL cannot type). This matches every workflow engine · GitHub Actions
 `steps.X.outputs` · Argo node context · Temporal result-vs-state · the task
@@ -168,7 +168,7 @@ result is a record, never a scalar masquerading as the namespace.
 
 When the producing task declares a structured-output **`schema:`** (an
 `infer:` or `agent:` task · [02](./02-verbs.md)), the shape of
-`tasks.X.output` is KNOWN at parse time — so a reference path INTO that
+`tasks.X.output` is KNOWN at parse time, so a reference path INTO that
 output (`${{ tasks.X.output.entities }}`) is statically checkable. The
 authoring contract ·
 
@@ -186,17 +186,17 @@ authoring contract ·
 - The static walk covers the v0.1 subset **`properties` · `items` ·
   `type` · `additionalProperties`** only. Any other construct at a level
   (`$ref` · `oneOf` / `anyOf` / `allOf` · `patternProperties` · a missing
-  `type` · …) makes that level **open** — the walk stops and the engine
+  `type` · …) makes that level **open**: the walk stops and the engine
   **MUST NOT** reject anything beneath it.
 - Tasks with NO declared schema (every `exec:` / `invoke:` task · an
-  `infer:` without `schema:`) are dynamic — paths into their output are
+  `infer:` without `schema:`) are dynamic: paths into their output are
   never statically rejected (a wrong path surfaces at run time as
   `NIKA-VAR-001`).
 
 This keeps the check **sound** (zero false rejections · a valid workflow
 is never refused) while making the declared-schema path the
-better-tooling path — one more reason structured output is the default
-authoring style.
+better-tooling path (one more reason structured output is the default
+authoring style).
 
 ### `${{ env.X }}` · environment variable
 
@@ -208,12 +208,12 @@ infer:
 ```
 
 `env` holds **non-sensitive** runtime config. Values may appear in logs +
-traces. For anything secret, use `secrets:` (below) instead — never put a
+traces. For anything secret, use `secrets:` (below) instead: never put a
 credential in `env`.
 
 **Declared-only · no ambient OS fallback** · `${{ env.X }}` resolves ONLY
 against the envelope `env:` block. An entry absent from the block is
-`NIKA-VAR-001` — the engine never silently reads the OS environment (a
+`NIKA-VAR-001`: the engine never silently reads the OS environment (a
 workflow's inputs are all visible in the file · sovereignty + portability).
 To pass an OS value in, do it explicitly at launch
 (`nika run flow.yaml --env LOG_LEVEL="$LOG_LEVEL"` · engine CLI concern).
@@ -230,19 +230,19 @@ headers:
 ```
 
 A secret is always a **reference to a store** (the local `nika-vault` by
-default), declared in the envelope `secrets:` block — never an inline
+default), declared in the envelope `secrets:` block, never an inline
 literal. The engine **masks** every resolved `secrets.X` value in logs,
 traces, and journal events (it renders as `••••••`). This `env` / `secrets`
 split is the modern secure-workflow default: non-sensitive config in `env`,
 masked references in `secrets`.
 
 > **The masking boundary (normative).** Masking covers the engine's OWN
-> observability surface — logs · traces · journal · the `nika:inspect`
+> observability surface: logs · traces · journal · the `nika:inspect`
 > output. It does NOT follow a secret value that the AUTHOR routes into a
 > subprocess or tool that then re-emits it: a `secrets.X` put into
 > `exec.env` (or a `nika:fetch` header) which the command echoes to stdout
 > is captured verbatim into `tasks.X.output` and flows downstream like any
-> other data — the engine cannot know that captured string IS the secret.
+> other data: the engine cannot know that captured string IS the secret.
 > **The contract:** the engine masks what IT prints; the author owns what
 > they pipe a secret INTO. The `nika check` pre-flight (lint) flags a
 > `secrets.X` reaching an `exec` capture or a tool whose output is bound,
@@ -311,7 +311,7 @@ ${{ tasks.api_call.status }}             # RESERVED · the task's own status (su
   the extracted jq result
 - `<name>` collisions with reserved words `output` · `status` · `error` ·
   `started_at` · `ended_at` · `duration_ms` are forbidden at parse time
-  (`NIKA-PARSE` · `validation_error` — the rule is structural · schema-checkable
+  (`NIKA-PARSE` · `validation_error`: the rule is structural · schema-checkable
   via `propertyNames` · `NIKA-VAR-NNN` stays reserved for reference *resolution*
   and binding *evaluation* errors)
 - If no `output:` block · only `tasks.X.output` is accessible (named
@@ -319,10 +319,10 @@ ${{ tasks.api_call.status }}             # RESERVED · the task's own status (su
 
 ### Path grammar · jq (the one data language)
 
-Output binding uses a **jq expression** — the SAME jq as the `nika:jq` builtin.
+Output binding uses a **jq expression**: the SAME jq as the `nika:jq` builtin.
 Nika has ONE data extraction-and-transform language (jq), **not two**: the former
 RFC 9535 JSONPath was dropped because jq is a superset (any JSONPath query + more)
-and a workflow language must not force the author — or an LLM — to choose between
+and a workflow language must not force the author (or an LLM) to choose between
 two extraction syntaxes (SOTA « one obvious way · ≤2 expression layers »). The two
 expression layers are **CEL** (inside `${{ }}` · conditions + value substitution)
 and **jq** (inside `output:` bindings + `nika:jq` · extraction + transform).
@@ -339,28 +339,28 @@ v0.1 jq conformance subset (every engine MUST support) ·
 ```
 
 The subset above is the portability floor every engine MUST support. Full jq
-(the `jaq` Rust impl · « full stdlib ») MAY be used — it is the single data
+(the `jaq` Rust impl · « full stdlib ») MAY be used: it is the single data
 extraction-and-transform language (`output:` bindings + the `nika:jq` builtin).
 
 #### Binding rules (single-value · pure-jq)
 
-- **A binding resolves to exactly ONE value.** A jq program emits a *stream* —
+- **A binding resolves to exactly ONE value.** A jq program emits a *stream*:
   `.users[]` yields N separate values, NOT an array. A binding whose program
   emits zero or multiple values is an **evaluation-time error**
   (`NIKA-VAR-002` · the emission count is data-dependent · undecidable at
-  parse) — the reference linter additionally WARNS at check time
+  parse). The reference linter additionally WARNS at check time
   (`one-obvious-way/009`) on the statically-visible smell (a binding jq
   ending in a trailing iterator `[]` with no collecting `[ … ]` wrapper).
   A jq program that itself errors at runtime is
   `NIKA-VAR-004`. Collect a stream with `[ … ]` (`[.users[].email]` → array)
   · take one with an index (`.users[0]`) or `first(…)`. One obvious way · no
   silent first-match, no implicit array-wrap.
-- **An `output:` jq expression is pure jq over the task's raw output** — it does
+- **An `output:` jq expression is pure jq over the task's raw output**: it does
   NOT contain `${{ }}` (the two expression layers never nest in one string ·
   CEL reads the namespaces · jq reads the task output). To parametrize an
   extraction by a workflow value, shape the verb's *input* with `${{ }}` ·
   the jq then runs over the result. (Exposing the read namespaces as jq
-  variables — `.items[] | select(.id == $vars.target)` — is a v0.2 candidate ·
+  variables, `.items[] | select(.id == $vars.target)`, is a v0.2 candidate ·
   jq-native · additive · NOT in the v0.1 subset.)
 
 ---
@@ -383,7 +383,7 @@ into a **string position** (e.g. inside a `prompt:` or `command:`), it renders
 as **compact JSON** · deterministic (object keys sorted · no insignificant
 whitespace). Scalars render as their natural string (numbers · booleans ·
 `null` → `null`). There are **no template pipe-filters** (`${{ x | json }}` is
-NOT a thing · per the §locked substitution surface) — to control the rendering,
+NOT a thing · per the §locked substitution surface). To control the rendering,
 extract a string with jq in `output:` (`@json` for JSON text · `tostring` /
 `@text` for scalar coercion) and reference that binding. One obvious way ·
 implicit compact-JSON by default · explicit jq when you need a specific shape.
@@ -392,7 +392,7 @@ A **bytes** output (tool-determined · e.g. MCP image content · a binary
 `nika:read`) is **opaque** · it flows tool→tool by reference
 (`${{ tasks.fetch_img.output }}` → another tool's `content:` arg · or a file
 path for `infer.vision`). Bytes **cannot** be jq-extracted (jq is JSON-only)
-nor substituted into a string position — that is an error (`NIKA-VAR-007`) ·
+nor substituted into a string position: that is an error (`NIKA-VAR-007`) ·
 the engine never silently UTF-8-coerces a blob (it would corrupt the data).
 For `nika:fetch` and `exec` (no binary value channel · the 9 fetch modes are
 text/JSON · `raw` is text), binary is **file-mediated** · write to a path,
@@ -413,7 +413,7 @@ infer:
 (Note · YAML escaping of backslash · `\\` in double-quoted strings · `\` in single-quoted or block scalars.)
 
 An **unclosed `${{`** (an unescaped opener with no closing `}}`) is rejected at
-parse time · `NIKA-VAR-008` · `validation_error` — the substitution surface belongs
+parse time · `NIKA-VAR-008` · `validation_error`: the substitution surface belongs
 to this section, even though the YAML itself parses fine.
 
 ---
@@ -434,7 +434,7 @@ Reasons ·
 
 ## Forward-compat
 
-The `${{ ... }}` substitution surface and the <!-- canon:namespaces -->5<!-- /canon --> namespaces are locked at v1. **Template pipe-filters (`${{ vars.x | json }}` · `| upper`) are NOT a growth path** (they would duplicate builtins + push CEL toward a string-DSL). Data transforms live in the `nika:jq` builtin; the `${{ }}` surface grows only with CEL-native features — the conditional `?:`, the `has()` presence macro, and the `contains`/`startsWith`/`endsWith` string tests ship in `cel-subset/0.1` ([03 §grammar](./03-dag.md)); `all`/`exists` and `matches()` regex stay reserved for a later additive minor. jq is the single extraction-and-transform language (`output:` + `nika:jq`).
+The `${{ ... }}` substitution surface and the <!-- canon:namespaces -->5<!-- /canon --> namespaces are locked at v1. **Template pipe-filters (`${{ vars.x | json }}` · `| upper`) are NOT a growth path** (they would duplicate builtins + push CEL toward a string-DSL). Data transforms live in the `nika:jq` builtin; the `${{ }}` surface grows only with CEL-native features: the conditional `?:`, the `has()` presence macro, and the `contains`/`startsWith`/`endsWith` string tests ship in `cel-subset/0.1` ([03 §grammar](./03-dag.md)); `all`/`exists` and `matches()` regex stay reserved for a later additive minor. jq is the single extraction-and-transform language (`output:` + `nika:jq`).
 
 Out of scope for v0.1 (deferred · see [`08-out-of-scope.md`](./08-out-of-scope.md)) ·
 - Expression language (no arithmetic in templates)

--- a/crates/nika-pack/pack/spec/05-errors.md
+++ b/crates/nika-pack/pack/spec/05-errors.md
@@ -44,7 +44,7 @@ Every error is a typed structure ·
 
 ## Error code namespaces
 
-Error codes follow the format `NIKA-<NAMESPACE>-<NNN>` where namespace is 2-9 uppercase letters and NNN is a 3-digit zero-padded number. A code MAY add an **optional sub-namespace** for self-documentation · `NIKA-<NAMESPACE>-<SUB>-<NNN>` (4-segment) — used per-builtin (`NIKA-BUILTIN-WAIT-001` · each builtin owns its own 001-099) or per-field (`NIKA-PARSE-WHEN-001` · the `when:` field of a parse error). The canonical regex is `^NIKA-[A-Z]{2,9}(-[A-Z][A-Z0-9_]{1,15})?-[0-9]{3}$` (also the `retry.on_codes` / `on_error.on_codes` validation pattern) — the sub-namespace segment admits underscores so underscore-named builtins encode cleanly (`NIKA-BUILTIN-JSON_MERGE_PATCH-001`).
+Error codes follow the format `NIKA-<NAMESPACE>-<NNN>` where namespace is 2-9 uppercase letters and NNN is a 3-digit zero-padded number. A code MAY add an **optional sub-namespace** for self-documentation · `NIKA-<NAMESPACE>-<SUB>-<NNN>` (4-segment), used per-builtin (`NIKA-BUILTIN-WAIT-001` · each builtin owns its own 001-099) or per-field (`NIKA-PARSE-WHEN-001` · the `when:` field of a parse error). The canonical regex is `^NIKA-[A-Z]{2,9}(-[A-Z][A-Z0-9_]{1,15})?-[0-9]{3}$` (also the `retry.on_codes` / `on_error.on_codes` validation pattern). The sub-namespace segment admits underscores so underscore-named builtins encode cleanly (`NIKA-BUILTIN-JSON_MERGE_PATCH-001`).
 
 | Namespace | Scope | Reserved range |
 |---|---|---|
@@ -67,7 +67,7 @@ A v0.1-compliant engine MUST use these namespaces for the canonical categories. 
 
 ### Concrete v0.1 codes · the normative floor
 
-The codes below are **allocated** — a conformant engine emits exactly these
+The codes below are **allocated**: a conformant engine emits exactly these
 codes for these failures (it MAY add more within a namespace's range · never
 repurpose). This closes the « placeholder » gap: a second engine matches
 these from this file alone.
@@ -127,23 +127,23 @@ these from this file alone.
 
 
 `NIKA-PARSE-016` is **retired** (never reuse): the jq-binding-contains-template
-class folded into `NIKA-VAR-005` at the deep-conformance registry remap — the
+class folded into `NIKA-VAR-005` at the deep-conformance registry remap: the
 allocation hole is deliberate, per the additive-never-repurposed rule above.
 
 ### Taxonomy ownership · the spec table is normative · engines derive
 
-**This table — not any engine's source code — owns the taxonomy.** A
+**This table, not any engine's source code, owns the taxonomy.** A
 conformant engine (the Rust reference included) *derives* its error types
 from this section: every spec-relevant error it emits MUST carry a code
 matching the canonical regex, in the namespace this table assigns to the
 failure's scope, with the category semantics of §Categories. An engine MAY
 keep richer internal error machinery (the reference engine's internal
-diagnostics codes, subsystem-specific numbering, extra metadata) — internal
+diagnostics codes, subsystem-specific numbering, extra metadata). Internal
 codes are **not** spec surface and MUST NOT leak into workflow-visible
 errors (`tasks.X.error` · run reports · conformance output) in place of the
 canonical form. Two consequences ·
 
-1. **A second engine can be error-conformant from this file alone** — the
+1. **A second engine can be error-conformant from this file alone**: the
    conformance suite matches on `code` OR `namespace`+`category`
    ([07](./07-conformance.md)) · nothing requires reading the reference
    implementation.
@@ -217,7 +217,7 @@ A task MAY declare a `retry:` block. Retries apply to **transient** errors only 
 With `jitter: true` (the default) the computed delay is randomized (full-jitter
 or equal-jitter family · per AWS « exponential backoff and jitter ») so many
 tasks retrying the same upstream do not synchronize into a thundering herd.
-`on_codes` lists canonical `NIKA-<NS>-<NNN>` codes (e.g. `NIKA-BUILTIN-FETCH-001`) — not
+`on_codes` lists canonical `NIKA-<NS>-<NNN>` codes (e.g. `NIKA-BUILTIN-FETCH-001`), not
 HTTP status numbers.
 
 ### Conformance
@@ -256,10 +256,10 @@ A task MAY declare an `on_error:` block to recover from non-transient errors (or
 
 | Field | Effect | Downstream sees |
 |---|---|---|
-| `recover: <value>` | Use a recovery output — a `${{ }}` ref (e.g. another task's output) OR a literal | `status: success` · output = recover value |
-| `skip: true` | Skip this task on error · **the original error stays readable** at `tasks.X.error` (status is `skipped` · error populated — the one state where both coexist · enables downstream per-code routing) | `status: skipped` · `error` = the original typed error |
+| `recover: <value>` | Use a recovery output: a `${{ }}` ref (e.g. another task's output) OR a literal | `status: success` · output = recover value |
+| `skip: true` | Skip this task on error · **the original error stays readable** at `tasks.X.error` (status is `skipped` · error populated · the one state where both coexist · enables downstream per-code routing) | `status: skipped` · `error` = the original typed error |
 | `fail_workflow: true` | Fail the whole workflow (default behavior) | n/a (workflow fails) |
-| `on_codes: [<NIKA-…>]` | **Optional filter** (combinable with exactly one action above) · the action applies ONLY when the final error's `code` is listed · an unlisted code falls through to the default (fail) — the catch-side mirror of `retry.on_codes` (same regex) | per the action |
+| `on_codes: [<NIKA-…>]` | **Optional filter** (combinable with exactly one action above) · the action applies ONLY when the final error's `code` is listed · an unlisted code falls through to the default (fail) · the catch-side mirror of `retry.on_codes` (same regex) | per the action |
 
 `recover:` merges the former `fallback:` (ref) + `value:` (literal) into one field
 (`${{ }}` resolves to values either way · 4 modes → 3 · one way).
@@ -292,18 +292,18 @@ Resolution happens at **recovery time** ·
    itself fails → the task fails as if `on_error:` were absent.
 
 **Recovery × `output:` bindings (normative)** · when `recover:` fires, the
-recovery value **substitutes the raw output BEFORE binding extraction** —
+recovery value **substitutes the raw output BEFORE binding extraction**:
 the task's `output:` jq bindings evaluate over the recovered value exactly
 as they would over a verb response. Downstream consumers stay shape-stable
 (`tasks.X.title` works whether the live call or the fallback produced the
-data) — which is why a recovery source SHOULD match the raw output's shape.
+data), which is why a recovery source SHOULD match the raw output's shape.
 A binding that fails over the recovered shape errors as usual
 (`NIKA-VAR-002` / `NIKA-VAR-004`) · the recovery does not mask it.
 
 **Parse-time acyclicity rule (`NIKA-DAG-004` · `validation_error`)** · a
 `recover:` reference to a task that **transitively depends on the declaring
 task** is rejected at parse time. At recovery time such a task could never
-reach a terminal state (it is waiting on the failing task) — the step-3 await
+reach a terminal state (it is waiting on the failing task): the step-3 await
 would deadlock. The [03 carve-out](./03-dag.md#referencing-a-task-requires-an-explicit-depends_on)
 exempts `recover:` from *edge creation*, not from *acyclicity*.
 
@@ -346,7 +346,7 @@ The `infer:` and `agent:` verbs may declare a JSON Schema for structured output.
 
 The engine MAY auto-retry validation failures internally (transparent to the
 workflow) before surfacing the error (`NIKA-INFER-002`). This behavior is
-engine-configurable — the SAME rule as [02 §infer conformance](./02-verbs.md#conformance)
+engine-configurable: the SAME rule as [02 §infer conformance](./02-verbs.md#conformance)
 (MAY · engine choice · the two sections state one contract).
 
 ```yaml
@@ -384,7 +384,7 @@ blanket kill** ·
   whose deps can no longer all end `success`/`skipped` is `cancelled`.
 - A not-yet-started task with an **explicit `when:`** still gets its
   evaluation once its deps are terminal (`failure` and `cancelled` ARE
-  terminal) · `true` → it RUNS (this is the **always-pattern** — a final
+  terminal) · `true` → it RUNS (this is the **always-pattern**: a final
   notify/cleanup task with `when: true` runs even in a failing workflow) ·
   `false` → `skipped`.
 - The workflow's final state stays `failure` even when always-pattern tasks

--- a/crates/nika-pack/pack/spec/06-stdlib-contract.md
+++ b/crates/nika-pack/pack/spec/06-stdlib-contract.md
@@ -44,9 +44,9 @@ Three reasons ·
 
 The stdlib has **independent versioning** ·
 
-- `stdlib/providers-v0.1.md` — the <!-- canon:providers -->14<!-- /canon --> canonical providers for v0.1
-- `stdlib/extract-modes-v0.1.md` — the <!-- canon:extract_modes -->9<!-- /canon --> canonical extract modes for v0.1
-- `stdlib/builtins-v0.1.md` — the <!-- canon:builtins -->23<!-- /canon --> canonical builtins for v0.1
+- `stdlib/providers-v0.1.md`, the <!-- canon:providers -->14<!-- /canon --> canonical providers for v0.1
+- `stdlib/extract-modes-v0.1.md`, the <!-- canon:extract_modes -->9<!-- /canon --> canonical extract modes for v0.1
+- `stdlib/builtins-v0.1.md`, the <!-- canon:builtins -->23<!-- /canon --> canonical builtins for v0.1
 
 When the stdlib evolves to v0.2 · those files become `*-v0.2.md` and new versions are published. The core language contract (`nika: v1`) is unchanged.
 
@@ -114,7 +114,7 @@ When these mature · they enter stdlib v0.x. The core language doesn't need to c
 
 ```yaml
 model: anthropic/claude-sonnet-4-6   # <provider>/<name> · see stdlib/providers-v0.1.md
-# model: ollama/llama3.1             # local · same shape
+# model: ollama/llama3.2:3b          # local · same shape
 ```
 
 ### Extract mode
@@ -153,7 +153,7 @@ These are not stdlib · they depend on the engine's MCP server registry being co
 
 ## Namespace ownership · `nika:` · `mcp:` (closed at v1)
 
-The namespace set is **CLOSED at v1** — `nika:` and `mcp:` are the only two
+The namespace set is **CLOSED at v1**: `nika:` and `mcp:` are the only two
 ([02 §tool reference grammar](./02-verbs.md#tool-reference-grammar-canonical) ·
 any other prefix is rejected at parse time) ·
 
@@ -166,7 +166,7 @@ The `nika:*` namespace is **spec-owned**. A custom engine MUST NOT add tools
 to the `nika:*` namespace · it would violate portability (a workflow using a
 vendor's `nika:custom` builtin would not run on a different engine).
 
-**Engine-specific tools route through `mcp:`** — an engine that ships custom
+**Engine-specific tools route through `mcp:`**: an engine that ships custom
 capabilities exposes them as an MCP server it hosts (`mcp:myengine/research`).
 That is exactly what the protocol is for · the tool is then *declared* in the
 engine's MCP registry like any other (portability semantics intact · any
@@ -174,7 +174,7 @@ engine with that server configured runs the workflow) · and no third
 namespace appears silently.
 
 (An OpenAPI-style `x-<vendor>:` prefix was considered and is **reserved as a
-possible future additive minor** — it does NOT exist in v0.1 · a parser that
+possible future additive minor**: it does NOT exist in v0.1 · a parser that
 accepts `x-anything:tool` today is non-conformant.)
 
 ---

--- a/crates/nika-pack/pack/spec/07-conformance.md
+++ b/crates/nika-pack/pack/spec/07-conformance.md
@@ -53,7 +53,7 @@ An engine claims « Core v0.1-compliant » if it ·
    - `${{ with.x }}` resolves to a declared task `with:` key
    - `${{ tasks.X.field }}` resolves to a declared upstream task + a valid field name
    - `${{ env.X }}` · `${{ secrets.X }}` resolve to declared namespaces
-   - `when:` and `for_each:` expressions are valid **CEL** (the v0.1 subset · see 03-dag) and their references **resolve to known namespaces** — Core parses but does NOT *evaluate* them (no execution = no `tasks.X.status` to compare against · that is Runtime's job)
+   - `when:` and `for_each:` expressions are valid **CEL** (the v0.1 subset · see 03-dag) and their references **resolve to known namespaces**: Core parses but does NOT *evaluate* them (no execution = no `tasks.X.status` to compare against · that is Runtime's job)
    - `output:` bindings are valid **jq** expressions (the one data language · see 04-variables) · `${{ }}` never appears inside a binding
    - Reports undefined references with `NIKA-VAR-001` · static expression violations with `NIKA-VAR-005` (the deep-static layer · CEL subset parse · jq compile · `when:` boolean shape)
 
@@ -68,9 +68,9 @@ A Core-compliant engine does NOT execute verbs and does NOT evaluate `when:` / `
 
 ### `nika check` · the static pre-flight (the audit-before-it-runs surface)
 
-Because the language is **statically analyzable by construction** — the DAG
+Because the language is **statically analyzable by construction** (the DAG
 is acyclic, `for_each` is bounded, CEL is non-Turing, and effects are
-declared — a conformant engine can answer « what will this workflow do, cost,
+declared), a conformant engine can answer « what will this workflow do, cost,
 and touch? » with **zero API calls and zero tokens spent**. `nika check` is
 the canonical CLI surface for that (Core conformance + the four static
 guarantees below) ·
@@ -80,14 +80,14 @@ guarantees below) ·
 | **Plan** | the wave topology · which tasks run in parallel · the critical path | DAG waves (Core §2) |
 | **Cost ceiling** | the worst-case spend · `Σ (max_tokens × provider price)` across `infer:`/`agent:` tasks · before one token is spent | the `nika:inspect view: cost` model, run statically |
 | **Secret leak** | every `secrets.X` that flows into an `exec` capture or a tool whose output is bound (the masking boundary · [04 §secrets](./04-variables.md)) | reference graph |
-| **Capability escape** | any effect outside a declared `permits:` block — a write outside `fs.write`, a fetch to an unlisted host, an `exec` under `exec: false`, an unlisted tool | `permits:` ([01](./01-envelope.md)) |
+| **Capability escape** | any effect outside a declared `permits:` block: a write outside `fs.write`, a fetch to an unlisted host, an `exec` under `exec: false`, an unlisted tool | `permits:` ([01](./01-envelope.md)) |
 | **Provider parity** | (`--providers`) that the workflow uses zero provider-specific fields → the same `schema:` runs identically on all 14 providers (incl. the 5 local) | the closed verb-field set |
 
 This is the property no other AI workflow runner gives: **GitHub Actions,
-Temporal, and LangGraph tell you nothing — and charge you nothing back —
+Temporal, and LangGraph tell you nothing (and charge you nothing back)
 until you run.** A Nika workflow is auditable for cost, capabilities,
 secrets, and portability *as a static fact about the file*. `nika check` is
-an engine CLI surface (not a separate conformance level — it composes Core
+an engine CLI surface (not a separate conformance level: it composes Core
 validation with the cost/secret/permits/parity reports); the guarantees it
 surfaces ARE normative (they derive from Core conformance + the `permits:`
 and `secrets:` MUSTs), the CLI ergonomics around them are the engine's.
@@ -101,8 +101,16 @@ this prose spec (kept in sync · the prose is normative on conflict).
 
 Editors (VS Code · Zed · JetBrains · Neovim) pick it up via the standard
 `yaml.schemas` association (or a `# yaml-language-server: $schema=…` modeline)
-to give **autocomplete + inline validation** as you type — the same DX as
-GitHub Actions and Docker Compose. This is also what makes a Nika file
+to give **autocomplete + inline validation** as you type, the same DX as
+GitHub Actions and Docker Compose. A working modeline today:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/supernovae-st/nika-spec/main/schemas/workflow.schema.json
+nika: v1
+```
+
+(The short `https://nika.sh/spec/v1/workflow.schema.json` form goes live
+with the site launch · both will resolve to the same schema.) This is also what makes a Nika file
 pleasant (and trap-free) for an AI to author: the schema constrains the shape
 before the engine ever runs. CEL expressions and jq expressions inside string
 fields are validated by the engine (Core level), not the JSON Schema.
@@ -154,7 +162,7 @@ An engine claims « Stdlib v0.1-compliant » if it satisfies Runtime conformance
 
 1. **Ships all 14 canonical providers** (per [stdlib/providers-v0.1.md](../stdlib/providers-v0.1.md))
 2. **Ships all 9 canonical extract modes** (per [stdlib/extract-modes-v0.1.md](../stdlib/extract-modes-v0.1.md))
-3. **Ships at least all 23 canonical builtins** (core 6 + file 5 + data 8 + introspection 2 + network 2 · the 24 media builtins are optional)
+3. **Ships at least all 23 canonical builtins** (core 6 + file 5 + data 8 + introspection 1 + network 2 · the 24 media builtins are optional)
 4. **Passes** all tests in `conformance/tests/stdlib/`
 
 A Stdlib-compliant engine is functionally equivalent to the reference implementation for any workflow that uses only the canonical stdlib elements.
@@ -176,7 +184,7 @@ What is populated TODAY vs what lands with the reference engine ·
 | **Runtime behavioral fixtures** (`tests/runtime/`) | ⏳ **post-announce** | verb execution · task fields · events · they require an executing engine · they land with the reference engine's vertical slice (1.0.0) |
 | **Stdlib behavioral fixtures** (`tests/stdlib/` · execution half) | ⏳ **post-announce** | provider/builtin/extract-mode *behavior* under the `mock` provider + HTTP mocks |
 
-Run the static gate yourself · `python conformance/runner.py all` — the
+Run the static gate yourself · `python conformance/runner.py all`: the
 runner output is the live count (counts in prose drift · the suite is the
 source). A « Core v0.1-compliant » claim is FULLY testable today. « Runtime »
 and « Stdlib v0.1 » claims are testable on their static halves today · their

--- a/crates/nika-pack/pack/spec/08-out-of-scope.md
+++ b/crates/nika-pack/pack/spec/08-out-of-scope.md
@@ -51,21 +51,21 @@ tasks: ...
 
 **Why deferred** · subroutine calling needs scope/binding rules that need thought · plus risks of stack overflow (recursion) and scheduler complexity. The proposed `nika:run` builtin is therefore deferred from v0.1 · use `exec: command: "nika run subroutine.yaml"` as the workaround.
 
-Workaround in v0.1 · use `exec: command: "nika run subroutine.yaml --output json"` to launch a sibling workflow process — `--output json` (engine CLI) prints the sub-workflow's typed `outputs:` as JSON on stdout · the parent binds it back with `capture: stdout` + a jq `output:` (the typed contract survives the process boundary).
+Workaround in v0.1 · use `exec: command: "nika run subroutine.yaml --output json"` to launch a sibling workflow process: `--output json` (engine CLI) prints the sub-workflow's typed `outputs:` as JSON on stdout · the parent binds it back with `capture: stdout` + a jq `output:` (the typed contract survives the process boundary).
 
 **Recursion guard (normative TODAY · even for the workaround)** · a run that
-launches runs — through the workaround now, through `nika:run` when it lands —
+launches runs (through the workaround now, through `nika:run` when it lands)
 MUST be bounded by the engine ·
 
 - **Depth cap** · nested run depth above the engine's limit fails the
   *launching task* (`NIKA-SEC` · the reference engine defaults to a small
-  single-digit depth) — never the host process.
+  single-digit depth), never the host process.
 - **Cycle detection** · a workflow file (transitively) launching itself is an
-  **unconditional block** (`NIKA-SEC` · `validation_error` at launch time) —
+  **unconditional block** (`NIKA-SEC` · `validation_error` at launch time):
   a self-launching workflow is a fork bomb, not a recursion scheme.
 
 The composition design (v0.2) inherits these rails unchanged · ONE invocation
-surface (`nika:run` under `invoke:` — per the
+surface (`nika:run` under `invoke:`: per the
 [02-verbs closure argument](./02-verbs.md#the-closure-argument--why-no-case-forces-a-5th-verb)
 a sub-workflow call is the dispatch-and-await model · never a verb).
 
@@ -87,7 +87,7 @@ macro retry_with_backoff:
 
 ## Control flow · DEFERRED
 
-> **Note** · bounded map iteration (`for_each:`) is **IN v1** — it ships as a
+> **Note** · bounded map iteration (`for_each:`) is **IN v1**: it ships as a
 > task field, see [03-dag.md](./03-dag.md#for_each--optional--map-a-task-over-a-collection).
 > What remains deferred is **unbounded** iteration (`while:`).
 
@@ -183,7 +183,7 @@ pin in the envelope (`nika: v1` already does this for the language contract). Pe
 ```
 
 **Why deferred** · idempotency keys are **table-stakes for the durable-execution
-class** (Temporal · Inngest · Restate · at-least-once delivery systems) — but
+class** (Temporal · Inngest · Restate · at-least-once delivery systems), but
 **not** for a finite single-run DAG (GitHub Actions · Argo single-run have no
 idempotency keys either). They earn their keep alongside **durable execution +
 resumption** (retries that survive a process restart), which is itself deferred
@@ -209,18 +209,18 @@ durable-class, not finite-DAG-class.)*
       top_k: 5
 ```
 
-**No 6th verb — ever.** When the Connectome (the engine's cognitive subsystem)
+**No 6th verb, ever.** When the Connectome (the engine's cognitive subsystem)
 ships, recall and ingest are exposed as **builtin tools under
-`invoke:`** — `nika:connectome/recall` · `nika:connectome/ingest` — NOT as a
+`invoke:`** (`nika:connectome/recall` · `nika:connectome/ingest`), NOT as a
 new verb. The 4 verbs are absolute: a new verb would
-require a `nika: v2` language contract — a frozen-forever envelope, so that is
+require a `nika: v2` language contract (a frozen-forever envelope), so that is
 effectively never. So
 the *shape* of cognitive access is already final today; only the *capability*
 waits on the engine.
 
 For v1 today · workflows that need recall use `invoke: mcp:memory-server/recall`
 with an external MCP memory server, then swap the tool id to
-`nika:connectome/recall` when the native Connectome admits — zero workflow-shape
+`nika:connectome/recall` when the native Connectome admits: zero workflow-shape
 change (same `invoke:` verb).
 
 ---
@@ -288,7 +288,7 @@ tasks: ...
 **Why deferred** · a workflow references MCP tools by `mcp:<server>/<tool>` · the
 server set lives in **engine config** (like provider config · not workflow YAML).
 A `requires_mcp:` manifest would let the engine *pre-flight* (« no `postgres`
-server configured » *before* the run) and document intent — but it is a
+server configured » *before* the run) and document intent, but it is a
 convenience, **not a v0.1 incompleteness** · a missing server already fails with
 a clear `NIKA-MCP` error at first call. Single-file v0.1 stays free of
 external-resolution declarations (the same rationale that defers `import:`).
@@ -323,21 +323,21 @@ If you need that · the reference engine's HTTP server exposes a per-workflow ru
 
 ### The three floors (canonical framing)
 
-« Never in the language » does NOT mean « impossible » — it means **not in
+« Never in the language » does NOT mean « impossible »: it means **not in
 the YAML**. The ladder ·
 
 | Floor | What | Where it lives | Status |
 |---|---|---|---|
 | **1 · launch a sibling run** | one workflow starts another, awaits its typed `outputs:` | `exec: nika run sub.yaml --output json` + `capture: stdout` (the documented workaround · [§composition](#sub-workflow-invocation--nikarun-builtin--import)) | ✅ works in v0.1 |
 | **2 · composition** | a parent calls a child INSIDE a run · dispatch-and-await · one observable tree | the deferred `nika:run` builtin under `invoke:` (+ recursion guard · binding rules) | ⏸️ deferred · additive minor |
-| **3 · orchestration** | long-lived meshes · cross-run dependencies · registries · scheduling · cross-run retry | an orchestrator built ON TOP of the per-workflow run API — never a language construct | 🚫 forever out |
+| **3 · orchestration** | long-lived meshes · cross-run dependencies · registries · scheduling · cross-run retry | an orchestrator built ON TOP of the per-workflow run API · never a language construct | 🚫 forever out |
 
 Why the line holds · the conformance contract ([07](./07-conformance.md))
-stays implementable — a conformant engine executes ONE workflow; if
+stays implementable: a conformant engine executes ONE workflow; if
 conformance demanded a durable state store, a scheduler and a registry, no
 alternative engine could ever exist and « one YAML · any conformant engine »
 dies. A language describes one run the way Make describes one build and a
-shell script describes one execution — your CI and your cron live above
+shell script describes one execution: your CI and your cron live above
 them, not inside them. **Composition IN the language (deferred · additive) ·
 orchestration ON TOP of the language (forever) · never the inverse.**
 
@@ -345,7 +345,7 @@ orchestration ON TOP of the language (forever) · never the inverse.**
 
 ## Horizon postures · the « did you think of X? » table (2026-06-10)
 
-Every recurring 2026-class workflow-language question, answered in one row —
+Every recurring 2026-class workflow-language question, answered in one row:
 the posture is written, silence is forbidden. **IN** = normative in v0.1 ·
 **PARTIAL** = a v0.1 piece exists, the rest is deferred · **OUT** = deferred
 or a non-goal, with the line that says whose job it is.
@@ -353,28 +353,28 @@ or a non-goal, with the line that says whose job it is.
 | # | Horizon | Posture | The one-paragraph answer |
 |---|---|---|---|
 | H1 | Durable execution (checkpoint · resume · replay) | **OUT** | A v0.1 run is a single OS process with in-memory state · crash = re-run from the top · `retry:` is in-process only. Checkpoint/resumption + idempotency keys land TOGETHER at the durable-execution waypoint (§Persistence · v0.2+) · until then durability is the **host's responsibility** (run under a supervisor · make side-effecting tools idempotent via their own args). |
-| H2 | Streaming between tasks | **OUT** | Tasks are synchronous · a dependent reads the **final assembled value** (§Streaming). Engines MAY stream provider tokens internally/to the user. A between-task stream changes what an *edge* delivers — a future additive edge semantic, never a verb ([02 closure](./02-verbs.md#the-closure-argument--why-no-case-forces-a-5th-verb)). Pub/sub listeners · NEVER in the finite-DAG v1. |
-| H3 | Multimodal artifacts (typed image/audio/video) | **PARTIAL** | v0.1 values are strings · JSON values · and **opaque bytes pass-through** (tool-determined · [02 §invoke output](./02-verbs.md#what--tasksidoutput--holds--per-verb) · `infer.vision` takes file/url refs). No typed media payloads · no content-addressing in the language. Both arrive with the deferred media builtins (stdlib v0.x · §Tooling extensibility) — addressing (e.g. blake3) is engine detail, not language surface. |
+| H2 | Streaming between tasks | **OUT** | Tasks are synchronous · a dependent reads the **final assembled value** (§Streaming). Engines MAY stream provider tokens internally/to the user. A between-task stream changes what an *edge* delivers: a future additive edge semantic, never a verb ([02 closure](./02-verbs.md#the-closure-argument--why-no-case-forces-a-5th-verb)). Pub/sub listeners · NEVER in the finite-DAG v1. |
+| H3 | Multimodal artifacts (typed image/audio/video) | **PARTIAL** | v0.1 values are strings · JSON values · and **opaque bytes pass-through** (tool-determined · [02 §invoke output](./02-verbs.md#what--tasksidoutput--holds--per-verb) · `infer.vision` takes file/url refs). No typed media payloads · no content-addressing in the language. Both arrive with the deferred media builtins (stdlib v0.x · §Tooling extensibility). Addressing (e.g. blake3) is engine detail, not language surface. |
 | H4 | Agent-of-agents (sub-agents · budget propagation · trust inheritance) | **PARTIAL** | The `agent:` verb is a **single loop** with per-task budgets (`max_turns` · `max_tokens_total` · normative · [02 §agent](./02-verbs.md)) and a default-deny tool whitelist. Budgets do NOT propagate across tasks (each declares its own). Multi-agent topology · §Advanced agent features (expressible today as multiple `agent:` tasks + explicit `with:` hand-off). Run-recursion is bounded by the §composition recursion guard. |
-| H5 | Human-in-the-loop (approval gates) | **IN** | `nika:prompt` — blocking confirm with `default:` for non-interactive mode — plus `nika:notify` (fire-and-forget). Pause-state is **live** (the run keeps a process while blocked · durable pauses arrive with H1) · time-bound it with the task-level `timeout:`. ONE construct · a tool under `invoke:` · forever. |
-| H6 | Evals in-language (asserts · LLM-judge · golden runs) | **PARTIAL** | v0.1 ships the pieces · `schema:` (per-task structured-output gate · auto-retry) · `nika:assert` (fail-fast CEL guard) · `nika:validate` (JSON Schema over data). An LLM-judge is an `infer:` task with a verdict `schema:` — no dedicated builtin needed. Golden-run testing reuses the conformance fixture shape (input + expected output on `mock/`). Declarative in-file eval blocks · deferred. |
+| H5 | Human-in-the-loop (approval gates) | **IN** | `nika:prompt` (blocking confirm with `default:` for non-interactive mode) plus `nika:notify` (fire-and-forget). Pause-state is **live** (the run keeps a process while blocked · durable pauses arrive with H1) · time-bound it with the task-level `timeout:`. ONE construct · a tool under `invoke:` · forever. |
+| H6 | Evals in-language (asserts · LLM-judge · golden runs) | **PARTIAL** | v0.1 ships the pieces · `schema:` (per-task structured-output gate · auto-retry) · `nika:assert` (fail-fast CEL guard) · `nika:validate` (JSON Schema over data). An LLM-judge is an `infer:` task with a verdict `schema:`, no dedicated builtin needed. Golden-run testing reuses the conformance fixture shape (input + expected output on `mock/`). Declarative in-file eval blocks · deferred. |
 | H7 | Cost governance (budgets in €/tokens) | **PARTIAL** | Reading IS in-language · `nika:inspect view: cost` (running cost). Enforcement is NOT · hard caps are engine config (§Observability · `budget:` blocks deferred v0.2). The `agent:` budgets (`max_tokens_total`) are the one normative in-language cap today. |
-| H8 | Model routing / fallback chains | **PARTIAL** | The language surface is ONE field · explicit `model:` per task (+ `vars` parameterization — one workflow, any backend). Provider-side routing exists TODAY via `openrouter/…` (gateway fallback). Declarative capability-based routing in YAML ("any vision model under $X") · deferred · it must not create a second way to pick a model. |
-| H9 | Memory / the Connectome | **IN (as posture)** | Recall is a TOOL, forever · `invoke: mcp:memory-server/recall` today · `nika:connectome/recall` + `/ingest` when the Connectome ships (§The Connectome) · the tool-reference grammar already reserves the `nika:connectome/*` group — the forward-compat seam exists NOW. Never a verb · never an ambient implicit memory. |
-| H10 | Provenance (claim + evidence + confidence) | **PARTIAL** | The **evidence-first shape** — `{ claim, evidence: { step, path, quote }, confidence }` — is the RECOMMENDED (informative) output convention for audit-class workflows · fully expressible today via `schema:`. A normative, ProofChain-compatible machine run-report schema is deferred with the run-report work (v0.2). |
-| H11 | Observability (OTel) | **OUT (mapping recommended)** | Engine concern (§Observability) · zero telemetry by default · local-first. The canonical mapping when an engine exports · **run = trace · task = span · retry attempts = span events** — recommended so two engines' traces line up · never required. |
-| H12 | Security in-language vs runtime | **WRITTEN** | Language-visible security is now FOUR surfaces · the `exec:` blocklist (MUST · + the argv form as the structural injection fix) · the `agent:` tools whitelist (default-deny MUST) · secrets masking + no-inline-literals (`secrets:` envelope) · and the workflow-level **`permits:`** capability boundary ([01 §permits](./01-envelope.md#permits--optional--the-declared-capability-boundary) · default-deny once present · enforced statically + at runtime · NIKA-SEC-004). Everything else — trust levels · spotlighting · canaries · taint tracking (the reference engine's Shield · NIKA-SEC family) — is **runtime-side** and intentionally NOT in YAML v0.1. |
+| H8 | Model routing / fallback chains | **PARTIAL** | The language surface is ONE field · explicit `model:` per task (+ `vars` parameterization: one workflow, any backend). Provider-side routing exists TODAY via `openrouter/…` (gateway fallback). Declarative capability-based routing in YAML ("any vision model under $X") · deferred · it must not create a second way to pick a model. |
+| H9 | Memory / the Connectome | **IN (as posture)** | Recall is a TOOL, forever · `invoke: mcp:memory-server/recall` today · `nika:connectome/recall` + `/ingest` when the Connectome ships (§The Connectome) · the tool-reference grammar already reserves the `nika:connectome/*` group: the forward-compat seam exists NOW. Never a verb · never an ambient implicit memory. |
+| H10 | Provenance (claim + evidence + confidence) | **PARTIAL** | The **evidence-first shape** (`{ claim, evidence: { step, path, quote }, confidence }`) is the RECOMMENDED (informative) output convention for audit-class workflows · fully expressible today via `schema:`. A normative, ProofChain-compatible machine run-report schema is deferred with the run-report work (v0.2). |
+| H11 | Observability (OTel) | **OUT (mapping recommended)** | Engine concern (§Observability) · zero telemetry by default · local-first. The canonical mapping when an engine exports · **run = trace · task = span · retry attempts = span events**, recommended so two engines' traces line up · never required. |
+| H12 | Security in-language vs runtime | **WRITTEN** | Language-visible security is now FOUR surfaces · the `exec:` blocklist (MUST · + the argv form as the structural injection fix) · the `agent:` tools whitelist (default-deny MUST) · secrets masking + no-inline-literals (`secrets:` envelope) · and the workflow-level **`permits:`** capability boundary ([01 §permits](./01-envelope.md#permits--optional--the-declared-capability-boundary) · default-deny once present · enforced statically + at runtime · NIKA-SEC-004). Everything else, trust levels · spotlighting · canaries · taint tracking (the reference engine's Shield · NIKA-SEC family), is **runtime-side** and intentionally NOT in YAML v0.1. |
 | H13 | Packaging / distribution (registries · semver · signing) | **OUT** | The envelope pin `nika: v1` is the only versioning surface in the language. Workflow registries · package manifests · signing are ecosystem/engine concerns (the reference engine plans `nika-pck`) · not spec surface. |
-| H14 | Testing workflows (dry-run · mocks · goldens) | **IN (pieces)** | The `mock/` provider is one of the 14 (deterministic · no LLM call) — `model: mock/echo` per task or via one `vars.model` swap turns any workflow into a test. Golden runs reuse the conformance fixture pattern. `--dry-run` (parse + plan · execute nothing) is an engine CLI concern · MAY. A workflow without a test story is a script — the test story is · swap to `mock/`, assert with `nika:assert`/`schema:`. |
+| H14 | Testing workflows (dry-run · mocks · goldens) | **IN (pieces)** | The `mock/` provider is one of the 14 (deterministic · no LLM call): `model: mock/echo` per task or via one `vars.model` swap turns any workflow into a test. Golden runs reuse the conformance fixture pattern. `--dry-run` (parse + plan · execute nothing) is an engine CLI concern · MAY. A workflow without a test story is a script: the test story is · swap to `mock/`, assert with `nika:assert`/`schema:`. |
 | H15 | Concurrency / rate governance | **PARTIAL** | In-language · `max_parallel` (per `for_each`) + `fail_fast` + wave-parallel scheduling (normative · [03 §execution model](./03-dag.md#dag-execution-model)). Per-provider rate limits · engine config (the engine MUST honor declared caps · how it throttles providers is its business). Cross-run/global scheduling · NEVER (§Multi-workflow orchestration). |
-| H16 | Interop (import/export GHA · LangGraph · Temporal) | **PROUD NON-GOAL** | Nika is a source language, not a compatibility layer — no importers/exporters, ever (a translated workflow is a worse workflow). The interop boundaries are **MCP** (any MCP tool is callable · `mcp:<server>/<tool>`) and **`exec:`** (anything with a CLI). That covers the actual need — calling the world — without chaining the language to others' semantics. |
-| H17 | Step caching / memoization (`cache_key:`) | **OUT (durable-adjacent)** | A v0.1 run executes every non-skipped task — no memoize field. The dominant cacheable class (deterministic `exec:`/`invoke:`) collides with side effects, and `infer:` is non-deterministic — a wrong default poisons correctness. Lands as an additive task field WITH the durable-execution waypoint (a run store exists then · H1). Until then · cache at the tool layer (`nika:read`/`nika:write` a content-keyed path · HTTP caches honor ETags). |
-| H18 | Matrix strategy (cartesian product · include/exclude) | **PARTIAL (idiom · no field)** | `for_each` is one-dimensional by design — a matrix is **precomputed data, not control flow** · emit the product with `nika:jq` (`[ .os[] as $o | .ver[] as $v | {os:$o, ver:$v} ]`) · `for_each` over it (`item.os` · `item.ver`) · include/exclude = jq filters on the product. A `matrix:` sugar field would restate this in control-flow clothing · deferred unless empirical demand. |
-| H19 | Value-conditioned retry / polling (« retry until the VALUE says done ») | **OUT (v0.2 `retry_when:` candidate)** | `retry:` fires on ERRORS · never on values. The v0.1 canonical polling pattern · make not-ready an error INSIDE the task — `nika:fetch` with a jq `mode` whose program `error("not ready")`s on the pending shape + `retry: { max_attempts: N, backoff_strategy: fixed, backoff_ms: 30000, on_codes: [...] }` · OR an `agent:` with fetch+wait+done (budget-bounded). `retry_when: ${{ … }}` is the additive v0.2 shape — it must not ship before the error-vs-value semantics are provably clean. |
-| H20 | Environment targeting (dev / staging / prod) | **WRITTEN (idiom · no field)** | No `environments:` block. The pattern is **launch-time `vars` + per-env secret paths** · pass `--var env=prod` (engine CLI), branch values with the CEL conditional (`model: ${{ vars.env == 'prod' ? … : … }}`), and select the secret store path the same way (`secrets.api_key.key` is a per-env vault path the deploy supplies, OR two declared secrets gated by `when:`). Connection-set switching as a first-class construct (GHA environments · Prefect deployments) is a host/deploy concern — the language stays single-file and the env is just another input. An `environments:` sugar block is deferred unless empirical demand. |
-| H21 | Else / default branch (exhaustive choice) | **WRITTEN (idiom · no construct)** | No `else:` / `Choice.Default` construct. Mutually-exclusive branches are two tasks with negated `when:` joined by the defined-null diamond pattern ([03 §branch joins](./03-dag.md)); an N-way switch is N tasks each `when: ${{ vars.mode == '<case>' }}`. Exhaustiveness is author-maintained (a missing case = all-skip = a `null` at the join, which downstream sees explicitly — it does not silently corrupt). A dedicated `switch:`/`else:` would add a second control-flow primitive beside `when:`/`depends_on` · deferred · the CEL conditional `?:` already covers conditional VALUES (the common case) without any branch at all. |
-| H22 | Embeddings (`embed(text) → vector`) | **WRITTEN (deliberate absence · `mcp:` / Connectome territory)** | No `embed:` verb and no `nika:embed` builtin. Raw embedding generation is not a language primitive — it is a tool, reached via `invoke: mcp:<embedder>/embed` (any embedding server) or `exec:` (a local model). Semantic RECALL (the RAG read path) is the reference engine's **Connectome** (`nika:connectome/*` · a deferred capability · [§Connectome](#the-connectome--deferred-capability--not-a-deferred-verb)), not a language verb. The language stays about ORCHESTRATION; embedding is a capability the orchestrated tools provide. Stated here because « an AI workflow language with no embeddings » is a fair « did you think of X » — yes · it is `mcp:`/tool territory by design, not a silent gap. |
-| H23 | Cursor pagination / unbounded iteration (« fetch page → follow next-cursor until none ») | **OUT (the bounded forms are written · `while:` stays deferred)** | `for_each` iterates a collection KNOWN up front ([03 §fan-out](./03-dag.md)) and a task cannot `for_each` its own output — cursor-following is inherently unbounded iteration, which is `while:` (deferred above · it breaks the acyclic guarantee AND the static cost story: a workflow whose request count depends on a server's answers is not auditable-before-run). The v0.1 canonical forms · **(a) depth-known** · precompute the page list (`[range(1; N+1)]` via `nika:jq`) + `for_each` with `max_parallel` — page-numbered APIs; **(b) depth-unknown** · an `agent:` task whitelisted to `nika:fetch` + `nika:done` with `max_turns` as the page budget — the loop is budget-bounded and the cap is IN the file (auditable); **(c) heavy crawls** · the host loop (`exec: nika run fetch-page.yaml` per cursor · the composition floor above). A dedicated bounded construct (`while_bounded:` / `unfold:` with a MANDATORY `max_iterations:`) is the additive v0.2 candidate IF empirical demand shows (b) too heavy — it must carry a static iteration cap or it never ships. |
+| H16 | Interop (import/export GHA · LangGraph · Temporal) | **PROUD NON-GOAL** | Nika is a source language, not a compatibility layer: no importers/exporters, ever (a translated workflow is a worse workflow). The interop boundaries are **MCP** (any MCP tool is callable · `mcp:<server>/<tool>`) and **`exec:`** (anything with a CLI). That covers the actual need (calling the world) without chaining the language to others' semantics. |
+| H17 | Step caching / memoization (`cache_key:`) | **OUT (durable-adjacent)** | A v0.1 run executes every non-skipped task: no memoize field. The dominant cacheable class (deterministic `exec:`/`invoke:`) collides with side effects, and `infer:` is non-deterministic (a wrong default poisons correctness). Lands as an additive task field WITH the durable-execution waypoint (a run store exists then · H1). Until then · cache at the tool layer (`nika:read`/`nika:write` a content-keyed path · HTTP caches honor ETags). |
+| H18 | Matrix strategy (cartesian product · include/exclude) | **PARTIAL (idiom · no field)** | `for_each` is one-dimensional by design: a matrix is **precomputed data, not control flow** · emit the product with `nika:jq` (`[ .os[] as $o | .ver[] as $v | {os:$o, ver:$v} ]`) · `for_each` over it (`item.os` · `item.ver`) · include/exclude = jq filters on the product. A `matrix:` sugar field would restate this in control-flow clothing · deferred unless empirical demand. |
+| H19 | Value-conditioned retry / polling (« retry until the VALUE says done ») | **OUT (v0.2 `retry_when:` candidate)** | `retry:` fires on ERRORS · never on values. The v0.1 canonical polling pattern · make not-ready an error INSIDE the task: `nika:fetch` with a jq `mode` whose program `error("not ready")`s on the pending shape + `retry: { max_attempts: N, backoff_strategy: fixed, backoff_ms: 30000, on_codes: [...] }` · OR an `agent:` with fetch+wait+done (budget-bounded). `retry_when: ${{ … }}` is the additive v0.2 shape: it must not ship before the error-vs-value semantics are provably clean. |
+| H20 | Environment targeting (dev / staging / prod) | **WRITTEN (idiom · no field)** | No `environments:` block. The pattern is **launch-time `vars` + per-env secret paths** · pass `--var env=prod` (engine CLI), branch values with the CEL conditional (`model: ${{ vars.env == 'prod' ? … : … }}`), and select the secret store path the same way (`secrets.api_key.key` is a per-env vault path the deploy supplies, OR two declared secrets gated by `when:`). Connection-set switching as a first-class construct (GHA environments · Prefect deployments) is a host/deploy concern: the language stays single-file and the env is just another input. An `environments:` sugar block is deferred unless empirical demand. |
+| H21 | Else / default branch (exhaustive choice) | **WRITTEN (idiom · no construct)** | No `else:` / `Choice.Default` construct. Mutually-exclusive branches are two tasks with negated `when:` joined by the defined-null diamond pattern ([03 §branch joins](./03-dag.md)); an N-way switch is N tasks each `when: ${{ vars.mode == '<case>' }}`. Exhaustiveness is author-maintained (a missing case = all-skip = a `null` at the join, which downstream sees explicitly: it does not silently corrupt). A dedicated `switch:`/`else:` would add a second control-flow primitive beside `when:`/`depends_on` · deferred · the CEL conditional `?:` already covers conditional VALUES (the common case) without any branch at all. |
+| H22 | Embeddings (`embed(text) → vector`) | **WRITTEN (deliberate absence · `mcp:` / Connectome territory)** | No `embed:` verb and no `nika:embed` builtin. Raw embedding generation is not a language primitive: it is a tool, reached via `invoke: mcp:<embedder>/embed` (any embedding server) or `exec:` (a local model). Semantic RECALL (the RAG read path) is the reference engine's **Connectome** (`nika:connectome/*` · a deferred capability · [§Connectome](#the-connectome--deferred-capability--not-a-deferred-verb)), not a language verb. The language stays about ORCHESTRATION; embedding is a capability the orchestrated tools provide. Stated here because « an AI workflow language with no embeddings » is a fair « did you think of X »: yes · it is `mcp:`/tool territory by design, not a silent gap. |
+| H23 | Cursor pagination / unbounded iteration (« fetch page → follow next-cursor until none ») | **OUT (the bounded forms are written · `while:` stays deferred)** | `for_each` iterates a collection KNOWN up front ([03 §fan-out](./03-dag.md)) and a task cannot `for_each` its own output: cursor-following is inherently unbounded iteration, which is `while:` (deferred above · it breaks the acyclic guarantee AND the static cost story: a workflow whose request count depends on a server's answers is not auditable-before-run). The v0.1 canonical forms · **(a) depth-known** · precompute the page list (`[range(1; N+1)]` via `nika:jq`) + `for_each` with `max_parallel` (page-numbered APIs); **(b) depth-unknown** · an `agent:` task whitelisted to `nika:fetch` + `nika:done` with `max_turns` as the page budget: the loop is budget-bounded and the cap is IN the file (auditable); **(c) heavy crawls** · the host loop (`exec: nika run fetch-page.yaml` per cursor · the composition floor above). A dedicated bounded construct (`while_bounded:` / `unfold:` with a MANDATORY `max_iterations:`) is the additive v0.2 candidate IF empirical demand shows (b) too heavy: it must carry a static iteration cap or it never ships. |
 
 ---
 

--- a/crates/nika-pack/pack/stdlib/builtins-coverage-matrix.md
+++ b/crates/nika-pack/pack/stdlib/builtins-coverage-matrix.md
@@ -58,11 +58,11 @@ real ones (`sleep`+`wait_until`→`wait` · 4 introspections→`inspect` ·
 disambiguating a format-bound operation (`json_diff` · `json_merge_patch`).
 Multi-format tools stay unprefixed (`validate` · `convert`). Multi-mode
 tools are ONE builtin with a discriminating argument (`wait` mode ·
-`inspect` view) — never N siblings.
+`inspect` view), never N siblings.
 
 ## Known set-level gap (work item)
 
-Per-builtin **formal args/returns schemas** are not yet published —
+Per-builtin **formal args/returns schemas** are not yet published:
 builtins-v0.1.md ships examples + prose. A per-builtin contract block
 (`args:` JSON Schema · `returns:` shape · `throws:` codes) is the next
 stdlib documentation milestone; until it lands, the YAML examples + the

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -10,7 +10,7 @@
 > jaq source-verified 2026-05-27 · `obj_merge` impl + test corpus + corelang
 > docs) · the validators merged · `task_status`/`orchestrate`/`locale_lookup`
 > cut. Step 3 (22 → 23 · 2026-06-13) · `nika:compose` · the agent loop's
-> self-verification intrinsic (ADR-096 · loop-only like `done`). Step 2
+> self-verification intrinsic (ADR-093 · loop-only like `done`). Step 2
 > (26 → 22 · ADR-086/087/088 Rams sweep 2026-05-27) · `convert`
 > replaces `csv_to_json` (multi-format · from:/to:) · `wait` unifies
 > `sleep`+`wait_until` (−1) · `inspect` unifies `cost`+`records`+`dag_info`+
@@ -57,9 +57,9 @@ Emit a custom machine event (consumed by subscribers · journal). Distinct from 
 ```yaml
 invoke: { tool: "nika:assert", args: { condition: "${{ tasks.X.output.count > 0 }}", message: "Expected non-empty result" } }
 ```
-Fail the task if `condition` (a **CEL `${{ }}` boolean**) is false · else no-op. The **fail-fast guard** (distinct from `when:` which is the **skip-guard**). `condition:` uses the canonical `${{ }}` CEL surface — never a legacy `$task` syntax.
+Fail the task if `condition` (a **CEL `${{ }}` boolean**) is false · else no-op. The **fail-fast guard** (distinct from `when:` which is the **skip-guard**). `condition:` uses the canonical `${{ }}` CEL surface, never a legacy `$task` syntax.
 
-Returns `true` on pass. Throws · `NIKA-BUILTIN-ASSERT-001` (assertion failed · `tool_error` · `transient: false` · `message:` lands in the error message · retryable via `retry.on_codes` — the polling pattern's lever).
+Returns `true` on pass. Throws · `NIKA-BUILTIN-ASSERT-001` (assertion failed · `tool_error` · `transient: false` · `message:` lands in the error message · retryable via `retry.on_codes`, the polling pattern's lever).
 
 ### `nika:prompt`
 ```yaml
@@ -75,14 +75,14 @@ is collected** (default `confirm`) ·
 
 | `mode` | Returns | Notes |
 |---|---|---|
-| `confirm` (default) | **boolean** | `true` = confirmed · `false` = refused. A refusal is a VALUE, never an error — gate downstream with `when:`. |
+| `confirm` (default) | **boolean** | `true` = confirmed · `false` = refused. A refusal is a VALUE, never an error: gate downstream with `when:`. |
 | `input` | **string** | the free text the human typed (may be empty). |
 | `choice` | **string** | the chosen element of `choices:` (required · non-empty array). Returns the chosen value (not its index) so it binds directly. |
 
 Non-interactive contract (normative · all modes) · when no human can answer
 (CI · daemon) the engine MUST use `default:` when present · and MUST fail
 `NIKA-BUILTIN-PROMPT-001` (`validation_error` · non-interactive without a
-`default:`) when absent — never hang forever · never silently pick an answer.
+`default:`) when absent: never hang forever · never silently pick an answer.
 A `choice` whose `default:` is not an element of `choices:` is a parse error
 (`NIKA-BUILTIN-PROMPT-002` · `validation_error`).
 
@@ -120,7 +120,7 @@ Read a file · returns **string** content (text mode · the default).
 `binary: true` (explicit · no content sniffing) returns **opaque bytes**
 ([04 §value rendering](../spec/04-variables.md) · they flow tool→tool ·
 never into a string position). Throws · `NIKA-BUILTIN-READ-001` (file not
-found — the code the state-file first-run pattern scopes its recovery to) ·
+found, the code the state-file first-run pattern scopes its recovery to) ·
 `-002` (IO failure · permission) · `-003` (text mode on non-UTF-8 content ·
 use `binary: true`). All `tool_error` · `transient: false`.
 
@@ -137,9 +137,9 @@ Write a file · returns the path. A binary `content` value (an opaque bytes outp
 invoke: { tool: "nika:edit", args: { path: "./file.md", find: "old", replace: "new" } }
 ```
 In-place find/replace · returns the modified path. `find:` is a **literal
-string** (not a regex — use `nika:grep` to locate · jq to transform) ·
+string** (not a regex: use `nika:grep` to locate · jq to transform) ·
 replaces **all occurrences** · `count:` caps replacements when set. Throws ·
-`NIKA-BUILTIN-EDIT-001` (`find:` matched nothing — an edit that edits
+`NIKA-BUILTIN-EDIT-001` (`find:` matched nothing: an edit that edits
 nothing is an authoring bug · `tool_error`) · `-002` (IO failure).
 
 ### `nika:glob`
@@ -168,9 +168,9 @@ sorted by `(path, line)`. `pattern:` is a **Rust-regex-class** expression
 ```yaml
 invoke: { tool: "nika:jq", args: { expression: ".items | map(.price) | add", input: "${{ tasks.X.output }}" } }
 ```
-Run a jq expression. **The single data-transform-and-extraction language** — map · filter · select · group_by · reshape · string-interpolation `"\(.x)"` · `@base64`/`@base64d`/`@csv` encoders · array `flatten` · `leaf_paths`/`getpath`/`setpath`. The same jq used in `output:` bindings (see `04-variables.md`).
+Run a jq expression. **The single data-transform-and-extraction language**: map · filter · select · group_by · reshape · string-interpolation `"\(.x)"` · `@base64`/`@base64d`/`@csv` encoders · array `flatten` · `leaf_paths`/`getpath`/`setpath`. The same jq used in `output:` bindings (see `04-variables.md`).
 
-**`input` is any JSON value** — a single ref (`input: "${{ tasks.X.output }}"`) OR a **constructed array for multi-input ops**. Recursive merge of two objects (this is exactly why `json_merge` is NOT a builtin · jaq's `*` does it) ·
+**`input` is any JSON value**: a single ref (`input: "${{ tasks.X.output }}"`) OR a **constructed array for multi-input ops**. Recursive merge of two objects (this is exactly why `json_merge` is NOT a builtin · jaq's `*` does it) ·
 ```yaml
 invoke:
   tool: nika:jq
@@ -180,10 +180,10 @@ invoke:
 ```
 Same shape combines / zips N inputs · build the array, index inside jq.
 
-**The arg is `expression:`** — exactly that name (not `query:` · not `expr:` ·
+**The arg is `expression:`**, exactly that name (not `query:` · not `expr:` ·
 one name everywhere · the conformance oracle gates it). Throws ·
-`NIKA-BUILTIN-JQ-001` (program error at runtime · `tool_error` — compile
-errors are caught statically · `NIKA-VAR-005`).
+`NIKA-BUILTIN-JQ-001` (program error at runtime · `tool_error`). Compile
+errors are caught statically (`NIKA-VAR-005`).
 
 **Implementation** · reference engine uses `jaq` (Rust jq).
 
@@ -198,7 +198,7 @@ JSON diff · returns **RFC 6902** JSON Patch. (jq can't diff.) Throws · `NIKA-B
 invoke: { tool: "nika:validate", args: { data: { ... }, schema: { type: object, ... }, format: json } }
 # format: json (default · validate a value) | yaml (parse a YAML string first, then validate)
 ```
-Validate data against a **JSON Schema** · returns `{ valid: bool, errors: [...] }` — invalid DATA is a **report, never a task failure** (gate on `.valid` downstream · or `nika:assert` it). Merges the former `json_verify` + `yaml_validate` (`format:` arg · one validator). Throws · `NIKA-BUILTIN-VALIDATE-001` (the `schema:` itself is not a valid JSON Schema · `validation_error`) · `-002` (`format: yaml` and the string does not parse as YAML).
+Validate data against a **JSON Schema** · returns `{ valid: bool, errors: [...] }`. Invalid DATA is a **report, never a task failure** (gate on `.valid` downstream · or `nika:assert` it). Merges the former `json_verify` + `yaml_validate` (`format:` arg · one validator). Throws · `NIKA-BUILTIN-VALIDATE-001` (the `schema:` itself is not a valid JSON Schema · `validation_error`) · `-002` (`format: yaml` and the string does not parse as YAML).
 
 ### `nika:json_merge_patch`
 ```yaml
@@ -248,7 +248,7 @@ Content hashing · default **blake3** (fastest modern cryptographic hash · para
 ## Network builtins (2)
 
 ### `nika:fetch`
-HTTP request + content extraction (reached via `invoke:` — fetching a URL is *calling a tool*, not a verb · see `02-verbs.md`).
+HTTP request + content extraction (reached via `invoke:` because fetching a URL is *calling a tool*, not a verb · see `02-verbs.md`).
 ```yaml
 invoke: { tool: "nika:fetch", args: { url: "https://example.com/article", mode: article } }
 ```
@@ -264,7 +264,7 @@ invoke: { tool: "nika:fetch", args: { url: "https://example.com/article", mode: 
 `NIKA-BUILTIN-FETCH-001` (`category: network_error` · `transient: true` for
 5xx/408/429 · `false` for other 4xx · `details.status_code` carries the
 status). To poll a pending resource · the jq-error pattern
-([08 H19](../spec/08-out-of-scope.md)) — not status-code inspection.
+([08 H19](../spec/08-out-of-scope.md)), not status-code inspection.
 Redirects follow up to an engine cap · the FINAL status decides.
 
 **Security (engine MUST)** · SSRF defense (reject private-net + cloud-metadata `169.254.169.254` unless configured) · honor task-level `timeout` · reject self-signed TLS by default.
@@ -273,7 +273,7 @@ Redirects follow up to an engine cap · the FINAL status decides.
 ```yaml
 invoke: { tool: "nika:notify", args: { channel: webhook, target: "https://hooks.slack.com/...", message: "Done · ${{ tasks.X.status }}", severity: info, data: { run: "${{ tasks.X.output }}" } } }
 ```
-Send notifications · `channel:` enum (`webhook`/`slack`/`email`/`discord`/`sms` · one builtin not 5). The 1.0 engine MUST support `webhook` · others MAY be feature-gated. `data:` (OPTIONAL · any JSON value) carries structured context alongside the human `message` — the webhook payload is `{ message, severity, data? }` (the key is absent when not given · receivers branch on machine fields, never parse the message). Returns `null` on accepted delivery. Throws · `NIKA-BUILTIN-NOTIFY-001` (channel unconfigured · `validation_error`) · `-002` (delivery failed · `network_error` · transient engine-assessed).
+Send notifications · `channel:` enum (`webhook`/`slack`/`email`/`discord`/`sms` · one builtin not 5). The 1.0 engine MUST support `webhook` · others MAY be feature-gated. `data:` (OPTIONAL · any JSON value) carries structured context alongside the human `message`: the webhook payload is `{ message, severity, data? }` (the key is absent when not given · receivers branch on machine fields, never parse the message). Returns `null` on accepted delivery. Throws · `NIKA-BUILTIN-NOTIFY-001` (channel unconfigured · `validation_error`) · `-002` (delivery failed · `network_error` · transient engine-assessed).
 
 ---
 
@@ -286,7 +286,7 @@ agent:
   tools: ["nika:compose"]            # the agent grants itself the self-check
 ```
 The agent loop's self-verification intrinsic · the model passes a workflow
-YAML draft it wrote, and gets the FULL `nika check` verdict back as JSON —
+YAML draft it wrote, and gets the FULL `nika check` verdict back as JSON:
 conformance violations (with codes + repair hints), secret-flow findings,
 permits escapes, and the termination/cost certificate. It **never executes**
 the draft (« generation is not permission » · the draft is an artifact + its
@@ -309,7 +309,7 @@ invoke:
 Workflow introspection · 1 builtin · 4 `view:` enum modes (Rams collapse per ADR-088 · 2026-05-27) ·
 
 - `view: cost` → `{ total_usd, by_task, by_provider }`. Running workflow cost.
-- `view: records` → `{ tasks: [{ id, status, duration_ms, ... }] }`. Full execution record. (Per-task status is also read directly via the `${{ tasks.X.status }}` namespace — same shape.)
+- `view: records` → `{ tasks: [{ id, status, duration_ms, ... }] }`. Full execution record. (Per-task status is also read directly via the `${{ tasks.X.status }}` namespace, same shape.)
 - `view: dag_info` → `{ nodes, edges, waves }`. DAG topology.
 - `view: threads` → `{ active, queued, completed }`. Engine task-pool state · **advisory** · counts reflect the engine's concurrency model (impl-dependent · use for coarse adaptive-throttling · not a portable contract-precise number).
 

--- a/crates/nika-pack/pack/stdlib/extract-modes-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/extract-modes-v0.1.md
@@ -62,7 +62,7 @@ invoke:
 
 **Behavior** · extracts the main article body · stripping navigation · sidebars · ads · share widgets · related-post blocks · comments. Page-type aware: on forum/discussion pages the posts and replies ARE the content (kept, not pruned).
 
-**Implementation** · reference engine runs a three-stage cascade (the failure modes are decorrelated, so the cascade beats any single extractor): (1) a Trafilatura-grade rule cascade — zone targeting (the semantic content container) + a boilerplate prune denylist, the 2024-2026 SOTA for main-content extraction; (2) a Readability pass (`dom_smoothie`) for markup-poor pages; (3) a Boilerpipe shallow-text-density floor for div-soup pages. The earlier stage wins when it yields a substantial body, else the next fires.
+**Implementation** · reference engine runs a three-stage cascade (the failure modes are decorrelated, so the cascade beats any single extractor): (1) a Trafilatura-grade rule cascade: zone targeting (the semantic content container) + a boilerplate prune denylist, the 2024-2026 SOTA for main-content extraction; (2) a Readability pass (`dom_smoothie`) for markup-poor pages; (3) a Boilerpipe shallow-text-density floor for div-soup pages. The earlier stage wins when it yields a substantial body, else the next fires.
 
 **Output** · Markdown string · article body only.
 
@@ -116,17 +116,17 @@ invoke:
     jq: "[.data.users[].email]"
 ```
 
-**Behavior** · parses response as JSON · applies the jq expression · returns the result. The SAME jq language used in `output:` bindings and the `nika:jq` builtin — Nika has ONE data language (replaces the former JSONPath mode · jq is a superset of JSONPath). **The exactly-one-output law applies** (same engine · same law as `nika:jq` per [04 §bindings](../spec/04-variables.md)) · an expression producing 0 or N outputs is `NIKA-BUILTIN-FETCH-001` — wrap streams in `[…]` to collect.
+**Behavior** · parses response as JSON · applies the jq expression · returns the result. The SAME jq language used in `output:` bindings and the `nika:jq` builtin: Nika has ONE data language (replaces the former JSONPath mode · jq is a superset of JSONPath). **The exactly-one-output law applies** (same engine · same law as `nika:jq` per [04 §bindings](../spec/04-variables.md)) · an expression producing 0 or N outputs is `NIKA-BUILTIN-FETCH-001` (wrap streams in `[…]` to collect).
 
 **Implementation** · reference engine uses `jaq` (Rust jq).
 
 **Output** · JSON value (string · array · object).
 
 **Examples** ·
-- `.` — whole response
-- `.data.users[0]` — first user
-- `[.data.users[].name]` — all user names (collected · one array)
-- `[.. | .price?] | map(select(. != null))` — all prices recursively
+- `.`, whole response
+- `.data.users[0]`, first user
+- `[.data.users[].name]`, all user names (collected · one array)
+- `[.. | .price?] | map(select(. != null))`, all prices recursively
 
 ---
 
@@ -140,7 +140,7 @@ invoke:
     mode: metadata
 ```
 
-**Behavior** · walks the HTML head + the embedded structured data. Returns a structured object. `og`/`twitter` are ALWAYS objects (stable shape); scalar keys are omitted when absent. `title`/`description` fall back to the `og:`/`twitter:` equivalents when the `<title>`/`<meta name=description>` is missing (common on SPAs). The URL-valued `og:image`/`og:url`/`twitter:image` are resolved to absolute against the effective base (like `canonical`). Beyond the `<meta>` tags it surfaces the two embedded-structured-data carriers: `jsonld` (schema.org `<script type=ld+json>` blocks, parsed) and `microdata` (schema.org `itemscope`/`itemprop` items, the W3C item model) — schema-agnostic, for a downstream `jq` step to walk.
+**Behavior** · walks the HTML head + the embedded structured data. Returns a structured object. `og`/`twitter` are ALWAYS objects (stable shape); scalar keys are omitted when absent. `title`/`description` fall back to the `og:`/`twitter:` equivalents when the `<title>`/`<meta name=description>` is missing (common on SPAs). The URL-valued `og:image`/`og:url`/`twitter:image` are resolved to absolute against the effective base (like `canonical`). Beyond the `<meta>` tags it surfaces the two embedded-structured-data carriers: `jsonld` (schema.org `<script type=ld+json>` blocks, parsed) and `microdata` (schema.org `itemscope`/`itemprop` items, the W3C item model). Both are schema-agnostic, for a downstream `jq` step to walk.
 
 **Output** ·
 ```json
@@ -179,7 +179,7 @@ invoke:
     mode: links
 ```
 
-**Behavior** · extracts all `<a href>` URLs. Resolves relative to absolute against the document's effective base — a `<base href>` element when present (WHATWG), else the fetch URL.
+**Behavior** · extracts all `<a href>` URLs. Resolves relative to absolute against the document's effective base: a `<base href>` element when present (WHATWG), else the fetch URL.
 
 **Output** · array of strings ·
 ```json
@@ -193,7 +193,7 @@ invoke:
 **Use case** · crawler · link analysis · sitemap building.
 
 **Combining metadata + links** · two tasks on the same URL (the canon
-set is CLOSED at v0.1 — a combined `metadata-links` mode is a stdlib
+set is CLOSED at v0.1: a combined `metadata-links` mode is a stdlib
 v0.x candidate, rejected today like `llm-txt`).
 
 ---
@@ -208,7 +208,7 @@ invoke:
     mode: feed
 ```
 
-**Behavior** · parses RSS · Atom · or JSON Feed. Returns normalized structure. Each item carries the short `summary` blurb AND, when present, the full `content` body (RSS `<content:encoded>` · Atom `<content>` · JSON Feed `content_html`) — `content` is the field for full-text pipelines. Items also carry `media` (attached audio/video — RSS `<enclosure>` + MediaRSS `<media:content>` — for podcast/video feeds). Fields absent from the source are omitted (absence over null · stable shape).
+**Behavior** · parses RSS · Atom · or JSON Feed. Returns normalized structure. Each item carries the short `summary` blurb AND, when present, the full `content` body (RSS `<content:encoded>` · Atom `<content>` · JSON Feed `content_html`): `content` is the field for full-text pipelines. Items also carry `media` (attached audio/video, RSS `<enclosure>` + MediaRSS `<media:content>`, for podcast/video feeds). Fields absent from the source are omitted (absence over null · stable shape).
 
 **Implementation** · reference engine uses `feed-rs`.
 
@@ -264,7 +264,7 @@ invoke:
 ### `llm-txt` · RESERVED (not a v0.1 mode)
 
 A future mode parsing the `llms.txt` convention (LLM-friendly site
-descriptions). **NOT in the v0.1 canonical set** — `mode: llm-txt` is
+descriptions). **NOT in the v0.1 canonical set**: `mode: llm-txt` is
 rejected today (the canon list of 9 is closed · the conformance oracle
 enforces it). Until it stabilizes (stdlib v0.2 candidate) · fetch with
 `mode: text` and parse with `nika:jq` / an `infer:` step.

--- a/crates/nika-pack/pack/stdlib/providers-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/providers-v0.1.md
@@ -10,7 +10,7 @@
 ## Model selection · ONE field · `model: <provider>/<name>`
 
 You select an LLM with a **single `model:` field** in the form
-`<provider>/<model-name>` — the de-facto standard convention (LiteLLM ·
+`<provider>/<model-name>`, the de-facto standard convention (LiteLLM ·
 OpenRouter · Vercel AI SDK · PydanticAI all converged on it). There is **no
 separate `provider:` field** · the provider is the prefix.
 
@@ -67,19 +67,19 @@ tasks:
 A Stdlib v0.1-compliant engine MUST ship all **14** (5 local · 8 cloud · 1 test).
 Any *other* OpenAI-compatible local server (Jan · llamafile · KoboldCpp ·
 text-generation-webui · a custom one) routes through the **`openai` escape
-hatch** below — no new provider name needed.
+hatch** below (no new provider name needed).
 
 > **2026-06-10 · `openrouter` promoted from escape hatch to named provider**
 > (D-2026-06-10-N2). Earlier revisions routed OpenRouter through
-> `openai`+`base_url`. That override **hijacks the `openai` prefix** — you
-> cannot reach vanilla OpenAI and OpenRouter from the same engine config —
+> `openai`+`base_url`. That override **hijacks the `openai` prefix** (you
+> cannot reach vanilla OpenAI and OpenRouter from the same engine config),
 > and the largest model-aggregation gateway deserves first-class one-field
 > selection. Together · Fireworks · custom gateways still use the escape hatch.
 
 ## Local vs cloud · the prefix decides
 
-The **provider prefix IS the local/cloud signal** — no separate `local:` flag,
-no hidden config to read:
+The **provider prefix IS the local/cloud signal** (no separate `local:` flag,
+no hidden config to read):
 
 ```
 ollama/…  lmstudio/…  llamacpp/…  localai/…  vllm/…   → LOCAL · localhost · no key · sovereign
@@ -95,7 +95,7 @@ zero-cloud run trivial.
 All 5 local providers are external **HTTP servers** (OpenAI-compatible API · the
 engine talks to them over localhost). They are NOT the in-process GGUF runtime
 `native`, which was DEFERRED (mistral.rs crashed
-the host) — re-enters stdlib v0.x when a candle/llama.cpp binding stabilizes +
+the host). It re-enters stdlib v0.x when a candle/llama.cpp binding stabilizes +
 30-day crash-free cohort + cross-platform conformance. **The named local
 providers are ergonomic shortcuts; the long tail uses the escape hatch.**
 
@@ -114,9 +114,9 @@ OPENAI_BASE_URL=http://localhost:1337/v1   # engine config · points at Jan
 This is the LiteLLM pattern: **named providers for the popular backends ·
 `openai`+base_url for everything else.** It is how Jan · llamafile ·
 KoboldCpp · text-generation-webui · and any custom OpenAI-compatible server
-run today — zero spec change, the stdlib stays curated, the long tail is
+run today: zero spec change, the stdlib stays curated, the long tail is
 covered. Adding a *new named* provider later (its own prefix) is an
-additive stdlib bump — `openrouter` (2026-06-10 · D-2026-06-10-N2) is the
+additive stdlib bump: `openrouter` (2026-06-10 · D-2026-06-10-N2) is the
 first such promotion.
 
 ## Provider config lives OUTSIDE the workflow
@@ -164,7 +164,7 @@ infer:
 
 **Auth** · none (localhost).
 
-**Features** · 100% local · zero cloud egress · GPU-accelerated by Ollama. The sovereign default — `model: ollama/<x>` runs offline / air-gapped, zero vendor lock-in. (NOT the in-process `native` GGUF runtime, which is deferred — Ollama is an external server, stable.)
+**Features** · 100% local · zero cloud egress · GPU-accelerated by Ollama. The sovereign default: `model: ollama/<x>` runs offline / air-gapped, zero vendor lock-in. (NOT the in-process `native` GGUF runtime, which is deferred: Ollama is an external server, stable.)
 
 ---
 
@@ -295,7 +295,7 @@ infer:
 
 **Features** · tool use · vision · structured output (JSON mode).
 
-**Escape hatch** · the openai provider routes ANY OpenAI-compatible endpoint via the `OPENAI_BASE_URL` engine-config override (see « The `openai` escape hatch » above). Covers the local servers without their own named provider — **Jan · llamafile · KoboldCpp · text-generation-webui** — plus cloud gateways (**Together · Fireworks**) and custom servers. Providers with their own named prefix (`openrouter` · `ollama` · `lmstudio` · `llamacpp` · `localai` · `vllm`) don't need this.
+**Escape hatch** · the openai provider routes ANY OpenAI-compatible endpoint via the `OPENAI_BASE_URL` engine-config override (see « The `openai` escape hatch » above). Covers the local servers without their own named provider (**Jan · llamafile · KoboldCpp · text-generation-webui**) plus cloud gateways (**Together · Fireworks**) and custom servers. Providers with their own named prefix (`openrouter` · `ollama` · `lmstudio` · `llamacpp` · `localai` · `vllm`) don't need this.
 
 ---
 
@@ -309,10 +309,10 @@ infer:
 
 The cross-vendor **gateway** · one API key reaches every major model
 (Anthropic · OpenAI · Meta · Mistral · Google · open-weight). Promoted from
-the `openai` escape hatch 2026-06-10 (D-2026-06-10-N2) — a named prefix means
+the `openai` escape hatch 2026-06-10 (D-2026-06-10-N2): a named prefix means
 OpenRouter and vanilla `openai` coexist in one engine config.
 
-**Models** · OpenRouter ids are themselves `vendor/model` — the workflow form
+**Models** · OpenRouter ids are themselves `vendor/model`: the workflow form
 is `openrouter/<vendor>/<model>` (everything after the first `/` passes
 through verbatim). E.g. `openrouter/anthropic/claude-sonnet-4-6` ·
 `openrouter/meta-llama/llama-3.1-70b-instruct` · `openrouter/deepseek/deepseek-r1`.
@@ -404,12 +404,12 @@ infer:
 **Backend** · deterministic test fixture · returns a configured response.
 
 **Models** ·
-- **`echo` · THE canonical test model** (`model: mock/echo` — what every
+- **`echo` · THE canonical test model** (`model: mock/echo`, what every
   canonical example uses) · returns the prompt text **verbatim** as the
   output · zero network · zero entropy (bit-identical across runs/engines).
   With a `schema:` declared · returns `{}` shaped to the schema's required
   scalar defaults (string `""` · number `0` · boolean `false` · array `[]` ·
-  object recursed) — deterministic · validates · carries no meaning (test
+  object recursed): deterministic · validates · carries no meaning (test
   the SHAPE of your DAG · not model quality).
 - `mock-deterministic` · returns the prompt verbatim (echo's long-form alias)
 - `mock-error` · returns a configured error
@@ -418,7 +418,7 @@ infer:
 
 The configured-response forms (`mock-error` · `mock-streaming` ·
 `mock-json`) read their fixture from **engine config** (NOT workflow YAML ·
-the workflow stays portable) — the behavioral conformance fixtures
+the workflow stays portable). The behavioral conformance fixtures
 (post-announce) pin their exact contract. `mock/echo` is fully normative
 TODAY (the static + example gates rely on it).
 

--- a/crates/nika-pack/pack/templates/agent-loop.nika.yaml
+++ b/crates/nika-pack/pack/templates/agent-loop.nika.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · agent-loop — plan with a fast model, execute with a
+# TEMPLATE · agent-loop · plan with a fast model, execute with a
 # budgeted agent, validate the typed result.
 # The default shape for open-ended work (research · review · triage).
 #
@@ -14,7 +14,7 @@ nika: v1
 workflow: agent-loop-template       # SLOT: kebab-case workflow id
 description: "plan → budgeted agent → typed result"   # SLOT
 
-model: mock/echo                    # SLOT: agents want a tool-calling model
+model: ollama/llama3.2:3b           # SLOT: a tool-calling model · local by default
 
 vars:
   goal:
@@ -54,7 +54,7 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ size(tasks.execute.output.findings) > 0 }}"
-        message: "Agent returned no findings — do not trust an empty run"   # SLOT
+        message: "Agent returned no findings, do not trust an empty run"   # SLOT
 
 outputs:
   findings:

--- a/crates/nika-pack/pack/templates/chain.nika.yaml
+++ b/crates/nika-pack/pack/templates/chain.nika.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · chain — gather facts → one model step → persist.
+# TEMPLATE · chain · gather facts → one model step → persist.
 # The default shape for « take real data, produce words, save them ».
 #
 # Instantiate (agents · deterministic) ·
@@ -15,7 +15,7 @@ nika: v1
 workflow: chain-template            # SLOT: kebab-case workflow id
 description: "gather → think → persist"   # SLOT: one honest sentence
 
-model: mock/echo                    # SLOT: provider/model (mock/echo = CI-safe)
+model: ollama/llama3.2:3b           # SLOT: provider/model · local · zero key
 
 vars:
   source: "./input.txt"             # SLOT: your inputs · typed where required

--- a/crates/nika-pack/pack/templates/etl-state.nika.yaml
+++ b/crates/nika-pack/pack/templates/etl-state.nika.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · etl-state — incremental data job with a state file.
+# TEMPLATE · etl-state · incremental data job with a state file.
 # The default shape for « only the NEW » jobs (feeds · exports · syncs)
 # and for batch pipelines that must survive bad input.
 #
@@ -34,7 +34,7 @@ tasks:
 
   - id: fresh
     invoke:
-      tool: "nika:fetch"            # SLOT: fetch / read / exec — the fresh data
+      tool: "nika:fetch"            # SLOT: fetch / read / exec · the fresh data
       args:
         url: "${{ vars.source_url }}"
         mode: jq

--- a/crates/nika-pack/pack/templates/fanout.nika.yaml
+++ b/crates/nika-pack/pack/templates/fanout.nika.yaml
@@ -1,21 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · fanout — discover a collection, process every item in
+# TEMPLATE · fanout: discover a collection, process every item in
 # parallel (with a leash), merge the results.
 # The default shape for « N pages / N files / N records » jobs.
 #
 # Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
 # The leash (pattern 4 · ALWAYS set all three) ·
 #   max_parallel  cap concurrency (APIs rate-limit · GPUs thrash)
-#   fail_fast: false + on_error recover: null — one bad item yields null
+#   fail_fast: false + on_error recover: null: one bad item yields null
 #     at its index (order preserved) · the batch lives · filter downstream
 #   per-iteration retry/timeout · the flaky world is normal
 nika: v1
 workflow: fanout-template           # SLOT: kebab-case workflow id
 description: "discover N items · process in parallel · merge"   # SLOT
 
-model: mock/echo                    # SLOT: provider/model
+model: ollama/llama3.2:3b           # SLOT: provider/model · local · zero key
 
 vars:
   collection_source: "./items"      # SLOT: where the collection comes from

--- a/crates/nika-pack/pack/templates/gate-and-act.nika.yaml
+++ b/crates/nika-pack/pack/templates/gate-and-act.nika.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · gate-and-act — check a condition, act only when it holds.
+# TEMPLATE · gate-and-act: check a condition, act only when it holds.
 # The default shape for monitors, alerts and threshold jobs. Often
 # needs ZERO model calls (pattern 1 · deterministic core).
 #

--- a/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
+++ b/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · human-gated-ship — gates in parallel, a human signs,
+# TEMPLATE · human-gated-ship: gates in parallel, a human signs,
 # the action ships, evidence always lands.
 # The default shape for anything irreversible (deploys · sends · publishes).
 #
@@ -10,7 +10,7 @@
 #   nothing irreversible happens before nika:prompt returns true
 #   the assert makes a RED gate terminal · the act fails LOUDLY (default
 #   capture) · a terminal `when: true` task records EVERY outcome
-#   (acted · refused · failed) — the always-pattern
+#   (acted · refused · failed): the always-pattern
 nika: v1
 workflow: human-gated-ship-template  # SLOT: kebab-case workflow id
 description: "verify in parallel · human GO · act · record"   # SLOT
@@ -46,7 +46,7 @@ tasks:
       tool: "nika:assert"
       args:
         condition: "${{ tasks.check_a.output.exit_code == 0 && tasks.check_b.output.exit_code == 0 }}"
-        message: "A gate is RED — refusing to proceed"   # SLOT
+        message: "A gate is RED: refusing to proceed"   # SLOT
 
   - id: human
     depends_on: [gates]
@@ -61,7 +61,7 @@ tasks:
     when: ${{ tasks.human.output == true }}
     exec:
       command: ["echo", "shipped"]   # SLOT: the irreversible action (argv · program must be in permits.exec)
-      # default capture · a failing ship fails LOUDLY (NIKA-EXEC-001) —
+      # default capture · a failing ship fails LOUDLY (NIKA-EXEC-001):
       # never `capture: structured` on the irreversible step (exit codes
       # would become data and a red ship would read as success)
 

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -743,6 +743,74 @@ tasks:
     }
 
     #[test]
+    fn future_clause_budget_rejects_cleanly() {
+        // Forward-compat anchor (overnight 2026-07-05) · the v0.2 seed
+        // clauses (budget: / approve: / policy: · draft ADRs in nika-spec)
+        // MUST fail as clean UnknownField on today's parser — never a
+        // panic, never silent acceptance. When a clause ships, its test
+        // here flips from expect_err to a positive parse.
+        let yaml = "\
+tasks:
+  - id: capped
+    budget: { usd: 0.50 }
+    infer: { prompt: hello }
+";
+        let err = parse_strict(yaml).expect_err("budget: is not shipped");
+        assert!(
+            matches!(&err, SchemaError::UnknownField { field, .. } if field == "budget"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn future_clause_approve_rejects_cleanly() {
+        let yaml = "\
+tasks:
+  - id: gated
+    approve: true
+    exec: { command: rm -rf ./dist }
+";
+        let err = parse_strict(yaml).expect_err("approve: is not shipped");
+        assert!(
+            matches!(&err, SchemaError::UnknownField { field, .. } if field == "approve"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn shipped_clause_retry_parses_with_the_real_grammar() {
+        // Anti-redundancy anchor (overnight 2026-07-05) · retry:/on_error:
+        // ALREADY ship (spec 05 · this night's socratic hypothesis « retry
+        // is the missing primitive » was refuted by this very test) — the
+        // v0.2 seed ADRs are budget/approve/policy only.
+        let yaml = "\
+tasks:
+  - id: flaky
+    retry: { max_attempts: 3, backoff_strategy: exponential, on_codes: [NIKA-INFER-001] }
+    infer: { prompt: hello }
+";
+        let wf = parse_strict(yaml).expect("retry with the real keys parses");
+        assert!(wf.tasks[0].value.retry.is_some());
+    }
+
+    #[test]
+    fn future_clause_policy_rejects_cleanly() {
+        // Workflow-level seed clause · same forward-compat contract.
+        let yaml = "\
+policy:
+  human_gate_before: [exec]
+tasks:
+  - id: t
+    exec: { command: echo hi }
+";
+        let err = parse_strict(yaml).expect_err("policy: is not shipped");
+        assert!(
+            matches!(&err, SchemaError::UnknownField { field, .. } if field == "policy"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
     fn depends_on_when_for_each() {
         let yaml = "\
 tasks:


### PR DESCRIPTION
Night batch B2 (overnight master plan 2026-07-05).

- Pack re-synced via sync-pack.sh (43 files · the 07-04/05 spec arc: README 60s-path + why-not table · working schema modeline · canon/showcase drift)
- Forward-compat anchors: the v0.2 seed clauses (budget:/approve:/policy:) fail as clean UnknownField until shipped — never a panic, never silent acceptance
- Socratic refutation baked in: the « retry is the missing primitive » hypothesis died against this battery — retry:/on_error: already ship with a full grammar (max_attempts · backoff · jitter · on_codes), anchored by a positive parse test so nobody re-drafts it

nika-schema 762/762 · clippy 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)