### PR TITLE
fix(nika-cli): doctor sees zed — the wire target it could not diagnose

### DIFF
--- a/crates/nika-cli/src/verbs/probe.rs
+++ b/crates/nika-cli/src/verbs/probe.rs
@@ -336,6 +336,16 @@ fn client_probes() -> Vec<ClientProbe> {
             &home.join(".claude.json"),
             &["mcpServers", "nika"],
         ));
+        // Zed: ~/.config on EVERY platform (upstream choice) · the MCP
+        // entry lives under `context_servers` (zed.dev/docs/ai/mcp). The
+        // JSON probe is best-effort on Zed's JSONC settings: a commented
+        // file parses as not-wired → the fix line says `nika wire zed`,
+        // which itself degrades to the ✋ manual snippet. Honest chain.
+        probes.push(client_probe(
+            "zed",
+            &home.join(".config").join("zed").join("settings.json"),
+            &["context_servers", "nika"],
+        ));
     } else {
         probes.push(client_probe(
             "cursor",


### PR DESCRIPTION
Fresh-user discovery probe on released 0.98.0: `nika doctor` lists wired agent clients (cursor/windsurf/claude/vscode) but **zed** — shipped in `nika wire` today (#310) — was invisible: doctor could neither confirm a wired zed nor prescribe `nika wire zed`.

One probe row (`~/.config/zed/settings.json` · `context_servers.nika`), same shape as every sibling. Best-effort on Zed's JSONC: a commented settings file reads as *not-wired* → the fix line prescribes `nika wire zed`, which itself degrades to the ✋ manual snippet — honest chain end-to-end.

E2E on the rebuilt binary: fake HOME with a wired zed settings → doctor prints `✔ agent zed wired at …`. Tests 7/7 · clippy 0 · fmt clean.

**Sibling gap flagged, not taken**: codex (`~/.codex/config.toml`) is also doctor-invisible — but it needs a TOML probe (the helper is JSON-only), its own small change.