### PR TITLE
refactor(nika-builtin): media/wire — the transient status matrix, named once

### DIFF
--- a/crates/nika-builtin/src/image/gemini.rs
+++ b/crates/nika-builtin/src/image/gemini.rs
@@ -17,6 +17,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::ImageArgs;
 use super::types::{
@@ -450,7 +451,7 @@ fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
     BuiltinFailure::new(C_REQUEST, format!("gemini HTTP {status}: {message}"))
-        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_transient(wire::transient_status(status))
         .with_details(serde_json::json!({ "status_code": status, "status": grpc_status }))
 }
 

--- a/crates/nika-builtin/src/image/local.rs
+++ b/crates/nika-builtin/src/image/local.rs
@@ -26,6 +26,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::ImageArgs;
 use super::types::{
@@ -264,7 +265,7 @@ fn map_error_status(status: u16, body: &[u8], key: Option<&Secret>) -> BuiltinFa
         C_REQUEST,
         format!("local image server HTTP {status}: {message}"),
     )
-    .with_transient(matches!(status, 500..=599 | 408 | 429))
+    .with_transient(wire::transient_status(status))
     .with_details(serde_json::json!({ "status_code": status }))
 }
 

--- a/crates/nika-builtin/src/image/openai.rs
+++ b/crates/nika-builtin/src/image/openai.rs
@@ -16,6 +16,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::ImageArgs;
 use super::types::{
@@ -339,7 +340,7 @@ fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
     }
 
     BuiltinFailure::new(C_REQUEST, format!("openai HTTP {status}: {message}"))
-        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_transient(wire::transient_status(status))
         .with_details(serde_json::json!({ "status_code": status, "code": code }))
 }
 

--- a/crates/nika-builtin/src/image/xai.rs
+++ b/crates/nika-builtin/src/image/xai.rs
@@ -15,6 +15,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::ImageArgs;
 use super::types::{
@@ -294,7 +295,7 @@ fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
         .take(300)
         .collect();
     BuiltinFailure::new(C_REQUEST, format!("xai HTTP {status}: {message}"))
-        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_transient(wire::transient_status(status))
         .with_details(serde_json::json!({ "status_code": status }))
 }
 

--- a/crates/nika-builtin/src/media/mod.rs
+++ b/crates/nika-builtin/src/media/mod.rs
@@ -16,3 +16,4 @@
 
 pub(crate) mod png;
 pub(crate) mod time;
+pub(crate) mod wire;

--- a/crates/nika-builtin/src/media/wire.rs
+++ b/crates/nika-builtin/src/media/wire.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Shared HTTP-wire scaffold for the media provider adapters — the parts
+//! that were copied verbatim across image/{openai,gemini,local,xai} and
+//! tts/{openai,local,elevenlabs} (architect review P1.1 · the 7× set).
+//!
+//! Re-homing only: the exact behavior every adapter had, named ONCE.
+//! The transient matrix is a SPEC-NORMATIVE
+//! rule (« Transient per the spec status table · 5xx/408/429 ») — inlined
+//! seven times is seven places to miss when the spec's table changes.
+
+/// Is this HTTP status transient (worth a retry)? The spec's status table:
+/// 5xx server errors + 408 Request Timeout + 429 Too Many Requests. THE
+/// single authority — `retry.on_codes` correctness rides on it matching
+/// the spec across every media provider.
+pub(crate) fn transient_status(status: u16) -> bool {
+    matches!(status, 500..=599 | 408 | 429)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_matches_the_spec_status_table() {
+        for s in [500, 502, 503, 599, 408, 429] {
+            assert!(transient_status(s), "{s} is transient");
+        }
+        for s in [200, 400, 401, 403, 404, 422] {
+            assert!(!transient_status(s), "{s} is terminal");
+        }
+    }
+}

--- a/crates/nika-builtin/src/tts/elevenlabs.rs
+++ b/crates/nika-builtin/src/tts/elevenlabs.rs
@@ -9,6 +9,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::TtsArgs;
 use super::types::{AudioFormat, C_ARGS, C_POLICY, C_REQUEST, ProviderAudio};
@@ -136,7 +137,7 @@ fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
         C_REQUEST
     };
     BuiltinFailure::new(code, format!("elevenlabs HTTP {status}: {message}"))
-        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_transient(wire::transient_status(status))
         .with_details(serde_json::json!({ "status_code": status }))
 }
 

--- a/crates/nika-builtin/src/tts/local.rs
+++ b/crates/nika-builtin/src/tts/local.rs
@@ -13,6 +13,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::TtsArgs;
 use super::types::{AudioFormat, C_REQUEST, ProviderAudio};
@@ -132,7 +133,7 @@ fn map_error_status(status: u16, body: &[u8], key: Option<&Secret>) -> BuiltinFa
         C_REQUEST,
         format!("local TTS server HTTP {status}: {message}"),
     )
-    .with_transient(matches!(status, 500..=599 | 408 | 429))
+    .with_transient(wire::transient_status(status))
     .with_details(serde_json::json!({ "status_code": status }))
 }
 

--- a/crates/nika-builtin/src/tts/openai.rs
+++ b/crates/nika-builtin/src/tts/openai.rs
@@ -8,6 +8,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
+use crate::media::wire;
 
 use super::args::TtsArgs;
 use super::types::{AudioFormat, C_POLICY, C_REQUEST, ProviderAudio};
@@ -106,7 +107,7 @@ fn map_error_status(status: u16, body: &[u8]) -> BuiltinFailure {
         C_REQUEST
     };
     BuiltinFailure::new(code, format!("openai speech HTTP {status}: {message}"))
-        .with_transient(matches!(status, 500..=599 | 408 | 429))
+        .with_transient(wire::transient_status(status))
         .with_details(serde_json::json!({ "status_code": status }))
 }
 


### PR DESCRIPTION
**M2 sequence ① continues** (the media/ core, after the time.rs/png.rs seed). The architect review's worst-named debt: the spec-normative transient rule `5xx/408/429` was inlined SEVEN times (image/{openai,gemini,local,xai} + tts/{openai,local,elevenlabs}) — seven places to miss when the spec's status table shifts, and every `retry.on_codes` verdict rides on all seven agreeing. Now one authority `media::wire::transient_status` with the spec table pinned in its own test. Pure re-homing, behavior identical, 236 lib tests · clippy 0 · 8 ratchets · public-api unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)