### PR TITLE
chore(pack): vendor the qwen3.5 teach-cascade from spec main

### DIFF
--- a/crates/nika-pack/pack/QUICKSTART.md
+++ b/crates/nika-pack/pack/QUICKSTART.md
@@ -19,7 +19,7 @@ Two header lines + one task ·
 nika: v1
 workflow: hello
 
-model: ollama/llama3.2:3b
+model: ollama/qwen3.5:4b
 
 tasks:
   - id: greet
@@ -33,8 +33,8 @@ tasks:
 - one task · `infer:` calls the model.
 
 > **Model note** · every step on this page runs local on
-> `ollama/llama3.2:3b` · zero key, nothing leaves your machine
-> (`ollama pull llama3.2:3b` first · or `lmstudio/…` · `llamacpp/…` ·
+> `ollama/qwen3.5:4b` · zero key, nothing leaves your machine
+> (`ollama pull qwen3.5:4b` first · or `lmstudio/…` · `llamacpp/…` ·
 > `vllm/…`). Prefer cloud? Swap the one `model:` line for any of the
 > <!-- canon:providers -->14<!-- /canon --> providers ·
 > `mistral/mistral-small` · `anthropic/claude-haiku-4-5` ·
@@ -51,7 +51,7 @@ graph · `${{ tasks.<id>.output }}` reads a prior task's result ·
 nika: v1
 workflow: summarize-and-translate
 
-model: ollama/llama3.2:3b
+model: ollama/qwen3.5:4b
 
 tasks:
   - id: summarize
@@ -83,7 +83,7 @@ vars:
   text: "Hello, world"
   target_lang: "French"
 
-model: ollama/llama3.2:3b
+model: ollama/qwen3.5:4b
 
 tasks:
   - id: translate
@@ -119,7 +119,7 @@ Everything else (fetching a URL, querying a DB, writing a file) is a
 nika: v1
 workflow: fetch-and-summarize
 
-model: ollama/llama3.2:3b
+model: ollama/qwen3.5:4b
 
 tasks:
   - id: fetch_page

--- a/crates/nika-pack/pack/examples/01-hello.nika.yaml
+++ b/crates/nika-pack/pack/examples/01-hello.nika.yaml
@@ -6,13 +6,13 @@
 # Demonstrates ·
 #   - the envelope · `nika: v1` (contract version) + `workflow:` (kebab-case id)
 #   - one task · the `infer:` verb (a single LLM call)
-#   - the `ollama/llama3.2:3b` model · local · no API key (mock/echo for CI)
+#   - the `ollama/qwen3.5:4b` model · local · no API key (mock/echo for CI)
 #
 # Run · nika run examples/01-hello.nika.yaml
 nika: v1
 workflow: hello
 
-model: ollama/llama3.2:3b   # local · zero key · swap for any cloud provider in the catalog
+model: ollama/qwen3.5:4b   # local · zero key · swap for any cloud provider in the catalog
 
 tasks:
   - id: greet

--- a/crates/nika-pack/pack/examples/showcase/t1-meeting-actions.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-meeting-actions.nika.yaml
@@ -17,7 +17,7 @@ nika: v1
 workflow: meeting-actions
 description: "Transcript → typed action items {owner, task, due}"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for openai/gpt-5.2 or any provider in the catalog
+model: ollama/qwen3.5:4b   # local · zero key · swap for openai/gpt-5.2 or any provider in the catalog
 
 vars:
   transcript_path:

--- a/crates/nika-pack/pack/examples/showcase/t1-social-repurpose.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-social-repurpose.nika.yaml
@@ -16,7 +16,7 @@ nika: v1
 workflow: social-repurpose
 description: "One post → thread + LinkedIn + newsletter, in parallel"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for mistral/mistral-large or any provider
+model: ollama/qwen3.5:4b   # local · zero key · swap for mistral/mistral-large or any provider
 
 vars:
   post_path: "./blog/launch-post.md"

--- a/crates/nika-pack/pack/examples/showcase/t1-standup-digest.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-standup-digest.nika.yaml
@@ -16,7 +16,7 @@ nika: v1
 workflow: standup-digest
 description: "Read yesterday's commits, write today's standup note"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for anthropic/claude-haiku-4-5 (fast one-liner job)
+model: ollama/qwen3.5:4b   # local · zero key · swap for anthropic/claude-haiku-4-5 (fast one-liner job)
 
 tasks:
   # No deps between these two → the engine runs them in parallel.

--- a/crates/nika-pack/pack/examples/showcase/t2-contract-guard.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-contract-guard.nika.yaml
@@ -8,7 +8,7 @@
 # validate + assert pair refuses to ship a memo built on bad data.
 #
 # Demonstrates ·
-#   - sovereignty · `model: ollama/llama3.2:3b`: sensitive docs stay local
+#   - sovereignty · `model: ollama/qwen3.5:4b`: sensitive docs stay local
 #   - `nika:validate` · re-check the extraction against a stricter schema
 #   - `nika:assert` · the fail-fast guard (vs `when:` · the skip-guard)
 #   - belt-and-braces · schema at infer time + validate + assert downstream
@@ -18,7 +18,7 @@ nika: v1
 workflow: contract-guard
 description: "Local-model clause extraction → schema gate → risk memo"
 
-model: ollama/llama3.2:3b   # the whole review runs offline · zero cloud
+model: ollama/qwen3.5:4b   # the whole review runs offline · zero cloud
 
 vars:
   contract_path:

--- a/crates/nika-pack/pack/examples/showcase/t2-invoice-chaser.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-invoice-chaser.nika.yaml
@@ -18,7 +18,7 @@ nika: v1
 workflow: invoice-chaser
 description: "Ledger CSV → overdue filter → drafted reminders → human gate → drafts file"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for groq/llama-3.3-70b (drafting is a fast-model job)
+model: ollama/qwen3.5:4b   # local · zero key · swap for groq/llama-3.3-70b (drafting is a fast-model job)
 
 vars:
   ledger_csv: "./finance/invoices.csv"

--- a/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
@@ -17,7 +17,7 @@ nika: v1
 workflow: release-notes
 description: "git log → typed release notes → CHANGELOG insert → team ping"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for mistral/mistral-large
+model: ollama/qwen3.5:4b   # local · zero key · swap for mistral/mistral-large
 
 vars:
   since_tag: "v0.80.0"

--- a/crates/nika-pack/pack/examples/showcase/t2-release-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-radar.nika.yaml
@@ -19,7 +19,7 @@ nika: v1
 workflow: release-radar
 description: "dependency release feed → diff vs last run → only the NEW ships"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for any of the 14 providers
+model: ollama/qwen3.5:4b   # local · zero key · swap for any of the 14 providers
 
 vars:
   releases_feed: "https://github.com/tokio-rs/tokio/releases.atom"

--- a/crates/nika-pack/pack/examples/showcase/t2-seo-content-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-seo-content-brief.nika.yaml
@@ -20,7 +20,7 @@ nika: v1
 workflow: seo-content-brief
 description: "Competitor sitemap → top page → gap analysis → typed brief"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for openai/gpt-5.2
+model: ollama/qwen3.5:4b   # local · zero key · swap for openai/gpt-5.2
 
 vars:
   competitor_sitemap: "https://competitor.example.com/sitemap.xml"

--- a/crates/nika-pack/pack/examples/showcase/t2-support-triage.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-support-triage.nika.yaml
@@ -18,7 +18,7 @@ nika: v1
 workflow: support-triage
 description: "Ticket queue → typed triage → urgent escalation → triage board"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for groq/llama-3.3-70b (triage wants speed)
+model: ollama/qwen3.5:4b   # local · zero key · swap for groq/llama-3.3-70b (triage wants speed)
 
 vars:
   queue_path: "./support/overnight-queue.json"

--- a/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
@@ -18,7 +18,7 @@ nika: v1
 workflow: competitor-radar
 description: "Sitemap → parallel page reads → one competitive brief + ping"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for anthropic/claude-sonnet-4-6
+model: ollama/qwen3.5:4b   # local · zero key · swap for anthropic/claude-sonnet-4-6
 
 vars:
   competitor_sitemap: "https://competitor.example.com/sitemap.xml"

--- a/crates/nika-pack/pack/examples/showcase/t3-config-drift-sentinel.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-config-drift-sentinel.nika.yaml
@@ -21,7 +21,7 @@ nika: v1
 workflow: config-drift-sentinel
 description: "live config vs sanctioned baseline → typed drift → explained alert"
 
-model: ollama/llama3.2:3b   # local · zero key · swap for anthropic/claude-haiku-4-5 (explain is cheap)
+model: ollama/qwen3.5:4b   # local · zero key · swap for anthropic/claude-haiku-4-5 (explain is cheap)
 
 vars:
   config_url: "https://api.internal.example.com/v1/config"

--- a/crates/nika-pack/pack/examples/showcase/t3-localization-factory.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-localization-factory.nika.yaml
@@ -18,7 +18,7 @@ nika: v1
 workflow: localization-factory
 description: "glob docs → parallel read → parallel translate → mirror tree"
 
-model: ollama/llama3.2:3b   # local default · swap for mistral/mistral-large (EU model for EU locales)
+model: ollama/qwen3.5:4b   # local default · swap for mistral/mistral-large (EU model for EU locales)
 
 vars:
   lang: "fr"

--- a/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
@@ -19,7 +19,7 @@ nika: v1
 workflow: pr-review-fanout
 description: "changed files → one read-only review agent each → merged REVIEW.md"
 
-model: ollama/llama3.2:3b   # local tool-calling model · swap for anthropic/claude-sonnet-4-6 for depth
+model: ollama/qwen3.5:4b   # local tool-calling model · swap for anthropic/claude-sonnet-4-6 for depth
 
 vars:
   base_ref: "main"

--- a/crates/nika-pack/pack/examples/showcase/t3-resume-screener.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-resume-screener.nika.yaml
@@ -20,7 +20,7 @@ nika: v1
 workflow: resume-screener
 description: "glob CVs → local-model rubric per candidate → deterministic shortlist"
 
-model: ollama/llama3.2:3b   # PII stays on the machine · the whole screen is offline
+model: ollama/qwen3.5:4b   # PII stays on the machine · the whole screen is offline
 
 permits:                    # the file IS the blast radius · no net category at all:
   fs:                       # CVs cannot leave this machine even if a prompt is hijacked

--- a/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
@@ -20,7 +20,7 @@ nika: v1
 workflow: ceo-monday-brief
 description: "news + repo pulse + KPIs → thinking synthesis → dated brief + cost ping"
 
-model: ollama/llama3.2:3b   # local default · the synthesis task below overrides to a stronger model
+model: ollama/qwen3.5:4b   # local default · the synthesis task below overrides to a stronger model
 
 vars:
   watch_query: "AI workflow engines"

--- a/crates/nika-pack/pack/examples/showcase/t4-deep-research-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-deep-research-brief.nika.yaml
@@ -20,7 +20,7 @@ nika: v1
 workflow: deep-research-brief
 description: "plan → budgeted research agent → thinking synthesis → brief on disk"
 
-model: ollama/llama3.2:3b   # local default · per-task overrides below pick stronger models
+model: ollama/qwen3.5:4b   # local default · per-task overrides below pick stronger models
 
 vars:
   topic:

--- a/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
@@ -19,7 +19,7 @@ nika: v1
 workflow: incident-war-room
 description: "parallel evidence → typed timeline → settle + recheck → postmortem draft"
 
-model: ollama/llama3.2:3b   # local default · the synthesis task below overrides to a stronger model
+model: ollama/qwen3.5:4b   # local default · the synthesis task below overrides to a stronger model
 
 vars:
   service: "checkout-api"

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -26,7 +26,7 @@
     },
     "model": {
       "type": "string",
-      "description": "Default model · `<provider>/<name>` (e.g. anthropic/claude-sonnet-4-6 · ollama/llama3.1 · mock/echo)."
+      "description": "Default model · `<provider>/<name>` (e.g. anthropic/claude-sonnet-4-6 · ollama/qwen3.5:9b · mock/echo)."
     },
     "vars": {
       "type": "object",

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -61,7 +61,7 @@ These 5 pillars are **locked forever** at `nika: v1`. Everything else (providers
 nika: v1
 workflow: hello
 
-model: ollama/llama3.2:3b
+model: ollama/qwen3.5:4b
 tasks:
   - id: greet
     infer:

--- a/crates/nika-pack/pack/spec/01-envelope.md
+++ b/crates/nika-pack/pack/spec/01-envelope.md
@@ -30,7 +30,7 @@ workflow: scrape-and-summarize          # required · kebab-case · unique withi
 description: "Fetch + summarize"         # optional · human-readable
 
 # Workflow-level default model · any task may override · <provider>/<name>
-model: ollama/llama3.2:3b         # optional · anthropic/claude-sonnet-4-6 for cloud
+model: ollama/qwen3.5:4b         # optional · anthropic/claude-sonnet-4-6 for cloud
 
 # Inputs · available as ${{ vars.<name> }} · untyped OR typed
 vars:
@@ -149,7 +149,7 @@ listings + LSP hover hints.
 ### `model` · *optional · default model · `<provider>/<name>`*
 
 ```yaml
-model: ollama/llama3.2:3b               # local
+model: ollama/qwen3.5:4b               # local
 # model: anthropic/claude-sonnet-4-6    # cloud · same shape
 ```
 

--- a/crates/nika-pack/pack/spec/03-dag.md
+++ b/crates/nika-pack/pack/spec/03-dag.md
@@ -204,7 +204,7 @@ the meaning of an expression that parses today. The conditional `?:`, the
 
 ```yaml
 # pick a model / a path / a prompt by condition — anywhere a value is taken
-model:  ${{ vars.env == 'prod' ? 'mistral/mistral-large' : 'ollama/llama3' }}
+model:  ${{ vars.env == 'prod' ? 'mistral/mistral-large' : 'ollama/qwen3.5:9b' }}
 prompt: ${{ has(vars.style) ? vars.style : 'be concise' }}
 when:   ${{ tasks.scan.output.contains('ERROR') }}      # branch on substring
 ```

--- a/crates/nika-pack/pack/spec/06-stdlib-contract.md
+++ b/crates/nika-pack/pack/spec/06-stdlib-contract.md
@@ -114,7 +114,7 @@ When these mature · they enter stdlib v0.x. The core language doesn't need to c
 
 ```yaml
 model: anthropic/claude-sonnet-4-6   # <provider>/<name> · see stdlib/providers-v0.1.md
-# model: ollama/llama3.2:3b          # local · same shape
+# model: ollama/qwen3.5:4b          # local · same shape
 ```
 
 ### Extract mode

--- a/crates/nika-pack/pack/spec/08-out-of-scope.md
+++ b/crates/nika-pack/pack/spec/08-out-of-scope.md
@@ -157,6 +157,15 @@ tasks: ...
 
 **Why deferred** · scheduling is an engine-runtime concern · not a language concern. A conformant engine handles cron at runtime · workflows themselves stay schedule-agnostic.
 
+### Trace retention · lifted by ADR-100 (proposed)
+
+> `.nika/traces/` is bounded by default (keep-last-N · age cap · size
+> budget) with two absolute exemptions — a `paused` trace (a pending human
+> gate) and each workflow's newest trace (the standing resume candidate) —
+> and a one-line visible report whenever collection removes anything ·
+> [ADR-100](../adr/adr-100-trace-retention.md). CLI surface (`nika trace
+> ls|rm`) and config wiring land with the engine arc.
+
 ### Workflow checkpointing / resumption
 
 ```yaml

--- a/crates/nika-pack/pack/stdlib/providers-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/providers-v0.1.md
@@ -16,7 +16,7 @@ separate `provider:` field** · the provider is the prefix.
 
 ```yaml
 infer:
-  model: ollama/llama3.1                 # local · no key
+  model: ollama/qwen3.5:9b                 # local · no key
   prompt: "..."
 
 infer:
@@ -28,15 +28,15 @@ infer:
 fields let you write the silent-nonsense combination `provider: anthropic` +
 `model: gpt-4o`. One `<provider>/<name>` string is atomic, self-documenting,
 trivially swappable, and the industry standard. The same open model served by
-different backends disambiguates cleanly · `groq/llama-3.1-70b` vs
-`ollama/llama-3.1-70b`.
+different backends disambiguates cleanly · `groq/qwen3.5-32b` vs
+`ollama/qwen3.5:27b`.
 
 **Parameterize it** · combine with typed inputs to run one workflow
 against any backend ·
 
 ```yaml
 vars:
-  model: { type: string, default: "ollama/llama3.1" }
+  model: { type: string, default: "ollama/qwen3.5:9b" }
 tasks:
   - id: x
     infer: { model: "${{ vars.model }}", prompt: "..." }
@@ -89,7 +89,7 @@ mock/…                                                 → TEST  · determinis
 ```
 
 Sovereignty · **local-first** · nothing leaves the machine unless a
-cloud provider is *explicitly* selected. `ollama/llama3.1` makes a sovereign,
+cloud provider is *explicitly* selected. `ollama/qwen3.5:9b` makes a sovereign,
 zero-cloud run trivial.
 
 All 5 local providers are external **HTTP servers** (OpenAI-compatible API · the
@@ -176,7 +176,7 @@ Every provider supports ·
 infer:
   prompt: "..."                # required
   system: "..."                # optional
-  model: <provider>/<name>     # one field · e.g. ollama/llama3.1
+  model: <provider>/<name>     # one field · e.g. ollama/qwen3.5:9b
   temperature: 0.0 to 2.0      # optional
   max_tokens: <int>            # optional
   schema: { ... }              # optional · structured output
@@ -194,13 +194,13 @@ Errors map to `NIKA-PROVIDER-NNN` codes with the provider-specific status.
 
 ```yaml
 infer:
-  model: ollama/llama3.1                 # or any pulled Ollama model
+  model: ollama/qwen3.5:9b                 # or any pulled Ollama model
   prompt: "..."
 ```
 
 **Backend** · the Ollama daemon (`http://localhost:11434`) · OpenAI-compatible API · the engine talks to it over HTTP.
 
-**Models** · any model pulled into Ollama (`llama3.1` · `qwen2.5` · `mistral` · `gemma2` · etc.) · pass-through.
+**Models** · any model pulled into Ollama (`qwen3.5:9b` · `qwen2.5` · `mistral` · `gemma2` · etc.) · pass-through.
 
 **Auth** · none (localhost).
 
@@ -478,7 +478,7 @@ When using the same workflow with different providers ·
 - The **structured output** uses JSON Schema (engine adapts to provider's native mechanism · JSON mode · function calling · etc.)
 - The **vision input** is provider-agnostic in the workflow · the engine adapts
 
-A workflow can switch providers with one line change (`model: ollama/llama3.1` → `model: mistral/mistral-large`, or any other `<provider>/<name>`) for most use cases.
+A workflow can switch providers with one line change (`model: ollama/qwen3.5:9b` → `model: mistral/mistral-large`, or any other `<provider>/<name>`) for most use cases.
 
 ---
 

--- a/crates/nika-pack/pack/templates/agent-loop.nika.yaml
+++ b/crates/nika-pack/pack/templates/agent-loop.nika.yaml
@@ -14,7 +14,7 @@ nika: v1
 workflow: agent-loop-template       # SLOT: kebab-case workflow id
 description: "plan → budgeted agent → typed result"   # SLOT
 
-model: ollama/llama3.2:3b           # SLOT: a tool-calling model · local by default
+model: ollama/qwen3.5:4b           # SLOT: a tool-calling model · local by default
 
 vars:
   goal:

--- a/crates/nika-pack/pack/templates/chain.nika.yaml
+++ b/crates/nika-pack/pack/templates/chain.nika.yaml
@@ -15,7 +15,7 @@ nika: v1
 workflow: chain-template            # SLOT: kebab-case workflow id
 description: "gather → think → persist"   # SLOT: one honest sentence
 
-model: ollama/llama3.2:3b           # SLOT: provider/model · local · zero key
+model: ollama/qwen3.5:4b           # SLOT: provider/model · local · zero key
 
 vars:
   source: "./input.txt"             # SLOT: your inputs · typed where required

--- a/crates/nika-pack/pack/templates/fanout.nika.yaml
+++ b/crates/nika-pack/pack/templates/fanout.nika.yaml
@@ -15,7 +15,7 @@ nika: v1
 workflow: fanout-template           # SLOT: kebab-case workflow id
 description: "discover N items · process in parallel · merge"   # SLOT
 
-model: ollama/llama3.2:3b           # SLOT: provider/model · local · zero key
+model: ollama/qwen3.5:4b           # SLOT: provider/model · local · zero key
 
 vars:
   collection_source: "./items"      # SLOT: where the collection comes from


### PR DESCRIPTION
The beginner-killer fix: embedded examples taught 2024 models — first-run died on « model not found ». De-gated by v0.93.0's 180s provider plane. 30 files · spec PR 5 merged upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)