### PR TITLE
feat(nika-cli): guided onboarding — bare init/new converse on a terminal

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -682,10 +682,11 @@ pub fn nika_cli::verbs::graph::run(path: &str, format: nika_cli::verbs::graph::G
 pub fn nika_cli::verbs::graph::to_dot(doc: &nika_cli::verbs::graph::GraphDoc) -> alloc::string::String
 pub fn nika_cli::verbs::graph::to_mermaid(doc: &nika_cli::verbs::graph::GraphDoc) -> alloc::string::String
 pub mod nika_cli::verbs::init
-pub fn nika_cli::verbs::init::run(dir: &str, force: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::inspect
 pub fn nika_cli::verbs::inspect::run(path: &str, ascii: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::new
+pub fn nika_cli::verbs::new::dispatch(from: core::option::Option<&str>, dest: core::option::Option<&str>, force: bool) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::new::run(template: &str, dest: core::option::Option<&str>, force: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::pack_surface
 pub fn nika_cli::verbs::pack_surface::examples_list() -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -178,6 +178,10 @@ enum Command {
         /// Overwrite existing files.
         #[arg(long)]
         force: bool,
+        /// Accept every default — never prompt (pipes and CI are
+        /// implicitly `--yes`; prompts only ever appear on a terminal).
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
     /// Wire Nika into editor/agent MCP clients (explicit, idempotent).
     Wire {
@@ -215,9 +219,11 @@ enum Command {
     },
     /// Instantiate an embedded template skeleton.
     New {
-        /// Template name (see `nika new --from '?'` for the set).
+        /// Template name or plain-words intent (`--from '?'` lists the
+        /// set). Omitted on a terminal → the guided three-question flow;
+        /// omitted in a pipe → fail fast naming this flag.
         #[arg(long)]
-        from: String,
+        from: Option<String>,
         /// Destination path (`*.nika.yaml`). Optional for the `--from '?'`
         /// discovery query; required to instantiate a template.
         dest: Option<String>,
@@ -546,7 +552,7 @@ fn main() -> std::process::ExitCode {
         }
         Command::Explain { code } => emit(&verbs::explain::run(&code)),
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json)),
-        Command::Init { dir, force } => emit(&verbs::init::run(&dir, force)),
+        Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target.into(), &dir)),
         Command::Spec { canon } => emit(&verbs::pack_surface::spec(canon)),
         Command::Schema => emit(&verbs::pack_surface::schema()),
@@ -562,7 +568,11 @@ fn main() -> std::process::ExitCode {
                 term_theme(color.with_no_color(false), false, link_when),
             ),
         },
-        Command::New { from, dest, force } => emit(&verbs::new::run(&from, dest.as_deref(), force)),
+        Command::New { from, dest, force } => emit(&verbs::new::dispatch(
+            from.as_deref(),
+            dest.as_deref(),
+            force,
+        )),
         Command::Completions { shell } => {
             write_completions(shell, &mut std::io::stdout());
             0

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -11,8 +11,13 @@
 //! `--force` is the explicit override (same law as `nika new`). Diagnose-and-
 //! report: every created/skipped path is named; a write failure is the one
 //! environment error (`exit 3`).
+//!
+//! Bare on a terminal, init then OFFERS the first workflow (the guided
+//! three-question flow shared with bare `nika new` — the gh-repo-create
+//! shape). `--yes`, any pipe, and CI keep the old behavior byte-for-byte.
 
 use std::fmt::Write as _;
+use std::io::IsTerminal;
 use std::path::Path;
 
 use crate::verbs::VerbOutput;
@@ -164,10 +169,22 @@ pub(crate) fn render(lines: &[(char, String)]) -> String {
     s
 }
 
+/// The beginner's next move · init used to end SILENTLY (the 2026-07-05
+/// beginner walk: « you init and… sit there ») — an onboarding surface
+/// must hand over to the next command. Golden path: offline proof in
+/// 10s → scaffold → audit-before-tokens. Byte-stable: this is the exact
+/// non-interactive shape scripts have seen since #158.
+const NEXT_BLOCK: &str = "next ·\n  nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n  nika new --from chain my-first.nika.yaml       # scaffold a real workflow\n  nika check my-first.nika.yaml                  # audit before a single token";
+
 /// Scaffold `dir` (default `.`). Creates parent dirs as needed. A write
 /// failure is the one environment error (`exit 3`); everything else is `0`.
+///
+/// Bare on a terminal (and not `--yes`) the scaffold report prints
+/// immediately and init hands over to the guided first-workflow flow —
+/// the gh-repo-create shape (bare on a TTY is guided · flags and pipes
+/// keep the exact old output).
 #[must_use]
-pub fn run(dir: &str, force: bool) -> VerbOutput {
+pub fn run(dir: &str, force: bool, yes: bool) -> VerbOutput {
     let plan = plan(dir, &|p| Path::new(p).exists(), force);
     let mut lines: Vec<(char, String)> = Vec::new();
     let mut failed = false;
@@ -192,16 +209,19 @@ pub fn run(dir: &str, force: bool) -> VerbOutput {
 
     let text = render(&lines);
     if failed {
-        VerbOutput::env(text)
-    } else {
-        // The beginner's next move · init used to end SILENTLY (the
-        // 2026-07-05 beginner walk: « you init and… sit there ») — an
-        // onboarding surface must hand over to the next command. Golden
-        // path: offline proof in 10s → scaffold → audit-before-tokens.
-        VerbOutput::ok(format!(
-            "{text}\n\nnext ·\n  nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n  nika new --from chain my-first.nika.yaml       # scaffold a real workflow\n  nika check my-first.nika.yaml                  # audit before a single token"
-        ))
+        return VerbOutput::env(text);
     }
+    if !yes && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        // Interactive: the wizard prints the report itself (the lib bans
+        // println! — output flows through its writer), then offers the
+        // first workflow. Declined → the classic hand-off, so nobody
+        // exits without a next command.
+        return match crate::verbs::new::offer_first_workflow(dir, &text) {
+            Some(v) => v,
+            None => VerbOutput::ok(NEXT_BLOCK.to_owned()),
+        };
+    }
+    VerbOutput::ok(format!("{text}\n\n{NEXT_BLOCK}"))
 }
 
 /// Create any missing parent dirs, then write the file.
@@ -226,12 +246,29 @@ mod tests {
         // over — the ok-path text carries the golden path.
         let tmp = std::env::temp_dir().join(format!("nika-init-handover-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).expect("mkdir");
-        let out = run(tmp.to_str().expect("utf8"), false);
+        let out = run(tmp.to_str().expect("utf8"), false, true);
         std::fs::remove_dir_all(&tmp).ok();
         assert_eq!(out.code, exit::OK);
         assert!(out.text.contains("next ·"), "{}", out.text);
         assert!(out.text.contains("nika examples run 01-hello"));
         assert!(out.text.contains("nika check"));
+    }
+
+    /// `--yes` (and any non-terminal) is the byte-stable script shape —
+    /// the report and the classic hand-off, zero prompts.
+    #[test]
+    fn yes_keeps_the_non_interactive_shape() {
+        let tmp = std::env::temp_dir().join(format!("nika-init-yes-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("mkdir");
+        let out = run(tmp.to_str().expect("utf8"), false, true);
+        std::fs::remove_dir_all(&tmp).ok();
+        assert_eq!(out.code, exit::OK);
+        assert!(out.text.contains("✔ created"), "{}", out.text);
+        assert!(
+            out.text.contains(NEXT_BLOCK),
+            "the classic block survives verbatim: {}",
+            out.text
+        );
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/new.rs
+++ b/crates/nika-cli/src/verbs/new.rs
@@ -19,15 +19,50 @@
 //!    zero-LLM — the floor of « the binary generates the best workflow
 //!    for the intent » (editor LLM loops build ON this rung).
 
+use std::fmt::Write as _;
+use std::io::{BufRead, IsTerminal};
 use std::path::Path;
 
 use nika_bm25::{BmIndex, BmParams};
 
 use crate::verbs::{VerbOutput, exit};
 
+/// `nika new` — resolve the missing `--from` per clig.dev: a terminal
+/// gets the guided flow (prompt for the missing argument) · a pipe/CI
+/// fails fast naming the flag (never REQUIRE interactivity).
+#[must_use]
+pub fn dispatch(from: Option<&str>, dest: Option<&str>, force: bool) -> VerbOutput {
+    match from {
+        Some(f) => run(f, dest, force),
+        None if interactive() => {
+            let stdin = std::io::stdin();
+            wizard_io(".", dest, force, &mut stdin.lock(), &mut std::io::stdout())
+        }
+        None => VerbOutput {
+            text: format!(
+                "nothing to scaffold — pass --from <template|intent> (`nika new --from '?'` lists the set)\nembedded set: {}",
+                nika_pack::template_names().join(" · ")
+            ),
+            code: exit::FILE,
+        },
+    }
+}
+
+/// Both ends of the conversation are a terminal — the only state in
+/// which any nika surface may prompt (clig.dev interactivity rule).
+fn interactive() -> bool {
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
 /// The `nika new` verb.
 #[must_use]
 pub fn run(template: &str, dest: Option<&str>, force: bool) -> VerbOutput {
+    // `?` is the documented discovery query — a question answered is a
+    // SUCCESS, not a finding (it used to reuse the unknown-template error
+    // and exit 2, which read as failure to a human following the help).
+    if template == "?" {
+        return discovery();
+    }
     let (name, body, routed) = match nika_pack::template(template) {
         Some(body) => (template.to_owned(), body, false),
         None => match route_intent(template) {
@@ -87,6 +122,331 @@ fn unknown(template: &str) -> VerbOutput {
             nika_pack::template_names().join(" · ")
         ),
         code: exit::FILE,
+    }
+}
+
+/// First-class `--from '?'` — the listing a human reads (name + tagline
+/// derived from each template's own `# TEMPLATE` header · no second
+/// source) with the `embedded set:` WIRE-CONTRACT line kept verbatim for
+/// the editor probes. Exit 0: a discovery query answered is a success.
+fn discovery() -> VerbOutput {
+    let names = nika_pack::template_names();
+    let mut text = String::from("the embedded template skeletons ·\n");
+    for name in &names {
+        let tag = nika_pack::template(name).map_or_else(String::new, |b| tagline(name, b));
+        let _ = writeln!(text, "  {name:<18} {tag}");
+    }
+    let _ = write!(text, "\nembedded set: {}", names.join(" · "));
+    text.push_str(
+        "\n\ntry ·\n  nika new --from chain my-first.nika.yaml\n  nika new --from \"describe the job in plain words\" my.nika.yaml   # routes to the closest skeleton\n  nika new                                                          # guided (terminal only)",
+    );
+    VerbOutput {
+        text,
+        code: exit::OK,
+    }
+}
+
+/// The one-line tagline out of a template's `# TEMPLATE · <name> · …`
+/// header. Empty when a body carries no header — the listing degrades
+/// gracefully instead of inventing prose. A header that wraps to the
+/// next comment line gets an honest `…` instead of ending mid-thought.
+fn tagline(name: &str, body: &str) -> String {
+    body.lines()
+        .find_map(|l| l.strip_prefix("# TEMPLATE"))
+        .map_or_else(String::new, |rest| {
+            let rest = rest.trim_start_matches([' ', '·']);
+            let rest = rest.strip_prefix(name).unwrap_or(rest);
+            let rest = rest.trim_start_matches([' ', '·', ':']).trim_end();
+            let clean = rest.trim_end_matches([',', ' ']);
+            if rest.ends_with('.') {
+                clean.to_owned()
+            } else {
+                format!("{clean}…")
+            }
+        })
+}
+
+// ─── The guided flow (the wizard) ────────────────────────────────────
+//
+// Three questions, every one Enter-skippable, reachable from two doors:
+// `nika new` bare on a terminal (missing argument → prompt · clig.dev)
+// and `nika init`'s hand-off (gh-repo-create shape: bare on a TTY is
+// guided · flags and pipes keep the exact old behavior). The answers
+// land in the SAME file the flag form writes — plus the three slots the
+// wizard can stamp honestly (id · description · model); the remaining
+// `# SLOT:` lines stay visible so the author fills them deliberately.
+
+/// The wizard's harvest — decoupled from the terminal (answers arrive
+/// through any `BufRead` · tests inject a cursor).
+struct Wizard {
+    template: String,
+    routed: bool,
+    dest: String,
+    model: String,
+    intent: String,
+}
+
+/// The default first-workflow file name (shared with the init hand-off).
+const WIZARD_DEST: &str = "my-first.nika.yaml";
+
+/// One prompt · one line back. `None` = EOF (the human left — cancel,
+/// never loop).
+fn ask(
+    input: &mut dyn BufRead,
+    out: &mut dyn std::io::Write,
+    prompt: &str,
+) -> std::io::Result<Option<String>> {
+    write!(out, "{prompt}\n> ")?;
+    out.flush()?;
+    let mut line = String::new();
+    if input.read_line(&mut line)? == 0 {
+        return Ok(None);
+    }
+    Ok(Some(line.trim().to_owned()))
+}
+
+/// Intent → template: exact name first, BM25 routing second, the
+/// `chain` default third (empty answer = the golden path).
+fn resolve_template(intent: &str) -> (String, bool) {
+    if intent.is_empty() {
+        return ("chain".to_owned(), false);
+    }
+    if nika_pack::template(intent).is_some() {
+        return (intent.to_owned(), false);
+    }
+    match route_intent(intent) {
+        Some(name) => (name, true),
+        None => ("chain".to_owned(), false),
+    }
+}
+
+/// The provider menu, DERIVED from the embedded catalog (no hardcoded
+/// model names to drift) in the doctrine presentation order · local
+/// first · offline mock · EU open-weight · then the US clouds.
+fn model_menu() -> Vec<(String, &'static str)> {
+    let export = nika_catalog::export::catalog_export();
+    [
+        ("ollama", "local · sovereign · zero key"),
+        ("mock", "offline preview · zero key · always works"),
+        ("mistral", "EU · open-weight"),
+        ("anthropic", ""),
+        ("openai", ""),
+    ]
+    .iter()
+    .filter_map(|(id, note)| {
+        export.providers.iter().find(|p| p.id == *id).map(|p| {
+            // `mock/echo` is THE teaching example on every other surface
+            // (the help footer · the init hand-off · AGENTS.md · docs) —
+            // the menu must not introduce a second mock spelling.
+            let model = if p.id == "mock" {
+                "echo"
+            } else {
+                p.default_model
+            };
+            (format!("{}/{model}", p.id), *note)
+        })
+    })
+    .collect()
+}
+
+/// A menu number, a full `provider/model`, or Enter → the offline mock
+/// (the one answer that succeeds with zero keys and zero network — the
+/// first run must not be able to fail).
+fn resolve_model(pick: &str, menu: &[(String, &'static str)]) -> String {
+    let fallback = || {
+        menu.get(1)
+            .map_or_else(|| "mock/echo".to_owned(), |(m, _)| m.clone())
+    };
+    if pick.is_empty() {
+        return fallback();
+    }
+    if let Ok(n) = pick.parse::<usize>()
+        && let Some((m, _)) = n.checked_sub(1).and_then(|i| menu.get(i))
+    {
+        return m.clone();
+    }
+    if pick.contains('/') {
+        return pick.to_owned();
+    }
+    fallback()
+}
+
+/// A kebab workflow id out of the destination file name.
+fn workflow_id(dest: &str) -> String {
+    let base = Path::new(dest)
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let stem = base.strip_suffix(".nika.yaml").unwrap_or(&base);
+    let id: String = stem
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let id = id.trim_matches('-').to_owned();
+    if id.is_empty() {
+        "my-first".to_owned()
+    } else {
+        id
+    }
+}
+
+/// Stamp the three answers the wizard KNOWS into the template — id ·
+/// description · model. Line-anchored on the template contract (every
+/// skeleton opens those keys at column 0); templates without a top-level
+/// `model:` (per-task models) are left alone.
+fn stamp(body: &str, id: &str, description: &str, model: &str) -> String {
+    let mut out: String = body
+        .lines()
+        .map(|line| {
+            if line.starts_with("workflow: ") {
+                format!("workflow: {id}")
+            } else if line.starts_with("description: ") && !description.is_empty() {
+                format!("description: \"{description}\"")
+            } else if line.starts_with("model: ") {
+                format!("model: {model}")
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    out.push('\n');
+    out
+}
+
+/// Run the three questions over injected io. `Ok(None)` = cancelled.
+fn read_wizard(
+    input: &mut dyn BufRead,
+    out: &mut dyn std::io::Write,
+    dest_hint: Option<&str>,
+) -> std::io::Result<Option<Wizard>> {
+    writeln!(
+        out,
+        "🦋 nika · your first workflow — Enter accepts a default · Ctrl-C exits"
+    )?;
+    let Some(intent) = ask(
+        input,
+        out,
+        "\nwhat should it do? — a plain sentence routes to the closest skeleton [chain]",
+    )?
+    else {
+        return Ok(None);
+    };
+    let (template, routed) = resolve_template(&intent);
+    let tag = nika_pack::template(&template).map_or_else(String::new, |b| tagline(&template, b));
+    writeln!(out, "  → template `{template}` — {tag}")?;
+
+    let default_dest = dest_hint.unwrap_or(WIZARD_DEST);
+    let Some(mut dest) = ask(input, out, &format!("\nfile [{default_dest}]"))? else {
+        return Ok(None);
+    };
+    if dest.is_empty() {
+        default_dest.clone_into(&mut dest);
+    }
+    if !dest.ends_with(".nika.yaml") {
+        dest.push_str(".nika.yaml");
+    }
+
+    let menu = model_menu();
+    writeln!(
+        out,
+        "\nmodel — the same file runs on any provider (`nika catalog` names them all)"
+    )?;
+    for (i, (m, note)) in menu.iter().enumerate() {
+        writeln!(out, "  {}  {m:<30} {note}", i + 1)?;
+    }
+    let Some(pick) = ask(input, out, "a number, or any provider/model [2]")? else {
+        return Ok(None);
+    };
+    let model = resolve_model(&pick, &menu);
+    Ok(Some(Wizard {
+        template,
+        routed,
+        dest,
+        model,
+        intent,
+    }))
+}
+
+/// The wizard over real io: converse, then materialize the file.
+pub(crate) fn wizard_io(
+    base: &str,
+    dest_hint: Option<&str>,
+    force: bool,
+    input: &mut dyn BufRead,
+    out: &mut dyn std::io::Write,
+) -> VerbOutput {
+    match read_wizard(input, out, dest_hint) {
+        Err(e) => VerbOutput {
+            text: format!("wizard i/o failed: {e}"),
+            code: exit::ENV,
+        },
+        Ok(None) => VerbOutput {
+            text: "cancelled — nothing written".to_owned(),
+            code: exit::ENV,
+        },
+        Ok(Some(w)) => materialize(base, &w, force),
+    }
+}
+
+/// `nika init`'s hand-off question — one keypress, Enter = yes (the
+/// golden path). `None` = declined (init prints its classic next block).
+pub(crate) fn offer_first_workflow(base: &str, report: &str) -> Option<VerbOutput> {
+    let stdin = std::io::stdin();
+    let mut input = stdin.lock();
+    let mut stdout = std::io::stdout();
+    let out: &mut dyn std::io::Write = &mut stdout;
+    // The scaffold report prints HERE (through the writer, macro-free —
+    // the lib bans println!): the conversation happens below it.
+    write!(out, "{report}").ok()?;
+    let answer = ask(
+        &mut input,
+        &mut *out,
+        "\nscaffold your first workflow now? [Y/n]",
+    )
+    .ok()??;
+    if answer.eq_ignore_ascii_case("n") || answer.eq_ignore_ascii_case("no") {
+        return None;
+    }
+    Some(wizard_io(base, None, false, &mut input, out))
+}
+
+/// Write the stamped template + hand over to the check-first loop, and
+/// teach the scriptable form of what the wizard just did (the wizard
+/// must map back to flags — reproducibility is part of the contract).
+fn materialize(base: &str, w: &Wizard, force: bool) -> VerbOutput {
+    let dest = if Path::new(&w.dest).is_absolute() || base == "." {
+        w.dest.clone()
+    } else {
+        Path::new(base).join(&w.dest).to_string_lossy().into_owned()
+    };
+    let Some(body) = nika_pack::template(&w.template) else {
+        return unknown(&w.template);
+    };
+    if Path::new(&dest).exists() && !force {
+        return VerbOutput {
+            text: format!("{dest} exists — pass --force to overwrite"),
+            code: exit::ENV,
+        };
+    }
+    let id = workflow_id(&dest);
+    let description = w.intent.replace('"', "");
+    let stamped = stamp(body, &id, &description, &w.model);
+    if let Err(e) = std::fs::write(&dest, &stamped) {
+        return VerbOutput {
+            text: format!("cannot write {dest}: {e}"),
+            code: exit::ENV,
+        };
+    }
+    let routing = if w.routed { "routed intent → " } else { "" };
+    VerbOutput {
+        text: format!(
+            "{dest} ← {routing}template `{tpl}` · stamped workflow `{id}` · model `{model}`\n\nnext ·\n  nika check {dest}                # the oracle — it names every remaining `# SLOT:` to fill\n  nika run {dest}                  # execute · live render (mock is offline · $0.00)\n\nscriptable form · nika new --from {tpl} {dest}",
+            tpl = w.template,
+            model = w.model,
+        ),
+        code: exit::OK,
     }
 }
 
@@ -224,14 +584,32 @@ mod tests {
         std::fs::remove_file(&d).ok();
     }
 
-    /// The wire contract: `nika new --from '?'` (NO dest) names the set.
-    /// Editor integrations probe this bare; clap used to require a dummy
-    /// dest, so the documented discovery command errored.
+    /// The wire contract: `nika new --from '?'` (NO dest) names the set —
+    /// and a discovery query answered is a SUCCESS (exit 0 · it used to
+    /// reuse the unknown-template error, so the documented command read
+    /// as a failure). The `embedded set:` line survives verbatim (the
+    /// editor probes regex exactly that grammar).
     #[test]
     fn discovery_query_lists_the_set_without_a_dest() {
         let out = run("?", None, false);
-        assert_eq!(out.code, exit::FILE, "{}", out.text);
+        assert_eq!(out.code, exit::OK, "{}", out.text);
         assert!(out.text.contains("embedded set:"), "{}", out.text);
+        for name in nika_pack::template_names() {
+            assert!(out.text.contains(&name), "lists `{name}`: {}", out.text);
+        }
+    }
+
+    /// The listing derives its taglines from the template bodies' own
+    /// `# TEMPLATE` headers — no second prose source to drift.
+    #[test]
+    fn discovery_taglines_come_from_the_bodies() {
+        let body = nika_pack::template("chain").expect("chain embedded");
+        let tag = tagline("chain", body);
+        assert!(!tag.is_empty(), "chain header carries a tagline");
+        assert!(
+            run("?", None, false).text.contains(&tag),
+            "the listing shows it"
+        );
     }
 
     /// A REAL template with no dest can't be instantiated — ask for one
@@ -292,13 +670,161 @@ mod tests {
 
     #[test]
     fn zero_evidence_intent_keeps_the_wire_contract_error() {
-        // '?' is the editor probe — the `embedded set:` line is parsed
-        // verbatim by integrations; gibberish shares no term either.
-        for q in ["?", "zzzz qqqq xxxx"] {
-            let out = run(q, Some(&dest("zero")), true);
-            assert_eq!(out.code, exit::FILE, "{}", out.text);
-            assert!(out.text.contains("embedded set:"), "{}", out.text);
+        // Gibberish shares no term with any template — the honest unknown
+        // (exit 2) still names the set on the `embedded set:` wire line.
+        let out = run("zzzz qqqq xxxx", Some(&dest("zero")), true);
+        assert_eq!(out.code, exit::FILE, "{}", out.text);
+        assert!(out.text.contains("embedded set:"), "{}", out.text);
+    }
+
+    // NOTE · the bare-`nika new`-in-a-pipe contract (fail fast naming
+    // `--from`) is pinned at the BINARY plane (bin_smoke) — is_terminal
+    // inside `cargo test` reflects the invoking terminal, so an
+    // in-process assert would flip between a laptop run and CI.
+
+    #[test]
+    fn dispatch_with_a_template_is_the_flag_path_unchanged() {
+        let d = dest("dispatch");
+        let out = dispatch(Some("chain"), Some(&d), true);
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        std::fs::remove_file(&d).ok();
+    }
+
+    // ─── The wizard's pure parts ─────────────────────────────────────
+
+    #[test]
+    fn resolve_template_covers_the_three_rungs() {
+        assert_eq!(resolve_template(""), ("chain".to_owned(), false));
+        assert_eq!(resolve_template("fanout"), ("fanout".to_owned(), false));
+        let (name, routed) = resolve_template("summarize every item in parallel");
+        assert_eq!(name, "fanout");
+        assert!(routed);
+        // Zero evidence → the chain default, never a dead end.
+        assert_eq!(resolve_template("zzzz qqqq"), ("chain".to_owned(), false));
+    }
+
+    #[test]
+    fn the_model_menu_derives_from_the_catalog_local_first() {
+        let menu = model_menu();
+        assert!(menu.len() >= 2, "catalog carries the menu providers");
+        assert!(
+            menu[0].0.starts_with("ollama/"),
+            "local first (presentation order): {menu:?}"
+        );
+        assert!(menu[1].0.starts_with("mock/"), "offline second: {menu:?}");
+        // Every entry is a full provider/model wire id from the catalog.
+        assert!(menu.iter().all(|(m, _)| m.contains('/')), "{menu:?}");
+    }
+
+    #[test]
+    fn resolve_model_defaults_to_the_offline_mock() {
+        let menu = model_menu();
+        let default = resolve_model("", &menu);
+        assert!(
+            default.starts_with("mock/"),
+            "Enter must never fail: {default}"
+        );
+        assert_eq!(resolve_model("1", &menu), menu[0].0);
+        assert_eq!(
+            resolve_model("ollama/llama3.2:3b", &menu),
+            "ollama/llama3.2:3b"
+        );
+        // A number off the menu or a word without `/` falls back safe.
+        assert!(resolve_model("99", &menu).starts_with("mock/"));
+        assert!(resolve_model("gpt", &menu).starts_with("mock/"));
+    }
+
+    #[test]
+    fn workflow_id_is_a_kebab_of_the_file_name() {
+        assert_eq!(workflow_id("my-first.nika.yaml"), "my-first");
+        assert_eq!(workflow_id("dir/Sub/PR Review.nika.yaml"), "pr-review");
+        assert_eq!(workflow_id(".nika.yaml"), "my-first");
+    }
+
+    #[test]
+    fn stamp_fills_exactly_the_three_known_slots() {
+        for name in nika_pack::template_names() {
+            let body = nika_pack::template(&name).expect("embedded");
+            let stamped = stamp(body, "field-demo", "their problem", "mock/echo");
+            assert!(
+                stamped.contains("workflow: field-demo"),
+                "{name}: id stamped"
+            );
+            assert!(
+                !stamped.contains("-template "),
+                "{name}: no template id remnant"
+            );
+            assert!(
+                stamped.contains("description: \"their problem\""),
+                "{name}: description stamped"
+            );
+            if body.lines().any(|l| l.starts_with("model: ")) {
+                assert!(
+                    stamped.contains("model: mock/echo"),
+                    "{name}: model stamped"
+                );
+            }
         }
+    }
+
+    /// The whole conversation over an injected cursor: three Enters =
+    /// the golden path (chain · default name · offline mock).
+    #[test]
+    fn read_wizard_three_enters_is_the_golden_path() {
+        let mut input = std::io::Cursor::new(b"\n\n\n".to_vec());
+        let mut out = Vec::new();
+        let w = read_wizard(&mut input, &mut out, None)
+            .expect("io ok")
+            .expect("not cancelled");
+        assert_eq!(w.template, "chain");
+        assert_eq!(w.dest, WIZARD_DEST);
+        assert!(w.model.starts_with("mock/"));
+        let shown = String::from_utf8(out).expect("utf8");
+        assert!(shown.contains("template `chain`"), "{shown}");
+        assert!(shown.contains("ollama/"), "menu shows local first: {shown}");
+    }
+
+    /// An intent answer routes; EOF mid-flow cancels instead of looping.
+    #[test]
+    fn read_wizard_routes_and_cancels_honestly() {
+        let mut input =
+            std::io::Cursor::new(b"process every item in parallel\nbatch\n2\n".to_vec());
+        let mut out = Vec::new();
+        let w = read_wizard(&mut input, &mut out, None)
+            .expect("io ok")
+            .expect("not cancelled");
+        assert_eq!(w.template, "fanout");
+        assert_eq!(w.dest, "batch.nika.yaml", "the suffix is appended");
+
+        let mut eof = std::io::Cursor::new(Vec::new());
+        let mut out2 = Vec::new();
+        assert!(
+            read_wizard(&mut eof, &mut out2, None)
+                .expect("io ok")
+                .is_none(),
+            "EOF = cancelled"
+        );
+    }
+
+    /// End-to-end over injected io: the file lands stamped + checkable.
+    #[test]
+    fn wizard_io_materializes_a_stamped_file() {
+        let dir = std::env::temp_dir().join(format!("nika-wizard-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let mut input = std::io::Cursor::new(b"\nfirst\n\n".to_vec());
+        let mut out = Vec::new();
+        let v = wizard_io(
+            dir.to_str().expect("utf8"),
+            None,
+            true,
+            &mut input,
+            &mut out,
+        );
+        assert_eq!(v.code, exit::OK, "{}", v.text);
+        assert!(v.text.contains("scriptable form"), "{}", v.text);
+        let written = std::fs::read_to_string(dir.join("first.nika.yaml")).expect("file written");
+        assert!(written.contains("workflow: first"));
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -401,7 +401,49 @@ fn init_scaffolds_a_repo_and_is_idempotent() {
         stdout.contains("skipped"),
         "idempotent re-run skips: {stdout}"
     );
+    // Off-terminal (output() nulls stdin) the classic hand-off block is
+    // byte-stable — scripts and CI never meet a prompt (clig.dev).
+    assert!(
+        stdout.contains("next ·"),
+        "non-interactive init keeps the hand-off: {stdout}"
+    );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn bare_new_in_a_pipe_fails_fast_naming_the_flag() {
+    // clig.dev: never REQUIRE interactivity. Bare `nika new` without a
+    // terminal must not hang waiting on stdin — it fails fast, names the
+    // missing flag, and still hands over the template set (wire line).
+    let out = bin()
+        .arg("new")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("binary runs");
+    assert_eq!(out.status.code(), Some(2), "fail fast, not a hang");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(text.contains("--from"), "names the flag: {text}");
+    assert!(text.contains("embedded set:"), "hands over the set: {text}");
+}
+
+#[test]
+fn discovery_query_is_a_success_at_the_binary_plane() {
+    // `nika new --from '?'` is the documented discovery command — exit 0
+    // (a question answered is a success), the wire-contract line intact.
+    let out = bin()
+        .arg("new")
+        .arg("--from")
+        .arg("?")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("binary runs");
+    assert_eq!(out.status.code(), Some(0), "discovery is a success");
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(stdout.contains("embedded set:"), "{stdout}");
 }
 
 #[test]

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -431,17 +431,33 @@ fn new_writes_a_template_that_passes_its_own_check() {
 }
 
 #[test]
-fn new_refuses_an_unknown_template_and_names_the_set() {
-    // `?` is the canonical discovery query — it shares no term with any
-    // template, so it hits the unknown() path that names the embedded set.
-    // (A garbage string like "no-such-template" spuriously ROUTES: its term
-    // "template" matches the `…-template` placeholder inside the bodies.)
+fn new_answers_the_discovery_query_as_a_success() {
+    // `?` is the canonical discovery query — first-class since the
+    // 2026-07-07 field walk (it used to reuse the unknown-template error
+    // and exit 2 · a documented command must not read as a failure). The
+    // `embedded set:` wire line survives verbatim for the editor probes,
+    // and a passed dest is never written.
     let out = new::run("?", Some("/tmp/never-written.nika.yaml"), false);
-    assert_eq!(out.code, exit::FILE);
-    assert!(out.text.contains("unknown template"));
+    assert_eq!(out.code, exit::OK, "{}", out.text);
+    assert!(out.text.contains("embedded set:"), "{}", out.text);
+    assert!(!std::path::Path::new("/tmp/never-written.nika.yaml").exists());
     for name in nika_pack::template_names() {
         assert!(out.text.contains(&name), "set names {name}");
     }
+}
+
+#[test]
+fn new_refuses_gibberish_and_names_the_set() {
+    // Zero-evidence text (no shared term with any template body) keeps
+    // the honest unknown-template error + the wire-contract set line.
+    let out = new::run(
+        "zzzz qqqq xxxx",
+        Some("/tmp/never-written.nika.yaml"),
+        false,
+    );
+    assert_eq!(out.code, exit::FILE);
+    assert!(out.text.contains("unknown template"));
+    assert!(out.text.contains("embedded set:"));
 }
 
 #[test]

--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -24,13 +24,13 @@ chrome ≤30%, zero decorative noise). And the human always keeps the hand.
 |---|---|---|
 | `nika run <file>` | execute a workflow · live render (§3) | 0 ok · 1 workflow failed |
 | `nika check <file>` | the ADR-092 static ladder (schema→DAG→CEL→effects→permits→cost) | 0 clean · 2 findings |
-| `nika init` | scaffold a repo (.vscode schema wiring · AGENTS.md templates) | 0 · 3 env |
+| `nika init` | scaffold a repo (.vscode schema wiring · AGENTS.md templates) · bare on a terminal it then OFFERS the guided first workflow (`--yes`/pipe/CI = the classic non-interactive shape byte-for-byte · prompts never appear off-terminal) | 0 · 3 env |
 | `nika inspect <file>` | static anatomy: tasks · verbs · DAG (ASCII §6) · permits · cost interval | 0 · 2 |
 | `nika graph <file> --mermaid\|dot\|json` | the ONE graph projector (§6) | 0 · 2 |
 | `nika doctor` | environment diagnosis (PATH · providers reachable · keys present-not-printed · config) | 0 · 3 |
 | `nika explain NIKA-XXXX` | teach one error code (cause · fix-form · doc link) | 0 · 2 unknown code |
 | `nika completions <shell>` | shell completions (clap-generated) | 0 |
-| `nika new --from <template>` | instantiate one of the 6 skeletons | 0 |
+| `nika new --from <template\|intent>` | instantiate one of the 6 skeletons (plain words BM25-route to the closest) · `--from '?'` = first-class discovery listing (exit 0 · the `embedded set:` line is the editor wire contract) · bare `nika new` on a terminal = the guided three-question flow (template → file → model · Enter-only path lands on the offline mock) · bare in a pipe fails fast naming `--from` | 0 · 2 unknown/bare-in-pipe · 3 env |
 | `nika spec` / `nika examples list\|show\|run` / `nika schema` | the embedded self-contained surface | 0 |
 | `nika lsp` | the in-binary language server (stdio) | — |
 | `nika mcp` | the in-binary MCP server | — |


### PR DESCRIPTION
## What

The 2026-07-07 field walk (AI Tinkerers demo prep) exposed two onboarding gaps: a new user inits and still faces four commands to chain by hand, and the DOCUMENTED discovery query `nika new --from '?'` exited 2 as an unknown-template finding — a help-following human reads that as failure.

Grounded on the 2026 CLI onboarding canon, primary-sourced (clig.dev interactivity rules · `gh repo create` · `bun`/`deno init` · `create-astro`):

- **`nika new --from '?'` is first-class discovery** — exit 0, per-template taglines derived from the `# TEMPLATE` headers (no second prose source), the `embedded set:` wire line byte-identical (the vscode probe regexes it and never gated on the exit code — verified in `cliContract.ts`).
- **Bare `nika new` on a terminal = the guided three-question flow** — intent (BM25-routes to a skeleton) → file (default `my-first.nika.yaml`) → model (catalog-derived menu, local first, Enter lands on `mock/echo` so the first run cannot fail). Stamps the three slots it honestly knows (`workflow` id · `description` · `model`), prints the scriptable flags-equivalent, hands over to `check`. Bare in a pipe **fails fast naming `--from`** (clig.dev: never require interactivity).
- **Bare `nika init` on a terminal offers that same flow** after the scaffold report (the `gh repo create` shape). `--yes`/`-y`, pipes and CI keep the pre-existing output **byte-for-byte** (test-pinned).

## Proof

- 249 lib + 24 verbs_static + 20 bin_smoke green · clippy `--all-targets -D warnings` clean
- Wizard driven end-to-end through a **real PTY** (expect) on the release binary: golden path (3 Enters), intent-routing path, init-offer path, cancel-on-EOF, `--yes` byte-stability
- Prompts read via injected `BufRead` — the conversation is unit-tested with cursors; TTY-dependent contracts pinned at the binary plane (`is_terminal` inside `cargo test` reflects the invoking terminal)
- public-api baseline hand-patched with exactly the two intentional deltas (`init::run` gains `yes` · `new::dispatch` added) — a full local regen would import ubuntu-vs-macos rustdoc noise

## Notes

- Spec §2 experience-contract rows updated (`init` · `new`)
- Operator flag (separate arc): catalog `default_model` staleness surfaced by the menu (`anthropic/claude-sonnet-4-20250514` · `openai/gpt-4o`) — codegen'd from the spec pack, needs the counts-derive cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)