### PR TITLE
feat(verb-infer): the coercion ladder — SAP-lite repair before a paid retry

### DIFF
--- a/crates/nika-verb-infer/src/coerce.rs
+++ b/crates/nika-verb-infer/src/coerce.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Schema-driven coercion — the repair ladder that runs BEFORE a paid
+//! retry (SAP-lite · the schema-aligned-parsing pattern BAML productionized;
+//! CRAFT per ADR-001, concept not code).
+//!
+//! When a candidate parses but misses the schema, one deterministic
+//! coercion pass walks value and schema together and repairs the
+//! near-misses weak models actually emit: string-encoded scalars
+//! (`"42"` where an integer is declared), a scalar where a
+//! single-element array is declared, a case/whitespace-drifted `enum`
+//! variant, a number/bool where a string is declared. Every rule is
+//! lossless or unambiguous, and the result is only USED if the FULL
+//! schema validates afterwards (`structured::extract_and_validate`
+//! re-runs the validator) — a coercion that does not reach full
+//! validity changes nothing and the retry proceeds on the original
+//! errors. Each landed coercion deletes an entire paid round-trip.
+//!
+//! Fences: composition and reference nodes (`$ref` · `anyOf` · `oneOf`
+//! · `allOf`) are left untouched — no resolver, never a guess. Keys are
+//! never renamed, members never added or dropped. Recursion mirrors the
+//! candidate's own depth, which the parser already bounds.
+
+use serde_json::Value;
+
+/// One coercion pass over the whole candidate (pure). Returns the
+/// (possibly unchanged) repaired value — the caller decides by
+/// re-validating in full.
+pub(crate) fn coerce_toward(value: &Value, schema: &Value) -> Value {
+    coerce_node(value, schema)
+}
+
+/// Repair one node, then its children.
+fn coerce_node(value: &Value, schema: &Value) -> Value {
+    let Some(node) = schema.as_object() else {
+        return value.clone();
+    };
+    if ["$ref", "anyOf", "oneOf", "allOf"]
+        .iter()
+        .any(|k| node.contains_key(*k))
+    {
+        return value.clone();
+    }
+    let types = declared_types(node);
+
+    // A declared array around a non-array candidate: wrap ONE element —
+    // but only when the candidate's own type is not itself declared
+    // (types ["array","string"] must keep a bare string as-is).
+    if types.iter().any(|t| t == "array")
+        && !value.is_array()
+        && !types.iter().any(|t| t == json_type_name(value))
+        && let Some(items) = node.get("items").filter(|i| !i.is_array())
+    {
+        return Value::Array(vec![coerce_node(value, items)]);
+    }
+
+    match value {
+        Value::Object(members) => {
+            let props = node.get("properties").and_then(Value::as_object);
+            let repaired = members
+                .iter()
+                .map(|(key, member)| {
+                    let child = props.and_then(|p| p.get(key));
+                    let value = child.map_or_else(|| member.clone(), |s| coerce_node(member, s));
+                    (key.clone(), value)
+                })
+                .collect();
+            Value::Object(repaired)
+        }
+        Value::Array(elements) => match node.get("items").filter(|i| !i.is_array()) {
+            Some(items) => Value::Array(elements.iter().map(|e| coerce_node(e, items)).collect()),
+            None => value.clone(),
+        },
+        scalar => coerce_scalar(scalar, node, &types),
+    }
+}
+
+/// The scalar rungs: string→number/integer/bool · number/bool→string ·
+/// enum case/whitespace snap. Each fires only when the value's own type
+/// is NOT declared (a type that already fits is never rewritten).
+fn coerce_scalar(value: &Value, node: &serde_json::Map<String, Value>, types: &[String]) -> Value {
+    let own_type_declared = types.iter().any(|t| t == json_type_name(value));
+    match value {
+        Value::String(text) if !own_type_declared => {
+            let trimmed = text.trim();
+            if types.iter().any(|t| t == "integer")
+                && let Ok(n) = trimmed.parse::<i64>()
+            {
+                return Value::Number(n.into());
+            }
+            if types.iter().any(|t| t == "number")
+                && let Ok(f) = trimmed.parse::<f64>()
+                && let Some(n) = serde_json::Number::from_f64(f)
+            {
+                return Value::Number(n);
+            }
+            if types.iter().any(|t| t == "boolean") {
+                if trimmed.eq_ignore_ascii_case("true") {
+                    return Value::Bool(true);
+                }
+                if trimmed.eq_ignore_ascii_case("false") {
+                    return Value::Bool(false);
+                }
+            }
+            value.clone()
+        }
+        Value::String(text) => enum_snap(text, node).unwrap_or_else(|| value.clone()),
+        Value::Number(n) if !own_type_declared && types.iter().any(|t| t == "string") => {
+            Value::String(n.to_string())
+        }
+        Value::Bool(b) if !own_type_declared && types.iter().any(|t| t == "string") => {
+            Value::String(b.to_string())
+        }
+        _ => value.clone(),
+    }
+}
+
+/// Snap a string onto the ONE `enum` variant it matches after trim +
+/// case-fold. An exact member stays untouched; an ambiguous fold (two
+/// variants differing only by case) never snaps — no guessing.
+fn enum_snap(text: &str, node: &serde_json::Map<String, Value>) -> Option<Value> {
+    let variants = node.get("enum")?.as_array()?;
+    if variants.iter().any(|v| v.as_str() == Some(text)) {
+        return None;
+    }
+    let folded = text.trim().to_lowercase();
+    let mut hits = variants
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|v| v.trim().to_lowercase() == folded);
+    let first = hits.next()?;
+    if hits.next().is_some() {
+        return None;
+    }
+    Some(Value::String(first.to_owned()))
+}
+
+/// The `type:` names a node declares (scalar or union form).
+fn declared_types(node: &serde_json::Map<String, Value>) -> Vec<String> {
+    match node.get("type") {
+        Some(Value::String(t)) => vec![t.clone()],
+        Some(Value::Array(list)) => list
+            .iter()
+            .filter_map(|t| t.as_str().map(str::to_owned))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The candidate value's own JSON-Schema type name.
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(n) if n.is_i64() || n.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn string_encoded_scalars_coerce_when_the_type_disagrees() {
+        let schema = json!({"type": "object", "properties": {
+            "age": {"type": "integer"},
+            "score": {"type": "number"},
+            "ok": {"type": "boolean"},
+            "label": {"type": "string"}
+        }});
+        let out = coerce_toward(
+            &json!({"age": " 42 ", "score": "3.5", "ok": "TRUE", "label": "keep"}),
+            &schema,
+        );
+        assert_eq!(
+            out,
+            json!({"age": 42, "score": 3.5, "ok": true, "label": "keep"})
+        );
+    }
+
+    #[test]
+    fn declared_string_never_rewrites_a_numeric_looking_string() {
+        // "42" against type:string stays a string — a fitting type is
+        // never touched, and a union declaring string keeps the string.
+        let schema = json!({"type": "object", "properties": {
+            "id": {"type": "string"},
+            "either": {"type": ["string", "integer"]}
+        }});
+        let input = json!({"id": "42", "either": "7"});
+        assert_eq!(coerce_toward(&input, &schema), input);
+    }
+
+    #[test]
+    fn number_and_bool_stringify_when_a_string_is_declared() {
+        let schema = json!({"type": "object", "properties": {
+            "code": {"type": "string"},
+            "flag": {"type": "string"}
+        }});
+        let out = coerce_toward(&json!({"code": 42, "flag": true}), &schema);
+        assert_eq!(out, json!({"code": "42", "flag": "true"}));
+    }
+
+    #[test]
+    fn scalar_wraps_into_the_declared_single_element_array() {
+        let schema = json!({"type": "object", "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "ids": {"type": "array", "items": {"type": "integer"}}
+        }});
+        // the wrapped element itself runs the ladder ("7" → 7).
+        let out = coerce_toward(&json!({"tags": "solo", "ids": "7"}), &schema);
+        assert_eq!(out, json!({"tags": ["solo"], "ids": [7]}));
+    }
+
+    #[test]
+    fn union_declaring_the_own_type_never_wraps() {
+        let schema = json!({"type": "object", "properties": {
+            "v": {"type": ["array", "string"], "items": {"type": "string"}}
+        }});
+        let input = json!({"v": "bare"});
+        assert_eq!(coerce_toward(&input, &schema), input);
+    }
+
+    #[test]
+    fn enum_snaps_on_unique_fold_never_on_ambiguity() {
+        let schema = json!({"type": "object", "properties": {
+            "field": {"type": "string", "enum": ["physics", "chemistry"]},
+            "twin": {"type": "string", "enum": ["Ab", "aB"]}
+        }});
+        let out = coerce_toward(&json!({"field": " Physics ", "twin": "ab"}), &schema);
+        assert_eq!(out["field"], "physics", "unique fold snaps");
+        assert_eq!(out["twin"], "ab", "ambiguous fold never guesses");
+    }
+
+    #[test]
+    fn nested_arrays_and_objects_recurse() {
+        let schema = json!({"type": "object", "properties": {
+            "rows": {"type": "array", "items": {
+                "type": "object",
+                "properties": {"n": {"type": "integer"}}
+            }}
+        }});
+        let out = coerce_toward(&json!({"rows": [{"n": "1"}, {"n": "2"}]}), &schema);
+        assert_eq!(out, json!({"rows": [{"n": 1}, {"n": 2}]}));
+    }
+
+    #[test]
+    fn composition_and_ref_nodes_stay_untouched() {
+        let schema = json!({"type": "object", "properties": {
+            "a": {"anyOf": [{"type": "integer"}]},
+            "b": {"$ref": "#/$defs/X"}
+        }});
+        let input = json!({"a": "1", "b": "2"});
+        assert_eq!(
+            coerce_toward(&input, &schema),
+            input,
+            "no resolver, no guess"
+        );
+    }
+
+    #[test]
+    fn unknown_members_and_unparseable_strings_pass_through() {
+        let schema = json!({"type": "object", "properties": {
+            "n": {"type": "integer"}
+        }});
+        let input = json!({"n": "not-a-number", "extra": "kept"});
+        assert_eq!(coerce_toward(&input, &schema), input);
+    }
+}

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -50,6 +50,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+mod coerce;
 mod errors;
 mod structured;
 
@@ -267,7 +268,7 @@ where
                 ));
             };
 
-            match structured::extract_and_validate(&text, validator) {
+            match structured::extract_and_validate(&text, validator, schema) {
                 structured::Validation::Valid(value) => {
                     return Ok(InferOutput::new(
                         InferValue::Structured(value),
@@ -1027,6 +1028,66 @@ mod tests {
         );
     }
 
+    /// The SAP-lite rescue deletes a paid retry: a reply whose only sin is
+    /// STRING-ENCODED scalars ("36" where an integer is declared · a
+    /// case-drifted enum) is repaired locally and lands in ONE round-trip —
+    /// the scripted second reply must never be requested.
+    #[tokio::test]
+    async fn coercible_reply_lands_in_one_round_trip() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":\"36\",\"field\":\" Mathematics \"}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":4}}"#,
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":36,\"field\":\"mathematics\"}"},"finish_reason":"stop"}],"usage":{}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "age": { "type": "integer" },
+                "field": { "type": "string", "enum": ["physics", "mathematics"] }
+            },
+            "required": ["name", "age", "field"],
+            "additionalProperties": false
+        }));
+        let out = openai_verb(&seam)
+            .run(input)
+            .await
+            .expect("the rescue repairs locally");
+        match &out.output {
+            InferValue::Structured(v) => {
+                assert_eq!(v["age"], 36, "string-encoded integer coerced");
+                assert_eq!(v["field"], "mathematics", "enum case-snapped");
+            }
+            other => panic!("expected structured, got {other:?}"),
+        }
+        assert_eq!(
+            seam.captured().len(),
+            1,
+            "the coercion DELETED the retry round-trip"
+        );
+        assert_eq!(out.usage.input_tokens, 9, "one round-trip billed");
+    }
+
+    /// A miss the ladder cannot repair (a missing required member) still
+    /// takes the ordinary retry path — the rescue never masks real gaps.
+    #[tokio::test]
+    async fn uncoercible_miss_still_retries() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\"}"},"finish_reason":"stop"}],"usage":{}}"#,
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":36}"},"finish_reason":"stop"}],"usage":{}}"#,
+        ]);
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let out = openai_verb(&seam).run(input).await.expect("retry conforms");
+        assert!(matches!(out.output, InferValue::Structured(_)));
+        assert_eq!(seam.captured().len(), 2, "a real gap still costs a retry");
+    }
+
     /// A NORMAL stop that fails the schema stays a plain schema mismatch —
     /// no truncation hint bolted onto an ordinary validation failure.
     #[tokio::test]
@@ -1153,10 +1214,11 @@ mod proptests {
         /// when it extracts, the candidate is real JSON.
         #[test]
         fn extraction_total_on_arbitrary_text(s in ".{0,400}") {
-            // Total function — must not panic.
-            let v = crate::structured::compile_schema(&serde_json::json!({ "type": "object" }))
+            // Total function — must not panic (the coercion pass included).
+            let schema = serde_json::json!({ "type": "object" });
+            let v = crate::structured::compile_schema(&schema)
                 .expect("trivial schema compiles");
-            let _ = crate::structured::extract_and_validate(&s, &v);
+            let _ = crate::structured::extract_and_validate(&s, &v, &schema);
         }
     }
 }

--- a/crates/nika-verb-infer/src/structured.rs
+++ b/crates/nika-verb-infer/src/structured.rs
@@ -53,7 +53,11 @@ pub(crate) fn render_schema(schema: &serde_json::Value) -> String {
 /// Extraction is lenient by design — models wrap JSON in prose and code
 /// fences. Strategy: try the whole trimmed text first, then the first
 /// fenced block, then the first balanced `{…}` or `[…]` span.
-pub(crate) fn extract_and_validate(text: &str, validator: &jsonschema::Validator) -> Validation {
+pub(crate) fn extract_and_validate(
+    text: &str,
+    validator: &jsonschema::Validator,
+    schema: &serde_json::Value,
+) -> Validation {
     let Some(candidate) = extract_json(text) else {
         return Validation::Invalid(vec!["no JSON value found in the model output".to_owned()]);
     };
@@ -71,10 +75,19 @@ pub(crate) fn extract_and_validate(text: &str, validator: &jsonschema::Validator
         })
         .collect();
     if rendered.is_empty() {
-        Validation::Valid(candidate)
-    } else {
-        Validation::Invalid(rendered)
+        return Validation::Valid(candidate);
     }
+    // SAP-lite rescue: one deterministic coercion pass (string-encoded
+    // scalars · single-element array wrap · enum case-snap), accepted
+    // ONLY when the FULL schema validates afterwards — each landed
+    // rescue deletes an entire paid retry round-trip. A rescue that
+    // falls short changes nothing: the retry proceeds on the ORIGINAL
+    // errors (the model is shown its own text, not our repair).
+    let repaired = crate::coerce::coerce_toward(&candidate, schema);
+    if repaired != candidate && validator.iter_errors(&repaired).next().is_none() {
+        return Validation::Valid(repaired);
+    }
+    Validation::Invalid(rendered)
 }
 
 /// Is the task schema UNDERSPECIFIED for a strict provider mode? — any
@@ -365,7 +378,11 @@ mod tests {
 
     #[test]
     fn bare_json_validates() {
-        let v = extract_and_validate(r#"{"name":"Ada","age":36}"#, &validator(&person_schema()));
+        let v = extract_and_validate(
+            r#"{"name":"Ada","age":36}"#,
+            &validator(&person_schema()),
+            &person_schema(),
+        );
         match v {
             Validation::Valid(val) => assert_eq!(val["name"], "Ada"),
             Validation::Invalid(d) => panic!("expected valid, got: {d:?}"),
@@ -376,7 +393,7 @@ mod tests {
     fn fenced_json_is_extracted() {
         let text = "Here you go:\n```json\n{\"name\":\"Ada\",\"age\":36}\n```\nDone.";
         assert!(matches!(
-            extract_and_validate(text, &validator(&person_schema())),
+            extract_and_validate(text, &validator(&person_schema()), &person_schema()),
             Validation::Valid(_)
         ));
     }
@@ -389,7 +406,7 @@ mod tests {
         // REAL providers' noisy replies.)
         let text = r#"mock(echo) · {"name":"Ada","age":36}"#;
         assert!(matches!(
-            extract_and_validate(text, &validator(&person_schema())),
+            extract_and_validate(text, &validator(&person_schema()), &person_schema()),
             Validation::Valid(_)
         ));
     }
@@ -397,7 +414,7 @@ mod tests {
     #[test]
     fn balanced_span_ignores_braces_inside_strings() {
         let text = r#"noise {"name":"A{d}a","age":1} trail"#;
-        match extract_and_validate(text, &validator(&person_schema())) {
+        match extract_and_validate(text, &validator(&person_schema()), &person_schema()) {
             Validation::Valid(val) => assert_eq!(val["name"], "A{d}a"),
             Validation::Invalid(d) => panic!("expected valid, got: {d:?}"),
         }
@@ -405,7 +422,11 @@ mod tests {
 
     #[test]
     fn schema_violation_reports_path() {
-        let v = extract_and_validate(r#"{"name":"Ada","age":-3}"#, &validator(&person_schema()));
+        let v = extract_and_validate(
+            r#"{"name":"Ada","age":-3}"#,
+            &validator(&person_schema()),
+            &person_schema(),
+        );
         match v {
             Validation::Invalid(d) => {
                 assert!(d.iter().any(|e| e.contains("age")), "path named: {d:?}");
@@ -417,7 +438,11 @@ mod tests {
     #[test]
     fn no_json_at_all_is_invalid() {
         assert!(matches!(
-            extract_and_validate("plain prose, nothing else", &validator(&person_schema())),
+            extract_and_validate(
+                "plain prose, nothing else",
+                &validator(&person_schema()),
+                &person_schema(),
+            ),
             Validation::Invalid(_)
         ));
     }
@@ -426,7 +451,7 @@ mod tests {
     fn arrays_are_supported() {
         let schema = json!({ "type": "array", "items": { "type": "integer" } });
         assert!(matches!(
-            extract_and_validate("the list is [1, 2, 3] ok", &validator(&schema)),
+            extract_and_validate("the list is [1, 2, 3] ok", &validator(&schema), &schema),
             Validation::Valid(_)
         ));
     }
@@ -580,7 +605,11 @@ mod tests {
     #[test]
     fn trailing_comma_in_object_is_repaired() {
         // The dominant local-model near-miss: a trailing comma before `}`.
-        let v = extract_and_validate(r#"{"name":"Ada","age":36,}"#, &validator(&person_schema()));
+        let v = extract_and_validate(
+            r#"{"name":"Ada","age":36,}"#,
+            &validator(&person_schema()),
+            &person_schema(),
+        );
         match v {
             Validation::Valid(val) => assert_eq!(val["age"], 36),
             Validation::Invalid(d) => panic!("expected repair to valid, got: {d:?}"),
@@ -591,7 +620,7 @@ mod tests {
     fn trailing_comma_in_array_and_nested_is_repaired() {
         let schema = json!({ "type": "array", "items": { "type": "integer" } });
         assert!(matches!(
-            extract_and_validate("[1, 2, 3, ]", &validator(&schema)),
+            extract_and_validate("[1, 2, 3, ]", &validator(&schema), &schema),
             Validation::Valid(_)
         ));
         // Nested + whitespace before the closer.
@@ -638,7 +667,7 @@ mod tests {
         // the real object that follows — the multi-candidate scan reaches it.
         let text = r#"I think [maybe] the answer is {"name":"Ada","age":36}."#;
         assert!(matches!(
-            extract_and_validate(text, &validator(&person_schema())),
+            extract_and_validate(text, &validator(&person_schema()), &person_schema()),
             Validation::Valid(_)
         ));
     }


### PR DESCRIPTION
## What

Phase E of the structured-output SOTA arc (#262 · #264 · #267 · #268 · #269): when a candidate parses but misses the schema, ONE deterministic coercion pass repairs the near-misses weak models actually emit — **string-encoded scalars** (`"42"`→42 · `"TRUE"`→true, only when `string` is not itself declared) · **number/bool→string** (lossless) · **scalar → single-element array** wrap (element re-laddered) · **enum case/whitespace snap** (unique fold only — ambiguity never guesses).

The repaired value is used **only when the full schema validates afterwards**; a rescue that falls short changes nothing and the retry proceeds on the ORIGINAL errors (the model sees its own text, never our repair). Composition/`$ref` nodes are fenced out (no resolver, no guessing); keys never renamed, members never added/dropped.

Evidence basis: schema-aligned parsing (BAML `jsonish`) is the strongest production pattern from the SOTA pass — near-zero parse-failure retries claimed. CRAFT per ADR-001: concept, not code.

## Proof

- **Pinned at the wire**: a reply whose only sins are a string-encoded integer + case-drifted enum lands `Structured` in **exactly ONE round-trip** (the scripted retry is never requested — each landed coercion deletes a paid call); a real gap (missing required member) still retries (2 round-trips pinned).
- 9 ladder unit tests (type disagreement · fitting-type never rewritten · union guards · wrap · nested recursion · ambiguous enum · composition fence · pass-through) + 2 e2e round-trip-count tests.
- 65 verb-infer lib green · workspace lib green · clippy `-D warnings` green · all 8 ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)