### PR TITLE
docs(readme): shared workflows have a home — the registry pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ The full gallery (27 workflows + 6 templates) lives in
 [`examples/`](examples/): foundation patterns, business showcases, and the
 skeletons `nika new --from <template>` instantiates.
 
+Shared workflows live on [**nika-registry**](https://github.com/supernovae-st/nika-registry) —
+every entry pinned to a full commit + sha256 and re-proven by CI (the
+conformance oracle + this engine's static certificate: exec · tools ·
+cost, visible before anything runs). `nika add` is on the roadmap; today
+the registry's `get.py` does resolve → verify → audit in one command.
+
 ## The model
 
 Four verbs, and nothing else. A small core that composes into arbitrary


### PR DESCRIPTION
Operator lock 2026-07-06 (AI/dev surfaces now, marketing at nika add): the engine README names nika-registry after the examples gallery — trust one-liner (pinned + re-proven + this engine's own certificate) and the honest today-flow (get.py; nika add roadmap). README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)