### PR TITLE
fix(nika-schema): check catches an out-of-range max_turns — audit before run

### DIFF
--- a/crates/nika-schema/src/parser/verbs.rs
+++ b/crates/nika-schema/src/parser/verbs.rs
@@ -215,7 +215,7 @@ fn parse_agent_body(cx: &Cx<'_>, body: &MarkedMappingNode) -> Result<RawAgentAct
     for tool in &action.tools {
         validate_whitelist_namespace(tool)?;
     }
-    action.max_turns = parse_u32_field(cx, body, "max_turns")?;
+    action.max_turns = parse_max_turns(cx, body)?;
     action.max_tokens_total = parse_u64_field(cx, body, "max_tokens_total")?;
     action.temperature = parse_temperature(cx, body)?;
     action.schema = parse_schema(cx, body)?;
@@ -242,6 +242,40 @@ fn parse_temperature(
     if !(0.0..=2.0).contains(&value) {
         return Err(SchemaError::Validation {
             message: format!("`temperature` must be in 0-2 (got {value})"),
+            span: cx.span(node.span()),
+        });
+    }
+    Ok(Some(Spanned::new(value, cx.span_or_zero(node.span()))))
+}
+
+/// `max_turns` — the agent loop bound. A LITERAL integer only (templates
+/// are rejected by the u32 parse), so its range is statically knowable:
+/// the runtime refuses anything outside 1..=1000 (NIKA-465), and
+/// `nika check` must catch that BEFORE the run — a `max_turns: 0` that
+/// audits clean then dies at dispatch breaks audit-before-run.
+///
+/// The ceiling MUST equal `nika_verb_agent::MAX_TURNS_CEILING` (this
+/// crate cannot import the runtime one — dependency direction); the
+/// runtime stays the enforcer, this is the early mirror.
+const MAX_TURNS_CEILING: u32 = 1000;
+
+fn parse_max_turns(
+    cx: &Cx<'_>,
+    body: &MarkedMappingNode,
+) -> Result<Option<Spanned<u32>>, SchemaError> {
+    let Some(node) = body.get_node("max_turns") else {
+        return Ok(None);
+    };
+    let value = node
+        .as_scalar()
+        .and_then(MarkedScalarNode::as_u32)
+        .ok_or_else(|| SchemaError::Validation {
+            message: "`max_turns` must be a non-negative integer".to_owned(),
+            span: cx.span(node.span()),
+        })?;
+    if !(1..=MAX_TURNS_CEILING).contains(&value) {
+        return Err(SchemaError::Validation {
+            message: format!("`max_turns` must be 1-{MAX_TURNS_CEILING} (got {value})"),
             span: cx.span(node.span()),
         });
     }
@@ -532,6 +566,37 @@ mod tests {
             .remove(0)
             .value
             .action
+    }
+
+    // ── agent max_turns range (audit-before-run · NIKA-465 mirror) ──
+
+    fn agent_wf(max_turns: &str) -> String {
+        format!(
+            "tasks:\n  - id: go\n    agent:\n      system: \"do\"\n      \
+             prompt: \"task\"\n      tools: [\"nika:done\"]\n      \
+             max_turns: {max_turns}\n      max_tokens_total: 1000\n"
+        )
+    }
+
+    #[test]
+    fn max_turns_range_is_caught_at_parse_not_deferred_to_runtime() {
+        // The runtime refuses max_turns outside 1..=1000 (NIKA-465); the
+        // static check must catch a LITERAL out-of-range value BEFORE the
+        // run, or a `max_turns: 0` audits clean then dies at dispatch.
+        for ok in ["1", "3", "1000"] {
+            assert!(
+                parse_strict(&agent_wf(ok)).is_ok(),
+                "max_turns {ok} is valid"
+            );
+        }
+        for bad in ["0", "1001", "99999"] {
+            let err = parse_strict(&agent_wf(bad)).expect_err("out of range");
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("max_turns") && msg.contains("1-1000"),
+                "{bad}: {msg}"
+            );
+        }
     }
 
     // ── infer ───────────────────────────────────────────────────────


### PR DESCRIPTION
A **user-sim of the `agent:` verb** (PTY + hostile params) caught a check/run disagreement: the runtime refuses `max_turns` outside `1..=1000` (NIKA-465 at dispatch), but `nika check` **passed** a literal `max_turns: 0` (and `99999`) clean — so a workflow audits green, the user commits, then `nika run` dies at parameter validation. That breaks **audit-before-run**, Nika's core promise (the same class as the MCP `isError` fix #270).

The parser already validates `temperature`'s 0-2 range at parse time (NIKA-PARSE-019); `max_turns` rode the generic non-negative-integer parse with no ceiling. It now gets a dedicated `parse_max_turns` mirroring `temperature`: a literal outside `1..=1000` fails the parse (so `nika check` fails), a valid one passes, and a `${{ }}` template stays rejected exactly as before (a loop bound is never templated).

**Proven at the binary:** `max_turns: 0`/`99999` now `check=2 run=2` (was `check=0 run=1`); a valid `3` stays `check=0 run=0`. Boundary pin (0/1/1000/1001/99999). 781 schema tests, clippy 0. The ceiling is cross-noted against `nika_verb_agent::MAX_TURNS_CEILING` (the parser can't import the runtime crate — dependency direction; the runtime stays the enforcer, this is the early mirror).

**Deeper agent-verb review, for your call (not blind-patched):** a rust-pro review of the loop confirmed it's **sound** — termination provably bounded, zero panics, graceful tool dispatch, correct stall math. Four findings surfaced, none CRITICAL/HIGH:
- **F1 (MEDIUM, verdict-correctness):** `classify_turn` discards `InferResponse::stop_reason`, so a provider truncation (`MaxTokens`) or content-filter with no tool call is reported as a successful `Completed` answer — a truncated response masquerading as complete. Fix needs a new error code / semantics change on active code.
- F2 (MEDIUM): byte-identical polling (`"PENDING"` verbatim) trips the stall detector at 5 repeats independent of `max_turns` — documented tradeoff, untested false-positive.
- F3 (LOW): schema re-asks on the terminal path bypass `max_tokens_total` (bounded, opt-in).
- F4 (LOW): an exact whitelist turns a benign model tool-name typo into a fatal run (availability cost of security-first).
- Also caught: an empty `prompt: ""` has the same check/run gap this PR fixes for max_turns, but its fix touches the shared `require_scalar` helper — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)