### PR TITLE
docs(adr): ratify ADR-094 — FCI-004 reserved-core catches the D4 taxonomy

### DIFF
--- a/docs/adr/adr-094-nika-pck-registry-architecture.md
+++ b/docs/adr/adr-094-nika-pck-registry-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-094
 title: "nika-pck · content-addressed sharing — identity decentralized, discovery a forkable index, trust in the artifact"
-status: proposed
+status: accepted
 date: 2026-06-11
 phase: "Phase 3+ · post-v0.81 (v0.9x sharing suite)"
 deciders: ["@ThibautMelen"]
@@ -23,6 +23,14 @@ follow_ups:
 ---
 
 # ADR-094: nika-pck — content-addressed sharing with trust in the artifact
+
+> **ACCEPTED 2026-07-08** (operator ratification · D-2026-07-08-N2): the D4
+> reserved-core taxonomy is LOCKED and FCI-004's pck-types list is amended to
+> match in the same PR (the prior 9-list was aspirational — `recipe`/`shield`/
+> `lints` had zero code usage). This unblocks `nika-pck-manifest`, the 42nd
+> crate (the 42/42 master plan §2: closed `#[non_exhaustive]` ArtifactKind of
+> the 11 named classes + `CustomTool(String)` for `x-<vendor>:*`, total
+> deserialization).
 
 ## Context
 

--- a/docs/architecture/forward-compat-invariants.md
+++ b/docs/architecture/forward-compat-invariants.md
@@ -113,8 +113,17 @@ per spec 02-verbs · engine-specific tools route through `mcp:` · the
 spec reserves `x-` as a possible future additive minor).
 
 **Locked namespaces**:
-- **pck types**: `workflow` / `skill` / `agent` / `provider` / `mcp` /
-  `eval` / `recipe` / `shield` / `lints` (9 core) + `x-*` community
+- **pck types** (reserved-core AMENDED 2026-07-08 · operator ratification of
+  ADR-094 D4 · the prior aspirational 9-list `workflow/skill/agent/provider/
+  mcp/eval/recipe/shield/lints` had zero code usage for `recipe`/`shield`/
+  `lints` and predated the 2026 registry-survey norm of closed-class +
+  vendor-namespaced escape): `workflow` / `pack` / `skill` / `agent-preset` /
+  `template-variant` / `model-pointer` / `mcp-config` / `conformance-fixture` /
+  `provider-profile` / `policy-preset` / `bench-suite` (11 core) +
+  `custom-tool` declarations under `x-<vendor>:*` (the open escape — the
+  namespace pattern itself is unchanged: reserved core + `x-*` community).
+  A 12th-class future reservation (cognitive-machinery bundles) is named in
+  ADR-094 D4, reserved not built.
 - **builtins**: `nika:tool` core + `mcp:server/tool` MCP-namespaced
 - **EventKind**: core variants + `Extension { ns, name, payload }` escape hatch
 - **Skill targets**: `claude-code`, `cursor`, `windsurf`, `zed` (4 IDEs) +


### PR DESCRIPTION
**Operator ratification 2026-07-08 (D-2026-07-08-N2).**

- `ADR-094` status `proposed` → `accepted` + dated acceptance note.
- **FCI-004** pck-types reserved-core amended to the ADR-094 D4 taxonomy (11 named classes + `x-<vendor>:*` custom-tool escape). The prior 9-list was aspirational — `recipe`/`shield`/`lints` had **zero** code usage (grep-confirmed in the 42/42 plan) — and the closed-class + vendor-namespaced-escape shape is the 2026 registry norm (Claude plugins · MCP registry · AWS ARA).
- The namespace PATTERN (reserved core + `x-*` community) is unchanged; the amendment revises the SET, exactly as FCI-004's own text anticipates.

**Unblocks:** `nika-pck-manifest` — the 42nd crate (closed `#[non_exhaustive]` `ArtifactKind` of the 11 named classes + `CustomTool(String)`, total deserialization) per the 42/42 master plan §2. Docs-only PR.