### PR TITLE
feat(nika-schema): the caller contract — a requirements section on check

### DIFF
--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -401,6 +401,7 @@ pub nika_schema::check::CheckReport::gate_findings: alloc::vec::Vec<nika_schema:
 pub nika_schema::check::CheckReport::hints: alloc::vec::Vec<nika_schema::Hint>
 pub nika_schema::check::CheckReport::missing_args: alloc::vec::Vec<nika_schema::check::MissingArg>
 pub nika_schema::check::CheckReport::report_version: u32
+pub nika_schema::check::CheckReport::requirements: nika_schema::check::Requirements
 pub nika_schema::check::CheckReport::schema_findings: alloc::vec::Vec<nika_schema::SchemaTypeFinding>
 pub nika_schema::check::CheckReport::schema_lints: alloc::vec::Vec<nika_schema::SchemaLintFinding>
 pub nika_schema::check::CheckReport::secret_egresses: alloc::vec::Vec<nika_schema::check::SecretEgress>
@@ -793,6 +794,103 @@ impl<T> dyn_clone::DynClone for nika_schema::check::MissingArg where T: core::cl
 pub fn nika_schema::check::MissingArg::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_schema::check::MissingArg where T: 'static
 pub fn nika_schema::check::MissingArg::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub struct nika_schema::check::ModelRequirement
+pub nika_schema::check::ModelRequirement::model: alloc::string::String
+pub nika_schema::check::ModelRequirement::tasks: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for nika_schema::check::ModelRequirement
+pub fn nika_schema::check::ModelRequirement::clone(&self) -> nika_schema::check::ModelRequirement
+impl core::cmp::Eq for nika_schema::check::ModelRequirement
+impl core::cmp::PartialEq for nika_schema::check::ModelRequirement
+pub fn nika_schema::check::ModelRequirement::eq(&self, other: &nika_schema::check::ModelRequirement) -> bool
+impl core::fmt::Debug for nika_schema::check::ModelRequirement
+pub fn nika_schema::check::ModelRequirement::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_schema::check::ModelRequirement
+impl serde_core::ser::Serialize for nika_schema::check::ModelRequirement
+pub fn nika_schema::check::ModelRequirement::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::ModelRequirement
+impl<Q, K> equivalent::Equivalent<K> for nika_schema::check::ModelRequirement where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::ModelRequirement::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::ModelRequirement where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::ModelRequirement where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::ModelRequirement::equivalent(&self, key: &K) -> bool
+pub fn nika_schema::check::ModelRequirement::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_schema::check::ModelRequirement where U: core::convert::From<T>
+pub fn nika_schema::check::ModelRequirement::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::ModelRequirement where U: core::convert::Into<T>
+pub type nika_schema::check::ModelRequirement::Error = core::convert::Infallible
+pub fn nika_schema::check::ModelRequirement::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::ModelRequirement where U: core::convert::TryFrom<T>
+pub type nika_schema::check::ModelRequirement::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::ModelRequirement::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::ModelRequirement where T: core::clone::Clone
+pub type nika_schema::check::ModelRequirement::Owned = T
+pub fn nika_schema::check::ModelRequirement::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::ModelRequirement::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::ModelRequirement where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::ModelRequirement::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::ModelRequirement where T: ?core::marker::Sized
+pub fn nika_schema::check::ModelRequirement::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::ModelRequirement where T: ?core::marker::Sized
+pub fn nika_schema::check::ModelRequirement::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::ModelRequirement where T: core::clone::Clone
+pub unsafe fn nika_schema::check::ModelRequirement::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::ModelRequirement
+pub fn nika_schema::check::ModelRequirement::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::ModelRequirement where T: core::clone::Clone
+pub fn nika_schema::check::ModelRequirement::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::ModelRequirement where T: 'static
+pub fn nika_schema::check::ModelRequirement::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub struct nika_schema::check::Requirements
+pub nika_schema::check::Requirements::env_defined: alloc::vec::Vec<alloc::string::String>
+pub nika_schema::check::Requirements::env_reads: alloc::vec::Vec<alloc::string::String>
+pub nika_schema::check::Requirements::models: alloc::vec::Vec<nika_schema::check::ModelRequirement>
+pub nika_schema::check::Requirements::secrets: alloc::vec::Vec<nika_schema::check::SecretRequirement>
+pub nika_schema::check::Requirements::vars_required: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for nika_schema::check::Requirements
+pub fn nika_schema::check::Requirements::clone(&self) -> nika_schema::check::Requirements
+impl core::cmp::Eq for nika_schema::check::Requirements
+impl core::cmp::PartialEq for nika_schema::check::Requirements
+pub fn nika_schema::check::Requirements::eq(&self, other: &nika_schema::check::Requirements) -> bool
+impl core::default::Default for nika_schema::check::Requirements
+pub fn nika_schema::check::Requirements::default() -> nika_schema::check::Requirements
+impl core::fmt::Debug for nika_schema::check::Requirements
+pub fn nika_schema::check::Requirements::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_schema::check::Requirements
+impl serde_core::ser::Serialize for nika_schema::check::Requirements
+pub fn nika_schema::check::Requirements::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::Requirements
+impl<Q, K> equivalent::Equivalent<K> for nika_schema::check::Requirements where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::Requirements::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::Requirements where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::Requirements where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::Requirements::equivalent(&self, key: &K) -> bool
+pub fn nika_schema::check::Requirements::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_schema::check::Requirements where U: core::convert::From<T>
+pub fn nika_schema::check::Requirements::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::Requirements where U: core::convert::Into<T>
+pub type nika_schema::check::Requirements::Error = core::convert::Infallible
+pub fn nika_schema::check::Requirements::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::Requirements where U: core::convert::TryFrom<T>
+pub type nika_schema::check::Requirements::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::Requirements::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::Requirements where T: core::clone::Clone
+pub type nika_schema::check::Requirements::Owned = T
+pub fn nika_schema::check::Requirements::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::Requirements::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::Requirements where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::Requirements::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::Requirements where T: ?core::marker::Sized
+pub fn nika_schema::check::Requirements::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::Requirements where T: ?core::marker::Sized
+pub fn nika_schema::check::Requirements::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::Requirements where T: core::clone::Clone
+pub unsafe fn nika_schema::check::Requirements::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::Requirements
+pub fn nika_schema::check::Requirements::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::Requirements where T: core::clone::Clone
+pub fn nika_schema::check::Requirements::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::Requirements where T: 'static
+pub fn nika_schema::check::Requirements::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::check::RunCertificate
 pub nika_schema::check::RunCertificate::derivation: alloc::vec::Vec<nika_schema::check::certificate::TaskContribution>
 pub nika_schema::check::RunCertificate::effect_calls: nika_schema::Bound
@@ -1037,6 +1135,53 @@ impl<T> dyn_clone::DynClone for nika_schema::SecretLeak where T: core::clone::Cl
 pub fn nika_schema::SecretLeak::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_schema::SecretLeak where T: 'static
 pub fn nika_schema::SecretLeak::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub struct nika_schema::check::SecretRequirement
+pub nika_schema::check::SecretRequirement::key: alloc::string::String
+pub nika_schema::check::SecretRequirement::name: alloc::string::String
+pub nika_schema::check::SecretRequirement::source: nika_schema::types::secret::SecretSource
+impl core::clone::Clone for nika_schema::check::SecretRequirement
+pub fn nika_schema::check::SecretRequirement::clone(&self) -> nika_schema::check::SecretRequirement
+impl core::cmp::Eq for nika_schema::check::SecretRequirement
+impl core::cmp::PartialEq for nika_schema::check::SecretRequirement
+pub fn nika_schema::check::SecretRequirement::eq(&self, other: &nika_schema::check::SecretRequirement) -> bool
+impl core::fmt::Debug for nika_schema::check::SecretRequirement
+pub fn nika_schema::check::SecretRequirement::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_schema::check::SecretRequirement
+impl serde_core::ser::Serialize for nika_schema::check::SecretRequirement
+pub fn nika_schema::check::SecretRequirement::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::SecretRequirement
+impl<Q, K> equivalent::Equivalent<K> for nika_schema::check::SecretRequirement where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::SecretRequirement::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::SecretRequirement where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::SecretRequirement where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::SecretRequirement::equivalent(&self, key: &K) -> bool
+pub fn nika_schema::check::SecretRequirement::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_schema::check::SecretRequirement where U: core::convert::From<T>
+pub fn nika_schema::check::SecretRequirement::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::SecretRequirement where U: core::convert::Into<T>
+pub type nika_schema::check::SecretRequirement::Error = core::convert::Infallible
+pub fn nika_schema::check::SecretRequirement::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::SecretRequirement where U: core::convert::TryFrom<T>
+pub type nika_schema::check::SecretRequirement::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::SecretRequirement::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::SecretRequirement where T: core::clone::Clone
+pub type nika_schema::check::SecretRequirement::Owned = T
+pub fn nika_schema::check::SecretRequirement::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::SecretRequirement::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::SecretRequirement where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::SecretRequirement::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::SecretRequirement where T: ?core::marker::Sized
+pub fn nika_schema::check::SecretRequirement::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::SecretRequirement where T: ?core::marker::Sized
+pub fn nika_schema::check::SecretRequirement::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::SecretRequirement where T: core::clone::Clone
+pub unsafe fn nika_schema::check::SecretRequirement::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::SecretRequirement
+pub fn nika_schema::check::SecretRequirement::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::SecretRequirement where T: core::clone::Clone
+pub fn nika_schema::check::SecretRequirement::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::SecretRequirement where T: 'static
+pub fn nika_schema::check::SecretRequirement::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::check::TaintTrace
 pub nika_schema::check::TaintTrace::secret: alloc::string::String
 impl nika_schema::check::TaintTrace
@@ -6473,6 +6618,7 @@ pub nika_schema::CheckReport::gate_findings: alloc::vec::Vec<nika_schema::GateFi
 pub nika_schema::CheckReport::hints: alloc::vec::Vec<nika_schema::Hint>
 pub nika_schema::CheckReport::missing_args: alloc::vec::Vec<nika_schema::check::MissingArg>
 pub nika_schema::CheckReport::report_version: u32
+pub nika_schema::CheckReport::requirements: nika_schema::check::Requirements
 pub nika_schema::CheckReport::schema_findings: alloc::vec::Vec<nika_schema::SchemaTypeFinding>
 pub nika_schema::CheckReport::schema_lints: alloc::vec::Vec<nika_schema::SchemaLintFinding>
 pub nika_schema::CheckReport::secret_egresses: alloc::vec::Vec<nika_schema::check::SecretEgress>

--- a/crates/nika-schema/src/check/flow.rs
+++ b/crates/nika-schema/src/check/flow.rs
@@ -376,7 +376,7 @@ fn propagate_cleanups(
 /// is never tainted from a prompt secret · ADR-092). To send a secret to a
 /// provider, the author sanctions it explicitly (`egress: [{ to: "infer" }]`
 /// / `{ to: "agent" }`).
-fn action_effect_fields(action: &RawAction) -> Vec<&str> {
+pub(crate) fn action_effect_fields(action: &RawAction) -> Vec<&str> {
     match action {
         RawAction::Exec(a) => {
             let mut fields = a.command.text_fragments();
@@ -403,7 +403,7 @@ fn action_effect_fields(action: &RawAction) -> Vec<&str> {
 
 /// The `prompt:` + optional `system:` text of an `infer:`/`agent:` action —
 /// the provider-egress sink surface (BUG#3).
-fn prompt_system_fields<'a>(
+pub(crate) fn prompt_system_fields<'a>(
     prompt: &'a str,
     system: Option<&'a crate::Spanned<String>>,
 ) -> Vec<&'a str> {
@@ -474,7 +474,7 @@ fn taint_of_refs_full(
 
 /// The `${{ … }}` references inside a string (via the real extractor — the
 /// same path the analyzer uses, so taint and `NIKA-VAR-001` agree).
-fn refs_in_str(text: &str) -> Vec<NamespaceRef> {
+pub(crate) fn refs_in_str(text: &str) -> Vec<NamespaceRef> {
     let Ok(islands) = scan_templates(text) else {
         return Vec::new();
     };
@@ -490,7 +490,7 @@ fn refs_in_json(value: &serde_json::Value) -> Vec<NamespaceRef> {
 }
 
 /// Every string leaf of a JSON value (for the ref/taint scan).
-fn collect_json_strings(value: &serde_json::Value) -> Vec<&str> {
+pub(crate) fn collect_json_strings(value: &serde_json::Value) -> Vec<&str> {
     let mut out = Vec::new();
     collect_json_strings_into(value, &mut out);
     out

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -38,6 +38,7 @@ mod infer_permits;
 mod metamorphic;
 mod permits_fit;
 mod reach;
+mod requirements;
 mod schema_lint;
 mod schema_typing;
 mod secrets;
@@ -55,6 +56,7 @@ pub use hints::Hint;
 pub use infer_permits::InferredPermits;
 pub use permits_fit::CapabilityEscape;
 pub use reach::{GateFinding, GateFindingKind, STATUS_VOCAB};
+pub use requirements::{ModelRequirement, Requirements, SecretRequirement};
 pub use schema_lint::SchemaLintFinding;
 pub use schema_typing::SchemaTypeFinding;
 pub use secrets::{SecretEgress, SecretLeak};
@@ -166,6 +168,13 @@ pub struct CheckReport {
     /// are degree-1 polynomials in the `for_each` collection sizes.
     /// Additive: `report_version` stays 1.
     pub certificate: RunCertificate,
+    /// What this workflow needs from its caller BEFORE any token is
+    /// spent — models per task · declared secrets (facts, no values) ·
+    /// env reads vs env defines · required vars. Declaration truth
+    /// only: presence checks stay with the caller (a static report
+    /// never depends on who runs it). Additive: `report_version`
+    /// stays 1.
+    pub requirements: Requirements,
     /// Every `secrets.X` that escapes the masking boundary into an
     /// `exec`/`invoke` effect (directly, via a `with:` alias, or
     /// transitively through a tainted upstream output · IFC · ADR-092).
@@ -322,6 +331,7 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         conformance,
         cost: cost::ceiling(wf),
         certificate: certificate::certify(wf),
+        requirements: requirements::collect(wf),
         secret_leaks: secrets::scan_leaks(wf, &flow),
         secret_egresses: secrets::scan_egresses(&flow),
         capability_escapes: permits_fit::scan_escapes(wf),

--- a/crates/nika-schema/src/check/requirements.rs
+++ b/crates/nika-schema/src/check/requirements.rs
@@ -1,0 +1,297 @@
+//! The workflow's REQUIREMENTS — what a caller must satisfy before any
+//! token is spent (E-REQ). Declaration facts from the typed AST only:
+//! models per task · declared secrets (never values) · `env` reads vs
+//! defines (the split IS the semantics) · required vars. PRESENCE stays
+//! the caller's check — a static report never depends on who runs it.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::expression::NamespaceRef;
+use crate::raw::{RawAction, RawWorkflow};
+
+use super::flow::{action_effect_fields, collect_json_strings, prompt_system_fields, refs_in_str};
+use crate::types::{SecretSource, VarDecl, WhenGate};
+
+/// One model the run will call, with the tasks that call it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ModelRequirement {
+    /// The combined `<provider>/<name>` form (task override ?? envelope).
+    pub model: String,
+    /// The infer/agent task ids that resolve to this model.
+    pub tasks: Vec<String>,
+}
+
+/// One declared secret — the declaration facts, never a value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SecretRequirement {
+    pub name: String,
+    /// `env` · `vault` · `file` (the spec's closed enum · serde lowercase).
+    pub source: SecretSource,
+    /// The lookup key (env-source: the variable name).
+    pub key: String,
+}
+
+/// What this workflow needs from its caller — additive on the report.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct Requirements {
+    /// Models the run will call (infer/agent · task ?? envelope).
+    pub models: Vec<ModelRequirement>,
+    /// Declared `secrets:` (facts only — presence is the caller's check).
+    pub secrets: Vec<SecretRequirement>,
+    /// `${{ env.X }}` names the BODY reads — the requirements.
+    pub env_reads: Vec<String>,
+    /// Envelope `env:` keys — configuration (covers a matching read).
+    pub env_defined: Vec<String>,
+    /// `vars:` that are `required: true` with no `default:`.
+    pub vars_required: Vec<String>,
+}
+
+/// Collect the requirements (total — a half-broken workflow still
+/// states what it declares).
+pub(crate) fn collect(wf: &RawWorkflow) -> Requirements {
+    let envelope_model = wf.model.as_ref().map(|m| m.value.clone());
+    let mut models: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut env_reads: BTreeSet<String> = BTreeSet::new();
+
+    for task in &wf.tasks {
+        // Model resolution: the verb's own override ?? the envelope.
+        let task_model = match &task.value.action {
+            RawAction::Infer(a) => Some(a.model.as_ref().map(|m| m.value.clone())),
+            RawAction::Agent(a) => Some(a.model.as_ref().map(|m| m.value.clone())),
+            _ => None,
+        };
+        if let Some(model) = task_model.and_then(|m| m.or_else(|| envelope_model.clone())) {
+            models
+                .entry(model)
+                .or_default()
+                .push(task.value.id.value.clone());
+        }
+
+        env_reads_of_task(task, &mut env_reads);
+    }
+
+    // The envelope `outputs:` return contract — its ${{ }} refs are body
+    // reads too (both declaration forms carry an expression string).
+    for (_, decl) in &wf.outputs {
+        match decl {
+            crate::types::OutputDecl::Untyped(expr) => {
+                collect_env_reads(&expr.value, &mut env_reads);
+            }
+            crate::types::OutputDecl::Typed { value, .. } => {
+                collect_env_reads(&value.value, &mut env_reads);
+            }
+        }
+    }
+
+    Requirements {
+        models: models
+            .into_iter()
+            .map(|(model, tasks)| ModelRequirement { model, tasks })
+            .collect(),
+        secrets: wf
+            .secrets
+            .iter()
+            .map(|(name, decl)| SecretRequirement {
+                name: name.value.clone(),
+                source: decl.value.source,
+                key: decl.value.key.clone(),
+            })
+            .collect(),
+        env_reads: env_reads.into_iter().collect(),
+        env_defined: wf.env.iter().map(|(k, _)| k.value.clone()).collect(),
+        vars_required: wf
+            .vars
+            .iter()
+            .filter(|(_, decl)| {
+                matches!(
+                    decl,
+                    VarDecl::Typed {
+                        required: true,
+                        default: None,
+                        ..
+                    }
+                )
+            })
+            .map(|(name, _)| name.value.clone())
+            .collect(),
+    }
+}
+
+/// Every `${{ env.X }}` read across ONE task's whole surface —
+/// action fields (prompts included) · `with` · when-CEL · `output` ·
+/// `for_each` · `on_error` recover · `on_finally` cleanups.
+fn env_reads_of_task(task: &crate::Spanned<crate::raw::RawTask>, env_reads: &mut BTreeSet<String>) {
+    // Env reads: every template-bearing string of the task surface,
+    // through the REAL extractor (the same path the analyzer uses).
+    for text in task_template_fields(&task.value.action) {
+        collect_env_reads(text, env_reads);
+    }
+    for (_, v) in &task.value.with {
+        for text in collect_json_strings(&v.value) {
+            collect_env_reads(text, env_reads);
+        }
+    }
+    if let Some(WhenGate::Expr(cel)) = task.value.when.as_ref().map(|g| &g.value) {
+        collect_env_reads(cel, env_reads);
+    }
+    for (_, expr) in &task.value.output {
+        collect_env_reads(&expr.value, env_reads);
+    }
+    // `for_each:` — the collection expression (or list literals) can
+    // read env like any other template surface.
+    if let Some(fe) = &task.value.for_each {
+        match &fe.value {
+            crate::raw::ForEachValue::Expression(expr) => {
+                collect_env_reads(expr, env_reads);
+            }
+            crate::raw::ForEachValue::List(list) => {
+                for text in collect_json_strings(list) {
+                    collect_env_reads(text, env_reads);
+                }
+            }
+        }
+    }
+    // `on_error: recover:` — the recovery value substitutes an output;
+    // its templates are body reads like any other.
+    if let Some(crate::types::OnErrorAction::Recover(value)) =
+        task.value.on_error.as_ref().map(|o| &o.value.action)
+    {
+        for text in collect_json_strings(&value.value) {
+            collect_env_reads(text, env_reads);
+        }
+    }
+    // `on_finally:` cleanups carry full actions (and gates) of their own.
+    for cleanup in &task.value.on_finally {
+        for text in task_template_fields(&cleanup.value.action) {
+            collect_env_reads(text, env_reads);
+        }
+        if let Some(WhenGate::Expr(cel)) = cleanup.value.when.as_ref().map(|g| &g.value) {
+            collect_env_reads(cel, env_reads);
+        }
+    }
+}
+
+/// Every template-bearing string of one action — flow's effect fields
+/// (command · stdin · exec env · invoke args) PLUS the prompts (an env
+/// read in a prompt is as much a requirement as one in a command).
+fn task_template_fields(action: &RawAction) -> Vec<&str> {
+    let mut fields = action_effect_fields(action);
+    match action {
+        RawAction::Infer(a) => {
+            fields.extend(prompt_system_fields(&a.prompt.value, a.system.as_ref()));
+        }
+        RawAction::Agent(a) => {
+            fields.extend(prompt_system_fields(&a.prompt.value, a.system.as_ref()));
+        }
+        RawAction::Exec(_) | RawAction::Invoke(_) => {}
+    }
+    fields
+}
+
+fn collect_env_reads(text: &str, out: &mut BTreeSet<String>) {
+    for r in refs_in_str(text) {
+        if let NamespaceRef::Env(name) = r
+            && !name.is_empty()
+        {
+            out.insert(name);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn wf_of(yaml: &str) -> RawWorkflow {
+        parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses")
+    }
+
+    #[test]
+    fn requirements_state_the_full_caller_contract() {
+        let wf = wf_of(
+            r#"
+nika: v1
+workflow: req-probe
+model: anthropic/claude-sonnet-4-6
+vars:
+  target_url: { type: string, required: true }
+  region: { type: string, required: true, default: "eu" }
+secrets:
+  gh_token:
+    source: env
+    key: GITHUB_TOKEN
+  vault_pass:
+    key: prod/db-pass
+env:
+  REGION: eu-west-1
+tasks:
+  - id: fetch
+    invoke:
+      tool: "nika:fetch"
+      args: { url: "https://api.example.com/${{ env.GITHUB_ORG }}" }
+  - id: digest
+    depends_on: [fetch]
+    infer:
+      prompt: "Summarize for ${{ env.REGION }}"
+  - id: local_pass
+    depends_on: [fetch]
+    for_each: "${{ env.SHARDS }}"
+    on_finally:
+      - exec: { command: ["echo", "${{ env.CLEANUP_FLAG }}"] }
+    infer:
+      model: ollama/qwen3
+      prompt: "rank"
+outputs:
+  report: "${{ env.REPORT_PATH }}"
+"#,
+        );
+        let req = collect(&wf);
+        assert_eq!(
+            req.models,
+            vec![
+                ModelRequirement {
+                    model: "anthropic/claude-sonnet-4-6".into(),
+                    tasks: vec!["digest".into()],
+                },
+                ModelRequirement {
+                    model: "ollama/qwen3".into(),
+                    tasks: vec!["local_pass".into()],
+                },
+            ]
+        );
+        assert_eq!(req.secrets.len(), 2);
+        assert_eq!(req.secrets[0].name, "gh_token");
+        assert_eq!(req.secrets[0].source, SecretSource::Env);
+        assert_eq!(req.secrets[0].key, "GITHUB_TOKEN");
+        assert_eq!(req.secrets[1].source, SecretSource::Vault);
+        // The split IS the semantics: REGION is read AND defined ·
+        // GITHUB_ORG is read-only (the caller requirement).
+        assert_eq!(
+            req.env_reads,
+            vec![
+                "CLEANUP_FLAG",
+                "GITHUB_ORG",
+                "REGION",
+                "REPORT_PATH",
+                "SHARDS"
+            ]
+        );
+        assert_eq!(req.env_defined, vec!["REGION"]);
+        // required + defaulted is NOT a requirement.
+        assert_eq!(req.vars_required, vec!["target_url"]);
+    }
+
+    #[test]
+    fn an_invoke_only_workflow_needs_no_model_and_says_so() {
+        let wf = wf_of(
+            "nika: v1\nworkflow: none\ntasks:\n  - id: a\n    invoke: { tool: \"nika:uuid\" }\n",
+        );
+        let req = collect(&wf);
+        assert!(req.models.is_empty());
+        assert!(req.env_reads.is_empty());
+    }
+}


### PR DESCRIPTION
## What

`check --json` gains a `requirements` section — the checker, which holds the typed AST, states what the workflow needs from its caller BEFORE any token is spent. Additive (`report_version` stays 1):

```json
"requirements": {
  "models":       [{ "model": "anthropic/claude-sonnet-4-6", "tasks": ["digest"] }],
  "secrets":      [{ "name": "gh_token", "source": "env", "key": "GITHUB_TOKEN" }],
  "env_reads":    ["GITHUB_ORG", "REGION"],
  "env_defined":  ["REGION"],
  "vars_required": ["target_url"]
}
```

- **models** · resolved per task (verb override ?? envelope) for infer/agent.
- **secrets** · declaration facts only (name · source · key) — never values.
- **env_reads** · `${{ env.X }}` names the BODY reads, walked through the REAL extractor (prompts + system + exec command/stdin/env + invoke args + with + when-CEL + output bindings). **env_defined** · envelope `env:` keys. The split IS the semantics: defined = covered, read-but-undefined = a caller requirement.
- **vars_required** · `required: true` with no `default:`.
- **Presence stays the caller's check** — a static report must never depend on who runs it (the checker reads no environment).

## Why

The editor preflight (« costs and secrets visible before any token ») had to client-parse the YAML — semantics duplicated outside the brain. The nika-vscode adapter is already on main (`factsFromRequirements` wins when the section is present; the client parser survives only as the <0.95 fallback).

## Proof

- Unit pins: the full contract on a rich fixture (the vault fixture learned its own law en route — `source: vault` requires `key:`) + the empty story (invoke-only workflow states no model).
- e2e on the built binary: the JSON is byte-conformant to the spec'd contract.
- nika-schema lib 769 ✓ · clippy -D warnings ✓ · 8/8 ci-ratchets ✓ · full pre-push suite green.
- Baseline regenerated with the CI's exact recipe (`cargo public-api` 0.51.0 · `--omit auto-trait-impls`): diff vs committed = **146 additive lines · zero removals · zero skew** — verified before adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)