### PR TITLE
feat(verb-infer): retry-loop economics — numbered repair list + truncation fast-fail

### DIFF
--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -276,21 +276,30 @@ where
                         usage_total,
                     ));
                 }
-                structured::Validation::Invalid(detail) => {
-                    if attempts > u32::from(self.schema_retry_budget) {
-                        // Un-mask a truncated or filtered reply: without this,
-                        // "cut off before the JSON closed" reads as a plain
-                        // schema mismatch and sends the author chasing the
-                        // wrong fix (review lens 5). The retries already ran —
-                        // a tightened instruction can fix VERBOSE truncation —
-                        // so this only annotates the terminal failure.
-                        let detail = format!("{detail}{}", stop_reason_hint(&response.stop_reason));
+                structured::Validation::Invalid(errors) => {
+                    // Terminal on either: (a) the retry budget is spent, or
+                    // (b) TRUNCATION fast-fail — a reply cut at `max_tokens`
+                    // cannot be repaired by re-asking at the SAME budget (the
+                    // identical request cuts again, and the retry message
+                    // makes the prompt LONGER), so every re-ask is a paid
+                    // call spent on a known failure class whose remedy is
+                    // the budget, not the schema. Providers document
+                    // length-exhaustion as its own escape hatch (structured
+                    // output explicitly does NOT hold across it); the
+                    // stop_reason_hint prints the actionable fix either way.
+                    let truncated = matches!(response.stop_reason, StopReason::MaxTokens);
+                    if truncated || attempts > u32::from(self.schema_retry_budget) {
+                        let detail = format!(
+                            "{}{}",
+                            errors.join("; "),
+                            stop_reason_hint(&response.stop_reason)
+                        );
                         return Err(VerbInferError::SchemaValidation { attempts, detail });
                     }
                     messages.push(Message::text(Role::Assistant, text));
                     messages.push(Message::text(
                         Role::User,
-                        structured::retry_message(&detail, schema),
+                        structured::retry_message(&errors, schema),
                     ));
                 }
             }
@@ -928,6 +937,93 @@ mod tests {
         assert!(
             msg.contains("token limit"),
             "the cause must be named: {msg}"
+        );
+    }
+
+    /// The truncation FAST-FAIL: a reply cut at `max_tokens` is terminal on
+    /// FIRST sight even with retry budget remaining — the identical request
+    /// would cut again (same budget · longer prompt), so every re-ask is a
+    /// paid call spent on a failure class whose remedy is the budget, not
+    /// the schema. The scripted SECOND reply must never be requested.
+    #[tokio::test]
+    async fn truncated_reply_fails_fast_without_burning_the_retry_budget() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\"}"},"finish_reason":"length"}],"usage":{}}"#,
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":36}"},"finish_reason":"stop"}],"usage":{}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let err = openai_verb(&seam)
+            .with_schema_retry_budget(3)
+            .run(input)
+            .await
+            .expect_err("truncation is terminal on first sight");
+        match &err {
+            VerbInferError::SchemaValidation { attempts, detail } => {
+                assert_eq!(*attempts, 1, "no blind re-ask at the same budget");
+                assert!(
+                    detail.contains("token limit"),
+                    "the real fix named: {detail}"
+                );
+            }
+            other => panic!("expected SchemaValidation, got {other:?}"),
+        }
+        assert_eq!(
+            seam.captured().len(),
+            1,
+            "exactly one paid round-trip — the budget was NOT burned"
+        );
+    }
+
+    /// The retry message is a NUMBERED repair list with the localized-edit
+    /// framing (« fix exactly these · keep everything else identical ») —
+    /// not a prose dump. Pinned at the wire: the SECOND request's last user
+    /// message carries the list, the framing and the failed path.
+    #[tokio::test]
+    async fn retry_message_is_a_numbered_repair_list_at_the_wire() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\"}"},"finish_reason":"stop"}],"usage":{}}"#,
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":36}"},"finish_reason":"stop"}],"usage":{}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let out = openai_verb(&seam).run(input).await.expect("retry conforms");
+        assert!(matches!(out.output, InferValue::Structured(_)));
+
+        let captured = seam.captured();
+        assert_eq!(captured.len(), 2, "one miss · one repair");
+        let second: serde_json::Value =
+            serde_json::from_slice(captured[1].body.as_ref().expect("retry body")).expect("json");
+        let messages = second["messages"].as_array().expect("messages");
+        let retry_prompt = messages
+            .last()
+            .and_then(|m| m["content"].as_str())
+            .expect("the retry user message");
+        assert!(
+            retry_prompt.contains("Repair instructions"),
+            "{retry_prompt}"
+        );
+        assert!(
+            retry_prompt.contains("\n1. "),
+            "numbered list: {retry_prompt}"
+        );
+        assert!(
+            retry_prompt.contains("keep everything else identical"),
+            "localized-edit framing: {retry_prompt}"
+        );
+        assert!(
+            retry_prompt.contains("\"age\""),
+            "the failed path is named: {retry_prompt}"
         );
     }
 

--- a/crates/nika-verb-infer/src/structured.rs
+++ b/crates/nika-verb-infer/src/structured.rs
@@ -15,8 +15,10 @@ pub(crate) enum Validation {
     /// The candidate parsed and satisfied the schema.
     Valid(serde_json::Value),
     /// No JSON candidate could be extracted, or it failed the schema.
-    /// Carries the human-readable detail used for the retry message.
-    Invalid(String),
+    /// Carries one rendered line per validation error (≤5) — the terminal
+    /// detail joins them; the retry message numbers them as repair
+    /// instructions (see [`retry_message`]).
+    Invalid(Vec<String>),
 }
 
 /// Cap on the schema text re-injected into prompts (retry + instruction
@@ -53,7 +55,7 @@ pub(crate) fn render_schema(schema: &serde_json::Value) -> String {
 /// fenced block, then the first balanced `{…}` or `[…]` span.
 pub(crate) fn extract_and_validate(text: &str, validator: &jsonschema::Validator) -> Validation {
     let Some(candidate) = extract_json(text) else {
-        return Validation::Invalid("no JSON value found in the model output".to_owned());
+        return Validation::Invalid(vec!["no JSON value found in the model output".to_owned()]);
     };
 
     let rendered: Vec<String> = validator
@@ -71,7 +73,7 @@ pub(crate) fn extract_and_validate(text: &str, validator: &jsonschema::Validator
     if rendered.is_empty() {
         Validation::Valid(candidate)
     } else {
-        Validation::Invalid(rendered.join("; "))
+        Validation::Invalid(rendered)
     }
 }
 
@@ -146,13 +148,31 @@ fn push_subschemas<'a>(
     }
 }
 
-/// The corrective user message appended on a validation retry.
-pub(crate) fn retry_message(detail: &str, schema: &serde_json::Value) -> String {
+/// The corrective user message appended on a validation retry — a NUMBERED
+/// repair list plus the localized-edit framing (« fix exactly these · keep
+/// everything else identical »), not a prose dump.
+///
+/// The shape is evidence-picked: machine-readable per-error repair
+/// instructions beat raw validator prose by +37-40pp task completion in
+/// the only direct eval (Self-Reflective APIs · arxiv.org/abs/2606.05037),
+/// and localized critique beats generic feedback (arxiv.org/abs/2407.02397)
+/// — a full regeneration invites NEW errors in the parts that were already
+/// right. The schema still renders (capped): on the native path it
+/// traveled server-side, so the retry is the model's only in-context look.
+pub(crate) fn retry_message(errors: &[String], schema: &serde_json::Value) -> String {
     let rendered = render_schema(schema);
+    let list = errors
+        .iter()
+        .enumerate()
+        .map(|(i, e)| format!("{}. {e}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
     format!(
-        "The previous reply did not satisfy the required output schema. \
-         Validation failed with: {detail}. Reply again with ONLY a JSON value \
-         that satisfies this JSON Schema, no prose, no code fences:\n{rendered}"
+        "The previous reply did not satisfy the required output schema.\n\
+         Repair instructions — fix exactly these, keep everything else identical:\n\
+         {list}\n\
+         Reply again with ONLY the corrected JSON value, no prose, no code \
+         fences. The schema:\n{rendered}"
     )
 }
 
@@ -348,7 +368,7 @@ mod tests {
         let v = extract_and_validate(r#"{"name":"Ada","age":36}"#, &validator(&person_schema()));
         match v {
             Validation::Valid(val) => assert_eq!(val["name"], "Ada"),
-            Validation::Invalid(d) => panic!("expected valid, got: {d}"),
+            Validation::Invalid(d) => panic!("expected valid, got: {d:?}"),
         }
     }
 
@@ -379,7 +399,7 @@ mod tests {
         let text = r#"noise {"name":"A{d}a","age":1} trail"#;
         match extract_and_validate(text, &validator(&person_schema())) {
             Validation::Valid(val) => assert_eq!(val["name"], "A{d}a"),
-            Validation::Invalid(d) => panic!("expected valid, got: {d}"),
+            Validation::Invalid(d) => panic!("expected valid, got: {d:?}"),
         }
     }
 
@@ -387,7 +407,9 @@ mod tests {
     fn schema_violation_reports_path() {
         let v = extract_and_validate(r#"{"name":"Ada","age":-3}"#, &validator(&person_schema()));
         match v {
-            Validation::Invalid(d) => assert!(d.contains("age"), "detail names the path: {d}"),
+            Validation::Invalid(d) => {
+                assert!(d.iter().any(|e| e.contains("age")), "path named: {d:?}");
+            }
             Validation::Valid(_) => panic!("expected invalid"),
         }
     }
@@ -484,7 +506,10 @@ mod tests {
 
     #[test]
     fn retry_message_carries_detail_and_schema() {
-        let msg = retry_message("at `/age`: -3 is less than 0", &person_schema());
+        let msg = retry_message(
+            &["at `/age`: -3 is less than 0".to_owned()],
+            &person_schema(),
+        );
         assert!(msg.contains("/age"));
         assert!(msg.contains("\"required\""));
     }
@@ -558,7 +583,7 @@ mod tests {
         let v = extract_and_validate(r#"{"name":"Ada","age":36,}"#, &validator(&person_schema()));
         match v {
             Validation::Valid(val) => assert_eq!(val["age"], 36),
-            Validation::Invalid(d) => panic!("expected repair to valid, got: {d}"),
+            Validation::Invalid(d) => panic!("expected repair to valid, got: {d:?}"),
         }
     }
 


### PR DESCRIPTION
## What

Two evidence-picked upgrades to the schema-retry loop (SOTA research pass · companion to the guided-decoding audit arc #262/#264/#267):

1. **Numbered repair list.** The re-ask message becomes machine-readable repair instructions with the localized-edit framing (« fix exactly these, keep everything else identical ») instead of a prose dump. Direct evidence: +37-40pp task completion vs raw validator prose (Self-Reflective APIs · arXiv 2606.05037); localized critique beats generic feedback (arXiv 2407.02397). `Validation::Invalid` now carries one rendered line per error (≤5) — terminal detail joins them, the retry numbers them.

2. **Truncation fast-fail.** A reply cut at `max_tokens` is terminal on FIRST sight even with retry budget remaining — the identical request cuts again (same budget · longer prompt), so every re-ask is a paid call spent on a failure class whose remedy is the budget, not the schema. #243 un-masked the cause at the terminal error; this stops paying for the doomed retries first.

## Proof

- 2 new wire-pinned tests: fast-fail (budget 3 · one truncated reply → `SchemaValidation` at attempts=1 · exactly ONE captured round-trip) · repair-list shape on the SECOND captured request (numbered · framing · failed path named).
- 54 verb-infer lib green · workspace lib green · clippy `-D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)