### PR TITLE
fix(nika-cli): the budget's unbounded warning names each reason, not the fixed disjunction

### DIFF
--- a/crates/nika-cli/src/verbs/run/budget.rs
+++ b/crates/nika-cli/src/verbs/run/budget.rs
@@ -7,7 +7,7 @@
 //! budget · warn loud when the ceiling cannot bound everything (the
 //! budget gates METERED spend only — local/mock work never trips it).
 
-use nika_schema::check::CheckReport;
+use nika_schema::check::{CheckReport, CostCeiling, UnboundedReason};
 
 use crate::verbs::exit;
 
@@ -27,14 +27,48 @@ pub(super) fn preflight(
         return Err(exit::FILE);
     }
     if report.cost.has_unbounded {
-        let unbounded = report.cost.tasks.iter().filter(|t| t.usd.is_none()).count();
         eprintln!(
-            "⚠ --max-cost-usd {budget}: {unbounded} task(s) have no static ceiling \
-             (no token bound · unknown iterations · unpriced model) — the budget \
-             bounds METERED spend only; local/mock work never trips it"
+            "⚠ --max-cost-usd {budget}: {} — the budget bounds METERED spend \
+             only; local/mock work never trips it",
+            unbounded_breakdown(&report.cost)
         );
     }
     Ok(())
+}
+
+/// Tally the unbounded tasks BY THEIR ACTUAL reason (the report carries
+/// `unbounded_reason` per task) instead of parroting the fixed
+/// disjunction — a priced-but-unbounded task read « unpriced model »,
+/// which misleads (the fixable one is `no max_tokens`, not the model).
+/// The operator sees WHICH kind they have, and which is fixable.
+fn unbounded_breakdown(cost: &CostCeiling) -> String {
+    let (mut no_tokens, mut unpriced, mut unknown_iters) = (0_usize, 0_usize, 0_usize);
+    for t in cost.tasks.iter().filter(|t| t.usd.is_none()) {
+        match t.unbounded_reason {
+            Some(UnboundedReason::NoTokenLimit) => no_tokens += 1,
+            Some(UnboundedReason::NoPrice) => unpriced += 1,
+            // A task with no price AND no ceiling records ONE reason
+            // (NoPrice wins in the check ladder); UnknownIterations, an
+            // unclassified None, and any FUTURE reason (the enum is
+            // #[non_exhaustive]) all count as the generic bucket.
+            _ => unknown_iters += 1,
+        }
+    }
+    let total = no_tokens + unpriced + unknown_iters;
+    let mut parts = Vec::new();
+    if no_tokens > 0 {
+        parts.push(format!("{no_tokens} with no `max_tokens`"));
+    }
+    if unpriced > 0 {
+        parts.push(format!("{unpriced} on an unpriced model"));
+    }
+    if unknown_iters > 0 {
+        parts.push(format!("{unknown_iters} with unknown iterations"));
+    }
+    format!(
+        "{total} task(s) have no static ceiling ({})",
+        parts.join(" · ")
+    )
 }
 
 /// `Some(refusal)` when the floor exceeds the budget — pure, so the
@@ -56,7 +90,52 @@ fn floor_refusal(floor: f64, budget: f64) -> Option<String> {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
-    use super::floor_refusal;
+    use nika_schema::{FileId, ParseMode, parse};
+
+    use super::{floor_refusal, unbounded_breakdown};
+
+    fn breakdown_of(yaml: &str) -> String {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+        unbounded_breakdown(&nika_schema::check::check(&wf).cost)
+    }
+
+    #[test]
+    fn breakdown_names_each_reason_not_the_fixed_disjunction() {
+        // A priced-but-unbounded task must read « no max_tokens », not
+        // « unpriced model » — the operator sees which is FIXABLE.
+        let msg = breakdown_of(
+            "nika: v1\nworkflow: m\ntasks:\n  \
+             - id: a\n    infer: { prompt: hi, model: \"anthropic/claude-sonnet-5\" }\n  \
+             - id: b\n    infer: { prompt: hi, max_tokens: 100, model: \"mock/echo\" }\n",
+        );
+        assert!(msg.contains("2 task(s)"), "{msg}");
+        assert!(
+            msg.contains("1 with no `max_tokens`"),
+            "the priced-unbounded task: {msg}"
+        );
+        assert!(
+            msg.contains("1 on an unpriced model"),
+            "the mock task: {msg}"
+        );
+    }
+
+    #[test]
+    fn breakdown_counts_only_the_unbounded_tasks() {
+        // A fully-bounded task (priced + max_tokens) is never in the tally.
+        // id b carries max_tokens so its reason is NoPrice (mock), not
+        // NoTokenLimit — proving the unpriced bucket AND the exclusion of
+        // the fully-bounded id a in one shot.
+        let msg = breakdown_of(
+            "nika: v1\nworkflow: m\ntasks:\n  \
+             - id: a\n    infer: { prompt: hi, max_tokens: 100, model: \"anthropic/claude-sonnet-5\" }\n  \
+             - id: b\n    infer: { prompt: hi, max_tokens: 100, model: \"mock/echo\" }\n",
+        );
+        assert!(
+            msg.contains("1 task(s)"),
+            "only the unpriced mock task: {msg}"
+        );
+        assert!(msg.contains("unpriced model"), "{msg}");
+    }
 
     #[test]
     fn floor_above_budget_refuses_with_both_numbers() {


### PR DESCRIPTION
A **user-sim of `--max-cost-usd`** caught the unbounded warning parroting a fixed three-way string — « (no token bound · unknown iterations · unpriced model) » — for **every** unbounded task. So a priced-but-unbounded `anthropic/claude-sonnet-5` task read « unpriced model », which misleads: the fixable lever is `max_tokens`, not the model.

The report already carries `unbounded_reason` per task (`NoTokenLimit` · `NoPrice` · `UnknownIterations`). The warning now **tallies by actual reason**:

```
⚠ --max-cost-usd 0.5: 2 task(s) have no static ceiling
   (1 with no `max_tokens` · 1 on an unpriced model) — the budget bounds
   METERED spend only; local/mock work never trips it
```

The operator sees which kind they have and which is fixable. Future `#[non_exhaustive]` reasons fold into the generic bucket.

Pure `unbounded_breakdown(&CostCeiling)` seam, driven through the **real check ladder** in the pins (I verified the precedence: `NoTokenLimit` wins over `NoPrice`, so a bounded-but-unpriced task is the `NoPrice` case). 4 budget tests, clippy 0.

The budget guard itself came back solid in the sim: negative/NaN budgets rejected (`must be a finite, non-negative USD amount`), floor-`>`-budget refuses before any spend (exit 2), floor-`==`-budget passes, mock/unpriced work never trips it. This is the one cosmetic wart on an otherwise sound surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)