### PR TITLE
fix(nika-types): cost.rs imports String from alloc — the no_std powerset holds

### DIFF
--- a/crates/nika-types/src/cost.rs
+++ b/crates/nika-types/src/cost.rs
@@ -12,6 +12,7 @@
 //! - Stripe uses i64 micro-units; `OpenAI` uses Decimal server-side.
 //! - Migration from f64 after 1M runs in `SQLite` = pain.
 
+use alloc::string::String;
 use core::fmt;
 use core::ops::{Add, Sub};
 


### PR DESCRIPTION
#288 merged with its `cargo-hack` check red: the new `SpendOnFailure` (billed-then-failed carrier) uses `String` bare in `cost.rs` — fine under default features (std prelude), a compile error in the no-default-features powerset since `nika-types` is `no_std`. Main's feature-matrix job is red right now; this is the one-line repair (same import shape as the sibling `net.rs`).

## Proof
`cargo check -p nika-types --no-default-features` 0 errors · default features 0 errors · 229/229 lib tests.