### PR TITLE
feat(nika-catalog): the 5 local servers get their catalog face

### DIFF
--- a/crates/nika-catalog/data/llm-providers.toml
+++ b/crates/nika-catalog/data/llm-providers.toml
@@ -769,6 +769,110 @@ model = "@cf/meta/llama-3.1-8b-instruct"
 context_window_tokens = 128000
 max_output_tokens = 4096
 
+# ── the 5 local OpenAI-compatible servers ────────────────────────────────────
+# Runtime profiles are const in nika-providers (loopback defaults · zero key ·
+# is_local classification) — these rows carry the CATALOG face: description,
+# discovery tags and a seed model each. A local server serves whatever model
+# the operator pulled, so the model list is a curated STARTING POINT, never a
+# closed set (resolve_model passes unknown names through verbatim). Seed ids
+# follow the repo's own teaching surface (README · docs · site).
+
+[[providers]]
+id = "ollama"
+name = "Ollama"
+aliases = []
+env_var = ""
+default_model = "qwen3.5:4b"
+cheap_model = "llama3.2:3b"
+requires_key = false
+description = "Local Ollama server (default port 11434) — serves any pulled model."
+api_dialect = "openai-chat"
+tags = ["local", "open-source"]
+
+[[providers.models]]
+id = "qwen"
+model = "qwen3.5:4b"
+context_window_tokens = 128000
+max_output_tokens = 8192
+
+[[providers.models]]
+id = "llama"
+model = "llama3.2:3b"
+context_window_tokens = 128000
+max_output_tokens = 8192
+
+[[providers]]
+id = "lmstudio"
+name = "LM Studio"
+aliases = ["lm-studio"]
+env_var = ""
+default_model = "qwen3.5-4b"
+cheap_model = "qwen3.5-4b"
+requires_key = false
+description = "LM Studio local server (default port 1234) — serves the loaded model."
+api_dialect = "openai-chat"
+tags = ["local", "open-source"]
+
+[[providers.models]]
+id = "qwen"
+model = "qwen3.5-4b"
+context_window_tokens = 128000
+max_output_tokens = 8192
+
+[[providers]]
+id = "llamacpp"
+name = "llama.cpp"
+aliases = ["llama-cpp"]
+env_var = ""
+default_model = "default"
+cheap_model = "default"
+requires_key = false
+description = "llama.cpp server (default port 8080) — serves the loaded GGUF; the wire model id is free-form."
+api_dialect = "openai-chat"
+tags = ["local", "open-source"]
+
+[[providers.models]]
+id = "default"
+model = "default"
+context_window_tokens = 128000
+max_output_tokens = 8192
+
+[[providers]]
+id = "localai"
+name = "LocalAI"
+aliases = []
+env_var = ""
+default_model = "default"
+cheap_model = "default"
+requires_key = false
+description = "LocalAI server (default port 8080) — an OpenAI-compatible gateway over local backends."
+api_dialect = "openai-chat"
+tags = ["local", "open-source"]
+
+[[providers.models]]
+id = "default"
+model = "default"
+context_window_tokens = 128000
+max_output_tokens = 8192
+
+[[providers]]
+id = "vllm"
+name = "vLLM"
+aliases = []
+env_var = ""
+default_model = "Qwen/Qwen3-8B"
+cheap_model = "Qwen/Qwen3-8B"
+requires_key = false
+description = "vLLM server (default port 8000) — serves Hugging Face model ids at throughput."
+api_dialect = "openai-chat"
+tags = ["local", "open-source"]
+
+[[providers.models]]
+id = "qwen"
+model = "Qwen/Qwen3-8B"
+context_window_tokens = 128000
+max_output_tokens = 8192
+
 [[providers]]
 id = "native"
 name = "Native Inference"

--- a/crates/nika-catalog/src/data/generated.rs
+++ b/crates/nika-catalog/src/data/generated.rs
@@ -86,8 +86,10 @@ mod tests {
         // new providers (nvidia-nim/deepinfra/replicate/hyperbolic/writer/
         // databricks/cloudflare), driving the count from 25 to 32; the
         // 2026-07-05 canonical promotion added huggingface (the Inference
-        // Providers router) and renamed nvidia-nim → nvidia: 32 → 33.
-        assert_eq!(ALL_PROVIDERS.len(), 33);
+        // Providers router) and renamed nvidia-nim → nvidia: 32 → 33; the
+        // 2026-07-06 local-rows fill gave the 5 local servers their catalog
+        // face (ollama/lmstudio/llamacpp/localai/vllm): 33 → 38.
+        assert_eq!(ALL_PROVIDERS.len(), 38);
     }
 
     #[test]

--- a/crates/nika-catalog/src/lib.rs
+++ b/crates/nika-catalog/src/lib.rs
@@ -125,8 +125,9 @@ mod tests {
     fn all_providers_non_empty() {
         // Session 4b added 7 providers (nvidia-nim, deepinfra, replicate,
         // hyperbolic, writer, databricks, cloudflare): 25 → 32; 2026-07-05
-        // huggingface joined (+ nvidia-nim → nvidia rename): 32 → 33.
-        assert_eq!(all_providers().len(), 33);
+        // huggingface joined (+ nvidia-nim → nvidia rename): 32 → 33;
+        // 2026-07-06 the 5 local servers got catalog rows: 33 → 38.
+        assert_eq!(all_providers().len(), 38);
     }
 
     #[test]

--- a/crates/nika-catalog/src/lookup.rs
+++ b/crates/nika-catalog/src/lookup.rs
@@ -97,7 +97,20 @@ mod tests {
 
     #[test]
     fn provider_unknown() {
-        assert!(find_provider("ollama").is_none());
+        assert!(find_provider("not-a-provider").is_none());
+    }
+
+    #[test]
+    fn local_servers_are_catalog_rows() {
+        // The 2026-07-06 fill: the 5 local servers have a catalog face
+        // (description · tags · seed models) — keyless by construction.
+        for id in ["ollama", "lmstudio", "llamacpp", "localai", "vllm"] {
+            let row = find_provider(id);
+            assert!(row.is_some(), "{id} missing from the catalog");
+            let row = row.expect("checked above");
+            assert!(!row.requires_key, "{id} must be keyless");
+            assert!(!row.models.is_empty(), "{id} needs a seed model");
+        }
     }
 
     #[test]

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -26,7 +26,7 @@
     },
     "model": {
       "type": "string",
-      "description": "Default model \u00b7 `<provider>/<name>` (e.g. anthropic/claude-sonnet-4-6 \u00b7 ollama/qwen3.5:9b \u00b7 mock/echo)."
+      "description": "Default model \u00b7 `<provider>/<name>` (e.g. ollama/qwen3.5:9b \u00b7 anthropic/claude-sonnet-4-6 \u00b7 mock/echo)."
     },
     "vars": {
       "type": "object",
@@ -562,7 +562,7 @@
           "oneOf": [
             {
               "type": "string",
-              "description": "`nika:*` builtin \u00b7 24 canonical per stdlib v0.1 (Core 6 \u00b7 File 5 \u00b7 Data 8 \u00b7 Network 2 \u00b7 Introspection 2 \u00b7 Media 1). Closed enum for `yaml-language-server` autocomplete.",
+              "description": "`nika:*` builtin \u00b7 the closed canonical stdlib (Core \u00b7 File \u00b7 Data \u00b7 Network \u00b7 Introspection \u00b7 Media \u00b7 counts live in canon.yaml). Closed enum for `yaml-language-server` autocomplete.",
               "enum": [
                 "nika:assert",
                 "nika:compose",

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -4,12 +4,12 @@
 //! Provider profiles — the canonical 16, as data.
 //!
 //! A profile binds a provider id to a wire format, a default endpoint and a
-//! key-loading recipe. Cloud rows are seeded from `nika-catalog` (codegen
-//! from `data/llm-providers.toml` — id · env var · model nicknames); the 5
-//! local servers are not catalog rows yet, so their profiles are const data
-//! here (upstreaming them to the catalog TOML is a follow-up — the set and
-//! its split are canon: `nika-spec/canon.yaml` `providers:` · 8 cloud + 5
-//! local + 1 test = 14 per D-2026-06-10-N2).
+//! key-loading recipe. Every canonical id joins its `nika-catalog` row
+//! (codegen from `data/llm-providers.toml` — description · tags · model
+//! nicknames): cloud rows carry env var + key prefixes, the 5 local
+//! servers' rows (the 2026-07-06 fill) carry the catalog face while their
+//! endpoints and keyless-ness stay const HERE — the loopback defaults and
+//! the `is_local` classification are runtime facts, never data.
 
 use nika_catalog::types::Provider as CatalogRow;
 
@@ -217,8 +217,9 @@ const CATALOG_WIRED: [(&str, WireFormat, &str); 11] = [
     ("mock", WireFormat::Mock, ""),
 ];
 
-/// The 5 local OpenAI-compatible servers (not catalog rows yet — const
-/// profiles · zero key · loopback defaults · operator-overridable).
+/// The 5 local OpenAI-compatible servers — endpoints and keyless-ness are
+/// const RUNTIME facts (loopback defaults · operator-overridable); their
+/// catalog rows (description · tags · seed models) join in [`seed`].
 ///
 /// `llamacpp` and `localai` both ship 8080 because that IS each upstream's
 /// own default; running both at once needs one `with_base_url` override
@@ -250,8 +251,11 @@ pub fn seed() -> Vec<Profile> {
             id,
             wire: WireFormat::OpenAiCompat,
             base_url,
+            // Keyless by CONSTRUCTION, never by data: a catalog edit
+            // flipping requires_key on a local row must not invent a
+            // key gate the servers don't have.
             requires_key: false,
-            catalog: None,
+            catalog: nika_catalog::find_provider(id),
         });
     }
     out
@@ -303,6 +307,23 @@ mod tests {
                 assert!(!p.requires_key, "{} must not require a key", p.id);
                 assert_eq!(p.wire, WireFormat::OpenAiCompat);
                 assert!(p.base_url.starts_with("http://127.0.0.1"), "{}", p.id);
+            }
+        }
+    }
+
+    #[test]
+    fn locals_join_their_catalog_rows_but_stay_keyless_by_construction() {
+        // The 2026-07-06 fill: local rows carry the catalog FACE
+        // (description · tags · seed models — `nika catalog` and the
+        // editor picker see them), while requires_key stays a literal
+        // false in seed(): a catalog edit can never invent a key gate.
+        for p in seed() {
+            if ["ollama", "lmstudio", "llamacpp", "localai", "vllm"].contains(&p.id) {
+                let row = p
+                    .catalog
+                    .unwrap_or_else(|| panic!("{} must join its row", p.id));
+                assert!(!row.models.is_empty(), "{} row needs a seed model", p.id);
+                assert!(!p.requires_key, "{} keyless by construction", p.id);
             }
         }
     }


### PR DESCRIPTION
## What

The known data gap since the catalog wire (#172): **ollama · lmstudio · llamacpp · localai · vllm** had const runtime profiles but no catalog rows — `nika catalog --json` (and the editor's model picker riding it) offered nothing for the sovereign path while every cloud provider listed its models. Local-first is the presentation order; the catalog now practices it.

Plus one chore riding the train: **re-vendor the pack schema from nika-spec main** (nika-spec#21 — count-free builtin description + local-first model example) so `nika schema` and every surface serving the binary's copy follow.

## How

- **5 TOML rows** — description, `local`/`open-source` tags, seed models from the repo's own teaching surface (`qwen3.5:4b`/`llama3.2:3b` for ollama · HF ids for vllm · free-form `default` for the single-model servers). A local server serves whatever the operator pulled: the list is a curated starting point, never a closed set (`resolve_model` passes unknown names through). **No pricing** — sovereign models stay « unpriced », never « free » (the honest-absence contract, untouched).
- **`seed()` joins the rows** so the catalog face reaches doctor/catalog/picker — while `requires_key` stays a literal `false`: keyless by CONSTRUCTION, a catalog edit can never invent a key gate.
- Count pins 33 → 38 with history; new tests both sides (rows exist keyless with seeds · locals join but stay keyless).

## Proof

- e2e on the built binary: `nika catalog --json` → 38 providers, the 5 locals carry their models, `requires_key: false`.
- Workspace lib tests green (39 crates) · clippy all-targets -D warnings · fmt · pre-push gates (8 ratchets + hygiene).

Cascade note: docs `_status-snapshot.mdx` pins `providers: 33` — reprojects with the next release train (the count gate reads the binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)