### PR TITLE
test(nika-cli): the own-corpus law is a ratchet — every template audits clean

### DIFF
--- a/crates/nika-cli/src/verbs/new.rs
+++ b/crates/nika-cli/src/verbs/new.rs
@@ -996,6 +996,57 @@ mod tests {
     }
 
     #[test]
+    fn every_embedded_template_audits_clean_or_is_a_documented_gap() {
+        // The own-corpus law (#261): every embedded skeleton a fresh
+        // scaffold can produce MUST audit clean — a red ladder on a first
+        // scaffold is the self-contradiction the wizard exists to avoid.
+        // This ratchet was MISSING (pack-integrity only hashes text), so
+        // `api-upload-and-create` shipped in #257 failing its OWN
+        // SECRETS-egress check, unnoticed, until a user-sim caught it.
+        //
+        // KNOWN GAP — an operator design call, NOT a template typo: the
+        // ADR-092 flow model taints an authenticated `invoke`'s OUTPUT (a
+        // secret in a fetch auth-header taints the response, exactly as a
+        // secret in the body would), with no `infer`/`agent`-style prompt
+        // exception and no output-declassification construct. So
+        // `api-upload-and-create` (upload+create, both secret-authed, the
+        // create response piped to `outputs:`) cannot surface its result
+        // to ANY sink — outputs, a local `nika:write`, or another tool
+        // all trip the egress. Resolving it needs a header-position
+        // exception in the taint analysis OR an output-declassification
+        // feature; both are design decisions. Until then it is the ONE
+        // documented exception: a SECOND dirty template — or this one
+        // becoming clean (the gap resolved) — fails this ratchet.
+        const KNOWN_GAP: &[&str] = &["api-upload-and-create"];
+        let mut clean = 0_usize;
+        for name in nika_pack::template_names() {
+            let body = nika_pack::template(&name).expect("template embedded");
+            let parsed = nika_schema::parse(
+                body,
+                nika_schema::FileId::new(0),
+                nika_schema::ParseMode::Strict,
+            );
+            assert!(parsed.is_ok(), "{name}: template must parse: {parsed:?}");
+            let wf = parsed.expect("asserted ok above");
+            let is_gap = KNOWN_GAP.contains(&name.as_str());
+            if nika_schema::check::check(&wf).is_clean() {
+                assert!(
+                    !is_gap,
+                    "{name}: now audits CLEAN — remove it from KNOWN_GAP, the design gap is resolved"
+                );
+                clean += 1;
+            } else {
+                assert!(
+                    is_gap,
+                    "{name}: a fresh scaffold FAILS its own `nika check` (own-corpus law · #261) — \
+                     fix the template, or (if a genuine flow-model design gap) document it in KNOWN_GAP"
+                );
+            }
+        }
+        assert!(clean >= 8, "expected >= 8 clean templates, got {clean}");
+    }
+
+    #[test]
     fn stamp_fills_exactly_the_three_known_slots() {
         for name in nika_pack::template_names() {
             let body = nika_pack::template(&name).expect("embedded");


### PR DESCRIPTION
A wizard-arc review + a PTY user-sim caught it: **`api-upload-and-create` shipped in #257 failing its own `nika check`** (SECRETS egress, exit 2). A user picking that scaffold from `nika new` gets a **red ladder on their very first file** — the exact self-contradiction #261's « every fresh scaffold checks clean » law forbids. Nothing enforced the law: `pack_integrity` only hashes the template TEXT, it never audits it.

This ratchet parses + `check`s every embedded template. **Eight audit clean**; `api-upload-and-create` is the **one documented `KNOWN_GAP`** — and the test fails if a SECOND template ships dirty, or if this one becomes clean (so the gap can't be silently forgotten once resolved).

**The gap is an operator design call, not a template typo** (spelled out in the test): the ADR-092 flow model taints an authenticated `invoke`'s OUTPUT — a secret in a fetch auth-header taints the response just as a body secret would, with no `infer`/`agent`-style prompt exception and no output-declassification construct. So that template cannot surface its create result to ANY sink (I verified: `outputs:`, a local `nika:write`, and another tool all trip the egress). Resolving it needs **a header-position taint exception** (mirroring the infer/agent prompt exception) **or an output-declassification feature** — both design decisions. The ratchet holds the line meanwhile.

Deterministic, self-contained (one nika-cli test), no vendored-pack or security-model change. clippy 0.

**Two design gaps this round surfaced, for your call** (not blind-patched):
1. ☝️ this one — surface an authenticated API response (huge common pattern).
2. `native-first` advisory heuristics (#258): a rust-pro review found Rule 005 is false-clean on a shell one-liner helper (`node helper.mjs args` — the arc's own motivating case) and Rules 001/004/005 false-dirty on string literals / inline `-c` programs. Root cause: token-level heuristics applied to `text_fragments()` units that aren't tokens. The core clean/dirty verdict is UNAFFECTED (native-first is hints-only) — it's an advisory-accuracy + `--native-strict` redesign, best done deliberately with the token-granularity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)