### PR TITLE
feat(hygiene): seam-discipline vector + chromiumoxide surface pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ accessibility = "0.2"   # nika-a11y L1 (M2.3 · macOS-gated) — safe AXUIElemen
 core-foundation = "0.10" # nika-a11y L1 (M2.3 · macOS-gated) — CFString/CFType for AXAttribute generic reads (value · subrole)
 atspi    = "0.29"   # nika-a11y L1 (M2.3-bis · Linux-gated · ADR-083) — pure-Rust async AT-SPI2 D-Bus client (root_accessible_on_registry · get_children · get_role · State::Sensitive) · CI-pending verify on a Linux/AT-SPI host
 enigo    = "0.6"    # nika-input L1 (M2.4 · ADR-083 cross-platform) — synthetic pointer+keyboard (macOS CGEvent · Windows SendInput · Linux X11/Wayland · per-OS unsafe encapsulated → keeps unsafe forbid) · API tarball-verified 0.6.1
-chromiumoxide = "0.9"   # nika-browser L1 (M2.5 · ADR-083) — CDP browser automation (tokio-native · kill_on_drop child per INV-011 · fetcher feature OFF: never silently download a browser) · API tarball-verified 0.9.1
+chromiumoxide = { version = "0.9", default-features = false, features = ["bytes"] }   # nika-browser L1 (M2.5 · ADR-083) — CDP browser automation (tokio-native · kill_on_drop child per INV-011) · fetcher EXPLICITLY out (default-features=false pins the sovereign surface · a future default-flip is caught by cargo, not silently activating a browser download) · API tarball-verified 0.9.1
 png      = "0.18"   # nika-browser L1 — Page.captureScreenshot PNG → RGBA8 kernel Frame decode (pure · headless-testable)
 futures-util  = { version = "0.3", default-features = false, features = ["std"] }   # nika-browser L1 — StreamExt::next to drain the CDP Handler stream (one owned task per session)
 jsonschema = { version = "0.33", default-features = false }   # nika-verb-infer L2 — structured-output schema validation (draft 2020-12 · no network resolver per sovereignty floor)

--- a/crates/nika-builtin/src/date.rs
+++ b/crates/nika-builtin/src/date.rs
@@ -14,12 +14,21 @@ use crate::{Args, BuiltinFailure, BuiltinOutcome, opt_str, req_str};
 // ─── nika:uuid ──────────────────────────────────────────────────────────
 
 /// Generate a UUID (v7 default · sortable · or v4 random).
+///
+/// `nika:uuid` is INTENTIONALLY non-hermetic — a uuid's purpose is a
+/// fresh, unique id. v7's time-prefix gives sortability, not
+/// reproducibility; threading the clock would make the timestamp
+/// hermetic but the 74 random bits are not, so a trace-replay CANNOT
+/// reproduce it (and shouldn't — that defeats uniqueness). The inverse
+/// of `date`'s tz, which MUST be sovereign: offsets are world-facts,
+/// ids are meant to be fresh. Rides getrandom's CSPRNG directly — the
+/// single deliberate seam bypass in the L1.5+ layer (check-seam-discipline).
 pub(crate) fn uuid(args: &Args) -> BuiltinOutcome {
     const C: &str = "NIKA-BUILTIN-UUID-001";
     let version = opt_str(args, "version", C)?.unwrap_or("v7");
     let id = match version {
-        "v7" => uuid::Uuid::now_v7(),
-        "v4" => uuid::Uuid::new_v4(),
+        "v7" => uuid::Uuid::now_v7(), // seam-bypass-ok: uuid is intentionally non-hermetic (entropy/freshness IS the id)
+        "v4" => uuid::Uuid::new_v4(), // seam-bypass-ok: v4 is pure entropy by design
         other => {
             return Err(BuiltinFailure::new(
                 C,

--- a/crates/nika-infer-local/src/candle_backend.rs
+++ b/crates/nika-infer-local/src/candle_backend.rs
@@ -100,8 +100,12 @@ impl CandleBackend {
     ) -> Result<Self, InferLocalError> {
         let device = Self::pick_device();
 
-        let mut file =
-            std::fs::File::open(gguf_path).map_err(|_| InferLocalError::ModelNotFound {
+        // The local-infer sidecar loads its OWN GGUF weights here — a
+        // subprocess resource loaded once at startup, NOT a workflow fs
+        // effect governed by permits.fs (behind the local-infer feature ·
+        // off in the default nika build).
+        let mut file = std::fs::File::open(gguf_path) // seam-bypass-ok: sidecar ML weight load, not a permits.fs workflow effect
+            .map_err(|_| InferLocalError::ModelNotFound {
                 model: gguf_path.display().to_string(),
             })?;
         let content =

--- a/scripts/hygiene/check-all.sh
+++ b/scripts/hygiene/check-all.sh
@@ -85,7 +85,7 @@ run_check() {
   fi
 }
 
-# --- All 37 live vectors (vectors 7 + 17 + 18 removed; 40 deployed minus 3 = 37 live).
+# --- All 38 live vectors (vectors 7 + 17 + 18 removed; 41 deployed minus 3 = 38 live).
 # 34-37 added 2026-06-10 (security/supply-chain + doctrine-enforcement arc):
 # cargo-deny policy, ADR-081 computer-use guard-presence admission gate,
 # cargo-machete unused-deps, error one-voice (NikaErrorCode trait completeness). ---
@@ -138,6 +138,7 @@ run_check "38 public-api-coverage " "check-public-api-coverage.sh"
 run_check "39 gate5-attestation   " "check-gate5-attestation.sh"
 run_check "40 kernel-io-typed-err  " "check-kernel-io-typed-errors.sh"
 run_check "41 canon-stale-terms    " "check-canon-stale-terms.sh"
+run_check "42 seam-discipline      " "check-seam-discipline.sh"
 
 # --- Output ---
 g=0

--- a/scripts/hygiene/check-seam-discipline.sh
+++ b/scripts/hygiene/check-seam-discipline.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Vector: seam discipline — L1.5+ crates must reach the OS through the
+# injected kernel seams, never std/dep defaults directly.
+#
+# The builtins deep-verify (2026-07-06) named the engine's DOMINANT bug
+# class: a builtin's stated contract silently defeated or bypassed by the
+# layer beneath it. Two of the three real bugs were seam bypasses — the
+# fs seam's unconditional mkdir defeating `create_dirs:false`, and a
+# dependency reading the system directly. A source sweep proved the class
+# is bounded engine-wide (one intended exception: uuid's entropy). This
+# vector is the ratchet that keeps it bounded: the NEXT unintended bypass
+# fails at commit time, not by luck in a review.
+#
+# Scope: L1.5/L2/L3 crates (the ones that COMPOSE effects and must go
+# through the injected seams). The L1 effect crates (nika-fs, nika-http,
+# nika-clock, nika-blob, nika-exec-runner, nika-screen, ...) ARE the seams
+# / effects and legitimately touch the OS — they are NOT scanned.
+#
+# Allowlist: a line carrying `// seam-bypass-ok: <reason>` is exempt —
+# the one intended exception is nika:uuid (entropy/freshness IS the id, so
+# it rides getrandom's CSPRNG directly · the inverse of tz which must be
+# sovereign). New exemptions require the marker + a reason (a reviewer's
+# deliberate sign-off, mirroring the `box-dyn-ok` convention).
+#
+# Reads layer membership from [workspace.metadata.diamond.layers.*] —
+# the same source-of-truth as check-layering.sh / check-no-async-in-l0.sh.
+#
+# Exit codes:
+#   0 -- GREEN (no unmarked bypass)
+#   1 -- YELLOW (reserved / no crates found)
+#   2 -- RED (at least one unmarked seam bypass)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+# Direct-OS constructs that MUST go through a seam at L1.5+. Time/entropy
+# (ride ClockDyn / are the uuid effect), filesystem, and network.
+FORBIDDEN_PATTERNS=(
+  'SystemTime::now' # wall clock — ride the injected ClockDyn (INV-027)
+  'Instant::now'    # monotonic clock — same
+  '\bUtc::now\b'    # chrono wall clock
+  '\bLocal::now\b'  # chrono local clock
+  'now_v7'          # uuid v7 (clock+entropy) — allowlisted at the uuid effect
+  'new_v4'          # uuid v4 (entropy) — allowlisted at the uuid effect
+  'thread_rng'      # rand thread RNG
+  'rand::random'    # rand convenience RNG
+  '\bgetrandom\b'   # direct entropy syscall
+  'std::fs::'       # filesystem — ride the FsDyn seam
+  'std::net::'      # network — ride the HttpDyn seam
+  '\breqwest::'     # http client — the nika-http seam owns reqwest
+  '\bTcpStream\b'   # raw sockets
+  '\bTcpListener\b'
+)
+
+# L1.5/L2/L3 crate names from workspace metadata.
+mapfile -t SCANNED_CRATES < <(grep -E '^layers\.[a-z0-9-]+ = "(L1\.5|L2|L3)"$' Cargo.toml \
+  | sed -E 's/^layers\.([a-z0-9-]+) = "(L1\.5|L2|L3)"$/\1/')
+
+if [ "${#SCANNED_CRATES[@]}" -eq 0 ]; then
+  echo "WARN: no L1.5/L2/L3 crates found in [workspace.metadata.diamond] — vector skipped"
+  exit 1
+fi
+
+violations=0
+violation_log=""
+
+for crate in "${SCANNED_CRATES[@]}"; do
+  src_dir="crates/$crate/src"
+  [ -d "$src_dir" ] || continue
+  # Scan every .rs file's PRODUCTION region only — the lines BEFORE the
+  # first `#[cfg(test)]` / `mod tests` (Rust convention: tests live in a
+  # trailing test module). A test naming a scratch dir by SystemTime or a
+  # boundary test writing real files is not a runtime bypass.
+  while IFS= read -r rs; do
+    cut=$(grep -nE '#\[cfg\(test\)\]|^[[:space:]]*mod tests' "$rs" 2>/dev/null \
+      | head -1 | cut -d: -f1)
+    prod=$(if [ -n "$cut" ]; then head -n $((cut - 1)) "$rs"; else cat "$rs"; fi)
+    for pat in "${FORBIDDEN_PATTERNS[@]}"; do
+      # Match with line numbers, then drop: line comments (//), `use`
+      # import lines (a TYPE import like `use std::net::SocketAddr` is not
+      # a bypass — only the CALL site is), and any line carrying the
+      # explicit `seam-bypass-ok:` allowlist marker.
+      # `grep -n` on a stream yields "N:content" (no filename · anchor at ^).
+      hits=$(printf '%s\n' "$prod" | grep -nE "$pat" 2>/dev/null \
+        | grep -vE '^[0-9]+:[[:space:]]*//' \
+        | grep -vE '^[0-9]+:[[:space:]]*use ' \
+        | grep -v 'seam-bypass-ok:' \
+        || true)
+      if [ -n "$hits" ]; then
+        violations=$((violations + 1))
+        violation_log+="\n  $crate ($(basename "$rs")) — unmarked bypass '$pat':\n"
+        violation_log+="$(echo "$hits" | head -3 | sed 's/^/    /')\n"
+      fi
+    done
+  done < <(find "$src_dir" -name '*.rs' 2>/dev/null)
+done
+
+if [ "$violations" -gt 0 ]; then
+  printf "RED: %d unmarked seam bypass(es) in L1.5+ crates:\n" "$violations"
+  printf "%b\n" "$violation_log"
+  echo ""
+  echo "Hint: L1.5+ crates must reach the OS through the injected kernel"
+  echo "seams (ClockDyn, FsDyn, HttpDyn — not std/dep defaults directly)."
+  echo "If a bypass is genuinely intended (like nika:uuid's entropy), add"
+  echo "a '// seam-bypass-ok: <reason>' marker on the line — a deliberate,"
+  echo "reviewable sign-off. See the seam-contract finding class."
+  exit 2
+fi
+
+echo "OK: no unmarked seam bypass in ${#SCANNED_CRATES[@]} L1.5+ crate(s)"
+exit 0


### PR DESCRIPTION
Two seam-contract-class follow-ups from the builtins deep-verify (operator-approved tickets).

**Vector 42 — the ratchet.** The campaign named the engine's dominant bug class: a builtin's stated contract silently defeated/bypassed by the layer beneath it. A source sweep proved it bounded engine-wide (one intended exception: uuid's entropy). `check-seam-discipline.sh` scans L1.5/L2/L3 prod regions for direct OS access (time/entropy/fs/net) outside the injected kernel seams; the next UNMARKED bypass fails at commit time. The three intended sites carry a `seam-bypass-ok` marker + reason. **Proven to fail, not just pass**: an injected `SystemTime::now()` turns it RED (exit 2) at the exact line; removing it returns GREEN. The value is visibility not prevention — a marker can silence it, but it's reasoned and diff-visible (the `#[allow]`/`unsafe` trust model).

**chromiumoxide pin.** The dep-default audit found a latent sovereignty fragility: bare `chromiumoxide = 0.9` delivered no-fetcher only because fetcher stays out of default features — a future minor could silently flip it into a browser download. Pinning `default-features=false, features=[bytes]` (same surface) makes it explicit: a flip is caught by cargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)