### PR TITLE
feat(nika-cli): wizard wow — the conversation speaks the display seam

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -682,11 +682,11 @@ pub fn nika_cli::verbs::graph::run(path: &str, format: nika_cli::verbs::graph::G
 pub fn nika_cli::verbs::graph::to_dot(doc: &nika_cli::verbs::graph::GraphDoc) -> alloc::string::String
 pub fn nika_cli::verbs::graph::to_mermaid(doc: &nika_cli::verbs::graph::GraphDoc) -> alloc::string::String
 pub mod nika_cli::verbs::init
-pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::inspect
 pub fn nika_cli::verbs::inspect::run(path: &str, ascii: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::new
-pub fn nika_cli::verbs::new::dispatch(from: core::option::Option<&str>, dest: core::option::Option<&str>, force: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::new::dispatch(from: core::option::Option<&str>, dest: core::option::Option<&str>, force: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::new::run(template: &str, dest: core::option::Option<&str>, force: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::pack_surface
 pub fn nika_cli::verbs::pack_surface::examples_list() -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -516,6 +516,7 @@ fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
     let color = cli.color;
     let link_when = cli.hyperlink.choice();
+    let plain_theme = term_theme(color.with_no_color(false), false, link_when);
     let code = match cli.command {
         Command::Check {
             file,
@@ -559,7 +560,7 @@ fn main() -> std::process::ExitCode {
         }
         Command::Explain { code } => emit(&verbs::explain::run(&code)),
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json)),
-        Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes)),
+        Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target.into(), &dir)),
         Command::Spec { canon } => emit(&verbs::pack_surface::spec(canon)),
         Command::Schema => emit(&verbs::pack_surface::schema()),
@@ -569,16 +570,15 @@ fn main() -> std::process::ExitCode {
             ExamplesAction::List => emit(&verbs::pack_surface::examples_list()),
             ExamplesAction::Show { slug } => emit(&verbs::pack_surface::examples_show(&slug)),
             // The L3 run verb shipped — execute the embedded example for real.
-            ExamplesAction::Run { slug, model } => verbs::run::example(
-                &slug,
-                model.as_deref(),
-                term_theme(color.with_no_color(false), false, link_when),
-            ),
+            ExamplesAction::Run { slug, model } => {
+                verbs::run::example(&slug, model.as_deref(), plain_theme)
+            }
         },
         Command::New { from, dest, force } => emit(&verbs::new::dispatch(
             from.as_deref(),
             dest.as_deref(),
             force,
+            plain_theme,
         )),
         Command::Completions { shell } => {
             write_completions(shell, &mut std::io::stdout());

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -20,6 +20,7 @@ use std::fmt::Write as _;
 use std::io::IsTerminal;
 use std::path::Path;
 
+use crate::display::theme::Theme;
 use crate::verbs::VerbOutput;
 
 /// `.vscode/settings.json` — wire `*.nika.yaml` to the canonical schema so any
@@ -184,7 +185,7 @@ const NEXT_BLOCK: &str = "next ·\n  nika examples run 01-hello --model mock/ech
 /// the gh-repo-create shape (bare on a TTY is guided · flags and pipes
 /// keep the exact old output).
 #[must_use]
-pub fn run(dir: &str, force: bool, yes: bool) -> VerbOutput {
+pub fn run(dir: &str, force: bool, yes: bool, theme: Theme) -> VerbOutput {
     let plan = plan(dir, &|p| Path::new(p).exists(), force);
     let mut lines: Vec<(char, String)> = Vec::new();
     let mut failed = false;
@@ -216,7 +217,7 @@ pub fn run(dir: &str, force: bool, yes: bool) -> VerbOutput {
         // println! — output flows through its writer), then offers the
         // first workflow. Declined → the classic hand-off, so nobody
         // exits without a next command.
-        return match crate::verbs::new::offer_first_workflow(dir, &text) {
+        return match crate::verbs::new::offer_first_workflow(dir, &text, theme) {
             Some(v) => v,
             None => VerbOutput::ok(NEXT_BLOCK.to_owned()),
         };
@@ -246,7 +247,12 @@ mod tests {
         // over — the ok-path text carries the golden path.
         let tmp = std::env::temp_dir().join(format!("nika-init-handover-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).expect("mkdir");
-        let out = run(tmp.to_str().expect("utf8"), false, true);
+        let out = run(
+            tmp.to_str().expect("utf8"),
+            false,
+            true,
+            Theme::new(false, false, false),
+        );
         std::fs::remove_dir_all(&tmp).ok();
         assert_eq!(out.code, exit::OK);
         assert!(out.text.contains("next ·"), "{}", out.text);
@@ -260,7 +266,12 @@ mod tests {
     fn yes_keeps_the_non_interactive_shape() {
         let tmp = std::env::temp_dir().join(format!("nika-init-yes-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).expect("mkdir");
-        let out = run(tmp.to_str().expect("utf8"), false, true);
+        let out = run(
+            tmp.to_str().expect("utf8"),
+            false,
+            true,
+            Theme::new(false, false, false),
+        );
         std::fs::remove_dir_all(&tmp).ok();
         assert_eq!(out.code, exit::OK);
         assert!(out.text.contains("✔ created"), "{}", out.text);

--- a/crates/nika-cli/src/verbs/new.rs
+++ b/crates/nika-cli/src/verbs/new.rs
@@ -25,18 +25,26 @@ use std::path::Path;
 
 use nika_bm25::{BmIndex, BmParams};
 
+use crate::display::theme::{Role, Theme};
 use crate::verbs::{VerbOutput, exit};
 
 /// `nika new` — resolve the missing `--from` per clig.dev: a terminal
 /// gets the guided flow (prompt for the missing argument) · a pipe/CI
 /// fails fast naming the flag (never REQUIRE interactivity).
 #[must_use]
-pub fn dispatch(from: Option<&str>, dest: Option<&str>, force: bool) -> VerbOutput {
+pub fn dispatch(from: Option<&str>, dest: Option<&str>, force: bool, theme: Theme) -> VerbOutput {
     match from {
         Some(f) => run(f, dest, force),
         None if interactive() => {
             let stdin = std::io::stdin();
-            wizard_io(".", dest, force, &mut stdin.lock(), &mut std::io::stdout())
+            wizard_io(
+                ".",
+                dest,
+                force,
+                theme,
+                &mut stdin.lock(),
+                &mut std::io::stdout(),
+            )
         }
         None => VerbOutput {
             text: format!(
@@ -190,13 +198,15 @@ struct Wizard {
 const WIZARD_DEST: &str = "my-first.nika.yaml";
 
 /// One prompt · one line back. `None` = EOF (the human left — cancel,
-/// never loop).
+/// never loop). The `>` is the single accent — the conversation's
+/// running line, same semantic slot as the run render's active task.
 fn ask(
     input: &mut dyn BufRead,
     out: &mut dyn std::io::Write,
+    theme: Theme,
     prompt: &str,
 ) -> std::io::Result<Option<String>> {
-    write!(out, "{prompt}\n> ")?;
+    write!(out, "{prompt}\n{} ", theme.paint(Role::Accent, ">"))?;
     out.flush()?;
     let mut line = String::new();
     if input.read_line(&mut line)? == 0 {
@@ -316,29 +326,58 @@ fn stamp(body: &str, id: &str, description: &str, model: &str) -> String {
 }
 
 /// Run the three questions over injected io. `Ok(None)` = cancelled.
+/// Styling stays inside the semantic seam (theme.rs): the brand mark on
+/// the header · dim for defaults/metadata · the accent on resolutions.
+/// Every register without colour keeps byte-identical text (paint is a
+/// no-op), so the conversation reads the same in a transcript.
 fn read_wizard(
     input: &mut dyn BufRead,
     out: &mut dyn std::io::Write,
     dest_hint: Option<&str>,
+    theme: Theme,
 ) -> std::io::Result<Option<Wizard>> {
     writeln!(
         out,
-        "🦋 nika · your first workflow — Enter accepts a default · Ctrl-C exits"
+        "{} nika · {} {}",
+        theme.logo(),
+        theme.paint(Role::Strong, "your first workflow"),
+        theme.paint(Role::Dim, "— Enter accepts a default · Ctrl-C exits"),
     )?;
     let Some(intent) = ask(
         input,
         out,
-        "\nwhat should it do? — a plain sentence routes to the closest skeleton [chain]",
+        theme,
+        &format!(
+            "\nwhat should it do? {}",
+            theme.paint(
+                Role::Dim,
+                "— a plain sentence routes to the closest skeleton [chain]"
+            )
+        ),
     )?
     else {
         return Ok(None);
     };
     let (template, routed) = resolve_template(&intent);
     let tag = nika_pack::template(&template).map_or_else(String::new, |b| tagline(&template, b));
-    writeln!(out, "  → template `{template}` — {tag}")?;
+    writeln!(
+        out,
+        "  → template `{}` {}",
+        theme.paint(Role::Accent, &template),
+        theme.paint(Role::Dim, &format!("— {tag}")),
+    )?;
 
     let default_dest = dest_hint.unwrap_or(WIZARD_DEST);
-    let Some(mut dest) = ask(input, out, &format!("\nfile [{default_dest}]"))? else {
+    let Some(mut dest) = ask(
+        input,
+        out,
+        theme,
+        &format!(
+            "\nfile {}",
+            theme.paint(Role::Dim, &format!("[{default_dest}]"))
+        ),
+    )?
+    else {
         return Ok(None);
     };
     if dest.is_empty() {
@@ -351,15 +390,34 @@ fn read_wizard(
     let menu = model_menu();
     writeln!(
         out,
-        "\nmodel — the same file runs on any provider (`nika catalog` names them all)"
+        "\nmodel {}",
+        theme.paint(
+            Role::Dim,
+            "— the same file runs on any provider (`nika catalog` names them all)"
+        )
     )?;
     for (i, (m, note)) in menu.iter().enumerate() {
-        writeln!(out, "  {}  {m:<30} {note}", i + 1)?;
+        writeln!(
+            out,
+            "  {}  {m:<30} {}",
+            theme.paint(Role::Strong, &(i + 1).to_string()),
+            theme.paint(Role::Dim, note),
+        )?;
     }
-    let Some(pick) = ask(input, out, "a number, or any provider/model [2]")? else {
+    let Some(pick) = ask(
+        input,
+        out,
+        theme,
+        &format!(
+            "a number, or any provider/model {}",
+            theme.paint(Role::Dim, "[2]")
+        ),
+    )?
+    else {
         return Ok(None);
     };
     let model = resolve_model(&pick, &menu);
+    writeln!(out, "  → model `{}`", theme.paint(Role::Accent, &model))?;
     Ok(Some(Wizard {
         template,
         routed,
@@ -374,10 +432,11 @@ pub(crate) fn wizard_io(
     base: &str,
     dest_hint: Option<&str>,
     force: bool,
+    theme: Theme,
     input: &mut dyn BufRead,
     out: &mut dyn std::io::Write,
 ) -> VerbOutput {
-    match read_wizard(input, out, dest_hint) {
+    match read_wizard(input, out, dest_hint, theme) {
         Err(e) => VerbOutput {
             text: format!("wizard i/o failed: {e}"),
             code: exit::ENV,
@@ -386,13 +445,13 @@ pub(crate) fn wizard_io(
             text: "cancelled — nothing written".to_owned(),
             code: exit::ENV,
         },
-        Ok(Some(w)) => materialize(base, &w, force),
+        Ok(Some(w)) => materialize(base, &w, force, theme),
     }
 }
 
 /// `nika init`'s hand-off question — one keypress, Enter = yes (the
 /// golden path). `None` = declined (init prints its classic next block).
-pub(crate) fn offer_first_workflow(base: &str, report: &str) -> Option<VerbOutput> {
+pub(crate) fn offer_first_workflow(base: &str, report: &str, theme: Theme) -> Option<VerbOutput> {
     let stdin = std::io::stdin();
     let mut input = stdin.lock();
     let mut stdout = std::io::stdout();
@@ -403,19 +462,25 @@ pub(crate) fn offer_first_workflow(base: &str, report: &str) -> Option<VerbOutpu
     let answer = ask(
         &mut input,
         &mut *out,
-        "\nscaffold your first workflow now? [Y/n]",
+        theme,
+        &format!(
+            "\nscaffold your first workflow now? {}",
+            theme.paint(Role::Dim, "[Y/n]")
+        ),
     )
     .ok()??;
     if answer.eq_ignore_ascii_case("n") || answer.eq_ignore_ascii_case("no") {
         return None;
     }
-    Some(wizard_io(base, None, false, &mut input, out))
+    Some(wizard_io(base, None, false, theme, &mut input, out))
 }
 
-/// Write the stamped template + hand over to the check-first loop, and
-/// teach the scriptable form of what the wizard just did (the wizard
-/// must map back to flags — reproducibility is part of the contract).
-fn materialize(base: &str, w: &Wizard, force: bool) -> VerbOutput {
+/// Write the stamped template, then RUN the audit and show the ladder —
+/// the wizard hands over a CHECKED workflow, not a suggestion to check
+/// (audit-before-run is the differentiator; the first minute must show
+/// it, not name it). Also teach the scriptable form of what the wizard
+/// just did — reproducibility is part of the contract.
+fn materialize(base: &str, w: &Wizard, force: bool, theme: Theme) -> VerbOutput {
     let dest = if Path::new(&w.dest).is_absolute() || base == "." {
         w.dest.clone()
     } else {
@@ -440,13 +505,26 @@ fn materialize(base: &str, w: &Wizard, force: bool) -> VerbOutput {
         };
     }
     let routing = if w.routed { "routed intent → " } else { "" };
-    VerbOutput {
-        text: format!(
-            "{dest} ← {routing}template `{tpl}` · stamped workflow `{id}` · model `{model}`\n\nnext ·\n  nika check {dest}                # the oracle — it names every remaining `# SLOT:` to fill\n  nika run {dest}                  # execute · live render (mock is offline · $0.00)\n\nscriptable form · nika new --from {tpl} {dest}",
-            tpl = w.template,
-            model = w.model,
+    let wrote = format!(
+        "{} {dest} ← {routing}template `{tpl}` · stamped workflow `{id}` · model `{model}`",
+        theme.paint(Role::Good, "✔"),
+        tpl = w.template,
+        model = w.model,
+    );
+    // The audit runs NOW — the ladder on screen inside the first minute
+    // is the product's argument (a red ladder would honestly propagate,
+    // but a fresh scaffold checks clean by the templates' own-corpus law).
+    let audit = crate::verbs::check::run(&dest, false, false, theme);
+    let next = format!(
+        "next ·\n  $EDITOR {dest}                   # fill the remaining `# SLOT:` lines\n  nika run {dest}                  # execute · live render (mock is offline · $0.00)\n\n{}",
+        theme.paint(
+            Role::Dim,
+            &format!("scriptable form · nika new --from {} {dest}", w.template)
         ),
-        code: exit::OK,
+    );
+    VerbOutput {
+        text: format!("{wrote}\n\n{}\n\n{next}", audit.text.trim_end()),
+        code: audit.code,
     }
 }
 
@@ -568,6 +646,8 @@ fn route_intent(intent: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    const PLAIN: Theme = Theme::new(false, false, false);
+
     fn dest(tag: &str) -> String {
         std::env::temp_dir()
             .join(format!("nika-new-{}-{tag}.nika.yaml", std::process::id()))
@@ -685,7 +765,7 @@ mod tests {
     #[test]
     fn dispatch_with_a_template_is_the_flag_path_unchanged() {
         let d = dest("dispatch");
-        let out = dispatch(Some("chain"), Some(&d), true);
+        let out = dispatch(Some("chain"), Some(&d), true, PLAIN);
         assert_eq!(out.code, exit::OK, "{}", out.text);
         std::fs::remove_file(&d).ok();
     }
@@ -773,7 +853,7 @@ mod tests {
     fn read_wizard_three_enters_is_the_golden_path() {
         let mut input = std::io::Cursor::new(b"\n\n\n".to_vec());
         let mut out = Vec::new();
-        let w = read_wizard(&mut input, &mut out, None)
+        let w = read_wizard(&mut input, &mut out, None, PLAIN)
             .expect("io ok")
             .expect("not cancelled");
         assert_eq!(w.template, "chain");
@@ -790,7 +870,7 @@ mod tests {
         let mut input =
             std::io::Cursor::new(b"process every item in parallel\nbatch\n2\n".to_vec());
         let mut out = Vec::new();
-        let w = read_wizard(&mut input, &mut out, None)
+        let w = read_wizard(&mut input, &mut out, None, PLAIN)
             .expect("io ok")
             .expect("not cancelled");
         assert_eq!(w.template, "fanout");
@@ -799,7 +879,7 @@ mod tests {
         let mut eof = std::io::Cursor::new(Vec::new());
         let mut out2 = Vec::new();
         assert!(
-            read_wizard(&mut eof, &mut out2, None)
+            read_wizard(&mut eof, &mut out2, None, PLAIN)
                 .expect("io ok")
                 .is_none(),
             "EOF = cancelled"
@@ -817,11 +897,15 @@ mod tests {
             dir.to_str().expect("utf8"),
             None,
             true,
+            PLAIN,
             &mut input,
             &mut out,
         );
         assert_eq!(v.code, exit::OK, "{}", v.text);
         assert!(v.text.contains("scriptable form"), "{}", v.text);
+        // The wow contract: the wizard SHOWS the audit ladder — the file
+        // arrives already checked, not with a suggestion to check.
+        assert!(v.text.contains("audited"), "the ladder ran: {}", v.text);
         let written = std::fs::read_to_string(dir.join("first.nika.yaml")).expect("file written");
         assert!(written.contains("workflow: first"));
         std::fs::remove_dir_all(&dir).ok();


### PR DESCRIPTION
## What

The wizard shipped functional (#253) but visually FLAT — zero `Theme` while every other surface carries the semantic seam — and it ENDED on a *suggestion* to check instead of showing the product's argument.

Two moves, per the UX Socratic pass:

1. **The conversation speaks the display seam.** `Theme` threaded from `main` (the one `term_theme` chain, hoisted as `plain_theme` — also shared by `examples run`): `logo()` header (ascii-aware · 🦋 / `[nika]`), Strong title, Dim for defaults/menu-notes/scriptable-form, the single Accent on the `>` prompt and on each resolution echo (`→ template` · `→ model`, the model echo is new). Semantic, never decorative — meaning never lives in colour alone.
2. **The wizard hands over a CHECKED workflow.** `materialize` now runs the audit and embeds the ladder: PLAN waves · SECRETS · TYPES · TOOLS · ARGS · SCHEMA on screen inside the first minute — audit-before-run **shown**, not named. A red ladder honestly propagates its exit code (a fresh scaffold checks clean by the templates' own-corpus law). The next-block adapts ($EDITOR the remaining SLOTs → run).

## Byte-stability

Every sober register keeps identical text: `paint` is a no-op without colour, the wizard stays TTY-gated, `--yes`/pipe/flag paths untouched (test-pinned). An adversarial refuter pass returned REFUTED against a **stale baseline** (it compared against a pre-#253 checkout — its three counterexamples are #253 features already on main); the real `git diff origin/main` touches only the wizard conversation + theme threading.

## Proof

- 259 lib + 24 verbs_static + 20 bin_smoke green · clippy `--all-targets -D warnings` clean · fn-length ratchet green (fn main hoisted back under 100)
- PTY (expect) on the release binary: bare-`new` golden path AND `init`-offer path both end on the embedded ladder, exit 0; ANSI-safe anchors (the styled prompts broke bracket-adjacent expect patterns — anchors now sit on plain substrings)
- Coloured capture: 8 accent + 25 dim spans, zero colour bleed into the check ladder (it renders through the same theme)
- public-api baseline: exactly two intentional deltas (`init::run` + `new::dispatch` gain `theme`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)