### PR TITLE
chore(release): v0.98.0 — structured output goes native, the checker closes its gaps

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,9 +129,9 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `feat/nika-tmpl`                                      |
-| HEAD             | `c6f4f0b54` (`c6f4f0b54f084022389c7b8f04f7d644ed0cd77d`)             |
-| workspace        | v0.97.0                                  |
+| branch           | `chore/release-0.98.0`                                      |
+| HEAD             | `25db7137d` (`25db7137dddbe6fdb7782663d1a07096cafb3bad`)             |
+| workspace        | v0.98.0                                  |
 | crates (workspace)| 41                                              |
 | crates (admitted)| 41 / 42                                   |
 | crates (WIP)     | 0 —                                   |
@@ -142,7 +142,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | L2               | 4                                              |
 | L3               | 1                                              |
 | L4               | 4                                              |
-| lib tests        | 3516 passed, 0 failed                              |
+| lib tests        | 3545 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 
 Narrative context (manually maintained):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,75 +10,89 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
-**Nika never lies about costs.** The pricing catalog identifies itself,
-the math prices what providers actually billed, agents stop hiding
-their LLM spend, `unknown` always says WHY, and the operator gets a
-real budget lever.
+**Structured output goes native, the checker closes its gaps — and the
+engine gets its one lexer.** Four arcs land together: the answer now
+rides each provider's own grammar; `nika check` catches what used to
+fail at run; costs stopped lying last cycle and now the budget can't be
+dodged; and the `${{ }}` scanner becomes a crate both the checker and
+the runtime share — parity by construction.
 
-### ✨ Features
+### The native-answer arc
 
-- **The pricing snapshot identifies itself** — `[meta]` (source ·
-  `as_of` · sha256 prefix) is machine-readable (schema `@1.1`):
-  `nika doctor` prints the identity line and WARNS past 120 days (the
-  staleness surface no surveyed tool ships), `check --json` carries
-  `pricing.snapshot`, and a priced run stamps `pricing_as_of` on its
-  terminal frame — every cost figure names the prices that produced it.
-- **Cache-aware cost math** — the snapshot now vendors upstream
-  `cache_read`/`cache_write` rates (248 rules) and the runtime prices
-  cache subsets at their OWN rates instead of full input price. Wires
-  normalize to the OTel `gen_ai` semantics (`input_tokens` INCLUDES the
-  cache subsets — Anthropic folds at the parse seam, sync + streaming).
-  Scope honesty: this bills what providers REPORT — live today for
-  implicit caching (OpenAI `cached_tokens` · Gemini
-  `cachedContentTokenCount`); Anthropic's opt-in `cache_control` is not
-  yet emitted by Nika's own requests, so its cache meters stay absent
-  until that ships (roadmapped, with the 1h-TTL write-premium axis).
-- **Agents meter their LLM spend** — the loop absorbs every turn's
-  usage split and the dispatch prices it with the same resolver `infer`
-  uses, on top of tool-reported spend. An agent task's `cost_usd` is
-  now the whole bill, not just its tools.
-- **`unknown` says why** — an unpriced task carries `cost_unpriced`:
-  `local_model` · `mock_provider` · `missing_catalog_price` ·
-  `provider_did_not_report_usage`. A PRICED model whose provider
-  reports no usage is absent+named — never a fake `$0.00`.
-- **Run cost totals on the trace** — the terminal frame carries
-  `total_cost_usd` · `priced_calls` · `unpriced_calls` ·
-  `cost_by_source` · `pricing_as_of` (only when honest: an unmetered
-  run stays field-free). `RunOutcome` mirrors them for embedders.
-- **`nika run --max-cost-usd <usd>`** — the operator budget (NIKA-1704):
-  refuses pre-run when the static cost floor already exceeds it, and
-  mid-run stops ADMITTING new work once metered spend crosses it —
-  in-flight calls complete and count (a killed call would spend
-  unrecorded money), unstarted tasks cancel, the error carries
-  spent-vs-budget. Unpriced work never trips it — said loudly upfront.
-- **Partial totals never read as complete** — the run meter, verdict
-  card and `trace outputs` render `≥ $X (N unpriced)` whenever part of
-  the run carried no meterable price.
+- **Anthropic native structured output** — `output_config.format`
+  replaces the instruction fallback on claude models that support it.
+- **Gemini rides `responseJsonSchema`** — the lossy OpenAPI converter
+  dies; the author's JSON Schema reaches the wire as written.
+- **OpenAI strict-mode honesty** — schemas carrying `not`/`allOf` are
+  stripped and flattened at the wire instead of 400ing; gpt-5/o-series
+  get `max_completion_tokens` (legacy models and every compatible peer
+  keep `max_tokens` — and the two spellings are ONE logical key, a raw
+  extras `max_tokens` can no longer ride alongside the routed one).
+- **Capability is a PROVIDER fact** — deepseek has no `json_schema`;
+  the profile says so instead of failing live. `nika doctor` names the
+  clouds that fall back to instruction mode.
+- **The coercion ladder** — SAP-lite repair (case-fold enums · string
+  numbers · singleton arrays) before any PAID retry; retry-loop
+  economics send a numbered repair list and fast-fail on truncation.
 
-### 📖 Documentation
+### The audit-before-run arc
 
-- `scripts/refresh-pricing.sh` grows a LiteLLM-style shrink guard
-  (a refresh losing >half the rules refuses to write) and emits the
-  `[meta]` provenance block.
-- **Billed-then-failed spend is visible** — a loop that burns real
-  money and then dies (schema retries exhausted · `max_turns` ·
-  `max_tokens_total` · a provider dying mid-loop) now carries that
-  spend on its error: `task_failed`/`task_skipped` frames ride
-  `cost_usd` (+ the unpriced WHY), run totals include it, and the
-  `--max-cost-usd` gate debits it PER ATTEMPT — a retry storm can no
-  longer spend past the budget invisibly. A recovered (`on_error:
-  recover`) task keeps its burned spend on the frame (recovery is not
-  a refund).
-- **Known limits (named, not silent — the honest-cost roadmap):**
-  costs use LIST RATES from the vendored public catalog (private/proxy/
-  Azure deals need the roadmapped override file) · long-context pricing
-  tiers are vendored at the BASE rate (a >200K-token gemini-2.5-pro
-  call bills ~2× the estimate) · a task KILLED BY ITS `timeout:` cannot
-  report the cancelled attempt's server-side spend (nothing was
-  reported, nothing can honestly ride) · `on_finally` cleanups stay the
-  best-effort unmetered lane.
+- **The compact block-sequence bomb is dead (CRITICAL)** — `- `×4000 on
+  one line used to stack-overflow-ABORT every `nika check`/`run` and
+  the LSP with them; the dash-run cap catches it as NIKA-PARSE-001. The
+  LSP additionally proves it SERVES the bomb as a document and keeps
+  answering (e2e), and floors mid-char offsets instead of panicking.
+- **`max_turns` out of 1-1000** and **`for_each` over a typed
+  non-array var** are check-time findings now, not run-time surprises.
+- **`env:` binds at run** — a green check referencing `${{ env.X }}`
+  used to fail with NIKA-VAR-001 because the runtime never bound the
+  namespace it was checked against. The exact parity class
+  audit-before-run exists to prevent; threaded end-to-end (gates ·
+  pause payloads · resume identity — an env change re-keys, never
+  wrong-skips).
+- **New hints**: `exec-json-capture` (a `capture: structured` task
+  whose bindings parse `.stdout | fromjson` and read nothing else of
+  the record — use `capture: stdout` so a failing helper errors as
+  NIKA-EXEC-001 instead of becoming data) · `native-first` (the check
+  names the builtin/MCP path an exec shells out to) ·
+  `schema-portability` (the grammar-blind keywords named).
+- **A dirty MCP check is `isError:true`** — the agent repair loop
+  (template → fill → check → repair) triggers again.
 
----
+### nika-tmpl — the 41st crate
+
+The `${{ … }}` island lexer, extracted from its two hand-duplicated
+copies (the drift already shipped one check-passed/run-broke bug) into
+a zero-dependency L0 leaf both consumers now share. Quote-aware close,
+`\${{` escape, byte-spans, AST-free. Mutation 46/51 (90.2%) with the 5
+survivors certified unkillable in-spec; parity pre-proven byte-identical
+across ~337k exhaustive inputs.
+
+### And
+
+- The wizard escapes user strings into YAML (a backslash in the intent
+  no longer scaffolds a file that fails its own check), survives spaced
+  filenames, and never promises what the file doesn't carry — with PTY
+  e2e coverage driving the real conversation.
+- fetch vNext: form posts · multipart · bounded traverse, then the
+  hardening pass (multipart cap unbypassable · cross-origin redirects
+  re-pin · userinfo redacted · robots.txt bounded).
+- The LSP honors `$/cancelRequest` — a request the editor discarded
+  (superseded completion · rapid typing) dies before its analysis runs.
+- `NIKA_<ID>_BASE_URL` reaches the CLOUDS — the locked long-tail hatch
+  (D-2026-06-10-N2) gets its operator surface: point any cloud profile
+  at an OpenAI-compatible endpoint (an EU host · a corporate gateway)
+  with zero catalog change, paired with the scoped `NIKA_<ID>_API_KEY`.
+- exec feeds stdin concurrently (a large input can no longer deadlock)
+  · the runtime honors the documented key ladder (`NIKA_` prefix wins)
+  · `nika init`'s AGENTS.md teaches the live clap tree · `nika welcome`
+  + `nika explain <file>` — the 30-seconds narrative layer.
+
+**Nika never lies about costs** (the cost arc, continued from 0.97):
+the pricing catalog identifies itself, the math prices what providers
+actually billed, agents stop hiding their LLM spend, `unknown` always
+says WHY, and the operator gets a real budget lever.
+
 ## [0.97.0](https://github.com/supernovae-st/nika/compare/v0.96.0..v0.97.0) - 2026-07-07
 
 **The run becomes evidence.** 0.96 made the run a place you can visit;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,7 +3521,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "clap",
  "futures",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cli"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "annotate-snippets 0.12.15",
  "anstyle",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "expect-test",
  "insta",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "insta",
  "miette",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-kernel",
  "nix 0.30.1",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "globset",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "nika-http"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "insta",
  "miette",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-builtin",
  "nika-catalog",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "include_dir",
  "sha2",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4028,14 +4028,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4076,14 +4076,14 @@ dependencies = [
 
 [[package]]
 name = "nika-tmpl"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "nika-types"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "loom",
  "proptest",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.97.0"
+version      = "0.98.0"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,9 +86,9 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `feat/nika-tmpl`                                      |
-| HEAD             | `c6f4f0b54` (`c6f4f0b54f084022389c7b8f04f7d644ed0cd77d`)             |
-| workspace        | v0.97.0                                  |
+| branch           | `chore/release-0.98.0`                                      |
+| HEAD             | `25db7137d` (`25db7137dddbe6fdb7782663d1a07096cafb3bad`)             |
+| workspace        | v0.98.0                                  |
 | crates (workspace)| 41                                              |
 | crates (admitted)| 41 / 42                                   |
 | crates (WIP)     | 0 —                                   |
@@ -99,7 +99,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | L2               | 4                                              |
 | L3               | 1                                              |
 | L4               | 4                                              |
-| lib tests        | 3516 passed, 0 failed                              |
+| lib tests        | 3545 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 
 | field            | value                                          |

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.97.0", optional = true }
-nika-error     = { path = "../nika-error", version = "0.97.0", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.97.0", optional = true }
+nika-types     = { path = "../nika-types", version = "0.98.0", optional = true }
+nika-error     = { path = "../nika-error", version = "0.98.0", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.98.0", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.97.0" }
+nika-types  = { path = "../nika-types", version = "0.98.0" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.97.0" }  # nika:fetch — the extract modes + page digest (L1.5→L1.5 same-layer)
-nika-types   = { path = "../nika-types", version = "0.97.0" }    # fetch traverse bound — ONE definition with the static checker
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.98.0" }  # nika:fetch — the extract modes + page digest (L1.5→L1.5 same-layer)
+nika-types   = { path = "../nika-types", version = "0.98.0" }    # fetch traverse bound — ONE definition with the static checker
 url           = { workspace = true }   # traverse — same-origin math + normalization (the WHATWG parse the transport uses)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
@@ -42,15 +42,15 @@ tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval o
 # required) — the SAME vocabulary the in-test drift guards pin to the
 # ToolDef schemas (one source, no drift). Minimal features: the builtin
 # catalog only, no provider/pricing data. L1.5→L0 downward (layering-clean).
-nika-catalog  = { path = "../nika-catalog", version = "0.97.0", default-features = false, features = ["builtins-transforms"] }
+nika-catalog  = { path = "../nika-catalog", version = "0.98.0", default-features = false, features = ["builtins-transforms"] }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.98.0" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.97.0" }
+nika-fs          = { path = "../nika-fs", version = "0.98.0" }
 # test-only: an INDEPENDENT PNG decoder proving the mock image provider's
 # hand-rolled stored-deflate encoder emits spec-valid files (not just bytes
 # our own sniffer accepts).

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.97.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.98.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde_json = { workspace = true }   # builtin arg-shape rules — pure data over Value (extracted 2026-07-07)
 serde      = { workspace = true }
 

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.97.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.98.0" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.97.0" }
+nika-error = { path = "../nika-error", version = "0.98.0" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.97.0" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.98.0" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.97.0" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.97.0" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.97.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.97.0" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.97.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
-nika-bm25   = { path = "../nika-bm25", version = "0.97.0" }   # intent→template routing (`nika new` · the deterministic floor)
+nika-event  = { path = "../nika-event", version = "0.98.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.98.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.98.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.98.0" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.98.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-bm25   = { path = "../nika-bm25", version = "0.98.0" }   # intent→template routing (`nika new` · the deterministic floor)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 sha2          = { workspace = true }   # run identity — workflow_sha256 on workflow_started
@@ -30,21 +30,21 @@ anstyle     = { workspace = true }                             # Role→Style ma
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.97.0" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.97.0" }       # the L3 executor (the composer drives it)
-nika-providers   = { path = "../nika-providers", version = "0.97.0" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.97.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.97.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.97.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.97.0" }
-nika-builtin     = { path = "../nika-builtin", version = "0.97.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.97.0" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.97.0" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.97.0" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.97.0" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.97.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
-nika-lsp         = { path = "../nika-lsp", version = "0.97.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-mcp         = { path = "../nika-mcp", version = "0.97.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-kernel      = { path = "../nika-kernel", version = "0.98.0" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.98.0" }       # the L3 executor (the composer drives it)
+nika-providers   = { path = "../nika-providers", version = "0.98.0" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.98.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.98.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.98.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.98.0" }
+nika-builtin     = { path = "../nika-builtin", version = "0.98.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.98.0" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.98.0" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.98.0" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.98.0" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.98.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
+nika-lsp         = { path = "../nika-lsp", version = "0.98.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-mcp         = { path = "../nika-mcp", version = "0.98.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [[bin]]
@@ -55,7 +55,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.98.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 expectrl = { workspace = true }   # PTY e2e · the wizard conversation is TTY-gated — unreachable

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.97.0" }
+nika-types = { path = "../nika-types", version = "0.98.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.97.0" }
-nika-error = { path = "../nika-error", version = "0.97.0" }
+nika-types = { path = "../nika-types", version = "0.98.0" }
+nika-error = { path = "../nika-error", version = "0.98.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.97.0" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.98.0" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.97.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.98.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.97.0" }
-nika-types   = { path = "../nika-types", version = "0.97.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.98.0" }
+nika-types   = { path = "../nika-types", version = "0.98.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.97.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.97.0" }
+nika-error       = { path = "../nika-error", version = "0.98.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.98.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.97.0" }
+nika-error    = { path = "../nika-error", version = "0.98.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.97.0" }
-nika-error    = { path = "../nika-error", version = "0.97.0" }
+nika-kernel   = { path = "../nika-kernel", version = "0.98.0" }
+nika-error    = { path = "../nika-error", version = "0.98.0" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.97.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.97.0" }
+nika-error       = { path = "../nika-error", version = "0.98.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.98.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.97.0" }
+nika-error    = { path = "../nika-error", version = "0.98.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.97.0" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.97.0" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.97.0" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.97.0" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.97.0" }
+nika-error          = { path = "../nika-error", version = "0.98.0" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.98.0" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.98.0" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.98.0" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.98.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.97.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-schema = { path = "../nika-schema", version = "0.98.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.97.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-error  = { path = "../nika-error", version = "0.97.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.97.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.98.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-error  = { path = "../nika-error", version = "0.98.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.98.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 # The embedded knowledge payloads (`nika_catalog` · `nika_tools`) — the SAME
 # versioned projections `nika catalog|tools --json` emit (one builder per
 # owning crate · zero duplication). L4→L0 / L4→L1.5, strictly downward.
-nika-catalog = { path = "../nika-catalog", version = "0.97.0", default-features = false, features = ["serde", "capabilities"] }
-nika-builtin = { path = "../nika-builtin", version = "0.97.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.98.0", default-features = false, features = ["serde", "capabilities"] }
+nika-builtin = { path = "../nika-builtin", version = "0.98.0" }
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.97.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.97.0", features = ["providers"] }
+nika-kernel  = { path = "../nika-kernel", version = "0.98.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.98.0", features = ["providers"] }
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,18 +11,18 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.97.0" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.97.0" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.97.0" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.97.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-tmpl        = { path = "../nika-tmpl", version = "0.97.0" }         # the ONE ${{ }} island lexer · shared with the checker (check⇄run parity)
-nika-catalog     = { path = "../nika-catalog", version = "0.97.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
-nika-cel         = { path = "../nika-cel", version = "0.97.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.97.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.97.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.97.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.97.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.97.0" }
+nika-types       = { path = "../nika-types", version = "0.98.0" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.98.0" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.98.0" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.98.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-tmpl        = { path = "../nika-tmpl", version = "0.98.0" }         # the ONE ${{ }} island lexer · shared with the checker (check⇄run parity)
+nika-catalog     = { path = "../nika-catalog", version = "0.98.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
+nika-cel         = { path = "../nika-cel", version = "0.98.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.98.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.98.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.98.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.98.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.98.0" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -35,9 +35,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.97.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.97.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.98.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.98.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.98.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -20,11 +20,11 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # reuse without pulling the parser; inlining them back to stay at 3 would defeat the
 # extractions + re-introduce the check⇄run scanner drift. High fan-in is intentional
 # for the schema assembler hub (ADR-027 · marker-based exemption).
-nika-error   = { path = "../nika-error", version = "0.97.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.97.0" }
-nika-types   = { path = "../nika-types", version = "0.97.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.97.0" }   # the permits vocab lives here now (extracted 2026-07-03)
-nika-tmpl    = { path = "../nika-tmpl", version = "0.97.0" }   # the ONE ${{ }} island lexer · shared with nika-runtime (check⇄run parity)
+nika-error   = { path = "../nika-error", version = "0.98.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.98.0" }
+nika-types   = { path = "../nika-types", version = "0.98.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.98.0" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-tmpl    = { path = "../nika-tmpl", version = "0.98.0" }   # the ONE ${{ }} island lexer · shared with nika-runtime (check⇄run parity)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -47,10 +47,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.97.0" }
+nika-event = { path = "../nika-event", version = "0.98.0" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.97.0" }
+nika-pack  = { path = "../nika-pack", version = "0.98.0" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-types      = { path = "../nika-types", version = "0.97.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
-nika-kernel      = { path = "../nika-kernel", version = "0.97.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.97.0" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.97.0" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.97.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.97.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-types      = { path = "../nika-types", version = "0.98.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
+nika-kernel      = { path = "../nika-kernel", version = "0.98.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.98.0" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.98.0" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.98.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.98.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -25,7 +25,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.98.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.97.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-error  = { path = "../nika-error", version = "0.98.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.97.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.98.0" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,10 +13,10 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-types      = { path = "../nika-types", version = "0.97.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
-nika-error     = { path = "../nika-error", version = "0.97.0" }
-nika-kernel    = { path = "../nika-kernel", version = "0.97.0" }
-nika-providers = { path = "../nika-providers", version = "0.97.0" }
+nika-types      = { path = "../nika-types", version = "0.98.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
+nika-error     = { path = "../nika-error", version = "0.98.0" }
+nika-kernel    = { path = "../nika-kernel", version = "0.98.0" }
+nika-providers = { path = "../nika-providers", version = "0.98.0" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.97.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.97.0" }
+nika-error  = { path = "../nika-error", version = "0.98.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.98.0" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "nika-types",
  "serde",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "miette",
  "nika-catalog-codegen",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "miette",
  "nika-types",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "nika-schema"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "jaq-core",
  "jaq-json",
@@ -905,11 +905,11 @@ dependencies = [
 
 [[package]]
 name = "nika-tmpl"
-version = "0.97.0"
+version = "0.98.0"
 
 [[package]]
 name = "nika-types"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "loom",
  "serde",


### PR DESCRIPTION
0.97 made the run evidence; **0.98 makes the answer native and the audit airtight** — and admits the crate that makes check⇄run parity structural.

## The four arcs (full narrative in CHANGELOG [Unreleased] → becomes [0.98.0])

- **Native answer**: anthropic `output_config.format` (#264) · gemini `responseJsonSchema` (#269) · openai strict strip/flatten (#267) + gpt-5/o-series budget key, one-logical-key extras guard (#294) · capability is a PROVIDER fact (#283) · coercion ladder before any paid retry (#280) · retry-loop economics (#268) · doctor names instruction-fallback clouds (#287)
- **Audit-before-run**: the compact block-sequence bomb is dead (CRITICAL #282, LSP serves it e2e #296) · max_turns (#279) + for_each-typed (#284) at check · `env:` binds at run (#293) · exec-json-capture (#295) / native-first (#258) / schema-portability (#262) hints · dirty MCP check is isError:true (#270)
- **nika-tmpl, the 41st crate** (#302): the ONE `${{ }}` island lexer both the checker and the runtime consume — Gate 5 90.2% (5 survivors certified in-spec), parity pre-proven ~337k inputs
- **Cost (continued)**: provenance + cache-aware math + agent split + budget guard (#271) · billed-then-failed spend visible (#288) · no_std powerset repair (#297)

Plus: the wizard hardening train (#275/#276/#266 + PTY e2e #285/#289) · fetch vNext + hardening (#259/#272) · `$/cancelRequest` (#303) · the clouds `NIKA_<ID>_BASE_URL` hatch (#304) · exec stdin concurrency (#291) · key ladder (#286) · welcome/explain (#298) · live structured-output battery (#299).

## Mechanics
113 pins / 35 Cargo.toml → 0.98.0 · locks regenerated · status block ×2 (vector 23 green) · CHANGELOG narrative pre-spliced (the post-tag cliff bot PR gets FUSED into it, not duplicated) · 3545 lib tests · clippy 0 · full pre-push suite green on the bumped tree.

Tag `v0.98.0` rides after merge (release.yml → 4 platforms → tap bump · then nika-vscode 0.98.0 lockstep).
