### PR TITLE
chore(ci): public-api baseline — Profile::supports_response_format joins

### DIFF
--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -51,6 +51,7 @@ pub nika_providers::profile::Profile::wire: nika_providers::profile::WireFormat
 impl nika_providers::profile::Profile
 pub fn nika_providers::profile::Profile::env_candidates(&self) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_providers::profile::Profile::resolve_model<'m>(&self, name: &'m str) -> &'m str
+pub fn nika_providers::profile::Profile::supports_response_format(&self) -> bool
 impl core::clone::Clone for nika_providers::profile::Profile
 pub fn nika_providers::profile::Profile::clone(&self) -> nika_providers::profile::Profile
 impl core::fmt::Debug for nika_providers::profile::Profile


### PR DESCRIPTION
#283 added the per-profile capability (`pub fn Profile::supports_response_format`) without patching the CI-only public-api snapshot — the `diff` job is not a required check, so auto-merge let it through and every later PR (#286 · #287) inherits a RED diff against a drift that is not theirs. Hand-patched delta = exactly the #283 intentional addition (never regenerate the whole snapshot locally — ubuntu-vs-macos noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)