### PR TITLE
fix(nika-cli): the wizard's hand-off commands survive a spaced filename

### DIFF
--- a/crates/nika-cli/src/verbs/new.rs
+++ b/crates/nika-cli/src/verbs/new.rs
@@ -28,6 +28,22 @@ use nika_bm25::{BmIndex, BmParams};
 use crate::display::theme::{Role, Theme};
 use crate::verbs::{VerbOutput, exit};
 
+/// POSIX shell-quote a path for a COPY-PASTEABLE command suggestion — a
+/// workflow named « My Cool Flow » becomes `My Cool Flow.nika.yaml`, and
+/// the wizard's `nika run <dest>` hint would parse as four arguments and
+/// fail the moment the user pastes it. Only quote when a shell-special
+/// char is present (the common kebab-case path stays bare). Single
+/// quotes with the `'\''` escape — the one form that is total.
+fn shell_quote(path: &str) -> std::borrow::Cow<'_, str> {
+    let safe =
+        |c: char| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/' | '@' | '+');
+    if !path.is_empty() && path.chars().all(safe) {
+        std::borrow::Cow::Borrowed(path)
+    } else {
+        std::borrow::Cow::Owned(format!("'{}'", path.replace('\'', "'\\''")))
+    }
+}
+
 /// `nika new` — resolve the missing `--from` per clig.dev: a terminal
 /// gets the guided flow (prompt for the missing argument) · a pipe/CI
 /// fails fast naming the flag (never REQUIRE interactivity).
@@ -114,7 +130,8 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> VerbOutput {
     let routing = if routed { "routed intent → " } else { "" };
     VerbOutput {
         text: format!(
-            "{dest} ← {routing}template `{name}` · fill the `# SLOT:` lines then `nika check {dest}`"
+            "{dest} ← {routing}template `{name}` · fill the `# SLOT:` lines then `nika check {q}`",
+            q = shell_quote(dest)
         ),
         code: exit::OK,
     }
@@ -583,11 +600,12 @@ fn materialize(base: &str, w: &Wizard, force: bool, theme: Theme) -> VerbOutput 
     // is the product's argument (a red ladder would honestly propagate,
     // but a fresh scaffold checks clean by the templates' own-corpus law).
     let audit = crate::verbs::check::run(&dest, false, false, theme);
+    let q = shell_quote(&dest);
     let next = format!(
-        "next ·\n  $EDITOR {dest}                   # fill the remaining `# SLOT:` lines\n  nika run {dest}                  # execute · live render (mock is offline · $0.00)\n\n{}",
+        "next ·\n  $EDITOR {q}                   # fill the remaining `# SLOT:` lines\n  nika run {q}                  # execute · live render (mock is offline · $0.00)\n\n{}",
         theme.paint(
             Role::Dim,
-            &format!("scriptable form · nika new --from {} {dest}", w.template)
+            &format!("scriptable form · nika new --from {} {q}", w.template)
         ),
     );
     VerbOutput {
@@ -715,6 +733,23 @@ mod tests {
     use super::*;
 
     const PLAIN: Theme = Theme::new(false, false, false);
+
+    #[test]
+    fn shell_quote_wraps_only_when_needed() {
+        // A kebab path stays bare (the common case · no visual noise);
+        // a spaced path is single-quoted so `nika run <it>` survives the
+        // copy-paste (a wizard hand-off must not emit a broken command).
+        assert_eq!(shell_quote("my-flow.nika.yaml"), "my-flow.nika.yaml");
+        assert_eq!(shell_quote("a/b/c.nika.yaml"), "a/b/c.nika.yaml");
+        assert_eq!(
+            shell_quote("My Cool Flow.nika.yaml"),
+            "'My Cool Flow.nika.yaml'"
+        );
+        // The `'` escape is the total POSIX form (close · escaped · open).
+        assert_eq!(shell_quote("it's.nika.yaml"), r"'it'\''s.nika.yaml'");
+        // Shell metacharacters (a `;`/`$`/`&` in a pasted name) are quoted.
+        assert_eq!(shell_quote("a;rm -rf.yaml"), "'a;rm -rf.yaml'");
+    }
 
     /// A unique EMPTY dir per test — the collision-aware default reads
     /// the base, so shared temp dirs would leak state between tests.


### PR DESCRIPTION
A **PTY-driven user-sim** of the interactive `nika new` wizard named a workflow « My Cool Flow » — and the wizard handed back copy-paste commands that **break the moment you paste them**:

```
$EDITOR My Cool Flow.nika.yaml      # shell sees 4 args
nika run My Cool Flow.nika.yaml     # → « too many arguments »
scriptable form · nika new --from chain My Cool Flow.nika.yaml
```

The wizard's whole value is a smooth first run inside the first minute; handing the user a broken command undoes it. Every suggested **command** now shell-quotes the dest (`nika run 'My Cool Flow.nika.yaml'`), while:
- the kebab-case common case stays **bare** (no visual noise),
- the status echo (`✔ <dest> ←`) keeps the raw filename (it's a display line, not a command),
- the total POSIX `'\''` escape neutralizes a `;`/`$`/`&` in a pasted name too, not just spaces.

Sites: the wizard `next ·` block + scriptable-form hint, and the `nika check <dest>` hint on the `run()` path. `shell_quote` is a pure `Cow` seam, pinned (bare · spaced · embedded-quote · shell-metachar). Proven at the rebuilt binary via PTY. 22 `nika new` tests, clippy 0.

Context: I also probed the wizard's coherence (#266) and input handling — the `workflow:` id is honestly sanitized, empty-name defaults gracefully, EOF cancels, out-of-range menu numbers fall back to the offline mock. The wizard is otherwise solid; this quoting gap was the one hand-off that broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)