### PR TITLE
feat(nika-event): task_recovered — the repair becomes readable in the kind stream

### DIFF
--- a/crates/nika-event/public-api.txt
+++ b/crates/nika-event/public-api.txt
@@ -233,6 +233,7 @@ pub nika_event::kind::EventKind::TaskCacheHit
 pub nika_event::kind::EventKind::TaskCancelled
 pub nika_event::kind::EventKind::TaskCompleted
 pub nika_event::kind::EventKind::TaskFailed
+pub nika_event::kind::EventKind::TaskRecovered
 pub nika_event::kind::EventKind::TaskRetrying
 pub nika_event::kind::EventKind::TaskScheduled
 pub nika_event::kind::EventKind::TaskSkipped
@@ -398,6 +399,7 @@ pub nika_event::prelude::EventKind::TaskCacheHit
 pub nika_event::prelude::EventKind::TaskCancelled
 pub nika_event::prelude::EventKind::TaskCompleted
 pub nika_event::prelude::EventKind::TaskFailed
+pub nika_event::prelude::EventKind::TaskRecovered
 pub nika_event::prelude::EventKind::TaskRetrying
 pub nika_event::prelude::EventKind::TaskScheduled
 pub nika_event::prelude::EventKind::TaskSkipped
@@ -686,6 +688,7 @@ pub nika_event::EventKind::TaskCacheHit
 pub nika_event::EventKind::TaskCancelled
 pub nika_event::EventKind::TaskCompleted
 pub nika_event::EventKind::TaskFailed
+pub nika_event::EventKind::TaskRecovered
 pub nika_event::EventKind::TaskRetrying
 pub nika_event::EventKind::TaskScheduled
 pub nika_event::EventKind::TaskSkipped

--- a/crates/nika-event/src/kind.rs
+++ b/crates/nika-event/src/kind.rs
@@ -55,6 +55,16 @@ pub enum EventKind {
     /// A task attempt failed and a retry is scheduled (`attempt` /
     /// `max_attempts` fields carry the counter — contract §3.1 `↻`).
     TaskRetrying,
+    /// A task's `on_error.recover` repaired a failure into a success —
+    /// emitted BETWEEN the (absorbed) failure and the terminal
+    /// [`EventKind::TaskCompleted`], which stays the ONE success
+    /// terminal (D-2026-07-08-N4: `… > task_recovered > task_completed`
+    /// · additive · completed-only consumers unaffected). The `code`
+    /// field carries what was recovered FROM; without this kind a
+    /// repaired success is byte-identical to a clean one in the kind
+    /// stream (empirically pinned by the corpus events-asserts,
+    /// 2026-07-08 · engine#301).
+    TaskRecovered,
     /// A task was cancelled (an upstream failure made the default gate
     /// unsatisfiable · operator stop · budget kill — contract §3.1 `◼`;
     /// distinct from [`EventKind::TaskFailed`]: cancellation is a
@@ -141,6 +151,7 @@ impl EventKind {
             Self::ToolInvoked => "tool_invoked",
             Self::CheckpointWritten => "checkpoint_written",
             Self::TaskRetrying => "task_retrying",
+            Self::TaskRecovered => "task_recovered",
             Self::TaskCancelled => "task_cancelled",
             Self::WorkflowCancelled => "workflow_cancelled",
             Self::CostIncurred => "cost_incurred",
@@ -216,6 +227,7 @@ impl EventKind {
             | Self::TaskFailed
             | Self::TaskSkipped
             | Self::TaskRetrying
+            | Self::TaskRecovered
             | Self::TaskCancelled
             | Self::TaskCacheHit => EventClass::Task,
             Self::VerbInvoked | Self::ToolInvoked => EventClass::Dispatch,
@@ -288,6 +300,7 @@ mod tests {
         EventKind::ToolInvoked,
         EventKind::CheckpointWritten,
         EventKind::TaskRetrying,
+        EventKind::TaskRecovered,
         EventKind::TaskCancelled,
         EventKind::WorkflowCancelled,
         EventKind::CostIncurred,
@@ -321,6 +334,7 @@ mod tests {
                 | EventKind::ToolInvoked
                 | EventKind::CheckpointWritten
                 | EventKind::TaskRetrying
+                | EventKind::TaskRecovered
                 | EventKind::TaskCancelled
                 | EventKind::WorkflowCancelled
                 | EventKind::CostIncurred
@@ -335,7 +349,7 @@ mod tests {
                 | EventKind::WorkflowPaused => {}
             }
         }
-        assert_eq!(ALL.len(), 24, "extend ALL when a variant is added");
+        assert_eq!(ALL.len(), 25, "extend ALL when a variant is added");
     }
 
     /// FCI-003: the canonical wire slug has TWO independent encoders — the

--- a/crates/nika-runtime/src/emit_task.rs
+++ b/crates/nika-runtime/src/emit_task.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Task terminal-frame emission — `task_completed` (+ its `task_recovered`
+//! prefix frame) extracted from the settle path (lib.rs sat at the
+//! 1500-line file cap; this trio is the cohesive cut).
+
+use serde_json::Value;
+
+use crate::{EventKind, EventSink, FieldValue, Stamper, emit, i, resume, s};
+
+/// `task_recovered` — the ONE emission site (INV#24 · engine#301 · the
+/// D-2026-07-08-N4 sequence lock): INSERTS before the terminal, so
+/// `task_completed` stays the one success terminal and audit surfaces read
+/// the repair from the kind stream. `code` = what was recovered FROM.
+pub(crate) fn emit_recovered(
+    id: &str,
+    code: &str,
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) {
+    emit(
+        stamper,
+        sink,
+        EventKind::TaskRecovered,
+        &[("task", s(id)), ("code", s(code))],
+    );
+}
+
+/// Emit one `task_completed` frame — the base fields (`note` ·
+/// `duration_ms`) + spend (`tokens`) + the OBS-E `warning` diagnostic
+/// when present + the ADR-099 checkpoint trio (`def_hash` · `input_hash`
+/// · `output` as ONE compact JSON text) when the task carries a resume
+/// stamp. Returns the terminal timestamp.
+// The payload knobs mirror the frame's field surface — a builder
+// struct would just restate them.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn emit_completed(
+    id: &str,
+    note: &str,
+    duration: i64,
+    tokens: Option<i64>,
+    cost_usd: Option<f64>,
+    cost_unpriced: Option<nika_types::cost::UnpricedReason>,
+    warning: Option<&str>,
+    resume: Option<&resume::ResumeStamp>,
+    value: &Value,
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) -> nika_types::timestamp::Timestamp {
+    let mut fields = vec![
+        ("task", s(id)),
+        ("note", s(note)),
+        ("duration_ms", i(duration)),
+    ];
+    if let Some(n) = tokens {
+        fields.push(("tokens", i(n)));
+    }
+    // Real spend rides next to the tokens it prices · absent = unpriced
+    // (mock · local) — the render layer already treats absent as honest.
+    if let Some(c) = cost_usd {
+        fields.push(("cost_usd", FieldValue::Float(c)));
+    }
+    // …and WHY it is absent (or partial), when it is — `unknown` is
+    // never masked: `local_model` · `mock_provider` ·
+    // `missing_catalog_price` · `provider_did_not_report_usage`.
+    if let Some(reason) = cost_unpriced {
+        fields.push(("cost_unpriced", s(reason.as_str())));
+    }
+    // OBS-E · a non-fatal diagnostic rides the success frame as a
+    // `warning` field (the reasoning-model blank-answer footgun) · the
+    // task still completes.
+    if let Some(msg) = warning {
+        fields.push(("warning", s(msg)));
+    }
+    // ADR-099 · the checkpoint fields — only a stamped success carries
+    // them (additive trace fields).
+    let output_text =
+        resume.map(|_| serde_json::to_string(value).unwrap_or_else(|_| "null".to_owned()));
+    if let (Some(stamp), Some(text)) = (resume, output_text.as_deref()) {
+        fields.push((resume::fields::DEF_HASH, s(&stamp.def_hash)));
+        fields.push((resume::fields::INPUT_HASH, s(&stamp.input_hash)));
+        fields.push((resume::fields::OUTPUT, s(text)));
+    }
+    emit(stamper, sink, EventKind::TaskCompleted, &fields)
+}

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -41,6 +41,7 @@
 
 mod agent_events;
 mod dispatch;
+mod emit_task;
 mod errors;
 mod expr;
 mod jq;
@@ -364,7 +365,7 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
 }
 
 /// Emit one stamped event with the given fields.
-fn emit(
+pub(crate) fn emit(
     stamper: &mut dyn Stamper,
     sink: &mut dyn EventSink,
     kind: EventKind,
@@ -379,11 +380,11 @@ fn emit(
     ts
 }
 
-fn s(v: &str) -> FieldValue {
+pub(crate) fn s(v: &str) -> FieldValue {
     FieldValue::String(v.to_owned())
 }
 
-fn i(v: i64) -> FieldValue {
+pub(crate) fn i(v: i64) -> FieldValue {
     FieldValue::Int(v)
 }
 
@@ -846,11 +847,15 @@ fn settle_ran(
         task::RunResult::Success {
             value,
             tokens,
+            recovered_from,
             warning,
             cost_usd,
             cost_unpriced,
         } => {
-            let ended = emit_completed(
+            if let Some(code) = recovered_from.as_deref() {
+                emit_task::emit_recovered(id, code, stamper, sink);
+            }
+            let ended = emit_task::emit_completed(
                 id,
                 &run.note,
                 duration,
@@ -940,64 +945,6 @@ fn push_spend_fields(
     if let Some(reason) = cost_unpriced {
         fields.push(("cost_unpriced", s(reason.as_str())));
     }
-}
-
-/// Emit one `task_completed` frame — the base fields (`note` ·
-/// `duration_ms`) + spend (`tokens`) + the OBS-E `warning` diagnostic
-/// when present + the ADR-099 checkpoint trio (`def_hash` · `input_hash`
-/// · `output` as ONE compact JSON text) when the task carries a resume
-/// stamp. Returns the terminal timestamp.
-// The payload knobs mirror the frame's field surface — a builder
-// struct would just restate them.
-#[allow(clippy::too_many_arguments)]
-fn emit_completed(
-    id: &str,
-    note: &str,
-    duration: i64,
-    tokens: Option<i64>,
-    cost_usd: Option<f64>,
-    cost_unpriced: Option<nika_types::cost::UnpricedReason>,
-    warning: Option<&str>,
-    resume: Option<&resume::ResumeStamp>,
-    value: &Value,
-    stamper: &mut dyn Stamper,
-    sink: &mut dyn EventSink,
-) -> nika_types::timestamp::Timestamp {
-    let mut fields = vec![
-        ("task", s(id)),
-        ("note", s(note)),
-        ("duration_ms", i(duration)),
-    ];
-    if let Some(n) = tokens {
-        fields.push(("tokens", i(n)));
-    }
-    // Real spend rides next to the tokens it prices · absent = unpriced
-    // (mock · local) — the render layer already treats absent as honest.
-    if let Some(c) = cost_usd {
-        fields.push(("cost_usd", FieldValue::Float(c)));
-    }
-    // …and WHY it is absent (or partial), when it is — `unknown` is
-    // never masked: `local_model` · `mock_provider` ·
-    // `missing_catalog_price` · `provider_did_not_report_usage`.
-    if let Some(reason) = cost_unpriced {
-        fields.push(("cost_unpriced", s(reason.as_str())));
-    }
-    // OBS-E · a non-fatal diagnostic rides the success frame as a
-    // `warning` field (the reasoning-model blank-answer footgun) · the
-    // task still completes.
-    if let Some(msg) = warning {
-        fields.push(("warning", s(msg)));
-    }
-    // ADR-099 · the checkpoint fields — only a stamped success carries
-    // them (additive trace fields).
-    let output_text =
-        resume.map(|_| serde_json::to_string(value).unwrap_or_else(|_| "null".to_owned()));
-    if let (Some(stamp), Some(text)) = (resume, output_text.as_deref()) {
-        fields.push((resume::fields::DEF_HASH, s(&stamp.def_hash)));
-        fields.push((resume::fields::INPUT_HASH, s(&stamp.input_hash)));
-        fields.push((resume::fields::OUTPUT, s(text)));
-    }
-    emit(stamper, sink, EventKind::TaskCompleted, &fields)
 }
 
 /// Resolve workflow `outputs:` from the final records · an output whose
@@ -1317,6 +1264,52 @@ outputs:
         assert!(value_matches_vartype(&json!(true), VarType::Boolean));
     }
 
+    /// A recovered success emits `task_recovered` BEFORE the terminal
+    /// `task_completed` (engine#301 · D-2026-07-08-N4 sequence lock:
+    /// `… > task_recovered > task_completed`) — and carries WHAT it
+    /// recovered from as a `code` field. A clean success emits no such
+    /// frame (pinned by every other Success test in this file).
+    #[test]
+    fn recovered_success_emits_task_recovered_before_completed() {
+        let ran = task::RanTask {
+            note: "exec · sh".to_owned(),
+            retries: Vec::new(),
+            agent_events: Vec::new(),
+            duration_ms: 0,
+            result: task::RunResult::Success {
+                value: Value::Number(99.into()),
+                tokens: None,
+                recovered_from: Some("NIKA-EXEC-001".to_owned()),
+                warning: None,
+                cost_usd: None,
+                cost_unpriced: None,
+            },
+        };
+        let mut ok = true;
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        settle_ran("risky", ran, None, &mut ok, &mut stamper, &mut sink);
+
+        let kinds: Vec<EventKind> = sink.events().iter().map(|e| e.kind).collect();
+        let rec = kinds
+            .iter()
+            .position(|k| *k == EventKind::TaskRecovered)
+            .expect("a TaskRecovered frame");
+        let done = kinds
+            .iter()
+            .position(|k| *k == EventKind::TaskCompleted)
+            .expect("a TaskCompleted frame — completed STAYS the one success terminal");
+        assert!(rec < done, "task_recovered inserts BEFORE the terminal");
+
+        let frame = &sink.events()[rec];
+        assert!(
+            frame.fields.iter().any(|f| f.key == "code"
+                && matches!(&f.value, FieldValue::String(s) if s == "NIKA-EXEC-001")),
+            "the frame names what was recovered FROM"
+        );
+        assert!(ok, "a recovered task is a SUCCESS at workflow level");
+    }
+
     /// A settled success carrying an OBS-E `warning` puts it on the
     /// `TaskCompleted` frame as a `warning` field — the wiring proof that
     /// the dispatch's diagnostic actually reaches the event stream.
@@ -1330,6 +1323,7 @@ outputs:
             result: task::RunResult::Success {
                 value: Value::String(String::new()),
                 tokens: Some(84),
+                recovered_from: None,
                 warning: Some("infer produced an empty answer · …".to_owned()),
                 cost_usd: Some(0.0125),
                 cost_unpriced: None,
@@ -1379,6 +1373,7 @@ outputs:
             result: task::RunResult::Success {
                 value: Value::String("ok".to_owned()),
                 tokens: None,
+                recovered_from: None,
                 warning: None,
                 cost_usd: None,
                 cost_unpriced: None,
@@ -1421,6 +1416,7 @@ outputs:
             result: task::RunResult::Success {
                 value: Value::String("bonjour".to_owned()),
                 tokens: Some(12),
+                recovered_from: None,
                 warning: None,
                 cost_usd: None,
                 cost_unpriced: Some(nika_types::cost::UnpricedReason::LocalModel),

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -158,6 +158,10 @@ pub(crate) enum RunResult {
     Success {
         value: Value,
         tokens: Option<i64>,
+        /// `Some(code)` when `on_error.recover` repaired this success —
+        /// the settle path emits `task_recovered` (one site · INV#24)
+        /// before the terminal `task_completed`.
+        recovered_from: Option<String>,
         warning: Option<String>,
         /// Real spend (catalog × usage split + tool-reported) · None =
         /// unpriced · honest. (The by-source attribution key lives on
@@ -1187,6 +1191,7 @@ fn dispatch_result(
         }) => RunResult::Success {
             value,
             tokens,
+            recovered_from: None,
             warning,
             cost_usd,
             cost_unpriced,
@@ -1210,6 +1215,7 @@ fn fan_out_result(
         None => RunResult::Success {
             value: Value::Array(outputs),
             tokens: tokens_sum,
+            recovered_from: None,
             warning: None,
             cost_usd,
             cost_unpriced,
@@ -1263,6 +1269,8 @@ fn apply_on_error(task: &RawTask, scope: &Scope<'_>, failed: FailedOutcome) -> R
             Ok(recovered) => RunResult::Success {
                 value: recovered,
                 tokens: None,
+                // the ONE producer of the marker (spec 05 §recover)
+                recovered_from: Some(error.code),
                 // A recovered value is author-supplied · no model reasoning
                 // — but the FAILED attempts' spend already happened and
                 // stays on the frame (recovery does not refund it).


### PR DESCRIPTION
Closes #301 · sequence **locked by the operator** (D-2026-07-08-N4 item 4, rc.1-scoped by D-N7 item 4):

```
task_scheduled > task_started > task_retrying ×N > task_recovered > task_completed
```

- `task_completed` STAYS the one success terminal — completed-only consumers untouched (strictly additive; `EventKind` is `#[non_exhaustive]`).
- The `task_recovered` frame carries `code` = what was recovered FROM (before this, a repaired success was byte-identical to a clean one in the kind stream — audit surfaces had to parse attributes).
- **One emission site** (INV#24), driven by an internal `RunResult::Success.recovered_from` marker whose one producer is `apply_on_error`'s Recover arm.
- The in-crate forward-compat guards fired exactly as designed (exhaustive-ALL match + length pin) — proof the ratchet works.

**E2E on the rebuilt binary** (corpus `errors/e14-on-error-recover-literal`): `fail_step · task_scheduled>task_started>task_recovered>task_completed` · `code=NIKA-EXEC-001` · clean tasks emit nothing new. Runtime 105/105 (incl. the new sequence test) · workspace clippy 0 · nika-event public-api regenerated.

Note: the lab corpus Events pilot still pins the OLD sequence against released 0.98.0 — it will report EVENTS-DRIFT when the release carrying this lands (the sensor doing its job); re-stamp then.