### PR TITLE
feat(nika-schema): unknown fields carry the did-you-mean — PARSE-005 teaches

### DIFF
--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -1617,6 +1617,7 @@ pub nika_schema::error::SchemaError::UnknownField
 pub nika_schema::error::SchemaError::UnknownField::field: alloc::string::String
 pub nika_schema::error::SchemaError::UnknownField::location: alloc::string::String
 pub nika_schema::error::SchemaError::UnknownField::span: core::option::Option<nika_schema::Span>
+pub nika_schema::error::SchemaError::UnknownField::suggestion: core::option::Option<alloc::string::String>
 pub nika_schema::error::SchemaError::UnknownTaskField
 pub nika_schema::error::SchemaError::UnknownTaskField::field: alloc::string::String
 pub nika_schema::error::SchemaError::UnknownTaskField::span: core::option::Option<nika_schema::Span>
@@ -5959,6 +5960,7 @@ pub nika_schema::SchemaError::UnknownField
 pub nika_schema::SchemaError::UnknownField::field: alloc::string::String
 pub nika_schema::SchemaError::UnknownField::location: alloc::string::String
 pub nika_schema::SchemaError::UnknownField::span: core::option::Option<nika_schema::Span>
+pub nika_schema::SchemaError::UnknownField::suggestion: core::option::Option<alloc::string::String>
 pub nika_schema::SchemaError::UnknownTaskField
 pub nika_schema::SchemaError::UnknownTaskField::field: alloc::string::String
 pub nika_schema::SchemaError::UnknownTaskField::span: core::option::Option<nika_schema::Span>

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -72,7 +72,10 @@ pub enum SchemaError {
     ///
     /// Spec `02-verbs.md` §forward-compat · « **Reject** with a clear
     /// error (strict mode · default for tests) ».
-    #[error("unknown field `{field}` in {location} (strict mode)")]
+    #[error(
+        "unknown field `{field}` in {location} (strict mode){}",
+        crate::suggest::suggestion_clause(suggestion.as_deref())
+    )]
     UnknownField {
         /// The unknown key.
         field: String,
@@ -80,6 +83,10 @@ pub enum SchemaError {
         location: String,
         /// Source span of the key.
         span: Option<Span>,
+        /// The nearest known key, when one is close enough to assert
+        /// (Damerau-Levenshtein · rustc threshold — the same suggestion
+        /// core every check finding shares · silence beats a wrong guess).
+        suggestion: Option<String>,
     },
 
     /// Task `id:` is not `snake_case`.
@@ -618,6 +625,7 @@ fn parse_level_variants() -> Vec<SchemaError> {
             field: String::new(),
             location: String::new(),
             span: None,
+            suggestion: None,
         },
         SchemaError::BadTaskId {
             id: String::new(),

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -229,16 +229,7 @@ impl Cx<'_> {
         if self.mode == ParseMode::Lenient {
             return Ok(());
         }
-        for (key, _) in mapping.iter() {
-            if !known.contains(&key.as_str()) {
-                return Err(SchemaError::UnknownField {
-                    field: key.as_str().to_owned(),
-                    location: location.to_owned(),
-                    span: self.span(key.span()),
-                });
-            }
-        }
-        Ok(())
+        self.check_unknown_keys_always(mapping, known, location)
     }
 
     /// Reject any mapping key outside `known` in BOTH parse modes.
@@ -258,6 +249,8 @@ impl Cx<'_> {
                     field: key.as_str().to_owned(),
                     location: location.to_owned(),
                     span: self.span(key.span()),
+                    suggestion: crate::suggest::did_you_mean(key.as_str(), known.iter().copied())
+                        .map(str::to_owned),
                 });
             }
         }
@@ -631,6 +624,26 @@ tasks:
             panic!("expected UnknownField, got {err:?}");
         };
         assert_eq!(field, "foo");
+    }
+
+    #[test]
+    fn unknown_field_suggests_near_typos_and_stays_silent_far() {
+        // The #1 beginner friction (user-sim punch list 2026-07-06): a
+        // typo'd verb key (`infr:`) died as a bare « unknown field » while
+        // the closed vocabulary sat RIGHT THERE in the rejection call.
+        // And the suggest module's own law: a wrong suggestion is worse
+        // than none — `zzzqx` is nowhere near the vocabulary, so silence.
+        let near = "nika: v1\nworkflow: h\ntasks:\n  - id: g\n    infr:\n      prompt: \"hi\"\n";
+        let err = parse_strict(near).expect_err("unknown key");
+        assert!(err.to_string().contains("did you mean `infer`?"), "{err}");
+        let SchemaError::UnknownField { suggestion, .. } = err else {
+            panic!("expected UnknownField, got {err:?}");
+        };
+        assert_eq!(suggestion.as_deref(), Some("infer"));
+
+        let far = "nika: v1\nworkflow: h\ntasks:\n  - id: g\n    zzzqx:\n      prompt: \"hi\"\n";
+        let msg = parse_strict(far).expect_err("unknown key").to_string();
+        assert!(!msg.contains("did you mean"), "{msg}");
     }
 
     #[test]


### PR DESCRIPTION
The #1 beginner friction (user-sim punch list 2026-07-06, item 1 — the claim on the old E4 arc had expired): a typo'd verb key (`infr:`) died as a bare « unknown field » while the closed vocabulary sat RIGHT THERE in the rejection call's `known` slice. Every other did-you-mean surface (unknown tools · unknown args · clap subcommands) already taught; the parser was the one that didn't.

`UnknownField` gains `suggestion: Option<String>` — computed through the crate's own suggest core (Damerau-Levenshtein · rustc threshold · silence beats a wrong guess), rendered as `` — did you mean `infer`? `` on every surface the Display rides (check face · check --json message · LSP diagnostics · MCP nika_check replies) with zero per-surface work. The two unknown-key walkers were twins after the change, so strict now delegates to always (one loop, one raise site — and the crate stays under the 15k hard cap the day's growth had reached).

Proven on the built binary:
```
PARSE ✗  [NIKA-PARSE-005] unknown field `infr` in task `x` (strict mode) — did you mean `infer`?
```

TDD (near-typo suggests · far garbage stays silent) · 771 nika-schema tests · workspace lib green · additive public-api baseline sync · crate-size vector back to OK · pre-push gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)