### PR TITLE
chore(lints): deny iter_over_hash_type — determinism as a ratchet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,11 @@ panic          = "deny"
 todo           = "warn"
 unimplemented  = "warn"
 dbg_macro      = "deny"
+# Iterating a HashMap/HashSet is ordering-nondeterminism by construction —
+# poison for an engine whose outputs, manifests and goldens must be
+# byte-stable. BTree/sorted structures everywhere (measured: 0 violations
+# across 40 crates when adopted · the ruff workspace carries the same lint).
+iter_over_hash_type = "deny"
 print_stdout   = "warn"
 print_stderr   = "warn"
 # Per-function 100-LOC soft cap (ADR-023). Function modularity discipline.


### PR DESCRIPTION
From the SOTA survey (ruff's workspace carries it — « the gem for an engine »): HashMap/HashSet iteration is ordering-nondeterminism by construction, poison for byte-stable outputs, manifests and goldens. **Measured before adopting: 0 violations across the 40-crate workspace** — the BTree discipline was already real, so the deny costs nothing and prevents the class forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)