### PR TITLE
fix(verb-infer): bill every round-trip, not just the last

### DIFF
--- a/crates/nika-types/public-api.txt
+++ b/crates/nika-types/public-api.txt
@@ -3178,6 +3178,7 @@ pub nika_types::prelude::TokenUsage::thinking_tokens: core::option::Option<u64>
 pub nika_types::prelude::TokenUsage::total_tokens: core::option::Option<u64>
 pub nika_types::prelude::TokenUsage::video_input_tokens: core::option::Option<u64>
 impl nika_types::token_usage::TokenUsage
+pub fn nika_types::token_usage::TokenUsage::absorb(&mut self, other: &Self)
 pub fn nika_types::token_usage::TokenUsage::new(input_tokens: u64, output_tokens: u64) -> Self
 impl core::clone::Clone for nika_types::token_usage::TokenUsage
 pub fn nika_types::token_usage::TokenUsage::clone(&self) -> nika_types::token_usage::TokenUsage
@@ -4067,6 +4068,7 @@ pub nika_types::token_usage::TokenUsage::thinking_tokens: core::option::Option<u
 pub nika_types::token_usage::TokenUsage::total_tokens: core::option::Option<u64>
 pub nika_types::token_usage::TokenUsage::video_input_tokens: core::option::Option<u64>
 impl nika_types::token_usage::TokenUsage
+pub fn nika_types::token_usage::TokenUsage::absorb(&mut self, other: &Self)
 pub fn nika_types::token_usage::TokenUsage::new(input_tokens: u64, output_tokens: u64) -> Self
 impl core::clone::Clone for nika_types::token_usage::TokenUsage
 pub fn nika_types::token_usage::TokenUsage::clone(&self) -> nika_types::token_usage::TokenUsage
@@ -5825,6 +5827,7 @@ pub nika_types::TokenUsage::thinking_tokens: core::option::Option<u64>
 pub nika_types::TokenUsage::total_tokens: core::option::Option<u64>
 pub nika_types::TokenUsage::video_input_tokens: core::option::Option<u64>
 impl nika_types::token_usage::TokenUsage
+pub fn nika_types::token_usage::TokenUsage::absorb(&mut self, other: &Self)
 pub fn nika_types::token_usage::TokenUsage::new(input_tokens: u64, output_tokens: u64) -> Self
 impl core::clone::Clone for nika_types::token_usage::TokenUsage
 pub fn nika_types::token_usage::TokenUsage::clone(&self) -> nika_types::token_usage::TokenUsage

--- a/crates/nika-types/src/token_usage.rs
+++ b/crates/nika-types/src/token_usage.rs
@@ -81,11 +81,105 @@ impl TokenUsage {
             num_requests: None,
         }
     }
+
+    /// Fold another round-trip's usage into this accumulator — the one
+    /// arithmetic for multi-call tasks (schema retries · agent turns), so
+    /// every consumer sums the same way and the ledger bills what was
+    /// actually spent.
+    ///
+    /// Scalars saturate (a corrupt provider count must not wrap a bill).
+    /// Optional meters sum when both sides report; when only one side
+    /// reports, its value carries — `None` means "not reported", not zero,
+    /// so a provider that reports a meter on one round-trip and omits it on
+    /// the next still totals honestly.
+    pub fn absorb(&mut self, other: &Self) {
+        /// `Option` meters: saturating sum when both report · the reporting
+        /// side wins otherwise.
+        fn fold(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+            match (a, b) {
+                (Some(x), Some(y)) => Some(x.saturating_add(y)),
+                (x, y) => x.or(y),
+            }
+        }
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_read_tokens = fold(self.cache_read_tokens, other.cache_read_tokens);
+        self.cache_write_tokens = fold(self.cache_write_tokens, other.cache_write_tokens);
+        self.cache_creation_tokens = fold(self.cache_creation_tokens, other.cache_creation_tokens);
+        self.reasoning_tokens = fold(self.reasoning_tokens, other.reasoning_tokens);
+        self.thinking_tokens = fold(self.thinking_tokens, other.thinking_tokens);
+        self.audio_input_tokens = fold(self.audio_input_tokens, other.audio_input_tokens);
+        self.audio_output_tokens = fold(self.audio_output_tokens, other.audio_output_tokens);
+        self.image_input_tokens = fold(self.image_input_tokens, other.image_input_tokens);
+        self.image_output_tokens = fold(self.image_output_tokens, other.image_output_tokens);
+        self.video_input_tokens = fold(self.video_input_tokens, other.video_input_tokens);
+        self.accepted_prediction_tokens = fold(
+            self.accepted_prediction_tokens,
+            other.accepted_prediction_tokens,
+        );
+        self.rejected_prediction_tokens = fold(
+            self.rejected_prediction_tokens,
+            other.rejected_prediction_tokens,
+        );
+        self.total_tokens = fold(self.total_tokens, other.total_tokens);
+        self.search_context_tokens = fold(self.search_context_tokens, other.search_context_tokens);
+        self.citation_tokens = fold(self.citation_tokens, other.citation_tokens);
+        self.num_requests = match (self.num_requests, other.num_requests) {
+            (Some(x), Some(y)) => Some(x.saturating_add(y)),
+            (x, y) => x.or(y),
+        };
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn absorb_sums_scalars_and_saturates() {
+        let mut a = TokenUsage::new(10, 5);
+        a.absorb(&TokenUsage::new(20, 7));
+        assert_eq!(a.input_tokens, 30);
+        assert_eq!(a.output_tokens, 12);
+        // A corrupt provider count must not wrap the bill.
+        let mut top = TokenUsage::new(u64::MAX, 1);
+        top.absorb(&TokenUsage::new(1, u64::MAX));
+        assert_eq!(top.input_tokens, u64::MAX);
+        assert_eq!(top.output_tokens, u64::MAX);
+    }
+
+    #[test]
+    fn absorb_option_meters_report_honestly() {
+        // Some+Some sums · Some+None keeps the reporting side (None means
+        // "not reported", never zero) · None+None stays unreported.
+        let mut a = TokenUsage::new(0, 0);
+        a.reasoning_tokens = Some(100);
+        a.thinking_tokens = None;
+        a.cache_read_tokens = Some(3);
+        let mut b = TokenUsage::new(0, 0);
+        b.reasoning_tokens = Some(50);
+        b.thinking_tokens = Some(9);
+        b.cache_read_tokens = None;
+        a.absorb(&b);
+        assert_eq!(a.reasoning_tokens, Some(150), "both report → sum");
+        assert_eq!(
+            a.thinking_tokens,
+            Some(9),
+            "only the other reports → carried"
+        );
+        assert_eq!(a.cache_read_tokens, Some(3), "only self reports → kept");
+        assert_eq!(a.total_tokens, None, "neither reports → stays unreported");
+    }
+
+    #[test]
+    fn absorb_counts_requests() {
+        let mut a = TokenUsage::new(1, 1);
+        a.num_requests = Some(1);
+        let mut b = TokenUsage::new(1, 1);
+        b.num_requests = Some(2);
+        a.absorb(&b);
+        assert_eq!(a.num_requests, Some(3));
+    }
 
     #[test]
     fn token_usage_new() {

--- a/crates/nika-verb-infer/public-api.txt
+++ b/crates/nika-verb-infer/public-api.txt
@@ -125,7 +125,7 @@ pub nika_verb_infer::InferOutput::output: nika_verb_infer::InferValue
 pub nika_verb_infer::InferOutput::response: nika_kernel_ai::provider::InferResponse
 pub nika_verb_infer::InferOutput::usage: nika_types::token_usage::TokenUsage
 impl nika_verb_infer::InferOutput
-pub fn nika_verb_infer::InferOutput::new(output: nika_verb_infer::InferValue, model_resolved: alloc::string::String, response: nika_kernel_ai::provider::InferResponse) -> Self
+pub fn nika_verb_infer::InferOutput::new(output: nika_verb_infer::InferValue, model_resolved: alloc::string::String, response: nika_kernel_ai::provider::InferResponse, usage: nika_types::token_usage::TokenUsage) -> Self
 impl core::fmt::Debug for nika_verb_infer::InferOutput
 pub fn nika_verb_infer::InferOutput::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_verb_infer::InferOutput

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -128,23 +128,34 @@ pub enum InferValue {
 pub struct InferOutput {
     /// The shaped output value (`.output` in spec terms).
     pub output: InferValue,
-    /// Token usage from the (final) provider round-trip — a convenience
-    /// duplicate of `response.usage` (intentional · ergonomic access).
+    /// Token usage summed across EVERY provider round-trip this task spent
+    /// (schema retries included) — the number the ledger bills. Before this
+    /// was the FINAL round-trip alone, so a structured task that retried
+    /// twice billed ~⅓ of its real spend. The final round-trip by itself
+    /// stays available as `response.usage`.
     pub usage: TokenUsage,
     /// The model string that was resolved (`provider/name`).
     pub model_resolved: String,
-    /// The full kernel response of the final round-trip (engine surface:
-    /// events · cost · trace propagation).
+    /// The full kernel response of the FINAL round-trip (engine surface:
+    /// events · cost · trace propagation). Its `usage` is that round-trip
+    /// alone — the task total lives in `self.usage`.
     pub response: InferResponse,
 }
 
 impl InferOutput {
-    /// Construct from the final round-trip pieces.
+    /// Construct from the final round-trip + the task-total usage the run
+    /// loop accumulated across every round-trip (single-shot tasks pass the
+    /// one response's usage — total and final coincide).
     #[must_use]
-    pub fn new(output: InferValue, model_resolved: String, response: InferResponse) -> Self {
+    pub fn new(
+        output: InferValue,
+        model_resolved: String,
+        response: InferResponse,
+        usage: TokenUsage,
+    ) -> Self {
         Self {
             output,
-            usage: response.usage.clone(),
+            usage,
             model_resolved,
             response,
         }
@@ -231,6 +242,11 @@ where
         // u32 counter: a u8 would saturate at budget = u8::MAX and loop
         // forever on paid calls (review lens 1 · P1).
         let mut attempts: u32 = 0;
+        // EVERY round-trip's usage folds in — a schema retry is a real paid
+        // call and the ledger bills `InferOutput::usage`. Keeping only the
+        // final response's usage under-billed retried tasks by up to
+        // budget+1 × (the cost-undercount finding · deep review 2026-07-07).
+        let mut usage_total = TokenUsage::default();
         loop {
             attempts += 1;
             let request = build_request(&input, provider.name(), messages.clone(), wire);
@@ -238,6 +254,7 @@ where
                 .infer(request)
                 .await
                 .map_err(|source| VerbInferError::ProviderCall { source })?;
+            usage_total.absorb(&response.usage);
             let text = response_text(&response);
 
             let (Some(schema), Some(validator)) = (input.schema.as_ref(), validator.as_ref())
@@ -246,6 +263,7 @@ where
                     InferValue::Text(text),
                     model.to_owned(),
                     response,
+                    usage_total,
                 ));
             };
 
@@ -255,6 +273,7 @@ where
                         InferValue::Structured(value),
                         model.to_owned(),
                         response,
+                        usage_total,
                     ));
                 }
                 structured::Validation::Invalid(detail) => {
@@ -848,6 +867,38 @@ mod tests {
             .as_str()
             .expect("prompt text");
         assert!(prompt.contains("JSON Schema"), "{prompt}");
+    }
+
+    /// A retried structured task bills EVERY round-trip: the first reply
+    /// misses the schema (10+5 tokens), the retry conforms (20+7) — the
+    /// task total is the sum, while `response.usage` stays the final
+    /// round-trip alone. Before the fix the first call's tokens vanished
+    /// (the cost-undercount finding · deep review 2026-07-07).
+    #[tokio::test]
+    async fn retried_structured_task_bills_every_round_trip() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\"}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":36}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":7}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let out = openai_verb(&seam)
+            .run(input)
+            .await
+            .expect("the retry conforms");
+        assert!(matches!(out.output, InferValue::Structured(_)));
+        assert_eq!(out.usage.input_tokens, 30, "task total sums both calls");
+        assert_eq!(out.usage.output_tokens, 12);
+        assert_eq!(
+            out.response.usage.input_tokens, 20,
+            "the final round-trip alone stays on response.usage"
+        );
+        assert_eq!(seam.captured().len(), 2, "exactly two round-trips");
     }
 
     /// A structured reply cut off at the token limit reports the TRUNCATION


### PR DESCRIPTION
A structured `infer` task that retried on schema-validation billed only the **final** round-trip's tokens — `InferOutput::usage` was a clone of the last `response.usage`, so a task that took 3 calls to conform charged for one (~⅓ of real spend). Flagged in the 2026-07-07 deep review, deliberately held until the pricing arc settled (it has — recent main work is all nika-cli).

- **`TokenUsage::absorb`** (nika-types): the one accumulator for multi-call tasks. Scalars saturate (a corrupt provider count must not wrap a bill); optional meters treat `None` as *not reported* — the reporting side carries, both-report sums.
- **run loop** folds every round-trip's usage; `InferOutput::new` now takes the task-total. The final round-trip alone stays reachable at `response.usage`.
- **dispatch bills `out.usage`** (verified at dispatch.rs:371/382-383) → the ledger reflects true spend with zero dispatch changes.

4 new tests (retry double-bills correctly · absorb sums/saturates · option meters honest · request counting). nika-types 229 + verb-infer 52 green, clippy -D clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)