### PR TITLE
feat(nika-builtin): content credentials — detect-and-preserve + surface

### DIFF
--- a/crates/nika-builtin/src/image/credentials.rs
+++ b/crates/nika-builtin/src/image/credentials.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Content-credentials DETECTION — the provenance signals upstream
+//! generators embed in the bytes they return (C2PA "Content Credentials"
+//! · the CAI/Adobe/OpenAI ecosystem standard).
+//!
+//! No workflow engine even LOOKS at these octets: re-encodes and naive
+//! pipelines strip them silently, which is exactly how provenance dies
+//! between the generator and the published asset. Nika's contract is the
+//! opposite and three-fold:
+//!
+//! 1. **DETECT** — conservative, exact-signature byte scans (a PNG `caBX`
+//!    chunk · a JPEG APP11 JUMBF segment · a WebP `C2PA` RIFF chunk).
+//! 2. **PRESERVE** — C2PA hard bindings hash the file's byte ranges, so
+//!    inserting OUR `nika` tEXt chunk into a signed PNG would INVALIDATE
+//!    the upstream signature. When credentials are detected, the embed
+//!    step stands down (their signed manifest outranks our informal
+//!    chunk) and the sidecar manifest records both facts.
+//! 3. **SURFACE** — `content_credentials: "detected" | "none"` rides the
+//!    output, the manifest and a dedicated event. Honesty rule: this is
+//!    presence DETECTION, never VALIDATION — the label never says
+//!    « verified » (offline verification is the reserved
+//!    `nika-media-provenance` crate's future).
+
+/// What the byte scan established for one image payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredentialSignal {
+    /// A C2PA manifest store is present (format-specific carriage).
+    C2pa,
+}
+
+impl CredentialSignal {
+    /// The stable wire label (output · manifest · events).
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::C2pa => "c2pa",
+        }
+    }
+}
+
+/// Scan one image payload for embedded content credentials. Conservative
+/// by design: exact container signatures only — a miss means « none
+/// SEEN », never « none present » (the docs say "detected", not
+/// "verified", for the same honesty reason).
+pub(crate) fn detect(bytes: &[u8]) -> Option<CredentialSignal> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return png_has_cabx(bytes).then_some(CredentialSignal::C2pa);
+    }
+    if bytes.starts_with(&[0xFF, 0xD8]) {
+        return jpeg_has_app11_jumbf(bytes).then_some(CredentialSignal::C2pa);
+    }
+    if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        return riff_has_c2pa_chunk(bytes).then_some(CredentialSignal::C2pa);
+    }
+    None
+}
+
+/// Scan one AUDIO payload for embedded content credentials (WAV rides
+/// RIFF `C2PA` chunks · MP3 rides an `ID3v2` `GEOB` frame with the
+/// `application/c2pa` MIME — the carriage Google's Lyria and the
+/// `ElevenLabs` compliance stack ship today).
+pub(crate) fn detect_audio(bytes: &[u8]) -> Option<CredentialSignal> {
+    if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WAVE" {
+        return riff_has_c2pa_chunk(bytes).then_some(CredentialSignal::C2pa);
+    }
+    if bytes.starts_with(b"ID3") {
+        return id3_has_c2pa_geob(bytes).then_some(CredentialSignal::C2pa);
+    }
+    None
+}
+
+/// `ID3v2`: a `GEOB` frame whose payload names the `application/c2pa`
+/// MIME type, searched within the declared tag bounds only.
+fn id3_has_c2pa_geob(bytes: &[u8]) -> bool {
+    if bytes.len() < 10 {
+        return false;
+    }
+    // syncsafe 28-bit tag size at offset 6.
+    let size = bytes[6..10]
+        .iter()
+        .fold(0usize, |acc, b| (acc << 7) | usize::from(b & 0x7F));
+    let end = 10usize.saturating_add(size).min(bytes.len());
+    let tag = &bytes[10..end];
+    let has = |token: &[u8]| tag.windows(token.len()).any(|w| w == token);
+    has(b"GEOB") && has(b"application/c2pa")
+}
+
+/// Walk PNG chunks for `caBX` (the C2PA-in-PNG carriage chunk).
+fn png_has_cabx(bytes: &[u8]) -> bool {
+    let mut off = 8usize;
+    while off + 8 <= bytes.len() {
+        let Some(len_bytes) = bytes
+            .get(off..off + 4)
+            .and_then(|s| <[u8; 4]>::try_from(s).ok())
+        else {
+            return false;
+        };
+        let len = u32::from_be_bytes(len_bytes) as usize;
+        let Some(kind) = bytes.get(off + 4..off + 8) else {
+            return false;
+        };
+        if kind == b"caBX" {
+            return true;
+        }
+        if kind == b"IEND" {
+            return false;
+        }
+        // length + type + data + crc
+        let Some(next) = off.checked_add(12 + len) else {
+            return false;
+        };
+        off = next;
+    }
+    false
+}
+
+/// Walk JPEG segments for APP11 (0xFFEB) carrying a JUMBF box — the
+/// C2PA-in-JPEG carriage (JPEG XT box format · the box type reads
+/// `jumb` after the `JP` CI header).
+fn jpeg_has_app11_jumbf(bytes: &[u8]) -> bool {
+    let mut off = 2usize; // past SOI
+    while off + 4 <= bytes.len() {
+        if bytes[off] != 0xFF {
+            return false; // lost sync — stop scanning, never guess
+        }
+        let marker = bytes[off + 1];
+        // Standalone markers without a length.
+        if (0xD0..=0xD9).contains(&marker) || marker == 0x01 {
+            off += 2;
+            continue;
+        }
+        let Some(len_bytes) = bytes
+            .get(off + 2..off + 4)
+            .and_then(|s| <[u8; 2]>::try_from(s).ok())
+        else {
+            return false;
+        };
+        let seg_len = u16::from_be_bytes(len_bytes) as usize;
+        if seg_len < 2 {
+            return false;
+        }
+        if marker == 0xEB {
+            // APP11 payload: "JP" CI + box instance/sequence, then a JUMBF
+            // superbox (`jumb`) labeled `c2pa` (spec 2.4 carriage — both
+            // tokens must appear · exact-signature conservatism).
+            let seg = bytes.get(off + 4..off + 2 + seg_len).unwrap_or(&[]);
+            let has = |token: &[u8]| seg.windows(token.len()).any(|w| w == token);
+            if seg.starts_with(b"JP") && has(b"jumb") && has(b"c2pa") {
+                return true;
+            }
+        }
+        if marker == 0xDA {
+            return false; // entropy-coded data begins — credentials live before SOS
+        }
+        let Some(next) = off.checked_add(2 + seg_len) else {
+            return false;
+        };
+        off = next;
+    }
+    false
+}
+
+/// Walk RIFF chunks (`WebP` · WAV · AVI) for a `C2PA` fourcc.
+fn riff_has_c2pa_chunk(bytes: &[u8]) -> bool {
+    let mut off = 12usize;
+    while off + 8 <= bytes.len() {
+        let Some(fourcc) = bytes.get(off..off + 4) else {
+            return false;
+        };
+        if fourcc == b"C2PA" {
+            return true;
+        }
+        let Some(len_bytes) = bytes
+            .get(off + 4..off + 8)
+            .and_then(|s| <[u8; 4]>::try_from(s).ok())
+        else {
+            return false;
+        };
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        // chunks are padded to even sizes
+        let Some(next) = off.checked_add(8 + len + (len & 1)) else {
+            return false;
+        };
+        off = next;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal PNG with one extra chunk of the given type spliced after
+    /// IHDR (CRC deliberately zero — detection reads types, not CRCs).
+    fn png_with_chunk(kind: [u8; 4]) -> Vec<u8> {
+        let mut out = b"\x89PNG\r\n\x1a\n".to_vec();
+        // IHDR (13 bytes of data · zero CRC — fine for the walker)
+        out.extend_from_slice(&13u32.to_be_bytes());
+        out.extend_from_slice(b"IHDR");
+        out.extend_from_slice(&[0u8; 13]);
+        out.extend_from_slice(&[0u8; 4]);
+        // the probe chunk
+        let payload = b"anything";
+        #[allow(clippy::cast_possible_truncation)] // tiny test fixture
+        out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        out.extend_from_slice(&kind);
+        out.extend_from_slice(payload);
+        out.extend_from_slice(&[0u8; 4]);
+        // IEND
+        out.extend_from_slice(&0u32.to_be_bytes());
+        out.extend_from_slice(b"IEND");
+        out.extend_from_slice(&[0u8; 4]);
+        out
+    }
+
+    #[test]
+    fn png_cabx_detected_and_clean_png_is_none() {
+        assert_eq!(
+            detect(&png_with_chunk(*b"caBX")),
+            Some(CredentialSignal::C2pa)
+        );
+        assert_eq!(
+            detect(&png_with_chunk(*b"tEXt")),
+            None,
+            "our own chunk is not C2PA"
+        );
+        let mock = super::super::mock::generate(&{
+            let serde_json::Value::Object(map) = serde_json::json!({
+                "provider": "mock", "prompt": "clean", "output_dir": "./out"
+            }) else {
+                unreachable!()
+            };
+            super::super::args::parse(&map).expect("valid")
+        })
+        .expect("mock");
+        assert_eq!(
+            detect(&mock.images[0].bytes),
+            None,
+            "mock renders are unsigned"
+        );
+    }
+
+    #[test]
+    fn jpeg_app11_jumbf_detected_and_plain_jpeg_is_none() {
+        // SOI + APP11("JP" + filler + "jumb") + SOS-ish tail
+        let mut jpeg = vec![0xFF, 0xD8];
+        let mut seg = b"JP".to_vec();
+        seg.extend_from_slice(&[0, 1, 0, 0, 0, 1]); // CI boxes filler
+        seg.extend_from_slice(&[0, 0, 0, 32]);
+        seg.extend_from_slice(b"jumb");
+        seg.extend_from_slice(&[0, 0, 0, 17]);
+        seg.extend_from_slice(b"jumdc2pa"); // the c2pa-labeled description box
+        #[allow(clippy::cast_possible_truncation)] // tiny test fixture
+        let seg_len = (seg.len() + 2) as u16;
+        jpeg.extend_from_slice(&[0xFF, 0xEB]);
+        jpeg.extend_from_slice(&seg_len.to_be_bytes());
+        jpeg.extend_from_slice(&seg);
+        jpeg.extend_from_slice(&[0xFF, 0xDA, 0, 2]);
+        assert_eq!(detect(&jpeg), Some(CredentialSignal::C2pa));
+
+        let plain = vec![0xFF, 0xD8, 0xFF, 0xE0, 0, 4, 0, 0, 0xFF, 0xDA, 0, 2];
+        assert_eq!(detect(&plain), None);
+        // an APP11 that is NOT JUMBF (no "JP"/"jumb") stays none — exact
+        // signatures only.
+        let mut odd = vec![0xFF, 0xD8, 0xFF, 0xEB, 0, 6];
+        odd.extend_from_slice(b"XXXX");
+        assert_eq!(detect(&odd), None);
+    }
+
+    /// The 28-bit syncsafe size encoding (test fixture helper).
+    fn syncsafe(n: usize) -> [u8; 4] {
+        #[allow(clippy::cast_possible_truncation)] // 7-bit masked
+        [
+            ((n >> 21) & 0x7F) as u8,
+            ((n >> 14) & 0x7F) as u8,
+            ((n >> 7) & 0x7F) as u8,
+            (n & 0x7F) as u8,
+        ]
+    }
+
+    #[test]
+    fn audio_wav_riff_and_mp3_geob_detected() {
+        // WAV with a C2PA RIFF chunk.
+        let mut wav = b"RIFF".to_vec();
+        wav.extend_from_slice(&40u32.to_le_bytes());
+        wav.extend_from_slice(b"WAVE");
+        wav.extend_from_slice(b"C2PA");
+        wav.extend_from_slice(&4u32.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        assert_eq!(detect_audio(&wav), Some(CredentialSignal::C2pa));
+
+        // A clean mock WAV is none.
+        let clean = super::super::super::tts::mock::render_wav("clean", 1000);
+        assert_eq!(detect_audio(&clean), None);
+
+        // MP3 with an ID3v2 GEOB frame carrying application/c2pa.
+        let mut body = b"GEOB".to_vec();
+        body.extend_from_slice(&[0, 0, 0, 40, 0, 0, 0]);
+        body.extend_from_slice(b"application/c2pa\0payload");
+        let mut mp3 = b"ID3\x04\x00\x00".to_vec();
+        mp3.extend_from_slice(&syncsafe(body.len()));
+        mp3.extend_from_slice(&body);
+        assert_eq!(detect_audio(&mp3), Some(CredentialSignal::C2pa));
+
+        // A GEOB with a different MIME is none.
+        let mut other = b"ID3\x04\x00\x00".to_vec();
+        let body2 = b"GEOB\x00\x00\x00\x10\x00\x00\x00image/png\0x";
+        other.extend_from_slice(&syncsafe(body2.len()));
+        other.extend_from_slice(body2);
+        assert_eq!(detect_audio(&other), None);
+        assert_eq!(detect_audio(b"ID3"), None, "truncated tag is total");
+    }
+
+    #[test]
+    fn webp_c2pa_chunk_detected_and_truncation_is_total() {
+        let mut webp = b"RIFF".to_vec();
+        webp.extend_from_slice(&40u32.to_le_bytes());
+        webp.extend_from_slice(b"WEBP");
+        webp.extend_from_slice(b"C2PA");
+        webp.extend_from_slice(&4u32.to_le_bytes());
+        webp.extend_from_slice(b"data");
+        assert_eq!(detect(&webp), Some(CredentialSignal::C2pa));
+
+        // Truncated/adversarial payloads never panic, never false-positive.
+        for junk in [
+            &b""[..],
+            &b"\x89PNG\r\n\x1a\n"[..],
+            &[0xFF, 0xD8, 0xFF][..],
+            &b"RIFF\x00\x00WEBP"[..],
+        ] {
+            assert_eq!(detect(junk), None);
+        }
+        // A PNG whose chunk length overflows must stop cleanly.
+        let mut evil = b"\x89PNG\r\n\x1a\n".to_vec();
+        evil.extend_from_slice(&u32::MAX.to_be_bytes());
+        evil.extend_from_slice(b"IHDR");
+        assert_eq!(detect(&evil), None);
+    }
+}

--- a/crates/nika-builtin/src/image/manifest.rs
+++ b/crates/nika-builtin/src/image/manifest.rs
@@ -33,6 +33,7 @@ pub(crate) fn build(
     saved: &[SavedImage],
     usage: Usage,
     cost_usd: Option<f64>,
+    content_credentials: Option<&str>,
     warnings: &[String],
     created_at: &str,
     revised_prompt: Option<&str>,
@@ -57,6 +58,15 @@ pub(crate) fn build(
         "images": saved.iter().map(image_entry).collect::<Vec<_>>(),
         "usage": usage.to_json(),
         "cost_usd": cost_usd,
+        "content_credentials": content_credentials,
+        // Provider-DECLARED watermarking (catalog fact, never byte-verified:
+        // SynthID detection is Google-hosted only). OpenAI + Google both
+        // declare SynthID on image outputs as of mid-2026.
+        "watermark_declared": match args.provider {
+            super::types::Provider::Openai | super::types::Provider::Gemini =>
+                Some("synthid (provider-declared · not byte-verified)"),
+            _ => None,
+        },
         "warnings": warnings,
         "metadata": args.metadata,
     })
@@ -206,6 +216,7 @@ mod tests {
                 thoughts_tokens: None,
             },
             Some(0.02),
+            None,
             &["seed_best_effort: x".to_owned()],
             "2026-07-05T12:00:00Z",
             None,
@@ -247,6 +258,7 @@ mod tests {
             &[],
             Usage::default(),
             None,
+            None,
             &[],
             "t",
             None,
@@ -257,6 +269,7 @@ mod tests {
             &args,
             &[],
             Usage::default(),
+            None,
             None,
             &[],
             "t",
@@ -271,6 +284,7 @@ mod tests {
             &other,
             &[],
             Usage::default(),
+            None,
             None,
             &[],
             "t",
@@ -307,6 +321,7 @@ mod tests {
             &args,
             &saved,
             Usage::default(),
+            None,
             None,
             &[],
             "t",

--- a/crates/nika-builtin/src/image/mod.rs
+++ b/crates/nika-builtin/src/image/mod.rs
@@ -30,6 +30,7 @@
 //! a credential (the `Secret` type is zeroizing + Debug-redacted).
 
 pub(crate) mod args;
+pub(crate) mod credentials;
 pub(crate) mod embed;
 pub(crate) mod gemini;
 pub(crate) mod local;
@@ -198,7 +199,7 @@ where
     // ── decode validation (header-only · magic authority) ───────────────
     let mut decoded = validate_decoded(images, &args, emitter, &mut warnings)?;
 
-    embed_provenance_into_pngs(&mut decoded, &args);
+    let content_credentials = detect_and_preserve_credentials(&mut decoded, &args, emitter);
 
     // ── save (boundary-gated · atomic · cleanup on partial failure) ─────
     let saved = save::save_all(fs, boundary, &args, decoded).await?;
@@ -222,6 +223,7 @@ where
         &saved,
         usage,
         cost_usd,
+        content_credentials,
         &warnings,
         &created_at,
         revised_prompt.as_deref(),
@@ -238,6 +240,7 @@ where
         &saved,
         usage,
         cost_usd,
+        content_credentials,
         &warnings,
         &created_at,
         revised_prompt.as_deref(),
@@ -287,6 +290,7 @@ async fn write_manifest<F, Em>(
     saved: &[SavedImage],
     usage: types::Usage,
     cost_usd: Option<f64>,
+    content_credentials: Option<&str>,
     warnings: &[String],
     created_at: &str,
     revised_prompt: Option<&str>,
@@ -306,6 +310,7 @@ where
         saved,
         usage,
         cost_usd,
+        content_credentials,
         warnings,
         created_at,
         revised_prompt,
@@ -325,16 +330,39 @@ where
 /// `ComfyUI`/`InvokeAI` interchange practice — no workflow engine does
 /// it). Embedded BEFORE hashing/saving so the filename sha and manifest
 /// sha cover the byte that lands on disk.
-fn embed_provenance_into_pngs(
+/// Detect upstream content credentials, then embed the `nika` tEXt chunk
+/// ONLY into unsigned PNG payloads — C2PA hard bindings hash the file's
+/// byte ranges, so inserting our chunk into a signed render would
+/// INVALIDATE the generator's own credentials (detect-and-PRESERVE ·
+/// their signed manifest outranks our informal chunk). Returns the batch
+/// label for output/manifest (`"c2pa"` when ANY image carried a signal).
+fn detect_and_preserve_credentials<Em: Emitter>(
     decoded: &mut [(types::RawImage, sniff::Sniffed, Vec<String>)],
     args: &ImageArgs,
-) {
-    for (image, sniffed, _) in decoded {
-        if sniffed.format == types::ImageFormat::Png {
-            let seed = image.seed;
-            image.bytes = embed::embed_provenance(std::mem::take(&mut image.bytes), args, seed);
+    emitter: &Em,
+) -> Option<&'static str> {
+    let mut batch_signal = None;
+    for (image, sniffed, image_warnings) in decoded {
+        match credentials::detect(&image.bytes) {
+            Some(signal) => {
+                batch_signal = Some(signal.label());
+                image_warnings.push(format!(
+                    "content_credentials_preserved: upstream {} manifest detected — the `nika` tEXt chunk was NOT embedded (it would invalidate the signature)",
+                    signal.label()
+                ));
+                emitter.emit(
+                    "image_generation.credentials_detected",
+                    serde_json::json!({ "standard": signal.label() }),
+                );
+            }
+            None if sniffed.format == types::ImageFormat::Png => {
+                let seed = image.seed;
+                image.bytes = embed::embed_provenance(std::mem::take(&mut image.bytes), args, seed);
+            }
+            None => {}
         }
     }
+    batch_signal
 }
 
 /// A provider returning fewer images than `n:` is a WARNED degradation,
@@ -509,6 +537,7 @@ fn output_json(
     saved: &[SavedImage],
     usage: types::Usage,
     cost_usd: Option<f64>,
+    content_credentials: Option<&str>,
     warnings: &[String],
     created_at: &str,
     revised_prompt: Option<&str>,
@@ -552,6 +581,7 @@ fn output_json(
         "images": images,
         "usage": usage.to_json(),
         "cost_usd": cost_usd,
+        "content_credentials": content_credentials,
         "warnings": warnings,
         "manifest_path": manifest_path,
         "output_dir": args.output_dir,

--- a/crates/nika-builtin/src/tts/mod.rs
+++ b/crates/nika-builtin/src/tts/mod.rs
@@ -163,6 +163,7 @@ where
 
     // Magic-byte authority: the payload names its own container.
     let sniffed = sniff::sniff(&bytes)?;
+    let content_credentials = detect_audio_credentials(&bytes, emitter);
     if let Some(asked) = args.format
         && asked != sniffed.format
         && !warnings.iter().any(|w| w.starts_with("format_mismatch:"))
@@ -184,7 +185,7 @@ where
 
     let created_at = rfc3339_now(clock);
     let manifest_path = if args.manifest {
-        let manifest = manifest_json(
+        let mut manifest = manifest_json(
             &args,
             &saved,
             cost_usd,
@@ -192,13 +193,16 @@ where
             &created_at,
             endpoint_host.as_deref(),
         );
+        if let serde_json::Value::Object(map) = &mut manifest {
+            map.insert("content_credentials".into(), content_credentials.into());
+        }
         Some(write_manifest(fs, boundary, &args, &saved, &manifest, emitter).await?)
     } else {
         None
     };
 
     emit_closing_events(emitter, clock, started, &saved, cost_usd, &warnings);
-    Ok(output_json(
+    let mut output = output_json(
         &args,
         &saved,
         cost_usd,
@@ -206,7 +210,26 @@ where
         &created_at,
         endpoint_host.as_deref(),
         manifest_path.as_deref(),
-    ))
+    );
+    if let serde_json::Value::Object(map) = &mut output {
+        map.insert("content_credentials".into(), content_credentials.into());
+    }
+    Ok(output)
+}
+
+/// Content credentials: Google's Lyria and the `ElevenLabs` stack already
+/// ship C2PA in audio bytes — detect and surface (presence, never
+/// « verified »; audio has no nika embed, so nothing to stand down).
+fn detect_audio_credentials<Em: Emitter>(bytes: &[u8], emitter: &Em) -> Option<&'static str> {
+    let label = super::image::credentials::detect_audio(bytes)
+        .map(super::image::credentials::CredentialSignal::label);
+    if let Some(standard) = label {
+        emitter.emit(
+            "tts_generation.credentials_detected",
+            serde_json::json!({ "standard": standard }),
+        );
+    }
+    label
 }
 
 /// The batch's closing telemetry — every warning as its own event, then

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -435,6 +435,24 @@ the const-endpoint design closed. The provenance manifest and output
 carry `endpoint_host` (which server actually rendered the asset — load-
 bearing for `local`, where the endpoint is configurable).
 
+**Content credentials: detect-and-PRESERVE (normative)** · upstream
+generators sign their returned bytes (OpenAI images and Google's media
+models emit C2PA manifests as of mid-2026 · carriage: PNG `caBX` chunk ·
+JPEG APP11 JUMBF · `WebP`/WAV RIFF `C2PA` · MP3 `ID3v2` GEOB
+`application/c2pa`), and C2PA hard bindings hash the asset's byte
+ranges — **any engine-side insert into a signed payload converts valid
+credentials into « present but tampered », which is worse than
+stripping them**. Engines MUST detect these signals before any in-file
+write, MUST stand their own embed down when credentials are present,
+and SHOULD surface presence as `content_credentials` in output +
+manifest (values are DETECTION labels — an engine that has not
+cryptographically validated the manifest must never say « verified »).
+Provider-declared watermarking (e.g. `SynthID` — detectable only by the
+vendor) MAY be surfaced as a `watermark_declared` manifest fact, marked
+as declared, never as verified. Preserving machine-readable marks is
+also the EU AI Act Article 50 robustness expectation (in force
+2026-08-02).
+
 **Provenance travels IN the file (PNG)** · engines SHOULD embed the
 deterministic provenance core (tool · engine version · provider · model ·
 clamped prompt · seed — no timestamp, so byte-determinism holds) as a


### PR DESCRIPTION
**The 2040 provenance thesis, v1 — and a real bug fix** (spec supernovae-st/nika-spec#15): OpenAI images + Google media models **sign their API bytes with C2PA today** (research primary-source verified · then proven in OUR OWN artifacts: tonight's real gpt-image-2 render carries a `caBX` chunk). C2PA hard bindings hash byte ranges — our in-file tEXt embed was converting their valid credentials into **« present but tampered »**, worse than stripping.

**What ships** (zero deps · exact-signature conservatism · total on adversarial input):
- `credentials.rs`: PNG `caBX` walk · JPEG APP11 JUMBF (`JP`+`jumb`+`c2pa` per C2PA 2.4 carriage) · RIFF `C2PA` (WebP+WAV) · MP3 ID3v2 GEOB `application/c2pa` (the Lyria/ElevenLabs audio carriage).
- **Detect BEFORE embed**: signed payloads keep their signature (our tEXt chunk stands down + loud `content_credentials_preserved:` warning) · unsigned payloads keep in-file provenance (mock regression pinned).
- **Surface**: `content_credentials` in output + manifest + a dedicated event (detection labels — the wire never says « verified »; offline validation = the reserved `nika-media-provenance` crate) · `watermark_declared` (SynthID — provider fact, vendor-only detection).

**E2E at the live wire**: a real openai render came back signed → the embed stood down → `chunks = IHDR·caBX·IDAT·IEND` · manifest carries `content_credentials: c2pa` + the preserved-note. **Nobody in the workflow-engine class even looks at these octets.**

EU AI Act Art. 50 lands **2026-08-02** — preserving machine-readable marks is a compliance surface. 3 298 lib tests · clippy 0 · 8 ratchets · public-api unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)