### PR TITLE
fix(nika-cli): the chain writer earns its anchor — the writer-side review batch

### DIFF
--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -824,12 +824,14 @@ enum TraceNote {
 /// contract: journaling is a rider, a broken rider is a note, not a
 /// failure). An fs error goes to stderr with the path when one was opened;
 /// a written journal prints its `trace:` pointer per [`TraceNote`].
-fn surface_trace(trace: TraceFileSink, note: TraceNote) {
+fn surface_trace(mut trace: TraceFileSink, note: TraceNote) {
+    // Durability BEFORE advertisement: the anchor must describe bytes
+    // that survive a power loss (flush reaches the page cache only).
+    trace.finalize();
     let path = trace.path().map(std::path::Path::to_path_buf);
-    // The printed head is the chain's free external anchor: CI logs and
-    // scrollback hold it, so a rewritten-whole journal no longer matches
-    // the record of the run that printed it (tamper-EVIDENT → checkable).
-    let head8 = trace.chain_head()[..16].to_owned();
+    // Read the anchor parts BEFORE into_error consumes the sink — they
+    // are only ADVERTISED after the error gate below passes.
+    let head = trace.chain_head().chars().take(32).collect::<String>();
     let count = trace.chain_len();
     if let Some(e) = trace.into_error() {
         // Name the file when the failure struck AFTER the open (a partial
@@ -846,16 +848,19 @@ fn surface_trace(trace: TraceFileSink, note: TraceNote) {
     let Some(path) = path else {
         return; // disabled · or a run that emitted zero events
     };
+    // The anchor: 32 hex (128-bit) — the scrollback head is the ONE
+    // thing a whole-file rewrite cannot touch; 16 hex capped forgery at
+    // ~2^63 with a malleable final line (the writer-side review's M4).
     match note {
         TraceNote::Stdout => {
             println!(
-                "    trace: {} · {count} events · chain {head8}",
+                "    trace: {} · {count} events · chain {head}",
                 path.display()
             );
         }
         TraceNote::Stderr => {
             eprintln!(
-                "nika run: trace: {} · {count} events · chain {head8}",
+                "nika run: trace: {} · {count} events · chain {head}",
                 path.display()
             );
         }

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -111,7 +111,7 @@ enum Lane {
     Open(BufWriter<File>),
 }
 
-/// The run journal — writes the SAME NDJSON stream as [`JsonSink`] into
+/// The run journal — the same EVENT stream as [`JsonSink`], each line
 /// `<dir>/<ISO-compact>-<short-id>.ndjson` (spec §3.3 final frame ·
 /// `.nika/traces/` in production). The flight recorder (`nika trace
 /// show|replay`), `--resume`, and the editor extension's runs view all
@@ -207,6 +207,25 @@ impl TraceFileSink {
         self.written
     }
 
+    /// Durability point — called ONCE before the anchor is advertised:
+    /// `flush()` reaches the page cache only; a power loss after the
+    /// anchor printed but before writeback would leave a shorter-but-
+    /// clean prefix on disk, and the anchor mismatch would FORGE a
+    /// tamper alarm against the operator's own hardware. One fsync per
+    /// run buys an honest anchor.
+    pub(super) fn finalize(&mut self) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Lane::Open(writer) = &mut self.lane {
+            let result = writer.flush().and_then(|()| writer.get_ref().sync_data());
+            if let Err(e) = result {
+                self.error = Some(e);
+                self.lane = Lane::Disabled;
+            }
+        }
+    }
+
     /// Create the directory + the journal file, named from the first
     /// event's identity.
     ///
@@ -269,24 +288,41 @@ impl EventSink for TraceFileSink {
         // re-serialization, is what makes `trace verify` total: no
         // canonical-JSON contract to drift. Event consumers ignore the
         // extra field (tolerant serde — pinned in verify tests).
+        let chain = self.chain.clone();
         let result = serde_json::to_value(&event)
             .map_err(std::io::Error::from)
             .and_then(|mut value| {
-                if let Some(obj) = value.as_object_mut() {
-                    obj.insert(
-                        "chain".to_owned(),
-                        serde_json::Value::String(self.chain.clone()),
-                    );
-                }
+                let Some(obj) = value.as_object_mut() else {
+                    // A non-object event is a WRITER defect — fail loudly
+                    // here; a silent chainless line would read as an
+                    // Unchained/Broken verdict (an attack) downstream.
+                    return Err(std::io::Error::other(
+                        "event did not serialize to a JSON object",
+                    ));
+                };
+                obj.insert("chain".to_owned(), serde_json::Value::String(chain));
                 let line = serde_json::to_string(&value).map_err(std::io::Error::from)?;
-                self.chain = sha256_hex(line.as_bytes());
-                self.written += 1;
                 writer.write_all(line.as_bytes())?;
                 writer.write_all(b"\n")?;
-                writer.flush()
+                writer.flush()?;
+                Ok(sha256_hex(line.as_bytes()))
             });
-        if let Err(e) = result {
-            self.error = Some(e);
+        // Chain state commits only AFTER the bytes landed: a failed
+        // write must never advance the head (a later "N events · chain
+        // X" note would otherwise describe bytes no file holds).
+        match result {
+            Ok(next) => {
+                self.chain = next;
+                self.written += 1;
+            }
+            Err(e) => {
+                self.error = Some(e);
+                // L4: retire the lane NOW — BufWriter's Drop re-flushes
+                // ignoring errors, and a recovered fs would complete the
+                // torn line AFTER the error was reported (the file's
+                // post-error content must not depend on the environment).
+                self.lane = Lane::Disabled;
+            }
         }
     }
 }
@@ -674,10 +710,11 @@ mod tests {
         assert!(!dir.exists(), "no emit → the directory is never created");
     }
 
-    /// The journal is the `--json` lane byte-for-byte: same events in,
-    /// identical NDJSON out (the file must parse wherever the stream does).
+    /// The journal is the `--json` lane SEMANTICALLY: same events in,
+    /// each line carrying one extra committed key (`chain`) — key order
+    /// is NOT byte-mirrored (the Value round-trip sorts keys).
     #[test]
-    fn trace_sink_journal_mirrors_the_json_lane_bytes() {
+    fn trace_sink_journal_mirrors_the_json_lane_semantically() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path().join("traces");
         let events = demo::success();


### PR DESCRIPTION
## The writer-side expert review (the reader was audited twice; the writer never)

Zero critical/high — the design held. Every medium/low repaired:

- **M1**: chain state commits only AFTER the bytes land — a failed write can no longer leave the in-memory head describing bytes no file holds. **L4**: on error the lane retires immediately (BufWriter's Drop re-flush could complete a torn line AFTER the error was reported).
- **M3 · the false-alarm forge**: `flush()` reaches the page cache only — a power loss after the anchor printed would leave a shorter-but-clean prefix, and the anchor mismatch would **forge a tamper alarm against the operator's own hardware**. `finalize()` (one `sync_data` per run) runs before the anchor is advertised.
- **M4**: the printed anchor grows to **32 hex (128-bit)** — 16 hex capped forgery at ~2^63 against a malleable final line, beneath the anchor's claim.
- **L3**: a non-object event serialization is a loud writer error, never a silent chainless line (which verify would misread as an attack).
- **M2**: the stale byte-identity claims corrected (doc · test header · test name) — the journal mirrors the `--json` lane SEMANTICALLY (one extra committed key; key order not byte-mirrored, the Value round-trip sorts).
- **L1**: anchor parts read before the error gate consumes the sink, advertised only after it passes; the `disabled()` genesis init documented as load-bearing.

## Proof

E2e at the binary: the run prints the 32-hex anchor, the fsync'd journal verifies with the same head. nika-cli lib 246 ✓ · clippy ✓ · 8/8 ratchets ✓ · no public API change. (Client note: the vscode anchor-capture regex matches a 16-hex prefix — forward-compatible with the 32-hex print.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)