### PR TITLE
test(nika-cli): pty e2e — the wizard conversation gets executable coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conpty"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72b06487a0d4683349ad74d62e87ad639b09667082b3c495c5b6bab7d84b3da"
+dependencies = [
+ "windows 0.44.0",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +1745,18 @@ checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
  "once_cell",
+]
+
+[[package]]
+name = "expectrl"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e0706d01b4f43adaf7e0fb460e07477c36b74ae60fdeb1d045001bd77b4bd1"
+dependencies = [
+ "conpty",
+ "nix 0.26.4",
+ "ptyprocess",
+ "regex",
 ]
 
 [[package]]
@@ -3144,7 +3165,7 @@ dependencies = [
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix",
+ "nix 0.30.1",
  "nom 8.0.0",
  "system-deps",
 ]
@@ -3367,6 +3388,15 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3655,6 +3685,7 @@ dependencies = [
  "anstyle",
  "clap",
  "clap_complete",
+ "expectrl",
  "nika-bm25",
  "nika-builtin",
  "nika-catalog",
@@ -3731,7 +3762,7 @@ name = "nika-exec-runner"
 version = "0.97.0"
 dependencies = [
  "nika-kernel",
- "nix",
+ "nix 0.30.1",
  "proptest",
  "tokio",
  "unicode-normalization",
@@ -4111,6 +4142,19 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -4714,6 +4758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,7 +4785,7 @@ dependencies = [
  "libc",
  "libspa",
  "libspa-sys",
- "nix",
+ "nix 0.30.1",
  "once_cell",
  "pipewire-sys",
  "thiserror 2.0.18",
@@ -4897,6 +4947,15 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101be273c0b1680d7056afddbaa88f02b6e9f2dc161165c30bee9914b6025a79"
+dependencies = [
+ "nix 0.26.4",
 ]
 
 [[package]]
@@ -6503,7 +6562,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -6955,7 +7014,7 @@ dependencies = [
  "dlib",
  "libc",
  "log",
- "memoffset",
+ "memoffset 0.9.1",
  "pkg-config",
 ]
 
@@ -7022,6 +7081,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -7245,6 +7313,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -7296,6 +7379,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7308,6 +7397,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7317,6 +7412,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7344,6 +7445,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7353,6 +7460,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7368,6 +7481,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7377,6 +7496,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,7 @@ insta       = { version = "1.42", features = ["yaml"] }
 tempfile    = "3"   # nika-ocr dev — model-load error-path fixtures (with_models headless tests)
 rstest      = "0.22"
 expect-test = "1.5"  # inline snapshots, see ADR-015
+expectrl    = "0.8"  # PTY e2e — the wizard's TTY-gated conversation (unix-only tests)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Release profile (post rust-perf audit 2026-05-12 · BLUEPRINT v1.2 §4 ship-now)

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -58,6 +58,8 @@ path = "src/main.rs"
 nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
+expectrl = { workspace = true }   # PTY e2e · the wizard conversation is TTY-gated — unreachable
+                                  # from piped harnesses by construction (tests/wizard_pty.rs · unix)
 
 [package.metadata.lore]
 daemon        = "messager"

--- a/crates/nika-cli/tests/wizard_pty.rs
+++ b/crates/nika-cli/tests/wizard_pty.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![cfg(unix)]
+#![allow(clippy::expect_used, clippy::panic)]
+// Same carve-out as bin_smoke: this suite's WHOLE JOB is to drive the real
+// binary — here through a PTY, because the wizard is TTY-gated by
+// construction (`is_terminal` on both ends) and therefore UNREACHABLE from
+// every piped harness. Without a PTY the guided conversation ships with
+// zero executable coverage (the tests-never-run gate-hole class).
+#![allow(clippy::disallowed_types)]
+
+//! PTY e2e — the guided onboarding conversation against the REAL binary
+//! on a REAL pseudo-terminal (expectrl · unix-only; the CI runner is
+//! linux, dev machines are macOS — both covered).
+//!
+//! Anchors are ANSI-SAFE on purpose: styled prompts carry escapes between
+//! words and brackets (the seam paints defaults dim), so every `expect`
+//! needle sits on a plain substring — the lesson the first manual expect
+//! proofs paid for. Deep assertions go past exit codes: the stamped file
+//! must re-`check` clean through a second binary invocation, cancel must
+//! leave the directory empty, `NO_COLOR` must strip every escape even on
+//! a terminal.
+
+use std::process::Command;
+use std::time::Duration;
+
+use expectrl::process::unix::WaitStatus;
+use expectrl::session::OsSession;
+use expectrl::{ControlCode, Eof, Expect};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_nika-cli")
+}
+
+fn fresh_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("nika-pty-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("tmp dir");
+    dir
+}
+
+/// Spawn `nika <args>` on a PTY in `dir`. `plain` = `NO_COLOR` (keeps the
+/// transcript byte-assertable); one test drops it to prove colour lives.
+fn spawn_pty(dir: &std::path::Path, args: &[&str], plain: bool) -> OsSession {
+    let mut cmd = Command::new(bin());
+    cmd.args(args).current_dir(dir);
+    if plain {
+        cmd.env("NO_COLOR", "1");
+    }
+    let mut session = OsSession::spawn(cmd).expect("pty spawn");
+    session.set_expect_timeout(Some(Duration::from_secs(30)));
+    session
+}
+
+/// Exit code of the finished session (unix wait status).
+fn exit_code(session: &mut OsSession) -> i32 {
+    match session.get_process_mut().wait().expect("wait") {
+        WaitStatus::Exited(_, code) => code,
+        other => panic!("process did not exit cleanly: {other:?}"),
+    }
+}
+
+#[test]
+fn golden_path_lands_a_checked_workflow() {
+    let dir = fresh_dir("golden");
+    let mut p = spawn_pty(&dir, &["new"], true);
+
+    p.expect("your first workflow").expect("header");
+    p.expect("what should it do?").expect("q1");
+    p.send_line("").expect("enter");
+    p.expect("template `chain`").expect("routed to the default");
+    p.expect("my-first.nika.yaml]").expect("file default shown");
+    p.send_line("").expect("enter");
+    p.expect("a number, or any provider/model")
+        .expect("model menu");
+    p.send_line("").expect("enter");
+    p.expect("model `mock/echo`")
+        .expect("offline default echoed");
+    p.expect("stamped workflow `my-first`").expect("summary");
+    // The wow contract: the audit ladder runs INSIDE the wizard.
+    p.expect("audited").expect("embedded ladder");
+    p.expect("scriptable form").expect("teaches its flags form");
+    let m = p.expect(Eof).expect("conversation ends");
+    assert!(
+        !String::from_utf8_lossy(m.as_bytes()).contains("error"),
+        "clean transcript"
+    );
+    assert_eq!(exit_code(&mut p), 0, "spec §4 · success");
+
+    // DEEP: the artifact stands on its own — a second binary run
+    // re-audits the stamped file clean (own-corpus law end to end).
+    let check = Command::new(bin())
+        .args(["check", "my-first.nika.yaml"])
+        .current_dir(&dir)
+        .output()
+        .expect("check runs");
+    assert_eq!(
+        check.status.code(),
+        Some(0),
+        "the wizard's file re-checks clean: {}",
+        String::from_utf8_lossy(&check.stdout)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn intent_routes_and_the_file_is_stamped() {
+    let dir = fresh_dir("intent");
+    let mut p = spawn_pty(&dir, &["new"], true);
+
+    p.expect("what should it do?").expect("q1");
+    p.send_line("summarize every item in parallel")
+        .expect("intent");
+    p.expect("template `fanout`").expect("BM25 routes");
+    p.expect("file ").expect("q2");
+    p.send_line("review-batch").expect("custom name");
+    p.expect("a number, or any provider/model").expect("q3");
+    p.send_line("2").expect("menu pick");
+    p.expect("routed intent → template `fanout`")
+        .expect("summary says the routing");
+    p.expect(Eof).expect("ends");
+    assert_eq!(exit_code(&mut p), 0);
+
+    // DEEP: the three stamps landed in the file itself.
+    let written =
+        std::fs::read_to_string(dir.join("review-batch.nika.yaml")).expect("file written");
+    assert!(written.contains("workflow: review-batch"), "id stamped");
+    assert!(
+        written.contains("description: 'summarize every item in parallel'"),
+        "the intent is the description"
+    );
+    assert!(written.contains("model: mock/echo"), "menu pick stamped");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_model_skeleton_completes_in_two_answers() {
+    let dir = fresh_dir("permodel");
+    let mut p = spawn_pty(&dir, &["new"], true);
+
+    p.expect("what should it do?").expect("q1");
+    p.send_line("gate-and-act").expect("exact template name");
+    p.expect("template `gate-and-act`").expect("rung 1");
+    p.expect("file ").expect("q2");
+    p.send_line("").expect("enter");
+    // The whole point: NO model question — the per-task truth instead,
+    // then straight to the summary + ladder. Everything to Eof in one
+    // capture so the absence is assertable.
+    let m = p.expect(Eof).expect("ends");
+    let transcript = String::from_utf8_lossy(m.as_bytes()).into_owned();
+    assert!(
+        transcript.contains("models are per-task in this skeleton"),
+        "{transcript}"
+    );
+    assert!(
+        !transcript.contains("a number, or any provider/model"),
+        "the model question must not fire: {transcript}"
+    );
+    assert!(transcript.contains("models per-task"), "honest summary");
+    assert!(transcript.contains("audited"), "ladder still runs");
+    assert_eq!(exit_code(&mut p), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn collision_walk_defaults_to_my_second() {
+    let dir = fresh_dir("collide");
+    std::fs::write(dir.join("my-first.nika.yaml"), "taken").expect("seed");
+    let mut p = spawn_pty(&dir, &["new"], true);
+
+    p.expect("what should it do?").expect("q1");
+    p.send_line("").expect("enter");
+    // The default walked past the taken name BEFORE asking.
+    p.expect("my-second.nika.yaml]")
+        .expect("collision-aware default");
+    p.send_line("").expect("enter");
+    p.expect("a number, or any provider/model").expect("q3");
+    p.send_line("").expect("enter");
+    p.expect(Eof).expect("ends");
+    assert_eq!(exit_code(&mut p), 0);
+
+    assert!(
+        dir.join("my-second.nika.yaml").is_file(),
+        "written next door"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("my-first.nika.yaml")).expect("read"),
+        "taken",
+        "the taken file is untouched"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn init_offer_accepted_flows_into_the_wizard() {
+    let dir = fresh_dir("init-yes");
+    let mut p = spawn_pty(&dir, &["init", "."], true);
+
+    p.expect("created").expect("scaffold report first");
+    p.expect("scaffold your first workflow now?")
+        .expect("the offer");
+    p.send_line("").expect("Enter = yes (the golden path)");
+    p.expect("what should it do?")
+        .expect("the wizard took over");
+    p.send_line("").expect("enter");
+    p.expect("my-first.nika.yaml]").expect("file default");
+    p.send_line("").expect("enter");
+    p.expect("a number, or any provider/model")
+        .expect("model menu");
+    p.send_line("").expect("enter");
+    p.expect("audited").expect("ladder");
+    p.expect(Eof).expect("ends");
+    assert_eq!(exit_code(&mut p), 0);
+
+    // DEEP: both halves landed — the scaffold AND the first workflow.
+    assert!(dir.join("AGENTS.md").is_file(), "scaffold written");
+    assert!(
+        dir.join(".vscode/settings.json").is_file(),
+        "wiring written"
+    );
+    assert!(dir.join("my-first.nika.yaml").is_file(), "workflow written");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn init_offer_declined_prints_the_classic_block() {
+    let dir = fresh_dir("init-no");
+    let mut p = spawn_pty(&dir, &["init", "."], true);
+
+    p.expect("scaffold your first workflow now?")
+        .expect("the offer");
+    p.send_line("n").expect("decline");
+    let m = p.expect(Eof).expect("ends");
+    let transcript = String::from_utf8_lossy(m.as_bytes()).into_owned();
+    assert!(
+        transcript.contains("nika examples run 01-hello"),
+        "the classic hand-off survives a decline: {transcript}"
+    );
+    assert_eq!(exit_code(&mut p), 0);
+
+    // Declining writes NO workflow — the scaffold alone.
+    assert!(dir.join("AGENTS.md").is_file());
+    assert!(
+        !dir.join("my-first.nika.yaml").exists(),
+        "no workflow on decline"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn eof_cancels_without_writing() {
+    let dir = fresh_dir("cancel");
+    let mut p = spawn_pty(&dir, &["new"], true);
+
+    p.expect("what should it do?").expect("q1");
+    // ^D = EOF mid-conversation: the human left. Cancel, never loop.
+    p.send(ControlCode::EndOfTransmission).expect("^D");
+    p.expect("cancelled — nothing written")
+        .expect("honest cancel");
+    p.expect(Eof).expect("ends");
+    assert_eq!(exit_code(&mut p), 3, "spec §4 · environment (cancelled)");
+
+    let leftovers: Vec<_> = std::fs::read_dir(&dir)
+        .expect("dir")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with(".nika.yaml"))
+        .collect();
+    assert!(leftovers.is_empty(), "nothing written: {leftovers:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn colour_lives_on_a_terminal_and_no_color_kills_every_escape() {
+    // Half 1 · a real PTY without NO_COLOR: the semantic accents exist
+    // (the wizard resolves --color auto → TTY → on).
+    let dir = fresh_dir("colour");
+    let mut p = spawn_pty(&dir, &["new"], false);
+    p.expect("what should it do?").expect("q1");
+    p.send_line("").expect("enter");
+    p.send_line("").expect("enter");
+    p.send_line("").expect("enter");
+    let m = p.expect(Eof).expect("ends");
+    let coloured = String::from_utf8_lossy(m.as_bytes()).into_owned();
+    assert!(
+        coloured.contains("\u{1b}[36m"),
+        "the single accent paints on a TTY"
+    );
+    assert!(coloured.contains("\u{1b}[2m"), "dim metadata paints");
+    assert_eq!(exit_code(&mut p), 0);
+
+    // Half 2 · NO_COLOR on the SAME terminal: zero escapes — the sober
+    // register is a promise even where colour is possible.
+    let dir2 = fresh_dir("nocolour");
+    let mut q = spawn_pty(&dir2, &["new"], true);
+    q.expect("what should it do?").expect("q1");
+    q.send_line("").expect("enter");
+    q.send_line("").expect("enter");
+    q.send_line("").expect("enter");
+    let m2 = q.expect(Eof).expect("ends");
+    let plain = String::from_utf8_lossy(m2.as_bytes()).into_owned();
+    assert!(
+        !plain.contains('\u{1b}'),
+        "NO_COLOR strips every escape, even on a terminal"
+    );
+    assert_eq!(exit_code(&mut q), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&dir2);
+}


### PR DESCRIPTION
## Why

The guided conversation is TTY-gated by construction (`is_terminal` on both ends) — every piped harness (bin_smoke · CI · the lib seam) is **structurally blind** to it: the tests-never-run gate-hole class. Its only proofs were manual expect scripts in a session scratchpad.

## What

`tests/wizard_pty.rs` (unix-only — CI is linux, dev is macOS · `expectrl` 0.8 workspace dev-dep · MIT · deny-clean) drives the **real binary on a real pseudo-terminal**, eight deep scenarios:

| Scenario | Deep assertion beyond exit code |
|---|---|
| golden 3-Enters | embedded ladder in transcript · then the stamped file **re-checks clean through a second binary run** (own-corpus e2e) |
| intent routing | summary says the routing · the three stamps land in the **file bytes** (single-quoted per the #276 `yaml_scalar` law) |
| no-model skeleton | completes in TWO answers · the model question **provably absent** from the full transcript |
| collision walk | seeded `my-first` → default shows `[my-second]` BEFORE asking · seeded file untouched |
| init offer → Enter | scaffold report → wizard → ladder · BOTH halves on disk |
| init offer → n | classic hand-off block · NO workflow written |
| ^D mid-conversation | « cancelled — nothing written » · exit 3 · directory provably empty |
| colour law | accents + dim present on a real TTY by default · `NO_COLOR` strips **every** escape even where colour is possible |

## Proof of value on its first run

The suite went RED against the sisters' overnight #276 (`yaml_scalar` single-quotes user strings) — my assertions were written against the older stamp. Exactly the drift class this harness exists to catch, now permanent in CI.

Craft note: `Eof` captures read `as_bytes()` — expectrl puts the remainder IN the match, not in `before()` (the docs' `is_eof = m[0].is_empty()` shape). Anchors are ANSI-safe substrings (the styled-prompt lesson).

All suites green: 284 lib + 24 + 20 + **8 PTY** · clippy `-D warnings` · fn-length · `cargo deny` licenses ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)