### PR TITLE
feat(nika-cli): check --json prices the models it found — rates before the first run

### DIFF
--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -42,7 +42,7 @@ nika-fs          = { path = "../nika-fs", version = "0.96.0" }            # Toki
 nika-clock       = { path = "../nika-clock", version = "0.96.0" }         # SystemClock — backoff + timeout + the date builtin
 nika-http        = { path = "../nika-http", version = "0.96.0" }          # ReqwestHttp — the registry + fetch effect
 nika-exec-runner = { path = "../nika-exec-runner", version = "0.96.0" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.96.0", features = ["providers"] }  # the env_var ladder per provider
+nika-catalog     = { path = "../nika-catalog", version = "0.96.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
 nika-lsp         = { path = "../nika-lsp", version = "0.96.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
 nika-mcp         = { path = "../nika-mcp", version = "0.96.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -34,6 +34,7 @@ pub fn run(path: &str, json: bool, theme: Theme) -> VerbOutput {
                 let clean = report.is_clean();
                 if let Some(obj) = payload.as_object_mut() {
                     obj.insert("clean".to_owned(), serde_json::Value::Bool(clean));
+                    obj.insert("pricing".to_owned(), pricing_section(&report));
                 }
                 let text = format!("{payload:#}");
                 if clean {
@@ -52,6 +53,28 @@ pub fn run(path: &str, json: bool, theme: Theme) -> VerbOutput {
     } else {
         VerbOutput::file(text)
     }
+}
+
+/// The rates the preflight shows BEFORE the first run: each model the
+/// requirements collected (#213), priced from the vendored catalog.
+/// UNKNOWN is null, never 0.00 — a missing price must look missing.
+/// Rates only (USD per 1M tokens): token counts are unknowable
+/// statically; the estimate with honest bounds is the next arc.
+fn pricing_section(report: &nika_schema::check::CheckReport) -> serde_json::Value {
+    let models: Vec<serde_json::Value> = report
+        .requirements
+        .models
+        .iter()
+        .map(|m| {
+            let priced = nika_catalog::find_pricing_for(&m.model);
+            serde_json::json!({
+                "model": m.model,
+                "input_per_million": priced.map(|p| p.input_per_million),
+                "output_per_million": priced.map(|p| p.output_per_million),
+            })
+        })
+        .collect();
+    serde_json::json!({ "models": models })
 }
 
 /// Section mark: `✔`-class verdict glyphs through the theme seam.
@@ -490,6 +513,32 @@ pub fn run_infer_permits(path: &str, json: bool) -> VerbOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pricing_section_rates_known_null_unknown() {
+        let wf = parse_wf(
+            "nika: v1\nworkflow: priced\nmodel: anthropic/claude-opus-4-5\ntasks:\n  - id: think\n    infer:\n      prompt: hi\n  - id: odd\n    infer:\n      model: custom/never-heard-of-it\n      prompt: hi\n",
+        );
+        let report = nika_schema::check(&wf);
+        let section = pricing_section(&report);
+        let models = section["models"].as_array().expect("array");
+        assert_eq!(models.len(), 2, "one row per requirements model");
+        let by_model = |name: &str| {
+            models
+                .iter()
+                .find(|m| m["model"] == name)
+                .expect("a row per requirements model")
+                .clone()
+        };
+        let priced = by_model("anthropic/claude-opus-4-5");
+        assert!((priced["input_per_million"].as_f64().expect("rate") - 5.0).abs() < 1e-9);
+        assert!((priced["output_per_million"].as_f64().expect("rate") - 25.0).abs() < 1e-9);
+        // UNKNOWN renders null — a missing price must look missing,
+        // never $0.00 (the silent-zero anti-pattern).
+        let unknown = by_model("custom/never-heard-of-it");
+        assert!(unknown["input_per_million"].is_null());
+        assert!(unknown["output_per_million"].is_null());
+    }
 
     fn parse_wf(yaml: &str) -> RawWorkflow {
         nika_schema::parse(


### PR DESCRIPTION
## What (PR-b of the pricing arc)

`check --json` gains an additive `pricing` section: every model the requirements collected (#213) priced from the vendored catalog (#233 — 602 rules, engine-id scoped):

```json
"pricing": { "models": [
  { "model": "anthropic/claude-sonnet-5", "input_per_million": 2.0, "output_per_million": 10.0 },
  { "model": "custom/never-heard-of-it", "input_per_million": null, "output_per_million": null }
]}
```

**Rates only** (USD per 1M): token counts are unknowable statically — the estimate with honest bounds (clamped by `max_cost_usd`) is the next arc, per the research-locked blueprint. **UNKNOWN is null, never 0.00** — the LiteLLM silent-zero anti-pattern, refused by construction.

## Layer line

The seam is the CLI's (payload enrichment beside `clean`) — `nika-schema` keeps zero catalog dependency. No new public API (the section builder is private; the local public-api diff is the known mac Sized-bounds skew only).

## Proof

Pinned (real rates on a priced model · nulls on an unknown · one row per requirements model) · e2e at the real binary (sonnet-5 → 2.0/10.0 — the #233 prices, 20 minutes after their merge) · nika-cli lib 226 ✓ · clippy ✓ · 8/8 ratchets ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)