### PR TITLE
chore(release): v0.93.0 — changelog + workspace version bump

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -131,7 +131,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 |------------------|------------------------------------------------|
 | branch           | `main`                                      |
 | HEAD             | `8ef43dddc` (`8ef43dddc1c0633a1156ef0eff9f2d10e51595fa`)             |
-| workspace        | v0.93.0-dev                                  |
+| workspace        | v0.93.0                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,448 @@
 # Changelog
 
+All notable changes to **Nika** are documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Nika follows [real semver toward 1.0](ROADMAP.md) — incremental quality, diamond-grade at every release (amended D-2026-06-20-N1 · was "forever-v0.x").
+
+Nika Diamond is a ground-up rewrite on the `nika-diamond` orphan branch.
+Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
+
+---
+## [0.93.0](https://github.com/supernovae-st/nika/compare/v0.92.0..v0.93.0) - 2026-07-05
+
+### ✨ Highlights
+
+- **Local thinking-era models unbricked** — the provider-plane HTTP timeout
+  rises to 180s ([PR 148](https://github.com/supernovae-st/nika/pull/148)): 2026 open-weight models (qwen3.5 · gemma4) spend
+  40-90s thinking before a structured answer on consumer hardware; every
+  local structured `infer:` died at the old 30s cloud-calibrated ceiling.
+  Field-fix train [PR 149](https://github.com/supernovae-st/nika/pull/149) pairs it with per-task transport-deadline semantics.
+- **`nika run --resume`** — durable-lite resume: the trace IS the checkpoint
+  (ADR-099 · [PR 154](https://github.com/supernovae-st/nika/pull/154)): completed tasks replay from the flight recorder as
+  visible cache hits · a paused/failed run continues where it stopped.
+- **`nika test`** — the workflow test harness + ADR-098 provider json-mode +
+  the CLI wow pass (waves · lanes · verdict card) landed in the Rounds 2+3
+  train ([PR 153](https://github.com/supernovae-st/nika/pull/153)).
+- **Onboarding golden path** — brew caveats walk the first 60 seconds ·
+  `nika init` hands over to the next command ([PR 158](https://github.com/supernovae-st/nika/pull/158)) · the embedded pack
+  carries the current spec (60s README · why-not table · llms.txt).
+
+### 🆕 Crates admitted
+- **nika-cap** — Admit to workspace — all 12 gates passed ([ea5b2090d](https://github.com/supernovae-st/nika/commit/ea5b2090de164f849369316236f587acbf69bb1d))
+
+### ✨ Features
+- **init** — Hand over to the next command · the beginner golden path ([#158](https://github.com/supernovae-st/nika/issues/158)) ([cd291a3b5](https://github.com/supernovae-st/nika/commit/cd291a3b54ff15c834d97c4af0de0ea52fa84626)) ([#158](https://github.com/supernovae-st/nika/pull/158))
+
+### 🐛 Bug Fixes
+- **cli** — Raise provider-plane http timeout to 180s for local models ([#148](https://github.com/supernovae-st/nika/issues/148)) ([f99828cbf](https://github.com/supernovae-st/nika/commit/f99828cbf728ce9f0c4ce07a1fd48271f7791573)) ([#148](https://github.com/supernovae-st/nika/pull/148))
+- **nika-schema** — Char-boundary panic in go-duration unknown-unit error path ([c1f73af89](https://github.com/supernovae-st/nika/commit/c1f73af89aaf61fd65a696b6bd1894045ca2f537))
+- **scripts** — Adr index generator tolerates missing optional fields ([#152](https://github.com/supernovae-st/nika/issues/152)) ([5d5982f41](https://github.com/supernovae-st/nika/commit/5d5982f418b444e415dc840e1db3ecfa94db028c)) ([#152](https://github.com/supernovae-st/nika/pull/152))
+
+### 📚 Documentation
+- **changelog** — Append v0.92.0 — auto-generated ([#147](https://github.com/supernovae-st/nika/issues/147)) ([2a42f0712](https://github.com/supernovae-st/nika/commit/2a42f0712783235630c940712e00632530b8dc52)) ([#147](https://github.com/supernovae-st/nika/pull/147))
+- **workspace** — Canonical pck crate names + fix publish adr citation ([58d9514bf](https://github.com/supernovae-st/nika/commit/58d9514bf1db97809c41ca95e8a751faf1d831e7))
+
+### 🧪 Tests
+- **nika-mcp** — Regression guard for the embedded-lookup injection-safety ([4f306d5f9](https://github.com/supernovae-st/nika/commit/4f306d5f99c2055695b103a63f0b008f9a9f8d65))
+- **schema** — Forward-compat anchors for the v0.2 seed clauses ([#156](https://github.com/supernovae-st/nika/issues/156)) ([5a84a4702](https://github.com/supernovae-st/nika/commit/5a84a4702586893a2bd077ee5c0f65ddd7942d07)) ([#156](https://github.com/supernovae-st/nika/pull/156))
+
+### 🧹 Chore
+- **ci** — Api-lock the last 3 uncovered lib crates ([539a039eb](https://github.com/supernovae-st/nika/commit/539a039ebb6441fe8863a0b383f407c92c8a89e2))
+- **ci** — Canonicalize 16 public-api baselines from the ci artifact ([1a44b139c](https://github.com/supernovae-st/nika/commit/1a44b139c26b596aacd73d379a8e3a872d4d0566))
+- **ci** — Nika-cli baseline from the ubuntu artifact ([688a851ea](https://github.com/supernovae-st/nika/commit/688a851ea2b317fe5ef894eb72f9a6829e40f6c0))
+- **nika-catalog** — Regenerate public-api baseline — additive builtin arg-shape surface ([a681d6044](https://github.com/supernovae-st/nika/commit/a681d6044855842fda455be8e0c4b5b5f237f8af))
+- **nika-pack** — Re-vendor the pack from the merged spec ([#157](https://github.com/supernovae-st/nika/issues/157)) ([0d5b6dd8c](https://github.com/supernovae-st/nika/commit/0d5b6dd8c46dc316a6f73c876accbc19b409c5f8)) ([#157](https://github.com/supernovae-st/nika/pull/157))
+- **version** — Main → 0.93.0-dev after the v0.92.0 release ([4ad3cbd20](https://github.com/supernovae-st/nika/commit/4ad3cbd203778b0f97d0af1c055fe2bc8c77aacf))
+
+### 💼 Other
+- Field fixes: local-model timeouts, mock-from-schema, --var, sitemap examples ([#149](https://github.com/supernovae-st/nika/issues/149))
+
+* fix(workspace): task timeout governs the provider http deadline
+
+The provider HTTP client aborted every round-trip at a hardcoded 30s
+total deadline, killing any local-model task regardless of its declared
+timeout: budget (408 at 30s on timeout: "7m" · F1 field report
+2026-07-04). The task budget now rides the whole chain — task.timeout →
+dispatch → InferInput → InferRequest → HttpRequest — and when no budget
+is declared the default is per provider CLASS: the 5 local servers get
+300s (a 14B model cannot answer a real prompt in 30s), cloud keeps the
+historical 30s. Streaming carries only an explicit budget (the idle-read
+guard reaps stalls). The provider client's config timeout is raised to a
+600s transport ceiling because reqwest arms the client-level read guard
+even while awaiting response headers — it would otherwise undercut any
+longer per-request deadline.
+
+Tests: wire-level parity across all 13 wired profiles (class default ·
+task budget wins · streaming explicit-only) + profile classification +
+verb plumb + the real parse→check→run chain against a capturing http
+seam. Baselines: nika-kernel-ai + nika-verb-infer public-api
+regenerated (additive timeout field on two #[non_exhaustive] DTOs).
+
+* feat(nika-providers): mock synthesizes schema-conformant output
+
+mock/echo echoed the prompt regardless of an attached schema, so EVERY
+structured workflow on the mock burned its 3-attempt retry budget and
+died NIKA-INFER-002 — no offline CI story for exactly the workflows
+that need one (F3 field report 2026-07-04). A request carrying
+response_format: JsonSchema now returns a SYNTHESIZED minimal instance
+of the schema as pure JSON: string → "mock" (enum → first entry ·
+const/default honored) · integer → minimum ?? 0 · number → 0.0 · bool →
+false · array → one item (minItems honored · allocation-capped) ·
+object → the required keys recursively. Total + deterministic
+(byte-stable) · unsupported keywords (pattern · $ref) degrade to an
+instance that honestly fails the verb's validation. The plain echo
+contract is untouched.
+
+Tests: generator matrix validated with the SAME jsonschema crate the
+verb floor uses (atlas-style enum severity + bounded integers green) ·
+verb-level offline dry-run + retry-exhaustion re-pinned on a pattern
+schema · mock wire pure-JSON determinism · e2e pipeline updated to the
+synthesized instance.
+
+* feat(nika-cli): repeatable --var key=value supplies workflow vars
+
+A workflow with a required: true var and no default was UNRUNNABLE
+from the CLI — nika run had no input surface, so the first
+${{ vars.x }} reference died NIKA-VAR-001 with no fix available (F4
+field report 2026-07-04). nika run gains a repeatable --var KEY=VALUE:
+values override a declared default:, satisfy required vars, parse as
+JSON when they parse (numbers · booleans · arrays) else ride as
+strings, and unknown keys are refused loudly with the declared set
+(exit 3 — a typo silently doing nothing would be the worst outcome).
+The runtime gains the with_var_overrides builder (merged over the
+envelope defaults at run start). NIKA-VAR-001 now teaches the fix on
+BOTH surfaces: the runtime message appends the --var hint for vars.*
+references, and nika explain NIKA-VAR-001 carries an engine-side fix
+line.
+
+Tests: required-var run green with --var / failed without · unknown
+key + malformed pair refused · JSON-else-string typing · override
+beats default through the real parse→check→run chain · both hint
+surfaces pinned. Baselines: nika-runtime regenerated (additive
+builder) · nika-cli run() signature line patched in place (the
+committed file is the ubuntu-canonical artifact — a full local regen
+would carry macOS render skew on unrelated lines).
+
+* fix(nika-pack): sitemap examples bind the root array not .urls
+
+nika:fetch mode: sitemap returns the ROOT ARRAY
+[{loc, changefreq, priority}, …] — the shape nika-extract pins in its
+own tests — but the embedded showcase examples bound a phantom .urls
+wrapper (t2-seo-content-brief .urls[:5] · t3-competitor-radar
+.urls[:8]) and the embedded spec 03-dag fan-out snippet taught
+pages: ".urls[]" (doubly wrong: phantom wrapper AND a stream binding
+where a binding is single-valued). Every user copying the examples hit
+NIKA-VAR-004 at the first sitemap task (F5 field report 2026-07-04).
+The engine is RIGHT — the teaching surface is fixed: .[:5] | map(.loc)
+/ .[:8] | map(.loc) / map(.loc), plus the t2 header now documents the
+sitemap shape and the mock-from-schema offline story F3 made true.
+
+manifest.yaml sha256_16 recomputed for both files (lean-hash algorithm
+cross-verified against all 27 committed rows · 27/27 match). Both fixed
+examples pass nika check clean with the built binary.
+
+FOLLOW-UP (out of this repo's scope): the pack is vendored from the
+nika-spec repo via scripts/sync-pack.sh — the SSOT needs the mirror
+fix (examples + 03-dag.md + manifest) before the next re-vendor, or it
+reverts this.
+
+* refactor(nika-cli): extract output-mode + dry-run helpers from run()
+
+The F4 --var block pushed run() to 114 lines and the F1 budget plumb
+pushed attempt_loop to 101 — both past the 100-line ratchet. Extract
+the --output validation (output_mode) and the dry-run plan render
+(render_dry_run) into named helpers; compress the attempt_loop budget
+comment. Behavior identical — the extracted code is verbatim, tests
+unchanged and green (110 + 78 lib).
+
+---------
+ ([90b19d589](https://github.com/supernovae-st/nika/commit/90b19d58960104d84e87235337da15cc82e3aa97)) ([#149](https://github.com/supernovae-st/nika/pull/149))
+- Rounds 2+3: nika test, DX, ADR-098 json-mode, CLI wow (rebased train) ([#153](https://github.com/supernovae-st/nika/issues/153))
+
+* fix(workspace): task timeout governs the provider http deadline
+
+The provider HTTP client aborted every round-trip at a hardcoded 30s
+total deadline, killing any local-model task regardless of its declared
+timeout: budget (408 at 30s on timeout: "7m" · F1 field report
+2026-07-04). The task budget now rides the whole chain — task.timeout →
+dispatch → InferInput → InferRequest → HttpRequest — and when no budget
+is declared the default is per provider CLASS: the 5 local servers get
+300s (a 14B model cannot answer a real prompt in 30s), cloud keeps the
+historical 30s. Streaming carries only an explicit budget (the idle-read
+guard reaps stalls). The provider client's config timeout is raised to a
+600s transport ceiling because reqwest arms the client-level read guard
+even while awaiting response headers — it would otherwise undercut any
+longer per-request deadline.
+
+Tests: wire-level parity across all 13 wired profiles (class default ·
+task budget wins · streaming explicit-only) + profile classification +
+verb plumb + the real parse→check→run chain against a capturing http
+seam. Baselines: nika-kernel-ai + nika-verb-infer public-api
+regenerated (additive timeout field on two #[non_exhaustive] DTOs).
+
+* feat(nika-providers): mock synthesizes schema-conformant output
+
+mock/echo echoed the prompt regardless of an attached schema, so EVERY
+structured workflow on the mock burned its 3-attempt retry budget and
+died NIKA-INFER-002 — no offline CI story for exactly the workflows
+that need one (F3 field report 2026-07-04). A request carrying
+response_format: JsonSchema now returns a SYNTHESIZED minimal instance
+of the schema as pure JSON: string → "mock" (enum → first entry ·
+const/default honored) · integer → minimum ?? 0 · number → 0.0 · bool →
+false · array → one item (minItems honored · allocation-capped) ·
+object → the required keys recursively. Total + deterministic
+(byte-stable) · unsupported keywords (pattern · $ref) degrade to an
+instance that honestly fails the verb's validation. The plain echo
+contract is untouched.
+
+Tests: generator matrix validated with the SAME jsonschema crate the
+verb floor uses (atlas-style enum severity + bounded integers green) ·
+verb-level offline dry-run + retry-exhaustion re-pinned on a pattern
+schema · mock wire pure-JSON determinism · e2e pipeline updated to the
+synthesized instance.
+
+* feat(nika-cli): repeatable --var key=value supplies workflow vars
+
+A workflow with a required: true var and no default was UNRUNNABLE
+from the CLI — nika run had no input surface, so the first
+${{ vars.x }} reference died NIKA-VAR-001 with no fix available (F4
+field report 2026-07-04). nika run gains a repeatable --var KEY=VALUE:
+values override a declared default:, satisfy required vars, parse as
+JSON when they parse (numbers · booleans · arrays) else ride as
+strings, and unknown keys are refused loudly with the declared set
+(exit 3 — a typo silently doing nothing would be the worst outcome).
+The runtime gains the with_var_overrides builder (merged over the
+envelope defaults at run start). NIKA-VAR-001 now teaches the fix on
+BOTH surfaces: the runtime message appends the --var hint for vars.*
+references, and nika explain NIKA-VAR-001 carries an engine-side fix
+line.
+
+Tests: required-var run green with --var / failed without · unknown
+key + malformed pair refused · JSON-else-string typing · override
+beats default through the real parse→check→run chain · both hint
+surfaces pinned. Baselines: nika-runtime regenerated (additive
+builder) · nika-cli run() signature line patched in place (the
+committed file is the ubuntu-canonical artifact — a full local regen
+would carry macOS render skew on unrelated lines).
+
+* fix(nika-pack): sitemap examples bind the root array not .urls
+
+nika:fetch mode: sitemap returns the ROOT ARRAY
+[{loc, changefreq, priority}, …] — the shape nika-extract pins in its
+own tests — but the embedded showcase examples bound a phantom .urls
+wrapper (t2-seo-content-brief .urls[:5] · t3-competitor-radar
+.urls[:8]) and the embedded spec 03-dag fan-out snippet taught
+pages: ".urls[]" (doubly wrong: phantom wrapper AND a stream binding
+where a binding is single-valued). Every user copying the examples hit
+NIKA-VAR-004 at the first sitemap task (F5 field report 2026-07-04).
+The engine is RIGHT — the teaching surface is fixed: .[:5] | map(.loc)
+/ .[:8] | map(.loc) / map(.loc), plus the t2 header now documents the
+sitemap shape and the mock-from-schema offline story F3 made true.
+
+manifest.yaml sha256_16 recomputed for both files (lean-hash algorithm
+cross-verified against all 27 committed rows · 27/27 match). Both fixed
+examples pass nika check clean with the built binary.
+
+FOLLOW-UP (out of this repo's scope): the pack is vendored from the
+nika-spec repo via scripts/sync-pack.sh — the SSOT needs the mirror
+fix (examples + 03-dag.md + manifest) before the next re-vendor, or it
+reverts this.
+
+* refactor(nika-cli): extract output-mode + dry-run helpers from run()
+
+The F4 --var block pushed run() to 114 lines and the F1 budget plumb
+pushed attempt_loop to 101 — both past the 100-line ratchet. Extract
+the --output validation (output_mode) and the dry-run plan render
+(render_dry_run) into named helpers; compress the attempt_loop budget
+comment. Behavior identical — the extracted code is verbatim, tests
+unchanged and green (110 + 78 lib).
+
+* feat(nika-cli): add nika test — golden outputs under mock (F7)
+
+The v1 workflow-testing surface the field report asked for: users had to
+hand-roll e2e harnesses (atlas ships one) because the verb tree had no
+test/eval/lint. nika test <file> checks (ADR-092 ladder · same gate as
+run), executes under the MOCK provider (deterministic + schema-conformant
+since F3 — the base that unblocked this), captures the typed outputs: as
+ONE canonical JSON (pretty · key-sorted · newline-terminated) and compares
+against the sibling <file>.golden.json. --update (re)writes the pin; no
+golden + no --update teaches how to create one (exit 3). Mismatch renders
+a readable per-path diff (golden → run · capped at 20 rows) and exits 1.
+
+Gates affected: Gate 3 (impl) + Gate 4 (clippy 0). Test delta: +8
+(update-then-match · drift mismatch · missing-golden hint · dirty-file
+findings · diff paths/missing/extra/cap · elision · golden-path mapping ·
+canonical bytes). 118 nika-cli lib tests green.
+
+* fix(workspace): quoted timeout fix-form + json failure envelope (F6)
+
+(a) nika-schema · the NIKA-PARSE-010 bare-number rejection now shows the
+author's OWN value quoted with a unit ("420s" for seconds · "7m" for
+minutes) — the correction becomes a copy-paste, not a spec hunt (the
+field report hit `timeout: 420` and had to guess the form).
+
+(b) nika-cli · `--output json` failures now emit ONE machine envelope
+{"error":{"code":"NIKA-…"|null,"message":"…"}} on stdout — it used to
+stay empty (pre-run findings) or print bare `{}` (run failures), so a
+machine consumer had to scrape stderr. Covers every failure class:
+parse/check findings · --var refusals · composition/executor ENV
+errors · executed-and-failed runs (the folded view's failed-row detail
+carries the wire code). Codes are extracted, never invented.
+
+(c) verified, no change: the NIKA-VAR-001 explain/fix hint already
+names `--var` (shipped with F4 · explain.rs cli_fix_hint plus its
+pinned test).
+
+Gates affected: Gate 3+4. Test delta: +5 (envelope shape/one-line ·
+code extraction incl. per-builtin and no-false-positive · findings-line
+condensing · failed-view envelope + empty-view fallback · parse-010
+quoted fix-form). nika-cli 122 + nika-schema 758 lib tests green.
+
+* feat(workspace): underspecified schemas ride json mode locally (F2)
+
+The field-report F2 wall: the translate-payload class ({type: object} ·
+or head/sections declared shapeless) 400s on OpenAI strict mode, and
+fully specifying a free-form payload recursively is impossible — the
+only workaround was schema-free promptware (zero guarantees).
+
+Conservative fix, zero YAML surface (ADR-098): when the task schema is
+UNDERSPECIFIED (any object without properties · any array without items
+in the tree) on a strict wire, do NOT forward it — request the
+provider's native JSON mode (ResponseFormat::Json), steer the shape
+through the prompt instruction, validate LOCALLY against the user
+schema (the existing floor + bounded retry). Fully-specified schemas
+keep today's strict path verbatim; anthropic keeps the instruction
+fallback; the MOCK keeps receiving the schema (its strict mode
+synthesizes from anything — F3/offline goldens depend on it).
+
+Seams: nika-verb-infer SchemaWire enum (None/Strict/JsonMode/
+Instruction) + is_underspecified iterative walker · nika-providers
+WireFormat::strict_rejects_underspecified (openai-compat + gemini
+true · mock + anthropic false) + the ResolvedProvider delegate.
+
+Gates affected: Gate 3+4+6-adjacent. Test delta: +9 (detection cases ·
+decision table · request mapping · {type:object} green on the REAL
+openai adapter with the http seam mocked + json_object on the wire ·
+fully-specified stays json_schema · mock synthesis non-regression).
+nika-verb-infer 42 + nika-providers 145 lib tests green.
+
+ADR: docs/adr/adr-098-underspecified-schema-json-mode-fallback.md
+(proposed + implemented · alternatives: json:true sugar · full
+recursive spec · schema tightening — all rejected with reasons).
+Note: docs/adr/index.json is stale at HEAD (generator exits 1 on
+ADR-096 · pre-existing) — index.toml regenerated with ADR-098.
+
+* refactor(nika-cli): keep main() and run() under the fn-length cap
+
+Behavior-identical extraction after the F6/F7 additions tripped the
+100-line ratchet (main 102 · run 104): the run clap surface moves into
+a dedicated RunArgs struct (the TraceArgs idiom) unpacked by run_verb();
+the runtime composition block moves into composed_runtime() with its
+full composition story preserved in the doc comment.
+
+cargo test -p nika-cli --lib: 122 passed, 0 failed. clippy -D clean.
+check-fn-length.sh: OK all fns <= 100 lines.
+
+* docs(nika-verb-infer): drop the private intra-doc link to SchemaWire
+
+The crate-level doc linked [`SchemaWire`] — a private enum — which
+fails `cargo doc --document-private-items -D warnings` (hygiene vector
+28 · Gate 8 extended per ADR-015). Plain backticks carry the same
+story without the broken link.
+
+* CLI wow: wave-group inspect, live lanes + ms, waterfall, verdict card ([#151](https://github.com/supernovae-st/nika/issues/151))
+
+* feat(nika-cli): inspect renders waves as bordered parallel groups
+
+The flat first-parent tree hid the scheduler's proof — waves were
+counted in the header but invisible in the body. inspect now renders
+each parallel wave as a bordered group ("N in parallel"), single-task
+waves as bare rows, and flow arrows between waves, so the DAG's real
+concurrency reads at a glance (CLI wow design 2026-07-05 §2a).
+
+- one projector law kept: the render slices the SAME GraphDoc node
+ order by report.waves sizes — nothing re-derived
+- --ascii parity first-class on every new glyph (box → +-|, diamond
+ → #, arrow → v) + a leak test pinning zero unicode under --ascii
+- boxes cap at 74 inner cells (graceful under 80 cols · overlong rows
+ truncate with a mark)
+- the spec §6 DAG-check footer + engineering analysis are unchanged;
+ --dry-run inherits the new plan render through the same verb
+
+* feat(nika-cli): per-task time, spend and parallel lane markers
+
+Time and money were footer-only — no per-task duration, no per-task
+cost, parallelism invisible. The storyboard now carries them first-
+class (CLI wow design 2026-07-05 §2b):
+
+- settled rows show their REAL wall time (the runtime-measured
+ duration_ms field wins · stamp-span fallback) right-aligned after
+ the note column; per-task spend follows when the stream reported it
+- the running/retrying row shows a LIVE elapsed against the latest
+ stamp the fold has seen (still a pure fold — no wall clock leaks)
+- new display/flow module reconstructs each task's interval as
+ [end − duration, end] (frames stamp at settle time · the measured
+ duration is the wall truth) and derives the ∥ lane markers from
+ honest overlap; the run verb injects the check report's wave plan
+ so markers speak the scheduler's truth (siblings only), replayed
+ traces fall back to pure overlap
+- retries counted + per-row start/end/cost stamped in the fold
+- --ascii parity (∥ → ||) with a leak test; machine lanes untouched
+ (--json NDJSON verbatim · --output json stdout unchanged)
+
+* feat(nika-cli): post-run waterfall closes the TTY final frame
+
+Where the seconds burned was invisible after a run — the answer lived
+in the trace but nothing drew it. The Live (TTY) final frame now ends
+with a wall-time waterfall + an outputs pointer (design §2c):
+
+- one scaled bar per task that RAN, offset by its reconstructed
+ interval ([end − measured duration, end] — the same reconstruction
+ the ∥ markers use), so real overlap reads as overlapping bars
+- failed bars paint red · running/retrying cyan · per-task spend rides
+ the row · a dotted time axis closes the chart
+- "outputs → key (type)" names what left the run (types only — a
+ pointer, never a data dump into the scrollback)
+- pure fold of the run's own event stream — zero new instrumentation,
+ and a solo-task run stays chart-free (a single bar is noise)
+- sober registers untouched: piped / --no-progress / --quiet / machine
+ modes never grow chart art (pinned in the piped bin test) · --ascii
+ parity for every glyph (bars → [#] · axis dots → .)
+
+* feat(nika-cli): shareable verdict card + trace replay renders the flow
+
+The final frame becomes the thing you paste in a README (design §2d):
+a bordered verdict card closing every Live run and every trace read —
+the mini DAG-shape glyph (wave sizes as diamond runs joined by flow
+arrows · "###" " => " "#" in ASCII · plan-true when the run injected
+the schedule, interval-reconstructed for a bare trace), the totals
+(tasks · waves · retries · wall · spend · the models the stream
+named), and an "outputs → key (type)" note for runs. No verdict → no
+card (a mid-run card would lie). Wide waves cap at five diamonds,
+long chains at six waves; the box never breaks (fit + one inner
+width, pinned).
+
+mini-ADR · replay surface naming
+Question: where does "render the waterfall from a past trace" live —
+extend "nika inspect --trace <file>", or a new subcommand?
+Decision: NEITHER — it rides the EXISTING "nika trace show|replay".
+Why: (1) house taste = fewest verbs: trace is already the flight-
+recorder reader (replay = re-render, never re-execute), and the
+waterfall IS a trace read, so it belongs there; (2) inspect is locked
+as the STATIC anatomy — its own module doc says "run overlays belong
+to the trace surface", and an --trace flag would fork one verb into
+two registers; (3) zero new verbs, zero new flags: "nika trace show
+run.ndjson" now closes on the waterfall + verdict card, and "trace
+replay" ends its animation on the same final frame a live TTY run
+paints. The machine lanes stay byte-frozen (--json / --output json).
+
+---------
+
+---------
+ ([da874faf6](https://github.com/supernovae-st/nika/commit/da874faf6fb4c02c1c6ebadb6a16a994be5ac02f)) ([#153](https://github.com/supernovae-st/nika/pull/153))
+- Durable-lite resume — --resume, visible cache hits, durable pause ([#154](https://github.com/supernovae-st/nika/issues/154)) ([91d7cf9bf](https://github.com/supernovae-st/nika/commit/91d7cf9bfb9848e2950ede531215662612105a7d)) ([#154](https://github.com/supernovae-st/nika/pull/154))
+# Changelog
+
 All notable changes to Nika are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "clap",
  "futures",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cli"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "expect-test",
  "insta",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "insta",
  "miette",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "nika-kernel",
  "nix",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "globset",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "nika-http"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "insta",
  "miette",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "nika-error",
  "nika-pack",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "include_dir",
  "sha2",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3985,14 +3985,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "loom",
  "proptest",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.93.0-dev"
+version      = "0.93.0"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ before it joins the workspace.
 
 See `docs/architecture/ai-velocity.md` for the full argument.
 
-## Current state — main is v0.93.0-dev after the v0.92.0 public release
+## Current state — main is v0.93.0 (release in flight this arc)
 
 > First public release (2026-06-21 · `brew install supernovae-st/tap/nika`).
 > 39/42 crates admitted (wip array empty) · RC-grade toward the **1.0.0** launch,
@@ -85,7 +85,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 |------------------|------------------------------------------------|
 | branch           | `main`                                      |
 | HEAD             | `8ef43dddc` (`8ef43dddc1c0633a1156ef0eff9f2d10e51595fa`)             |
-| workspace        | v0.93.0-dev                                  |
+| workspace        | v0.93.0                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.93.0-dev", optional = true }
-nika-error     = { path = "../nika-error", version = "0.93.0-dev", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.93.0-dev", optional = true }
+nika-types     = { path = "../nika-types", version = "0.93.0", optional = true }
+nika-error     = { path = "../nika-error", version = "0.93.0", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.93.0", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.93.0-dev" }
+nika-types  = { path = "../nika-types", version = "0.93.0" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.93.0-dev" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.93.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
 jaq-std       = { workspace = true }
@@ -35,15 +35,15 @@ serde_json    = { workspace = true }
 tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval off the async executor
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0-dev" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.93.0-dev" }
+nika-fs          = { path = "../nika-fs", version = "0.93.0" }
 # test-only: the drift guard pinning tool_defs() arg keys to the catalog
 # Builtin::args vocabulary nika check validates against (one source, no drift).
-nika-catalog     = { path = "../nika-catalog", version = "0.93.0-dev" }
+nika-catalog     = { path = "../nika-catalog", version = "0.93.0" }
 proptest         = { workspace = true }
 tokio            = { workspace = true }
 

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.0-dev" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.93.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.93.0-dev" }
+nika-catalog = { path = "../nika-catalog", version = "0.93.0" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.93.0-dev" }
+nika-error = { path = "../nika-error", version = "0.93.0" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.93.0-dev" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.93.0" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.93.0-dev" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.93.0-dev" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.93.0-dev" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.93.0-dev" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.93.0-dev" }   # the embedded language pack (`nika spec|schema|examples|new`)
-nika-bm25   = { path = "../nika-bm25", version = "0.93.0-dev" }   # intent→template routing (`nika new` · the deterministic floor)
+nika-event  = { path = "../nika-event", version = "0.93.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.93.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.93.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.93.0" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.93.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-bm25   = { path = "../nika-bm25", version = "0.93.0" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde       = { workspace = true }                             # graph projection envelope (§6)
@@ -27,21 +27,21 @@ uuid        = { workspace = true }                             # deterministic d
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.93.0-dev" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.93.0-dev" }       # the L3 executor (the composer drives it)
-nika-providers   = { path = "../nika-providers", version = "0.93.0-dev" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.0-dev" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.0-dev" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0-dev" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.0-dev" }
-nika-builtin     = { path = "../nika-builtin", version = "0.93.0-dev" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.93.0-dev" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.93.0-dev" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.93.0-dev" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.93.0-dev" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.93.0-dev", features = ["providers"] }  # the env_var ladder per provider
-nika-lsp         = { path = "../nika-lsp", version = "0.93.0-dev" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-mcp         = { path = "../nika-mcp", version = "0.93.0-dev" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-kernel      = { path = "../nika-kernel", version = "0.93.0" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.93.0" }       # the L3 executor (the composer drives it)
+nika-providers   = { path = "../nika-providers", version = "0.93.0" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.0" }
+nika-builtin     = { path = "../nika-builtin", version = "0.93.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.93.0" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.93.0" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.93.0" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.93.0" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.93.0", features = ["providers"] }  # the env_var ladder per provider
+nika-lsp         = { path = "../nika-lsp", version = "0.93.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-mcp         = { path = "../nika-mcp", version = "0.93.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [[bin]]
@@ -52,7 +52,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0-dev" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 
 [package.metadata.lore]

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.0-dev" }
+nika-types = { path = "../nika-types", version = "0.93.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.0-dev" }
-nika-error = { path = "../nika-error", version = "0.93.0-dev" }
+nika-types = { path = "../nika-types", version = "0.93.0" }
+nika-error = { path = "../nika-error", version = "0.93.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.93.0-dev" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.93.0" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.93.0-dev" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.93.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.93.0-dev" }
-nika-types   = { path = "../nika-types", version = "0.93.0-dev" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.93.0" }
+nika-types   = { path = "../nika-types", version = "0.93.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.93.0-dev" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.0-dev" }
+nika-error       = { path = "../nika-error", version = "0.93.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.93.0-dev" }
+nika-error    = { path = "../nika-error", version = "0.93.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.93.0-dev" }
-nika-error    = { path = "../nika-error", version = "0.93.0-dev" }
+nika-kernel   = { path = "../nika-kernel", version = "0.93.0" }
+nika-error    = { path = "../nika-error", version = "0.93.0" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.93.0-dev" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.0-dev" }
+nika-error       = { path = "../nika-error", version = "0.93.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.93.0-dev" }
+nika-error    = { path = "../nika-error", version = "0.93.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.93.0-dev" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.93.0-dev" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.93.0-dev" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.93.0-dev" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.93.0-dev" }
+nika-error          = { path = "../nika-error", version = "0.93.0" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.93.0" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.93.0" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.93.0" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.93.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.93.0-dev" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-schema = { path = "../nika-schema", version = "0.93.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.93.0-dev" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-error  = { path = "../nika-error", version = "0.93.0-dev" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.93.0-dev" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.93.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-error  = { path = "../nika-error", version = "0.93.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.93.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.93.0-dev" }
-nika-catalog = { path = "../nika-catalog", version = "0.93.0-dev", features = ["providers"] }
+nika-kernel  = { path = "../nika-kernel", version = "0.93.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.93.0", features = ["providers"] }
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,16 +11,16 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.93.0-dev" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.93.0-dev" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.93.0-dev" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.93.0-dev" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-cel         = { path = "../nika-cel", version = "0.93.0-dev" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.93.0-dev" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.0-dev" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.0-dev" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0-dev" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.0-dev" }
+nika-types       = { path = "../nika-types", version = "0.93.0" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.93.0" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.93.0" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.93.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-cel         = { path = "../nika-cel", version = "0.93.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.93.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.0" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -33,9 +33,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0-dev" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.93.0-dev" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.93.0-dev" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.93.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.93.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -17,10 +17,10 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # nika-cap permits). The 4th (nika-cap) is the permits boundary extracted 2026-07-03
 # for reuse by nika-policy/runtime WITHOUT pulling the parser; inlining it back to
 # stay at 3 would defeat the extraction. High fan-in is intentional here (ADR-027).
-nika-error   = { path = "../nika-error", version = "0.93.0-dev" }
-nika-catalog = { path = "../nika-catalog", version = "0.93.0-dev" }
-nika-types   = { path = "../nika-types", version = "0.93.0-dev" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.93.0-dev" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-error   = { path = "../nika-error", version = "0.93.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.93.0" }
+nika-types   = { path = "../nika-types", version = "0.93.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.93.0" }   # the permits vocab lives here now (extracted 2026-07-03)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -43,10 +43,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.93.0-dev" }
+nika-event = { path = "../nika-event", version = "0.93.0" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.93.0-dev" }
+nika-pack  = { path = "../nika-pack", version = "0.93.0" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-kernel      = { path = "../nika-kernel", version = "0.93.0-dev" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.93.0-dev" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0-dev" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.93.0-dev" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.93.0-dev" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-kernel      = { path = "../nika-kernel", version = "0.93.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.93.0" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.93.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.93.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -24,7 +24,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0-dev" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.93.0-dev" }
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-error  = { path = "../nika-error", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0-dev" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error     = { path = "../nika-error", version = "0.93.0-dev" }
-nika-kernel    = { path = "../nika-kernel", version = "0.93.0-dev" }
-nika-providers = { path = "../nika-providers", version = "0.93.0-dev" }
+nika-error     = { path = "../nika-error", version = "0.93.0" }
+nika-kernel    = { path = "../nika-kernel", version = "0.93.0" }
+nika-providers = { path = "../nika-providers", version = "0.93.0" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.93.0-dev" }
-nika-kernel = { path = "../nika-kernel", version = "0.93.0-dev" }
+nika-error  = { path = "../nika-error", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }


### PR DESCRIPTION
Night batch B5 · the release carrier.

**Highlights** (hand-written block over the git-cliff section — the three squash-merged trains have non-conventional subjects cliff drops):
- Local thinking-era models unbricked (provider-plane 180s · PR 148 + field-fix train PR 149)
- `nika run --resume` durable-lite (ADR-099 · PR 154)
- `nika test` + json-mode + CLI wow pass (PR 153)
- Beginner golden path (tap caveats v2 + init handover · PR 158)

Version 0.93.0-dev → 0.93.0 across the workspace pins · status block refreshed (3116 lib tests · clippy 0) · status docs aligned.

**Pre-bump main SHA for concurrent-branch rebases: cd291a3b5.**

Tag v0.93.0 lands on the squash-merge commit → release.yml builds the binaries → tap bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)