### PR TITLE
feat(nika-cli): doctor --json — the diagnosis speaks machine (Q7)

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -471,7 +471,7 @@ pub fn nika_cli::verbs::check::run_infer_permits(path: &str, json: bool) -> nika
 pub mod nika_cli::verbs::dap
 pub fn nika_cli::verbs::dap::run_stdio() -> u8
 pub mod nika_cli::verbs::doctor
-pub fn nika_cli::verbs::doctor::run(ping: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::doctor::run(ping: bool, json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::exit
 pub const nika_cli::verbs::exit::ENV: u8
 pub const nika_cli::verbs::exit::FILE: u8

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -163,6 +163,10 @@ enum Command {
         /// 300ms cap · nothing is sent on the socket). Offline without it.
         #[arg(long)]
         ping: bool,
+        /// Emit the findings as JSON (summary + findings[] · agents/CI
+        /// branch on `summary.fail` instead of parsing glyphs).
+        #[arg(long)]
+        json: bool,
     },
     /// Scaffold a repo (`.vscode` schema wiring · `AGENTS.md` · Cursor rule ·
     /// `.agents/skills` authoring skill). Existing files are skipped —
@@ -541,7 +545,7 @@ fn main() -> std::process::ExitCode {
             emit(&verbs::graph::run(&file, format))
         }
         Command::Explain { code } => emit(&verbs::explain::run(&code)),
-        Command::Doctor { ping } => emit(&verbs::doctor::run(ping)),
+        Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json)),
         Command::Init { dir, force } => emit(&verbs::init::run(&dir, force)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target.into(), &dir)),
         Command::Spec { canon } => emit(&verbs::pack_surface::spec(canon)),

--- a/crates/nika-cli/src/verbs/doctor.rs
+++ b/crates/nika-cli/src/verbs/doctor.rs
@@ -30,7 +30,8 @@ use serde_json::Value;
 use crate::verbs::{VerbOutput, exit};
 
 /// Severity of one diagnosis line.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum Level {
     /// `✔` healthy.
     Ok,
@@ -61,7 +62,7 @@ pub(crate) enum PingState {
 }
 
 /// One diagnosis line · a problem carries the exact PRINTED fix (never run).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub(crate) struct Finding {
     pub level: Level,
     pub label: String,
@@ -336,6 +337,21 @@ pub(crate) fn exit_code(findings: &[Finding]) -> u8 {
 /// padded · detail · an indented `fix:` line under a problem) — opened by the
 /// ONE verdict line (`✔ 6 ok · 4 warn · 0 fail`) so the state of the
 /// environment reads before the sections do. Sections stay unchanged.
+/// The machine lane (Q7): findings verbatim + a computed summary —
+/// agents/CI branch on `summary.fail` instead of parsing glyphs.
+pub(crate) fn render_json(findings: &[Finding]) -> String {
+    let count = |lvl: Level| findings.iter().filter(|f| f.level == lvl).count();
+    let payload = serde_json::json!({
+        "summary": {
+            "ok": count(Level::Ok),
+            "warn": count(Level::Warn),
+            "fail": count(Level::Fail),
+        },
+        "findings": findings,
+    });
+    format!("{payload:#}")
+}
+
 pub(crate) fn render(findings: &[Finding]) -> String {
     let mut s = String::new();
     let count = |level: Level| findings.iter().filter(|f| f.level == level).count();
@@ -505,7 +521,7 @@ fn collect_local_pings(
 /// Build the real probe from the environment (PRESENCE-only key checks · the
 /// value is never bound) + the canonical provider catalog, then diagnose.
 #[must_use]
-pub fn run(ping: bool) -> VerbOutput {
+pub fn run(ping: bool, json: bool) -> VerbOutput {
     let registry = ProviderRegistry::without_http(ProvidersConfig::new());
     let providers = registry
         .profiles()
@@ -570,7 +586,11 @@ pub fn run(ping: bool) -> VerbOutput {
     let findings = diagnose(&probe);
     let code = exit_code(&findings);
     VerbOutput {
-        text: render(&findings),
+        text: if json {
+            render_json(&findings)
+        } else {
+            render(&findings)
+        },
         code,
     }
 }
@@ -836,6 +856,30 @@ mod tests {
         assert_eq!(exit_code(&f), exit::OK, "a local path is usable");
     }
 
+    #[test]
+    fn json_lane_carries_summary_and_findings_verbatim() {
+        let findings = vec![
+            Finding {
+                level: Level::Ok,
+                label: "binary".to_owned(),
+                detail: "v0.96.0".to_owned(),
+                fix: None,
+            },
+            Finding {
+                level: Level::Fail,
+                label: "config".to_owned(),
+                detail: "broken".to_owned(),
+                fix: Some("nika wire claude".to_owned()),
+            },
+        ];
+        let json: serde_json::Value =
+            serde_json::from_str(&render_json(&findings)).expect("valid JSON");
+        assert_eq!(json["summary"]["ok"], 1);
+        assert_eq!(json["summary"]["fail"], 1);
+        assert_eq!(json["findings"][0]["level"], "ok");
+        assert_eq!(json["findings"][1]["fix"], "nika wire claude");
+    }
+
     /// Each severity prints a DISTINCT glyph — a `Default::default()` mutant
     /// (the null char `'\0'`) would erase the level cue the operator scans for.
     #[test]
@@ -901,7 +945,7 @@ mod tests {
         // The wired run() over the canonical catalog: local providers exist, so
         // there is never a hard Fail (exit 0) even with no keys in the test env.
         // ping=false — the default run stays fully offline, in tests too.
-        let out = run(false);
+        let out = run(false, false);
         assert_eq!(out.code, exit::OK, "the catalog always offers a path");
         assert!(out.text.contains("binary"), "renders the binary line");
         // The LLM test backend stays hidden (no `mock — key` provider row);

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.94.0"
+version = "0.96.0"
 dependencies = [
  "nika-types",
  "serde",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.94.0"
+version = "0.96.0"
 dependencies = [
  "miette",
  "nika-catalog-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.94.0"
+version = "0.96.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.94.0"
+version = "0.96.0"
 dependencies = [
  "miette",
  "nika-types",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-schema"
-version = "0.94.0"
+version = "0.96.0"
 dependencies = [
  "jaq-core",
  "jaq-json",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.94.0"
+version = "0.96.0"
 dependencies = [
  "loom",
  "serde",


### PR DESCRIPTION
## Q7 of the socratic ledger

doctor's findings were already a typed model (`Level` · `Finding` · the pure `diagnose()`); only the machine lane was missing:

```json
{
  "summary": { "ok": 11, "warn": 10, "fail": 0 },
  "findings": [
    { "level": "ok", "label": "binary", "detail": "v0.96.0 · self-contained…", "fix": null },
    { "level": "warn", "label": "agent", "detail": "windsurf not wired", "fix": "nika wire windsurf" }
  ]
}
```

Agents and CI branch on `summary.fail` instead of parsing glyphs; every problem carries its exact `fix` string untouched (the same PRINTED-never-run contract as the human lane). Exit codes unchanged (0 healthy · 3 any fail).

## Proof

Pinned (summary counts · lowercase levels · fix verbatim) · e2e at the binary (21 findings · 10 fixes carried) · nika-cli lib 236 ✓ · clippy ✓ · 8/8 ratchets ✓ · the `run(ping, json)` signature change rides the baseline in-commit (0.96 unreleased line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)