### PR TITLE
chore(release): v0.95.0 — the catalog practices local-first

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,9 +129,9 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `chore/release-v0.94.0`                                      |
-| HEAD             | `ee090d760` (`ee090d7601b66dd816de42f58c3901824c3f4857`)             |
-| workspace        | v0.94.0                                  |
+| branch           | `chore/release-0.95.0`                                      |
+| HEAD             | `dd829f451` (`dd829f45138e6e6d2ec83393eb441356841265a9`)             |
+| workspace        | v0.95.0                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |
@@ -142,7 +142,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | L2               | 4                                              |
 | L3               | 1                                              |
 | L4               | 4                                              |
-| lib tests        | 3325 passed, 0 failed                              |
+| lib tests        | 3334 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 
 Narrative context (manually maintained):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ Nika Diamond is a ground-up rewrite on the `nika-diamond` orphan branch.
 Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ---
+## [0.95.0](https://github.com/supernovae-st/nika/compare/v0.94.0..v0.95.0) - 2026-07-06
+
+### ✨ Highlights
+
+- **The 5 local servers get their catalog face** ([PR 208](https://github.com/supernovae-st/nika/pull/208)) —
+  ollama · lmstudio · llamacpp · localai · vllm join `nika catalog` (and
+  `catalog --json`, so editor model pickers see them) with descriptions,
+  `local`/`open-source` tags and seed models. Keyless by construction:
+  a catalog edit can never invent a key gate. Sovereign models stay
+  « unpriced », never « free ». 38 catalog providers total.
+- **The lost-user footer** ([PR 203](https://github.com/supernovae-st/nika/pull/203)) — a bare `nika`
+  suggests the next command instead of a wall of clap.
+- **Hygiene: the seam-discipline vector** ([PR 207](https://github.com/supernovae-st/nika/pull/207)) +
+  the chromiumoxide surface pin.
+
+### 🐛 Fixes
+
+- `nika:write` honors `create_dirs: false` — a missing parent is refused
+  loudly instead of silently materializing a tree ([PR 196](https://github.com/supernovae-st/nika/pull/196)).
+- `nika:date` resolves named timezones from the bundled tz db, not the
+  OS ([PR 199](https://github.com/supernovae-st/nika/pull/199)).
+- `nika:log` neutralizes terminal control sequences ([PR 204](https://github.com/supernovae-st/nika/pull/204)).
+- The MCP stdio transport bounds its line reads — no unbounded buffer
+  on a hostile client ([PR 209](https://github.com/supernovae-st/nika/pull/209)).
+
+### 📚 Docs & internals
+
+- Doc-comments go count-free (« 22-builtin » / « 5/23 » swept — the
+  catalog is the count · [PR 206](https://github.com/supernovae-st/nika/pull/206)); README daily
+  commands catch the 0.94 loop ([PR 205](https://github.com/supernovae-st/nika/pull/205)).
+- The embedded pack re-vendors nika-spec main: count-free schema
+  description (nika-spec#21) and `create_dirs` enforcement prose
+  (nika-spec#20).
+- `nika:validate` SSRF floor + deep-YAML totality pinned ([PR 197](https://github.com/supernovae-st/nika/pull/197));
+  public-api baselines synced ([PR 198](https://github.com/supernovae-st/nika/pull/198)/[PR 200](https://github.com/supernovae-st/nika/pull/200)).
+
 ## [0.94.0](https://github.com/supernovae-st/nika/compare/v0.93.1..v0.94.0) - 2026-07-06
 
 ### ✨ Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "clap",
  "futures",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cli"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "annotate-snippets 0.12.15",
  "anstyle",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "expect-test",
  "insta",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "insta",
  "miette",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "nika-kernel",
  "nix",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "globset",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "nika-http"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "insta",
  "miette",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "nika-builtin",
  "nika-catalog",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "include_dir",
  "sha2",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3993,14 +3993,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "loom",
  "proptest",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.94.0"
+version      = "0.95.0"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,9 +83,9 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `chore/release-v0.94.0`                                      |
-| HEAD             | `ee090d760` (`ee090d7601b66dd816de42f58c3901824c3f4857`)             |
-| workspace        | v0.94.0                                  |
+| branch           | `chore/release-0.95.0`                                      |
+| HEAD             | `dd829f451` (`dd829f45138e6e6d2ec83393eb441356841265a9`)             |
+| workspace        | v0.95.0                                  |
 | crates (workspace)| 40                                              |
 | crates (admitted)| 40 / 42                                   |
 | crates (WIP)     | 0 —                                   |
@@ -96,7 +96,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | L2               | 4                                              |
 | L3               | 1                                              |
 | L4               | 4                                              |
-| lib tests        | 3325 passed, 0 failed                              |
+| lib tests        | 3334 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 
 Diamond foundation — orphan branch from scratch. Live counts (admitted ·

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.94.0", optional = true }
-nika-error     = { path = "../nika-error", version = "0.94.0", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.94.0", optional = true }
+nika-types     = { path = "../nika-types", version = "0.95.0", optional = true }
+nika-error     = { path = "../nika-error", version = "0.95.0", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.95.0", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.94.0" }
+nika-types  = { path = "../nika-types", version = "0.95.0" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.94.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.95.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
 jaq-std       = { workspace = true }
@@ -40,15 +40,15 @@ tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval o
 # required) — the SAME vocabulary the in-test drift guards pin to the
 # ToolDef schemas (one source, no drift). Minimal features: the builtin
 # catalog only, no provider/pricing data. L1.5→L0 downward (layering-clean).
-nika-catalog  = { path = "../nika-catalog", version = "0.94.0", default-features = false, features = ["builtins-transforms"] }
+nika-catalog  = { path = "../nika-catalog", version = "0.95.0", default-features = false, features = ["builtins-transforms"] }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.95.0" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.94.0" }
+nika-fs          = { path = "../nika-fs", version = "0.95.0" }
 # test-only: an INDEPENDENT PNG decoder proving the mock image provider's
 # hand-rolled stored-deflate encoder emits spec-valid files (not just bytes
 # our own sniffer accepts).

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.94.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.95.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.94.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.95.0" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.94.0" }
+nika-error = { path = "../nika-error", version = "0.95.0" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.94.0" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.95.0" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.94.0" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.94.0" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.94.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.94.0" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.94.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
-nika-bm25   = { path = "../nika-bm25", version = "0.94.0" }   # intent→template routing (`nika new` · the deterministic floor)
+nika-event  = { path = "../nika-event", version = "0.95.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.95.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.95.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.95.0" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.95.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-bm25   = { path = "../nika-bm25", version = "0.95.0" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde       = { workspace = true }                             # graph projection envelope (§6)
@@ -29,21 +29,21 @@ anstyle     = { workspace = true }                             # Role→Style ma
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.94.0" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.94.0" }       # the L3 executor (the composer drives it)
-nika-providers   = { path = "../nika-providers", version = "0.94.0" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.94.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.94.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.94.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.94.0" }
-nika-builtin     = { path = "../nika-builtin", version = "0.94.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.94.0" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.94.0" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.94.0" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.94.0" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.94.0", features = ["providers"] }  # the env_var ladder per provider
-nika-lsp         = { path = "../nika-lsp", version = "0.94.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-mcp         = { path = "../nika-mcp", version = "0.94.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-kernel      = { path = "../nika-kernel", version = "0.95.0" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.95.0" }       # the L3 executor (the composer drives it)
+nika-providers   = { path = "../nika-providers", version = "0.95.0" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.95.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.95.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.95.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.95.0" }
+nika-builtin     = { path = "../nika-builtin", version = "0.95.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.95.0" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.95.0" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.95.0" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.95.0" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.95.0", features = ["providers"] }  # the env_var ladder per provider
+nika-lsp         = { path = "../nika-lsp", version = "0.95.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-mcp         = { path = "../nika-mcp", version = "0.95.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [[bin]]
@@ -54,7 +54,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.95.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.94.0" }
+nika-types = { path = "../nika-types", version = "0.95.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.94.0" }
-nika-error = { path = "../nika-error", version = "0.94.0" }
+nika-types = { path = "../nika-types", version = "0.95.0" }
+nika-error = { path = "../nika-error", version = "0.95.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.94.0" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.95.0" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.94.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.95.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.94.0" }
-nika-types   = { path = "../nika-types", version = "0.94.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.95.0" }
+nika-types   = { path = "../nika-types", version = "0.95.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.94.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.94.0" }
+nika-error       = { path = "../nika-error", version = "0.95.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.95.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.94.0" }
+nika-error    = { path = "../nika-error", version = "0.95.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.94.0" }
-nika-error    = { path = "../nika-error", version = "0.94.0" }
+nika-kernel   = { path = "../nika-kernel", version = "0.95.0" }
+nika-error    = { path = "../nika-error", version = "0.95.0" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.94.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.94.0" }
+nika-error       = { path = "../nika-error", version = "0.95.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.95.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.94.0" }
+nika-error    = { path = "../nika-error", version = "0.95.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.94.0" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.94.0" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.94.0" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.94.0" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.94.0" }
+nika-error          = { path = "../nika-error", version = "0.95.0" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.95.0" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.95.0" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.95.0" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.95.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.94.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-schema = { path = "../nika-schema", version = "0.95.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.94.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-error  = { path = "../nika-error", version = "0.94.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.94.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.95.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-error  = { path = "../nika-error", version = "0.95.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.95.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 # The embedded knowledge payloads (`nika_catalog` · `nika_tools`) — the SAME
 # versioned projections `nika catalog|tools --json` emit (one builder per
 # owning crate · zero duplication). L4→L0 / L4→L1.5, strictly downward.
-nika-catalog = { path = "../nika-catalog", version = "0.94.0", default-features = false, features = ["serde", "capabilities"] }
-nika-builtin = { path = "../nika-builtin", version = "0.94.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.95.0", default-features = false, features = ["serde", "capabilities"] }
+nika-builtin = { path = "../nika-builtin", version = "0.95.0" }
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -142,7 +142,7 @@ invoke: { tool: "nika:write", args: { path: "./out.md", content: "...", create_d
 ```
 Write a file · returns the path. A binary `content` value (an opaque bytes output from an upstream tool · e.g. MCP image content) is written as-is · no `output_format` declaration needed (the value carries its own type).
 
-`overwrite:` defaults **true** · `create_dirs:` defaults **false**. Throws · `NIKA-BUILTIN-WRITE-001` (IO failure) · `-002` (`overwrite: false` and the path exists). Both `tool_error` · `transient: false`.
+`overwrite:` defaults **true** · `create_dirs:` defaults **false** — and a false `create_dirs:` is ENFORCED, not ignored: a missing parent directory is refused loudly (a typo'd path surfaces rather than silently materializing a directory tree), so pass `create_dirs: true` to create the parent. Throws · `NIKA-BUILTIN-WRITE-001` (IO failure, or a missing parent while `create_dirs: false`) · `-002` (`overwrite: false` and the path exists). Both `tool_error` · `transient: false`.
 
 ### `nika:edit`
 ```yaml

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.94.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.94.0", features = ["providers"] }
+nika-kernel  = { path = "../nika-kernel", version = "0.95.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.95.0", features = ["providers"] }
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,17 +11,17 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.94.0" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.94.0" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.94.0" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.94.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-catalog     = { path = "../nika-catalog", version = "0.94.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
-nika-cel         = { path = "../nika-cel", version = "0.94.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.94.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.94.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.94.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.94.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.94.0" }
+nika-types       = { path = "../nika-types", version = "0.95.0" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.95.0" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.95.0" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.95.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-catalog     = { path = "../nika-catalog", version = "0.95.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
+nika-cel         = { path = "../nika-cel", version = "0.95.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.95.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.95.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.95.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.95.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.95.0" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -34,9 +34,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.94.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.94.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.95.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.95.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.95.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -17,10 +17,10 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # nika-cap permits). The 4th (nika-cap) is the permits boundary extracted 2026-07-03
 # for reuse by nika-policy/runtime WITHOUT pulling the parser; inlining it back to
 # stay at 3 would defeat the extraction. High fan-in is intentional here (ADR-027).
-nika-error   = { path = "../nika-error", version = "0.94.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.94.0" }
-nika-types   = { path = "../nika-types", version = "0.94.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.94.0" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-error   = { path = "../nika-error", version = "0.95.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.95.0" }
+nika-types   = { path = "../nika-types", version = "0.95.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.95.0" }   # the permits vocab lives here now (extracted 2026-07-03)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -43,10 +43,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.94.0" }
+nika-event = { path = "../nika-event", version = "0.95.0" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.94.0" }
+nika-pack  = { path = "../nika-pack", version = "0.95.0" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-kernel      = { path = "../nika-kernel", version = "0.94.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.94.0" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.94.0" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.94.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.94.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-kernel      = { path = "../nika-kernel", version = "0.95.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.95.0" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.95.0" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.95.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.95.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -24,7 +24,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.95.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.94.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-error  = { path = "../nika-error", version = "0.95.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.94.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.95.0" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error     = { path = "../nika-error", version = "0.94.0" }
-nika-kernel    = { path = "../nika-kernel", version = "0.94.0" }
-nika-providers = { path = "../nika-providers", version = "0.94.0" }
+nika-error     = { path = "../nika-error", version = "0.95.0" }
+nika-kernel    = { path = "../nika-kernel", version = "0.95.0" }
+nika-providers = { path = "../nika-providers", version = "0.95.0" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.94.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.94.0" }
+nika-error  = { path = "../nika-error", version = "0.95.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.95.0" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }


### PR DESCRIPTION
The v0.95.0 train. Highlights:

- **The 5 local servers get their catalog face** (#208) — 38 providers, keyless by construction, editor pickers see them.
- **The lost-user footer** (#203) · seam-discipline hygiene vector (#207).
- Fixes: `write` honors `create_dirs: false` (#196) · `date` bundled tz db (#199) · `log` control-seq neutralized (#204) · MCP stdio bounded (#209).
- Count-free doc-comments (#206) · pack re-vendored from spec main (count-free schema nika-spec#21 · create_dirs prose nika-spec#20).

Mechanics: 109 pins / 36 Cargo.toml → 0.95.0 · Cargo.lock · CHANGELOG entry · status block re-projected in `.claude/CLAUDE.md` + `ROADMAP.md` (vector 23 green) · 3334 lib tests · clippy 0 · pre-push gates green.

Post-merge: tag `v0.95.0` on the squash commit → release.yml (4 signed platforms) → SHA sidecars → `update-formula.sh` → tap · docs/website cascades follow the published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)