### PR TITLE
fix(nika-builtin): heal the tts↔image drift — the architect review's cheap P-items

### DIFF
--- a/crates/nika-builtin/src/lib.rs
+++ b/crates/nika-builtin/src/lib.rs
@@ -449,12 +449,6 @@ where
         }
     }
 
-    /// Enforce the `permits.fs` boundary for every `access` direction the
-    /// op needs on its `path:` arg, THEN run the builtin. A path that
-    /// resolves outside the boundary fails (`NIKA-SEC-004`) before the op —
-    /// the capability boundary, not the I/O, is the gate. When `path:` is
-    /// absent the op runs (its own arg ladder surfaces the missing-arg
-    /// error · the boundary has nothing to confine).
     /// The `nika:tts_generate` plumbing (kept out of `route`'s match for
     /// the fn-length budget — pure delegation).
     async fn route_tts(&self, args: &Args) -> BuiltinOutcome {
@@ -470,6 +464,12 @@ where
         .await
     }
 
+    /// Enforce the `permits.fs` boundary for every `access` direction the
+    /// op needs on its `path:` arg, THEN run the builtin. A path that
+    /// resolves outside the boundary fails (`NIKA-SEC-004`) before the op —
+    /// the capability boundary, not the I/O, is the gate. When `path:` is
+    /// absent the op runs (its own arg ladder surfaces the missing-arg
+    /// error · the boundary has nothing to confine).
     async fn guarded_fs<'a, Fut>(
         &'a self,
         args: &'a Args,

--- a/crates/nika-builtin/src/tts/args.rs
+++ b/crates/nika-builtin/src/tts/args.rs
@@ -153,9 +153,15 @@ fn parse_timeout(args: &Args, provider: Provider) -> Result<u64, BuiltinFailure>
         None => Ok(default),
         Some(v) => v
             .as_u64()
-            .filter(|ms| (1..=MAX_TIMEOUT_MS).contains(ms))
+            .filter(|ms| (1_000..=MAX_TIMEOUT_MS).contains(ms))
             .ok_or_else(|| {
-                BuiltinFailure::new(C_ARGS, format!("`timeout_ms` must be 1..={MAX_TIMEOUT_MS}"))
+                BuiltinFailure::new(
+                    C_ARGS,
+                    format!(
+                        "`timeout_ms` must be 1000..={MAX_TIMEOUT_MS} — under 1s is a typo'd \
+                         unit (the image family's floor, applied uniformly)"
+                    ),
+                )
             }),
     }
 }
@@ -262,6 +268,10 @@ mod tests {
         assert!(parse(&base(serde_json::json!({ "text": "x".repeat(5000) }))).is_err());
         assert!(parse(&base(serde_json::json!({ "speed": 9.0 }))).is_err());
         assert!(parse(&base(serde_json::json!({ "format": "flac" }))).is_err());
+        assert!(
+            parse(&base(serde_json::json!({ "timeout_ms": 5 }))).is_err(),
+            "sub-second timeouts are typo'd units (image-family floor parity)"
+        );
         let s = parse(&base(serde_json::json!({ "speed": 1.5 }))).expect("speed");
         assert_eq!(s.speed_permille(), 1500);
         assert!((s.speed_f64() - 1.5).abs() < 1e-9);

--- a/crates/nika-builtin/src/tts/elevenlabs.rs
+++ b/crates/nika-builtin/src/tts/elevenlabs.rs
@@ -99,6 +99,13 @@ fn map_transport(error: HttpError) -> BuiltinFailure {
             BuiltinFailure::new(C_REQUEST, format!("elevenlabs connection failed: {reason}"))
                 .with_transient(true)
         }
+        HttpError::TooLarge { size, max } => BuiltinFailure::new(
+            C_REQUEST,
+            format!(
+                "elevenlabs response was {size} bytes (cap {max}) — shorten `text:` or \\
+                 split the script across tasks"
+            ),
+        ),
         other => BuiltinFailure::new(C_REQUEST, format!("elevenlabs request failed: {other}")),
     }
 }

--- a/crates/nika-builtin/src/tts/local.rs
+++ b/crates/nika-builtin/src/tts/local.rs
@@ -97,6 +97,13 @@ fn map_transport(error: HttpError) -> BuiltinFailure {
             ),
         )
         .with_transient(true),
+        HttpError::TooLarge { size, max } => BuiltinFailure::new(
+            C_REQUEST,
+            format!(
+                "local TTS response was {size} bytes (cap {max}) — shorten `text:` or \\
+                 split the script across tasks"
+            ),
+        ),
         other => BuiltinFailure::new(C_REQUEST, format!("local TTS request failed: {other}")),
     }
 }

--- a/crates/nika-builtin/src/tts/mod.rs
+++ b/crates/nika-builtin/src/tts/mod.rs
@@ -292,45 +292,55 @@ fn output_json(
     })
 }
 
+/// The resolved wire for one synthesis call — built by `call_provider`'s
+/// ONE provider match (the mock arm returns from inside it, so no
+/// panic-class `unreachable!` arm exists — the image family's zero-panic
+/// pattern, applied down · architect finding P2.3).
+enum Wire<'k> {
+    Openai(&'k Secret),
+    Elevenlabs(&'k Secret),
+    Local {
+        base_url: String,
+        key: Option<&'k Secret>,
+    },
+}
+
 async fn call_provider<H: HttpPostDyn>(
     http: Option<&H>,
     keys: &TtsKeys,
     args: &TtsArgs,
 ) -> Result<ProviderAudio, BuiltinFailure> {
-    if args.provider == Provider::Mock {
-        return Ok(mock::generate(args));
-    }
+    let wire = match args.provider {
+        Provider::Mock => return Ok(mock::generate(args)),
+        Provider::Openai => Wire::Openai(
+            keys.openai
+                .as_ref()
+                .ok_or_else(|| missing_key("openai", "NIKA_OPENAI_API_KEY or OPENAI_API_KEY"))?,
+        ),
+        Provider::Elevenlabs => Wire::Elevenlabs(keys.elevenlabs.as_ref().ok_or_else(|| {
+            missing_key(
+                "elevenlabs",
+                "NIKA_ELEVENLABS_API_KEY or ELEVENLABS_API_KEY",
+            )
+        })?),
+        Provider::Local => Wire::Local {
+            base_url: keys
+                .local_base_url
+                .clone()
+                .unwrap_or_else(|| local::DEFAULT_BASE_URL.to_owned()),
+            key: keys.local_api_key.as_ref(),
+        },
+    };
     let http = http.ok_or_else(|| {
         BuiltinFailure::new(
             C_PROVIDER_UNAVAILABLE,
             "the TTS plane is not wired — the composition root did not inject an HTTP client",
         )
     })?;
-    match args.provider {
-        Provider::Openai => {
-            let key = keys
-                .openai
-                .as_ref()
-                .ok_or_else(|| missing_key("openai", "NIKA_OPENAI_API_KEY or OPENAI_API_KEY"))?;
-            openai::generate(http, key, args).await
-        }
-        Provider::Elevenlabs => {
-            let key = keys.elevenlabs.as_ref().ok_or_else(|| {
-                missing_key(
-                    "elevenlabs",
-                    "NIKA_ELEVENLABS_API_KEY or ELEVENLABS_API_KEY",
-                )
-            })?;
-            elevenlabs::generate(http, key, args).await
-        }
-        Provider::Local => {
-            let base = keys
-                .local_base_url
-                .clone()
-                .unwrap_or_else(|| local::DEFAULT_BASE_URL.to_owned());
-            local::generate(http, &base, keys.local_api_key.as_ref(), args).await
-        }
-        Provider::Mock => unreachable!("handled above"),
+    match wire {
+        Wire::Openai(key) => openai::generate(http, key, args).await,
+        Wire::Elevenlabs(key) => elevenlabs::generate(http, key, args).await,
+        Wire::Local { base_url, key } => local::generate(http, &base_url, key, args).await,
     }
 }
 

--- a/crates/nika-builtin/src/tts/openai.rs
+++ b/crates/nika-builtin/src/tts/openai.rs
@@ -79,6 +79,13 @@ fn map_transport(error: HttpError) -> BuiltinFailure {
             BuiltinFailure::new(C_REQUEST, format!("openai connection failed: {reason}"))
                 .with_transient(true)
         }
+        HttpError::TooLarge { size, max } => BuiltinFailure::new(
+            C_REQUEST,
+            format!(
+                "openai speech response was {size} bytes (cap {max}) — shorten `text:` or \\
+                 split the script across tasks"
+            ),
+        ),
         other => BuiltinFailure::new(C_REQUEST, format!("openai request failed: {other}")),
     }
 }


### PR DESCRIPTION
A rust-architect pass over the 48h-old media subsystem found the « copy for 2 instances » premise already broken (tts imports from image ×4) and drifted where it did copy. This PR heals the behavior-visible items: `timeout_ms` floor 1→1000ms (a 5ms timeout was accepted) · the tts `Wire` enum kills the `Provider::Mock => unreachable!` panic-class arm the image family engineered away the same week · `TooLarge` transport arms ×3 · `guarded_fs` doc restored. The structural items (media/ core · type-states · plane consolidation · ToolUsageMeta) are a reviewed 4-PR sequence in the private strategy doc. 233 builtin tests · clippy 0 · ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)