### PR TITLE
feat(nika-cli): trace reproduce — is this run reproducible, and WHY not

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -969,6 +969,8 @@ pub fn nika_cli::verbs::trace::outputs(trace: &str, theme: nika_cli::display::th
 pub fn nika_cli::verbs::trace::peek(trace: &str, task: &str, raw: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::trace_otel
 pub fn nika_cli::verbs::trace_otel::export(trace: &str, out: core::option::Option<&str>, include_content: bool) -> nika_cli::verbs::VerbOutput
+pub mod nika_cli::verbs::trace_reproduce
+pub fn nika_cli::verbs::trace_reproduce::reproduce(recorded: &str, fresh: &str) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::trace_verify
 pub fn nika_cli::verbs::trace_verify::verify(trace: &str) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::wire

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -337,6 +337,16 @@ enum TraceAction {
         /// Trace NDJSON path (one `nika-event` Event per line).
         trace: PathBuf,
     },
+    /// Is this run reproducible? Compare a recorded journal against a
+    /// fresh one and classify every task: reproduced · nondeterministic
+    /// (same def+inputs, different output) · authored · environment ·
+    /// status-changed · unverifiable. Exit 0 reproduced · 2 diverged.
+    Reproduce {
+        /// The RECORDED journal (the reference frame).
+        recorded: PathBuf,
+        /// A FRESH journal of the same workflow (run it again first).
+        fresh: PathBuf,
+    },
     /// Read ONE task's full output + its identity (hashes · duration ·
     /// tokens). `--raw` prints the exact value only (pipe it to jq).
     Peek {
@@ -612,6 +622,10 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
         TraceAction::Verify { trace } => {
             emit(&verbs::trace_verify::verify(&trace.to_string_lossy()))
         }
+        TraceAction::Reproduce { recorded, fresh } => emit(&verbs::trace_reproduce::reproduce(
+            &recorded.to_string_lossy(),
+            &fresh.to_string_lossy(),
+        )),
         TraceAction::Export {
             trace,
             out,

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -25,6 +25,7 @@ pub mod test;
 pub mod tools;
 pub mod trace;
 pub mod trace_otel;
+pub mod trace_reproduce;
 pub mod trace_verify;
 pub mod wire;
 

--- a/crates/nika-cli/src/verbs/trace_reproduce.rs
+++ b/crates/nika-cli/src/verbs/trace_reproduce.rs
@@ -1,0 +1,365 @@
+//! `nika trace reproduce` — is this run reproducible? (Proof Arc P3)
+//!
+//! Compares a RECORDED journal against a FRESH one of the same
+//! workflow and classifies every recorded task by WHY it did or did
+//! not reproduce — the ADR-099 stamps make the taxonomy total:
+//!
+//! - `reproduced` — def and inputs match · output identical
+//! - `nondeterministic` — def and inputs match · output DIFFERS (the
+//!   interesting one: a model call · a clock · an unpinned tool)
+//! - `authored` — `def_hash` differs: the task itself changed
+//! - `environment` — inputs differ (upstream outputs · vars · env)
+//! - `status-changed` — settled differently (completed → failed · …)
+//! - `unverifiable` — no stamps to compare (skips · cancels · fails)
+//! - `missing` — absent from the fresh run
+//!
+//! Exit codes: 0 = every comparable task reproduced · 2 (FILE) = any
+//! divergence. Unverifiable tasks never fail the verdict — stated,
+//! never guessed. Both journals get a chain walk first (P2: verify
+//! before trust — broken is WARNED, never blocked).
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use nika_event::{Event, EventKind};
+
+use super::VerbOutput;
+
+#[must_use]
+pub fn reproduce(recorded: &str, fresh: &str) -> VerbOutput {
+    let rec_raw = match std::fs::read_to_string(recorded) {
+        Ok(raw) => raw,
+        Err(e) => return VerbOutput::env(format!("cannot read {recorded}: {e}")),
+    };
+    let new_raw = match std::fs::read_to_string(fresh) {
+        Ok(raw) => raw,
+        Err(e) => return VerbOutput::env(format!("cannot read {fresh}: {e}")),
+    };
+    let rec = match super::run::recover_events(&rec_raw, recorded) {
+        Ok(r) => r,
+        Err(e) => return VerbOutput::env(e),
+    };
+    let new = match super::run::recover_events(&new_raw, fresh) {
+        Ok(r) => r,
+        Err(e) => return VerbOutput::env(e),
+    };
+
+    let mut out = String::new();
+    for (label, raw) in [("recorded", &rec_raw), ("fresh", &new_raw)] {
+        if let super::trace_verify::Verdict::Broken { line, .. } = super::trace_verify::walk(raw) {
+            let _ = writeln!(
+                out,
+                "WARNING — the {label} journal fails verification (chain broken at line {line}); its claims are unverified"
+            );
+        }
+    }
+
+    let report = compare(&rec.events, &new.events);
+    let _ = write!(out, "{}", render(&report));
+    if report.diverged() {
+        VerbOutput::file(out)
+    } else {
+        VerbOutput::ok(out)
+    }
+}
+
+/// One recorded task's reproduction verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Verdict {
+    Reproduced,
+    Nondeterministic,
+    Authored,
+    Environment,
+    StatusChanged { recorded: String, fresh: String },
+    Unverifiable,
+    Missing,
+}
+
+pub(crate) struct Row {
+    pub(crate) task: String,
+    pub(crate) verdict: Verdict,
+}
+
+pub(crate) struct Report {
+    pub(crate) rows: Vec<Row>,
+    /// `engine_version/platform` per side, when attested (#235).
+    pub(crate) recorded_env: Option<String>,
+    pub(crate) fresh_env: Option<String>,
+}
+
+impl Report {
+    pub(crate) fn diverged(&self) -> bool {
+        self.rows
+            .iter()
+            .any(|r| !matches!(r.verdict, Verdict::Reproduced | Verdict::Unverifiable))
+    }
+}
+
+/// One task's comparable settle facts.
+#[derive(Default, Clone)]
+struct Settle {
+    status: Option<&'static str>,
+    def_hash: Option<String>,
+    input_hash: Option<String>,
+    output: Option<String>,
+}
+
+/// The pure comparison — the RECORDED journal is the reference frame.
+pub(crate) fn compare(recorded: &[Event], fresh: &[Event]) -> Report {
+    let rec = settles_of(recorded);
+    let new = settles_of(fresh);
+
+    let rows = rec
+        .iter()
+        .map(|(task, r)| {
+            let verdict = match new.get(task) {
+                None => Verdict::Missing,
+                Some(n) => classify(r, n),
+            };
+            Row {
+                task: task.clone(),
+                verdict,
+            }
+        })
+        .collect();
+
+    Report {
+        rows,
+        recorded_env: attestation_of(recorded),
+        fresh_env: attestation_of(fresh),
+    }
+}
+
+fn classify(rec: &Settle, new: &Settle) -> Verdict {
+    if rec.status != new.status {
+        return Verdict::StatusChanged {
+            recorded: rec.status.unwrap_or("?").to_owned(),
+            fresh: new.status.unwrap_or("?").to_owned(),
+        };
+    }
+    // Stamps ride completed frames only — anything else has nothing
+    // to compare beyond its (matching) status.
+    let (Some(rd), Some(nd)) = (&rec.def_hash, &new.def_hash) else {
+        return Verdict::Unverifiable;
+    };
+    if rd != nd {
+        return Verdict::Authored;
+    }
+    match (&rec.input_hash, &new.input_hash) {
+        (Some(ri), Some(ni)) if ri != ni => return Verdict::Environment,
+        _ => {}
+    }
+    if rec.output == new.output {
+        Verdict::Reproduced
+    } else {
+        Verdict::Nondeterministic
+    }
+}
+
+/// Fold the terminal frame per task (first terminal wins — reruns
+/// within one journal are the resume path's business, not ours).
+fn settles_of(events: &[Event]) -> BTreeMap<String, Settle> {
+    let mut out: BTreeMap<String, Settle> = BTreeMap::new();
+    for e in events {
+        let status = match e.kind {
+            EventKind::TaskCompleted => "completed",
+            EventKind::TaskFailed => "failed",
+            EventKind::TaskSkipped => "skipped",
+            EventKind::TaskCancelled => "cancelled",
+            EventKind::TaskCacheHit => "cache-hit",
+            _ => continue,
+        };
+        let Some(task) = field_str(e, "task") else {
+            continue;
+        };
+        let entry = out.entry(task.to_owned()).or_default();
+        if entry.status.is_some() {
+            continue;
+        }
+        entry.status = Some(status);
+        entry.def_hash = field_str(e, "def_hash").map(ToOwned::to_owned);
+        entry.input_hash = field_str(e, "input_hash").map(ToOwned::to_owned);
+        entry.output = field_str(e, "output").map(ToOwned::to_owned);
+    }
+    out
+}
+
+fn attestation_of(events: &[Event]) -> Option<String> {
+    let started = events
+        .iter()
+        .find(|e| e.kind == EventKind::WorkflowStarted)?;
+    let version = field_str(started, "engine_version")?;
+    let platform = field_str(started, "platform").unwrap_or("?");
+    Some(format!("{version}/{platform}"))
+}
+
+fn render(report: &Report) -> String {
+    let mut out = String::new();
+    let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for row in &report.rows {
+        let (tag, detail) = match &row.verdict {
+            Verdict::Reproduced => ("reproduced", String::new()),
+            Verdict::Nondeterministic => (
+                "NONDETERMINISTIC",
+                " — same def, same inputs, different output".to_owned(),
+            ),
+            Verdict::Authored => ("AUTHORED", " — the task changed".to_owned()),
+            Verdict::Environment => ("ENVIRONMENT", " — inputs differ".to_owned()),
+            Verdict::StatusChanged { recorded, fresh } => {
+                ("STATUS-CHANGED", format!(" — {recorded} → {fresh}"))
+            }
+            Verdict::Unverifiable => ("unverifiable", String::new()),
+            Verdict::Missing => ("MISSING", " — absent from the fresh run".to_owned()),
+        };
+        *counts.entry(tag).or_default() += 1;
+        let _ = writeln!(out, "  {tag:<16} {}{detail}", row.task);
+    }
+    let summary: Vec<String> = counts.iter().map(|(tag, n)| format!("{n} {tag}")).collect();
+    let verdict = if report.diverged() {
+        "DIVERGED"
+    } else {
+        "REPRODUCED"
+    };
+    let _ = writeln!(out, "\n{verdict} — {}", summary.join(" · "));
+    match (&report.recorded_env, &report.fresh_env) {
+        (Some(r), Some(f)) if r != f => {
+            let _ = writeln!(out, "  engines differ: recorded {r} · fresh {f}");
+        }
+        (Some(r), Some(_)) => {
+            let _ = writeln!(out, "  engine: {r} (both runs)");
+        }
+        _ => {}
+    }
+    out
+}
+
+fn field_str<'e>(event: &'e Event, key: &str) -> Option<&'e str> {
+    event.fields.iter().find_map(|f| match (&f.key, &f.value) {
+        (k, nika_types::resource::Value::String(s)) if k == key => Some(s.as_str()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_types::id::EventId;
+    use nika_types::resource::{KeyValue, Value as FieldValue};
+    use nika_types::timestamp::Timestamp;
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn ev(seed: u8, kind: EventKind, fields: &[(&str, &str)]) -> Event {
+        let mut e = Event::new(
+            EventId::new(Uuid::from_bytes([seed; 16])),
+            Timestamp::from_unix_ns(i64::from(seed) * 1_000),
+            kind,
+        );
+        for (k, v) in fields {
+            e = e.with_field(KeyValue::new(*k, FieldValue::String((*v).to_owned())));
+        }
+        e
+    }
+
+    fn completed(seed: u8, task: &str, def: &str, input: &str, output: &str) -> Event {
+        ev(
+            seed,
+            EventKind::TaskCompleted,
+            &[
+                ("task", task),
+                ("def_hash", def),
+                ("input_hash", input),
+                ("output", output),
+            ],
+        )
+    }
+
+    #[test]
+    fn the_taxonomy_names_why() {
+        let recorded = vec![
+            ev(
+                1,
+                EventKind::WorkflowStarted,
+                &[
+                    ("workflow", "w"),
+                    ("engine_version", "0.95.0"),
+                    ("platform", "macos/aarch64"),
+                ],
+            ),
+            completed(2, "same", "d1", "i1", "\"out\""),
+            completed(3, "flaky", "d2", "i2", "\"a\""),
+            completed(4, "edited", "d3", "i3", "\"x\""),
+            completed(5, "shifted", "d4", "i4", "\"x\""),
+            ev(6, EventKind::TaskSkipped, &[("task", "gated")]),
+            completed(7, "gone", "d5", "i5", "\"x\""),
+        ];
+        let fresh = vec![
+            ev(
+                8,
+                EventKind::WorkflowStarted,
+                &[
+                    ("workflow", "w"),
+                    ("engine_version", "0.96.0"),
+                    ("platform", "macos/aarch64"),
+                ],
+            ),
+            completed(9, "same", "d1", "i1", "\"out\""),
+            completed(10, "flaky", "d2", "i2", "\"b\""),
+            completed(11, "edited", "dX", "i3", "\"x\""),
+            completed(12, "shifted", "d4", "iX", "\"x\""),
+            ev(13, EventKind::TaskSkipped, &[("task", "gated")]),
+        ];
+        let report = compare(&recorded, &fresh);
+        let verdict = |task: &str| {
+            report
+                .rows
+                .iter()
+                .find(|r| r.task == task)
+                .expect("row")
+                .verdict
+                .clone()
+        };
+        assert_eq!(verdict("same"), Verdict::Reproduced);
+        assert_eq!(verdict("flaky"), Verdict::Nondeterministic);
+        assert_eq!(verdict("edited"), Verdict::Authored);
+        assert_eq!(verdict("shifted"), Verdict::Environment);
+        assert_eq!(
+            verdict("gated"),
+            Verdict::Unverifiable,
+            "skips have no stamps"
+        );
+        assert_eq!(verdict("gone"), Verdict::Missing);
+        assert!(report.diverged());
+        // The attestation comparison rides (#235 closing another loop).
+        assert_eq!(report.recorded_env.as_deref(), Some("0.95.0/macos/aarch64"));
+        assert_eq!(report.fresh_env.as_deref(), Some("0.96.0/macos/aarch64"));
+    }
+
+    #[test]
+    fn a_status_flip_names_both_sides() {
+        let recorded = vec![completed(1, "a", "d", "i", "\"x\"")];
+        let fresh = vec![ev(
+            2,
+            EventKind::TaskFailed,
+            &[("task", "a"), ("detail", "boom")],
+        )];
+        let report = compare(&recorded, &fresh);
+        assert_eq!(
+            report.rows[0].verdict,
+            Verdict::StatusChanged {
+                recorded: "completed".to_owned(),
+                fresh: "failed".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn identical_runs_reproduce_with_exit_zero_semantics() {
+        let run = vec![
+            completed(1, "a", "d1", "i1", "\"x\""),
+            ev(2, EventKind::TaskSkipped, &[("task", "g")]),
+        ];
+        let report = compare(&run, &run);
+        assert!(!report.diverged(), "unverifiable never fails the verdict");
+    }
+}


### PR DESCRIPTION
## Proof Arc · P3

The ADR-099 stamps (`def_hash · input_hash · output` on every completed frame — normal runs stamp them all, verified at the binary) make reproducibility a **total taxonomy**, not a diff:

```
$ nika trace reproduce .nika/traces/<t1> .nika/traces/<t2>
  NONDETERMINISTIC clock — same def, same inputs, different output
  reproduced       stable

DIVERGED — 1 NONDETERMINISTIC · 1 reproduced
  engine: 0.96.0/macos/aarch64 (both runs)
```

| verdict | meaning |
|---|---|
| `reproduced` | def+inputs match · output identical |
| `NONDETERMINISTIC` | def+inputs match · output differs — a model, a clock, an unpinned tool |
| `AUTHORED` | the task changed (`def_hash`) |
| `ENVIRONMENT` | inputs differ (upstream outputs · vars · env) |
| `STATUS-CHANGED` | completed → failed (both sides named) |
| `unverifiable` | no stamps (skips · cancels) — stated, never failed |
| `MISSING` | absent from the fresh run |

- **Exit 0/2** = a CI determinism gate for free.
- The **#235 attestation** rides the verdict; both journals get the **P2 chain walk** first (broken → warned, never blocked).
- Two-journal compare by design (UNIX) — an auto-rerun `--rerun` can come later without changing the contract.

Rides along: `crossbeam-epoch 0.9.20` (RUSTSEC-2026-0204 landed in the overnight DB refresh and turned the audit gate red fleet-wide — one-line lockfile bump per the advisory's own solution).

## Proof

3 lib pins (full taxonomy · status flip · unverifiable-never-fails) · e2e at the binary (`date +%s%N` → NONDETERMINISTIC · exit 2) · nika-cli lib 235 ✓ · clippy ✓ · 8/8 ratchets ✓ · audit+deny green post-bump · baseline +2 in-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)