### PR TITLE
fix(nika-cli): the drift warn tells a re-encode from an edit

### DIFF
--- a/crates/nika-cli/src/verbs/dap/replay.rs
+++ b/crates/nika-cli/src/verbs/dap/replay.rs
@@ -96,13 +96,27 @@ impl ReplaySession {
         Ok(session)
     }
 
-    /// The #210 identity check against the CURRENT source bytes.
+    /// The #210 identity check against the CURRENT source bytes — in
+    /// content terms, not byte terms: an editor re-encoding CRLF↔LF (or
+    /// adding a BOM) cannot move a breakpoint line, and the 0.96.0
+    /// review proved the raw compare cried wolf on exactly that. Raw
+    /// match first; then LF normal forms (against the recorded raw for
+    /// LF-recorded files, against `workflow_sha256_lf` for
+    /// CRLF-recorded ones). Only a CONTENT change survives all three.
     fn drift_of(yaml: &str, events: &[nika_event::Event]) -> Option<bool> {
-        let recorded = events
+        let started = events
             .iter()
-            .find(|e| e.kind == EventKind::WorkflowStarted)
-            .and_then(|e| field_str(e, "workflow_sha256"))?;
-        Some(super::super::run::sha256_hex(yaml.as_bytes()) != recorded)
+            .find(|e| e.kind == EventKind::WorkflowStarted)?;
+        let recorded = field_str(started, "workflow_sha256")?;
+        if super::super::run::sha256_hex(yaml.as_bytes()) == recorded {
+            return Some(false);
+        }
+        let lf_sha =
+            super::super::run::sha256_hex(super::super::run::lf_normal_form(yaml).as_bytes());
+        if lf_sha == recorded || field_str(started, "workflow_sha256_lf") == Some(lf_sha.as_str()) {
+            return Some(false);
+        }
+        Some(true)
     }
 
     /// The testable core: source text + folded events.
@@ -244,13 +258,19 @@ impl ReplaySession {
     }
 
     /// Variables at the cursor: every settle up to and including it —
-    /// the output when recorded, else the terminal kind.
-    pub(crate) fn variables(&self) -> Vec<(String, String)> {
+    /// the output when recorded, else the terminal kind. Recorded
+    /// outputs are BORROWED: the per-call clone of the whole settled
+    /// prefix was the deep-cursor latency cliff on very long runs
+    /// (the 0.96.0 review's fan-out finding).
+    pub(crate) fn variables(&self) -> Vec<(&str, std::borrow::Cow<'_, str>)> {
         self.stops[..=self.cursor.min(self.stops.len() - 1)]
             .iter()
             .map(|s| {
-                let value = s.output.clone().unwrap_or_else(|| format!("({})", s.kind));
-                (s.task.clone(), value)
+                let value = s.output.as_deref().map_or_else(
+                    || std::borrow::Cow::Owned(format!("({})", s.kind)),
+                    std::borrow::Cow::Borrowed,
+                );
+                (s.task.as_str(), value)
             })
             .collect()
     }
@@ -333,7 +353,8 @@ mod tests {
         assert_eq!(s.current().task, "beta");
         // alpha's recorded output + beta's kind (no output recorded).
         let vars = s.variables();
-        assert_eq!(vars[0], ("alpha".to_owned(), "\"a\"".to_owned()));
+        assert_eq!(vars[0].0, "alpha");
+        assert_eq!(vars[0].1, "\"a\"");
         assert_eq!(vars[1].1, "(completed)");
 
         assert!(s.step());
@@ -395,6 +416,39 @@ mod tests {
         };
         assert_eq!(make(&sha).drifted, Some(false));
         assert_eq!(make(&"ab".repeat(32)).drifted, Some(true));
+    }
+
+    #[test]
+    fn a_reencode_is_not_drift_but_an_edit_is() {
+        // The four quadrants of the encoding rule. Raw shas differ in
+        // the two re-encode cases; the LF normal forms agree — only a
+        // content change may say drifted.
+        let crlf = YAML.replace('\n', "\r\n");
+        let raw = |text: &str| super::super::super::run::sha256_hex(text.as_bytes());
+        let started = |fields: &[(&str, &str)]| vec![ev(1, EventKind::WorkflowStarted, fields)];
+
+        // LF-recorded · current CRLF → the LF form matches the recorded raw.
+        let rec_lf = started(&[("workflow_sha256", &raw(YAML))]);
+        assert_eq!(ReplaySession::drift_of(&crlf, &rec_lf), Some(false));
+
+        // CRLF-recorded (journal carries the _lf sibling) · current LF.
+        let rec_crlf = started(&[
+            ("workflow_sha256", &raw(&crlf)),
+            ("workflow_sha256_lf", &raw(YAML)),
+        ]);
+        assert_eq!(ReplaySession::drift_of(YAML, &rec_crlf), Some(false));
+
+        // BOM added by an editor → not an edit either.
+        let bom = format!("\u{feff}{YAML}");
+        assert_eq!(ReplaySession::drift_of(&bom, &rec_lf), Some(false));
+
+        // A real content edit still drifts, whatever the encoding.
+        let edited = YAML.replace("alpha", "omega");
+        assert_eq!(ReplaySession::drift_of(&edited, &rec_lf), Some(true));
+        assert_eq!(
+            ReplaySession::drift_of(&edited.replace('\n', "\r\n"), &rec_crlf),
+            Some(true)
+        );
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -24,6 +24,7 @@
 mod compose;
 mod resume;
 mod sink;
+mod source_id;
 mod stamp;
 
 pub use compose::{
@@ -36,6 +37,7 @@ pub use stamp::SystemStamper;
 
 mod scope;
 use scope::scope_to_task;
+pub(crate) use source_id::{lf_normal_form, sha256_hex};
 
 use sink::{TRACE_DIR, Tee, TraceFileSink};
 
@@ -469,20 +471,6 @@ fn parse_var_overrides(
 // The 7 knobs ARE the composition surface (var overrides · resume plan ·
 // answers · pause flag) — the same clap-surface idiom as `run` itself.
 #[allow(clippy::too_many_arguments)]
-/// The run's source identity: sha256 hex over the exact bytes read.
-pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
-    use sha2::{Digest as _, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    let digest = hasher.finalize();
-    let mut hex = String::with_capacity(64);
-    for byte in digest {
-        use std::fmt::Write as _;
-        let _ = write!(hex, "{byte:02x}");
-    }
-    hex
-}
-
 fn composed_runtime(
     wf: &RawWorkflow,
     source: &str,
@@ -505,6 +493,16 @@ fn composed_runtime(
                 // The run's identity: the journal names the definition it
                 // recorded (sha256 of the exact bytes this composer read).
                 .with_source_sha256(sha256_hex(source.as_bytes()));
+            // A CRLF/BOM source ALSO records its LF normal form, so drift
+            // checks can tell a re-encode from an edit. LF sources skip
+            // the field (the forms coincide — the journal stays lean).
+            let raw_sha = sha256_hex(source.as_bytes());
+            let lf_sha = sha256_hex(lf_normal_form(source).as_bytes());
+            let rt = if lf_sha == raw_sha {
+                rt
+            } else {
+                rt.with_source_sha256_lf(lf_sha)
+            };
             Ok(match resume_plan {
                 Some(plan) => rt.with_resume_plan(plan),
                 None => rt,

--- a/crates/nika-cli/src/verbs/run/source_id.rs
+++ b/crates/nika-cli/src/verbs/run/source_id.rs
@@ -1,0 +1,54 @@
+// source_id.rs — the run's SOURCE identity seam.
+//
+// A journal names the definition it recorded: `workflow_sha256` hashes
+// the exact bytes the composer read, and CRLF/BOM sources additionally
+// record `workflow_sha256_lf` (the LF normal form) so drift checks can
+// tell an editor re-encode from a content edit. Hash + normal form
+// live together here; the stamping happens in the composer (mod.rs)
+// and the comparison in dap replay.
+
+/// The run's source identity: sha256 hex over the exact bytes read.
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// LF normal form of a workflow source: UTF-8 BOM stripped, CRLF → LF.
+/// The SAME content re-encoded by an editor hashes identically here —
+/// a re-encode is not an edit (the 0.96.0 dap review proved the raw
+/// byte-compare cried drift on CRLF-only churn).
+pub(crate) fn lf_normal_form(source: &str) -> std::borrow::Cow<'_, str> {
+    let stripped = source.strip_prefix('\u{feff}').unwrap_or(source);
+    if stripped.contains("\r\n") {
+        std::borrow::Cow::Owned(stripped.replace("\r\n", "\n"))
+    } else {
+        std::borrow::Cow::Borrowed(stripped)
+    }
+}
+
+#[cfg(test)]
+mod lf_normal_form_tests {
+    use super::lf_normal_form;
+
+    #[test]
+    fn strips_bom_and_crlf_only() {
+        assert_eq!(lf_normal_form("a\r\nb\r\n"), "a\nb\n");
+        assert_eq!(lf_normal_form("\u{feff}a\nb"), "a\nb");
+        // Untouched LF content BORROWS (no allocation on the common path).
+        assert!(matches!(
+            lf_normal_form("a\nb"),
+            std::borrow::Cow::Borrowed("a\nb")
+        ));
+        // A lone \r is CONTENT (old-Mac endings are extinct; do not
+        // normalize what an editor would not produce today).
+        assert_eq!(lf_normal_form("a\rb"), "a\rb");
+    }
+}

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -287,6 +287,7 @@ pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_prompt_pause(self, pause: b
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_resume_plan(self, plan: nika_runtime::resume::ResumePlan) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_secret_resolver(self, resolver: alloc::sync::Arc<dyn nika_runtime::WorkflowSecretResolver>) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_source_sha256(self, hex: alloc::string::String) -> Self
+pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_source_sha256_lf(self, hex: alloc::string::String) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_var_overrides(self, overrides: alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>) -> Self
 impl<D> owo_colors::OwoColorize for nika_runtime::Runtime<S, T, H, P, D, C>
 impl<T, U> core::convert::Into<U> for nika_runtime::Runtime<S, T, H, P, D, C> where U: core::convert::From<T>

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -191,6 +191,10 @@ pub struct Runtime<S, T, H, P, D, C> {
     /// fork surfaces can prove « the file changed since this run »
     /// instead of guessing. `None` (embedded/test callers) = no claim.
     source_sha256: Option<String>,
+    /// The LF normal form's sha256 — present only when the source bytes
+    /// were CRLF/BOM-encoded (the two hashes differ). Lets drift checks
+    /// tell a re-encode from an edit.
+    source_sha256_lf: Option<String>,
 }
 
 impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
@@ -220,6 +224,7 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
             pause_on_prompt: false,
             prompt_answers: BTreeMap::new(),
             source_sha256: None,
+            source_sha256_lf: None,
         }
     }
 
@@ -277,6 +282,15 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
         self
     }
 
+    /// Stamp the LF-normal-form sibling (`workflow_sha256_lf`) — only
+    /// meaningful when it differs from the raw sha (CRLF/BOM sources);
+    /// the composer owns that comparison, the runtime never re-reads.
+    #[must_use]
+    pub fn with_source_sha256_lf(mut self, hex: String) -> Self {
+        self.source_sha256_lf = Some(hex);
+        self
+    }
+
     /// Supply prompt answers (`--answer task=value` · ADR-099 rider):
     /// bound as the named task's prompt `default:` at dispatch — the
     /// answered branch of the stdlib contract, type-validated per mode
@@ -319,6 +333,7 @@ fn emit_prologue(
     wf: &RawWorkflow,
     workflow_name: &str,
     source_sha256: Option<&str>,
+    source_sha256_lf: Option<&str>,
     stamper: &mut dyn Stamper,
     sink: &mut dyn EventSink,
 ) {
@@ -338,6 +353,9 @@ fn emit_prologue(
     let mut opening = vec![("workflow", s(workflow_name)), ("permits", s(permits_desc))];
     if let Some(hex) = source_sha256 {
         opening.push(("workflow_sha256", s(hex)));
+    }
+    if let Some(hex) = source_sha256_lf {
+        opening.push(("workflow_sha256_lf", s(hex)));
     }
     // Environment attestation (Q11): reproducing a failure needs to know
     // WHICH engine on WHICH platform wrote the journal. Compile-time
@@ -434,6 +452,7 @@ where
             wf,
             &workflow_name,
             self.source_sha256.as_deref(),
+            self.source_sha256_lf.as_deref(),
             stamper,
             sink,
         );


### PR DESCRIPTION
The 0.96.0 adversarial review's remaining dap finding (the design-call follow-up named in #242): the #210 identity check was a **raw byte compare**, so an editor re-encoding CRLF↔LF or adding a BOM — churn that cannot move a single breakpoint line — tripped « workflow changed since this run was recorded ». A trust signal that cries wolf erodes the trust it exists to carry.

**Content terms now, not byte terms:**

- Runs on CRLF/BOM sources additionally record **`workflow_sha256_lf`** (the LF normal form's hash · additive field). LF sources skip it — the forms coincide, the journal stays lean.
- dap drift checks the **four encoding quadrants**: raw match · LF form vs recorded raw (LF-recorded, saved as CRLF) · LF form vs the recorded sibling (CRLF-recorded, saved as LF). Only a CONTENT change survives all three compares.
- A lone `\r` stays content — old-Mac endings are extinct; we don't normalize what no editor produces today.

**Rider 1:** `variables()` borrows recorded outputs (`Cow`) — the per-call clone of the whole settled prefix was the review's deep-cursor latency cliff on very long runs. That closes the review's last open finding.

**Rider 2:** `run/mod.rs` was at 1536 LOC (≥1500 cap — it was ~1490 before this branch; anyone's next touch would have blown it). The source-identity seam (`sha256_hex` + `lf_normal_form` + pins) now lives in `run/source_id.rs`, mod.rs back to 1495.

**Proven at the binary:** CRLF run → journal carries `_lf` · re-encode LF → dap **SILENT** · content edit → **DRIFT-WARN** · byte-identical → SILENT.

Pins: the four quadrants · `lf_normal_form` (BOM / CRLF / borrow-on-LF / lone-`\r`) · nika-cli lib 240/240 · runtime 99/99 · clippy -D warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)