### PR TITLE
feat(nika-builtin): nika:tts_generate — the 25th builtin (stdlib §Audio)

### DIFF
--- a/crates/nika-builtin/public-api.txt
+++ b/crates/nika-builtin/public-api.txt
@@ -89,11 +89,49 @@ impl<T> nika_error::traits::AsAny for nika_builtin::permits::FsBoundary where T:
 pub fn nika_builtin::permits::FsBoundary::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> typenum::type_operators::Same for nika_builtin::permits::FsBoundary
 pub type nika_builtin::permits::FsBoundary::Output = T
+pub mod nika_builtin::tts
+#[non_exhaustive] pub struct nika_builtin::tts::TtsKeys
+pub nika_builtin::tts::TtsKeys::elevenlabs: core::option::Option<nika_kernel_core::infra::secret::Secret>
+pub nika_builtin::tts::TtsKeys::local_api_key: core::option::Option<nika_kernel_core::infra::secret::Secret>
+pub nika_builtin::tts::TtsKeys::local_base_url: core::option::Option<alloc::string::String>
+pub nika_builtin::tts::TtsKeys::openai: core::option::Option<nika_kernel_core::infra::secret::Secret>
+impl nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::new() -> Self
+pub fn nika_builtin::tts::TtsKeys::with_elevenlabs(self, key: nika_kernel_core::infra::secret::Secret) -> Self
+pub fn nika_builtin::tts::TtsKeys::with_local_api_key(self, key: nika_kernel_core::infra::secret::Secret) -> Self
+pub fn nika_builtin::tts::TtsKeys::with_local_base_url(self, base_url: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn nika_builtin::tts::TtsKeys::with_openai(self, key: nika_kernel_core::infra::secret::Secret) -> Self
+impl core::default::Default for nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::default() -> nika_builtin::tts::TtsKeys
+impl core::fmt::Debug for nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_builtin::tts::TtsKeys
+impl<T, U> core::convert::Into<U> for nika_builtin::tts::TtsKeys where U: core::convert::From<T>
+pub fn nika_builtin::tts::TtsKeys::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_builtin::tts::TtsKeys where U: core::convert::Into<T>
+pub type nika_builtin::tts::TtsKeys::Error = core::convert::Infallible
+pub fn nika_builtin::tts::TtsKeys::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_builtin::tts::TtsKeys where U: core::convert::TryFrom<T>
+pub type nika_builtin::tts::TtsKeys::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_builtin::tts::TtsKeys::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_builtin::tts::TtsKeys where T: 'static + ?core::marker::Sized
+pub fn nika_builtin::tts::TtsKeys::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_builtin::tts::TtsKeys where T: ?core::marker::Sized
+pub fn nika_builtin::tts::TtsKeys::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_builtin::tts::TtsKeys where T: ?core::marker::Sized
+pub fn nika_builtin::tts::TtsKeys::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_builtin::tts::TtsKeys where T: 'static
+pub fn nika_builtin::tts::TtsKeys::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> typenum::type_operators::Same for nika_builtin::tts::TtsKeys
+pub type nika_builtin::tts::TtsKeys::Output = T
 pub struct nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>
 impl<F, H, C, Em, P, W> nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>
 pub fn nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>::new(fs: alloc::sync::Arc<F>, http: alloc::sync::Arc<H>, clock: alloc::sync::Arc<C>, emitter: alloc::sync::Arc<Em>, prompter: alloc::sync::Arc<P>, workflow: alloc::sync::Arc<W>) -> Self
 pub fn nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>::with_fs_boundary(self, boundary: nika_builtin::permits::FsBoundary) -> Self
 pub fn nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>::with_image_plane(self, http: alloc::sync::Arc<H>, keys: nika_builtin::image::ImageKeys) -> Self
+pub fn nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>::with_tts_plane(self, http: alloc::sync::Arc<H>, keys: nika_builtin::tts::TtsKeys) -> Self
 impl<F, H, C, Em, P, W> nika_kernel_ai::tool_defs::ToolDefinitionProviderDyn for nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W> where F: nika_kernel_core::io::fs::FsReadDyn + nika_kernel_core::io::fs::FsWriteDyn + nika_kernel_core::io::fs::FsListDyn + core::marker::Send + core::marker::Sync, H: nika_kernel_core::io::http::HttpGetDyn + nika_kernel_core::io::http::HttpPostDyn + core::marker::Send + core::marker::Sync, C: nika_kernel_core::io::clock::ClockDyn + core::marker::Send + core::marker::Sync, Em: nika_builtin::Emitter, P: nika_builtin::Prompter, W: nika_builtin::WorkflowIntrospect
 pub async fn nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W>::tool_defs(&self) -> core::result::Result<alloc::vec::Vec<nika_kernel_ai::provider::ToolDef>, nika_kernel_ai::tool_defs::ToolDefsError>
 impl<F, H, C, Em, P, W> nika_kernel_runtime::tool_executor::ToolBatchDyn for nika_builtin::BuiltinDispatcher<F, H, C, Em, P, W> where F: nika_kernel_core::io::fs::FsReadDyn + nika_kernel_core::io::fs::FsWriteDyn + nika_kernel_core::io::fs::FsListDyn + core::marker::Send + core::marker::Sync, H: nika_kernel_core::io::http::HttpGetDyn + nika_kernel_core::io::http::HttpPostDyn + core::marker::Send + core::marker::Sync, C: nika_kernel_core::io::clock::ClockDyn + core::marker::Send + core::marker::Sync, Em: nika_builtin::Emitter, P: nika_builtin::Prompter, W: nika_builtin::WorkflowIntrospect
@@ -386,6 +424,42 @@ impl<T> outref::AsOut<T> for nika_builtin::NullEmitter where T: core::marker::Co
 pub fn nika_builtin::NullEmitter::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> typenum::type_operators::Same for nika_builtin::NullEmitter
 pub type nika_builtin::NullEmitter::Output = T
+#[non_exhaustive] pub struct nika_builtin::TtsKeys
+pub nika_builtin::TtsKeys::elevenlabs: core::option::Option<nika_kernel_core::infra::secret::Secret>
+pub nika_builtin::TtsKeys::local_api_key: core::option::Option<nika_kernel_core::infra::secret::Secret>
+pub nika_builtin::TtsKeys::local_base_url: core::option::Option<alloc::string::String>
+pub nika_builtin::TtsKeys::openai: core::option::Option<nika_kernel_core::infra::secret::Secret>
+impl nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::new() -> Self
+pub fn nika_builtin::tts::TtsKeys::with_elevenlabs(self, key: nika_kernel_core::infra::secret::Secret) -> Self
+pub fn nika_builtin::tts::TtsKeys::with_local_api_key(self, key: nika_kernel_core::infra::secret::Secret) -> Self
+pub fn nika_builtin::tts::TtsKeys::with_local_base_url(self, base_url: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn nika_builtin::tts::TtsKeys::with_openai(self, key: nika_kernel_core::infra::secret::Secret) -> Self
+impl core::default::Default for nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::default() -> nika_builtin::tts::TtsKeys
+impl core::fmt::Debug for nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_builtin::tts::TtsKeys
+impl<T, U> core::convert::Into<U> for nika_builtin::tts::TtsKeys where U: core::convert::From<T>
+pub fn nika_builtin::tts::TtsKeys::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_builtin::tts::TtsKeys where U: core::convert::Into<T>
+pub type nika_builtin::tts::TtsKeys::Error = core::convert::Infallible
+pub fn nika_builtin::tts::TtsKeys::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_builtin::tts::TtsKeys where U: core::convert::TryFrom<T>
+pub type nika_builtin::tts::TtsKeys::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_builtin::tts::TtsKeys::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_builtin::tts::TtsKeys where T: 'static + ?core::marker::Sized
+pub fn nika_builtin::tts::TtsKeys::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_builtin::tts::TtsKeys where T: ?core::marker::Sized
+pub fn nika_builtin::tts::TtsKeys::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_builtin::tts::TtsKeys where T: ?core::marker::Sized
+pub fn nika_builtin::tts::TtsKeys::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_builtin::tts::TtsKeys
+pub fn nika_builtin::tts::TtsKeys::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_builtin::tts::TtsKeys where T: 'static
+pub fn nika_builtin::tts::TtsKeys::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> typenum::type_operators::Same for nika_builtin::tts::TtsKeys
+pub type nika_builtin::tts::TtsKeys::Output = T
 pub const nika_builtin::NAMESPACE: &str
 pub const nika_builtin::TOOLS_EXPORT_VERSION: u32
 pub trait nika_builtin::Emitter: core::marker::Send + core::marker::Sync

--- a/crates/nika-builtin/src/defs.rs
+++ b/crates/nika-builtin/src/defs.rs
@@ -344,34 +344,54 @@ fn introspection_defs() -> Vec<ToolDef> {
 }
 
 fn media_defs() -> Vec<ToolDef> {
-    vec![def(
-        "image_generate",
-        "Generate image assets (local compat servers · openai gpt-image-2 · gemini gemini-3.1-flash-image · xai grok-imagine-image · mock for offline runs) — saves files under output_dir and returns paths + dimensions + sha256 (+ a provenance manifest); image bytes never ride outputs.",
-        serde_json::json!({
-            "provider": s("local | openai | gemini | xai | mock (inferred from model: when omitted · local is never inferred)"),
-            "model": s("provider model id · defaults: stablediffusion (local · LocalAI convention) · gpt-image-2 · gemini-3.1-flash-image · grok-imagine-image · mock-image-1"),
-            "prompt": s("the creative brief the provider renders"),
-            "mode": s("generate (default) — `edit` is on the media roadmap, rejected loudly"),
-            "n": { "type": "integer", "description": "variant count 1..=10 (gemini runs n sequential calls)" },
-            "aspect_ratio": s("1:1 | 16:9 | 9:16 | 4:3 | 3:4 | 3:2 | 2:3 | 21:9"),
-            "size": s("exact WIDTHxHEIGHT (gpt-image-2 arbitrary /16 sizes · gemini folds to a size class) or auto — an exact size wins over aspect_ratio"),
-            "quality": s("auto (default) | low | medium | high | ultra (folds to high on openai · model-tier on gemini)"),
-            "format": s("png (default) | jpeg | webp — magic bytes are the authority on what lands"),
-            "compression": { "type": "integer", "description": "0..=100 · jpeg/webp only (openai output_compression)" },
-            "background": s("auto (default) | transparent (needs png/webp and a supporting model) | opaque"),
-            "seed": { "type": "integer", "description": "gemini best-effort · openai has no seed (warned + dropped)" },
-            "reference_images": { "type": "array", "items": {"type": "string"}, "description": "media roadmap — rejected loudly in V1" },
-            "provider_options": { "type": "object", "description": "vetted pass-through · openai {moderation, user} · gemini {thinking_level, image_size} · xai {user, resolution}" },
-            "output_dir": s("directory the assets land in (rides the declared permits.fs boundary)"),
-            "filename_prefix": s("filename stem (else metadata.page_slug, else `image`) — sanitized, traversal-free"),
-            "save": { "type": "boolean", "description": "V1 contract: stays true — assets land on disk, never inline" },
-            "manifest": { "type": "boolean", "description": "write the provenance manifest JSON beside the assets (default true)" },
-            "metadata": { "type": "object", "description": "free provenance fields (campaign · page_slug · locale …) echoed to output + manifest" },
-            "timeout_ms": { "type": "integer", "description": "per-request deadline · default 180000 · 1000..=600000" },
-            "debug": { "type": "boolean", "description": "echo the sanitized raw provider response (base64 stripped)" }
-        }),
-        &["prompt", "output_dir"],
-    )]
+    vec![
+        def(
+            "tts_generate",
+            "Synthesize speech audio (local compat servers · openai gpt-4o-mini-tts · elevenlabs · mock for offline runs) — saves ONE audio file under output_dir and returns path + format + sha256 + duration (+ a provenance manifest); audio bytes never ride outputs.",
+            serde_json::json!({
+                "provider": s("local | openai | elevenlabs | mock (inferred from model: when omitted · local is never inferred)"),
+                "model": s("provider model id · defaults: tts-1 (local · LocalAI convention) · gpt-4o-mini-tts · eleven_multilingual_v2 · mock-tts-1"),
+                "text": s("the text to speak · ≤4096 chars (fan long scripts out with for_each)"),
+                "voice": s("provider voice · defaults: alloy (openai/local) · Rachel's id (elevenlabs) · sine (mock)"),
+                "format": s("mp3 | wav | auto (default · provider-native · the saved extension follows the bytes)"),
+                "speed": { "type": "number", "description": "0.25..=4.0 (openai/local · warned-dropped elsewhere)" },
+                "output_dir": s("directory the audio lands in (created if missing · fs-permit gated)"),
+                "filename_prefix": s("filename stem (default: metadata.page_slug, else `speech`)"),
+                "metadata": { "type": "object", "description": "free-form provenance echoed into output + manifest" },
+                "manifest": { "type": "boolean", "description": "write the sidecar provenance manifest (default true)" },
+                "timeout_ms": { "type": "integer", "description": "per-request cap · default 120000 (local 300000) · max 600000" },
+            }),
+            &["text", "output_dir"],
+        ),
+        def(
+            "image_generate",
+            "Generate image assets (local compat servers · openai gpt-image-2 · gemini gemini-3.1-flash-image · xai grok-imagine-image · mock for offline runs) — saves files under output_dir and returns paths + dimensions + sha256 (+ a provenance manifest); image bytes never ride outputs.",
+            serde_json::json!({
+                "provider": s("local | openai | gemini | xai | mock (inferred from model: when omitted · local is never inferred)"),
+                "model": s("provider model id · defaults: stablediffusion (local · LocalAI convention) · gpt-image-2 · gemini-3.1-flash-image · grok-imagine-image · mock-image-1"),
+                "prompt": s("the creative brief the provider renders"),
+                "mode": s("generate (default) — `edit` is on the media roadmap, rejected loudly"),
+                "n": { "type": "integer", "description": "variant count 1..=10 (gemini runs n sequential calls)" },
+                "aspect_ratio": s("1:1 | 16:9 | 9:16 | 4:3 | 3:4 | 3:2 | 2:3 | 21:9"),
+                "size": s("exact WIDTHxHEIGHT (gpt-image-2 arbitrary /16 sizes · gemini folds to a size class) or auto — an exact size wins over aspect_ratio"),
+                "quality": s("auto (default) | low | medium | high | ultra (folds to high on openai · model-tier on gemini)"),
+                "format": s("png (default) | jpeg | webp — magic bytes are the authority on what lands"),
+                "compression": { "type": "integer", "description": "0..=100 · jpeg/webp only (openai output_compression)" },
+                "background": s("auto (default) | transparent (needs png/webp and a supporting model) | opaque"),
+                "seed": { "type": "integer", "description": "gemini best-effort · openai has no seed (warned + dropped)" },
+                "reference_images": { "type": "array", "items": {"type": "string"}, "description": "media roadmap — rejected loudly in V1" },
+                "provider_options": { "type": "object", "description": "vetted pass-through · openai {moderation, user} · gemini {thinking_level, image_size} · xai {user, resolution}" },
+                "output_dir": s("directory the assets land in (rides the declared permits.fs boundary)"),
+                "filename_prefix": s("filename stem (else metadata.page_slug, else `image`) — sanitized, traversal-free"),
+                "save": { "type": "boolean", "description": "V1 contract: stays true — assets land on disk, never inline" },
+                "manifest": { "type": "boolean", "description": "write the provenance manifest JSON beside the assets (default true)" },
+                "metadata": { "type": "object", "description": "free provenance fields (campaign · page_slug · locale …) echoed to output + manifest" },
+                "timeout_ms": { "type": "integer", "description": "per-request deadline · default 180000 · 1000..=600000" },
+                "debug": { "type": "boolean", "description": "echo the sanitized raw provider response (base64 stripped)" }
+            }),
+            &["prompt", "output_dir"],
+        ),
+    ]
 }
 
 #[cfg(test)]
@@ -437,13 +457,13 @@ mod tests {
     }
 
     #[test]
-    fn the_catalog_is_the_canonical_24_with_no_dupes() {
+    fn the_catalog_is_the_canonical_25_with_no_dupes() {
         let defs = tool_defs();
         assert_eq!(
             defs.len(),
-            24,
-            "stdlib ships exactly 24 (22 Rams-swept + nika:compose ADR-096 + \
-             nika:image_generate stdlib §Media)"
+            25,
+            "stdlib ships exactly 25 (22 Rams-swept + nika:compose ADR-096 + \
+             nika:image_generate stdlib §Media + nika:tts_generate stdlib §Audio)"
         );
         let mut names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         names.sort_unstable();

--- a/crates/nika-builtin/src/lib.rs
+++ b/crates/nika-builtin/src/lib.rs
@@ -36,6 +36,7 @@ pub mod image;
 pub mod inspect;
 pub mod net;
 pub mod permits;
+pub mod tts;
 
 use std::sync::Arc;
 
@@ -50,6 +51,7 @@ use nika_kernel::runtime::tool_executor::{
 pub use defs::{TOOLS_EXPORT_VERSION, tool_defs, tools_json};
 pub use image::ImageKeys;
 pub use permits::FsBoundary;
+pub use tts::TtsKeys;
 
 /// The closed builtin namespace prefix.
 pub const NAMESPACE: &str = "nika:";
@@ -267,9 +269,13 @@ pub struct BuiltinDispatcher<F, H, C, Em, P, W> {
     /// correct carrier — the fetch client's 30s idle guard would kill
     /// 60–120s image renders.
     image_http: Option<Arc<H>>,
+    /// The TTS plane — the same provider-plane philosophy (SSRF-disabled
+    /// client · const/config endpoints · wired via [`Self::with_tts_plane`]).
+    tts_http: Option<Arc<H>>,
     /// Image-provider credentials (composition-root resolved · never read
     /// from the environment here).
     image_keys: image::ImageKeys,
+    tts_keys: tts::TtsKeys,
 }
 
 impl<F, H, C, Em, P, W> BuiltinDispatcher<F, H, C, Em, P, W> {
@@ -292,7 +298,9 @@ impl<F, H, C, Em, P, W> BuiltinDispatcher<F, H, C, Em, P, W> {
             workflow,
             fs_boundary: FsBoundary::unbounded(),
             image_http: None,
+            tts_http: None,
             image_keys: image::ImageKeys::new(),
+            tts_keys: tts::TtsKeys::new(),
         }
     }
 
@@ -318,6 +326,15 @@ impl<F, H, C, Em, P, W> BuiltinDispatcher<F, H, C, Em, P, W> {
     pub fn with_image_plane(mut self, http: Arc<H>, keys: image::ImageKeys) -> Self {
         self.image_http = Some(http);
         self.image_keys = keys;
+        self
+    }
+
+    /// Wire the TTS plane (provider-plane client + composition-root keys)
+    /// — `nika:tts_generate` cloud/local providers need it; mock never does.
+    #[must_use]
+    pub fn with_tts_plane(mut self, http: Arc<H>, keys: tts::TtsKeys) -> Self {
+        self.tts_http = Some(http);
+        self.tts_keys = keys;
         self
     }
 }
@@ -422,6 +439,7 @@ where
                 args,
             )
             .await),
+            "tts_generate" => Ok(self.route_tts(args).await),
             // introspection 2
             "compose" => Ok(core_tools::compose()),
             "inspect" => Ok(inspect::inspect(self.workflow.as_ref(), args)),
@@ -437,6 +455,21 @@ where
     /// the capability boundary, not the I/O, is the gate. When `path:` is
     /// absent the op runs (its own arg ladder surfaces the missing-arg
     /// error · the boundary has nothing to confine).
+    /// The `nika:tts_generate` plumbing (kept out of `route`'s match for
+    /// the fn-length budget — pure delegation).
+    async fn route_tts(&self, args: &Args) -> BuiltinOutcome {
+        tts::generate(
+            self.fs.as_ref(),
+            self.tts_http.as_deref(),
+            &self.tts_keys,
+            self.clock.as_ref(),
+            self.emitter.as_ref(),
+            &self.fs_boundary,
+            args,
+        )
+        .await
+    }
+
     async fn guarded_fs<'a, Fut>(
         &'a self,
         args: &'a Args,
@@ -712,9 +745,9 @@ mod tests {
             let outcome = rig.execute(call(&def.name, serde_json::json!({}))).await;
             assert!(outcome.is_ok(), "{} must route (got {outcome:?})", def.name);
         }
-        // …and the count is the canonical 24 (stdlib v0.1 · +compose per
-        // ADR-096 · +image_generate stdlib §Media).
-        assert_eq!(tool_defs().len(), 24);
+        // …and the count is the canonical 25 (stdlib v0.1 · +compose per
+        // ADR-096 · +image_generate stdlib §Media · +tts_generate §Audio).
+        assert_eq!(tool_defs().len(), 25);
     }
 
     #[tokio::test]
@@ -774,7 +807,7 @@ mod tests {
         let defs = ToolDefinitionProviderDyn::tool_defs(&rig())
             .await
             .expect("enumerates");
-        assert_eq!(defs.len(), 24);
+        assert_eq!(defs.len(), 25);
         assert!(defs.iter().all(|d| d.name.starts_with(NAMESPACE)));
         assert!(defs.iter().all(|d| !d.description.is_empty()));
         assert!(

--- a/crates/nika-builtin/src/tts/args.rs
+++ b/crates/nika-builtin/src/tts/args.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika:tts_generate` argument parsing — closed enums · loud refusals ·
+//! the image family's honesty rules (never silently drop a knob).
+
+use std::time::Duration;
+
+use crate::{Args, BuiltinFailure};
+
+use super::types::{AudioFormat, C_ARGS, Provider};
+
+/// Cloud synthesis is seconds-class; local CPU synthesis can take longer.
+const DEFAULT_TIMEOUT_MS: u64 = 120_000;
+const DEFAULT_LOCAL_TIMEOUT_MS: u64 = 300_000;
+const MAX_TIMEOUT_MS: u64 = 600_000;
+/// The strictest documented per-request input cap (`OpenAI` 4096 chars) —
+/// one cap for every provider keeps the contract portable.
+const MAX_TEXT_CHARS: usize = 4_096;
+
+#[derive(Debug)]
+pub(crate) struct TtsArgs {
+    pub(crate) provider: Provider,
+    pub(crate) model: String,
+    pub(crate) text: String,
+    pub(crate) voice: String,
+    /// `None` = provider-native container (openai/elevenlabs/local mp3 ·
+    /// mock wav) — an explicit ask is honored where the wire allows and
+    /// warned as `format_mismatch:` where the bytes say otherwise.
+    pub(crate) format: Option<AudioFormat>,
+    /// 0.25–4.0 · stored ×1000 (`speed_permille`) so `TtsArgs` stays Eq-able.
+    speed_permille: u32,
+    pub(crate) speed_explicit: bool,
+    pub(crate) output_dir: String,
+    pub(crate) filename_prefix: Option<String>,
+    pub(crate) manifest: bool,
+    pub(crate) metadata: serde_json::Map<String, serde_json::Value>,
+    pub(crate) timeout: Duration,
+    pub(crate) warnings: Vec<String>,
+}
+
+impl TtsArgs {
+    pub(crate) const fn speed_permille(&self) -> u32 {
+        self.speed_permille
+    }
+
+    /// The wire value (1.0-centred float) when explicitly set.
+    pub(crate) fn speed_f64(&self) -> f64 {
+        f64::from(self.speed_permille) / 1000.0
+    }
+}
+
+pub(crate) fn parse(args: &Args) -> Result<TtsArgs, BuiltinFailure> {
+    let mut warnings = Vec::new();
+
+    let text = args
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| BuiltinFailure::new(C_ARGS, "`text` (non-empty string) is required"))?
+        .to_owned();
+    if text.chars().count() > MAX_TEXT_CHARS {
+        return Err(BuiltinFailure::new(
+            C_ARGS,
+            format!(
+                "`text` is {} chars — the portable per-request cap is {MAX_TEXT_CHARS} \
+                 (split long scripts into tasks; a `for_each` over paragraphs fans out cleanly)",
+                text.chars().count()
+            ),
+        ));
+    }
+
+    let provider = parse_provider(args)?;
+    let model = opt_str(args, "model")?.unwrap_or_else(|| provider.default_model().to_owned());
+    let voice = opt_str(args, "voice")?.unwrap_or_else(|| provider.default_voice().to_owned());
+
+    let format = match opt_str(args, "format")?.as_deref() {
+        None | Some("auto") => None,
+        Some("mp3") => Some(AudioFormat::Mp3),
+        Some("wav") => Some(AudioFormat::Wav),
+        Some(other) => {
+            return Err(BuiltinFailure::new(
+                C_ARGS,
+                format!("unknown `format:` `{other}` — one of mp3 · wav · auto"),
+            ));
+        }
+    };
+    if format == Some(AudioFormat::Mp3) && provider == Provider::Mock {
+        warnings.push(
+            "format_mismatch: the mock renders WAV only — the request rides, the bytes decide"
+                .to_owned(),
+        );
+    }
+
+    let (speed_permille, speed_explicit) = match args.get("speed") {
+        None => (1000, false),
+        Some(v) => {
+            let s = v.as_f64().ok_or_else(|| {
+                BuiltinFailure::new(C_ARGS, "`speed` must be a number (0.25–4.0)")
+            })?;
+            if !(0.25..=4.0).contains(&s) {
+                return Err(BuiltinFailure::new(
+                    C_ARGS,
+                    format!("`speed` {s} out of range — 0.25–4.0"),
+                ));
+            }
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            // 250..=4000 by the range check
+            ((s * 1000.0).round() as u32, true)
+        }
+    };
+    if speed_explicit && provider == Provider::Elevenlabs {
+        warnings.push(
+            "speed_unsupported: elevenlabs has no speed knob on this wire — dropped (voice \
+             settings govern pace)"
+                .to_owned(),
+        );
+    }
+
+    let output_dir = opt_str(args, "output_dir")?
+        .ok_or_else(|| BuiltinFailure::new(C_ARGS, "`output_dir` is required"))?;
+
+    let timeout_ms = parse_timeout(args, provider)?;
+    let (metadata, manifest) = parse_provenance_knobs(args)?;
+
+    Ok(TtsArgs {
+        provider,
+        model,
+        text,
+        voice,
+        format,
+        speed_permille,
+        speed_explicit,
+        output_dir,
+        filename_prefix: opt_str(args, "filename_prefix")?,
+        manifest,
+        metadata,
+        timeout: Duration::from_millis(timeout_ms),
+        warnings,
+    })
+}
+
+/// `timeout_ms` with the provider-aware default (local CPU synthesis gets
+/// the wide one).
+fn parse_timeout(args: &Args, provider: Provider) -> Result<u64, BuiltinFailure> {
+    let default = if provider == Provider::Local {
+        DEFAULT_LOCAL_TIMEOUT_MS
+    } else {
+        DEFAULT_TIMEOUT_MS
+    };
+    match args.get("timeout_ms") {
+        None => Ok(default),
+        Some(v) => v
+            .as_u64()
+            .filter(|ms| (1..=MAX_TIMEOUT_MS).contains(ms))
+            .ok_or_else(|| {
+                BuiltinFailure::new(C_ARGS, format!("`timeout_ms` must be 1..={MAX_TIMEOUT_MS}"))
+            }),
+    }
+}
+
+/// `metadata` + `manifest` (the provenance knobs).
+fn parse_provenance_knobs(
+    args: &Args,
+) -> Result<(serde_json::Map<String, serde_json::Value>, bool), BuiltinFailure> {
+    let metadata = match args.get("metadata") {
+        None => serde_json::Map::new(),
+        Some(serde_json::Value::Object(map)) => map.clone(),
+        Some(_) => {
+            return Err(BuiltinFailure::new(C_ARGS, "`metadata` must be an object"));
+        }
+    };
+    let manifest = match args.get("manifest") {
+        None => true,
+        Some(v) => v
+            .as_bool()
+            .ok_or_else(|| BuiltinFailure::new(C_ARGS, "`manifest` must be a boolean"))?,
+    };
+    Ok((metadata, manifest))
+}
+
+fn parse_provider(args: &Args) -> Result<Provider, BuiltinFailure> {
+    match args.get("provider").and_then(serde_json::Value::as_str) {
+        Some("local") => Ok(Provider::Local),
+        Some("openai") => Ok(Provider::Openai),
+        Some("elevenlabs") => Ok(Provider::Elevenlabs),
+        Some("mock") => Ok(Provider::Mock),
+        Some(other) => Err(BuiltinFailure::new(
+            C_ARGS,
+            format!(
+                "unknown `provider:` `{other}` — one of local · openai · elevenlabs · mock \
+                 (local is never inferred: model names are server-specific)"
+            ),
+        )),
+        // Model-prefix inference mirrors the image family; `local` stays
+        // explicit-only.
+        None => match args.get("model").and_then(serde_json::Value::as_str) {
+            Some(m) if m.starts_with("eleven") => Ok(Provider::Elevenlabs),
+            Some(m) if m.starts_with("gpt-") || m.starts_with("tts-") => Ok(Provider::Openai),
+            Some(m) if m.starts_with("mock") => Ok(Provider::Mock),
+            Some(other) => Err(BuiltinFailure::new(
+                C_ARGS,
+                format!(
+                    "cannot infer a provider from model `{other}` — set `provider:` \
+                     (local · openai · elevenlabs · mock)"
+                ),
+            )),
+            None => Err(BuiltinFailure::new(
+                C_ARGS,
+                "`provider:` is required (local · openai · elevenlabs · mock)",
+            )),
+        },
+    }
+}
+
+fn opt_str(args: &Args, key: &str) -> Result<Option<String>, BuiltinFailure> {
+    match args.get(key) {
+        None => Ok(None),
+        Some(serde_json::Value::String(s)) if !s.trim().is_empty() => Ok(Some(s.trim().to_owned())),
+        Some(_) => Err(BuiltinFailure::new(
+            C_ARGS,
+            format!("`{key}` must be a non-empty string"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base(extra: serde_json::Value) -> Args {
+        let serde_json::Value::Object(mut map) = serde_json::json!({
+            "provider": "mock", "text": "bonjour", "output_dir": "./out"
+        }) else {
+            unreachable!()
+        };
+        if let serde_json::Value::Object(e) = extra {
+            map.extend(e);
+        }
+        map
+    }
+
+    #[test]
+    fn parse_covers_the_contract_edges() {
+        let parsed_mock = parse(&base(serde_json::json!({}))).expect("valid");
+        assert_eq!(parsed_mock.provider, Provider::Mock);
+        assert_eq!(parsed_mock.voice, "sine");
+        assert_eq!(parsed_mock.speed_permille(), 1000);
+        assert!(parsed_mock.manifest);
+        let mut m = base(serde_json::json!({ "model": "eleven_flash_v2_5" }));
+        m.remove("provider");
+        assert_eq!(parse(&m).expect("inferred").provider, Provider::Elevenlabs);
+        let mut m = base(serde_json::json!({ "model": "gpt-4o-mini-tts" }));
+        m.remove("provider");
+        assert_eq!(parse(&m).expect("inferred").provider, Provider::Openai);
+        let mut m = base(serde_json::json!({ "model": "kokoro" }));
+        m.remove("provider");
+        assert!(parse(&m).is_err(), "local never inferred");
+
+        // caps + ranges.
+        assert!(parse(&base(serde_json::json!({ "text": "x".repeat(5000) }))).is_err());
+        assert!(parse(&base(serde_json::json!({ "speed": 9.0 }))).is_err());
+        assert!(parse(&base(serde_json::json!({ "format": "flac" }))).is_err());
+        let s = parse(&base(serde_json::json!({ "speed": 1.5 }))).expect("speed");
+        assert_eq!(s.speed_permille(), 1500);
+        assert!((s.speed_f64() - 1.5).abs() < 1e-9);
+
+        // elevenlabs speed warn-drop.
+        let e = parse(&base(serde_json::json!({
+            "provider": "elevenlabs", "speed": 2.0
+        })))
+        .expect("valid");
+        assert!(
+            e.warnings
+                .iter()
+                .any(|w| w.starts_with("speed_unsupported:"))
+        );
+
+        // local default timeout is the CPU-wide one.
+        let l = parse(&base(serde_json::json!({ "provider": "local" }))).expect("valid");
+        assert_eq!(l.timeout.as_millis(), 300_000);
+    }
+}

--- a/crates/nika-builtin/src/tts/elevenlabs.rs
+++ b/crates/nika-builtin/src/tts/elevenlabs.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `ElevenLabs` adapter — `POST /v1/text-to-speech/{voice_id}` (the voice
+//! rides the PATH, so it is sanitized against injection), `xi-api-key`
+//! header, raw audio bytes back. `output_format` rides the query string.
+
+use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
+use nika_kernel::secret::Secret;
+
+use crate::BuiltinFailure;
+
+use super::args::TtsArgs;
+use super::types::{AudioFormat, C_ARGS, C_POLICY, C_REQUEST, ProviderAudio};
+
+const ENDPOINT_STEM: &str = "https://api.elevenlabs.io/v1/text-to-speech/";
+
+pub(crate) async fn generate<H: HttpPostDyn>(
+    http: &H,
+    key: &Secret,
+    args: &TtsArgs,
+) -> Result<ProviderAudio, BuiltinFailure> {
+    let (request, warnings) = build_request(args, key)?;
+    let response = http.post(request).await.map_err(map_transport)?;
+    if !(200..300).contains(&response.status) {
+        return Err(map_error_status(response.status, &response.body));
+    }
+    Ok(ProviderAudio {
+        bytes: response.body.to_vec(),
+        cost_usd: None, // subscription-quota billing · no response cost field
+        endpoint_host: Some("api.elevenlabs.io".to_owned()),
+        warnings,
+    })
+}
+
+fn build_request(
+    args: &TtsArgs,
+    key: &Secret,
+) -> Result<(HttpRequest, Vec<String>), BuiltinFailure> {
+    let mut warnings = Vec::new();
+    // The voice id rides the URL path — restrict to the id alphabet so a
+    // crafted `voice:` can never smuggle path segments or a query string.
+    if !args
+        .voice
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        || args.voice.len() > 64
+    {
+        return Err(BuiltinFailure::new(
+            C_ARGS,
+            "elevenlabs `voice:` must be a voice id ([A-Za-z0-9_-] · ≤64 chars) — find ids \
+             in your ElevenLabs voice library",
+        ));
+    }
+    let format_param = match args.format {
+        Some(AudioFormat::Wav) => {
+            // The compat-plan reality: raw PCM tiers exist but plan-gated;
+            // mp3 is the universal tier. The bytes decide the extension.
+            warnings.push(
+                "format_mismatch: elevenlabs serves mp3 on the standard tier — the wav ask \
+                 rides as mp3 (the saved extension follows the bytes)"
+                    .to_owned(),
+            );
+            "mp3_44100_128"
+        }
+        _ => "mp3_44100_128",
+    };
+    let url = format!("{ENDPOINT_STEM}{}?output_format={format_param}", args.voice);
+
+    let body = serde_json::json!({
+        "text": args.text,
+        "model_id": args.model,
+    });
+
+    let mut request = HttpRequest::post(&url);
+    request
+        .headers
+        .insert("xi-api-key".to_owned(), key.expose().to_owned());
+    request
+        .headers
+        .insert("content-type".to_owned(), "application/json".to_owned());
+    request.timeout = Some(args.timeout);
+    request.body = Some(
+        serde_json::to_vec(&body)
+            .map_err(|e| BuiltinFailure::new(C_REQUEST, format!("request serialization: {e}")))?
+            .into(),
+    );
+    Ok((request, warnings))
+}
+
+fn map_transport(error: HttpError) -> BuiltinFailure {
+    match error {
+        HttpError::Timeout { duration_ms } => BuiltinFailure::new(
+            C_REQUEST,
+            format!("elevenlabs timed out after {duration_ms}ms — raise `timeout_ms:`"),
+        )
+        .with_transient(true),
+        HttpError::Connection { reason } => {
+            BuiltinFailure::new(C_REQUEST, format!("elevenlabs connection failed: {reason}"))
+                .with_transient(true)
+        }
+        other => BuiltinFailure::new(C_REQUEST, format!("elevenlabs request failed: {other}")),
+    }
+}
+
+fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
+    let envelope: serde_json::Value = serde_json::from_slice(body).unwrap_or_default();
+    // ElevenLabs error shape: {"detail": {"status": "...", "message": "..."}}
+    // (or a bare {"detail": "..."} string) — never the raw body (the local
+    // adapter's reflected-credential lesson applies to every vendor).
+    let message: String = envelope
+        .get("detail")
+        .map_or_else(
+            || "no error message".to_owned(),
+            |d| {
+                d.get("message")
+                    .and_then(serde_json::Value::as_str)
+                    .or_else(|| d.as_str())
+                    .unwrap_or("no error message")
+                    .to_owned()
+            },
+        )
+        .chars()
+        .take(300)
+        .collect();
+    let code = if message.to_ascii_lowercase().contains("moderat") {
+        C_POLICY
+    } else {
+        C_REQUEST
+    };
+    BuiltinFailure::new(code, format!("elevenlabs HTTP {status}: {message}"))
+        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_details(serde_json::json!({ "status_code": status }))
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_kernel_mock::MockHttp;
+
+    use super::super::args;
+    use super::*;
+
+    fn parsed(extra: serde_json::Value) -> TtsArgs {
+        let serde_json::Value::Object(mut map) = serde_json::json!({
+            "provider": "elevenlabs", "text": "bonjour", "output_dir": "./out"
+        }) else {
+            unreachable!()
+        };
+        if let serde_json::Value::Object(e) = extra {
+            map.extend(e);
+        }
+        args::parse(&map).expect("valid")
+    }
+
+    #[test]
+    fn voice_path_injection_is_structurally_impossible() {
+        let key = Secret::new("xi-KEY".to_owned());
+        let (request, _) = build_request(&parsed(serde_json::json!({})), &key).expect("builds");
+        assert!(request.url.starts_with(ENDPOINT_STEM));
+        assert!(request.url.contains("21m00Tcm4TlvDq8ikWAM"));
+        assert_eq!(
+            request.headers.get("xi-api-key").map(String::as_str),
+            Some("xi-KEY")
+        );
+        for evil in ["../admin", "v?stream=true", "a/b", "x y", &"v".repeat(65)] {
+            let err = build_request(&parsed(serde_json::json!({ "voice": evil })), &key)
+                .expect_err("refused");
+            assert!(err.code.ends_with("-001"), "{evil} → {}", err.code);
+        }
+    }
+
+    #[tokio::test]
+    async fn success_and_detail_error_shapes() {
+        let key = Secret::new("xi-KEY-never-echoed".to_owned());
+        let http = MockHttp::new().enqueue_ok(200, b"ID3\x04audio".to_vec());
+        let audio = generate(&http, &key, &parsed(serde_json::json!({})))
+            .await
+            .expect("ok");
+        assert_eq!(audio.endpoint_host.as_deref(), Some("api.elevenlabs.io"));
+
+        let http = MockHttp::new().enqueue_ok(
+            401,
+            br#"{"detail":{"status":"invalid_api_key","message":"bad key"}}"#.to_vec(),
+        );
+        let err = generate(&http, &key, &parsed(serde_json::json!({})))
+            .await
+            .expect_err("401");
+        assert!(err.message.contains("bad key"));
+        assert!(!err.message.contains("never-echoed"), "{}", err.message);
+
+        // wav ask on the standard tier warns + rides as mp3.
+        let (req, warns) =
+            build_request(&parsed(serde_json::json!({ "format": "wav" })), &key).expect("builds");
+        assert!(req.url.contains("output_format=mp3_44100_128"));
+        assert!(warns.iter().any(|w| w.starts_with("format_mismatch:")));
+    }
+}

--- a/crates/nika-builtin/src/tts/local.rs
+++ b/crates/nika-builtin/src/tts/local.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The LOCAL TTS adapter — one `OpenAI`-speech-compatible wire covers
+//! `LocalAI` (also `ElevenLabs`-compatible upstream), Kokoro-FastAPI,
+//! Speaches and openedai-speech: `POST {base}/v1/audio/speech` → raw
+//! audio bytes. The base URL is ENGINE CONFIG (`NIKA_TTS_LOCAL_URL` ·
+//! default `LocalAI`'s `http://localhost:8080`), never workflow data —
+//! the same sanctioned-boundary reasoning as the image family, and the
+//! reflected-credential scrub applies here too.
+
+use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
+use nika_kernel::secret::Secret;
+
+use crate::BuiltinFailure;
+
+use super::args::TtsArgs;
+use super::types::{AudioFormat, C_REQUEST, ProviderAudio};
+
+pub(crate) const DEFAULT_BASE_URL: &str = "http://localhost:8080";
+
+pub(crate) async fn generate<H: HttpPostDyn>(
+    http: &H,
+    base_url: &str,
+    key: Option<&Secret>,
+    args: &TtsArgs,
+) -> Result<ProviderAudio, BuiltinFailure> {
+    let request = build_request(base_url, key, args)?;
+    let response = http.post(request).await.map_err(map_transport)?;
+    if !(200..300).contains(&response.status) {
+        return Err(map_error_status(response.status, &response.body, key));
+    }
+    Ok(ProviderAudio {
+        bytes: response.body.to_vec(),
+        cost_usd: None, // self-hosted — no billing axis
+        endpoint_host: Some(super::super::image::local::host_of(base_url)),
+        warnings: Vec::new(),
+    })
+}
+
+fn build_request(
+    base_url: &str,
+    key: Option<&Secret>,
+    args: &TtsArgs,
+) -> Result<HttpRequest, BuiltinFailure> {
+    let mut body = serde_json::Map::new();
+    body.insert("model".into(), args.model.clone().into());
+    body.insert("input".into(), args.text.clone().into());
+    body.insert("voice".into(), args.voice.clone().into());
+    body.insert(
+        "response_format".into(),
+        match args.format {
+            Some(AudioFormat::Wav) => "wav",
+            _ => "mp3",
+        }
+        .into(),
+    );
+    if args.speed_explicit {
+        body.insert("speed".into(), args.speed_f64().into());
+    }
+
+    let endpoint = format!("{}/v1/audio/speech", base_url.trim_end_matches('/'));
+    let mut request = HttpRequest::post(&endpoint);
+    if let Some(key) = key {
+        request.headers.insert(
+            "authorization".to_owned(),
+            format!("Bearer {}", key.expose()),
+        );
+    }
+    request
+        .headers
+        .insert("content-type".to_owned(), "application/json".to_owned());
+    request.timeout = Some(args.timeout);
+    request.body = Some(
+        serde_json::to_vec(&serde_json::Value::Object(body))
+            .map_err(|e| BuiltinFailure::new(C_REQUEST, format!("request serialization: {e}")))?
+            .into(),
+    );
+    Ok(request)
+}
+
+fn map_transport(error: HttpError) -> BuiltinFailure {
+    match error {
+        HttpError::Timeout { duration_ms } => BuiltinFailure::new(
+            C_REQUEST,
+            format!(
+                "local TTS server timed out after {duration_ms}ms — CPU synthesis can run \
+                 minutes on long texts; raise `timeout_ms:` (max 600000)"
+            ),
+        )
+        .with_transient(true),
+        HttpError::Connection { reason } => BuiltinFailure::new(
+            C_REQUEST,
+            format!(
+                "no local TTS server answered ({reason}) — start one (LocalAI :8080 · \
+                 Kokoro-FastAPI · Speaches) or point NIKA_TTS_LOCAL_URL at it"
+            ),
+        )
+        .with_transient(true),
+        other => BuiltinFailure::new(C_REQUEST, format!("local TTS request failed: {other}")),
+    }
+}
+
+/// Best-effort error mapping with the raw-body fallback that makes local
+/// errors USEFUL — and the same reflected-Bearer scrub the image family
+/// carries (a verbose self-hosted server may echo the Authorization
+/// header into its error body).
+fn map_error_status(status: u16, body: &[u8], key: Option<&Secret>) -> BuiltinFailure {
+    let envelope: serde_json::Value = serde_json::from_slice(body).unwrap_or_default();
+    let mut message: String = envelope
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .map_or_else(|| String::from_utf8_lossy(body).into_owned(), str::to_owned)
+        .chars()
+        .take(300)
+        .collect();
+    if let Some(key) = key {
+        let exposed = key.expose();
+        if !exposed.is_empty() && message.contains(exposed) {
+            message = message.replace(exposed, "***");
+        }
+    }
+    BuiltinFailure::new(
+        C_REQUEST,
+        format!("local TTS server HTTP {status}: {message}"),
+    )
+    .with_transient(matches!(status, 500..=599 | 408 | 429))
+    .with_details(serde_json::json!({ "status_code": status }))
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_kernel_mock::MockHttp;
+
+    use super::super::args;
+    use super::*;
+
+    fn parsed() -> TtsArgs {
+        let serde_json::Value::Object(map) = serde_json::json!({
+            "provider": "local", "text": "bonjour", "output_dir": "./out"
+        }) else {
+            unreachable!()
+        };
+        args::parse(&map).expect("valid")
+    }
+
+    #[tokio::test]
+    async fn keyless_default_custom_base_and_reflected_key_scrub() {
+        let http = MockHttp::new().enqueue_ok(200, b"ID3\x04mp3".to_vec());
+        let audio = generate(&http, DEFAULT_BASE_URL, None, &parsed())
+            .await
+            .expect("keyless ok");
+        assert_eq!(audio.endpoint_host.as_deref(), Some("localhost:8080"));
+        let sent = http.sent_requests();
+        assert_eq!(sent[0].url, "http://localhost:8080/v1/audio/speech");
+        assert!(!sent[0].headers.contains_key("authorization"));
+
+        let http = MockHttp::new().enqueue_ok(200, b"ID3\x04mp3".to_vec());
+        let key = Secret::new("local-TTS-key".to_owned());
+        let _ = generate(&http, "http://10.0.0.5:8880/", Some(&key), &parsed())
+            .await
+            .expect("custom base");
+        assert_eq!(
+            http.sent_requests()[0].url,
+            "http://10.0.0.5:8880/v1/audio/speech",
+            "trailing slash folded"
+        );
+
+        let reflected = format!("unauthorized, you sent: Bearer {}", "local-TTS-key");
+        let http = MockHttp::new().enqueue_ok(401, reflected.into_bytes());
+        let err = generate(&http, DEFAULT_BASE_URL, Some(&key), &parsed())
+            .await
+            .expect_err("401");
+        assert!(!err.message.contains("local-TTS-key"), "{}", err.message);
+        assert!(err.message.contains("***"));
+    }
+}

--- a/crates/nika-builtin/src/tts/mock.rs
+++ b/crates/nika-builtin/src/tts/mock.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The deterministic in-process TTS mock — a REAL, playable WAV file
+//! (16-bit mono PCM · 16 kHz · a text-seeded sine sweep) with zero
+//! network and zero keys, mirroring the image mock's honesty: real
+//! decodable bytes, byte-stable for goldens.
+
+use super::args::TtsArgs;
+use super::types::ProviderAudio;
+
+const SAMPLE_RATE: u32 = 16_000;
+
+/// Render the mock WAV for the parsed args (duration scales with text
+/// length · pitch seeds from the text so different inputs sound — and
+/// hash — different).
+pub(crate) fn generate(args: &TtsArgs) -> ProviderAudio {
+    ProviderAudio {
+        bytes: render_wav(&args.text, args.speed_permille()),
+        cost_usd: None,
+        endpoint_host: None, // in-process — no wire was crossed
+        warnings: Vec::new(),
+    }
+}
+
+/// Pure WAV synthesis (also the sniffer's test fixture).
+pub(crate) fn render_wav(text: &str, speed_permille: u32) -> Vec<u8> {
+    // ~55ms per character, clamped to [0.4s, 10s], scaled by speed.
+    let base_ms = (text.chars().count() as u64 * 55).clamp(400, 10_000);
+    let ms = (base_ms * 1000 / u64::from(speed_permille.max(250))).clamp(200, 20_000);
+    #[allow(clippy::cast_possible_truncation)] // ≤ 20_000 by clamp
+    let samples = (u64::from(SAMPLE_RATE) * ms / 1000) as u32;
+
+    // Text-seeded fundamental in a speech-ish band (110–330 Hz).
+    let seed = text.bytes().fold(0x811c_9dc5_u32, |h, b| {
+        (h ^ u32::from(b)).wrapping_mul(0x0100_0193)
+    });
+    let f0 = 110.0 + f64::from(seed % 220);
+
+    let mut pcm = Vec::with_capacity(samples as usize * 2);
+    for i in 0..samples {
+        let t = f64::from(i) / f64::from(SAMPLE_RATE);
+        // A slow sweep + a quiet third harmonic → obviously synthetic,
+        // clearly audible, never mistaken for real speech.
+        let sweep = f0 * (1.0 + 0.15 * (t * 1.3).sin());
+        let v = (t * sweep * std::f64::consts::TAU).sin() * 0.6
+            + (t * sweep * 3.0 * std::f64::consts::TAU).sin() * 0.15;
+        // Fade the edges to avoid clicks.
+        let total = f64::from(samples) / f64::from(SAMPLE_RATE);
+        let env = (t / 0.02)
+            .min(1.0)
+            .min(((total - t) / 0.02).min(1.0))
+            .max(0.0);
+        #[allow(clippy::cast_possible_truncation)] // |v·env| ≤ 0.75 → in i16 range
+        let s = (v * env * f64::from(i16::MAX) * 0.8) as i16;
+        pcm.extend_from_slice(&s.to_le_bytes());
+    }
+
+    let byte_rate = SAMPLE_RATE * 2;
+    #[allow(clippy::cast_possible_truncation)] // ≤ 640_000 by the sample clamp
+    let data_len = pcm.len() as u32;
+    let mut wav = Vec::with_capacity(44 + pcm.len());
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&(36 + data_len).to_le_bytes());
+    wav.extend_from_slice(b"WAVEfmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk
+    wav.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    wav.extend_from_slice(&1u16.to_le_bytes()); // mono
+    wav.extend_from_slice(&SAMPLE_RATE.to_le_bytes());
+    wav.extend_from_slice(&byte_rate.to_le_bytes());
+    wav.extend_from_slice(&2u16.to_le_bytes()); // block align
+    wav.extend_from_slice(&16u16.to_le_bytes()); // bits/sample
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_len.to_le_bytes());
+    wav.extend_from_slice(&pcm);
+    wav
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_wav_is_deterministic_text_sensitive_and_speed_aware() {
+        let a = render_wav("bonjour le monde", 1000);
+        let b = render_wav("bonjour le monde", 1000);
+        assert_eq!(a, b, "byte-stable");
+        assert_ne!(a, render_wav("hello world", 1000), "text-seeded");
+        let fast = render_wav("bonjour le monde", 2000);
+        assert!(fast.len() < a.len(), "speed shortens");
+        assert_eq!(&a[..4], b"RIFF");
+    }
+}

--- a/crates/nika-builtin/src/tts/mod.rs
+++ b/crates/nika-builtin/src/tts/mod.rs
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika:tts_generate` — the second Media builtin (stdlib §Audio): text
+//! in, a REAL audio file on disk out, through the image family's exact
+//! discipline — assets not blobs (bytes never ride outputs), magic-byte
+//! authority (the extension follows what the payload IS), boundary-gated
+//! atomic saves, a provenance manifest, honest warnings, and the
+//! sovereign path first (one `OpenAI`-speech-compatible wire covers
+//! `LocalAI` · Kokoro-FastAPI · Speaches · openedai-speech).
+//!
+//! Keys ride [`TtsKeys`], resolved at the composition root (the ONE
+//! sanctioned env boundary — `NIKA_OPENAI_API_KEY`→`OPENAI_API_KEY` ·
+//! `NIKA_ELEVENLABS_API_KEY`→`ELEVENLABS_API_KEY` · `NIKA_TTS_LOCAL_URL`
+//! plus optional `NIKA_TTS_LOCAL_API_KEY`) and injected via
+//! [`crate::BuiltinDispatcher::with_tts_plane`]. Calls ride the SAME
+//! provider-plane http seam philosophy as `image_generate` and `infer:`.
+
+pub(crate) mod args;
+pub(crate) mod elevenlabs;
+pub(crate) mod local;
+pub(crate) mod mock;
+pub(crate) mod openai;
+pub(crate) mod sniff;
+pub(crate) mod types;
+
+use std::path::Path;
+
+use nika_kernel::io::clock::ClockDyn;
+use nika_kernel::io::fs::{FsReadDyn, FsWriteDyn};
+use nika_kernel::io::http::HttpPostDyn;
+use nika_kernel::secret::Secret;
+
+use crate::permits::{FsAccess, FsBoundary};
+use crate::{Args, BuiltinFailure, BuiltinOutcome, Emitter};
+
+use self::args::TtsArgs;
+use self::types::{C_NO_AUDIO, C_PROVIDER_UNAVAILABLE, C_SAVE, Provider, ProviderAudio};
+
+use super::image::save::{sanitize_component, sha256_hex};
+
+/// The TTS-plane connection config (composition-root resolved — this
+/// crate never reads the environment; the `Secret` type is zeroizing and
+/// Debug-redacted).
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct TtsKeys {
+    /// The `OpenAI` API key, when present.
+    pub openai: Option<Secret>,
+    /// The `ElevenLabs` API key, when present.
+    pub elevenlabs: Option<Secret>,
+    /// The LOCAL speech server base URL (`NIKA_TTS_LOCAL_URL`) — defaults
+    /// to `LocalAI`'s `http://localhost:8080` when unset.
+    pub local_base_url: Option<String>,
+    /// The optional local-server key (`NIKA_TTS_LOCAL_API_KEY`).
+    pub local_api_key: Option<Secret>,
+}
+
+impl TtsKeys {
+    /// No keys — the mock provider still works (offline CI · first run).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attach the `OpenAI` key.
+    #[must_use]
+    pub fn with_openai(mut self, key: Secret) -> Self {
+        self.openai = Some(key);
+        self
+    }
+
+    /// Attach the `ElevenLabs` key.
+    #[must_use]
+    pub fn with_elevenlabs(mut self, key: Secret) -> Self {
+        self.elevenlabs = Some(key);
+        self
+    }
+
+    /// Point the `local` provider at a specific speech server.
+    #[must_use]
+    pub fn with_local_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.local_base_url = Some(base_url.into());
+        self
+    }
+
+    /// Attach the optional local-server key.
+    #[must_use]
+    pub fn with_local_api_key(mut self, key: Secret) -> Self {
+        self.local_api_key = Some(key);
+        self
+    }
+}
+
+/// Run `nika:tts_generate` end-to-end (the wrapper owns the error event).
+pub(crate) async fn generate<F, H, C, Em>(
+    fs: &F,
+    http: Option<&H>,
+    keys: &TtsKeys,
+    clock: &C,
+    emitter: &Em,
+    boundary: &FsBoundary,
+    raw_args: &Args,
+) -> BuiltinOutcome
+where
+    F: FsReadDyn + FsWriteDyn,
+    H: HttpPostDyn,
+    C: ClockDyn,
+    Em: Emitter,
+{
+    match run(fs, http, keys, clock, emitter, boundary, raw_args).await {
+        Ok(value) => Ok(value),
+        Err(failure) => {
+            emitter.emit(
+                "tts_generation.error",
+                serde_json::json!({ "code": failure.code, "message": failure.message }),
+            );
+            Err(failure)
+        }
+    }
+}
+
+async fn run<F, H, C, Em>(
+    fs: &F,
+    http: Option<&H>,
+    keys: &TtsKeys,
+    clock: &C,
+    emitter: &Em,
+    boundary: &FsBoundary,
+    raw_args: &Args,
+) -> BuiltinOutcome
+where
+    F: FsReadDyn + FsWriteDyn,
+    H: HttpPostDyn,
+    C: ClockDyn,
+    Em: Emitter,
+{
+    let started = clock.now();
+    let mut args = args::parse(raw_args)?;
+    let mut warnings = std::mem::take(&mut args.warnings);
+    emitter.emit(
+        "tts_generation.started",
+        serde_json::json!({
+            "provider": args.provider.id(), "model": args.model, "voice": args.voice,
+            "chars": args.text.chars().count(),
+        }),
+    );
+
+    let audio = call_provider(http, keys, &args).await?;
+    let ProviderAudio {
+        bytes,
+        cost_usd,
+        endpoint_host,
+        warnings: adapter_warnings,
+    } = audio;
+    warnings.extend(adapter_warnings);
+    if bytes.is_empty() {
+        return Err(BuiltinFailure::new(
+            C_NO_AUDIO,
+            "the provider returned an empty audio payload",
+        ));
+    }
+
+    // Magic-byte authority: the payload names its own container.
+    let sniffed = sniff::sniff(&bytes)?;
+    if let Some(asked) = args.format
+        && asked != sniffed.format
+        && !warnings.iter().any(|w| w.starts_with("format_mismatch:"))
+    {
+        warnings.push(format!(
+            "format_mismatch: asked {} — the payload is {} (the extension follows the bytes)",
+            asked.name(),
+            sniffed.format.name()
+        ));
+    }
+
+    let saved = save_audio(fs, boundary, &args, &bytes, sniffed).await?;
+    emitter.emit(
+        "tts_generation.saved",
+        serde_json::json!({
+            "path": saved.path, "sha256_8": &saved.sha256[..8], "size_bytes": saved.size_bytes,
+        }),
+    );
+
+    let created_at = rfc3339_now(clock);
+    let manifest_path = if args.manifest {
+        let manifest = manifest_json(
+            &args,
+            &saved,
+            cost_usd,
+            &warnings,
+            &created_at,
+            endpoint_host.as_deref(),
+        );
+        Some(write_manifest(fs, boundary, &args, &saved, &manifest, emitter).await?)
+    } else {
+        None
+    };
+
+    for warning in &warnings {
+        emitter.emit(
+            "tts_generation.warning",
+            serde_json::json!({ "message": warning }),
+        );
+    }
+    emitter.emit(
+        "tts_generation.completed",
+        serde_json::json!({
+            "size_bytes": saved.size_bytes,
+            "duration_ms_audio": saved.duration_ms,
+            "cost_usd": cost_usd,
+            "duration_ms":
+                u64::try_from(clock.elapsed(started).as_millis()).unwrap_or(u64::MAX),
+        }),
+    );
+
+    Ok(serde_json::json!({
+        "provider": args.provider.id(),
+        "model": args.model,
+        "voice": args.voice,
+        "created_at": created_at,
+        "endpoint_host": endpoint_host,
+        "audio": {
+            "path": saved.path,
+            "filename": saved.filename,
+            "format": saved.format,
+            "mime_type": saved.mime_type,
+            "size_bytes": saved.size_bytes,
+            "sha256": saved.sha256,
+            "duration_ms": saved.duration_ms,
+        },
+        "cost_usd": cost_usd,
+        "warnings": warnings,
+        "manifest_path": manifest_path,
+        "output_dir": args.output_dir,
+    }))
+}
+
+async fn call_provider<H: HttpPostDyn>(
+    http: Option<&H>,
+    keys: &TtsKeys,
+    args: &TtsArgs,
+) -> Result<ProviderAudio, BuiltinFailure> {
+    if args.provider == Provider::Mock {
+        return Ok(mock::generate(args));
+    }
+    let http = http.ok_or_else(|| {
+        BuiltinFailure::new(
+            C_PROVIDER_UNAVAILABLE,
+            "the TTS plane is not wired — the composition root did not inject an HTTP client",
+        )
+    })?;
+    match args.provider {
+        Provider::Openai => {
+            let key = keys
+                .openai
+                .as_ref()
+                .ok_or_else(|| missing_key("openai", "NIKA_OPENAI_API_KEY or OPENAI_API_KEY"))?;
+            openai::generate(http, key, args).await
+        }
+        Provider::Elevenlabs => {
+            let key = keys.elevenlabs.as_ref().ok_or_else(|| {
+                missing_key(
+                    "elevenlabs",
+                    "NIKA_ELEVENLABS_API_KEY or ELEVENLABS_API_KEY",
+                )
+            })?;
+            elevenlabs::generate(http, key, args).await
+        }
+        Provider::Local => {
+            let base = keys
+                .local_base_url
+                .clone()
+                .unwrap_or_else(|| local::DEFAULT_BASE_URL.to_owned());
+            local::generate(http, &base, keys.local_api_key.as_ref(), args).await
+        }
+        Provider::Mock => unreachable!("handled above"),
+    }
+}
+
+fn missing_key(provider: &str, vars: &str) -> BuiltinFailure {
+    BuiltinFailure::new(
+        C_PROVIDER_UNAVAILABLE,
+        format!("no {provider} API key configured — set {vars}"),
+    )
+}
+
+/// One saved audio asset (the audio analogue of `SavedImage`).
+#[derive(Debug)]
+struct SavedAudio {
+    path: String,
+    filename: String,
+    format: &'static str,
+    mime_type: &'static str,
+    size_bytes: u64,
+    sha256: String,
+    duration_ms: Option<u64>,
+}
+
+/// Boundary-gated atomic save — `{stem}-{provider}-{model}-{sha8}.{ext}`
+/// (idempotent by content hash: a re-run with identical bytes lands on
+/// the same name and never rewrites).
+async fn save_audio<F: FsReadDyn + FsWriteDyn>(
+    fs: &F,
+    boundary: &FsBoundary,
+    args: &TtsArgs,
+    bytes: &[u8],
+    sniffed: sniff::Sniffed,
+) -> Result<SavedAudio, BuiltinFailure> {
+    let stem = args
+        .filename_prefix
+        .as_deref()
+        .map(sanitize_component)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            args.metadata
+                .get("page_slug")
+                .and_then(serde_json::Value::as_str)
+                .map(sanitize_component)
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "speech".to_owned());
+    let sha256 = sha256_hex(bytes);
+    let filename = format!(
+        "{stem}-{}-{}-{}.{}",
+        args.provider.id(),
+        sanitize_component(&args.model),
+        &sha256[..8],
+        sniffed.format.extension()
+    );
+    let path = Path::new(&args.output_dir).join(&filename);
+    let path_str = path.to_string_lossy().into_owned();
+    boundary.enforce(fs, &path_str, FsAccess::Write).await?;
+    if !fs.exists(&path).await {
+        fs.write(&path, bytes).await.map_err(|e| {
+            BuiltinFailure::new(C_SAVE, format!("audio write failed for `{path_str}`: {e}"))
+        })?;
+    }
+    Ok(SavedAudio {
+        path: path_str,
+        filename,
+        format: sniffed.format.name(),
+        mime_type: sniffed.format.mime(),
+        size_bytes: bytes.len() as u64,
+        sha256,
+        duration_ms: sniffed.duration_ms,
+    })
+}
+
+fn manifest_json(
+    args: &TtsArgs,
+    saved: &SavedAudio,
+    cost_usd: Option<f64>,
+    warnings: &[String],
+    created_at: &str,
+    endpoint_host: Option<&str>,
+) -> serde_json::Value {
+    let request = serde_json::json!({
+        "provider": args.provider.id(),
+        "model": args.model,
+        "voice": args.voice,
+        "text": args.text,
+        "format": args.format.map(types::AudioFormat::name),
+        "speed": args.speed_explicit.then(|| args.speed_f64()),
+        "timeout_ms": u64::try_from(args.timeout.as_millis()).unwrap_or(u64::MAX),
+    });
+    serde_json::json!({
+        "manifest_version": 1,
+        "nika_version": env!("CARGO_PKG_VERSION"),
+        "created_at": created_at,
+        "tool": "nika:tts_generate",
+        "provider": args.provider.id(),
+        "model": args.model,
+        "voice": args.voice,
+        "endpoint_host": endpoint_host,
+        "request": request,
+        "input_hash": sha256_hex(request.to_string().as_bytes()),
+        "audio": {
+            "path": saved.path,
+            "filename": saved.filename,
+            "format": saved.format,
+            "mime_type": saved.mime_type,
+            "size_bytes": saved.size_bytes,
+            "sha256": saved.sha256,
+            "duration_ms": saved.duration_ms,
+        },
+        "cost_usd": cost_usd,
+        "warnings": warnings,
+        "metadata": args.metadata,
+    })
+}
+
+async fn write_manifest<F: FsReadDyn + FsWriteDyn, Em: Emitter>(
+    fs: &F,
+    boundary: &FsBoundary,
+    args: &TtsArgs,
+    saved: &SavedAudio,
+    manifest: &serde_json::Value,
+    emitter: &Em,
+) -> Result<String, BuiltinFailure> {
+    let filename = format!(
+        "{}-{}.manifest.json",
+        saved
+            .filename
+            .trim_end_matches(&format!(".{}", saved.format)),
+        &sha256_hex(saved.sha256.as_bytes())[..8]
+    );
+    let path = Path::new(&args.output_dir).join(&filename);
+    let path_str = path.to_string_lossy().into_owned();
+    boundary.enforce(fs, &path_str, FsAccess::Write).await?;
+    let pretty = serde_json::to_vec_pretty(manifest)
+        .map_err(|e| BuiltinFailure::new(C_SAVE, format!("manifest serialization failed: {e}")))?;
+    fs.write(&path, &pretty).await.map_err(|e| {
+        BuiltinFailure::new(
+            C_SAVE,
+            format!("manifest write failed for `{path_str}`: {e}"),
+        )
+    })?;
+    emitter.emit(
+        "tts_generation.manifest_written",
+        serde_json::json!({ "path": path_str }),
+    );
+    Ok(path_str)
+}
+
+fn rfc3339_now<C: ClockDyn>(clock: &C) -> String {
+    jiff::Timestamp::try_from(clock.system_now())
+        .map_or_else(|_| "1970-01-01T00:00:00Z".to_owned(), |ts| ts.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_fs::TokioFs;
+    use nika_kernel_mock::{MockClock, MockHttp};
+
+    use crate::NullEmitter;
+
+    use super::*;
+
+    fn scratch() -> std::path::PathBuf {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("nika-tts-{}-{n}", std::process::id()));
+        std::fs::create_dir_all(&root).expect("scratch");
+        root
+    }
+
+    fn args_for(dir: &std::path::Path) -> Args {
+        let serde_json::Value::Object(map) = serde_json::json!({
+            "provider": "mock",
+            "text": "bonjour le monde, ceci est un test",
+            "output_dir": dir.to_string_lossy(),
+            "metadata": { "page_slug": "accueil" },
+        }) else {
+            unreachable!()
+        };
+        map
+    }
+
+    #[tokio::test]
+    async fn mock_pipeline_saves_real_wav_with_manifest_and_is_idempotent() {
+        let root = scratch();
+        let fs = TokioFs;
+        let clock = MockClock::default();
+        let emitter = NullEmitter;
+        let boundary = FsBoundary::unbounded();
+        let keys = TtsKeys::new();
+
+        let out = generate::<_, MockHttp, _, _>(
+            &fs,
+            None,
+            &keys,
+            &clock,
+            &emitter,
+            &boundary,
+            &args_for(&root),
+        )
+        .await
+        .expect("mock synthesis");
+        let path = out["audio"]["path"].as_str().expect("path").to_owned();
+        assert!(path.contains("accueil-mock-mock-tts-1-"), "{path}");
+        assert!(
+            std::path::Path::new(&path)
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("wav"))
+        );
+        let bytes = std::fs::read(&path).expect("file exists");
+        assert_eq!(&bytes[..4], b"RIFF");
+        assert_eq!(
+            out["audio"]["sha256"].as_str().map(str::len),
+            Some(64),
+            "full sha in output"
+        );
+        assert!(out["audio"]["duration_ms"].as_u64().expect("wav math") > 300);
+        assert!(out["manifest_path"].as_str().is_some());
+        assert!(out.get("audio").and_then(|a| a.get("b64")).is_none());
+
+        // Idempotent re-run: same bytes → same name → no new files.
+        let before = std::fs::read_dir(&root).expect("dir").count();
+        let _ = generate::<_, MockHttp, _, _>(
+            &fs,
+            None,
+            &keys,
+            &clock,
+            &emitter,
+            &boundary,
+            &args_for(&root),
+        )
+        .await
+        .expect("re-run");
+        assert_eq!(std::fs::read_dir(&root).expect("dir").count(), before);
+    }
+
+    #[tokio::test]
+    async fn unwired_plane_and_missing_keys_fail_002() {
+        let root = scratch();
+        let fs = TokioFs;
+        let clock = MockClock::default();
+        let emitter = NullEmitter;
+        let boundary = FsBoundary::unbounded();
+
+        let serde_json::Value::Object(cloud) = serde_json::json!({
+            "provider": "openai", "text": "x", "output_dir": root.to_string_lossy(),
+        }) else {
+            unreachable!()
+        };
+        let err = generate::<_, MockHttp, _, _>(
+            &fs,
+            None,
+            &TtsKeys::new(),
+            &clock,
+            &emitter,
+            &boundary,
+            &cloud,
+        )
+        .await
+        .expect_err("unwired");
+        assert!(err.code.ends_with("-002"), "{}", err.code);
+
+        let http = MockHttp::new();
+        let err = generate(
+            &fs,
+            Some(&http),
+            &TtsKeys::new(),
+            &clock,
+            &emitter,
+            &boundary,
+            &cloud,
+        )
+        .await
+        .expect_err("no key");
+        assert!(err.message.contains("OPENAI_API_KEY"), "{}", err.message);
+    }
+}

--- a/crates/nika-builtin/src/tts/mod.rs
+++ b/crates/nika-builtin/src/tts/mod.rs
@@ -197,7 +197,29 @@ where
         None
     };
 
-    for warning in &warnings {
+    emit_closing_events(emitter, clock, started, &saved, cost_usd, &warnings);
+    Ok(output_json(
+        &args,
+        &saved,
+        cost_usd,
+        &warnings,
+        &created_at,
+        endpoint_host.as_deref(),
+        manifest_path.as_deref(),
+    ))
+}
+
+/// The batch's closing telemetry — every warning as its own event, then
+/// the ONE `completed` summary.
+fn emit_closing_events<C: ClockDyn, Em: Emitter>(
+    emitter: &Em,
+    clock: &C,
+    started: std::time::Instant,
+    saved: &SavedAudio,
+    cost_usd: Option<f64>,
+    warnings: &[String],
+) {
+    for warning in warnings {
         emitter.emit(
             "tts_generation.warning",
             serde_json::json!({ "message": warning }),
@@ -213,8 +235,19 @@ where
                 u64::try_from(clock.elapsed(started).as_millis()).unwrap_or(u64::MAX),
         }),
     );
+}
 
-    Ok(serde_json::json!({
+/// The normalized output object — path + hashes, never bytes.
+fn output_json(
+    args: &TtsArgs,
+    saved: &SavedAudio,
+    cost_usd: Option<f64>,
+    warnings: &[String],
+    created_at: &str,
+    endpoint_host: Option<&str>,
+    manifest_path: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
         "provider": args.provider.id(),
         "model": args.model,
         "voice": args.voice,
@@ -233,7 +266,7 @@ where
         "warnings": warnings,
         "manifest_path": manifest_path,
         "output_dir": args.output_dir,
-    }))
+    })
 }
 
 async fn call_provider<H: HttpPostDyn>(

--- a/crates/nika-builtin/src/tts/openai.rs
+++ b/crates/nika-builtin/src/tts/openai.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `OpenAI` speech adapter — `POST /v1/audio/speech` returns RAW audio
+//! bytes (no JSON envelope on success · a JSON error body on failure).
+
+use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
+use nika_kernel::secret::Secret;
+
+use crate::BuiltinFailure;
+
+use super::args::TtsArgs;
+use super::types::{AudioFormat, C_POLICY, C_REQUEST, ProviderAudio};
+
+const ENDPOINT: &str = "https://api.openai.com/v1/audio/speech";
+
+pub(crate) async fn generate<H: HttpPostDyn>(
+    http: &H,
+    key: &Secret,
+    args: &TtsArgs,
+) -> Result<ProviderAudio, BuiltinFailure> {
+    let request = build_request(args, key)?;
+    let response = http.post(request).await.map_err(map_transport)?;
+    if !(200..300).contains(&response.status) {
+        return Err(map_error_status(response.status, &response.body));
+    }
+    Ok(ProviderAudio {
+        bytes: response.body.to_vec(),
+        cost_usd: None, // token-priced · audio models unpriced in the catalog
+        endpoint_host: Some("api.openai.com".to_owned()),
+        warnings: Vec::new(),
+    })
+}
+
+/// Pure request builder (unit-testable without a transport).
+fn build_request(args: &TtsArgs, key: &Secret) -> Result<HttpRequest, BuiltinFailure> {
+    let mut body = serde_json::Map::new();
+    body.insert("model".into(), args.model.clone().into());
+    body.insert("input".into(), args.text.clone().into());
+    body.insert("voice".into(), args.voice.clone().into());
+    body.insert(
+        "response_format".into(),
+        match args.format {
+            Some(AudioFormat::Wav) => "wav",
+            // mp3 is both the explicit ask and the provider-native default.
+            _ => "mp3",
+        }
+        .into(),
+    );
+    if args.speed_explicit {
+        body.insert("speed".into(), args.speed_f64().into());
+    }
+
+    let mut request = HttpRequest::post(ENDPOINT);
+    request.headers.insert(
+        "authorization".to_owned(),
+        format!("Bearer {}", key.expose()),
+    );
+    request
+        .headers
+        .insert("content-type".to_owned(), "application/json".to_owned());
+    request.timeout = Some(args.timeout);
+    request.body = Some(
+        serde_json::to_vec(&serde_json::Value::Object(body))
+            .map_err(|e| BuiltinFailure::new(C_REQUEST, format!("request serialization: {e}")))?
+            .into(),
+    );
+    Ok(request)
+}
+
+fn map_transport(error: HttpError) -> BuiltinFailure {
+    match error {
+        HttpError::Timeout { duration_ms } => BuiltinFailure::new(
+            C_REQUEST,
+            format!("openai speech timed out after {duration_ms}ms — raise `timeout_ms:`"),
+        )
+        .with_transient(true),
+        HttpError::Connection { reason } => {
+            BuiltinFailure::new(C_REQUEST, format!("openai connection failed: {reason}"))
+                .with_transient(true)
+        }
+        other => BuiltinFailure::new(C_REQUEST, format!("openai request failed: {other}")),
+    }
+}
+
+fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
+    let envelope: serde_json::Value = serde_json::from_slice(body).unwrap_or_default();
+    let message: String = envelope
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("no error message")
+        .chars()
+        .take(300)
+        .collect();
+    let code = if status == 400 && message.to_ascii_lowercase().contains("policy") {
+        C_POLICY
+    } else {
+        C_REQUEST
+    };
+    BuiltinFailure::new(code, format!("openai speech HTTP {status}: {message}"))
+        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_details(serde_json::json!({ "status_code": status }))
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_kernel_mock::MockHttp;
+
+    use super::super::args;
+    use super::*;
+
+    fn parsed(extra: serde_json::Value) -> TtsArgs {
+        let serde_json::Value::Object(mut map) = serde_json::json!({
+            "provider": "openai", "text": "bonjour le monde", "output_dir": "./out"
+        }) else {
+            unreachable!()
+        };
+        if let serde_json::Value::Object(e) = extra {
+            map.extend(e);
+        }
+        args::parse(&map).expect("valid")
+    }
+
+    #[test]
+    fn request_shape_and_key_never_leaks_in_errors() {
+        let key = Secret::new("sk-SPEECH-not-in-messages".to_owned());
+        let request =
+            build_request(&parsed(serde_json::json!({ "speed": 1.25 })), &key).expect("builds");
+        assert_eq!(request.url, ENDPOINT);
+        let body: serde_json::Value =
+            serde_json::from_slice(request.body.as_ref().expect("body")).expect("json");
+        assert_eq!(body["model"], "gpt-4o-mini-tts");
+        assert_eq!(body["voice"], "alloy");
+        assert_eq!(body["response_format"], "mp3");
+        assert_eq!(body["speed"], 1.25);
+        // default speed is omitted (provider default rules).
+        let quiet = build_request(&parsed(serde_json::json!({})), &key).expect("builds");
+        let qbody: serde_json::Value =
+            serde_json::from_slice(quiet.body.as_ref().expect("body")).expect("json");
+        assert!(qbody.get("speed").is_none());
+
+        let err = map_error_status(401, br#"{"error":{"message":"bad key"}}"#);
+        assert!(!err.message.contains("SPEECH"), "{}", err.message);
+        assert!(!err.transient);
+        assert!(map_error_status(429, b"{}").transient);
+    }
+
+    #[tokio::test]
+    async fn raw_bytes_success_and_policy_mapping() {
+        let http = MockHttp::new().enqueue_ok(200, b"ID3\x04fake-mp3".to_vec());
+        let key = Secret::new("k".to_owned());
+        let audio = generate(&http, &key, &parsed(serde_json::json!({})))
+            .await
+            .expect("ok");
+        assert_eq!(&audio.bytes[..3], b"ID3");
+        assert_eq!(audio.endpoint_host.as_deref(), Some("api.openai.com"));
+
+        let http = MockHttp::new().enqueue_ok(
+            400,
+            br#"{"error":{"message":"content policy violation"}}"#.to_vec(),
+        );
+        let err = generate(&http, &key, &parsed(serde_json::json!({})))
+            .await
+            .expect_err("policy");
+        assert!(err.code.ends_with("-005"), "{}", err.code);
+    }
+}

--- a/crates/nika-builtin/src/tts/sniff.rs
+++ b/crates/nika-builtin/src/tts/sniff.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Audio magic-byte sniffing — the same authority model as the image
+//! family: what the bytes SAY beats what the provider declared. WAV
+//! additionally yields an exact duration from its header (no decode);
+//! MP3 duration would need frame-walking → honestly `None` in v1.
+
+use crate::BuiltinFailure;
+
+use super::types::{AudioFormat, C_VALIDATE};
+
+/// What the magic bytes established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Sniffed {
+    pub(crate) format: AudioFormat,
+    /// Exact for WAV (header math) · `None` for MP3 (never a guess).
+    pub(crate) duration_ms: Option<u64>,
+}
+
+/// Identify the payload or fail `-007` (a non-audio payload is a hard
+/// error — the provider contract broke).
+pub(crate) fn sniff(bytes: &[u8]) -> Result<Sniffed, BuiltinFailure> {
+    if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WAVE" {
+        return Ok(Sniffed {
+            format: AudioFormat::Wav,
+            duration_ms: wav_duration_ms(bytes),
+        });
+    }
+    // MP3: an ID3v2 tag, or a bare MPEG frame sync (0xFF Ex/Fx).
+    let mp3 = bytes.len() >= 3
+        && (&bytes[..3] == b"ID3" || (bytes[0] == 0xFF && (bytes[1] & 0xE0) == 0xE0));
+    if mp3 {
+        return Ok(Sniffed {
+            format: AudioFormat::Mp3,
+            duration_ms: None,
+        });
+    }
+    Err(BuiltinFailure::new(
+        C_VALIDATE,
+        format!(
+            "the provider returned a payload that is not WAV or MP3 ({} bytes · starts {:02x?})",
+            bytes.len(),
+            &bytes[..bytes.len().min(4)]
+        ),
+    ))
+}
+
+/// Duration from the `fmt ` byte-rate and the `data` chunk length —
+/// pure header math, total (any malformed chunk → `None`, never a panic).
+fn wav_duration_ms(bytes: &[u8]) -> Option<u64> {
+    let mut off = 12usize;
+    let mut byte_rate: Option<u64> = None;
+    let mut data_len: Option<u64> = None;
+    while off + 8 <= bytes.len() {
+        let id = &bytes[off..off + 4];
+        let len = u32::from_le_bytes(bytes[off + 4..off + 8].try_into().ok()?) as usize;
+        if id == b"fmt " && off + 8 + 16 <= bytes.len() {
+            byte_rate = Some(u64::from(u32::from_le_bytes(
+                bytes[off + 16..off + 20].try_into().ok()?,
+            )));
+        }
+        if id == b"data" {
+            data_len = Some(len as u64);
+        }
+        off = off.checked_add(8 + len + (len & 1))?;
+    }
+    let (rate, data) = (byte_rate?, data_len?);
+    if rate == 0 {
+        return None;
+    }
+    Some(data.saturating_mul(1000) / rate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wav_mp3_and_junk_sniff_correctly() {
+        let wav = super::super::mock::render_wav("hello", 42);
+        let s = sniff(&wav).expect("wav");
+        assert_eq!(s.format, AudioFormat::Wav);
+        let ms = s.duration_ms.expect("header math");
+        assert!((400..=2000).contains(&ms), "plausible duration: {ms}");
+
+        let id3 = sniff(b"ID3\x04rest").expect("id3");
+        assert_eq!((id3.format, id3.duration_ms), (AudioFormat::Mp3, None));
+        let frame = sniff(&[0xFF, 0xFB, 0x90, 0x00]).expect("frame sync");
+        assert_eq!(frame.format, AudioFormat::Mp3);
+
+        assert!(sniff(b"").is_err(), "empty refused");
+        assert!(sniff(b"PK\x03\x04zip").is_err(), "junk refused");
+        assert!(
+            sniff(b"RIFF\x00\x00\x00\x00AVI ").is_err(),
+            "AVI is not WAVE"
+        );
+    }
+}

--- a/crates/nika-builtin/src/tts/types.rs
+++ b/crates/nika-builtin/src/tts/types.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Shared vocabulary of the `nika:tts_generate` module family (stdlib
+//! §Audio) — the closed enums the arg parser produces and every provider
+//! adapter consumes, plus the spec error codes.
+
+/// 001 — invalid arguments (empty text · over-cap · bad enum · mask-class
+/// refusals have no analogue here).
+pub(crate) const C_ARGS: &str = "NIKA-BUILTIN-TTS_GENERATE-001";
+/// 002 — provider unavailable (missing API key · tts plane not wired).
+pub(crate) const C_PROVIDER_UNAVAILABLE: &str = "NIKA-BUILTIN-TTS_GENERATE-002";
+/// 003 — provider request failed (transport · HTTP status · rate limit).
+/// Transient per the spec status table (5xx/408/429 + timeout/connection).
+pub(crate) const C_REQUEST: &str = "NIKA-BUILTIN-TTS_GENERATE-003";
+/// 004 — the provider returned no audio / a malformed audio payload.
+pub(crate) const C_NO_AUDIO: &str = "NIKA-BUILTIN-TTS_GENERATE-004";
+/// 005 — content policy block.
+pub(crate) const C_POLICY: &str = "NIKA-BUILTIN-TTS_GENERATE-005";
+/// 006 — saving the audio or the manifest failed.
+pub(crate) const C_SAVE: &str = "NIKA-BUILTIN-TTS_GENERATE-006";
+/// 007 — decoded audio failed validation (magic bytes · empty payload).
+pub(crate) const C_VALIDATE: &str = "NIKA-BUILTIN-TTS_GENERATE-007";
+
+/// The v1 TTS providers — a closed set, sovereign path first (the image
+/// family's Rule-3 lesson applied from day one).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Provider {
+    /// A user-run LOCAL `OpenAI`-speech-compatible server (`LocalAI` ·
+    /// Kokoro-FastAPI · Speaches · openedai-speech — one wire). The base
+    /// URL is ENGINE CONFIG (`NIKA_TTS_LOCAL_URL`), never workflow data.
+    Local,
+    /// `OpenAI` Audio API (`POST /v1/audio/speech`).
+    Openai,
+    /// `ElevenLabs` (`POST /v1/text-to-speech/{voice_id}`).
+    Elevenlabs,
+    /// Deterministic in-process mock — a real WAV, zero network, zero key.
+    Mock,
+}
+
+impl Provider {
+    pub(crate) const fn id(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Openai => "openai",
+            Self::Elevenlabs => "elevenlabs",
+            Self::Mock => "mock",
+        }
+    }
+
+    /// Research-verified defaults (2026-07).
+    pub(crate) const fn default_model(self) -> &'static str {
+        match self {
+            // The LocalAI convention (its bundled voice models register
+            // under simple names; other compat servers differ — set
+            // `model:` explicitly alongside your base URL).
+            Self::Local => "tts-1",
+            Self::Openai => "gpt-4o-mini-tts",
+            Self::Elevenlabs => "eleven_multilingual_v2",
+            Self::Mock => "mock-tts-1",
+        }
+    }
+
+    /// The default voice per provider (a REQUIRED axis on every real
+    /// wire — `alloy` is `OpenAI`'s documented default · Rachel is
+    /// `ElevenLabs`' public default voice id).
+    pub(crate) const fn default_voice(self) -> &'static str {
+        match self {
+            Self::Local | Self::Openai => "alloy",
+            Self::Elevenlabs => "21m00Tcm4TlvDq8ikWAM",
+            Self::Mock => "sine",
+        }
+    }
+}
+
+/// Output audio containers (closed · `format:` arg).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AudioFormat {
+    Mp3,
+    Wav,
+}
+
+impl AudioFormat {
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::Mp3 => "mp3",
+            Self::Wav => "wav",
+        }
+    }
+
+    pub(crate) const fn mime(self) -> &'static str {
+        match self {
+            Self::Mp3 => "audio/mpeg",
+            Self::Wav => "audio/wav",
+        }
+    }
+
+    pub(crate) const fn extension(self) -> &'static str {
+        self.name()
+    }
+}
+
+/// What a provider adapter returns for one synthesis call.
+#[derive(Debug, Default)]
+pub(crate) struct ProviderAudio {
+    pub(crate) bytes: Vec<u8>,
+    /// Real spend in USD when computable exactly — v1 providers are
+    /// subscription/token-priced without a response cost field → `None`
+    /// (honest · the shape matches the image family for the ledger seam).
+    pub(crate) cost_usd: Option<f64>,
+    /// The host the synthesis came from (provenance — load-bearing for
+    /// `local`). `None` for the in-process mock.
+    pub(crate) endpoint_host: Option<String>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canon_ids_defaults_and_formats_hold() {
+        for (p, id) in [
+            (Provider::Local, "local"),
+            (Provider::Openai, "openai"),
+            (Provider::Elevenlabs, "elevenlabs"),
+            (Provider::Mock, "mock"),
+        ] {
+            assert_eq!(p.id(), id);
+            assert!(!p.default_model().is_empty());
+            assert!(!p.default_voice().is_empty());
+        }
+        assert_eq!(AudioFormat::Mp3.mime(), "audio/mpeg");
+        assert_eq!(AudioFormat::Wav.extension(), "wav");
+        assert!(C_ARGS.ends_with("-001") && C_VALIDATE.ends_with("-007"));
+    }
+}

--- a/crates/nika-catalog/src/data/builtins.rs
+++ b/crates/nika-catalog/src/data/builtins.rs
@@ -140,6 +140,28 @@ pub static ALL_BUILTINS: &[Builtin] = &[
         &["message"],
     ),
     Builtin::with_required("read", File, &["path", "binary"], &["path"]),
+    // `tts_generate` (stdlib §Audio · the second Media-class builtin ·
+    // local/openai/elevenlabs/mock — sovereign-first · ONE audio file on
+    // disk, output carries path+sha256+duration, never bytes ·
+    // NIKA-BUILTIN-TTS_GENERATE-001..007).
+    Builtin::with_required(
+        "tts_generate",
+        Media,
+        &[
+            "provider",
+            "model",
+            "text",
+            "voice",
+            "format",
+            "speed",
+            "output_dir",
+            "filename_prefix",
+            "manifest",
+            "metadata",
+            "timeout_ms",
+        ],
+        &["text", "output_dir"],
+    ),
     Builtin::with_args("uuid", Data, &["version"]),
     Builtin::with_required(
         "validate",
@@ -179,7 +201,7 @@ mod tests {
 
     #[test]
     fn builtin_count() {
-        assert_eq!(ALL_BUILTINS.len(), 24);
+        assert_eq!(ALL_BUILTINS.len(), 25);
     }
 
     #[test]
@@ -272,12 +294,12 @@ mod tests {
             "expected 2 introspection builtins (inspect runtime · compose static · ADR-096)"
         );
         assert_eq!(
-            media, 1,
-            "expected 1 media builtin (image_generate · the first §Media graduate)"
+            media, 2,
+            "expected 2 media builtins (image_generate §Media · tts_generate §Audio)"
         );
         assert_eq!(
             core + file + data + network + intro + media,
-            24,
+            25,
             "total must equal 24"
         );
     }

--- a/crates/nika-catalog/src/lib.rs
+++ b/crates/nika-catalog/src/lib.rs
@@ -143,7 +143,7 @@ mod tests {
         // introspection → 1) + ADR-087 wait (sleep + wait_until → 1) +
         // ADR-086 convert (csv_to_json → 1) + D-2026-05-22-N6
         // stdlib-collapse 42→26.
-        assert_eq!(all_builtins().len(), 24);
+        assert_eq!(all_builtins().len(), 25);
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/run/compose.rs
+++ b/crates/nika-cli/src/verbs/run/compose.rs
@@ -20,7 +20,9 @@
 
 use std::sync::Arc;
 
-use nika_builtin::{BuiltinDispatcher, Emitter, FsBoundary, ImageKeys, NoWorkflow, NonInteractive};
+use nika_builtin::{
+    BuiltinDispatcher, Emitter, FsBoundary, ImageKeys, NoWorkflow, NonInteractive, TtsKeys,
+};
 use nika_clock::SystemClock;
 use nika_exec_runner::TokioShell;
 use nika_fs::TokioFs;
@@ -238,6 +240,35 @@ fn image_keys_from_env() -> ImageKeys {
     // Single-name read (no conventional fallback exists for a local key —
     // the array shape just reuses the ladder helper).
     if let Some(key) = read(["NIKA_IMAGE_LOCAL_API_KEY", "NIKA_IMAGE_LOCAL_API_KEY"]) {
+        keys = keys.with_local_api_key(key);
+    }
+    keys
+}
+
+/// The TTS plane's composition-root env resolution — the exact sibling of
+/// [`image_keys_from_env`] (same sanctioned boundary · same laddering).
+fn tts_keys_from_env() -> TtsKeys {
+    let read = |ladder: [&str; 2]| {
+        ladder.into_iter().find_map(|name| {
+            #[allow(clippy::disallowed_methods)] // the sanctioned env→secret boundary (see doc)
+            let value = std::env::var(name).ok()?;
+            (!value.is_empty()).then(|| Secret::new(value))
+        })
+    };
+    let mut keys = TtsKeys::new();
+    if let Some(key) = read(["NIKA_OPENAI_API_KEY", "OPENAI_API_KEY"]) {
+        keys = keys.with_openai(key);
+    }
+    if let Some(key) = read(["NIKA_ELEVENLABS_API_KEY", "ELEVENLABS_API_KEY"]) {
+        keys = keys.with_elevenlabs(key);
+    }
+    #[allow(clippy::disallowed_methods)] // the sanctioned env boundary (see doc)
+    if let Ok(url) = std::env::var("NIKA_TTS_LOCAL_URL")
+        && !url.is_empty()
+    {
+        keys = keys.with_local_base_url(url);
+    }
+    if let Some(key) = read(["NIKA_TTS_LOCAL_API_KEY", "NIKA_TTS_LOCAL_API_KEY"]) {
         keys = keys.with_local_api_key(key);
     }
     keys
@@ -528,7 +559,8 @@ pub fn production_runtime(
         // the 600s transport ceiling image renders need — the fetch
         // client's idle guard would kill them), with keys resolved at THIS
         // boundary only.
-        .with_image_plane(Arc::clone(&provider_http), image_keys_from_env()),
+        .with_image_plane(Arc::clone(&provider_http), image_keys_from_env())
+        .with_tts_plane(Arc::clone(&provider_http), tts_keys_from_env()),
     );
     let invoke = Arc::new(InvokeVerb::new(Arc::clone(&dispatcher)));
 
@@ -722,8 +754,12 @@ mod tests {
         // whatever the shell exports, and the Debug rendering can never
         // spell a credential (Secret is Debug-redacted by construction).
         let keys = image_keys_from_env();
-        let rendered = format!("{keys:?}");
+        let tts = tts_keys_from_env();
+        let rendered = format!("{keys:?} {tts:?}");
         for env in [
+            "NIKA_ELEVENLABS_API_KEY",
+            "ELEVENLABS_API_KEY",
+            "NIKA_TTS_LOCAL_API_KEY",
             "NIKA_OPENAI_API_KEY",
             "OPENAI_API_KEY",
             "NIKA_GEMINI_API_KEY",

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -25,6 +25,7 @@
 # v0.1 · 2026-05-27 · populated from .ttl HEAD (post atomic-language audit · the
 #   most-current canonical truth · cohort 42→27→26→25→22 builtins → 23 (compose
 #   added 2026-06-13) → 24 (image_generate · first §Media graduate · 2026-07-05)
+#   → 25 (tts_generate · §Audio · 2026-07-05)
 #   + NIKA-FETCH fold into NIKA-BUILTIN per "fetch is a
 #   builtin, not a verb" D-N18).
 # v0.2 · 2026-05-27 evening · schema_version 1 + 6 extended dimensions
@@ -43,7 +44,7 @@ schema_version: 1
 counts:
   verbs: 4
   namespaces: 5
-  builtins: 24
+  builtins: 25
   providers: 16
   extract_modes: 9
   error_namespaces: 14
@@ -87,12 +88,12 @@ namespaces:
     - secrets
 
 # ---------------------------------------------------------------- builtins
-# Post atomic-language audit · 42→27→26→25→22 (-20 · -48% · zero functional loss) → 23 (compose added 2026-06-13 · ADR-093 · agent-loop self-check intrinsic, loop-only like done) → 24 (image_generate added 2026-07-05 · the first stdlib §Media graduate · openai/gemini/mock · assets land on disk, never inline).
+# Post atomic-language audit · 42→27→26→25→22 (-20 · -48% · zero functional loss) → 23 (compose added 2026-06-13 · ADR-093 · agent-loop self-check intrinsic, loop-only like done) → 24 (image_generate added 2026-07-05 · the first stdlib §Media graduate · openai/gemini/mock · assets land on disk, never inline) → 25 (tts_generate added 2026-07-05 · §Audio · local/openai/elevenlabs/mock · sovereign-first).
 # stdlib/builtins-v0.1.md is the prose home (matches at 24 · cascade complete 2026-07-05 · image providers v1.1 local-first + xai same day).
 # Admission test · 3 razors · (1) NOT-expressible-in-jq+CEL+Schema · (2) canonical
 # interop format (RFC-6902/7396/9562 · etc.) · (3) cookbook-clarity.
 builtins:
-  count: 24
+  count: 25
   reference: stdlib/builtins-v0.1.md
   items:
     - assert
@@ -115,6 +116,7 @@ builtins:
     - notify
     - prompt
     - read
+    - tts_generate
     - uuid
     - validate
     - wait

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://nika.sh/spec/v1/workflow.schema.json",
-  "title": "Nika workflow · v1",
-  "description": "Structural contract for a Nika v1 workflow file. Hand-derived from the prose spec (spec/01-08) at v0.1 · to be superseded by the engine-generated `nika-schema` (schemars) output at engine GA · both derive from the same prose source of truth. Strict on structure (envelope · exactly-one-verb-per-task · enums · id patterns · unknown-key rejection) · permissive on leaf value types where a `${{ }}` CEL template may appear in place of a literal.",
-  "$comment": "INTERIM hand-derived schema · prose spec is the single source of truth · regenerate + diff against engine `nika-schema` at GA.",
+  "title": "Nika workflow \u00b7 v1",
+  "description": "Structural contract for a Nika v1 workflow file. Hand-derived from the prose spec (spec/01-08) at v0.1 \u00b7 to be superseded by the engine-generated `nika-schema` (schemars) output at engine GA \u00b7 both derive from the same prose source of truth. Strict on structure (envelope \u00b7 exactly-one-verb-per-task \u00b7 enums \u00b7 id patterns \u00b7 unknown-key rejection) \u00b7 permissive on leaf value types where a `${{ }}` CEL template may appear in place of a literal.",
+  "$comment": "INTERIM hand-derived schema \u00b7 prose spec is the single source of truth \u00b7 regenerate + diff against engine `nika-schema` at GA.",
   "type": "object",
   "required": [
     "nika",
@@ -14,23 +14,23 @@
   "properties": {
     "nika": {
       "const": "v1",
-      "description": "Language contract version · exactly `v1` for the v1 lifetime. NOT `v1.0` · `1` · `1.0`."
+      "description": "Language contract version \u00b7 exactly `v1` for the v1 lifetime. NOT `v1.0` \u00b7 `1` \u00b7 `1.0`."
     },
     "workflow": {
       "type": "string",
       "pattern": "^[a-z][a-z0-9-]*$",
-      "description": "Workflow id · kebab-case · unique within file · the document-type discriminator."
+      "description": "Workflow id \u00b7 kebab-case \u00b7 unique within file \u00b7 the document-type discriminator."
     },
     "description": {
       "type": "string"
     },
     "model": {
       "type": "string",
-      "description": "Default model · `<provider>/<name>` (e.g. anthropic/claude-sonnet-4-6 · ollama/qwen3.5:9b · mock/echo)."
+      "description": "Default model \u00b7 `<provider>/<name>` (e.g. anthropic/claude-sonnet-4-6 \u00b7 ollama/qwen3.5:9b \u00b7 mock/echo)."
     },
     "vars": {
       "type": "object",
-      "description": "Workflow inputs · `${{ vars.X }}`. Each value is untyped (the literal default) OR a typed declaration object.",
+      "description": "Workflow inputs \u00b7 `${{ vars.X }}`. Each value is untyped (the literal default) OR a typed declaration object.",
       "additionalProperties": {
         "anyOf": [
           {
@@ -94,13 +94,13 @@
               ]
             }
           },
-          "$comment": "A typed-var declaration (an object carrying a string `type:`) MUST use the closed type enum per spec/01-envelope.md §vars · the untyped-object default form (no `type:` key) is untouched."
+          "$comment": "A typed-var declaration (an object carrying a string `type:`) MUST use the closed type enum per spec/01-envelope.md \u00a7vars \u00b7 the untyped-object default form (no `type:` key) is untouched."
         }
       }
     },
     "env": {
       "type": "object",
-      "description": "Non-sensitive runtime config · `${{ env.X }}` · may appear in logs.",
+      "description": "Non-sensitive runtime config \u00b7 `${{ env.X }}` \u00b7 may appear in logs.",
       "additionalProperties": {
         "type": [
           "string",
@@ -111,7 +111,7 @@
     },
     "secrets": {
       "type": "object",
-      "description": "Vault-backed masked references · `${{ secrets.X }}` · never inline literals.",
+      "description": "Vault-backed masked references \u00b7 `${{ secrets.X }}` \u00b7 never inline literals.",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
@@ -125,7 +125,7 @@
               "env",
               "file"
             ],
-            "description": "Where the secret lives · never an inline value (spec/01-envelope.md §secrets)."
+            "description": "Where the secret lives \u00b7 never an inline value (spec/01-envelope.md \u00a7secrets)."
           },
           "key": {
             "type": "string",
@@ -133,11 +133,11 @@
           },
           "path": {
             "type": "string",
-            "description": "File path · file source only · contents read at resolve time · masked."
+            "description": "File path \u00b7 file source only \u00b7 contents read at resolve time \u00b7 masked."
           },
           "egress": {
             "type": "array",
-            "description": "Sanctioned destinations for this secret · declassification (spec/01-envelope.md §egress) · absent/empty = default-deny (every exec:/invoke: reach is a leak).",
+            "description": "Sanctioned destinations for this secret \u00b7 declassification (spec/01-envelope.md \u00a7egress) \u00b7 absent/empty = default-deny (every exec:/invoke: reach is a leak).",
             "items": {
               "type": "object",
               "additionalProperties": false,
@@ -147,15 +147,15 @@
               "properties": {
                 "to": {
                   "type": "string",
-                  "description": "The sanctioned sink · a tool id (`nika:fetch` · `nika:notify` · `mcp:<server>/<tool>`), `exec`, or a provider-egress sink `infer` / `agent` (a secret in an infer/agent prompt) · SPECIFIC (no cross-tool laundering)."
+                  "description": "The sanctioned sink \u00b7 a tool id (`nika:fetch` \u00b7 `nika:notify` \u00b7 `mcp:<server>/<tool>`), `exec`, or a provider-egress sink `infer` / `agent` (a secret in an infer/agent prompt) \u00b7 SPECIFIC (no cross-tool laundering)."
                 },
                 "host": {
                   "type": "string",
-                  "description": "Static-literal destination host · sanctions only when the sink's destination arg is exactly this host (a templated host stays the runtime check). Mutually exclusive with host_from_self."
+                  "description": "Static-literal destination host \u00b7 sanctions only when the sink's destination arg is exactly this host (a templated host stays the runtime check). Mutually exclusive with host_from_self."
                 },
                 "host_from_self": {
                   "type": "boolean",
-                  "description": "The secret value IS the destination URL (host unknown statically) · sanctions only the direct-secret-URL shape with the non-occlusion guard. Mutually exclusive with host."
+                  "description": "The secret value IS the destination URL (host unknown statically) \u00b7 sanctions only the direct-secret-URL shape with the non-occlusion guard. Mutually exclusive with host."
                 }
               },
               "not": {
@@ -198,40 +198,64 @@
             }
           }
         ],
-        "description": "A secret is a reference to a store · discriminated by source · vault/env require key · file requires path · optional egress: sanctioned-destination list (spec/01-envelope.md)."
+        "description": "A secret is a reference to a store \u00b7 discriminated by source \u00b7 vault/env require key \u00b7 file requires path \u00b7 optional egress: sanctioned-destination list (spec/01-envelope.md)."
       }
     },
     "permits": {
       "type": "object",
       "additionalProperties": false,
-      "description": "The declared capability boundary · once present every category is default-deny unless listed (spec/01-envelope.md §permits · NIKA-SEC-004).",
+      "description": "The declared capability boundary \u00b7 once present every category is default-deny unless listed (spec/01-envelope.md \u00a7permits \u00b7 NIKA-SEC-004).",
       "properties": {
         "fs": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "read": { "type": "array", "items": { "type": "string" } },
-            "write": { "type": "array", "items": { "type": "string" } }
+            "read": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "write": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         },
         "net": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "http": { "type": "array", "items": { "type": "string" } }
+            "http": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         },
         "exec": {
-          "description": "false = no shells · true = any (blocklist-gated) · array = allowed program names.",
+          "description": "false = no shells \u00b7 true = any (blocklist-gated) \u00b7 array = allowed program names.",
           "oneOf": [
-            { "type": "boolean" },
-            { "type": "array", "items": { "type": "string" } }
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           ]
         },
         "tools": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Allowed nika:/mcp: tool ids · globs ok."
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowed nika:/mcp: tool ids \u00b7 globs ok."
         }
       }
     },
@@ -244,7 +268,7 @@
     },
     "outputs": {
       "type": "object",
-      "description": "The workflow's return value · symmetric to vars. Each entry is a `${{ tasks.X.output }}` reference (untyped form · string) OR a typed declaration { value · type · description }. Powers `nika run` result + the output half of the callable-workflow schema.",
+      "description": "The workflow's return value \u00b7 symmetric to vars. Each entry is a `${{ tasks.X.output }}` reference (untyped form \u00b7 string) OR a typed declaration { value \u00b7 type \u00b7 description }. Powers `nika run` result + the output half of the callable-workflow schema.",
       "additionalProperties": {
         "anyOf": [
           {
@@ -287,7 +311,7 @@
         "id"
       ],
       "additionalProperties": false,
-      "description": "A DAG node. MUST bind exactly one of the 4 verbs (infer · exec · invoke · agent).",
+      "description": "A DAG node. MUST bind exactly one of the 4 verbs (infer \u00b7 exec \u00b7 invoke \u00b7 agent).",
       "allOf": [
         {
           "oneOf": [
@@ -318,7 +342,7 @@
         "id": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9_]*$",
-          "description": "Task id · snake_case (CEL-safe · no hyphens) · unique within workflow."
+          "description": "Task id \u00b7 snake_case (CEL-safe \u00b7 no hyphens) \u00b7 unique within workflow."
         },
         "depends_on": {
           "type": "array",
@@ -331,18 +355,18 @@
           "oneOf": [
             {
               "type": "boolean",
-              "description": "YAML boolean literal · the always/never pattern (when: true runs regardless of upstream outcome · spec/03-dag.md §Task states)."
+              "description": "YAML boolean literal \u00b7 the always/never pattern (when: true runs regardless of upstream outcome \u00b7 spec/03-dag.md \u00a7Task states)."
             },
             {
               "type": "string",
               "format": "cel-expression",
-              "description": "A ${{ }} CEL boolean expression (cel-subset/0.1 · spec/03-dag.md). Statically non-boolean-shaped roots are rejected (NIKA-VAR-005)."
+              "description": "A ${{ }} CEL boolean expression (cel-subset/0.1 \u00b7 spec/03-dag.md). Statically non-boolean-shaped roots are rejected (NIKA-VAR-005)."
             }
           ],
-          "description": "Conditional execution gate · a ${{ }} CEL boolean OR the YAML literal true/false. An explicit when: replaces the default success-gate (spec/03-dag.md §Task states)."
+          "description": "Conditional execution gate \u00b7 a ${{ }} CEL boolean OR the YAML literal true/false. An explicit when: replaces the default success-gate (spec/03-dag.md \u00a7Task states)."
         },
         "for_each": {
-          "description": "Map this task over a collection · `${{ ... }}` reference OR a literal array.",
+          "description": "Map this task over a collection \u00b7 `${{ ... }}` reference OR a literal array.",
           "type": [
             "string",
             "array"
@@ -351,11 +375,11 @@
         "max_parallel": {
           "type": "integer",
           "minimum": 1,
-          "description": "Cap concurrent for_each iterations · default unbounded · 1 = sequential."
+          "description": "Cap concurrent for_each iterations \u00b7 default unbounded \u00b7 1 = sequential."
         },
         "fail_fast": {
           "type": "boolean",
-          "description": "for_each abort-on-error · default true."
+          "description": "for_each abort-on-error \u00b7 default true."
         },
         "retry": {
           "$ref": "#/$defs/retry"
@@ -365,23 +389,23 @@
         },
         "timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$",
-          "description": "Go-duration string · quoted · e.g. \"30s\" \"5m\" \"1h30m\" \"2.5s\". Max 24h."
+          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|\u00b5s|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|\u00b5s|ms|s|m|h))*$",
+          "description": "Go-duration string \u00b7 quoted \u00b7 e.g. \"30s\" \"5m\" \"1h30m\" \"2.5s\". Max 24h."
         },
         "on_finally": {
           "type": "array",
-          "description": "Cleanup mini-tasks · ALWAYS run (success/fail/timeout/cancel) · sequential · best-effort.",
+          "description": "Cleanup mini-tasks \u00b7 ALWAYS run (success/fail/timeout/cancel) \u00b7 sequential \u00b7 best-effort.",
           "items": {
             "$ref": "#/$defs/finallyStep"
           }
         },
         "with": {
           "type": "object",
-          "description": "Task-level scope injection · `${{ with.X }}`."
+          "description": "Task-level scope injection \u00b7 `${{ with.X }}`."
         },
         "output": {
           "type": "object",
-          "description": "Named jq-expression bindings · `${{ tasks.X.<name> }}`. jq is the single data extraction-and-transform language (the former RFC 9535 JSONPath was dropped · jq is a superset · per spec/04-variables.md §216-225). Reserved names forbidden at parse time (spec/04-variables.md §Rules): output · status · error · started_at · ended_at · duration_ms — enforced via propertyNames.",
+          "description": "Named jq-expression bindings \u00b7 `${{ tasks.X.<name> }}`. jq is the single data extraction-and-transform language (the former RFC 9535 JSONPath was dropped \u00b7 jq is a superset \u00b7 per spec/04-variables.md \u00a7216-225). Reserved names forbidden at parse time (spec/04-variables.md \u00a7Rules): output \u00b7 status \u00b7 error \u00b7 started_at \u00b7 ended_at \u00b7 duration_ms \u2014 enforced via propertyNames.",
           "propertyNames": {
             "not": {
               "enum": [
@@ -434,7 +458,7 @@
             "number",
             "string"
           ],
-          "description": "0-2 · number or `${{ }}`."
+          "description": "0-2 \u00b7 number or `${{ }}`."
         },
         "max_tokens": {
           "type": [
@@ -444,7 +468,7 @@
         },
         "schema": {
           "type": "object",
-          "description": "JSON Schema · structured output contract."
+          "description": "JSON Schema \u00b7 structured output contract."
         },
         "thinking": {
           "type": "object",
@@ -491,10 +515,14 @@
         "command": {
           "description": "String -> /bin/sh -c (shell). Array -> execve, no shell (the injection-safe form).",
           "oneOf": [
-            { "type": "string" },
+            {
+              "type": "string"
+            },
             {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "minItems": 1
             }
           ]
@@ -530,11 +558,11 @@
       "additionalProperties": false,
       "properties": {
         "tool": {
-          "description": "Tool reference · nika:<path> (closed v0.1 builtin set) OR mcp:<server>/<tool> (requires the slash). The namespace set is CLOSED at v1 (spec/02-verbs.md) — an x-<vendor>: prefix is RESERVED, not valid (engine-specific tools route through mcp: · spec/06-stdlib-contract.md §Namespace ownership).",
+          "description": "Tool reference \u00b7 nika:<path> (closed v0.1 builtin set) OR mcp:<server>/<tool> (requires the slash). The namespace set is CLOSED at v1 (spec/02-verbs.md) \u2014 an x-<vendor>: prefix is RESERVED, not valid (engine-specific tools route through mcp: \u00b7 spec/06-stdlib-contract.md \u00a7Namespace ownership).",
           "oneOf": [
             {
               "type": "string",
-              "description": "`nika:*` builtin · 24 canonical per stdlib v0.1 (Core 6 · File 5 · Data 8 · Network 2 · Introspection 2 · Media 1). Closed enum for `yaml-language-server` autocomplete.",
+              "description": "`nika:*` builtin \u00b7 24 canonical per stdlib v0.1 (Core 6 \u00b7 File 5 \u00b7 Data 8 \u00b7 Network 2 \u00b7 Introspection 2 \u00b7 Media 1). Closed enum for `yaml-language-server` autocomplete.",
               "enum": [
                 "nika:assert",
                 "nika:compose",
@@ -556,6 +584,7 @@
                 "nika:notify",
                 "nika:prompt",
                 "nika:read",
+                "nika:tts_generate",
                 "nika:uuid",
                 "nika:validate",
                 "nika:wait",
@@ -564,7 +593,7 @@
             },
             {
               "type": "string",
-              "description": "`mcp:<server>/<tool>` external MCP tool · open (pattern · `/` separates path). · mcp: requires the slash (mcp:<server>/<tool> · server kebab-case · spec/02-verbs.md §tool reference grammar)",
+              "description": "`mcp:<server>/<tool>` external MCP tool \u00b7 open (pattern \u00b7 `/` separates path). \u00b7 mcp: requires the slash (mcp:<server>/<tool> \u00b7 server kebab-case \u00b7 spec/02-verbs.md \u00a7tool reference grammar)",
               "pattern": "^mcp:[a-z][a-z0-9-]*/[A-Za-z0-9_/-]+$"
             }
           ]
@@ -592,7 +621,7 @@
         },
         "tools": {
           "type": "array",
-          "description": "Whitelist · DEFAULT-DENY (no tools if absent) · gitignore-style globs · `!` negation.",
+          "description": "Whitelist \u00b7 DEFAULT-DENY (no tools if absent) \u00b7 gitignore-style globs \u00b7 `!` negation.",
           "items": {
             "type": "string"
           }
@@ -617,7 +646,7 @@
         },
         "schema": {
           "type": "object",
-          "description": "JSON Schema · validate the agent's final message as structured output."
+          "description": "JSON Schema \u00b7 validate the agent's final message as structured output."
         }
       }
     },
@@ -661,10 +690,10 @@
     "onError": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Error recovery · exactly ONE action (recover / skip / fail_workflow · the oneOf enforces it) + optional on_codes filter (spec/05-errors.md §Fields · catch-side mirror of retry.on_codes · skip preserves the original error at tasks.X.error).",
+      "description": "Error recovery \u00b7 exactly ONE action (recover / skip / fail_workflow \u00b7 the oneOf enforces it) + optional on_codes filter (spec/05-errors.md \u00a7Fields \u00b7 catch-side mirror of retry.on_codes \u00b7 skip preserves the original error at tasks.X.error).",
       "properties": {
         "recover": {
-          "description": "Recovery output · a `${{ }}` ref OR a literal (merges the former fallback/value per spec/05-errors.md)."
+          "description": "Recovery output \u00b7 a `${{ }}` ref OR a literal (merges the former fallback/value per spec/05-errors.md)."
         },
         "skip": {
           "type": "boolean"
@@ -679,7 +708,7 @@
             "type": "string",
             "pattern": "^NIKA-[A-Z]{2,9}(-[A-Z][A-Z0-9_]{1,15})?-[0-9]{3}$"
           },
-          "description": "Optional catch-side filter (mirror of retry.on_codes · same regex) · the action applies ONLY when the final error code is listed · unlisted codes fall through to the default fail (spec/05-errors.md §Fields)."
+          "description": "Optional catch-side filter (mirror of retry.on_codes \u00b7 same regex) \u00b7 the action applies ONLY when the final error code is listed \u00b7 unlisted codes fall through to the default fail (spec/05-errors.md \u00a7Fields)."
         }
       },
       "oneOf": [
@@ -708,15 +737,15 @@
           "oneOf": [
             {
               "type": "boolean",
-              "description": "YAML boolean literal · the always/never pattern (when: true runs regardless of upstream outcome · spec/03-dag.md §Task states)."
+              "description": "YAML boolean literal \u00b7 the always/never pattern (when: true runs regardless of upstream outcome \u00b7 spec/03-dag.md \u00a7Task states)."
             },
             {
               "type": "string",
               "format": "cel-expression",
-              "description": "A ${{ }} CEL boolean expression (cel-subset/0.1 · spec/03-dag.md). Statically non-boolean-shaped roots are rejected (NIKA-VAR-005)."
+              "description": "A ${{ }} CEL boolean expression (cel-subset/0.1 \u00b7 spec/03-dag.md). Statically non-boolean-shaped roots are rejected (NIKA-VAR-005)."
             }
           ],
-          "description": "Conditional execution gate · a ${{ }} CEL boolean OR the YAML literal true/false. An explicit when: replaces the default success-gate (spec/03-dag.md §Task states)."
+          "description": "Conditional execution gate \u00b7 a ${{ }} CEL boolean OR the YAML literal true/false. An explicit when: replaces the default success-gate (spec/03-dag.md \u00a7Task states)."
         },
         "timeout": {
           "type": "string"

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -22,6 +22,12 @@
 > LocalAI · Ollama · sd.cpp · SGLang · vLLM-Omni) · openai `gpt-image-2` ·
 > gemini `gemini-3.1-flash-image` · xai `grok-imagine-image` · `mock` for
 > offline runs · assets land on disk, never inline base64.
+> Step 5 (24 → 25 · 2026-07-05) · `nika:tts_generate` · the SECOND
+> Media-class graduate (stdlib §Audio) · sovereign-first — `local` (any
+> OpenAI-speech-compatible server: LocalAI · Kokoro-FastAPI · Speaches ·
+> openedai-speech) · openai `gpt-4o-mini-tts` · elevenlabs · `mock` (a
+> real deterministic WAV · offline CI) · ONE audio file on disk, never
+> inline bytes.
 
 ---
 
@@ -34,10 +40,10 @@
 | Data | 8 | `jq` (THE data language) + 7 capabilities jq can't express (json_diff · validate · json_merge_patch · convert · uuid · date · hash) |
 | Introspection | 2 | Self-awareness · `inspect` (runtime state · 4 views) · `compose` (static check of a drafted workflow · agent loops only) |
 | Network | 2 | fetch (HTTP+extraction) · notify (alerts out) |
-| Media | 1 | `image_generate` (the first §Media graduate · 2026-07-05) — the REST of the media class stays deferred to stdlib v0.x |
-| **Total v0.1** | **24** | |
+| Media | 2 | `image_generate` (§Media · 2026-07-05) · `tts_generate` (§Audio · same day) — the REST of the media class stays deferred to stdlib v0.x |
+| **Total v0.1** | **25** | |
 
-A Stdlib v0.1-compliant engine MUST ship these 24.
+A Stdlib v0.1-compliant engine MUST ship these 25.
 
 ---
 
@@ -349,7 +355,7 @@ outputs** (no base64 in `tasks.X.output`, logs, or traces · normative).
 | Arg | Notes |
 |---|---|
 | `provider` | `local` · `openai` · `gemini` · `xai` · `mock` — optional when inferable from `model:` (`gpt-image*`→openai · `gemini-*`→gemini · `grok*`→xai · `mock*`→mock · `local` is NEVER inferred: its model names are server-specific) |
-| `model` | per-provider default (reference engine 2026-07: `stablediffusion` for local — the LocalAI convention · `gpt-image-2` · `gemini-3.1-flash-image` · `grok-imagine-image` — the `-quality` tier is the model knob · `mock-image-1`) |
+| `model` | per-provider default (reference engine 2026-07: `stablediffusion` for local — the LocalAI convention · SD-family servers also honor the `positive \| negative` split INSIDE `prompt:` (LocalAI pipe syntax) — no separate arg needed · `gpt-image-2` · `gemini-3.1-flash-image` · `grok-imagine-image` — the `-quality` tier is the model knob · `mock-image-1`) |
 | `prompt` | **required** · the creative brief · may use `${{ … }}` |
 | `mode` | `generate` (default) · `edit` is RESERVED (rejected loudly in v0.1 · media roadmap) |
 | `n` | 1..=10 variants (engines MAY satisfy n via sequential provider calls · documented per adapter) |
@@ -384,9 +390,15 @@ NEVER a credential: keys live a composition layer away by construction).
 prompt, revised_prompt, provider_text, created_at, count, images: [{ index,
 path, filename, mime_type, format, width, height, size_bytes, sha256,
 provider, model, seed, variant_id, warnings, metadata }], usage:
-{ input_tokens, output_tokens, total_tokens, thoughts_tokens }, warnings,
-manifest_path, output_dir }` — absent usage axes are `null`, never
-zero-that-looks-real.
+{ input_tokens, output_tokens, total_tokens, thoughts_tokens }, cost_usd,
+warnings, manifest_path, output_dir }` — absent usage axes are `null`,
+never zero-that-looks-real. `cost_usd` is the render's REAL spend when
+the provider reports it exactly (xai bills `cost_in_usd_ticks` in the
+response · 1 cent = 10⁸ ticks) and `null` otherwise — never an estimate
+dressed as truth. **Invoke-cost metering (normative)** · a tool whose
+structured output carries a top-level numeric `cost_usd` reports real
+spend; engines SHOULD meter it into the run's cost ledger through the
+same honest-spend channel `infer:` rides.
 
 **Security (engine MUST)** · provider endpoints are ENGINE-FIXED constants
 (never workflow data — the provider egress is engine transport, exactly like
@@ -423,6 +435,15 @@ the const-endpoint design closed. The provenance manifest and output
 carry `endpoint_host` (which server actually rendered the asset — load-
 bearing for `local`, where the endpoint is configurable).
 
+**Provenance travels IN the file (PNG)** · engines SHOULD embed the
+deterministic provenance core (tool · engine version · provider · model ·
+clamped prompt · seed — no timestamp, so byte-determinism holds) as a
+`nika` tEXt chunk in saved PNG renders — the ComfyUI/InvokeAI
+interchange practice: a sidecar manifest answers « where does this come
+from? » only until the file is copied without it. JPEG/WebP have no
+equally-universal text container and are documented as manifest-only,
+never silently faked.
+
 Throws · `NIKA-BUILTIN-IMAGE_GENERATE-001` invalid arguments (incl. the v0.1
 RESERVED options · `validation_error`) · `-002` provider unavailable
 (missing credentials / image plane unwired · `validation_error`) · `-003`
@@ -436,6 +457,60 @@ mismatch · dimension/byte bounds · `tool_error`). Plus the boundary
 `NIKA-SEC-004` (an `output_dir:` outside `permits.fs.write`).
 
 ---
+
+### `nika:tts_generate` · provider-backed speech synthesis (§Audio)
+
+```yaml
+- id: narrate
+  invoke:
+    tool: "nika:tts_generate"
+    args:
+      provider: local              # sovereign first — or openai · elevenlabs · mock
+      text: "Bienvenue — the launch is live."
+      voice: "alloy"
+      output_dir: "./assets/audio"
+```
+
+The image family's contract, applied to audio: ONE audio file lands under
+`output_dir:` (permit-gated per final path BEFORE I/O · atomic write ·
+content-hash-named `{stem}-{provider}-{model}-{sha8}.{ext}` so identical
+re-runs are idempotent), the output carries `{ provider, model, voice,
+created_at, endpoint_host, audio: { path, filename, format, mime_type,
+size_bytes, sha256, duration_ms }, cost_usd, warnings, manifest_path,
+output_dir }` — **audio bytes NEVER ride outputs**, and a sidecar
+provenance manifest (`manifest: true` default) echoes the resolved
+request.
+
+| Arg | Contract |
+|---|---|
+| `provider` | REQUIRED-or-inferred · closed: `local` (any OpenAI-speech-compatible self-hosted server — LocalAI · Kokoro-FastAPI · Speaches · openedai-speech · ONE wire: `POST {base}/v1/audio/speech` → raw bytes · base URL is ENGINE CONFIG `NIKA_TTS_LOCAL_URL`, default `http://localhost:8080`, never workflow data · never inferred) · `openai` · `elevenlabs` · `mock` (a REAL deterministic WAV · zero network/keys). Inference: `eleven*` → elevenlabs · `gpt-*`/`tts-*` → openai · `mock*` → mock. |
+| `model` | per-provider default (reference engine 2026-07: `tts-1` local convention · `gpt-4o-mini-tts` · `eleven_multilingual_v2` · `mock-tts-1`) |
+| `text` | REQUIRED · non-empty · ≤4096 chars (the strictest documented wire cap, held portably — fan longer scripts out with `for_each`) |
+| `voice` | provider voice id · defaults: `alloy` (openai/local) · Rachel's public id (elevenlabs — ids are path components, so engines MUST restrict them to the id alphabet) · `sine` (mock) |
+| `format` | `mp3 \| wav \| auto` (default auto = provider-native) — the saved EXTENSION follows the sniffed bytes (magic authority), never the ask; a lossy fold is a `format_mismatch:` warning |
+| `speed` | 0.25–4.0 (openai/local native) — warned-dropped (`speed_unsupported:`) where the wire has no knob |
+| `output_dir` · `filename_prefix` · `metadata` · `manifest` | as `image_generate` (stem falls back to `metadata.page_slug`, then `speech`) |
+| `timeout_ms` | default 120000 · local 300000 (CPU synthesis) · max 600000 |
+
+**Validation (engine MUST)** · the payload is sniffed (WAV `RIFF…WAVE` ·
+MP3 `ID3`/frame-sync) — a non-audio payload is a hard `-007`; WAV
+`duration_ms` is exact header math, MP3 duration is honestly `null`
+(never a guess). Empty payloads are `-004`.
+
+**Security (engine MUST)** · endpoints are engine-fixed constants (the
+`local` base URL is engine config at the composition root — the same
+sanction as `image_generate` and `infer:`) · keys are engine-configured
+(`OPENAI_API_KEY` · `ELEVENLABS_API_KEY` · `NIKA_TTS_LOCAL_API_KEY` or
+the `NIKA_`-prefixed forms), never workflow args, never logged · a
+verbose local server reflecting the Bearer into an error body MUST be
+scrubbed (the image family's rule).
+
+Throws · `NIKA-BUILTIN-TTS_GENERATE-001` invalid arguments
+(`validation_error`) · `-002` provider unavailable (`validation_error`) ·
+`-003` request failed (`network_error` · `transient: true` for
+5xx/408/429 + timeout/connection) · `-004` empty audio · `-005` content
+policy · `-006` save failed · `-007` payload validation (all
+`runtime_error` unless noted).
 
 ## What jq subsumes (cut from v0.1)
 

--- a/crates/nika-schema/src/analyzer/builtin_shape.rs
+++ b/crates/nika-schema/src/analyzer/builtin_shape.rs
@@ -64,7 +64,67 @@ fn check_action(action: &RawAction, task: &str, errors: &mut Vec<SchemaError>) {
         // surface for one builtin. Its `Builtin::required` stays empty.
         "nika:fetch" => check_fetch_shape(task, tool, args, span, errors),
         "nika:image_generate" => check_image_generate_shape(task, tool, args, span, errors),
+        "nika:tts_generate" => check_tts_generate_shape(task, tool, args, span, errors),
         _ => {}
+    }
+}
+
+/// `nika:tts_generate` static contracts (stdlib §Audio): closed enums +
+/// literal numeric ranges, mirroring the runtime parser — templated
+/// values are runtime business (statically silent).
+fn check_tts_generate_shape(
+    task: &str,
+    tool: &str,
+    args: Option<&serde_json::Value>,
+    span: Span,
+    errors: &mut Vec<SchemaError>,
+) {
+    let object = args.and_then(serde_json::Value::as_object);
+    let literal = |key: &str| -> Option<&str> {
+        let value = object?.get(key)?.as_str()?;
+        (!value.contains("${{")).then_some(value)
+    };
+
+    let enums: [(&str, &[&str]); 2] = [
+        ("provider", &["local", "openai", "elevenlabs", "mock"]),
+        ("format", &["mp3", "wav", "auto"]),
+    ];
+    for (key, allowed) in enums {
+        if let Some(value) = literal(key)
+            && !allowed.contains(&value)
+        {
+            errors.push(shape(
+                task,
+                tool,
+                &format!(
+                    "`{key}: {value}` is not in the closed set — {}",
+                    allowed.join(" · ")
+                ),
+                span,
+            ));
+        }
+    }
+    if let Some(value) = object.and_then(|map| map.get("speed"))
+        && let Some(s) = value.as_f64()
+        && !(0.25..=4.0).contains(&s)
+    {
+        errors.push(shape(
+            task,
+            tool,
+            &format!("`speed: {s}` out of range — 0.25..=4.0"),
+            span,
+        ));
+    }
+    if let Some(value) = object.and_then(|map| map.get("timeout_ms"))
+        && let Some(n) = value.as_i64()
+        && !(1_000..=600_000).contains(&n)
+    {
+        errors.push(shape(
+            task,
+            tool,
+            &format!("`timeout_ms: {n}` out of range — 1000..=600000"),
+            span,
+        ));
     }
 }
 

--- a/crates/nika-schema/src/codegen.rs
+++ b/crates/nika-schema/src/codegen.rs
@@ -76,10 +76,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn enum_has_24_entries() {
+    fn enum_has_25_entries() {
         let schema = nika_builtin_tool_enum_schema();
         let arr = schema["enum"].as_array().expect("enum must be array");
-        assert_eq!(arr.len(), 24, "expected 24 spec-canonical builtins");
+        assert_eq!(arr.len(), 25, "expected 25 spec-canonical builtins");
     }
 
     #[test]

--- a/typos.toml
+++ b/typos.toml
@@ -9,6 +9,8 @@ extend-ignore-identifiers-re = [
 ]
 
 [default.extend-words]
+# Speaches is a real project (speaches.ai · OpenAI-compat speech server), not a typo of "Speeches".
+Speaches = "Speaches"
 # Project-specific terms that look like typos but aren't
 Nika       = "Nika"
 nika       = "nika"


### PR DESCRIPTION
**The media-suite research executed** (spec supernovae-st/nika-spec#14 merged · docs#5 merged · website#6 merged): TTS = the lowest-machinery next builtin — sync-bytes everywhere · **ONE OpenAI-speech-compatible wire** covers LocalAI · Kokoro-FastAPI · Speaches · openedai-speech.

**Providers v1 (sovereign-first)**: `local` (`NIKA_TTS_LOCAL_URL` · reflected-Bearer scrub inherited) · `openai` `gpt-4o-mini-tts` · `elevenlabs` (NEW vendor — voice ids ride the URL path, restricted to the id alphabet: **path injection structurally impossible**) · `mock` (a REAL deterministic 16 kHz WAV · byte-stable).

**The §Media contract applied to §Audio verbatim**: assets-not-blobs · magic-byte authority (wav `duration_ms` exact · mp3 honestly `null`) · content-hash filenames · permit-gated atomic saves · provenance manifest · honest warnings · codes `-001..-007`.

**E2E at the built binary (live APIs)**: mock WAV `file(1)`-verified · **openai REAL 2.2 s → true MPEG-III mp3, played locally** · elevenlabs real-wire negative (401 mapped cleanly · zero leak) · **local over REAL TCP** (route ✓ Bearer ✓ asserted server-side) · **the chain: gemini writes → openai speaks**.

Cascade: tts plane · ToolDef #25 · 7 count-pins (incl. the JSON-schema tool enum, caught by the oracle) · shape ladder · compose env + leak riders · codegen · pack ×2. 3 294 lib tests · clippy 0 · 8 ratchets · public-api +74 additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)