### PR TITLE
feat(nika-runtime): the skip and the cancel say WHY — when + blocked_by

### DIFF
--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -580,25 +580,25 @@ fn settle(
     let named = finish.named;
     let resume = finish.resume;
     match finish.settle {
-        SettleAs::Cancelled { note } => {
-            emit(
-                stamper,
-                sink,
-                EventKind::TaskCancelled,
-                &[("task", s(&id)), ("note", s(note))],
-            );
+        SettleAs::Cancelled { note, blocked_by } => {
+            // The WHY rides along: which upstream kept the gate closed.
+            let mut fields = vec![("task", s(&id)), ("note", s(note))];
+            if let Some(culprit) = &blocked_by {
+                fields.push(("blocked_by", s(culprit)));
+            }
+            emit(stamper, sink, EventKind::TaskCancelled, &fields);
             records.insert(
                 id,
                 with_named(TaskRecord::unran(TaskStatus::Cancelled), named),
             );
         }
-        SettleAs::SkippedGate { note } => {
-            emit(
-                stamper,
-                sink,
-                EventKind::TaskSkipped,
-                &[("task", s(&id)), ("note", s(note))],
-            );
+        SettleAs::SkippedGate { note, expr } => {
+            // The gate's own CEL text — « why did this not run » verbatim.
+            let mut fields = vec![("task", s(&id)), ("note", s(note))];
+            if let Some(cel) = &expr {
+                fields.push(("when", s(cel)));
+            }
+            emit(stamper, sink, EventKind::TaskSkipped, &fields);
             records.insert(
                 id,
                 with_named(TaskRecord::unran(TaskStatus::Skipped), named),

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -68,11 +68,20 @@ pub(crate) struct Finish {
 /// How the task settles (spec 03 §task states).
 pub(crate) enum SettleAs {
     /// The default gate became unsatisfiable (upstream failure /
-    /// cancellation) — a decision, not a defect.
-    Cancelled { note: &'static str },
+    /// cancellation) — a decision, not a defect. `blocked_by` names the
+    /// first unsatisfied dependency (the WHY the journal can teach).
+    Cancelled {
+        note: &'static str,
+        blocked_by: Option<String>,
+    },
     /// The `when:` gate evaluated false · or an empty `for_each`
     /// collection (pure skip · no cascade).
-    SkippedGate { note: &'static str },
+    SkippedGate {
+        note: &'static str,
+        /// The CEL text that evaluated false (`when:` closes only) —
+        /// the journal answers « why did this not run » verbatim.
+        expr: Option<String>,
+    },
     /// A pre-dispatch failure (gate eval · `with:` render · `for_each`
     /// collection) — never started · no `on_finally:` (spec 03).
     FailedBeforeStart {
@@ -348,6 +357,7 @@ where
         if items.is_empty() {
             return SettleAs::SkippedGate {
                 note: "for_each · empty collection",
+                expr: None,
             };
         }
 
@@ -890,6 +900,7 @@ fn gate_finish(
             }
             SettleAs::Cancelled {
                 note: "upstream failed",
+                blocked_by: first_unsatisfied_dep(task, records),
             }
         }
         // Explicit `when:` REPLACES the default gate — evaluated once
@@ -899,6 +910,12 @@ fn gate_finish(
             Ok(true) => return None,
             Ok(false) => SettleAs::SkippedGate {
                 note: "when: gate closed",
+                expr: match &gate.value {
+                    nika_schema::types::WhenGate::Expr(cel) => Some(cel.clone()),
+                    // `when: false` — the literal IS the story; the
+                    // note already says the gate closed.
+                    _ => None,
+                },
             },
             Err(err) => SettleAs::FailedBeforeStart {
                 stage: "when",
@@ -916,6 +933,21 @@ fn gate_finish(
 
 /// The default gate's verdict (spec 03 · `depends_on` IS the
 /// success-gate): open iff ALL deps ∈ {success, skipped}.
+/// The first dependency that keeps the default gate closed — the
+/// culprit `blocked_by` names in the journal (id order = declaration
+/// order, deterministic).
+fn first_unsatisfied_dep(task: &RawTask, records: &BTreeMap<String, TaskRecord>) -> Option<String> {
+    task.depends_on
+        .iter()
+        .find(|dep| {
+            !matches!(
+                records.get(&dep.value).map(|r| r.status),
+                Some(TaskStatus::Success | TaskStatus::Skipped)
+            )
+        })
+        .map(|dep| dep.value.clone())
+}
+
 fn default_gate_open(task: &RawTask, records: &BTreeMap<String, TaskRecord>) -> bool {
     task.depends_on.iter().all(|dep| {
         matches!(

--- a/crates/nika-runtime/tests/output_fidelity.rs
+++ b/crates/nika-runtime/tests/output_fidelity.rs
@@ -544,3 +544,85 @@ tasks:
         "no source injected → no identity claim"
     );
 }
+
+// ─── the skip/cancel WHY rides the journal (skip-why · 2026-07-06) ───────────
+
+/// « Why did this task not run? » must be answerable from the journal
+/// alone: a `when:` gate that closes journals its own CEL text on the
+/// `when` field; a default-gate cancellation names the first
+/// unsatisfied dependency on `blocked_by`. Both additive.
+#[tokio::test]
+async fn skip_and_cancel_events_carry_their_why() {
+    let yaml = r#"
+nika: v1
+workflow: skip-why
+tasks:
+  - id: seed
+    invoke: { tool: "nika:jq", args: { input: { x: 1 }, expression: ".x" } }
+  - id: gated
+    depends_on: [seed]
+    when: "${{ tasks.seed.status == 'failure' }}"
+    invoke: { tool: "nika:jq", args: { input: { x: 2 }, expression: ".x" } }
+  - id: doomed
+    depends_on: [seed]
+    exec: { command: ["false"] }
+  - id: downstream
+    depends_on: [doomed]
+    invoke: { tool: "nika:jq", args: { input: { x: 3 }, expression: ".x" } }
+"#;
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_schema::check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder");
+    let tools = MockToolExecutor::new()
+        .enqueue_ok(ToolResult::success("seed", "1").with_structured(serde_json::json!(1)));
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(tools)));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new().enqueue_fail(7, "boom"))),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("the run itself is not an error");
+    assert!(!outcome.ok, "doomed fails the workflow");
+    let events = sink.into_events();
+
+    let skipped = events
+        .iter()
+        .find(|e| e.kind == EventKind::TaskSkipped)
+        .expect("the gated task skips");
+    assert_eq!(str_field(skipped, "task"), Some("gated"));
+    assert_eq!(
+        str_field(skipped, "when"),
+        Some("${{ tasks.seed.status == 'failure' }}"),
+        "the gate's own CEL text answers the why"
+    );
+
+    let cancelled = events
+        .iter()
+        .find(|e| e.kind == EventKind::TaskCancelled)
+        .expect("the downstream task cancels");
+    assert_eq!(str_field(cancelled, "task"), Some("downstream"));
+    assert_eq!(
+        str_field(cancelled, "blocked_by"),
+        Some("doomed"),
+        "the culprit upstream is named"
+    );
+}


### PR DESCRIPTION
## What

« Why did this task not run? » was unanswerable from the journal: a closed gate said `when: gate closed` without its expression; an upstream cascade said `upstream failed` without naming which. The producers already HOLD both facts — this rides them out, additively:

- **`TaskSkipped` (gate close) gains `when`** — the gate's own CEL text, verbatim. A literal `when: false` carries no expr (the note already tells the story); the empty-`for_each` skip stays note-only.
- **`TaskCancelled` gains `blocked_by`** — the FIRST unsatisfied dependency (declaration order, deterministic), via `first_unsatisfied_dep` beside `default_gate_open` — same matching truth, never two logics.

## Why

The editor's Runs view / run report can now answer the documented #1 confusion of gated DAGs (« pourquoi ma task n'a pas run ») from the journal alone — the consumer (fold + Runs row + report notes, self-gating on field presence) is already on nika-vscode main.

## Proof

- New fidelity pin: a diamond fixture where the gate's CEL rides the skipped event verbatim and the cancelled event names `doomed`. Bonus: **the checker corrected the fixture itself** (`gate_findings`: status vocabulary is `failure`, not `failed`) — the pedagogy teaching its own test.
- nika-runtime lib 99 ✓ · output_fidelity 11 ✓ · clippy -D warnings ✓ · 8/8 ci-ratchets ✓ · full pre-push suite green.
- Internal enum (`SettleAs`) — zero public-API delta. Additive event fields only.

Note: `floor_deep_path_system_template_resolves` fails on CLEAN origin/main in this environment too (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)