### PR TITLE
feat(providers): huggingface + nvidia join the canonical catalog (16)

### DIFF
--- a/crates/nika-catalog/data/llm-providers.toml
+++ b/crates/nika-catalog/data/llm-providers.toml
@@ -185,6 +185,31 @@ context_window_tokens = 131072
 max_output_tokens = 8192
 
 [[providers]]
+id = "huggingface"
+name = "Hugging Face"
+aliases = ["hf"]
+env_var = "HF_TOKEN"
+key_prefixes = ["hf_"]
+default_model = "Qwen/Qwen3.5-397B-A17B:fastest"
+cheap_model = "Qwen/Qwen3.5-9B:cheapest"
+requires_key = true
+description = "Inference Providers router · 100+ open-weight models across 18 providers (Groq · Cerebras · Together · Scaleway · OVHcloud · …) · zero markup · :provider or :fastest/:cheapest routing suffix."
+api_dialect = "openai-chat"
+tags = ["function-calling", "open-source", "streaming"]
+
+[[providers.models]]
+id = "default"
+model = "Qwen/Qwen3.5-397B-A17B:fastest"
+context_window_tokens = 262144
+max_output_tokens = 32768
+
+[[providers.models]]
+id = "cheap"
+model = "Qwen/Qwen3.5-9B:cheapest"
+context_window_tokens = 262144
+max_output_tokens = 16384
+
+[[providers]]
 id = "openrouter"
 name = "OpenRouter"
 aliases = ["or"]
@@ -588,26 +613,33 @@ max_output_tokens = 4096
 # ─── Session 4b additions (8 new providers) ────────────────────────────
 
 [[providers]]
-id = "nvidia-nim"
-name = "NVIDIA NIM"
-aliases = ["nim"]
+id = "nvidia"
+name = "NVIDIA"
+aliases = ["nim", "nvidia-nim"]
 env_var = "NVIDIA_API_KEY"
-default_model = "meta/llama-3.1-70b-instruct"
-cheap_model = "meta/llama-3.1-8b-instruct"
+key_prefixes = ["nvapi-"]
+default_model = "nvidia/nemotron-3-super-120b-a12b"
+cheap_model = "nvidia/nemotron-3-nano-30b-a3b"
 requires_key = true
-description = "NVIDIA NIM inference microservices. Nemotron, Llama, Mistral on NVIDIA GPUs."
+description = "NVIDIA API (integrate.api.nvidia.com) · Nemotron 3 family (Open Model License · agentic-first) + hosted open models · self-hosted NIM containers expose the same surface."
 api_dialect = "openai-chat"
-tags = ["function-calling", "local", "streaming"]
+tags = ["function-calling", "open-source", "streaming"]
+
+[[providers.models]]
+id = "default"
+model = "nvidia/nemotron-3-super-120b-a12b"
+context_window_tokens = 262144
+max_output_tokens = 32768
+
+[[providers.models]]
+id = "cheap"
+model = "nvidia/nemotron-3-nano-30b-a3b"
+context_window_tokens = 262144
+max_output_tokens = 16384
 
 [[providers.models]]
 id = "llama-70b"
 model = "meta/llama-3.1-70b-instruct"
-context_window_tokens = 128000
-max_output_tokens = 4096
-
-[[providers.models]]
-id = "llama-8b"
-model = "meta/llama-3.1-8b-instruct"
 context_window_tokens = 128000
 max_output_tokens = 4096
 

--- a/crates/nika-catalog/data/model-capabilities.toml
+++ b/crates/nika-catalog/data/model-capabilities.toml
@@ -489,8 +489,8 @@ routing_complete = true
 
 # [43] NVIDIA NIM — text-only fallback. OpenAI-compat: json_schema YES.
 [[rules]]
-name             = "nvidia-nim-any-model"
-scope            = { providers = ["nvidia-nim"] }
+name             = "nvidia-any-model"
+scope            = { providers = ["nvidia"] }
 match            = { kind = "any" }
 caps             = { input_modalities = ["text"], output_modalities = ["text"], supported_parameters = ["parallel-tool-calls"], json_mode = "schema" }
 routing_complete = true

--- a/crates/nika-catalog/src/data/generated.rs
+++ b/crates/nika-catalog/src/data/generated.rs
@@ -84,8 +84,10 @@ mod tests {
     fn providers_count_pinned() {
         // Pinned to detect silent additions/removals. Session 4b added 7
         // new providers (nvidia-nim/deepinfra/replicate/hyperbolic/writer/
-        // databricks/cloudflare), driving the count from 25 to 32.
-        assert_eq!(ALL_PROVIDERS.len(), 32);
+        // databricks/cloudflare), driving the count from 25 to 32; the
+        // 2026-07-05 canonical promotion added huggingface (the Inference
+        // Providers router) and renamed nvidia-nim → nvidia: 32 → 33.
+        assert_eq!(ALL_PROVIDERS.len(), 33);
     }
 
     #[test]

--- a/crates/nika-catalog/src/lib.rs
+++ b/crates/nika-catalog/src/lib.rs
@@ -118,8 +118,9 @@ mod tests {
     #[test]
     fn all_providers_non_empty() {
         // Session 4b added 7 providers (nvidia-nim, deepinfra, replicate,
-        // hyperbolic, writer, databricks, cloudflare): 25 → 32.
-        assert_eq!(all_providers().len(), 32);
+        // hyperbolic, writer, databricks, cloudflare): 25 → 32; 2026-07-05
+        // huggingface joined (+ nvidia-nim → nvidia rename): 32 → 33.
+        assert_eq!(all_providers().len(), 33);
     }
 
     #[test]

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -306,9 +306,11 @@ mod tests {
                 "groq/",
                 "xai/",
                 "openrouter/",
+                "huggingface/",
+                "nvidia/",
                 "mock/",
             ],
-            "the 14-provider catalog, local-first, each suffixed with `/`"
+            "the 16-provider catalog, local-first, each suffixed with `/`"
         );
         // every provider item is a VALUE with a non-empty detail (the kind +
         // detail fields, not just the label).

--- a/crates/nika-lsp/src/analysis/vocab.rs
+++ b/crates/nika-lsp/src/analysis/vocab.rs
@@ -13,7 +13,7 @@
 //! The verb set + the envelope/task keys mirror the strict parser's own
 //! tables (`nika_schema::parser` `TOP_LEVEL_KEYS` + the closed task shape
 //! of spec `03-dag.md`). The provider list is mirrored-from-canon (the
-//! canonical 14-provider LLM catalog · spec `stdlib/providers-v0.1.md` +
+//! canonical 16-provider LLM catalog · spec `stdlib/providers-v0.1.md` +
 //! `spec/canon.yaml` SSOT); it is presented local/open-weight-first per
 //! the studio's vendor-agnostic ordering. A drift between this mirror and
 //! the catalog is caught the day `nika-lsp` grows a `nika-catalog` dep
@@ -161,7 +161,7 @@ pub const TASK_FIELD_KEYS: &[Entry] = &[
 
 /// The canonical LLM provider names for `model: <provider>/<name>`.
 ///
-/// MIRRORED-FROM-CANON: the 14-provider catalog (spec `canon.yaml` SSOT ·
+/// MIRRORED-FROM-CANON: the 16-provider catalog (spec `canon.yaml` SSOT ·
 /// `stdlib/providers-v0.1.md`). Ordered local/open-weight-first per the
 /// studio's vendor-agnostic presentation convention (the TEACHING surface
 /// leads with sovereign options). Keep in sync with the catalog when the
@@ -218,6 +218,14 @@ pub const PROVIDERS: &[Entry] = &[
     Entry {
         name: "openrouter",
         doc: "OpenRouter (cloud router across many providers/models).",
+    },
+    Entry {
+        name: "huggingface",
+        doc: "Hugging Face Inference Providers router (open-weight catalog · 18 backends · :provider or :fastest/:cheapest suffix).",
+    },
+    Entry {
+        name: "nvidia",
+        doc: "NVIDIA API (Nemotron 3 family · Open Model License · NIM self-hostable).",
     },
     Entry {
         name: "mock",
@@ -278,7 +286,7 @@ mod tests {
     #[test]
     fn providers_are_local_first_and_complete() {
         let names: Vec<&str> = PROVIDERS.iter().map(|e| e.name).collect();
-        assert_eq!(names.len(), 14, "the canonical 14-provider catalog");
+        assert_eq!(names.len(), 16, "the canonical 16-provider catalog");
         // local/open-weight first (vendor-agnostic teaching order)
         assert_eq!(names[0], "ollama");
         assert!(names.contains(&"anthropic"));

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! Provider profiles — the canonical 14, as data.
+//! Provider profiles — the canonical 16, as data.
 //!
 //! A profile binds a provider id to a wire format, a default endpoint and a
 //! key-loading recipe. Cloud rows are seeded from `nika-catalog` (codegen
@@ -21,7 +21,7 @@ pub enum WireFormat {
     Anthropic,
     /// `OpenAI` Chat Completions — also every OpenAI-compatible server
     /// (cloud: `openai` · `deepseek` · `mistral` · `xai` · `groq` ·
-    /// `openrouter` · local: `ollama` · `lmstudio` · `llamacpp` ·
+    /// `openrouter` · `huggingface` · `nvidia` · local: `ollama` · `lmstudio` · `llamacpp` ·
     /// `localai` · `vllm`).
     OpenAiCompat,
     /// Google Gemini `generateContent` (wired s8.6). The profile
@@ -130,8 +130,8 @@ impl Profile {
     }
 }
 
-/// The canonical provider ids, in canon order (8 cloud · 5 local · 1 test).
-pub const CANONICAL_IDS: [&str; 14] = [
+/// The canonical provider ids, in canon order (10 cloud · 5 local · 1 test).
+pub const CANONICAL_IDS: [&str; 16] = [
     "anthropic",
     "openai",
     "gemini",
@@ -140,6 +140,8 @@ pub const CANONICAL_IDS: [&str; 14] = [
     "xai",
     "groq",
     "openrouter",
+    "huggingface",
+    "nvidia",
     "ollama",
     "lmstudio",
     "llamacpp",
@@ -148,12 +150,12 @@ pub const CANONICAL_IDS: [&str; 14] = [
     "mock",
 ];
 
-/// The 8 cloud rows (catalog-backed) + the in-process mock.
+/// The 10 cloud rows (catalog-backed) + the in-process mock.
 ///
 /// gemini's `base_url` is a STEM (`…/v1beta`) — the s8.6 adapter appends
 /// `/models/{model}:generateContent` per request (unlike the other wires,
 /// whose `base_url` is the complete endpoint).
-const CATALOG_WIRED: [(&str, WireFormat, &str); 9] = [
+const CATALOG_WIRED: [(&str, WireFormat, &str); 11] = [
     (
         "anthropic",
         WireFormat::Anthropic,
@@ -194,6 +196,24 @@ const CATALOG_WIRED: [(&str, WireFormat, &str); 9] = [
         WireFormat::OpenAiCompat,
         "https://openrouter.ai/api/v1/chat/completions",
     ),
+    // huggingface · the Inference Providers router (chat-only surface ·
+    // 100+ open-weights across 18 backend providers · zero markup) ·
+    // model names carry an INNER slash + optional :provider/:policy
+    // suffix (`Qwen/Qwen3.5-9B:groq`) — resolve() split_once already
+    // hands the whole rest through untouched.
+    (
+        "huggingface",
+        WireFormat::OpenAiCompat,
+        "https://router.huggingface.co/v1/chat/completions",
+    ),
+    // nvidia · integrate.api.nvidia.com (NIM cloud) · Nemotron 3 family
+    // (Open Model License) + hosted open models · self-hosted NIM
+    // containers expose the same surface (override base_url).
+    (
+        "nvidia",
+        WireFormat::OpenAiCompat,
+        "https://integrate.api.nvidia.com/v1/chat/completions",
+    ),
     ("mock", WireFormat::Mock, ""),
 ];
 
@@ -211,10 +231,10 @@ const LOCAL: [(&str, &str); 5] = [
     ("vllm", "http://127.0.0.1:8000/v1/chat/completions"),
 ];
 
-/// Build the canonical 14 profiles (catalog-joined where rows exist).
+/// Build the canonical 16 profiles (catalog-joined where rows exist).
 #[must_use]
 pub fn seed() -> Vec<Profile> {
-    let mut out = Vec::with_capacity(14);
+    let mut out = Vec::with_capacity(16);
     for (id, wire, base_url) in CATALOG_WIRED {
         let catalog = nika_catalog::find_provider(id);
         out.push(Profile {
@@ -244,7 +264,7 @@ mod tests {
     #[test]
     fn seed_yields_the_canonical_fourteen() {
         let profiles = seed();
-        assert_eq!(profiles.len(), 14);
+        assert_eq!(profiles.len(), 16);
         let mut ids: Vec<&str> = profiles.iter().map(|p| p.id).collect();
         ids.sort_unstable();
         let mut canon = CANONICAL_IDS.to_vec();

--- a/crates/nika-providers/src/registry.rs
+++ b/crates/nika-providers/src/registry.rs
@@ -326,7 +326,7 @@ mod tests {
     #[tokio::test]
     async fn profiles_view_exposes_the_canonical_fourteen() {
         let reg = ProviderRegistry::new(Arc::new(NoHttp), hermetic());
-        assert_eq!(reg.profiles().len(), 14);
+        assert_eq!(reg.profiles().len(), 16);
     }
 
     #[test]

--- a/crates/nika-providers/src/wire/mod.rs
+++ b/crates/nika-providers/src/wire/mod.rs
@@ -152,11 +152,11 @@ pub(crate) fn gen_ai_system(provider_id: &str) -> GenAiSystem {
         "mistral" => GenAiSystem::Mistral,
         "deepseek" => GenAiSystem::DeepSeek,
         "xai" => GenAiSystem::Xai,
-        // groq · openrouter · the 5 local servers all speak the
-        // OpenAI-compatible dialect; mock is Unknown by design.
-        "groq" | "openrouter" | "ollama" | "lmstudio" | "llamacpp" | "localai" | "vllm" => {
-            GenAiSystem::OpenAiCompatible
-        }
+        // groq · openrouter · huggingface (Inference Providers router) ·
+        // nvidia (integrate.api.nvidia.com / NIM) · the 5 local servers all
+        // speak the OpenAI-compatible dialect; mock is Unknown by design.
+        "groq" | "openrouter" | "huggingface" | "nvidia" | "ollama" | "lmstudio" | "llamacpp"
+        | "localai" | "vllm" => GenAiSystem::OpenAiCompatible,
         _ => GenAiSystem::Unknown,
     }
 }
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn gen_ai_system_covers_all_fourteen() {
+    fn gen_ai_system_covers_all_sixteen() {
         for id in crate::profile::CANONICAL_IDS {
             let sys = gen_ai_system(id);
             if id == "mock" {


### PR DESCRIPTION
Cycle-2 C2 · operator-requested pair · the openrouter-promotion precedent (D-2026-06-10-N2) applied to the two missing ACCESS CATEGORIES:

| Provider | Category | Endpoint | Auth |
|---|---|---|---|
| `huggingface` | hub-router (open-weight house · 18 backends · zero markup · `:provider`/`:fastest`/`:cheapest` suffix) | router.huggingface.co/v1/chat/completions | HF_TOKEN (`hf_`) |
| `nvidia` | enterprise-NIM (Nemotron 3 · Open Model License · self-hostable same surface) | integrate.api.nvidia.com/v1/chat/completions | NVIDIA_API_KEY (`nvapi-`) |

- nvidia = PROMOTION of the catalog-only `nvidia-nim` row (aliases keep both old names · capability-rule FK cascaded)
- Model ids verified LIVE against /v1/models (121 models · the drafted nano-4b did not exist → corrected to nano-30b-a3b)
- Full cascade: CANONICAL_IDS/WIRED/gen_ai/catalog-count/LSP vocab+completion
- Spec-side PR (canon.yaml 16 + prose + ADR draft) follows

catalog 232 · providers 145 · lsp 124 · cli 145 · clippy 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)