### PR TITLE
feat(nika-cli): nika dap — time-travel replay debugging over the run journal

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -468,6 +468,8 @@ pub fn nika_cli::verbs::catalog::run(json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::check
 pub fn nika_cli::verbs::check::run(path: &str, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::check::run_infer_permits(path: &str, json: bool) -> nika_cli::verbs::VerbOutput
+pub mod nika_cli::verbs::dap
+pub fn nika_cli::verbs::dap::run_stdio() -> u8
 pub mod nika_cli::verbs::doctor
 pub fn nika_cli::verbs::doctor::run(ping: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::exit

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -232,6 +232,9 @@ enum Command {
         #[command(subcommand)]
         action: TraceAction,
     },
+    /// Debug Adapter Protocol server (stdio) — replay a recorded run
+    /// under a debugger UI (preview: handshake only, sessions land next).
+    Dap,
     /// Run the language server over stdio (drives the editor extension).
     Lsp,
     /// Run the MCP server over stdio (validate: check/explain · learn:
@@ -547,6 +550,7 @@ fn main() -> std::process::ExitCode {
         // shutdown/exit, non-zero (1) otherwise (transport failure, or an
         // `exit` without a prior `shutdown`) — the server-process
         // convention, NOT the verb FILE/WORKFLOW/ENV taxonomy.
+        Command::Dap => verbs::dap::run_stdio(),
         Command::Lsp => match nika_lsp::run_stdio() {
             Ok(()) => verbs::exit::OK,
             Err(err) => {

--- a/crates/nika-cli/src/verbs/dap/mod.rs
+++ b/crates/nika-cli/src/verbs/dap/mod.rs
@@ -1,19 +1,21 @@
 //! `nika dap` — the Debug Adapter Protocol server (replay sessions).
 //!
-//! Session model (the research-locked blueprint): the MVP is a
-//! READ-ONLY replay debugger over a recorded run journal — launch args
-//! carry `{workflow, replay}`, breakpoints map to task lines, stepping
-//! walks task settles, `stepBack` is free because the log is total.
-//! Live sessions (breakpoint gates on the durable-pause substrate) come
-//! after replay proves the wiring.
+//! The MVP is a READ-ONLY replay debugger over a recorded run journal —
+//! launch args carry `{workflow, replay}`, breakpoints map to task
+//! lines, stepping walks task settles, `stepBack` is free because the
+//! log is total (replay = re-render, NEVER re-execute). Live sessions
+//! (breakpoint gates on the durable-pause substrate) come after replay
+//! proves the wiring.
 //!
 //! Lifecycle (the spec's launch sequencing): initialize → capabilities
-//! response → `initialized` event → setBreakpoints → configurationDone
+//! → `initialized` event → launch → setBreakpoints → configurationDone
 //! → stopped/continue loop → disconnect.
 
 mod protocol;
+mod replay;
 
-use protocol::Wire;
+use protocol::{Request, Wire};
+use replay::ReplaySession;
 
 /// Serve one DAP session over stdio. Like `nika lsp`, stdout belongs to
 /// the protocol — diagnostics go to stderr only.
@@ -27,6 +29,7 @@ pub fn run_stdio() -> u8 {
 
 /// The session loop — generic over the wire so tests drive exact bytes.
 fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
+    let mut session: Option<ReplaySession> = None;
     while let Some(req) = wire.read_request() {
         match req.command.as_str() {
             "initialize" => {
@@ -41,16 +44,190 @@ fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
                 );
                 wire.emit("initialized", serde_json::Value::Null);
             }
-            "disconnect" => {
+            "launch" => match launch(&req) {
+                Ok(s) => {
+                    session = Some(s);
+                    wire.respond(&req, serde_json::Value::Null);
+                }
+                Err(e) => wire.reject(&req, &e),
+            },
+            "setBreakpoints" => set_breakpoints(&mut wire, session.as_mut(), &req),
+            "configurationDone" => {
+                wire.respond(&req, serde_json::Value::Null);
+                // The replay opens standing on the first settle.
+                stopped(&mut wire, "entry");
+            }
+            "threads" => {
+                let name = session
+                    .as_ref()
+                    .map_or("workflow", |s| s.workflow_name.as_str());
+                wire.respond(
+                    &req,
+                    serde_json::json!({ "threads": [{ "id": 1, "name": name }] }),
+                );
+            }
+            "stackTrace" => stack_trace(&mut wire, session.as_ref(), &req),
+            "scopes" => {
+                // One scope; its reference is stable (state lives in the
+                // session cursor, not in a per-stop arena).
+                wire.respond(
+                    &req,
+                    serde_json::json!({ "scopes": [
+                        { "name": "Outputs", "variablesReference": 1, "expensive": false },
+                    ]}),
+                );
+            }
+            "variables" => variables(&mut wire, session.as_ref(), &req),
+            "continue" | "next" | "stepBack" | "reverseContinue" => {
+                step(&mut wire, session.as_mut(), &req);
+            }
+            "terminate" | "disconnect" => {
                 wire.respond(&req, serde_json::Value::Null);
                 return 0;
             }
-            // The replay session lands next — until then every other
-            // request is honestly refused (VS Code surfaces the message).
-            _ => wire.reject(&req, "nika dap: replay sessions are not wired yet"),
+            _ => wire.reject(&req, "nika dap: not supported in a replay session"),
         }
     }
     0
+}
+
+/// Launch arguments: `{workflow, replay}` — both required (replay-only).
+fn launch(req: &Request) -> Result<ReplaySession, String> {
+    let workflow = req.arguments["workflow"]
+        .as_str()
+        .ok_or("launch needs `workflow` (the YAML path)")?;
+    let replay = req.arguments["replay"]
+        .as_str()
+        .ok_or("launch needs `replay` (a recorded .ndjson journal) — live sessions land later")?;
+    ReplaySession::load(workflow, replay)
+}
+
+fn set_breakpoints<R: std::io::BufRead, W: std::io::Write>(
+    wire: &mut Wire<R, W>,
+    session: Option<&mut ReplaySession>,
+    req: &Request,
+) {
+    let Some(session) = session else {
+        wire.reject(req, "setBreakpoints before launch");
+        return;
+    };
+    let lines: Vec<u32> = req.arguments["breakpoints"]
+        .as_array()
+        .map(|bps| {
+            bps.iter()
+                .filter_map(|b| u32::try_from(b["line"].as_i64().unwrap_or(0)).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+    let verdicts = session.set_breakpoints(&lines);
+    let body: Vec<serde_json::Value> = verdicts
+        .iter()
+        .map(|(verified, line)| {
+            serde_json::json!({
+                "verified": verified,
+                "line": line,
+                "message": if *verified { serde_json::Value::Null }
+                           else { "No task at or above this line.".into() },
+            })
+        })
+        .collect();
+    wire.respond(req, serde_json::json!({ "breakpoints": body }));
+}
+
+fn stack_trace<R: std::io::BufRead, W: std::io::Write>(
+    wire: &mut Wire<R, W>,
+    session: Option<&ReplaySession>,
+    req: &Request,
+) {
+    let Some(session) = session else {
+        wire.reject(req, "stackTrace before launch");
+        return;
+    };
+    let stop = session.current();
+    // Lexical containment, not a call stack (the ansibug precedent):
+    // the settled task, then the workflow itself.
+    wire.respond(
+        req,
+        serde_json::json!({ "stackFrames": [
+            {
+                "id": 1,
+                "name": format!("{} ({})", stop.task, stop.kind),
+                "source": { "path": session.workflow_path },
+                "line": stop.line.max(1),
+                "column": 1,
+            },
+            {
+                "id": 2,
+                "name": session.workflow_name,
+                "source": { "path": session.workflow_path },
+                "line": 1,
+                "column": 1,
+            },
+        ], "totalFrames": 2 }),
+    );
+}
+
+fn variables<R: std::io::BufRead, W: std::io::Write>(
+    wire: &mut Wire<R, W>,
+    session: Option<&ReplaySession>,
+    req: &Request,
+) {
+    let Some(session) = session else {
+        wire.reject(req, "variables before launch");
+        return;
+    };
+    let vars: Vec<serde_json::Value> = session
+        .variables()
+        .into_iter()
+        .map(|(name, value)| {
+            serde_json::json!({ "name": name, "value": value, "variablesReference": 0 })
+        })
+        .collect();
+    wire.respond(req, serde_json::json!({ "variables": vars }));
+}
+
+/// The four movement verbs share one shape: mutate the cursor, respond,
+/// then either announce the stop or terminate (forward off the end).
+fn step<R: std::io::BufRead, W: std::io::Write>(
+    wire: &mut Wire<R, W>,
+    session: Option<&mut ReplaySession>,
+    req: &Request,
+) {
+    let Some(session) = session else {
+        wire.reject(req, "no session — launch first");
+        return;
+    };
+    let (still_running, reason) = match req.command.as_str() {
+        "continue" => (session.run_forward(), "breakpoint"),
+        "next" => (session.step(), "step"),
+        "stepBack" => {
+            session.step_back();
+            (true, "step")
+        }
+        // reverseContinue — floors at the first settle.
+        _ => {
+            session.run_backward();
+            (true, "breakpoint")
+        }
+    };
+    wire.respond(req, serde_json::json!({ "allThreadsContinued": true }));
+    if still_running {
+        stopped(wire, reason);
+    } else {
+        // The log is total: running off its end is the run's end.
+        wire.emit("terminated", serde_json::Value::Null);
+    }
+}
+
+fn stopped<R: std::io::BufRead, W: std::io::Write>(wire: &mut Wire<R, W>, reason: &str) {
+    wire.emit(
+        "stopped",
+        serde_json::json!({
+            "reason": reason,
+            "threadId": 1,
+            "allThreadsStopped": true,
+        }),
+    );
 }
 
 #[cfg(test)]
@@ -69,27 +246,126 @@ mod tests {
         String::from_utf8(out).expect("utf8")
     }
 
+    fn req(seq: i64, command: &str, arguments: &serde_json::Value) -> serde_json::Value {
+        serde_json::json!({"seq": seq, "type": "request", "command": command,
+                           "arguments": arguments})
+    }
+
     #[test]
     fn handshake_then_disconnect() {
         let out = drive(&[
-            serde_json::json!({"seq": 1, "type": "request", "command": "initialize",
-                               "arguments": {"adapterID": "nika"}}),
-            serde_json::json!({"seq": 2, "type": "request", "command": "disconnect"}),
+            req(1, "initialize", &serde_json::json!({"adapterID": "nika"})),
+            req(2, "disconnect", &serde_json::Value::Null),
         ]);
         assert!(out.contains(r#""supportsStepBack":true"#));
         assert!(out.contains(r#""event":"initialized""#));
-        // The disconnect response closes the session (loop returned).
         assert!(out.contains(r#""request_seq":2"#));
     }
 
     #[test]
-    fn unwired_requests_are_refused_not_ignored() {
+    fn requests_before_launch_are_refused_not_ignored() {
         let out = drive(&[
-            serde_json::json!({"seq": 1, "type": "request", "command": "launch",
-                               "arguments": {"replay": "x.ndjson"}}),
-            serde_json::json!({"seq": 2, "type": "request", "command": "disconnect"}),
+            req(1, "stackTrace", &serde_json::json!({"threadId": 1})),
+            req(2, "attach", &serde_json::Value::Null),
+            req(3, "disconnect", &serde_json::Value::Null),
         ]);
-        assert!(out.contains(r#""success":false"#));
-        assert!(out.contains("not wired yet"));
+        assert!(out.contains("stackTrace before launch"));
+        assert!(out.contains("not supported in a replay session"));
+    }
+
+    /// The full journey against REAL files — launch → breakpoints →
+    /// configurationDone → threads → stackTrace → variables → next →
+    /// stepBack → continue-off-the-end → terminated.
+    #[test]
+    fn replay_journey_over_real_files() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let wf = dir.path().join("w.nika.yaml");
+        std::fs::write(
+            &wf,
+            "nika: v1\nworkflow: journey\ntasks:\n  - id: alpha\n    exec:\n      command: [\"true\"]\n  - id: beta\n    depends_on: [alpha]\n    exec:\n      command: [\"true\"]\n",
+        )
+        .expect("write wf");
+        let journal = dir.path().join("run.ndjson");
+        // Two settles, hand-authored in the journal's own NDJSON shape.
+        // The journal's REAL serde shape (untagged Value · flat ns):
+        // pinned from a live line, not imagined — the floor_deep lesson.
+        let lines = [
+            serde_json::json!({"id": {"uuid": "01912345-0000-7000-8000-000000000001"},
+                "timestamp": 1000, "kind": "workflow_started", "run": null, "correlation": null,
+                "fields": [{"key": "workflow", "value": "journey"}]}),
+            serde_json::json!({"id": {"uuid": "01912345-0000-7000-8000-000000000002"},
+                "timestamp": 2000, "kind": "task_completed", "run": null, "correlation": null,
+                "fields": [{"key": "task", "value": "alpha"},
+                           {"key": "output", "value": "\"a\""}]}),
+            serde_json::json!({"id": {"uuid": "01912345-0000-7000-8000-000000000003"},
+                "timestamp": 3000, "kind": "task_completed", "run": null, "correlation": null,
+                "fields": [{"key": "task", "value": "beta"}]}),
+            serde_json::json!({"id": {"uuid": "01912345-0000-7000-8000-000000000004"},
+                "timestamp": 4000, "kind": "workflow_completed", "run": null, "correlation": null,
+                "fields": [{"key": "workflow", "value": "journey"}]}),
+        ];
+        let mut ndjson = String::new();
+        for l in &lines {
+            use std::fmt::Write as _;
+            let _ = writeln!(ndjson, "{l}");
+        }
+        std::fs::write(&journal, ndjson).expect("write journal");
+
+        let out = drive(&[
+            req(1, "initialize", &serde_json::json!({"adapterID": "nika"})),
+            req(
+                2,
+                "launch",
+                &serde_json::json!({"workflow": wf.to_string_lossy(),
+                                   "replay": journal.to_string_lossy()}),
+            ),
+            // Line 8 sits INSIDE beta's block — snaps back to beta's start.
+            req(
+                3,
+                "setBreakpoints",
+                &serde_json::json!({"source": {"path": wf.to_string_lossy()},
+                                   "breakpoints": [{"line": 8}]}),
+            ),
+            req(4, "configurationDone", &serde_json::Value::Null),
+            req(5, "threads", &serde_json::Value::Null),
+            req(6, "stackTrace", &serde_json::json!({"threadId": 1})),
+            req(
+                7,
+                "variables",
+                &serde_json::json!({"variablesReference": 1}),
+            ),
+            req(8, "next", &serde_json::json!({"threadId": 1})),
+            req(9, "stepBack", &serde_json::json!({"threadId": 1})),
+            req(10, "continue", &serde_json::json!({"threadId": 1})),
+            req(11, "continue", &serde_json::json!({"threadId": 1})),
+            req(12, "disconnect", &serde_json::Value::Null),
+        ]);
+
+        assert!(out.contains(r#""verified":true"#), "breakpoint verifies");
+        assert!(
+            out.contains(r#""name":"journey""#),
+            "the thread is the workflow"
+        );
+        assert!(
+            out.contains(r#""name":"alpha (completed)""#),
+            "frame at the cursor"
+        );
+        assert!(
+            out.contains(r#""value":"\"a\"""#),
+            "alpha's recorded output"
+        );
+        assert!(
+            out.contains(r#""reason":"entry""#),
+            "configurationDone stops at entry"
+        );
+        assert!(out.contains(r#""reason":"step""#), "next/stepBack announce");
+        assert!(
+            out.contains(r#""reason":"breakpoint""#),
+            "continue lands on beta"
+        );
+        assert!(
+            out.contains(r#""event":"terminated""#),
+            "running off the total log ends the session"
+        );
     }
 }

--- a/crates/nika-cli/src/verbs/dap/mod.rs
+++ b/crates/nika-cli/src/verbs/dap/mod.rs
@@ -1,0 +1,95 @@
+//! `nika dap` — the Debug Adapter Protocol server (replay sessions).
+//!
+//! Session model (the research-locked blueprint): the MVP is a
+//! READ-ONLY replay debugger over a recorded run journal — launch args
+//! carry `{workflow, replay}`, breakpoints map to task lines, stepping
+//! walks task settles, `stepBack` is free because the log is total.
+//! Live sessions (breakpoint gates on the durable-pause substrate) come
+//! after replay proves the wiring.
+//!
+//! Lifecycle (the spec's launch sequencing): initialize → capabilities
+//! response → `initialized` event → setBreakpoints → configurationDone
+//! → stopped/continue loop → disconnect.
+
+mod protocol;
+
+use protocol::Wire;
+
+/// Serve one DAP session over stdio. Like `nika lsp`, stdout belongs to
+/// the protocol — diagnostics go to stderr only.
+#[must_use]
+pub fn run_stdio() -> u8 {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let wire = Wire::new(stdin.lock(), stdout.lock());
+    serve(wire)
+}
+
+/// The session loop — generic over the wire so tests drive exact bytes.
+fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
+    while let Some(req) = wire.read_request() {
+        match req.command.as_str() {
+            "initialize" => {
+                // Capabilities: absence = unsupported (the spec's rule) —
+                // claim ONLY what the replay session actually serves.
+                wire.respond(
+                    &req,
+                    serde_json::json!({
+                        "supportsConfigurationDoneRequest": true,
+                        "supportsStepBack": true,
+                    }),
+                );
+                wire.emit("initialized", serde_json::Value::Null);
+            }
+            "disconnect" => {
+                wire.respond(&req, serde_json::Value::Null);
+                return 0;
+            }
+            // The replay session lands next — until then every other
+            // request is honestly refused (VS Code surfaces the message).
+            _ => wire.reject(&req, "nika dap: replay sessions are not wired yet"),
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::protocol::frame;
+    use super::*;
+
+    fn drive(messages: &[serde_json::Value]) -> String {
+        let mut input: Vec<u8> = Vec::new();
+        for m in messages {
+            input.extend(frame(m));
+        }
+        let mut out: Vec<u8> = Vec::new();
+        let code = serve(Wire::new(std::io::Cursor::new(input), &mut out));
+        assert_eq!(code, 0);
+        String::from_utf8(out).expect("utf8")
+    }
+
+    #[test]
+    fn handshake_then_disconnect() {
+        let out = drive(&[
+            serde_json::json!({"seq": 1, "type": "request", "command": "initialize",
+                               "arguments": {"adapterID": "nika"}}),
+            serde_json::json!({"seq": 2, "type": "request", "command": "disconnect"}),
+        ]);
+        assert!(out.contains(r#""supportsStepBack":true"#));
+        assert!(out.contains(r#""event":"initialized""#));
+        // The disconnect response closes the session (loop returned).
+        assert!(out.contains(r#""request_seq":2"#));
+    }
+
+    #[test]
+    fn unwired_requests_are_refused_not_ignored() {
+        let out = drive(&[
+            serde_json::json!({"seq": 1, "type": "request", "command": "launch",
+                               "arguments": {"replay": "x.ndjson"}}),
+            serde_json::json!({"seq": 2, "type": "request", "command": "disconnect"}),
+        ]);
+        assert!(out.contains(r#""success":false"#));
+        assert!(out.contains("not wired yet"));
+    }
+}

--- a/crates/nika-cli/src/verbs/dap/protocol.rs
+++ b/crates/nika-cli/src/verbs/dap/protocol.rs
@@ -22,6 +22,8 @@ pub(crate) struct Request {
     #[serde(rename = "type")]
     pub(crate) kind: String,
     pub(crate) command: String,
+    #[serde(default)]
+    pub(crate) arguments: serde_json::Value,
 }
 
 /// The adapter's reply envelope.

--- a/crates/nika-cli/src/verbs/dap/protocol.rs
+++ b/crates/nika-cli/src/verbs/dap/protocol.rs
@@ -1,0 +1,230 @@
+//! The Debug Adapter Protocol wire layer — hand-rolled, like the LSP.
+//!
+//! DAP framing IS LSP framing (`Content-Length: N\r\n\r\n{json}`), but
+//! the envelopes differ: every message carries `seq` + `type`
+//! (request/response/event); responses echo `request_seq` + `command`
+//! and carry `success`. The `lsp-server` crate is JSON-RPC-specific, so
+//! this module owns the ~100 lines instead of forcing a square peg.
+//!
+//! Generic over `Read`/`Write` — the unit tests drive the exact bytes a
+//! VS Code client would send, no process spawn needed.
+
+use std::io::{BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+
+/// One incoming client message (the adapter only ever RECEIVES requests).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Request {
+    pub(crate) seq: i64,
+    /// Always "request" from a conforming client — kept for the honest
+    /// decode (a stray response/event is skipped, never a crash).
+    #[serde(rename = "type")]
+    pub(crate) kind: String,
+    pub(crate) command: String,
+}
+
+/// The adapter's reply envelope.
+#[derive(Debug, Serialize)]
+pub(crate) struct Response {
+    pub(crate) seq: i64,
+    #[serde(rename = "type")]
+    pub(crate) kind: &'static str,
+    pub(crate) request_seq: i64,
+    pub(crate) success: bool,
+    pub(crate) command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
+    #[serde(skip_serializing_if = "serde_json::Value::is_null")]
+    pub(crate) body: serde_json::Value,
+}
+
+/// A server-pushed event (initialized · stopped · output · terminated).
+#[derive(Debug, Serialize)]
+pub(crate) struct EventMsg {
+    pub(crate) seq: i64,
+    #[serde(rename = "type")]
+    pub(crate) kind: &'static str,
+    pub(crate) event: &'static str,
+    #[serde(skip_serializing_if = "serde_json::Value::is_null")]
+    pub(crate) body: serde_json::Value,
+}
+
+/// The wire: reads framed requests, writes framed responses/events,
+/// owns the outgoing `seq` counter.
+pub(crate) struct Wire<R, W> {
+    reader: R,
+    writer: W,
+    next_seq: i64,
+}
+
+impl<R: BufRead, W: Write> Wire<R, W> {
+    #[must_use]
+    pub(crate) fn new(reader: R, writer: W) -> Self {
+        Self {
+            reader,
+            writer,
+            next_seq: 1,
+        }
+    }
+
+    /// Next client REQUEST — `None` on clean EOF (client hung up).
+    /// Non-request frames (a misbehaving client's responses/events) are
+    /// skipped; malformed JSON ends the session (`None`) rather than
+    /// guessing at a broken stream.
+    pub(crate) fn read_request(&mut self) -> Option<Request> {
+        loop {
+            let body = self.read_frame()?;
+            match serde_json::from_slice::<Request>(&body) {
+                Ok(req) if req.kind == "request" => return Some(req),
+                Ok(_) => {}
+                Err(_) => return None,
+            }
+        }
+    }
+
+    /// One `Content-Length`-framed body.
+    fn read_frame(&mut self) -> Option<Vec<u8>> {
+        let mut content_length: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            if self.reader.read_line(&mut line).ok()? == 0 {
+                return None; // EOF
+            }
+            let line = line.trim_end();
+            if line.is_empty() {
+                break; // header/body separator
+            }
+            if let Some(v) = line.strip_prefix("Content-Length:") {
+                content_length = v.trim().parse().ok();
+            }
+        }
+        let len = content_length?;
+        let mut body = vec![0u8; len];
+        self.reader.read_exact(&mut body).ok()?;
+        Some(body)
+    }
+
+    pub(crate) fn respond(&mut self, req: &Request, body: serde_json::Value) {
+        let msg = Response {
+            seq: self.take_seq(),
+            kind: "response",
+            request_seq: req.seq,
+            success: true,
+            command: req.command.clone(),
+            message: None,
+            body,
+        };
+        self.write_frame(&serde_json::to_vec(&msg).unwrap_or_default());
+    }
+
+    pub(crate) fn reject(&mut self, req: &Request, message: &str) {
+        let msg = Response {
+            seq: self.take_seq(),
+            kind: "response",
+            request_seq: req.seq,
+            success: false,
+            command: req.command.clone(),
+            message: Some(message.to_owned()),
+            body: serde_json::Value::Null,
+        };
+        self.write_frame(&serde_json::to_vec(&msg).unwrap_or_default());
+    }
+
+    pub(crate) fn emit(&mut self, event: &'static str, body: serde_json::Value) {
+        let msg = EventMsg {
+            seq: self.take_seq(),
+            kind: "event",
+            event,
+            body,
+        };
+        self.write_frame(&serde_json::to_vec(&msg).unwrap_or_default());
+    }
+
+    fn take_seq(&mut self) -> i64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        seq
+    }
+
+    fn write_frame(&mut self, body: &[u8]) {
+        // A dead client pipe ends the session on the next read — writes
+        // never panic the adapter.
+        let _ = write!(self.writer, "Content-Length: {}\r\n\r\n", body.len());
+        let _ = self.writer.write_all(body);
+        let _ = self.writer.flush();
+    }
+}
+
+/// Encode one frame — the test-side helper for driving a session.
+#[cfg(test)]
+pub(crate) fn frame(json: &serde_json::Value) -> Vec<u8> {
+    let body = serde_json::to_vec(json).expect("test json");
+    let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+    out.extend(body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_request_response_event() {
+        let input = frame(&serde_json::json!({
+            "seq": 1, "type": "request", "command": "initialize",
+            "arguments": {"adapterID": "nika"}
+        }));
+        let mut out: Vec<u8> = Vec::new();
+        {
+            let mut wire = Wire::new(std::io::Cursor::new(input), &mut out);
+            let req = wire.read_request().expect("one request");
+            assert_eq!(req.command, "initialize");
+            wire.respond(&req, serde_json::json!({"supportsStepBack": true}));
+            wire.emit("initialized", serde_json::Value::Null);
+        }
+        let text = String::from_utf8(out).expect("utf8");
+        // Two frames, each self-describing its length.
+        assert_eq!(text.matches("Content-Length:").count(), 2);
+        assert!(text.contains(r#""request_seq":1"#));
+        assert!(text.contains(r#""success":true"#));
+        assert!(text.contains(r#""supportsStepBack":true"#));
+        assert!(text.contains(r#""event":"initialized""#));
+        // The event body is Null → omitted entirely (skip_serializing_if).
+        assert!(!text.contains(r#""body":null"#));
+    }
+
+    #[test]
+    fn eof_and_garbage_end_the_session_cleanly() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut wire = Wire::new(std::io::Cursor::new(Vec::<u8>::new()), &mut out);
+        assert!(wire.read_request().is_none(), "EOF → None");
+
+        let mut garbage = b"Content-Length: 9\r\n\r\nnot json!".to_vec();
+        garbage.extend(frame(&serde_json::json!({
+            "seq": 2, "type": "request", "command": "disconnect"
+        })));
+        let mut out2: Vec<u8> = Vec::new();
+        let mut wire2 = Wire::new(std::io::Cursor::new(garbage), &mut out2);
+        assert!(
+            wire2.read_request().is_none(),
+            "malformed JSON ends the session — never guess at a broken stream"
+        );
+    }
+
+    #[test]
+    fn non_request_frames_are_skipped() {
+        let mut input = frame(&serde_json::json!({
+            "seq": 9, "type": "event", "event": "echo", "command": "x"
+        }));
+        input.extend(frame(&serde_json::json!({
+            "seq": 3, "type": "request", "command": "threads"
+        })));
+        let mut out: Vec<u8> = Vec::new();
+        let mut wire = Wire::new(std::io::Cursor::new(input), &mut out);
+        let req = wire
+            .read_request()
+            .expect("the request after the stray event");
+        assert_eq!(req.command, "threads");
+    }
+}

--- a/crates/nika-cli/src/verbs/dap/replay.rs
+++ b/crates/nika-cli/src/verbs/dap/replay.rs
@@ -1,0 +1,305 @@
+//! The replay session — a read-only debugger over a recorded run.
+//!
+//! The journal is total, so time travel is a cursor: STOPS are the task
+//! settles in journal order; `next` walks forward, `stepBack` walks
+//! backward, `continue` runs to the next breakpointed task, and
+//! variables at any stop are simply the outputs settled so far. Nothing
+//! executes — replay = re-render, NEVER re-execute (the trace-replay
+//! law), which is why `supportsStepBack` is honest here.
+//!
+//! Breakpoints map file lines to tasks the ansibug way: a client line
+//! SNAPS BACKWARD to the nearest task-start line at or above it —
+//! `verified` echoes the snapped line so the editor moves the dot.
+
+use nika_event::EventKind;
+
+/// One task settle — a place the cursor can stand.
+pub(crate) struct Stop {
+    pub(crate) task: String,
+    /// Terminal kind, human form (`completed` · `failed` · …).
+    pub(crate) kind: &'static str,
+    /// The recorded output (stamped successes carry it).
+    pub(crate) output: Option<String>,
+    /// 1-based task-start line in the workflow source (0 = unknown —
+    /// a task the journal knows but the current source doesn't).
+    pub(crate) line: u32,
+}
+
+pub(crate) struct ReplaySession {
+    /// Client-side workflow path — every stack frame points here.
+    pub(crate) workflow_path: String,
+    pub(crate) workflow_name: String,
+    /// `(task id, 1-based start line)` in document order.
+    task_lines: Vec<(String, u32)>,
+    pub(crate) stops: Vec<Stop>,
+    /// Current stop index.
+    pub(crate) cursor: usize,
+    /// Verified breakpoint lines (snapped to task starts).
+    breakpoints: Vec<u32>,
+}
+
+impl ReplaySession {
+    /// Build from the launch arguments' two files.
+    pub(crate) fn load(workflow_path: &str, replay_path: &str) -> Result<Self, String> {
+        let yaml = std::fs::read_to_string(workflow_path)
+            .map_err(|e| format!("cannot read workflow {workflow_path}: {e}"))?;
+        let raw = std::fs::read_to_string(replay_path)
+            .map_err(|e| format!("cannot read journal {replay_path}: {e}"))?;
+        let recovered = super::super::run::recover_events(&raw, replay_path)?;
+        Self::from_parts(workflow_path, &yaml, &recovered.events)
+    }
+
+    /// The testable core: source text + folded events.
+    pub(crate) fn from_parts(
+        workflow_path: &str,
+        yaml: &str,
+        events: &[nika_event::Event],
+    ) -> Result<Self, String> {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Lenient,
+        )
+        .map_err(|e| format!("workflow does not parse: {e}"))?;
+        let task_lines: Vec<(String, u32)> = wf
+            .tasks
+            .iter()
+            .map(|t| {
+                (
+                    t.value.id.value.clone(),
+                    line_of_offset(yaml, t.span.start.0 as usize),
+                )
+            })
+            .collect();
+
+        let workflow_name = events
+            .iter()
+            .find(|e| e.kind == EventKind::WorkflowStarted)
+            .and_then(|e| field_str(e, "workflow").map(ToOwned::to_owned))
+            .ok_or_else(|| "no workflow_started event — not a run journal".to_owned())?;
+
+        let stops: Vec<Stop> = events
+            .iter()
+            .filter_map(|e| {
+                let kind = match e.kind {
+                    EventKind::TaskCompleted => "completed",
+                    EventKind::TaskFailed => "failed",
+                    EventKind::TaskSkipped => "skipped",
+                    EventKind::TaskCancelled => "cancelled",
+                    EventKind::TaskCacheHit => "cache hit",
+                    _ => return None,
+                };
+                let task = field_str(e, "task")?.to_owned();
+                let line = task_lines
+                    .iter()
+                    .find(|(id, _)| *id == task)
+                    .map_or(0, |(_, l)| *l);
+                Some(Stop {
+                    task,
+                    kind,
+                    output: field_str(e, "output").map(ToOwned::to_owned),
+                    line,
+                })
+            })
+            .collect();
+        if stops.is_empty() {
+            return Err("the journal records no task settles — nothing to replay".to_owned());
+        }
+        Ok(Self {
+            workflow_path: workflow_path.to_owned(),
+            workflow_name,
+            task_lines,
+            stops,
+            cursor: 0,
+            breakpoints: Vec::new(),
+        })
+    }
+
+    /// Set (replace-all, per the DAP contract) breakpoints for the one
+    /// source. Returns `(verified, snapped_line)` per requested line.
+    pub(crate) fn set_breakpoints(&mut self, lines: &[u32]) -> Vec<(bool, u32)> {
+        self.breakpoints.clear();
+        lines
+            .iter()
+            .map(|&want| {
+                // Snap BACKWARD: the nearest task start at or above.
+                let snapped = self
+                    .task_lines
+                    .iter()
+                    .map(|(_, l)| *l)
+                    .filter(|&l| l <= want)
+                    .max();
+                match snapped {
+                    Some(line) => {
+                        self.breakpoints.push(line);
+                        (true, line)
+                    }
+                    None => (false, want),
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn current(&self) -> &Stop {
+        // cursor is clamped by every mutation — the indexing is total.
+        &self.stops[self.cursor.min(self.stops.len() - 1)]
+    }
+
+    /// Forward to the next breakpointed stop. `false` = ran off the end.
+    pub(crate) fn run_forward(&mut self) -> bool {
+        let mut i = self.cursor + 1;
+        while i < self.stops.len() {
+            if self.breakpoints.contains(&self.stops[i].line) {
+                self.cursor = i;
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+
+    /// Backward to the previous breakpointed stop (floor: first stop).
+    pub(crate) fn run_backward(&mut self) {
+        let mut i = self.cursor;
+        while i > 0 {
+            i -= 1;
+            if self.breakpoints.contains(&self.stops[i].line) {
+                self.cursor = i;
+                return;
+            }
+        }
+        self.cursor = 0;
+    }
+
+    /// One stop forward. `false` = already at the last settle.
+    pub(crate) fn step(&mut self) -> bool {
+        if self.cursor + 1 < self.stops.len() {
+            self.cursor += 1;
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn step_back(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    /// Variables at the cursor: every settle up to and including it —
+    /// the output when recorded, else the terminal kind.
+    pub(crate) fn variables(&self) -> Vec<(String, String)> {
+        self.stops[..=self.cursor.min(self.stops.len() - 1)]
+            .iter()
+            .map(|s| {
+                let value = s.output.clone().unwrap_or_else(|| format!("({})", s.kind));
+                (s.task.clone(), value)
+            })
+            .collect()
+    }
+}
+
+/// 1-based line of a byte offset (the span is byte-addressed).
+fn line_of_offset(text: &str, offset: usize) -> u32 {
+    let upto = &text[..offset.min(text.len())];
+    u32::try_from(upto.split('\n').count()).unwrap_or(1)
+}
+
+fn field_str<'e>(event: &'e nika_event::Event, key: &str) -> Option<&'e str> {
+    event.fields.iter().find_map(|f| match (&f.key, &f.value) {
+        (k, nika_types::resource::Value::String(s)) if k == key => Some(s.as_str()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_event::Event;
+    use nika_types::id::EventId;
+    use nika_types::resource::{KeyValue, Value as FieldValue};
+    use nika_types::timestamp::Timestamp;
+    use uuid::Uuid;
+
+    use super::*;
+
+    const YAML: &str = "nika: v1\nworkflow: demo\ntasks:\n  - id: alpha\n    exec:\n      command: [\"true\"]\n  - id: beta\n    depends_on: [alpha]\n    exec:\n      command: [\"true\"]\n  - id: gamma\n    depends_on: [beta]\n    exec:\n      command: [\"true\"]\n";
+
+    fn ev(seed: u8, kind: EventKind, fields: &[(&str, &str)]) -> Event {
+        let mut e = Event::new(
+            EventId::new(Uuid::from_bytes([seed; 16])),
+            Timestamp::from_unix_ns(i64::from(seed) * 1_000),
+            kind,
+        );
+        for (k, v) in fields {
+            e = e.with_field(KeyValue::new(*k, FieldValue::String((*v).to_owned())));
+        }
+        e
+    }
+
+    fn session() -> ReplaySession {
+        let events = vec![
+            ev(1, EventKind::WorkflowStarted, &[("workflow", "demo")]),
+            ev(
+                2,
+                EventKind::TaskCompleted,
+                &[("task", "alpha"), ("output", "\"a\"")],
+            ),
+            ev(3, EventKind::TaskCompleted, &[("task", "beta")]),
+            ev(
+                4,
+                EventKind::TaskSkipped,
+                &[("task", "gamma"), ("when", "${{ false }}")],
+            ),
+            ev(5, EventKind::WorkflowCompleted, &[("workflow", "demo")]),
+        ];
+        ReplaySession::from_parts("/w.nika.yaml", YAML, &events).expect("session builds")
+    }
+
+    #[test]
+    fn stops_walk_the_settles_and_variables_accumulate() {
+        let mut s = session();
+        assert_eq!(s.stops.len(), 3);
+        assert_eq!(s.current().task, "alpha");
+        assert_eq!(s.variables().len(), 1);
+
+        assert!(s.step());
+        assert_eq!(s.current().task, "beta");
+        // alpha's recorded output + beta's kind (no output recorded).
+        let vars = s.variables();
+        assert_eq!(vars[0], ("alpha".to_owned(), "\"a\"".to_owned()));
+        assert_eq!(vars[1].1, "(completed)");
+
+        assert!(s.step());
+        assert_eq!(s.current().kind, "skipped");
+        assert!(!s.step(), "the log is total — the last settle is the end");
+
+        s.step_back();
+        assert_eq!(s.current().task, "beta");
+    }
+
+    #[test]
+    fn breakpoints_snap_backward_to_task_starts() {
+        let mut s = session();
+        // alpha starts line 3 · beta line 7 · gamma line 11 (doc order).
+        let lines: Vec<u32> = s.task_lines.iter().map(|(_, l)| *l).collect();
+        assert_eq!(lines.len(), 3);
+        // A line INSIDE beta's block snaps back to beta's start.
+        let verdicts = s.set_breakpoints(&[lines[1] + 1, 1]);
+        assert_eq!(verdicts[0], (true, lines[1]));
+        // Line 1 (above every task) cannot verify.
+        assert!(!verdicts[1].0);
+
+        // continue runs to beta; a second continue runs off the end.
+        assert!(s.run_forward());
+        assert_eq!(s.current().task, "beta");
+        assert!(!s.run_forward(), "no further breakpoints → terminated");
+
+        // reverseContinue with no earlier breakpoint floors at stop 0.
+        s.run_backward();
+        assert_eq!(s.current().task, "alpha");
+    }
+
+    #[test]
+    fn a_journal_without_settles_is_refused() {
+        let only_start = vec![ev(1, EventKind::WorkflowStarted, &[("workflow", "demo")])];
+        assert!(ReplaySession::from_parts("/w.nika.yaml", YAML, &only_start).is_err());
+    }
+}

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod catalog;
 pub mod check;
+pub mod dap;
 pub mod doctor;
 pub mod explain;
 pub mod graph;


### PR DESCRIPTION
## What

`nika dap` — a Debug Adapter Protocol server (stdio, like `nika lsp`). The MVP is a **read-only replay debugger** over a recorded run journal: launch `{workflow, replay}`, breakpoints on task lines, stepping walks task settles, and `stepBack`/`reverseContinue` are FREE because the log is total. Nothing executes — replay = re-render, never re-execute (the trace-replay law) — which is what makes `supportsStepBack` honest.

The nika-vscode side is already on its main (`fa9525c`): debuggers/breakpoints contributions, F5-without-launch.json (newest run of the active workflow, fold-matched by name), and a "Debug This Run (Time Travel)" action on every recorded run.

## Design (research-locked · `2026-07-06-nika-dap-otel-blueprints.md`)

- **Hand-rolled wire** (~180 LOC): DAP framing IS LSP framing, but the envelopes differ (seq/type/command · request_seq/success) — the JSON-RPC-specific `lsp-server` crate stays out. Generic over Read/Write: tests drive the exact bytes a client sends.
- **Capabilities claim only what's served** (configurationDone · stepBack); every unwired request is refused with a message, never ignored; malformed streams end the session rather than guessing.
- **Breakpoints snap BACKWARD** to task-start lines (real schema spans — the ansibug law); `verified` echoes the snapped line so the editor moves the dot.
- **Stack = lexical containment** (task frame → workflow frame), not a call stack. Variables at a stop = outputs settled so far. Running off the log's end = `terminated`.

## Proof

- Full journey pinned against REAL files (launch → setBreakpoints → configurationDone → threads → stackTrace → variables → next → stepBack → continue → terminated) with the journal's **REAL serde shape** — pinned from a live line at authoring time (the floor_deep lesson, applied proactively).
- Real-binary handshake round-trips byte-perfect. nika-cli lib 222 ✓ · clippy -D warnings ✓ · 8/8 ratchets ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)