### PR TITLE
docs(src): stdlib counts leave the doc-comments — the catalog is the count

### DIFF
--- a/crates/nika-catalog/src/types/builtin.rs
+++ b/crates/nika-catalog/src/types/builtin.rs
@@ -30,7 +30,7 @@ pub struct Builtin {
     /// The UNCONDITIONALLY required argument keys (the JSON-Schema
     /// `required` set the model-facing `ToolDef` declares). `nika check`
     /// flags a call missing any of these at check time instead of at run
-    /// time (the « 5/23 builtins had a static required-arg check » gap).
+    /// time (the « only a handful of builtins had a static required-arg check » gap).
     /// A subset of [`Self::args`]. Builtins whose requirement is
     /// CONDITIONAL (`nika:wait` `duration` XOR `until` · `nika:fetch`
     /// mode-dependent `jq`/`selector`) keep `&[]` here — the

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -188,8 +188,9 @@ pub struct CheckReport {
     /// DAG order — empty when `conformance` has entries.
     pub gate_findings: Vec<GateFinding>,
     /// Every `nika:` tool that names no canonical builtin (the closed
-    /// 22-builtin catalog) — a runtime dispatch failure moved to check
-    /// time, with the « did you mean » fix attached.
+    /// stdlib catalog — the count lives in `nika-builtin`, never here) —
+    /// a runtime dispatch failure moved to check time, with the
+    /// « did you mean » fix attached.
     pub unknown_tools: Vec<UnknownTool>,
     /// Every `invoke` call passing an `args:` key the named builtin does
     /// not declare — the silent-footgun class (`nika:jq` with `data:`
@@ -197,8 +198,9 @@ pub struct CheckReport {
     /// surfaced at check time with the « did you mean » fix.
     pub unknown_args: Vec<UnknownArg>,
     /// Every `invoke` call MISSING an unconditionally-required `args:` key
-    /// (the `Builtin::required` set). Closes the « only 5/23 builtins had a
-    /// static required-arg check » gap — a required-arg builtin now fails
+    /// (the `Builtin::required` set). Closes the « only a handful of
+    /// builtins had a static required-arg check » gap — a required-arg
+    /// builtin now fails
     /// `nika check` instead of passing `check {}` and failing at run. The
     /// conditional contracts (`nika:wait`, `nika:fetch`) stay in
     /// `conformance` (the `builtin_shape` ladder) — no double report.

--- a/crates/nika-verb-invoke/src/lib.rs
+++ b/crates/nika-verb-invoke/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! - **Dispatcher injected, never owned** — the verb rides the kernel
 //!   `ToolExecuteDyn` seam: production wiring injects the engine's
-//!   builtin+MCP dispatcher (resolves `nika:*` against the closed 22-builtin
+//!   builtin+MCP dispatcher (resolves `nika:*` against the closed builtin
 //!   set + `mcp:*` against the configured server registry); tests inject a
 //!   mock executor. NO Cargo dep on `nika-builtin` / `nika-mcp`.
 //! - **The closed-namespace contract (spec §invoke)** — the tool-ref
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn tool_ref_validation_matrix() {
         // `nika:connectome/recall` is verb-LEVEL valid (grammar shape ok);
-        // the injected dispatcher rejects it against the closed 22-builtin
+        // the injected dispatcher rejects it against the closed builtin
         // set today (spec 02-verbs §invoke · the verb does shape, the
         // dispatcher does the closed-set check).
         assert!(validate_tool_ref("nika:read").is_ok());


### PR DESCRIPTION
Round-23 cross-repo audit leftovers, swept in one pass: doc-comments fossilized at « 22-builtin » and « 5/23 builtins » while the stdlib grew to 25 (media suite). Same hand-written-count drift class the website (23-builtin schema fossil) and the spec schema description (« 24 canonical ») paid today — all three surfaces now count-free; the catalog/canon are the count.

- `nika-schema/src/check/mod.rs` — unknown_tools + missing_args doc-comments
- `nika-catalog/src/types/builtin.rs` — required-arg gap note
- `nika-verb-invoke/src/lib.rs` — module doc + test comment

Prose only, zero behavior. clippy -D warnings + lib tests green on all three crates; full pre-push gates green (8 ratchets · hygiene).

Sibling of nika-spec#21 (schema description count-free at the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)