### PR TITLE
feat(run): run journal + --task cone + CEL expression completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,6 +3674,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml_edit",
  "uuid",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -54,6 +54,7 @@ path = "src/main.rs"
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
 nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
+tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 
 [package.metadata.lore]
 daemon        = "messager"

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -290,6 +290,13 @@ struct RunArgs {
     /// value parses as JSON when it parses, else rides as a string.
     #[arg(long = "answer", value_name = "TASK=VALUE", requires = "resume")]
     answer: Vec<String>,
+    /// Run ONE task and its transitive upstream only (the regenerate-one-
+    /// block move): the full workflow still audits (spans · findings stay
+    /// whole-file faithful), then execution scopes to the ancestor
+    /// sub-DAG and the plan/cost re-derive for exactly what will run.
+    /// Workflow `outputs:` are skipped (they may read unscoped tasks).
+    #[arg(long, value_name = "TASK_ID", conflicts_with = "resume")]
+    task: Option<String>,
     /// Skip the run journal (`.nika/traces/<ts>-<id>.ndjson` · spec §3.3).
     /// Every run writes one by default so `nika trace show|replay`,
     /// `--resume` and the editor's runs view have a file to read.
@@ -435,6 +442,7 @@ fn run_verb(args: &RunArgs) -> u8 {
         &args.var,
         resume.as_ref(),
         args.no_trace_file || env_flag("NIKA_NO_TRACE_FILE"),
+        args.task.as_deref(),
     )
 }
 

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -225,7 +225,7 @@ enum TraceAction {
 }
 
 #[derive(Args)]
-// Five independent CLI flags ARE five bools — the clap-surface idiom
+// Six independent CLI flags ARE six bools — the clap-surface idiom
 // (same as TraceArgs), not a state machine to encode.
 #[allow(clippy::struct_excessive_bools)]
 struct RunArgs {
@@ -290,6 +290,12 @@ struct RunArgs {
     /// value parses as JSON when it parses, else rides as a string.
     #[arg(long = "answer", value_name = "TASK=VALUE", requires = "resume")]
     answer: Vec<String>,
+    /// Skip the run journal (`.nika/traces/<ts>-<id>.ndjson` · spec §3.3).
+    /// Every run writes one by default so `nika trace show|replay`,
+    /// `--resume` and the editor's runs view have a file to read.
+    /// `NIKA_NO_TRACE_FILE` (any non-empty value) opts out globally.
+    #[arg(long)]
+    no_trace_file: bool,
 }
 
 #[derive(Args)]
@@ -428,6 +434,7 @@ fn run_verb(args: &RunArgs) -> u8 {
         args.model.as_deref(),
         &args.var,
         resume.as_ref(),
+        args.no_trace_file || env_flag("NIKA_NO_TRACE_FILE"),
     )
 }
 
@@ -568,9 +575,10 @@ fn recover_events(raw: &str, label: &str) -> Result<Vec<Event>, String> {
 
 /// Read a boolean presentation flag from the environment.
 ///
-/// Presentation flags (`NO_COLOR` · `NIKA_REDUCED_MOTION`) are not secrets —
-/// the workspace `disallowed_methods` ban on `std::env::var` exists to route
-/// SECRET reads through the kernel vault seam, which has no business in a
+/// Presentation flags (`NO_COLOR` · `NIKA_REDUCED_MOTION` ·
+/// `NIKA_NO_TRACE_FILE`) are not secrets — the workspace
+/// `disallowed_methods` ban on `std::env::var` exists to route SECRET
+/// reads through the kernel vault seam, which has no business in a
 /// colour toggle. Scoped allow, single seam.
 #[allow(clippy::disallowed_methods)]
 fn env_flag(name: &str) -> bool {

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -34,6 +34,8 @@ pub use resume::{RecoveredTrace, ResumeRequest, recover_events};
 pub use sink::{FoldSink, JsonSink, RenderMode};
 pub use stamp::SystemStamper;
 
+use sink::{TRACE_DIR, Tee, TraceFileSink};
+
 use std::collections::BTreeMap;
 use std::io::Write as _;
 
@@ -68,7 +70,11 @@ use crate::verbs::exit;
 /// journal into a skip plan; the runtime recomputes each task's identity
 /// and skips iff BOTH hashes match (visible `task_cache_hit` · never
 /// silent). `--from <task_id>` forces a subtree to re-run.
-// Nine independent CLI parameters ARE the clap surface — the same idiom
+///
+/// `no_trace_file` — skip the run journal (`.nika/traces/` · spec §3.3):
+/// `--no-trace-file` / `NIKA_NO_TRACE_FILE` opt out; `examples run`
+/// disables it too (a staged temp-file run is not a workspace run).
+// Ten independent CLI parameters ARE the clap surface — the same idiom
 // as TraceArgs' four bools, not a state machine to encode in a struct.
 #[allow(clippy::too_many_arguments)]
 #[must_use]
@@ -82,6 +88,7 @@ pub fn run(
     model_override: Option<&str>,
     vars: &[String],
     resume: Option<&ResumeRequest>,
+    no_trace_file: bool,
 ) -> u8 {
     // `--output` validated up front so an unknown format fails before any
     // work (machine-result mode · see `output_mode`).
@@ -158,6 +165,13 @@ pub fn run(
         Ok(rt) => rt,
         Err(code) => return code,
     };
+    // The run journal (spec §3.3) — composed HERE like the other seams;
+    // `execute` receives the sink, never a flag.
+    let trace = if no_trace_file {
+        TraceFileSink::disabled()
+    } else {
+        TraceFileSink::new(TRACE_DIR)
+    };
     rt.block_on(execute(
         &runtime,
         &wf,
@@ -167,6 +181,7 @@ pub fn run(
         theme,
         mode,
         resume.is_some(),
+        trace,
     ))
 }
 
@@ -308,6 +323,10 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         model_override,
         &[],
         None,
+        // No run journal: the example is staged to a TEMP file — `.nika/
+        // traces/` belongs to workspace runs (the same drive underneath,
+        // deliberately disabled here).
+        true,
     );
     // The example's own envelope model — what we suggest overriding when a
     // run fails offline. A parse miss leaves it empty (the tip then never
@@ -521,7 +540,13 @@ fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
 }
 
 /// Drive the runtime through the chosen sink · return the exit code.
-// The 9th parameter is the `--resume` summary switch — same clap-surface
+///
+/// Every lane tees the run journal (`trace` · a [`TraceFileSink`] ·
+/// `.nika/traces/` · spec §3.3) BESIDE its primary surface: the primary's
+/// bytes stay exact (the rider can only buffer its own fs error, surfaced
+/// after the run · never the exit code). The caller composes the journal
+/// (enabled or disabled) like every other seam.
+// The 8th parameter is the `--resume` summary switch — same clap-surface
 // idiom as `run` itself.
 #[allow(clippy::too_many_arguments)]
 async fn execute(
@@ -533,6 +558,7 @@ async fn execute(
     theme: Theme,
     mode: RenderMode,
     resumed: bool,
+    trace: TraceFileSink,
 ) -> u8 {
     let mut stamper = SystemStamper::new();
     if output_json {
@@ -544,10 +570,13 @@ async fn execute(
         // `Plain` deliberately: the fold goes to stderr (a pipe in the
         // composition path · never the live TTY redraw); the one final
         // storyboard frame is what matters, not the animation.
-        let mut sink = FoldSink::new(std::io::stderr().lock(), theme, RenderMode::Plain);
-        sink.set_plan(plan_waves(wf, report));
-        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
+        let mut fold = FoldSink::new(std::io::stderr().lock(), theme, RenderMode::Plain);
+        fold.set_plan(plan_waves(wf, report));
+        let mut tee = Tee::new(fold, trace);
+        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
+        let (mut sink, trace) = tee.into_parts();
         sink.print_final();
+        surface_trace(trace, TraceNote::Stderr);
         print_resume_summary(&outcome, resumed, true);
         // Built BEFORE the sink is consumed — the failure envelope reads
         // the folded view (the failed row's detail carries the wire code).
@@ -577,8 +606,12 @@ async fn execute(
         }
         code
     } else if json {
-        let mut sink = JsonSink::new(std::io::stdout().lock());
-        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
+        let mut tee = Tee::new(JsonSink::new(std::io::stdout().lock()), trace);
+        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
+        let (sink, trace) = tee.into_parts();
+        // stdout stays NDJSON verbatim (byte-identical with or without the
+        // journal) — the trace note rides on stderr here.
+        surface_trace(trace, TraceNote::Stderr);
         if let Some(e) = sink.into_error() {
             eprintln!("nika run: stream write failed: {e}");
             return exit::ENV;
@@ -586,9 +619,11 @@ async fn execute(
         print_resume_summary(&outcome, resumed, true);
         code
     } else {
-        let mut sink = FoldSink::new(std::io::stdout().lock(), theme, mode);
-        sink.set_plan(plan_waves(wf, report));
-        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut sink).await;
+        let mut fold = FoldSink::new(std::io::stdout().lock(), theme, mode);
+        fold.set_plan(plan_waves(wf, report));
+        let mut tee = Tee::new(fold, trace);
+        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
+        let (mut sink, trace) = tee.into_parts();
         // `Live` painted in place during the run; `Plain`/`Quiet` folded
         // silently · print the ONE final frame now.
         if mode != RenderMode::Live {
@@ -601,12 +636,65 @@ async fn execute(
         if mode == RenderMode::Live {
             print_flow_epilogue(sink.view(), &outcome.outputs, theme);
         }
+        // The spec §3.3 final-frame pointer (`trace: …`) — under the frame
+        // on the storytelling surfaces; `--quiet` keeps its compact-card
+        // promise (the file still exists · errors still reach stderr).
+        surface_trace(
+            trace,
+            if mode == RenderMode::Quiet {
+                TraceNote::Silent
+            } else {
+                TraceNote::Stdout
+            },
+        );
         print_resume_summary(&outcome, resumed, false);
         if let Some(e) = sink.into_error() {
             eprintln!("nika run: render failed: {e}");
             return exit::ENV;
         }
         code
+    }
+}
+
+/// Where the run journal's `trace:` pointer lands (per lane).
+#[derive(Clone, Copy)]
+enum TraceNote {
+    /// The human storytelling surfaces (`Live` · `Plain`) — the spec §3.3
+    /// final-frame pointer, printed under the frame.
+    Stdout,
+    /// The machine lanes (`--json` · `--output json`) — their stdout is a
+    /// byte-exact contract, so the pointer rides the diagnostic stream.
+    Stderr,
+    /// `--quiet` — the compact-card promise holds (no pointer · the
+    /// journal is still written · an fs error still reaches stderr).
+    Silent,
+}
+
+/// Surface the run journal AFTER the run — NEVER the exit code (the sink
+/// contract: journaling is a rider, a broken rider is a note, not a
+/// failure). An fs error goes to stderr with the path when one was opened;
+/// a written journal prints its `trace:` pointer per [`TraceNote`].
+fn surface_trace(trace: TraceFileSink, note: TraceNote) {
+    let path = trace.path().map(std::path::Path::to_path_buf);
+    if let Some(e) = trace.into_error() {
+        // Name the file when the failure struck AFTER the open (a partial
+        // journal on disk) — the operator sees exactly what to distrust.
+        match &path {
+            Some(p) => eprintln!(
+                "nika run: trace file {}: {e} — the run itself is unaffected",
+                p.display()
+            ),
+            None => eprintln!("nika run: trace file: {e} — the run itself is unaffected"),
+        }
+        return;
+    }
+    let Some(path) = path else {
+        return; // disabled · or a run that emitted zero events
+    };
+    match note {
+        TraceNote::Stdout => println!("    trace: {}", path.display()),
+        TraceNote::Stderr => eprintln!("nika run: trace: {}", path.display()),
+        TraceNote::Silent => {}
     }
 }
 
@@ -923,6 +1011,7 @@ mod tests {
             Some("mock/echo"),
             &[],
             None,
+            true, // tests never write .nika/traces (cwd hygiene)
         );
         assert_eq!(
             code,
@@ -952,6 +1041,7 @@ mod tests {
             Some("mock/echo"),
             &[],
             None,
+            true, // tests never write .nika/traces (cwd hygiene)
         );
         assert_eq!(
             overridden,
@@ -978,6 +1068,7 @@ mod tests {
             None,
             vars,
             None,
+            true, // tests never write .nika/traces (cwd hygiene)
         )
     }
 

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -89,6 +89,7 @@ pub fn run(
     vars: &[String],
     resume: Option<&ResumeRequest>,
     no_trace_file: bool,
+    task_filter: Option<&str>,
 ) -> u8 {
     // `--output` validated up front so an unknown format fails before any
     // work (machine-result mode · see `output_mode`).
@@ -107,6 +108,24 @@ pub fn run(
             emit_diagnostic(&out.text, output_json);
             return out.code;
         }
+    };
+
+    // ── `--task` scope (the regenerate-one-block move) ──
+    // The FULL workflow audited above (whole-file spans · findings) — the
+    // sub-DAG re-checks below so the plan/waves/cost describe exactly
+    // what will run. Scoping happens before any effect.
+    let (wf, report) = match task_filter {
+        None => (wf, report),
+        Some(target) => match scope_to_task(wf, target) {
+            Ok(sub) => {
+                let sub_report = nika_schema::check(&sub);
+                (sub, sub_report)
+            }
+            Err(msg) => {
+                emit_diagnostic(&msg, output_json);
+                return exit::ENV;
+            }
+        },
     };
     if !report.is_clean() {
         // The SAME findings `nika check` renders — the user must see why
@@ -327,6 +346,8 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         // traces/` belongs to workspace runs (the same drive underneath,
         // deliberately disabled here).
         true,
+        // Examples always run whole (tiny by design · no scoping surface).
+        None,
     );
     // The example's own envelope model — what we suggest overriding when a
     // run fails offline. A parse miss leaves it empty (the tip then never
@@ -527,6 +548,55 @@ fn offline_tip_applies(exit_code: u8, override_given: bool, model: &str) -> bool
 /// The static wave plan as task ids (the check report's schedule) —
 /// injected into the display fold so the ∥ lane markers and the DAG-shape
 /// glyph speak the scheduler's truth, not a reconstruction.
+/// Scope a workflow to ONE task + its transitive upstream (`--task`).
+///
+/// Ancestors must run — their outputs feed the target's bindings; nothing
+/// downstream or sibling executes. Document order is preserved (stable
+/// waves) and workflow `outputs:` drop (they may reference tasks outside
+/// the scope — the target's own output IS the point of the run). Unknown
+/// ids fail with the available set (environment class · exit 3 · before
+/// any effect — the same lane as an unknown `--var` key).
+fn scope_to_task(mut wf: RawWorkflow, target: &str) -> Result<RawWorkflow, String> {
+    use std::collections::{BTreeSet, VecDeque};
+
+    let mut deps_of: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for t in &wf.tasks {
+        deps_of.insert(
+            t.value.id.value.as_str().to_owned(),
+            t.value
+                .depends_on
+                .iter()
+                .map(|d| d.value.as_str().to_owned())
+                .collect(),
+        );
+    }
+    if !deps_of.contains_key(target) {
+        let known = deps_of.keys().cloned().collect::<Vec<_>>().join(" · ");
+        return Err(format!(
+            "--task `{target}` names no task in this workflow — tasks: {known}"
+        ));
+    }
+
+    let mut keep: BTreeSet<String> = BTreeSet::new();
+    let mut queue: VecDeque<String> = VecDeque::from([target.to_owned()]);
+    while let Some(id) = queue.pop_front() {
+        if !keep.insert(id.clone()) {
+            continue;
+        }
+        if let Some(deps) = deps_of.get(&id) {
+            for d in deps {
+                queue.push_back(d.clone());
+            }
+        }
+    }
+
+    wf.tasks
+        .retain(|t| keep.contains(t.value.id.value.as_str()));
+    wf.outputs.clear();
+    Ok(wf)
+}
+
 fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
     report
         .waves
@@ -923,7 +993,7 @@ fn run_failure_envelope(view: &crate::RunView) -> String {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use super::{RenderMode, exit, offline_tip_applies, outputs_json_line, run};
+    use super::{RenderMode, exit, offline_tip_applies, outputs_json_line, run, scope_to_task};
     use crate::Theme;
     use serde_json::{Value, json};
     use std::collections::BTreeMap;
@@ -1012,6 +1082,7 @@ mod tests {
             &[],
             None,
             true, // tests never write .nika/traces (cwd hygiene)
+            None, // whole-workflow runs (scoping has its own tests)
         );
         assert_eq!(
             code,
@@ -1042,6 +1113,7 @@ mod tests {
             &[],
             None,
             true, // tests never write .nika/traces (cwd hygiene)
+            None, // whole-workflow runs (scoping has its own tests)
         );
         assert_eq!(
             overridden,
@@ -1069,6 +1141,7 @@ mod tests {
             vars,
             None,
             true, // tests never write .nika/traces (cwd hygiene)
+            None, // whole-workflow runs (scoping has its own tests)
         )
     }
 
@@ -1223,5 +1296,60 @@ mod tests {
         let eq = super::parse_var_overrides(&["topic=a=b".to_owned()], &wf)
             .expect("value may carry '='");
         assert_eq!(eq["topic"], json!("a=b"));
+    }
+    /// `--task` scope · the diamond proves ancestors-only semantics: the
+    /// target + transitive upstream survive · siblings and downstream drop
+    /// · outputs clear (they may read unscoped tasks).
+    #[test]
+    fn scope_to_task_keeps_the_ancestor_cone() {
+        let yaml = "nika: v1\nworkflow: diamond\nmodel: mock/echo\ntasks:\n  - id: discover\n    invoke: { tool: \"nika:glob\", args: { pattern: \"*.md\" } }\n  - id: stats\n    depends_on: [discover]\n    infer: { prompt: \"count ${{ tasks.discover.output }}\" }\n  - id: digest\n    depends_on: [discover]\n    infer: { prompt: \"sum ${{ tasks.discover.output }}\" }\n  - id: report\n    depends_on: [stats, digest]\n    infer: { prompt: \"merge ${{ tasks.stats.output }} ${{ tasks.digest.output }}\" }\noutputs:\n  all: ${{ tasks.report.output }}\n";
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("diamond parses");
+
+        let stats_only = scope_to_task(wf.clone(), "stats").expect("stats scopes");
+        let ids: Vec<&str> = stats_only
+            .tasks
+            .iter()
+            .map(|t| t.value.id.value.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["discover", "stats"],
+            "target + its one ancestor · document order"
+        );
+        assert!(stats_only.outputs.is_empty(), "outputs drop under scope");
+
+        let full = scope_to_task(wf.clone(), "report").expect("report scopes");
+        assert_eq!(full.tasks.len(), 4, "the sink's cone is the whole diamond");
+
+        let err = scope_to_task(wf, "nope").expect_err("unknown id refused");
+        assert!(
+            err.contains("nope") && err.contains("discover"),
+            "names the id + the available set"
+        );
+    }
+
+    /// The scoped sub-workflow re-checks CLEAN — the plan/waves/cost the
+    /// run renders describe exactly the cone, not the original file.
+    #[test]
+    fn scoped_workflow_rechecks_clean() {
+        let yaml = "nika: v1\nworkflow: pair\nmodel: mock/echo\ntasks:\n  - id: a\n    infer: { prompt: \"hi\" }\n  - id: b\n    depends_on: [a]\n    infer: { prompt: \"use ${{ tasks.a.output }}\" }\n";
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("pair parses");
+        let sub = scope_to_task(wf, "a").expect("a scopes");
+        let report = nika_schema::check(&sub);
+        assert!(
+            report.is_clean(),
+            "the cone stands alone (no dangling refs)"
+        );
+        assert_eq!(sub.tasks.len(), 1);
     }
 }

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -117,43 +117,16 @@ pub fn run(
         }
     };
 
-    // ── `--task` scope (the regenerate-one-block move) ──
-    // The FULL workflow audited above (whole-file spans · findings) — the
-    // sub-DAG re-checks below so the plan/waves/cost describe exactly
-    // what will run. Scoping happens before any effect.
-    let (wf, report) = match task_filter {
-        None => (wf, report),
-        Some(target) => match scope_to_task(wf, target) {
-            Ok(sub) => {
-                let sub_report = nika_schema::check(&sub);
-                (sub, sub_report)
-            }
-            Err(msg) => {
-                emit_diagnostic(&msg, output_json);
-                return exit::ENV;
-            }
-        },
-    };
-    if !report.is_clean() {
-        // The SAME findings `nika check` renders — the user must see why
-        // it won't run. Reuses the locked check rendering (exit 2). In
-        // machine mode the findings go to stderr (stdout stays clean JSON).
-        let out = crate::verbs::check::run(file, json, theme);
-        emit_diagnostic(&out.text, output_json);
-        return out.code;
-    }
-
-    // ── `--var` overrides (F4) — parse + validate BEFORE any work ────
-    // An unknown key is refused loudly (a typo'd override silently doing
-    // nothing would be the worst outcome) · same exit class as an unknown
-    // `--output` format (operator input · exit 3).
-    let overrides = match parse_var_overrides(vars, &wf) {
+    // ── `--task` scope + clean gate + `--var` overrides (all before
+    //    any effect — the whole operator-input preflight) ──
+    let (wf, report) =
+        match scoped_clean_gate(wf, report, task_filter, file, json, theme, output_json) {
+            Ok(pair) => pair,
+            Err(code) => return code,
+        };
+    let overrides = match validated_var_overrides(vars, &wf, output_json) {
         Ok(map) => map,
-        Err(message) => {
-            eprintln!("nika run: {message}");
-            emit_error_envelope(&message, output_json);
-            return exit::ENV;
-        }
+        Err(code) => return code,
     };
 
     // ── Dry-run (spec §10 · "plan only · zero effects") ─────────────
@@ -578,6 +551,71 @@ fn offline_tip_applies(exit_code: u8, override_given: bool, model: &str) -> bool
 /// The static wave plan as task ids (the check report's schedule) —
 /// injected into the display fold so the ∥ lane markers and the DAG-shape
 /// glyph speak the scheduler's truth, not a reconstruction.
+/// `--var` overrides (F4), parsed + validated BEFORE any work: an
+/// unknown key refuses loudly (a typo'd override silently doing nothing
+/// would be the worst outcome) · the operator-input exit class (3).
+fn validated_var_overrides(
+    vars: &[String],
+    wf: &RawWorkflow,
+    output_json: bool,
+) -> Result<std::collections::BTreeMap<String, serde_json::Value>, u8> {
+    parse_var_overrides(vars, wf).map_err(|message| {
+        eprintln!("nika run: {message}");
+        emit_error_envelope(&message, output_json);
+        exit::ENV
+    })
+}
+
+/// The `--task` scope + the clean gate, fused (both run before any
+/// effect): scope to the target's ancestor cone when requested (the
+/// sub-DAG re-checks so plan/waves/cost describe exactly what runs) ·
+/// then refuse a dirty report with the SAME findings `nika check`
+/// renders (locked rendering · exit 2 · stderr in machine mode).
+#[allow(clippy::too_many_arguments)]
+fn scoped_clean_gate(
+    wf: RawWorkflow,
+    report: CheckReport,
+    task_filter: Option<&str>,
+    file: &str,
+    json: bool,
+    theme: Theme,
+    output_json: bool,
+) -> Result<(RawWorkflow, CheckReport), u8> {
+    let (wf, report) = apply_task_scope(wf, report, task_filter, output_json)?;
+    if !report.is_clean() {
+        let out = crate::verbs::check::run(file, json, theme);
+        emit_diagnostic(&out.text, output_json);
+        return Err(out.code);
+    }
+    Ok((wf, report))
+}
+
+/// Apply the `--task` scope when requested (the regenerate-one-block
+/// move). The FULL workflow audited already (whole-file spans · faithful
+/// findings) — the sub-DAG RE-CHECKS here so the plan/waves/cost describe
+/// exactly what will run. Scoping happens before any effect; an unknown
+/// id refuses on the diagnostic surface with the environment exit class.
+fn apply_task_scope(
+    wf: RawWorkflow,
+    report: CheckReport,
+    task_filter: Option<&str>,
+    output_json: bool,
+) -> Result<(RawWorkflow, CheckReport), u8> {
+    let Some(target) = task_filter else {
+        return Ok((wf, report));
+    };
+    match scope_to_task(wf, target) {
+        Ok(sub) => {
+            let sub_report = nika_schema::check(&sub);
+            Ok((sub, sub_report))
+        }
+        Err(msg) => {
+            emit_diagnostic(&msg, output_json);
+            Err(exit::ENV)
+        }
+    }
+}
+
 /// Scope a workflow to ONE task + its transitive upstream (`--task`).
 ///
 /// Ancestors must run — their outputs feed the target's bindings; nothing
@@ -724,47 +762,78 @@ async fn execute(
         print_resume_summary(&outcome, resumed, true);
         code
     } else {
-        let mut fold = FoldSink::new(std::io::stdout().lock(), theme, mode);
-        fold.set_plan(plan_waves(wf, report));
-        // The shape tails ride the INTERACTIVE surface only (`Live` =
-        // TTY): the piped/`--no-progress`/`--quiet` registers keep their
-        // exact bytes — CI logs and scripts never grow tails.
-        if mode == RenderMode::Live && outputs {
-            fold.show_outputs(true);
-        }
-        let mut tee = Tee::new(fold, trace);
-        let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
-        let (mut sink, trace) = tee.into_parts();
-        // `Live` painted in place during the run; `Plain`/`Quiet` folded
-        // silently · print the ONE final frame now.
-        if mode != RenderMode::Live {
-            sink.print_final();
-        }
-        // The Live (TTY) final frame carries the flow epilogue: the wall-
-        // time waterfall + the outputs pointer (design §2c). The sober
-        // registers (piped `Plain` · `--quiet` · machine modes) stay
-        // untouched — CI logs never grow chart art.
-        if mode == RenderMode::Live {
-            print_flow_epilogue(sink.view(), &outcome.outputs, theme, file);
-        }
-        // The spec §3.3 final-frame pointer (`trace: …`) — under the frame
-        // on the storytelling surfaces; `--quiet` keeps its compact-card
-        // promise (the file still exists · errors still reach stderr).
-        surface_trace(
+        execute_fold_lane(
+            runtime,
+            wf,
+            report,
+            &mut stamper,
+            file,
+            theme,
+            mode,
+            resumed,
             trace,
-            if mode == RenderMode::Quiet {
-                TraceNote::Silent
-            } else {
-                TraceNote::Stdout
-            },
-        );
-        print_resume_summary(&outcome, resumed, false);
-        if let Some(e) = sink.into_error() {
-            eprintln!("nika run: render failed: {e}");
-            return exit::ENV;
-        }
-        code
+            outputs,
+        )
+        .await
     }
+}
+
+/// The human fold lane (`Live` · `Plain` · `Quiet`) — extracted whole so
+/// `execute` stays a lane DISPATCHER (fn-length ratchet · the three lanes
+/// are peers, not one long body). Storytelling surfaces get the flow
+/// epilogue + the spec §3.3 `trace:` pointer; `--quiet` keeps its
+/// compact-card promise.
+#[allow(clippy::too_many_arguments)]
+async fn execute_fold_lane(
+    runtime: &ProdRuntime,
+    wf: &RawWorkflow,
+    report: &CheckReport,
+    stamper: &mut SystemStamper,
+    file: &str,
+    theme: Theme,
+    mode: RenderMode,
+    resumed: bool,
+    trace: TraceFileSink,
+    outputs: bool,
+) -> u8 {
+    let mut fold = FoldSink::new(std::io::stdout().lock(), theme, mode);
+    fold.set_plan(plan_waves(wf, report));
+    // The shape tails ride the INTERACTIVE surface only (`Live` = TTY):
+    // the piped/`--no-progress`/`--quiet` registers keep their exact
+    // bytes — CI logs and scripts never grow tails.
+    if mode == RenderMode::Live && outputs {
+        fold.show_outputs(true);
+    }
+    let mut tee = Tee::new(fold, trace);
+    let (code, outcome) = drive(runtime, wf, report, stamper, &mut tee).await;
+    let (mut sink, trace) = tee.into_parts();
+    // `Live` painted in place during the run; `Plain`/`Quiet` folded
+    // silently · print the ONE final frame now.
+    if mode != RenderMode::Live {
+        sink.print_final();
+    }
+    // The Live (TTY) final frame carries the flow epilogue: the wall-
+    // time waterfall + the outputs pointer (design §2c). The sober
+    // registers stay untouched — CI logs never grow chart art.
+    if mode == RenderMode::Live {
+        print_flow_epilogue(sink.view(), &outcome.outputs, theme, file);
+    }
+    // The spec §3.3 final-frame pointer (`trace: …`) — under the frame
+    // on the storytelling surfaces.
+    surface_trace(
+        trace,
+        if mode == RenderMode::Quiet {
+            TraceNote::Silent
+        } else {
+            TraceNote::Stdout
+        },
+    );
+    print_resume_summary(&outcome, resumed, false);
+    if let Some(e) = sink.into_error() {
+        eprintln!("nika run: render failed: {e}");
+        return exit::ENV;
+    }
+    code
 }
 
 /// Where the run journal's `trace:` pointer lands (per lane).

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -34,6 +34,9 @@ pub use resume::{RecoveredTrace, ResumeRequest, recover_events};
 pub use sink::{FoldSink, JsonSink, RenderMode};
 pub use stamp::SystemStamper;
 
+mod scope;
+use scope::scope_to_task;
+
 use sink::{TRACE_DIR, Tee, TraceFileSink};
 
 use std::collections::BTreeMap;
@@ -614,55 +617,6 @@ fn apply_task_scope(
             Err(exit::ENV)
         }
     }
-}
-
-/// Scope a workflow to ONE task + its transitive upstream (`--task`).
-///
-/// Ancestors must run — their outputs feed the target's bindings; nothing
-/// downstream or sibling executes. Document order is preserved (stable
-/// waves) and workflow `outputs:` drop (they may reference tasks outside
-/// the scope — the target's own output IS the point of the run). Unknown
-/// ids fail with the available set (environment class · exit 3 · before
-/// any effect — the same lane as an unknown `--var` key).
-fn scope_to_task(mut wf: RawWorkflow, target: &str) -> Result<RawWorkflow, String> {
-    use std::collections::{BTreeSet, VecDeque};
-
-    let mut deps_of: std::collections::BTreeMap<String, Vec<String>> =
-        std::collections::BTreeMap::new();
-    for t in &wf.tasks {
-        deps_of.insert(
-            t.value.id.value.as_str().to_owned(),
-            t.value
-                .depends_on
-                .iter()
-                .map(|d| d.value.as_str().to_owned())
-                .collect(),
-        );
-    }
-    if !deps_of.contains_key(target) {
-        let known = deps_of.keys().cloned().collect::<Vec<_>>().join(" · ");
-        return Err(format!(
-            "--task `{target}` names no task in this workflow — tasks: {known}"
-        ));
-    }
-
-    let mut keep: BTreeSet<String> = BTreeSet::new();
-    let mut queue: VecDeque<String> = VecDeque::from([target.to_owned()]);
-    while let Some(id) = queue.pop_front() {
-        if !keep.insert(id.clone()) {
-            continue;
-        }
-        if let Some(deps) = deps_of.get(&id) {
-            for d in deps {
-                queue.push_back(d.clone());
-            }
-        }
-    }
-
-    wf.tasks
-        .retain(|t| keep.contains(t.value.id.value.as_str()));
-    wf.outputs.clear();
-    Ok(wf)
 }
 
 fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {

--- a/crates/nika-cli/src/verbs/run/scope.rs
+++ b/crates/nika-cli/src/verbs/run/scope.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `--task` scoping — the ancestor-cone cut behind the regenerate-one-
+//! block move (its gate + re-check live in the parent module; this file
+//! is the pure graph walk).
+
+use nika_schema::raw::RawWorkflow;
+
+/// Scope a workflow to ONE task + its transitive upstream (`--task`).
+///
+/// Ancestors must run — their outputs feed the target's bindings; nothing
+/// downstream or sibling executes. Document order is preserved (stable
+/// waves) and workflow `outputs:` drop (they may reference tasks outside
+/// the scope — the target's own output IS the point of the run). Unknown
+/// ids fail with the available set (environment class · exit 3 · before
+/// any effect — the same lane as an unknown `--var` key).
+pub(super) fn scope_to_task(mut wf: RawWorkflow, target: &str) -> Result<RawWorkflow, String> {
+    use std::collections::{BTreeSet, VecDeque};
+
+    let mut deps_of: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for t in &wf.tasks {
+        deps_of.insert(
+            t.value.id.value.as_str().to_owned(),
+            t.value
+                .depends_on
+                .iter()
+                .map(|d| d.value.as_str().to_owned())
+                .collect(),
+        );
+    }
+    if !deps_of.contains_key(target) {
+        let known = deps_of.keys().cloned().collect::<Vec<_>>().join(" · ");
+        return Err(format!(
+            "--task `{target}` names no task in this workflow — tasks: {known}"
+        ));
+    }
+
+    let mut keep: BTreeSet<String> = BTreeSet::new();
+    let mut queue: VecDeque<String> = VecDeque::from([target.to_owned()]);
+    while let Some(id) = queue.pop_front() {
+        if !keep.insert(id.clone()) {
+            continue;
+        }
+        if let Some(deps) = deps_of.get(&id) {
+            for d in deps {
+                queue.push_back(d.clone());
+            }
+        }
+    }
+
+    wf.tasks
+        .retain(|t| keep.contains(t.value.id.value.as_str()));
+    wf.outputs.clear();
+    Ok(wf)
+}

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -1,20 +1,30 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The production [`EventSink`] lanes — `--json` (NDJSON verbatim) and
-//! the live TTY fold (`RunView` repaint per event).
+//! The production [`EventSink`] lanes — `--json` (NDJSON verbatim), the
+//! live TTY fold (`RunView` repaint per event), and the run journal
+//! ([`TraceFileSink`] · `.nika/traces/` · teed beside either via [`Tee`]).
 //!
-//! Both are consumers of the SAME stream (the fold law · spec §3): the
+//! All are consumers of the SAME stream (the fold law · spec §3): the
 //! sink shape decides the surface, never the runtime. The sink contract
 //! is INFALLIBLE (a write error never changes the run's verdict — it is
 //! buffered and surfaced at the end).
 
-use std::io::Write;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
 
 use nika_event::Event;
 use nika_runtime::EventSink;
+use nika_types::timestamp::Timestamp;
+use uuid::Uuid;
 
 use crate::{RunView, Theme, frame, verdict_frame};
+
+/// Where run journals land, relative to the run's CWD (the workspace
+/// root by convention — the editor extension watches exactly this
+/// directory, and spec §3.3 prints it in the final frame).
+pub(super) const TRACE_DIR: &str = ".nika/traces";
 
 /// How the live fold reaches the terminal (spec §3.5 reduced surfaces).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +79,211 @@ impl<W: Write> EventSink for JsonSink<W> {
         if let Err(e) = result {
             self.error = Some(e);
         }
+    }
+}
+
+/// The run-journal state: which disk lane, if any, this sink drives.
+enum Lane {
+    /// `--no-trace-file` / `NIKA_NO_TRACE_FILE` / a non-workspace run
+    /// (`examples run` stages a temp file) — emit is a no-op by design,
+    /// so the caller keeps ONE code path whether journaling or not.
+    Disabled,
+    /// Enabled but not yet on disk — the file is NAMED from the first
+    /// event's identity (its `UUIDv7` id carries the run's mint time),
+    /// so nothing can open before the stream starts.
+    Pending,
+    /// Open and appending one NDJSON line per event.
+    Open(BufWriter<File>),
+}
+
+/// The run journal — writes the SAME NDJSON stream as [`JsonSink`] into
+/// `<dir>/<ISO-compact>-<short-id>.ndjson` (spec §3.3 final frame ·
+/// `.nika/traces/` in production). The flight recorder (`nika trace
+/// show|replay`), `--resume`, and the editor extension's runs view all
+/// read this file back — it exists so EVERY run leaves a journal, not
+/// only the ones piped through `--json`.
+///
+/// Three constraints shape it:
+/// - **Lazy open** — file creation waits for the FIRST emit: the name
+///   needs the first event's `UUIDv7` id + wall timestamp, and a run
+///   that never starts (audit refusal · composition failure) must not
+///   litter an empty file.
+/// - **Infallible** (the [`EventSink`] contract) — an fs error (read-only
+///   checkout · disk full) is buffered, never panics, never changes the
+///   run's verdict or its primary bytes; the caller surfaces it AFTER
+///   the run as a stderr note.
+/// - **Rider, never a surface** — it tees BESIDE the chosen primary lane
+///   (via [`Tee`]); with the sink disabled or broken, the primary lane's
+///   output stays byte-identical.
+pub(super) struct TraceFileSink {
+    /// The journal directory (created on first emit · `TRACE_DIR` in
+    /// production · a temp dir under test). Meaningless when disabled.
+    dir: PathBuf,
+    lane: Lane,
+    /// The opened file's path (`None` until the lazy open · stays `None`
+    /// when disabled or when the open itself failed).
+    path: Option<PathBuf>,
+    /// The first fs error, buffered (the sink contract is infallible
+    /// w.r.t. the run · the caller surfaces this after the run).
+    error: Option<std::io::Error>,
+}
+
+impl TraceFileSink {
+    /// An enabled journal rooted at `dir` (lazy — no fs effect here).
+    pub(super) fn new(dir: impl Into<PathBuf>) -> Self {
+        Self {
+            dir: dir.into(),
+            lane: Lane::Pending,
+            path: None,
+            error: None,
+        }
+    }
+
+    /// A permanently-silent journal (`emit` = no-op · zero fs effects) —
+    /// the opt-out shape that keeps the caller's wiring branch-free.
+    #[must_use]
+    pub(super) fn disabled() -> Self {
+        Self {
+            dir: PathBuf::new(),
+            lane: Lane::Disabled,
+            path: None,
+            error: None,
+        }
+    }
+
+    /// The journal file's path, once the lazy open happened.
+    #[must_use]
+    pub(super) fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    /// The buffered fs error, if journaling ever failed.
+    #[must_use]
+    pub(super) fn into_error(self) -> Option<std::io::Error> {
+        self.error
+    }
+
+    /// Create the directory + the journal file, named from the first
+    /// event's identity.
+    ///
+    /// The runtime does not stamp `event.run` today, so the first
+    /// event's own id IS the run-unique mint (`SystemStamper` `UUIDv7` ·
+    /// ADR-033); `run` is preferred whenever a future runtime sets it.
+    fn open(&mut self, first: &Event) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.dir)?;
+        let id = first.run.as_ref().map_or(first.id.uuid, |r| r.uuid);
+        let path = self.dir.join(trace_file_name(first.timestamp, id));
+        // `create_new` refuses to clobber: two runs in the same SECOND can
+        // share the 4-hex short id (16 random bits — a real risk under a
+        // parallel CI matrix), and truncating a sibling run's journal would
+        // be silent data loss. The fallback name carries the full 32-hex id
+        // (uuid-unique), so it cannot collide again.
+        let create = |p: &Path| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(p)
+        };
+        let (file, path) = match create(&path) {
+            Ok(f) => (f, path),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let full = self.dir.join(format!(
+                    "{}-{}.ndjson",
+                    compact_ts(first.timestamp),
+                    id.as_simple()
+                ));
+                (create(&full)?, full)
+            }
+            Err(e) => return Err(e),
+        };
+        self.lane = Lane::Open(BufWriter::new(file));
+        self.path = Some(path);
+        Ok(())
+    }
+}
+
+impl EventSink for TraceFileSink {
+    fn emit(&mut self, event: Event) {
+        if self.error.is_some() {
+            return; // already broken · stop touching a dead lane
+        }
+        if matches!(self.lane, Lane::Pending)
+            && let Err(e) = self.open(&event)
+        {
+            // The failed open is FINAL (the error gate above short-circuits
+            // every later emit) — no retry storm against a read-only disk.
+            self.error = Some(e);
+            return;
+        }
+        let Lane::Open(writer) = &mut self.lane else {
+            return; // Disabled — a deliberate no-op
+        };
+        // Mirror JsonSink byte-for-byte (one JSON document per line · flush
+        // per event): the journal must parse wherever the `--json` stream
+        // parses, and the extension's watcher tails it for liveness.
+        let result = serde_json::to_writer(&mut *writer, &event)
+            .map_err(std::io::Error::from)
+            .and_then(|()| writer.write_all(b"\n"))
+            .and_then(|()| writer.flush());
+        if let Err(e) = result {
+            self.error = Some(e);
+        }
+    }
+}
+
+/// The journal's timestamp component: RFC 3339 compacted for a path —
+/// second precision (drop `.fff`) and `:` → `-` (colons are illegal on
+/// Windows paths and hostile in macOS Finder). `2026-06-11T14:02:33.123Z`
+/// becomes `2026-06-11T14-02-33Z`.
+fn compact_ts(ts: Timestamp) -> String {
+    let iso = ts.to_string();
+    // Display always renders `…SS.mmmZ`; the guard keeps this total if
+    // that ever changes (worst case: the full string, still path-safe
+    // after the replace below except the dot — acceptable, never wrong).
+    let seconds = iso.split('.').next().unwrap_or(&iso);
+    format!("{}Z", seconds.replace(':', "-"))
+}
+
+/// The journal file name (spec §3.3 final frame): `<ISO-compact>-<short>
+/// .ndjson`, e.g. `2026-06-11T14-02-33Z-a3f2.ndjson`. The short id is
+/// the LAST 4 hex chars of the `UUIDv7` — the tail is the random part
+/// (the v7 PREFIX encodes coarse mint-time and is near-constant across
+/// weeks, so it would disambiguate nothing the timestamp doesn't).
+fn trace_file_name(ts: Timestamp, id: Uuid) -> String {
+    let simple = id.as_simple().to_string();
+    let short = &simple[simple.len().saturating_sub(4)..];
+    format!("{}-{short}.ndjson", compact_ts(ts))
+}
+
+/// Fans one event stream into two sinks — `emit` delivers to BOTH (one
+/// clone per event · events are small values). This is how the run
+/// journal rides beside every primary surface without forking `drive`:
+/// the primary lane `a` keeps its exact bytes; the rider `b` (the trace
+/// file) observes the same stream. Both sides are [`EventSink`]s, so
+/// infallibility composes — neither can veto the run or the other lane.
+pub(super) struct Tee<A: EventSink, B: EventSink> {
+    a: A,
+    b: B,
+}
+
+impl<A: EventSink, B: EventSink> Tee<A, B> {
+    /// Pair the primary surface `a` with the rider `b`.
+    pub(super) fn new(a: A, b: B) -> Self {
+        Self { a, b }
+    }
+
+    /// Take both lanes back after the run (the caller reads the fold's
+    /// verdict from `a` and surfaces buffered errors from each side).
+    pub(super) fn into_parts(self) -> (A, B) {
+        (self.a, self.b)
+    }
+}
+
+impl<A: EventSink, B: EventSink> EventSink for Tee<A, B> {
+    fn emit(&mut self, event: Event) {
+        // Primary first (the user-facing surface leads) · rider second.
+        self.a.emit(event.clone());
+        self.b.emit(event);
     }
 }
 
@@ -325,6 +540,178 @@ mod tests {
         assert!(
             !text.contains('\x1b'),
             "no prior frame to clear → no cursor-up escape: {text:?}"
+        );
+    }
+
+    // ───────────────────────── run journal (TraceFileSink · Tee) ─────
+
+    /// The spec §3.3 name form: `<ISO-compact>-<short>.ndjson` — second
+    /// precision, `:` → `-`, the short id = the LAST 4 hex of the uuid.
+    #[test]
+    fn trace_file_name_matches_the_spec_form() {
+        let id = Uuid::from_u128(0xa3f2);
+        assert_eq!(
+            trace_file_name(Timestamp::from_unix_ms(0), id),
+            "1970-01-01T00-00-00Z-a3f2.ndjson"
+        );
+        // Milliseconds are dropped, never rounded (1.5s stays second 1).
+        assert_eq!(
+            trace_file_name(Timestamp::from_unix_ms(1500), id),
+            "1970-01-01T00-00-01Z-a3f2.ndjson"
+        );
+    }
+
+    /// Lazy open: a sink that never receives an event leaves ZERO fs
+    /// footprint — no directory, no empty journal file.
+    #[test]
+    fn trace_sink_is_lazy_zero_events_zero_fs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("traces");
+        {
+            let sink = TraceFileSink::new(&dir);
+            assert!(sink.path().is_none());
+            assert!(sink.into_error().is_none());
+        }
+        assert!(!dir.exists(), "no emit → the directory is never created");
+    }
+
+    /// The journal is the `--json` lane byte-for-byte: same events in,
+    /// identical NDJSON out (the file must parse wherever the stream does).
+    #[test]
+    fn trace_sink_journal_mirrors_the_json_lane_bytes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("traces");
+        let events = demo::success();
+
+        let mut expected = Vec::new();
+        let mut json = JsonSink::new(&mut expected);
+        for ev in &events {
+            json.emit(ev.clone());
+        }
+
+        let mut sink = TraceFileSink::new(&dir);
+        for ev in &events {
+            sink.emit(ev.clone());
+        }
+        let path = sink.path().expect("opened on first emit").to_path_buf();
+        assert!(path.starts_with(&dir), "journal lives under its dir");
+        assert_eq!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("ndjson"),
+            "the spec extension"
+        );
+        assert!(sink.into_error().is_none(), "a writable dir never errors");
+
+        let written = std::fs::read(&path).expect("journal readable");
+        assert_eq!(written, expected, "trace file == JsonSink bytes");
+        // split() over adding a bytecount dep for one test assertion
+        // (clippy::naive_bytecount fires on the filter().count() idiom).
+        assert_eq!(
+            written.split(|&b| b == b'\n').count() - 1,
+            events.len(),
+            "one NDJSON line per event"
+        );
+    }
+
+    /// The opt-out shape: `disabled()` swallows every event with zero fs
+    /// effects — the caller's wiring stays branch-free.
+    #[test]
+    fn trace_sink_disabled_never_touches_disk() {
+        let mut sink = TraceFileSink::disabled();
+        for ev in demo::success() {
+            sink.emit(ev);
+        }
+        assert!(sink.path().is_none(), "disabled never opens");
+        assert!(sink.into_error().is_none(), "disabled never errors");
+    }
+
+    /// Order-recording sink — proves the Tee delivery contract.
+    struct RecordingSink {
+        tag: char,
+        log: std::rc::Rc<std::cell::RefCell<Vec<(char, u128)>>>,
+    }
+
+    impl EventSink for RecordingSink {
+        fn emit(&mut self, event: Event) {
+            self.log
+                .borrow_mut()
+                .push((self.tag, event.id.uuid.as_u128()));
+        }
+    }
+
+    /// Tee fans each event to BOTH sinks, primary (`a`) first — per event,
+    /// not batched (the rider observes the same liveness the surface does).
+    #[test]
+    fn tee_delivers_to_both_primary_first_per_event() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let a = RecordingSink {
+            tag: 'a',
+            log: std::rc::Rc::clone(&log),
+        };
+        let b = RecordingSink {
+            tag: 'b',
+            log: std::rc::Rc::clone(&log),
+        };
+        let mut tee = Tee::new(a, b);
+        let events = demo::success();
+        tee.emit(events[0].clone());
+        tee.emit(events[1].clone());
+        let (a, b) = tee.into_parts();
+        assert_eq!((a.tag, b.tag), ('a', 'b'), "parts come back in order");
+        let id0 = events[0].id.uuid.as_u128();
+        let id1 = events[1].id.uuid.as_u128();
+        assert_eq!(
+            *log.borrow(),
+            vec![('a', id0), ('b', id0), ('a', id1), ('b', id1)],
+            "primary first · rider second · per event"
+        );
+    }
+
+    /// Infallible under a broken destination: the error is buffered ONCE,
+    /// later emits are silent no-ops, nothing panics (the run's verdict
+    /// never depends on the journal).
+    #[test]
+    fn trace_sink_buffers_the_error_and_goes_silent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // A FILE where the directory must go → create_dir_all fails on
+        // every platform (no chmod games · works under any uid).
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"not a dir").expect("fixture");
+        let mut sink = TraceFileSink::new(blocker.join("traces"));
+        for ev in demo::success() {
+            sink.emit(ev); // first emit fails the open · the rest no-op
+        }
+        assert!(sink.path().is_none(), "a failed open never half-opens");
+        assert!(sink.into_error().is_some(), "the fs error is buffered");
+    }
+
+    /// Two runs colliding on the same second + short id: the second open
+    /// falls back to the FULL 32-hex id — never truncates a sibling.
+    #[test]
+    fn trace_sink_collision_falls_back_to_the_full_id_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("traces");
+        let events = demo::success();
+
+        let mut first = TraceFileSink::new(&dir);
+        let mut second = TraceFileSink::new(&dir);
+        for ev in &events {
+            first.emit(ev.clone());
+            second.emit(ev.clone()); // same ids · same second → collision
+        }
+        let p1 = first.path().expect("first opened").to_path_buf();
+        let p2 = second.path().expect("second opened").to_path_buf();
+        assert_ne!(p1, p2, "the fallback picked a different name");
+        assert!(second.into_error().is_none(), "collision is not an error");
+        let full = events[0].id.uuid.as_simple().to_string();
+        assert!(
+            p2.to_string_lossy().contains(&full),
+            "fallback carries the full uuid: {p2:?}"
+        );
+        // Both journals intact — byte-identical streams, zero clobbering.
+        assert_eq!(
+            std::fs::read(&p1).expect("first journal"),
+            std::fs::read(&p2).expect("second journal")
         );
     }
 }

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -40,6 +40,12 @@ pub fn completion(text: &str, offset: usize) -> Vec<CompletionItem> {
     if in_open_depends_on(text, offset) || is_template_tasks_ref(prefix) {
         return task_ids(text);
     }
+    if is_expression_post_dot(prefix) {
+        return cel_methods();
+    }
+    if is_expression_start(prefix) {
+        return expression_roots();
+    }
     if is_top_level_key(prefix) {
         return keyword_items(vocab::TOP_LEVEL_KEYS);
     }
@@ -104,6 +110,121 @@ fn is_template_tasks_ref(prefix: &str) -> bool {
     };
     let after = prefix.get(island..).unwrap_or("");
     !after.contains("}}") && after.trim_end().ends_with("tasks.")
+}
+
+/// The open `${{ … }}` island of `prefix`, when one exists on this line.
+fn open_island(prefix: &str) -> Option<&str> {
+    let island = prefix.rfind("${{")?;
+    let after = prefix.get(island + 3..).unwrap_or("");
+    if after.contains("}}") {
+        None
+    } else {
+        Some(after)
+    }
+}
+
+/// Post-dot INSIDE an expression, past a data path (`tasks.x.output.` ·
+/// `vars.name.`) — the CEL method position. The bare `tasks.` island is
+/// task-id territory (checked before this) so ids win there.
+fn is_expression_post_dot(prefix: &str) -> bool {
+    let Some(after) = open_island(prefix) else {
+        return false;
+    };
+    let t = after.trim_end();
+    // A dot that FOLLOWS at least one path segment (`root.seg…`) — one
+    // trailing dot with no prior dot is the root's own member position.
+    t.ends_with('.') && t.trim_end_matches('.').contains('.')
+}
+
+/// The very start of an expression island (`${{ ` · or a bare partial
+/// identifier with no dot yet) — the roots + free-functions position.
+fn is_expression_start(prefix: &str) -> bool {
+    let Some(after) = open_island(prefix) else {
+        return false;
+    };
+    let t = after.trim_start();
+    t.is_empty() || (!t.contains('.') && t.chars().all(|c| c.is_alphanumeric() || c == '_'))
+}
+
+/// The cel-subset/0.1 METHOD set — mirrors `nika-cel`'s parser arity
+/// table (the vocabulary is CLOSED there: an unknown method is a static
+/// error, so this list cannot silently drift wider than the engine).
+fn cel_methods() -> Vec<CompletionItem> {
+    const METHODS: &[(&str, &str, &str)] = &[
+        (
+            "size()",
+            "size",
+            "length of a string · list · map (cel-subset/0.1)",
+        ),
+        (
+            "contains(…)",
+            "contains",
+            "substring test on a string (cel-subset/0.1)",
+        ),
+        (
+            "startsWith(…)",
+            "startsWith",
+            "prefix test on a string (cel-subset/0.1)",
+        ),
+        (
+            "endsWith(…)",
+            "endsWith",
+            "suffix test on a string (cel-subset/0.1)",
+        ),
+    ];
+    METHODS
+        .iter()
+        .map(|(label, insert, doc)| CompletionItem {
+            label: (*label).to_owned(),
+            insert_text: Some((*insert).to_owned()),
+            kind: Some(CompletionItemKind::METHOD),
+            detail: Some((*doc).to_owned()),
+            ..CompletionItem::default()
+        })
+        .collect()
+}
+
+/// Expression ROOTS (the five locked namespaces · D-N11) + the two free
+/// functions the parser accepts (`size` · `has` — a closed set there too).
+fn expression_roots() -> Vec<CompletionItem> {
+    const ROOTS: &[(&str, &str)] = &[
+        ("tasks", "an upstream task's output (`tasks.<id>.output`)"),
+        ("vars", "a declared workflow var"),
+        ("env", "an allowed environment value"),
+        ("secrets", "a declared secret (never echoed)"),
+        ("with", "this task's own `with:` aliases"),
+        ("item", "the current `for_each` element"),
+    ];
+    let mut items: Vec<CompletionItem> = ROOTS
+        .iter()
+        .map(|(name, doc)| CompletionItem {
+            label: (*name).to_owned(),
+            kind: Some(CompletionItemKind::VARIABLE),
+            detail: Some((*doc).to_owned()),
+            ..CompletionItem::default()
+        })
+        .collect();
+    for (label, insert, doc) in [
+        (
+            "size(…)",
+            "size",
+            "length of a string · list · map (free form)",
+        ),
+        (
+            "has(…)",
+            "has",
+            "presence test — true when the path resolves",
+        ),
+    ] {
+        items.push(CompletionItem {
+            label: label.to_owned(),
+            insert_text: Some(insert.to_owned()),
+            kind: Some(CompletionItemKind::FUNCTION),
+            detail: Some(doc.to_owned()),
+            ..CompletionItem::default()
+        });
+    }
+    items
 }
 
 /// A top-level key position — column 0 (no indentation) and the prefix is
@@ -638,6 +759,67 @@ mod tests {
         assert!(
             labels(&items).contains(&"on_error".to_owned()),
             "and the rest"
+        );
+    }
+
+    /// B6 · the CEL method position: a dot PAST a data path inside an
+    /// open island completes the closed cel-subset/0.1 method set — and
+    /// the bare `tasks.` island stays task-id territory (checked first).
+    #[test]
+    fn expression_post_dot_completes_cel_methods() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.output.";
+        let items = completion(text, text.len());
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels.contains(&"size()"),
+            "cel methods at post-path dot: {labels:?}"
+        );
+        assert!(labels.contains(&"startsWith(…)"));
+        assert_eq!(
+            items.len(),
+            4,
+            "the method set is CLOSED (parser arity table)"
+        );
+
+        // Bare `tasks.` still resolves to task IDS, never methods.
+        let bare = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    exec: { command: \"echo ${{ tasks.";
+        let ids: Vec<String> = completion(bare, bare.len())
+            .into_iter()
+            .map(|i| i.label)
+            .collect();
+        assert!(
+            ids.contains(&"a".to_owned()),
+            "task ids win on the bare root: {ids:?}"
+        );
+    }
+
+    /// B6 · the island start completes the five locked roots + item +
+    /// the two free functions — and outside any island, nothing changes.
+    #[test]
+    fn expression_start_completes_roots_and_free_functions() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ ";
+        let labels: Vec<String> = completion(text, text.len())
+            .into_iter()
+            .map(|i| i.label)
+            .collect();
+        for root in ["tasks", "vars", "env", "secrets", "with", "item"] {
+            assert!(
+                labels.contains(&root.to_owned()),
+                "missing root {root}: {labels:?}"
+            );
+        }
+        assert!(labels.contains(&"has(…)".to_owned()));
+
+        // A closed island offers nothing from the expression vocab.
+        let closed =
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ vars.x }} and ";
+        let after: Vec<String> = completion(closed, closed.len())
+            .into_iter()
+            .map(|i| i.label)
+            .collect();
+        assert!(
+            !after.contains(&"has(…)".to_owned()),
+            "closed island leaks: {after:?}"
         );
     }
 


### PR DESCRIPTION
Three authoring-OS legs, each e2e-proven on the signature workflow:

**Run journal (B1)** — every run writes `.nika/traces/<ISO>-<id>.ndjson` via a `Tee<A,B>` beside each lane's primary sink (lazy open on the first event's UUIDv7 · infallible: fs errors buffer to a stderr note, never the exit code · primary bytes proven byte-identical with/without). Opt-outs: `--no-trace-file` · `NIKA_NO_TRACE_FILE` · `examples run`. Closes the spec'd-not-shipped gap the editor's runs view was watching.

**`--task` scope (B5)** — run ONE task + its transitive upstream (the regenerate-one-block move): full-file audit first, then the ancestor cone re-checks so plan/waves/cost describe exactly what runs. Unknown ids refuse (env class) with the available set. Proven on the diamond: `--task translate` → exactly {discover digest draft translate}.

**CEL completion (B6)** — `nika lsp` completes inside `${{ }}` islands: post-path dot → the closed cel-subset/0.1 method set (mirrored from nika-cel's parser arity table — cannot drift wider than the engine) · island start → the five locked roots + `item` + `size`/`has`. Wire-proven: the before-bench returned 0 items at both probes, after returns 4 and 8.

Merged with main (round-8 + comprehension pass absorbed · lane-dispatcher refactor keeps fn-length/loc-limits green). 196 nika-cli + 126 nika-lsp lib tests · clippy all-targets -D warnings · engine hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)