### PR TITLE
feat(providers): anthropic native structured output — output_config.format

### DIFF
--- a/crates/nika-cli/src/verbs/run/compose.rs
+++ b/crates/nika-cli/src/verbs/run/compose.rs
@@ -701,9 +701,9 @@ mod tests {
     #[test]
     fn registry_provider_reports_the_resolved_models_capability() {
         // BUG#11 robustness: the per-call bridge reports its `default_model`'s
-        // ACTUAL wire capability (was hardcoded false). gemini/openai-family
-        // → native structured output (robust under a tight budget) · anthropic
-        // → false (the instruction fallback its wire requires).
+        // ACTUAL wire capability (was hardcoded false). Every wired cloud
+        // family is native today — anthropic joined 2026-07-07
+        // (output_config.format · GA 2026-01-29).
         use nika_kernel::ai::provider::ProviderMeta;
 
         let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::new()));
@@ -713,8 +713,8 @@ mod tests {
         assert!(openai.supports_response_format(), "openai → native");
         let anthropic = RegistryProvider::new(Arc::clone(&registry), "anthropic/sonnet");
         assert!(
-            !anthropic.supports_response_format(),
-            "anthropic → instruction fallback (wire rejects response_format)"
+            anthropic.supports_response_format(),
+            "anthropic → native (output_config.format)"
         );
         // An exec-only workflow has no envelope model → safe fallback.
         let none = RegistryProvider::new(registry, "");

--- a/crates/nika-providers/src/parity_tests.rs
+++ b/crates/nika-providers/src/parity_tests.rs
@@ -271,11 +271,17 @@ fn meta_is_coherent_across_the_fourteen() {
             .unwrap_or_else(|e| panic!("[{}] resolves: {e}", p.id));
         assert_eq!(rp.name(), p.id, "[{}] ProviderMeta::name", p.id);
         let supports = rp.supports_response_format();
+        // Every wire family carries a native structured mode today
+        // (anthropic joined 2026-07-07 · output_config.format). A FUTURE
+        // variant fails this exhaustive match at compile time — its author
+        // writes the honest arm.
         match p.wire {
-            WireFormat::OpenAiCompat | WireFormat::Mock | WireFormat::Gemini => {
+            WireFormat::OpenAiCompat
+            | WireFormat::Mock
+            | WireFormat::Gemini
+            | WireFormat::Anthropic => {
                 assert!(supports, "[{}] response_format supported", p.id);
             }
-            _ => assert!(!supports, "[{}] honest capability answer", p.id),
         }
     }
 }
@@ -301,24 +307,23 @@ async fn json_mode_encodes_per_dialect_across_every_wired_profile() {
         let result = rp.infer(req).await;
 
         match wire {
-            // Anthropic has no response_format at v0.1 — the HONEST refusal
-            // fires in request-build, BEFORE any HTTP call (capability == false
-            // per meta_is_coherent). The error is typed and names the field.
+            // Anthropic has no bare JSON mode — `Json` is a deliberate wire
+            // NO-OP, not an error: the verb's ADR-098 JsonMode fallback (how
+            // an underspecified schema reaches this wire) carries the schema
+            // instruction in the prompt and validates locally. The request
+            // SUCCEEDS and carries neither `response_format` nor
+            // `output_config` (JsonSchema is the native path — the
+            // per-dialect tests pin that shape).
             WireFormat::Anthropic => {
-                let err = result
-                    .err()
-                    .unwrap_or_else(|| panic!("[{id}] anthropic must refuse response_format"));
+                result.unwrap_or_else(|e| panic!("[{id}] json-mode no-op must infer: {e}"));
+                let sent = fake.captured();
+                let body: serde_json::Value =
+                    serde_json::from_slice(sent[0].body.as_ref().expect("request body"))
+                        .expect("request body is json");
+                assert!(body.get("response_format").is_none(), "[{id}] no alien key");
                 assert!(
-                    matches!(err, ProviderError::Other { .. }),
-                    "[{id}] refusal typed Other, got {err:?}"
-                );
-                assert!(
-                    err.to_string().contains("response_format"),
-                    "[{id}] refusal names the field: {err}"
-                );
-                assert!(
-                    fake.captured().is_empty(),
-                    "[{id}] no request leaves on an honest refusal"
+                    body.get("output_config").is_none(),
+                    "[{id}] Json is not JsonSchema — no output_config"
                 );
             }
             WireFormat::OpenAiCompat => {

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -42,15 +42,20 @@ impl WireFormat {
     /// provider) and `ProviderRegistry::supports_response_format`
     /// (keyless · per model string) answer through here.
     ///
-    /// v0.1 approximation, per wire family: `OpenAiCompat` (some local
-    /// servers lack strict `json_schema`, but the family does) and
-    /// `Gemini` (an OpenAPI-style subset via `responseSchema`) support it;
-    /// `Anthropic` does NOT (the wire rejects `response_format` outright ·
-    /// callers must fall back to a schema instruction). `Mock` answers
-    /// `true` so structured-output tests need no live provider.
+    /// Per wire family: `OpenAiCompat` (some local servers lack strict
+    /// `json_schema`, but the family does), `Gemini` (an OpenAPI-style
+    /// subset via `responseSchema`) and `Anthropic` (grammar-constrained
+    /// `output_config.format` · GA 2026-01-29 · the wire normalizes to
+    /// its narrower dialect) all carry a native mode. `Mock` answers
+    /// `true` so structured-output tests need no live provider. Every
+    /// family being native today, the matches! stays — a future wire
+    /// variant defaults to the instruction fallback until proven.
     #[must_use]
     pub fn supports_response_format(self) -> bool {
-        matches!(self, Self::OpenAiCompat | Self::Mock | Self::Gemini)
+        matches!(
+            self,
+            Self::OpenAiCompat | Self::Mock | Self::Gemini | Self::Anthropic
+        )
     }
 
     /// Whether this wire family's STRICT structured mode rejects an
@@ -59,14 +64,16 @@ impl WireFormat {
     ///
     /// The real strict modes do: `OpenAI`'s `json_schema`+`strict` 400s
     /// on exactly this class (the whole family is treated as its peer),
-    /// and gemini's `responseSchema` `OpenAPI` subset carries its own
-    /// rejection surface — callers fall back to the native JSON mode + LOCAL
-    /// validation there. `Mock` SYNTHESIZES a conformant instance from
-    /// ANY schema (F3 · the offline-CI base) and `Anthropic` has no
-    /// native mode at all (instruction fallback) — neither rejects.
+    /// gemini's `responseSchema` `OpenAPI` subset carries its own
+    /// rejection surface, and `Anthropic`'s grammar compiler rejects a
+    /// free-form object (`additionalProperties` must be `false`) — all
+    /// three fall back to the native JSON mode + LOCAL validation (on
+    /// anthropic the JSON mode is a wire no-op: the schema instruction
+    /// rides the prompt). `Mock` SYNTHESIZES a conformant instance from
+    /// ANY schema (F3 · the offline-CI base) — never rejects.
     #[must_use]
     pub fn strict_rejects_underspecified(self) -> bool {
-        matches!(self, Self::OpenAiCompat | Self::Gemini)
+        matches!(self, Self::OpenAiCompat | Self::Gemini | Self::Anthropic)
     }
 }
 
@@ -359,14 +366,17 @@ mod tests {
     #[test]
     fn wire_response_format_capability_is_the_single_source() {
         // The one matrix both the resolved provider and the keyless
-        // registry query answer through.
+        // registry query answer through. Anthropic joined 2026-07-07
+        // (output_config.format · GA 2026-01-29) — the instruction
+        // fallback is no longer its schema path.
         assert!(WireFormat::OpenAiCompat.supports_response_format());
         assert!(WireFormat::Gemini.supports_response_format());
         assert!(WireFormat::Mock.supports_response_format());
-        assert!(
-            !WireFormat::Anthropic.supports_response_format(),
-            "anthropic rejects response_format · instruction fallback required"
-        );
+        assert!(WireFormat::Anthropic.supports_response_format());
+        // The strict-reject nuance rides with it: anthropic's grammar
+        // compiler rejects free-form objects → ADR-098 fallback applies.
+        assert!(WireFormat::Anthropic.strict_rejects_underspecified());
+        assert!(!WireFormat::Mock.strict_rejects_underspecified());
     }
 
     #[test]

--- a/crates/nika-providers/src/registry.rs
+++ b/crates/nika-providers/src/registry.rs
@@ -121,7 +121,7 @@ impl<H> ProviderRegistry<H> {
     /// `resolve()` (which would also demand a key). An unknown provider or
     /// a malformed model string answers `false` — the SAFE default: a
     /// caller that can't confirm native support falls back to a schema
-    /// INSTRUCTION, which is correct on every wire (anthropic REQUIRES it).
+    /// INSTRUCTION — correct (if no longer required) on every wire.
     #[must_use]
     pub fn supports_response_format(&self, model: &str) -> bool {
         model
@@ -356,9 +356,9 @@ mod tests {
         assert!(reg.supports_response_format("deepseek/chat")); // openai-compat
         assert!(reg.supports_response_format("ollama/llama3")); // openai-compat local
         assert!(reg.supports_response_format("mock/echo"));
-        // anthropic → false (its wire rejects response_format · instruction
-        // fallback REQUIRED).
-        assert!(!reg.supports_response_format("anthropic/sonnet"));
+        // anthropic → native since 2026-07-07 (output_config.format ·
+        // GA 2026-01-29 · the wire normalizes to its narrower dialect).
+        assert!(reg.supports_response_format("anthropic/sonnet"));
     }
 
     #[test]

--- a/crates/nika-providers/src/wire/anthropic.rs
+++ b/crates/nika-providers/src/wire/anthropic.rs
@@ -120,14 +120,6 @@ fn request_body(
     stream: bool,
     names: &ToolNameMap,
 ) -> Result<Value, ProviderError> {
-    if !matches!(req.response_format, ResponseFormat::Text) {
-        return Err(ProviderError::Other {
-            reason: "anthropic does not support response_format at v0.1 · \
-                     use an openai-compat provider or prompt-level JSON"
-                .to_owned(),
-        });
-    }
-
     let mut system = String::new();
     let mut messages = Vec::new();
     for m in &req.messages {
@@ -185,6 +177,23 @@ fn request_body(
             json!({ "type": "enabled", "budget_tokens": budget }),
         );
     }
+    // Structured output rides `output_config.format` (GA 2026-01-29 ·
+    // grammar-constrained sampling on the final text; extended thinking
+    // stays unconstrained — the grammar applies only to the direct output).
+    // `ResponseFormat::Json` is a deliberate NO-OP, not an error: Anthropic
+    // has no bare JSON mode, and the verb's JsonMode fallback (ADR-098 ·
+    // how an UNDERSPECIFIED schema reaches this wire) already carries the
+    // schema instruction in the prompt and validates locally — the wire
+    // adds nothing.
+    if let ResponseFormat::JsonSchema(schema) = &req.response_format {
+        obj.insert(
+            "output_config".to_owned(),
+            json!({ "format": {
+                "type": "json_schema",
+                "schema": normalize_output_schema(schema),
+            }}),
+        );
+    }
     // Provider extras never override the structural keys this adapter set
     // (model · messages · stream · tools · …) — first-write-wins.
     for (k, v) in &req.extra.params {
@@ -193,6 +202,136 @@ fn request_body(
         }
     }
     Ok(body)
+}
+
+/// The `format:` values Anthropic's structured-output dialect accepts —
+/// anything else 400s at grammar compilation and is stripped at the wire.
+const SUPPORTED_FORMATS: [&str; 10] = [
+    "date",
+    "date-time",
+    "duration",
+    "email",
+    "hostname",
+    "ipv4",
+    "ipv6",
+    "time",
+    "uri",
+    "uuid",
+];
+
+/// Rewrite a JSON Schema into Anthropic's structured-output dialect
+/// (GA 2026-01-29 · platform.claude.com/docs · structured-outputs).
+///
+/// NARROWER than `OpenAI` strict, and different in one welcome way: every
+/// object MUST carry `additionalProperties: false` (injected), but
+/// author-optional properties STAY optional — no required-all/nullable
+/// widening. `oneOf` is not accepted (`anyOf` is) and folds into it. The
+/// keywords the wire rejects at grammar compilation — numeric bounds ·
+/// string lengths · array bounds beyond `minItems: 0|1` · the
+/// negation/conditional family · non-whitelisted `format` values — are
+/// STRIPPED at the wire; the authored constraints stay enforced by the
+/// verb's LOCAL validation + retry (the same contract as the `uniqueItems`
+/// strip on the openai path).
+fn normalize_output_schema(schema: &Value) -> Value {
+    let mut out = schema.clone();
+    normalize_node(&mut out);
+    out
+}
+
+/// In-place dialect rewrite of one schema node and its descendants.
+fn normalize_node(node: &mut Value) {
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+    descend_subschemas(obj);
+    fold_oneof_into_anyof(obj);
+    strip_unsupported(obj);
+    if obj.get("type").and_then(Value::as_str) == Some("object") {
+        obj.insert("additionalProperties".to_owned(), Value::Bool(false));
+    }
+}
+
+/// Recurse into every child that is itself a schema (composition +
+/// container keywords; internal `$ref`/`$defs` are supported upstream, so
+/// the definitions are normalized too).
+fn descend_subschemas(obj: &mut serde_json::Map<String, Value>) {
+    if let Some(props) = obj.get_mut("properties").and_then(Value::as_object_mut) {
+        props.values_mut().for_each(normalize_node);
+    }
+    match obj.get_mut("items") {
+        Some(Value::Array(items)) => items.iter_mut().for_each(normalize_node),
+        Some(child) => normalize_node(child),
+        None => {}
+    }
+    for key in ["$defs", "definitions"] {
+        if let Some(defs) = obj.get_mut(key).and_then(Value::as_object_mut) {
+            defs.values_mut().for_each(normalize_node);
+        }
+    }
+    for key in ["anyOf", "allOf", "oneOf"] {
+        if let Some(branches) = obj.get_mut(key).and_then(Value::as_array_mut) {
+            branches.iter_mut().for_each(normalize_node);
+        }
+    }
+}
+
+/// `oneOf` → `anyOf` (the dialect accepts `anyOf`, not `oneOf`) — same
+/// fold as the openai strict path: existing `anyOf` branches keep their
+/// place, the `oneOf` branches append, no `oneOf` survives.
+fn fold_oneof_into_anyof(obj: &mut serde_json::Map<String, Value>) {
+    let Some(Value::Array(one_of)) = obj.remove("oneOf") else {
+        return;
+    };
+    match obj.get_mut("anyOf").and_then(Value::as_array_mut) {
+        Some(any_of) => any_of.extend(one_of),
+        None => {
+            obj.insert("anyOf".to_owned(), Value::Array(one_of));
+        }
+    }
+}
+
+/// Strip every keyword the dialect 400s on (constraints stay locally
+/// enforced). `minItems` is special-cased: the dialect accepts 0 and 1.
+fn strip_unsupported(obj: &mut serde_json::Map<String, Value>) {
+    for kw in [
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+        "maxItems",
+        "uniqueItems",
+        "not",
+        "if",
+        "then",
+        "else",
+        "patternProperties",
+        "prefixItems",
+        "propertyNames",
+        "minProperties",
+        "maxProperties",
+        "contains",
+        "minContains",
+        "maxContains",
+        "dependentRequired",
+        "dependentSchemas",
+    ] {
+        obj.remove(kw);
+    }
+    if obj
+        .get("minItems")
+        .and_then(Value::as_u64)
+        .is_some_and(|n| n > 1)
+    {
+        obj.remove("minItems");
+    }
+    if let Some(format) = obj.get("format").and_then(Value::as_str)
+        && !SUPPORTED_FORMATS.contains(&format)
+    {
+        obj.remove("format");
+    }
 }
 
 /// Insert `tools` + `tool_choice`. Each tool name is sanitized to the
@@ -574,11 +713,141 @@ mod tests {
     }
 
     #[test]
-    fn response_format_is_an_honest_error() {
+    fn json_schema_rides_output_config() {
+        // The GA structured-output shape (2026-01-29): the schema travels
+        // in `output_config.format`, normalized to the dialect — objects
+        // gain `additionalProperties: false`, but author-optional
+        // properties STAY optional (no required-all widening — the one
+        // welcome difference from openai strict).
+        let mut r = req(vec![Message::text(Role::User, "extract")]);
+        r.response_format = ResponseFormat::JsonSchema(serde_json::json!({
+            "type": "object",
+            "properties": { "id": {"type": "string"}, "note": {"type": "string"} },
+            "required": ["id"]
+        }));
+        let body = body_of("m", &r, false).expect("body");
+        let format = &body["output_config"]["format"];
+        assert_eq!(format["type"], "json_schema");
+        assert_eq!(format["schema"]["additionalProperties"], false);
+        assert_eq!(
+            format["schema"]["required"],
+            serde_json::json!(["id"]),
+            "author optionality preserved — no required-all widening"
+        );
+        assert_eq!(
+            format["schema"]["properties"]["note"]["type"], "string",
+            "no nullable widening either"
+        );
+    }
+
+    #[test]
+    fn json_mode_is_a_deliberate_noop() {
+        // ResponseFormat::Json must neither error nor emit output_config:
+        // it is the ADR-098 underspecified-schema fallback reaching this
+        // wire — the schema instruction rides the prompt, validation is
+        // local, the wire adds nothing.
         let mut r = req(vec![Message::text(Role::User, "json")]);
         r.response_format = ResponseFormat::Json;
-        let err = body_of("m", &r, false).unwrap_err();
-        assert!(err.to_string().contains("response_format"));
+        let body = body_of("m", &r, false).expect("no error");
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn dialect_strips_wire_rejected_keywords_locally_enforced() {
+        // Numeric bounds · string lengths · array bounds > minItems 1 ·
+        // not/if/then/else · non-whitelisted formats all 400 at grammar
+        // compilation — stripped at the wire, held by local validation.
+        let mut r = req(vec![Message::text(Role::User, "x")]);
+        r.response_format = ResponseFormat::JsonSchema(serde_json::json!({
+            "type": "object",
+            "required": ["age", "tags", "mail", "phone"],
+            "properties": {
+                "age": {"type": "integer", "minimum": 0, "maximum": 150},
+                "tags": {
+                    "type": "array", "items": {"type": "string"},
+                    "minItems": 3, "maxItems": 10, "uniqueItems": true
+                },
+                "mail": {"type": "string", "format": "email", "maxLength": 100},
+                "phone": {"type": "string", "format": "phone", "not": {"enum": ["0"]}}
+            }
+        }));
+        let body = body_of("m", &r, false).expect("body");
+        let props = &body["output_config"]["format"]["schema"]["properties"];
+        assert!(props["age"].get("minimum").is_none(), "{props}");
+        assert!(props["age"].get("maximum").is_none());
+        assert!(
+            props["tags"].get("minItems").is_none(),
+            "minItems 3 > 1 dropped"
+        );
+        assert!(props["tags"].get("maxItems").is_none());
+        assert!(props["tags"].get("uniqueItems").is_none());
+        assert!(props["mail"].get("maxLength").is_none());
+        assert_eq!(props["mail"]["format"], "email", "whitelisted format kept");
+        assert!(
+            props["phone"].get("format").is_none(),
+            "unknown format dropped"
+        );
+        assert!(props["phone"].get("not").is_none());
+    }
+
+    #[test]
+    fn dialect_keeps_min_items_zero_or_one_and_folds_oneof() {
+        let mut r = req(vec![Message::text(Role::User, "x")]);
+        r.response_format = ResponseFormat::JsonSchema(serde_json::json!({
+            "type": "object",
+            "required": ["items", "kind"],
+            "properties": {
+                "items": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+                "kind": {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+            }
+        }));
+        let body = body_of("m", &r, false).expect("body");
+        let props = &body["output_config"]["format"]["schema"]["properties"];
+        assert_eq!(
+            props["items"]["minItems"], 1,
+            "minItems 0|1 accepted upstream"
+        );
+        assert!(props["kind"].get("oneOf").is_none(), "no oneOf survives");
+        assert_eq!(
+            props["kind"]["anyOf"].as_array().expect("anyOf").len(),
+            2,
+            "both branches preserved"
+        );
+    }
+
+    #[test]
+    fn dialect_normalizes_nested_defs_and_array_elements() {
+        // The walk reaches $defs entries and array element schemas — a
+        // nested object deep in the tree still gains the mandatory
+        // additionalProperties: false.
+        let mut r = req(vec![Message::text(Role::User, "x")]);
+        r.response_format = ResponseFormat::JsonSchema(serde_json::json!({
+            "type": "object",
+            "required": ["rows", "node"],
+            "properties": {
+                "rows": {"type": "array", "items": {
+                    "type": "object",
+                    "required": ["sku"],
+                    "properties": {"sku": {"type": "string", "minLength": 2}}
+                }},
+                "node": {"$ref": "#/$defs/Node"}
+            },
+            "$defs": {
+                "Node": {"type": "object", "properties": {"label": {"type": "string"}}}
+            }
+        }));
+        let body = body_of("m", &r, false).expect("body");
+        let schema = &body["output_config"]["format"]["schema"];
+        let elem = &schema["properties"]["rows"]["items"];
+        assert_eq!(
+            elem["additionalProperties"], false,
+            "array element tightened"
+        );
+        assert!(elem["properties"]["sku"].get("minLength").is_none());
+        assert_eq!(
+            schema["$defs"]["Node"]["additionalProperties"], false,
+            "$defs entry tightened"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Anthropic gets **native structured output**: `ResponseFormat::JsonSchema` now travels as `output_config.format` (`type: json_schema`) on the Messages wire, with a dialect normalizer; the capability matrix flips (`supports_response_format` · `strict_rejects_underspecified` → true for `WireFormat::Anthropic`).

## Why

The matrix said « Anthropic does NOT support response_format · instruction fallback required ». **Stale since 2026-01-29**: the Messages API ships grammar-constrained structured output GA (no beta header · Sonnet/Opus/Haiku/Fable families — platform.claude.com docs fetched 2026-07-07, SOTA research pass). The engine's biggest remaining structured-output gap was a solved provider problem. The « never mention JSON » prompt tension on the anthropic path falls with it — the schema rides the wire, not the prompt.

## The dialect normalizer

Anthropic's subset is **narrower than openai strict, and different in one welcome way**:

- Every object MUST carry `additionalProperties: false` → injected on every object node.
- Author-optional properties **stay optional** — no required-all/nullable widening (unlike openai strict).
- `oneOf` → folds into `anyOf` (same fold as the openai path).
- Keywords the grammar compiler 400s on are **stripped at the wire** and stay enforced by the verb's local validation + retry (the `uniqueItems` precedent): numeric bounds (`minimum`/`maximum`/`exclusive*`/`multipleOf`) · string lengths · array bounds beyond `minItems: 0|1` · `uniqueItems` · `not`/`if`/`then`/`else` · `patternProperties`/`prefixItems`/`propertyNames`/`contains`/`dependent*` · non-whitelisted `format` values (whitelist: date, date-time, duration, email, hostname, ipv4, ipv6, time, uri, uuid).

`ResponseFormat::Json` is a deliberate wire **no-op** (was: hard error): Anthropic has no bare JSON mode, and `Json` is exactly how the ADR-098 underspecified-schema fallback reaches this wire — schema instruction in the prompt, local validation, the wire adds nothing. `strict_rejects_underspecified() → true` (the grammar compiler rejects free-form objects) so that fallback fires for anthropic too.

## Proof

- 5 new dialect tests: `output_config` shape · optionality preserved · strip matrix · `minItems 0|1` kept + `oneOf` fold · `$defs`/array-element descent.
- Capability tests flipped across `profile.rs` / `registry.rs` / `parity_tests.rs` / `nika-cli` compose (the parity json-mode arm now pins the no-op: request succeeds, no `output_config`, no `response_format`).
- Workspace `--lib` green · clippy `-D warnings` green · pre-push gauntlet green.

## ⚠ Operator gate before merge

**One live e2e run is still owed** — the machine's `ANTHROPIC_API_KEY` has zero credits (billing error verified 2026-07-07), so the wire shape is doc-anchored but not live-proven. Suggested proof once credits exist:

```bash
nika run guided.nika.yaml   # model: anthropic/haiku · schema: nested enum+required
```

Verify > Ship: please run it (or top up credits and ping) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
