### PR TITLE
feat(check): findings carry severity + docs_url — the --explain wire

### DIFF
--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -84,6 +84,8 @@ fn render(report: &CheckReport, wf: &RawWorkflow, path: &str, t: Theme) -> Strin
             c.code,
             c.message
         );
+        // The rustc `--explain` move: every code links its own page.
+        let _ = writeln!(out, "   {}", t.paint(Role::Dim, &c.docs_url));
     }
 
     plan(&mut out, report, t);

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -275,6 +275,27 @@ fn check_json_is_the_report_plus_clean_flag_never_coloured() {
 }
 
 #[test]
+fn check_json_conformance_carries_severity_and_docs_url() {
+    // The agent-loop wire: every conformance finding stamps its own
+    // severity + per-code docs page (the rustc --explain move, machine
+    // form). Consumers link the code without re-deriving anything.
+    let broken = WORKFLOW.replace("depends_on: [gather, probe]", "depends_on: [ghost]");
+    let path = fixture_path("check-severity.nika.yaml", &broken);
+    let out = check::run(&path, true, PLAIN);
+    let doc: serde_json::Value = serde_json::from_str(&out.text).expect("valid JSON");
+    let c = &doc["conformance"][0];
+    assert_eq!(c["severity"], "error");
+    let url = c["docs_url"].as_str().expect("docs_url string");
+    assert_eq!(
+        url,
+        format!(
+            "https://nika.sh/errors/{}",
+            c["code"].as_str().expect("code")
+        )
+    );
+}
+
+#[test]
 fn check_parse_error_is_a_file_finding_exit_2() {
     let path = fixture_path("check-parse.nika.yaml", "nika: v1\nworkflow: [broken");
     let out = check::run(&path, false, PLAIN);

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -47,6 +47,56 @@ impl<T> nika_error::traits::AsAny for nika_schema::analyzer::AnalyzedWorkflow wh
 pub fn nika_schema::analyzer::AnalyzedWorkflow::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub fn nika_schema::analyzer::analyze(wf: &nika_schema::raw::workflow::RawWorkflow) -> core::result::Result<nika_schema::analyzer::AnalyzedWorkflow, alloc::vec::Vec<nika_schema::error::SchemaError>>
 pub mod nika_schema::check
+#[non_exhaustive] pub enum nika_schema::check::FindingSeverity
+pub nika_schema::check::FindingSeverity::Error
+pub nika_schema::check::FindingSeverity::Info
+pub nika_schema::check::FindingSeverity::Warning
+impl core::clone::Clone for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::clone(&self) -> nika_schema::check::FindingSeverity
+impl core::cmp::Eq for nika_schema::check::FindingSeverity
+impl core::cmp::PartialEq for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::eq(&self, other: &nika_schema::check::FindingSeverity) -> bool
+impl core::fmt::Debug for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_schema::check::FindingSeverity
+impl core::marker::StructuralPartialEq for nika_schema::check::FindingSeverity
+impl serde_core::ser::Serialize for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::FindingSeverity
+impl<Q, K> equivalent::Equivalent<K> for nika_schema::check::FindingSeverity where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::FindingSeverity where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::FindingSeverity where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::equivalent(&self, key: &K) -> bool
+pub fn nika_schema::check::FindingSeverity::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_schema::check::FindingSeverity where U: core::convert::From<T>
+pub fn nika_schema::check::FindingSeverity::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::FindingSeverity where U: core::convert::Into<T>
+pub type nika_schema::check::FindingSeverity::Error = core::convert::Infallible
+pub fn nika_schema::check::FindingSeverity::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::FindingSeverity where U: core::convert::TryFrom<T>
+pub type nika_schema::check::FindingSeverity::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::FindingSeverity::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::FindingSeverity where T: core::clone::Clone
+pub type nika_schema::check::FindingSeverity::Owned = T
+pub fn nika_schema::check::FindingSeverity::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::FindingSeverity::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::FindingSeverity where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::FindingSeverity where T: ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::FindingSeverity where T: ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::FindingSeverity where T: core::clone::Clone
+pub unsafe fn nika_schema::check::FindingSeverity::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::FindingSeverity where T: core::clone::Clone
+pub fn nika_schema::check::FindingSeverity::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::FindingSeverity where T: 'static
+pub fn nika_schema::check::FindingSeverity::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_schema::check::FindingSeverity where T: core::marker::Copy
+pub fn nika_schema::check::FindingSeverity::as_out(&mut self) -> outref::Out<'_, T>
 #[non_exhaustive] pub enum nika_schema::check::GateFindingKind
 pub nika_schema::check::GateFindingKind::BadStatusLiteral
 pub nika_schema::check::GateFindingKind::DeadTask
@@ -396,7 +446,9 @@ impl<T> nika_error::traits::AsAny for nika_schema::check::CheckReport where T: '
 pub fn nika_schema::check::CheckReport::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::check::ConformanceViolation
 pub nika_schema::check::ConformanceViolation::code: alloc::string::String
+pub nika_schema::check::ConformanceViolation::docs_url: alloc::string::String
 pub nika_schema::check::ConformanceViolation::message: alloc::string::String
+pub nika_schema::check::ConformanceViolation::severity: nika_schema::check::FindingSeverity
 pub nika_schema::check::ConformanceViolation::span: core::option::Option<nika_schema::check::ByteSpan>
 impl core::clone::Clone for nika_schema::check::ConformanceViolation
 pub fn nika_schema::check::ConformanceViolation::clone(&self) -> nika_schema::check::ConformanceViolation
@@ -1207,6 +1259,7 @@ impl<T> dyn_clone::DynClone for nika_schema::UnknownTool where T: core::clone::C
 pub fn nika_schema::UnknownTool::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_schema::UnknownTool where T: 'static
 pub fn nika_schema::UnknownTool::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_schema::check::ERROR_DOCS_BASE: &str
 pub const nika_schema::check::REPORT_VERSION: u32
 pub const nika_schema::check::STATUS_VOCAB: [&str; 4]
 pub fn nika_schema::check::check(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::check::CheckReport
@@ -5363,6 +5416,56 @@ pub fn nika_schema::types::extract::ExtractMode::as_any(&self) -> &(dyn core::an
 impl<T> outref::AsOut<T> for nika_schema::types::extract::ExtractMode where T: core::marker::Copy
 pub fn nika_schema::types::extract::ExtractMode::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> serde_core::de::DeserializeOwned for nika_schema::types::extract::ExtractMode where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub enum nika_schema::FindingSeverity
+pub nika_schema::FindingSeverity::Error
+pub nika_schema::FindingSeverity::Info
+pub nika_schema::FindingSeverity::Warning
+impl core::clone::Clone for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::clone(&self) -> nika_schema::check::FindingSeverity
+impl core::cmp::Eq for nika_schema::check::FindingSeverity
+impl core::cmp::PartialEq for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::eq(&self, other: &nika_schema::check::FindingSeverity) -> bool
+impl core::fmt::Debug for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_schema::check::FindingSeverity
+impl core::marker::StructuralPartialEq for nika_schema::check::FindingSeverity
+impl serde_core::ser::Serialize for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::FindingSeverity
+impl<Q, K> equivalent::Equivalent<K> for nika_schema::check::FindingSeverity where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::FindingSeverity where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::FindingSeverity where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::equivalent(&self, key: &K) -> bool
+pub fn nika_schema::check::FindingSeverity::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_schema::check::FindingSeverity where U: core::convert::From<T>
+pub fn nika_schema::check::FindingSeverity::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::FindingSeverity where U: core::convert::Into<T>
+pub type nika_schema::check::FindingSeverity::Error = core::convert::Infallible
+pub fn nika_schema::check::FindingSeverity::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::FindingSeverity where U: core::convert::TryFrom<T>
+pub type nika_schema::check::FindingSeverity::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::FindingSeverity::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::FindingSeverity where T: core::clone::Clone
+pub type nika_schema::check::FindingSeverity::Owned = T
+pub fn nika_schema::check::FindingSeverity::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::FindingSeverity::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::FindingSeverity where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::FindingSeverity where T: ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::FindingSeverity where T: ?core::marker::Sized
+pub fn nika_schema::check::FindingSeverity::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::FindingSeverity where T: core::clone::Clone
+pub unsafe fn nika_schema::check::FindingSeverity::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::FindingSeverity
+pub fn nika_schema::check::FindingSeverity::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::FindingSeverity where T: core::clone::Clone
+pub fn nika_schema::check::FindingSeverity::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::FindingSeverity where T: 'static
+pub fn nika_schema::check::FindingSeverity::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_schema::check::FindingSeverity where T: core::marker::Copy
+pub fn nika_schema::check::FindingSeverity::as_out(&mut self) -> outref::Out<'_, T>
 #[non_exhaustive] pub enum nika_schema::GateFindingKind
 pub nika_schema::GateFindingKind::BadStatusLiteral
 pub nika_schema::GateFindingKind::DeadTask
@@ -6415,7 +6518,9 @@ impl<T> nika_error::traits::AsAny for nika_schema::check::CheckReport where T: '
 pub fn nika_schema::check::CheckReport::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::ConformanceViolation
 pub nika_schema::ConformanceViolation::code: alloc::string::String
+pub nika_schema::ConformanceViolation::docs_url: alloc::string::String
 pub nika_schema::ConformanceViolation::message: alloc::string::String
+pub nika_schema::ConformanceViolation::severity: nika_schema::check::FindingSeverity
 pub nika_schema::ConformanceViolation::span: core::option::Option<nika_schema::check::ByteSpan>
 impl core::clone::Clone for nika_schema::check::ConformanceViolation
 pub fn nika_schema::check::ConformanceViolation::clone(&self) -> nika_schema::check::ConformanceViolation
@@ -7424,6 +7529,7 @@ impl<T> dyn_clone::DynClone for nika_schema::UnknownTool where T: core::clone::C
 pub fn nika_schema::UnknownTool::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_schema::UnknownTool where T: 'static
 pub fn nika_schema::UnknownTool::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_schema::ERROR_DOCS_BASE: &str
 pub const nika_schema::REPORT_VERSION: u32
 pub const nika_schema::STATUS_VOCAB: [&str; 4]
 pub fn nika_schema::analyze(wf: &nika_schema::raw::workflow::RawWorkflow) -> core::result::Result<nika_schema::analyzer::AnalyzedWorkflow, alloc::vec::Vec<nika_schema::error::SchemaError>>

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -86,6 +86,29 @@ impl ByteSpan {
     }
 }
 
+/// The base URL of the per-code error pages (`<base>/<CODE>`) — the
+/// human twin of the machine registry served at
+/// `https://nika.sh/errors/catalog.json`. Findings stamp their own
+/// [`ConformanceViolation::docs_url`] from it so consumers never
+/// hardcode the scheme.
+pub const ERROR_DOCS_BASE: &str = "https://nika.sh/errors";
+
+/// A finding's severity, stamped BY the engine (the one truth — no
+/// consumer re-derives it from the code or the family). `lowercase`
+/// on the wire (`"error"`). Additive: `report_version` stays 1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum FindingSeverity {
+    /// The workflow will not run correctly — fails `is_clean`.
+    Error,
+    /// Suspicious but runnable (reserved — no warning-grade
+    /// conformance rule exists today).
+    Warning,
+    /// Advisory (reserved for future finding families).
+    Info,
+}
+
 /// One Core-conformance violation, in report shape (the canonical spec
 /// code + the rendered message, which carries the location and any
 /// did-you-mean repair).
@@ -101,6 +124,15 @@ pub struct ConformanceViolation {
     /// diagnostics for workflow YAML). Additive: `report_version`
     /// stays 1.
     pub span: Option<ByteSpan>,
+    /// Engine-stamped severity — conformance violations are always
+    /// [`FindingSeverity::Error`] (they block the DAG). Additive:
+    /// `report_version` stays 1.
+    pub severity: FindingSeverity,
+    /// The per-code documentation page
+    /// (`https://nika.sh/errors/<CODE>` · [`ERROR_DOCS_BASE`]) —
+    /// editors surface the code as a clickable link. Additive:
+    /// `report_version` stays 1.
+    pub docs_url: String,
 }
 
 /// The static pre-flight report — everything `nika check` learns without
@@ -252,13 +284,19 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         Err(errors) => (
             errors
                 .iter()
-                .map(|e| ConformanceViolation {
-                    code: e.spec_code().to_string(),
-                    message: e.to_string(),
-                    span: e.span().map(|s| ByteSpan {
-                        start: s.start.0,
-                        end: s.end.0,
-                    }),
+                .map(|e| {
+                    let code = e.spec_code().to_string();
+                    let docs_url = format!("{ERROR_DOCS_BASE}/{code}");
+                    ConformanceViolation {
+                        code,
+                        message: e.to_string(),
+                        span: e.span().map(|s| ByteSpan {
+                            start: s.start.0,
+                            end: s.end.0,
+                        }),
+                        severity: FindingSeverity::Error,
+                        docs_url,
+                    }
                 })
                 .collect(),
             Vec::new(),
@@ -322,6 +360,39 @@ mod tests {
     fn check_yaml(yaml: &str) -> CheckReport {
         let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         check(&wf)
+    }
+
+    #[test]
+    fn conformance_violations_carry_severity_and_docs_url() {
+        // An unresolved dependency -> a conformance violation. The finding
+        // must stamp its own severity AND the canonical docs URL so every
+        // consumer (extension diagnostics, agent loops, CI) reads ONE
+        // truth without re-deriving either.
+        let r = check_yaml(
+            "\
+nika: v1
+workflow: t
+tasks:
+  - id: a
+    depends_on: [ghost]
+    exec: { command: \"echo hi\" }
+",
+        );
+        assert!(!r.conformance.is_empty());
+        let v = &r.conformance[0];
+        assert_eq!(v.severity, FindingSeverity::Error);
+        assert_eq!(v.docs_url, format!("{ERROR_DOCS_BASE}/{}", v.code));
+
+        // The wire form: lowercase severity, absolute per-code URL.
+        let json = serde_json::to_value(&r).expect("report serializes");
+        let c = &json["conformance"][0];
+        assert_eq!(c["severity"], "error");
+        assert!(
+            c["docs_url"]
+                .as_str()
+                .expect("docs_url is a string")
+                .starts_with("https://nika.sh/errors/NIKA-"),
+        );
     }
 
     #[test]

--- a/crates/nika-schema/src/lib.rs
+++ b/crates/nika-schema/src/lib.rs
@@ -53,9 +53,9 @@ pub mod types;
 pub use analyzer::{AnalyzedWorkflow, analyze};
 pub use check::{
     Bound, ByteSpan, CapabilityEscape, CertTerm, CheckReport, ConformanceViolation, CostCeiling,
-    GateFinding, GateFindingKind, Hint, InferredPermits, REPORT_VERSION, RunCertificate,
-    STATUS_VOCAB, SchemaLintFinding, SchemaTypeFinding, SecretLeak, TaskCost, UnknownTool, check,
-    infer_permits,
+    ERROR_DOCS_BASE, FindingSeverity, GateFinding, GateFindingKind, Hint, InferredPermits,
+    REPORT_VERSION, RunCertificate, STATUS_VOCAB, SchemaLintFinding, SchemaTypeFinding, SecretLeak,
+    TaskCost, UnknownTool, check, infer_permits,
 };
 pub use codegen::nika_builtin_tool_enum_schema;
 pub use error::{SchemaError, SpecCategory, SpecCode};


### PR DESCRIPTION
## What

Every `ConformanceViolation` in `nika check --json` now stamps:

- **`severity`** — a `FindingSeverity` enum (`error` · `warning` · `info`, lowercase on the wire). Conformance violations are always `error` (they block the DAG); the enum is `#[non_exhaustive]` so future finding families reuse it.
- **`docs_url`** — `https://nika.sh/errors/<CODE>` (`ERROR_DOCS_BASE`), the per-code page of the error register. The rustc `--explain` move, machine form: editors surface the code as a clickable link, agents follow it without re-deriving anything.

The human renderer prints the docs link under each CONFORM line.

**Additive only** — `report_version` stays 1; consumers ignoring unknown fields are unaffected.

## Why

Workflow-intelligence roadmap E4 (the extension currently re-derives severity client-side per code family — one truth should come from the engine). The nika.sh register page (`/errors` + `/errors/:code` deep-links) ships in the website repo in the same arc.

## Tests

- `nika-schema` lib: struct + serde wire shape (lowercase severity · absolute URL)
- `nika-cli` `verbs_static`: the `check --json` wire pins `severity`/`docs_url` per code
- public-api baseline: +106 additive lines, regenerated with cargo-public-api 0.51.0, byte-verified against the committed baseline's own pre-change render (zero platform skew)

Full workspace `--lib` + clippy + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)