### PR TITLE
feat(nika-runtime): the run knows its source — workflow_sha256 on workflow_started

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "toml_edit",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -19,6 +19,7 @@ nika-pack   = { path = "../nika-pack", version = "0.94.0" }   # the embedded lan
 nika-bm25   = { path = "../nika-bm25", version = "0.94.0" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
+sha2          = { workspace = true }   # run identity — workflow_sha256 on workflow_started
 serde       = { workspace = true }                             # graph projection envelope (§6)
 serde_json  = { workspace = true }                             # trace NDJSON parse · --json surfaces
 toml_edit   = { workspace = true }                             # wire codex · ~/.codex/config.toml (comment-preserving)

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -109,7 +109,7 @@ pub fn run(
     };
 
     // ── Audit BEFORE run (spec §3 · INV the runtime also enforces) ──
-    let (wf, report) = match crate::verbs::load_checked(file) {
+    let (source, wf, report) = match crate::verbs::load_checked_with_source(file) {
         Ok(pair) => pair,
         Err(out) => {
             // Pre-run diagnostics obey the export contract too: in machine
@@ -142,15 +142,15 @@ pub fn run(
         Ok(setup) => setup,
         Err(code) => return code,
     };
-    // The pause rider binds to the NON-INTERACTIVE machine surfaces only
-    // (`--json` · `--output json` — ADR-099: « under a non-interactive
-    // surface »); the human TTY/plain surfaces keep today's PROMPT-001
-    // contract untouched.
+    // ADR-099: the pause rider binds to the NON-INTERACTIVE machine
+    // surfaces only (`--json` · `--output json`); human TTY/plain
+    // surfaces keep today's PROMPT-001 contract untouched.
     let pause_on_prompt = json || output_json;
 
     // ── Compose the production runtime (real seams · env keys) ──────
     let runtime = match composed_runtime(
         &wf,
+        &source,
         model_override,
         overrides,
         setup.plan,
@@ -469,8 +469,23 @@ fn parse_var_overrides(
 // The 7 knobs ARE the composition surface (var overrides · resume plan ·
 // answers · pause flag) — the same clap-surface idiom as `run` itself.
 #[allow(clippy::too_many_arguments)]
+/// The run's source identity: sha256 hex over the exact bytes read.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
 fn composed_runtime(
     wf: &RawWorkflow,
+    source: &str,
     model_override: Option<&str>,
     overrides: BTreeMap<String, Value>,
     resume_plan: Option<ResumePlan>,
@@ -486,7 +501,10 @@ fn composed_runtime(
             let rt = rt
                 .with_var_overrides(overrides)
                 .with_prompt_pause(pause_on_prompt)
-                .with_prompt_answers(answers);
+                .with_prompt_answers(answers)
+                // The run's identity: the journal names the definition it
+                // recorded (sha256 of the exact bytes this composer read).
+                .with_source_sha256(sha256_hex(source.as_bytes()));
             Ok(match resume_plan {
                 Some(plan) => rt.with_resume_plan(plan),
                 None => rt,

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -286,6 +286,7 @@ pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_prompt_answers(self, answer
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_prompt_pause(self, pause: bool) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_resume_plan(self, plan: nika_runtime::resume::ResumePlan) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_secret_resolver(self, resolver: alloc::sync::Arc<dyn nika_runtime::WorkflowSecretResolver>) -> Self
+pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_source_sha256(self, hex: alloc::string::String) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_var_overrides(self, overrides: alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>) -> Self
 impl<D> owo_colors::OwoColorize for nika_runtime::Runtime<S, T, H, P, D, C>
 impl<T, U> core::convert::Into<U> for nika_runtime::Runtime<S, T, H, P, D, C> where U: core::convert::From<T>

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -184,6 +184,13 @@ pub struct Runtime<S, T, H, P, D, C> {
     /// task=value`): bound as the prompt's `default:` at dispatch (the
     /// answered branch), never part of the task's resume identity.
     prompt_answers: BTreeMap<String, Value>,
+    /// The run's SOURCE identity — sha256 hex over the exact bytes the
+    /// operator ran (computed by the composer that read the file; the
+    /// runtime never re-reads). Stamped on `workflow_started` so every
+    /// journal names the definition it recorded: replay, diff and
+    /// fork surfaces can prove « the file changed since this run »
+    /// instead of guessing. `None` (embedded/test callers) = no claim.
+    source_sha256: Option<String>,
 }
 
 impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
@@ -212,6 +219,7 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
             resume_plan: resume::ResumePlan::new(),
             pause_on_prompt: false,
             prompt_answers: BTreeMap::new(),
+            source_sha256: None,
         }
     }
 
@@ -259,6 +267,16 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
         self
     }
 
+    /// Stamp the run's source identity (sha256 hex of the exact bytes
+    /// the operator ran) on `workflow_started` — the journal then names
+    /// the definition it recorded (drift detection for replay/diff/fork
+    /// surfaces). Absent by default: no source, no claim.
+    #[must_use]
+    pub fn with_source_sha256(mut self, hex: String) -> Self {
+        self.source_sha256 = Some(hex);
+        self
+    }
+
     /// Supply prompt answers (`--answer task=value` · ADR-099 rider):
     /// bound as the named task's prompt `default:` at dispatch — the
     /// answered branch of the stdlib contract, type-validated per mode
@@ -300,6 +318,7 @@ fn i(v: i64) -> FieldValue {
 fn emit_prologue(
     wf: &RawWorkflow,
     workflow_name: &str,
+    source_sha256: Option<&str>,
     stamper: &mut dyn Stamper,
     sink: &mut dyn EventSink,
 ) {
@@ -316,12 +335,11 @@ fn emit_prologue(
     } else {
         "engine floor (no boundary declared)"
     };
-    emit(
-        stamper,
-        sink,
-        EventKind::WorkflowStarted,
-        &[("workflow", s(workflow_name)), ("permits", s(permits_desc))],
-    );
+    let mut opening = vec![("workflow", s(workflow_name)), ("permits", s(permits_desc))];
+    if let Some(hex) = source_sha256 {
+        opening.push(("workflow_sha256", s(hex)));
+    }
+    emit(stamper, sink, EventKind::WorkflowStarted, &opening);
     for task in &wf.tasks {
         emit(
             stamper,
@@ -404,7 +422,13 @@ where
         // The declared capability boundary (spec 01 §permits) flows to every
         // task's dispatch scope so the exec sink can enforce it (NIKA-SEC-004).
         let permits = wf.permits.as_ref().map(|spanned| &spanned.value);
-        emit_prologue(wf, &workflow_name, stamper, sink);
+        emit_prologue(
+            wf,
+            &workflow_name,
+            self.source_sha256.as_deref(),
+            stamper,
+            sink,
+        );
 
         let mut records: BTreeMap<String, TaskRecord> = BTreeMap::new();
         let mut ok = true;

--- a/crates/nika-runtime/tests/output_fidelity.rs
+++ b/crates/nika-runtime/tests/output_fidelity.rs
@@ -467,3 +467,80 @@ tasks:
         "no declared boundary → the engine-floor truth · got: {permits}"
     );
 }
+
+// ─── the run knows its source (WorkflowStarted workflow_sha256) ──────────────
+
+/// The journal must name the DEFINITION it recorded: with a source
+/// identity injected, `workflow_started` carries `workflow_sha256`
+/// verbatim — replay/diff/fork surfaces can then prove « the file
+/// changed since this run » instead of guessing from task shapes.
+/// Without one (embedded/test callers), the field is ABSENT: no
+/// source, no claim.
+#[tokio::test]
+async fn workflow_started_carries_the_source_identity_when_injected() {
+    let yaml = r#"
+nika: v1
+workflow: source-identity
+tasks:
+  - id: t
+    invoke: { tool: "nika:jq", args: { input: { x: 1 }, expression: ".x" } }
+"#;
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_schema::check(&wf);
+    let tools = MockToolExecutor::new()
+        .enqueue_ok(ToolResult::success("t", "1").with_structured(serde_json::json!(1)));
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(tools)));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new())),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    )
+    .with_source_sha256("ab".repeat(32));
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("runs clean");
+    let events = sink.into_events();
+    let started = events
+        .iter()
+        .find(|e| e.kind == EventKind::WorkflowStarted)
+        .expect("a workflow_started frame");
+    assert_eq!(
+        str_field(started, "workflow_sha256").expect("the identity field"),
+        "ab".repeat(32),
+    );
+
+    // The companion truth: a PLAIN run makes no source claim.
+    let (_outcome, events) = run_to_events(
+        yaml,
+        MockShell::new(),
+        MockToolExecutor::new()
+            .enqueue_ok(ToolResult::success("t", "1").with_structured(serde_json::json!(1))),
+        MockProvider::new("mock"),
+    )
+    .await;
+    let plain = events
+        .iter()
+        .find(|e| e.kind == EventKind::WorkflowStarted)
+        .expect("a workflow_started frame");
+    assert!(
+        str_field(plain, "workflow_sha256").is_none(),
+        "no source injected → no identity claim"
+    );
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "nika-types",
  "serde",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "miette",
  "nika-catalog-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "miette",
  "nika-types",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-schema"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "jaq-core",
  "jaq-json",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "loom",
  "serde",


### PR DESCRIPTION
## What

The journal records everything about a run except WHICH definition ran. This PR stamps the run's source identity — sha256 hex over the exact bytes the operator ran — on `workflow_started`:

- `Runtime::with_source_sha256(hex)` — additive builder; no source injected (embedded/test callers) = no field = **no claim**.
- The CLI `run` verb switches to `load_checked_with_source` (the text already rides for painted diagnostics); the hash is composed where the seams are composed (`composed_runtime` — the fn-length ratchet kept `run()` an orchestrator).
- The prologue rides the field after `permits`. `sha2` was already a workspace dep (`nika:hash`).

## Why

Replay, diff, fork and golden surfaces in the editor can only *guess* definition drift from task shapes. With the journal naming its definition, « the file changed since this run » becomes a provable statement — the extension consumer (drift banner on replay, self-gating on field presence) is already on nika-vscode main.

## Proof

- e2e on the built binary: journaled hex == `sha256(file bytes)` byte-for-byte.
- `output_fidelity`: injected identity rides verbatim + a plain run makes **no** source claim (companion assert).
- nika-runtime lib 99 ✓ · nika-cli lib 210 ✓ · clippy -D warnings ✓ · 8/8 ci-ratchets ✓ · full pre-push suite green.
- Public API: +1 additive line, hand-added in sort position (no mac-render skew).

Additive event field · additive API · zero behavior change for existing consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)