### PR TITLE
ci(coherence): the bot self-tests before every run — and survives pre-releases

### DIFF
--- a/.github/workflows/ecosystem-coherence.yml
+++ b/.github/workflows/ecosystem-coherence.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      - name: Self-test the bot (offline decision table — grace · lockstep · pre-release · dark surfaces)
+        run: python3 scripts/ci/test-ecosystem-coherence.py
       - name: Run the coherence bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci/ecosystem-coherence.py
+++ b/scripts/ci/ecosystem-coherence.py
@@ -59,6 +59,12 @@ def mm(v):
     return ".".join(v.lstrip("v").split(".")[:2])
 
 
+def semver_key(v):
+    """`0.97.0` / `0.97.0-rc1` → (0, 97, 0) — a pre-release suffix must
+    never crash the nightly (int("0-rc1") did, latently)."""
+    return tuple(int(part.split("-")[0].split("+")[0]) for part in v.lstrip("v").split(".")[:3])
+
+
 def main():
     rel = json.loads(fetch("https://api.github.com/repos/supernovae-st/nika/releases/latest"))
     tag = rel["tag_name"].lstrip("v")
@@ -127,7 +133,7 @@ def main():
 
     # Lockstep-at-convergence · WARN preview below 0.97 · FAIL from 0.97.
     if engine_main:
-        lock_sev = "FAIL" if tuple(map(int, engine_main.split("."))) >= (0, 97, 0) else "WARN"
+        lock_sev = "FAIL" if semver_key(engine_main) >= (0, 97, 0) else "WARN"
         for name, ver in (("vscode", vscode_repo), ("client-sdk", sdk_repo)):
             if ver and mm(ver) != mm(engine_main):
                 FINDINGS.append((lock_sev, f"lockstep {name}",
@@ -142,4 +148,8 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 — a dead bot must still say why
+        print(f"FAIL  bot              crashed: {exc.__class__.__name__}: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/ci/test-ecosystem-coherence.py
+++ b/scripts/ci/test-ecosystem-coherence.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#
+# test-ecosystem-coherence.py — the bot self-tests before every real run.
+#
+# The nightly is only useful if it CANNOT die silently and its severity
+# ladder does what the doctrine says. This harness imports the bot,
+# monkeypatches `fetch`, and drives the decision table offline:
+#   T1  a fresh release (<24h) demotes tag-pins to WARN (grace window)
+#   T2  a day-old release makes a stale tap a hard FAIL (exit 1)
+#   T3  lockstep is WARN below engine 0.97, FAIL from 0.97
+#   T4  a pre-release engine version (0.97.0-rc1) must not crash
+#   T5  every surface unreadable → WARNs only, never a crash, exit 0
+# Zero network: every URL resolves from the FIXTURES table.
+
+import datetime
+import importlib.util
+import json
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("bot", HERE / "ecosystem-coherence.py")
+bot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bot)
+
+
+def iso(hours_ago: float) -> str:
+    dt = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=hours_ago)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def fixtures(*, tag="0.95.0", age_h=48.0, tap="0.95.0", site="0.95.0",
+             sdk="0.90.0", npm="0.90.0", pack="0.1.0-draft", spec_v="0.1.0-draft",
+             engine="0.95.0", vscode="0.96.0", docs="0.95.0", reg_n=21):
+    R = bot.RAW
+    return {
+        "https://api.github.com/repos/supernovae-st/nika/releases/latest":
+            json.dumps({"tag_name": f"v{tag}", "published_at": iso(age_h)}),
+        f"{R}/supernovae-st/homebrew-tap/main/Formula/nika.rb": f'  version "{tap}"\n',
+        f"{R}/supernovae-st/nika.sh/main/src/content.ts": f"export const ENGINE_VERSION = 'v{site}'\n",
+        f"{R}/supernovae-st/nika-client/main/package.json": json.dumps({"version": sdk}),
+        "https://registry.npmjs.org/@supernovae-st%2Fnika-client": json.dumps({"dist-tags": {"latest": npm}}),
+        f"{R}/supernovae-st/nika/main/crates/nika-pack/pack/VERSION": pack + "\n",
+        f"{R}/supernovae-st/nika-spec/main/VERSION": spec_v + "\n",
+        f"{R}/supernovae-st/nika-vscode/main/package.json": json.dumps({"version": vscode}),
+        "https://open-vsx.org/api/supernovae-st/nika-vscode": json.dumps({"version": vscode}),
+        f"{R}/supernovae-st/nika/main/Cargo.toml": f'version      = "{engine}"\n',
+        f"{R}/supernovae-st/nika-docs/main/snippets/_status-snapshot.mdx": f'  version: "{docs}",\n',
+        f"{R}/supernovae-st/nika-registry/main/SPEC_PIN": "# pin\n" + "a" * 40 + "\n",
+        f"{R}/supernovae-st/nika-registry/main/index.json": json.dumps({"artifacts": [{}] * reg_n}),
+        "https://api.github.com/repos/supernovae-st/nika-spec/commits/" + "a" * 40: "{}",
+    }
+
+
+def run(table):
+    bot.FINDINGS.clear()
+    # fetch RAISES on a missing fixture the way urllib raises on a miss.
+    def fetch(url, timeout=20):
+        if url in table:
+            return table[url]
+        raise OSError(f"no fixture for {url}")
+    bot.fetch = fetch
+    code = bot.main()
+    return code, list(bot.FINDINGS)
+
+
+fails = []
+
+
+def check(name, cond, detail=""):
+    print(f"{'✓' if cond else '✗'} {name}" + (f"  {detail}" if detail and not cond else ""))
+    if not cond:
+        fails.append(name)
+
+
+# T1 · fresh release + stale tap → WARN (grace), exit 0
+code, f = run(fixtures(age_h=2.0, tap="0.94.0"))
+check("T1 grace demotes tag-pins", code == 0 and ("WARN", "tap", ) == tuple(next(x for x in f if x[1] == "tap")[:2]), f)
+
+# T2 · old release + stale tap → FAIL, exit 1
+code, f = run(fixtures(age_h=48.0, tap="0.94.0"))
+check("T2 stale tap hard-fails post-grace", code == 1 and any(x[0] == "FAIL" and x[1] == "tap" for x in f), f)
+
+# T3 · lockstep severity flips at 0.97
+code, f = run(fixtures(engine="0.96.0", vscode="0.99.0"))
+check("T3a lockstep WARN below 0.97", any(x[0] == "WARN" and "lockstep vscode" == x[1] for x in f), f)
+code, f = run(fixtures(engine="0.97.0", site="0.97.0", tap="0.97.0", tag="0.97.0", docs="0.97.0", vscode="0.99.0"))
+check("T3b lockstep FAIL from 0.97", code == 1 and any(x[0] == "FAIL" and "lockstep vscode" == x[1] for x in f), f)
+
+# T4 · pre-release engine version must not crash
+try:
+    code, f = run(fixtures(engine="0.97.0-rc1", vscode="0.99.0"))
+    check("T4 pre-release engine survives", any("lockstep" in x[1] for x in f), f)
+except Exception as exc:  # noqa: BLE001
+    check("T4 pre-release engine survives", False, repr(exc))
+
+# T5 · every surface dark → WARNs only, exit 0 (the bot reports, never dies)
+try:
+    code, f = run({"https://api.github.com/repos/supernovae-st/nika/releases/latest":
+                   json.dumps({"tag_name": "v0.95.0", "published_at": iso(48)})})
+    check("T5 dark surfaces = WARNs, no crash", code == 0 and all(x[0] == "WARN" for x in f), f)
+except Exception as exc:  # noqa: BLE001
+    check("T5 dark surfaces = WARNs, no crash", False, repr(exc))
+
+print(f"\nself-test: {'PASS (6/6)' if not fails else 'FAIL ' + str(fails)}")
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
The review reached the one critical surface never mutation-tested: the nightly itself. Two latent faults fixed (lockstep crashed on a pre-release workspace version · raw-traceback death) + an offline self-test harness driving the full decision table (grace <24h · stale-tap FAIL · lockstep WARN→FAIL at 0.97 · pre-release survives · all-surfaces-dark = WARNs, exit 0). The workflow runs the harness before the real sweep — a broken bot reddens itself. Proven locally 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)