### PR TITLE
feat(nika-catalog): the pricing catalog refreshes from models.dev — 62 rules become 602

### DIFF
--- a/crates/nika-catalog/data/model-pricing.toml
+++ b/crates/nika-catalog/data/model-pricing.toml
@@ -1,381 +1,3640 @@
 schema = "nika/model-pricing@1.0"
 
-# ── Anthropic ───────────────────────────────────────────────
-[[rules]]
-provider = "Anthropic"
-model_pattern = "claude-3-haiku"
-input_per_million = 0.25
-output_per_million = 1.25
+# ── GENERATED · do not hand-edit ────────────────────────────
+# Source: https://models.dev/api.json (MIT · sst/models.dev)
+# as_of: 2026-07-06 · source sha256[:16]: ad917b2482fa6b38
+# Refresh: bash scripts/refresh-pricing.sh
+# Values: USD per 1M tokens. Lookup: exact match, then contains()
+# fallback (first hit wins — longest patterns emitted first).
+
+# ── anthropic (15 models) ──
 
 [[rules]]
-provider = "Anthropic"
-model_pattern = "opus-4"
+provider = "anthropic"
+model_pattern = "claude-sonnet-4-5-20250929"
+input_per_million = 3.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-haiku-4-5-20251001"
+input_per_million = 1.0
+output_per_million = 5.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-opus-4-1-20250805"
 input_per_million = 15.0
 output_per_million = 75.0
 
 [[rules]]
-provider = "Anthropic"
-model_pattern = "sonnet-4"
+provider = "anthropic"
+model_pattern = "claude-opus-4-5-20251101"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-sonnet-4-5"
 input_per_million = 3.0
 output_per_million = 15.0
 
 [[rules]]
-provider = "Anthropic"
-model_pattern = "haiku-4"
-input_per_million = 0.8
-output_per_million = 4.0
-
-[[rules]]
-provider = "Anthropic"
-model_pattern = "claude-3-5-sonnet"
+provider = "anthropic"
+model_pattern = "claude-sonnet-4-6"
 input_per_million = 3.0
 output_per_million = 15.0
 
 [[rules]]
-provider = "Anthropic"
-model_pattern = "claude-3-5-haiku"
-input_per_million = 0.8
-output_per_million = 4.0
+provider = "anthropic"
+model_pattern = "claude-haiku-4-5"
+input_per_million = 1.0
+output_per_million = 5.0
 
 [[rules]]
-provider = "Anthropic"
-model_pattern = "claude-3-opus"
+provider = "anthropic"
+model_pattern = "claude-opus-4-1"
 input_per_million = 15.0
 output_per_million = 75.0
 
 [[rules]]
-provider = "Anthropic"
-model_pattern = "claude-3-sonnet"
+provider = "anthropic"
+model_pattern = "claude-opus-4-5"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-opus-4-6"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-opus-4-7"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-opus-4-8"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "anthropic"
+model_pattern = "claude-sonnet-4"
 input_per_million = 3.0
 output_per_million = 15.0
 
-# ── OpenAI (ordering critical for contains fallback) ────────
 [[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4o-mini"
-input_per_million = 0.15
-output_per_million = 0.6
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4o"
-input_per_million = 2.5
+provider = "anthropic"
+model_pattern = "claude-sonnet-5"
+input_per_million = 2.0
 output_per_million = 10.0
 
 [[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4.1-nano"
-input_per_million = 0.1
-output_per_million = 0.4
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4.1-mini"
-input_per_million = 0.4
-output_per_million = 1.6
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4.1"
-input_per_million = 2.0
-output_per_million = 8.0
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-3.5-turbo"
-input_per_million = 0.5
-output_per_million = 1.5
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4-turbo"
+provider = "anthropic"
+model_pattern = "claude-fable-5"
 input_per_million = 10.0
-output_per_million = 30.0
+output_per_million = 50.0
+
+# ── deepseek (4 models) ──
 
 [[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-4"
-input_per_million = 30.0
-output_per_million = 60.0
+provider = "deepseek"
+model_pattern = "deepseek-reasoner"
+input_per_million = 0.14
+output_per_million = 0.28
 
 [[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-5.4-nano"
-input_per_million = 0.10
-output_per_million = 0.40
+provider = "deepseek"
+model_pattern = "deepseek-v4-flash"
+input_per_million = 0.14
+output_per_million = 0.28
 
 [[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-5.4-mini"
-input_per_million = 0.40
-output_per_million = 1.60
+provider = "deepseek"
+model_pattern = "deepseek-v4-pro"
+input_per_million = 0.435
+output_per_million = 0.87
 
 [[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-5.4"
-input_per_million = 2.00
-output_per_million = 8.00
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-5.2-pro"
-input_per_million = 21.0
-output_per_million = 168.0
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-5.2"
-input_per_million = 1.75
-output_per_million = 14.0
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "gpt-5"
-input_per_million = 1.75
-output_per_million = 14.0
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "o1-mini"
-input_per_million = 3.0
-output_per_million = 12.0
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "o1"
-input_per_million = 15.0
-output_per_million = 60.0
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "o3-mini"
-input_per_million = 1.1
-output_per_million = 4.4
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "o4-mini"
-input_per_million = 1.1
-output_per_million = 4.4
-
-[[rules]]
-provider = "OpenAI"
-model_pattern = "o3"
-input_per_million = 2.0
-output_per_million = 8.0
-
-# o4-mini BEFORE o4 (contains "o4" substring)
-[[rules]]
-provider = "OpenAI"
-model_pattern = "o4"
-input_per_million = 2.0
-output_per_million = 8.0
-
-# ── Mistral ─────────────────────────────────────────────────
-[[rules]]
-provider = "Mistral"
-model_pattern = "mistral-large"
-input_per_million = 2.0
-output_per_million = 6.0
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "mistral-medium"
-input_per_million = 2.7
-output_per_million = 8.1
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "mistral-small"
-input_per_million = 0.2
-output_per_million = 0.6
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "codestral"
-input_per_million = 0.3
-output_per_million = 0.9
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "ministral-8b"
-input_per_million = 0.1
-output_per_million = 0.1
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "ministral-3b"
-input_per_million = 0.04
-output_per_million = 0.04
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "pixtral-large"
-input_per_million = 2.0
-output_per_million = 6.0
-
-[[rules]]
-provider = "Mistral"
-model_pattern = "pixtral-12b"
-input_per_million = 0.15
-output_per_million = 0.15
-
-# ── Groq ────────────────────────────────────────────────────
-[[rules]]
-provider = "Groq"
-model_pattern = "llama-3.3-70b-specdec"
-input_per_million = 0.59
-output_per_million = 0.99
-
-[[rules]]
-provider = "Groq"
-model_pattern = "llama-3.3-70b"
-input_per_million = 0.59
-output_per_million = 0.79
-
-[[rules]]
-provider = "Groq"
-model_pattern = "llama-3.1-70b"
-input_per_million = 0.59
-output_per_million = 0.79
-
-[[rules]]
-provider = "Groq"
-model_pattern = "llama-3.1-8b"
-input_per_million = 0.05
-output_per_million = 0.08
-
-[[rules]]
-provider = "Groq"
-model_pattern = "llama3-70b"
-input_per_million = 0.59
-output_per_million = 0.79
-
-[[rules]]
-provider = "Groq"
-model_pattern = "llama3-8b"
-input_per_million = 0.05
-output_per_million = 0.08
-
-[[rules]]
-provider = "Groq"
-model_pattern = "mixtral-8x7b"
-input_per_million = 0.24
-output_per_million = 0.24
-
-[[rules]]
-provider = "Groq"
-model_pattern = "gemma2-9b"
-input_per_million = 0.20
-output_per_million = 0.20
-
-# ── DeepSeek ────────────────────────────────────────────────
-[[rules]]
-provider = "DeepSeek"
+provider = "deepseek"
 model_pattern = "deepseek-chat"
 input_per_million = 0.14
 output_per_million = 0.28
 
-[[rules]]
-provider = "DeepSeek"
-model_pattern = "deepseek-reasoner"
-input_per_million = 0.55
-output_per_million = 2.19
+# ── google (20 models) ──
 
 [[rules]]
-provider = "DeepSeek"
-model_pattern = "deepseek-coder"
-input_per_million = 0.14
-output_per_million = 0.28
-
-# ── Gemini ──────────────────────────────────────────────────
-[[rules]]
-provider = "Gemini"
-model_pattern = "gemini-2.5-flash"
-input_per_million = 0.15
-output_per_million = 0.6
+provider = "google"
+model_pattern = "gemini-3.1-pro-preview-customtools"
+input_per_million = 2.0
+output_per_million = 12.0
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-2.5-pro"
-input_per_million = 1.25
+provider = "google"
+model_pattern = "gemini-3.1-flash-image-preview"
+input_per_million = 0.5
+output_per_million = 60.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-3.1-flash-lite-preview"
+input_per_million = 0.25
+output_per_million = 1.5
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-2.5-flash-preview-tts"
+input_per_million = 0.5
 output_per_million = 10.0
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-2.0-flash-exp"
-input_per_million = 0.0
+provider = "google"
+model_pattern = "gemini-2.5-pro-preview-tts"
+input_per_million = 1.0
+output_per_million = 20.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-3-pro-image-preview"
+input_per_million = 2.0
+output_per_million = 120.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-flash-lite-latest"
+input_per_million = 0.1
+output_per_million = 0.4
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-2.5-flash-image"
+input_per_million = 0.3
+output_per_million = 30.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-3-flash-preview"
+input_per_million = 0.5
+output_per_million = 3.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-3.1-pro-preview"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-2.0-flash-lite"
+input_per_million = 0.075
+output_per_million = 0.3
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-2.5-flash-lite"
+input_per_million = 0.1
+output_per_million = 0.4
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-3.1-flash-lite"
+input_per_million = 0.25
+output_per_million = 1.5
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-3-pro-preview"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-embedding-001"
+input_per_million = 0.15
 output_per_million = 0.0
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-2.0-flash-thinking"
-input_per_million = 0.0
-output_per_million = 0.0
+provider = "google"
+model_pattern = "gemini-flash-latest"
+input_per_million = 0.3
+output_per_million = 2.5
 
 [[rules]]
-provider = "Gemini"
+provider = "google"
 model_pattern = "gemini-2.0-flash"
 input_per_million = 0.1
 output_per_million = 0.4
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-1.5-flash-8b"
-input_per_million = 0.0375
-output_per_million = 0.15
+provider = "google"
+model_pattern = "gemini-2.5-flash"
+input_per_million = 0.3
+output_per_million = 2.5
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-1.5-flash"
+provider = "google"
+model_pattern = "gemini-3.5-flash"
+input_per_million = 1.5
+output_per_million = 9.0
+
+[[rules]]
+provider = "google"
+model_pattern = "gemini-2.5-pro"
+input_per_million = 1.25
+output_per_million = 10.0
+
+# ── groq (9 models) ──
+
+[[rules]]
+provider = "groq"
+model_pattern = "meta-llama/llama-4-scout-17b-16e-instruct"
+input_per_million = 0.11
+output_per_million = 0.34
+
+[[rules]]
+provider = "groq"
+model_pattern = "meta-llama/llama-prompt-guard-2-22m"
+input_per_million = 0.03
+output_per_million = 0.03
+
+[[rules]]
+provider = "groq"
+model_pattern = "meta-llama/llama-prompt-guard-2-86m"
+input_per_million = 0.04
+output_per_million = 0.04
+
+[[rules]]
+provider = "groq"
+model_pattern = "openai/gpt-oss-safeguard-20b"
 input_per_million = 0.075
 output_per_million = 0.3
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-1.5-pro"
-input_per_million = 1.25
+provider = "groq"
+model_pattern = "llama-3.3-70b-versatile"
+input_per_million = 0.59
+output_per_million = 0.79
+
+[[rules]]
+provider = "groq"
+model_pattern = "llama-3.1-8b-instant"
+input_per_million = 0.05
+output_per_million = 0.08
+
+[[rules]]
+provider = "groq"
+model_pattern = "openai/gpt-oss-120b"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "groq"
+model_pattern = "openai/gpt-oss-20b"
+input_per_million = 0.075
+output_per_million = 0.3
+
+[[rules]]
+provider = "groq"
+model_pattern = "qwen/qwen3-32b"
+input_per_million = 0.29
+output_per_million = 0.59
+
+# ── huggingface (50 models) ──
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Coder-480B-A35B-Instruct"
+input_per_million = 2.0
+output_per_million = 2.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-235B-A22B-Thinking-2507"
+input_per_million = 0.3
+output_per_million = 3.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+input_per_million = 0.07
+output_per_million = 0.26
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "meta-llama/Llama-3.3-70B-Instruct"
+input_per_million = 0.59
+output_per_million = 0.79
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Next-80B-A3B-Instruct"
+input_per_million = 0.25
+output_per_million = 1.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Next-80B-A3B-Thinking"
+input_per_million = 0.3
+output_per_million = 2.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "moonshotai/Kimi-K2-Instruct-0905"
+input_per_million = 1.0
+output_per_million = 3.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "deepseek-ai/DeepSeek-V4-Flash"
+input_per_million = 0.14
+output_per_million = 0.28
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "deepseek-ai/DeepSeek-R1-0528"
+input_per_million = 3.0
 output_per_million = 5.0
 
 [[rules]]
-provider = "Gemini"
-model_pattern = "gemini-pro"
+provider = "huggingface"
+model_pattern = "deepseek-ai/DeepSeek-V4-Pro"
+input_per_million = 0.435
+output_per_million = 0.87
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "moonshotai/Kimi-K2-Instruct"
+input_per_million = 1.0
+output_per_million = 3.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "moonshotai/Kimi-K2-Thinking"
+input_per_million = 0.6
+output_per_million = 2.5
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "deepseek-ai/DeepSeek-V3.2"
+input_per_million = 0.28
+output_per_million = 0.4
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "google/gemma-4-26B-A4B-it"
+input_per_million = 0.13
+output_per_million = 0.4
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "moonshotai/Kimi-K2.7-Code"
+input_per_million = 0.95
+output_per_million = 4.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "stepfun-ai/Step-3.5-Flash"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "stepfun-ai/Step-3.7-Flash"
+input_per_million = 0.2
+output_per_million = 1.15
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "XiaomiMiMo/MiMo-V2-Flash"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "XiaomiMiMo/MiMo-V2.5-Pro"
+input_per_million = 1.0
+output_per_million = 3.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Embedding-4B"
+input_per_million = 0.01
+output_per_million = 0.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Embedding-8B"
+input_per_million = 0.01
+output_per_million = 0.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "deepseek-ai/DeepSeek-R1"
+input_per_million = 0.7
+output_per_million = 2.5
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "MiniMaxAI/MiniMax-M2.1"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "MiniMaxAI/MiniMax-M2.5"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "MiniMaxAI/MiniMax-M2.7"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.5-122B-A10B"
+input_per_million = 0.4
+output_per_million = 3.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.5-397B-A17B"
+input_per_million = 0.6
+output_per_million = 3.6
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-Coder-Next"
+input_per_million = 0.2
+output_per_million = 1.5
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "google/gemma-4-31B-it"
+input_per_million = 0.14
+output_per_million = 0.4
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-4.7-Flash"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "MiniMaxAI/MiniMax-M2"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "MiniMaxAI/MiniMax-M3"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-235B-A22B"
+input_per_million = 0.2
+output_per_million = 0.8
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.5-35B-A3B"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.6-35B-A3B"
+input_per_million = 0.15
+output_per_million = 0.95
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "moonshotai/Kimi-K2.5"
+input_per_million = 0.6
+output_per_million = 3.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "moonshotai/Kimi-K2.6"
+input_per_million = 0.95
+output_per_million = 4.0
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "openai/gpt-oss-120b"
+input_per_million = 0.25
+output_per_million = 0.69
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-4.5-Air"
+input_per_million = 0.13
+output_per_million = 0.85
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.5-27B"
+input_per_million = 0.3
+output_per_million = 2.4
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.6-27B"
+input_per_million = 0.47
+output_per_million = 3.19
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-4.5V"
+input_per_million = 0.6
+output_per_million = 1.8
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3.5-9B"
+input_per_million = 0.17
+output_per_million = 0.25
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-4.5"
+input_per_million = 0.6
+output_per_million = 2.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-4.6"
+input_per_million = 0.55
+output_per_million = 2.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-4.7"
+input_per_million = 0.6
+output_per_million = 2.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-5.1"
+input_per_million = 1.0
+output_per_million = 3.2
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-5.2"
+input_per_million = 1.4
+output_per_million = 4.4
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "Qwen/Qwen3-32B"
+input_per_million = 0.29
+output_per_million = 0.59
+
+[[rules]]
+provider = "huggingface"
+model_pattern = "zai-org/GLM-5"
+input_per_million = 1.0
+output_per_million = 3.2
+
+# ── mistral (30 models) ──
+
+[[rules]]
+provider = "mistral"
+model_pattern = "labs-devstral-small-2512"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "magistral-medium-latest"
+input_per_million = 2.0
+output_per_million = 5.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "devstral-medium-latest"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-medium-latest"
+input_per_million = 1.5
+output_per_million = 7.5
+
+[[rules]]
+provider = "mistral"
+model_pattern = "devstral-medium-2507"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-large-latest"
 input_per_million = 0.5
 output_per_million = 1.5
 
-# ── xAI ─────────────────────────────────────────────────────
 [[rules]]
-provider = "xAI"
-model_pattern = "grok-4"
-input_per_million = 3.0
+provider = "mistral"
+model_pattern = "mistral-small-latest"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "mistral"
+model_pattern = "pixtral-large-latest"
+input_per_million = 2.0
+output_per_million = 6.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "devstral-small-2505"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "mistral"
+model_pattern = "devstral-small-2507"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "mistral"
+model_pattern = "ministral-3b-latest"
+input_per_million = 0.04
+output_per_million = 0.04
+
+[[rules]]
+provider = "mistral"
+model_pattern = "ministral-8b-latest"
+input_per_million = 0.1
+output_per_million = 0.1
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-medium-2505"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-medium-2508"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-medium-2604"
+input_per_million = 1.5
+output_per_million = 7.5
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-large-2411"
+input_per_million = 2.0
+output_per_million = 6.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-large-2512"
+input_per_million = 0.5
+output_per_million = 1.5
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-small-2506"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-small-2603"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "mistral"
+model_pattern = "open-mixtral-8x22b"
+input_per_million = 2.0
+output_per_million = 6.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "open-mistral-nemo"
+input_per_million = 0.15
+output_per_million = 0.15
+
+[[rules]]
+provider = "mistral"
+model_pattern = "open-mixtral-8x7b"
+input_per_million = 0.7
+output_per_million = 0.7
+
+[[rules]]
+provider = "mistral"
+model_pattern = "codestral-latest"
+input_per_million = 0.3
+output_per_million = 0.9
+
+[[rules]]
+provider = "mistral"
+model_pattern = "devstral-latest"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "magistral-small"
+input_per_million = 0.5
+output_per_million = 1.5
+
+[[rules]]
+provider = "mistral"
+model_pattern = "open-mistral-7b"
+input_per_million = 0.25
+output_per_million = 0.25
+
+[[rules]]
+provider = "mistral"
+model_pattern = "devstral-2512"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-embed"
+input_per_million = 0.1
+output_per_million = 0.0
+
+[[rules]]
+provider = "mistral"
+model_pattern = "mistral-nemo"
+input_per_million = 0.15
+output_per_million = 0.15
+
+[[rules]]
+provider = "mistral"
+model_pattern = "pixtral-12b"
+input_per_million = 0.15
+output_per_million = 0.15
+
+# ── nvidia (84 models) ──
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mistral-large-3-675b-instruct-2512"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/llama-3_1-nemotron-safety-guard-8b-v3"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/llama-3_2-nemoretriever-300m-embed-v1"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-content-safety-reasoning-4b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "abacusai/dracarys-llama-3_1-70b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-4-maverick-17b-128e-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/riva-translate-4b-instruct-v1_1"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/llama-nemotron-rerank-vl-1b-v2"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "black-forest-labs/flux_1-kontext-dev"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/llama-nemotron-embed-vl-1b-v2"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "microsoft/phi-4-multimodal-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mistral-medium-3-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mistral-small-4-119b-2603"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen3-coder-480b-a35b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.2-11b-vision-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.2-90b-vision-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "black-forest-labs/flux_2-klein-4b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mistral-7b-instruct-v03"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-3-super-120b-a12b"
+input_per_million = 0.2
+output_per_million = 0.8
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-3-ultra-550b-a55b"
+input_per_million = 0.5
+output_per_million = 2.5
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nvidia-nemotron-nano-9b-v2"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "black-forest-labs/flux_1-schnell"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mixtral-8x22b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "moonshotai/kimi-k2-instruct-0905"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-3-content-safety"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-mini-4b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen3-next-80b-a3b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "bytedance/seed-oss-36b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mixtral-8x7b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/active-speaker-detection"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/synthetic-video-detector"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen2.5-coder-32b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/magistral-small-2506"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-3-nano-30b-a3b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "deepseek-ai/deepseek-v4-flash"
+input_per_million = 0.14
+output_per_million = 0.28
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "microsoft/phi-4-mini-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "black-forest-labs/flux.1-dev"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/cosmos-transfer2_5-2b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "upstage/solar-10_7b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "deepseek-ai/deepseek-v4-pro"
+input_per_million = 0.435
+output_per_million = 0.87
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.1-70b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.3-70b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/rerank-qa-mistral-4b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.1-8b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.2-1b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-3.2-3b-instruct"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "mistralai/mistral-nemotron"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/cosmos-transfer1-7b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/magpie-tts-zeroshot"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/cosmos-predict1-5b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nemotron-voicechat"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nv-embedcode-7b-v1"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "stepfun-ai/step-3.5-flash"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "stepfun-ai/step-3.7-flash"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "google/google-paligemma"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "openai/whisper-large-v3"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "google/gemma-3n-e2b-it"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "google/gemma-3n-e4b-it"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/llama-guard-4-12b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "minimaxai/minimax-m2.7"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen3.5-122b-a10b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen3.5-397b-a17b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "google/gemma-4-31b-it"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "google/gemma-2-2b-it"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "minimaxai/minimax-m3"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "moonshotai/kimi-k2.6"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen-image-edit"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "openai/gpt-oss-120b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/nv-embed-v1"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/sparsedrive"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/studiovoice"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/usdvalidate"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "openai/gpt-oss-20b"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/gliner-pii"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/streampetr"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "sarvamai/sarvam-m"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/bevformer"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "qwen/qwen-image"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/esm2-650m"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "nvidia/usdcode"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "meta/esmfold"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "z-ai/glm-5.2"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "nvidia"
+model_pattern = "baai/bge-m3"
+input_per_million = 0.0
+output_per_million = 0.0
+
+# ── openai (47 models) ──
+
+[[rules]]
+provider = "openai"
+model_pattern = "text-embedding-3-large"
+input_per_million = 0.13
+output_per_million = 0.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "text-embedding-3-small"
+input_per_million = 0.02
+output_per_million = 0.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "text-embedding-ada-002"
+input_per_million = 0.1
+output_per_million = 0.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o4-mini-deep-research"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.1-chat-latest"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.2-chat-latest"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.3-chat-latest"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.3-codex-spark"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.1-codex-mini"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4o-2024-05-13"
+input_per_million = 5.0
 output_per_million = 15.0
 
 [[rules]]
-provider = "xAI"
-model_pattern = "grok-3-mini-fast"
+provider = "openai"
+model_pattern = "gpt-4o-2024-08-06"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4o-2024-11-20"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5-chat-latest"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.1-codex-max"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o3-deep-research"
+input_per_million = 10.0
+output_per_million = 40.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-3.5-turbo"
+input_per_million = 0.5
+output_per_million = 1.5
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.1-codex"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.2-codex"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.3-codex"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4.1-mini"
+input_per_million = 0.4
+output_per_million = 1.6
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4.1-nano"
 input_per_million = 0.1
 output_per_million = 0.4
 
 [[rules]]
-provider = "xAI"
-model_pattern = "grok-3-mini"
+provider = "openai"
+model_pattern = "gpt-5.4-mini"
+input_per_million = 0.75
+output_per_million = 4.5
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.4-nano"
+input_per_million = 0.2
+output_per_million = 1.25
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4-turbo"
+input_per_million = 10.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4o-mini"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5-codex"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.2-pro"
+input_per_million = 21.0
+output_per_million = 168.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.4-pro"
+input_per_million = 30.0
+output_per_million = 180.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.5-pro"
+input_per_million = 30.0
+output_per_million = 180.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-image-2"
+input_per_million = 5.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5-mini"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5-nano"
+input_per_million = 0.05
+output_per_million = 0.4
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5-pro"
+input_per_million = 15.0
+output_per_million = 120.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4.1"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.1"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.2"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.4"
+input_per_million = 2.5
+output_per_million = 15.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5.5"
+input_per_million = 5.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o3-mini"
+input_per_million = 1.1
+output_per_million = 4.4
+
+[[rules]]
+provider = "openai"
+model_pattern = "o4-mini"
+input_per_million = 1.1
+output_per_million = 4.4
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4o"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o1-pro"
+input_per_million = 150.0
+output_per_million = 600.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o3-pro"
+input_per_million = 20.0
+output_per_million = 80.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-4"
+input_per_million = 30.0
+output_per_million = 60.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "gpt-5"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o1"
+input_per_million = 15.0
+output_per_million = 60.0
+
+[[rules]]
+provider = "openai"
+model_pattern = "o3"
+input_per_million = 2.0
+output_per_million = 8.0
+
+# ── openrouter (336 models) ──
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "cognitivecomputations/dolphin-mistral-24b-venice-edition:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-flash-lite-preview-09-2025"
+input_per_million = 0.1
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-pro-preview-customtools"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-small-24b-instruct-2501"
+input_per_million = 0.05
+output_per_million = 0.08
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nousresearch/hermes-3-llama-3.1-405b:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.2-11b-vision-instruct"
+input_per_million = 0.345
+output_per_million = 0.345
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-small-3.1-24b-instruct"
+input_per_million = 0.351
+output_per_million = 0.555
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-small-3.2-24b-instruct"
+input_per_million = 0.075
+output_per_million = 0.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+input_per_million = 0.4
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3.5-content-safety:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-r1-distill-llama-70b"
+input_per_million = 0.8
+output_per_million = 0.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.3-70b-instruct:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-super-120b-a12b:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-ultra-550b-a55b:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-flash-image-preview"
+input_per_million = 0.5
+output_per_million = 3.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.2-3b-instruct:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-next-80b-a3b-instruct:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-flash-lite-preview"
+input_per_million = 0.25
+output_per_million = 1.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "inflection/inflection-3-productivity"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nousresearch/hermes-3-llama-3.1-405b"
+input_per_million = 1.0
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-pro-preview-05-06"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nousresearch/hermes-3-llama-3.1-70b"
+input_per_million = 0.7
+output_per_million = 0.7
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-nano-30b-a3b:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-nano-12b-v2-vl:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-flash-lite-image"
+input_per_million = 0.25
+output_per_million = 1.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen-plus-2025-07-28:thinking"
+input_per_million = 0.26
+output_per_million = 0.78
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-235b-a22b-thinking-2507"
+input_per_million = 0.1495
+output_per_million = 1.495
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3-pro-image-preview"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "liquid/lfm-2.5-1.2b-instruct:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "liquid/lfm-2.5-1.2b-thinking:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.1-70b-instruct"
+input_per_million = 0.4
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.3-70b-instruct"
+input_per_million = 0.1
+output_per_million = 0.32
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-super-120b-a12b"
+input_per_million = 0.08
+output_per_million = 0.45
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-ultra-550b-a55b"
+input_per_million = 0.5
+output_per_million = 2.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-mini-search-preview"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-coder-30b-a3b-instruct"
+input_per_million = 0.07
+output_per_million = 0.27
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.1-8b-instruct"
+input_per_million = 0.02
+output_per_million = 0.03
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.2-1b-instruct"
+input_per_million = 0.027
+output_per_million = 0.201
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3.2-3b-instruct"
+input_per_million = 0.0509
+output_per_million = 0.335
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mixtral-8x22b-instruct"
+input_per_million = 2.0
+output_per_million = 6.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/voxtral-small-24b-2507"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen-2.5-coder-32b-instruct"
+input_per_million = 0.66
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-30b-a3b-instruct-2507"
+input_per_million = 0.04815
+output_per_million = 0.19305
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-30b-a3b-thinking-2507"
+input_per_million = 0.13
+output_per_million = 1.56
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-next-80b-a3b-instruct"
+input_per_million = 0.09
+output_per_million = 1.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-next-80b-a3b-thinking"
+input_per_million = 0.0975
+output_per_million = 0.78
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-235b-a22b-instruct"
+input_per_million = 0.2
+output_per_million = 0.88
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-235b-a22b-thinking"
+input_per_million = 0.26
+output_per_million = 2.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "arcee-ai/trinity-large-thinking"
+input_per_million = 0.25
+output_per_million = 0.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-v3.1-terminus"
+input_per_million = 0.27
+output_per_million = 0.95
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "ibm-granite/granite-4.0-h-micro"
+input_per_million = 0.017
+output_per_million = 0.112
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-nano-9b-v2:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~anthropic/claude-sonnet-latest"
+input_per_million = 2.0
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "aion-labs/aion-rp-llama-3.1-8b"
+input_per_million = 0.8
+output_per_million = 1.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.7-fast"
+input_per_million = 30.0
+output_per_million = 150.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.8-fast"
+input_per_million = 10.0
+output_per_million = 50.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-chat-v3-0324"
+input_per_million = 0.24
+output_per_million = 0.9
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-4-26b-a4b-it:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-3-8b-instruct"
+input_per_million = 0.14
+output_per_million = 0.14
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nvidia/nemotron-3-nano-30b-a3b"
+input_per_million = 0.05
+output_per_million = 0.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "perplexity/sonar-deep-research"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "perplexity/sonar-reasoning-pro"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-30b-a3b-instruct"
+input_per_million = 0.13
+output_per_million = 0.52
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-30b-a3b-thinking"
+input_per_million = 0.13
+output_per_million = 1.56
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~anthropic/claude-fable-latest"
+input_per_million = 10.0
+output_per_million = 50.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~anthropic/claude-haiku-latest"
+input_per_million = 1.0
+output_per_million = 5.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "bytedance-seed/seed-1.6-flash"
+input_per_million = 0.075
+output_per_million = 0.3
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "cohere/command-r-plus-08-2024"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-flash-image"
 input_per_million = 0.3
-output_per_million = 0.5
+output_per_million = 2.5
 
 [[rules]]
-provider = "xAI"
-model_pattern = "grok-3-fast"
-input_per_million = 0.6
-output_per_million = 4.0
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-pro-preview"
+input_per_million = 1.25
+output_per_million = 10.0
 
 [[rules]]
-provider = "xAI"
-model_pattern = "grok-3"
+provider = "openrouter"
+model_pattern = "google/gemini-3-flash-preview"
+input_per_million = 0.5
+output_per_million = 3.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-flash-image"
+input_per_million = 0.5
+output_per_million = 3.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-pro-preview"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-3.5-turbo-instruct"
+input_per_million = 1.5
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-mini-2024-07-18"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "tencent/hunyuan-a13b-instruct"
+input_per_million = 0.14
+output_per_million = 0.57
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~anthropic/claude-opus-latest"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthracite-org/magnum-v4-72b"
+input_per_million = 3.0
+output_per_million = 5.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "baidu/ernie-4.5-vl-424b-a47b"
+input_per_million = 0.42
+output_per_million = 1.25
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "bytedance-seed/seed-2.0-lite"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "bytedance-seed/seed-2.0-mini"
+input_per_million = 0.1
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-flash-lite"
+input_per_million = 0.1
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.1-flash-lite"
+input_per_million = 0.25
+output_per_million = 1.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-guard-4-12b"
+input_per_million = 0.18
+output_per_million = 0.18
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/ministral-14b-2512"
+input_per_million = 0.2
+output_per_million = 0.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-large-2407"
+input_per_million = 2.0
+output_per_million = 6.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-large-2512"
+input_per_million = 0.5
+output_per_million = 1.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-medium-3-5"
+input_per_million = 1.5
+output_per_million = 7.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-medium-3.1"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-small-2603"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-search-preview"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-oss-safeguard-20b"
+input_per_million = 0.075
+output_per_million = 0.3
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o4-mini-deep-research"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen2.5-vl-72b-instruct"
+input_per_million = 0.8
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-sonnet-4.5"
 input_per_million = 3.0
 output_per_million = 15.0
 
 [[rules]]
-provider = "xAI"
-model_pattern = "grok-2"
+provider = "openrouter"
+model_pattern = "anthropic/claude-sonnet-4.6"
+input_per_million = 3.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "cohere/north-mini-code:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepcogito/cogito-v2.1-671b"
+input_per_million = 1.25
+output_per_million = 1.25
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-chat-v3.1"
+input_per_million = 0.21
+output_per_million = 0.79
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/lyria-3-clip-preview"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-4-maverick"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/ministral-3b-2512"
+input_per_million = 0.1
+output_per_million = 0.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/ministral-8b-2512"
+input_per_million = 0.15
+output_per_million = 0.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "moonshotai/kimi-k2-thinking"
+input_per_million = 0.6
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "perplexity/sonar-pro-search"
+input_per_million = 3.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "poolside/laguna-xs-2.1:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "thedrummer/cydonia-24b-v4.1"
+input_per_million = 0.3
+output_per_million = 0.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~google/gemini-flash-latest"
+input_per_million = 1.5
+output_per_million = 9.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-haiku-4.5"
+input_per_million = 1.0
+output_per_million = 5.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "cohere/command-r7b-12-2024"
+input_per_million = 0.0375
+output_per_million = 0.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-v3.2-exp"
+input_per_million = 0.27
+output_per_million = 0.41
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-v4-flash"
+input_per_million = 0.09
+output_per_million = 0.18
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-4-31b-it:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/lyria-3-pro-preview"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "ibm-granite/granite-4.1-8b"
+input_per_million = 0.05
+output_per_million = 0.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "inclusionai/ling-2.6-flash"
+input_per_million = 0.01
+output_per_million = 0.03
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "inflection/inflection-3-pi"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "kwaipilot/kat-coder-pro-v2"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "microsoft/wizardlm-2-8x22b"
+input_per_million = 0.62
+output_per_million = 0.62
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-medium-3"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nousresearch/hermes-4-405b"
+input_per_million = 1.0
+output_per_million = 3.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4-turbo-preview"
+input_per_million = 10.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen-2.5-72b-instruct"
+input_per_million = 0.36
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-32b-instruct"
+input_per_million = 0.104
+output_per_million = 0.416
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-plus-20260420"
+input_per_million = 0.3
+output_per_million = 1.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "x-ai/grok-4.20-multi-agent"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.1"
+input_per_million = 15.0
+output_per_million = 75.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.5"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.6"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.7"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4.8"
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-sonnet-4"
+input_per_million = 3.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-sonnet-5"
 input_per_million = 2.0
 output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-r1-0528"
+input_per_million = 0.5
+output_per_million = 2.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3-pro-image"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-4-26b-a4b-it"
+input_per_million = 0.06
+output_per_million = 0.33
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "moonshotai/kimi-k2.7-code"
+input_per_million = 0.74
+output_per_million = 3.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nousresearch/hermes-4-70b"
+input_per_million = 0.13
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-3.5-turbo-0613"
+input_per_million = 1.0
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.1-codex-mini"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "perceptron/perceptron-mk1"
+input_per_million = 0.15
+output_per_million = 1.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "poolside/laguna-xs.2:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen-2.5-7b-instruct"
+input_per_million = 0.04
+output_per_million = 0.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen-plus-2025-07-28"
+input_per_million = 0.26
+output_per_million = 0.78
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-235b-a22b-2507"
+input_per_million = 0.09
+output_per_million = 0.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-8b-instruct"
+input_per_million = 0.117
+output_per_million = 0.455
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-vl-8b-thinking"
+input_per_million = 0.117
+output_per_million = 1.365
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "sao10k/l3.1-70b-hanami-x1"
+input_per_million = 3.0
+output_per_million = 3.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "thedrummer/skyfall-36b-v2"
+input_per_million = 0.55
+output_per_million = 0.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "thedrummer/unslopnemo-12b"
+input_per_million = 0.4
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~google/gemini-pro-latest"
+input_per_million = 2.0
+output_per_million = 12.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "allenai/olmo-3-32b-think"
+input_per_million = 0.15
+output_per_million = 0.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-3-haiku"
+input_per_million = 0.25
+output_per_million = 1.25
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-fable-5"
+input_per_million = 10.0
+output_per_million = 50.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "bytedance/ui-tars-1.5-7b"
+input_per_million = 0.1
+output_per_million = 0.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "cohere/command-r-08-2024"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-v4-pro"
+input_per_million = 0.435
+output_per_million = 0.87
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "meta-llama/llama-4-scout"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/codestral-2508"
+input_per_million = 0.3
+output_per_million = 0.9
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-3.5-turbo-16k"
+input_per_million = 3.0
+output_per_million = 4.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-2024-05-13"
+input_per_million = 5.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-2024-08-06"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-2024-11-20"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.1-codex-max"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-oss-120b:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "poolside/laguna-m.1:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-flash-02-23"
+input_per_million = 0.065
+output_per_million = 0.26
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.6-max-preview"
+input_per_million = 1.04
+output_per_million = 6.24
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "thedrummer/rocinante-12b"
+input_per_million = 0.25
+output_per_million = 0.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "undi95/remm-slerp-l2-13b"
+input_per_million = 0.45
+output_per_million = 0.65
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "aion-labs/aion-1.0-mini"
+input_per_million = 0.7
+output_per_million = 1.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "anthropic/claude-opus-4"
+input_per_million = 15.0
+output_per_million = 75.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "arcee-ai/virtuoso-large"
+input_per_million = 0.75
+output_per_million = 1.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "bytedance-seed/seed-1.6"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-flash"
+input_per_million = 0.3
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-3.5-flash"
+input_per_million = 1.5
+output_per_million = 9.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "inclusionai/ling-2.6-1t"
+input_per_million = 0.075
+output_per_million = 0.625
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "inclusionai/ring-2.6-1t"
+input_per_million = 0.075
+output_per_million = 0.625
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/devstral-2512"
+input_per_million = 0.4
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-large"
+input_per_million = 2.0
+output_per_million = 6.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "moonshotai/kimi-k2-0905"
+input_per_million = 0.6
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-image-mini"
+input_per_million = 2.5
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-oss-20b:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o3-deep-research"
+input_per_million = 10.0
+output_per_million = 40.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-max-thinking"
+input_per_million = 0.78
+output_per_million = 3.9
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-plus-02-15"
+input_per_million = 0.26
+output_per_million = 1.56
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "sao10k/l3.1-euryale-70b"
+input_per_million = 0.85
+output_per_million = 0.85
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "sao10k/l3.3-euryale-70b"
+input_per_million = 0.65
+output_per_million = 0.75
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~moonshotai/kimi-latest"
+input_per_million = 0.66
+output_per_million = 3.41
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~openai/gpt-mini-latest"
+input_per_million = 0.75
+output_per_million = 4.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "amazon/nova-premier-v1"
+input_per_million = 2.5
+output_per_million = 12.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-chat"
+input_per_million = 0.2002
+output_per_million = 0.8001
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-v3.2"
+input_per_million = 0.2288
+output_per_million = 0.3432
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-3n-e4b-it"
+input_per_million = 0.06
+output_per_million = 0.12
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "gryphe/mythomax-l2-13b"
+input_per_million = 0.06
+output_per_million = 0.06
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m2-her"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-nemo"
+input_per_million = 0.02
+output_per_million = 0.03
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mistralai/mistral-saba"
+input_per_million = 0.2
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.4-image-2"
+input_per_million = 8.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-chat-latest"
+input_per_million = 5.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "poolside/laguna-xs-2.1"
+input_per_million = 0.06
+output_per_million = 0.12
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-coder-flash"
+input_per_million = 0.195
+output_per_million = 0.975
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-122b-a10b"
+input_per_million = 0.26
+output_per_million = 2.08
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-397b-a17b"
+input_per_million = 0.385
+output_per_million = 2.45
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "stepfun/step-3.5-flash"
+input_per_million = 0.1
+output_per_million = 0.3
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "stepfun/step-3.7-flash"
+input_per_million = 0.2
+output_per_million = 1.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "amazon/nova-2-lite-v1"
+input_per_million = 0.3
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "arcee-ai/trinity-mini"
+input_per_million = 0.045
+output_per_million = 0.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemini-2.5-pro"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-2-27b-it"
+input_per_million = 0.65
+output_per_million = 0.65
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-3-12b-it"
+input_per_million = 0.05
+output_per_million = 0.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-3-27b-it"
+input_per_million = 0.08
+output_per_million = 0.16
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-4-31b-it"
+input_per_million = 0.12
+output_per_million = 0.35
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-audio-mini"
+input_per_million = 0.6
+output_per_million = 2.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-coder-next"
+input_per_million = 0.11
+output_per_million = 0.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-coder-plus"
+input_per_million = 0.65
+output_per_million = 3.25
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-coder:free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "relace/relace-apply-3"
+input_per_million = 0.85
+output_per_million = 1.25
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "ai21/jamba-large-1.7"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "amazon/nova-micro-v1"
+input_per_million = 0.035
+output_per_million = 0.14
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "arcee-ai/coder-large"
+input_per_million = 0.5
+output_per_million = 0.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "deepseek/deepseek-r1"
+input_per_million = 0.7
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "google/gemma-3-4b-it"
+input_per_million = 0.05
+output_per_million = 0.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "liquid/lfm-2-24b-a2b"
+input_per_million = 0.03
+output_per_million = 0.12
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m2.1"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m2.5"
+input_per_million = 0.12
+output_per_million = 0.48
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m2.7"
+input_per_million = 0.18
+output_per_million = 0.72
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "moonshotai/kimi-k2.5"
+input_per_million = 0.375
+output_per_million = 2.025
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "moonshotai/kimi-k2.6"
+input_per_million = 0.66
+output_per_million = 3.41
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "morph/morph-v3-large"
+input_per_million = 0.9
+output_per_million = 1.9
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-3.5-turbo"
+input_per_million = 0.5
+output_per_million = 1.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.1-codex"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.2-codex"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.3-codex"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "perplexity/sonar-pro"
+input_per_million = 3.0
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "poolside/laguna-xs.2"
+input_per_million = 0.1
+output_per_million = 0.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-235b-a22b"
+input_per_million = 0.455
+output_per_million = 1.82
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-35b-a3b"
+input_per_million = 0.14
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.6-35b-a3b"
+input_per_million = 0.14
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "relace/relace-search"
+input_per_million = 1.0
+output_per_million = 3.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "sao10k/l3-lunaris-8b"
+input_per_million = 0.04
+output_per_million = 0.05
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "xiaomi/mimo-v2.5-pro"
+input_per_million = 0.435
+output_per_million = 0.87
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "amazon/nova-lite-v1"
+input_per_million = 0.06
+output_per_million = 0.24
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "inception/mercury-2"
+input_per_million = 0.25
+output_per_million = 0.75
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "morph/morph-v3-fast"
+input_per_million = 0.8
+output_per_million = 1.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4.1-mini"
+input_per_million = 0.4
+output_per_million = 1.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4.1-nano"
+input_per_million = 0.1
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.1-chat"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.2-chat"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.3-chat"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.4-mini"
+input_per_million = 0.75
+output_per_million = 4.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.4-nano"
+input_per_million = 0.2
+output_per_million = 1.25
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-oss-120b"
+input_per_million = 0.03
+output_per_million = 0.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o3-mini-high"
+input_per_million = 1.1
+output_per_million = 4.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o4-mini-high"
+input_per_million = 1.1
+output_per_million = 4.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "poolside/laguna-m.1"
+input_per_million = 0.2
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "rekaai/reka-flash-3"
+input_per_million = 0.1
+output_per_million = 0.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "tencent/hy3-preview"
+input_per_million = 0.063
+output_per_million = 0.21
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "upstage/solar-pro-3"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "x-ai/grok-build-0.1"
+input_per_million = 1.0
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "aion-labs/aion-1.0"
+input_per_million = 4.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "aion-labs/aion-2.0"
+input_per_million = 0.8
+output_per_million = 1.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "amazon/nova-pro-v1"
+input_per_million = 0.8
+output_per_million = 3.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-01"
+input_per_million = 0.2
+output_per_million = 1.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m1"
+input_per_million = 0.4
+output_per_million = 2.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m2"
+input_per_million = 0.255
+output_per_million = 1.02
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "minimax/minimax-m3"
+input_per_million = 0.3
+output_per_million = 1.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "moonshotai/kimi-k2"
+input_per_million = 0.57
+output_per_million = 2.3
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "nex-agi/nex-n2-pro"
+input_per_million = 0.25
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4-turbo"
+input_per_million = 10.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o-mini"
+input_per_million = 0.15
+output_per_million = 0.6
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-codex"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-image"
+input_per_million = 10.0
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.2-pro"
+input_per_million = 21.0
+output_per_million = 168.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.4-pro"
+input_per_million = 30.0
+output_per_million = 180.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.5-pro"
+input_per_million = 30.0
+output_per_million = 180.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-oss-20b"
+input_per_million = 0.029
+output_per_million = 0.14
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-30b-a3b"
+input_per_million = 0.12
+output_per_million = 0.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.6-flash"
+input_per_million = 0.1875
+output_per_million = 1.125
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "switchpoint/router"
+input_per_million = 0.85
+output_per_million = 3.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.7-flash"
+input_per_million = 0.06
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "~openai/gpt-latest"
+input_per_million = 5.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-chat"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-mini"
+input_per_million = 0.25
+output_per_million = 2.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-nano"
+input_per_million = 0.05
+output_per_million = 0.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.6-plus"
+input_per_million = 0.325
+output_per_million = 1.95
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.7-plus"
+input_per_million = 0.32
+output_per_million = 1.28
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "sakana/fugu-ultra"
+input_per_million = 5.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "writer/palmyra-x5"
+input_per_million = 0.6
+output_per_million = 6.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-5v-turbo"
+input_per_million = 1.2
+output_per_million = 4.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "cohere/command-a"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5-pro"
+input_per_million = 15.0
+output_per_million = 120.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-audio"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "perplexity/sonar"
+input_per_million = 1.0
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-coder"
+input_per_million = 0.22
+output_per_million = 1.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-27b"
+input_per_million = 0.195
+output_per_million = 1.56
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.6-27b"
+input_per_million = 0.285
+output_per_million = 2.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.7-max"
+input_per_million = 1.25
+output_per_million = 3.75
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "rekaai/reka-edge"
+input_per_million = 0.1
+output_per_million = 0.1
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "xiaomi/mimo-v2.5"
+input_per_million = 0.105
+output_per_million = 0.28
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.5-air"
+input_per_million = 0.13
+output_per_million = 0.85
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-5-turbo"
+input_per_million = 1.2
+output_per_million = 4.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "microsoft/phi-4"
+input_per_million = 0.07
+output_per_million = 0.14
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openrouter/free"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3.5-9b"
+input_per_million = 0.1
+output_per_million = 0.15
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4.1"
+input_per_million = 2.0
+output_per_million = 8.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.1"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.2"
+input_per_million = 1.75
+output_per_million = 14.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.4"
+input_per_million = 2.5
+output_per_million = 15.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5.5"
+input_per_million = 5.0
+output_per_million = 30.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o3-mini"
+input_per_million = 1.1
+output_per_million = 4.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o4-mini"
+input_per_million = 1.1
+output_per_million = 4.4
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen-plus"
+input_per_million = 0.26
+output_per_million = 0.78
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-14b"
+input_per_million = 0.1
+output_per_million = 0.24
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-32b"
+input_per_million = 0.08
+output_per_million = 0.28
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-max"
+input_per_million = 0.78
+output_per_million = 3.9
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "x-ai/grok-4.20"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "mancer/weaver"
+input_per_million = 0.75
+output_per_million = 1.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4o"
+input_per_million = 2.5
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o1-pro"
+input_per_million = 150.0
+output_per_million = 600.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o3-pro"
+input_per_million = 20.0
+output_per_million = 80.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "qwen/qwen3-8b"
+input_per_million = 0.117
+output_per_million = 0.455
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "x-ai/grok-4.3"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.5v"
+input_per_million = 0.6
+output_per_million = 1.8
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.6v"
+input_per_million = 0.3
+output_per_million = 0.9
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-4"
+input_per_million = 30.0
+output_per_million = 60.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/gpt-5"
+input_per_million = 1.25
+output_per_million = 10.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.5"
+input_per_million = 0.6
+output_per_million = 2.2
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.6"
+input_per_million = 0.43
+output_per_million = 1.74
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-4.7"
+input_per_million = 0.4
+output_per_million = 1.75
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-5.1"
+input_per_million = 0.966
+output_per_million = 3.036
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-5.2"
+input_per_million = 0.686
+output_per_million = 2.156
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "z-ai/glm-5"
+input_per_million = 0.6
+output_per_million = 1.92
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o1"
+input_per_million = 15.0
+output_per_million = 60.0
+
+[[rules]]
+provider = "openrouter"
+model_pattern = "openai/o3"
+input_per_million = 2.0
+output_per_million = 8.0
+
+# ── xai (7 models) ──
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-4.20-0309-non-reasoning"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-4.20-multi-agent-0309"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-4.20-0309-reasoning"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-3-mini-fast"
+input_per_million = 0.6
+output_per_million = 4.0
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-build-0.1"
+input_per_million = 1.0
+output_per_million = 2.0
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-4.3"
+input_per_million = 1.25
+output_per_million = 2.5
+
+[[rules]]
+provider = "xai"
+model_pattern = "grok-3"
+input_per_million = 3.0
+output_per_million = 15.0

--- a/crates/nika-catalog/src/data/models.rs
+++ b/crates/nika-catalog/src/data/models.rs
@@ -218,7 +218,27 @@ mod tests {
 
     #[test]
     fn pricing_count() {
-        assert_eq!(ALL_PRICING.len(), 62);
+        // DERIVED, never pinned (the born-stale law): the generated
+        // catalog moves with upstream — the structural truths are
+        // non-emptiness and every cloud provider being represented.
+        assert!(ALL_PRICING.len() > 100, "got {}", ALL_PRICING.len());
+        for provider in [
+            "anthropic",
+            "openai",
+            "google",
+            "deepseek",
+            "mistral",
+            "xai",
+            "groq",
+            "openrouter",
+            "huggingface",
+            "nvidia",
+        ] {
+            assert!(
+                ALL_PRICING.iter().any(|p| p.provider == provider),
+                "no pricing rules for {provider}"
+            );
+        }
     }
 
     // ── Capabilities ────────────────────────────────────────────
@@ -391,8 +411,11 @@ mod tests {
 
     #[test]
     fn contains_fallback_for_dated_variants() {
-        let p = find_pricing("claude-sonnet-4-20250514").unwrap();
-        assert_eq!(p.provider, "Anthropic");
+        // A dated variant contains-matches its base pattern (providers
+        // are the ENGINE ids since the models.dev regen — the display
+        // names never matched eq_ignore_ascii_case("google", …)).
+        let p = find_pricing("claude-sonnet-4-5-20991231").unwrap();
+        assert_eq!(p.provider, "anthropic");
         assert!((p.input_per_million - 3.0).abs() < f64::EPSILON);
     }
 
@@ -403,7 +426,7 @@ mod tests {
 
     #[test]
     fn estimate_cost_sonnet_1k_tokens() {
-        let est = estimate_cost("claude-sonnet-4-20250514", 1000, 500).unwrap();
+        let est = estimate_cost("claude-sonnet-4-5-20991231", 1000, 500).unwrap();
         let expected = (1000.0 * 3.0 + 500.0 * 15.0) / 1_000_000.0;
         assert!((est.usd - expected).abs() < 1e-10);
     }
@@ -416,7 +439,7 @@ mod tests {
             "zero tokens must produce zero cost, got {}",
             est.usd,
         );
-        assert_eq!(est.provider, "OpenAI");
+        assert_eq!(est.provider, "openai");
         assert_eq!(est.model, "gpt-4o");
     }
 
@@ -433,7 +456,7 @@ mod tests {
     #[test]
     fn find_pricing_for_provider_prefixed_resolves_scoped() {
         let p = find_pricing_for("openai/gpt-4o-mini").expect("priced model");
-        assert_eq!(p.provider, "OpenAI");
+        assert_eq!(p.provider, "openai");
         // The prefixed form and the explicit scoped call resolve to the
         // SAME row — one resolution, two spellings.
         let scoped = find_pricing_scoped("openai", "gpt-4o-mini").expect("scoped hit");
@@ -462,7 +485,7 @@ mod tests {
         let expected = (1000.0 * p.input_per_million + 500.0 * p.output_per_million) / 1e6;
         assert!((est.usd - expected).abs() < 1e-12);
         assert_eq!(est.model, "openai/gpt-4o-mini", "carries the queried form");
-        assert_eq!(est.provider, "OpenAI");
+        assert_eq!(est.provider, "openai");
     }
 
     #[test]
@@ -487,11 +510,15 @@ mod tests {
     }
 
     #[test]
-    fn specdec_different_from_versatile() {
-        let specdec = find_pricing("llama-3.3-70b-specdec").unwrap();
+    fn family_variants_price_differently() {
+        // The lookup distinguishes same-family variants — the SUBJECT is
+        // no-cross-contamination, not any specific price (derived law).
         let versatile = find_pricing("llama-3.3-70b-versatile").unwrap();
-        assert!((specdec.output_per_million - 0.99).abs() < f64::EPSILON);
-        assert!((versatile.output_per_million - 0.79).abs() < f64::EPSILON);
+        let instant = find_pricing("llama-3.1-8b-instant").unwrap();
+        assert!(
+            (versatile.output_per_million - instant.output_per_million).abs() > f64::EPSILON,
+            "distinct variants must not collapse onto one rule"
+        );
     }
 
     #[test]
@@ -544,15 +571,17 @@ mod tests {
     #[test]
     fn scoped_pricing_exact_match() {
         let p = find_pricing_scoped("openai", "gpt-4o").unwrap();
-        assert_eq!(p.provider, "OpenAI");
+        assert_eq!(p.provider, "openai");
         assert!((p.input_per_million - 2.5).abs() < f64::EPSILON);
     }
 
     #[test]
     fn scoped_pricing_contains_fallback() {
-        // Dated variant — should fall through to the "claude-sonnet-4" contains match.
+        // Dated variant — falls through to the "claude-sonnet-4"
+        // supplement row (referenced-but-retired · kept for the
+        // provider default_model integrity gate).
         let p = find_pricing_scoped("anthropic", "claude-sonnet-4-20250514").unwrap();
-        assert_eq!(p.provider, "Anthropic");
+        assert_eq!(p.provider, "anthropic");
     }
 
     #[test]

--- a/crates/nika-catalog/src/lib.rs
+++ b/crates/nika-catalog/src/lib.rs
@@ -154,6 +154,7 @@ mod tests {
 
     #[test]
     fn all_pricing_non_empty() {
-        assert_eq!(all_pricing().len(), 62);
+        // Derived, never pinned — the generated catalog moves upstream.
+        assert!(!all_pricing().is_empty());
     }
 }

--- a/crates/nika-catalog/src/types/catalog_source.rs
+++ b/crates/nika-catalog/src/types/catalog_source.rs
@@ -175,15 +175,17 @@ mod tests {
     fn static_source_resolves_pricing() {
         let ds = StaticCatalogDataSource;
         let p = ds.find_pricing("gpt-4o").unwrap();
-        assert_eq!(p.provider, "OpenAI");
+        assert_eq!(p.provider, "openai");
     }
 
     #[test]
     #[cfg(feature = "pricing")]
     fn static_source_scoped_pricing() {
         let ds = StaticCatalogDataSource;
-        let p = ds.find_pricing_scoped("anthropic", "sonnet-4").unwrap();
-        assert_eq!(p.provider, "Anthropic");
+        let p = ds
+            .find_pricing_scoped("anthropic", "claude-sonnet-4-5")
+            .unwrap();
+        assert_eq!(p.provider, "anthropic");
     }
 
     #[test]
@@ -192,7 +194,7 @@ mod tests {
         let ds = StaticCatalogDataSource;
         let est = ds.estimate_cost("gpt-4o", 1000, 500).unwrap();
         assert!(est.usd > 0.0);
-        assert_eq!(est.provider, "OpenAI");
+        assert_eq!(est.provider, "openai");
     }
 
     /// Object-safety requires the full feature set (all cfg-gated methods

--- a/scripts/refresh-pricing.sh
+++ b/scripts/refresh-pricing.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Refresh data/model-pricing.toml from models.dev (MIT · sst/models.dev).
+#
+# The pricing catalog is a VENDORED SNAPSHOT, refreshed at maintenance
+# time — never a runtime fetch (supernovae-alignment Rule 1: a static
+# report must not depend on a vendor endpoint being up). models.dev is
+# the one machine-readable source covering every cloud provider in the
+# engine catalog (verified 2026-07-06: openrouter 336 priced models ·
+# huggingface 50 · nvidia 84 — LiteLLM carries zero huggingface).
+#
+# Usage:
+#   bash scripts/refresh-pricing.sh              # fetch live
+#   bash scripts/refresh-pricing.sh api.json     # from a local snapshot
+#
+# Emission laws (matched to src/data/models.rs lookup semantics):
+# - provider strings = the ENGINE's canonical ids (anthropic · google ·
+#   …) so `find_pricing_scoped(engine_id, …)` matches (the hand era
+#   wrote display names — "Gemini" — which eq_ignore_ascii_case never
+#   matched against "google").
+# - within a provider, rules sort by pattern length DESC: the contains()
+#   fallback takes the FIRST hit, so `claude-opus-4-5` must outrank any
+#   shorter pattern a versioned id also contains.
+# - values always carry a decimal point (TOML integers do not
+#   deserialize into f64 fields).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SRC="${1:-}"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+if [ -z "$SRC" ]; then
+  curl -sL --max-time 120 https://models.dev/api.json -o "$TMP"
+  SRC="$TMP"
+fi
+
+python3 - "$SRC" <<'PYEOF'
+import hashlib
+import json
+import sys
+from datetime import date
+
+src = sys.argv[1]
+raw = open(src, "rb").read()
+sha = hashlib.sha256(raw).hexdigest()[:16]
+data = json.loads(raw)
+
+# Engine canonical id → models.dev provider id (identical today; the
+# map exists so a future rename upstream is one line here).
+PROVIDERS = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google": "google",
+    "deepseek": "deepseek",
+    "mistral": "mistral",
+    "xai": "xai",
+    "groq": "groq",
+    "openrouter": "openrouter",
+    "huggingface": "huggingface",
+    "nvidia": "nvidia",
+}
+
+def toml_float(v: float) -> str:
+    s = f"{v:.10g}"
+    return s if ("." in s or "e" in s) else s + ".0"
+
+# Referenced-but-retired: models the PROVIDER CATALOG still points at
+# (default_model rows) that upstream dropped — priced from LiteLLM's
+# historical table (values verified 2026-07-06). The integrity gate
+# (validate::provider_models_have_pricing) holds through upstream churn;
+# retiring these requires the default_model canon to move first.
+SUPPLEMENTS = [
+    ("anthropic", "claude-sonnet-4", 3.0, 15.0),
+    ("xai", "grok-3", 3.0, 15.0),
+    ("xai", "grok-3-mini-fast", 0.6, 4.0),
+]
+
+rules = []
+seen = set()
+for engine_id, upstream_id in PROVIDERS.items():
+    prov = data.get(upstream_id)
+    if not prov:
+        print(f"WARN: {upstream_id} missing upstream", file=sys.stderr)
+        continue
+    for mid, m in prov["models"].items():
+        cost = m.get("cost")
+        if not cost or "input" not in cost or "output" not in cost:
+            continue  # unpriced (previews · embeddings without rates)
+        key = (engine_id, mid)
+        if key in seen:
+            continue
+        seen.add(key)
+        rules.append((engine_id, mid, float(cost["input"]), float(cost["output"])))
+
+for prov, mid, inp, outp in SUPPLEMENTS:
+    if (prov, mid) not in seen:
+        seen.add((prov, mid))
+        rules.append((prov, mid, inp, outp))
+
+# Contains-fallback safety: longest pattern first within each provider.
+rules.sort(key=lambda r: (r[0], -len(r[1]), r[1]))
+
+out = []
+out.append('schema = "nika/model-pricing@1.0"')
+out.append("")
+out.append("# ── GENERATED · do not hand-edit ────────────────────────────")
+out.append("# Source: https://models.dev/api.json (MIT · sst/models.dev)")
+out.append(f"# as_of: {date.today().isoformat()} · source sha256[:16]: {sha}")
+out.append("# Refresh: bash scripts/refresh-pricing.sh")
+out.append("# Values: USD per 1M tokens. Lookup: exact match, then contains()")
+out.append("# fallback (first hit wins — longest patterns emitted first).")
+
+current = None
+for prov, mid, inp, outp in rules:
+    if prov != current:
+        out.append("")
+        out.append(f"# ── {prov} ({sum(1 for r in rules if r[0] == prov)} models) ──")
+        current = prov
+    out.append("")
+    out.append("[[rules]]")
+    out.append(f'provider = "{prov}"')
+    out.append(f'model_pattern = "{mid}"')
+    out.append(f"input_per_million = {toml_float(inp)}")
+    out.append(f"output_per_million = {toml_float(outp)}")
+
+target = "crates/nika-catalog/data/model-pricing.toml"
+open(target, "w").write("\n".join(out) + "\n")
+per = {}
+for r in rules:
+    per[r[0]] = per.get(r[0], 0) + 1
+print(f"wrote {target}: {len(rules)} rules · " + " · ".join(f"{k}:{v}" for k, v in sorted(per.items())))
+PYEOF


### PR DESCRIPTION
## The three holes (found while scoping the preflight-estimate arc)

1. **7 providers of 16** — no openrouter (336 priced models), no huggingface (50), no nvidia (84).
2. **Stale-price danger**: the `opus-4` rule (15/75) contains-matched `claude-opus-4-5` whose real price is 5/25 — **a 3.0x overcharge** on every estimate. sonnet-5 and fable-5 were absent entirely.
3. **Scoped lookups never matched**: the hand era wrote display names (`"Gemini"`) which `eq_ignore_ascii_case` never matched against the engine's `google`.

## The fix

`scripts/refresh-pricing.sh` — maintenance-time regeneration (never a runtime fetch · Rule 1) from **models.dev** (MIT · sst — the one machine-readable source covering all ten cloud providers; LiteLLM carries zero huggingface):

- **602 rules · 10 providers** · engine-canonical ids · patterns longest-first (the contains-fallback takes the first hit) · `as_of` + source sha256 stamped.
- **SUPPLEMENTS**: the three referenced-but-retired `default_model`s stay priced (claude-sonnet-4 · grok-3 · grok-3-mini-fast — LiteLLM historical values) so `validate::provider_models_have_pricing` holds through upstream churn. ⚠ operator follow-up: those defaults are stale in llm-providers.toml — refreshing them = a separate runtime-behavior decision.
- OpenRouter's own API is ToS-barred from vendoring (§7(5)) — its pricing arrives via models.dev, MIT-clean.

## Pins with the era

Nine updated — the `==62` count is now **derived** (non-empty + every cloud provider represented · the born-stale law from #218's catches); sonnet-4/display-name pins retarget to live ids; the variant test asserts its subject (no cross-family collapse), not two hardcoded prices.

## Proof

246/246 catalog (all-features) · workspace lib sweep green · clippy -D warnings · 8/8 ratchets · adversarial TOML scan (0 negative · 0 absurd · 0 dups · ordering verified) · quantified: 1k-in/500-out on opus-4-5 was \$0.0525, is \$0.0175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)