### PR TITLE
fix(providers): capability is a PROVIDER fact — deepseek has no json_schema

### DIFF
--- a/crates/nika-providers/src/parity_tests.rs
+++ b/crates/nika-providers/src/parity_tests.rs
@@ -271,18 +271,32 @@ fn meta_is_coherent_across_the_fourteen() {
             .unwrap_or_else(|e| panic!("[{}] resolves: {e}", p.id));
         assert_eq!(rp.name(), p.id, "[{}] ProviderMeta::name", p.id);
         let supports = rp.supports_response_format();
-        // Every wire family carries a native structured mode today
-        // (anthropic joined 2026-07-07 · output_config.format). A FUTURE
-        // variant fails this exhaustive match at compile time — its author
-        // writes the honest arm.
-        match p.wire {
+        // Capability is a PROVIDER fact, not only a wire fact: the resolved
+        // provider must agree with the profile it was resolved from, and
+        // exactly ONE provider corrects its family answer today — deepseek
+        // (text|json_object only · json_schema is out-of-enum → 4xx ·
+        // api-docs.deepseek.com · 2026-07-08). Every wire family is native
+        // (anthropic joined 2026-07-07 · output_config.format · live-proven
+        // 2026-07-08).
+        assert_eq!(
+            supports,
+            p.supports_response_format(),
+            "[{}] resolved answer == profile answer",
+            p.id
+        );
+        let family = matches!(
+            p.wire,
             WireFormat::OpenAiCompat
-            | WireFormat::Mock
-            | WireFormat::Gemini
-            | WireFormat::Anthropic => {
-                assert!(supports, "[{}] response_format supported", p.id);
-            }
-        }
+                | WireFormat::Mock
+                | WireFormat::Gemini
+                | WireFormat::Anthropic
+        );
+        assert_eq!(
+            supports,
+            family && p.id != "deepseek",
+            "[{}] deepseek is the one family-corrected cloud",
+            p.id
+        );
     }
 }
 

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -121,6 +121,20 @@ impl Profile {
         LOCAL.iter().any(|(id, _)| *id == self.id)
     }
 
+    /// Whether THIS provider supports native `response_format:
+    /// json_schema` — the wire-family answer with one per-provider
+    /// correction: deepseek's API accepts only `text | json_object`
+    /// (api-docs.deepseek.com create-chat-completion · fetched
+    /// 2026-07-08 · `json_schema` is out-of-enum → 4xx), so it takes
+    /// the instruction fallback + local validation like a non-native
+    /// wire. Capability is a PROVIDER fact, not only a wire fact —
+    /// every consumer (resolved provider · keyless registry query)
+    /// answers through here.
+    #[must_use]
+    pub fn supports_response_format(&self) -> bool {
+        self.id != "deepseek" && self.wire.supports_response_format()
+    }
+
     /// Resolve a model nickname through the catalog row (`"sonnet"` →
     /// `"claude-sonnet-4-20250514"`). Unknown names pass through verbatim —
     /// the wire model namespace is the provider's, not ours.

--- a/crates/nika-providers/src/registry.rs
+++ b/crates/nika-providers/src/registry.rs
@@ -143,7 +143,7 @@ impl<H> ProviderRegistry<H> {
         model
             .split_once('/')
             .and_then(|(provider_id, _)| self.profiles.iter().find(|p| p.id == provider_id))
-            .is_some_and(|profile| profile.wire.supports_response_format())
+            .is_some_and(Profile::supports_response_format)
     }
 }
 
@@ -327,7 +327,7 @@ where
     /// The resolved provider's actual capability · delegates to the
     /// wire-family source of truth ([`WireFormat::supports_response_format`]).
     fn supports_response_format(&self) -> bool {
-        self.profile.wire.supports_response_format()
+        self.profile.supports_response_format()
     }
 }
 
@@ -369,7 +369,10 @@ mod tests {
         // gemini + openai-family → native structured output (robust).
         assert!(reg.supports_response_format("gemini/flash"));
         assert!(reg.supports_response_format("openai/gpt-4o"));
-        assert!(reg.supports_response_format("deepseek/chat")); // openai-compat
+        // deepseek is the per-PROFILE correction on an openai-compat wire:
+        // its API accepts only text|json_object (json_schema out-of-enum →
+        // 4xx · api-docs.deepseek.com · 2026-07-08) → instruction fallback.
+        assert!(!reg.supports_response_format("deepseek/chat"));
         assert!(reg.supports_response_format("ollama/llama3")); // openai-compat local
         assert!(reg.supports_response_format("mock/echo"));
         // anthropic → native since 2026-07-07 (output_config.format ·

--- a/crates/nika-verb-infer/src/lib.rs
+++ b/crates/nika-verb-infer/src/lib.rs
@@ -878,6 +878,43 @@ mod tests {
         assert!(prompt.contains("JSON Schema"), "{prompt}");
     }
 
+    /// deepseek is the ONE cloud whose API has no `json_schema`
+    /// (`response_format` enum = `text`|`json_object` · out-of-enum → 4xx ·
+    /// api-docs.deepseek.com · 2026-07-08): a fully-specified schema takes
+    /// the INSTRUCTION wire there — no `response_format` on the body at
+    /// all, the schema riding the prompt, validation local. Before the
+    /// per-profile capability correction this request died at the wire.
+    #[tokio::test]
+    async fn deepseek_schema_takes_the_instruction_wire() {
+        let seam = SeamHttp::with_json(&[
+            r#"{"choices":[{"message":{"content":"{\"name\":\"Ada\",\"age\":36}"},"finish_reason":"stop"}],"usage":{}}"#,
+        ]);
+        let registry = Registry::new(
+            Arc::clone(&seam),
+            ProvidersConfig::new().with_key("deepseek", Secret::new("sk-test")),
+        );
+        let verb = InferVerb::new(Arc::new(registry), "deepseek/deepseek-chat");
+        let mut input = InferInput::new("extract the person");
+        input.schema = Some(json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+            "required": ["name", "age"],
+            "additionalProperties": false
+        }));
+        let out = verb.run(input).await.expect("the instruction path lands");
+        assert!(matches!(out.output, InferValue::Structured(_)));
+        let body = wire_body(&seam);
+        assert!(
+            body.get("response_format").is_none(),
+            "no out-of-enum json_schema may reach deepseek: {body}"
+        );
+        let prompt = body["messages"][0]["content"].as_str().expect("prompt");
+        assert!(
+            prompt.contains("JSON Schema"),
+            "the schema rides the prompt"
+        );
+    }
+
     /// A retried structured task bills EVERY round-trip: the first reply
     /// misses the schema (10+5 tokens), the retry conforms (20+7) — the
     /// task total is the sum, while `response.usage` stays the final


### PR DESCRIPTION
## What

The agnosticity review probed all 10 cloud peers against primary docs: **DeepSeek's `response_format` enum is `text | json_object` only** (api-docs.deepseek.com, fetched 2026-07-08) — `json_schema` is out-of-enum, so **every structured task on deepseek died 4xx at the first wire call**. The family-level capability (« OpenAiCompat → native ») was the one place the engine privileged a wire family over provider reality.

`supports_response_format` moves from `WireFormat` to `Profile` (wire answer + the one per-provider correction); both consumers (resolved provider · keyless registry query) answer through the profile. DeepSeek takes the instruction fallback + local validation — the universally-correct path.

## Proof

- Verb-level SeamHttp e2e pin: a fully-specified schema on `deepseek/deepseek-chat` sends **no `response_format` at all**, the schema rides the prompt, the run lands `Structured`.
- Parity meta test upgraded: resolved answer == profile answer across the 16 · deepseek named as the one corrected cloud. Registry keyless test flipped with the citation.
- Live battery this pass (engine binary): **xai first live proof** (nested enforced · `not`/`uniqueItems` verbatim accepted — no 400) · openai #267-strip e2e · gemini · ollama · llamacpp. 130 providers + 55 verb-infer lib green · clippy green · gauntlet green.

## Same-review verdicts (documented in the HQ audit, no code change)

mistral/xai/openrouter/hf verbatim-safe · groq best-effort (floor covers) · **key-gated flags**: mistral `strict:true` injection (real enforcement vs prompt-prepend default) · nvidia hosted probe (response_format undocumented — NIM-native seam is `guided_json`).

⚠ Expect a trivial conflict with #264 in `parity_tests.rs` — keep the per-profile equality asserts, add Anthropic to the supported families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)