### PR TITLE
refactor(nika-builtin): seed the media/ core — first two re-homings

### DIFF
--- a/crates/nika-builtin/src/image/embed.rs
+++ b/crates/nika-builtin/src/image/embed.rs
@@ -55,7 +55,7 @@ fn push_text_chunk(out: &mut Vec<u8>, data: &[u8]) {
     out.extend_from_slice(data);
     let mut crc_input = b"tEXt".to_vec();
     crc_input.extend_from_slice(data);
-    out.extend_from_slice(&super::mock::crc32(&crc_input).to_be_bytes());
+    out.extend_from_slice(&crate::media::png::crc32(&crc_input).to_be_bytes());
 }
 
 /// The deterministic provenance core as pure-ASCII JSON (`\uXXXX`-escaped

--- a/crates/nika-builtin/src/image/mock.rs
+++ b/crates/nika-builtin/src/image/mock.rs
@@ -15,6 +15,8 @@ use crate::BuiltinFailure;
 use super::args::ImageArgs;
 use super::types::{C_ARGS, ImageFormat, ProviderBatch, RawImage, SizeSpec, Usage};
 
+use crate::media::png::crc32;
+
 /// Mock renders uncompressed rows (stored deflate) — cap the edge so one
 /// mock image stays well under the per-image byte ceiling.
 const MOCK_MAX_EDGE: u32 = 2_048;
@@ -183,22 +185,6 @@ fn zlib_stored(raw: &[u8]) -> Vec<u8> {
     }
     out.extend_from_slice(&adler32(raw).to_be_bytes());
     out
-}
-
-/// PNG CRC-32 (ISO 3309 · reflected 0xEDB88320) — bitwise, table-free.
-pub(crate) fn crc32(data: &[u8]) -> u32 {
-    let mut crc = 0xffff_ffffu32;
-    for &byte in data {
-        crc ^= u32::from(byte);
-        for _ in 0..8 {
-            crc = if crc & 1 == 1 {
-                (crc >> 1) ^ 0xedb8_8320
-            } else {
-                crc >> 1
-            };
-        }
-    }
-    !crc
 }
 
 /// zlib Adler-32 over the UNCOMPRESSED stream.

--- a/crates/nika-builtin/src/image/mod.rs
+++ b/crates/nika-builtin/src/image/mod.rs
@@ -47,6 +47,7 @@ use nika_kernel::io::fs::{FsReadDyn, FsWriteDyn};
 use nika_kernel::io::http::HttpPostDyn;
 use nika_kernel::secret::Secret;
 
+use crate::media::time::rfc3339_now;
 use crate::permits::FsBoundary;
 use crate::{Args, BuiltinFailure, BuiltinOutcome, Emitter};
 
@@ -519,13 +520,6 @@ where
         }),
     );
     Ok(batch)
-}
-
-/// RFC 3339 wall-clock timestamp through the injected clock seam (test
-/// hermeticity — invariant #27).
-fn rfc3339_now<C: ClockDyn>(clock: &C) -> String {
-    jiff::Timestamp::try_from(clock.system_now())
-        .map_or_else(|_| "1970-01-01T00:00:00Z".to_owned(), |ts| ts.to_string())
 }
 
 /// Assemble the normalized output object — paths + hashes + usage, never

--- a/crates/nika-builtin/src/lib.rs
+++ b/crates/nika-builtin/src/lib.rs
@@ -34,6 +34,7 @@ pub mod defs;
 pub mod file;
 pub mod image;
 pub mod inspect;
+pub(crate) mod media;
 pub mod net;
 pub mod permits;
 pub mod tts;

--- a/crates/nika-builtin/src/media/mod.rs
+++ b/crates/nika-builtin/src/media/mod.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The shared media core — vocabulary and scaffold the media-class
+//! builtin families (`image/` · `tts/` · future `video/`) draw from.
+//!
+//! Seeded per the 2026-07-06 architecture review (P1.1): the second
+//! family already IMPORTED from the first instead of copying, so the
+//! shared core exists either way — this module gives it a home with the
+//! dependency direction pointing the right way (families depend on
+//! `media`, never on each other). Sub-module boundaries align with the
+//! reserved `nika-media-*` crate split, so graduation is a `git mv`.
+//!
+//! Grows by RE-HOMING only (behavior-free moves pinned by the mock's
+//! byte-stable goldens) — never by speculation.
+
+pub(crate) mod png;
+pub(crate) mod time;

--- a/crates/nika-builtin/src/media/png.rs
+++ b/crates/nika-builtin/src/media/png.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! PNG byte-level primitives shared by the mock renderer and the
+//! provenance embedder — integrity math homed HERE so production code
+//! never depends on a mock module (review P3.1).
+
+/// CRC-32 (ISO 3309 · the PNG chunk checksum) — table-free bitwise form,
+/// plenty for the small chunks we seal (tEXt provenance · mock IHDR/IDAT).
+pub(crate) fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffffu32;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            crc = if crc & 1 == 1 {
+                (crc >> 1) ^ 0xedb8_8320
+            } else {
+                crc >> 1
+            };
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc32_matches_the_png_test_vectors() {
+        // The canonical check value for "123456789" (ISO 3309 / PNG).
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32(b""), 0);
+        assert_eq!(
+            crc32(b"IEND"),
+            0xAE42_6082,
+            "the constant every PNG ends with"
+        );
+    }
+}

--- a/crates/nika-builtin/src/media/time.rs
+++ b/crates/nika-builtin/src/media/time.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Manifest timestamps — one clock-to-RFC3339 seam for every media
+//! family (was duplicated verbatim in `image/` and `tts/` · review P3.5).
+
+use nika_kernel::io::clock::ClockDyn;
+
+/// The manifest `created_at` — RFC 3339 UTC from the injected clock
+/// (total: a pre-epoch or unrepresentable clock falls back loudly to
+/// the epoch string rather than panicking).
+pub(crate) fn rfc3339_now<C: ClockDyn>(clock: &C) -> String {
+    jiff::Timestamp::try_from(clock.system_now())
+        .map_or_else(|_| "1970-01-01T00:00:00Z".to_owned(), |ts| ts.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_kernel_mock::MockClock;
+
+    use super::*;
+
+    #[test]
+    fn rfc3339_shape_holds() {
+        let stamp = rfc3339_now(&MockClock::default());
+        assert!(stamp.ends_with('Z') && stamp.contains('T'), "{stamp}");
+    }
+}

--- a/crates/nika-builtin/src/tts/mod.rs
+++ b/crates/nika-builtin/src/tts/mod.rs
@@ -31,6 +31,7 @@ use nika_kernel::io::fs::{FsReadDyn, FsWriteDyn};
 use nika_kernel::io::http::HttpPostDyn;
 use nika_kernel::secret::Secret;
 
+use crate::media::time::rfc3339_now;
 use crate::permits::{FsAccess, FsBoundary};
 use crate::{Args, BuiltinFailure, BuiltinOutcome, Emitter};
 
@@ -477,11 +478,6 @@ async fn write_manifest<F: FsReadDyn + FsWriteDyn, Em: Emitter>(
         serde_json::json!({ "path": path_str }),
     );
     Ok(path_str)
-}
-
-fn rfc3339_now<C: ClockDyn>(clock: &C) -> String {
-    jiff::Timestamp::try_from(clock.system_now())
-        .map_or_else(|_| "1970-01-01T00:00:00Z".to_owned(), |ts| ts.to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Sequence ① of the architecture review begins with the two cheapest residents, both pure moves pinned by the mock's byte-stable goldens: **`media/time.rs`** (`rfc3339_now`, duplicated verbatim in image/+tts/ — P3.5) and **`media/png.rs`** (`crc32` — production provenance sealing imported it from the MOCK module, P3.1's inverted dependency; PNG test vectors pinned). The module doc states the growth rule: re-homing only, never speculation; sub-module boundaries align with the reserved `nika-media-*` crate split. 235 builtin tests · clippy 0 · ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)