### PR TITLE
CLI comprehension pass: see WHAT ran — outputs, peek, flow, clarity

### DIFF
--- a/crates/nika-cli/src/demo.rs
+++ b/crates/nika-cli/src/demo.rs
@@ -150,7 +150,7 @@ pub fn failure() -> Vec<Event> {
                 "summarize failed · NIKA-431 provider refused (429) · retried 2×",
             )),
         // Spec 03 · an upstream failure CANCELS default-gate downstream
-        // (§3.1 `◼` · a decision, not a defect — the runtime's cascade).
+        // (blocked `⊘` · a decision, not a defect — the runtime's cascade).
         at(31, 5610, EventKind::TaskCancelled)
             .with_field(s("task", "write_md"))
             .with_field(s("note", "upstream failed")),

--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -305,11 +305,19 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
     lines
 }
 
-/// The card's totals row: wall time · spend · the models the stream
-/// named (the fold kept them off the `infer · <model>` / `agent ·
-/// <model>` notes — rendered only when the stream actually said them).
+/// The card's totals row: wall time · total tokens (when any task
+/// reported usage — tokens are real TODAY, dollars stay honest-zero
+/// until the engine prices them) · spend · the models the stream named
+/// (the fold kept them off the `infer · <model>` / `agent · <model>`
+/// notes — rendered only when the stream actually said them).
 fn totals_row(view: &RunView) -> String {
-    let mut row = format!("{} · ${:.4}", fmt_wall_ms(view.elapsed_ms), view.cost_usd);
+    use std::fmt::Write as _;
+    let mut row = fmt_wall_ms(view.elapsed_ms);
+    let tokens: u64 = view.token_samples.iter().sum();
+    if tokens > 0 {
+        let _ = write!(row, " · {tokens} tok");
+    }
+    let _ = write!(row, " · ${:.4}", view.cost_usd);
     let mut models: Vec<&str> = Vec::new();
     for r in view.rows() {
         if let Some(m) = r.model.as_deref()
@@ -619,8 +627,8 @@ mod tests {
             "{lines:?}"
         );
         assert!(
-            lines[2].contains("4.7s · $0.0110 · claude-sonnet"),
-            "totals + the model the stream named: {lines:?}"
+            lines[2].contains("4.7s · 710 tok · $0.0110 · claude-sonnet"),
+            "totals (wall · tokens · spend) + the model the stream named: {lines:?}"
         );
         assert!(lines[3].contains("outputs → review (object)"), "{lines:?}");
         assert!(

--- a/crates/nika-cli/src/display/mod.rs
+++ b/crates/nika-cli/src/display/mod.rs
@@ -10,3 +10,4 @@ pub mod render;
 pub mod shape;
 pub mod state;
 pub mod theme;
+pub(crate) mod vocab;

--- a/crates/nika-cli/src/display/mod.rs
+++ b/crates/nika-cli/src/display/mod.rs
@@ -2,10 +2,11 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
 //! The display module — fold (`state`) · glyphs/colour (`theme`) · frames
-//! (`render`) · execution-flow reads (`flow`). One truth in, text out; no
-//! I/O lives here.
+//! (`render`) · execution-flow reads (`flow`) · bounded output summaries
+//! (`shape`). One truth in, text out; no I/O lives here.
 
 pub mod flow;
 pub mod render;
+pub mod shape;
 pub mod state;
 pub mod theme;

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -16,6 +16,23 @@ const NOTE_COL_CAP: usize = 40;
 /// Render one frame of the run card.
 #[must_use]
 pub fn frame(view: &RunView, theme: &Theme, tick: usize) -> Vec<String> {
+    frame_impl(view, theme, tick, false)
+}
+
+/// Render one frame WITH the shape tails — completed rows carry their
+/// bounded output summary + tokens (`→ {…} · 312B · 90 tok`). The
+/// interactive-TTY surface only: `frame` (no tails) stays the byte-exact
+/// register for pipes · CI logs · `--no-outputs`.
+#[must_use]
+pub fn frame_with_outputs(view: &RunView, theme: &Theme, tick: usize) -> Vec<String> {
+    frame_impl(view, theme, tick, true)
+}
+
+/// The one frame assembler behind both public forms.
+// `&Theme` to match the public `frame` borrow that threads it here — the
+// same one-calling-convention rationale as `task_line`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<String> {
     let mut lines = Vec::with_capacity(view.rows().len() + 6);
 
     // Header: identity + the statically-proven ceiling.
@@ -63,6 +80,11 @@ pub fn frame(view: &RunView, theme: &Theme, tick: usize) -> Vec<String> {
         .unwrap_or(0);
     for (i, row) in view.rows().iter().enumerate() {
         let mark = marks.get(i).copied().unwrap_or(false);
+        let tail = if outputs {
+            crate::display::shape::output_tail(row.output_json.as_deref(), row.tokens, theme)
+        } else {
+            None
+        };
         lines.push(task_line(
             row,
             view,
@@ -71,6 +93,7 @@ pub fn frame(view: &RunView, theme: &Theme, tick: usize) -> Vec<String> {
             (width, note_w, time_w),
             times[i].as_deref(),
             mark,
+            tail.as_deref(),
         ));
     }
 
@@ -116,12 +139,14 @@ fn row_wall(row: &TaskRow, view: &RunView) -> Option<String> {
 }
 
 /// Assemble one storyboard row: glyph · id · dimmed note · then the
-/// time/cost/lane suffix, column-aligned on RAW (pre-paint) widths so
-/// ANSI escapes never skew the layout. Rows with no suffix keep the
+/// time/cost/tail/lane suffix, column-aligned on RAW (pre-paint) widths
+/// so ANSI escapes never skew the layout. Rows with no suffix keep the
 /// legacy shape exactly (no trailing padding).
 // `&Theme` to match the `frame` borrow that threads it here — the same
-// one-calling-convention rationale as `append_failure_card`.
-#[allow(clippy::trivially_copy_pass_by_ref)]
+// one-calling-convention rationale as `append_failure_card`. The 8th
+// parameter is the optional output tail — the same clap-surface idiom
+// the run verb carries.
+#[allow(clippy::trivially_copy_pass_by_ref, clippy::too_many_arguments)]
 fn task_line(
     row: &TaskRow,
     view: &RunView,
@@ -130,6 +155,7 @@ fn task_line(
     (id_w, note_w, time_w): (usize, usize, usize),
     time: Option<&str>,
     mark: bool,
+    tail: Option<&str>,
 ) -> String {
     let mut note = row.note.clone();
     if row.state == TaskState::Running && !view.token_samples.is_empty() {
@@ -145,7 +171,7 @@ fn task_line(
         theme.paint(Role::Dim, &note),
     );
     let cost = row.cost_usd.map(|c| format!(" · ${c:.4}"));
-    if time.is_none() && cost.is_none() && !mark {
+    if time.is_none() && cost.is_none() && !mark && tail.is_none() {
         return line;
     }
     // Column pad computed on the RAW note (paint added escapes, the
@@ -156,6 +182,11 @@ fn task_line(
     line.push_str(&theme.paint(Role::Dim, cell.trim_end()));
     if let Some(cost) = cost {
         line.push_str(&theme.paint(Role::Dim, &cost));
+    }
+    if let Some(tail) = tail {
+        // Already painted by the shape module — one metadata unit.
+        line.push_str("  ");
+        line.push_str(tail);
     }
     if mark {
         line.push_str(&theme.paint(Role::Accent, if theme.ascii { " ||" } else { " ∥" }));
@@ -431,6 +462,56 @@ mod tests {
     fn frame_is_stable_under_ticks_when_nothing_runs() {
         let view = fold(&demo::success());
         assert_eq!(frame(&view, &UNICODE, 0), frame(&view, &UNICODE, 9));
+    }
+
+    /// A view with output-carrying completions: `frame_with_outputs`
+    /// appends the bounded shape tail (+ tokens) on those rows while
+    /// `frame` stays BYTE-IDENTICAL to today — the piped/CI register
+    /// never grows tails.
+    #[test]
+    fn frame_with_outputs_adds_tails_and_frame_stays_bare() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+
+        let mut view = RunView::new();
+        let task = |n: &str| KeyValue::new("task", Value::String(n.to_owned()));
+        view.apply(&demo::bare_event(EventKind::TaskStarted, 0).with_field(task("audit")));
+        view.apply(
+            &demo::bare_event(EventKind::TaskCompleted, 100)
+                .with_field(task("audit"))
+                .with_field(KeyValue::new(
+                    "output",
+                    Value::String(r#"{"verdict":"P0","fixes":[1,2]}"#.to_owned()),
+                ))
+                .with_field(KeyValue::new("tokens", Value::Int(90))),
+        );
+        let with = frame_with_outputs(&view, &UNICODE, 0);
+        let audit = with.iter().find(|l| l.contains("audit")).expect("row");
+        assert!(
+            audit.contains("→ {fixes[2], verdict} · 30B · 90 tok"),
+            "tail rides the completed row: {audit}"
+        );
+        let bare = frame(&view, &UNICODE, 0);
+        assert!(
+            !bare.iter().any(|l| l.contains('→')),
+            "the bare frame never grows tails: {bare:?}"
+        );
+
+        // ASCII parity — the arrow degrades, nothing unicode leaks.
+        let ascii = frame_with_outputs(&view, &ASCII, 0);
+        assert!(
+            ascii.iter().any(|l| l.contains("-> {fixes[2], verdict}")),
+            "{ascii:?}"
+        );
+
+        // The demo storyboard carries no output fields — with-outputs
+        // renders byte-identically to the bare frame (no invented data).
+        let demo_view = fold(&demo::success());
+        assert_eq!(
+            frame_with_outputs(&demo_view, &UNICODE, 0),
+            frame(&demo_view, &UNICODE, 0),
+            "no output fields → no tails, ever"
+        );
     }
 
     /// The running row shows a LIVE elapsed (now − started) and `∥` marks

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -62,13 +62,15 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
     // are first-class columns: a settled row carries its REAL wall time
     // (+ per-task spend when the stream reported one), a running row its
     // live elapsed, and `∥` marks wave-siblings that actually overlapped.
+    // Never-ran rows speak their REASON (`cache hit (resume)` · `when:
+    // false` · `blocked · <task> failed`) through the display-note map.
     let width = view.rows().iter().map(|r| r.id.len()).max().unwrap_or(8);
     let marks = lane_marks(view);
     let times: Vec<Option<String>> = view.rows().iter().map(|r| row_wall(r, view)).collect();
-    let note_w = view
-        .rows()
+    let notes: Vec<String> = view.rows().iter().map(|r| display_note(r, view)).collect();
+    let note_w = notes
         .iter()
-        .map(|r| r.note.chars().count())
+        .map(|n| n.chars().count())
         .max()
         .unwrap_or(0)
         .min(NOTE_COL_CAP);
@@ -87,7 +89,7 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         };
         lines.push(task_line(
             row,
-            view,
+            (view, &notes[i]),
             theme,
             tick,
             (width, note_w, time_w),
@@ -138,6 +140,48 @@ fn row_wall(row: &TaskRow, view: &RunView) -> Option<String> {
     }
 }
 
+/// The row's DISPLAY note — the skip-reason vocabulary over the raw
+/// fold note. Three never-ran classes speak distinctly: a rehydrated
+/// row says `cache hit (resume)`, a closed `when:` gate says `when:
+/// false`, a dead-path cancellation says `blocked · <task> failed`
+/// (naming the failed upstream when the run has exactly ONE failed
+/// task — with several, ancestry is ambiguous from the stream alone,
+/// so the honest generic `upstream failed` stays). Every other note
+/// renders verbatim (the runtime's vocabulary is already teaching).
+fn display_note(row: &TaskRow, view: &RunView) -> String {
+    if row.cached {
+        return "cache hit (resume)".to_owned();
+    }
+    match (row.state, row.note.as_str()) {
+        (TaskState::Skipped, "when: gate closed") => "when: false".to_owned(),
+        (TaskState::Cancelled, "upstream failed") => {
+            let failed: Vec<&str> = view
+                .rows()
+                .iter()
+                .filter(|r| r.state == TaskState::Failed)
+                .map(|r| r.id.as_str())
+                .collect();
+            match failed.as_slice() {
+                [one] => format!("blocked · {one} failed"),
+                _ => "blocked · upstream failed".to_owned(),
+            }
+        }
+        _ => row.note.clone(),
+    }
+}
+
+/// The row's glyph — the ONE render-level override: a cache-hit row is
+/// Ok in the fold (the value is real) but reads as the skip family
+/// (`↷` · it never ran HERE), so green stays reserved for work done.
+// `&Theme` to match the `task_line` borrow that threads it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn row_glyph(row: &TaskRow, theme: &Theme, tick: usize) -> String {
+    if row.cached {
+        return theme.glyph(TaskState::Skipped, tick);
+    }
+    theme.glyph(row.state, tick)
+}
+
 /// Assemble one storyboard row: glyph · id · dimmed note · then the
 /// time/cost/tail/lane suffix, column-aligned on RAW (pre-paint) widths
 /// so ANSI escapes never skew the layout. Rows with no suffix keep the
@@ -145,11 +189,12 @@ fn row_wall(row: &TaskRow, view: &RunView) -> Option<String> {
 // `&Theme` to match the `frame` borrow that threads it here — the same
 // one-calling-convention rationale as `append_failure_card`. The 8th
 // parameter is the optional output tail — the same clap-surface idiom
-// the run verb carries.
+// the run verb carries; the display note rides beside the view it was
+// derived from.
 #[allow(clippy::trivially_copy_pass_by_ref, clippy::too_many_arguments)]
 fn task_line(
     row: &TaskRow,
-    view: &RunView,
+    (view, display_note): (&RunView, &str),
     theme: &Theme,
     tick: usize,
     (id_w, note_w, time_w): (usize, usize, usize),
@@ -157,7 +202,7 @@ fn task_line(
     mark: bool,
     tail: Option<&str>,
 ) -> String {
-    let mut note = row.note.clone();
+    let mut note = display_note.to_owned();
     if row.state == TaskState::Running && !view.token_samples.is_empty() {
         let spark = theme.sparkline(&view.token_samples);
         if !spark.is_empty() {
@@ -166,7 +211,7 @@ fn task_line(
     }
     let mut line = format!(
         "  {} {:<id_w$}  {}",
-        theme.glyph(row.state, tick),
+        row_glyph(row, theme, tick),
         row.id,
         theme.paint(Role::Dim, &note),
     );
@@ -176,7 +221,7 @@ fn task_line(
     }
     // Column pad computed on the RAW note (paint added escapes, the
     // sparkline may ride a running row — transient shift accepted).
-    let pad = note_w.saturating_sub(row.note.chars().count());
+    let pad = note_w.saturating_sub(display_note.chars().count());
     line.push_str(&" ".repeat(pad + 2));
     let cell = format!("{:>time_w$}", time.unwrap_or(""));
     line.push_str(&theme.paint(Role::Dim, cell.trim_end()));
@@ -315,7 +360,7 @@ mod tests {
             "  ✔  extract_ai    jq · 0.1s · 12 items           130ms",
             "  ✔  summarize     claude-sonnet · 3.1s · $0.011   3.0s · $0.0110",
             "  ✔  write_md      2.1 KB written                 290ms",
-            "  ⊘  notify_slack  when: env.CI != 'true'",
+            "  ↷  notify_slack  when: env.CI != 'true'",
         ];
         assert_eq!(&lines[..8], &expected[..]);
         // The meter line: pinned prefix + rule-padded to a stable width.
@@ -349,24 +394,93 @@ mod tests {
         assert_eq!(tail[1], "    fix: nika explain NIKA-431");
     }
 
-    /// The cascade rows RENDER as §3.1 `◼` (the runtime's
-    /// upstream-failure cancellation · dim · never red) — the fold and
-    /// the glyph were each pinned alone; this pins the assembled line.
+    /// The cascade rows RENDER as blocked `⊘` (the runtime's
+    /// upstream-failure cancellation · dim · never red) — and because
+    /// the demo failure has exactly ONE failed task, the note NAMES it:
+    /// `blocked · summarize failed` (unambiguous from the stream).
     #[test]
     fn golden_failure_frame_renders_cancelled_rows() {
         let lines = frame(&fold(&demo::failure()), &UNICODE, 0);
         assert!(
             lines
                 .iter()
-                .any(|l| l.starts_with("  ◼  write_md") && l.contains("upstream failed")),
-            "unicode cancelled row: {lines:?}"
+                .any(|l| l.starts_with("  ⊘  write_md") && l.contains("blocked · summarize failed")),
+            "unicode blocked row names the one failed upstream: {lines:?}"
         );
         let ascii = frame(&fold(&demo::failure()), &ASCII, 0);
         assert!(
             ascii
                 .iter()
-                .any(|l| l.starts_with("  x  write_md") && l.contains("upstream failed")),
-            "ascii cancelled row (err X ≠ cancelled x): {ascii:?}"
+                .any(|l| l.starts_with("  x  write_md") && l.contains("blocked · summarize failed")),
+            "ascii blocked row (err X ≠ blocked x): {ascii:?}"
+        );
+    }
+
+    /// The three never-ran classes render DISTINCTLY (the skip-reason
+    /// law): `↷ cache hit (resume)` · `↷ when: false` · `⊘ blocked ·
+    /// upstream failed` — the generic blocked form when SEVERAL tasks
+    /// failed (ancestry is ambiguous from the stream alone).
+    #[test]
+    fn skip_reasons_render_their_three_classes() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let task = |n: &str| KeyValue::new("task", Value::String(n.to_owned()));
+        let note = |n: &str| KeyValue::new("note", Value::String(n.to_owned()));
+
+        let mut view = RunView::new();
+        view.apply(&demo::bare_event(EventKind::TaskCacheHit, 5).with_field(task("read")));
+        view.apply(
+            &demo::bare_event(EventKind::TaskSkipped, 10)
+                .with_field(task("deploy"))
+                .with_field(note("when: gate closed")),
+        );
+        // TWO failures → the blocked row cannot name ONE upstream.
+        view.apply(&demo::bare_event(EventKind::TaskFailed, 15).with_field(task("a")));
+        view.apply(&demo::bare_event(EventKind::TaskFailed, 16).with_field(task("b")));
+        view.apply(
+            &demo::bare_event(EventKind::TaskCancelled, 20)
+                .with_field(task("notify"))
+                .with_field(note("upstream failed")),
+        );
+
+        let lines = frame(&view, &UNICODE, 0);
+        let find = |id: &str| {
+            lines
+                .iter()
+                .find(|l| l.contains(id))
+                .cloned()
+                .expect("every staged row renders")
+        };
+        assert!(
+            find("read").starts_with("  ↷ ") && find("read").contains("cache hit (resume)"),
+            "cache hit: {}",
+            find("read")
+        );
+        assert!(
+            find("deploy").starts_with("  ↷ ") && find("deploy").contains("when: false"),
+            "when gate: {}",
+            find("deploy")
+        );
+        assert!(
+            find("notify").starts_with("  ⊘ ")
+                && find("notify").contains("blocked · upstream failed"),
+            "ambiguous blocked stays generic: {}",
+            find("notify")
+        );
+
+        // ASCII parity for the whole vocabulary: ~> skip · x blocked.
+        let ascii = frame(&view, &ASCII, 0);
+        assert!(
+            ascii.iter().any(|l| l.starts_with("  ~> read")),
+            "ascii skip glyph: {ascii:?}"
+        );
+        assert!(
+            ascii.iter().any(|l| l.starts_with("  x  notify")),
+            "ascii blocked glyph: {ascii:?}"
+        );
+        assert!(
+            !ascii.iter().any(|l| l.contains('↷') || l.contains('⊘')),
+            "no unicode leaks into --ascii: {ascii:?}"
         );
     }
 

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -287,7 +287,10 @@ fn append_failure_card(lines: &mut Vec<String>, view: &RunView, theme: &Theme) {
             theme.paint(Role::Strong, detail),
         ));
         if let Some(code) = detail.split_whitespace().find(|w| w.starts_with("NIKA-")) {
-            lines.push(theme.paint(Role::Dim, &format!("    fix: nika explain {code}")));
+            lines.push(format!(
+                "    {}",
+                crate::display::vocab::hint(*theme, "fix", &format!("nika explain {code}"))
+            ));
         }
     }
     for row in view.rows() {
@@ -303,7 +306,10 @@ fn append_failure_card(lines: &mut Vec<String>, view: &RunView, theme: &Theme) {
                 .split_whitespace()
                 .find(|w| w.starts_with("NIKA-"))
             {
-                lines.push(theme.paint(Role::Dim, &format!("    fix: nika explain {code}")));
+                lines.push(format!(
+                    "    {}",
+                    crate::display::vocab::hint(*theme, "fix", &format!("nika explain {code}"))
+                ));
             }
         }
     }

--- a/crates/nika-cli/src/display/shape.rs
+++ b/crates/nika-cli/src/display/shape.rs
@@ -105,7 +105,7 @@ pub fn output_tail(
     use std::fmt::Write as _;
     let text = output_json?;
     let shape = summarize(text, SHAPE_CELLS)?;
-    let arrow = if theme.ascii { "->" } else { "→" };
+    let arrow = crate::display::vocab::arrow(theme.ascii);
     let mut tail = format!("{arrow} {shape} · {}", fmt_bytes(text.len()));
     if let Some(tok) = tokens {
         let _ = write!(tail, " · {tok} tok");

--- a/crates/nika-cli/src/display/shape.rs
+++ b/crates/nika-cli/src/display/shape.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Type-aware bounded output summaries — the storyboard's shape tail.
+//!
+//! One law: **shape, never a data dump**. An object reads as its keys
+//! (`{verdict, findings[4], summary}`), an array as its length (`[12]`),
+//! a string as its bounded head (`"Horaires des …"`), scalars literally.
+//! Every summary is deterministic and width-bounded, so a tail can ride
+//! a live storyboard row without ever flooding it.
+//!
+//! Secrets: the runtime drops the `output` trace field wholesale when a
+//! task's output text carries a resolved secret value (ADR-099 §1 — the
+//! stamp filter), so no summary here can ever see one. This module adds
+//! NO secret read of its own; the bounded width is defence in depth.
+
+use crate::display::theme::{Role, Theme};
+
+/// Widest a shape summary grows (display cells) before it ellipsizes —
+/// keeps a typical storyboard row graceful under 80 columns.
+pub(crate) const SHAPE_CELLS: usize = 24;
+
+/// A byte size for humans: `89B` · `1.2KB` · `3.4MB` (no space — the
+/// tail vocabulary, distinct from runtime note prose like `34 KB`).
+#[must_use]
+pub fn fmt_bytes(n: usize) -> String {
+    if n < 1_000 {
+        return format!("{n}B");
+    }
+    #[allow(clippy::cast_precision_loss)] // display-only magnitude
+    let f = n as f64;
+    if n < 1_000_000 {
+        return format!("{:.1}KB", f / 1_000.0);
+    }
+    format!("{:.1}MB", f / 1_000_000.0)
+}
+
+/// Summarize one task output (its compact JSON text) as a bounded,
+/// type-aware shape. `None` when the text is not valid JSON — never
+/// render garbage from a hand-edited trace.
+#[must_use]
+pub fn summarize(json_text: &str, max_cells: usize) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(json_text).ok()?;
+    Some(fit(&shape_of(&value), max_cells))
+}
+
+/// The unbounded shape text for one JSON value (fit separately).
+fn shape_of(value: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match value {
+        Value::Null => "null".to_owned(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => format!("\"{}\"", s.replace(['\n', '\r'], " ")),
+        Value::Array(items) => format!("[{}]", items.len()),
+        Value::Object(map) => {
+            // Key names only (values stay in `peek`) — an array-valued
+            // key carries its length so the DAG's fan-out reads at a
+            // glance. Four keys shown, the rest counted by `…`.
+            let mut keys: Vec<String> = map
+                .iter()
+                .take(4)
+                .map(|(k, v)| match v {
+                    Value::Array(items) => format!("{k}[{}]", items.len()),
+                    _ => k.clone(),
+                })
+                .collect();
+            if map.len() > 4 {
+                keys.push("…".to_owned());
+            }
+            format!("{{{}}}", keys.join(", "))
+        }
+    }
+}
+
+/// Truncate to `max` display cells, ellipsis-marked — a string head keeps
+/// its closing quote so the shape stays readable when clipped.
+fn fit(shape: &str, max: usize) -> String {
+    if shape.chars().count() <= max {
+        return shape.to_owned();
+    }
+    let quoted = shape.starts_with('"');
+    // Reserve the ellipsis (and the closing quote for a string head).
+    let keep = max.saturating_sub(if quoted { 2 } else { 1 });
+    let mut out: String = shape.chars().take(keep).collect();
+    out.push('…');
+    if quoted {
+        out.push('"');
+    }
+    out
+}
+
+/// The assembled row tail: `→ <shape> · <size>[ · <tok> tok]` — painted
+/// dim as one metadata unit, ASCII-parity arrow (`->`). `None` when the
+/// row carries no output (a skip · a failure · the engine's secret-drop).
+// `&Theme` to match the render borrow that threads it here — the same
+// one-calling-convention rationale as `frame_impl`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+#[must_use]
+pub fn output_tail(
+    output_json: Option<&str>,
+    tokens: Option<u64>,
+    theme: &Theme,
+) -> Option<String> {
+    use std::fmt::Write as _;
+    let text = output_json?;
+    let shape = summarize(text, SHAPE_CELLS)?;
+    let arrow = if theme.ascii { "->" } else { "→" };
+    let mut tail = format!("{arrow} {shape} · {}", fmt_bytes(text.len()));
+    if let Some(tok) = tokens {
+        let _ = write!(tail, " · {tok} tok");
+    }
+    Some(theme.paint(Role::Dim, &tail))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PLAIN: Theme = Theme {
+        color: false,
+        ascii: false,
+        animate: false,
+    };
+    const ASCII: Theme = Theme {
+        color: false,
+        ascii: true,
+        animate: false,
+    };
+
+    /// Objects read as their key set — array-valued keys carry `[N]`,
+    /// values never leak into the shape (the design's one law).
+    #[test]
+    fn object_shape_is_keys_with_array_lengths() {
+        let json = r#"{"verdict":"P0","findings":[1,2,3,4],"summary":"long text"}"#;
+        assert_eq!(
+            summarize(json, 60).as_deref(),
+            Some("{findings[4], summary, verdict}"),
+            "serde_json map iteration is key-sorted (BTreeMap-backed)"
+        );
+        assert!(
+            !summarize(json, 60).expect("shape").contains("P0"),
+            "values never leak into an object shape"
+        );
+    }
+
+    /// More than four keys collapse into `…` — the fan-out stays bounded
+    /// however wide the object grows.
+    #[test]
+    fn object_shape_caps_at_four_keys() {
+        let json = r#"{"a":1,"b":2,"c":3,"d":4,"e":5,"f":6}"#;
+        assert_eq!(summarize(json, 60).as_deref(), Some("{a, b, c, d, …}"));
+    }
+
+    /// Strings render their quoted head; arrays their length; scalars
+    /// literally — one deterministic form per JSON type.
+    #[test]
+    fn string_array_and_scalar_shapes() {
+        let horaires = "\"Horaires des marées pour demain matin à Saint-Malo\"";
+        let s = summarize(horaires, SHAPE_CELLS).expect("string shape");
+        assert!(s.starts_with("\"Horaires des"), "head kept: {s}");
+        assert!(s.ends_with("…\""), "clipped head keeps its quote: {s}");
+        assert_eq!(summarize("[1,2,3]", 60).as_deref(), Some("[3]"));
+        assert_eq!(summarize("42", 60).as_deref(), Some("42"));
+        assert_eq!(summarize("true", 60).as_deref(), Some("true"));
+        assert_eq!(summarize("null", 60).as_deref(), Some("null"));
+    }
+
+    /// Nested containers stay ONE level deep: an object-valued key reads
+    /// as its bare name, a nested array only by its top-level count —
+    /// depth never explodes the tail.
+    #[test]
+    fn nesting_never_descends_past_level_one() {
+        let json = r#"{"head":{"title":"x","deep":{"more":1}},"items":[[1,2],[3]]}"#;
+        assert_eq!(summarize(json, 60).as_deref(), Some("{head, items[2]}"));
+    }
+
+    /// The width bound holds for every type — a shape never exceeds its
+    /// cell budget (the storyboard row's graceful-under-80 guarantee).
+    #[test]
+    fn width_bound_holds_for_every_type() {
+        let long_string = format!("\"{}\"", "x".repeat(500));
+        let wide_object = format!(
+            "{{{}}}",
+            (0..8)
+                .map(|i| format!("\"very_long_key_name_{i}\":1"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        for json in [long_string.as_str(), wide_object.as_str()] {
+            let s = summarize(json, SHAPE_CELLS).expect("shape");
+            assert!(
+                s.chars().count() <= SHAPE_CELLS,
+                "bounded ≤{SHAPE_CELLS}: {s} ({})",
+                s.chars().count()
+            );
+        }
+    }
+
+    /// Not-JSON renders NOTHING — a truncated or hand-edited trace field
+    /// must never paint garbage on the storyboard.
+    #[test]
+    fn invalid_json_summarizes_to_none() {
+        assert_eq!(summarize("{not json", 60), None);
+        assert_eq!(summarize("", 60), None);
+    }
+
+    /// The engine invariant extends to previews structurally: a resolved
+    /// secret value never reaches this module because the runtime drops
+    /// the whole `output` trace field when the output text leaks one
+    /// (ADR-099 §1 stamp filter) — the tail then has NO input at all.
+    /// Pinned here as the no-output arm; the fold-side test pins that a
+    /// field-less completion folds to `output_json: None`.
+    #[test]
+    fn no_output_means_no_tail_the_secret_drop_arm() {
+        assert_eq!(output_tail(None, Some(90), &PLAIN), None);
+    }
+
+    /// The assembled tail: arrow · shape · byte size · tokens — with
+    /// full ASCII parity (`→` → `->`) and byte-size ramps.
+    #[test]
+    fn tail_assembles_arrow_shape_size_and_tokens() {
+        let json = r#"{"verdict":"P0","findings":[1,2]}"#;
+        assert_eq!(
+            output_tail(Some(json), Some(90), &PLAIN).as_deref(),
+            Some("→ {findings[2], verdict} · 33B · 90 tok")
+        );
+        assert_eq!(
+            output_tail(Some(json), None, &ASCII).as_deref(),
+            Some("-> {findings[2], verdict} · 33B"),
+            "no tokens reported → no tok segment · ascii arrow"
+        );
+        let ascii = output_tail(Some(json), Some(1), &ASCII).expect("tail");
+        assert!(!ascii.contains('→'), "no unicode leaks into --ascii");
+    }
+
+    #[test]
+    fn byte_format_scales() {
+        assert_eq!(fmt_bytes(0), "0B");
+        assert_eq!(fmt_bytes(89), "89B");
+        assert_eq!(fmt_bytes(999), "999B");
+        assert_eq!(fmt_bytes(1_200), "1.2KB");
+        assert_eq!(fmt_bytes(999_949), "999.9KB");
+        assert_eq!(fmt_bytes(3_400_000), "3.4MB");
+    }
+}

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -75,6 +75,12 @@ pub struct TaskRow {
     /// terminal note overwrites `note`, this survives for the per-task
     /// trace readers (`trace outputs`' verb column).
     pub started_note: Option<String>,
+    /// The ADR-099 task-definition hash (`def_hash` · blake3 hex) when
+    /// the terminal frame carried the checkpoint trio — the identity
+    /// half `trace peek` surfaces beside the value.
+    pub def_hash: Option<String>,
+    /// The ADR-099 resolved-input hash (`input_hash` · blake3 hex).
+    pub input_hash: Option<String>,
 }
 
 impl TaskRow {
@@ -281,14 +287,22 @@ impl RunView {
         }
     }
 
-    /// Keep the ADR-099 `output` field (the task's value as ONE compact
-    /// JSON text) when the frame carried one. A frame without it folds
-    /// to `None` — the honest no-data arm every downstream summary
-    /// respects (notably the runtime's secret-drop: a leaking output
-    /// never rides the stream, so no preview can ever see it).
+    /// Keep the ADR-099 checkpoint trio (the `output` value as ONE
+    /// compact JSON text + the `def_hash`/`input_hash` identity) when
+    /// the frame carried it. A frame without it folds to `None` — the
+    /// honest no-data arm every downstream summary respects (notably
+    /// the runtime's secret-drop: a leaking output never rides the
+    /// stream, so no preview can ever see it).
     fn keep_output(&mut self, i: usize, event: &Event) {
+        let row = &mut self.rows[i];
         if let Some(text) = str_field(event, "output") {
-            self.rows[i].output_json = Some(text.to_owned());
+            row.output_json = Some(text.to_owned());
+        }
+        if let Some(hash) = str_field(event, "def_hash") {
+            row.def_hash = Some(hash.to_owned());
+        }
+        if let Some(hash) = str_field(event, "input_hash") {
+            row.input_hash = Some(hash.to_owned());
         }
     }
 
@@ -314,6 +328,8 @@ impl RunView {
                 output_json: None,
                 tokens: None,
                 started_note: None,
+                def_hash: None,
+                input_hash: None,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -30,10 +30,10 @@ pub enum TaskState {
     Failed,
     /// An attempt failed · a retry is scheduled (§3.1 `↻` · yellow).
     Retrying,
-    /// Guard false — never ran, by design.
+    /// Guard false — never ran, by design (`↷` · dim · a decision).
     Skipped,
-    /// Cancelled (upstream failure · operator stop · §3.1 `◼` · dim ·
-    /// a decision, not a defect — never red).
+    /// Cancelled (upstream failure · operator stop · `⊘ blocked` · dim
+    /// · the path died upstream — never red, the defect is elsewhere).
     Cancelled,
 }
 
@@ -81,6 +81,10 @@ pub struct TaskRow {
     pub def_hash: Option<String>,
     /// The ADR-099 resolved-input hash (`input_hash` · blake3 hex).
     pub input_hash: Option<String>,
+    /// The row reached Ok via a `task_cache_hit` rehydration (ADR-099
+    /// `--resume`), never by running here — the render distinguishes
+    /// `↷ cache hit (resume)` from a ran-to-green row.
+    pub cached: bool,
 }
 
 impl TaskRow {
@@ -227,6 +231,7 @@ impl RunView {
             EventKind::TaskCacheHit => {
                 if let Some(i) = self.touch(event, TaskState::Ok) {
                     self.rows[i].ended_ms = Some(ts);
+                    self.rows[i].cached = true;
                     self.keep_output(i, event);
                 }
             }
@@ -247,7 +252,7 @@ impl RunView {
                 self.retries = self.retries.saturating_add(1);
                 self.touch(event, TaskState::Retrying);
             }
-            // §3.1 `◼` — a decision, not a defect (dim · never red).
+            // §3.1 blocked `⊘` — a decision, not a defect (dim · never red).
             EventKind::TaskCancelled => {
                 if let Some(i) = self.touch(event, TaskState::Cancelled) {
                     self.rows[i].ended_ms = Some(ts);
@@ -330,6 +335,7 @@ impl RunView {
                 started_note: None,
                 def_hash: None,
                 input_hash: None,
+                cached: false,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -70,6 +70,11 @@ pub struct TaskRow {
     pub output_json: Option<String>,
     /// Per-task token usage (`tokens` on the terminal frame).
     pub tokens: Option<u64>,
+    /// The FIRST `task_started` note (`infer · <model>` · `invoke ·
+    /// nika:fetch` — the runtime's verb vocabulary), kept verbatim: the
+    /// terminal note overwrites `note`, this survives for the per-task
+    /// trace readers (`trace outputs`' verb column).
+    pub started_note: Option<String>,
 }
 
 impl TaskRow {
@@ -185,7 +190,11 @@ impl RunView {
             }
             EventKind::TaskStarted => {
                 if let Some(i) = self.touch(event, TaskState::Running) {
-                    self.rows[i].started_ms = Some(ts);
+                    let row = &mut self.rows[i];
+                    row.started_ms = Some(ts);
+                    if row.started_note.is_none() && !row.note.is_empty() {
+                        row.started_note = Some(row.note.clone());
+                    }
                 }
             }
             EventKind::TaskCompleted => {
@@ -304,6 +313,7 @@ impl RunView {
                 model: None,
                 output_json: None,
                 tokens: None,
+                started_note: None,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);
@@ -546,6 +556,23 @@ mod tests {
         assert_eq!(view.rows()[1].output_json, None, "no field → None");
         assert_eq!(view.rows()[1].tokens, None);
         assert_eq!(view.rows()[2].output_json.as_deref(), Some("\"hi\""));
+    }
+
+    /// The FIRST started note (the verb vocabulary — `invoke ·
+    /// nika:fetch`) survives the terminal-note overwrite — the trace
+    /// readers' verb column depends on it.
+    #[test]
+    fn started_note_survives_the_terminal_overwrite() {
+        let mut view = RunView::new();
+        for ev in demo::success() {
+            view.apply(&ev);
+        }
+        let fetch = &view.rows()[0];
+        assert_eq!(fetch.started_note.as_deref(), Some("invoke · nika:fetch"));
+        assert_eq!(fetch.note, "http 200 · 1.2s · 34 KB", "terminal note won");
+        // A row that never started (skipped) keeps None.
+        let skipped = view.rows().iter().find(|r| r.id == "notify_slack");
+        assert_eq!(skipped.and_then(|r| r.started_note.as_deref()), None);
     }
 
     /// The retry counter folds every `task_retrying` frame (feeds the

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -62,6 +62,14 @@ pub struct TaskRow {
     /// terminal note overwrites `note`, this survives for the verdict
     /// surface.
     pub model: Option<String>,
+    /// The task's output as ONE compact JSON text — the ADR-099 `output`
+    /// trace field on `task_completed` / `task_cache_hit`. `None` when
+    /// the frame carried none: a skip · a failure · an older engine's
+    /// trace · the runtime's secret-drop (an output text leaking a
+    /// resolved secret value never reaches the stream — ADR-099 §1).
+    pub output_json: Option<String>,
+    /// Per-task token usage (`tokens` on the terminal frame).
+    pub tokens: Option<u64>,
 }
 
 impl TaskRow {
@@ -184,6 +192,10 @@ impl RunView {
                 let usd = float_field(event, "cost_usd");
                 if let Some(i) = self.touch(event, TaskState::Ok) {
                     self.stamp_terminal(i, ts, event, usd);
+                    self.keep_output(i, event);
+                    if let Some(tokens) = int_field(event, "tokens") {
+                        self.rows[i].tokens = u64::try_from(tokens).ok();
+                    }
                 }
                 if let Some(usd) = usd {
                     self.cost_usd += usd;
@@ -194,10 +206,13 @@ impl RunView {
             }
             // ADR-099 `--resume` — a rehydrated success: the row reads Ok
             // with the "cache hit" note the frame carries (VISIBLE, never
-            // silent); zero duration/spend (the task never ran here).
+            // silent); zero duration/spend (the task never ran here). The
+            // rehydrated output rides the frame — the shape tail and the
+            // trace readers see the SAME value a live run would carry.
             EventKind::TaskCacheHit => {
                 if let Some(i) = self.touch(event, TaskState::Ok) {
                     self.rows[i].ended_ms = Some(ts);
+                    self.keep_output(i, event);
                 }
             }
             EventKind::TaskFailed => {
@@ -257,6 +272,17 @@ impl RunView {
         }
     }
 
+    /// Keep the ADR-099 `output` field (the task's value as ONE compact
+    /// JSON text) when the frame carried one. A frame without it folds
+    /// to `None` — the honest no-data arm every downstream summary
+    /// respects (notably the runtime's secret-drop: a leaking output
+    /// never rides the stream, so no preview can ever see it).
+    fn keep_output(&mut self, i: usize, event: &Event) {
+        if let Some(text) = str_field(event, "output") {
+            self.rows[i].output_json = Some(text.to_owned());
+        }
+    }
+
     /// Upsert the row a task event addresses, updating state + notes.
     /// Returns the row index so the caller can stamp kind-specific facts.
     fn touch(&mut self, event: &Event, state: TaskState) -> Option<usize> {
@@ -276,6 +302,8 @@ impl RunView {
                 duration_ms: None,
                 cost_usd: None,
                 model: None,
+                output_json: None,
+                tokens: None,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);
@@ -480,6 +508,44 @@ mod tests {
         );
         assert_eq!(measured.rows()[0].wall_ms(), Some(40), "measured wins");
         assert_eq!(measured.last_ts_ms(), Some(5000), "now = latest stamp");
+    }
+
+    /// The fold keeps the ADR-099 per-task payload fields verbatim —
+    /// `output` (compact JSON text) + `tokens` land on the row; a frame
+    /// WITHOUT an `output` field folds to `None` (older engines · skips
+    /// · the runtime's secret-drop, ADR-099 §1: an output text leaking a
+    /// resolved secret never reaches the stream — so every preview
+    /// surface inherits the invariant structurally).
+    #[test]
+    fn completed_rows_keep_output_text_and_tokens() {
+        use nika_types::resource::{KeyValue, Value};
+        let mut view = RunView::new();
+        let task = |name: &str| KeyValue::new("task", Value::String(name.to_owned()));
+        view.apply(
+            &demo::bare_event(EventKind::TaskCompleted, 10)
+                .with_field(task("audit"))
+                .with_field(KeyValue::new(
+                    "output",
+                    Value::String(r#"{"total":9}"#.to_owned()),
+                ))
+                .with_field(KeyValue::new("tokens", Value::Int(90))),
+        );
+        // The secret-drop / older-engine arm: no `output` field at all.
+        view.apply(&demo::bare_event(EventKind::TaskCompleted, 20).with_field(task("bare")));
+        // A cache hit rehydrates its output onto the row too (ADR-099).
+        view.apply(
+            &demo::bare_event(EventKind::TaskCacheHit, 30)
+                .with_field(task("cached"))
+                .with_field(KeyValue::new("output", Value::String("\"hi\"".to_owned()))),
+        );
+        assert_eq!(
+            view.rows()[0].output_json.as_deref(),
+            Some(r#"{"total":9}"#)
+        );
+        assert_eq!(view.rows()[0].tokens, Some(90));
+        assert_eq!(view.rows()[1].output_json, None, "no field → None");
+        assert_eq!(view.rows()[1].tokens, None);
+        assert_eq!(view.rows()[2].output_json.as_deref(), Some("\"hi\""));
     }
 
     /// The retry counter folds every `task_retrying` frame (feeds the

--- a/crates/nika-cli/src/display/theme.rs
+++ b/crates/nika-cli/src/display/theme.rs
@@ -78,14 +78,17 @@ impl Theme {
             return self.paint(Role::Accent, &format!("{frame} "));
         }
         let raw = if self.ascii {
-            // The LOCKED §3.1 ASCII column (err `X` ≠ cancelled `x`).
+            // The §3.1 ASCII column (err `X` ≠ blocked `x`). The
+            // comprehension pass re-voiced the never-ran pair: a SKIP
+            // (a decision — gate false · cache hit) reads `~>` (flows
+            // past), a BLOCKED cancellation reads `x` (the path died).
             match state {
                 TaskState::Pending => ". ",
                 TaskState::Running => "> ",
                 TaskState::Ok => "ok",
                 TaskState::Failed => "X ",
                 TaskState::Retrying => "r ",
-                TaskState::Skipped => "- ",
+                TaskState::Skipped => "~>",
                 TaskState::Cancelled => "x ",
             }
         } else {
@@ -95,8 +98,8 @@ impl Theme {
                 TaskState::Ok => "✔ ",
                 TaskState::Failed => "✖ ",
                 TaskState::Retrying => "↻ ",
-                TaskState::Skipped => "⊘ ",
-                TaskState::Cancelled => "◼ ",
+                TaskState::Skipped => "↷ ",
+                TaskState::Cancelled => "⊘ ",
             }
         };
         let role = match state {
@@ -174,11 +177,15 @@ mod tests {
 
     #[test]
     fn locked_contract_glyphs_for_the_new_states() {
-        // §3.1 LOCKED table · retrying ↻/r yellow · cancelled ◼/x dim ·
-        // err `X` ≠ cancelled `x` (the case IS the distinction).
+        // §3.1 table (comprehension-pass vocabulary) · retrying ↻/r
+        // yellow · skip ↷/~> dim (a decision: gate false · cache hit) ·
+        // blocked-cancelled ⊘/x dim · err `X` ≠ blocked `x` (the case
+        // IS the distinction).
         assert_eq!(PLAIN.glyph(TaskState::Retrying, 0), "↻ ");
         assert_eq!(ASCII.glyph(TaskState::Retrying, 0), "r ");
-        assert_eq!(PLAIN.glyph(TaskState::Cancelled, 0), "◼ ");
+        assert_eq!(PLAIN.glyph(TaskState::Skipped, 0), "↷ ");
+        assert_eq!(ASCII.glyph(TaskState::Skipped, 0), "~>");
+        assert_eq!(PLAIN.glyph(TaskState::Cancelled, 0), "⊘ ");
         assert_eq!(ASCII.glyph(TaskState::Cancelled, 0), "x ");
         assert_ne!(
             ASCII.glyph(TaskState::Failed, 0),

--- a/crates/nika-cli/src/display/vocab.rs
+++ b/crates/nika-cli/src/display/vocab.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ONE glyph + hint vocabulary every comprehension surface speaks.
+//!
+//! One arrow, one hint form (`label: command`), one ASCII-parity seam —
+//! the storyboard tail, the trace readers, the failure card and the
+//! verb epilogues all pull from here, so the registers can never drift
+//! apart glyph-by-glyph.
+
+use crate::display::theme::{Role, Theme};
+
+/// The data arrow (`→` · `->` under `--ascii`) — output tails, flow
+/// edges, outputs pointers.
+#[must_use]
+pub(crate) fn arrow(ascii: bool) -> &'static str {
+    if ascii { "->" } else { "→" }
+}
+
+/// The comparison mark for "at least" (`≥` · `>=` under `--ascii`) —
+/// the audited card's cost floor.
+#[must_use]
+pub(crate) fn at_least(ascii: bool) -> &'static str {
+    if ascii { ">=" } else { "≥" }
+}
+
+/// One actionable hint: `label: command` — painted dim as a unit. The
+/// caller owns indentation; the FORM is the vocabulary (`fix: nika
+/// explain NIKA-431` · `re-baseline: nika test wf.yaml --update` ·
+/// `explore: nika trace outputs run.ndjson`).
+#[must_use]
+pub(crate) fn hint(theme: Theme, label: &str, command: &str) -> String {
+    theme.paint(Role::Dim, &format!("{label}: {command}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PLAIN: Theme = Theme {
+        color: false,
+        ascii: false,
+        animate: false,
+    };
+
+    /// Every vocabulary glyph carries its ASCII twin — the parity law.
+    #[test]
+    fn glyphs_have_ascii_parity() {
+        assert_eq!(arrow(false), "→");
+        assert_eq!(arrow(true), "->");
+        assert_eq!(at_least(false), "≥");
+        assert_eq!(at_least(true), ">=");
+    }
+
+    /// The hint form is fixed: `label: command`, dim as one unit.
+    #[test]
+    fn hint_form_is_label_colon_command() {
+        assert_eq!(
+            hint(PLAIN, "explore", "nika trace outputs run.ndjson"),
+            "explore: nika trace outputs run.ndjson"
+        );
+        let coloured = Theme {
+            color: true,
+            ..PLAIN
+        };
+        let painted = hint(coloured, "fix", "nika explain NIKA-431");
+        assert!(
+            painted.starts_with("\x1b[2m") && painted.ends_with("\x1b[0m"),
+            "one dim unit: {painted:?}"
+        );
+    }
+}

--- a/crates/nika-cli/src/lib.rs
+++ b/crates/nika-cli/src/lib.rs
@@ -22,6 +22,6 @@ pub mod demo;
 pub mod display;
 pub mod verbs;
 
-pub use display::render::{frame, verdict_frame};
+pub use display::render::{frame, frame_with_outputs, verdict_frame};
 pub use display::state::{RunView, TaskRow, TaskState};
 pub use display::theme::{Role, Theme};

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -222,6 +222,18 @@ enum TraceAction {
     Replay(TraceArgs),
     /// Print the final card only.
     Show(TraceArgs),
+    /// Browse per-task outputs: verb · duration · tokens · bounded
+    /// preview (full value: `trace peek`).
+    Outputs {
+        /// Trace NDJSON path (one `nika-event` Event per line).
+        trace: PathBuf,
+        /// Force the ASCII glyph theme.
+        #[arg(long)]
+        ascii: bool,
+        /// Disable colour output.
+        #[arg(long)]
+        no_color: bool,
+    },
 }
 
 #[derive(Args)]
@@ -382,6 +394,14 @@ fn main() -> std::process::ExitCode {
         Command::Trace { action } => match action {
             TraceAction::Replay(args) => trace_render(&args, true),
             TraceAction::Show(args) => trace_render(&args, false),
+            TraceAction::Outputs {
+                trace,
+                ascii,
+                no_color,
+            } => emit(&verbs::trace::outputs(
+                &trace.to_string_lossy(),
+                term_theme(no_color, ascii),
+            )),
         },
         // The language server OWNS stdout (JSON-RPC) — it must not go through
         // `emit`. It follows the LSP exit-code convention: 0 on a clean

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -225,7 +225,7 @@ enum TraceAction {
 }
 
 #[derive(Args)]
-// Five independent CLI flags ARE five bools — the clap-surface idiom
+// Six independent CLI flags ARE six bools — the clap-surface idiom
 // (same as TraceArgs), not a state machine to encode.
 #[allow(clippy::struct_excessive_bools)]
 struct RunArgs {
@@ -290,10 +290,15 @@ struct RunArgs {
     /// value parses as JSON when it parses, else rides as a string.
     #[arg(long = "answer", value_name = "TASK=VALUE", requires = "resume")]
     answer: Vec<String>,
+    /// Hide the per-task output summaries (`→ {…} · 312B`) on the live
+    /// storyboard. Interactive TTY only — pipes · CI · the machine modes
+    /// never carry them anyway.
+    #[arg(long)]
+    no_outputs: bool,
 }
 
 #[derive(Args)]
-// Four independent CLI flags ARE four bools — the clap-surface idiom, not
+// Five independent CLI flags ARE five bools — the clap-surface idiom, not
 // a state machine to encode.
 #[allow(clippy::struct_excessive_bools)]
 struct TraceArgs {
@@ -314,6 +319,11 @@ struct TraceArgs {
     /// Disable colour output.
     #[arg(long)]
     no_color: bool,
+    /// Hide the per-task output summaries (`→ {…} · 312B`) on the
+    /// rendered storyboard. Interactive TTY only — a piped `trace show`
+    /// never carries them anyway.
+    #[arg(long)]
+    no_outputs: bool,
 }
 
 fn main() -> std::process::ExitCode {
@@ -428,6 +438,7 @@ fn run_verb(args: &RunArgs) -> u8 {
         args.model.as_deref(),
         &args.var,
         resume.as_ref(),
+        args.no_outputs,
     )
 }
 
@@ -473,14 +484,23 @@ fn trace_render(args: &TraceArgs, replay: bool) -> u8 {
         animate: tty && replay && !env_flag("NIKA_REDUCED_MOTION"),
     };
 
+    // The shape tails ride the interactive surface only: a TTY render
+    // (show OR replay) carries them unless `--no-outputs`; a piped
+    // `trace show` keeps its exact legacy bytes.
+    let outputs = tty && !args.no_outputs;
     let mut view = RunView::new();
     if theme.animate {
-        live_replay(&events, &mut view, theme, args.speed);
+        live_replay(&events, &mut view, theme, args.speed, outputs);
     } else {
         for event in &events {
             view.apply(event);
         }
-        print_lines(&frame(&view, &theme, 0));
+        let lines = if outputs {
+            nika_cli::frame_with_outputs(&view, &theme, 0)
+        } else {
+            frame(&view, &theme, 0)
+        };
+        print_lines(&lines);
     }
     // The trace surface owns the run overlays (replay = re-render, never
     // re-execute): the waterfall + the verdict card close the read, from
@@ -493,7 +513,7 @@ fn trace_render(args: &TraceArgs, replay: bool) -> u8 {
 
 /// Replay with compressed timing: spinner ticks between events, frames
 /// redrawn in place (cursor-up + clear).
-fn live_replay(events: &[Event], view: &mut RunView, theme: Theme, speed: f64) {
+fn live_replay(events: &[Event], view: &mut RunView, theme: Theme, speed: f64, outputs: bool) {
     let mut drawn = 0usize;
     let mut tick = 0usize;
     let mut last_ms = events.first().map_or(0, |e| e.timestamp.unix_ms());
@@ -508,19 +528,23 @@ fn live_replay(events: &[Event], view: &mut RunView, theme: Theme, speed: f64) {
         // display pacing only — precision is irrelevant at 80ms granularity
         let steps = ((gap_ms as f64 / speed.max(0.1) / 80.0).ceil() as u64).clamp(1, 50);
         for _ in 0..steps {
-            drawn = redraw(view, theme, tick, drawn);
+            drawn = redraw(view, theme, tick, drawn, outputs);
             tick += 1;
             std::thread::sleep(Duration::from_millis(80));
         }
         last_ms = ts;
         view.apply(event);
-        drawn = redraw(view, theme, tick, drawn);
+        drawn = redraw(view, theme, tick, drawn, outputs);
     }
 }
 
 /// Draw one frame in place; returns the line count for the next clear.
-fn redraw(view: &RunView, theme: Theme, tick: usize, drawn: usize) -> usize {
-    let lines = frame(view, &theme, tick);
+fn redraw(view: &RunView, theme: Theme, tick: usize, drawn: usize, outputs: bool) -> usize {
+    let lines = if outputs {
+        nika_cli::frame_with_outputs(view, &theme, tick)
+    } else {
+        frame(view, &theme, tick)
+    };
     let mut out = std::io::stdout().lock();
     if drawn > 0 {
         // Cursor up over the previous frame, then clear to end of screen.

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -234,6 +234,23 @@ enum TraceAction {
         #[arg(long)]
         no_color: bool,
     },
+    /// Read ONE task's full output + its identity (hashes · duration ·
+    /// tokens). `--raw` prints the exact value only (pipe it to jq).
+    Peek {
+        /// Trace NDJSON path (one `nika-event` Event per line).
+        trace: PathBuf,
+        /// The task id whose output to read.
+        task: String,
+        /// Print the exact recorded value only (machine-friendly).
+        #[arg(long)]
+        raw: bool,
+        /// Force the ASCII glyph theme.
+        #[arg(long)]
+        ascii: bool,
+        /// Disable colour output.
+        #[arg(long)]
+        no_color: bool,
+    },
 }
 
 #[derive(Args)]
@@ -400,6 +417,18 @@ fn main() -> std::process::ExitCode {
                 no_color,
             } => emit(&verbs::trace::outputs(
                 &trace.to_string_lossy(),
+                term_theme(no_color, ascii),
+            )),
+            TraceAction::Peek {
+                trace,
+                task,
+                raw,
+                ascii,
+                no_color,
+            } => emit(&verbs::trace::peek(
+                &trace.to_string_lossy(),
+                &task,
+                raw,
                 term_theme(no_color, ascii),
             )),
         },

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -251,6 +251,22 @@ enum TraceAction {
         #[arg(long)]
         no_color: bool,
     },
+    /// The data waterfall: which output fed which task, with recorded
+    /// sizes (plan bindings from the workflow file × sizes from the
+    /// trace).
+    Flow {
+        /// Trace NDJSON path (one `nika-event` Event per line).
+        trace: PathBuf,
+        /// The workflow file the run executed (`*.nika.yaml`) — the
+        /// trace records values, the definition records the bindings.
+        workflow: String,
+        /// Force the ASCII glyph theme.
+        #[arg(long)]
+        ascii: bool,
+        /// Disable colour output.
+        #[arg(long)]
+        no_color: bool,
+    },
 }
 
 #[derive(Args)]
@@ -408,30 +424,7 @@ fn main() -> std::process::ExitCode {
             clap_complete::generate(shell, &mut cmd, "nika-cli", &mut std::io::stdout());
             0
         }
-        Command::Trace { action } => match action {
-            TraceAction::Replay(args) => trace_render(&args, true),
-            TraceAction::Show(args) => trace_render(&args, false),
-            TraceAction::Outputs {
-                trace,
-                ascii,
-                no_color,
-            } => emit(&verbs::trace::outputs(
-                &trace.to_string_lossy(),
-                term_theme(no_color, ascii),
-            )),
-            TraceAction::Peek {
-                trace,
-                task,
-                raw,
-                ascii,
-                no_color,
-            } => emit(&verbs::trace::peek(
-                &trace.to_string_lossy(),
-                &task,
-                raw,
-                term_theme(no_color, ascii),
-            )),
-        },
+        Command::Trace { action } => trace_verb(action),
         // The language server OWNS stdout (JSON-RPC) — it must not go through
         // `emit`. It follows the LSP exit-code convention: 0 on a clean
         // shutdown/exit, non-zero (1) otherwise (transport failure, or an
@@ -468,6 +461,45 @@ fn emit(out: &VerbOutput) -> u8 {
         println!("{}", out.text.trim_end());
     }
     out.code
+}
+
+/// Dispatch the `trace` verb family: the live renders (replay · show)
+/// plus the static readers (outputs · peek · flow).
+fn trace_verb(action: TraceAction) -> u8 {
+    match action {
+        TraceAction::Replay(args) => trace_render(&args, true),
+        TraceAction::Show(args) => trace_render(&args, false),
+        TraceAction::Outputs {
+            trace,
+            ascii,
+            no_color,
+        } => emit(&verbs::trace::outputs(
+            &trace.to_string_lossy(),
+            term_theme(no_color, ascii),
+        )),
+        TraceAction::Peek {
+            trace,
+            task,
+            raw,
+            ascii,
+            no_color,
+        } => emit(&verbs::trace::peek(
+            &trace.to_string_lossy(),
+            &task,
+            raw,
+            term_theme(no_color, ascii),
+        )),
+        TraceAction::Flow {
+            trace,
+            workflow,
+            ascii,
+            no_color,
+        } => emit(&verbs::trace::flow(
+            &trace.to_string_lossy(),
+            &workflow,
+            term_theme(no_color, ascii),
+        )),
+    }
 }
 
 /// Unpack the `run` clap surface into the library verb call.

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -211,6 +211,7 @@ fn arg_rows(report: &CheckReport) -> Vec<String> {
 
 /// Advisory hints + the one-line verdict (the report's last words).
 fn hints_and_verdict(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
+    let mut hint_count = report.hints.len();
     for h in &report.hints {
         let _ = writeln!(
             out,
@@ -223,6 +224,7 @@ fn hints_and_verdict(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t
     }
     let inputs = required_inputs(wf);
     if !inputs.is_empty() {
+        hint_count += 1;
         let pass = inputs
             .iter()
             .map(|n| format!("--var {n}=…"))
@@ -237,17 +239,34 @@ fn hints_and_verdict(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t
         );
     }
     if report.is_clean() {
-        let _ = writeln!(
-            out,
-            " {}",
-            t.paint(
-                Role::Good,
-                "✔ clean — audited before a single token was spent"
-            )
-        );
+        let _ = writeln!(out, " {}", audited_line(report, wf, hint_count, t));
     } else {
         let _ = writeln!(out, " {}", t.paint(Role::Bad, "✖ findings above"));
     }
+}
+
+/// The clean verdict as ONE informative card line — what was proven,
+/// at a glance: `✔ audited · N tasks · M waves · permits <state> ·
+/// est ≥$X · K hints`. The hints themselves stay above; this line
+/// counts them so a scroll-past never misses advice silently.
+fn audited_line(report: &CheckReport, wf: &RawWorkflow, hints: usize, t: Theme) -> String {
+    let tasks: usize = report.waves.iter().map(Vec::len).sum();
+    let permits = if wf.permits.is_some() {
+        "declared"
+    } else {
+        "none"
+    };
+    let floor = crate::display::vocab::at_least(t.ascii);
+    let hint_word = if hints == 1 { "hint" } else { "hints" };
+    let mark = if t.ascii { "ok" } else { "✔" };
+    t.paint(
+        Role::Good,
+        &format!(
+            "{mark} audited · {tasks} task(s) · {} wave(s) · permits {permits} · est {floor}${:.4} · {hints} {hint_word}",
+            report.waves.len(),
+            report.cost.min_path_total_usd,
+        ),
+    )
 }
 
 /// A finding section: one OK line when empty, one row per finding else.
@@ -553,6 +572,35 @@ mod tests {
         assert!(
             !text.contains("xyzzy"),
             "mark never emits a placeholder: {text}"
+        );
+    }
+
+    /// The clean verdict is the audited CARD line: tasks · waves ·
+    /// permits state · the cost floor · the hint count — with full
+    /// ASCII parity (`ok audited` · `>=`).
+    #[test]
+    fn clean_verdict_is_the_audited_card_line() {
+        let yaml = "nika: v1\nworkflow: card\nmodel: mock/echo\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo bye\" }\n";
+        let text = checked_text("audited-card.nika.yaml", yaml, false);
+        assert!(
+            text.contains(
+                "✔ audited · 2 task(s) · 2 wave(s) · permits none · est ≥$0.0000 · 1 hint"
+            ),
+            "the audited card line: {text}"
+        );
+        let ascii = checked_text("audited-card-ascii.nika.yaml", yaml, true);
+        assert!(
+            ascii.contains("ok audited") && ascii.contains("est >=$0.0000"),
+            "ascii parity (ok · >=): {ascii}"
+        );
+        assert!(
+            !ascii.contains('≥'),
+            "no unicode leaks into --ascii: {ascii}"
+        );
+        // Hint pluralization: 1 hint here (the permits advisory).
+        assert!(
+            text.contains("1 hint") && !text.contains("1 hints"),
+            "{text}"
         );
     }
 

--- a/crates/nika-cli/src/verbs/doctor.rs
+++ b/crates/nika-cli/src/verbs/doctor.rs
@@ -230,9 +230,15 @@ pub(crate) fn exit_code(findings: &[Finding]) -> u8 {
 }
 
 /// Render findings as the `nika doctor` report (spec §8 layout · glyph · label
-/// padded · detail · an indented `fix:` line under a problem).
+/// padded · detail · an indented `fix:` line under a problem) — opened by the
+/// ONE verdict line (`✔ 6 ok · 4 warn · 0 fail`) so the state of the
+/// environment reads before the sections do. Sections stay unchanged.
 pub(crate) fn render(findings: &[Finding]) -> String {
     let mut s = String::new();
+    let count = |level: Level| findings.iter().filter(|f| f.level == level).count();
+    let (ok, warn, fail) = (count(Level::Ok), count(Level::Warn), count(Level::Fail));
+    let verdict = if fail > 0 { Level::Fail } else { Level::Ok };
+    let _ = writeln!(s, "{} {ok} ok · {warn} warn · {fail} fail", verdict.glyph());
     for f in findings {
         let _ = writeln!(s, "{} {:<10} {}", f.level.glyph(), f.label, f.detail);
         if let Some(fix) = &f.fix {
@@ -595,6 +601,41 @@ mod tests {
         assert_eq!(out.code, exit::OK, "the catalog always offers a path");
         assert!(out.text.contains("binary"), "renders the binary line");
         assert!(!out.text.contains("mock"), "the test backend is hidden");
+    }
+
+    /// The report opens on the ONE verdict line — level counts first,
+    /// sections unchanged below. The glyph tracks the WORST level (✔
+    /// with warns · ✖ only on a fail).
+    #[test]
+    fn render_opens_with_the_verdict_count_line() {
+        let ok = Finding {
+            level: Level::Ok,
+            label: "binary".to_owned(),
+            detail: "v0 · self-contained".to_owned(),
+            fix: None,
+        };
+        let warn = Finding {
+            level: Level::Warn,
+            label: "provider".to_owned(),
+            detail: "x — KEY unset".to_owned(),
+            fix: Some("export KEY=…".to_owned()),
+        };
+        let text = render(&[ok.clone(), ok.clone(), warn.clone()]);
+        let first = text.lines().next().expect("verdict line");
+        assert_eq!(first, "✔ 2 ok · 1 warn · 0 fail");
+        assert!(text.contains("binary"), "sections unchanged: {text}");
+
+        let fail = Finding {
+            level: Level::Fail,
+            label: "providers".to_owned(),
+            detail: "no path".to_owned(),
+            fix: None,
+        };
+        let red = render(&[ok, warn, fail]);
+        assert!(
+            red.starts_with("✖ 1 ok · 1 warn · 1 fail"),
+            "a fail flips the verdict glyph: {red}"
+        );
     }
 
     #[allow(clippy::disallowed_methods)]

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -20,6 +20,7 @@ pub mod new;
 pub mod pack_surface;
 pub mod run;
 pub mod test;
+pub mod trace;
 pub mod wire;
 
 use nika_schema::check::CheckReport;

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -68,8 +68,13 @@ use crate::verbs::exit;
 /// journal into a skip plan; the runtime recomputes each task's identity
 /// and skips iff BOTH hashes match (visible `task_cache_hit` · never
 /// silent). `--from <task_id>` forces a subtree to re-run.
-// Nine independent CLI parameters ARE the clap surface — the same idiom
-// as TraceArgs' four bools, not a state machine to encode in a struct.
+///
+/// `no_outputs` — `--no-outputs` (the comprehension pass): suppress the
+/// shape tails on the Live storyboard. Only the interactive TTY surface
+/// ever grows tails — pipes · CI · the machine modes stay byte-unchanged
+/// with or without the flag.
+// Ten independent CLI parameters ARE the clap surface — the same idiom
+// as TraceArgs' bools, not a state machine to encode in a struct.
 #[allow(clippy::too_many_arguments)]
 #[must_use]
 pub fn run(
@@ -82,6 +87,7 @@ pub fn run(
     model_override: Option<&str>,
     vars: &[String],
     resume: Option<&ResumeRequest>,
+    no_outputs: bool,
 ) -> u8 {
     // `--output` validated up front so an unknown format fails before any
     // work (machine-result mode · see `output_mode`).
@@ -167,6 +173,7 @@ pub fn run(
         theme,
         mode,
         resume.is_some(),
+        !no_outputs,
     ))
 }
 
@@ -308,6 +315,7 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         model_override,
         &[],
         None,
+        false,
     );
     // The example's own envelope model — what we suggest overriding when a
     // run fails offline. A parse miss leaves it empty (the tip then never
@@ -521,9 +529,10 @@ fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
 }
 
 /// Drive the runtime through the chosen sink · return the exit code.
-// The 9th parameter is the `--resume` summary switch — same clap-surface
-// idiom as `run` itself.
-#[allow(clippy::too_many_arguments)]
+// The 9th/10th parameters are the `--resume` summary switch + the
+// outputs-tail switch — same clap-surface idiom as `run` itself (four
+// independent flags ARE four bools, not a state machine).
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 async fn execute(
     runtime: &ProdRuntime,
     wf: &RawWorkflow,
@@ -533,6 +542,7 @@ async fn execute(
     theme: Theme,
     mode: RenderMode,
     resumed: bool,
+    outputs: bool,
 ) -> u8 {
     let mut stamper = SystemStamper::new();
     if output_json {
@@ -588,6 +598,12 @@ async fn execute(
     } else {
         let mut sink = FoldSink::new(std::io::stdout().lock(), theme, mode);
         sink.set_plan(plan_waves(wf, report));
+        // The shape tails ride the INTERACTIVE surface only (`Live` =
+        // TTY): the piped/`--no-progress`/`--quiet` registers keep their
+        // exact bytes — CI logs and scripts never grow tails.
+        if mode == RenderMode::Live && outputs {
+            sink.show_outputs(true);
+        }
         let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
         // `Live` painted in place during the run; `Plain`/`Quiet` folded
         // silently · print the ONE final frame now.
@@ -923,6 +939,7 @@ mod tests {
             Some("mock/echo"),
             &[],
             None,
+            false,
         );
         assert_eq!(
             code,
@@ -952,6 +969,7 @@ mod tests {
             Some("mock/echo"),
             &[],
             None,
+            false,
         );
         assert_eq!(
             overridden,
@@ -978,6 +996,7 @@ mod tests {
             None,
             vars,
             None,
+            false,
         )
     }
 

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -166,7 +166,7 @@ pub fn run(
     };
     rt.block_on(execute(
         &runtime,
-        &wf,
+        (file, &wf),
         &report,
         json,
         output_json,
@@ -529,13 +529,15 @@ fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
 }
 
 /// Drive the runtime through the chosen sink · return the exit code.
-// The 9th/10th parameters are the `--resume` summary switch + the
+// The trailing parameters are the `--resume` summary switch + the
 // outputs-tail switch — same clap-surface idiom as `run` itself (four
-// independent flags ARE four bools, not a state machine).
+// independent flags ARE four bools, not a state machine). The workflow
+// rides as (path, parsed) — the epilogue hint teaches a command over
+// the SAME file the operator just ran.
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 async fn execute(
     runtime: &ProdRuntime,
-    wf: &RawWorkflow,
+    (file, wf): (&str, &RawWorkflow),
     report: &CheckReport,
     json: bool,
     output_json: bool,
@@ -615,7 +617,7 @@ async fn execute(
         // registers (piped `Plain` · `--quiet` · machine modes) stay
         // untouched — CI logs never grow chart art.
         if mode == RenderMode::Live {
-            print_flow_epilogue(sink.view(), &outcome.outputs, theme);
+            print_flow_epilogue(sink.view(), &outcome.outputs, theme, file);
         }
         print_resume_summary(&outcome, resumed, false);
         if let Some(e) = sink.into_error() {
@@ -649,8 +651,17 @@ fn print_resume_summary(outcome: &RunOutcome, resumed: bool, to_stderr: bool) {
 
 /// The TTY final-frame epilogue: the post-run waterfall (real durations ·
 /// real overlap · pure fold of the run's own event stream) then the
-/// shareable verdict card, its outputs note naming what left the run.
-fn print_flow_epilogue(view: &crate::RunView, outputs: &BTreeMap<String, Value>, theme: Theme) {
+/// shareable verdict card, its outputs note naming what left the run —
+/// closed by the explore hint. SEAM (stated, not faked): a live run
+/// writes no trace file today, so the hint teaches the two-step that
+/// works NOW (record with `--json`, then browse); when auto-trace
+/// recording ships, this collapses to the recorded path.
+fn print_flow_epilogue(
+    view: &crate::RunView,
+    outputs: &BTreeMap<String, Value>,
+    theme: Theme,
+    file: &str,
+) {
     for line in crate::display::flow::waterfall(view, &theme) {
         println!("{line}");
     }
@@ -658,6 +669,11 @@ fn print_flow_epilogue(view: &crate::RunView, outputs: &BTreeMap<String, Value>,
     for line in crate::display::flow::verdict_card(view, &theme, note.as_deref()) {
         println!("{line}");
     }
+    let record = format!("nika run {file} --json > run.ndjson · nika trace outputs run.ndjson");
+    println!(
+        "  {}",
+        crate::display::vocab::hint(theme, "explore", &record)
+    );
 }
 
 /// The card's outputs note: `outputs → key (type) · key2 (type)` — the

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use nika_event::Event;
 use nika_runtime::EventSink;
 
-use crate::{RunView, Theme, frame, verdict_frame};
+use crate::{RunView, Theme, frame, frame_with_outputs, verdict_frame};
 
 /// How the live fold reaches the terminal (spec §3.5 reduced surfaces).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +84,10 @@ pub struct FoldSink<W: Write> {
     /// (TTY only · cursor control), `Plain`/`Quiet` fold silently and the
     /// caller prints ONE final frame (no escape noise in a captured log).
     mode: RenderMode,
+    /// Paint the shape tails (`→ {…} · 312B · 90 tok`) on completed rows.
+    /// The interactive-TTY comprehension surface — the run verb enables it
+    /// for `Live` only (pipes · CI · `--no-outputs` stay byte-unchanged).
+    outputs: bool,
     /// Lines painted by the previous frame (to clear before the redraw).
     last_lines: usize,
     error: Option<std::io::Error>,
@@ -99,9 +103,17 @@ impl<W: Write> FoldSink<W> {
             theme,
             view: RunView::new(),
             mode,
+            outputs: false,
             last_lines: 0,
             error: None,
         }
+    }
+
+    /// Enable the shape tails on completed rows (the interactive-TTY
+    /// comprehension surface). Off by default — every existing register
+    /// keeps its exact bytes until a caller opts in.
+    pub fn show_outputs(&mut self, on: bool) {
+        self.outputs = on;
     }
 
     /// The folded view (the caller renders the FINAL frame + the failure
@@ -126,6 +138,7 @@ impl<W: Write> FoldSink<W> {
         }
         let lines = match self.mode {
             RenderMode::Quiet => verdict_frame(&self.view, &self.theme),
+            _ if self.outputs => frame_with_outputs(&self.view, &self.theme, 0),
             _ => frame(&self.view, &self.theme, 0),
         };
         for line in &lines {
@@ -151,7 +164,11 @@ impl<W: Write> FoldSink<W> {
             write!(self.writer, "\x1b[{}A", self.last_lines)?;
             write!(self.writer, "\x1b[0J")?;
         }
-        let lines = frame(&self.view, &self.theme, 0);
+        let lines = if self.outputs {
+            frame_with_outputs(&self.view, &self.theme, 0)
+        } else {
+            frame(&self.view, &self.theme, 0)
+        };
         for line in &lines {
             writeln!(self.writer, "{line}")?;
         }
@@ -302,6 +319,38 @@ mod tests {
             sink.emit(ev);
         }
         assert_eq!(sink.view().verdict, Some(false));
+    }
+
+    /// The outputs knob is OPT-IN per sink: the same output-carrying
+    /// stream paints tails only after `show_outputs(true)` — the piped
+    /// (`Plain`) register stays byte-free of tails unless a caller
+    /// explicitly asks (the run verb only ever asks for `Live`).
+    #[test]
+    fn fold_sink_tails_are_opt_in() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let theme = Theme {
+            color: false,
+            ascii: true,
+            animate: false,
+        };
+        let completed = demo::bare_event(EventKind::TaskCompleted, 5)
+            .with_field(KeyValue::new("task", Value::String("audit".into())))
+            .with_field(KeyValue::new("output", Value::String("[1,2]".into())));
+        let render = |opt_in: bool| {
+            let mut buf = Vec::new();
+            let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Plain);
+            sink.show_outputs(opt_in);
+            sink.emit(completed.clone());
+            sink.print_final();
+            String::from_utf8(buf).expect("utf8")
+        };
+        assert!(!render(false).contains("->"), "default: no tails");
+        assert!(
+            render(true).contains("-> [2] · 5B"),
+            "opted in: the tail rides: {}",
+            render(true)
+        );
     }
 
     /// The repaint clears the PRIOR frame only when one exists (`last_lines >

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -107,8 +107,13 @@ pub fn run(file: &str, update: bool, theme: Theme) -> u8 {
     };
 
     if expected == actual {
+        // The match verdict says WHAT was pinned, not just that it holds:
+        // top-level output keys + the canonical document's byte size.
+        let keys = actual.as_object().map_or(0, serde_json::Map::len);
+        let bytes = crate::display::shape::fmt_bytes(canonical_json(&actual).len());
+        let key_word = if keys == 1 { "key" } else { "keys" };
         println!(
-            "{} outputs match the golden {}",
+            "{} golden match · {keys} {key_word} · {bytes} {}",
             theme.paint(Role::Good, if theme.ascii { "ok" } else { "✔" }),
             theme.paint(Role::Dim, &format!("· {golden_path}"))
         );
@@ -181,7 +186,13 @@ fn render_mismatch(
     for line in diff_lines(expected, actual) {
         let _ = writeln!(out, "  {line}");
     }
-    let _ = writeln!(out, "\n  intended? re-pin with: nika test {file} --update");
+    // The ONE hint vocabulary (`label: command`) — same form as the
+    // failure card's fix hint and the run epilogue's explore hint.
+    let _ = writeln!(
+        out,
+        "\n  intended? {}",
+        crate::display::vocab::hint(theme, "re-baseline", &format!("nika test {file} --update"))
+    );
     out
 }
 

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -371,16 +371,14 @@ fn render_flow(edges: &[FlowEdge], theme: Theme) -> String {
         .max()
         .unwrap_or(0);
     for edge in edges {
+        let arrow = crate::display::vocab::arrow(theme.ascii);
         let rail = match edge.bytes {
             Some(n) => {
                 let size = shape::fmt_bytes(n);
-                if theme.ascii {
-                    format!("-{size}->")
-                } else {
-                    format!("─{size}→")
-                }
+                let dash = if theme.ascii { "-" } else { "─" };
+                format!("{dash}{size}{arrow}")
             }
-            None => (if theme.ascii { "->" } else { "→" }).to_owned(),
+            None => arrow.to_owned(),
         };
         let _ = writeln!(
             out,
@@ -390,7 +388,7 @@ fn render_flow(edges: &[FlowEdge], theme: Theme) -> String {
             edge.to
         );
     }
-    let arrow = if theme.ascii { "->" } else { "→" };
+    let arrow = crate::display::vocab::arrow(theme.ascii);
     let join = if theme.ascii { "x" } else { "×" };
     let mut totals = format!("  {} edge(s)", edges.len());
     if let Some(widest) = edges

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The static trace readers — `nika trace outputs` (per-task browser)
-//! + `nika trace peek` (full fidelity).
+//! The static trace readers — `nika trace outputs` (per-task browser) ·
+//! `nika trace peek` (full fidelity) · `nika trace flow` (the data
+//! waterfall: which output fed which task, with real sizes).
 //!
 //! Pure reads over a recorded NDJSON trace: load (the SAME tolerant
 //! recovery `--resume` and `trace show` fold through) → fold into the
 //! ONE [`RunView`] truth → render. Three densities, one source: the
 //! storyboard shows SHAPE tails, the table shows bounded previews,
-//! `peek` shows the whole value + its ADR-099 identity.
+//! `peek` shows the whole value + its ADR-099 identity. `flow` joins
+//! the plan (the checked definition's bindings) with the trace (the
+//! recorded sizes) — a fold over two existing truths, zero new
+//! analysis.
 
 use std::fmt::Write as _;
 
@@ -238,6 +242,169 @@ fn clip_hash(hash: &str, theme: Theme) -> String {
     format!("{head}{}", if theme.ascii { ".." } else { "…" })
 }
 
+/// One data edge: `from` fed `to` — `bytes` is the SOURCE task's
+/// recorded output size when the trace carries it (the honest measure
+/// of what flowed; a consumer may read a subpath of it).
+struct FlowEdge {
+    from: String,
+    to: String,
+    bytes: Option<usize>,
+}
+
+/// `nika trace flow <trace> <workflow>` — the data waterfall: edges
+/// from the checked definition's bindings (`depends_on` + `${{ tasks.X
+/// }}` references · the SAME over-collecting scan `--resume --from`
+/// walks) × output sizes from the trace, plus the `outputs.<name>`
+/// terminal edges. The time-waterfall shows WHEN; this shows WHY.
+#[must_use]
+pub fn flow(trace: &str, workflow: &str, theme: Theme) -> VerbOutput {
+    let view = match load_view(trace) {
+        Ok(view) => view,
+        Err(out) => return out,
+    };
+    let (wf, _report) = match super::load_checked(workflow) {
+        Ok(pair) => pair,
+        Err(out) => return out,
+    };
+    let mut out = String::new();
+    // Honesty header when the two inputs disagree on the workflow name.
+    let declared = wf.workflow.as_ref().map(|w| w.value.as_str());
+    if let Some(name) = declared
+        && !view.workflow.is_empty()
+        && view.workflow != name
+    {
+        let note = format!(
+            "note: the trace records workflow `{}` · {workflow} declares `{name}`",
+            view.workflow
+        );
+        let _ = writeln!(out, "  {}", theme.paint(Role::Warn, &note));
+    }
+    out.push_str(&render_flow(&flow_edges(&wf, &view), theme));
+    VerbOutput::ok(out)
+}
+
+/// Join plan bindings × trace sizes into the edge list (task edges in
+/// definition order, then the `outputs.<name>` terminal edges).
+fn flow_edges(wf: &nika_schema::raw::RawWorkflow, view: &RunView) -> Vec<FlowEdge> {
+    let ids: Vec<&str> = wf.tasks.iter().map(|t| t.value.id.value.as_str()).collect();
+    let size_of = |task: &str| -> Option<usize> {
+        view.rows()
+            .iter()
+            .find(|r| r.id == task)
+            .and_then(|r| r.output_json.as_deref())
+            .map(str::len)
+    };
+    let mut edges = Vec::new();
+    for task in &wf.tasks {
+        let to = task.value.id.value.as_str();
+        for from in nika_runtime::resume::referenced_upstreams(&task.value) {
+            // The scan over-collects by design — keep only edges from a
+            // REAL sibling task (never self).
+            if from != to && ids.contains(&from.as_str()) {
+                edges.push(FlowEdge {
+                    bytes: size_of(&from),
+                    from,
+                    to: to.to_owned(),
+                });
+            }
+        }
+    }
+    for (key, decl) in &wf.outputs {
+        let template = match decl {
+            nika_schema::types::OutputDecl::Untyped(v) => &v.value,
+            nika_schema::types::OutputDecl::Typed { value, .. } => &value.value,
+            // #[non_exhaustive] future forms carry no v0 template.
+            _ => continue,
+        };
+        let mut refs = std::collections::BTreeSet::new();
+        scan_task_refs(template, &mut refs);
+        for from in refs {
+            if ids.contains(&from.as_str()) {
+                edges.push(FlowEdge {
+                    bytes: size_of(&from),
+                    from,
+                    to: format!("outputs.{}", key.value),
+                });
+            }
+        }
+    }
+    edges
+}
+
+/// Collect every `tasks.<snake_case_id>` token — the SAME boundary scan
+/// the runtime's `referenced_upstreams` applies to task definitions
+/// (task ids are checker-enforced `snake_case`; over-collection is
+/// safe, the caller filters to real task ids).
+fn scan_task_refs(text: &str, out: &mut std::collections::BTreeSet<String>) {
+    let mut rest = text;
+    while let Some(at) = rest.find("tasks.") {
+        let after = &rest[at + "tasks.".len()..];
+        let end = after
+            .find(|c: char| !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'))
+            .unwrap_or(after.len());
+        if end > 0 {
+            out.insert(after[..end].to_owned());
+        }
+        rest = &after[end..];
+    }
+}
+
+/// Render the waterfall: one `from ─size→ to` line per edge (a source
+/// the trace never sized keeps the bare arrow — never an invented
+/// number), then the totals line naming the widest edge.
+fn render_flow(edges: &[FlowEdge], theme: Theme) -> String {
+    let mut out = String::new();
+    if edges.is_empty() {
+        let _ = writeln!(
+            out,
+            "  {}",
+            theme.paint(
+                Role::Dim,
+                "no data edges — no task references another task's output"
+            )
+        );
+        return out;
+    }
+    let from_w = edges
+        .iter()
+        .map(|e| e.from.chars().count())
+        .max()
+        .unwrap_or(0);
+    for edge in edges {
+        let rail = match edge.bytes {
+            Some(n) => {
+                let size = shape::fmt_bytes(n);
+                if theme.ascii {
+                    format!("-{size}->")
+                } else {
+                    format!("─{size}→")
+                }
+            }
+            None => (if theme.ascii { "->" } else { "→" }).to_owned(),
+        };
+        let _ = writeln!(
+            out,
+            "  {:<from_w$} {} {}",
+            edge.from,
+            theme.paint(Role::Dim, &rail),
+            edge.to
+        );
+    }
+    let arrow = if theme.ascii { "->" } else { "→" };
+    let join = if theme.ascii { "x" } else { "×" };
+    let mut totals = format!("  {} edge(s)", edges.len());
+    if let Some(widest) = edges
+        .iter()
+        .filter(|e| e.bytes.is_some())
+        .max_by_key(|e| e.bytes)
+    {
+        let _ = write!(totals, " · widest: {}{arrow}{}", widest.from, widest.to);
+    }
+    let _ = write!(totals, " · derived from plan bindings {join} trace sizes");
+    let _ = writeln!(out, "{}", theme.paint(Role::Dim, &totals));
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -428,6 +595,128 @@ mod tests {
         let out = peek(&path.to_string_lossy(), "audit", true, plain());
         assert_eq!(out.code, exit::OK);
         assert_eq!(out.text, r#"{"fixes":["a"],"total":9}"#);
+    }
+
+    /// Stage a workflow file whose bindings draw the mockup DAG:
+    /// `read_payload` → `audit` → `outputs.geo_score`.
+    fn flow_workflow(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join("nika-cli-trace-verb");
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let path = dir.join(name);
+        std::fs::write(
+            &path,
+            "nika: v1\nworkflow: geo-audit\nmodel: mock/echo\ntasks:\n  - id: read_payload\n    invoke: { tool: \"nika:read\", args: { path: \"x.json\" } }\n  - id: audit\n    depends_on: [read_payload]\n    infer: { prompt: \"score ${{ tasks.read_payload.output }}\" }\noutputs:\n  geo_score: ${{ tasks.audit.output }}\n",
+        )
+        .expect("workflow staged");
+        path
+    }
+
+    /// A trace with recorded outputs for both tasks (real sizes).
+    fn flow_trace(name: &str) -> std::path::PathBuf {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let s = |k: &str, v: &str| KeyValue::new(k, Value::String(v.to_owned()));
+        let events = vec![
+            demo::bare_event(EventKind::WorkflowStarted, 0).with_field(s("workflow", "geo-audit")),
+            demo::bare_event(EventKind::TaskCompleted, 10)
+                .with_field(s("task", "read_payload"))
+                .with_field(s("output", &format!("\"{}\"", "p".repeat(3598)))),
+            demo::bare_event(EventKind::TaskCompleted, 40)
+                .with_field(s("task", "audit"))
+                .with_field(s("output", r#"{"total":9}"#)),
+        ];
+        stage(name, &events)
+    }
+
+    /// The waterfall: plan-binding edges × trace sizes + the
+    /// outputs.<name> terminal edge + the totals line naming the widest.
+    #[test]
+    fn flow_joins_plan_edges_with_trace_sizes() {
+        let wf = flow_workflow("flow.nika.yaml");
+        let tr = flow_trace("flow.ndjson");
+        let out = flow(&tr.to_string_lossy(), &wf.to_string_lossy(), plain());
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        let text = &out.text;
+        assert!(
+            text.contains("read_payload ─3.6KB→ audit"),
+            "sized task edge: {text}"
+        );
+        assert!(
+            text.contains("audit        ─11B→ outputs.geo_score"),
+            "terminal outputs edge (aligned): {text}"
+        );
+        assert!(
+            text.contains("2 edge(s) · widest: read_payload→audit"),
+            "totals + widest: {text}"
+        );
+        assert!(
+            text.contains("derived from plan bindings × trace sizes"),
+            "honesty label: {text}"
+        );
+        // No mismatch note when the names agree.
+        assert!(!text.contains("note:"), "{text}");
+
+        // ASCII parity — rails, arrows and the join glyph all degrade.
+        let ascii = flow(
+            &tr.to_string_lossy(),
+            &wf.to_string_lossy(),
+            Theme {
+                color: false,
+                ascii: true,
+                animate: false,
+            },
+        );
+        assert!(
+            ascii.text.contains("read_payload -3.6KB-> audit"),
+            "{}",
+            ascii.text
+        );
+        assert!(
+            ascii.text.contains("plan bindings x trace sizes"),
+            "{}",
+            ascii.text
+        );
+        for glyph in ['─', '→', '×'] {
+            assert!(
+                !ascii.text.contains(glyph),
+                "unicode {glyph} leaked into --ascii: {}",
+                ascii.text
+            );
+        }
+    }
+
+    /// A trace from an older engine (no output fields): the STRUCTURE
+    /// still renders (bare arrows · never an invented size), and a
+    /// name mismatch between trace and file says so.
+    #[test]
+    fn flow_degrades_honestly_without_sizes_and_flags_mismatch() {
+        use nika_types::resource::{KeyValue, Value};
+        let wf = flow_workflow("flow-bare.nika.yaml");
+        let events = vec![
+            demo::bare_event(nika_event::EventKind::WorkflowStarted, 0)
+                .with_field(KeyValue::new("workflow", Value::String("other-run".into()))),
+            demo::bare_event(nika_event::EventKind::TaskCompleted, 10)
+                .with_field(KeyValue::new("task", Value::String("read_payload".into()))),
+        ];
+        let tr = stage("flow-bare.ndjson", &events);
+        let out = flow(&tr.to_string_lossy(), &wf.to_string_lossy(), plain());
+        assert_eq!(out.code, exit::OK);
+        assert!(
+            out.text.contains("read_payload → audit"),
+            "structure without sizes: {}",
+            out.text
+        );
+        assert!(
+            out.text
+                .contains("note: the trace records workflow `other-run`"),
+            "mismatch surfaces: {}",
+            out.text
+        );
+        assert!(
+            !out.text.contains("widest"),
+            "no sized edge → no widest claim: {}",
+            out.text
+        );
     }
 
     /// Errors teach: an unknown task lists what the trace records; a

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The static trace readers — `nika trace outputs` (per-task browser).
+//!
+//! Pure reads over a recorded NDJSON trace: load (the SAME tolerant
+//! recovery `--resume` and `trace show` fold through) → fold into the
+//! ONE [`RunView`] truth → render. Three densities, one source: the
+//! storyboard shows SHAPE tails, this table shows bounded previews,
+//! `trace peek` shows full fidelity.
+
+use std::fmt::Write as _;
+
+use crate::display::flow::fmt_wall_ms;
+use crate::display::shape;
+use crate::display::theme::{Role, Theme};
+use crate::{RunView, TaskRow};
+
+use super::VerbOutput;
+
+/// Widest the output-preview column grows (display cells) — the table
+/// has more room than a storyboard row, less than a pager.
+const PREVIEW_CELLS: usize = 36;
+
+/// `nika trace outputs <trace>` — one row per task: verb · duration ·
+/// tokens · bounded output preview, then the totals line + the peek
+/// hint. The browsing density between the storyboard tail and `peek`.
+#[must_use]
+pub fn outputs(trace: &str, theme: Theme) -> VerbOutput {
+    let view = match load_view(trace) {
+        Ok(view) => view,
+        Err(out) => return out,
+    };
+    VerbOutput::ok(render_outputs(&view, trace, theme))
+}
+
+/// Load + tolerantly parse + fold one trace file (the shared entry of
+/// every static trace reader).
+pub(crate) fn load_view(trace: &str) -> Result<RunView, VerbOutput> {
+    let raw = std::fs::read_to_string(trace)
+        .map_err(|e| VerbOutput::env(format!("cannot read {trace}: {e}")))?;
+    let recovered = super::run::recover_events(&raw, trace).map_err(VerbOutput::env)?;
+    let mut view = RunView::new();
+    for event in &recovered.events {
+        view.apply(event);
+    }
+    Ok(view)
+}
+
+/// The em-dash cell for "no data" — `-` under `--ascii`.
+fn dash(theme: Theme) -> &'static str {
+    if theme.ascii { "-" } else { "—" }
+}
+
+/// One task's preview cell: the bounded shape + its byte size, or the
+/// no-data dash (a skip · a failure · an older engine's trace).
+fn preview_cell(row: &TaskRow, theme: Theme) -> String {
+    match row.output_json.as_deref() {
+        Some(text) => match shape::summarize(text, PREVIEW_CELLS) {
+            Some(s) => format!("{s} · {}", shape::fmt_bytes(text.len())),
+            None => dash(theme).to_owned(),
+        },
+        None => dash(theme).to_owned(),
+    }
+}
+
+/// Render the per-task table + totals + the peek hint.
+fn render_outputs(view: &RunView, trace: &str, theme: Theme) -> String {
+    let rows = view.rows();
+    let cells: Vec<[String; 4]> = rows
+        .iter()
+        .map(|r| {
+            [
+                r.id.clone(),
+                r.started_note
+                    .clone()
+                    .unwrap_or_else(|| dash(theme).to_owned()),
+                r.wall_ms().map(fmt_wall_ms).unwrap_or_default(),
+                r.tokens
+                    .map_or_else(|| dash(theme).to_owned(), |t| t.to_string()),
+            ]
+        })
+        .collect();
+    let header = ["task", "verb", "dur", "tok"];
+    let width = |i: usize| {
+        cells
+            .iter()
+            .map(|c| c[i].chars().count())
+            .chain(std::iter::once(header[i].len()))
+            .max()
+            .unwrap_or(0)
+    };
+    let (w0, w1, w2, w3) = (width(0), width(1), width(2), width(3));
+
+    let mut out = String::new();
+    let head = format!(
+        "  {:<w0$}  {:<w1$}  {:>w2$}  {:>w3$}  output",
+        header[0], header[1], header[2], header[3],
+    );
+    let _ = writeln!(out, "{}", theme.paint(Role::Dim, &head));
+    for (row, c) in rows.iter().zip(&cells) {
+        let _ = writeln!(
+            out,
+            "  {:<w0$}  {}  {:>w2$}  {:>w3$}  {}",
+            c[0],
+            theme.paint(Role::Dim, &format!("{:<w1$}", c[1])),
+            c[2],
+            c[3],
+            preview_cell(row, theme),
+        );
+    }
+    let _ = writeln!(out, "{}", totals_line(view, trace, theme));
+    out
+}
+
+/// The closing line: `N tasks · <wall> · <tok> tok · full value: …` —
+/// the peek hint carries the REAL trace path (copy-paste ready, the
+/// task id is the one placeholder).
+fn totals_line(view: &RunView, trace: &str, theme: Theme) -> String {
+    let mut line = format!(
+        "  {} task(s) · {}",
+        view.rows().len(),
+        fmt_wall_ms(view.elapsed_ms)
+    );
+    let tokens: u64 = view.rows().iter().filter_map(|r| r.tokens).sum();
+    if tokens > 0 {
+        let _ = write!(line, " · {tokens} tok");
+    }
+    let _ = write!(line, " · full value: nika trace peek {trace} <task>");
+    theme.paint(Role::Dim, &line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::demo;
+    use crate::verbs::exit;
+
+    fn plain() -> Theme {
+        Theme {
+            color: false,
+            ascii: false,
+            animate: false,
+        }
+    }
+
+    /// Stage a real NDJSON trace from the demo storyboard events.
+    fn stage(name: &str, events: &[nika_event::Event]) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join("nika-cli-trace-verb");
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let path = dir.join(name);
+        let mut body = String::new();
+        for ev in events {
+            body.push_str(&serde_json::to_string(ev).expect("event serializes"));
+            body.push('\n');
+        }
+        std::fs::write(&path, body).expect("trace staged");
+        path
+    }
+
+    /// One row per task: verb (the started note) · duration · tokens ·
+    /// preview or the honest dash — plus the totals + peek hint with
+    /// the REAL trace path.
+    #[test]
+    fn outputs_table_renders_per_task_rows_and_totals() {
+        let path = stage("outputs-demo.ndjson", &demo::success());
+        let trace = path.to_string_lossy();
+        let out = outputs(&trace, plain());
+        assert_eq!(out.code, exit::OK);
+        let text = &out.text;
+        assert!(
+            text.contains("task") && text.contains("verb") && text.contains("output"),
+            "header row: {text}"
+        );
+        assert!(
+            text.contains("invoke · nika:fetch"),
+            "verb column carries the started note: {text}"
+        );
+        // The demo reports tokens on exactly one completion (710).
+        assert!(text.contains("710"), "token cell: {text}");
+        // Demo completions carry no ADR-099 output field → honest dash.
+        assert!(text.contains('—'), "no output → dash: {text}");
+        assert!(
+            text.contains(&format!("full value: nika trace peek {trace} <task>")),
+            "peek hint carries the real path: {text}"
+        );
+        assert!(text.contains("5 task(s)"), "totals: {text}");
+        assert!(text.contains("710 tok"), "token total: {text}");
+    }
+
+    /// Output-carrying completions preview their bounded shape + size.
+    #[test]
+    fn outputs_table_previews_shapes_with_sizes() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let events = vec![
+            demo::bare_event(EventKind::TaskStarted, 0)
+                .with_field(KeyValue::new("task", Value::String("audit".into())))
+                .with_field(KeyValue::new(
+                    "note",
+                    Value::String("infer · mock/echo".into()),
+                )),
+            demo::bare_event(EventKind::TaskCompleted, 40)
+                .with_field(KeyValue::new("task", Value::String("audit".into())))
+                .with_field(KeyValue::new(
+                    "output",
+                    Value::String(r#"{"total":9,"fixes":["a","b"]}"#.into()),
+                ))
+                .with_field(KeyValue::new("tokens", Value::Int(90)))
+                .with_field(KeyValue::new("duration_ms", Value::Int(38))),
+        ];
+        let path = stage("outputs-shapes.ndjson", &events);
+        let out = outputs(&path.to_string_lossy(), plain());
+        assert!(
+            out.text.contains("{fixes[2], total} · 29B"),
+            "bounded preview + byte size: {}",
+            out.text
+        );
+        assert!(out.text.contains("38ms"), "measured duration: {}", out.text);
+        // ASCII parity: the dash cell + no unicode leak.
+        let ascii = outputs(
+            &path.to_string_lossy(),
+            Theme {
+                color: false,
+                ascii: true,
+                animate: false,
+            },
+        );
+        assert!(!ascii.text.contains('—'), "ascii dash: {}", ascii.text);
+    }
+
+    /// An unreadable path is the environment class — actionable message,
+    /// exit 3, never a panic.
+    #[test]
+    fn missing_trace_is_env_class() {
+        let out = outputs("/nonexistent/trace.ndjson", plain());
+        assert_eq!(out.code, exit::ENV);
+        assert!(out.text.contains("cannot read"), "{}", out.text);
+    }
+}

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The static trace readers — `nika trace outputs` (per-task browser).
+//! The static trace readers — `nika trace outputs` (per-task browser)
+//! + `nika trace peek` (full fidelity).
 //!
 //! Pure reads over a recorded NDJSON trace: load (the SAME tolerant
 //! recovery `--resume` and `trace show` fold through) → fold into the
 //! ONE [`RunView`] truth → render. Three densities, one source: the
-//! storyboard shows SHAPE tails, this table shows bounded previews,
-//! `trace peek` shows full fidelity.
+//! storyboard shows SHAPE tails, the table shows bounded previews,
+//! `peek` shows the whole value + its ADR-099 identity.
 
 use std::fmt::Write as _;
 
@@ -130,6 +131,113 @@ fn totals_line(view: &RunView, trace: &str, theme: Theme) -> String {
     theme.paint(Role::Dim, &line)
 }
 
+/// `nika trace peek <trace> <task>` — the full-fidelity read: the
+/// task's whole output pretty-printed under a compact identity block
+/// (verb · duration · tokens · the ADR-099 hashes). `--raw` prints the
+/// EXACT recorded value as one JSON text — pipeable to jq, never
+/// coloured, nothing else on stdout.
+#[must_use]
+pub fn peek(trace: &str, task: &str, raw: bool, theme: Theme) -> VerbOutput {
+    let view = match load_view(trace) {
+        Ok(view) => view,
+        Err(out) => return out,
+    };
+    let Some(row) = view.rows().iter().find(|r| r.id == task) else {
+        return VerbOutput::env(unknown_task_message(&view, trace, task));
+    };
+    let Some(text) = row.output_json.as_deref() else {
+        return VerbOutput::env(no_output_message(&view, row));
+    };
+    if raw {
+        // The exact recorded value — the machine arm of peek.
+        return VerbOutput::ok(text.to_owned());
+    }
+    VerbOutput::ok(render_peek(row, text, theme))
+}
+
+/// The readable unknown-task refusal: name what the trace DOES record.
+fn unknown_task_message(view: &RunView, trace: &str, task: &str) -> String {
+    let known: Vec<&str> = view.rows().iter().map(|r| r.id.as_str()).collect();
+    if known.is_empty() {
+        return format!("unknown task `{task}` — {trace} records no tasks");
+    }
+    format!(
+        "unknown task `{task}` — this trace records: {}",
+        known.join(" · ")
+    )
+}
+
+/// The readable no-output refusal: say WHY this row has no value and
+/// name the rows that do.
+fn no_output_message(view: &RunView, row: &TaskRow) -> String {
+    let with_outputs: Vec<&str> = view
+        .rows()
+        .iter()
+        .filter(|r| r.output_json.is_some())
+        .map(|r| r.id.as_str())
+        .collect();
+    let state = format!("{:?}", row.state).to_lowercase();
+    let mut message = format!("task `{}` recorded no output ({state})", row.id);
+    if with_outputs.is_empty() {
+        message.push_str(" — no task in this trace carries one (an older engine's trace?)");
+    } else {
+        let _ = write!(
+            message,
+            " — outputs recorded for: {}",
+            with_outputs.join(" · ")
+        );
+    }
+    message
+}
+
+/// The pretty read: identity block (task · verb · time · tokens ·
+/// hashes) then the full value, pretty-printed. A value that is not
+/// valid JSON (a hand-edited trace) prints verbatim — honesty over
+/// polish.
+fn render_peek(row: &TaskRow, text: &str, theme: Theme) -> String {
+    let mut out = String::new();
+    let title = match row.started_note.as_deref() {
+        Some(note) => format!("{} · {note}", row.id),
+        None => row.id.clone(),
+    };
+    let _ = writeln!(out, "  {}", theme.paint(Role::Strong, &title));
+    let mut meta = row
+        .wall_ms()
+        .map_or_else(|| dash(theme).to_owned(), fmt_wall_ms);
+    if let Some(tok) = row.tokens {
+        let _ = write!(meta, " · {tok} tok");
+    }
+    let _ = write!(meta, " · {}", shape::fmt_bytes(text.len()));
+    let _ = writeln!(out, "  {}", theme.paint(Role::Dim, &meta));
+    if let (Some(def), Some(input)) = (row.def_hash.as_deref(), row.input_hash.as_deref()) {
+        let line = format!(
+            "def_hash {} · input_hash {}",
+            clip_hash(def, theme),
+            clip_hash(input, theme)
+        );
+        let _ = writeln!(out, "  {}", theme.paint(Role::Dim, &line));
+    }
+    let _ = writeln!(out);
+    let pretty = serde_json::from_str::<serde_json::Value>(text)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| text.to_owned());
+    for line in pretty.lines() {
+        let _ = writeln!(out, "  {line}");
+    }
+    out
+}
+
+/// A hash for eyeballing: the leading 12 hex chars + a theme-true mark
+/// (comparison across runs · the full hex lives in the trace itself).
+fn clip_hash(hash: &str, theme: Theme) -> String {
+    if hash.chars().count() <= 12 {
+        return hash.to_owned();
+    }
+    let head: String = hash.chars().take(12).collect();
+    format!("{head}{}", if theme.ascii { ".." } else { "…" })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,5 +344,113 @@ mod tests {
         let out = outputs("/nonexistent/trace.ndjson", plain());
         assert_eq!(out.code, exit::ENV);
         assert!(out.text.contains("cannot read"), "{}", out.text);
+    }
+
+    /// A trace with the ADR-099 checkpoint trio for one task.
+    fn peek_fixture(name: &str) -> std::path::PathBuf {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let events = vec![
+            demo::bare_event(EventKind::TaskStarted, 0)
+                .with_field(KeyValue::new("task", Value::String("audit".into())))
+                .with_field(KeyValue::new(
+                    "note",
+                    Value::String("infer · mock/echo".into()),
+                )),
+            demo::bare_event(EventKind::TaskCompleted, 40)
+                .with_field(KeyValue::new("task", Value::String("audit".into())))
+                .with_field(KeyValue::new(
+                    "output",
+                    Value::String(r#"{"fixes":["a"],"total":9}"#.into()),
+                ))
+                .with_field(KeyValue::new("tokens", Value::Int(90)))
+                .with_field(KeyValue::new("duration_ms", Value::Int(38)))
+                .with_field(KeyValue::new(
+                    "def_hash",
+                    Value::String("5b2fa9e9232ed4174f3af03bf835".into()),
+                ))
+                .with_field(KeyValue::new(
+                    "input_hash",
+                    Value::String("7f14c732ad33dd042b82325cda86".into()),
+                )),
+            demo::bare_event(EventKind::TaskSkipped, 50)
+                .with_field(KeyValue::new("task", Value::String("deploy".into())))
+                .with_field(KeyValue::new(
+                    "note",
+                    Value::String("when: gate closed".into()),
+                )),
+        ];
+        stage(name, &events)
+    }
+
+    /// The pretty peek: identity block (verb · time · tokens · clipped
+    /// hashes) then the FULL value pretty-printed.
+    #[test]
+    fn peek_renders_identity_block_and_pretty_value() {
+        let path = peek_fixture("peek-pretty.ndjson");
+        let out = peek(&path.to_string_lossy(), "audit", false, plain());
+        assert_eq!(out.code, exit::OK);
+        let text = &out.text;
+        assert!(text.contains("audit · infer · mock/echo"), "title: {text}");
+        assert!(text.contains("38ms · 90 tok · 25B"), "meta: {text}");
+        assert!(
+            text.contains("def_hash 5b2fa9e9232e… · input_hash 7f14c732ad33…"),
+            "clipped hashes: {text}"
+        );
+        assert!(
+            text.contains("\"fixes\": [") && text.contains("\"total\": 9"),
+            "pretty value: {text}"
+        );
+        // ASCII parity: the hash clip mark degrades, no unicode leak.
+        let ascii = peek(
+            &path.to_string_lossy(),
+            "audit",
+            false,
+            Theme {
+                color: false,
+                ascii: true,
+                animate: false,
+            },
+        );
+        assert!(
+            ascii.text.contains("5b2fa9e9232e.."),
+            "ascii clip: {}",
+            ascii.text
+        );
+        assert!(!ascii.text.contains('…'), "no unicode under --ascii");
+    }
+
+    /// `--raw` prints the EXACT recorded JSON text and nothing else —
+    /// the jq-pipe contract.
+    #[test]
+    fn peek_raw_is_the_exact_value_only() {
+        let path = peek_fixture("peek-raw.ndjson");
+        let out = peek(&path.to_string_lossy(), "audit", true, plain());
+        assert_eq!(out.code, exit::OK);
+        assert_eq!(out.text, r#"{"fixes":["a"],"total":9}"#);
+    }
+
+    /// Errors teach: an unknown task lists what the trace records; a
+    /// task without an output names its state + the rows that have one.
+    #[test]
+    fn peek_errors_are_readable_and_actionable() {
+        let path = peek_fixture("peek-errors.ndjson");
+        let trace = path.to_string_lossy();
+        let unknown = peek(&trace, "ghost", false, plain());
+        assert_eq!(unknown.code, exit::ENV);
+        assert!(
+            unknown.text.contains("unknown task `ghost`")
+                && unknown.text.contains("audit · deploy"),
+            "{}",
+            unknown.text
+        );
+        let skipped = peek(&trace, "deploy", false, plain());
+        assert_eq!(skipped.code, exit::ENV);
+        assert!(
+            skipped.text.contains("recorded no output (skipped)")
+                && skipped.text.contains("outputs recorded for: audit"),
+            "{}",
+            skipped.text
+        );
     }
 }

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -236,9 +236,14 @@ fn check_clean_file_exits_0_with_grep_stable_sections() {
     ] {
         assert!(out.text.contains(section), "missing section {section}");
     }
+    // The clean verdict is the audited card line: what was proven, at a
+    // glance (tasks · waves · permits state · cost floor · hint count).
     assert!(
+        out.text.contains("audited ·")
+            && out.text.contains("wave(s)")
+            && out.text.contains("permits"),
+        "the audited card line closes a clean report: {}",
         out.text
-            .contains("clean — audited before a single token was spent")
     );
     // mock/echo is unpriced: the cost lane says FLOOR, never invents.
     assert!(out.text.contains("UNBOUNDED"), "{}", out.text);

--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -71,8 +71,15 @@ never a fork in truth.
 | ok | `✔` | `ok` | green |
 | failed | `✖` | `X` | red |
 | retrying | `↻` | `r` | yellow |
-| skipped (when:false) | `⊘` | `-` | dim |
-| cancelled | `◼` | `x` | dim |
+| skipped (when: false · empty for_each · on_error skip) | `↷` | `~>` | dim |
+| cache hit (resume rehydration · Ok in the fold, skip family on screen) | `↷` | `~>` | dim |
+| cancelled (blocked · upstream failed) | `⊘` | `x` | dim |
+
+Skip reasons speak (the comprehension pass): `↷ cache hit (resume)` ·
+`↷ when: false` · `⊘ blocked · <task> failed` (the failed upstream is
+named when the run has exactly ONE failed task — with several, the
+stream alone cannot prove ancestry, so the generic `blocked · upstream
+failed` stays honest).
 
 The ASCII column is a **first-class theme** (CI logs, legacy conhost, screen
 readers via `--no-progress`), not a degraded mode — snapshot tests pin BOTH.
@@ -99,7 +106,7 @@ frame N (during · one line per task · topological order · stable rows)
   ✔ extract_ai       jq · 0.1s · 12 items
   ◐ summarize        claude-sonnet · 3.1s · ~$0.011 ▁▃▅
   ○ write_md         waiting on summarize
-  ⊘ notify_slack     skipped (when: false)
+  ↷ notify_slack     when: false
   ── 2/6 done · $0.011 of ≤$0.04 · elapsed 4.4s ──────────────────
    ↑ footer meter: count · LIVE cost vs static ceiling · wall clock
 


### PR DESCRIPTION
Round 7 · the run explains its DATA, not just its timing. 6 commits · 171 nika-cli lib tests · machine surfaces byte-frozen (external cmp vs main: 157B identical · pinned in tests too).

- **shape tails** on storyboard rows: `→ {6 axes, top_fixes[3]} · 312B · 90 tok` (TTY only · bounded · `--no-outputs` opt-out)
- **`nika trace outputs <trace>`** — the per-task browser (verb · dur · tok · typed preview + sizes)
- **`nika trace peek <trace> <task>`** — full-fidelity output + identity block (hashes · `--raw` for jq)
- **skip reasons speak** — `↷ cache hit` · `↷ when: false` · `⊘ blocked · upstream failed` (anti-hidden-magic)
- **`nika trace flow <trace> <workflow>`** — the DATA waterfall (which output fed which task · real sizes)
- **every-command clarity** — check audited-card · doctor verdict line · test keys+bytes · run explore-hint · ONE shared vocab module

Live proof on the signature demo (9 tasks · 4 verbs): the outputs table renders for_each·4-items and agent·turns rows with shape tails. Dogfood: atlas `nika test` 4/4 green at the AFTER binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)