### PR TITLE
feat(nika-cli): export and replay verify before they trust — Proof Arc P2

### DIFF
--- a/crates/nika-cli/src/verbs/dap/mod.rs
+++ b/crates/nika-cli/src/verbs/dap/mod.rs
@@ -52,6 +52,15 @@ fn serve<R: std::io::BufRead, W: std::io::Write>(mut wire: Wire<R, W>) -> u8 {
                     // The #210 identity check speaks BEFORE the first stop:
                     // a drifted source means snapped breakpoint lines may
                     // not match what actually ran.
+                    if s.chain_broken {
+                        wire.emit(
+                            "output",
+                            serde_json::json!({
+                                "category": "console",
+                                "output": "⚠ this journal FAILS verification (nika trace verify) — its recorded outputs are unverified\n",
+                            }),
+                        );
+                    }
                     if s.drifted == Some(true) {
                         wire.emit(
                             "output",

--- a/crates/nika-cli/src/verbs/dap/replay.rs
+++ b/crates/nika-cli/src/verbs/dap/replay.rs
@@ -33,6 +33,9 @@ pub(crate) struct ReplaySession {
     /// from the bytes the run executed (breakpoint lines may be off) ·
     /// None = the journal predates `workflow_sha256`.
     pub(crate) drifted: Option<bool>,
+    /// The chain check (P2): the journal fails verification — its
+    /// claims are unverified. False for intact/torn/unchained.
+    pub(crate) chain_broken: bool,
     /// `(task id, 1-based start line)` in document order.
     task_lines: Vec<(String, u32)>,
     pub(crate) stops: Vec<Stop>,
@@ -50,7 +53,15 @@ impl ReplaySession {
         let raw = std::fs::read_to_string(replay_path)
             .map_err(|e| format!("cannot read journal {replay_path}: {e}"))?;
         let recovered = super::super::run::recover_events(&raw, replay_path)?;
-        Self::from_parts(workflow_path, &yaml, &recovered.events)
+        let mut session = Self::from_parts(workflow_path, &yaml, &recovered.events)?;
+        // Verify before trusting: a broken chain replays (warn, never
+        // block — coherent with tamper-EVIDENT), but the debugger says
+        // so before the first stop.
+        session.chain_broken = matches!(
+            super::super::trace_verify::walk(&raw),
+            super::super::trace_verify::Verdict::Broken { .. }
+        );
+        Ok(session)
     }
 
     /// The #210 identity check against the CURRENT source bytes.
@@ -122,6 +133,7 @@ impl ReplaySession {
             workflow_path: workflow_path.to_owned(),
             workflow_name,
             drifted: Self::drift_of(yaml, events),
+            chain_broken: false,
             task_lines,
             stops,
             cursor: 0,

--- a/crates/nika-cli/src/verbs/trace_otel.rs
+++ b/crates/nika-cli/src/verbs/trace_otel.rs
@@ -42,7 +42,18 @@ pub fn export(trace: &str, out: Option<&str>, include_content: bool) -> VerbOutp
         Ok(recovered) => recovered,
         Err(e) => return VerbOutput::env(e),
     };
-    let line = match project(&recovered.events, include_content) {
+    // Verify before trusting (the git index-pack model — affordable at
+    // 0.4µs/line): a BROKEN chain still exports, but says so; the head
+    // rides the export so the anchor travels with the trace.
+    let chain = match super::trace_verify::walk(&raw) {
+        super::trace_verify::Verdict::Intact { head, .. }
+        | super::trace_verify::Verdict::TornTail { head, .. } => Some(("intact", head)),
+        super::trace_verify::Verdict::Broken { line, .. } => {
+            Some(("broken", format!("chain broken at line {line}")))
+        }
+        _ => None, // unchained (pre-chain journal) — nothing to claim
+    };
+    let line = match project_with_chain(&recovered.events, include_content, chain.as_ref()) {
         Ok(line) => line,
         Err(e) => return VerbOutput::env(e),
     };
@@ -50,9 +61,17 @@ pub fn export(trace: &str, out: Option<&str>, include_content: bool) -> VerbOutp
     if let Err(e) = std::fs::write(&target, format!("{line}\n")) {
         return VerbOutput::env(format!("cannot write {target}: {e}"));
     }
-    VerbOutput::ok(format!(
+    let mut msg = format!(
         "exported → {target}\n  view: drag into Jaeger UI (≥1.60) · or POST the line to any OTLP/HTTP endpoint (`:4318/v1/traces`)"
-    ))
+    );
+    if let Some(("broken", detail)) = chain.as_ref().map(|(k, d)| (*k, d)) {
+        use std::fmt::Write as _;
+        let _ = write!(
+            msg,
+            "\n  WARNING — this journal fails verification ({detail}); its claims are unverified"
+        );
+    }
+    VerbOutput::ok(msg)
 }
 
 /// `run.ndjson` → `run.otlp.jsonl`, beside the journal.
@@ -63,8 +82,20 @@ fn default_out_path(trace: &str) -> String {
     )
 }
 
-/// One journal → one `{"resourceSpans":[…]}` JSON value (one line).
+/// One journal → one `{"resourceSpans":[…]}` JSON value (one line) —
+/// the chain-less shape the unit pins drive.
+#[cfg(test)]
 pub(crate) fn project(events: &[Event], include_content: bool) -> Result<String, String> {
+    project_with_chain(events, include_content, None)
+}
+
+/// The full projection — `chain` carries the verify verdict so the
+/// anchor (or the broken flag) travels with the export.
+pub(crate) fn project_with_chain(
+    events: &[Event],
+    include_content: bool,
+    chain: Option<&(&str, String)>,
+) -> Result<String, String> {
     let started = events
         .iter()
         .find(|e| e.kind == EventKind::WorkflowStarted)
@@ -105,6 +136,15 @@ pub(crate) fn project(events: &[Event], include_content: bool) -> Result<String,
     ];
     if let Some(platform) = field_str(started, "platform") {
         resource_attrs.push(kv_str("nika.platform", platform));
+    }
+    match chain {
+        Some(("intact", head)) => {
+            resource_attrs.push(kv_str("nika.trace.chain_head", head));
+        }
+        Some(("broken", _)) => {
+            resource_attrs.push(kv_str("nika.trace.chain", "broken"));
+        }
+        _ => {}
     }
     let payload = serde_json::json!({
         "resourceSpans": [{

--- a/crates/nika-cli/src/verbs/trace_verify.rs
+++ b/crates/nika-cli/src/verbs/trace_verify.rs
@@ -47,7 +47,7 @@ pub fn verify(trace: &str) -> VerbOutput {
     }
 }
 
-enum Verdict {
+pub(crate) enum Verdict {
     Intact {
         events: usize,
         head: String,
@@ -70,7 +70,7 @@ enum Verdict {
 }
 
 /// The pure walk — recompute the chain over exact line bytes.
-fn walk(raw: &str) -> Verdict {
+pub(crate) fn walk(raw: &str) -> Verdict {
     let lines: Vec<&str> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
     if lines.is_empty() {
         return Verdict::Empty;


### PR DESCRIPTION
## Proof Arc · P2 (research-locked)

The trust boundaries adopt the **git index-pack model** (the SOTA sweep's finding: verify-at-boundary is git's actual posture, affordable here at 0.4µs/line; warn-never-block is coherent with the tamper-EVIDENT claim):

- **`trace export` walks the chain first.** Intact/torn → the head rides the export as `nika.trace.chain_head` (the anchor travels with the trace — the C2SP checkpoint pattern). Broken → a WARNING naming the line in the verb output + `nika.trace.chain: "broken"` in the OTLP resource, so the viewer sees it too. Unchained (pre-chain journal) → silence, no retroactive alarm.
- **`nika dap` (replay)** announces a broken chain in the Debug Console before the first stop — beside the drift warning: « its recorded outputs are unverified ».

## Proof

E2e at the binary: intact export carries the head · one flipped byte → `WARNING — this journal fails verification (chain broken at line 3)` + the broken flag in the resource. nika-cli lib 232 ✓ · clippy ✓ · 8/8 ratchets ✓ · no new public API.

Remaining Proof Arc (master plan): P3 `trace reproduce` (the ADR-099 substrate) · P4 registry provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)