### PR TITLE
feat(nika-cli): the scaffolded agents.md teaches the live clap tree

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -26,6 +26,13 @@ oracle; the human runs it.
    every remaining `exec:` is in the exec ledger (below).
 6. The human (or CI) runs it: `nika run <file>`. Preview offline with
    `--model mock/echo`; run locally with `--model ollama/<model>`.
+   Inputs ride `--var key=value` (repeatable · unknown keys refused);
+   a run paused on a `nika:prompt` resumes with
+   `nika run <file> --resume <trace> --answer <task>=<value>`
+   (confirm gates take booleans: `--answer approve=true`).
+7. Pin it for CI: `nika test <file> --update` writes
+   `<file>.golden.json` from an offline mock run; `nika test <file>`
+   replays and compares — deterministic, zero keys.
 
 ## The four verbs (exactly one per task)
 

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -683,6 +683,7 @@ pub fn nika_cli::verbs::graph::run(path: &str, format: nika_cli::verbs::graph::G
 pub fn nika_cli::verbs::graph::to_dot(doc: &nika_cli::verbs::graph::GraphDoc) -> alloc::string::String
 pub fn nika_cli::verbs::graph::to_mermaid(doc: &nika_cli::verbs::graph::GraphDoc) -> alloc::string::String
 pub mod nika_cli::verbs::init
+pub fn nika_cli::verbs::init::agents_md() -> &'static str
 pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::inspect
 pub fn nika_cli::verbs::inspect::run(path: &str, ascii: bool) -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -962,6 +962,33 @@ mod tests {
     #![allow(clippy::expect_used)]
     use super::*;
 
+    /// The scaffolded AGENTS.md must teach the LIVE clap tree — a verb
+    /// the binary ships and the guide never names is a verb a wired
+    /// agent will never reach (inherited from the stalled 2026-07-05
+    /// field-fixes branch: the scaffold then taught zero of the new
+    /// train). Derived from the tree itself so it can never lag again.
+    #[test]
+    fn the_scaffolded_agents_md_teaches_the_live_clap_tree() {
+        let agents = nika_cli::verbs::init::agents_md();
+        for sub in Cli::command().get_subcommands() {
+            let name = sub.get_name();
+            if name == "help" {
+                continue; // clap's auto subcommand — not a teaching target
+            }
+            assert!(
+                agents.contains(name),
+                "the scaffolded AGENTS.md must teach `nika {name}`"
+            );
+        }
+        // The flags an agent needs daily — inputs, resume, goldens, scaffold.
+        for flag in ["--var", "--resume", "--answer", "--update", "--from"] {
+            assert!(
+                agents.contains(flag),
+                "the scaffolded AGENTS.md must teach `{flag}`"
+            );
+        }
+    }
+
     #[test]
     fn max_cost_usd_help_names_its_three_real_limits() {
         // The rust-pro review's meta-point: the budget's real boundary

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -36,11 +36,16 @@ const VSCODE_SETTINGS: &str = r#"{
 "#;
 
 /// `AGENTS.md` — the repo's agent guide: the loop, the four verbs, the
-/// discipline. Concise on purpose (the engine teaches the rest via `check`).
+/// discipline. Concise on purpose (the engine teaches the rest via `check`)
+/// — but COMPLETE over the live clap tree: a verb the binary ships and the
+/// guide never names is a verb a wired agent will never reach (found stale
+/// 2026-07-05 — the scaffold taught zero of the then-new train). The bin
+/// test `the_scaffolded_agents_md_teaches_the_live_clap_tree` pins the
+/// parity, derived from the tree itself.
 const AGENTS_MD: &str = r"# AGENTS.md — Nika workflows in this repo
 
 Nika is a sovereign AI workflow engine. Workflows are `*.nika.yaml` files,
-**audited before they run**.
+**audited before they run**. (This guide is scaffolded by `nika init`.)
 
 ## The loop
 - **Author** · `nika new --from <template> <file>.nika.yaml` (or write one —
@@ -48,6 +53,12 @@ Nika is a sovereign AI workflow engine. Workflows are `*.nika.yaml` files,
 - **Check** · `nika check <file>` — the static audit BEFORE any run (schema ·
   DAG · CEL · effects · permits · cost). Exit `0` clean · `2` findings.
 - **Run** · `nika run <file>` — execute · live render. Exit `0` ok · `1` failed.
+  Inputs ride `--var key=value` (repeatable · unknown keys refused); a run
+  paused on a `nika:prompt` resumes with `--resume <trace> --answer
+  <task>=<value>` (confirm gates take booleans: `--answer approve=true`).
+- **Pin** · `nika test <file> --update` writes `<file>.golden.json` from an
+  offline mock run; `nika test <file>` replays and compares — deterministic,
+  zero keys, the CI gate.
 - **Diagnose** · `nika doctor` — the environment (providers · keys · config).
 - **Explain** · `nika explain NIKA-XXXX` — teach one error code.
 - **Wire** · `nika wire <cursor|vscode|windsurf|claude|codex|all>` — point an
@@ -72,7 +83,19 @@ or MCP tool) · `agent` (a multi-turn ReAct loop).
 ## Don't invent structure — route to a skeleton
 `nika new --from '?'` lists the 6 skeletons · `nika examples list` / `show
 <slug>` reads a runnable example that exercises a construct · `nika schema`
-is the JSON Schema · `nika spec --canon` is the SSOT. Copy, fill, check.
+is the JSON Schema · `nika spec --canon` is the SSOT · `nika catalog` names
+the providers/models · `nika tools` names the `nika:` builtins. Copy, fill,
+check.
+
+## Understand · replay
+- `nika inspect <file>` — static anatomy: tasks · verbs · wave groups · cost.
+- `nika graph <file> --format mermaid|dot|json` — the ONE graph projector.
+- `nika trace show|replay <run>` — the flight recorder (every run records).
+- `nika dap` — step a recorded run under a debugger UI, forward AND back.
+
+## Servers (stdio · for editors and agent clients)
+`nika lsp` (language server) · `nika mcp` (MCP: check/explain/schema/examples
+as tools) · `nika completions <shell>` generates shell completions.
 
 ## Discipline
 - Every effect is gated by `permits:` (default-deny · `nika check --infer-permits`
@@ -128,6 +151,16 @@ const AGENT_SKILL: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../.agents/plugins/nika/skills/nika-authoring/SKILL.md"
 ));
+
+/// The scaffolded agent guide, exposed for the bin-side parity test —
+/// a verb the binary ships and the guide never names is a verb a wired
+/// agent will never reach (found stale 2026-07-05: the scaffold taught
+/// zero of the then-new train). The test derives the expectation from
+/// the live clap tree itself, so the guide can never silently lag.
+#[must_use]
+pub fn agents_md() -> &'static str {
+    AGENTS_MD
+}
 
 /// The scaffold set · (relative path, body). The ONE source of what `init`
 /// writes — `plan` and the docs both read it.


### PR DESCRIPTION
## What

Inherited from the stalled `wt-field-fixes` worktree branch (`feat/cli-teaching-followups` · 2026-07-05 · never pushed · base ~30 merges behind): the AGENTS.md that `init` scaffolds taught the loop but named none of the newer verbs — **a verb the binary ships and the guide never names is a verb a wired agent will never reach**. The same principle the wizard-coherence PR applied to humans (#266: never promise what the file doesn't carry), applied to the agent guide: never omit what the binary carries.

- **The parity test** `the_scaffolded_agents_md_teaches_the_live_clap_tree` (bin-side — the clap tree lives in `main.rs`) pins the guide against the tree itself: every subcommand except clap's auto `help`, plus the daily flags `--var/--resume/--answer/--update/--from`. TDD: it went RED on `nika inspect` before the rewrite — the guide can never silently lag again.
- **AGENTS_MD gains the missing surface, organized**: Pin (`test --update` golden) · Understand·replay (`inspect` · `graph --format` · `trace show|replay` · `dap`) · discovery grows `catalog` + `tools` · Servers (`lsp` · `mcp` · `completions`). Every taught flag/subcommand **verified against the real binary output** (not the sister's 0.93 text — the tree moved).
- **The authoring SKILL** (SSOT for init's 4th scaffold file · byte-parity test-enforced) gains the sister's two hunks adapted: run inputs (`--var` · `--resume/--answer` confirm gates) + step 7 golden pin.
- `agents_md()` pub accessor: +1 public-api baseline line (hand-patched — the CI-artifact baseline law).

## Not inherited (flagged honestly)

The branch's second commit (doctor + explain speak the round-8 display seam · 238 lines in `doctor.rs`) is **superseded ×3** — doctor was reworked on main since (#229 parallel ping · #244 `--json` · #248 trust surface). It needs a fresh look against today's doctor, not a rebase. The `wt-field-fixes` worktree is now fully harvested.

## Proof

284 lib (incl. the new parity + byte-parity SKILL tests) + 24 verbs_static + 20 bin_smoke green · clippy `-D warnings` clean · fn-length ratchet green · pre-push gates 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)