### PR TITLE
fix(nika-schema): the envelope model resolves like any surface — deep/019

### DIFF
--- a/crates/nika-schema/src/analyzer/mod.rs
+++ b/crates/nika-schema/src/analyzer/mod.rs
@@ -434,6 +434,19 @@ tasks:
     }
 
     #[test]
+    fn envelope_model_unresolved_var_is_flagged() {
+        // deep/019 — the oracle false-green class: an envelope
+        // `model: "${{ vars.nope }}"` was ACCEPTED and died at dispatch.
+        let yaml = "nika: v1\nworkflow: w\nmodel: \"${{ vars.nope }}\"\ntasks:\n  - id: a\n    infer: { prompt: hi }\n";
+        let errors = analyze_yaml(yaml).expect_err("envelope model ref must flag");
+        assert_has(
+            &errors,
+            |e| matches!(e, SchemaError::UnresolvedNamespaceRef { reference, .. } if reference == "vars.nope"),
+            "vars.nope unresolved at the envelope",
+        );
+    }
+
+    #[test]
     fn with_undeclared_errors() {
         // Conformance fixture variables/004-with-undeclared.
         let yaml = "\

--- a/crates/nika-schema/src/analyzer/scan.rs
+++ b/crates/nika-schema/src/analyzer/scan.rs
@@ -119,18 +119,24 @@ pub(super) fn scan_workflow(wf: &RawWorkflow, errors: &mut Vec<SchemaError>) {
         scan_task(&task.value, &index, errors);
     }
 
-    // Envelope `outputs:` — workflow level · no with/item/index · no
-    // edge rule (NIKA-VAR existence only · fixture variables/001).
-    let outputs_ctx = ScanCtx {
-        location: "outputs".to_owned(),
-        task_id: "", // workflow level · no edge/loop-local rule fires here
+    // Workflow-level surfaces share one ctx shape (no task id · no
+    // edge/loop-local rule): `outputs:` (fixture variables/001) and the
+    // one templated envelope field, `model:` (deep/019 — an unresolved
+    // ref there is NIKA-VAR-001 like any task surface).
+    let envelope_ctx = |location: &str| ScanCtx {
+        location: location.to_owned(),
+        task_id: "",
         edge_set: None,
         with_names: None,
         allow_loop_locals: false,
     };
+    let outputs_ctx = envelope_ctx("outputs");
     for (_, decl) in &wf.outputs {
         let value = decl.value();
         scan_string(value, &outputs_ctx, &index, errors);
+    }
+    if let Some(model) = &wf.model {
+        scan_string(model, &envelope_ctx("model"), &index, errors);
     }
 }
 

--- a/crates/nika-schema/src/check/requirements.rs
+++ b/crates/nika-schema/src/check/requirements.rs
@@ -1,8 +1,6 @@
-//! The workflow's REQUIREMENTS — what a caller must satisfy before any
-//! token is spent (E-REQ). Declaration facts from the typed AST only:
-//! models per task · declared secrets (never values) · `env` reads vs
-//! defines (the split IS the semantics) · required vars. PRESENCE stays
-//! the caller's check — a static report never depends on who runs it.
+//! The workflow's REQUIREMENTS (E-REQ) — declaration facts only:
+//! models per task · secrets (never values) · env reads vs defines ·
+//! required vars. Presence stays the caller's check.
 
 use std::collections::{BTreeMap, BTreeSet};
 


### PR DESCRIPTION
## The unblock (every open engine PR is red right now)

Spec #28 merged the oracle-false-green fixtures ahead of their engine half — the battery (#218) runs the deep conformance suite against the spec's main, so **every engine PR now fails CI** on:

> `019-envelope-unresolved-ref · expected INVALID (NIKA-VAR-001+variable_error) · engine accepted`

## The real gap it caught

An envelope `model: "${{ vars.nope }}"` was ACCEPTED by check and died at dispatch. `scan_workflow` walked `outputs:` but never the one templated envelope field. The model now runs through the same `scan_string` path — an unresolved ref is NIKA-VAR-001 like any task surface.

The two workflow-level surfaces (outputs · model) share one ctx builder — the DRY that paid the crate-size cap (nika-schema was 2 LOC under it after the sister's merges; no doc-gutting, the closure + my own module doc trim covered it).

## Proof

Lib pin (analyzer: envelope ref flagged) · **both conformance suites green against the fresh spec main** (deep/019 included) · nika-schema lib 771 ✓ · clippy ✓ · 8/8 ratchets ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)