### PR TITLE
feat(nika-cli): dap launch warns when the workflow drifted since the run

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -232,8 +232,10 @@ enum Command {
         #[command(subcommand)]
         action: TraceAction,
     },
-    /// Debug Adapter Protocol server (stdio) — replay a recorded run
-    /// under a debugger UI (preview: handshake only, sessions land next).
+    /// Debug Adapter Protocol server (stdio) — time-travel a recorded
+    /// run under a debugger UI: breakpoints on task lines · step forward
+    /// AND back through settles · outputs in the variables pane. Replay
+    /// re-renders, never re-executes.
     Dap,
     /// Run the language server over stdio (drives the editor extension).
     Lsp,

--- a/crates/nika-cli/src/verbs/dap/mod.rs
+++ b/crates/nika-cli/src/verbs/dap/mod.rs
@@ -42,7 +42,10 @@ fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
                         "supportsStepBack": true,
                     }),
                 );
-                wire.emit("initialized", serde_json::Value::Null);
+                // `initialized` waits for launch: the adapter is only
+                // ready for setBreakpoints once a session exists (a
+                // config-first client would lose its breakpoints to
+                // "before launch" rejections — the M1 finding).
             }
             "launch" => match launch(&req) {
                 Ok(s) => {
@@ -60,14 +63,18 @@ fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
                     }
                     session = Some(s);
                     wire.respond(&req, serde_json::Value::Null);
+                    wire.emit("initialized", serde_json::Value::Null);
                 }
                 Err(e) => wire.reject(&req, &e),
             },
             "setBreakpoints" => set_breakpoints(&mut wire, session.as_mut(), &req),
             "configurationDone" => {
                 wire.respond(&req, serde_json::Value::Null);
-                // The replay opens standing on the first settle.
-                stopped(&mut wire, "entry");
+                // The replay opens standing on the first settle — but a
+                // failed launch must not announce a phantom stop.
+                if session.is_some() {
+                    stopped(&mut wire, "entry");
+                }
             }
             "threads" => {
                 let name = session
@@ -123,11 +130,33 @@ fn set_breakpoints<R: std::io::BufRead, W: std::io::Write>(
         wire.reject(req, "setBreakpoints before launch");
         return;
     };
+    // The session debugs ONE source: breakpoints from any other file
+    // must not clobber the set (VS Code sends one setBreakpoints per
+    // file — the H1 finding). Mismatch → all unverified, set untouched.
+    let requested = req.arguments["source"]["path"].as_str();
+    if let Some(path) = requested
+        && path != session.workflow_path
+    {
+        let n = req.arguments["breakpoints"].as_array().map_or(0, Vec::len);
+        let body: Vec<serde_json::Value> = (0..n)
+            .map(|_| {
+                serde_json::json!({
+                    "verified": false,
+                    "message": "Breakpoints only bind in the replayed workflow file.",
+                })
+            })
+            .collect();
+        wire.respond(req, serde_json::json!({ "breakpoints": body }));
+        return;
+    }
+    // `map`, never `filter_map`: the response array must stay 1:1 with
+    // the request (clients align by index — the L2 finding). A bad line
+    // becomes 0, which snaps to nothing → an honest unverified verdict.
     let lines: Vec<u32> = req.arguments["breakpoints"]
         .as_array()
         .map(|bps| {
             bps.iter()
-                .filter_map(|b| u32::try_from(b["line"].as_i64().unwrap_or(0)).ok())
+                .map(|b| u32::try_from(b["line"].as_i64().unwrap_or(0)).unwrap_or(0))
                 .collect()
         })
         .unwrap_or_default();
@@ -270,7 +299,10 @@ mod tests {
             req(2, "disconnect", &serde_json::Value::Null),
         ]);
         assert!(out.contains(r#""supportsStepBack":true"#));
-        assert!(out.contains(r#""event":"initialized""#));
+        // `initialized` waits for a session (M1): no launch → no event —
+        // a config-first client must never lose breakpoints to
+        // "before launch" rejections.
+        assert!(!out.contains(r#""event":"initialized""#));
         assert!(out.contains(r#""request_seq":2"#));
     }
 

--- a/crates/nika-cli/src/verbs/dap/mod.rs
+++ b/crates/nika-cli/src/verbs/dap/mod.rs
@@ -46,6 +46,18 @@ fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
             }
             "launch" => match launch(&req) {
                 Ok(s) => {
+                    // The #210 identity check speaks BEFORE the first stop:
+                    // a drifted source means snapped breakpoint lines may
+                    // not match what actually ran.
+                    if s.drifted == Some(true) {
+                        wire.emit(
+                            "output",
+                            serde_json::json!({
+                                "category": "console",
+                                "output": "⚠ workflow changed since this run was recorded — breakpoint lines may be off (re-run to refresh the journal)\n",
+                            }),
+                        );
+                    }
                     session = Some(s);
                     wire.respond(&req, serde_json::Value::Null);
                 }

--- a/crates/nika-cli/src/verbs/dap/protocol.rs
+++ b/crates/nika-cli/src/verbs/dap/protocol.rs
@@ -52,6 +52,10 @@ pub(crate) struct EventMsg {
     pub(crate) body: serde_json::Value,
 }
 
+/// Frame-size ceiling — a malformed/hostile `Content-Length` ends the
+/// session instead of becoming an allocation.
+const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+
 /// The wire: reads framed requests, writes framed responses/events,
 /// owns the outgoing `seq` counter.
 pub(crate) struct Wire<R, W> {
@@ -102,6 +106,11 @@ impl<R: BufRead, W: Write> Wire<R, W> {
             }
         }
         let len = content_length?;
+        // A hostile header (`Content-Length: 9e15`) must not become an
+        // allocation. Real DAP messages are KBs; 16 MiB is generous.
+        if len > MAX_FRAME_BYTES {
+            return None;
+        }
         let mut body = vec![0u8; len];
         self.reader.read_exact(&mut body).ok()?;
         Some(body)
@@ -211,6 +220,20 @@ mod tests {
         assert!(
             wire2.read_request().is_none(),
             "malformed JSON ends the session — never guess at a broken stream"
+        );
+    }
+
+    #[test]
+    fn a_hostile_content_length_ends_the_session_not_the_memory() {
+        let hostile = b"Content-Length: 9999999999999
+
+"
+        .to_vec();
+        let mut out: Vec<u8> = Vec::new();
+        let mut wire = Wire::new(std::io::Cursor::new(hostile), &mut out);
+        assert!(
+            wire.read_request().is_none(),
+            "a frame beyond MAX_FRAME_BYTES is refused, never allocated"
         );
     }
 

--- a/crates/nika-cli/src/verbs/dap/protocol.rs
+++ b/crates/nika-cli/src/verbs/dap/protocol.rs
@@ -9,18 +9,23 @@
 //! Generic over `Read`/`Write` — the unit tests drive the exact bytes a
 //! VS Code client would send, no process spawn needed.
 
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read as _, Write};
 
 use serde::{Deserialize, Serialize};
 
 /// One incoming client message (the adapter only ever RECEIVES requests).
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct Request {
+    #[serde(default)]
     pub(crate) seq: i64,
     /// Always "request" from a conforming client — kept for the honest
     /// decode (a stray response/event is skipped, never a crash).
     #[serde(rename = "type")]
     pub(crate) kind: String,
+    /// Defaulted: events/responses carry no `command`, and they must
+    /// deserialize so the skip arm can drop them (a real stray event
+    /// killing the session was the M2 finding).
+    #[serde(default)]
     pub(crate) command: String,
     #[serde(default)]
     pub(crate) arguments: serde_json::Value,
@@ -55,6 +60,10 @@ pub(crate) struct EventMsg {
 /// Frame-size ceiling — a malformed/hostile `Content-Length` ends the
 /// session instead of becoming an allocation.
 const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+
+/// Header-line ceiling — a peer streaming bytes with no newline must
+/// not grow the line buffer unboundedly (`read_line` reads to \n).
+const MAX_HEADER_LINE: u64 = 8 * 1024;
 
 /// The wire: reads framed requests, writes framed responses/events,
 /// owns the outgoing `seq` counter.
@@ -94,8 +103,19 @@ impl<R: BufRead, W: Write> Wire<R, W> {
         let mut content_length: Option<usize> = None;
         loop {
             let mut line = String::new();
-            if self.reader.read_line(&mut line).ok()? == 0 {
+            // `take` bounds ONE line: a newline-less stream ends the
+            // session at the cap instead of growing the buffer.
+            let n = self
+                .reader
+                .by_ref()
+                .take(MAX_HEADER_LINE)
+                .read_line(&mut line)
+                .ok()?;
+            if n == 0 {
                 return None; // EOF
+            }
+            if n as u64 >= MAX_HEADER_LINE && !line.ends_with('\n') {
+                return None; // hostile: an unterminated header line
             }
             let line = line.trim_end();
             if line.is_empty() {
@@ -239,8 +259,10 @@ mod tests {
 
     #[test]
     fn non_request_frames_are_skipped() {
+        // A REAL stray event — no command field (the doctored fixture
+        // used to smuggle one in, masking the M2 session-kill).
         let mut input = frame(&serde_json::json!({
-            "seq": 9, "type": "event", "event": "echo", "command": "x"
+            "seq": 9, "type": "event", "event": "echo"
         }));
         input.extend(frame(&serde_json::json!({
             "seq": 3, "type": "request", "command": "threads"

--- a/crates/nika-cli/src/verbs/dap/replay.rs
+++ b/crates/nika-cli/src/verbs/dap/replay.rs
@@ -213,8 +213,18 @@ impl ReplaySession {
 
 /// 1-based line of a byte offset (the span is byte-addressed).
 fn line_of_offset(text: &str, offset: usize) -> u32 {
-    let upto = &text[..offset.min(text.len())];
-    u32::try_from(upto.split('\n').count()).unwrap_or(1)
+    // Byte-wise walk — string slicing would PANIC on a non-char-boundary
+    // offset (multi-byte chars upstream of a span are enough).
+    let mut line: u32 = 1;
+    for (i, b) in text.bytes().enumerate() {
+        if i >= offset {
+            break;
+        }
+        if b == b'\n' {
+            line = line.saturating_add(1);
+        }
+    }
+    line
 }
 
 fn field_str<'e>(event: &'e nika_event::Event, key: &str) -> Option<&'e str> {
@@ -309,6 +319,15 @@ mod tests {
         // reverseContinue with no earlier breakpoint floors at stop 0.
         s.run_backward();
         assert_eq!(s.current().task, "alpha");
+    }
+
+    #[test]
+    fn line_of_offset_survives_multibyte_text() {
+        // « é » is 2 bytes — an offset INSIDE it must not panic.
+        let text = "é\nx";
+        assert_eq!(line_of_offset(text, 1), 1);
+        assert_eq!(line_of_offset(text, 3), 2);
+        assert_eq!(line_of_offset(text, 999), 2);
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/dap/replay.rs
+++ b/crates/nika-cli/src/verbs/dap/replay.rs
@@ -29,6 +29,10 @@ pub(crate) struct ReplaySession {
     /// Client-side workflow path — every stack frame points here.
     pub(crate) workflow_path: String,
     pub(crate) workflow_name: String,
+    /// The #210 identity check: Some(true) = the CURRENT yaml differs
+    /// from the bytes the run executed (breakpoint lines may be off) ·
+    /// None = the journal predates `workflow_sha256`.
+    pub(crate) drifted: Option<bool>,
     /// `(task id, 1-based start line)` in document order.
     task_lines: Vec<(String, u32)>,
     pub(crate) stops: Vec<Stop>,
@@ -47,6 +51,15 @@ impl ReplaySession {
             .map_err(|e| format!("cannot read journal {replay_path}: {e}"))?;
         let recovered = super::super::run::recover_events(&raw, replay_path)?;
         Self::from_parts(workflow_path, &yaml, &recovered.events)
+    }
+
+    /// The #210 identity check against the CURRENT source bytes.
+    fn drift_of(yaml: &str, events: &[nika_event::Event]) -> Option<bool> {
+        let recorded = events
+            .iter()
+            .find(|e| e.kind == EventKind::WorkflowStarted)
+            .and_then(|e| field_str(e, "workflow_sha256"))?;
+        Some(super::super::run::sha256_hex(yaml.as_bytes()) != recorded)
     }
 
     /// The testable core: source text + folded events.
@@ -108,6 +121,7 @@ impl ReplaySession {
         Ok(Self {
             workflow_path: workflow_path.to_owned(),
             workflow_name,
+            drifted: Self::drift_of(yaml, events),
             task_lines,
             stops,
             cursor: 0,
@@ -295,6 +309,28 @@ mod tests {
         // reverseContinue with no earlier breakpoint floors at stop 0.
         s.run_backward();
         assert_eq!(s.current().task, "alpha");
+    }
+
+    #[test]
+    fn drift_verdict_tracks_the_recorded_sha() {
+        // No workflow_sha256 on the started frame → pre-#210 journal → None.
+        assert_eq!(session().drifted, None);
+
+        // A recorded sha that MATCHES the current bytes → not drifted.
+        let sha = crate::verbs::run::sha256_hex(YAML.as_bytes());
+        let make = |recorded: &str| {
+            let events = vec![
+                ev(
+                    1,
+                    EventKind::WorkflowStarted,
+                    &[("workflow", "demo"), ("workflow_sha256", recorded)],
+                ),
+                ev(2, EventKind::TaskCompleted, &[("task", "alpha")]),
+            ];
+            ReplaySession::from_parts("/w.nika.yaml", YAML, &events).expect("builds")
+        };
+        assert_eq!(make(&sha).drifted, Some(false));
+        assert_eq!(make(&"ab".repeat(32)).drifted, Some(true));
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -470,7 +470,7 @@ fn parse_var_overrides(
 // answers · pause flag) — the same clap-surface idiom as `run` itself.
 #[allow(clippy::too_many_arguments)]
 /// The run's source identity: sha256 hex over the exact bytes read.
-fn sha256_hex(bytes: &[u8]) -> String {
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest as _, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bytes);

--- a/crates/nika-cli/src/verbs/trace_otel.rs
+++ b/crates/nika-cli/src/verbs/trace_otel.rs
@@ -149,7 +149,7 @@ fn root_span(
         "name": format!("invoke_workflow {workflow}"),
         "kind": 1,
         "startTimeUnixNano": started.timestamp.unix_ns.to_string(),
-        "endTimeUnixNano": last_ns.max(started.timestamp.unix_ns + 1).to_string(),
+        "endTimeUnixNano": last_ns.max(started.timestamp.unix_ns.saturating_add(1)).to_string(),
         "attributes": attributes,
         "status": status,
     })
@@ -223,11 +223,15 @@ fn one_task_span(
     // backward from it. Frame-gap fallback for duration-less terminals
     // (skip · cancel · cache-hit) — those genuinely take ~no time.
     let end_ns = terminal.timestamp.unix_ns;
+    // A negative measured duration is a corrupt journal — treat it as
+    // duration-less (the frame-gap arm), never a forward-running span.
     let start_ns = match field(terminal, "duration_ms") {
-        Some(FieldValue::Int(ms)) => end_ns.saturating_sub(ms.saturating_mul(1_000_000)),
+        Some(FieldValue::Int(ms)) if *ms >= 0 => {
+            end_ns.saturating_sub(ms.saturating_mul(1_000_000))
+        }
         _ => anchor.timestamp.unix_ns,
     };
-    let end_ns = end_ns.max(start_ns + 1);
+    let end_ns = end_ns.max(start_ns.saturating_add(1));
 
     let mut attributes = vec![kv_str("nika.task.id", task)];
     if let Some(note) = field_str(terminal, "note") {
@@ -354,7 +358,7 @@ fn unfinished_task_span(
         "name": task,
         "kind": 1,
         "startTimeUnixNano": start_ns.to_string(),
-        "endTimeUnixNano": last_ns.max(start_ns + 1).to_string(),
+        "endTimeUnixNano": last_ns.max(start_ns.saturating_add(1)).to_string(),
         "attributes": attributes,
         "events": task_span_events(task_events),
         "status": {},
@@ -367,7 +371,15 @@ fn unfinished_task_span(
 /// The high half is a millisecond timestamp: two events born in the
 /// same ms would collide there.
 fn span_id_of(event: &Event) -> String {
-    hex_bytes(&event.id.uuid.as_bytes()[8..16])
+    let id = hex_bytes(&event.id.uuid.as_bytes()[8..16]);
+    // The docstring's own law, enforced: an all-zero id (nil-uuid line
+    // in a corrupted journal) is OTLP-invalid — strict consumers drop
+    // the span silently. Substitute a constant non-zero sentinel; the
+    // ids of a nil-uuid journal were never meaningful to begin with.
+    if id == "0000000000000000" {
+        return "6e696b612d302d30".to_owned(); // "nika-0-0"
+    }
+    id
 }
 
 fn hex_bytes(bytes: &[u8]) -> String {


### PR DESCRIPTION
## What

The #210 identity closes its own loop: `nika dap` launch hashes the CURRENT yaml bytes (the run verb's own `sha256_hex`) against the journal's `workflow_sha256` — a mismatch emits an `output` event in the Debug Console **before the first stop**:

> ⚠ workflow changed since this run was recorded — breakpoint lines may be off (re-run to refresh the journal)

Pre-#210 journals (no recorded sha) stay silent — `None`, never a false alarm.

## Why

Replay breakpoints snap to the CURRENT file's task lines; an edited workflow silently shifts them. The journal has carried the truth since this morning's #210 — the debugger just had to look.

## Proof

Pinned three-way: matching sha → `Some(false)` · foreign sha → `Some(true)` · absent → `None`. nika-cli lib 223 ✓ · clippy ✓ · 8/8 ratchets ✓. Public API untouched (all `pub(crate)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)