### PR TITLE
feat(nika-verb-agent): meter tool-reported cost through the loop

### DIFF
--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -433,7 +433,11 @@ where
                     }
                 };
                 let tokens = Some(i64::try_from(out.total_tokens).unwrap_or(i64::MAX));
-                Dispatched::ok(note, value, tokens)
+                // The loop's TOOL spend (exact · tool-reported) rides the
+                // ledger — an agent-driven $0.02 render must never show as
+                // $0.00. The LLM turns' own cost stays the documented
+                // follow-up seam (the loop keeps no input/output split).
+                Dispatched::ok_metered(note, value, tokens, None, out.tools_cost_usd)
             }
             Err(err) => Dispatched::verb_err("agent · ?".to_owned(), &err),
         }

--- a/crates/nika-verb-agent/public-api.txt
+++ b/crates/nika-verb-agent/public-api.txt
@@ -820,10 +820,12 @@ pub fn nika_verb_agent::AgentInput::as_any(&self) -> &(dyn core::any::Any + 'sta
 #[non_exhaustive] pub struct nika_verb_agent::AgentOutput
 pub nika_verb_agent::AgentOutput::output: nika_verb_agent::AgentValue
 pub nika_verb_agent::AgentOutput::stop_reason: nika_kernel_runtime::agent::AgentStopReason
+pub nika_verb_agent::AgentOutput::tools_cost_usd: core::option::Option<f64>
 pub nika_verb_agent::AgentOutput::total_tokens: u64
 pub nika_verb_agent::AgentOutput::turns: u32
 impl nika_verb_agent::AgentOutput
 pub fn nika_verb_agent::AgentOutput::new(output: nika_verb_agent::AgentValue, stop_reason: nika_kernel_runtime::agent::AgentStopReason, turns: u32, total_tokens: u64) -> Self
+pub fn nika_verb_agent::AgentOutput::with_tools_cost_usd(self, cost: core::option::Option<f64>) -> Self
 impl core::fmt::Debug for nika_verb_agent::AgentOutput
 pub fn nika_verb_agent::AgentOutput::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_verb_agent::AgentOutput

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -202,6 +202,12 @@ pub struct AgentOutput {
     pub turns: u32,
     /// Cumulative tokens across all turns (input + output).
     pub total_tokens: u64,
+    /// Real spend reported by the loop's TOOLS (a tool whose structured
+    /// output carries a top-level numeric `cost_usd` — the image builtin
+    /// on tick-billed providers · future paid tools). `None` when no tool
+    /// reported spend — never a fake zero. The LLM turns' own cost is a
+    /// separate (documented) seam.
+    pub tools_cost_usd: Option<f64>,
 }
 
 impl AgentOutput {
@@ -219,7 +225,16 @@ impl AgentOutput {
             stop_reason,
             turns,
             total_tokens,
+            tools_cost_usd: None,
         }
+    }
+
+    /// Attach the loop's accumulated tool spend (builder — `new()` stays
+    /// stable for existing callers).
+    #[must_use]
+    pub fn with_tools_cost_usd(mut self, cost: Option<f64>) -> Self {
+        self.tools_cost_usd = cost;
+        self
     }
 }
 
@@ -346,19 +361,13 @@ where
         input: AgentInput,
         observer: &dyn AgentObserver,
     ) -> Result<AgentOutput, VerbAgentError> {
-        validate_params(&input)?;
-        let whitelist = Whitelist::new(&input.tools);
-        let defs = self.whitelisted_defs(&whitelist).await?;
-        let model = input
-            .model
-            .clone()
-            .unwrap_or_else(|| self.default_model.clone());
-        let max_turns = input.max_turns.unwrap_or(DEFAULT_MAX_TURNS);
+        let (whitelist, defs, model, max_turns) = self.arm_run(&input).await?;
         let (mut router, mut guard) = self.arm_loop(observer, &model, &defs);
 
         let mut messages = opening_messages(&input);
         let mut turns: u32 = 0;
         let mut total_tokens: u64 = 0;
+        let mut tools_cost_usd = 0.0_f64;
         let mut last_text = String::new();
         let mut last_observations = String::new();
 
@@ -417,7 +426,7 @@ where
                     .await?
                 }
                 TurnVerdict::Dispatch(tool_uses) => {
-                    last_observations = self
+                    let (digest, batch_cost) = self
                         .dispatch_and_feed(
                             observer,
                             turns,
@@ -430,6 +439,8 @@ where
                             &last_text,
                         )
                         .await?;
+                    tools_cost_usd += batch_cost;
+                    last_observations = digest;
                     continue;
                 }
             };
@@ -437,7 +448,9 @@ where
                 turns,
                 total_tokens,
             });
-            return Ok(output);
+            // The loop's accumulated TOOL spend rides the output — absent
+            // (never zero) when no tool reported real cost.
+            return Ok(output.with_tools_cost_usd((tools_cost_usd > 0.0).then_some(tools_cost_usd)));
         }
     }
 
@@ -459,7 +472,7 @@ where
         guard: &mut Guard,
         messages: &mut Vec<Message>,
         last_text: &str,
-    ) -> Result<String, VerbAgentError> {
+    ) -> Result<(String, f64), VerbAgentError> {
         if turns >= max_turns {
             return Err(VerbAgentError::MaxTurns {
                 turns,
@@ -475,6 +488,24 @@ where
                 repeats,
                 partial_output: last_text.to_owned(),
             })
+    }
+
+    /// Validate + resolve one run's fixed parameters (params · whitelist ·
+    /// tool universe · model · turn budget) — the preamble `run_observed`
+    /// executes before the loop arms.
+    async fn arm_run(
+        &self,
+        input: &AgentInput,
+    ) -> Result<(Whitelist, Vec<ToolDef>, String, u32), VerbAgentError> {
+        validate_params(input)?;
+        let whitelist = Whitelist::new(&input.tools);
+        let defs = self.whitelisted_defs(&whitelist).await?;
+        let model = input
+            .model
+            .clone()
+            .unwrap_or_else(|| self.default_model.clone());
+        let max_turns = input.max_turns.unwrap_or(DEFAULT_MAX_TURNS);
+        Ok((whitelist, defs, model, max_turns))
     }
 
     /// Arm the intelligence layer for one run: build the router + the
@@ -634,7 +665,7 @@ where
         router: &mut ToolRouter,
         guard: &mut Guard,
         messages: &mut Vec<Message>,
-    ) -> Result<String, (u32, u32)> {
+    ) -> Result<(String, f64), (u32, u32)> {
         let batch = self.run_batch(observer, turn, tool_uses, router).await;
         // Consult the guard BEFORE pushing, so a nudge rides INSIDE the
         // same user message as the tool results — never a second adjacent
@@ -665,7 +696,7 @@ where
             }
         }
         messages.push(Message::new(Role::User, content));
-        Ok(batch.observations_digest)
+        Ok((batch.observations_digest, batch.tools_cost_usd))
     }
 
     /// Dispatch one turn's validated tool batch — CONCURRENTLY, results
@@ -716,7 +747,11 @@ where
         // repair). Tracked separately from the per-block is_error.
         let mut all_dispatch_errors = true;
         let mut had_dispatch = false;
+        let mut tools_cost_usd = 0.0_f64;
         for r in resolved {
+            if let Some(cost) = r.cost_usd {
+                tools_cost_usd += cost;
+            }
             // An intrinsic reports ComposeChecked; a real dispatch reports
             // ToolCompleted. They are NOT both — `nika:compose` is
             // loop-served, never a tool invocation, so it must not surface
@@ -760,6 +795,7 @@ where
         BatchOutcome {
             signature: guard::turn_signature(&sig_calls, &sig_results),
             results,
+            tools_cost_usd,
             observations_digest,
             // No real dispatch this turn (compose-only) ⇒ no error streak.
             all_errors: had_dispatch && all_dispatch_errors,
@@ -779,13 +815,16 @@ where
                 },
                 name: u.name,
                 args: u.args,
+                cost_usd: None,
                 compose: Some(outcome),
             }
         } else {
+            let (block, cost_usd) = self.dispatch(&u.id, &u.name, u.args.clone()).await;
             Resolved {
-                block: self.dispatch(&u.id, &u.name, u.args.clone()).await,
+                block,
                 name: u.name,
                 args: u.args,
+                cost_usd,
                 compose: None,
             }
         }
@@ -852,21 +891,43 @@ where
     /// Dispatch one whitelisted tool call; a failing tool is FED BACK
     /// (`is_error: true`), never fatal (spec §2 · the ONE exception is
     /// the whitelist, handled before dispatch).
-    async fn dispatch(&self, id: &str, name: &str, args: serde_json::Value) -> ContentBlock {
+    async fn dispatch(
+        &self,
+        id: &str,
+        name: &str,
+        args: serde_json::Value,
+    ) -> (ContentBlock, Option<f64>) {
         let mut call = InvokeInput::new(name);
         call.args = args;
         call.call_id = Some(id.to_owned());
         match self.invoke.run(call).await {
-            Ok(output) => ContentBlock::ToolResult {
-                tool_use_id: id.to_owned(),
-                content: output.content,
-                is_error: false,
-            },
-            Err(err) => ContentBlock::ToolResult {
-                tool_use_id: id.to_owned(),
-                content: feedback_text(&err),
-                is_error: true,
-            },
+            Ok(output) => {
+                // The honest-spend channel (the same filter the runtime's
+                // invoke path applies): a top-level finite non-negative
+                // `cost_usd` in the tool's structured output is REAL spend.
+                let cost_usd = output
+                    .structured
+                    .as_ref()
+                    .and_then(|v| v.get("cost_usd"))
+                    .and_then(serde_json::Value::as_f64)
+                    .filter(|c| c.is_finite() && *c >= 0.0);
+                (
+                    ContentBlock::ToolResult {
+                        tool_use_id: id.to_owned(),
+                        content: output.content,
+                        is_error: false,
+                    },
+                    cost_usd,
+                )
+            }
+            Err(err) => (
+                ContentBlock::ToolResult {
+                    tool_use_id: id.to_owned(),
+                    content: feedback_text(&err),
+                    is_error: true,
+                },
+                None,
+            ),
         }
     }
 }
@@ -878,6 +939,9 @@ struct Resolved {
     block: ContentBlock,
     name: String,
     args: serde_json::Value,
+    /// Real spend the tool reported (top-level `cost_usd` in its
+    /// structured output) — summed into the batch.
+    cost_usd: Option<f64>,
     compose: Option<intrinsic::ComposeOutcome>,
 }
 
@@ -885,6 +949,8 @@ struct Resolved {
 struct BatchOutcome {
     /// The tool-result blocks, in dispatch order.
     results: Vec<ContentBlock>,
+    /// Σ of the batch's tool-reported real spend (0.0 = none reported).
+    tools_cost_usd: f64,
     /// Turn signature over actions + observations (see `guard`).
     signature: u64,
     /// A bounded digest of the observations, for the next routing query.

--- a/crates/nika-verb-agent/src/tests.rs
+++ b/crates/nika-verb-agent/src/tests.rs
@@ -168,6 +168,10 @@ async fn agent_feeds_the_content_string_even_when_the_tool_is_structured() {
     input.tools = vec!["nika:glob".to_owned()];
     let out = r.verb.run(input).await.expect("completes");
     assert_eq!(out.output, AgentValue::Text("found two files".to_owned()));
+    assert_eq!(
+        out.tools_cost_usd, None,
+        "no tool reported spend — absent, never a fake zero"
+    );
 
     // The model's fed-back ToolResult block carries the CONTENT string —
     // the rendered text, NOT the structured array.
@@ -181,6 +185,43 @@ async fn agent_feeds_the_content_string_even_when_the_tool_is_structured() {
         )),
         "the LLM reads the content String · never the structured value"
     );
+}
+
+/// The honest-spend channel through the LOOP: a tool whose structured
+/// output carries a top-level `cost_usd` (the image builtin on
+/// tick-billed providers) accumulates into `tools_cost_usd` — an
+/// agent-driven $0.02 render must never surface as $0.00.
+#[tokio::test]
+async fn agent_accumulates_tool_reported_cost() {
+    let r = rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response(
+                "call-1",
+                "nika:image_generate",
+                serde_json::json!({"prompt": "logo", "output_dir": "./out"}),
+            ))
+            .enqueue_response(tool_use_response(
+                "call-2",
+                "nika:image_generate",
+                serde_json::json!({"prompt": "logo v2", "output_dir": "./out"}),
+            ))
+            .enqueue_response(text_response("both rendered")),
+        MockToolExecutor::new()
+            .enqueue_ok(
+                ToolResult::success("call-1", r#"{"images":[]}"#)
+                    .with_structured(serde_json::json!({"images": [], "cost_usd": 0.02})),
+            )
+            .enqueue_ok(
+                ToolResult::success("call-2", r#"{"images":[]}"#)
+                    .with_structured(serde_json::json!({"images": [], "cost_usd": 0.07})),
+            ),
+        vec![def("nika:image_generate")],
+    );
+    let mut input = AgentInput::new("render the logo twice");
+    input.tools = vec!["nika:image_generate".to_owned()];
+    let out = r.verb.run(input).await.expect("completes");
+    let cost = out.tools_cost_usd.expect("spend accumulated");
+    assert!((cost - 0.09).abs() < 1e-9, "0.02 + 0.07 → {cost}");
 }
 
 // ── §6 · nika:done with / without result ───────────────────────────


### PR DESCRIPTION
**Found in user-shoes e2e**: an agent whose tool call rendered a real $0.02 xai image showed `agent · 2 turns · $0.00` — the honest-spend channel stopped at `dispatch_invoke` and never crossed the ReAct loop. The deepest case (the model *deciding* to spend) was the one losing the honesty.

The loop extracts top-level `cost_usd` from each tool's structured output (same filter as the runtime invoke path), sums per batch, rides `AgentOutput.tools_cost_usd` (absent ≠ zero), and the runtime meters it: **`✔ designer · agent · 2 turns · $0.02` proven at the live wire** (real xai render inside a real gemini agent loop). LLM-turn cost stays the documented follow-up seam.

API additive only (`#[non_exhaustive]` field + builder · `new()` untouched · +2 lines). 3 299 lib tests · clippy 0 · 8 ratchets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)