### PR TITLE
feat(nika-mcp): accept protocol 2025-11-25 — the version clients send today

### DIFF
--- a/crates/nika-mcp/src/protocol.rs
+++ b/crates/nika-mcp/src/protocol.rs
@@ -33,7 +33,13 @@ pub(crate) const PROTOCOL_VERSION: &str = "2026-07-28";
 /// tools/call surface; batching (a 2024-11-05 / 2025-03-26 feature) is handled
 /// by [`dispatch`]; statelessness (2026-07-28) is the dispatcher's native
 /// shape. SUPPORTED stays additive — no client ever breaks (no flag-day).
-pub(crate) const SUPPORTED: [&str; 4] = ["2026-07-28", "2025-06-18", "2025-03-26", "2024-11-05"];
+pub(crate) const SUPPORTED: [&str; 5] = [
+    "2026-07-28",
+    "2025-11-25",
+    "2025-06-18",
+    "2025-03-26",
+    "2024-11-05",
+];
 /// The advertised server name (`serverInfo.name`).
 pub(crate) const SERVER_NAME: &str = "nika";
 
@@ -284,7 +290,7 @@ mod tests {
     fn initialize_echoes_a_supported_client_version() {
         // Spec lifecycle MUST: a client on an older supported rev gets THAT rev
         // back (not our latest) — so it connects instead of disconnecting.
-        for v in ["2024-11-05", "2025-03-26", "2025-06-18"] {
+        for v in ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"] {
             let resp = handle(&json!({
                 "jsonrpc": "2.0", "id": 1, "method": "initialize",
                 "params": { "protocolVersion": v }


### PR DESCRIPTION
From the MCP-readiness research (primary sources): Claude Code sends `initialize` with `protocolVersion: 2025-11-25`; the tools-only surface is unchanged across 2025 revisions, so echoing the client's own version beats falling back to our older latest. Reviewer note: `2026-07-28` in SUPPORTED (added earlier) is era-semantically odd — the new era doesn't use `initialize` (probe = `server/discover`); harmless today, worth a look when adopting the modern trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)