### PR TITLE
chore(nika-cli): sync public-api baseline — doctor::run gained ping

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -469,7 +469,7 @@ pub mod nika_cli::verbs::check
 pub fn nika_cli::verbs::check::run(path: &str, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::check::run_infer_permits(path: &str, json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::doctor
-pub fn nika_cli::verbs::doctor::run() -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::doctor::run(ping: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::exit
 pub const nika_cli::verbs::exit::ENV: u8
 pub const nika_cli::verbs::exit::FILE: u8


### PR DESCRIPTION
#195 (doctor --ping) changed `doctor::run()` → `run(ping: bool)` but didn't regenerate the public-api snapshot, leaving main's `diff` gate **red** — every open PR fails against the stale baseline. Syncs the one drifted line to the shipped code, unblocking the merge queue. Surgical (not a full regen) because local cargo-public-api renders blanket bounds differently than CI (the Sized+ noise class); the line matches exactly what CI computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)