### PR TITLE
chore(release): v0.93.1 — the embedded pack teaches 2026 models

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -131,7 +131,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 |------------------|------------------------------------------------|
 | branch           | `main`                                      |
 | HEAD             | `8ef43dddc` (`8ef43dddc1c0633a1156ef0eff9f2d10e51595fa`)             |
-| workspace        | v0.93.0                                  |
+| workspace        | v0.93.1                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Nika Diamond is a ground-up rewrite on the `nika-diamond` orphan branch.
 Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ---
+## [0.93.1](https://github.com/supernovae-st/nika/compare/v0.93.0..v0.93.1) - 2026-07-05
+
+### ✨ Highlights
+
+- **The embedded pack teaches 2026 models** — `nika examples` /
+  `nika new` / `nika spec` now carry the qwen3.5 cascade
+  ([PR 161](https://github.com/supernovae-st/nika/pull/161)): the very
+  first `nika examples run 01-hello` of a fresh install works against
+  the models people actually pull in July 2026 (the v0.93.0 binary
+  still embedded the pre-cascade pack — this patch closes the reach).
+- README daily-commands block ([PR 162](https://github.com/supernovae-st/nika/pull/162)).
+
+### 📚 Documentation
+- **readme** — Daily commands — the full 0.93 user loop in one block ([#162](https://github.com/supernovae-st/nika/issues/162)) ([8356df6f7](https://github.com/supernovae-st/nika/commit/8356df6f7e481c089bb86f6efd907a1b1f3240a0))
+
+### 🧹 Chore
+- **pack** — Vendor the qwen3.5 teach-cascade from spec main ([#161](https://github.com/supernovae-st/nika/issues/161)) ([e8f500f73](https://github.com/supernovae-st/nika/commit/e8f500f7362b02cb44a649f861d1228fde16d0cc))
 ## [0.93.0](https://github.com/supernovae-st/nika/compare/v0.92.0..v0.93.0) - 2026-07-05
 
 ### ✨ Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "criterion",
  "insta",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "criterion",
  "insta",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "clap",
  "futures",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cli"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "expect-test",
  "insta",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "insta",
  "miette",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "nika-kernel",
  "nix",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "globset",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "nika-http"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "insta",
  "miette",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "miette",
  "nika-error",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "nika-error",
  "nika-pack",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "include_dir",
  "sha2",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3985,14 +3985,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "criterion",
  "insta",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "loom",
  "proptest",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "miette",
  "nika-error",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.93.0"
+version      = "0.93.1"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ before it joins the workspace.
 
 See `docs/architecture/ai-velocity.md` for the full argument.
 
-## Current state — main is v0.93.0 (release in flight this arc)
+## Current state — main is v0.93.1 (patch release in flight)
 
 > First public release (2026-06-21 · `brew install supernovae-st/tap/nika`).
 > 39/42 crates admitted (wip array empty) · RC-grade toward the **1.0.0** launch,
@@ -85,7 +85,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 |------------------|------------------------------------------------|
 | branch           | `main`                                      |
 | HEAD             | `8ef43dddc` (`8ef43dddc1c0633a1156ef0eff9f2d10e51595fa`)             |
-| workspace        | v0.93.0                                  |
+| workspace        | v0.93.1                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.93.0", optional = true }
-nika-error     = { path = "../nika-error", version = "0.93.0", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.93.0", optional = true }
+nika-types     = { path = "../nika-types", version = "0.93.1", optional = true }
+nika-error     = { path = "../nika-error", version = "0.93.1", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.93.1", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.93.0" }
+nika-types  = { path = "../nika-types", version = "0.93.1" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.93.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.93.1" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
 jaq-std       = { workspace = true }
@@ -35,15 +35,15 @@ serde_json    = { workspace = true }
 tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval off the async executor
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.93.0" }
+nika-fs          = { path = "../nika-fs", version = "0.93.1" }
 # test-only: the drift guard pinning tool_defs() arg keys to the catalog
 # Builtin::args vocabulary nika check validates against (one source, no drift).
-nika-catalog     = { path = "../nika-catalog", version = "0.93.0" }
+nika-catalog     = { path = "../nika-catalog", version = "0.93.1" }
 proptest         = { workspace = true }
 tokio            = { workspace = true }
 

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.93.1" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.93.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.93.1" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.93.0" }
+nika-error = { path = "../nika-error", version = "0.93.1" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.93.0" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.93.1" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.93.0" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.93.0" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.93.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.93.0" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.93.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
-nika-bm25   = { path = "../nika-bm25", version = "0.93.0" }   # intent→template routing (`nika new` · the deterministic floor)
+nika-event  = { path = "../nika-event", version = "0.93.1" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.93.1" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.93.1" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.93.1" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.93.1" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-bm25   = { path = "../nika-bm25", version = "0.93.1" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde       = { workspace = true }                             # graph projection envelope (§6)
@@ -27,21 +27,21 @@ uuid        = { workspace = true }                             # deterministic d
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.93.0" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.93.0" }       # the L3 executor (the composer drives it)
-nika-providers   = { path = "../nika-providers", version = "0.93.0" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.0" }
-nika-builtin     = { path = "../nika-builtin", version = "0.93.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.93.0" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.93.0" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.93.0" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.93.0" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.93.0", features = ["providers"] }  # the env_var ladder per provider
-nika-lsp         = { path = "../nika-lsp", version = "0.93.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-mcp         = { path = "../nika-mcp", version = "0.93.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.93.1" }       # the L3 executor (the composer drives it)
+nika-providers   = { path = "../nika-providers", version = "0.93.1" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.1" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.1" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.1" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.1" }
+nika-builtin     = { path = "../nika-builtin", version = "0.93.1" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.93.1" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.93.1" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.93.1" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.93.1" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.93.1", features = ["providers"] }  # the env_var ladder per provider
+nika-lsp         = { path = "../nika-lsp", version = "0.93.1" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-mcp         = { path = "../nika-mcp", version = "0.93.1" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [[bin]]
@@ -52,7 +52,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 
 [package.metadata.lore]

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.0" }
+nika-types = { path = "../nika-types", version = "0.93.1" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.0" }
-nika-error = { path = "../nika-error", version = "0.93.0" }
+nika-types = { path = "../nika-types", version = "0.93.1" }
+nika-error = { path = "../nika-error", version = "0.93.1" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.93.0" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.93.1" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.93.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.93.1" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.93.0" }
-nika-types   = { path = "../nika-types", version = "0.93.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.93.1" }
+nika-types   = { path = "../nika-types", version = "0.93.1" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.93.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.0" }
+nika-error       = { path = "../nika-error", version = "0.93.1" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.1" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.93.0" }
+nika-error    = { path = "../nika-error", version = "0.93.1" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.93.0" }
-nika-error    = { path = "../nika-error", version = "0.93.0" }
+nika-kernel   = { path = "../nika-kernel", version = "0.93.1" }
+nika-error    = { path = "../nika-error", version = "0.93.1" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.93.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.0" }
+nika-error       = { path = "../nika-error", version = "0.93.1" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.1" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.93.0" }
+nika-error    = { path = "../nika-error", version = "0.93.1" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.93.0" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.93.0" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.93.0" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.93.0" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.93.0" }
+nika-error          = { path = "../nika-error", version = "0.93.1" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.93.1" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.93.1" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.93.1" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.93.1" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.93.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-schema = { path = "../nika-schema", version = "0.93.1" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.93.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-error  = { path = "../nika-error", version = "0.93.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.93.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.93.1" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-error  = { path = "../nika-error", version = "0.93.1" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.93.1" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.93.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.93.0", features = ["providers"] }
+nika-kernel  = { path = "../nika-kernel", version = "0.93.1" }
+nika-catalog = { path = "../nika-catalog", version = "0.93.1", features = ["providers"] }
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,16 +11,16 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.93.0" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.93.0" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.93.0" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.93.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-cel         = { path = "../nika-cel", version = "0.93.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.93.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.0" }
+nika-types       = { path = "../nika-types", version = "0.93.1" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.93.1" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.93.1" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.93.1" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-cel         = { path = "../nika-cel", version = "0.93.1" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.1" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.1" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.1" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.1" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -33,9 +33,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.93.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.93.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.93.1" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.93.1" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -17,10 +17,10 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # nika-cap permits). The 4th (nika-cap) is the permits boundary extracted 2026-07-03
 # for reuse by nika-policy/runtime WITHOUT pulling the parser; inlining it back to
 # stay at 3 would defeat the extraction. High fan-in is intentional here (ADR-027).
-nika-error   = { path = "../nika-error", version = "0.93.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.93.0" }
-nika-types   = { path = "../nika-types", version = "0.93.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.93.0" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-error   = { path = "../nika-error", version = "0.93.1" }
+nika-catalog = { path = "../nika-catalog", version = "0.93.1" }
+nika-types   = { path = "../nika-types", version = "0.93.1" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.93.1" }   # the permits vocab lives here now (extracted 2026-07-03)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -43,10 +43,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.93.0" }
+nika-event = { path = "../nika-event", version = "0.93.1" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.93.0" }
+nika-pack  = { path = "../nika-pack", version = "0.93.1" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-kernel      = { path = "../nika-kernel", version = "0.93.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.93.0" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.0" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.93.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.93.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.93.1" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.1" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.93.1" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.93.1" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -24,7 +24,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.93.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-error  = { path = "../nika-error", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error     = { path = "../nika-error", version = "0.93.0" }
-nika-kernel    = { path = "../nika-kernel", version = "0.93.0" }
-nika-providers = { path = "../nika-providers", version = "0.93.0" }
+nika-error     = { path = "../nika-error", version = "0.93.1" }
+nika-kernel    = { path = "../nika-kernel", version = "0.93.1" }
+nika-providers = { path = "../nika-providers", version = "0.93.1" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.93.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.93.0" }
+nika-error  = { path = "../nika-error", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -828,8 +828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nika-cap"
+version = "0.93.0"
+dependencies = [
+ "nika-types",
+ "serde",
+]
+
+[[package]]
 name = "nika-catalog"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "miette",
  "nika-catalog-codegen",
@@ -843,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -855,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "miette",
  "nika-types",
@@ -866,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-schema"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "jaq-core",
  "jaq-json",
@@ -874,6 +882,7 @@ dependencies = [
  "jsonschema",
  "marked-yaml",
  "miette",
+ "nika-cap",
  "nika-catalog",
  "nika-error",
  "nika-types",
@@ -894,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.93.0-dev"
+version = "0.93.0"
 dependencies = [
  "loom",
  "serde",


### PR DESCRIPTION
Patch: the 0.93.0 tag predated the pack-cascade merge — its binary still embedded pre-cascade examples (proven live). Closes the reach. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)