### PR TITLE
feat(nika-cli): a failed run teaches its own forensics — the autopsy line

### DIFF
--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -33,6 +33,7 @@ pub use compose::{
 };
 pub use resume::{RecoveredTrace, ResumeRequest, recover_events};
 pub use sink::{FoldSink, JsonSink, RenderMode};
+use sink::{TraceNote, surface_trace};
 pub use stamp::SystemStamper;
 
 mod scope;
@@ -689,7 +690,7 @@ async fn execute(
         let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
         let (mut sink, trace) = tee.into_parts();
         sink.print_final();
-        surface_trace(trace, TraceNote::Stderr);
+        surface_trace(trace, TraceNote::Stderr, None);
         print_resume_summary(&outcome, resumed, true);
         // Built BEFORE the sink is consumed — the failure envelope reads
         // the folded view (the failed row's detail carries the wire code).
@@ -724,7 +725,7 @@ async fn execute(
         let (sink, trace) = tee.into_parts();
         // stdout stays NDJSON verbatim (byte-identical with or without the
         // journal) — the trace note rides on stderr here.
-        surface_trace(trace, TraceNote::Stderr);
+        surface_trace(trace, TraceNote::Stderr, None);
         if let Some(e) = sink.into_error() {
             eprintln!("nika run: stream write failed: {e}");
             return exit::ENV;
@@ -790,6 +791,12 @@ async fn execute_fold_lane(
     }
     // The spec §3.3 final-frame pointer (`trace: …`) — under the frame
     // on the storytelling surfaces.
+    let failed_task = sink
+        .view()
+        .rows()
+        .iter()
+        .find(|r| r.state == crate::TaskState::Failed)
+        .map(|r| r.id.clone());
     surface_trace(
         trace,
         if mode == RenderMode::Quiet {
@@ -797,6 +804,7 @@ async fn execute_fold_lane(
         } else {
             TraceNote::Stdout
         },
+        failed_task.as_deref(),
     );
     print_resume_summary(&outcome, resumed, false);
     if let Some(e) = sink.into_error() {
@@ -804,68 +812,6 @@ async fn execute_fold_lane(
         return exit::ENV;
     }
     code
-}
-
-/// Where the run journal's `trace:` pointer lands (per lane).
-#[derive(Clone, Copy)]
-enum TraceNote {
-    /// The human storytelling surfaces (`Live` · `Plain`) — the spec §3.3
-    /// final-frame pointer, printed under the frame.
-    Stdout,
-    /// The machine lanes (`--json` · `--output json`) — their stdout is a
-    /// byte-exact contract, so the pointer rides the diagnostic stream.
-    Stderr,
-    /// `--quiet` — the compact-card promise holds (no pointer · the
-    /// journal is still written · an fs error still reaches stderr).
-    Silent,
-}
-
-/// Surface the run journal AFTER the run — NEVER the exit code (the sink
-/// contract: journaling is a rider, a broken rider is a note, not a
-/// failure). An fs error goes to stderr with the path when one was opened;
-/// a written journal prints its `trace:` pointer per [`TraceNote`].
-fn surface_trace(mut trace: TraceFileSink, note: TraceNote) {
-    // Durability BEFORE advertisement: the anchor must describe bytes
-    // that survive a power loss (flush reaches the page cache only).
-    trace.finalize();
-    let path = trace.path().map(std::path::Path::to_path_buf);
-    // Read the anchor parts BEFORE into_error consumes the sink — they
-    // are only ADVERTISED after the error gate below passes.
-    let head = trace.chain_head().chars().take(32).collect::<String>();
-    let count = trace.chain_len();
-    if let Some(e) = trace.into_error() {
-        // Name the file when the failure struck AFTER the open (a partial
-        // journal on disk) — the operator sees exactly what to distrust.
-        match &path {
-            Some(p) => eprintln!(
-                "nika run: trace file {}: {e} — the run itself is unaffected",
-                p.display()
-            ),
-            None => eprintln!("nika run: trace file: {e} — the run itself is unaffected"),
-        }
-        return;
-    }
-    let Some(path) = path else {
-        return; // disabled · or a run that emitted zero events
-    };
-    // The anchor: 32 hex (128-bit) — the scrollback head is the ONE
-    // thing a whole-file rewrite cannot touch; 16 hex capped forgery at
-    // ~2^63 with a malleable final line (the writer-side review's M4).
-    match note {
-        TraceNote::Stdout => {
-            println!(
-                "    trace: {} · {count} events · chain {head}",
-                path.display()
-            );
-        }
-        TraceNote::Stderr => {
-            eprintln!(
-                "nika run: trace: {} · {count} events · chain {head}",
-                path.display()
-            );
-        }
-        TraceNote::Silent => {}
-    }
 }
 
 /// The `--resume` post-run summary (`resumed · N skipped · M ran live`) —

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -901,3 +901,74 @@ mod tests {
         );
     }
 }
+
+/// Where the run journal's `trace:` pointer lands (per lane).
+#[derive(Clone, Copy)]
+pub(super) enum TraceNote {
+    /// The human storytelling surfaces (`Live` · `Plain`) — the spec §3.3
+    /// final-frame pointer, printed under the frame.
+    Stdout,
+    /// The machine lanes (`--json` · `--output json`) — their stdout is a
+    /// byte-exact contract, so the pointer rides the diagnostic stream.
+    Stderr,
+    /// `--quiet` — the compact-card promise holds (no pointer · the
+    /// journal is still written · an fs error still reaches stderr).
+    Silent,
+}
+
+/// Surface the run journal AFTER the run — NEVER the exit code (the sink
+/// contract: journaling is a rider, a broken rider is a note, not a
+/// failure). An fs error goes to stderr with the path when one was opened;
+/// a written journal prints its `trace:` pointer per [`TraceNote`].
+pub(super) fn surface_trace(mut trace: TraceFileSink, note: TraceNote, autopsy: Option<&str>) {
+    // Durability BEFORE advertisement: the anchor must describe bytes
+    // that survive a power loss (flush reaches the page cache only).
+    trace.finalize();
+    let path = trace.path().map(std::path::Path::to_path_buf);
+    // Read the anchor parts BEFORE into_error consumes the sink — they
+    // are only ADVERTISED after the error gate below passes.
+    let head = trace.chain_head().chars().take(32).collect::<String>();
+    let count = trace.chain_len();
+    if let Some(e) = trace.into_error() {
+        // Name the file when the failure struck AFTER the open (a partial
+        // journal on disk) — the operator sees exactly what to distrust.
+        match &path {
+            Some(p) => eprintln!(
+                "nika run: trace file {}: {e} — the run itself is unaffected",
+                p.display()
+            ),
+            None => eprintln!("nika run: trace file: {e} — the run itself is unaffected"),
+        }
+        return;
+    }
+    let Some(path) = path else {
+        return; // disabled · or a run that emitted zero events
+    };
+    // The anchor: 32 hex (128-bit) — the scrollback head is the ONE
+    // thing a whole-file rewrite cannot touch; 16 hex capped forgery at
+    // ~2^63 with a malleable final line (the writer-side review's M4).
+    match note {
+        TraceNote::Stdout => {
+            println!(
+                "    trace: {} · {count} events · chain {head}",
+                path.display()
+            );
+            // The autopsy line — a FAILED run teaches its own forensics:
+            // the journal it just wrote replays, peeks and time-travels.
+            if let Some(task) = autopsy {
+                println!(
+                    "    autopsy: nika trace peek {} {task} · replay: nika trace replay {} · or F5 in VS Code",
+                    path.display(),
+                    path.display()
+                );
+            }
+        }
+        TraceNote::Stderr => {
+            eprintln!(
+                "nika run: trace: {} · {count} events · chain {head}",
+                path.display()
+            );
+        }
+        TraceNote::Silent => {}
+    }
+}

--- a/crates/nika-cli/tests/trace_export_e2e.rs
+++ b/crates/nika-cli/tests/trace_export_e2e.rs
@@ -125,3 +125,46 @@ fn export_projects_the_real_journal_with_true_durations() {
             .contains("tasks.seed.status")
     );
 }
+
+/// The failure moment teaches its own forensics (runtime UX): a failed
+/// run's trace pointer carries the autopsy line naming the failed task;
+/// a clean run stays autopsy-free.
+#[test]
+fn a_failed_run_prints_its_autopsy_a_clean_run_does_not() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    std::fs::write(
+        dir.path().join("fail.nika.yaml"),
+        "nika: v1\nworkflow: fail-ux\ntasks:\n  - id: boom\n    exec:\n      command: [\"false\"]\n",
+    )
+    .expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+        .args(["run", "fail.nika.yaml", "--no-progress"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawns");
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("autopsy: nika trace peek") && text.contains(" boom"),
+        "the autopsy names the failed task: {text}"
+    );
+    assert!(
+        text.contains("trace replay"),
+        "the replay path rides: {text}"
+    );
+
+    std::fs::write(
+        dir.path().join("ok.nika.yaml"),
+        "nika: v1\nworkflow: ok-ux\ntasks:\n  - id: fine\n    exec:\n      command: [\"true\"]\n",
+    )
+    .expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+        .args(["run", "ok.nika.yaml", "--no-progress"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawns");
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !text.contains("autopsy:"),
+        "a clean run is autopsy-free: {text}"
+    );
+}


### PR DESCRIPTION
## The runtime-UX friction (found by being the user at the binary)

A failed run was a dead end: an error detail, `fix: nika explain NIKA-XXX`, and a journal full of time-travel capability the user was never told about. Now:

```
  ✖ NIKA-EXEC-001 · command exited with status 1
    fix: nika explain NIKA-EXEC-001
    trace: .nika/traces/…ndjson · 8 events · chain a63af5c8…
    autopsy: nika trace peek <trace> boom · replay: nika trace replay <trace> · or F5 in VS Code
```

- Human surfaces only — machine lanes keep their byte-exact stdout, `--quiet` keeps its promise.
- Clean runs stay autopsy-free — pinned both ways in the battery-run e2e.
- The trace-surface block (`TraceNote` · `surface_trace`) moves to sink.rs — `run/mod.rs` returns under the 1500-line cap by extraction, not comment-gutting.

## Proof

E2e pin (failed → autopsy names `boom` · clean → none) · nika-cli lib 257 ✓ · clippy ✓ · 8/8 ratchets ✓ · no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)