### PR TITLE
fix(nika-cli): init hand-off loses its phantom indentation

### DIFF
--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -199,7 +199,7 @@ pub fn run(dir: &str, force: bool) -> VerbOutput {
         // onboarding surface must hand over to the next command. Golden
         // path: offline proof in 10s → scaffold → audit-before-tokens.
         VerbOutput::ok(format!(
-            "{text}\n\nnext ·\n               nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n               nika new --from chain my-first.nika.yaml       # scaffold a real workflow\n               nika check my-first.nika.yaml                  # audit before a single token"
+            "{text}\n\nnext ·\n  nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n  nika new --from chain my-first.nika.yaml       # scaffold a real workflow\n  nika check my-first.nika.yaml                  # audit before a single token"
         ))
     }
 }


### PR DESCRIPTION
User-sim walkthrough finding (2026-07-06): the init next-command block rendered with fifteen leading spaces — broken left edge on every fresh init. Two-space indent, the house list rhythm. cargo test -p nika-cli --lib 194 passed · full pre-push hook chain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)