### PR TITLE
fix(verb-infer): repair near-miss json, reach longer stall cycles

### DIFF
--- a/crates/nika-verb-agent/src/config.rs
+++ b/crates/nika-verb-agent/src/config.rs
@@ -109,11 +109,11 @@ impl RouterConfig {
 /// REACH INVARIANT (the review caught this): a period-`p` cycle can repeat
 /// at most `floor(window / p)` times inside the window, so a cycle is only
 /// detectable when `window ≥ p · stall_after`. The default `window` is
-/// sized at `stall_after · 5` so cycles up to period 5 reach the stall
-/// threshold; `Guard::new` additionally clamps `window ≥ stall_after` so a
-/// misconfigured small window can never silently disarm even period-1
-/// detection. (Period > window/2 is inherently invisible — a cycle that
-/// long is indistinguishable from forward progress over the window.)
+/// sized at `stall_after · MAX_TRACKED_PERIOD` so cycles up to that period
+/// reach the stall threshold; `Guard::new` additionally clamps the window to
+/// the same floor so a misconfigured small window can never silently disarm
+/// detection. (Period > window/2 is inherently invisible — a cycle that long
+/// is indistinguishable from forward progress over the window.)
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct GuardConfig {
@@ -139,9 +139,11 @@ pub struct GuardConfig {
 impl Default for GuardConfig {
     fn default() -> Self {
         Self {
-            // stall_after · 5 — cycles up to period 5 reach the stall
-            // threshold (floor(25/5) = 5); see the REACH INVARIANT above.
-            window: 25,
+            // stall_after · MAX_TRACKED_PERIOD (5 · 8 = 40) — cycles up to
+            // period 8 reach the stall threshold (floor(40/8) = 5); see the
+            // REACH INVARIANT above. Raised from 25 (period-5) in the 2026-07
+            // review that found a period-6 cycle ran to max_turns.
+            window: 40,
             nudge_after: 3,
             stall_after: 5,
             max_reflections: 1,

--- a/crates/nika-verb-agent/src/guard.rs
+++ b/crates/nika-verb-agent/src/guard.rs
@@ -27,6 +27,19 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use crate::config::GuardConfig;
 use crate::observe::NudgeReason;
 
+/// The longest byte-identical action cycle the stall guard is GUARANTEED to
+/// stop. A period-`p` cycle reaches `stall_after` repeats only once the
+/// window holds `p · stall_after` signatures, so [`Guard::new`] floors the
+/// window at `stall_after · MAX_TRACKED_PERIOD` (REACH INVARIANT). Cycles
+/// longer than this fall through to `max_turns`; a byte-identical ≥9-step
+/// ritual is rare (models drift within a longer loop) and the per-turn scan
+/// is `window²/4`, so the bound trades a vanishing tail for a smaller scan.
+///
+/// Raised from an implicit 5 to 8 (2026-07 review): at ×5 a period-6 cycle
+/// nudged once then ran to `max_turns` — the exact class the period-4 fix
+/// targeted, one period further out.
+pub(crate) const MAX_TRACKED_PERIOD: usize = 8;
+
 /// What the guard tells the loop after observing one turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GuardVerdict {
@@ -58,10 +71,13 @@ impl Guard {
     pub(crate) fn new(mut cfg: GuardConfig) -> Self {
         // REACH INVARIANT clamp (config.rs · GuardConfig): a window smaller
         // than the periods it must hold silently disarms detection. Floor
-        // the window at `stall_after · 5` so cycles up to period 5 can
-        // actually reach the stop — a too-small configured window can never
-        // make the guard a no-op.
-        cfg.window = cfg.window.max(cfg.stall_after as usize * 5).max(2);
+        // the window at `stall_after · MAX_TRACKED_PERIOD` so every cycle up
+        // to that period can actually reach the stop — a too-small configured
+        // window can never make the guard a no-op.
+        cfg.window = cfg
+            .window
+            .max(cfg.stall_after as usize * MAX_TRACKED_PERIOD)
+            .max(2);
         let capacity = cfg.window;
         Self {
             cfg,
@@ -319,6 +335,31 @@ mod tests {
     }
 
     #[test]
+    fn a_period_eight_cycle_reaches_the_stall_under_defaults() {
+        // The 2026-07 review-caught bug, one period further out than the
+        // period-4 fix: at window 25 (stall·5) a period-6+ byte-identical
+        // cycle repeats at most floor(25/6) = 4 < stall_after 5 → nudges once
+        // then runs to max_turns. With MAX_TRACKED_PERIOD = 8 the default
+        // window is 40 (stall·8), so a period-8 cycle MUST reach the stall.
+        let mut g = Guard::new(GuardConfig::new());
+        let cycle = [11_u64, 22, 33, 44, 55, 66, 77, 88];
+        let mut stalled = None;
+        'outer: for _ in 0..8 {
+            for &s in &cycle {
+                if let GuardVerdict::Stall { period, repeats } = g.observe_turn(s, false) {
+                    stalled = Some((period, repeats));
+                    break 'outer;
+                }
+            }
+        }
+        assert_eq!(
+            stalled,
+            Some((8, 5)),
+            "a period-8 cycle MUST reach NIKA-467 under default config"
+        );
+    }
+
+    #[test]
     fn a_tiny_configured_window_cannot_disarm_detection() {
         // Misconfig: window 3 with stall_after 5 — the clamp must lift the
         // window so period-1 still stops (the second prong of the bug).
@@ -447,13 +488,14 @@ mod tests {
 
     proptest! {
         /// Injected periodic suffixes are detected; random aperiodic
-        /// prefixes never mask them. Cycle length 1..=5 — the post-fix
-        /// reach (window 25 = stall·5 holds 5 periods up to period 5),
-        /// which the old window-16 default could not (period-4 was unstoppable).
+        /// prefixes never mask them. Cycle length 1..=8 — the post-fix reach
+        /// (window 40 = stall·MAX_TRACKED_PERIOD holds 5 periods up to period
+        /// 8), which the old window-25 default could not (period-6+ ran to
+        /// max_turns).
         #[test]
         fn injected_cycles_are_detected(
             prefix in proptest::collection::vec(0u64..1000, 0..6),
-            cycle in proptest::collection::vec(0u64..4, 1..6),
+            cycle in proptest::collection::vec(0u64..8, 1..9),
             extra in 0u32..3,
         ) {
             // Default config: window is clamped to stall_after·5 = 25, big

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -57,7 +57,7 @@ use std::sync::Arc;
 
 use nika_kernel::ai::provider::{
     ContentBlock, InferRequest, InferResponse, Message, ProviderInferDyn, ProviderMeta,
-    ResponseFormat, Role, TokenUsage,
+    ResponseFormat, Role, StopReason, TokenUsage,
 };
 use nika_kernel::http::HttpPostDyn;
 use nika_providers::ProviderRegistry;
@@ -259,6 +259,13 @@ where
                 }
                 structured::Validation::Invalid(detail) => {
                     if attempts > u32::from(self.schema_retry_budget) {
+                        // Un-mask a truncated or filtered reply: without this,
+                        // "cut off before the JSON closed" reads as a plain
+                        // schema mismatch and sends the author chasing the
+                        // wrong fix (review lens 5). The retries already ran —
+                        // a tightened instruction can fix VERBOSE truncation —
+                        // so this only annotates the terminal failure.
+                        let detail = format!("{detail}{}", stop_reason_hint(&response.stop_reason));
                         return Err(VerbInferError::SchemaValidation { attempts, detail });
                     }
                     messages.push(Message::text(Role::Assistant, text));
@@ -374,6 +381,21 @@ fn build_request(
         _ => {}
     }
     request
+}
+
+/// An actionable suffix when a structured reply failed AND the provider
+/// stopped for a reason that EXPLAINS the failure — truncation and content
+/// filtering otherwise masquerade as a bare schema mismatch, hiding the real
+/// cause. Empty for a normal stop (the schema genuinely went unmet).
+fn stop_reason_hint(stop: &StopReason) -> &'static str {
+    match stop {
+        StopReason::MaxTokens => {
+            " · the reply was cut off at the token limit before it could \
+             complete — raise `max_tokens` or simplify the schema"
+        }
+        StopReason::ContentFilter => " · the provider's content filter blocked the reply",
+        _ => "",
+    }
 }
 
 /// Concatenated text blocks of the response content.
@@ -826,6 +848,61 @@ mod tests {
             .as_str()
             .expect("prompt text");
         assert!(prompt.contains("JSON Schema"), "{prompt}");
+    }
+
+    /// A structured reply cut off at the token limit reports the TRUNCATION
+    /// as the cause, not a bare schema mismatch (review lens 5 · finding #5).
+    /// `finish_reason: "length"` → `StopReason::MaxTokens` on the openai
+    /// adapter; the terminal error must name the real fix.
+    #[tokio::test]
+    async fn truncated_structured_reply_names_the_token_limit() {
+        // Valid JSON, but the required `age` never arrived — the reply was
+        // cut off. Budget 0 → single shot → straight to the terminal error.
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\"}"},"finish_reason":"length"}],"usage":{}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let err = openai_verb(&seam)
+            .with_schema_retry_budget(0)
+            .run(input)
+            .await
+            .expect_err("a truncated reply that misses the schema must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("token limit"),
+            "the cause must be named: {msg}"
+        );
+    }
+
+    /// A NORMAL stop that fails the schema stays a plain schema mismatch —
+    /// no truncation hint bolted onto an ordinary validation failure.
+    #[tokio::test]
+    async fn a_normal_stop_carries_no_truncation_hint() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\"}"},"finish_reason":"stop"}],"usage":{}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let err = openai_verb(&seam)
+            .with_schema_retry_budget(0)
+            .run(input)
+            .await
+            .expect_err("missing required field must still error");
+        assert!(
+            !err.to_string().contains("token limit"),
+            "a clean stop must not claim truncation: {err}"
+        );
     }
 
     /// F2 non-regression: a fully-specified schema keeps today's strict

--- a/crates/nika-verb-infer/src/structured.rs
+++ b/crates/nika-verb-infer/src/structured.rs
@@ -156,19 +156,101 @@ pub(crate) fn retry_message(detail: &str, schema: &serde_json::Value) -> String 
     )
 }
 
+/// The most candidate spans `extract_json` will try before giving up —
+/// bounds the balanced-span scan at O(CAP · n) on adversarial input (a
+/// 1 MB tool result full of `{` must not become O(n²)). Real model output
+/// carries the value near the start or in the first fence; 16 starts covers
+/// prose-wrapped replies without opening a `DoS` surface.
+const MAX_SPAN_CANDIDATES: usize = 16;
+
 /// Pull the first plausible JSON value out of free-form model text.
+///
+/// Layered, most-specific first: the whole trimmed text, the first fenced
+/// block, then EACH balanced `{…}`/`[…]` span in turn (not just the first —
+/// leading prose containing a stray `{`/`[` used to hide the real value that
+/// followed · review lens 4). Every candidate is tried STRICT then through a
+/// conservative repair (trailing commas) — the near-miss JSON local/open-weight
+/// models emit (`PromptPort` · arxiv.org/abs/2601.06151) costs a wasted paid
+/// retry otherwise.
 fn extract_json(text: &str) -> Option<serde_json::Value> {
     let trimmed = text.trim();
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+    if let Some(v) = parse_lenient(trimmed) {
         return Some(v);
     }
     if let Some(fenced) = first_fenced_block(trimmed)
-        && let Ok(v) = serde_json::from_str::<serde_json::Value>(fenced)
+        && let Some(v) = parse_lenient(fenced)
     {
         return Some(v);
     }
-    first_balanced_span(trimmed)
-        .and_then(|span| serde_json::from_str::<serde_json::Value>(span).ok())
+    balanced_spans(trimmed).into_iter().find_map(parse_lenient)
+}
+
+/// Parse a candidate STRICT, then — only if that fails — through one
+/// conservative repair pass. The repair is deterministic and never runs on
+/// already-valid JSON (a valid value returns at the strict branch), so the
+/// strict contract is never weakened for well-formed providers.
+fn parse_lenient(candidate: &str) -> Option<serde_json::Value> {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(candidate) {
+        return Some(v);
+    }
+    let repaired = strip_trailing_commas(candidate);
+    // Only reparse if the repair actually changed something — otherwise it is
+    // the same strict failure, not a near-miss.
+    if repaired.len() != candidate.len() {
+        return serde_json::from_str::<serde_json::Value>(&repaired).ok();
+    }
+    None
+}
+
+/// Drop trailing commas (`,]` / `,}`) — the single most common near-miss
+/// JSON weak local models emit (`PromptPort` canonicalization ·
+/// arxiv.org/abs/2601.06151). String-literal-aware, so a comma inside a
+/// value is never touched; applied ONLY after a strict parse already failed,
+/// and its result is reparsed strict, so a genuinely malformed value still
+/// fails. (Smart-quote / single-quote repair is deliberately NOT done —
+/// those are ambiguous against string content and risk corrupting a value.)
+fn strip_trailing_commas(candidate: &str) -> String {
+    let bytes = candidate.as_bytes();
+    // Copy bytes through unchanged and skip ONLY the ASCII `,` we drop — the
+    // comma byte (0x2C) never appears inside a UTF-8 multibyte sequence, so
+    // multibyte string content is preserved byte-for-byte and the result is
+    // always valid UTF-8.
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            out.push(b);
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if b == b'"' {
+            in_string = true;
+            out.push(b);
+        } else if b == b',' && next_nonspace_closes(bytes, i + 1) {
+            // trailing comma before `]`/`}` — drop it
+        } else {
+            out.push(b);
+        }
+    }
+    // SAFETY-EQUIVALENT: only whole ASCII bytes were removed from valid UTF-8.
+    String::from_utf8(out).unwrap_or_else(|_| candidate.to_owned())
+}
+
+/// Is the next non-whitespace byte a closing `]` or `}`? (trailing-comma test)
+/// ASCII-only scan is correct: JSON structural whitespace and the closers are
+/// all ASCII, and multibyte UTF-8 continuation bytes are never `< 0x80`.
+fn next_nonspace_closes(bytes: &[u8], from: usize) -> bool {
+    bytes[from..]
+        .iter()
+        .find(|&&b| !b.is_ascii_whitespace())
+        .is_some_and(|&b| b == b']' || b == b'}')
 }
 
 /// The body of the first code fence (with or without a language tag).
@@ -181,10 +263,34 @@ fn first_fenced_block(text: &str) -> Option<&str> {
     Some(body[..end].trim())
 }
 
-/// The first balanced `{…}` or `[…]` span, string-literal aware.
-fn first_balanced_span(text: &str) -> Option<&str> {
-    let open_idx = text.find(['{', '['])?;
+/// Every balanced `{…}`/`[…]` span, in source order, string-literal aware —
+/// bounded to [`MAX_SPAN_CANDIDATES`] start positions. Trying each span (not
+/// just the first) is what lets a real value survive leading prose that
+/// carries a stray `{`/`[`: the caller parses candidates in order and takes
+/// the first that succeeds.
+fn balanced_spans(text: &str) -> Vec<&str> {
     let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+    let mut search_from = 0;
+    while spans.len() < MAX_SPAN_CANDIDATES {
+        let Some(rel) = text[search_from..].find(['{', '[']) else {
+            break;
+        };
+        let open_idx = search_from + rel;
+        if let Some(end) = balanced_end(bytes, open_idx) {
+            spans.push(&text[open_idx..=end]);
+        }
+        // Advance past this opener (ASCII · a char boundary) to the next
+        // candidate — a span that never closed is skipped, not abandoned.
+        search_from = open_idx + 1;
+    }
+    spans
+}
+
+/// The index of the matching close for the delimiter at `open_idx`, or
+/// `None` if the span never balances. String-literal aware: braces/brackets
+/// inside a `"…"` value never move the depth.
+fn balanced_end(bytes: &[u8], open_idx: usize) -> Option<usize> {
     let open = bytes[open_idx];
     let close = if open == b'{' { b'}' } else { b']' };
     let mut depth = 0usize;
@@ -207,7 +313,7 @@ fn first_balanced_span(text: &str) -> Option<&str> {
             _ if b == close => {
                 depth = depth.saturating_sub(1);
                 if depth == 0 {
-                    return Some(&text[open_idx..=i]);
+                    return Some(i);
                 }
             }
             _ => {}
@@ -434,12 +540,88 @@ mod tests {
 
     #[test]
     fn array_span_must_close_with_a_bracket() {
-        // `[` opens an array span; a stray `}` must not close it.
+        // `[` opens an array span; a stray `}` must not close it. The first
+        // `[` never balances (its only closer is `]`, reached inside a longer
+        // unbalanced run) so it yields no parseable candidate — but the
+        // extractor now advances to the NEXT candidate `[3, 4]` and returns
+        // it (multi-candidate · review lens 4). A stray `}` still never
+        // mis-pairs an array.
         let text = "data [1, 2} oops [3, 4] real";
-        // The first `[` span is `[1, 2} oops [3, 4]` — unparseable. The
-        // extractor deliberately does NOT backtrack to later candidates
-        // (first-plausible-span contract); it returns None rather than
-        // mis-pairing delimiters.
-        assert_eq!(extract_json(text), None);
+        assert_eq!(extract_json(text), Some(serde_json::json!([3, 4])));
+    }
+
+    // ── near-miss repair (PromptPort · local-model robustness) ────────
+
+    #[test]
+    fn trailing_comma_in_object_is_repaired() {
+        // The dominant local-model near-miss: a trailing comma before `}`.
+        let v = extract_and_validate(r#"{"name":"Ada","age":36,}"#, &validator(&person_schema()));
+        match v {
+            Validation::Valid(val) => assert_eq!(val["age"], 36),
+            Validation::Invalid(d) => panic!("expected repair to valid, got: {d}"),
+        }
+    }
+
+    #[test]
+    fn trailing_comma_in_array_and_nested_is_repaired() {
+        let schema = json!({ "type": "array", "items": { "type": "integer" } });
+        assert!(matches!(
+            extract_and_validate("[1, 2, 3, ]", &validator(&schema)),
+            Validation::Valid(_)
+        ));
+        // Nested + whitespace before the closer.
+        assert_eq!(
+            extract_json("{\"a\":[1,2,],\n}"),
+            Some(serde_json::json!({"a":[1,2]}))
+        );
+    }
+
+    #[test]
+    fn a_comma_inside_a_string_is_never_stripped() {
+        // The repair is string-aware: a comma that is real content stays, and
+        // a genuine trailing comma in the SAME value is still dropped.
+        assert_eq!(
+            extract_json(r#"{"s":"a, b","n":2,}"#),
+            Some(serde_json::json!({"s":"a, b","n":2}))
+        );
+    }
+
+    #[test]
+    fn repair_preserves_multibyte_utf8() {
+        // The byte-level comma strip must not corrupt multibyte string
+        // content (café · 🦋) — it copies every non-dropped byte verbatim.
+        assert_eq!(
+            extract_json(r#"{"who":"café 🦋","k":1,}"#),
+            Some(serde_json::json!({"who":"café 🦋","k":1}))
+        );
+    }
+
+    #[test]
+    fn a_valid_value_never_reaches_the_repair() {
+        // Well-formed JSON with a legitimate `,]`-looking sequence INSIDE a
+        // string parses strict on the first try — the repair branch (which
+        // could only see it post-failure) is never consulted.
+        assert_eq!(
+            extract_json(r#"{"note":"ends with ,]"}"#),
+            Some(serde_json::json!({"note":"ends with ,]"}))
+        );
+    }
+
+    #[test]
+    fn a_later_candidate_survives_leading_prose_brackets() {
+        // Leading prose carrying a stray `[maybe]` (not JSON) must not hide
+        // the real object that follows — the multi-candidate scan reaches it.
+        let text = r#"I think [maybe] the answer is {"name":"Ada","age":36}."#;
+        assert!(matches!(
+            extract_and_validate(text, &validator(&person_schema())),
+            Validation::Valid(_)
+        ));
+    }
+
+    #[test]
+    fn a_genuinely_malformed_value_still_fails() {
+        // The repair only strips trailing commas; a missing colon is still a
+        // hard parse failure (no silent acceptance of structural garbage).
+        assert!(extract_json(r#"{"a" 1, "b" 2}"#).is_none());
     }
 }


### PR DESCRIPTION
Deep e2e review of the two core verbs (`infer` · `agent`), grounded in current agentic SOTA (PromptPort near-miss canonicalization 2601.06151 · the "Format Tax" line 2604.03616/2408.02442 · TRAIL loop taxonomy 2505.08638). Three fixes, each proven by test (malformed input rejected before, handled after) + live through the rebuilt binary.

## infer — extractor (`structured.rs`)
- **Multi-candidate spans**: `first_balanced_span` tried only the *first* `{`/`[` → leading prose with a stray bracket hid the real value. Now every balanced span is tried in order, bounded 16 starts → O(16·n) not O(n²) on a 1 MB tool result.
- **Trailing-comma repair**: local/open-weight models emit `,]`/`,}` that serde rejects strict, burning a paid retry. String-literal-aware **byte-level** strip (multibyte preserved), runs *only* post-strict-fail, reparsed strict. Smart-quote repair deliberately omitted (ambiguous vs string content).

## infer — truncation un-masked (`lib.rs`)
A `stop_reason: MaxTokens`/content-filtered structured reply reported as a bare schema mismatch → terminal error now names the real cause. Retries still run first (verbose truncation is fixable by the "reply with ONLY the value" instruction).

## agent — guard reaches longer cycles (`guard.rs`, `config.rs`)
Window was `stall_after·5` → a byte-identical period-6+ cycle nudged once then ran to `max_turns`. Named `MAX_TRACKED_PERIOD=8`, floored window at `stall_after·8` (25→40); period-8 cycle now reaches NIKA-467. Proptest widened to period 8.

**10 new tests · infer 82 + agent 51 green · clippy -D warnings clean · zero unwrap.**

**Deliberately NOT here** (flagged): retry-token cost undercount (touches billing semantics the pricing arc is actively shipping — not raced); "never mention JSON" wording (behavior-shifting, wants its own pass · the real SOTA fix is grammar-constrained decoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)