### PR TITLE
test(nika-builtin): pin validate's SSRF floor + deep-YAML totality

### DIFF
--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -18,7 +18,7 @@ jaq-core      = { workspace = true }   # nika:jq — THE data language
 jaq-std       = { workspace = true }
 jaq-json      = { workspace = true }
 json-patch    = { workspace = true }   # nika:json_diff (RFC 6902) + nika:json_merge_patch (RFC 7396)
-jsonschema    = { workspace = true }   # nika:validate
+jsonschema    = { workspace = true }   # nika:validate — SSRF floor: workspace pins default-features=false (no http/file resolver); regression `validate_never_fetches_a_remote_ref` guards the flip
 jiff          = { workspace = true }   # nika:date (IANA tzdb bundled · sovereign)
 serde_yaml_bw = { workspace = true }   # nika:convert yaml + nika:validate format:yaml
 toml_convert  = { workspace = true }   # nika:convert toml

--- a/crates/nika-builtin/src/data.rs
+++ b/crates/nika-builtin/src/data.rs
@@ -789,6 +789,54 @@ mod tests {
     }
 
     #[test]
+    fn validate_never_fetches_a_remote_ref() {
+        // SSRF FLOOR: jsonschema is compiled `default-features = false`
+        // (no resolve-http / resolve-file), so a remote `$ref` CANNOT be
+        // fetched — it must surface loudly as a compile error, never a
+        // network call or a silent pass. This pins the structurally-closed
+        // property so a future `default-features` flip is caught here, not
+        // in the wild. (Proven at the binary: the remote $ref returns
+        // VALIDATE-001 with no hang.)
+        for uri in [
+            "https://example.com/evil.json",
+            "http://169.254.169.254/latest/meta-data",
+            "file:///etc/passwd",
+        ] {
+            let refused = validate(&args(serde_json::json!({
+                "data": {}, "schema": { "$ref": uri }
+            })));
+            assert!(
+                matches!(&refused, Err(f) if f.code == "NIKA-BUILTIN-VALIDATE-001"),
+                "remote/file $ref `{uri}` must refuse (SSRF/LFI floor), got {refused:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_deep_yaml_is_bounded_never_a_stack_overflow() {
+        // TOTALITY: a deeply-nested YAML `data:` string must not overflow
+        // the parser's stack (the classic serde_yaml crash class). The
+        // `serde_yaml_bw` fork bounds nesting, so this returns a clean
+        // parse error, never a SIGSEGV. Pinned across a depth sweep so a
+        // dep swap that reintroduces the crash is caught. (Proven at the
+        // binary: 200 → 50k deep, all clean exits, zero crashes.)
+        let schema = serde_json::json!({ "type": "array" });
+        for depth in [128_usize, 1_000, 20_000] {
+            let deep = format!("{}{}", "[".repeat(depth), "]".repeat(depth));
+            let out = validate(&args(serde_json::json!({
+                "data": deep, "schema": schema, "format": "yaml"
+            })));
+            // Either it parses (bounded-ok) or it refuses (VALIDATE-002) —
+            // both are total; the ONLY unacceptable outcome is a crash,
+            // which this call returning at all disproves.
+            assert!(
+                out.is_ok() || matches!(&out, Err(f) if f.code == "NIKA-BUILTIN-VALIDATE-002"),
+                "depth {depth} must be total (ok or -002), got {out:?}"
+            );
+        }
+    }
+
+    #[test]
     fn convert_round_trips_and_rejects_identity() {
         // json → yaml → json round-trip.
         let yaml = convert(&args(serde_json::json!({


### PR DESCRIPTION
The data-json deep-verify (rust-pro review) confirmed two `validate` security properties are structurally safe today — this **locks them against silent regression**:

- **SSRF/LFI floor**: `jsonschema` compiled `default-features=false` (no http/file resolver) → a remote/file `$ref` refuses `VALIDATE-001` instead of fetching. Proven at the binary (no hang); pinned across https/metadata-IP/`file://`. A future `default-features` flip fails this test, not a prod SSRF. Dep line carries the marker.
- **Deep-nest totality**: deeply-nested YAML `data:` returns cleanly (parse or -002), never a stack overflow (serde_yaml_bw bounds nesting). Proven 200→50k deep; pinned at 128/1k/20k.

243 lib tests (+2) · clippy 0 · 8 ratchets. Noted in the campaign ledger (not fixed here): jq eval-DoS is a real but documented-accepted gap needing a jaq step-budget — a larger arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)