### PR TITLE
feat(check): native-first — the check names the native path

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -16,11 +16,14 @@ oracle; the human runs it.
    `nika new --from <template> <file>.nika.yaml`
 2. **Write the file.** Envelope is always `nika: v1` +
    `workflow: <kebab-id>` + `tasks:`.
-3. **Check it**: `nika check <file>`. Exit 0 = clean · 2 = findings.
+3. **Check it**: `nika check <file>` (exit 0 = clean · 2 = findings),
+   then `nika check --native-strict <file>` — it fails on any
+   `native-first` hint (an `exec:` a builtin covers).
 4. **Repair from the diagnostics** — they name the exact task, reference
    and fix. Unknown code? `nika explain NIKA-XXXX`.
 5. Repeat 3–4 until clean. **Never hand a file to the human that does
-   not pass `nika check`.**
+   not pass `nika check`** — and pass `--native-strict` too, unless
+   every remaining `exec:` is in the exec ledger (below).
 6. The human (or CI) runs it: `nika run <file>`. Preview offline with
    `--model mock/echo`; run locally with `--model ollama/<model>`.
 
@@ -28,11 +31,45 @@ oracle; the human runs it.
 
 - `infer:` — an LLM call (`prompt`, `schema?` for typed output,
   `max_tokens?`)
-- `exec:` — a shell command (`command`, `capture: text|structured`)
+- `exec:` — a shell command (`command`, `capture: text|structured`) ·
+  **last resort**: run the native-first interrogation first (below)
 - `invoke:` — a builtin or MCP tool (`tool`, `args`) · HTTP fetch is
   `tool: "nika:fetch"`, a tool, not a verb
 - `agent:` — a bounded multi-turn loop (`prompt`, `tools` allowlist,
   `max_turns`, `max_tokens_total`)
+
+## Native-first (the law)
+
+The order is `invoke: nika:*` → `invoke: mcp:<server>/<tool>` →
+`exec:`. Before writing ANY `exec:`, answer in your head:
+
+1. **Which builtin replaces it?** `nika tools --json` is the catalog.
+   HTTP (curl/wget/helper fetch) → `nika:fetch` · uploads →
+   `multipart:` · site crawls → `traverse:` · file plumbing
+   (cat/tee/cp/mkdir) → `nika:read`/`nika:write` (`create_dirs: true`) ·
+   JSON shaping (jq/sed) → `nika:jq` (or an `output:` binding) ·
+   in-place edits → `nika:edit` · image/speech provider calls →
+   `nika:image_generate`/`nika:tts_generate`.
+2. **Which MCP tool replaces it?** A product API deserves an MCP
+   server, never a helper script.
+3. **Neither?** Name the exact gap — then `exec:` is legitimate
+   (build tools · git · a product CLI with no MCP surface yet) and
+   goes in the ledger.
+
+Never write a helper script (`node bin/helper.mjs …`) that wraps
+HTTP/files/JSON — that is `native-first/005`, the exact failure class
+this law exists for.
+
+## Exec ledger (mandatory when any exec remains)
+
+Every surviving `exec:` gets a row in the workflow's header comment:
+
+```
+# EXEC LEDGER ·
+# | task | command | why no native path | unlock that removes it |
+```
+
+`--native-strict` + a complete ledger = a reviewable workflow.
 
 ## Discipline
 
@@ -46,3 +83,6 @@ oracle; the human runs it.
   the tightest `permits:` block — paste it in (default-deny from then on).
 - Structured output: give `infer:` a `schema:`; add
   `additionalProperties: false` for a deterministic shape.
+- Auth rides `headers: { x-api-key: "${{ secrets.KEY }}" }` (masked ·
+  declared in `secrets:` with its `egress:` sink) — never `exec: curl`
+  for the sake of a header.

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -466,7 +466,7 @@ pub mod nika_cli::verbs
 pub mod nika_cli::verbs::catalog
 pub fn nika_cli::verbs::catalog::run(json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::check
-pub fn nika_cli::verbs::check::run(path: &str, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::check::run(path: &str, json: bool, native_strict: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::check::run_infer_permits(path: &str, json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::dap
 pub fn nika_cli::verbs::dap::run_stdio() -> u8

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -111,6 +111,11 @@ enum Command {
         /// Print an inferred `permits:` boundary instead of the report.
         #[arg(long)]
         infer_permits: bool,
+        /// Fail (exit 2) when any `native-first` hint remains — an
+        /// `exec:` a builtin or MCP tool probably covers. The agent/CI
+        /// posture; hints stay advisory without it.
+        #[arg(long)]
+        native_strict: bool,
         /// Disable colour output.
         #[arg(long)]
         no_color: bool,
@@ -510,6 +515,7 @@ fn main() -> std::process::ExitCode {
             file,
             json,
             infer_permits,
+            native_strict,
             no_color,
             ascii,
         } => {
@@ -519,6 +525,7 @@ fn main() -> std::process::ExitCode {
                 verbs::check::run(
                     &file,
                     json,
+                    native_strict,
                     term_theme(color.with_no_color(no_color), ascii, link_when),
                 )
             };

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -631,6 +631,35 @@ mod tests {
         )
     }
 
+    /// `--json --native-strict`: the payload's `native_strict_clean` and
+    /// the exit code must agree (the review-swarm untested-branch gap).
+    #[test]
+    fn native_strict_json_payload_agrees_with_the_exit_code() {
+        let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://acme.test\" }\n";
+        let dir = std::env::temp_dir().join("nika-cli-killtests");
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let path = dir.join("native-strict-json.nika.yaml");
+        std::fs::write(&path, helper).expect("fixture body");
+        let theme = Theme::new(false, true, false);
+        let out = run(path.to_str().expect("utf8 path"), true, true, theme);
+        assert_eq!(
+            out.code, 2,
+            "strict hint-only workflow exits FILE: {}",
+            out.text
+        );
+        let payload: serde_json::Value = serde_json::from_str(&out.text).expect("json");
+        assert_eq!(
+            payload["clean"],
+            serde_json::json!(true),
+            "spec-clean stays true"
+        );
+        assert_eq!(
+            payload["native_strict_clean"],
+            serde_json::json!(false),
+            "the strict verdict rides the payload: {payload:#}"
+        );
+    }
+
     /// `--native-strict` promotes native-first hints to failure: the SAME
     /// spec-valid workflow exits 0 by default and 2 under strict, with the
     /// strict verdict naming the count; a natively-written twin stays exit

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -20,13 +20,22 @@ use nika_schema::types::VarDecl;
 use crate::display::theme::{Role, Theme};
 use crate::verbs::{VerbOutput, load_checked, load_checked_with_source};
 
-/// The `nika check <file>` verb.
+/// The `nika check <file>` verb. `native_strict` promotes the advisory
+/// `native-first` hints to failures (exit 2) — the agent/CI posture:
+/// spec-validity is unchanged, but an `exec:` with a probable native
+/// path no longer sails through silently.
 #[must_use]
-pub fn run(path: &str, json: bool, theme: Theme) -> VerbOutput {
+pub fn run(path: &str, json: bool, native_strict: bool, theme: Theme) -> VerbOutput {
     let (source, wf, report) = match load_checked_with_source(path) {
         Ok(triple) => triple,
         Err(out) => return out,
     };
+    let native_hints = report
+        .hints
+        .iter()
+        .filter(|h| h.kind == "native-first")
+        .count();
+    let strict_clean = report.is_clean() && (!native_strict || native_hints == 0);
 
     if json {
         return match serde_json::to_value(&report) {
@@ -35,9 +44,15 @@ pub fn run(path: &str, json: bool, theme: Theme) -> VerbOutput {
                 if let Some(obj) = payload.as_object_mut() {
                     obj.insert("clean".to_owned(), serde_json::Value::Bool(clean));
                     obj.insert("pricing".to_owned(), pricing_section(&report));
+                    if native_strict {
+                        obj.insert(
+                            "native_strict_clean".to_owned(),
+                            serde_json::Value::Bool(strict_clean),
+                        );
+                    }
                 }
                 let text = format!("{payload:#}");
-                if clean {
+                if strict_clean {
                     VerbOutput::ok(text)
                 } else {
                     VerbOutput::file(text)
@@ -47,8 +62,22 @@ pub fn run(path: &str, json: bool, theme: Theme) -> VerbOutput {
         };
     }
 
-    let text = render(&report, &wf, &source, path, theme);
-    if report.is_clean() {
+    let mut text = render(&report, &wf, &source, path, theme);
+    if native_strict && report.is_clean() && native_hints > 0 {
+        let hint_word = if native_hints == 1 { "hint" } else { "hints" };
+        let _ = writeln!(
+            text,
+            " {}",
+            theme.paint(
+                Role::Bad,
+                &format!(
+                    "✖ native-strict · {native_hints} native-first {hint_word} above — \
+                     replace the exec(s) or record them in the exec ledger"
+                ),
+            )
+        );
+    }
+    if strict_clean {
         VerbOutput::ok(text)
     } else {
         VerbOutput::file(text)
@@ -583,7 +612,60 @@ mod tests {
         let path = dir.join(name);
         std::fs::write(&path, yaml).expect("fixture body");
         let theme = Theme::new(false, ascii, false);
-        run(path.to_str().expect("utf8 path"), false, theme).text
+        run(path.to_str().expect("utf8 path"), false, false, theme).text
+    }
+
+    /// Same fixture plumbing, full `VerbOutput` (exit-code assertions) —
+    /// the `--native-strict` posture tests read `.code`.
+    fn checked_output(name: &str, yaml: &str, native_strict: bool) -> VerbOutput {
+        let dir = std::env::temp_dir().join("nika-cli-killtests");
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let path = dir.join(name);
+        std::fs::write(&path, yaml).expect("fixture body");
+        let theme = Theme::new(false, true, false);
+        run(
+            path.to_str().expect("utf8 path"),
+            false,
+            native_strict,
+            theme,
+        )
+    }
+
+    /// `--native-strict` promotes native-first hints to failure: the SAME
+    /// spec-valid workflow exits 0 by default and 2 under strict, with the
+    /// strict verdict naming the count; a natively-written twin stays exit
+    /// 0 under strict.
+    #[test]
+    fn native_strict_fails_on_native_first_hints_only() {
+        let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://acme.test\" }\n";
+        let default_run = checked_output("native-default.nika.yaml", helper, false);
+        assert_eq!(
+            default_run.code, 0,
+            "advisory by default: {}",
+            default_run.text
+        );
+        assert!(
+            default_run.text.contains("[native-first]"),
+            "{}",
+            default_run.text
+        );
+
+        let strict = checked_output("native-strict.nika.yaml", helper, true);
+        assert_eq!(
+            strict.code, 2,
+            "strict promotes to failure: {}",
+            strict.text
+        );
+        assert!(
+            strict.text.contains("native-strict · 1 native-first hint"),
+            "{}",
+            strict.text
+        );
+
+        let native_twin = "nika: v1\nworkflow: native\ntasks:\n  - id: crawl\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://acme.test\" } }\n";
+        let twin = checked_output("native-twin.nika.yaml", native_twin, true);
+        assert_eq!(twin.code, 0, "the native twin passes strict: {}", twin.text);
+        assert!(!twin.text.contains("native-strict ·"), "{}", twin.text);
     }
 
     /// The COST section names a DISTINCT reason per unbounded task — a deleted

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -604,7 +604,7 @@ fn scoped_clean_gate(
 ) -> Result<(RawWorkflow, CheckReport), u8> {
     let (wf, report) = apply_task_scope(wf, report, task_filter, output_json)?;
     if !report.is_clean() {
-        let out = crate::verbs::check::run(file, json, theme);
+        let out = crate::verbs::check::run(file, json, false, theme);
         emit_diagnostic(&out.text, output_json);
         return Err(out.code);
     }

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -63,7 +63,7 @@ pub fn run(file: &str, update: bool, theme: Theme) -> u8 {
     if !report.is_clean() {
         // The SAME findings `nika check` renders — a dirty file never
         // pins (or judges) a golden.
-        let out = crate::verbs::check::run(file, false, theme);
+        let out = crate::verbs::check::run(file, false, false, theme);
         print!("{}", out.text);
         return out.code;
     }

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -225,7 +225,7 @@ fn inspect_draws_the_wave_groups_with_static_facts() {
 #[test]
 fn check_clean_file_exits_0_with_grep_stable_sections() {
     let path = fixture_path("check-clean.nika.yaml", WORKFLOW);
-    let out = check::run(&path, false, PLAIN);
+    let out = check::run(&path, false, false, PLAIN);
     assert_eq!(out.code, exit::OK, "{}", out.text);
     for section in [
         "PLAN", "COST", "SECRETS", "TYPES", "TOOLS", "SCHEMA", "PERMITS",
@@ -249,7 +249,7 @@ fn check_clean_file_exits_0_with_grep_stable_sections() {
 fn check_dirty_file_exits_2_and_names_the_fix() {
     let dirty = WORKFLOW.replace("\"nika:read\"", "\"nika:reed\"");
     let path = fixture_path("check-dirty.nika.yaml", &dirty);
-    let out = check::run(&path, false, PLAIN);
+    let out = check::run(&path, false, false, PLAIN);
     assert_eq!(out.code, exit::FILE);
     assert!(out.text.contains("TOOLS"), "{}", out.text);
     assert!(
@@ -265,7 +265,7 @@ fn check_json_is_the_report_plus_clean_flag_never_coloured() {
     let path = fixture_path("check-json.nika.yaml", WORKFLOW);
     // Colour requested — json must ignore it (the contract bytes).
     let coloured = Theme::new(true, false, false);
-    let out = check::run(&path, true, coloured);
+    let out = check::run(&path, true, false, coloured);
     assert_eq!(out.code, exit::OK);
     assert!(!out.text.contains('\x1b'), "json is never coloured");
     let doc: serde_json::Value = serde_json::from_str(&out.text).expect("valid JSON");
@@ -281,7 +281,7 @@ fn check_json_conformance_carries_severity_and_docs_url() {
     // form). Consumers link the code without re-deriving anything.
     let broken = WORKFLOW.replace("depends_on: [gather, probe]", "depends_on: [ghost]");
     let path = fixture_path("check-severity.nika.yaml", &broken);
-    let out = check::run(&path, true, PLAIN);
+    let out = check::run(&path, true, false, PLAIN);
     let doc: serde_json::Value = serde_json::from_str(&out.text).expect("valid JSON");
     let c = &doc["conformance"][0];
     assert_eq!(c["severity"], "error");
@@ -298,14 +298,14 @@ fn check_json_conformance_carries_severity_and_docs_url() {
 #[test]
 fn check_parse_error_is_a_file_finding_exit_2() {
     let path = fixture_path("check-parse.nika.yaml", "nika: v1\nworkflow: [broken");
-    let out = check::run(&path, false, PLAIN);
+    let out = check::run(&path, false, false, PLAIN);
     assert_eq!(out.code, exit::FILE);
     assert!(out.text.contains("PARSE"), "{}", out.text);
 }
 
 #[test]
 fn check_unreadable_file_is_an_environment_error_exit_3() {
-    let out = check::run("/nonexistent/missing.nika.yaml", false, PLAIN);
+    let out = check::run("/nonexistent/missing.nika.yaml", false, false, PLAIN);
     assert_eq!(out.code, exit::ENV);
     assert!(out.text.contains("cannot read"));
 }
@@ -414,7 +414,7 @@ fn new_writes_a_template_that_passes_its_own_check() {
     );
 
     // The own-corpus law: what we scaffold must pass our own ladder.
-    let checked = check::run(&dest_str, false, PLAIN);
+    let checked = check::run(&dest_str, false, false, PLAIN);
     assert_eq!(
         checked.code,
         exit::OK,

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -2154,6 +2154,7 @@ pub fn nika_schema::lints::Lint::__clone_box(&self, _: dyn_clone::sealed::Privat
 impl<T> nika_error::traits::AsAny for nika_schema::lints::Lint where T: 'static
 pub fn nika_schema::lints::Lint::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub fn nika_schema::lints::arg_injection(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<nika_schema::lints::Lint>
+pub fn nika_schema::lints::native_first(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<nika_schema::lints::Lint>
 pub fn nika_schema::lints::one_obvious_way(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<nika_schema::lints::Lint>
 pub mod nika_schema::parser
 #[non_exhaustive] pub enum nika_schema::parser::ParseMode

--- a/crates/nika-schema/src/check/hints.rs
+++ b/crates/nika-schema/src/check/hints.rs
@@ -34,6 +34,10 @@
 //!   [`push_retry_effects_hint`].
 //! - **concurrent same-path writers** (`parallel-writers`) — emitted by
 //!   the DAG analysis pass (`check/analysis.rs`) and merged here.
+//! - **exec with a native path** (`native-first`) — emitted by the
+//!   `check/native_first.rs` pass (the `native-first/001..005` ruleset:
+//!   http/file/data/media/helper commands a builtin or MCP tool
+//!   covers); `nika check --native-strict` promotes them to failures.
 
 use std::collections::BTreeSet;
 
@@ -47,8 +51,9 @@ use crate::types::OnErrorAction;
 pub struct Hint {
     /// The hint class — the closed set today: `cost` · `dead-spend` ·
     /// `typing` · `permits` · `strictness` · `redundant-gate` ·
-    /// `retry-effects` · `parallel-writers` · `secrets-store` (additive ·
-    /// agents route on it; the module doc describes each).
+    /// `retry-effects` · `parallel-writers` · `secrets-store` ·
+    /// `native-first` (additive · agents route on it; the module doc
+    /// describes each).
     pub kind: &'static str,
     /// The task it concerns (`-` for workflow-level hints).
     pub task: String,

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -34,7 +34,7 @@ mod declass;
 mod flow;
 mod hints;
 mod infer_permits;
-mod native_first;
+pub(crate) mod native_first;
 mod permits_fit;
 mod reach;
 mod requirements;

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -34,8 +34,6 @@ mod declass;
 mod flow;
 mod hints;
 mod infer_permits;
-#[cfg(test)]
-mod metamorphic;
 mod native_first;
 mod permits_fit;
 mod reach;

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -36,6 +36,7 @@ mod hints;
 mod infer_permits;
 #[cfg(test)]
 mod metamorphic;
+mod native_first;
 mod permits_fit;
 mod reach;
 mod requirements;
@@ -325,6 +326,7 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         analysis::DagRead::skipped()
     };
     let mut hints = hints::scan_hints(wf);
+    hints.extend(native_first::scan(wf));
     hints.extend(dag_read.conflicts);
     CheckReport {
         report_version: REPORT_VERSION,

--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -52,8 +52,9 @@ const FILE_PROGRAMS: [&str; 9] = [
 /// Data-transform programs (003).
 const DATA_PROGRAMS: [&str; 3] = ["jq", "sed", "awk"];
 /// Script interpreters (005 · and the 001 one-liner carve-in).
-const INTERPRETERS: [&str; 10] = [
-    "node", "python", "python3", "bash", "sh", "zsh", "deno", "bun", "ruby", "perl",
+const INTERPRETERS: [&str; 12] = [
+    "node", "python", "python3", "pythonw", "bash", "sh", "dash", "zsh", "deno", "bun", "ruby",
+    "perl",
 ];
 /// Script-file suffixes an interpreter head promotes to 005.
 const SCRIPT_SUFFIXES: [&str; 8] = [".mjs", ".cjs", ".js", ".ts", ".py", ".sh", ".rb", ".pl"];
@@ -66,7 +67,16 @@ const MEDIA_MARKERS: [&str; 4] = [
     "api.elevenlabs.io",
 ];
 /// HTTP one-liner markers inside interpreter code (001 carve-in).
-const HTTP_CODE_MARKERS: [&str; 4] = ["fetch(", "axios", "http.request", "https.request"];
+const HTTP_CODE_MARKERS: [&str; 8] = [
+    "fetch(",
+    "axios",
+    "http.request",
+    "https.request",
+    "requests.get(",
+    "requests.post(",
+    "urlopen(",
+    "httpx.",
+];
 
 /// Scan every `exec:` task (and `on_finally` cleanups) for a native
 /// path — at most one hint per task.
@@ -100,7 +110,7 @@ fn push_native_first(action: &RawAction, id: &str, hints: &mut Vec<Hint>) {
 /// the check hint AND the reference linter ruleset
 /// (`lints::native_first`) both classify HERE.
 pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
-    let head = command_head(command)?;
+    let (head, pathed) = command_head(command)?;
     if head == "nika" {
         return None; // nested `nika run …` — the sanctioned composition
     }
@@ -140,8 +150,10 @@ pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
             ),
         ));
     }
-    // 001 · an HTTP client program, or an interpreter one-liner around one.
-    if HTTP_PROGRAMS.contains(&head.as_str()) || (is_interpreter && has_marker(&HTTP_CODE_MARKERS))
+    // 001 · an HTTP client program (bare head only — `./scripts/curl` is
+    // the author's own tool), or an interpreter one-liner around one.
+    if (!pathed && HTTP_PROGRAMS.contains(&head.as_str()))
+        || (is_interpreter && has_marker(&HTTP_CODE_MARKERS))
     {
         return Some((
             "native-first/001",
@@ -152,8 +164,8 @@ pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
             ),
         ));
     }
-    // 002 · file plumbing.
-    if FILE_PROGRAMS.contains(&head.as_str()) {
+    // 002 · file plumbing (bare head only).
+    if !pathed && FILE_PROGRAMS.contains(&head.as_str()) {
         return Some((
             "native-first/002",
             format!(
@@ -163,8 +175,8 @@ pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
             ),
         ));
     }
-    // 003 · data transforms.
-    if DATA_PROGRAMS.contains(&head.as_str()) {
+    // 003 · data transforms (bare head only).
+    if !pathed && DATA_PROGRAMS.contains(&head.as_str()) {
         return Some((
             "native-first/003",
             format!(
@@ -177,10 +189,15 @@ pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
     None
 }
 
-/// The literal program head: `argv[0]` for the argv form, the first
-/// non-assignment token of a shell string. Basename'd (`/usr/bin/curl`
-/// counts as `curl`); a templated head (`${{ … }}`) makes no claim.
-fn command_head(command: &RawCommand) -> Option<String> {
+/// The literal program head + whether it was PATH-QUALIFIED: `argv[0]`
+/// for the argv form, the first non-assignment token of a shell string.
+/// Basename'd (`/usr/bin/curl` counts as `curl`) — but the program-name
+/// families (001/002/003) only fire on a BARE head: `./scripts/cat` is
+/// an author's own tool that merely shares a utility's name (review
+/// finding · false-positive class), while a pathed INTERPRETER
+/// (`/usr/bin/python3 helper.py`) legitimately stays rule-005 material.
+/// A templated head (`${{ … }}`) makes no claim.
+fn command_head(command: &RawCommand) -> Option<(String, bool)> {
     let raw = match command {
         RawCommand::Argv(_) => command.argv_program()?.to_owned(),
         RawCommand::Shell(s) => {
@@ -201,8 +218,9 @@ fn command_head(command: &RawCommand) -> Option<String> {
     if raw.contains("${{") {
         return None; // templated — runtime business, no static claim
     }
+    let pathed = raw.contains('/');
     let head = raw.rsplit('/').next().unwrap_or(&raw);
-    (!head.is_empty()).then(|| head.to_owned())
+    (!head.is_empty()).then(|| (head.to_owned(), pathed))
 }
 
 #[cfg(test)]
@@ -239,8 +257,30 @@ mod tests {
     }
 
     #[test]
-    fn fires_on_argv_wget_and_pathed_program() {
-        let h = sole_native_hint(&exec_wf("[\"/usr/bin/wget\", \"https://x.test\"]"));
+    fn pathed_program_names_never_fire_the_name_families() {
+        // The author's own tool sharing a utility name (review FP class):
+        // path-qualified heads make no program-name claim.
+        for command in [
+            "[\"./scripts/cat\", \"--render\", \"template.json\"]",
+            "[\"/usr/local/bin/curl\", \"https://x.test\"]",
+            "\"./tools/jq-like transform.json\"",
+        ] {
+            let hints = hints_of(&exec_wf(command));
+            assert!(
+                !hints.iter().any(|h| h.kind == "native-first"),
+                "{command} must stay silent: {hints:?}"
+            );
+        }
+        // …but a pathed INTERPRETER + script is still the helper class.
+        let h = sole_native_hint(&exec_wf("[\"/usr/bin/python3\", \"scripts/upload.py\"]"));
+        assert!(h.advice.contains("native-first/005"), "{h:?}");
+    }
+
+    #[test]
+    fn fires_on_python_requests_one_liner_001() {
+        let h = sole_native_hint(&exec_wf(
+            "\"python3 -c 'import requests; requests.get(\\\"https://x.test\\\")'\"",
+        ));
         assert!(h.advice.contains("native-first/001"), "{h:?}");
     }
 

--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Native-first hints — `exec:` with a probable native path
+//! (the `native-first/*` preference ruleset · spec 03 §native-first).
+//!
+//! An agent authoring a workflow reaches for the shell because the
+//! shell always works — and `nika check` stayed silent about the
+//! builtin that would have made the task portable, auditable and
+//! sandboxed. This pass names the native path. Empirical trigger: a
+//! generated site-asset workflow shipped FOUR avoidable `exec` tasks
+//! (curl crawl · node upload helper · shell jq · curl image API) and
+//! checked clean.
+//!
+//! Five deterministic rules, each keyed on LITERAL command fragments
+//! (`RawCommand::argv_program` / leading shell token / fragments — a
+//! templated head makes no claim):
+//!
+//! - `native-first/001 exec-http` — `curl`/`wget`/`xh`/`http(s)` (or an
+//!   interpreter one-liner around `fetch(`/`axios`/`http.request`) →
+//!   `nika:fetch` (uploads: `multipart:` · crawls: `traverse:`).
+//! - `native-first/002 exec-file` — `cat`/`tee`/`cp`/`mv`/`mkdir`/
+//!   `touch`/`head`/`tail`/`ls` → `nika:read`/`nika:write`/`nika:glob`.
+//! - `native-first/003 exec-data` — `jq`/`sed`/`awk` → `nika:jq` (or an
+//!   `output:` binding — the same jq engine, zero subprocess).
+//! - `native-first/004 exec-media` — an image/speech provider endpoint
+//!   in the command → `nika:image_generate`/`nika:tts_generate`.
+//! - `native-first/005 exec-helper` — an interpreter running a script
+//!   file → inventory the helper (HTTP→fetch · files→read/write ·
+//!   JSON→jq · product APIs→an MCP server) and keep only a genuine
+//!   subprocess, recorded in the exec ledger.
+//!
+//! ADVISORY like every hint (`is_clean` ignores them) — the strict
+//! posture is the CLI's: `nika check --native-strict` fails on any
+//! `native-first` hint. One hint per task (the most specific rule
+//! wins: helper ≻ media ≻ http ≻ file ≻ data); `nika run …` nested
+//! invocations are never flagged (the sanctioned composition path).
+
+use crate::raw::{RawAction, RawCommand, RawWorkflow};
+
+use super::hints::Hint;
+
+/// The hint kind (agents route on it · `hints.rs` kind registry).
+const KIND: &str = "native-first";
+
+/// HTTP client programs (001).
+const HTTP_PROGRAMS: [&str; 5] = ["curl", "wget", "xh", "http", "https"];
+/// File-op programs (002).
+const FILE_PROGRAMS: [&str; 9] = [
+    "cat", "tee", "cp", "mv", "mkdir", "touch", "head", "tail", "ls",
+];
+/// Data-transform programs (003).
+const DATA_PROGRAMS: [&str; 3] = ["jq", "sed", "awk"];
+/// Script interpreters (005 · and the 001 one-liner carve-in).
+const INTERPRETERS: [&str; 10] = [
+    "node", "python", "python3", "bash", "sh", "zsh", "deno", "bun", "ruby", "perl",
+];
+/// Script-file suffixes an interpreter head promotes to 005.
+const SCRIPT_SUFFIXES: [&str; 8] = [".mjs", ".cjs", ".js", ".ts", ".py", ".sh", ".rb", ".pl"];
+/// Media provider endpoint markers (004) — endpoint fragments, not
+/// bare words (a prompt mentioning "tts" must not fire).
+const MEDIA_MARKERS: [&str; 4] = [
+    "images/generations",
+    "images/edits",
+    "/v1/audio/speech",
+    "api.elevenlabs.io",
+];
+/// HTTP one-liner markers inside interpreter code (001 carve-in).
+const HTTP_CODE_MARKERS: [&str; 4] = ["fetch(", "axios", "http.request", "https.request"];
+
+/// Scan every `exec:` task (and `on_finally` cleanups) for a native
+/// path — at most one hint per task.
+pub(super) fn scan(wf: &RawWorkflow) -> Vec<Hint> {
+    let mut hints = Vec::new();
+    for task in &wf.tasks {
+        let id = task.value.id.value.as_str();
+        push_native_first(&task.value.action, id, &mut hints);
+        for cleanup in &task.value.on_finally {
+            push_native_first(&cleanup.value.action, id, &mut hints);
+        }
+    }
+    hints
+}
+
+fn push_native_first(action: &RawAction, id: &str, hints: &mut Vec<Hint>) {
+    let RawAction::Exec(exec) = action else {
+        return;
+    };
+    if let Some(advice) = native_advice(&exec.command) {
+        hints.push(Hint {
+            kind: KIND,
+            task: id.to_owned(),
+            advice,
+        });
+    }
+}
+
+/// The rule ladder — most specific first, one verdict.
+fn native_advice(command: &RawCommand) -> Option<String> {
+    let head = command_head(command)?;
+    if head == "nika" {
+        return None; // nested `nika run …` — the sanctioned composition
+    }
+    let fragments = command.text_fragments();
+    let has_marker = |markers: &[&str]| {
+        fragments
+            .iter()
+            .any(|f| markers.iter().any(|m| f.contains(m)))
+    };
+    let is_interpreter = INTERPRETERS.contains(&head.as_str());
+
+    // 005 · interpreter + script file — the helper umbrella.
+    if is_interpreter
+        && fragments
+            .iter()
+            .any(|f| !f.contains("${{") && SCRIPT_SUFFIXES.iter().any(|suffix| f.ends_with(suffix)))
+    {
+        return Some(format!(
+            "native-first/005 · `{head}` runs a helper script — inventory it: \
+             HTTP calls → `nika:fetch` (uploads: `multipart:` · crawls: `traverse:`) · \
+             file I/O → `nika:read`/`nika:write` · JSON shaping → `nika:jq` · \
+             a product API → wrap it as an MCP server (`mcp:<server>/<tool>`); \
+             keep `exec:` only for a genuine subprocess and record it in the exec ledger"
+        ));
+    }
+    // 004 · a media provider endpoint in the command.
+    if has_marker(&MEDIA_MARKERS) {
+        return Some(format!(
+            "native-first/004 · `{head}` calls a media provider endpoint — \
+             `nika:image_generate`/`nika:tts_generate` cover generation natively \
+             (provider-portable · provenance manifest · permits.fs-gated saves)"
+        ));
+    }
+    // 001 · an HTTP client program, or an interpreter one-liner around one.
+    if HTTP_PROGRAMS.contains(&head.as_str()) || (is_interpreter && has_marker(&HTTP_CODE_MARKERS))
+    {
+        return Some(format!(
+            "native-first/001 · `{head}` is an HTTP fetch — `nika:fetch` covers \
+             GET/POST + extraction (SSRF-defended · permits-gated); uploads take \
+             `multipart:` · crawls take `traverse:` (builtins-v0.1.md §nika:fetch)"
+        ));
+    }
+    // 002 · file plumbing.
+    if FILE_PROGRAMS.contains(&head.as_str()) {
+        return Some(format!(
+            "native-first/002 · `{head}` is file plumbing — `nika:read`/`nika:write` \
+             (`create_dirs: true` replaces mkdir) / `nika:glob` cover it inside the \
+             permits.fs boundary (no subprocess)"
+        ));
+    }
+    // 003 · data transforms.
+    if DATA_PROGRAMS.contains(&head.as_str()) {
+        return Some(format!(
+            "native-first/003 · `{head}` reshapes data — `nika:jq` (or an `output:` \
+             jq binding) covers JSON in-process · `nika:edit` covers in-place \
+             literal file edits (one data language · no quoting traps)"
+        ));
+    }
+    None
+}
+
+/// The literal program head: argv[0] for the argv form, the first
+/// non-assignment token of a shell string. Basename'd (`/usr/bin/curl`
+/// counts as `curl`); a templated head (`${{ … }}`) makes no claim.
+fn command_head(command: &RawCommand) -> Option<String> {
+    let raw = match command {
+        RawCommand::Argv(_) => command.argv_program()?.to_owned(),
+        RawCommand::Shell(s) => {
+            let mut tokens = s.value.split_whitespace();
+            // `FOO=bar cmd …` — skip leading env assignments (a `=`
+            // before any `/` is an assignment, not a path).
+            loop {
+                let token = tokens.next()?;
+                let is_assignment = token
+                    .split_once('=')
+                    .is_some_and(|(name, _)| !name.contains('/') && !name.is_empty());
+                if !is_assignment {
+                    break token.to_owned();
+                }
+            }
+        }
+    };
+    if raw.contains("${{") {
+        return None; // templated — runtime business, no static claim
+    }
+    let head = raw.rsplit('/').next().unwrap_or(&raw);
+    (!head.is_empty()).then(|| head.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn hints_of(yaml: &str) -> Vec<Hint> {
+        scan(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+    }
+
+    fn exec_wf(command_yaml: &str) -> String {
+        format!(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: {{ command: {command_yaml} }}\n"
+        )
+    }
+
+    fn sole_native_hint(yaml: &str) -> Hint {
+        let hints = hints_of(yaml);
+        let native: Vec<&Hint> = hints.iter().filter(|h| h.kind == "native-first").collect();
+        assert_eq!(native.len(), 1, "exactly one per task: {hints:?}");
+        native[0].clone()
+    }
+
+    #[test]
+    fn fires_on_curl_naming_fetch_001() {
+        let h = sole_native_hint(&exec_wf(
+            "\"curl -s https://api.test/items -H 'x-api-key: k'\"",
+        ));
+        assert_eq!(h.task, "t");
+        assert!(h.advice.contains("native-first/001"), "{h:?}");
+        assert!(h.advice.contains("nika:fetch"), "{h:?}");
+    }
+
+    #[test]
+    fn fires_on_argv_wget_and_pathed_program() {
+        let h = sole_native_hint(&exec_wf("[\"/usr/bin/wget\", \"https://x.test\"]"));
+        assert!(h.advice.contains("native-first/001"), "{h:?}");
+    }
+
+    #[test]
+    fn fires_on_node_helper_script_005_not_001() {
+        // An interpreter + script file is the HELPER class even when the
+        // script name suggests HTTP — the umbrella advice owns it.
+        let h = sole_native_hint(&exec_wf(
+            "[\"node\", \"workflows/site/bin/crawl-and-upload.mjs\", \"--url\", \"${{ vars.site }}\"]",
+        ));
+        assert!(h.advice.contains("native-first/005"), "{h:?}");
+        assert!(h.advice.contains("exec ledger"), "{h:?}");
+    }
+
+    #[test]
+    fn fires_on_python_inline_fetch_as_001() {
+        let h = sole_native_hint(&exec_wf(
+            "\"python3 -c 'import urllib; fetch(\\\"https://x.test\\\")'\"",
+        ));
+        assert!(h.advice.contains("native-first/001"), "{h:?}");
+    }
+
+    #[test]
+    fn fires_on_media_endpoint_004_over_http_001() {
+        let h = sole_native_hint(&exec_wf(
+            "\"curl -X POST https://api.openai.com/v1/images/generations -d @body.json\"",
+        ));
+        assert!(h.advice.contains("native-first/004"), "{h:?}");
+        assert!(h.advice.contains("nika:image_generate"), "{h:?}");
+    }
+
+    #[test]
+    fn fires_on_file_and_data_programs() {
+        let file = sole_native_hint(&exec_wf("\"cat out/manifest.json\""));
+        assert!(file.advice.contains("native-first/002"), "{file:?}");
+        let data = sole_native_hint(&exec_wf(
+            "\"jq '.items | map(.name)' out/crawl.json > out/names.json\"",
+        ));
+        assert!(data.advice.contains("native-first/003"), "{data:?}");
+        let env_prefixed = sole_native_hint(&exec_wf("\"LC_ALL=C sed s/a/b/ in.txt\""));
+        assert!(
+            env_prefixed.advice.contains("native-first/003"),
+            "assignments are skipped to the real head: {env_prefixed:?}"
+        );
+    }
+
+    #[test]
+    fn silent_on_genuine_subprocesses() {
+        for command in [
+            "\"cargo test --workspace --lib\"",
+            "\"git commit -m 'x'\"",
+            "[\"qrt\", \"product\", \"create\", \"--json\"]",
+            "\"make release\"",
+            "\"nika run subroutine.nika.yaml\"",
+            "\"${{ vars.tool }} --flag\"",
+        ] {
+            let hints = hints_of(&exec_wf(command));
+            assert!(
+                !hints.iter().any(|h| h.kind == "native-first"),
+                "{command} must stay silent: {hints:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn silent_on_interpreter_without_script_or_http() {
+        // A bare interpreter computation is a legitimate subprocess.
+        let hints = hints_of(&exec_wf("\"python3 -c 'print(6*7)'\""));
+        assert!(!hints.iter().any(|h| h.kind == "native-first"), "{hints:?}");
+    }
+
+    #[test]
+    fn on_finally_cleanups_are_scanned_too() {
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"make build\" }\n    on_finally:\n      - exec: { command: \"curl -X POST https://hooks.test/done\" }\n";
+        let hints = hints_of(yaml);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.kind == "native-first" && h.task == "t"),
+            "{hints:?}"
+        );
+    }
+
+    #[test]
+    fn the_site_asset_regression_fixture_yields_all_four_hints() {
+        // The genericized empirical trigger: a site-asset workflow whose
+        // four exec tasks are all natively expressible. Spec-VALID (it
+        // parses + checks) yet every task earns its native-first hint.
+        let yaml = r#"nika: v1
+workflow: site-asset
+model: mock/echo
+tasks:
+  - id: crawl_site
+    exec: { command: "curl -s https://acme.test -o out/site.html" }
+  - id: upload_background
+    depends_on: [crawl_site]
+    exec:
+      command: ["node", "workflows/site/bin/helper.mjs", "upload", "--file", "out/bg.png"]
+  - id: render_background
+    depends_on: [crawl_site]
+    exec: { command: "curl -X POST https://api.openai.com/v1/images/generations" }
+  - id: write_manifest
+    depends_on: [upload_background, render_background]
+    exec: { command: "jq -n '{done: true}' > out/manifest.json" }
+"#;
+        let hints = hints_of(yaml);
+        let by_task: Vec<(&str, &str)> = hints
+            .iter()
+            .filter(|h| h.kind == "native-first")
+            .map(|h| {
+                let rule = h
+                    .advice
+                    .split_once(" · ")
+                    .map(|(rule, _)| rule)
+                    .unwrap_or_default();
+                (h.task.as_str(), rule)
+            })
+            .collect();
+        assert_eq!(
+            by_task,
+            vec![
+                ("crawl_site", "native-first/001"),
+                ("upload_background", "native-first/005"),
+                ("render_background", "native-first/004"),
+                ("write_manifest", "native-first/003"),
+            ],
+            "{hints:?}"
+        );
+    }
+}

--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -86,17 +86,20 @@ fn push_native_first(action: &RawAction, id: &str, hints: &mut Vec<Hint>) {
     let RawAction::Exec(exec) = action else {
         return;
     };
-    if let Some(advice) = native_advice(&exec.command) {
+    if let Some((rule, advice)) = classify(&exec.command) {
         hints.push(Hint {
             kind: KIND,
             task: id.to_owned(),
-            advice,
+            advice: format!("{rule} · {advice}"),
         });
     }
 }
 
-/// The rule ladder — most specific first, one verdict.
-fn native_advice(command: &RawCommand) -> Option<String> {
+/// The rule ladder — most specific first, one verdict. Returns the
+/// stable rule id (`native-first/00N`) + the advice body. ONE truth:
+/// the check hint AND the reference linter ruleset
+/// (`lints::native_first`) both classify HERE.
+pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
     let head = command_head(command)?;
     if head == "nika" {
         return None; // nested `nika run …` — the sanctioned composition
@@ -115,45 +118,60 @@ fn native_advice(command: &RawCommand) -> Option<String> {
             .iter()
             .any(|f| !f.contains("${{") && SCRIPT_SUFFIXES.iter().any(|suffix| f.ends_with(suffix)))
     {
-        return Some(format!(
-            "native-first/005 · `{head}` runs a helper script — inventory it: \
-             HTTP calls → `nika:fetch` (uploads: `multipart:` · crawls: `traverse:`) · \
-             file I/O → `nika:read`/`nika:write` · JSON shaping → `nika:jq` · \
-             a product API → wrap it as an MCP server (`mcp:<server>/<tool>`); \
-             keep `exec:` only for a genuine subprocess and record it in the exec ledger"
+        return Some((
+            "native-first/005",
+            format!(
+                "`{head}` runs a helper script — inventory it: \
+                 HTTP calls → `nika:fetch` (uploads: `multipart:` · crawls: `traverse:`) · \
+                 file I/O → `nika:read`/`nika:write` · JSON shaping → `nika:jq` · \
+                 a product API → wrap it as an MCP server (`mcp:<server>/<tool>`); \
+                 keep `exec:` only for a genuine subprocess and record it in the exec ledger"
+            ),
         ));
     }
     // 004 · a media provider endpoint in the command.
     if has_marker(&MEDIA_MARKERS) {
-        return Some(format!(
-            "native-first/004 · `{head}` calls a media provider endpoint — \
-             `nika:image_generate`/`nika:tts_generate` cover generation natively \
-             (provider-portable · provenance manifest · permits.fs-gated saves)"
+        return Some((
+            "native-first/004",
+            format!(
+                "`{head}` calls a media provider endpoint — \
+                 `nika:image_generate`/`nika:tts_generate` cover generation natively \
+                 (provider-portable · provenance manifest · permits.fs-gated saves)"
+            ),
         ));
     }
     // 001 · an HTTP client program, or an interpreter one-liner around one.
     if HTTP_PROGRAMS.contains(&head.as_str()) || (is_interpreter && has_marker(&HTTP_CODE_MARKERS))
     {
-        return Some(format!(
-            "native-first/001 · `{head}` is an HTTP fetch — `nika:fetch` covers \
-             GET/POST + extraction (SSRF-defended · permits-gated); uploads take \
-             `multipart:` · crawls take `traverse:` (builtins-v0.1.md §nika:fetch)"
+        return Some((
+            "native-first/001",
+            format!(
+                "`{head}` is an HTTP fetch — `nika:fetch` covers \
+                 GET/POST + extraction (SSRF-defended · permits-gated); uploads take \
+                 `multipart:` · crawls take `traverse:` (builtins-v0.1.md §nika:fetch)"
+            ),
         ));
     }
     // 002 · file plumbing.
     if FILE_PROGRAMS.contains(&head.as_str()) {
-        return Some(format!(
-            "native-first/002 · `{head}` is file plumbing — `nika:read`/`nika:write` \
-             (`create_dirs: true` replaces mkdir) / `nika:glob` cover it inside the \
-             permits.fs boundary (no subprocess)"
+        return Some((
+            "native-first/002",
+            format!(
+                "`{head}` is file plumbing — `nika:read`/`nika:write` \
+                 (`create_dirs: true` replaces mkdir) / `nika:glob` cover it inside the \
+                 permits.fs boundary (no subprocess)"
+            ),
         ));
     }
     // 003 · data transforms.
     if DATA_PROGRAMS.contains(&head.as_str()) {
-        return Some(format!(
-            "native-first/003 · `{head}` reshapes data — `nika:jq` (or an `output:` \
-             jq binding) covers JSON in-process · `nika:edit` covers in-place \
-             literal file edits (one data language · no quoting traps)"
+        return Some((
+            "native-first/003",
+            format!(
+                "`{head}` reshapes data — `nika:jq` (or an `output:` \
+                 jq binding) covers JSON in-process · `nika:edit` covers in-place \
+                 literal file edits (one data language · no quoting traps)"
+            ),
         ));
     }
     None

--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -159,7 +159,7 @@ fn native_advice(command: &RawCommand) -> Option<String> {
     None
 }
 
-/// The literal program head: argv[0] for the argv form, the first
+/// The literal program head: `argv[0]` for the argv form, the first
 /// non-assignment token of a shell string. Basename'd (`/usr/bin/curl`
 /// counts as `curl`); a templated head (`${{ … }}`) makes no claim.
 fn command_head(command: &RawCommand) -> Option<String> {

--- a/crates/nika-schema/src/lints/mod.rs
+++ b/crates/nika-schema/src/lints/mod.rs
@@ -8,13 +8,17 @@
 //! run on the raw AST after [`crate::parse`] succeeds and are orthogonal
 //! to [`crate::analyze`] (which emits spec ERRORS).
 //!
-//! v0.1 ships TWO rule sets · [`one_obvious_way`] — the control-flow
-//! preference rules the spec marks « normative for linters » — and
+//! v0.1 ships THREE rule sets · [`one_obvious_way`] — the control-flow
+//! preference rules the spec marks « normative for linters » —
+//! [`native_first()`] — the verb-choice preference rules (spec
+//! `03-dag.md` §Native-first · exec with a probable native path) — and
 //! [`arg_injection()`] — argument-injection advisories for the array command
 //! form (spec `02-verbs.md` §exec Security · the differentiator).
 
 mod arg_injection;
+mod native_first;
 mod preference_rules;
 
 pub use arg_injection::arg_injection;
+pub use native_first::native_first;
 pub use preference_rules::{Lint, one_obvious_way};

--- a/crates/nika-schema/src/lints/native_first.rs
+++ b/crates/nika-schema/src/lints/native_first.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `native-first` rule set — spec `03-dag.md` §Native-first
+//! (rules 001-005 · « normative for lints »): an `exec:` whose literal
+//! command a stdlib builtin (or an MCP tool) covers.
+//!
+//! The CLASSIFICATION is `check::native_first::classify` — one truth
+//! shared with the check-report hint (kind `native-first`), so the
+//! linter ruleset and the audit surface can never disagree on what
+//! fires. This module only reshapes the verdict into [`Lint`] records
+//! (rule id · task · span · message · suggestion).
+
+use crate::check::native_first::classify;
+use crate::raw::{RawAction, RawWorkflow};
+
+use super::preference_rules::Lint;
+
+/// Run the `native-first/001..005` preference rules over a parsed
+/// workflow. Output is deterministic — task order, main action before
+/// its `on_finally` cleanups, at most one lint per action.
+#[must_use]
+pub fn native_first(wf: &RawWorkflow) -> Vec<Lint> {
+    let mut lints = Vec::new();
+    for task in &wf.tasks {
+        let t = &task.value;
+        push(&t.action, t.id.value.as_str(), t.id.span, &mut lints);
+        for cleanup in &t.on_finally {
+            push(
+                &cleanup.value.action,
+                t.id.value.as_str(),
+                t.id.span,
+                &mut lints,
+            );
+        }
+    }
+    lints
+}
+
+fn push(action: &RawAction, id: &str, span: crate::source::Span, lints: &mut Vec<Lint>) {
+    let RawAction::Exec(exec) = action else {
+        return;
+    };
+    if let Some((rule, advice)) = classify(&exec.command) {
+        lints.push(Lint::new(
+            rule,
+            id.to_owned(),
+            span,
+            "`exec:` with a probable native path (spec 03 §Native-first)".to_owned(),
+            advice,
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn lints_of(yaml: &str) -> Vec<(String, String)> {
+        native_first(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+            .into_iter()
+            .map(|l| (l.rule.to_owned(), l.task_id))
+            .collect()
+    }
+
+    /// The three spec conformance fixtures, inline (the corpus itself is
+    /// exercised by `tests/lints_one_obvious_way.rs` against ../spec).
+    #[test]
+    fn mirrors_the_spec_lints_fixtures() {
+        let fired = lints_of(
+            "nika: v1\nworkflow: curl-crawl\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://example.com -o out/site.html\" }\n",
+        );
+        assert_eq!(
+            fired,
+            vec![("native-first/001".to_owned(), "crawl".to_owned())]
+        );
+
+        let helper = lints_of(
+            "nika: v1\nworkflow: helper\ntasks:\n  - id: upload\n    exec:\n      command: [\"node\", \"workflows/site/bin/helper.mjs\", \"upload\", \"--file\", \"out/bg.png\"]\n",
+        );
+        assert_eq!(
+            helper,
+            vec![("native-first/005".to_owned(), "upload".to_owned())]
+        );
+
+        let silent = lints_of(
+            "nika: v1\nworkflow: build\ntasks:\n  - id: test\n    exec: { command: \"cargo test --workspace --lib\" }\n  - id: nested\n    depends_on: [test]\n    exec: { command: \"nika run subroutine.nika.yaml\" }\n",
+        );
+        assert!(silent.is_empty(), "{silent:?}");
+    }
+}

--- a/crates/nika-schema/tests/lints_one_obvious_way.rs
+++ b/crates/nika-schema/tests/lints_one_obvious_way.rs
@@ -18,12 +18,14 @@
 mod common;
 
 use common::{fixture_dirs, skip_in_mutants_sandbox, spec_dir};
-use nika_schema::lints::{Lint, one_obvious_way};
+use nika_schema::lints::{Lint, native_first, one_obvious_way};
 use nika_schema::{FileId, ParseMode, parse};
 
 fn lint(yaml: &str) -> Vec<Lint> {
     let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("lint fixture must parse");
-    one_obvious_way(&wf)
+    let mut lints = one_obvious_way(&wf);
+    lints.extend(native_first(&wf));
+    lints
 }
 
 #[derive(Debug, serde::Deserialize, PartialEq)]

--- a/crates/nika-schema/tests/metamorphic.rs
+++ b/crates/nika-schema/tests/metamorphic.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 //! Metamorphic conformance (ADR-092 ladder #9 · the first slice).
 //!
@@ -32,9 +33,7 @@ use std::fmt::Write as _;
 
 use proptest::prelude::*;
 
-use super::certificate::Bound;
-use super::certificate::RunCertificate;
-use crate::{FileId, ParseMode, parse};
+use nika_schema::{Bound, CheckReport, FileId, ParseMode, RunCertificate, check, parse};
 
 /// One generated task — a STRUCTURE, rendered to YAML with any id
 /// prefix (that is what makes R2 trivial and exact).
@@ -122,9 +121,9 @@ fn to_yaml(tasks: &[TaskSpec], prefix: &str) -> String {
 }
 
 /// Front-door run: parse (strict) then the infallible check.
-fn run(yaml: &str) -> Result<super::CheckReport, String> {
+fn run(yaml: &str) -> Result<CheckReport, String> {
     let wf = parse(yaml, FileId::new(0), ParseMode::Strict).map_err(|e| e.to_string())?;
-    Ok(super::check(&wf))
+    Ok(check(&wf))
 }
 
 /// A bound as an order-free multiset (terms sorted) for comparison
@@ -331,7 +330,7 @@ proptest! {
     fn r6_honest_certificates_always_audit_clean(tasks in workflow_strategy()) {
         let yaml = to_yaml(&tasks, "t");
         let wf = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parses");
-        let report = super::check(&wf);
+        let report = check(&wf);
         prop_assert!(
             report.certificate.audit(&wf).is_ok(),
             "honest certificate rejected on:\n{yaml}"


### PR DESCRIPTION
## What

The pressure half: `nika check` validated the exec-helper workflow CLEAN. Now:

- **`native-first` hint family** (`check/native_first.rs` · the `native-first/001..005` ruleset): exec-http (curl/wget/xh + interpreter fetch() one-liners) → `nika:fetch` · exec-file → `nika:read/write/glob` · exec-data (jq/sed/awk) → `nika:jq`/`nika:edit` · exec-media (provider endpoints) → `nika:image_generate`/`nika:tts_generate` · exec-helper (interpreter + script file) → inventory it + the exec ledger. Deterministic on literal heads · one hint per task (helper ≻ media ≻ http ≻ file ≻ data) · `nika run` nesting + genuine subprocesses (cargo/git/make/product CLIs) stay silent — **zero false positives across the whole embedded pack corpus** (verified: every existing example/template exec head is silent).
- **`nika check --native-strict`** — promotes the hints to failure (exit FILE=2) on an otherwise-clean workflow; `--json` gains `native_strict_clean` (additive, only under the flag). The agent/CI posture the authoring skill teaches.
- **`lints::native_first`** — the reference linter emits the same ruleset (spec 03 §Native-first marks it « normative for lints »), classification shared with the hint (`classify()` — one truth, two surfaces). The spec conformance corpus (nika-spec#30 `nf00N-*` fixtures) pins it via the same harness as one-obvious-way.
- **nika-authoring skill vNext** (source of truth here · mirror = nika-agents#4): native-first law (builtin? MCP? name the gap) · exec ledger · --native-strict in the loop.

Also rides: metamorphic → tests/ (same move as E1 · trivial merge) · argv[0] doc escape.

## MERGE ORDER

This PR **before** nika-spec#30 (the engine lint-corpus harness reads spec main — fixtures for a ruleset the linter doesn't emit yet would RED the corpus).

## Gates

781 schema lib tests (incl. the genericized site-asset regression fixture asserting all four rules fire) · 239 cli lib tests (strict default-0/strict-2 + native twin stays 0) · clippy 0 all-targets · size 14856/15000 · hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
