### PR TITLE
chore(release): v0.97.0 — the run becomes evidence

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,6 +129,24 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
+| branch           | `release/0.97.0`                                      |
+| HEAD             | `54838424f` (`54838424f7e256b86501af51550007a7968f2fc0`)             |
+| workspace        | v0.97.0                                  |
+| crates (workspace)| 40                                              |
+| crates (admitted)| 40 / 42                                   |
+| crates (WIP)     | 0 —                                   |
+| L0               | 9                                              |
+| L0.5             | 6                                              |
+| L1               | 12                                              |
+| L1.5             | 4                                              |
+| L2               | 4                                              |
+| L3               | 1                                              |
+| L4               | 4                                              |
+| lib tests        | 3411 passed, 0 failed                              |
+| clippy           | 0 warnings                              |
+
+| field            | value                                          |
+|------------------|------------------------------------------------|
 | branch           | `chore/release-0.96.0`                                      |
 | HEAD             | `05cdaab1e` (`05cdaab1ec68217f3a7fb03841dbe5f7720767d4`)             |
 | workspace        | v0.96.0                                  |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ Nika Diamond is a ground-up rewrite on the `nika-diamond` orphan branch.
 Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ---
+## [0.97.0](https://github.com/supernovae-st/nika/compare/v0.96.0..v0.97.0) - 2026-07-07
+
+**The run becomes evidence.** 0.96 made the run a place you can visit;
+0.97 makes it a record you can trust — and prices it before you pay.
+
+### ✨ Features
+
+- **The journal is tamper-evident** — every line carries a hash chain;
+  `nika trace verify` walks it and names the first broken link ([PR 237](https://github.com/supernovae-st/nika/pull/237)).
+  Export and replay check the chain BEFORE trusting the data ([PR 238](https://github.com/supernovae-st/nika/pull/238)).
+- **`nika trace reproduce`** — is this run reproducible, and WHY not:
+  the verdict names every non-deterministic ingredient ([PR 241](https://github.com/supernovae-st/nika/pull/241)).
+- **The journal attests its engine** — `engine_version` + platform ride
+  `workflow_started`: a failure report says WHICH binary WHERE ([PR 235](https://github.com/supernovae-st/nika/pull/235)).
+- **Models are priced before the first run** — the vendored catalog
+  refreshed from models.dev (62 rules → 602 · [PR 233](https://github.com/supernovae-st/nika/pull/233)) and `check --json`
+  carries per-model rates ([PR 236](https://github.com/supernovae-st/nika/pull/236)): the editor preflight (nika-vscode
+  0.97.3) shows `$in/$out per 1M` with zero spend — it lights up on this tag.
+- **`check` IS the dry-run** — the plan names WHAT dispatches WHEN:
+  waves, gates, blast radius, before anything runs ([PR 245](https://github.com/supernovae-st/nika/pull/245)).
+- **`doctor --json`** — the diagnosis speaks machine ([PR 244](https://github.com/supernovae-st/nika/pull/244)).
+- **Guided onboarding** — bare `nika init`/`nika new` converse on a
+  terminal instead of demanding flags ([PR 253](https://github.com/supernovae-st/nika/pull/253)).
+- **Envelope-model did-you-mean resolves like any surface** — deep/019 ([PR 239](https://github.com/supernovae-st/nika/pull/239)).
+
+### 🐛 Bug Fixes
+
+- **The trust surface stops lying at its edges** — the rust-pro batch
+  hardens verify/export/replay edge cases ([PR 248](https://github.com/supernovae-st/nika/pull/248)),
+  and the chain writer earns its anchor — the writer-side review
+  batch ([PR 252](https://github.com/supernovae-st/nika/pull/252)).
+- **infer bills every round-trip, not just the last** — multi-cycle
+  runs report their true cost ([PR 250](https://github.com/supernovae-st/nika/pull/250)).
+- **The drift warn tells a re-encode from an edit** — CRLF/BOM sources
+  record `workflow_sha256_lf` (the LF normal form); dap replay compares
+  content, not bytes — an editor re-encode no longer cries
+  « workflow changed » ([PR 247](https://github.com/supernovae-st/nika/pull/247)).
+- **dap launch gets the file-side bounds** — 64 MiB cap, regular files
+  only (a device/FIFO hung the adapter), and a torn-tail journal says
+  « valid prefix only » instead of replaying silently ([PR 242](https://github.com/supernovae-st/nika/pull/242)).
+- **infer repairs near-miss JSON** and reaches longer stall cycles ([PR 243](https://github.com/supernovae-st/nika/pull/243)).
+- **Strict `json_schema` claims travel only where earned** ([PR 246](https://github.com/supernovae-st/nika/pull/246)).
+
+### 📦 Pack
+
+- Vendored spec pack synced to nika-spec main — `nika:edit count:` is a
+  strict non-negative integer: the string `"2"` is a loud arg error,
+  never a silent replace-all (spec [PR 26](https://github.com/supernovae-st/nika-spec/pull/26)).
+
 ## [0.96.0](https://github.com/supernovae-st/nika/compare/v0.95.0..v0.96.0) - 2026-07-06
 
 ### ✨ Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "clap",
  "futures",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cli"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "annotate-snippets 0.12.15",
  "anstyle",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "expect-test",
  "insta",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "insta",
  "miette",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-kernel",
  "nix",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "globset",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "nika-http"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "insta",
  "miette",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-builtin",
  "nika-catalog",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "include_dir",
  "sha2",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3994,14 +3994,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "loom",
  "proptest",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4071,7 +4071,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.96.0"
+version      = "0.97.0"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,6 +86,24 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
+| branch           | `release/0.97.0`                                      |
+| HEAD             | `54838424f` (`54838424f7e256b86501af51550007a7968f2fc0`)             |
+| workspace        | v0.97.0                                  |
+| crates (workspace)| 40                                              |
+| crates (admitted)| 40 / 42                                   |
+| crates (WIP)     | 0 —                                   |
+| L0               | 9                                              |
+| L0.5             | 6                                              |
+| L1               | 12                                              |
+| L1.5             | 4                                              |
+| L2               | 4                                              |
+| L3               | 1                                              |
+| L4               | 4                                              |
+| lib tests        | 3411 passed, 0 failed                              |
+| clippy           | 0 warnings                              |
+
+| field            | value                                          |
+|------------------|------------------------------------------------|
 | branch           | `chore/release-0.96.0`                                      |
 | HEAD             | `05cdaab1e` (`05cdaab1ec68217f3a7fb03841dbe5f7720767d4`)             |
 | workspace        | v0.96.0                                  |

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.96.0", optional = true }
-nika-error     = { path = "../nika-error", version = "0.96.0", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.96.0", optional = true }
+nika-types     = { path = "../nika-types", version = "0.97.0", optional = true }
+nika-error     = { path = "../nika-error", version = "0.97.0", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.97.0", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.96.0" }
+nika-types  = { path = "../nika-types", version = "0.97.0" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.96.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.97.0" }  # nika:fetch — the 8 extract modes (L1.5→L1.5 same-layer)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
 jaq-std       = { workspace = true }
@@ -40,15 +40,15 @@ tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval o
 # required) — the SAME vocabulary the in-test drift guards pin to the
 # ToolDef schemas (one source, no drift). Minimal features: the builtin
 # catalog only, no provider/pricing data. L1.5→L0 downward (layering-clean).
-nika-catalog  = { path = "../nika-catalog", version = "0.96.0", default-features = false, features = ["builtins-transforms"] }
+nika-catalog  = { path = "../nika-catalog", version = "0.97.0", default-features = false, features = ["builtins-transforms"] }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.96.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.96.0" }
+nika-fs          = { path = "../nika-fs", version = "0.97.0" }
 # test-only: an INDEPENDENT PNG decoder proving the mock image provider's
 # hand-rolled stored-deflate encoder emits spec-valid files (not just bytes
 # our own sniffer accepts).

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.96.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.97.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.96.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.97.0" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.96.0" }
+nika-error = { path = "../nika-error", version = "0.97.0" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.96.0" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.97.0" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.96.0" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.96.0" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.96.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.96.0" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.96.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
-nika-bm25   = { path = "../nika-bm25", version = "0.96.0" }   # intent→template routing (`nika new` · the deterministic floor)
+nika-event  = { path = "../nika-event", version = "0.97.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.97.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.97.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.97.0" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.97.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-bm25   = { path = "../nika-bm25", version = "0.97.0" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 sha2          = { workspace = true }   # run identity — workflow_sha256 on workflow_started
@@ -30,21 +30,21 @@ anstyle     = { workspace = true }                             # Role→Style ma
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.96.0" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.96.0" }       # the L3 executor (the composer drives it)
-nika-providers   = { path = "../nika-providers", version = "0.96.0" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.96.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.96.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.96.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.96.0" }
-nika-builtin     = { path = "../nika-builtin", version = "0.96.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.96.0" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.96.0" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.96.0" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.96.0" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.96.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
-nika-lsp         = { path = "../nika-lsp", version = "0.96.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-mcp         = { path = "../nika-mcp", version = "0.96.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-kernel      = { path = "../nika-kernel", version = "0.97.0" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.97.0" }       # the L3 executor (the composer drives it)
+nika-providers   = { path = "../nika-providers", version = "0.97.0" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.97.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.97.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.97.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.97.0" }
+nika-builtin     = { path = "../nika-builtin", version = "0.97.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.97.0" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.97.0" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.97.0" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.97.0" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.97.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
+nika-lsp         = { path = "../nika-lsp", version = "0.97.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-mcp         = { path = "../nika-mcp", version = "0.97.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [[bin]]
@@ -55,7 +55,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.96.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.96.0" }
+nika-types = { path = "../nika-types", version = "0.97.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.96.0" }
-nika-error = { path = "../nika-error", version = "0.96.0" }
+nika-types = { path = "../nika-types", version = "0.97.0" }
+nika-error = { path = "../nika-error", version = "0.97.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.96.0" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.97.0" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.96.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.97.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.96.0" }
-nika-types   = { path = "../nika-types", version = "0.96.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.97.0" }
+nika-types   = { path = "../nika-types", version = "0.97.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.96.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.96.0" }
+nika-error       = { path = "../nika-error", version = "0.97.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.97.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.96.0" }
+nika-error    = { path = "../nika-error", version = "0.97.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.96.0" }
-nika-error    = { path = "../nika-error", version = "0.96.0" }
+nika-kernel   = { path = "../nika-kernel", version = "0.97.0" }
+nika-error    = { path = "../nika-error", version = "0.97.0" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.96.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.96.0" }
+nika-error       = { path = "../nika-error", version = "0.97.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.97.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.96.0" }
+nika-error    = { path = "../nika-error", version = "0.97.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.96.0" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.96.0" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.96.0" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.96.0" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.96.0" }
+nika-error          = { path = "../nika-error", version = "0.97.0" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.97.0" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.97.0" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.97.0" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.97.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.96.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-schema = { path = "../nika-schema", version = "0.97.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.96.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-error  = { path = "../nika-error", version = "0.96.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.96.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.97.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-error  = { path = "../nika-error", version = "0.97.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.97.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 # The embedded knowledge payloads (`nika_catalog` · `nika_tools`) — the SAME
 # versioned projections `nika catalog|tools --json` emit (one builder per
 # owning crate · zero duplication). L4→L0 / L4→L1.5, strictly downward.
-nika-catalog = { path = "../nika-catalog", version = "0.96.0", default-features = false, features = ["serde", "capabilities"] }
-nika-builtin = { path = "../nika-builtin", version = "0.96.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.97.0", default-features = false, features = ["serde", "capabilities"] }
+nika-builtin = { path = "../nika-builtin", version = "0.97.0" }
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -150,9 +150,14 @@ invoke: { tool: "nika:edit", args: { path: "./file.md", find: "old", replace: "n
 ```
 In-place find/replace · returns the modified path. `find:` is a **literal
 string** (not a regex: use `nika:grep` to locate · jq to transform) ·
-replaces **all occurrences** · `count:` caps replacements when set. Throws ·
+replaces **all occurrences** · `count:` (when set) caps replacements to the
+first N. `count:` MUST be a non-negative integer — a present non-integer
+(e.g. the string `"2"`) is a loud `-001` arg error, NEVER silently the
+replace-all default (that silent fall-through would over-edit the file · the
+intent-inversion footgun class). Throws ·
 `NIKA-BUILTIN-EDIT-001` (`find:` matched nothing: an edit that edits
-nothing is an authoring bug · `tool_error`) · `-002` (IO failure).
+nothing is an authoring bug · `tool_error` · also a non-integer `count:`) ·
+`-002` (IO failure).
 
 ### `nika:glob`
 ```yaml

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.96.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.96.0", features = ["providers"] }
+nika-kernel  = { path = "../nika-kernel", version = "0.97.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.97.0", features = ["providers"] }
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,17 +11,17 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.96.0" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.96.0" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.96.0" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.96.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-catalog     = { path = "../nika-catalog", version = "0.96.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
-nika-cel         = { path = "../nika-cel", version = "0.96.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.96.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.96.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.96.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.96.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.96.0" }
+nika-types       = { path = "../nika-types", version = "0.97.0" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.97.0" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.97.0" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.97.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-catalog     = { path = "../nika-catalog", version = "0.97.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
+nika-cel         = { path = "../nika-cel", version = "0.97.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.97.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.97.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.97.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.97.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.97.0" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -34,9 +34,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.96.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.96.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.96.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.97.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.97.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -17,10 +17,10 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # nika-cap permits). The 4th (nika-cap) is the permits boundary extracted 2026-07-03
 # for reuse by nika-policy/runtime WITHOUT pulling the parser; inlining it back to
 # stay at 3 would defeat the extraction. High fan-in is intentional here (ADR-027).
-nika-error   = { path = "../nika-error", version = "0.96.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.96.0" }
-nika-types   = { path = "../nika-types", version = "0.96.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.96.0" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-error   = { path = "../nika-error", version = "0.97.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.97.0" }
+nika-types   = { path = "../nika-types", version = "0.97.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.97.0" }   # the permits vocab lives here now (extracted 2026-07-03)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -43,10 +43,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.96.0" }
+nika-event = { path = "../nika-event", version = "0.97.0" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.96.0" }
+nika-pack  = { path = "../nika-pack", version = "0.97.0" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-kernel      = { path = "../nika-kernel", version = "0.96.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.96.0" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.96.0" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.96.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.96.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-kernel      = { path = "../nika-kernel", version = "0.97.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.97.0" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.97.0" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.97.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.97.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -24,7 +24,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.96.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.96.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-error  = { path = "../nika-error", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.96.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,9 +13,9 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error     = { path = "../nika-error", version = "0.96.0" }
-nika-kernel    = { path = "../nika-kernel", version = "0.96.0" }
-nika-providers = { path = "../nika-providers", version = "0.96.0" }
+nika-error     = { path = "../nika-error", version = "0.97.0" }
+nika-kernel    = { path = "../nika-kernel", version = "0.97.0" }
+nika-providers = { path = "../nika-providers", version = "0.97.0" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.96.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.96.0" }
+nika-error  = { path = "../nika-error", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "nika-types",
  "serde",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "miette",
  "nika-catalog-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "miette",
  "nika-types",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-schema"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "jaq-core",
  "jaq-json",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "nika-types"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "loom",
  "serde",


### PR DESCRIPTION
**The train.** 0.96 made the run a place you can visit; 0.97 makes it a record you can trust — and prices it before you pay.

13 merged PRs ride: hash chain + `trace verify` (#237) · verify-before-trust export/replay (#238) · `trace reproduce` (#241) · engine/platform attestation (#235) · 602 pricing rules (#233) + rates in `check --json` (#236) · `check` dry-run plan (#245) · `doctor --json` (#244) · envelope did-you-mean (#239) · dap file-side bounds + torn-tail (#242) · drift in content terms + `workflow_sha256_lf` (#247) · infer JSON repair (#243) · strict json_schema claims (#246).

**Client features this tag lights up** (capability-probed, zero extension release): the nika-vscode 0.97.3 preflight rates (`$in/$out per 1M`) and the drift-badge content rule (vscode #7).

Ritual: pack synced from spec main (spec #26 strict `count:`) · 109 pins/36 Cargo.toml → 0.97.0 · CHANGELOG (+ the 0.95/0.96 bot-append duplicate sections merged into single narrative+detail sections) · status block ×2 (vector 23) · 3391 lib tests · clippy 0 · pre-push hygiene green.

Post-merge: tag `v0.97.0` on the squash → 4 platforms → manual tap (TAP_GITHUB_TOKEN still dead — operator gate) → re-probe release binary → cascades website/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)