### PR TITLE
feat(nika-runtime): the journal attests its engine and platform

### DIFF
--- a/crates/nika-cli/src/verbs/trace_otel.rs
+++ b/crates/nika-cli/src/verbs/trace_otel.rs
@@ -95,12 +95,20 @@ pub(crate) fn project(events: &[Event], include_content: bool) -> Result<String,
         include_content,
     ));
 
+    // The resource names the engine that RAN, not the one exporting —
+    // the journal's own attestation (Q11) wins; the exporter's version
+    // is only the fallback for pre-attestation journals.
+    let ran_version = field_str(started, "engine_version").unwrap_or(env!("CARGO_PKG_VERSION"));
+    let mut resource_attrs = vec![
+        kv_str("service.name", "nika"),
+        kv_str("service.version", ran_version),
+    ];
+    if let Some(platform) = field_str(started, "platform") {
+        resource_attrs.push(kv_str("nika.platform", platform));
+    }
     let payload = serde_json::json!({
         "resourceSpans": [{
-            "resource": { "attributes": [
-                kv_str("service.name", "nika"),
-                kv_str("service.version", env!("CARGO_PKG_VERSION")),
-            ]},
+            "resource": { "attributes": resource_attrs },
             "scopeSpans": [{
                 "scope": { "name": "nika", "version": env!("CARGO_PKG_VERSION") },
                 "spans": spans,

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -339,6 +339,14 @@ fn emit_prologue(
     if let Some(hex) = source_sha256 {
         opening.push(("workflow_sha256", s(hex)));
     }
+    // Environment attestation (Q11): reproducing a failure needs to know
+    // WHICH engine on WHICH platform wrote the journal. Compile-time
+    // constants only — the workspace releases in lockstep, so the
+    // runtime crate's version IS the engine version; no clock, no I/O,
+    // determinism intact.
+    opening.push(("engine_version", s(env!("CARGO_PKG_VERSION"))));
+    let platform = format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH);
+    opening.push(("platform", s(&platform)));
     emit(stamper, sink, EventKind::WorkflowStarted, &opening);
     for task in &wf.tasks {
         emit(

--- a/crates/nika-runtime/tests/output_fidelity.rs
+++ b/crates/nika-runtime/tests/output_fidelity.rs
@@ -626,3 +626,35 @@ tasks:
         "the culprit upstream is named"
     );
 }
+
+// ─── the environment attestation rides the opening frame (Q11) ──────────────
+
+/// Reproducing a failure needs WHICH engine on WHICH platform — the
+/// prologue attests both, from compile-time constants only.
+#[tokio::test]
+async fn workflow_started_attests_engine_and_platform() {
+    let yaml =
+        "nika: v1\nworkflow: attest\ntasks:\n  - id: a\n    exec:\n      command: [\"true\"]\n";
+    let (_outcome, events) = run_to_events(
+        yaml,
+        MockShell::new(),
+        MockToolExecutor::new(),
+        MockProvider::new("mock"),
+    )
+    .await;
+    let started = events
+        .iter()
+        .find(|e| e.kind == EventKind::WorkflowStarted)
+        .expect("a workflow_started frame");
+    let version = str_field(started, "engine_version").expect("engine_version attested");
+    assert_eq!(
+        version.split('.').count(),
+        3,
+        "semver shape (got {version})"
+    );
+    let platform = str_field(started, "platform").expect("platform attested");
+    assert!(
+        platform.contains('/') && !platform.starts_with('/'),
+        "os/arch shape (got {platform})"
+    );
+}


### PR DESCRIPTION
## What (Q11 · the socratic ledger)

`workflow_started` gains two additive fields — `engine_version` and `platform` (os/arch) — from **compile-time constants only** (the workspace releases in lockstep, so the runtime crate's version IS the engine's). No clock, no I/O, determinism intact.

## The coherence loop

`nika trace export` now names the engine that **ran** in the OTLP resource (`service.version` = the journal's attestation, `nika.platform` beside it) rather than the binary exporting — a 0.94 journal exported by a 0.96 binary renders as 0.94, which is the truth. Pre-attestation journals fall back to the exporter's version.

Downstream this feeds the DAP drift-warning's next refinement (« this run came from a 0.94 engine ») and cross-machine failure reproduction.

## Proof

Pinned in the battery-run fidelity suite (semver shape · os/arch shape) · e2e at the real binary: run → journal attests `0.95.0 · macos/aarch64` → export carries both · runtime 99 ✓ · cli 225 ✓ · clippy ✓ · 8/8 ratchets ✓. Additive only — no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)