### PR TITLE
fix(nika-schema): native-first rule 004 gets the bare-head guard its siblings have

### DIFF
--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -139,8 +139,13 @@ pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
             ),
         ));
     }
-    // 004 · a media provider endpoint in the command.
-    if has_marker(&MEDIA_MARKERS) {
+    // 004 · a media provider endpoint in the command. Bare head only —
+    // a PATHED head (`./deploy.sh …`) is the author's own tool and must
+    // not be second-guessed because a media-provider domain appears in
+    // its args, exactly as 001/002/003 suppress a pathed head (the
+    // rust-pro review's F2: `./deploy.sh --host api.elevenlabs.io`
+    // false-fired 004 while the same pathed head is silent for HTTP).
+    if !pathed && has_marker(&MEDIA_MARKERS) {
         return Some((
             "native-first/004",
             format!(
@@ -301,6 +306,25 @@ mod tests {
             "\"python3 -c 'import urllib; fetch(\\\"https://x.test\\\")'\"",
         ));
         assert!(h.advice.contains("native-first/001"), "{h:?}");
+    }
+
+    #[test]
+    fn pathed_head_never_fires_media_004() {
+        // The author's own script whose ARG names a media-provider domain
+        // must not be second-guessed into `nika:image_generate` — a
+        // pathed head is silent for 001/002/003 and now for 004 too
+        // (the review's F2 false-dirty: `./deploy.sh --host
+        // api.elevenlabs.io` fired 004 while a pathed curl stays silent).
+        for command in [
+            "[\"./deploy.sh\", \"--host\", \"api.elevenlabs.io\"]",
+            "\"./tools/publish.sh https://api.openai.com/v1/images/generations\"",
+        ] {
+            let hints = hints_of(&exec_wf(command));
+            assert!(
+                !hints.iter().any(|h| h.advice.contains("native-first/004")),
+                "pathed head must not fire media 004: {hints:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The native-first rust-pro review's **F2** (a MEDIUM, cleanly isolable): rule 004 (media-provider → `nika:image_generate`/`tts_generate`) fired on a **pathed head** — a secret-free `./deploy.sh --host api.elevenlabs.io` got advised to switch to an image generator (**false-dirty under `--native-strict`**) — because it matched a media marker with **no `!pathed` guard**, while rules 001/002/003 correctly stay silent on a pathed head (the author's own tool, never second-guessed).

004 now carries the same `!pathed &&` guard as its siblings. A bare-head media call (`curl …/images/generations`) still fires; the author's own script whose arg merely names a provider domain does not. The pin mirrors the pathed-head negative 001/002/003 already have.

**Scope** — this closes the pathed-head false-dirty only. The review's other native-first findings share a deeper root cause (token-level heuristics applied to `text_fragments()` units that aren't command tokens: a shell one-liner helper false-CLEAN under strict · HTTP markers matching string literals · inline `-c` programs mislabeled) and want the granularity redesign, not a spot patch — **flagged, not blind-patched**. The core clean/dirty verdict is unaffected throughout (native-first is hints-only, `is_clean` excludes hints; the review PROVED this).

13 native_first tests, clippy 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)