### PR TITLE
ci(changelog): idempotence guard — no double section on tag

### DIFF
--- a/.github/workflows/changelog-cliff.yml
+++ b/.github/workflows/changelog-cliff.yml
@@ -40,6 +40,15 @@ jobs:
             echo "No changelog content — skipping"
             exit 0
           fi
+          # Idempotence guard: the release PR often lands a curated
+          # "## [X.Y.Z]" section before this workflow runs — prepending
+          # again doubles the header (the 0.95/0.96 duplicate class,
+          # cleaned in #251). Fixed-string match on the header prefix.
+          VER="${TAG#v}"
+          if grep -qF "## [${VER}]" CHANGELOG.md; then
+            echo "CHANGELOG already carries a [${VER}] section — skipping (idempotence guard)"
+            exit 0
+          fi
           BR="chore/changelog-${TAG}"
           git config user.name "nika-bot 🦋"
           git config user.email "nika@supernovae.studio"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,7 +119,7 @@ notes · key decisions), not a census.
 - **nika-catalog** — static catalogs with phf+unicase lookup (226 tests after 4B)
   - 42-variant typed `Tag` enum, Cargo feature gating, Shield XOR invariant
   - 105 MCP servers, **32 LLM providers**, 13 embeddings, 63 builtins, 65 transforms
-    *(this is the `nika-catalog` **inventory** — what the engine has metadata for. Distinct from the `nika-spec` **v0.1 stdlib contract** of 14 providers · 23 builtins · 9 extract modes that a conformant engine must support · the extra builtins are media/opt-in, deferred to stdlib v0.x. The 63→22 catalog reconciliation was D-2026-05-26-N5/N6 + ADR-086/087/088 Rams sweep 2026-05-27.)*
+    *(this is the `nika-catalog` **inventory** — what the engine has metadata for. Distinct from the `nika-spec` **v0.1 stdlib contract** of 16 providers · 23 builtins · 9 extract modes that a conformant engine must support (16 per canon.yaml since ADR-104 promoted huggingface + nvidia) · the extra builtins are media/opt-in, deferred to stdlib v0.x. The 63→22 catalog reconciliation was D-2026-05-26-N5/N6 + ADR-086/087/088 Rams sweep 2026-05-27.)*
   - **TOML-driven capability resolver** — **49 rules**, zero-alloc, proptest 10k parity
   - `api_dialect` on all 32 providers (closed set, FK-validated at build time)
   - **12-field `ModelCapabilities`**: token_limit_param + temperature + stop + reasoning + input/output modalities + tokenizer (**12 families**: Cl100k/O200k/ClaudeV3/Gemini/LlamaV3/LlamaV4/MistralV3/DeepSeek/Qwen/Granite/Glm/Grok) + supported_parameters (**13 flags**: incl. BatchApi/ContextCaching/PredictedOutputs/ComputerUse/Citations/IncludeReasoning) + system_messages + context_window_tokens + max_output_tokens + json_mode


### PR DESCRIPTION
## What (Socratic round 2 — root-cause the #251 symptom)

**`.github/workflows/changelog-cliff.yml`** — the tag workflow prepended the git-cliff section without checking whether `CHANGELOG.md` already carries a `## [X.Y.Z]` header. The release PR usually lands the curated section first, so **every release reproduced the duplicate-header class** that #251 cleaned by hand (0.95 and 0.96 were doubled). The prepend now exits early when the section exists (fixed-string match, `VER` from the existing quoted `TAG` env — no new interpolation surface).

**`ROADMAP.md`** — the nika-spec v0.1 stdlib-contract parenthetical said **14 providers in the present tense**; `canon.yaml` (the count SSOT) says **16** since ADR-104 promoted huggingface + nvidia. The historical 0.91 ladder row keeps its 14 (accurate at that tag). The remaining `14-provider` strings live in the **vendored pack** (`crates/nika-pack/pack/spec/`) — that fix belongs upstream in nika-spec + re-vendor, not here.

## Verify

- YAML parses (`yaml.safe_load`) · guard is a no-op when no section exists (first-run path unchanged).
- Docs-only + workflow diff; local pre-commit hooks green.
- Without this guard, the 0.97.0 tag re-creates the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)