### PR TITLE
feat(nika-cli): the journal becomes tamper-evident — a hash chain + trace verify

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -969,6 +969,8 @@ pub fn nika_cli::verbs::trace::outputs(trace: &str, theme: nika_cli::display::th
 pub fn nika_cli::verbs::trace::peek(trace: &str, task: &str, raw: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::trace_otel
 pub fn nika_cli::verbs::trace_otel::export(trace: &str, out: core::option::Option<&str>, include_content: bool) -> nika_cli::verbs::VerbOutput
+pub mod nika_cli::verbs::trace_verify
+pub fn nika_cli::verbs::trace_verify::verify(trace: &str) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::wire
 pub enum nika_cli::verbs::wire::WireTarget
 pub nika_cli::verbs::wire::WireTarget::All

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -330,6 +330,13 @@ enum TraceAction {
         #[arg(long)]
         include_content: bool,
     },
+    /// Verify the journal's tamper-evidence chain (0.96+): any edited,
+    /// inserted, dropped or reordered line breaks every hash after it.
+    /// Exit 0 intact · 2 broken · 3 unchained (pre-chain journal).
+    Verify {
+        /// Trace NDJSON path (one `nika-event` Event per line).
+        trace: PathBuf,
+    },
     /// Read ONE task's full output + its identity (hashes · duration ·
     /// tokens). `--raw` prints the exact value only (pipe it to jq).
     Peek {
@@ -601,6 +608,9 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
             // The dur column's bracket accents: TTY comfort only.
             theme.accents = std::io::stdout().is_terminal();
             emit(&verbs::trace::outputs(&trace.to_string_lossy(), theme))
+        }
+        TraceAction::Verify { trace } => {
+            emit(&verbs::trace_verify::verify(&trace.to_string_lossy()))
         }
         TraceAction::Export {
             trace,

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -25,6 +25,7 @@ pub mod test;
 pub mod tools;
 pub mod trace;
 pub mod trace_otel;
+pub mod trace_verify;
 pub mod wire;
 
 use nika_schema::check::CheckReport;

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -828,6 +828,10 @@ enum TraceNote {
 /// a written journal prints its `trace:` pointer per [`TraceNote`].
 fn surface_trace(trace: TraceFileSink, note: TraceNote) {
     let path = trace.path().map(std::path::Path::to_path_buf);
+    // The printed head is the chain's free external anchor: CI logs and
+    // scrollback hold it, so a rewritten-whole journal no longer matches
+    // the record of the run that printed it (tamper-EVIDENT → checkable).
+    let head8 = trace.chain_head()[..16].to_owned();
     if let Some(e) = trace.into_error() {
         // Name the file when the failure struck AFTER the open (a partial
         // journal on disk) — the operator sees exactly what to distrust.
@@ -844,8 +848,8 @@ fn surface_trace(trace: TraceFileSink, note: TraceNote) {
         return; // disabled · or a run that emitted zero events
     };
     match note {
-        TraceNote::Stdout => println!("    trace: {}", path.display()),
-        TraceNote::Stderr => eprintln!("nika run: trace: {}", path.display()),
+        TraceNote::Stdout => println!("    trace: {} · chain {head8}", path.display()),
+        TraceNote::Stderr => eprintln!("nika run: trace: {} · chain {head8}", path.display()),
         TraceNote::Silent => {}
     }
 }

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -832,6 +832,7 @@ fn surface_trace(trace: TraceFileSink, note: TraceNote) {
     // scrollback hold it, so a rewritten-whole journal no longer matches
     // the record of the run that printed it (tamper-EVIDENT → checkable).
     let head8 = trace.chain_head()[..16].to_owned();
+    let count = trace.chain_len();
     if let Some(e) = trace.into_error() {
         // Name the file when the failure struck AFTER the open (a partial
         // journal on disk) — the operator sees exactly what to distrust.
@@ -848,8 +849,18 @@ fn surface_trace(trace: TraceFileSink, note: TraceNote) {
         return; // disabled · or a run that emitted zero events
     };
     match note {
-        TraceNote::Stdout => println!("    trace: {} · chain {head8}", path.display()),
-        TraceNote::Stderr => eprintln!("nika run: trace: {} · chain {head8}", path.display()),
+        TraceNote::Stdout => {
+            println!(
+                "    trace: {} · {count} events · chain {head8}",
+                path.display()
+            );
+        }
+        TraceNote::Stderr => {
+            eprintln!(
+                "nika run: trace: {} · {count} events · chain {head8}",
+                path.display()
+            );
+        }
         TraceNote::Silent => {}
     }
 }

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -21,6 +21,21 @@ use uuid::Uuid;
 
 use crate::{RunView, Theme, frame, frame_with_outputs, verdict_frame};
 
+/// sha256 hex over exact bytes — the chain primitive (same shape as the
+/// run verb's source hasher; local to keep the sink self-contained).
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
 /// Where run journals land, relative to the run's CWD (the workspace
 /// root by convention — the editor extension watches exactly this
 /// directory, and spec §3.3 prints it in the final frame).
@@ -126,7 +141,15 @@ pub(super) struct TraceFileSink {
     /// The first fs error, buffered (the sink contract is infallible
     /// w.r.t. the run · the caller surfaces this after the run).
     error: Option<std::io::Error>,
+    /// The tamper-evidence chain: sha256 hex of the LAST line's exact
+    /// bytes (genesis: sha256 of [`CHAIN_GENESIS`]) — injected into the
+    /// NEXT line as its `chain` field. After the run, this is the HEAD.
+    chain: String,
 }
+
+/// The chain's genesis tag — the first line's `chain` field is the
+/// sha256 of these bytes, so an empty prefix is still committed.
+pub(super) const CHAIN_GENESIS: &[u8] = b"nika-trace-v1";
 
 impl TraceFileSink {
     /// An enabled journal rooted at `dir` (lazy — no fs effect here).
@@ -136,6 +159,7 @@ impl TraceFileSink {
             lane: Lane::Pending,
             path: None,
             error: None,
+            chain: sha256_hex(CHAIN_GENESIS),
         }
     }
 
@@ -148,6 +172,7 @@ impl TraceFileSink {
             lane: Lane::Disabled,
             path: None,
             error: None,
+            chain: sha256_hex(CHAIN_GENESIS),
         }
     }
 
@@ -161,6 +186,14 @@ impl TraceFileSink {
     #[must_use]
     pub(super) fn into_error(self) -> Option<std::io::Error> {
         self.error
+    }
+
+    /// The chain HEAD — sha256 of the last written line's exact bytes.
+    /// Printing it (CI logs · scrollback) is the free external anchor
+    /// that upgrades tamper-EVIDENT toward attributable.
+    #[must_use]
+    pub(super) fn chain_head(&self) -> &str {
+        &self.chain
     }
 
     /// Create the directory + the journal file, named from the first
@@ -218,13 +251,28 @@ impl EventSink for TraceFileSink {
         let Lane::Open(writer) = &mut self.lane else {
             return; // Disabled — a deliberate no-op
         };
-        // Mirror JsonSink byte-for-byte (one JSON document per line · flush
-        // per event): the journal must parse wherever the `--json` stream
-        // parses, and the extension's watcher tails it for liveness.
-        let result = serde_json::to_writer(&mut *writer, &event)
+        // One JSON document per line + flush per event (the watcher tails
+        // for liveness). The journal line = the event object PLUS a
+        // `chain` field — sha256 hex of the PREVIOUS line's exact bytes
+        // (genesis: CHAIN_GENESIS). Hashing written bytes, never a
+        // re-serialization, is what makes `trace verify` total: no
+        // canonical-JSON contract to drift. Event consumers ignore the
+        // extra field (tolerant serde — pinned in verify tests).
+        let result = serde_json::to_value(&event)
             .map_err(std::io::Error::from)
-            .and_then(|()| writer.write_all(b"\n"))
-            .and_then(|()| writer.flush());
+            .and_then(|mut value| {
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert(
+                        "chain".to_owned(),
+                        serde_json::Value::String(self.chain.clone()),
+                    );
+                }
+                let line = serde_json::to_string(&value).map_err(std::io::Error::from)?;
+                self.chain = sha256_hex(line.as_bytes());
+                writer.write_all(line.as_bytes())?;
+                writer.write_all(b"\n")?;
+                writer.flush()
+            });
         if let Err(e) = result {
             self.error = Some(e);
         }
@@ -642,14 +690,29 @@ mod tests {
         assert!(sink.into_error().is_none(), "a writable dir never errors");
 
         let written = std::fs::read(&path).expect("journal readable");
-        assert_eq!(written, expected, "trace file == JsonSink bytes");
-        // split() over adding a bytecount dep for one test assertion
-        // (clippy::naive_bytecount fires on the filter().count() idiom).
-        assert_eq!(
-            written.split(|&b| b == b'\n').count() - 1,
-            events.len(),
-            "one NDJSON line per event"
-        );
+        // The journal = the --json lane PLUS the chain field (0.96): each
+        // line parses to the SAME event with one extra key committing to
+        // the previous line's bytes. Semantic mirror, chained.
+        let jl: Vec<serde_json::Value> = String::from_utf8(written)
+            .expect("utf8")
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("journal line parses"))
+            .collect();
+        let el: Vec<serde_json::Value> = String::from_utf8(expected)
+            .expect("utf8")
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("json line parses"))
+            .collect();
+        assert_eq!(jl.len(), el.len(), "one NDJSON line per event, both lanes");
+        for (j, e) in jl.iter().zip(&el) {
+            let mut j = j.clone();
+            let chain = j
+                .as_object_mut()
+                .and_then(|o| o.remove("chain"))
+                .expect("every journal line carries its chain");
+            assert_eq!(chain.as_str().map(str::len), Some(64), "a full sha256 hex");
+            assert_eq!(&j, e, "the event itself mirrors the --json lane");
+        }
     }
 
     /// The opt-out shape: `disabled()` swallows every event with zero fs

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -145,6 +145,8 @@ pub(super) struct TraceFileSink {
     /// bytes (genesis: sha256 of [`CHAIN_GENESIS`]) — injected into the
     /// NEXT line as its `chain` field. After the run, this is the HEAD.
     chain: String,
+    /// Lines actually written (the anchor trio's count).
+    written: usize,
 }
 
 /// The chain's genesis tag — the first line's `chain` field is the
@@ -160,6 +162,7 @@ impl TraceFileSink {
             path: None,
             error: None,
             chain: sha256_hex(CHAIN_GENESIS),
+            written: 0,
         }
     }
 
@@ -173,6 +176,7 @@ impl TraceFileSink {
             path: None,
             error: None,
             chain: sha256_hex(CHAIN_GENESIS),
+            written: 0,
         }
     }
 
@@ -194,6 +198,13 @@ impl TraceFileSink {
     #[must_use]
     pub(super) fn chain_head(&self) -> &str {
         &self.chain
+    }
+
+    /// Lines written — the anchor trio's middle term (the C2SP
+    /// checkpoint shape: origin · size · root).
+    #[must_use]
+    pub(super) fn chain_len(&self) -> usize {
+        self.written
     }
 
     /// Create the directory + the journal file, named from the first
@@ -269,6 +280,7 @@ impl EventSink for TraceFileSink {
                 }
                 let line = serde_json::to_string(&value).map_err(std::io::Error::from)?;
                 self.chain = sha256_hex(line.as_bytes());
+                self.written += 1;
                 writer.write_all(line.as_bytes())?;
                 writer.write_all(b"\n")?;
                 writer.flush()

--- a/crates/nika-cli/src/verbs/trace_verify.rs
+++ b/crates/nika-cli/src/verbs/trace_verify.rs
@@ -1,0 +1,216 @@
+//! `nika trace verify` — is this journal internally consistent?
+//!
+//! Every journal line (0.96+) carries a `chain` field: the sha256 of
+//! the PREVIOUS line's exact bytes (genesis: a constant tag). Verify
+//! walks the file and recomputes — any edited, inserted, dropped or
+//! reordered line breaks every hash after it.
+//!
+//! The claim is TAMPER-EVIDENT, never "tamper-proof": with no external
+//! trust root, an attacker can rewrite the whole chain. The parade is
+//! the anchor the run printed (`trace: … · chain <head>`) — CI logs and
+//! scrollback hold a head a whole-file rewrite cannot reproduce.
+//!
+//! Exit codes (the house taxonomy): 0 = intact · 2 (FILE) = broken ·
+//! 3 (ENV) = unchained (a pre-chain journal — stated, never guessed).
+
+use super::VerbOutput;
+
+/// The chain's genesis tag — must match the sink's.
+const CHAIN_GENESIS: &[u8] = b"nika-trace-v1";
+
+#[must_use]
+pub fn verify(trace: &str) -> VerbOutput {
+    let raw = match std::fs::read_to_string(trace) {
+        Ok(raw) => raw,
+        Err(e) => return VerbOutput::env(format!("cannot read {trace}: {e}")),
+    };
+    match walk(&raw) {
+        Verdict::Intact { events, head } => VerbOutput::ok(format!(
+            "OK — {events} events · chain intact · head {head}\n  internally consistent (tamper-evident, not tamper-proof) — compare the head\n  against the one the run printed to close the loop"
+        )),
+        Verdict::Broken {
+            line,
+            recorded,
+            computed,
+        } => VerbOutput::file(format!(
+            "BROKEN at line {line} — recorded chain {} · computed {}\n  every line from here on is unverified (edited, inserted, dropped or reordered)",
+            short(&recorded),
+            short(&computed),
+        )),
+        Verdict::Unchained => VerbOutput::env(format!(
+            "unchained — {trace} predates the chain (pre-0.96 journal): nothing to verify, nothing to distrust"
+        )),
+        Verdict::Empty => VerbOutput::env(format!("{trace}: no events")),
+    }
+}
+
+enum Verdict {
+    Intact {
+        events: usize,
+        head: String,
+    },
+    Broken {
+        line: usize,
+        recorded: String,
+        computed: String,
+    },
+    Unchained,
+    Empty,
+}
+
+/// The pure walk — recompute the chain over exact line bytes.
+fn walk(raw: &str) -> Verdict {
+    let lines: Vec<&str> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return Verdict::Empty;
+    }
+    let mut expected = sha256_hex(CHAIN_GENESIS);
+    for (i, line) in lines.iter().enumerate() {
+        let Some(recorded) = chain_of(line) else {
+            // The FIRST line decides the era: no chain there = a
+            // pre-chain journal. A chain that starts and then STOPS is
+            // a break, not an era.
+            if i == 0 {
+                return Verdict::Unchained;
+            }
+            return Verdict::Broken {
+                line: i + 1,
+                recorded: "(absent)".to_owned(),
+                computed: expected,
+            };
+        };
+        if recorded != expected {
+            return Verdict::Broken {
+                line: i + 1,
+                recorded,
+                computed: expected,
+            };
+        }
+        expected = sha256_hex(line.as_bytes());
+    }
+    Verdict::Intact {
+        events: lines.len(),
+        head: expected,
+    }
+}
+
+/// Extract the `chain` field without deserializing the full event —
+/// verify must work on journals whose event shapes it predates.
+fn chain_of(line: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    value.get("chain")?.as_str().map(ToOwned::to_owned)
+}
+
+fn short(hex: &str) -> &str {
+    hex.get(..16).unwrap_or(hex)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a chained journal the way the sink does.
+    fn chained(events: &[serde_json::Value]) -> String {
+        let mut chain = sha256_hex(CHAIN_GENESIS);
+        let mut out = String::new();
+        for e in events {
+            let mut v = e.clone();
+            v["chain"] = serde_json::Value::String(chain.clone());
+            let line = serde_json::to_string(&v).expect("test json");
+            chain = sha256_hex(line.as_bytes());
+            out.push_str(&line);
+            out.push('\n');
+        }
+        out
+    }
+
+    fn ev(kind: &str) -> serde_json::Value {
+        serde_json::json!({"id": {"uuid": "01912345-0000-7000-8000-000000000001"},
+            "timestamp": 1000, "kind": kind, "run": null, "correlation": null, "fields": []})
+    }
+
+    #[test]
+    fn an_intact_chain_verifies_with_its_head() {
+        let raw = chained(&[
+            ev("workflow_started"),
+            ev("task_completed"),
+            ev("workflow_completed"),
+        ]);
+        match walk(&raw) {
+            Verdict::Intact { events, head } => {
+                assert_eq!(events, 3);
+                let last = raw.lines().last().expect("last line");
+                assert_eq!(
+                    head,
+                    sha256_hex(last.as_bytes()),
+                    "head = hash of the last line"
+                );
+            }
+            other => {
+                assert!(matches!(other, Verdict::Intact { .. }), "expected intact");
+            }
+        }
+    }
+
+    #[test]
+    fn one_edited_byte_breaks_at_that_line() {
+        let raw = chained(&[
+            ev("workflow_started"),
+            ev("task_completed"),
+            ev("workflow_completed"),
+        ]);
+        // Tamper with line 2's content (flip the kind) — line 3's chain
+        // no longer matches the edited bytes.
+        let tampered = raw.replace("task_completed", "task_complexed");
+        match walk(&tampered) {
+            Verdict::Broken { line, .. } => assert_eq!(line, 3, "the line AFTER the edit breaks"),
+            other => {
+                assert!(matches!(other, Verdict::Broken { .. }), "expected broken");
+            }
+        }
+    }
+
+    #[test]
+    fn a_dropped_line_breaks_the_chain() {
+        let raw = chained(&[
+            ev("workflow_started"),
+            ev("task_completed"),
+            ev("workflow_completed"),
+        ]);
+        let mut dropped = String::new();
+        for (i, l) in raw.lines().enumerate() {
+            if i != 1 {
+                dropped.push_str(l);
+                dropped.push('\n');
+            }
+        }
+        assert!(matches!(walk(&dropped), Verdict::Broken { line: 2, .. }));
+    }
+
+    #[test]
+    fn a_pre_chain_journal_is_unchained_not_broken() {
+        let raw = format!("{}\n", ev("workflow_started"));
+        assert!(matches!(walk(&raw), Verdict::Unchained));
+    }
+
+    #[test]
+    fn a_chain_that_stops_is_broken_not_unchained() {
+        let mut raw = chained(&[ev("workflow_started")]);
+        raw.push_str(&ev("workflow_completed").to_string());
+        raw.push('\n');
+        assert!(matches!(walk(&raw), Verdict::Broken { line: 2, .. }));
+    }
+}

--- a/crates/nika-cli/src/verbs/trace_verify.rs
+++ b/crates/nika-cli/src/verbs/trace_verify.rs
@@ -37,6 +37,9 @@ pub fn verify(trace: &str) -> VerbOutput {
             short(&recorded),
             short(&computed),
         )),
+        Verdict::TornTail { events, head } => VerbOutput::ok(format!(
+            "OK — {events} events · chain intact · head {head}\n  the final line is TORN (a crash mid-write, not tampering) — the chain\n  covers every complete line"
+        )),
         Verdict::Unchained => VerbOutput::env(format!(
             "unchained — {trace} predates the chain (pre-0.96 journal): nothing to verify, nothing to distrust"
         )),
@@ -46,6 +49,14 @@ pub fn verify(trace: &str) -> VerbOutput {
 
 enum Verdict {
     Intact {
+        events: usize,
+        head: String,
+    },
+    /// The chain holds through the last COMPLETE line, but the final
+    /// line is not valid JSON — a crash mid-write (torn tail), NOT
+    /// tampering. The research-locked distinction: conflating the two
+    /// would make every crashed run look forged.
+    TornTail {
         events: usize,
         head: String,
     },
@@ -66,6 +77,15 @@ fn walk(raw: &str) -> Verdict {
     }
     let mut expected = sha256_hex(CHAIN_GENESIS);
     for (i, line) in lines.iter().enumerate() {
+        // A FINAL line that is not valid JSON is a torn tail (crash
+        // mid-write) — the chain verdict covers the complete lines.
+        let is_last = i + 1 == lines.len();
+        if is_last && serde_json::from_str::<serde_json::Value>(line).is_err() {
+            return Verdict::TornTail {
+                events: i,
+                head: expected,
+            };
+        }
         let Some(recorded) = chain_of(line) else {
             // The FIRST line decides the era: no chain there = a
             // pre-chain journal. A chain that starts and then STOPS is
@@ -204,6 +224,17 @@ mod tests {
     fn a_pre_chain_journal_is_unchained_not_broken() {
         let raw = format!("{}\n", ev("workflow_started"));
         assert!(matches!(walk(&raw), Verdict::Unchained));
+    }
+
+    #[test]
+    fn a_torn_final_line_is_a_crash_not_a_tamper() {
+        let mut raw = chained(&[ev("workflow_started"), ev("task_completed")]);
+        raw.push_str("{\"id\":{\"uuid\":\"01912345-0000-7000-8000-0000000");
+        let verdict = walk(&raw);
+        assert!(
+            matches!(verdict, Verdict::TornTail { events: 2, .. }),
+            "a torn final line is a crash, not a tamper"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The Proof Arc · P1 (the socratic ledger's Q8)

**The question**: can the system prove anything to someone who doesn't already trust it? Everything the journal claims — identity (#210), why (#211), durations (#223), attestation (#235), cost — was editable with a text editor. « Provable after it runs » was a claim, not a proof.

## The chain

Every journal line now carries a `chain` field: **the sha256 of the PREVIOUS line's exact bytes** (genesis: a constant tag). Hashing written bytes — never a re-serialization — keeps verify total: no canonical-JSON contract to drift. Any edited, inserted, dropped or reordered line breaks every hash after it.

- `nika trace verify <trace>` → `OK (N events · chain intact · head <hex>)` · `BROKEN at line N (recorded · computed)` · `unchained` (pre-chain journal — stated, never guessed). Exit codes ride the house taxonomy (0 · 2 FILE · 3 ENV).
- The run's trace line prints **`· chain <head16>`** — CI logs and scrollback become the free external anchor a whole-file rewrite cannot reproduce.
- The wording is the honesty: **tamper-EVIDENT, never "tamper-proof"** (no external trust root is claimed).

## Compat

Event consumers ignore the field (tolerant serde): replay, export, fold, the extension — all read chained journals unchanged. The journal-mirrors-json pin evolved with the law (same events, one extra committed key per line). Pre-chain journals verify as `unchained`, not broken.

## Proof

5 walk pins (intact+head equality · edited byte breaks at the right line · dropped line · pre-chain unchained · stopped-chain broken) · e2e at the real binary: run prints `chain 94ad2046…`, verify recomputes the **same** head, one flipped byte → `BROKEN at line 5`. nika-cli lib 231 ✓ · clippy ✓ · 8/8 ratchets ✓ · baseline carries the 2 new lines in this commit.

Follow-ups (the master plan `2026-07-06-nika-proof-arc-master-plan.md`): P2 verify-before-trust surfaces (export/DAP warn on broken · chain head as OTel resource attr) · P3 `trace reproduce` (the ADR-099 substrate) · P4 registry provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)