### PR TITLE
docs(pack): surgical vendor — provider count catches canon (16)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,7 +137,7 @@ notes · key decisions), not a census.
 - **nika-catalog** — static catalogs with phf+unicase lookup (226 tests after 4B)
   - 42-variant typed `Tag` enum, Cargo feature gating, Shield XOR invariant
   - 105 MCP servers, **32 LLM providers**, 13 embeddings, 63 builtins, 65 transforms
-    *(this is the `nika-catalog` **inventory** — what the engine has metadata for. Distinct from the `nika-spec` **v0.1 stdlib contract** of 16 providers · 23 builtins · 9 extract modes that a conformant engine must support (16 per canon.yaml since ADR-104 promoted huggingface + nvidia) · the extra builtins are media/opt-in, deferred to stdlib v0.x. The 63→22 catalog reconciliation was D-2026-05-26-N5/N6 + ADR-086/087/088 Rams sweep 2026-05-27.)*
+    *(this is the `nika-catalog` **inventory** — what the engine has metadata for. Distinct from the `nika-spec` **v0.1 stdlib contract** of 16 providers · 25 builtins · 9 extract modes that a conformant engine must support (counts per canon.yaml · ADR-104 promoted huggingface + nvidia · the media pair joined the contract at 0.94) · the catalog's extra builtins beyond the contract stay opt-in metadata. The 63→22 catalog reconciliation was D-2026-05-26-N5/N6 + ADR-086/087/088 Rams sweep 2026-05-27.)*
   - **TOML-driven capability resolver** — **49 rules**, zero-alloc, proptest 10k parity
   - `api_dialect` on all 32 providers (closed set, FK-validated at build time)
   - **12-field `ModelCapabilities`**: token_limit_param + temperature + stop + reasoning + input/output modalities + tokenizer (**12 families**: Cl100k/O200k/ClaudeV3/Gemini/LlamaV3/LlamaV4/MistralV3/DeepSeek/Qwen/Granite/Glm/Grok) + supported_parameters (**13 flags**: incl. BatchApi/ContextCaching/PredictedOutputs/ComputerUse/Citations/IncludeReasoning) + system_messages + context_window_tokens + max_output_tokens + json_mode
@@ -518,7 +518,7 @@ Grok 4 variants (grok-4/grok-4-fast).
 `response: {full, binary}`, reached via `invoke: {tool: "nika:fetch"}`.
 Per D-2026-05-22-N18.)
 
-**63 builtin tools** (full engine inventory · the `nika-spec` **v0.1 stdlib contract** curates **22** of these — 6 core · 5 file · 8 data · 1 introspection · 2 network — per the ADR-086/087/088 Rams collapses (jq-subsumption · `wait` + `inspect` unifications) · was 42 · and defers 24 media builtins to stdlib v0.x) split by domain (lives in `nika-builtin` L2, with native API adapters split into bundle crates `nika-builtin-{github,cloud,workspace}` for heavy deps isolation):
+**63 builtin tools** (full engine inventory · the `nika-spec` **v0.1 stdlib contract** curates **25** of these — 6 core · 5 file · 8 data · 2 network · 2 introspection · 2 media — per the ADR-086/087/088 Rams collapses (jq-subsumption · `wait` + `inspect` unifications · was 42 → 22, then `nika:compose` + the media pair joined) · the remaining media builtins stay stdlib-v0.x opt-in) split by domain (lives in `nika-builtin` L2, with native API adapters split into bundle crates `nika-builtin-{github,cloud,workspace}` for heavy deps isolation):
 - Core (7): `sleep`, `log`, `emit`, `assert`, `prompt`, `run`, `complete`
 - File (5): `read`, `write`, `edit`, `glob`, `grep`
 - Introspection (6): `dag_info`, `task_status`, `threads`, `orchestrate`, `cost`, `records`

--- a/crates/nika-pack/pack/spec/01-envelope.md
+++ b/crates/nika-pack/pack/spec/01-envelope.md
@@ -158,7 +158,7 @@ Default model for any `infer:` or `agent:` verb in this workflow, as a single
 there is no separate `provider:` field). The provider prefix selects the
 backend and decides local-vs-cloud (`ollama/` · `lmstudio/` = local · the rest
 = cloud). See [stdlib/providers-v0.1.md](../stdlib/providers-v0.1.md) for the
-14-provider catalog.
+<!-- canon:providers -->16<!-- /canon -->-provider catalog.
 
 A task may override this. If absent · each `infer:`/`agent:` task must specify
 its own `model:`.

--- a/crates/nika-pack/pack/spec/07-conformance.md
+++ b/crates/nika-pack/pack/spec/07-conformance.md
@@ -81,7 +81,7 @@ guarantees below) ·
 | **Cost ceiling** | the worst-case spend · `Σ (max_tokens × provider price)` across `infer:`/`agent:` tasks · before one token is spent | the `nika:inspect view: cost` model, run statically |
 | **Secret leak** | every `secrets.X` that flows into an `exec` capture or a tool whose output is bound (the masking boundary · [04 §secrets](./04-variables.md)) | reference graph |
 | **Capability escape** | any effect outside a declared `permits:` block: a write outside `fs.write`, a fetch to an unlisted host, an `exec` under `exec: false`, an unlisted tool | `permits:` ([01](./01-envelope.md)) |
-| **Provider parity** | (`--providers`) that the workflow uses zero provider-specific fields → the same `schema:` runs identically on all 14 providers (incl. the 5 local) | the closed verb-field set |
+| **Provider parity** | (`--providers`) that the workflow uses zero provider-specific fields → the same `schema:` runs identically on all <!-- canon:providers -->16<!-- /canon --> providers (incl. the 5 local) | the closed verb-field set |
 
 This is the property no other AI workflow runner gives: **GitHub Actions,
 Temporal, and LangGraph tell you nothing (and charge you nothing back)


### PR DESCRIPTION
## What (closing the open item from the socratic passes)

**Embedded pack** — two pages still taught **14 providers**; nika-spec main fixed both with `canon:providers` markers (nika-spec#31). This is a **surgical two-file vendor**, deliberately NOT a full `sync-pack.sh` run:

- spec main also carries the fetch-vNext surface (nika-spec#30) — its 3 new templates would trip the `template_names() == 6` pin in `pack_integrity.rs`. That full re-vendor belongs to the fetch-vNext engine train.
- The two files diff **exactly** the provider-count hunks against the vendored copies (verified pre-copy) → pack counts (doc_paths · examples · templates) untouched.

**ROADMAP.md** — the stdlib-contract parentheticals catch canon.yaml: **25 builtins** (22 → `nika:compose` → the 0.94 media pair) with the 6-category breakdown (6 core · 5 file · 8 data · 2 network · 2 introspection · 2 media), and the media-deferred clause now scoped to the catalog extras beyond the contract. The 2026-06-11 providers **ship-note keeps its 14** (accurate at that date — historical, like the 0.91 ladder row).

## Verify

- `diff pack/spec/{01,07}*.md` vs spec main pre-copy = exactly the two count hunks.
- Category breakdown derived from `stdlib/builtins-v0.1.md` headings (6+5+8+2+2+2 = 25 = canon.yaml `counts.builtins`).
- Docs-only diff (4+/4−) · no `.rs` touched · pack pins unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)