### PR TITLE
feat(cli): the Unix dash — check/graph/inspect read stdin

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -99,7 +99,7 @@ impl ColorWhenArg {
 enum Command {
     /// Static pre-flight: the ADR-092 ladder (audit BEFORE run).
     Check {
-        /// Workflow file (`*.nika.yaml`).
+        /// Workflow file (`*.nika.yaml`) · `-` reads stdin.
         file: String,
         /// Emit the machine-readable report (never coloured).
         #[arg(long)]
@@ -133,7 +133,7 @@ enum Command {
     },
     /// Static anatomy: tasks · verbs · wave groups · cost · permits.
     Inspect {
-        /// Workflow file (`*.nika.yaml`).
+        /// Workflow file (`*.nika.yaml`) · `-` reads stdin.
         file: String,
         /// Force the ASCII glyph theme (CI logs · legacy terminals).
         #[arg(long)]
@@ -141,7 +141,7 @@ enum Command {
     },
     /// The ONE graph projector (json canonical · mermaid/dot derived).
     Graph {
-        /// Workflow file (`*.nika.yaml`).
+        /// Workflow file (`*.nika.yaml`) · `-` reads stdin.
         file: String,
         /// Output format.
         #[arg(long, value_enum, default_value_t = GraphFormatArg::Json)]

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -118,13 +118,25 @@ pub(crate) fn linked_path(theme: crate::Theme, path: &str) -> String {
     }
 }
 
-/// Read + strict-parse + ladder-check one workflow file.
+/// Read + strict-parse + ladder-check one workflow file. The Unix dash
+/// (`-`) reads stdin — the editor wire: a dirty buffer pipes straight
+/// in, no tmp-file dance; every verb on this seam (check · graph ·
+/// inspect · test) inherits it.
 ///
 /// Failure mapping per spec §4: unreadable = environment (`3`) · parse
 /// error = a finding in the FILE (`2`).
 pub(crate) fn load_checked(path: &str) -> Result<(RawWorkflow, CheckReport), VerbOutput> {
-    let yaml = std::fs::read_to_string(path)
-        .map_err(|e| VerbOutput::env(format!("cannot read {path}: {e}")))?;
+    let yaml = if path == "-" {
+        use std::io::Read as _;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| VerbOutput::env(format!("cannot read stdin: {e}")))?;
+        buf
+    } else {
+        std::fs::read_to_string(path)
+            .map_err(|e| VerbOutput::env(format!("cannot read {path}: {e}")))?
+    };
     let wf = nika_schema::parse(&yaml, FileId::new(0), ParseMode::Strict)
         .map_err(|e| VerbOutput::file(format!("PARSE ✗  [{}] {e}", e.spec_code())))?;
     let report = nika_schema::check(&wf);

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -34,9 +34,24 @@ use crate::verbs::exit;
 /// flooding a CI log when a whole subtree changed.
 const DIFF_LINE_CAP: usize = 20;
 
+/// stdin (`-`) is `load_checked`'s seam, but this verb needs the FILE
+/// twice over: the golden lives beside it (`<file>.golden.json`) and a
+/// dirty doc re-renders through `check::run` — which would re-read an
+/// already-consumed stdin and report a lying parse error. Refused with
+/// guidance (spec §4: environment · exit 3).
+fn refuse_stdin() -> u8 {
+    eprintln!(
+        "nika test: stdin (`-`) is not supported — the golden lives beside the file (<file>.golden.json)"
+    );
+    3
+}
+
 /// The `nika test <file> [--update]` verb (spec §4 exit contract).
 #[must_use]
 pub fn run(file: &str, update: bool, theme: Theme) -> u8 {
+    if file == "-" {
+        return refuse_stdin();
+    }
     // ── Audit BEFORE run — the same gate `nika run` holds ───────────
     let (wf, report) = match crate::verbs::load_checked(file) {
         Ok(pair) => pair,

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -474,3 +474,104 @@ fn mcp_serves_initialize_and_lists_tools() {
         "tools/list named the catalog: {stdout}"
     );
 }
+
+// ─── stdin (`-`) · the editor wire without the tmp-file dance ────────────────
+
+/// `nika check - --json` reads the workflow from stdin: exit 0 + clean
+/// report for a valid doc — the seam every `load_checked` verb inherits.
+#[test]
+fn check_dash_reads_stdin_valid() {
+    use std::process::Stdio;
+    let mut child = bin()
+        .args(["check", "-", "--json"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(VALID.as_bytes())
+        .expect("pipe body");
+    let out = child.wait_with_output().expect("wait");
+    assert_eq!(out.status.code(), Some(0), "clean stdin doc exits 0");
+    let doc: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("json report on stdout");
+    assert_eq!(doc["clean"], true);
+}
+
+/// Findings on a stdin doc keep the exit-code contract (`2` = file).
+#[test]
+fn check_dash_reads_stdin_findings_exit_2() {
+    use std::process::Stdio;
+    let mut child = bin()
+        .args(["check", "-", "--json"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(INVALID.as_bytes())
+        .expect("pipe body");
+    let out = child.wait_with_output().expect("wait");
+    assert_eq!(out.status.code(), Some(2), "stdin findings exit 2");
+    let doc: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("json report on stdout");
+    assert_eq!(doc["clean"], false);
+}
+
+/// `nika graph - --format json` inherits the dash (`load_checked` seam).
+#[test]
+fn graph_dash_reads_stdin() {
+    use std::process::Stdio;
+    let mut child = bin()
+        .args(["graph", "-", "--format", "json"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(VALID.as_bytes())
+        .expect("pipe body");
+    let out = child.wait_with_output().expect("wait");
+    assert_eq!(out.status.code(), Some(0), "graph on stdin doc exits 0");
+    let doc: serde_json::Value = serde_json::from_slice(&out.stdout).expect("graph json on stdout");
+    assert!(doc["nodes"].is_array());
+}
+
+/// `nika test -` is REFUSED with guidance (exit 3): the golden lives
+/// beside the file, and a dirty doc would re-read consumed stdin.
+#[test]
+fn test_dash_is_refused_with_guidance() {
+    use std::process::Stdio;
+    let mut child = bin()
+        .args(["test", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(VALID.as_bytes())
+        .expect("pipe body");
+    let out = child.wait_with_output().expect("wait");
+    assert_eq!(out.status.code(), Some(3), "refused as environment");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("golden lives beside the file"),
+        "guidance: {err}"
+    );
+}


### PR DESCRIPTION
## What

`nika check - --json` (and `graph -` · `inspect -`) reads the workflow from **stdin**: the Unix dash, on the ONE `load_checked` seam all three verbs share. Exit contract unchanged (`0` clean · `2` findings · `3` env).

`nika test -` is **refused with guidance** (exit 3): the golden lives beside the FILE (`<file>.golden.json`), and a dirty doc re-renders through `check::run` — which would re-read an already-consumed stdin and report a lying parse error.

## Why

Workflow-intelligence roadmap **E6a** — the editor wire without the tmp-file dance: the VS Code extension currently copies every dirty buffer to a tmp file per keystroke-debounce to run `check --json`/`graph`. With the dash it pipes the buffer straight in (extension consumption lands next on its side).

## Tests

Four `bin_smoke` tests against the REAL binary (`CARGO_BIN_EXE`): stdin valid → exit 0 + clean JSON · stdin findings → exit 2 · `graph -` → nodes JSON · `test -` → refused with the guidance line.

Full workspace `--lib` + clippy + fmt + fn-length ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)