### PR TITLE
feat(nika-cli): the plan names WHAT dispatches WHEN — check IS the dry-run

### DIFF
--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -14,7 +14,7 @@ use std::fmt::Write as _;
 
 use nika_schema::check::{CheckReport, UnboundedReason};
 use nika_schema::infer_permits;
-use nika_schema::raw::RawWorkflow;
+use nika_schema::raw::{RawAction, RawWorkflow};
 use nika_schema::types::VarDecl;
 
 use crate::display::theme::{Role, Theme};
@@ -117,7 +117,7 @@ fn render(report: &CheckReport, wf: &RawWorkflow, source: &str, path: &str, t: T
         }
     }
 
-    plan(&mut out, report, t);
+    plan(&mut out, report, wf, t);
     cost(&mut out, report, t);
 
     section_list(&mut out, t, "SECRETS", "no information-flow escapes", {
@@ -325,7 +325,7 @@ fn section_list(out: &mut String, t: Theme, label: &str, ok_msg: &str, rows: Vec
     }
 }
 
-fn plan(out: &mut String, report: &CheckReport, t: Theme) {
+fn plan(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
     if report.waves.is_empty() {
         if !report.conformance.is_empty() {
             let _ = writeln!(
@@ -372,6 +372,62 @@ fn plan(out: &mut String, report: &CheckReport, t: Theme) {
         t.paint(Role::Strong, "PLAN"),
         report.waves.len(),
     );
+    // The membership — WHAT dispatches WHEN (the dry-run answer: check
+    // is the dry-run; this line is what `run` will do, wave by wave).
+    // Compact workflows only: past 12 tasks the summary line carries it.
+    if tasks <= 12 {
+        for (i, wave) in report.waves.iter().enumerate() {
+            let members: Vec<String> = wave
+                .iter()
+                .filter_map(|&ix| wf.tasks.get(ix))
+                .map(|task| {
+                    let (verb, target) = verb_of(&task.value.action, wf);
+                    match target {
+                        Some(target) => format!("{} ({verb} · {target})", task.value.id.value),
+                        None => format!("{} ({verb})", task.value.id.value),
+                    }
+                })
+                .collect();
+            let _ = writeln!(
+                out,
+                "      {} {}",
+                t.paint(Role::Dim, &format!("wave {}", i + 1)),
+                members.join(" · ")
+            );
+        }
+    }
+}
+
+/// A task's verb + dispatch target (model · tool · `argv[0]`) for the plan.
+fn verb_of<'w>(action: &'w RawAction, wf: &'w RawWorkflow) -> (&'static str, Option<String>) {
+    match action {
+        RawAction::Infer(a) => (
+            "infer",
+            a.model
+                .as_ref()
+                .map(|m| m.value.clone())
+                .or_else(|| wf.model.as_ref().map(|m| m.value.clone())),
+        ),
+        RawAction::Agent(a) => (
+            "agent",
+            a.model
+                .as_ref()
+                .map(|m| m.value.clone())
+                .or_else(|| wf.model.as_ref().map(|m| m.value.clone())),
+        ),
+        RawAction::Exec(a) => (
+            "exec",
+            match &a.command {
+                nika_schema::raw::RawCommand::Shell(_) => Some("sh -c".to_owned()),
+                nika_schema::raw::RawCommand::Argv(argv) => argv.first().map(|w| w.value.clone()),
+                // #[non_exhaustive] — a future command form names itself.
+                _ => None,
+            },
+        ),
+        RawAction::Invoke(a) => ("invoke", Some(a.tool.value.clone())),
+        // #[non_exhaustive] — a future verb must not break this build.
+        _ => ("task", None),
+    }
 }
 
 fn cost(out: &mut String, report: &CheckReport, t: Theme) {
@@ -660,6 +716,24 @@ mod tests {
     /// When conformance FAILS there is no valid DAG, so PLAN announces the skip
     /// (gated on `!conformance.is_empty()`) — a deleted `!` would suppress the
     /// line and leave the operator wondering where the plan went.
+    #[test]
+    fn plan_prints_wave_membership_with_verbs_and_targets() {
+        let text = checked_text(
+            "plan-membership.nika.yaml",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-5\ntasks:\n  - id: think\n    infer: { prompt: hi }\n  - id: after\n    depends_on: [think]\n    exec:\n      command: [\"echo\", \"x\"]\n",
+            true,
+        );
+        assert!(text.contains("wave 1"), "membership renders: {text}");
+        assert!(
+            text.contains("think (infer · anthropic/claude-sonnet-5)"),
+            "the envelope model resolves into the plan line: {text}"
+        );
+        assert!(
+            text.contains("after (exec · echo)"),
+            "argv[0] names the exec: {text}"
+        );
+    }
+
     #[test]
     fn plan_announces_the_skip_when_conformance_fails() {
         let text = checked_text(


### PR DESCRIPTION
## Q2/Q9 of the socratic ledger, resolved by premise-check

The ledger asked for `nika run --dry`; the premise check found **check already IS the dry-run** — plan, cost floor with UNBOUNDED named per task, secrets, permits, hints. A separate dry verb would have duplicated the whole audit. The one honest delta was wave **membership**, and the PLAN section now carries it:

```
 ✔ PLAN     2 wave(s) · 3 task(s) · max parallelism 2
      wave 1 think (infer · anthropic/claude-sonnet-5) · fetchit (invoke · nika:fetch)
      wave 2 after (exec · echo)
```

Verbs name their dispatch target (model — envelope-resolved · tool · argv[0] · `sh -c`). Compact workflows only (≤12 tasks). Wildcard arms on the `#[non_exhaustive]` enums.

## Proof

Pinned through the suite's own `checked_text` harness · e2e at the binary · nika-cli lib 238 ✓ · clippy ✓ · doc-private-items ✓ (the `argv[0]` doc-link false-positive backticked) · 8/8 ratchets ✓ · no public-api change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)