### PR TITLE
feat(nika-builtin): openai edit wire — M-A.2 (multipart · proven live)

### DIFF
--- a/crates/nika-builtin/src/image/mod.rs
+++ b/crates/nika-builtin/src/image/mod.rs
@@ -373,6 +373,31 @@ fn detect_and_preserve_credentials<Em: Emitter>(
     batch_signal
 }
 
+/// Route one EDIT call — openai carries the first wire (M-A.2); the
+/// other providers refuse loudly until their adapters land (M-B/M-C).
+/// The ONE provider match means no panic-class `unreachable!` arm exists
+/// (the zero-panic pattern · mock returns before any wire is built).
+async fn dispatch_edit<H: HttpPostDyn>(
+    http: &H,
+    wire: Wire<'_>,
+    args: &ImageArgs,
+    inputs: &[types::InputImage],
+) -> Result<ProviderBatch, BuiltinFailure> {
+    let id = match wire {
+        Wire::Openai(key) => return openai::edit(http, key, args, inputs).await,
+        Wire::Gemini(_) => "gemini",
+        Wire::Xai(_) => "xai",
+        Wire::Local { .. } => "local",
+    };
+    Err(BuiltinFailure::new(
+        types::C_ARGS,
+        format!(
+            "`mode: edit` is wired for openai (and mock) today — the {id} edit \
+             adapter ships next (use provider: openai, or mock offline)"
+        ),
+    ))
+}
+
 /// A provider returning fewer images than `n:` is a WARNED degradation,
 /// never silent (Ollama's compat route ignores `n` · openai may under-
 /// deliver on moderation-filtered variants).
@@ -499,6 +524,7 @@ where
             path: (*path).to_owned(),
             sha256: save::sha256_hex(&bytes),
             format: sniffed.format,
+            bytes: bytes.to_vec(),
         });
     }
     Ok(inputs)
@@ -578,11 +604,16 @@ where
             "endpoint_host": endpoint_host, "n": args.n,
         }),
     );
-    let batch = match wire {
-        Wire::Openai(key) => openai::generate(http, key, args).await?,
-        Wire::Gemini(key) => gemini::generate(http, key, args).await?,
-        Wire::Xai(key) => xai::generate(http, key, args).await?,
-        Wire::Local { base_url, key } => local::generate(http, &base_url, key, args).await?,
+    let batch = match (args.mode, wire) {
+        // ── generate (the default text→image path) ──
+        (types::Mode::Generate, Wire::Openai(key)) => openai::generate(http, key, args).await?,
+        (types::Mode::Generate, Wire::Gemini(key)) => gemini::generate(http, key, args).await?,
+        (types::Mode::Generate, Wire::Xai(key)) => xai::generate(http, key, args).await?,
+        (types::Mode::Generate, Wire::Local { base_url, key }) => {
+            local::generate(http, &base_url, key, args).await?
+        }
+        // ── edit (source image(s) + instruction) · openai first (M-A.2) ──
+        (types::Mode::Edit, wire) => dispatch_edit(http, wire, args, inputs).await?,
     };
     emitter.emit(
         "image_generation.provider_response",

--- a/crates/nika-builtin/src/image/openai.rs
+++ b/crates/nika-builtin/src/image/openai.rs
@@ -16,7 +16,7 @@ use nika_kernel::io::http::{HttpError, HttpPostDyn, HttpRequest};
 use nika_kernel::secret::Secret;
 
 use crate::BuiltinFailure;
-use crate::media::wire;
+use crate::media::wire::{self, Part};
 
 use super::args::ImageArgs;
 use super::types::{
@@ -43,6 +43,90 @@ pub(crate) async fn generate<H: HttpPostDyn>(
     let mut batch = parse_response(response.status, &response.body, args)?;
     batch.warnings.splice(0..0, warnings);
     Ok(batch)
+}
+
+const EDIT_ENDPOINT: &str = "https://api.openai.com/v1/images/edits";
+
+/// Run one EDIT batch (`mode: edit`) — the multipart `/v1/images/edits`
+/// wire: `image[]` file parts (raw bytes · never base64 in multipart) +
+/// the instruction + optional `mask`. The response is the SAME
+/// `ImagesResponse` shape as generations, so `parse_response` is reused
+/// verbatim. `input_fidelity` is deliberately NOT sent — gpt-image-2
+/// rejects it (always high · research-verified).
+pub(crate) async fn edit<H: HttpPostDyn>(
+    http: &H,
+    key: &Secret,
+    args: &ImageArgs,
+    inputs: &[super::types::InputImage],
+) -> Result<ProviderBatch, BuiltinFailure> {
+    let (request, warnings) = build_edit_request(args, inputs, key)?;
+    let response = http.post(request).await.map_err(map_transport)?;
+    let mut batch = parse_response(response.status, &response.body, args)?;
+    batch.warnings.splice(0..0, warnings);
+    Ok(batch)
+}
+
+/// Build the multipart edit request (pure). The mask, when present, is
+/// the LAST input (the read stage appends it) and rides its own `mask`
+/// part; every other input is an `image[]` source part.
+fn build_edit_request(
+    args: &ImageArgs,
+    inputs: &[super::types::InputImage],
+    key: &Secret,
+) -> Result<(HttpRequest, Vec<String>), BuiltinFailure> {
+    let mut warnings = Vec::new();
+    let n_string = args.n.to_string();
+    let mut parts: Vec<Part<'_>> = vec![
+        Part::Text {
+            name: "model",
+            value: &args.model,
+        },
+        Part::Text {
+            name: "prompt",
+            value: &args.prompt,
+        },
+        Part::Text {
+            name: "n",
+            value: &n_string,
+        },
+    ];
+    let size_string = resolve_size(args, &mut warnings)?;
+    if let Some(size) = size_string.as_deref() {
+        parts.push(Part::Text {
+            name: "size",
+            value: size,
+        });
+    }
+    let has_mask = args.mask_path.is_some();
+    let source_count = if has_mask {
+        inputs.len().saturating_sub(1)
+    } else {
+        inputs.len()
+    };
+    for (i, input) in inputs.iter().enumerate() {
+        let is_mask = has_mask && i == source_count;
+        // The filename extension is LOAD-BEARING (servers sniff it) — the
+        // read stage's magic-byte format names it truthfully.
+        parts.push(Part::File {
+            name: if is_mask { "mask" } else { "image[]" },
+            filename: if is_mask { "mask.png" } else { "source.png" },
+            mime: input.format.mime(),
+            bytes: &input.bytes,
+        });
+    }
+    let (body, content_type) = wire::multipart(&parts);
+
+    let mut request = HttpRequest::post(EDIT_ENDPOINT);
+    request.headers.insert(
+        "authorization".to_owned(),
+        format!("Bearer {}", key.expose()),
+    );
+    request
+        .headers
+        .insert("content-type".to_owned(), content_type);
+    request.timeout = Some(args.timeout);
+    request.body = Some(body.into());
+    Ok((request, warnings))
 }
 
 /// Build the wire request (pure — unit-testable without a transport).
@@ -368,6 +452,83 @@ mod tests {
 
     fn key() -> Secret {
         Secret::new("sk-test-XYZ-do-not-leak".to_owned())
+    }
+
+    fn edit_args(patch: serde_json::Value) -> ImageArgs {
+        let serde_json::Value::Object(mut map) = serde_json::json!({
+            "provider": "openai", "mode": "edit", "image": "src.png",
+            "prompt": "make the sky a sunset", "output_dir": "./out"
+        }) else {
+            unreachable!()
+        };
+        if let serde_json::Value::Object(p) = patch {
+            for (k, v) in p {
+                map.insert(k, v);
+            }
+        }
+        args::parse(&map).expect("valid")
+    }
+
+    fn input(bytes: &[u8]) -> super::super::types::InputImage {
+        super::super::types::InputImage {
+            path: "src.png".to_owned(),
+            format: super::super::types::ImageFormat::Png,
+            sha256: "ab".repeat(32),
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn edit_request_is_multipart_with_verbatim_bytes_and_no_key_in_body() {
+        let args = edit_args(serde_json::json!({}));
+        let inputs = vec![input(b"\x89PNG-source-bytes")];
+        let (request, _) = build_edit_request(&args, &inputs, &key()).expect("builds");
+        assert_eq!(request.url, EDIT_ENDPOINT);
+        let ct = request.headers.get("content-type").expect("ct");
+        assert!(ct.starts_with("multipart/form-data; boundary="), "{ct}");
+        let body = request.body.as_ref().expect("body");
+        let s = String::from_utf8_lossy(body);
+        assert!(s.contains("name=\"image[]\"; filename=\"source.png\""));
+        assert!(s.contains("name=\"prompt\"\r\n\r\nmake the sky a sunset"));
+        assert!(s.contains("name=\"model\""));
+        // raw bytes verbatim — multipart files are never base64.
+        assert!(body.windows(17).any(|w| w == b"\x89PNG-source-bytes"));
+        // the credential rides the header ONLY.
+        assert!(!s.contains("sk-test-XYZ"), "key never in the body");
+        assert_eq!(
+            request.headers.get("authorization").map(String::as_str),
+            Some("Bearer sk-test-XYZ-do-not-leak")
+        );
+        // input_fidelity is deliberately absent (gpt-image-2 rejects it).
+        assert!(!s.contains("input_fidelity"));
+    }
+
+    #[test]
+    fn edit_request_appends_the_mask_as_its_own_part() {
+        let args = edit_args(serde_json::json!({ "mask": "m.png" }));
+        // the read stage appends the mask LAST.
+        let inputs = vec![input(b"src-bytes"), input(b"mask-bytes")];
+        let (request, _) = build_edit_request(&args, &inputs, &key()).expect("builds");
+        let s = String::from_utf8_lossy(request.body.as_ref().expect("body"));
+        assert!(s.contains("name=\"mask\"; filename=\"mask.png\""));
+        let sources = s.matches("name=\"image[]\"").count();
+        assert_eq!(sources, 1, "one source · the mask is not an image[] part");
+    }
+
+    #[tokio::test]
+    async fn edit_reuses_the_generations_response_parse() {
+        let (b64, raw) = wire_png_b64();
+        let response = serde_json::json!({ "data": [{ "b64_json": b64 }] });
+        let http = MockHttp::new().enqueue_ok(200, response.to_string().into_bytes());
+        let batch = edit(
+            &http,
+            &key(),
+            &edit_args(serde_json::json!({})),
+            &[input(b"src")],
+        )
+        .await
+        .expect("edit ok");
+        assert_eq!(batch.images[0].bytes, raw, "same ImagesResponse shape");
     }
 
     /// A tiny valid PNG payload (via the mock renderer) base64-encoded

--- a/crates/nika-builtin/src/image/types.rs
+++ b/crates/nika-builtin/src/image/types.rs
@@ -43,16 +43,15 @@ impl Mode {
 
 /// One input image read from disk for `mode: edit` — the bytes + the
 /// sniffed format + the path/sha for the provenance chain.
-///
-/// M-A stores the identity (path · sha · format) that the mock edit and
-/// the manifest provenance chain need; the wire adapters (M-A.2) will add
-/// the byte payload they data-URL-encode. Growing the struct then is
-/// additive and behavior-free.
 #[derive(Debug, Clone)]
 pub(crate) struct InputImage {
     pub(crate) path: String,
     pub(crate) format: ImageFormat,
     pub(crate) sha256: String,
+    /// The source payload the wire adapters send (openai edit rides the
+    /// raw bytes as multipart file parts). Arrived WITH its first
+    /// consumer (M-A.2) — never stored ahead of use.
+    pub(crate) bytes: Vec<u8>,
 }
 
 /// The v1.1 image providers — a closed set (local + xai joined 2026-07-05

--- a/crates/nika-builtin/src/media/wire.rs
+++ b/crates/nika-builtin/src/media/wire.rs
@@ -18,9 +18,92 @@ pub(crate) fn transient_status(status: u16) -> bool {
     matches!(status, 500..=599 | 408 | 429)
 }
 
+/// One field of a `multipart/form-data` body — a text value or a named
+/// file part (the edit wires: openai/local `/v1/images/edits`).
+pub(crate) enum Part<'a> {
+    Text {
+        name: &'a str,
+        value: &'a str,
+    },
+    File {
+        name: &'a str,
+        filename: &'a str,
+        mime: &'a str,
+        bytes: &'a [u8],
+    },
+}
+
+/// A fixed, collision-safe multipart boundary. It only has to not occur
+/// inside the parts; a studio-constant token is fine (payloads are image
+/// bytes + short fields — never this exact ASCII run), and a constant
+/// keeps request bytes deterministic (golden-friendly · no RNG).
+const MULTIPART_BOUNDARY: &str = "----nika-media-boundary-7f3a9c2e";
+
+/// Build a `multipart/form-data` body + the matching `content-type`
+/// header value. Parts are emitted in the given order — callers control
+/// ordering (xai's edit wire documents `file` LAST).
+pub(crate) fn multipart(parts: &[Part<'_>]) -> (Vec<u8>, String) {
+    let mut body = Vec::new();
+    for part in parts {
+        body.extend_from_slice(format!("--{MULTIPART_BOUNDARY}\r\n").as_bytes());
+        match part {
+            Part::Text { name, value } => {
+                body.extend_from_slice(
+                    format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+                );
+                body.extend_from_slice(value.as_bytes());
+            }
+            Part::File {
+                name,
+                filename,
+                mime,
+                bytes,
+            } => {
+                body.extend_from_slice(
+                    format!(
+                        "Content-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\n"
+                    )
+                    .as_bytes(),
+                );
+                body.extend_from_slice(format!("Content-Type: {mime}\r\n\r\n").as_bytes());
+                body.extend_from_slice(bytes);
+            }
+        }
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{MULTIPART_BOUNDARY}--\r\n").as_bytes());
+    (
+        body,
+        format!("multipart/form-data; boundary={MULTIPART_BOUNDARY}"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn multipart_frames_text_and_file_parts_with_the_boundary() {
+        let (body, ct) = multipart(&[
+            Part::Text {
+                name: "model",
+                value: "gpt-image-2",
+            },
+            Part::File {
+                name: "image[]",
+                filename: "src.png",
+                mime: "image/png",
+                bytes: b"\x89PNG",
+            },
+        ]);
+        assert!(ct.contains("boundary=----nika-media-boundary"));
+        let s = String::from_utf8_lossy(&body);
+        assert!(s.contains("name=\"model\"\r\n\r\ngpt-image-2"));
+        assert!(s.contains("filename=\"src.png\"") && s.contains("Content-Type: image/png"));
+        assert!(s.trim_end().ends_with("--"), "closing delimiter");
+        // raw file bytes ride verbatim (multipart files are NOT base64).
+        assert!(body.windows(4).any(|w| w == b"\x89PNG"));
+    }
 
     #[test]
     fn transient_matches_the_spec_status_table() {


### PR DESCRIPTION
**The first real edit adapter** (M-A merged as #188 · spec fixtures merged). `media::wire` gains the hand-rolled multipart builder (~40 LOC on `body: Bytes` · zero deps · deterministic boundary · caller-ordered parts for xai's file-last quirk). `openai::edit` posts `image[]` RAW-byte file parts + prompt/model/n/size + the optional `mask` part; `input_fidelity` deliberately absent (gpt-image-2 rejects it); **`parse_response` reused verbatim** (edit answers the same `ImagesResponse`).

**Proven at the live wire, dataflow-chained**: a real openai render (19.9s · caBX-signed) fed via `${{ tasks.source.output.images[0].path }}` into a real openai EDIT (37s · **multipart worked first try**) — and the discovery: **openai signs its EDITS too** (the output carries caBX · detect-and-preserve stood our chunk down · `IHDR·caBX·IDAT·IEND` intact). Manifest: `mode:edit` + `source_images` — the generate→edit provenance chain of the 2040 thesis, live.

`InputImage` gains `bytes` WITH its first consumer (the M-A dead-code lesson) · `dispatch_edit`'s single match kills the panic-class `unreachable!` arm. 241 lib tests · clippy 0 · 8 ratchets · public-api unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)