### PR TITLE
feat(nika-runtime): real per-task spend — cost_usd rides task_completed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,6 +3962,7 @@ dependencies = [
  "jaq-json",
  "jaq-std",
  "miette",
+ "nika-catalog",
  "nika-cel",
  "nika-error",
  "nika-event",

--- a/crates/nika-catalog/src/data/models.rs
+++ b/crates/nika-catalog/src/data/models.rs
@@ -138,21 +138,65 @@ pub fn find_pricing_scoped(provider: &str, model: &str) -> Option<&'static Model
         .find(|p| p.provider.eq_ignore_ascii_case(provider) && model.contains(p.model_pattern))
 }
 
-/// Estimate cost for a model invocation.
+/// Find pricing for a model string that MAY carry a `provider/` prefix —
+/// the resolved form the engine passes around (`"openai/gpt-4o-mini"`).
+///
+/// A prefixed string resolves via [`find_pricing_scoped`] (contains-fallback
+/// never crosses provider boundaries) · a bare string falls back to
+/// [`find_pricing`]. This is the ONE model-string → pricing resolution:
+/// the check-time cost floor (`nika-schema` check/cost) and the runtime's
+/// task-completion pricing both call it — the two surfaces can never
+/// disagree on which row prices a model.
 #[cfg(feature = "pricing")]
 #[must_use]
+pub fn find_pricing_for(model: &str) -> Option<&'static ModelPricing> {
+    match model.split_once('/') {
+        Some((provider, name)) => find_pricing_scoped(provider, name),
+        None => find_pricing(model),
+    }
+}
+
+/// The pricing math — one site for both estimate surfaces.
+#[cfg(feature = "pricing")]
 // REASON: casting `u64` token counts to `f64` for the rate multiplication.
 // Token counts cap at provider context windows (≤ 10 M = 2²³), well below
 // the `f64` precision horizon (2⁵³). A saturating conversion would hide a
 // real data bug if that ever changed; the cast is the right primitive here.
 #[allow(clippy::cast_precision_loss)]
+fn usd_for(pricing: &ModelPricing, input_tokens: u64, output_tokens: u64) -> f64 {
+    (input_tokens as f64 * pricing.input_per_million
+        + output_tokens as f64 * pricing.output_per_million)
+        / 1_000_000.0
+}
+
+/// Estimate cost for a model invocation.
+#[cfg(feature = "pricing")]
+#[must_use]
 pub fn estimate_cost(model: &str, input_tokens: u64, output_tokens: u64) -> Option<CostEstimate> {
     let pricing = find_pricing(model)?;
-    let usd = (input_tokens as f64 * pricing.input_per_million
-        + output_tokens as f64 * pricing.output_per_million)
-        / 1_000_000.0;
     Some(CostEstimate::new(
-        usd,
+        usd_for(pricing, input_tokens, output_tokens),
+        pricing.input_per_million,
+        pricing.output_per_million,
+        model.to_string(),
+        pricing.provider.to_string(),
+    ))
+}
+
+/// Estimate cost for a RESOLVED model string (`provider/name` or bare) —
+/// [`find_pricing_for`] resolution × the same per-million math as
+/// [`estimate_cost`]. `None` when the model has no catalog price (mock ·
+/// unknown local) — the caller emits nothing rather than a fake number.
+#[cfg(feature = "pricing")]
+#[must_use]
+pub fn estimate_cost_for(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+) -> Option<CostEstimate> {
+    let pricing = find_pricing_for(model)?;
+    Some(CostEstimate::new(
+        usd_for(pricing, input_tokens, output_tokens),
         pricing.input_per_million,
         pricing.output_per_million,
         model.to_string(),
@@ -382,6 +426,55 @@ mod tests {
             estimate_cost("nonexistent-model-xyz", 100, 50).is_none(),
             "unknown model must return None",
         );
+    }
+
+    // ── find_pricing_for / estimate_cost_for (resolved strings) ──
+
+    #[test]
+    fn find_pricing_for_provider_prefixed_resolves_scoped() {
+        let p = find_pricing_for("openai/gpt-4o-mini").expect("priced model");
+        assert_eq!(p.provider, "OpenAI");
+        // The prefixed form and the explicit scoped call resolve to the
+        // SAME row — one resolution, two spellings.
+        let scoped = find_pricing_scoped("openai", "gpt-4o-mini").expect("scoped hit");
+        assert!(std::ptr::eq(p, scoped));
+    }
+
+    #[test]
+    fn find_pricing_for_bare_falls_back_unscoped() {
+        let p = find_pricing_for("gpt-4o-mini").expect("bare model resolves");
+        let unscoped = find_pricing("gpt-4o-mini").expect("unscoped hit");
+        assert!(std::ptr::eq(p, unscoped));
+    }
+
+    #[test]
+    fn find_pricing_for_mock_and_unknown_local_are_none() {
+        // The honest-absence contract: a mock or local model prices to
+        // None — the runtime emits NO cost fields for these.
+        assert!(find_pricing_for("mock/mock-echo").is_none());
+        assert!(find_pricing_for("ollama/qwen3.5:4b").is_none());
+    }
+
+    #[test]
+    fn estimate_cost_for_prefixed_matches_scoped_math() {
+        let est = estimate_cost_for("openai/gpt-4o-mini", 1000, 500).expect("priced");
+        let p = find_pricing_scoped("openai", "gpt-4o-mini").expect("scoped hit");
+        let expected = (1000.0 * p.input_per_million + 500.0 * p.output_per_million) / 1e6;
+        assert!((est.usd - expected).abs() < 1e-12);
+        assert_eq!(est.model, "openai/gpt-4o-mini", "carries the queried form");
+        assert_eq!(est.provider, "OpenAI");
+    }
+
+    #[test]
+    fn estimate_cost_for_unpriced_is_none() {
+        assert!(estimate_cost_for("mock/mock-echo", 100, 50).is_none());
+        assert!(estimate_cost_for("llamacpp/local-gguf", 100, 50).is_none());
+    }
+
+    #[test]
+    fn estimate_cost_for_zero_tokens_is_zero_usd() {
+        let est = estimate_cost_for("openai/gpt-4o", 0, 0).expect("priced");
+        assert!(est.usd.abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/nika-catalog/src/lib.rs
+++ b/crates/nika-catalog/src/lib.rs
@@ -54,7 +54,9 @@ pub use lookup::find_provider;
 #[cfg(feature = "capabilities")]
 pub use lookup::model_capabilities;
 #[cfg(feature = "pricing")]
-pub use lookup::{estimate_cost, find_pricing, find_pricing_scoped};
+pub use lookup::{
+    estimate_cost, estimate_cost_for, find_pricing, find_pricing_for, find_pricing_scoped,
+};
 #[cfg(feature = "builtins-transforms")]
 pub use lookup::{find_builtin, find_transform, is_known_builtin, is_known_transform};
 #[cfg(feature = "mcp")]

--- a/crates/nika-catalog/src/lookup.rs
+++ b/crates/nika-catalog/src/lookup.rs
@@ -17,7 +17,9 @@ pub use crate::data::generated::find_provider;
 #[cfg(feature = "capabilities")]
 pub use crate::data::models::model_capabilities;
 #[cfg(feature = "pricing")]
-pub use crate::data::models::{estimate_cost, find_pricing, find_pricing_scoped};
+pub use crate::data::models::{
+    estimate_cost, estimate_cost_for, find_pricing, find_pricing_for, find_pricing_scoped,
+};
 #[cfg(feature = "builtins-transforms")]
 pub use crate::data::transforms::{find_transform, is_known_transform};
 pub use crate::types::provider::validate_key_format;

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -15,6 +15,7 @@ nika-types       = { path = "../nika-types", version = "0.93.1" }        # Event
 nika-error       = { path = "../nika-error", version = "0.93.1" }        # NIKA_1700..1703 registry constants
 nika-event       = { path = "../nika-event", version = "0.93.1" }        # Event · EventKind (the stream this crate emits)
 nika-schema      = { path = "../nika-schema", version = "0.93.1" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-catalog     = { path = "../nika-catalog", version = "0.93.1", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
 nika-cel         = { path = "../nika-cel", version = "0.93.1" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
 nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
 nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.1" }

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -49,6 +49,10 @@ pub(crate) struct DispatchOk {
     pub value: Value,
     pub tokens: Option<i64>,
     pub warning: Option<String>,
+    /// Real spend in USD (catalog pricing × the provider's reported
+    /// usage split) · None for unpriced models (mock · local · unknown):
+    /// absent is honest — never a fake zero.
+    pub cost_usd: Option<f64>,
 }
 
 impl Dispatched {
@@ -59,19 +63,28 @@ impl Dispatched {
                 value,
                 tokens,
                 warning: None,
+                cost_usd: None,
             }),
         }
     }
 
-    /// `ok` with an OBS-E diagnostic attached (infer/agent only · the
-    /// effect verbs never reason).
-    fn ok_warned(note: String, value: Value, tokens: Option<i64>, warning: Option<String>) -> Self {
+    /// `ok_warned` + real spend — the infer path (the one verb whose
+    /// provider reports a priced usage split today · agent's loop only
+    /// accumulates a total, its split is the documented follow-up seam).
+    fn ok_metered(
+        note: String,
+        value: Value,
+        tokens: Option<i64>,
+        warning: Option<String>,
+        cost_usd: Option<f64>,
+    ) -> Self {
         Self {
             note,
             result: Ok(DispatchOk {
                 value,
                 tokens,
                 warning,
+                cost_usd,
             }),
         }
     }
@@ -350,7 +363,17 @@ where
                 // reasoning model that ate its budget on thinking) as a
                 // non-fatal warning · the task still succeeds.
                 let warning = empty_thinking_warning(&value, &out.usage);
-                Dispatched::ok_warned(note, value, tokens, warning)
+                // Real spend: catalog pricing × the provider's usage split ·
+                // the SAME resolver as the check-time floor (they can never
+                // disagree on which row prices a model) · unpriced models
+                // (mock · local · unknown) emit nothing.
+                let cost_usd = nika_catalog::estimate_cost_for(
+                    &out.model_resolved,
+                    out.usage.input_tokens,
+                    out.usage.output_tokens,
+                )
+                .map(|e| e.usd);
+                Dispatched::ok_metered(note, value, tokens, warning, cost_usd)
             }
             Err(err) => Dispatched::verb_err("infer · ?".to_owned(), &err),
         }

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -679,12 +679,14 @@ fn settle_ran(
             value,
             tokens,
             warning,
+            cost_usd,
         } => {
             let ended = emit_completed(
                 id,
                 &run.note,
                 duration,
                 tokens,
+                cost_usd,
                 warning.as_deref(),
                 resume,
                 &value,
@@ -745,6 +747,7 @@ fn emit_completed(
     note: &str,
     duration: i64,
     tokens: Option<i64>,
+    cost_usd: Option<f64>,
     warning: Option<&str>,
     resume: Option<&resume::ResumeStamp>,
     value: &Value,
@@ -758,6 +761,11 @@ fn emit_completed(
     ];
     if let Some(n) = tokens {
         fields.push(("tokens", i(n)));
+    }
+    // Real spend rides next to the tokens it prices · absent = unpriced
+    // (mock · local) — the render layer already treats absent as honest.
+    if let Some(c) = cost_usd {
+        fields.push(("cost_usd", FieldValue::Float(c)));
     }
     // OBS-E · a non-fatal diagnostic rides the success frame as a
     // `warning` field (the reasoning-model blank-answer footgun) · the
@@ -1032,6 +1040,7 @@ outputs:
                 value: Value::String(String::new()),
                 tokens: Some(84),
                 warning: Some("infer produced an empty answer · …".to_owned()),
+                cost_usd: Some(0.0125),
             },
         };
         let mut ok = true;
@@ -1053,6 +1062,17 @@ outputs:
             matches!(&warning.value, FieldValue::String(s) if s.contains("empty answer")),
             "the diagnostic text is carried verbatim"
         );
+        // Real spend rides the same frame · absent-when-unpriced is pinned
+        // by the sibling test below (its cost_usd is None · no field).
+        let cost = completed
+            .fields
+            .iter()
+            .find(|f| f.key == "cost_usd")
+            .expect("the cost_usd field rides the priced success frame");
+        assert!(
+            matches!(&cost.value, FieldValue::Float(c) if (*c - 0.0125).abs() < f64::EPSILON),
+            "the priced spend is carried verbatim"
+        );
     }
 
     /// The common path · a success with no OBS-E diagnostic emits NO
@@ -1068,6 +1088,7 @@ outputs:
                 value: Value::String("ok".to_owned()),
                 tokens: None,
                 warning: None,
+                cost_usd: None,
             },
         };
         let mut ok = true;
@@ -1083,6 +1104,10 @@ outputs:
         assert!(
             !completed.fields.iter().any(|f| f.key == "warning"),
             "no warning on a clean success"
+        );
+        assert!(
+            !completed.fields.iter().any(|f| f.key == "cost_usd"),
+            "an unpriced success carries NO cost field — absent is honest, never a fake zero"
         );
     }
 }

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -127,6 +127,8 @@ pub(crate) enum RunResult {
         value: Value,
         tokens: Option<i64>,
         warning: Option<String>,
+        /// Real spend (catalog × usage split) · None = unpriced · honest.
+        cost_usd: Option<f64>,
     },
     /// `on_error: skip` — skipped with the original error readable
     /// (spec 05 · the one coexist state).
@@ -377,6 +379,7 @@ where
                 // success carries no single warning (a per-element note
                 // would need its own channel · out of scope here).
                 warning: None,
+                cost_usd: acc.cost_sum,
             },
             Some(error) => RunResult::Failed { error },
         };
@@ -638,6 +641,9 @@ struct FanOutAccum {
     /// Per-iteration token spend SUMMED onto the parent (a 50-infer fan-out
     /// must never report zero to the cost meter) · None until any reports.
     tokens_sum: Option<i64>,
+    /// Per-iteration USD spend SUMMED the same way (same-model iterations ·
+    /// per-turn pricing sums exactly) · None until any priced call reports.
+    cost_sum: Option<f64>,
 }
 
 /// Drain the buffered iteration stream, reducing it to a [`FanOutAccum`] in
@@ -654,6 +660,7 @@ where
         agent_events: Vec::new(),
         first_error: None,
         tokens_sum: None,
+        cost_sum: None,
     };
 
     while let Some(iter_ran) = stream.next().await {
@@ -662,10 +669,18 @@ where
         match iter_ran.result {
             // OBS-E `warning` is per-call · a fan-out element's diagnostic
             // is not aggregated up (only `value` + `tokens` fold).
-            RunResult::Success { value, tokens, .. } => {
+            RunResult::Success {
+                value,
+                tokens,
+                cost_usd,
+                ..
+            } => {
                 acc.outputs.push(value);
                 if let Some(n) = tokens {
                     acc.tokens_sum = Some(acc.tokens_sum.unwrap_or(0).saturating_add(n));
+                }
+                if let Some(c) = cost_usd {
+                    acc.cost_sum = Some(acc.cost_sum.unwrap_or(0.0) + c);
                 }
             }
             // Per-iteration `on_error: skip` contributes null at its
@@ -956,10 +971,12 @@ fn dispatch_result(
             value,
             tokens,
             warning,
+            cost_usd,
         }) => RunResult::Success {
             value,
             tokens,
             warning,
+            cost_usd,
         },
         Err(error) => apply_on_error(task, scope, error),
     }
@@ -981,6 +998,7 @@ fn apply_on_error(task: &RawTask, scope: &Scope<'_>, error: TaskErrorRecord) -> 
                 tokens: None,
                 // A recovered value is author-supplied · no model reasoning.
                 warning: None,
+                cost_usd: None,
             },
             // Recovery itself failed → the task fails as if
             // `on_error:` were absent (spec 05 §recover resolution).

--- a/crates/nika-schema/src/check/cost.rs
+++ b/crates/nika-schema/src/check/cost.rs
@@ -172,19 +172,17 @@ pub(super) fn ceiling(wf: &RawWorkflow) -> CostCeiling {
 
 /// Output price (USD per million tokens) for a `<provider>/<model>` string.
 ///
-/// Resolves through the catalog's PROVIDER-SCOPED lookup
-/// (`find_pricing_scoped`) — a bare cross-provider substring match
-/// (`"my-gpt-4-finetune".contains("gpt-4")`) would misprice an unrelated
-/// model at another provider's rate, the exact collision the catalog
-/// warns about. With no `provider/` prefix we fall back to the unscoped
-/// lookup (a bare model id). Returns `None` for local/unknown models —
-/// sovereign zero-price models are « unpriced », never « free ».
+/// Resolves through the catalog's ONE resolved-string lookup
+/// (`find_pricing_for`): a `provider/` prefix scopes the search so a bare
+/// cross-provider substring match (`"my-gpt-4-finetune".contains("gpt-4")`)
+/// can never misprice an unrelated model at another provider's rate; a
+/// bare model id falls back to the unscoped lookup. The runtime's
+/// task-completion pricing resolves through the SAME function — the floor
+/// and the actual can never disagree on which row prices a model. Returns
+/// `None` for local/unknown models — sovereign zero-price models are
+/// « unpriced », never « free ».
 pub(super) fn output_price_per_million(model: &str) -> Option<f64> {
-    let pricing = match model.split_once('/') {
-        Some((provider, name)) => nika_catalog::find_pricing_scoped(provider, name),
-        None => nika_catalog::find_pricing(model),
-    };
-    pricing.map(|p| p.output_per_million)
+    nika_catalog::find_pricing_for(model).map(|p| p.output_per_million)
 }
 
 /// A `for_each:` count that is statically known: the expression is exactly


### PR DESCRIPTION
## Real per-task spend — cost_usd rides task_completed

The engine now prices every metered task at completion time: `nika-runtime` computes real dollars from `nika-catalog` pricing × the provider's actual usage split, and emits `cost_usd` on `task_completed` events. The CLI's meter, verdict card, waterfall and trace surfaces render it.

### Proof (real API run · openai/gpt-4o-mini · 2026-07-05)

Event line:
```
audit · tokens: 110 · cost_usd: 0.00028425
```

Verdict card:
```
3.0s · 110 tok · $0.0003 · openai/gpt-4o-mini
```

### Design

- `DispatchOk` gains `cost_usd: Option<f64>` — computed at the ONE dispatch seam via `nika_catalog::estimate_cost_for(model_resolved, input_tokens, output_tokens)`; unpriced models emit NO field (absence = honest unknown, never $0).
- `nika-schema` check-time floor switched to the shared `find_pricing_for` seam — the pre-run estimate and the post-run actual can never disagree on pricing rows.
- FanOutAccum accumulates `cost_sum` exactly like `tokens_sum` (fanout cards show aggregate spend).
- Dead `ok_warned` constructor removed (`ok_metered` subsumes).

### Honesty invariants

- mock/echo runs stay byte-frozen (no cost field · goldens untouched · pinned by tests).
- Tests pin BOTH presence (0.0125 for a priced model) and absence (unpriced → no field).
- 171 nika-cli + 98 nika-runtime tests green · full workspace green at the merge base.
