### PR TITLE
feat(nika-cli): round-8 visual polish — links, sync frames, heat, one formatter

### DIFF
--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -286,12 +286,12 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
     let title_raw = format!("{h} nika {mark_raw} {} ", view.workflow);
 
     let waves = wave_sizes(view).len();
+    let retries_cell = format!("{} retries", view.retries);
     let mut rows = vec![
         format!(
-            "{}    {} tasks · {waves} waves · {} retries",
+            "{}    {} tasks · {waves} waves · {retries_cell}",
             dag_shape(view, theme),
             view.rows().len(),
-            view.retries,
         ),
         totals_row(view),
     ];
@@ -321,7 +321,17 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
         let pad = inner
             .saturating_sub(4)
             .saturating_sub(fitted.chars().count());
-        lines.push(format!("  {v}  {fitted}{}  {v}", " ".repeat(pad)));
+        // Verdict-count discipline (cargo school · design §1.7): only a
+        // NON-ZERO bad count earns colour — `0 retries` stays plain, a
+        // real retry count paints yellow. The paint lands on the FITTED
+        // text AFTER the width math (escapes add zero visible cells; a
+        // truncated row simply keeps its plain form).
+        let shown = if view.retries > 0 {
+            fitted.replace(&retries_cell, &theme.paint(Role::Warn, &retries_cell))
+        } else {
+            fitted
+        };
+        lines.push(format!("  {v}  {shown}{}  {v}", " ".repeat(pad)));
     }
     let bottom: String = std::iter::repeat_n(h, inner).collect();
     lines.push(format!("  {bl}{bottom}{br}"));
@@ -670,6 +680,55 @@ mod tests {
                 "unicode {glyph} leaked into --ascii: {ascii:?}"
             );
         }
+    }
+
+    /// Verdict-count discipline (cargo school): `0 retries` renders
+    /// PLAIN even with colour on — only a real retry count paints
+    /// yellow, and the paint never disturbs the box alignment (escapes
+    /// land after the width math).
+    #[test]
+    fn verdict_card_colours_only_non_zero_retries() {
+        let coloured = Theme::new(true, false, false);
+
+        let mut clean = RunView::new();
+        for e in demo::success() {
+            clean.apply(&e);
+        }
+        let lines = verdict_card(&clean, &coloured, None);
+        let totals = lines.iter().find(|l| l.contains("retries")).expect("row");
+        assert!(
+            totals.contains("0 retries") && !totals.contains("\x1b[33m"),
+            "a zero count stays plain: {totals:?}"
+        );
+
+        let mut retried = RunView::new();
+        for e in demo::retrying() {
+            retried.apply(&e);
+        }
+        retried.apply(&ev(EventKind::WorkflowCompleted, 9_000, &[]));
+        let lines = verdict_card(&retried, &coloured, None);
+        let totals = lines.iter().find(|l| l.contains("retries")).expect("row");
+        assert!(
+            totals.contains("\x1b[33m1 retries\x1b[0m"),
+            "a real retry count paints yellow: {totals:?}"
+        );
+        // The box still closes at one visible column: strip the escapes
+        // and every border row measures the same width.
+        let bare: Vec<usize> = lines
+            .iter()
+            .map(|l| {
+                l.replace("\x1b[33m", "")
+                    .replace("\x1b[32m", "")
+                    .replace("\x1b[1m", "")
+                    .replace("\x1b[0m", "")
+                    .chars()
+                    .count()
+            })
+            .collect();
+        assert!(
+            bare.iter().all(|w| *w == bare[0]),
+            "escape-stripped alignment holds: {bare:?}"
+        );
     }
 
     /// A failed run cards the ✖ mark; a run with no verdict cards nothing

--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -142,6 +142,10 @@ pub fn waterfall(view: &RunView, theme: &Theme) -> Vec<String> {
         .collect();
     let time_w = durs.iter().map(|d| d.chars().count()).max().unwrap_or(0);
 
+    // The heat scale anchors on the run's own long pole (max wall time).
+    let wall_of = |iv: &Interval| u64::try_from(iv.end.saturating_sub(iv.start)).unwrap_or(0);
+    let wall_max = ran.iter().map(|(_, iv)| wall_of(iv)).max().unwrap_or(1);
+
     let mut lines = Vec::with_capacity(ran.len() + 1);
     for ((row, iv), dur) in ran.iter().zip(&durs) {
         let off = cell(iv.start).min(BAR_WIDTH - 1);
@@ -151,11 +155,20 @@ pub fn waterfall(view: &RunView, theme: &Theme) -> Vec<String> {
             TaskState::Running | TaskState::Retrying => Role::Accent,
             _ => Role::Good,
         };
+        // Duration heat rides SUCCESS bars only (design §1.5): the
+        // verdict hues (failed red · running accent) always win — heat
+        // is data, never a verdict. Off (flat Good) unless COLORTERM
+        // proved truecolor (`theme.heat`).
+        let bar_raw = bar.to_string().repeat(len);
+        let painted = if theme.heat && role == Role::Good {
+            theme.heat_step(heat_bucket(wall_of(iv), wall_max), &bar_raw)
+        } else {
+            theme.paint(role, &bar_raw)
+        };
         let mut line = format!(
-            "  {:<id_w$}  {edge_l}{}{}{edge_r}",
+            "  {:<id_w$}  {edge_l}{}{painted}{edge_r}",
             row.id,
             " ".repeat(off),
-            theme.paint(role, &bar.to_string().repeat(len)),
         );
         line.push_str(&" ".repeat(BAR_WIDTH - off - len));
         line.push_str("  ");
@@ -174,6 +187,15 @@ pub fn waterfall(view: &RunView, theme: &Theme) -> Vec<String> {
         &format!("  0s {} {total}", dot.to_string().repeat(dots)),
     ));
     lines
+}
+
+/// Quantize one duration onto the 5-step heat ramp: 0 (the fastest
+/// band) … 4 (the run's long pole). The run's own max anchors the
+/// scale — heat compares tasks WITHIN a run, never across runs.
+pub(crate) fn heat_bucket(wall_ms: u64, max_ms: u64) -> usize {
+    usize::try_from(wall_ms.saturating_mul(4) / max_ms.max(1))
+        .unwrap_or(4)
+        .min(4)
 }
 
 /// Widest the verdict card grows (inner cells) — 2-indent + corners keeps
@@ -678,5 +700,63 @@ mod tests {
         assert_eq!(fmt_wall_ms(3_200), "3.2s");
         assert_eq!(fmt_wall_ms(59_949), "59.9s");
         assert_eq!(fmt_wall_ms(124_000), "2m04s");
+    }
+
+    /// The heat quantizer: 5 bands anchored on the run's long pole —
+    /// zero-length lands in band 0, the max in band 4, and the scale is
+    /// linear in between (the exact boundaries pin the `*4/max` math
+    /// against off-by-one mutations).
+    #[test]
+    fn heat_bucket_quantizes_five_bands() {
+        assert_eq!(heat_bucket(0, 1_000), 0);
+        assert_eq!(heat_bucket(249, 1_000), 0);
+        assert_eq!(heat_bucket(250, 1_000), 1);
+        assert_eq!(heat_bucket(500, 1_000), 2);
+        assert_eq!(heat_bucket(750, 1_000), 3);
+        assert_eq!(heat_bucket(1_000, 1_000), 4);
+        // Degenerate scales stay in range (a zero-max run · overshoot).
+        assert_eq!(heat_bucket(5, 0), 4, "max clamps · never a panic");
+        assert_eq!(heat_bucket(2_000, 1_000), 4, "overshoot clamps to 4");
+    }
+
+    /// Duration heat rides SUCCESS bars only, truecolor only: with
+    /// `theme.heat` the ok bars carry `38;2;r;g;b` SGRs (the long pole
+    /// in the ramp's deepest step · the failed bar KEEPS its red) — and
+    /// without it the same view renders zero truecolor bytes (the
+    /// 256-colour fallback is flat, never approximated).
+    #[test]
+    fn waterfall_heat_is_truecolor_gated_and_success_only() {
+        let mut view = RunView::new();
+        view.apply(&ev(EventKind::TaskStarted, 0, &[("task", s("fast"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 250, &[("task", s("fast"))]));
+        view.apply(&ev(EventKind::TaskStarted, 250, &[("task", s("long"))]));
+        view.apply(&ev(EventKind::TaskCompleted, 1_250, &[("task", s("long"))]));
+        view.apply(&ev(EventKind::TaskStarted, 1_250, &[("task", s("bad"))]));
+        view.apply(&ev(EventKind::TaskFailed, 1_500, &[("task", s("bad"))]));
+
+        let mut heat = Theme::new(true, false, false);
+        heat.heat = true;
+        let lines = waterfall(&view, &heat);
+        let ramp_top = crate::display::theme::HEAT_RAMP[4];
+        let deepest = format!("\x1b[38;2;{};{};{}m", ramp_top.0, ramp_top.1, ramp_top.2);
+        assert!(
+            lines[1].contains(&deepest),
+            "the long pole wears the deepest step: {lines:?}"
+        );
+        assert!(
+            lines[0].contains("\x1b[38;2;"),
+            "the fast bar wears a paler step: {lines:?}"
+        );
+        assert!(
+            lines[2].contains("\x1b[31m") && !lines[2].contains("38;2;"),
+            "the failed bar stays RED — verdict beats heat: {lines:?}"
+        );
+
+        // COLORTERM absent → theme.heat off → flat bars, zero truecolor.
+        let flat = waterfall(&view, &Theme::new(true, false, false));
+        assert!(
+            !flat.iter().any(|l| l.contains("38;2;")),
+            "no COLORTERM proof → no truecolor: {flat:?}"
+        );
     }
 }

--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -10,6 +10,7 @@
 //! honest overlap. Everything here (lane markers · durations) derives
 //! from that one reconstruction.
 
+use crate::display::format::fmt_cost_usd;
 use crate::display::state::{RunView, TaskRow, TaskState};
 use crate::display::theme::{Role, Theme};
 
@@ -160,7 +161,7 @@ pub fn waterfall(view: &RunView, theme: &Theme) -> Vec<String> {
         line.push_str("  ");
         line.push_str(&theme.paint(Role::Dim, &format!("{dur:>time_w$}")));
         if let Some(cost) = row.cost_usd {
-            line.push_str(&theme.paint(Role::Dim, &format!(" · ${cost:.4}")));
+            line.push_str(&theme.paint(Role::Dim, &format!(" · {}", fmt_cost_usd(cost))));
         }
         lines.push(line);
     }
@@ -317,7 +318,7 @@ fn totals_row(view: &RunView) -> String {
     if tokens > 0 {
         let _ = write!(row, " · {tokens} tok");
     }
-    let _ = write!(row, " · ${:.4}", view.cost_usd);
+    let _ = write!(row, " · {}", fmt_cost_usd(view.cost_usd));
     let mut models: Vec<&str> = Vec::new();
     for r in view.rows() {
         if let Some(m) = r.model.as_deref()
@@ -477,16 +478,8 @@ mod tests {
         assert!(marks[2] && marks[3], "running ∥ settled sibling: {marks:?}");
     }
 
-    const PLAIN: Theme = Theme {
-        color: false,
-        ascii: false,
-        animate: false,
-    };
-    const ASCII: Theme = Theme {
-        color: false,
-        ascii: true,
-        animate: false,
-    };
+    const PLAIN: Theme = Theme::new(false, false, false);
+    const ASCII: Theme = Theme::new(false, true, false);
 
     /// Golden waterfall — bars scale to wall time, offsets carry the real
     /// sequencing, the axis closes the chart (design §2c geometry pinned:
@@ -562,7 +555,7 @@ mod tests {
         let lines = waterfall(&view, &PLAIN);
         assert_eq!(lines.len(), 3, "two ran bars + axis (no cancelled bar)");
         assert!(
-            lines[0].contains("work") && lines[0].ends_with("· $0.0020"),
+            lines[0].contains("work") && lines[0].ends_with("· $0.002"),
             "failed row bars + keeps its spend: {lines:?}"
         );
         assert!(
@@ -627,7 +620,7 @@ mod tests {
             "{lines:?}"
         );
         assert!(
-            lines[2].contains("4.7s · 710 tok · $0.0110 · claude-sonnet"),
+            lines[2].contains("4.7s · 710 tok · $0.01 · claude-sonnet"),
             "totals (wall · tokens · spend) + the model the stream named: {lines:?}"
         );
         assert!(lines[3].contains("outputs → review (object)"), "{lines:?}");

--- a/crates/nika-cli/src/display/format.rs
+++ b/crates/nika-cli/src/display/format.rs
@@ -142,8 +142,8 @@ const COST_MAX_PLACES: usize = 6;
 ///
 /// Two regimes: an amount that survives 2-place rounding is plain money
 /// (`$1.50` · `$0.01` — the dollars-and-cents baseline); a sub-cent
-/// amount renders at the [`COST_MAX_PLACES`] cap with trailing zeros
-/// stripped (`$0.002` · `$0.000284` — every digit shown is real).
+/// amount renders at the 6-place cap (`COST_MAX_PLACES`) with trailing
+/// zeros stripped (`$0.002` · `$0.000284` — every digit shown is real).
 /// `$0.00` for zero and for dust below the 6-place floor — a cost the
 /// engine cannot render honestly is a cost of zero cents, not a lie of
 /// trailing zeros. Non-finite input (a corrupt trace float) renders the

--- a/crates/nika-cli/src/display/format.rs
+++ b/crates/nika-cli/src/display/format.rs
@@ -76,6 +76,64 @@ pub fn color_enabled(choice: ColorChoice, env: ColorEnv, tty: bool) -> bool {
     }
 }
 
+/// The `--hyperlink <WHEN>` tri-state (fd · ls convention) — OSC-8
+/// terminal hyperlinks on the paths we print.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkChoice {
+    /// Force links on (pagers that pass escapes · captured demos).
+    Always,
+    /// Force links off.
+    Never,
+    /// TTY + `TERM != dumb` — links NEVER reach a pipe (the default).
+    Auto,
+}
+
+/// Resolve the hyperlink decision. `auto` is strictly TTY-gated (a
+/// machine surface must never grow OSC escapes by default); `always`
+/// is the operator's explicit override for escape-passing pagers.
+#[must_use]
+pub fn links_enabled(choice: LinkChoice, tty: bool, term_dumb: bool) -> bool {
+    match choice {
+        LinkChoice::Always => true,
+        LinkChoice::Never => false,
+        LinkChoice::Auto => tty && !term_dumb,
+    }
+}
+
+/// One OSC-8 hyperlink: `ESC]8;params;URL ST text ESC]8;; ST` — raw
+/// escapes, no crate (the mainstream-2026 form every relevant emulator
+/// speaks). `id` groups fragments of ONE link across wrapped/multi-line
+/// renders (the spec's `id=` param) — pass it whenever the same target
+/// repeats so the pointer highlights as one unit.
+#[must_use]
+pub fn osc8(url: &str, text: &str, id: Option<&str>) -> String {
+    let params = id.map(|i| format!("id={i}")).unwrap_or_default();
+    format!("\x1b]8;{params};{url}\x1b\\{text}\x1b]8;;\x1b\\")
+}
+
+/// A `file://` URL for one ABSOLUTE path: `file://{host}{path}`,
+/// percent-encoded. The hostname matters — iTerm2 opens file links only
+/// when the host names this machine (GNU ls does the same); an empty
+/// host reads as localhost (RFC 8089) and degrades gracefully.
+#[must_use]
+pub fn file_url(host: &str, abs_path: &str) -> String {
+    let mut url = String::with_capacity(7 + host.len() + abs_path.len());
+    url.push_str("file://");
+    url.push_str(host);
+    for b in abs_path.bytes() {
+        // RFC 3986 unreserved + the path separator stay literal; every
+        // other byte (space · unicode · quotes) rides percent-encoded.
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/') {
+            url.push(b as char);
+        } else {
+            let _ = write!(url, "%{b:02X}");
+        }
+    }
+    url
+}
+
+use std::fmt::Write as _;
+
 /// Widest a sub-cent cost may grow (decimal places) before it honestly
 /// rounds to the flat zero form.
 const COST_MAX_PLACES: usize = 6;
@@ -152,6 +210,45 @@ mod tests {
     fn cost_formatter_survives_non_finite() {
         assert_eq!(fmt_cost_usd(f64::NAN), "$0.00");
         assert_eq!(fmt_cost_usd(f64::INFINITY), "$0.00");
+    }
+
+    /// The hyperlink decision: `always`/`never` are absolute · `auto`
+    /// fires ONLY on a TTY with a capable TERM (never to pipes).
+    #[test]
+    fn link_resolution_is_tty_gated_under_auto() {
+        assert!(links_enabled(LinkChoice::Always, false, true), "forced on");
+        assert!(!links_enabled(LinkChoice::Never, true, false), "forced off");
+        assert!(links_enabled(LinkChoice::Auto, true, false));
+        assert!(!links_enabled(LinkChoice::Auto, false, false), "pipe");
+        assert!(!links_enabled(LinkChoice::Auto, true, true), "TERM=dumb");
+    }
+
+    /// The OSC-8 wire form, byte-exact: `ESC]8;;URL ST text ESC]8;; ST`
+    /// — and the `id=` param rides when a multi-line link needs to
+    /// highlight as one unit.
+    #[test]
+    fn osc8_emits_the_exact_escape_form() {
+        assert_eq!(
+            osc8("file://mac/tmp/a.yaml", "a.yaml", None),
+            "\x1b]8;;file://mac/tmp/a.yaml\x1b\\a.yaml\x1b]8;;\x1b\\"
+        );
+        assert_eq!(
+            osc8("https://nika.sh", "spec", Some("s1")),
+            "\x1b]8;id=s1;https://nika.sh\x1b\\spec\x1b]8;;\x1b\\"
+        );
+    }
+
+    /// `file://` URLs carry the host (iTerm2 requirement) and percent-
+    /// encode everything outside unreserved+`/` — bytes, not chars, so
+    /// unicode paths ride as UTF-8 %-sequences.
+    #[test]
+    fn file_url_encodes_the_path_and_keeps_the_host() {
+        assert_eq!(
+            file_url("mac.local", "/tmp/demo file.yaml"),
+            "file://mac.local/tmp/demo%20file.yaml"
+        );
+        assert_eq!(file_url("", "/a/b_c-d.~e/f"), "file:///a/b_c-d.~e/f");
+        assert_eq!(file_url("h", "/é"), "file://h/%C3%A9");
     }
 
     /// The full priority chain (module doc order) — each rung beats

--- a/crates/nika-cli/src/display/format.rs
+++ b/crates/nika-cli/src/display/format.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ONE formatting + colour-capability vocabulary (the round-8 seam).
+//!
+//! ## The cost rule (one formatter · every surface)
+//!
+//! Money speaks through [`fmt_cost_usd`] everywhere a run's spend renders
+//! (the footer meter · the verdict card · per-task cells · the waterfall).
+//! The rule: dollars-and-cents baseline (`$1.50` · `$0.01`); a SUB-CENT
+//! cost renders at the 6-place cap with trailing zeros stripped
+//! (`$0.0003` · `$0.000284` — the honest precision, never the
+//! first-rounding lie that would call 0.000284 "`$0.0003`"); zero and
+//! sub-floor dust render the flat `$0.00`. Before this seam the meter
+//! said `$0.000` while the card said `$0.0003` on the SAME run.
+//!
+//! ## The colour split (locked)
+//!
+//! CHROME — borders · labels · state glyphs · verdicts — speaks the
+//! ANSI-16 slots via [`crate::display::theme::Role`]: the USER's terminal
+//! theme decides the actual hues, we only name semantics. TRUECOLOR is
+//! reserved for DATA (the duration-heat ramp) and fires only under an
+//! explicit `COLORTERM` capability signal — never for decoration.
+//!
+//! ## The colour-resolution order (the fd/cargo convention)
+//!
+//! `--color always|never|auto` > `CLICOLOR_FORCE` (set · non-empty ·
+//! not `0`) > `NO_COLOR` (any non-empty value) > `CLICOLOR=0` > the
+//! auto floor: stdout is a TTY and `TERM != dumb`. [`color_enabled`] is
+//! the pure decision; the binary collects the environment facts (this
+//! module does no I/O).
+
+/// The `--color <WHEN>` tri-state (fd · ls · cargo convention).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorChoice {
+    /// Force colour on (pagers · `watch` · captured demos).
+    Always,
+    /// Force colour off (`--no-color` folds here).
+    Never,
+    /// Resolve from the environment chain + TTY (the default).
+    Auto,
+}
+
+/// The environment facts the `auto` arm reads — collected once by the
+/// binary (the display layer stays I/O-free · pure · testable).
+// Four INDEPENDENT environment facts, not a state machine — the same
+// flags-are-flags exemption the clap arg structs carry (main.rs).
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ColorEnv {
+    /// `CLICOLOR_FORCE` set · non-empty · not `"0"`.
+    pub force: bool,
+    /// `NO_COLOR` set to any non-empty value (<https://no-color.org>).
+    pub no_color: bool,
+    /// `CLICOLOR` set to exactly `"0"`.
+    pub clicolor_zero: bool,
+    /// `TERM` is exactly `dumb`.
+    pub term_dumb: bool,
+}
+
+/// Resolve the colour decision (the locked priority order · module doc).
+#[must_use]
+pub fn color_enabled(choice: ColorChoice, env: ColorEnv, tty: bool) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => {
+            if env.force {
+                return true;
+            }
+            if env.no_color || env.clicolor_zero {
+                return false;
+            }
+            tty && !env.term_dumb
+        }
+    }
+}
+
+/// Widest a sub-cent cost may grow (decimal places) before it honestly
+/// rounds to the flat zero form.
+const COST_MAX_PLACES: usize = 6;
+
+/// Format a run spend in dollars (the ONE cost formatter — module doc).
+///
+/// Two regimes: an amount that survives 2-place rounding is plain money
+/// (`$1.50` · `$0.01` — the dollars-and-cents baseline); a sub-cent
+/// amount renders at the [`COST_MAX_PLACES`] cap with trailing zeros
+/// stripped (`$0.002` · `$0.000284` — every digit shown is real).
+/// `$0.00` for zero and for dust below the 6-place floor — a cost the
+/// engine cannot render honestly is a cost of zero cents, not a lie of
+/// trailing zeros. Non-finite input (a corrupt trace float) renders the
+/// zero form too — never a panic, never `$NaN`.
+#[must_use]
+pub fn fmt_cost_usd(usd: f64) -> String {
+    if !usd.is_finite() {
+        return "$0.00".to_owned();
+    }
+    let cents = format!("{usd:.2}");
+    if has_visible_amount(&cents) {
+        return format!("${cents}");
+    }
+    let full = format!("{usd:.COST_MAX_PLACES$}");
+    if !has_visible_amount(&full) {
+        return "$0.00".to_owned();
+    }
+    format!("${}", full.trim_end_matches('0'))
+}
+
+/// Does a formatted decimal show any non-zero digit? (`0.00` no · `0.01`
+/// yes — the "visibly non-zero" test both regimes share.)
+fn has_visible_amount(text: &str) -> bool {
+    text.bytes().any(|b| b.is_ascii_digit() && b != b'0')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The cost rule, pinned end-to-end: baseline cents · the sub-cent
+    /// 6-place cap with trailing zeros stripped · the flat zero.
+    #[test]
+    fn cost_formatter_extends_places_until_non_zero() {
+        assert_eq!(fmt_cost_usd(0.0), "$0.00");
+        assert_eq!(fmt_cost_usd(1.5), "$1.50");
+        assert_eq!(fmt_cost_usd(0.04), "$0.04");
+        assert_eq!(fmt_cost_usd(0.01), "$0.01");
+        // Super-cent: the dollars-and-cents baseline.
+        assert_eq!(fmt_cost_usd(0.011), "$0.01");
+        // Sub-cent: honest places up to the cap (the field bug: the meter
+        // said $0.000 while the card said $0.0003 on the SAME run).
+        assert_eq!(fmt_cost_usd(0.002), "$0.002");
+        assert_eq!(fmt_cost_usd(0.0003), "$0.0003");
+        assert_eq!(fmt_cost_usd(0.000_284_25), "$0.000284", "cap-6 · no lie");
+        assert_eq!(fmt_cost_usd(0.000_01), "$0.00001");
+        assert_eq!(fmt_cost_usd(0.000_004), "$0.000004");
+        // Below the 6-place floor: the honest flat zero, never 0.000000.
+        assert_eq!(fmt_cost_usd(0.000_000_4), "$0.00");
+    }
+
+    /// The regime boundary is 2-place rounding: `0.005` survives it
+    /// (`$0.01` · baseline money) while `0.0049` does not and renders its
+    /// REAL sub-cent places (`$0.0049` — never the rounded `$0.005`).
+    #[test]
+    fn cost_formatter_rejects_zero_looking_roundings() {
+        assert_eq!(fmt_cost_usd(0.0049), "$0.0049");
+        assert_eq!(fmt_cost_usd(0.005), "$0.01", "rounds up at 2 places");
+        assert_eq!(fmt_cost_usd(0.9999), "$1.00");
+    }
+
+    /// Corrupt input never panics and never prints `$NaN`.
+    #[test]
+    fn cost_formatter_survives_non_finite() {
+        assert_eq!(fmt_cost_usd(f64::NAN), "$0.00");
+        assert_eq!(fmt_cost_usd(f64::INFINITY), "$0.00");
+    }
+
+    /// The full priority chain (module doc order) — each rung beats
+    /// everything below it.
+    #[test]
+    fn color_resolution_priority_chain() {
+        let plain = ColorEnv::default();
+        // The explicit flag beats every environment fact.
+        let hostile = ColorEnv {
+            force: false,
+            no_color: true,
+            clicolor_zero: true,
+            term_dumb: true,
+        };
+        assert!(color_enabled(ColorChoice::Always, hostile, false));
+        let forcing = ColorEnv {
+            force: true,
+            ..hostile
+        };
+        assert!(!color_enabled(ColorChoice::Never, forcing, true));
+
+        // CLICOLOR_FORCE beats NO_COLOR, CLICOLOR=0 and the pipe floor.
+        assert!(color_enabled(ColorChoice::Auto, forcing, false));
+
+        // NO_COLOR (non-empty) kills colour even on a TTY.
+        let no_color = ColorEnv {
+            no_color: true,
+            ..plain
+        };
+        assert!(!color_enabled(ColorChoice::Auto, no_color, true));
+
+        // CLICOLOR=0 likewise.
+        let clicolor_zero = ColorEnv {
+            clicolor_zero: true,
+            ..plain
+        };
+        assert!(!color_enabled(ColorChoice::Auto, clicolor_zero, true));
+
+        // The auto floor: TTY and TERM≠dumb.
+        assert!(color_enabled(ColorChoice::Auto, plain, true));
+        assert!(!color_enabled(ColorChoice::Auto, plain, false));
+        let dumb = ColorEnv {
+            term_dumb: true,
+            ..plain
+        };
+        assert!(!color_enabled(ColorChoice::Auto, dumb, true));
+    }
+}

--- a/crates/nika-cli/src/display/mod.rs
+++ b/crates/nika-cli/src/display/mod.rs
@@ -3,9 +3,11 @@
 
 //! The display module — fold (`state`) · glyphs/colour (`theme`) · frames
 //! (`render`) · execution-flow reads (`flow`) · bounded output summaries
-//! (`shape`). One truth in, text out; no I/O lives here.
+//! (`shape`) · the shared formatter + colour-capability seam (`format`).
+//! One truth in, text out; no I/O lives here.
 
 pub mod flow;
+pub mod format;
 pub mod render;
 pub mod shape;
 pub mod state;

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -226,7 +226,7 @@ fn task_line(
     // sparkline may ride a running row — transient shift accepted).
     let pad = note_w.saturating_sub(display_note.chars().count());
     line.push_str(&" ".repeat(pad + 2));
-    let cell = format!("{:>time_w$}", time.unwrap_or(""));
+    let cell = duration_cell(theme, time, time_w);
     line.push_str(&theme.paint(Role::Dim, cell.trim_end()));
     if let Some(cost) = cost {
         line.push_str(&theme.paint(Role::Dim, &cost));
@@ -240,6 +240,21 @@ fn task_line(
         line.push_str(&theme.paint(Role::Accent, if theme.ascii { " ||" } else { " ∥" }));
     }
     line
+}
+
+/// The duration cell: bare right-aligned (`  2.7s` · the sober
+/// registers) or the nextest bracket form (`[  2.7s]`) under the
+/// interactive accents. Width math happens on RAW text (paint comes
+/// after) — ANSI never skews the column; a row without a duration
+/// stays empty in both forms.
+// `&Theme` to match the `task_line` borrow that threads it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn duration_cell(theme: &Theme, time: Option<&str>, time_w: usize) -> String {
+    match (theme.accents, time) {
+        (true, Some(t)) => format!("[{t:>time_w$}]"),
+        (true, None) => String::new(),
+        (false, t) => format!("{:>time_w$}", t.unwrap_or("")),
+    }
 }
 
 /// Render the COMPACT final card (spec §3.5 `--quiet` · "final card only ·
@@ -577,6 +592,39 @@ mod tests {
     fn frame_is_stable_under_ticks_when_nothing_runs() {
         let view = fold(&demo::success());
         assert_eq!(frame(&view, &UNICODE, 0), frame(&view, &UNICODE, 9));
+    }
+
+    /// The interactive accents bracket the duration column (nextest
+    /// school · `[  1.2s]`), right-aligned inside the SAME width the
+    /// sober form uses — and rows without a duration (the skipped row)
+    /// grow no brackets. The sober frame stays byte-identical to the
+    /// golden above by construction (accents default OFF).
+    #[test]
+    fn accents_bracket_the_duration_column_tty_only() {
+        let mut accented = UNICODE;
+        accented.accents = true;
+        let lines = frame(&fold(&demo::success()), &accented, 0);
+        assert!(
+            lines[3].ends_with("[ 1.2s]"),
+            "bracketed right-aligned cell: {}",
+            lines[3]
+        );
+        assert!(
+            lines[4].ends_with("[130ms]"),
+            "the widest cell sets the width: {}",
+            lines[4]
+        );
+        assert!(
+            !lines[7].contains('['),
+            "the skipped row grows no brackets: {}",
+            lines[7]
+        );
+        // Cost still rides AFTER the bracketed cell on the row that has one.
+        assert!(
+            lines[5].contains("[ 3.0s] · $0.01"),
+            "cost follows the cell: {}",
+            lines[5]
+        );
     }
 
     /// A view with output-carrying completions: `frame_with_outputs`

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -226,8 +226,14 @@ fn task_line(
     // sparkline may ride a running row — transient shift accepted).
     let pad = note_w.saturating_sub(display_note.chars().count());
     line.push_str(&" ".repeat(pad + 2));
+    let slow = theme.accents && is_slow(row, view);
     let cell = duration_cell(theme, time, time_w);
-    line.push_str(&theme.paint(Role::Dim, cell.trim_end()));
+    let cell_role = if slow { Role::Warn } else { Role::Dim };
+    line.push_str(&theme.paint(cell_role, cell.trim_end()));
+    if slow {
+        line.push(' ');
+        line.push_str(&theme.paint(Role::Warn, "slow"));
+    }
     if let Some(cost) = cost {
         line.push_str(&theme.paint(Role::Dim, &cost));
     }
@@ -240,6 +246,37 @@ fn task_line(
         line.push_str(&theme.paint(Role::Accent, if theme.ascii { " ||" } else { " ∥" }));
     }
     line
+}
+
+/// The SLOW threshold (nextest school · design §1.4): a settled task
+/// whose wall time exceeds `max(2 × median settled duration, 30s)`
+/// self-identifies. `None` until at least TWO tasks settled — a median
+/// of one can only compare the task to itself. The 30s floor keeps
+/// fast runs (mock demos · sub-second pipelines) accent-free: nothing
+/// moves that doesn't inform.
+fn slow_threshold_ms(view: &RunView) -> Option<u64> {
+    let mut walls: Vec<u64> = view
+        .rows()
+        .iter()
+        .filter(|r| matches!(r.state, TaskState::Ok | TaskState::Failed))
+        .filter_map(TaskRow::wall_ms)
+        .collect();
+    if walls.len() < 2 {
+        return None;
+    }
+    walls.sort_unstable();
+    let median = walls[walls.len() / 2];
+    Some(median.saturating_mul(2).max(30_000))
+}
+
+/// Does this row's REAL wall time cross the run's SLOW threshold?
+/// Settled rows only — a running row's elapsed is still moving, its
+/// verdict can wait for the terminal frame.
+fn is_slow(row: &TaskRow, view: &RunView) -> bool {
+    matches!(row.state, TaskState::Ok | TaskState::Failed)
+        && slow_threshold_ms(view)
+            .zip(row.wall_ms())
+            .is_some_and(|(threshold, wall)| wall > threshold)
 }
 
 /// The duration cell: bare right-aligned (`  2.7s` · the sober
@@ -624,6 +661,79 @@ mod tests {
             lines[5].contains("[ 3.0s] · $0.01"),
             "cost follows the cell: {}",
             lines[5]
+        );
+        // The demo runs sub-second — under the 30s SLOW floor, so even
+        // the accented frame carries no accidental `slow` marker.
+        assert!(
+            !lines.iter().any(|l| l.contains("slow")),
+            "fast runs stay marker-free: {lines:?}"
+        );
+    }
+
+    /// The SLOW accent (design §1.4): a settled task past
+    /// `max(2 × median, 30s)` renders its duration YELLOW + the `slow`
+    /// word — interactive accents only, and the threshold floor keeps
+    /// mid-scale tasks quiet.
+    #[test]
+    fn slow_tasks_self_identify_under_accents() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let task = |n: &str| KeyValue::new("task", Value::String(n.to_owned()));
+        let dur = |ms: i64| KeyValue::new("duration_ms", Value::Int(ms));
+
+        let mut view = RunView::new();
+        for (name, ms, at) in [
+            ("a", 1_000, 1_000u64),
+            ("b", 1_200, 2_000),
+            ("c", 100_000, 5_000),
+        ] {
+            view.apply(&demo::bare_event(EventKind::TaskStarted, 0).with_field(task(name)));
+            view.apply(
+                &demo::bare_event(EventKind::TaskCompleted, at)
+                    .with_field(task(name))
+                    .with_field(dur(ms)),
+            );
+        }
+
+        // Sober register: never the marker, whatever the durations.
+        let sober = frame(&view, &UNICODE, 0);
+        assert!(!sober.iter().any(|l| l.contains("slow")), "{sober:?}");
+
+        // Accents + colour: the 100s task (median 1.2s → floor 30s)
+        // carries the yellow cell + the word; its siblings stay dim.
+        let mut accented = Theme::new(true, false, false);
+        accented.accents = true;
+        let lines = frame(&view, &accented, 0);
+        let c_row = lines.iter().find(|l| l.contains(" c ")).expect("c row");
+        assert!(
+            c_row.contains("\x1b[33m") && c_row.contains("slow"),
+            "the slow task self-identifies in yellow: {c_row:?}"
+        );
+        let a_row = lines.iter().find(|l| l.contains(" a ")).expect("a row");
+        assert!(
+            !a_row.contains("slow") && !a_row.contains("\x1b[33m"),
+            "median-scale siblings stay quiet: {a_row:?}"
+        );
+
+        // The floor: 25s over a 20s median is NOT slow (2×median = 40s
+        // wins the max) — no marker.
+        let mut mid = RunView::new();
+        for (name, ms, at) in [
+            ("x", 10_000, 1_000u64),
+            ("y", 20_000, 2_000),
+            ("z", 25_000, 3_000),
+        ] {
+            mid.apply(&demo::bare_event(EventKind::TaskStarted, 0).with_field(task(name)));
+            mid.apply(
+                &demo::bare_event(EventKind::TaskCompleted, at)
+                    .with_field(task(name))
+                    .with_field(dur(ms)),
+            );
+        }
+        let quiet = frame(&mid, &accented, 0);
+        assert!(
+            !quiet.iter().any(|l| l.contains("slow")),
+            "2x-median dominates the floor: {quiet:?}"
         );
     }
 

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -6,6 +6,7 @@
 //! the truth-to-text mapping. Snapshot tests pin BOTH glyph themes.
 
 use crate::display::flow::{fmt_wall_ms, lane_marks};
+use crate::display::format::fmt_cost_usd;
 use crate::display::state::{RunView, TaskRow, TaskState};
 use crate::display::theme::{Role, Theme};
 
@@ -38,7 +39,7 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
     // Header: identity + the statically-proven ceiling.
     let ceiling = view
         .ceiling_usd
-        .map(|c| format!(" · ceiling ≤ ${c:.2}"))
+        .map(|c| format!(" · ceiling ≤ {}", fmt_cost_usd(c)))
         .unwrap_or_default();
     lines.push(format!(
         "  {} nika · {} · {} tasks{ceiling}",
@@ -99,10 +100,12 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         ));
     }
 
-    // Footer meter: progress · live cost vs ceiling · wall clock.
+    // Footer meter: progress · live cost vs ceiling · wall clock. The
+    // spend speaks the ONE cost formatter (format.rs) — the meter and the
+    // verdict card can never again disagree on the same run's dollars.
     let cost = match view.ceiling_usd {
-        Some(c) => format!("${:.3} of ≤${c:.2}", view.cost_usd),
-        None => format!("${:.3}", view.cost_usd),
+        Some(c) => format!("{} of ≤{}", fmt_cost_usd(view.cost_usd), fmt_cost_usd(c)),
+        None => fmt_cost_usd(view.cost_usd),
     };
     #[allow(clippy::cast_precision_loss)] // display-only seconds
     let secs = view.elapsed_ms as f64 / 1000.0;
@@ -215,7 +218,7 @@ fn task_line(
         row.id,
         theme.paint(Role::Dim, &note),
     );
-    let cost = row.cost_usd.map(|c| format!(" · ${c:.4}"));
+    let cost = row.cost_usd.map(|c| format!(" · {}", fmt_cost_usd(c)));
     if time.is_none() && cost.is_none() && !mark && tail.is_none() {
         return line;
     }
@@ -252,8 +255,8 @@ pub fn verdict_frame(view: &RunView, theme: &Theme) -> Vec<String> {
         None => theme.glyph(TaskState::Pending, 0),
     };
     let cost = match view.ceiling_usd {
-        Some(c) => format!("${:.3} of ≤${c:.2}", view.cost_usd),
-        None => format!("${:.3}", view.cost_usd),
+        Some(c) => format!("{} of ≤{}", fmt_cost_usd(view.cost_usd), fmt_cost_usd(c)),
+        None => fmt_cost_usd(view.cost_usd),
     };
     #[allow(clippy::cast_precision_loss)] // display-only seconds
     let secs = view.elapsed_ms as f64 / 1000.0;
@@ -340,16 +343,8 @@ mod tests {
         view
     }
 
-    const UNICODE: Theme = Theme {
-        color: false,
-        ascii: false,
-        animate: false,
-    };
-    const ASCII: Theme = Theme {
-        color: false,
-        ascii: true,
-        animate: false,
-    };
+    const UNICODE: Theme = Theme::new(false, false, false);
+    const ASCII: Theme = Theme::new(false, true, false);
 
     /// Golden frame — the unicode theme, colour off (the exact spec story).
     /// Time is a first-class column now: each settled row carries its wall
@@ -364,14 +359,14 @@ mod tests {
             "",
             "  ✔  fetch_top     http 200 · 1.2s · 34 KB         1.2s",
             "  ✔  extract_ai    jq · 0.1s · 12 items           130ms",
-            "  ✔  summarize     claude-sonnet · 3.1s · $0.011   3.0s · $0.0110",
+            "  ✔  summarize     claude-sonnet · 3.1s · $0.011   3.0s · $0.01",
             "  ✔  write_md      2.1 KB written                 290ms",
             "  ↷  notify_slack  when: env.CI != 'true'",
         ];
         assert_eq!(&lines[..8], &expected[..]);
         // The meter line: pinned prefix + rule-padded to a stable width.
         assert!(
-            lines[8].starts_with("  ── 5/5 done · $0.011 of ≤$0.04 · elapsed 4.7s "),
+            lines[8].starts_with("  ── 5/5 done · $0.01 of ≤$0.04 · elapsed 4.7s "),
             "meter: {}",
             lines[8]
         );
@@ -525,7 +520,7 @@ mod tests {
             "verdict line: {}",
             lines[0]
         );
-        assert!(lines[0].contains("$0.011 of ≤$0.04"), "cost: {}", lines[0]);
+        assert!(lines[0].contains("$0.01 of ≤$0.04"), "cost: {}", lines[0]);
         // NOT the storyboard — no per-task row leaks into the quiet card.
         assert!(
             !lines.iter().any(|l| l.contains("fetch_top")),

--- a/crates/nika-cli/src/display/shape.rs
+++ b/crates/nika-cli/src/display/shape.rs
@@ -117,16 +117,8 @@ pub fn output_tail(
 mod tests {
     use super::*;
 
-    const PLAIN: Theme = Theme {
-        color: false,
-        ascii: false,
-        animate: false,
-    };
-    const ASCII: Theme = Theme {
-        color: false,
-        ascii: true,
-        animate: false,
-    };
+    const PLAIN: Theme = Theme::new(false, false, false);
+    const ASCII: Theme = Theme::new(false, true, false);
 
     /// Objects read as their key set — array-valued keys carry `[N]`,
     /// values never leak into the shape (the design's one law).

--- a/crates/nika-cli/src/display/theme.rs
+++ b/crates/nika-cli/src/display/theme.rs
@@ -14,6 +14,21 @@ use crate::display::state::TaskState;
 /// Braille spinner frames (80ms cadence at the call site).
 pub const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
+/// The duration-heat ramp (design §1.5): ONE hue (azure ≈ 200°), five
+/// quantized LIGHTNESS steps — short bars pale, the long pole bright.
+/// Perceptual single-hue by design: never red→green (deuteranopia) ·
+/// never a second semantic hue (red stays the failure verdict alone).
+/// Truecolor ONLY — the caller gates on `Theme.heat` (`COLORTERM` said
+/// truecolor/24bit); the 256-colour fallback is the FLAT bar, never an
+/// approximated ramp. A const table, no colour crate.
+pub(crate) const HEAT_RAMP: [(u8, u8, u8); 5] = [
+    (96, 125, 139),
+    (86, 143, 163),
+    (74, 162, 189),
+    (58, 183, 217),
+    (38, 205, 247),
+];
+
 /// Token-arrival sparkline ramp (low → high).
 pub const SPARK: [char; 7] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇'];
 
@@ -161,6 +176,20 @@ impl Theme {
         } else {
             text.to_owned()
         }
+    }
+
+    /// Paint a DATA run in one heat step (truecolor SGR · [`HEAT_RAMP`])
+    /// — the ONLY truecolor seam in the binary: chrome (borders · labels
+    /// · verdicts) stays on the ANSI-16 `Role` slots forever (the user's
+    /// terminal theme decides those hues). Plain text when colour is
+    /// off; the CALLER gates on `self.heat` (the `COLORTERM` capability).
+    #[must_use]
+    pub(crate) fn heat_step(self, step: usize, text: &str) -> String {
+        if !self.color {
+            return text.to_owned();
+        }
+        let (r, g, b) = HEAT_RAMP[step.min(HEAT_RAMP.len() - 1)];
+        format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
     }
 
     /// Render a 3-sample sparkline from token-arrival counts.

--- a/crates/nika-cli/src/display/theme.rs
+++ b/crates/nika-cli/src/display/theme.rs
@@ -143,6 +143,18 @@ impl Theme {
         if self.ascii { "[nika]" } else { "🦋" }
     }
 
+    /// Wrap `text` as an OSC-8 hyperlink to `url` — a no-op unless the
+    /// `links` capability resolved on (TTY + `--hyperlink` chain), so
+    /// every sober register keeps its exact bytes.
+    #[must_use]
+    pub fn link(&self, url: &str, text: &str) -> String {
+        if self.links {
+            crate::display::format::osc8(url, text, None)
+        } else {
+            text.to_owned()
+        }
+    }
+
     /// Render a 3-sample sparkline from token-arrival counts.
     #[must_use]
     pub fn sparkline(&self, samples: &[u64]) -> String {

--- a/crates/nika-cli/src/display/theme.rs
+++ b/crates/nika-cli/src/display/theme.rs
@@ -68,12 +68,19 @@ pub struct Theme {
     /// Emit OSC-8 hyperlinks (`--hyperlink` · auto = TTY + `TERM≠dumb` ·
     /// never to pipes).
     pub links: bool,
+    /// The interactive duration accents (nextest school): bracketed
+    /// right-aligned duration cells (`[  2.7s]`) + the `slow` marker.
+    /// TTY comfort ONLY — these are TEXT, so every sober register
+    /// (pipes · CI · `--no-progress` · machine modes) keeps its exact
+    /// bytes by leaving this off.
+    pub accents: bool,
 }
 
 impl Theme {
     /// The 3-knob constructor every call site speaks — capability tiers
-    /// (`heat` · `links`) default OFF so a bare theme is exactly the
-    /// pre-round-8 surface (pipes · CI · tests stay byte-identical).
+    /// (`heat` · `links` · `accents`) default OFF so a bare theme is
+    /// exactly the pre-round-8 surface (pipes · CI · tests stay
+    /// byte-identical).
     #[must_use]
     pub const fn new(color: bool, ascii: bool, animate: bool) -> Self {
         Self {
@@ -82,6 +89,7 @@ impl Theme {
             animate,
             heat: false,
             links: false,
+            accents: false,
         }
     }
     /// Paint `text` in a semantic role (no-op when colour is off).

--- a/crates/nika-cli/src/display/theme.rs
+++ b/crates/nika-cli/src/display/theme.rs
@@ -47,18 +47,43 @@ impl Role {
     }
 }
 
-/// One theme = colour on/off × glyph family × motion.
+/// One theme = colour on/off × glyph family × motion × capability tier.
+// Five INDEPENDENT render knobs, not a state machine — the same
+// flags-are-flags exemption the clap arg structs carry (main.rs).
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy)]
 pub struct Theme {
-    /// Emit ANSI colour (resolved from `--color`/`NO_COLOR`/TTY upstream).
+    /// Emit ANSI colour (resolved through the ONE priority chain —
+    /// `display::format::color_enabled` · `--color` > `CLICOLOR_FORCE` >
+    /// `NO_COLOR` > `CLICOLOR=0` > TTY+`TERM≠dumb`).
     pub color: bool,
     /// Use the ASCII glyph column (CI logs · legacy conhost · `--ascii`).
     pub ascii: bool,
     /// Animate the running glyph (TTY + motion allowed).
     pub animate: bool,
+    /// Truecolor DATA ramps allowed (`COLORTERM` said truecolor/24bit ·
+    /// the duration-heat waterfall). Chrome NEVER rides this — the
+    /// ANSI-16 `Role` slots stay the chrome vocabulary (format.rs doc).
+    pub heat: bool,
+    /// Emit OSC-8 hyperlinks (`--hyperlink` · auto = TTY + `TERM≠dumb` ·
+    /// never to pipes).
+    pub links: bool,
 }
 
 impl Theme {
+    /// The 3-knob constructor every call site speaks — capability tiers
+    /// (`heat` · `links`) default OFF so a bare theme is exactly the
+    /// pre-round-8 surface (pipes · CI · tests stay byte-identical).
+    #[must_use]
+    pub const fn new(color: bool, ascii: bool, animate: bool) -> Self {
+        Self {
+            color,
+            ascii,
+            animate,
+            heat: false,
+            links: false,
+        }
+    }
     /// Paint `text` in a semantic role (no-op when colour is off).
     #[must_use]
     pub fn paint(&self, role: Role, text: &str) -> String {
@@ -144,16 +169,8 @@ impl Theme {
 mod tests {
     use super::*;
 
-    const PLAIN: Theme = Theme {
-        color: false,
-        ascii: false,
-        animate: false,
-    };
-    const ASCII: Theme = Theme {
-        color: false,
-        ascii: true,
-        animate: false,
-    };
+    const PLAIN: Theme = Theme::new(false, false, false);
+    const ASCII: Theme = Theme::new(false, true, false);
 
     #[test]
     fn every_state_has_a_two_cell_glyph_in_both_themes() {
@@ -191,11 +208,7 @@ mod tests {
             ASCII.glyph(TaskState::Failed, 0),
             ASCII.glyph(TaskState::Cancelled, 0)
         );
-        let coloured = Theme {
-            color: true,
-            ascii: false,
-            animate: false,
-        };
+        let coloured = Theme::new(true, false, false);
         assert!(
             coloured.glyph(TaskState::Retrying, 0).contains("\x1b[33m"),
             "retrying paints yellow (Warn)"

--- a/crates/nika-cli/src/display/vocab.rs
+++ b/crates/nika-cli/src/display/vocab.rs
@@ -37,11 +37,7 @@ pub(crate) fn hint(theme: Theme, label: &str, command: &str) -> String {
 mod tests {
     use super::*;
 
-    const PLAIN: Theme = Theme {
-        color: false,
-        ascii: false,
-        animate: false,
-    };
+    const PLAIN: Theme = Theme::new(false, false, false);
 
     /// Every vocabulary glyph carries its ASCII twin — the parity law.
     #[test]

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -32,6 +32,7 @@ use nika_event::Event;
 // filename, so the version/usage/errors must say `nika`, not the seed crate name.
 #[command(
     name = "nika",
+    bin_name = "nika",
     version,
     about = "nika · the AI workflow engine — operator surface"
 )]
@@ -487,8 +488,7 @@ fn main() -> std::process::ExitCode {
         },
         Command::New { from, dest, force } => emit(&verbs::new::run(&from, dest.as_deref(), force)),
         Command::Completions { shell } => {
-            let mut cmd = Cli::command();
-            clap_complete::generate(shell, &mut cmd, "nika-cli", &mut std::io::stdout());
+            write_completions(shell, &mut std::io::stdout());
             0
         }
         Command::Trace { action } => trace_verb(action, color, link_when),
@@ -615,6 +615,14 @@ fn resolve_run_mode(quiet: bool, no_progress: bool) -> verbs::run::RenderMode {
     }
 }
 
+/// Write shell completions attached to the PUBLIC binary name — `nika`,
+/// never the seed crate's file name (`#compdef nika-cli` would wire
+/// completions to a command users never type · found live 2026-07-05).
+fn write_completions(shell: clap_complete::Shell, out: &mut dyn std::io::Write) {
+    let mut cmd = Cli::command();
+    clap_complete::generate(shell, &mut cmd, "nika", out);
+}
+
 /// Collect the colour-relevant environment facts once (the pure priority
 /// chain lives in `display::format::color_enabled` — this is its I/O half).
 fn color_env() -> ColorEnv {
@@ -642,8 +650,11 @@ fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg, link_when: 
     let events = match load_events(args) {
         Ok(events) => events,
         Err(message) => {
-            eprintln!("nika-cli: {message}");
-            return 3; // environment error (spec §4)
+            eprintln!("nika trace: {message}");
+            eprintln!(
+                "  fix: a trace is the NDJSON a run records — nika run <wf> --json > run.ndjson"
+            );
+            return verbs::exit::ENV; // environment error (spec §4)
         }
     };
 
@@ -791,6 +802,36 @@ fn env_value(name: &str) -> Option<String> {
 mod tests {
     #![allow(clippy::expect_used)]
     use super::*;
+
+    /// The public name is `nika` EVERYWHERE clap speaks (found live
+    /// 2026-07-05): the Usage line (`bin_name`) and the generated shell
+    /// completions — `#compdef nika-cli` attached completions to a
+    /// command users never type, dead on arrival.
+    #[test]
+    fn clap_surfaces_speak_the_public_binary_name() {
+        let help = Cli::command().render_help().to_string();
+        assert!(help.contains("Usage: nika "), "usage speaks `nika`: {help}");
+        assert!(!help.contains("nika-cli"), "the seed name never leaks");
+
+        let mut zsh = Vec::new();
+        write_completions(clap_complete::Shell::Zsh, &mut zsh);
+        let zsh = String::from_utf8(zsh).expect("utf8");
+        assert!(
+            zsh.starts_with("#compdef nika\n"),
+            "zsh attaches to `nika`: {}",
+            zsh.lines().next().unwrap_or_default()
+        );
+
+        let mut bash = Vec::new();
+        write_completions(clap_complete::Shell::Bash, &mut bash);
+        let bash = String::from_utf8(bash).expect("utf8");
+        assert!(
+            bash.contains("complete -F _nika -o nosort -o bashdefault -o default nika")
+                || (bash.contains("default nika") && !bash.contains("nika-cli")),
+            "bash completes `nika`, never nika-cli: {bash}"
+        );
+        assert!(!bash.contains("nika-cli"), "the seed name never leaks");
+    }
 
     /// One valid serialized Event line — reuse the demo's real events.
     fn valid_line() -> String {

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -584,6 +584,8 @@ fn run_verb(args: &RunArgs, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     // sober registers (piped · --no-progress · --quiet) keep their
     // exact bytes.
     theme.accents = mode == verbs::run::RenderMode::Live;
+    // Duration heat additionally needs colour + the truecolor PROOF.
+    theme.heat = theme.accents && theme.color && truecolor_env();
     verbs::run::run(
         &args.file,
         args.json,
@@ -651,6 +653,8 @@ fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg, link_when: 
     // The duration accents ride the interactive surface only — a piped
     // `trace show` keeps its exact legacy bytes.
     theme.accents = tty;
+    // Duration heat additionally needs colour + the truecolor PROOF.
+    theme.heat = tty && theme.color && truecolor_env();
 
     // The shape tails ride the interactive surface only: a TTY render
     // (show OR replay) carries them unless `--no-outputs`; a piped
@@ -767,6 +771,13 @@ fn recover_events(raw: &str, label: &str) -> Result<Vec<Event>, String> {
 #[allow(clippy::disallowed_methods)]
 fn env_flag(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|v| !v.is_empty())
+}
+
+/// Did the terminal PROVE truecolor (`COLORTERM=truecolor|24bit`)?
+/// The duration-heat ramp fires only on proof — 256-colour terminals
+/// get the flat fallback, never an approximated ramp (design §1.5).
+fn truecolor_env() -> bool {
+    env_value("COLORTERM").is_some_and(|v| v == "truecolor" || v == "24bit")
 }
 
 /// Read a presentation variable's VALUE (`CLICOLOR` · `TERM` ·

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use nika_cli::display::format::{ColorChoice, ColorEnv, color_enabled};
 use nika_cli::verbs::{self, VerbOutput};
 use nika_cli::{RunView, Theme, frame};
 use nika_event::Event;
@@ -35,8 +36,37 @@ use nika_event::Event;
     about = "nika · the AI workflow engine — operator surface"
 )]
 struct Cli {
+    /// When to colour the output (auto = TTY + `TERM != dumb` · honours
+    /// `CLICOLOR_FORCE` · `NO_COLOR` · `CLICOLOR=0` in that order).
+    #[arg(long, global = true, value_enum, default_value_t = ColorWhenArg::Auto)]
+    color: ColorWhenArg,
     #[command(subcommand)]
     command: Command,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum ColorWhenArg {
+    /// Force colour on (pagers accepting escapes · captured demos).
+    Always,
+    /// Force colour off (the `--no-color` flags fold here).
+    Never,
+    /// Resolve from the environment chain + TTY (the default).
+    Auto,
+}
+
+impl ColorWhenArg {
+    /// Fold a verb's legacy `--no-color` sugar into the tri-state: an
+    /// explicit off wins (both flags together = the conservative read).
+    fn with_no_color(self, no_color: bool) -> ColorChoice {
+        if no_color {
+            return ColorChoice::Never;
+        }
+        match self {
+            Self::Always => ColorChoice::Always,
+            Self::Never => ColorChoice::Never,
+            Self::Auto => ColorChoice::Auto,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -373,6 +403,7 @@ struct TraceArgs {
 
 fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
+    let color = cli.color;
     let code = match cli.command {
         Command::Check {
             file,
@@ -384,17 +415,25 @@ fn main() -> std::process::ExitCode {
             let out = if infer_permits {
                 verbs::check::run_infer_permits(&file, json)
             } else {
-                verbs::check::run(&file, json, term_theme(no_color, ascii))
+                verbs::check::run(
+                    &file,
+                    json,
+                    term_theme(color.with_no_color(no_color), ascii),
+                )
             };
             emit(&out)
         }
-        Command::Run(args) => run_verb(&args),
+        Command::Run(args) => run_verb(&args, color),
         Command::Test {
             file,
             update,
             no_color,
             ascii,
-        } => verbs::test::run(&file, update, term_theme(no_color, ascii)),
+        } => verbs::test::run(
+            &file,
+            update,
+            term_theme(color.with_no_color(no_color), ascii),
+        ),
         Command::Inspect { file, ascii } => emit(&verbs::inspect::run(&file, ascii)),
         Command::Graph { file, format } => {
             let format = match format {
@@ -414,9 +453,11 @@ fn main() -> std::process::ExitCode {
             ExamplesAction::List => emit(&verbs::pack_surface::examples_list()),
             ExamplesAction::Show { slug } => emit(&verbs::pack_surface::examples_show(&slug)),
             // The L3 run verb shipped — execute the embedded example for real.
-            ExamplesAction::Run { slug, model } => {
-                verbs::run::example(&slug, model.as_deref(), term_theme(false, false))
-            }
+            ExamplesAction::Run { slug, model } => verbs::run::example(
+                &slug,
+                model.as_deref(),
+                term_theme(color.with_no_color(false), false),
+            ),
         },
         Command::New { from, dest, force } => emit(&verbs::new::run(&from, dest.as_deref(), force)),
         Command::Completions { shell } => {
@@ -424,7 +465,7 @@ fn main() -> std::process::ExitCode {
             clap_complete::generate(shell, &mut cmd, "nika-cli", &mut std::io::stdout());
             0
         }
-        Command::Trace { action } => trace_verb(action),
+        Command::Trace { action } => trace_verb(action, color),
         // The language server OWNS stdout (JSON-RPC) — it must not go through
         // `emit`. It follows the LSP exit-code convention: 0 on a clean
         // shutdown/exit, non-zero (1) otherwise (transport failure, or an
@@ -465,17 +506,17 @@ fn emit(out: &VerbOutput) -> u8 {
 
 /// Dispatch the `trace` verb family: the live renders (replay · show)
 /// plus the static readers (outputs · peek · flow).
-fn trace_verb(action: TraceAction) -> u8 {
+fn trace_verb(action: TraceAction, color: ColorWhenArg) -> u8 {
     match action {
-        TraceAction::Replay(args) => trace_render(&args, true),
-        TraceAction::Show(args) => trace_render(&args, false),
+        TraceAction::Replay(args) => trace_render(&args, true, color),
+        TraceAction::Show(args) => trace_render(&args, false, color),
         TraceAction::Outputs {
             trace,
             ascii,
             no_color,
         } => emit(&verbs::trace::outputs(
             &trace.to_string_lossy(),
-            term_theme(no_color, ascii),
+            term_theme(color.with_no_color(no_color), ascii),
         )),
         TraceAction::Peek {
             trace,
@@ -487,7 +528,7 @@ fn trace_verb(action: TraceAction) -> u8 {
             &trace.to_string_lossy(),
             &task,
             raw,
-            term_theme(no_color, ascii),
+            term_theme(color.with_no_color(no_color), ascii),
         )),
         TraceAction::Flow {
             trace,
@@ -497,13 +538,13 @@ fn trace_verb(action: TraceAction) -> u8 {
         } => emit(&verbs::trace::flow(
             &trace.to_string_lossy(),
             &workflow,
-            term_theme(no_color, ascii),
+            term_theme(color.with_no_color(no_color), ascii),
         )),
     }
 }
 
 /// Unpack the `run` clap surface into the library verb call.
-fn run_verb(args: &RunArgs) -> u8 {
+fn run_verb(args: &RunArgs, color: ColorWhenArg) -> u8 {
     let resume = args.resume.as_ref().map(|trace| verbs::run::ResumeRequest {
         trace: trace.clone(),
         from: args.from.clone(),
@@ -513,7 +554,7 @@ fn run_verb(args: &RunArgs) -> u8 {
         &args.file,
         args.json,
         args.output.as_deref(),
-        term_theme(args.no_color, args.ascii),
+        term_theme(color.with_no_color(args.no_color), args.ascii),
         resolve_run_mode(args.quiet, args.no_progress),
         args.dry_run,
         args.model.as_deref(),
@@ -538,18 +579,25 @@ fn resolve_run_mode(quiet: bool, no_progress: bool) -> verbs::run::RenderMode {
     }
 }
 
-/// Resolve the colour/glyph theme for static (non-animated) surfaces.
-fn term_theme(no_color: bool, ascii: bool) -> Theme {
-    let tty = std::io::stdout().is_terminal();
-    Theme {
-        color: tty && !no_color && !env_flag("NO_COLOR"),
-        ascii,
-        animate: false,
+/// Collect the colour-relevant environment facts once (the pure priority
+/// chain lives in `display::format::color_enabled` — this is its I/O half).
+fn color_env() -> ColorEnv {
+    ColorEnv {
+        force: env_value("CLICOLOR_FORCE").is_some_and(|v| !v.is_empty() && v != "0"),
+        no_color: env_flag("NO_COLOR"),
+        clicolor_zero: env_value("CLICOLOR").is_some_and(|v| v == "0"),
+        term_dumb: env_value("TERM").is_some_and(|v| v == "dumb"),
     }
 }
 
+/// Resolve the colour/glyph theme for static (non-animated) surfaces.
+fn term_theme(choice: ColorChoice, ascii: bool) -> Theme {
+    let tty = std::io::stdout().is_terminal();
+    Theme::new(color_enabled(choice, color_env(), tty), ascii, false)
+}
+
 /// Load events, fold, render — live replay or final card.
-fn trace_render(args: &TraceArgs, replay: bool) -> u8 {
+fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg) -> u8 {
     let events = match load_events(args) {
         Ok(events) => events,
         Err(message) => {
@@ -559,11 +607,8 @@ fn trace_render(args: &TraceArgs, replay: bool) -> u8 {
     };
 
     let tty = std::io::stdout().is_terminal();
-    let theme = Theme {
-        color: tty && !args.no_color && !env_flag("NO_COLOR"),
-        ascii: args.ascii,
-        animate: tty && replay && !env_flag("NIKA_REDUCED_MOTION"),
-    };
+    let mut theme = term_theme(color.with_no_color(args.no_color), args.ascii);
+    theme.animate = tty && replay && !env_flag("NIKA_REDUCED_MOTION");
 
     // The shape tails ride the interactive surface only: a TTY render
     // (show OR replay) carries them unless `--no-outputs`; a piped
@@ -680,6 +725,13 @@ fn recover_events(raw: &str, label: &str) -> Result<Vec<Event>, String> {
 #[allow(clippy::disallowed_methods)]
 fn env_flag(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|v| !v.is_empty())
+}
+
+/// Read a presentation variable's VALUE (`CLICOLOR` · `TERM` ·
+/// `COLORTERM`) — the same non-secret seam as [`env_flag`].
+#[allow(clippy::disallowed_methods)]
+fn env_value(name: &str) -> Option<String> {
+    std::env::var(name).ok()
 }
 
 #[cfg(test)]

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
-use nika_cli::display::format::{ColorChoice, ColorEnv, color_enabled};
+use nika_cli::display::format::{ColorChoice, ColorEnv, LinkChoice, color_enabled, links_enabled};
 use nika_cli::verbs::{self, VerbOutput};
 use nika_cli::{RunView, Theme, frame};
 use nika_event::Event;
@@ -40,8 +40,33 @@ struct Cli {
     /// `CLICOLOR_FORCE` · `NO_COLOR` · `CLICOLOR=0` in that order).
     #[arg(long, global = true, value_enum, default_value_t = ColorWhenArg::Auto)]
     color: ColorWhenArg,
+    /// When to emit OSC-8 hyperlinks on printed paths (auto = TTY +
+    /// `TERM != dumb` · never to pipes; always = force them, for pagers
+    /// that pass escapes — tmux/screen may render them as plain text).
+    #[arg(long, global = true, value_enum, default_value_t = LinkWhenArg::Auto)]
+    hyperlink: LinkWhenArg,
     #[command(subcommand)]
     command: Command,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum LinkWhenArg {
+    /// Force hyperlinks on (escape-passing pagers · captured demos).
+    Always,
+    /// Force hyperlinks off.
+    Never,
+    /// TTY + `TERM != dumb` — never to pipes (the default).
+    Auto,
+}
+
+impl LinkWhenArg {
+    fn choice(self) -> LinkChoice {
+        match self {
+            Self::Always => LinkChoice::Always,
+            Self::Never => LinkChoice::Never,
+            Self::Auto => LinkChoice::Auto,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -404,6 +429,7 @@ struct TraceArgs {
 fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
     let color = cli.color;
+    let link_when = cli.hyperlink.choice();
     let code = match cli.command {
         Command::Check {
             file,
@@ -418,12 +444,12 @@ fn main() -> std::process::ExitCode {
                 verbs::check::run(
                     &file,
                     json,
-                    term_theme(color.with_no_color(no_color), ascii),
+                    term_theme(color.with_no_color(no_color), ascii, link_when),
                 )
             };
             emit(&out)
         }
-        Command::Run(args) => run_verb(&args, color),
+        Command::Run(args) => run_verb(&args, color, link_when),
         Command::Test {
             file,
             update,
@@ -432,7 +458,7 @@ fn main() -> std::process::ExitCode {
         } => verbs::test::run(
             &file,
             update,
-            term_theme(color.with_no_color(no_color), ascii),
+            term_theme(color.with_no_color(no_color), ascii, link_when),
         ),
         Command::Inspect { file, ascii } => emit(&verbs::inspect::run(&file, ascii)),
         Command::Graph { file, format } => {
@@ -456,7 +482,7 @@ fn main() -> std::process::ExitCode {
             ExamplesAction::Run { slug, model } => verbs::run::example(
                 &slug,
                 model.as_deref(),
-                term_theme(color.with_no_color(false), false),
+                term_theme(color.with_no_color(false), false, link_when),
             ),
         },
         Command::New { from, dest, force } => emit(&verbs::new::run(&from, dest.as_deref(), force)),
@@ -465,7 +491,7 @@ fn main() -> std::process::ExitCode {
             clap_complete::generate(shell, &mut cmd, "nika-cli", &mut std::io::stdout());
             0
         }
-        Command::Trace { action } => trace_verb(action, color),
+        Command::Trace { action } => trace_verb(action, color, link_when),
         // The language server OWNS stdout (JSON-RPC) — it must not go through
         // `emit`. It follows the LSP exit-code convention: 0 on a clean
         // shutdown/exit, non-zero (1) otherwise (transport failure, or an
@@ -506,17 +532,17 @@ fn emit(out: &VerbOutput) -> u8 {
 
 /// Dispatch the `trace` verb family: the live renders (replay · show)
 /// plus the static readers (outputs · peek · flow).
-fn trace_verb(action: TraceAction, color: ColorWhenArg) -> u8 {
+fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     match action {
-        TraceAction::Replay(args) => trace_render(&args, true, color),
-        TraceAction::Show(args) => trace_render(&args, false, color),
+        TraceAction::Replay(args) => trace_render(&args, true, color, link_when),
+        TraceAction::Show(args) => trace_render(&args, false, color, link_when),
         TraceAction::Outputs {
             trace,
             ascii,
             no_color,
         } => emit(&verbs::trace::outputs(
             &trace.to_string_lossy(),
-            term_theme(color.with_no_color(no_color), ascii),
+            term_theme(color.with_no_color(no_color), ascii, link_when),
         )),
         TraceAction::Peek {
             trace,
@@ -528,7 +554,7 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg) -> u8 {
             &trace.to_string_lossy(),
             &task,
             raw,
-            term_theme(color.with_no_color(no_color), ascii),
+            term_theme(color.with_no_color(no_color), ascii, link_when),
         )),
         TraceAction::Flow {
             trace,
@@ -538,13 +564,13 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg) -> u8 {
         } => emit(&verbs::trace::flow(
             &trace.to_string_lossy(),
             &workflow,
-            term_theme(color.with_no_color(no_color), ascii),
+            term_theme(color.with_no_color(no_color), ascii, link_when),
         )),
     }
 }
 
 /// Unpack the `run` clap surface into the library verb call.
-fn run_verb(args: &RunArgs, color: ColorWhenArg) -> u8 {
+fn run_verb(args: &RunArgs, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     let resume = args.resume.as_ref().map(|trace| verbs::run::ResumeRequest {
         trace: trace.clone(),
         from: args.from.clone(),
@@ -554,7 +580,7 @@ fn run_verb(args: &RunArgs, color: ColorWhenArg) -> u8 {
         &args.file,
         args.json,
         args.output.as_deref(),
-        term_theme(color.with_no_color(args.no_color), args.ascii),
+        term_theme(color.with_no_color(args.no_color), args.ascii, link_when),
         resolve_run_mode(args.quiet, args.no_progress),
         args.dry_run,
         args.model.as_deref(),
@@ -590,14 +616,19 @@ fn color_env() -> ColorEnv {
     }
 }
 
-/// Resolve the colour/glyph theme for static (non-animated) surfaces.
-fn term_theme(choice: ColorChoice, ascii: bool) -> Theme {
+/// Resolve the colour/glyph/link theme for static (non-animated)
+/// surfaces — colour and hyperlinks each ride their own capability
+/// chain over the SAME environment facts.
+fn term_theme(choice: ColorChoice, ascii: bool, link_when: LinkChoice) -> Theme {
     let tty = std::io::stdout().is_terminal();
-    Theme::new(color_enabled(choice, color_env(), tty), ascii, false)
+    let env = color_env();
+    let mut theme = Theme::new(color_enabled(choice, env, tty), ascii, false);
+    theme.links = links_enabled(link_when, tty, env.term_dumb);
+    theme
 }
 
 /// Load events, fold, render — live replay or final card.
-fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg) -> u8 {
+fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     let events = match load_events(args) {
         Ok(events) => events,
         Err(message) => {
@@ -607,7 +638,7 @@ fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg) -> u8 {
     };
 
     let tty = std::io::stdout().is_terminal();
-    let mut theme = term_theme(color.with_no_color(args.no_color), args.ascii);
+    let mut theme = term_theme(color.with_no_color(args.no_color), args.ascii, link_when);
     theme.animate = tty && replay && !env_flag("NIKA_REDUCED_MOTION");
 
     // The shape tails ride the interactive surface only: a TTY render

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -540,10 +540,12 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
             trace,
             ascii,
             no_color,
-        } => emit(&verbs::trace::outputs(
-            &trace.to_string_lossy(),
-            term_theme(color.with_no_color(no_color), ascii, link_when),
-        )),
+        } => {
+            let mut theme = term_theme(color.with_no_color(no_color), ascii, link_when);
+            // The dur column's bracket accents: TTY comfort only.
+            theme.accents = std::io::stdout().is_terminal();
+            emit(&verbs::trace::outputs(&trace.to_string_lossy(), theme))
+        }
         TraceAction::Peek {
             trace,
             task,
@@ -576,12 +578,18 @@ fn run_verb(args: &RunArgs, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
         from: args.from.clone(),
         answers: args.answer.clone(),
     });
+    let mode = resolve_run_mode(args.quiet, args.no_progress);
+    let mut theme = term_theme(color.with_no_color(args.no_color), args.ascii, link_when);
+    // The duration accents ride the interactive surface ONLY — the
+    // sober registers (piped · --no-progress · --quiet) keep their
+    // exact bytes.
+    theme.accents = mode == verbs::run::RenderMode::Live;
     verbs::run::run(
         &args.file,
         args.json,
         args.output.as_deref(),
-        term_theme(color.with_no_color(args.no_color), args.ascii, link_when),
-        resolve_run_mode(args.quiet, args.no_progress),
+        theme,
+        mode,
         args.dry_run,
         args.model.as_deref(),
         &args.var,
@@ -640,6 +648,9 @@ fn trace_render(args: &TraceArgs, replay: bool, color: ColorWhenArg, link_when: 
     let tty = std::io::stdout().is_terminal();
     let mut theme = term_theme(color.with_no_color(args.no_color), args.ascii, link_when);
     theme.animate = tty && replay && !env_flag("NIKA_REDUCED_MOTION");
+    // The duration accents ride the interactive surface only — a piped
+    // `trace show` keeps its exact legacy bytes.
+    theme.accents = tty;
 
     // The shape tails ride the interactive surface only: a TTY render
     // (show OR replay) carries them unless `--no-outputs`; a piped

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -525,11 +525,7 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("tmp dir");
         let path = dir.join(name);
         std::fs::write(&path, yaml).expect("fixture body");
-        let theme = Theme {
-            color: false,
-            ascii,
-            animate: false,
-        };
+        let theme = Theme::new(false, ascii, false);
         run(path.to_str().expect("utf8 path"), false, theme).text
     }
 

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -91,6 +91,13 @@ pub(crate) fn link_host() -> String {
         .unwrap_or_default()
 }
 
+/// Did the terminal PROVE truecolor (`COLORTERM=truecolor|24bit`)?
+/// Presentation env — the same scoped exemption as [`link_host`].
+#[allow(clippy::disallowed_methods)]
+pub(crate) fn truecolor_env() -> bool {
+    std::env::var("COLORTERM").is_ok_and(|v| v == "truecolor" || v == "24bit")
+}
+
 /// Render one on-disk path as an OSC-8 `file://` hyperlink when the
 /// theme's `links` capability resolved on — the TEXT stays the path the
 /// verb already prints (byte-identical registers when links are off).

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -78,6 +78,37 @@ impl VerbOutput {
     }
 }
 
+/// Best-effort hostname for `file://` links (iTerm2 opens them only when
+/// the host names this machine). Env-only — no libc, no subprocess; an
+/// empty host degrades to RFC 8089 localhost. The read is presentation
+/// state, not a secret — the same scoped exemption as `env_flag` in
+/// `main.rs` (the workspace `disallowed_methods` ban routes SECRET reads
+/// through the kernel vault seam, which has no business here).
+#[allow(clippy::disallowed_methods)]
+pub(crate) fn link_host() -> String {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("HOST"))
+        .unwrap_or_default()
+}
+
+/// Render one on-disk path as an OSC-8 `file://` hyperlink when the
+/// theme's `links` capability resolved on — the TEXT stays the path the
+/// verb already prints (byte-identical registers when links are off).
+/// A path that will not canonicalize (deleted mid-run · unsaved) stays
+/// plain: a link that cannot open is worse than no link.
+pub(crate) fn linked_path(theme: crate::Theme, path: &str) -> String {
+    if !theme.links {
+        return path.to_owned();
+    }
+    match std::fs::canonicalize(path) {
+        Ok(abs) => {
+            let url = crate::display::format::file_url(&link_host(), &abs.to_string_lossy());
+            theme.link(&url, path)
+        }
+        Err(_) => path.to_owned(),
+    }
+}
+
 /// Read + strict-parse + ladder-check one workflow file.
 ///
 /// Failure mapping per spec §4: unreadable = environment (`3`) · parse
@@ -94,6 +125,36 @@ pub(crate) fn load_checked(path: &str) -> Result<(RawWorkflow, CheckReport), Ver
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pipe-parity pin: with the `links` capability OFF (every sober
+    /// register), `linked_path` returns the path VERBATIM — zero escapes.
+    /// With it on, the OSC-8 wrapper carries a `file://` URL and keeps
+    /// the printed text unchanged; a path that will not canonicalize
+    /// stays plain (a dead link is worse than no link).
+    #[test]
+    fn linked_path_is_byte_identical_when_links_are_off() {
+        let dir = std::env::temp_dir().join("nika-cli-linkedpath-tests");
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let file = dir.join("wf.nika.yaml");
+        std::fs::write(&file, "nika: v1\n").expect("fixture");
+        let path = file.to_str().expect("utf8 path");
+
+        let plain = crate::Theme::new(false, false, false);
+        assert_eq!(linked_path(plain, path), path, "sober register: verbatim");
+
+        let mut linked = crate::Theme::new(false, false, false);
+        linked.links = true;
+        let out = linked_path(linked, path);
+        assert!(
+            out.starts_with("\x1b]8;;file://") && out.ends_with("\x1b]8;;\x1b\\"),
+            "OSC-8 wrapper: {out:?}"
+        );
+        assert!(out.contains(path), "the printed text stays the path");
+
+        let ghost = dir.join("never-written.yaml");
+        let ghost = ghost.to_str().expect("utf8 path");
+        assert_eq!(linked_path(linked, ghost), ghost, "no file → no link");
+    }
 
     /// Regression · a parse-stage rejection must surface its spec wire code,
     /// exactly like the CONFORM stage. The multiple-verbs short-circuit used

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -103,7 +103,7 @@ pub fn run(
             // Pre-run diagnostics obey the export contract too: in machine
             // mode they go to stderr so a `capture: stdout` consumer never
             // mistakes the "cannot read" text for the JSON result.
-            emit_diagnostic(&out.text, output_json);
+            emit_diagnostic(&refusal_text(&out), output_json);
             return out.code;
         }
     };
@@ -346,6 +346,22 @@ fn example_model(yaml: &str) -> String {
     .ok()
     .and_then(|wf| wf.model.map(|m| m.value))
     .unwrap_or_default()
+}
+
+/// House-voice a pre-run refusal (the empty-state audit · design §3):
+/// the ENV class (an unreadable/missing file) gains the `nika run:`
+/// prefix, ONE `fix:` line and a closing newline — a bare
+/// `cannot read …(os error 2)` glued to the prompt taught nothing.
+/// FILE findings pass through untouched (the check renderer's card is
+/// already the teaching surface).
+fn refusal_text(out: &crate::verbs::VerbOutput) -> String {
+    if out.code != exit::ENV {
+        return out.text.clone();
+    }
+    format!(
+        "nika run: {}\n  fix: check the path — `nika examples list` names runnable demos\n",
+        out.text.trim_end()
+    )
 }
 
 /// Validate `--output` up front — `Ok(true)` selects the machine-result
@@ -926,6 +942,30 @@ mod tests {
         // failure cannot be model-related — the nudge would mislead (the
         // cold-user e2e hit exactly this on 16-exec-pipeline).
         assert!(!offline_tip_applies(exit::WORKFLOW, false, ""));
+    }
+
+    /// The empty-state voice (design §3 rider): an ENV refusal (missing
+    /// file) carries the house prefix + ONE fix line + a closing
+    /// newline; FILE findings pass through to the check card untouched.
+    #[test]
+    fn refusal_text_teaches_only_the_env_class() {
+        let env = crate::verbs::VerbOutput {
+            text: "cannot read demo.yaml: No such file or directory (os error 2)".to_owned(),
+            code: exit::ENV,
+        };
+        let voiced = super::refusal_text(&env);
+        assert!(
+            voiced.starts_with("nika run: cannot read demo.yaml"),
+            "{voiced}"
+        );
+        assert!(voiced.contains("fix: check the path"), "{voiced}");
+        assert!(voiced.ends_with('\n'), "closes its own line: {voiced:?}");
+
+        let findings = crate::verbs::VerbOutput {
+            text: "PARSE X  [NIKA-PARSE-009] two verbs".to_owned(),
+            code: exit::FILE,
+        };
+        assert_eq!(super::refusal_text(&findings), findings.text);
     }
 
     /// A noiseless theme (no colour · no animation) for the run tests — they

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -305,9 +305,11 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
     } else {
         RenderMode::Plain
     };
-    // The interactive duration accents follow the same TTY gate.
+    // The interactive duration accents follow the same TTY gate; heat
+    // additionally needs colour + the truecolor proof.
     let mut theme = theme;
     theme.accents = mode == RenderMode::Live;
+    theme.heat = theme.accents && theme.color && crate::verbs::truecolor_env();
     let code = run(
         &path.to_string_lossy(),
         false,

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -921,11 +921,7 @@ mod tests {
     /// A noiseless theme (no colour · no animation) for the run tests — they
     /// exercise the COMPOSITION + exit code, not the render surface.
     fn plain_theme() -> Theme {
-        Theme {
-            color: false,
-            ascii: true,
-            animate: false,
-        }
+        Theme::new(false, true, false)
     }
 
     fn stage(name: &str, yaml: &str) -> std::path::PathBuf {

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -669,7 +669,12 @@ fn print_flow_epilogue(
     for line in crate::display::flow::verdict_card(view, &theme, note.as_deref()) {
         println!("{line}");
     }
-    let record = format!("nika run {file} --json > run.ndjson · nika trace outputs run.ndjson");
+    // The workflow path is CLICKABLE on link-capable terminals (OSC-8 ·
+    // file:// — the one real file in the hint; the ndjson names are the
+    // suggested two-step, not files that exist yet).
+    let file_cell = crate::verbs::linked_path(theme, file);
+    let record =
+        format!("nika run {file_cell} --json > run.ndjson · nika trace outputs run.ndjson");
     println!(
         "  {}",
         crate::display::vocab::hint(theme, "explore", &record)

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -305,6 +305,9 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
     } else {
         RenderMode::Plain
     };
+    // The interactive duration accents follow the same TTY gate.
+    let mut theme = theme;
+    theme.accents = mode == RenderMode::Live;
     let code = run(
         &path.to_string_lossy(),
         false,

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -160,7 +160,18 @@ impl<W: Write> FoldSink<W> {
     fn repaint(&mut self) -> std::io::Result<()> {
         // Move the cursor up over the previous frame and clear from there
         // down (ANSI · the spinner family). TTY-only — `emit` gates this.
-        if self.last_lines > 0 {
+        // A REDRAW rides inside a DEC-2026 synchronized-output frame
+        // (`CSI ?2026h … ?2026l`): kitty/WezTerm/Ghostty/Rio hold the
+        // screen until the frame closes (no clear-then-paint flicker);
+        // every other terminal ignores the pair (zero-cost no-op). The
+        // FIRST paint appends without clearing — nothing can tear, so it
+        // stays escape-free (the first-frame law the tests pin). A write
+        // error mid-frame leaves the pair unclosed once, harmlessly: the
+        // sink goes silent (buffered error) and DEC-2026 terminals
+        // time the frame out on their own.
+        let redraw = self.last_lines > 0;
+        if redraw {
+            write!(self.writer, "\x1b[?2026h")?;
             write!(self.writer, "\x1b[{}A", self.last_lines)?;
             write!(self.writer, "\x1b[0J")?;
         }
@@ -171,6 +182,9 @@ impl<W: Write> FoldSink<W> {
         };
         for line in &lines {
             writeln!(self.writer, "{line}")?;
+        }
+        if redraw {
+            write!(self.writer, "\x1b[?2026l")?;
         }
         self.last_lines = lines.len();
         self.writer.flush()
@@ -350,6 +364,41 @@ mod tests {
         assert!(
             !text.contains('\x1b'),
             "no prior frame to clear → no cursor-up escape: {text:?}"
+        );
+    }
+
+    /// Every Live REDRAW rides inside one DEC-2026 synchronized-output
+    /// frame: `?2026h` opens BEFORE the cursor-up + clear, `?2026l`
+    /// closes AFTER the last repainted line — the flicker-free contract
+    /// on kitty/WezTerm/Ghostty (a no-op pair everywhere else). The
+    /// FIRST paint (append-only) carries no pair.
+    #[test]
+    fn fold_sink_live_redraws_inside_synchronized_frames() {
+        let theme = Theme::new(false, false, false);
+        let mut buf = Vec::new();
+        {
+            let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Live);
+            for ev in demo::success() {
+                sink.emit(ev);
+            }
+            assert!(sink.into_error().is_none());
+        }
+        let text = String::from_utf8(buf).expect("utf8");
+        let opens = text.matches("\x1b[?2026h").count();
+        let closes = text.matches("\x1b[?2026l").count();
+        let frames = demo::success().len();
+        assert_eq!(opens, frames - 1, "every redraw opens a frame: {text:?}");
+        assert_eq!(opens, closes, "every open closes");
+        // The pair BRACKETS the redraw: the open is IMMEDIATELY followed
+        // by the cursor-up escape (h before any clearing), and the very
+        // last write closes the final frame (l after the repaint).
+        assert!(
+            text.contains("\x1b[?2026h\x1b["),
+            "h opens before the cursor-up: {text:?}"
+        );
+        assert!(
+            text.ends_with("\x1b[?2026l"),
+            "the last write closes the frame"
         );
     }
 }

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -235,11 +235,7 @@ mod tests {
 
     #[test]
     fn fold_sink_non_interactive_folds_silent_then_prints_one_frame() {
-        let theme = Theme {
-            color: false,
-            ascii: true,
-            animate: false,
-        };
+        let theme = Theme::new(false, true, false);
         let mut buf = Vec::new();
         {
             // Plain: no per-event repaint · one final storyboard frame.
@@ -262,11 +258,7 @@ mod tests {
 
     #[test]
     fn fold_sink_quiet_prints_only_the_verdict_card() {
-        let theme = Theme {
-            color: false,
-            ascii: true,
-            animate: false,
-        };
+        let theme = Theme::new(false, true, false);
         let mut buf = Vec::new();
         {
             let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Quiet);
@@ -288,11 +280,7 @@ mod tests {
 
     #[test]
     fn fold_sink_interactive_repaints_in_place() {
-        let theme = Theme {
-            color: false,
-            ascii: false,
-            animate: false,
-        };
+        let theme = Theme::new(false, false, false);
         let mut buf = Vec::new();
         {
             let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Live);
@@ -308,11 +296,7 @@ mod tests {
 
     #[test]
     fn fold_sink_failure_keeps_the_false_verdict() {
-        let theme = Theme {
-            color: false,
-            ascii: false,
-            animate: false,
-        };
+        let theme = Theme::new(false, false, false);
         let mut buf = Vec::new();
         let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Plain);
         for ev in demo::failure() {
@@ -329,11 +313,7 @@ mod tests {
     fn fold_sink_tails_are_opt_in() {
         use nika_event::EventKind;
         use nika_types::resource::{KeyValue, Value};
-        let theme = Theme {
-            color: false,
-            ascii: true,
-            animate: false,
-        };
+        let theme = Theme::new(false, true, false);
         let completed = demo::bare_event(EventKind::TaskCompleted, 5)
             .with_field(KeyValue::new("task", Value::String("audit".into())))
             .with_field(KeyValue::new("output", Value::String("[1,2]".into())));
@@ -361,11 +341,7 @@ mod tests {
     /// control).
     #[test]
     fn fold_sink_live_first_frame_writes_no_cursor_jump() {
-        let theme = Theme {
-            color: false,
-            ascii: false,
-            animate: false,
-        };
+        let theme = Theme::new(false, false, false);
         let mut buf = Vec::new();
         let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Live);
         let events = demo::success();

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -262,11 +262,7 @@ mod tests {
 
     /// A noiseless theme — the tests exercise verdicts, not paint.
     fn plain_theme() -> Theme {
-        Theme {
-            color: false,
-            ascii: true,
-            animate: false,
-        }
+        Theme::new(false, true, false)
     }
 
     /// A deterministic mock workflow with a typed `outputs:` block.

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -115,7 +115,10 @@ pub fn run(file: &str, update: bool, theme: Theme) -> u8 {
         println!(
             "{} golden match · {keys} {key_word} · {bytes} {}",
             theme.paint(Role::Good, if theme.ascii { "ok" } else { "✔" }),
-            theme.paint(Role::Dim, &format!("· {golden_path}"))
+            theme.paint(
+                Role::Dim,
+                &format!("· {}", crate::verbs::linked_path(theme, &golden_path)),
+            )
         );
         return exit::OK;
     }
@@ -150,7 +153,10 @@ fn write_golden(golden_path: &str, actual: &Value, theme: Theme) -> u8 {
     println!(
         "{} golden written {}",
         theme.paint(Role::Good, if theme.ascii { "ok" } else { "✔" }),
-        theme.paint(Role::Dim, &format!("· {golden_path}"))
+        theme.paint(
+            Role::Dim,
+            &format!("· {}", crate::verbs::linked_path(theme, golden_path)),
+        )
     );
     println!("  review it once, commit it — `nika test` now guards this workflow");
     exit::OK
@@ -181,7 +187,10 @@ fn render_mismatch(
         out,
         "{} outputs drifted from the golden {}",
         theme.paint(Role::Bad, if theme.ascii { "X" } else { "✖" }),
-        theme.paint(Role::Dim, &format!("· {golden_path}"))
+        theme.paint(
+            Role::Dim,
+            &format!("· {}", crate::verbs::linked_path(theme, golden_path)),
+        )
     );
     for line in diff_lines(expected, actual) {
         let _ = writeln!(out, "  {line}");

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -410,11 +410,7 @@ mod tests {
     use crate::verbs::exit;
 
     fn plain() -> Theme {
-        Theme {
-            color: false,
-            ascii: false,
-            animate: false,
-        }
+        Theme::new(false, false, false)
     }
 
     /// Stage a real NDJSON trace from the demo storyboard events.
@@ -491,14 +487,7 @@ mod tests {
         );
         assert!(out.text.contains("38ms"), "measured duration: {}", out.text);
         // ASCII parity: the dash cell + no unicode leak.
-        let ascii = outputs(
-            &path.to_string_lossy(),
-            Theme {
-                color: false,
-                ascii: true,
-                animate: false,
-            },
-        );
+        let ascii = outputs(&path.to_string_lossy(), Theme::new(false, true, false));
         assert!(!ascii.text.contains('—'), "ascii dash: {}", ascii.text);
     }
 
@@ -571,11 +560,7 @@ mod tests {
             &path.to_string_lossy(),
             "audit",
             false,
-            Theme {
-                color: false,
-                ascii: true,
-                animate: false,
-            },
+            Theme::new(false, true, false),
         );
         assert!(
             ascii.text.contains("5b2fa9e9232e.."),
@@ -658,11 +643,7 @@ mod tests {
         let ascii = flow(
             &tr.to_string_lossy(),
             &wf.to_string_lossy(),
-            Theme {
-                color: false,
-                ascii: true,
-                animate: false,
-            },
+            Theme::new(false, true, false),
         );
         assert!(
             ascii.text.contains("read_payload -3.6KB-> audit"),

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -97,19 +97,36 @@ fn render_outputs(view: &RunView, trace: &str, theme: Theme) -> String {
     };
     let (w0, w1, w2, w3) = (width(0), width(1), width(2), width(3));
 
+    // The dur column speaks the nextest bracket form (`[  2.7s]`) under
+    // the interactive accents (TTY) — sober registers keep the bare
+    // right-aligned cell. Empty cells and the header pad to the same
+    // width in both forms so the tok column never drifts.
+    let dur_cell = |d: &str, bare: bool| -> String {
+        if !theme.accents {
+            format!("{d:>w2$}")
+        } else if bare {
+            format!(" {d:>w2$} ")
+        } else {
+            format!("[{d:>w2$}]")
+        }
+    };
+
     let mut out = String::new();
     let head = format!(
-        "  {:<w0$}  {:<w1$}  {:>w2$}  {:>w3$}  output",
-        header[0], header[1], header[2], header[3],
+        "  {:<w0$}  {:<w1$}  {}  {:>w3$}  output",
+        header[0],
+        header[1],
+        dur_cell(header[2], true),
+        header[3],
     );
     let _ = writeln!(out, "{}", theme.paint(Role::Dim, &head));
     for (row, c) in rows.iter().zip(&cells) {
         let _ = writeln!(
             out,
-            "  {:<w0$}  {}  {:>w2$}  {:>w3$}  {}",
+            "  {:<w0$}  {}  {}  {:>w3$}  {}",
             c[0],
             theme.paint(Role::Dim, &format!("{:<w1$}", c[1])),
-            c[2],
+            dur_cell(&c[2], c[2].is_empty()),
             c[3],
             preview_cell(row, theme),
         );
@@ -503,6 +520,38 @@ mod tests {
         let out = outputs("/nonexistent/trace.ndjson", plain());
         assert_eq!(out.code, exit::ENV);
         assert!(out.text.contains("cannot read"), "{}", out.text);
+    }
+
+    /// The interactive accents bracket the dur column (`[38ms]` ·
+    /// nextest school) while the sober register (accents off · every
+    /// pipe) keeps the bare right-aligned cell — pinned on the SAME
+    /// staged trace.
+    #[test]
+    fn outputs_table_brackets_durations_under_accents_only() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let events = vec![
+            demo::bare_event(EventKind::TaskStarted, 0)
+                .with_field(KeyValue::new("task", Value::String("audit".into()))),
+            demo::bare_event(EventKind::TaskCompleted, 40)
+                .with_field(KeyValue::new("task", Value::String("audit".into())))
+                .with_field(KeyValue::new("duration_ms", Value::Int(38))),
+        ];
+        let path = stage("outputs-accents.ndjson", &events);
+        let sober = outputs(&path.to_string_lossy(), plain());
+        assert!(
+            !sober.text.contains("[38ms]"),
+            "sober register: no brackets: {}",
+            sober.text
+        );
+        let mut accented = plain();
+        accented.accents = true;
+        let rich = outputs(&path.to_string_lossy(), accented);
+        assert!(
+            rich.text.contains("[38ms]"),
+            "accents bracket the dur cell: {}",
+            rich.text
+        );
     }
 
     /// A trace with the ADR-099 checkpoint trio for one task.

--- a/crates/nika-cli/src/verbs/trace.rs
+++ b/crates/nika-cli/src/verbs/trace.rs
@@ -131,7 +131,12 @@ fn totals_line(view: &RunView, trace: &str, theme: Theme) -> String {
     if tokens > 0 {
         let _ = write!(line, " · {tokens} tok");
     }
-    let _ = write!(line, " · full value: nika trace peek {trace} <task>");
+    // The trace path is CLICKABLE on link-capable terminals (OSC-8).
+    let _ = write!(
+        line,
+        " · full value: nika trace peek {} <task>",
+        crate::verbs::linked_path(theme, trace)
+    );
     theme.paint(Role::Dim, &line)
 }
 

--- a/crates/nika-cli/tests/e2e_pipeline.rs
+++ b/crates/nika-cli/tests/e2e_pipeline.rs
@@ -221,11 +221,7 @@ fn states(view: &RunView) -> BTreeMap<String, TaskState> {
         .collect()
 }
 
-const PLAIN: Theme = Theme {
-    color: false,
-    ascii: false,
-    animate: false,
-};
+const PLAIN: Theme = Theme::new(false, false, false);
 
 // ─── test 1 · the static audit (the run's precondition) ─────────────────
 

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -11,11 +11,7 @@ use nika_cli::verbs::graph::{GraphFormat, project, to_dot, to_mermaid};
 use nika_cli::verbs::{check, exit, explain, graph, inspect, new, pack_surface};
 use nika_schema::{FileId, ParseMode};
 
-const PLAIN: Theme = Theme {
-    color: false,
-    ascii: false,
-    animate: false,
-};
+const PLAIN: Theme = Theme::new(false, false, false);
 
 /// The shared fixture — same shape as the e2e pipeline workflow.
 const WORKFLOW: &str = r#"
@@ -268,11 +264,7 @@ fn check_dirty_file_exits_2_and_names_the_fix() {
 fn check_json_is_the_report_plus_clean_flag_never_coloured() {
     let path = fixture_path("check-json.nika.yaml", WORKFLOW);
     // Colour requested — json must ignore it (the contract bytes).
-    let coloured = Theme {
-        color: true,
-        ascii: false,
-        animate: false,
-    };
+    let coloured = Theme::new(true, false, false);
     let out = check::run(&path, true, coloured);
     assert_eq!(out.code, exit::OK);
     assert!(!out.text.contains('\x1b'), "json is never coloured");


### PR DESCRIPTION
## Round-8 · visual polish — the run gets premium without losing sobriety

The 7 research-locked adopts + the field riders, one concern per commit (9 commits):

1. **One cost formatter + colour-resolution seam** (`display/format.rs`) — fixes the live `$0.000`-meter vs `$0.0003`-card split (sub-cent extends places until non-zero · cap 6 · zero = `$0.00`) · colour order: `--color` > `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR=0` > isatty+TERM≠dumb · chrome speaks ANSI-16 roles, truecolor is data-only.
2. **OSC-8 hyperlinks** — trace paths/golden paths/doctor fix-lines clickable (`--hyperlink=auto|always|never` · auto never fires on pipes · file:// carries the hostname for iTerm2).
3. **DEC-2026 synchronized output** — live repaints wrapped in `CSI ?2026h/l` · flicker-free waves on kitty/WezTerm/Ghostty · no-op elsewhere.
4. **nextest-style duration column** — right-aligned `[  2.7s]` brackets · ANSI-aware widths.
5. **SLOW accent** — a task > max(2× median wave, 30s) self-identifies (yellow + `slow`).
6. **Duration-heat on the waterfall** — single-hue lightness ramp · 4 quantized steps · truecolor only under COLORTERM · 256-colour stays flat (deuteranopia-safe).
7. **Verdict-count discipline** — only non-zero-bad counts get colour (`0 failed` stays plain).
8. **Riders (field finds)** — `bin_name("nika")` kills the `nika-cli` Usage leak · **completions now emit `#compdef nika`** (they attached to the wrong command name on every shipped version — dead on arrival for brew users) · empty-states speak the house voice with one `fix:` line each.
9. Public doc unlinked from the private cost cap.

### Hard rules held
Machine surfaces byte-frozen (pipe/NO_COLOR/--json pinned by parity tests) · --ascii twin for every new glyph · TTY-only escapes by construction · no new crates (raw escape writes + a const heat table).
