### PR TITLE
chore(release): v0.94.0 — media suite · run journal · the catalog on the wire

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,9 +129,9 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `main`                                      |
-| HEAD             | `8ef43dddc` (`8ef43dddc1c0633a1156ef0eff9f2d10e51595fa`)             |
-| workspace        | v0.93.1                                  |
+| branch           | `chore/release-v0.94.0`                                      |
+| HEAD             | `ee090d760` (`ee090d7601b66dd816de42f58c3901824c3f4857`)             |
+| workspace        | v0.94.0                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |
@@ -142,7 +142,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | L2               | 4                                              |
 | L3               | 1                                              |
 | L4               | 4                                              |
-| lib tests        | 3023 passed, 0 failed                              |
+| lib tests        | 3325 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 
 Narrative context (manually maintained):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ Nika Diamond is a ground-up rewrite on the `nika-diamond` orphan branch.
 Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ---
+## [0.94.0](https://github.com/supernovae-st/nika/compare/v0.93.1..v0.94.0) - 2026-07-06
+
+### ✨ Highlights
+
+- **The media suite** — two new builtins take the stdlib to 25.
+  `nika:image_generate` ([PR 173](https://github.com/supernovae-st/nika/pull/173) · providers v1.1 local-first + xai
+  [PR 174](https://github.com/supernovae-st/nika/pull/174) · `mode: edit` M-A/M-A.2
+  [PR 188](https://github.com/supernovae-st/nika/pull/188)/[PR 189](https://github.com/supernovae-st/nika/pull/189)) and
+  `nika:tts_generate` ([PR 176](https://github.com/supernovae-st/nika/pull/176) · one sovereign
+  `/v1/audio/speech` wire = LocalAI/Kokoro/Speaches · openai · elevenlabs · a real
+  deterministic WAV under mock). Assets land on disk with provenance manifests —
+  content credentials detected and preserved ([PR 177](https://github.com/supernovae-st/nika/pull/177)) ·
+  the elevenlabs watermark declared ([PR 183](https://github.com/supernovae-st/nika/pull/183)).
+- **Every run leaves a journal** — `.nika/traces/<ts>-<id>.ndjson` by default
+  ([PR 170](https://github.com/supernovae-st/nika/pull/170) · opt out `--no-trace-file` /
+  `NIKA_NO_TRACE_FILE`), and `nika run --task <id>` scopes execution to one task
+  and its upstream cone. CEL expression completion lands in the LSP.
+- **The catalog rides the wire** — `nika catalog --json` · `nika tools --json`
+  ([PR 172](https://github.com/supernovae-st/nika/pull/172)) + their MCP twins:
+  the oracle now serves 8 read-only tools, and the server speaks MCP
+  2026-07-28 natively ([PR 171](https://github.com/supernovae-st/nika/pull/171)) while
+  accepting 2025-11-25 clients ([PR 185](https://github.com/supernovae-st/nika/pull/185)).
+- **Honest money** — real per-task spend: `cost_usd` rides `task_completed`
+  ([PR 168](https://github.com/supernovae-st/nika/pull/168) · absent for mock/local,
+  never a fake zero) and agent loops meter tool-reported cost
+  ([PR 178](https://github.com/supernovae-st/nika/pull/178)).
+- **Providers 16** — huggingface + nvidia join the canonical catalog
+  ([PR 167](https://github.com/supernovae-st/nika/pull/167) · ADR-104).
+- **`nika doctor --ping`** — the local ports, actually probed
+  ([PR 195](https://github.com/supernovae-st/nika/pull/195) · TCP connect-only ·
+  300ms cap · loopback/configured URLs only · the default run stays offline).
+  `nika check` findings carry severity + a docs URL
+  ([PR 184](https://github.com/supernovae-st/nika/pull/184)).
+
+### 🧹 Chore
+
+- **pack** — re-vendored from spec main: the 16-provider/25-builtin markers ·
+  the tts error-category ladder · the new `mcp:` canon section ride the binary.
+- **ci** — the test gate runs under nextest ([PR 192](https://github.com/supernovae-st/nika/pull/192)) ·
+  public-api baselines canonicalized from the ubuntu artifact ·
+  `iter_over_hash_type` denied ([PR 181](https://github.com/supernovae-st/nika/pull/181)).
+- **cli** — round-8 visual polish ([PR 169](https://github.com/supernovae-st/nika/pull/169)) ·
+  the comprehension pass ([PR 166](https://github.com/supernovae-st/nika/pull/166)) ·
+  the init hand-off drops its phantom indentation ([PR 194](https://github.com/supernovae-st/nika/pull/194)).
+
 ## [0.93.1](https://github.com/supernovae-st/nika/compare/v0.93.0..v0.93.1) - 2026-07-05
 
 ### ✨ Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "clap",
  "futures",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cli"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "annotate-snippets 0.12.15",
  "anstyle",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "expect-test",
  "insta",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "insta",
  "miette",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-kernel",
  "nix",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "globset",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "nika-http"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "insta",
  "miette",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-builtin",
  "nika-catalog",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "include_dir",
  "sha2",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3992,14 +3992,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "loom",
  "proptest",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.93.1"
+version      = "0.94.0"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,9 +83,9 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `main`                                      |
-| HEAD             | `8ef43dddc` (`8ef43dddc1c0633a1156ef0eff9f2d10e51595fa`)             |
-| workspace        | v0.93.1                                  |
+| branch           | `chore/release-v0.94.0`                                      |
+| HEAD             | `ee090d760` (`ee090d7601b66dd816de42f58c3901824c3f4857`)             |
+| workspace        | v0.94.0                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |
@@ -96,7 +96,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | L2               | 4                                              |
 | L3               | 1                                              |
 | L4               | 4                                              |
-| lib tests        | 3023 passed, 0 failed                              |
+| lib tests        | 3325 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 
 Diamond foundation — orphan branch from scratch. Live counts (admitted ·

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.93.1", optional = true }
-nika-error     = { path = "../nika-error", version = "0.93.1", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.93.1", optional = true }
+nika-types     = { path = "../nika-types", version = "0.94.0", optional = true }
+nika-error     = { path = "../nika-error", version = "0.94.0", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.94.0", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.93.1" }
+nika-types  = { path = "../nika-types", version = "0.94.0" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.93.1" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.94.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
 jaq-std       = { workspace = true }
@@ -39,15 +39,15 @@ tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval o
 # required) — the SAME vocabulary the in-test drift guards pin to the
 # ToolDef schemas (one source, no drift). Minimal features: the builtin
 # catalog only, no provider/pricing data. L1.5→L0 downward (layering-clean).
-nika-catalog  = { path = "../nika-catalog", version = "0.93.1", default-features = false, features = ["builtins-transforms"] }
+nika-catalog  = { path = "../nika-catalog", version = "0.94.0", default-features = false, features = ["builtins-transforms"] }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.93.1" }
+nika-fs          = { path = "../nika-fs", version = "0.94.0" }
 # test-only: an INDEPENDENT PNG decoder proving the mock image provider's
 # hand-rolled stored-deflate encoder emits spec-valid files (not just bytes
 # our own sniffer accepts).

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.1" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.94.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.93.1" }
+nika-catalog = { path = "../nika-catalog", version = "0.94.0" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.93.1" }
+nika-error = { path = "../nika-error", version = "0.94.0" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.93.1" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.94.0" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.93.1" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.93.1" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.93.1" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.93.1" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.93.1" }   # the embedded language pack (`nika spec|schema|examples|new`)
-nika-bm25   = { path = "../nika-bm25", version = "0.93.1" }   # intent→template routing (`nika new` · the deterministic floor)
+nika-event  = { path = "../nika-event", version = "0.94.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.94.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.94.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.94.0" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.94.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-bm25   = { path = "../nika-bm25", version = "0.94.0" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde       = { workspace = true }                             # graph projection envelope (§6)
@@ -29,21 +29,21 @@ anstyle     = { workspace = true }                             # Role→Style ma
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.93.1" }       # the L3 executor (the composer drives it)
-nika-providers   = { path = "../nika-providers", version = "0.93.1" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.1" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.1" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.1" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.1" }
-nika-builtin     = { path = "../nika-builtin", version = "0.93.1" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.93.1" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.93.1" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.93.1" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.93.1" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.93.1", features = ["providers"] }  # the env_var ladder per provider
-nika-lsp         = { path = "../nika-lsp", version = "0.93.1" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-mcp         = { path = "../nika-mcp", version = "0.93.1" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-kernel      = { path = "../nika-kernel", version = "0.94.0" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.94.0" }       # the L3 executor (the composer drives it)
+nika-providers   = { path = "../nika-providers", version = "0.94.0" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.94.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.94.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.94.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.94.0" }
+nika-builtin     = { path = "../nika-builtin", version = "0.94.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.94.0" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.94.0" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.94.0" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.94.0" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.94.0", features = ["providers"] }  # the env_var ladder per provider
+nika-lsp         = { path = "../nika-lsp", version = "0.94.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-mcp         = { path = "../nika-mcp", version = "0.94.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [[bin]]
@@ -54,7 +54,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.1" }
+nika-types = { path = "../nika-types", version = "0.94.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.93.1" }
-nika-error = { path = "../nika-error", version = "0.93.1" }
+nika-types = { path = "../nika-types", version = "0.94.0" }
+nika-error = { path = "../nika-error", version = "0.94.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.93.1" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.94.0" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.93.1" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.94.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.93.1" }
-nika-types   = { path = "../nika-types", version = "0.93.1" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.94.0" }
+nika-types   = { path = "../nika-types", version = "0.94.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.93.1" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.1" }
+nika-error       = { path = "../nika-error", version = "0.94.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.94.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.93.1" }
+nika-error    = { path = "../nika-error", version = "0.94.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.93.1" }
-nika-error    = { path = "../nika-error", version = "0.93.1" }
+nika-kernel   = { path = "../nika-kernel", version = "0.94.0" }
+nika-error    = { path = "../nika-error", version = "0.94.0" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.93.1" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.93.1" }
+nika-error       = { path = "../nika-error", version = "0.94.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.94.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.93.1" }
+nika-error    = { path = "../nika-error", version = "0.94.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.93.1" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.93.1" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.93.1" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.93.1" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.93.1" }
+nika-error          = { path = "../nika-error", version = "0.94.0" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.94.0" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.94.0" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.94.0" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.94.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.93.1" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-schema = { path = "../nika-schema", version = "0.94.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.93.1" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-error  = { path = "../nika-error", version = "0.93.1" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.93.1" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.94.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-error  = { path = "../nika-error", version = "0.94.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.94.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 # The embedded knowledge payloads (`nika_catalog` · `nika_tools`) — the SAME
 # versioned projections `nika catalog|tools --json` emit (one builder per
 # owning crate · zero duplication). L4→L0 / L4→L1.5, strictly downward.
-nika-catalog = { path = "../nika-catalog", version = "0.93.1", default-features = false, features = ["serde", "capabilities"] }
-nika-builtin = { path = "../nika-builtin", version = "0.93.1" }
+nika-catalog = { path = "../nika-catalog", version = "0.94.0", default-features = false, features = ["serde", "capabilities"] }
+nika-builtin = { path = "../nika-builtin", version = "0.94.0" }
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-pack/pack/QUICKSTART.md
+++ b/crates/nika-pack/pack/QUICKSTART.md
@@ -36,7 +36,7 @@ tasks:
 > `ollama/qwen3.5:4b` · zero key, nothing leaves your machine
 > (`ollama pull qwen3.5:4b` first · or `lmstudio/…` · `llamacpp/…` ·
 > `vllm/…`). Prefer cloud? Swap the one `model:` line for any of the
-> <!-- canon:providers -->14<!-- /canon --> providers ·
+> <!-- canon:providers -->16<!-- /canon --> providers ·
 > `mistral/mistral-small` · `anthropic/claude-haiku-4-5` ·
 > `openai/gpt-5.2` · the rest of the file doesn't change.
 
@@ -208,7 +208,7 @@ a caller receives).
 - **[templates/](./templates/)**: writing your own? Instantiate a
   skeleton (6 valid, slot-marked) instead of starting blank, the
   deterministic path agents follow ([protocol](AGENTS.md))
-- **[stdlib/](./stdlib/)**: the <!-- canon:providers -->14<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->24<!-- /canon --> builtins
+- **[stdlib/](./stdlib/)**: the <!-- canon:providers -->16<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->25<!-- /canon --> builtins
 - **[examples/](./examples/)**: 7 foundation + 20 showcase workflows, all shipped and CI-gated
 - **[README.md](./README.md)**: why a language · repo layout · governance
 

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -58,6 +58,9 @@ counts:
   diamond_layers: 7
   steal_pattern_tiers: 4
   severity: 4
+  # ---- extended 2026-07-06 · the MCP oracle surface
+  mcp_tools: 8
+  mcp_protocol_versions: 5
 
 # ---------------------------------------------------------------- verbs
 # D-2026-05-22-N18 · "the count is 4, absolute · immutable forever".
@@ -89,7 +92,7 @@ namespaces:
 
 # ---------------------------------------------------------------- builtins
 # Post atomic-language audit · 42→27→26→25→22 (-20 · -48% · zero functional loss) → 23 (compose added 2026-06-13 · ADR-093 · agent-loop self-check intrinsic, loop-only like done) → 24 (image_generate added 2026-07-05 · the first stdlib §Media graduate · openai/gemini/mock · assets land on disk, never inline) → 25 (tts_generate added 2026-07-05 · §Audio · local/openai/elevenlabs/mock · sovereign-first).
-# stdlib/builtins-v0.1.md is the prose home (matches at 24 · cascade complete 2026-07-05 · image providers v1.1 local-first + xai same day).
+# stdlib/builtins-v0.1.md is the prose home (matches at 25 · cascade complete 2026-07-06 · image providers v1.1 local-first + xai · tts_generate §Audio same arc).
 # Admission test · 3 razors · (1) NOT-expressible-in-jq+CEL+Schema · (2) canonical
 # interop format (RFC-6902/7396/9562 · etc.) · (3) cookbook-clarity.
 builtins:
@@ -338,6 +341,36 @@ severity:
   count: 4
   reference: studio-internal
   items: [BLOCKER, HIGH, MED, LOW]
+
+# ---------------------------------------------------------------- mcp
+# The in-binary MCP server surface (`nika mcp` · read-only oracle). Tools and
+# protocol revisions are ENGINE-VERIFIED facts (crates/nika-mcp · protocol.rs
+# SUPPORTED array + tools.rs registry) — projected, never hand-typed (the
+# 2026-07-06 audit found the two-tool framing fossilized on four satellite
+# surfaces while the engine served eight).
+mcp:
+  tools:
+    count: 8
+    reference: crates/nika-mcp/src/tools.rs
+    items:
+      - nika_check
+      - nika_explain
+      - nika_schema
+      - nika_examples
+      - nika_template
+      - nika_canon
+      - nika_catalog
+      - nika_tools
+  protocol_versions:
+    count: 5
+    latest: "2026-07-28"
+    reference: crates/nika-mcp/src/protocol.rs
+    items:
+      - "2026-07-28"
+      - "2025-11-25"
+      - "2025-06-18"
+      - "2025-03-26"
+      - "2024-11-05"
 
 # ---------------------------------------------------------------- canonical phrasing
 # F2 one-voice registry (2026-06-10 night arc · B1) · the LOAD-BEARING sentences

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -2,7 +2,7 @@
 # from VERSION + examples/ + examples/showcase/ — the versioned pack
 # contract. DO NOT EDIT · regenerate: python3 scripts/showcase-projector.py --write
 # Consumers · the reference engine embeds this pack (nika examples ·
-# nika docs) · docs + website render projections of the same files.
+# nika spec) · docs + website render projections of the same files.
 pack_version: 0.1.0-draft
 workflow_count: 28
 foundation:

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -123,7 +123,7 @@ outputs:                              # what the workflow returns · symmetric t
 | [07 conformance](./07-conformance.md) | What « v0.1-compliant » means |
 | [08 out of scope](./08-out-of-scope.md) | Explicit defer list (memory · macros · etc.) |
 
-**Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/): **<!-- canon:providers -->14<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->24<!-- /canon --> builtins** (6 core · 5 file · 8 data · 1 introspection · 2 network · post ADR-086/087/088 Rams sweep 2026-05-27).
+**Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/): **<!-- canon:providers -->16<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->25<!-- /canon --> builtins** (6 core · 5 file · 8 data · 2 network · 2 introspection · 2 media).
 
 ---
 

--- a/crates/nika-pack/pack/spec/02-verbs.md
+++ b/crates/nika-pack/pack/spec/02-verbs.md
@@ -230,7 +230,7 @@ spec minor. It never appears silently.
       path: "./config.yaml"
 ```
 
-See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) for the canonical builtin list (<!-- canon:builtins -->24<!-- /canon --> builtins in v0.1).
+See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) for the canonical builtin list (<!-- canon:builtins -->25<!-- /canon --> builtins in v0.1).
 
 > **Grouped paths are grammar-legal · v0.1 ships none.** The reference
 > grammar admits `nika:<group>/<tool>` (the `nika:connectome/recall`

--- a/crates/nika-pack/pack/spec/06-stdlib-contract.md
+++ b/crates/nika-pack/pack/spec/06-stdlib-contract.md
@@ -44,9 +44,9 @@ Three reasons ·
 
 The stdlib has **independent versioning** ·
 
-- `stdlib/providers-v0.1.md`, the <!-- canon:providers -->14<!-- /canon --> canonical providers for v0.1
+- `stdlib/providers-v0.1.md`, the <!-- canon:providers -->16<!-- /canon --> canonical providers for v0.1
 - `stdlib/extract-modes-v0.1.md`, the <!-- canon:extract_modes -->9<!-- /canon --> canonical extract modes for v0.1
-- `stdlib/builtins-v0.1.md`, the <!-- canon:builtins -->24<!-- /canon --> canonical builtins for v0.1
+- `stdlib/builtins-v0.1.md`, the <!-- canon:builtins -->25<!-- /canon --> canonical builtins for v0.1
 
 When the stdlib evolves to v0.2 · those files become `*-v0.2.md` and new versions are published. The core language contract (`nika: v1`) is unchanged.
 
@@ -188,7 +188,7 @@ See [07-conformance.md](./07-conformance.md). In summary ·
 |---|---|
 | Core | None · only parse + DAG + variable + error · no execution needed |
 | Runtime | Must execute the 4 verbs · provider/tool implementations engine's choice |
-| Stdlib v0.1 | Must ship the <!-- canon:providers -->14<!-- /canon --> providers + <!-- canon:extract_modes -->9<!-- /canon --> extract modes + <!-- canon:builtins -->24<!-- /canon --> builtins |
+| Stdlib v0.1 | Must ship the <!-- canon:providers -->16<!-- /canon --> providers + <!-- canon:extract_modes -->9<!-- /canon --> extract modes + <!-- canon:builtins -->25<!-- /canon --> builtins |
 | Stdlib v0.1+media | RESERVED · enumerated when the media set publishes (stdlib v0.x · the 24 names are not yet normative) |
 
 A v0.1-compliant engine for a workflow author depends on which level they need.

--- a/crates/nika-pack/pack/spec/07-conformance.md
+++ b/crates/nika-pack/pack/spec/07-conformance.md
@@ -24,7 +24,7 @@ Three nested levels · increasing scope ·
 |---|---|---|
 | **Core** | Parse + validate · DAG semantics · variable resolution · error structure | Linters · spec editors · static analyzers |
 | **Runtime** | Core + verb execution | Working engine (with own provider/tool impls) |
-| **Stdlib v0.1** | Runtime + the <!-- canon:providers -->14<!-- /canon --> providers + <!-- canon:extract_modes -->9<!-- /canon --> extract modes + <!-- canon:builtins -->24<!-- /canon --> builtins | Full reference-impl-equivalent engine |
+| **Stdlib v0.1** | Runtime + the <!-- canon:providers -->16<!-- /canon --> providers + <!-- canon:extract_modes -->9<!-- /canon --> extract modes + <!-- canon:builtins -->25<!-- /canon --> builtins | Full reference-impl-equivalent engine |
 
 A higher level **includes** the lower levels.
 

--- a/crates/nika-pack/pack/stdlib/builtins-coverage-matrix.md
+++ b/crates/nika-pack/pack/stdlib/builtins-coverage-matrix.md
@@ -1,6 +1,6 @@
 # Stdlib v0.1 · Builtin coverage matrix
 
-> The <!-- canon:builtins -->24<!-- /canon --> builtins audited **as a SET** (2026-06-10) · capability coverage ·
+> The <!-- canon:builtins -->25<!-- /canon --> builtins audited **as a SET** (2026-06-10) · capability coverage ·
 > overlap boundaries · naming grammar · deliberate absences. Per-builtin
 > specs live in [builtins-v0.1.md](./builtins-v0.1.md); this file answers
 > the set-level questions · « can it do everything? » and « is anything
@@ -21,7 +21,8 @@
 | time | `wait` (relative XOR absolute) · `date` | ✅ |
 | hash / crypto | `hash` | ✅ hashing · signing/encryption = deliberate absence (B2) |
 | notify / human | `notify` · `prompt` (blocking approval) | ✅ full |
-| media / image generation | `image_generate` (openai · gemini · mock · assets land on disk + provenance manifest) | ✅ first §Media graduate (2026-07-05) · editing + the rest of the media class deferred |
+| media / image generation | `image_generate` (local · openai · gemini · xai · mock · assets land on disk + provenance manifest) | ✅ §Media (2026-07-05) · `mode: edit` specified ([builtins-v0.1 §edit](./builtins-v0.1.md)) · the rest of the media class deferred |
+| media / speech synthesis | `tts_generate` (local · openai · elevenlabs · mock · assets land on disk + manifest incl. `watermark_declared`) | ✅ §Audio (2026-07-05) |
 | control / observability | `assert` · `done` · `log` · `emit` · `inspect` (+ DAG-side `when` · `for_each`) | ✅ full |
 
 Every capability class is covered or carries a **written deliberate-absence
@@ -71,4 +72,4 @@ reference engine define the precise shapes.
 
 ---
 
-🦋 *<!-- canon:builtins -->24<!-- /canon --> builtins · zero duplicates · every absence written.*
+🦋 *<!-- canon:builtins -->25<!-- /canon --> builtins · zero duplicates · every absence written.*

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -1,6 +1,6 @@
 # Stdlib v0.1 · Builtins
 
-> **<!-- canon:builtins -->24<!-- /canon --> canonical builtins** shipped with Stdlib v0.1-compliant engines.
+> **<!-- canon:builtins -->25<!-- /canon --> canonical builtins** shipped with Stdlib v0.1-compliant engines.
 > Invoked via `invoke: tool: "nika:<name>"`. Plus the remaining media
 > builtins deferred to stdlib v0.x (opt-in feature flag).
 >
@@ -331,7 +331,7 @@ Throws · `NIKA-BUILTIN-INSPECT-001` if `view:` value not in the canonical enum.
 
 ---
 
-## Media builtins (1)
+## Media builtins (2)
 
 ### `nika:image_generate` · provider-backed image asset generation
 
@@ -357,7 +357,9 @@ outputs** (no base64 in `tasks.X.output`, logs, or traces · normative).
 | `provider` | `local` · `openai` · `gemini` · `xai` · `mock` — optional when inferable from `model:` (`gpt-image*`→openai · `gemini-*`→gemini · `grok*`→xai · `mock*`→mock · `local` is NEVER inferred: its model names are server-specific) |
 | `model` | per-provider default (reference engine 2026-07: `stablediffusion` for local — the LocalAI convention · SD-family servers also honor the `positive \| negative` split INSIDE `prompt:` (LocalAI pipe syntax) — no separate arg needed · `gpt-image-2` · `gemini-3.1-flash-image` · `grok-imagine-image` — the `-quality` tier is the model knob · `mock-image-1`) |
 | `prompt` | **required** · the creative brief · may use `${{ … }}` |
-| `mode` | `generate` (default) · `edit` is RESERVED (rejected loudly in v0.1 · media roadmap) |
+| `mode` | `generate` (default · text→image) · `edit` (source image(s) + instruction → image · M2.2 · 2026-07-06) |
+| `image` / `images` | mode:edit source · one path (`image:`) XOR many (`images:` · capped per provider: openai 16 · gemini 14 · xai 3) · **read + permit-gated** (`permits.fs.read` must cover them — the mirror of the save boundary) |
+| `mask` | mode:edit optional pixel-mask path · openai/local only — a mask on an instruction-only provider (gemini/xai) is REFUSED loudly, never silently dropped (the output would be wrong outside the region) |
 | `n` | 1..=10 variants (engines MAY satisfy n via sequential provider calls · documented per adapter) |
 | `aspect_ratio` | closed set `1:1 · 16:9 · 9:16 · 4:3 · 3:4 · 3:2 · 2:3 · 21:9` |
 | `size` | exact `WIDTHxHEIGHT` or `auto` · an exact size WINS over `aspect_ratio:` (with a warning) · providers that render size CLASSES fold it (loudly) |
@@ -526,9 +528,10 @@ scrubbed (the image family's rule).
 Throws · `NIKA-BUILTIN-TTS_GENERATE-001` invalid arguments
 (`validation_error`) · `-002` provider unavailable (`validation_error`) ·
 `-003` request failed (`network_error` · `transient: true` for
-5xx/408/429 + timeout/connection) · `-004` empty audio · `-005` content
-policy · `-006` save failed · `-007` payload validation (all
-`runtime_error` unless noted).
+5xx/408/429 + timeout/connection) · `-004` empty audio (`tool_error`) ·
+`-005` content policy (`security_error` · never transient) · `-006` save
+failed (`tool_error`) · `-007` payload validation (`tool_error`) — the
+image twin's category ladder, code for code.
 
 ## What jq subsumes (cut from v0.1)
 
@@ -584,4 +587,4 @@ external users · before the forever-clock).
 
 ---
 
-🦋 *<!-- canon:builtins -->24<!-- /canon --> builtins canonical · jq = the data language · 5-layer Rams symmetry (fetch+extract · jq · convert · wait · inspect) · assets land on disk, never inline · clear forever.*
+🦋 *<!-- canon:builtins -->25<!-- /canon --> builtins canonical · jq = the data language · 5-layer Rams symmetry (fetch+extract · jq · convert · wait · inspect) · assets land on disk, never inline · clear forever.*

--- a/crates/nika-pack/pack/stdlib/providers-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/providers-v0.1.md
@@ -1,6 +1,6 @@
 # Stdlib v0.1 · Providers
 
-> The canonical <!-- canon:providers -->14<!-- /canon --> providers shipped with v0.1-compliant engines. Each
+> The canonical <!-- canon:providers -->16<!-- /canon --> providers shipped with v0.1-compliant engines. Each
 > provider implements the same interface (LLM chat completion + optional
 > streaming + vision + structured output) against a different backend.
 > You select one with a single `model: <provider>/<name>` field.
@@ -570,4 +570,4 @@ The reference engine implements `provider_options:` as best-effort pass-through.
 
 ---
 
-🦋 *<!-- canon:providers -->14<!-- /canon --> providers · 1 contract · sovereignty preserved.*
+🦋 *<!-- canon:providers -->16<!-- /canon --> providers · 1 contract · sovereignty preserved.*

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.93.1" }
-nika-catalog = { path = "../nika-catalog", version = "0.93.1", features = ["providers"] }
+nika-kernel  = { path = "../nika-kernel", version = "0.94.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.94.0", features = ["providers"] }
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,17 +11,17 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.93.1" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.93.1" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.93.1" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.93.1" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-catalog     = { path = "../nika-catalog", version = "0.93.1", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
-nika-cel         = { path = "../nika-cel", version = "0.93.1" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.93.1" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.93.1" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.1" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.93.1" }
+nika-types       = { path = "../nika-types", version = "0.94.0" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.94.0" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.94.0" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.94.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-catalog     = { path = "../nika-catalog", version = "0.94.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
+nika-cel         = { path = "../nika-cel", version = "0.94.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.94.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.94.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.94.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.94.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.94.0" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -34,9 +34,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.93.1" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.93.1" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.94.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.94.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -17,10 +17,10 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # nika-cap permits). The 4th (nika-cap) is the permits boundary extracted 2026-07-03
 # for reuse by nika-policy/runtime WITHOUT pulling the parser; inlining it back to
 # stay at 3 would defeat the extraction. High fan-in is intentional here (ADR-027).
-nika-error   = { path = "../nika-error", version = "0.93.1" }
-nika-catalog = { path = "../nika-catalog", version = "0.93.1" }
-nika-types   = { path = "../nika-types", version = "0.93.1" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.93.1" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-error   = { path = "../nika-error", version = "0.94.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.94.0" }
+nika-types   = { path = "../nika-types", version = "0.94.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.94.0" }   # the permits vocab lives here now (extracted 2026-07-03)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -43,10 +43,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.93.1" }
+nika-event = { path = "../nika-event", version = "0.94.0" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.93.1" }
+nika-pack  = { path = "../nika-pack", version = "0.94.0" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-kernel      = { path = "../nika-kernel", version = "0.93.1" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.93.1" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.93.1" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.93.1" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.93.1" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-kernel      = { path = "../nika-kernel", version = "0.94.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.94.0" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.94.0" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.94.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.94.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -24,7 +24,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.93.1" }
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-error  = { path = "../nika-error", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.93.1" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error     = { path = "../nika-error", version = "0.93.1" }
-nika-kernel    = { path = "../nika-kernel", version = "0.93.1" }
-nika-providers = { path = "../nika-providers", version = "0.93.1" }
+nika-error     = { path = "../nika-error", version = "0.94.0" }
+nika-kernel    = { path = "../nika-kernel", version = "0.94.0" }
+nika-providers = { path = "../nika-providers", version = "0.94.0" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.93.1" }
-nika-kernel = { path = "../nika-kernel", version = "0.93.1" }
+nika-error  = { path = "../nika-error", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }


### PR DESCRIPTION
The tag the docs already describe: 25 builtins (media suite + provenance) · run journal with --task cone · catalog/tools --json + 8-tool MCP oracle on 2026-07-28 · honest cost_usd · 16 providers · doctor --ping. Pack re-vendored from spec main BEFORE the tag (the v0.93.1 lesson) · status blocks parity-synced (vector 23). 3325 lib tests · clippy 0 warnings · full hook chain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)