### PR TITLE
ci(release): the tap job pins homebrew-tap — the canonical brew mapping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,9 +229,10 @@ jobs:
       - uses: actions/checkout@v4
         if: steps.guard.outputs.ok == 'true'
         with:
-          # The tap repo was renamed homebrew-tap → homebrew-nika (GitHub
-          # redirects, but pin the canonical name).
-          repository: supernovae-st/homebrew-nika
+          # The tap repo is homebrew-tap — the canonical brew mapping for
+          # `brew install supernovae-st/tap/nika` (renamed back 2026-07-06;
+          # the homebrew-nika interlude survives as a GitHub redirect).
+          repository: supernovae-st/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
       - name: Update + push the formula


### PR DESCRIPTION
Operator call 2026-07-06: the tap repo is homebrew-tap again (one studio tap · the brew canon command resolves natively · the homebrew-nika interlude survives as a GitHub redirect). The release workflow's bump job follows. Workflow-comment-and-slug-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)