### PR TITLE
fix(nika-mcp): a dirty check is isError:true — the repair loop must trigger

### DIFF
--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -662,13 +662,14 @@ fn mcp_tools_call_check_carries_the_did_you_mean() {
         .expect("tools/call reply");
     let doc: serde_json::Value = serde_json::from_str(reply).expect("json reply");
     assert_eq!(
-        doc["result"]["isError"], false,
-        "findings are content, not a tool failure: {reply}"
+        doc["result"]["isError"], true,
+        "a dirty check is isError:true so the agent's repair loop fires \
+         (mirrors the CLI's exit-2-on-dirty): {reply}"
     );
     let text = doc["result"]["content"][0]["text"].as_str().expect("text");
     assert!(
         text.contains("mesage") && text.contains("message"),
-        "the did-you-mean rides the reply: {text}"
+        "the did-you-mean still rides the reply so the agent repairs: {text}"
     );
 }
 

--- a/crates/nika-mcp/src/protocol.rs
+++ b/crates/nika-mcp/src/protocol.rs
@@ -234,6 +234,31 @@ mod tests {
     }
 
     #[test]
+    fn tools_call_dirty_check_is_iserror_so_the_repair_loop_triggers() {
+        // A workflow with findings comes back isError:true (the model
+        // sees the findings AND a repair-on-error harness fires) — the
+        // MCP lane must agree with the CLI's exit-2-on-dirty.
+        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let resp = handle(&json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "nika_check", "arguments": { "workflow": wf } }
+        }))
+        .expect("reply");
+        assert!(resp.get("error").is_none(), "not a protocol error");
+        assert_eq!(
+            resp["result"]["isError"], true,
+            "dirty check signals isError"
+        );
+        assert!(
+            resp["result"]["content"][0]["text"]
+                .as_str()
+                .expect("text")
+                .contains("findings"),
+            "the findings still ride the content so the model repairs"
+        );
+    }
+
+    #[test]
     fn tools_call_tool_error_is_iserror_not_protocol_error() {
         let resp = handle(&json!({
             "jsonrpc": "2.0", "id": 4, "method": "tools/call",

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -163,7 +163,15 @@ fn check(args: &Value) -> Result<String, String> {
     // dropping 9 classes · a model can parse the JSON + repair from it).
     let detail = serde_json::to_string_pretty(&report)
         .map_err(|e| format!("check report serialization failed: {e}"))?;
-    Ok(format!(
+    // A DIRTY workflow is an `Err` so the dispatcher flags `isError: true`:
+    // the model then SEES the findings AND the harness triggers its repair
+    // loop (the authoring protocol is template→fill→check→REPAIR). This
+    // mirrors the CLI's exit-2-on-dirty — the two machine lanes must not
+    // disagree (a `nika check` that fails the shell must not read as
+    // success over MCP). The full report rides the Err text unchanged, so
+    // the model repairs from the same JSON either way (the user-sim
+    // finding · the is_clean mirror law applied to the MCP lane).
+    Err(format!(
         "✖ findings — the workflow is not clean · the full check report:\n{detail}"
     ))
 }
@@ -304,11 +312,14 @@ mod tests {
     }
 
     #[test]
-    fn check_a_broken_workflow_lists_findings() {
+    fn check_a_broken_workflow_is_an_error_carrying_the_findings() {
         // A dangling depends_on edge — a DAG finding the ladder catches.
+        // Dirty is an `Err` (→ isError:true) so a wired agent's repair
+        // loop triggers, mirroring the CLI's exit-2-on-dirty; the full
+        // report still rides the text so the model repairs from it.
         let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
-        let out = execute("nika_check", &json!({ "workflow": wf })).expect("ran");
-        assert!(out.contains("findings") && out.contains("NIKA-"), "{out}");
+        let err = execute("nika_check", &json!({ "workflow": wf })).expect_err("dirty is an error");
+        assert!(err.contains("findings") && err.contains("NIKA-"), "{err}");
     }
 
     #[test]
@@ -324,7 +335,7 @@ mod tests {
         // only `conformance` → an empty "✖ findings" body for this whole class
         // (the P1). The full-report render must surface it.
         let wf = "nika: v1\nworkflow: t\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: x\n      max_tokens: 10\n      schema: { type: object, properties: { a: { type: string } }, required: [b] }\n";
-        let out = execute("nika_check", &json!({ "workflow": wf })).expect("ran");
+        let out = execute("nika_check", &json!({ "workflow": wf })).expect_err("dirty is an error");
         assert!(out.contains("findings"), "flags not-clean: {out}");
         assert!(
             out.contains("schema_lints") && out.contains('b'),


### PR DESCRIPTION
A **user-sim over the MCP wire** caught the machine lanes disagreeing.

`nika check` on a workflow WITH findings exits **2** — the shell sees failure. But the MCP `nika_check` tool returned **`isError: false`** on the same dirty workflow: a wired agent gating on `isError` read « success » and would run a workflow the check had just condemned.

The authoring protocol is **template→fill→check→repair-until-clean**. For an agent's repair loop to fire, a dirty check must signal `isError: true` — which is exactly what the MCP-law comment already in `protocol.rs` prescribes: « isError:true so the model SEES the error and can adapt ». The full structured report still rides the `Err` text unchanged, so the model repairs from the same JSON either way; only the flag flips.

Both machine lanes now agree: **dirty is a failure on the shell AND over MCP** (the is_clean mirror law, applied to the MCP surface).

Proven at the wire (rebuilt binary, real `nika mcp` stdio): dirty → `isError:true` · clean → `isError:false`. 41 nika-mcp tests, clippy 0. A protocol-level pin locks the dirty→isError:true path so it can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)