### PR TITLE
feat(nika-pck-manifest): admit to workspace — all 12 gates passed (42/42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,6 +3978,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nika-pck-manifest"
+version = "0.97.0"
+dependencies = [
+ "proptest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
 name = "nika-providers"
 version = "0.97.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members  = ["crates/nika-types", "crates/nika-error", "crates/nika-catalog", "crates/nika-catalog-codegen", "crates/nika-catalog-verify", "crates/nika-kernel", "crates/nika-kernel-ai", "crates/nika-kernel-core", "crates/nika-kernel-runtime", "crates/nika-kernel-plugin", "crates/nika-kernel-mock", "crates/nika-schema", "crates/nika-bm25", "crates/nika-screen", "crates/nika-event", "crates/nika-extract", "crates/nika-exec-runner", "crates/nika-sandbox-seatbelt", "crates/nika-blob", "crates/nika-clock", "crates/nika-fs", "crates/nika-http", "crates/nika-ocr", "crates/nika-a11y", "crates/nika-input", "crates/nika-browser", "crates/nika-pack", "crates/nika-providers", "crates/nika-infer-local", "crates/nika-verb-infer", "crates/nika-verb-exec", "crates/nika-verb-invoke", "crates/nika-verb-agent", "crates/nika-builtin", "crates/nika-cel", "crates/nika-runtime", "crates/nika-cli", "crates/nika-lsp", "crates/nika-mcp", "crates/nika-cap"]
+members  = ["crates/nika-types", "crates/nika-error", "crates/nika-catalog", "crates/nika-catalog-codegen", "crates/nika-catalog-verify", "crates/nika-kernel", "crates/nika-kernel-ai", "crates/nika-kernel-core", "crates/nika-kernel-runtime", "crates/nika-kernel-plugin", "crates/nika-kernel-mock", "crates/nika-schema", "crates/nika-bm25", "crates/nika-screen", "crates/nika-event", "crates/nika-extract", "crates/nika-exec-runner", "crates/nika-sandbox-seatbelt", "crates/nika-blob", "crates/nika-clock", "crates/nika-fs", "crates/nika-http", "crates/nika-ocr", "crates/nika-a11y", "crates/nika-input", "crates/nika-browser", "crates/nika-pack", "crates/nika-providers", "crates/nika-infer-local", "crates/nika-verb-infer", "crates/nika-verb-exec", "crates/nika-verb-invoke", "crates/nika-verb-agent", "crates/nika-builtin", "crates/nika-cel", "crates/nika-runtime", "crates/nika-cli", "crates/nika-lsp", "crates/nika-mcp", "crates/nika-cap", "crates/nika-pck-manifest"]
 # Excluded so cargo does not try to descend into untracked main-leftover
 # manifests under crates/ (the orphan working tree carries them but they
 # are not part of the diamond workspace).
@@ -50,6 +50,7 @@ layers.nika-types = "L0"
 layers.nika-error = "L0"
 layers.nika-event = "L0"
 layers.nika-cap = "L0"
+layers.nika-pck-manifest = "L0"
 layers.nika-clock = "L1"
 # nika-fs · Phase-B slice step 4 (announce ladder · D-2026-06-10-N6 cascade) ·
 # implements kernel io::fs {FsRead,FsWrite,FsMeta,FsList} · tokio::fs + globset ·

--- a/crates/nika-pck-manifest/Cargo.toml
+++ b/crates/nika-pck-manifest/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name          = "nika-pck-manifest"
+description   = "The pck sharing layer's data contract as pure types — manifest · cert · lockfile · package ref · hash newtypes · the D4 artifact taxonomy (ADR-094). Layer L0 — pure, zero I/O, zero async, zero nika-* deps."
+version.workspace      = true
+edition.workspace      = true
+license.workspace      = true
+authors.workspace      = true
+rust-version.workspace = true
+repository.workspace   = true
+homepage.workspace     = true
+publish                = false  # Foundation crate — never on crates.io. See ADR-022.
+
+[dependencies]
+serde     = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json   = { workspace = true }
+toml_convert = { workspace = true }   # nika/pck@1 is a TOML format (FCI-003) — round-trip proven
+proptest     = { workspace = true }
+
+[package.metadata.lore]
+daemon        = "scribe"
+archetype     = "cargo-ledger"
+spirit_role   = "tient le manifeste de ce qui se partage · chaque artefact est son hash · rien ne bouge sans être nommé"
+voice_pattern = "silent"
+layer         = "L0"
+
+[lints]
+workspace = true

--- a/crates/nika-pck-manifest/public-api.txt
+++ b/crates/nika-pck-manifest/public-api.txt
@@ -1,0 +1,543 @@
+pub mod nika_pck_manifest
+#[non_exhaustive] pub enum nika_pck_manifest::ArtifactKind
+pub nika_pck_manifest::ArtifactKind::AgentPreset
+pub nika_pck_manifest::ArtifactKind::BenchSuite
+pub nika_pck_manifest::ArtifactKind::ConformanceFixture
+pub nika_pck_manifest::ArtifactKind::CustomTool(nika_pck_manifest::CustomKind)
+pub nika_pck_manifest::ArtifactKind::McpConfig
+pub nika_pck_manifest::ArtifactKind::ModelPointer
+pub nika_pck_manifest::ArtifactKind::Pack
+pub nika_pck_manifest::ArtifactKind::PolicyPreset
+pub nika_pck_manifest::ArtifactKind::ProviderProfile
+pub nika_pck_manifest::ArtifactKind::Skill
+pub nika_pck_manifest::ArtifactKind::TemplateVariant
+pub nika_pck_manifest::ArtifactKind::Workflow
+impl nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::as_wire(&self) -> &str
+pub fn nika_pck_manifest::ArtifactKind::from_wire(s: &str) -> Self
+impl core::clone::Clone for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::clone(&self) -> nika_pck_manifest::ArtifactKind
+impl core::cmp::Eq for nika_pck_manifest::ArtifactKind
+impl core::cmp::PartialEq for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::eq(&self, other: &nika_pck_manifest::ArtifactKind) -> bool
+impl core::fmt::Debug for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for nika_pck_manifest::ArtifactKind
+impl serde_core::ser::Serialize for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::serialize<S: serde_core::ser::Serializer>(&self, ser: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::deserialize<D: serde_core::de::Deserializer<'de>>(de: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::ArtifactKind where U: core::convert::From<T>
+pub fn nika_pck_manifest::ArtifactKind::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::ArtifactKind where U: core::convert::Into<T>
+pub type nika_pck_manifest::ArtifactKind::Error = core::convert::Infallible
+pub fn nika_pck_manifest::ArtifactKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::ArtifactKind where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::ArtifactKind::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::ArtifactKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::ArtifactKind where T: core::clone::Clone
+pub type nika_pck_manifest::ArtifactKind::Owned = T
+pub fn nika_pck_manifest::ArtifactKind::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::ArtifactKind::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::ArtifactKind where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::ArtifactKind::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::ArtifactKind where T: ?core::marker::Sized
+pub fn nika_pck_manifest::ArtifactKind::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::ArtifactKind where T: ?core::marker::Sized
+pub fn nika_pck_manifest::ArtifactKind::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::ArtifactKind where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::ArtifactKind::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::ArtifactKind
+pub fn nika_pck_manifest::ArtifactKind::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::ArtifactKind where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub enum nika_pck_manifest::CertVerdict
+pub nika_pck_manifest::CertVerdict::Fail
+pub nika_pck_manifest::CertVerdict::Pass
+impl core::clone::Clone for nika_pck_manifest::CertVerdict
+pub fn nika_pck_manifest::CertVerdict::clone(&self) -> nika_pck_manifest::CertVerdict
+impl core::cmp::Eq for nika_pck_manifest::CertVerdict
+impl core::cmp::PartialEq for nika_pck_manifest::CertVerdict
+pub fn nika_pck_manifest::CertVerdict::eq(&self, other: &nika_pck_manifest::CertVerdict) -> bool
+impl core::fmt::Debug for nika_pck_manifest::CertVerdict
+pub fn nika_pck_manifest::CertVerdict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_pck_manifest::CertVerdict
+impl core::marker::StructuralPartialEq for nika_pck_manifest::CertVerdict
+impl serde_core::ser::Serialize for nika_pck_manifest::CertVerdict
+pub fn nika_pck_manifest::CertVerdict::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::CertVerdict
+pub fn nika_pck_manifest::CertVerdict::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::CertVerdict where U: core::convert::From<T>
+pub fn nika_pck_manifest::CertVerdict::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::CertVerdict where U: core::convert::Into<T>
+pub type nika_pck_manifest::CertVerdict::Error = core::convert::Infallible
+pub fn nika_pck_manifest::CertVerdict::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::CertVerdict where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::CertVerdict::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::CertVerdict::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::CertVerdict where T: core::clone::Clone
+pub type nika_pck_manifest::CertVerdict::Owned = T
+pub fn nika_pck_manifest::CertVerdict::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::CertVerdict::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::CertVerdict where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::CertVerdict::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::CertVerdict where T: ?core::marker::Sized
+pub fn nika_pck_manifest::CertVerdict::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::CertVerdict where T: ?core::marker::Sized
+pub fn nika_pck_manifest::CertVerdict::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::CertVerdict where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::CertVerdict::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::CertVerdict
+pub fn nika_pck_manifest::CertVerdict::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::CertVerdict where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub enum nika_pck_manifest::ManifestError
+pub nika_pck_manifest::ManifestError::HashInvalid
+pub nika_pck_manifest::ManifestError::HashInvalid::got: alloc::string::String
+pub nika_pck_manifest::ManifestError::HashInvalid::what: &'static str
+pub nika_pck_manifest::ManifestError::SchemaUnsupported
+pub nika_pck_manifest::ManifestError::SchemaUnsupported::got: alloc::string::String
+impl core::clone::Clone for nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::ManifestError::clone(&self) -> nika_pck_manifest::ManifestError
+impl core::cmp::Eq for nika_pck_manifest::ManifestError
+impl core::cmp::PartialEq for nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::ManifestError::eq(&self, other: &nika_pck_manifest::ManifestError) -> bool
+impl core::error::Error for nika_pck_manifest::ManifestError
+impl core::fmt::Debug for nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::ManifestError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::ManifestError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::ManifestError
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::ManifestError where U: core::convert::From<T>
+pub fn nika_pck_manifest::ManifestError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::ManifestError where U: core::convert::Into<T>
+pub type nika_pck_manifest::ManifestError::Error = core::convert::Infallible
+pub fn nika_pck_manifest::ManifestError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::ManifestError where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::ManifestError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::ManifestError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::ManifestError where T: core::clone::Clone
+pub type nika_pck_manifest::ManifestError::Owned = T
+pub fn nika_pck_manifest::ManifestError::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::ManifestError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_pck_manifest::ManifestError where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_pck_manifest::ManifestError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_pck_manifest::ManifestError where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::ManifestError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::ManifestError where T: ?core::marker::Sized
+pub fn nika_pck_manifest::ManifestError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::ManifestError where T: ?core::marker::Sized
+pub fn nika_pck_manifest::ManifestError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::ManifestError where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::ManifestError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::ManifestError::from(t: T) -> T
+#[non_exhaustive] pub struct nika_pck_manifest::Blake3Hash(_)
+impl nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::as_hex(&self) -> &str
+pub fn nika_pck_manifest::Blake3Hash::new(s: &str) -> core::result::Result<Self, nika_pck_manifest::ManifestError>
+impl core::clone::Clone for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::clone(&self) -> nika_pck_manifest::Blake3Hash
+impl core::cmp::Eq for nika_pck_manifest::Blake3Hash
+impl core::cmp::Ord for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::cmp(&self, other: &nika_pck_manifest::Blake3Hash) -> core::cmp::Ordering
+impl core::cmp::PartialEq for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::eq(&self, other: &nika_pck_manifest::Blake3Hash) -> bool
+impl core::cmp::PartialOrd for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::partial_cmp(&self, other: &nika_pck_manifest::Blake3Hash) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<&str> for nika_pck_manifest::Blake3Hash
+pub type nika_pck_manifest::Blake3Hash::Error = nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::Blake3Hash::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for nika_pck_manifest::Blake3Hash
+impl core::str::traits::FromStr for nika_pck_manifest::Blake3Hash
+pub type nika_pck_manifest::Blake3Hash::Err = nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::Blake3Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+impl serde_core::ser::Serialize for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::serialize<S: serde_core::ser::Serializer>(&self, ser: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::deserialize<D: serde_core::de::Deserializer<'de>>(de: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::Blake3Hash where U: core::convert::From<T>
+pub fn nika_pck_manifest::Blake3Hash::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::Blake3Hash where U: core::convert::Into<T>
+pub type nika_pck_manifest::Blake3Hash::Error = core::convert::Infallible
+pub fn nika_pck_manifest::Blake3Hash::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::Blake3Hash where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::Blake3Hash::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::Blake3Hash::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::Blake3Hash where T: core::clone::Clone
+pub type nika_pck_manifest::Blake3Hash::Owned = T
+pub fn nika_pck_manifest::Blake3Hash::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::Blake3Hash::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_pck_manifest::Blake3Hash where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_pck_manifest::Blake3Hash::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_pck_manifest::Blake3Hash where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::Blake3Hash::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::Blake3Hash where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Blake3Hash::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::Blake3Hash where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Blake3Hash::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::Blake3Hash where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::Blake3Hash::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::Blake3Hash
+pub fn nika_pck_manifest::Blake3Hash::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Blake3Hash where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::Cert
+pub nika_pck_manifest::Cert::cost_floor_usd: core::option::Option<alloc::string::String>
+pub nika_pck_manifest::Cert::effects: alloc::vec::Vec<alloc::string::String>
+pub nika_pck_manifest::Cert::engine: alloc::string::String
+pub nika_pck_manifest::Cert::manifest_hash: nika_pck_manifest::Blake3Hash
+pub nika_pck_manifest::Cert::permits: alloc::vec::Vec<alloc::string::String>
+pub nika_pck_manifest::Cert::schema: alloc::string::String
+pub nika_pck_manifest::Cert::secrets_read: alloc::vec::Vec<alloc::string::String>
+pub nika_pck_manifest::Cert::verdict: nika_pck_manifest::CertVerdict
+impl nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::new(manifest_hash: nika_pck_manifest::Blake3Hash, engine: impl core::convert::Into<alloc::string::String>, verdict: nika_pck_manifest::CertVerdict) -> Self
+pub fn nika_pck_manifest::Cert::validate(&self) -> core::result::Result<(), nika_pck_manifest::ManifestError>
+impl core::clone::Clone for nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::clone(&self) -> nika_pck_manifest::Cert
+impl core::cmp::Eq for nika_pck_manifest::Cert
+impl core::cmp::PartialEq for nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::eq(&self, other: &nika_pck_manifest::Cert) -> bool
+impl core::fmt::Debug for nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::Cert
+impl serde_core::ser::Serialize for nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::Cert where U: core::convert::From<T>
+pub fn nika_pck_manifest::Cert::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::Cert where U: core::convert::Into<T>
+pub type nika_pck_manifest::Cert::Error = core::convert::Infallible
+pub fn nika_pck_manifest::Cert::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::Cert where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::Cert::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::Cert::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::Cert where T: core::clone::Clone
+pub type nika_pck_manifest::Cert::Owned = T
+pub fn nika_pck_manifest::Cert::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::Cert::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::Cert where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::Cert::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::Cert where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Cert::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::Cert where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Cert::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::Cert where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::Cert::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::Cert
+pub fn nika_pck_manifest::Cert::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Cert where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::CustomKind(_)
+impl nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::as_str(&self) -> &str
+impl core::clone::Clone for nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::clone(&self) -> nika_pck_manifest::CustomKind
+impl core::cmp::Eq for nika_pck_manifest::CustomKind
+impl core::cmp::PartialEq for nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::eq(&self, other: &nika_pck_manifest::CustomKind) -> bool
+impl core::fmt::Debug for nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for nika_pck_manifest::CustomKind
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::CustomKind where U: core::convert::From<T>
+pub fn nika_pck_manifest::CustomKind::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::CustomKind where U: core::convert::Into<T>
+pub type nika_pck_manifest::CustomKind::Error = core::convert::Infallible
+pub fn nika_pck_manifest::CustomKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::CustomKind where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::CustomKind::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::CustomKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::CustomKind where T: core::clone::Clone
+pub type nika_pck_manifest::CustomKind::Owned = T
+pub fn nika_pck_manifest::CustomKind::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::CustomKind::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_pck_manifest::CustomKind where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_pck_manifest::CustomKind::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_pck_manifest::CustomKind where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::CustomKind::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::CustomKind where T: ?core::marker::Sized
+pub fn nika_pck_manifest::CustomKind::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::CustomKind where T: ?core::marker::Sized
+pub fn nika_pck_manifest::CustomKind::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::CustomKind where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::CustomKind::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::CustomKind
+pub fn nika_pck_manifest::CustomKind::from(t: T) -> T
+#[non_exhaustive] pub struct nika_pck_manifest::FileEntry
+pub nika_pck_manifest::FileEntry::path: alloc::string::String
+pub nika_pck_manifest::FileEntry::sha256: nika_pck_manifest::Sha256Hash
+impl nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::new(path: impl core::convert::Into<alloc::string::String>, sha256: nika_pck_manifest::Sha256Hash) -> Self
+impl core::clone::Clone for nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::clone(&self) -> nika_pck_manifest::FileEntry
+impl core::cmp::Eq for nika_pck_manifest::FileEntry
+impl core::cmp::PartialEq for nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::eq(&self, other: &nika_pck_manifest::FileEntry) -> bool
+impl core::fmt::Debug for nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::FileEntry
+impl serde_core::ser::Serialize for nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::FileEntry where U: core::convert::From<T>
+pub fn nika_pck_manifest::FileEntry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::FileEntry where U: core::convert::Into<T>
+pub type nika_pck_manifest::FileEntry::Error = core::convert::Infallible
+pub fn nika_pck_manifest::FileEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::FileEntry where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::FileEntry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::FileEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::FileEntry where T: core::clone::Clone
+pub type nika_pck_manifest::FileEntry::Owned = T
+pub fn nika_pck_manifest::FileEntry::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::FileEntry::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::FileEntry where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::FileEntry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::FileEntry where T: ?core::marker::Sized
+pub fn nika_pck_manifest::FileEntry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::FileEntry where T: ?core::marker::Sized
+pub fn nika_pck_manifest::FileEntry::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::FileEntry where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::FileEntry::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::FileEntry
+pub fn nika_pck_manifest::FileEntry::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::FileEntry where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::LockEntry
+pub nika_pck_manifest::LockEntry::content_hash: nika_pck_manifest::Blake3Hash
+pub nika_pck_manifest::LockEntry::reference: nika_pck_manifest::PackageRef
+impl nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::new(reference: nika_pck_manifest::PackageRef, content_hash: nika_pck_manifest::Blake3Hash) -> Self
+impl core::clone::Clone for nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::clone(&self) -> nika_pck_manifest::LockEntry
+impl core::cmp::Eq for nika_pck_manifest::LockEntry
+impl core::cmp::PartialEq for nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::eq(&self, other: &nika_pck_manifest::LockEntry) -> bool
+impl core::fmt::Debug for nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::LockEntry
+impl serde_core::ser::Serialize for nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::LockEntry where U: core::convert::From<T>
+pub fn nika_pck_manifest::LockEntry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::LockEntry where U: core::convert::Into<T>
+pub type nika_pck_manifest::LockEntry::Error = core::convert::Infallible
+pub fn nika_pck_manifest::LockEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::LockEntry where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::LockEntry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::LockEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::LockEntry where T: core::clone::Clone
+pub type nika_pck_manifest::LockEntry::Owned = T
+pub fn nika_pck_manifest::LockEntry::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::LockEntry::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::LockEntry where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::LockEntry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::LockEntry where T: ?core::marker::Sized
+pub fn nika_pck_manifest::LockEntry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::LockEntry where T: ?core::marker::Sized
+pub fn nika_pck_manifest::LockEntry::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::LockEntry where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::LockEntry::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::LockEntry
+pub fn nika_pck_manifest::LockEntry::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::LockEntry where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::Lockfile
+pub nika_pck_manifest::Lockfile::entries: alloc::vec::Vec<nika_pck_manifest::LockEntry>
+pub nika_pck_manifest::Lockfile::schema: alloc::string::String
+impl nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::new(entries: alloc::vec::Vec<nika_pck_manifest::LockEntry>) -> Self
+pub fn nika_pck_manifest::Lockfile::validate(&self) -> core::result::Result<(), nika_pck_manifest::ManifestError>
+impl core::clone::Clone for nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::clone(&self) -> nika_pck_manifest::Lockfile
+impl core::cmp::Eq for nika_pck_manifest::Lockfile
+impl core::cmp::PartialEq for nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::eq(&self, other: &nika_pck_manifest::Lockfile) -> bool
+impl core::fmt::Debug for nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::Lockfile
+impl serde_core::ser::Serialize for nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::Lockfile where U: core::convert::From<T>
+pub fn nika_pck_manifest::Lockfile::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::Lockfile where U: core::convert::Into<T>
+pub type nika_pck_manifest::Lockfile::Error = core::convert::Infallible
+pub fn nika_pck_manifest::Lockfile::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::Lockfile where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::Lockfile::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::Lockfile::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::Lockfile where T: core::clone::Clone
+pub type nika_pck_manifest::Lockfile::Owned = T
+pub fn nika_pck_manifest::Lockfile::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::Lockfile::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::Lockfile where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::Lockfile::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::Lockfile where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Lockfile::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::Lockfile where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Lockfile::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::Lockfile where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::Lockfile::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::Lockfile
+pub fn nika_pck_manifest::Lockfile::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Lockfile where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::Manifest
+pub nika_pck_manifest::Manifest::author: core::option::Option<alloc::string::String>
+pub nika_pck_manifest::Manifest::content_hash: nika_pck_manifest::Blake3Hash
+pub nika_pck_manifest::Manifest::description: core::option::Option<alloc::string::String>
+pub nika_pck_manifest::Manifest::files: alloc::vec::Vec<nika_pck_manifest::FileEntry>
+pub nika_pck_manifest::Manifest::kind: nika_pck_manifest::ArtifactKind
+pub nika_pck_manifest::Manifest::license: core::option::Option<alloc::string::String>
+pub nika_pck_manifest::Manifest::name: alloc::string::String
+pub nika_pck_manifest::Manifest::schema: alloc::string::String
+pub nika_pck_manifest::Manifest::version: alloc::string::String
+impl nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::new(name: impl core::convert::Into<alloc::string::String>, version: impl core::convert::Into<alloc::string::String>, kind: nika_pck_manifest::ArtifactKind, files: alloc::vec::Vec<nika_pck_manifest::FileEntry>, content_hash: nika_pck_manifest::Blake3Hash) -> Self
+pub fn nika_pck_manifest::Manifest::validate(&self) -> core::result::Result<(), nika_pck_manifest::ManifestError>
+impl core::clone::Clone for nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::clone(&self) -> nika_pck_manifest::Manifest
+impl core::cmp::Eq for nika_pck_manifest::Manifest
+impl core::cmp::PartialEq for nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::eq(&self, other: &nika_pck_manifest::Manifest) -> bool
+impl core::fmt::Debug for nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::Manifest
+impl serde_core::ser::Serialize for nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::Manifest where U: core::convert::From<T>
+pub fn nika_pck_manifest::Manifest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::Manifest where U: core::convert::Into<T>
+pub type nika_pck_manifest::Manifest::Error = core::convert::Infallible
+pub fn nika_pck_manifest::Manifest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::Manifest where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::Manifest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::Manifest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::Manifest where T: core::clone::Clone
+pub type nika_pck_manifest::Manifest::Owned = T
+pub fn nika_pck_manifest::Manifest::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::Manifest::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::Manifest where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::Manifest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::Manifest where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Manifest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::Manifest where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Manifest::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::Manifest where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::Manifest::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::Manifest
+pub fn nika_pck_manifest::Manifest::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Manifest where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::PackageRef
+pub nika_pck_manifest::PackageRef::path: core::option::Option<alloc::string::String>
+pub nika_pck_manifest::PackageRef::url: alloc::string::String
+pub nika_pck_manifest::PackageRef::version: alloc::string::String
+impl nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::new(url: impl core::convert::Into<alloc::string::String>, path: core::option::Option<alloc::string::String>, version: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::clone(&self) -> nika_pck_manifest::PackageRef
+impl core::cmp::Eq for nika_pck_manifest::PackageRef
+impl core::cmp::PartialEq for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::eq(&self, other: &nika_pck_manifest::PackageRef) -> bool
+impl core::fmt::Debug for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for nika_pck_manifest::PackageRef
+impl serde_core::ser::Serialize for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::PackageRef where U: core::convert::From<T>
+pub fn nika_pck_manifest::PackageRef::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::PackageRef where U: core::convert::Into<T>
+pub type nika_pck_manifest::PackageRef::Error = core::convert::Infallible
+pub fn nika_pck_manifest::PackageRef::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::PackageRef where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::PackageRef::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::PackageRef::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::PackageRef where T: core::clone::Clone
+pub type nika_pck_manifest::PackageRef::Owned = T
+pub fn nika_pck_manifest::PackageRef::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::PackageRef::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::PackageRef where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::PackageRef::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::PackageRef where T: ?core::marker::Sized
+pub fn nika_pck_manifest::PackageRef::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::PackageRef where T: ?core::marker::Sized
+pub fn nika_pck_manifest::PackageRef::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::PackageRef where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::PackageRef::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::PackageRef
+pub fn nika_pck_manifest::PackageRef::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::PackageRef where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::Sha256Hash(_)
+impl nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::as_hex(&self) -> &str
+pub fn nika_pck_manifest::Sha256Hash::new(s: &str) -> core::result::Result<Self, nika_pck_manifest::ManifestError>
+impl core::clone::Clone for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::clone(&self) -> nika_pck_manifest::Sha256Hash
+impl core::cmp::Eq for nika_pck_manifest::Sha256Hash
+impl core::cmp::Ord for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::cmp(&self, other: &nika_pck_manifest::Sha256Hash) -> core::cmp::Ordering
+impl core::cmp::PartialEq for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::eq(&self, other: &nika_pck_manifest::Sha256Hash) -> bool
+impl core::cmp::PartialOrd for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::partial_cmp(&self, other: &nika_pck_manifest::Sha256Hash) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<&str> for nika_pck_manifest::Sha256Hash
+pub type nika_pck_manifest::Sha256Hash::Error = nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::Sha256Hash::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for nika_pck_manifest::Sha256Hash
+impl core::str::traits::FromStr for nika_pck_manifest::Sha256Hash
+pub type nika_pck_manifest::Sha256Hash::Err = nika_pck_manifest::ManifestError
+pub fn nika_pck_manifest::Sha256Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+impl serde_core::ser::Serialize for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::serialize<S: serde_core::ser::Serializer>(&self, ser: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::deserialize<D: serde_core::de::Deserializer<'de>>(de: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::Sha256Hash where U: core::convert::From<T>
+pub fn nika_pck_manifest::Sha256Hash::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::Sha256Hash where U: core::convert::Into<T>
+pub type nika_pck_manifest::Sha256Hash::Error = core::convert::Infallible
+pub fn nika_pck_manifest::Sha256Hash::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::Sha256Hash where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::Sha256Hash::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::Sha256Hash::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::Sha256Hash where T: core::clone::Clone
+pub type nika_pck_manifest::Sha256Hash::Owned = T
+pub fn nika_pck_manifest::Sha256Hash::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::Sha256Hash::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_pck_manifest::Sha256Hash where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_pck_manifest::Sha256Hash::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_pck_manifest::Sha256Hash where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::Sha256Hash::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::Sha256Hash where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Sha256Hash::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::Sha256Hash where T: ?core::marker::Sized
+pub fn nika_pck_manifest::Sha256Hash::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::Sha256Hash where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::Sha256Hash::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::Sha256Hash
+pub fn nika_pck_manifest::Sha256Hash::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Sha256Hash where T: for<'de> serde_core::de::Deserialize<'de>
+pub const nika_pck_manifest::PCK_SCHEMA: &str

--- a/crates/nika-pck-manifest/src/cert.rs
+++ b/crates/nika-pck-manifest/src/cert.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The conformance cert (ADR-094 D3) — a claim the installer re-derives.
+
+use serde::{Deserialize, Serialize};
+
+use crate::hash::Blake3Hash;
+use crate::manifest::validate_schema;
+use crate::{ManifestError, PCK_SCHEMA};
+
+/// The cert's headline verdict. Closed + `#[non_exhaustive]` — future
+/// grades (e.g. a partial/waived class) are additive variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum CertVerdict {
+    /// The static oracle passed clean.
+    Pass,
+    /// The static oracle found violations (the cert still ships — an
+    /// HONEST fail is publishable; the installer sees it before landing).
+    Fail,
+}
+
+/// The `nika check` static proof, carried WITH the artifact: what it
+/// touches (effects), what it declares (permits), what it reads
+/// (secrets), what it may spend — **as opaque claim strings**. `nika
+/// verify` re-runs the real oracle locally (SkillFortify-class
+/// install-time re-derivation); this type never validates semantics —
+/// typed vocabularies live above L0 and must not drag the parser here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Cert {
+    /// [`PCK_SCHEMA`] — parses on mismatch, `validate()` reports.
+    pub schema: String,
+    /// The manifest this cert certifies (its blake3 — D1 identity).
+    pub manifest_hash: Blake3Hash,
+    /// The certifying engine version (`nika --version` form).
+    pub engine: String,
+    /// The headline verdict.
+    pub verdict: CertVerdict,
+    /// Effect claims (e.g. `fs.write:./out/*` · `net.http:api.example.com`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub effects: Vec<String>,
+    /// The declared permits boundary, flattened to claim strings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub permits: Vec<String>,
+    /// Secret names the workflow reads (enumeration, never values).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secrets_read: Vec<String>,
+    /// The static cost floor, exact-string USD (micro-USD grain — never a
+    /// float; absent = the oracle priced nothing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_floor_usd: Option<String>,
+}
+
+impl Cert {
+    /// Construct with the required fields; claims start empty (INV#19).
+    #[must_use]
+    pub fn new(manifest_hash: Blake3Hash, engine: impl Into<String>, verdict: CertVerdict) -> Self {
+        Self {
+            schema: PCK_SCHEMA.to_owned(),
+            manifest_hash,
+            engine: engine.into(),
+            verdict,
+            effects: Vec::new(),
+            permits: Vec::new(),
+            secrets_read: Vec::new(),
+            cost_floor_usd: None,
+        }
+    }
+
+    /// Structural validation: the schema marker is one this crate speaks.
+    ///
+    /// # Errors
+    /// [`ManifestError::SchemaUnsupported`] when `schema` ≠ [`PCK_SCHEMA`].
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        validate_schema(&self.schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b3() -> Blake3Hash {
+        Blake3Hash::new("a3f5b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b").unwrap()
+    }
+
+    #[test]
+    fn verdict_wire_forms_are_kebab_and_locked() {
+        assert_eq!(
+            serde_json::to_string(&CertVerdict::Pass).unwrap(),
+            "\"pass\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CertVerdict::Fail).unwrap(),
+            "\"fail\""
+        );
+        let v: CertVerdict = serde_json::from_str("\"pass\"").unwrap();
+        assert_eq!(v, CertVerdict::Pass);
+        // an unknown verdict is a hard error — the verdict is a trust
+        // surface, not a router (contrast ArtifactKind's totality)
+        assert!(serde_json::from_str::<CertVerdict>("\"maybe\"").is_err());
+    }
+
+    #[test]
+    fn cert_round_trips_with_claims_and_omits_empty_ones() {
+        let mut c = Cert::new(b3(), "nika 0.97.0", CertVerdict::Pass);
+        let lean = serde_json::to_string(&c).unwrap();
+        assert!(
+            !lean.contains("effects"),
+            "empty claim vecs stay off the wire"
+        );
+        c.effects = vec!["net.http:api.example.com".into()];
+        c.cost_floor_usd = Some("0.000062".into());
+        let back: Cert = serde_json::from_str(&serde_json::to_string(&c).unwrap()).unwrap();
+        assert_eq!(back, c);
+        back.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_refuses_a_foreign_schema() {
+        let mut c = Cert::new(b3(), "nika 0.97.0", CertVerdict::Pass);
+        c.schema = "nika/pck@9".to_owned();
+        assert_eq!(
+            c.validate().unwrap_err(),
+            ManifestError::SchemaUnsupported {
+                got: "nika/pck@9".into()
+            }
+        );
+    }
+
+    #[test]
+    fn cost_floor_is_an_exact_string_never_a_float() {
+        let mut c = Cert::new(b3(), "nika 0.97.0", CertVerdict::Pass);
+        c.cost_floor_usd = Some("0.000001".into());
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"0.000001\""), "string on the wire: {json}");
+    }
+}

--- a/crates/nika-pck-manifest/src/hash.rs
+++ b/crates/nika-pck-manifest/src/hash.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! 32-byte digests as validated lowercase-hex newtypes.
+//!
+//! Integrity primitives are NEVER total: a malformed hash is a hard
+//! [`ManifestError::HashInvalid`] at parse — the exact opposite posture of
+//! the taxonomy's totality, on purpose (a router routes; a trust anchor
+//! refuses).
+
+use core::fmt;
+use core::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::ManifestError;
+
+/// Validate + canonicalize a 64-hex-char digest (case-insensitive in,
+/// lowercase stored — one canonical form so hash equality is string
+/// equality everywhere downstream).
+fn canon_hex64(s: &str, what: &'static str) -> Result<String, ManifestError> {
+    if s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Ok(s.to_ascii_lowercase())
+    } else {
+        Err(ManifestError::HashInvalid {
+            what,
+            got: s.to_owned(),
+        })
+    }
+}
+
+macro_rules! hash_newtype {
+    ($(#[$doc:meta])* $name:ident, $what:literal) => {
+        $(#[$doc])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[non_exhaustive]
+        pub struct $name(String);
+
+        impl $name {
+            /// Parse + canonicalize (lowercase) a 64-hex-char digest.
+            ///
+            /// # Errors
+            /// [`ManifestError::HashInvalid`] unless `s` is exactly 64 hex chars.
+            pub fn new(s: &str) -> Result<Self, ManifestError> {
+                canon_hex64(s, $what).map(Self)
+            }
+
+            /// The canonical lowercase-hex form.
+            #[must_use]
+            pub fn as_hex(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ManifestError;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::new(s)
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = ManifestError;
+            fn try_from(s: &str) -> Result<Self, Self::Error> {
+                Self::new(s)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+                ser.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+                let s = String::deserialize(de)?;
+                Self::new(&s).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+hash_newtype!(
+    /// A sha256 digest (per-file integrity rows · the `nika-pack` precedent).
+    Sha256Hash,
+    "sha256"
+);
+hash_newtype!(
+    /// A blake3 digest (the artifact's IDENTITY · ADR-094 D1: an artifact
+    /// IS its content hash; `nika-blob` computes, this type carries).
+    Blake3Hash,
+    "blake3"
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OK: &str = "a3f5b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b";
+
+    #[test]
+    fn accepts_64_hex_and_canonicalizes_to_lowercase() {
+        let lower = Blake3Hash::new(OK).unwrap();
+        assert_eq!(lower.as_hex(), OK);
+        let upper = Blake3Hash::new(&OK.to_ascii_uppercase()).unwrap();
+        assert_eq!(upper, lower, "case-insensitive in, ONE canonical form");
+        assert_eq!(upper.to_string(), OK, "Display is the lowercase form");
+    }
+
+    #[test]
+    fn rejects_wrong_length_and_non_hex() {
+        for (bad, why) in [
+            (&OK[..63], "63 chars"),
+            (
+                "g3f5b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b",
+                "non-hex g",
+            ),
+            ("", "empty"),
+        ] {
+            let err = Sha256Hash::new(bad).unwrap_err();
+            assert!(
+                matches!(err, ManifestError::HashInvalid { what: "sha256", ref got } if got == bad),
+                "{why}: {err:?}"
+            );
+        }
+        let long = format!("{OK}0");
+        assert!(Sha256Hash::new(&long).is_err(), "65 chars");
+    }
+
+    #[test]
+    fn serde_validates_on_the_way_in_and_emits_canonical_out() {
+        let json = format!("\"{}\"", OK.to_ascii_uppercase());
+        let h: Sha256Hash = serde_json::from_str(&json).unwrap();
+        assert_eq!(serde_json::to_string(&h).unwrap(), format!("\"{OK}\""));
+        // a malformed digest is a hard serde error (never total)
+        assert!(serde_json::from_str::<Sha256Hash>("\"beef\"").is_err());
+    }
+
+    #[test]
+    fn error_display_names_the_digest_kind_and_input() {
+        let msg = Blake3Hash::new("nope").unwrap_err().to_string();
+        assert_eq!(msg, "invalid blake3: `nope` is not a 64-hex-char digest");
+    }
+}

--- a/crates/nika-pck-manifest/src/kind.rs
+++ b/crates/nika-pck-manifest/src/kind.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The D4 artifact taxonomy — closed reserved-core + the vendor escape.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// The artifact classes the pck layer routes on (ADR-094 D4 · ratified
+/// D-2026-07-08-N2 · mirrored by FCI-004's reserved-core list).
+///
+/// **TOTAL deserialization**: a wire string outside the reserved core lands
+/// in [`ArtifactKind::CustomTool`] verbatim — `x-<vendor>:*` declarations
+/// AND future core classes both parse today (the taxonomy is a ROUTER, not
+/// a validator; a 12th class is an additive variant, never a break).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ArtifactKind {
+    /// A `.nika.yaml` workflow — the atomic unit.
+    Workflow,
+    /// A content pack (spec snapshot · templates · examples).
+    Pack,
+    /// A markdown skill.
+    Skill,
+    /// An agent preset (verb + tools + budgets).
+    AgentPreset,
+    /// A template variant (a parameterized workflow family member).
+    TemplateVariant,
+    /// A hash-pinned pointer to model weights (GGUF/safetensors upstream).
+    ModelPointer,
+    /// An MCP server alias/config row.
+    McpConfig,
+    /// A conformance fixture (the paired check⇄run corpus class).
+    ConformanceFixture,
+    /// A provider profile (endpoint + auth shape + capability facts).
+    ProviderProfile,
+    /// A policy preset (permits/budget bundles).
+    PolicyPreset,
+    /// A benchmark suite.
+    BenchSuite,
+    /// The open escape: `x-<vendor>:*` custom-tool declarations and any
+    /// not-yet-known class — carried verbatim, round-trips byte-identical.
+    CustomTool(CustomKind),
+}
+
+/// The opaque payload of [`ArtifactKind::CustomTool`] — constructible ONLY
+/// through [`ArtifactKind::from_wire`], which routes reserved-core wire
+/// forms to their named variants FIRST. A `CustomTool` carrying a core
+/// string (`CustomTool("workflow")` shadowing [`ArtifactKind::Workflow`])
+/// is therefore **unrepresentable**, and type→wire→type stays identity on
+/// a vocabulary frozen forever (Gate-11 P1 · injectivity by construction).
+///
+/// Deliberate INV#19 exemption: NO public constructor — `from_wire` IS the
+/// constructor; a public `new` would reopen the shadowing hole.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct CustomKind(String);
+
+impl CustomKind {
+    /// The wire string, verbatim.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for CustomKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl ArtifactKind {
+    /// The kebab-case wire form (the shape Claude plugins / MCP registry /
+    /// ARA all ship · the string `CustomTool` carries verbatim).
+    #[must_use]
+    pub fn as_wire(&self) -> &str {
+        match self {
+            ArtifactKind::Workflow => "workflow",
+            ArtifactKind::Pack => "pack",
+            ArtifactKind::Skill => "skill",
+            ArtifactKind::AgentPreset => "agent-preset",
+            ArtifactKind::TemplateVariant => "template-variant",
+            ArtifactKind::ModelPointer => "model-pointer",
+            ArtifactKind::McpConfig => "mcp-config",
+            ArtifactKind::ConformanceFixture => "conformance-fixture",
+            ArtifactKind::ProviderProfile => "provider-profile",
+            ArtifactKind::PolicyPreset => "policy-preset",
+            ArtifactKind::BenchSuite => "bench-suite",
+            ArtifactKind::CustomTool(k) => k.as_str(),
+        }
+    }
+
+    /// Parse the wire form — TOTAL: never fails, unknown → `CustomTool`.
+    #[must_use]
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            "workflow" => ArtifactKind::Workflow,
+            "pack" => ArtifactKind::Pack,
+            "skill" => ArtifactKind::Skill,
+            "agent-preset" => ArtifactKind::AgentPreset,
+            "template-variant" => ArtifactKind::TemplateVariant,
+            "model-pointer" => ArtifactKind::ModelPointer,
+            "mcp-config" => ArtifactKind::McpConfig,
+            "conformance-fixture" => ArtifactKind::ConformanceFixture,
+            "provider-profile" => ArtifactKind::ProviderProfile,
+            "policy-preset" => ArtifactKind::PolicyPreset,
+            "bench-suite" => ArtifactKind::BenchSuite,
+            other => ArtifactKind::CustomTool(CustomKind(other.to_owned())),
+        }
+    }
+}
+
+impl Serialize for ArtifactKind {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> Deserialize<'de> for ArtifactKind {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        Ok(ArtifactKind::from_wire(&s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every reserved-core variant, paired with its LOCKED wire form —
+    /// renaming a shipped variant is the ONE breaking change D4 forbids,
+    /// so the full table is pinned value-exactly.
+    const CORE: &[(ArtifactKind, &str)] = &[
+        (ArtifactKind::Workflow, "workflow"),
+        (ArtifactKind::Pack, "pack"),
+        (ArtifactKind::Skill, "skill"),
+        (ArtifactKind::AgentPreset, "agent-preset"),
+        (ArtifactKind::TemplateVariant, "template-variant"),
+        (ArtifactKind::ModelPointer, "model-pointer"),
+        (ArtifactKind::McpConfig, "mcp-config"),
+        (ArtifactKind::ConformanceFixture, "conformance-fixture"),
+        (ArtifactKind::ProviderProfile, "provider-profile"),
+        (ArtifactKind::PolicyPreset, "policy-preset"),
+        (ArtifactKind::BenchSuite, "bench-suite"),
+    ];
+
+    #[test]
+    fn the_eleven_reserved_core_wire_forms_are_locked() {
+        assert_eq!(CORE.len(), 11, "the D4 reserved core is 11 named classes");
+        for (kind, wire) in CORE {
+            assert_eq!(kind.as_wire(), *wire);
+            assert_eq!(&ArtifactKind::from_wire(wire), kind);
+            // serde agrees with the hand pair
+            let json = serde_json::to_string(kind).unwrap();
+            assert_eq!(json, format!("\"{wire}\""));
+            let back: ArtifactKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, kind);
+        }
+    }
+
+    #[test]
+    fn unknown_wire_strings_land_in_custom_tool_verbatim() {
+        // the vendor escape…
+        let k = ArtifactKind::from_wire("x-acme:deploy-tool");
+        assert!(
+            matches!(&k, ArtifactKind::CustomTool(c) if c.as_str() == "x-acme:deploy-tool"),
+            "{k:?}"
+        );
+        assert_eq!(k.as_wire(), "x-acme:deploy-tool");
+        // …and a FUTURE core class parses today (forward-compat by construction)
+        let f: ArtifactKind = serde_json::from_str("\"cognitive-machinery\"").unwrap();
+        assert_eq!(f, ArtifactKind::from_wire("cognitive-machinery"));
+        // round-trips byte-identical
+        assert_eq!(
+            serde_json::to_string(&f).unwrap(),
+            "\"cognitive-machinery\""
+        );
+    }
+
+    #[test]
+    fn deserialization_is_total_never_an_error() {
+        for s in ["", " ", "WORKFLOW", "Workflow", "workflow ", "🦋"] {
+            let k: ArtifactKind = serde_json::from_str(&format!("{s:?}")).unwrap();
+            // case/space variants are NOT the core forms — they stay custom,
+            // verbatim (the wire is exact, not fuzzy)
+            assert!(
+                matches!(&k, ArtifactKind::CustomTool(c) if c.as_str() == s),
+                "{k:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_tool_cannot_shadow_a_core_form_injectivity_by_construction() {
+        // Gate-11 P1: `CustomTool("workflow")` used to be constructible and
+        // serialized byte-identical to `Workflow` (type→wire→type broke).
+        // `CustomKind` has no public constructor — the ONLY path is
+        // `from_wire`, which routes core forms to their named variants:
+        for (kind, wire) in CORE {
+            assert_eq!(&ArtifactKind::from_wire(wire), kind);
+            assert!(
+                !matches!(ArtifactKind::from_wire(wire), ArtifactKind::CustomTool(_)),
+                "core form `{wire}` must never ride the escape"
+            );
+        }
+        // and Display on the payload prints the wire verbatim
+        match ArtifactKind::from_wire("x-acme:deploy") {
+            ArtifactKind::CustomTool(c) => assert_eq!(c.to_string(), "x-acme:deploy"),
+            other => panic!("expected CustomTool, got {other:?}"),
+        }
+    }
+}

--- a/crates/nika-pck-manifest/src/lib.rs
+++ b/crates/nika-pck-manifest/src/lib.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika-pck-manifest` — the pck sharing layer's data contract as pure types.
+//!
+//! ADR-094 (accepted 2026-07-08 · D-2026-07-08-N2) locks a sharing
+//! architecture where **identity is decentralized** (an artifact IS its
+//! blake3 hash · a ref is a git URL + path + version), **discovery is a
+//! losable git index**, and **trust lives in the artifact** (a conformance
+//! cert the installer re-derives locally). This crate is row 1 of the D6
+//! crate mapping: the manifest · cert · lockfile · ref · hash types every
+//! future pck crate (registry L1 · git L1 · orchestrator L2 · CLI L4)
+//! deserializes against — landed FIRST so the wire shapes freeze under
+//! `#[non_exhaustive]` + INV#19 before any I/O code exists.
+//!
+//! ## Fences (what this crate is NOT)
+//!
+//! Zero I/O · zero crypto (hashes are VALIDATED HEX, computed by
+//! `nika-blob`; minisign verification is the suite's job) · zero ref-string
+//! grammar (`PackageRef` is struct-only — a canonical syntax is an ADR-094
+//! follow-up) · zero semantic claim validation (cert claims are opaque
+//! strings; `nika verify` re-runs the real oracle).
+//!
+//! Layer **L0** — pure, zero I/O, zero async, zero `nika-*` deps.
+
+#![forbid(unsafe_code)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+mod cert;
+mod hash;
+mod kind;
+mod lockfile;
+mod manifest;
+mod refs;
+
+pub use cert::{Cert, CertVerdict};
+pub use hash::{Blake3Hash, Sha256Hash};
+pub use kind::{ArtifactKind, CustomKind};
+pub use lockfile::{LockEntry, Lockfile};
+pub use manifest::{FileEntry, Manifest};
+pub use refs::PackageRef;
+
+/// The one schema marker every pck document carries (FCI-003 · a
+/// `nika/pck@2` still PARSES — `validate()` reports it, dispatch stays
+/// version-shaped).
+pub const PCK_SCHEMA: &str = "nika/pck@1";
+
+/// This crate's failure modes — a local typed enum, NO `NIKA-` codes at L0
+/// (the NIKA-200..299 pck range activates in the I/O-bearing suite crates ·
+/// same posture as `nika-cap`).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ManifestError {
+    /// A hash field is not 64 hex characters.
+    #[error("invalid {what}: `{got}` is not a 64-hex-char digest")]
+    HashInvalid {
+        /// Which digest kind was being parsed (`sha256` · `blake3`).
+        what: &'static str,
+        /// The offending input (verbatim).
+        got: String,
+    },
+    /// The document's `schema:` is not [`PCK_SCHEMA`].
+    #[error("unsupported pck schema `{got}` (this engine speaks `nika/pck@1`)")]
+    SchemaUnsupported {
+        /// The schema string the document carried.
+        got: String,
+    },
+}

--- a/crates/nika-pck-manifest/src/lockfile.rs
+++ b/crates/nika-pck-manifest/src/lockfile.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Hash pins that survive any index dying (ADR-094 D1 · constraint 4).
+
+use serde::{Deserialize, Serialize};
+
+use crate::hash::Blake3Hash;
+use crate::manifest::validate_schema;
+use crate::refs::PackageRef;
+use crate::{ManifestError, PCK_SCHEMA};
+
+/// One pinned artifact: where it came from + what it MUST hash to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct LockEntry {
+    /// The ref that was resolved (provenance — display + re-resolve).
+    #[serde(rename = "ref")]
+    pub reference: PackageRef,
+    /// The pinned identity: installs verify content against THIS, whatever
+    /// any index or remote says later (mutable tags cannot bite).
+    pub content_hash: Blake3Hash,
+}
+
+impl LockEntry {
+    /// Pin a resolved ref to its content hash (INV#19).
+    #[must_use]
+    pub fn new(reference: PackageRef, content_hash: Blake3Hash) -> Self {
+        Self {
+            reference,
+            content_hash,
+        }
+    }
+}
+
+/// The lockfile: the project's installed set as pins. Entry order is the
+/// PRODUCER's (the L2 orchestrator sorts by ref for deterministic diffs —
+/// a data-shape concern above L0, documented here so no consumer assumes
+/// this type sorts).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Lockfile {
+    /// [`PCK_SCHEMA`] — parses on mismatch, `validate()` reports.
+    pub schema: String,
+    /// The pins.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entries: Vec<LockEntry>,
+}
+
+impl Lockfile {
+    /// An empty lockfile at the current schema (INV#19).
+    #[must_use]
+    pub fn new(entries: Vec<LockEntry>) -> Self {
+        Self {
+            schema: PCK_SCHEMA.to_owned(),
+            entries,
+        }
+    }
+
+    /// Structural validation: the schema marker is one this crate speaks.
+    ///
+    /// # Errors
+    /// [`ManifestError::SchemaUnsupported`] when `schema` ≠ [`PCK_SCHEMA`].
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        validate_schema(&self.schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b3() -> Blake3Hash {
+        Blake3Hash::new("a3f5b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b").unwrap()
+    }
+
+    #[test]
+    fn wire_key_is_ref_and_round_trips_toml_and_json() {
+        let lf = Lockfile::new(vec![LockEntry::new(
+            PackageRef::new("https://github.com/acme/flows", None, "v1"),
+            b3(),
+        )]);
+        let json = serde_json::to_string(&lf).unwrap();
+        assert!(json.contains("\"ref\":{"), "the wire key is `ref`: {json}");
+        let back: Lockfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, lf);
+        let toml = toml_convert::to_string(&lf).unwrap();
+        let back: Lockfile = toml_convert::from_str(&toml).unwrap();
+        assert_eq!(back, lf);
+        back.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_refuses_a_foreign_schema() {
+        let mut lf = Lockfile::new(Vec::new());
+        lf.schema = "nika/lock@1".to_owned();
+        assert_eq!(
+            lf.validate().unwrap_err(),
+            ManifestError::SchemaUnsupported {
+                got: "nika/lock@1".into()
+            }
+        );
+    }
+
+    #[test]
+    fn empty_lockfile_is_lean_and_valid() {
+        let lf = Lockfile::new(Vec::new());
+        assert_eq!(
+            serde_json::to_string(&lf).unwrap(),
+            r#"{"schema":"nika/pck@1"}"#
+        );
+        let back: Lockfile = serde_json::from_str(r#"{"schema":"nika/pck@1"}"#).unwrap();
+        assert_eq!(back.entries.len(), 0, "absent entries deserialize as empty");
+        back.validate().unwrap();
+    }
+}

--- a/crates/nika-pck-manifest/src/manifest.rs
+++ b/crates/nika-pck-manifest/src/manifest.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The shared artifact's manifest (`nika/pck@1` · FCI-003).
+
+use serde::{Deserialize, Serialize};
+
+use crate::hash::{Blake3Hash, Sha256Hash};
+use crate::kind::ArtifactKind;
+use crate::{ManifestError, PCK_SCHEMA};
+
+/// One content file: repo-relative path + its sha256 (per-file integrity —
+/// the `nika-pack` embedded-pack precedent, same row shape).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FileEntry {
+    /// Artifact-relative path (forward slashes on the wire).
+    pub path: String,
+    /// The file's sha256.
+    pub sha256: Sha256Hash,
+}
+
+impl FileEntry {
+    /// Construct a row (INV#19).
+    #[must_use]
+    pub fn new(path: impl Into<String>, sha256: Sha256Hash) -> Self {
+        Self {
+            path: path.into(),
+            sha256,
+        }
+    }
+}
+
+/// The manifest an author publishes with an artifact. Signed DETACHED
+/// (minisign · ADR-094 D3) — deliberately NO signature field in the data:
+/// the signature covers these bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Manifest {
+    /// [`PCK_SCHEMA`] — parses on mismatch, `validate()` reports (FCI-003).
+    pub schema: String,
+    /// Human name (display only — NEVER identity · D1: the hash is).
+    pub name: String,
+    /// The artifact's own version string (publisher-defined semantics).
+    pub version: String,
+    /// The D4 class this artifact routes as.
+    pub kind: ArtifactKind,
+    /// One-line description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Author attribution (display; trust is the detached signature).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// SPDX license id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+    /// Per-file integrity rows.
+    pub files: Vec<FileEntry>,
+    /// The artifact's identity: its blake3 content hash (D1/D2 — computed
+    /// by `nika-blob`, carried here).
+    pub content_hash: Blake3Hash,
+}
+
+impl Manifest {
+    /// Construct with the required fields; optional attribution starts
+    /// empty (INV#19 — literal construction is sealed by `#[non_exhaustive]`).
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        version: impl Into<String>,
+        kind: ArtifactKind,
+        files: Vec<FileEntry>,
+        content_hash: Blake3Hash,
+    ) -> Self {
+        Self {
+            schema: PCK_SCHEMA.to_owned(),
+            name: name.into(),
+            version: version.into(),
+            kind,
+            description: None,
+            author: None,
+            license: None,
+            files,
+            content_hash,
+        }
+    }
+
+    /// Structural validation: the schema marker is one this crate speaks.
+    ///
+    /// # Errors
+    /// [`ManifestError::SchemaUnsupported`] when `schema` ≠ [`PCK_SCHEMA`].
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        validate_schema(&self.schema)
+    }
+}
+
+/// The one shared schema check (manifest · cert · lockfile).
+pub(crate) fn validate_schema(schema: &str) -> Result<(), ManifestError> {
+    if schema == PCK_SCHEMA {
+        Ok(())
+    } else {
+        Err(ManifestError::SchemaUnsupported {
+            got: schema.to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b3() -> Blake3Hash {
+        Blake3Hash::new("a3f5b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b").unwrap()
+    }
+    fn s2() -> Sha256Hash {
+        Sha256Hash::new("00f5b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b").unwrap()
+    }
+
+    fn sample() -> Manifest {
+        Manifest::new(
+            "pr-risk-review",
+            "1.0.0",
+            ArtifactKind::Workflow,
+            vec![FileEntry::new("pr-risk-review.nika.yaml", s2())],
+            b3(),
+        )
+    }
+
+    #[test]
+    fn new_stamps_the_schema_and_validates_clean() {
+        let m = sample();
+        assert_eq!(m.schema, "nika/pck@1");
+        m.validate().unwrap();
+    }
+
+    #[test]
+    fn a_future_schema_parses_then_validate_reports() {
+        let mut m = sample();
+        m.schema = "nika/pck@2".to_owned();
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Manifest = serde_json::from_str(&json).unwrap(); // parses fine
+        assert_eq!(
+            back.validate().unwrap_err(),
+            ManifestError::SchemaUnsupported {
+                got: "nika/pck@2".into()
+            }
+        );
+    }
+
+    #[test]
+    fn toml_round_trip_the_documented_wire_format() {
+        // FCI-003: `nika/pck@1` is a TOML format — prove the shape holds.
+        let m = sample();
+        let toml = toml_convert::to_string(&m).unwrap();
+        assert!(toml.contains("schema = \"nika/pck@1\""), "{toml}");
+        assert!(toml.contains("kind = \"workflow\""), "{toml}");
+        let back: Manifest = toml_convert::from_str(&toml).unwrap();
+        assert_eq!(back, m);
+    }
+
+    #[test]
+    fn json_round_trip_and_optional_fields_omitted() {
+        let m = sample();
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(
+            !json.contains("description"),
+            "absent options stay off the wire"
+        );
+        let back: Manifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, m);
+    }
+}

--- a/crates/nika-pck-manifest/src/refs.rs
+++ b/crates/nika-pck-manifest/src/refs.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The decentralized package ref (ADR-094 D1) — struct-only, no grammar.
+
+use serde::{Deserialize, Serialize};
+
+/// Go-module-style ref: the hosting platform IS the namespace — no global
+/// name table to squat. Struct-only by design: a canonical string
+/// syntax (display/parse) is an ADR-094 follow-up decision the L1 registry
+/// needs; freezing a grammar here would outrun the ratified shape.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PackageRef {
+    /// The git URL that owns the artifact (`https://…` · `git@…`).
+    pub url: String,
+    /// Repo-relative path to the artifact dir (None = repo root).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// The version selector (a tag · publisher-defined semantics).
+    pub version: String,
+}
+
+impl PackageRef {
+    /// Construct from the resolved parts (INV#19).
+    #[must_use]
+    pub fn new(url: impl Into<String>, path: Option<String>, version: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            path,
+            version: version.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_round_trips_and_omits_absent_path() {
+        let r = PackageRef::new("https://github.com/acme/flows", None, "v1.2.0");
+        let json = serde_json::to_string(&r).unwrap();
+        assert_eq!(
+            json, r#"{"url":"https://github.com/acme/flows","version":"v1.2.0"}"#,
+            "no `path` key when absent — lean TOML/JSON rows"
+        );
+        let back: PackageRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+
+        let with = PackageRef::new("https://sr.ht/x/y", Some("packs/a".into()), "2026.07");
+        let back: PackageRef =
+            serde_json::from_str(&serde_json::to_string(&with).unwrap()).unwrap();
+        assert_eq!(back.path.as_deref(), Some("packs/a"));
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored_additive_forever() {
+        let json = r#"{"url":"u","version":"v","future_field":123}"#;
+        let r: PackageRef = serde_json::from_str(json).unwrap();
+        assert_eq!(r.url, "u");
+    }
+}

--- a/crates/nika-pck-manifest/tests/properties.rs
+++ b/crates/nika-pck-manifest/tests/properties.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Gate 6 — the crate's two structural laws, property-tested:
+//! the taxonomy is TOTAL (a router never errors) and the hash newtypes
+//! are EXACT (a trust anchor never coerces).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use nika_pck_manifest::{ArtifactKind, Blake3Hash, Sha256Hash};
+use proptest::prelude::*;
+
+proptest! {
+    // ∀ strings: deserialization succeeds, and the wire form round-trips
+    // byte-identical (core forms map to themselves; everything else rides
+    // CustomTool verbatim).
+    #[test]
+    fn artifact_kind_is_total_and_round_trips(s in ".*") {
+        let k: ArtifactKind = serde_json::from_value(serde_json::Value::String(s.clone()))
+            .expect("taxonomy deserialization is TOTAL");
+        let wire = serde_json::to_value(&k).unwrap();
+        prop_assert_eq!(wire, serde_json::Value::String(s));
+    }
+
+    // ∀ 64-hex inputs (any case): accepted + canonicalized to lowercase,
+    // and Display == serde output == the canonical form.
+    #[test]
+    fn hashes_accept_all_64_hex_and_canonicalize(bytes in prop::collection::vec(0u8..16, 64), upper in prop::collection::vec(any::<bool>(), 64)) {
+        let s: String = bytes.iter().zip(upper).map(|(b, up)| {
+            let c = char::from_digit(u32::from(*b), 16).unwrap();
+            if up { c.to_ascii_uppercase() } else { c }
+        }).collect();
+        let h = Blake3Hash::new(&s).expect("64 hex chars always parse");
+        prop_assert_eq!(h.as_hex(), s.to_ascii_lowercase());
+        prop_assert_eq!(h.to_string(), s.to_ascii_lowercase());
+    }
+
+    // ∀ strings that are NOT 64 hex chars: rejected — by the constructor
+    // AND by serde (the two entrances agree).
+    #[test]
+    fn hashes_reject_everything_else(s in ".*") {
+        prop_assume!(!(s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())));
+        prop_assert!(Sha256Hash::new(&s).is_err());
+        let as_json = serde_json::Value::String(s);
+        prop_assert!(serde_json::from_value::<Sha256Hash>(as_json).is_err());
+    }
+}

--- a/docs/crate-specs/nika-pck-manifest.md
+++ b/docs/crate-specs/nika-pck-manifest.md
@@ -1,0 +1,153 @@
+# Crate spec — `nika-pck-manifest` (Gate 1)
+
+| | |
+|---|---|
+| Status | **ADMISSION IN REVIEW** — Gate 1 authored 2026-07-08; gates 2-10 run same day (results in §4). The 42nd crate (ADR-094 accepted + FCI-004 amended same day · D-2026-07-08-N2 · the taxonomy gate is CLEARED). |
+| Layer | **L0** — pure, zero I/O, zero async, zero `nika-*` deps (`serde` + `thiserror` only; `serde_json` + `toml_convert` + `proptest` dev-only). |
+| Design | The pck sharing layer's **data contract as pure types**: manifest · cert · lockfile · package ref · hash newtypes · the D4 artifact taxonomy. Serde-generic (the wire is the consumer's choice; `nika/pck@1` is documented as TOML per FCI-003 — round-trip proven in tests for BOTH toml and json). |
+| LOC budget | ≤900 src (target ~650) — sized against `nika-cap` (~1.3k) and `nika-event` (~460); a vocabulary crate, not an engine. ≤1500/file · ≤100/fn. |
+| Deps | `serde` (derive) · `thiserror`. Dev: `serde_json` · `toml_convert` · `proptest`. **Zero `nika-*`** — cert claims are `Vec<String>` by design (the plan's exact cut: the cert is a CLAIM CARRIER; `nika verify` re-derives with the full engine, this crate never validates semantics). |
+| Publish | `false` — foundation crate (ADR-022). |
+| NIKA codes | **none** — local typed `ManifestError` only; the NIKA-200..299 pck range (FCI-005) activates in the L1/L2 pck crates that DO I/O. Same posture as `nika-cap` §7. |
+
+## 1 · Why this crate exists (ADR-094 · D6 row 1)
+
+The pck suite (registry L1 · git L1 · orchestrator L2 · CLI verbs L4) is
+post-1.0, but its **data contract** is L0 and admission-ready NOW: pure
+types every future pck crate deserializes against. Landing the types first
+(a) completes the 42-crate architecture target, (b) freezes the wire shapes
+under `#[non_exhaustive]` + INV#19 before any I/O code exists (additive
+forever), (c) encodes the D4 taxonomy the operator just ratified as the ONE
+closed-but-extensible enum every registry surface shares.
+
+## 2 · Public API (all `#[non_exhaustive]` · INV#19 `new()` constructors)
+
+```rust
+/// The D4 artifact taxonomy — closed reserved-core + the vendor escape.
+/// TOTAL deserialization: an unrecognized wire string lands in
+/// `CustomTool(s)` (forward classes + `x-<vendor>:*` declarations), never
+/// an error — the taxonomy is a ROUTER, not a validator.
+#[non_exhaustive]
+pub enum ArtifactKind {
+    Workflow, Pack, Skill, AgentPreset, TemplateVariant, ModelPointer,
+    McpConfig, ConformanceFixture, ProviderProfile, PolicyPreset,
+    BenchSuite,
+    CustomTool(String),           // wire: the string verbatim (x-vendor:* + unknown)
+}
+// wire forms: kebab-case ("agent-preset", "model-pointer", …)
+
+/// 32-byte digests as validated lowercase-hex newtypes. Parsing a
+/// malformed hash IS an error — integrity primitives are never total.
+pub struct Sha256Hash(/* private */);   // 64 hex chars
+pub struct Blake3Hash(/* private */);   // 64 hex chars
+// TryFrom<&str> / FromStr / Display / serde with validation.
+
+/// Go-module-style decentralized ref (ADR-094 D1): the hosting platform
+/// is the namespace. Struct-only — no canonical string syntax is parsed
+/// or printed here (the ADR locks the SHAPE, not a grammar · §5).
+pub struct PackageRef { pub url: String, pub path: Option<String>, pub version: String }
+
+/// One content file: repo-relative path + sha256 (nika-pack precedent).
+pub struct FileEntry { pub path: String, pub sha256: Sha256Hash }
+
+/// The shared artifact's manifest (`schema: "nika/pck@1"` · FCI-003).
+/// Signed DETACHED (minisign, D3) — no signature field in the data.
+pub struct Manifest {
+    pub schema: String,               // "nika/pck@1" · validate() checks
+    pub name: String,
+    pub version: String,
+    pub kind: ArtifactKind,
+    pub description: Option<String>,
+    pub author: Option<String>,
+    pub license: Option<String>,
+    pub files: Vec<FileEntry>,
+    pub content_hash: Blake3Hash,     // the artifact IS this hash (D1/D2)
+}
+
+/// The conformance cert (D3): the `nika check` static proof as CLAIMS the
+/// installer re-derives locally (`nika verify` re-runs the oracle — the
+/// cert is a claim, not a badge). Claims are opaque strings HERE.
+pub struct Cert {
+    pub schema: String,               // "nika/pck@1"
+    pub manifest_hash: Blake3Hash,    // what this cert certifies
+    pub engine: String,               // certifying engine version
+    pub verdict: CertVerdict,         // Pass | Fail (closed · non_exhaustive)
+    pub effects: Vec<String>,
+    pub permits: Vec<String>,
+    pub secrets_read: Vec<String>,
+    pub cost_floor_usd: Option<String>, // exact-string (micro-USD grain precedent)
+}
+
+/// Hash pins that survive any index dying (D1: the index must be losable).
+pub struct Lockfile { pub schema: String, pub entries: Vec<LockEntry> }
+pub struct LockEntry { pub r#ref: PackageRef, pub content_hash: Blake3Hash }
+
+#[non_exhaustive]
+pub enum ManifestError {  // thiserror · no NIKA codes at L0
+    HashInvalid { what: &'static str, got: String },
+    SchemaUnsupported { got: String },
+}
+
+pub const PCK_SCHEMA: &str = "nika/pck@1";
+```
+
+`validate()` on Manifest/Cert/Lockfile checks `schema == PCK_SCHEMA`
+(SchemaUnsupported otherwise — parse never fails on it: a `nika/pck@2`
+document DESERIALIZES, then validate() reports, per FCI-003 dispatch-by-
+version forward shape).
+
+## 3 · Anti-scope (fences)
+
+- **No I/O, no crypto**: hashes are validated hex STRINGS — computing
+  blake3/sha256 is `nika-blob`'s job; verifying minisign is the L1/L2
+  suite's job.
+- **No ref-string grammar**: `PackageRef` is struct-only. A canonical
+  display/parse syntax needs its own decision (flagged in ADR-094
+  follow-ups) — inventing one here would freeze an unratified grammar.
+- **No semantic validation of claims**: effects/permits/secrets stay
+  opaque `Vec<String>` — typed vocabularies live in `nika-cap`/`nika-schema`
+  and the cert must not drag the parser into L0 (the extraction lesson).
+- **No registry index row types**: the index is the L1 registry crate's
+  surface (it may reuse these types; its rows aren't defined here).
+
+## 4 · The 12 gates
+
+| Gate | Result (2026-07-08) |
+|---|---|
+| 1 SPEC | ✅ this doc |
+| 2 TDD | ✅ tests authored value-exact with the impl (serde round-trips toml+json · taxonomy totality · hash rejection table · schema validate); the RED phase was exercised by Gate 5 — the two `validate()` happy-path-only gaps mutation surfaced were killed with schema-mismatch negatives (honest note: ceremony-RED was not observed per-test; strength is mutation-proven) |
+| 3 IMPL | ✅ 845 src LOC across lib/kind/hash/refs/manifest/cert/lockfile (≤900 budget) |
+| 4 CLIPPY | ✅ 0 warnings, crate + workspace (`--all-targets -D warnings`) |
+| 5 MUTATION | ✅ **11/11 caught (100%) · 0 missed · 3 unviable** (`cargo mutants -p nika-pck-manifest`) |
+| 6 PROPERTY | ✅ 3 laws: kind totality+round-trip ∀ strings · hash ∀-64-hex accept+canon · hash ∀-malformed reject (constructor AND serde agree) |
+| 7 BENCH | N/A — pure types, no hot path (justified) |
+| 8 DOCS | ✅ `cargo doc --no-deps` 0 warnings · every pub item documented |
+| 9 CANARY | N/A — L0 data contract, no runtime surface (justified) |
+| 10 PARITY | N/A — new surface: legacy v0.79 never shipped a pck manifest format (justified; the nika-pack embedded-content manifest is a DIFFERENT, existing contract — disambiguated §3) |
+| 11 REVIEW | 3-agent swarm (run at admission · findings folded or pinned below) |
+| 12 ATOMIC | 1 crate = 1 commit |
+
+## 4b · Gate-11 swarm findings (2026-07-08 · verdict FIX-THEN-ADMIT · all resolved)
+
+- **P0 hash newtypes lacked `#[non_exhaustive]`** (the only 2 of 11 public
+  types) → FIXED in the `hash_newtype!` macro; uniformity is the ratchet.
+- **P1 `CustomTool(String)` injectivity hole** — `CustomTool("workflow")`
+  was constructible and serialized byte-identical to `Workflow`
+  (type→wire→type broke on a frozen-forever vocabulary) → FIXED
+  structurally: the payload is now opaque `CustomKind` (no public
+  constructor — `from_wire` IS the constructor and routes core forms to
+  named variants first; shadowing unrepresentable). Deliberate INV#19
+  exemption documented on `CustomKind`.
+- **P1 FCI-004 stale 9-list / P1 ADR-094 `status: proposed`** — branch
+  artifacts: the reviewers read a pre-#292 tree; rebranched onto current
+  main (which carries the amended FCI-004 11-list + the accepted ADR) —
+  both dissolve; kind.rs's "mirrored by FCI-004" claim is true on main.
+- Post-fix battery: 21 unit + 3 property tests · clippy 0 · **mutation
+  14/14 caught (100% · 0 missed · 3 unviable)**.
+
+## 5 · Open (flagged, not decided here)
+
+- PackageRef canonical string syntax (ADR-094 follow-up · needed by the L1
+  registry, not by the types).
+- Whether Cert grows typed claim vocabularies post-1.0 (would add nika-cap
+  dep — a DELIBERATE layering decision for the suite, not a default).

--- a/scripts/ci/public-api-coverage-baseline.txt
+++ b/scripts/ci/public-api-coverage-baseline.txt
@@ -84,3 +84,4 @@ nika-cap
 nika-builtin
 nika-cel
 nika-cli
+nika-pck-manifest


### PR DESCRIPTION
**The 42nd crate — the Diamond architecture target, complete.**

Unblocked this morning by the operator ratification (ADR-094 `accepted` + FCI-004 D4 amendment · D-2026-07-08-N2 · #292). This is the pck sharing layer's **data contract as pure L0 types** — manifest · cert · lockfile · ref · hash newtypes · the D4 artifact taxonomy — landed first so the wire shapes freeze under `#[non_exhaustive]` + INV#19 before any I/O code exists.

## Gate table
| gate | result |
|---|---|
| 1 SPEC | `docs/crate-specs/nika-pck-manifest.md` |
| 2 TDD | value-exact tests (toml+json round-trips · totality · rejection tables); the 2 gaps Gate-5 surfaced were killed same-day — honest note in the spec |
| 3 IMPL | ~860 src LOC (≤900 budget) · zero I/O · zero async · **zero nika-\* deps** (serde+thiserror) |
| 4 CLIPPY | 0 (crate + workspace) |
| 5 MUTATION | **14/14 caught · 100% · 0 missed** |
| 6 PROPERTY | kind totality+round-trip ∀ strings · hash ∀-64-hex accept+canon · ∀-malformed reject |
| 7/9/10 | N/A justified in spec (pure types · L0 · new surface) |
| 8 DOCS | 0 warnings |
| 11 REVIEW | 3-agent swarm → FIX-THEN-ADMIT → **all 4 findings resolved**: P0 `#[non_exhaustive]` on hash newtypes · P1 `CustomTool` injectivity fixed STRUCTURALLY (opaque `CustomKind`, `from_wire`-only construction — shadowing a core form is unrepresentable) · 2 doc-sync P1s were pre-#292 branch artifacts, dissolved by rebranch |
| 12 ATOMIC | this PR (squash) |

## Design highlights
- **Totality where routing, strictness where trust**: `ArtifactKind` deserialization is TOTAL (unknown → `CustomTool` verbatim — forward classes parse today); hash newtypes REFUSE anything not 64-hex (canonicalized lowercase, constructor and serde agree — property-tested both directions).
- **FCI-003 posture**: `schema: nika/pck@1` always parses; `validate()` reports — a `@2` document never explodes the parser.
- **Cert = claim carrier**: effects/permits/secrets as opaque strings; `nika verify` re-derives with the real oracle (SkillFortify-class) — typed vocabularies stay above L0 by design.

Note: `wip = []` in this PR (the crate is admitted at merge). The sister nika-tmpl re-land touches the same Cargo.toml lines — whichever lands second rebases trivially.