### PR TITLE
ci: the test gate runs under nextest — process isolation, parallel

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -64,6 +64,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: diamond
+      - name: Install cargo-nextest (tests leg)
+        if: matrix.job == 'tests'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Run rust job
         run: ./scripts/ci/check-"$JOB".sh
 

--- a/scripts/ci/check-tests.sh
+++ b/scripts/ci/check-tests.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Ratchet: cargo test --workspace --lib.
+# Ratchet: the workspace lib-test battery.
 #
+# Runner: cargo-nextest when installed (process-per-test isolation + parallel
+# scheduling — the 2026 flagship standard; CI installs it), plain `cargo test`
+# as the everywhere-fallback so a machine without nextest still gates.
 # Always `--lib` on macOS to avoid the Keychain popup triggered by integration
 # tests that touch real secret stores (feedback_no_keychain_popup).
 set -euo pipefail
@@ -11,4 +14,7 @@ if grep -qE '^\s*members\s*=\s*\[\s*\]\s*$' Cargo.toml; then
   exit 0
 fi
 
+if command -v cargo-nextest >/dev/null 2>&1; then
+  exec cargo nextest run --workspace --lib
+fi
 exec cargo test --workspace --lib


### PR DESCRIPTION
The last deferred quick win from the rust-sota survey (master plan M2.3): `check-tests.sh` prefers **cargo-nextest** when installed (the runner ruff/uv/biome gate on — per-test process isolation + parallel scheduling) with plain `cargo test` as the everywhere-fallback. The CI `tests` leg installs it via `taiki-e/install-action`; other legs untouched. **This PR's own tests leg is the workspace-wide proof** (the workflow change applies to the PR's merge ref). Local crate-scope proof: 226/226 in 0.7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)