### PR TITLE
feat(nika-cli): doctor + explain speak the display seam

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -103,6 +103,8 @@ Every surviving `exec:` gets a row in the workflow's header comment:
   `depends_on: [<id>]`.
 - Models are `provider/name` (`ollama/llama3.2:3b` local-first ·
   `mock/echo` offline preview).
+- Timeouts are quoted Go-durations (`timeout: "7m"`) — give local
+  providers ≥300s: thinking models routinely think past 30s.
 - Declare the blast radius: `nika check --infer-permits <file>` prints
   the tightest `permits:` block — paste it in (default-deny from then on).
 - Structured output: give `infer:` a `schema:`; add

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -472,7 +472,7 @@ pub fn nika_cli::verbs::check::run_infer_permits(path: &str, json: bool) -> nika
 pub mod nika_cli::verbs::dap
 pub fn nika_cli::verbs::dap::run_stdio() -> u8
 pub mod nika_cli::verbs::doctor
-pub fn nika_cli::verbs::doctor::run(ping: bool, json: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::doctor::run(ping: bool, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::exit
 pub const nika_cli::verbs::exit::ENV: u8
 pub const nika_cli::verbs::exit::FILE: u8
@@ -480,9 +480,9 @@ pub const nika_cli::verbs::exit::OK: u8
 pub const nika_cli::verbs::exit::PAUSED: u8
 pub const nika_cli::verbs::exit::WORKFLOW: u8
 pub mod nika_cli::verbs::explain
-pub fn nika_cli::verbs::explain::run(wire: &str) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::explain::run(wire: &str, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::explain_file
-pub fn nika_cli::verbs::explain_file::dispatch(query: &str, json: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::explain_file::dispatch(query: &str, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::explain_file::run(path: &str, json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::graph
 pub enum nika_cli::verbs::graph::GraphFormat

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use nika_cli::display::format::{ColorChoice, ColorEnv, LinkChoice, color_enabled, links_enabled};
+use nika_cli::verbs::explain_file::dispatch as explain_dispatch;
 use nika_cli::verbs::{self, VerbOutput};
 use nika_cli::{RunView, Theme, frame};
 use nika_event::Event;
@@ -677,8 +678,8 @@ fn main() -> std::process::ExitCode {
             };
             emit(&verbs::welcome::run(json, theme))
         }
-        Command::Explain { code, json } => emit(&verbs::explain_file::dispatch(&code, json)),
-        Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json)),
+        Command::Explain { code, json } => emit(&explain_dispatch(&code, json, plain_theme)),
+        Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json, plain_theme)),
         Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target.into(), &dir)),
         Command::Spec { canon } => emit(&verbs::pack_surface::spec(canon)),

--- a/crates/nika-cli/src/verbs/doctor.rs
+++ b/crates/nika-cli/src/verbs/doctor.rs
@@ -24,6 +24,7 @@ use std::fmt::Write as _;
 // The probe layer (structs + collectors) lives in `verbs::probe` — the ONE
 // detection engine `doctor` and `welcome` share. Re-exported `pub(crate)` so
 // this module's tests (and historical importers) keep their names.
+use crate::display::theme::{Role, Theme};
 pub(crate) use crate::verbs::probe::{
     ClientProbe, ImageProbe, PingState, PricingProbe, Probe, ProviderProbe, TtsProbe,
 };
@@ -42,6 +43,17 @@ pub(crate) enum Level {
 }
 
 impl Level {
+    /// The semantic colour role — the SAME closed vocabulary the run
+    /// storyboard speaks (`Role` · theme.rs): green ok · yellow advisory ·
+    /// red hard-fail. Never decorative.
+    const fn role(self) -> Role {
+        match self {
+            Self::Ok => Role::Good,
+            Self::Warn => Role::Warn,
+            Self::Fail => Role::Bad,
+        }
+    }
+
     fn glyph(self) -> char {
         match self {
             Self::Ok => '✔',
@@ -350,19 +362,65 @@ pub(crate) fn render_json(findings: &[Finding]) -> String {
     format!("{payload:#}")
 }
 
-pub(crate) fn render(findings: &[Finding]) -> String {
+/// The fixed label column (nextest school: one grid, computed on RAW text).
+/// Every label `diagnose` can emit fits STRICTLY inside it (pinned by
+/// `every_label_fits_the_fixed_column`) so the detail column never shears.
+const LABEL_COL: usize = 10;
+
+/// Render the findings through the ONE colour seam (`Theme` · semantic
+/// never decorative — the same law welcome/run obey). Doctor rows carry NO
+/// durations, so the nextest discipline reduces to the status/label
+/// columns — a fixed 1-cell status glyph + the fixed [`LABEL_COL`] label
+/// cell, both laid out on RAW text and painted AFTER (ANSI escapes never
+/// enter width arithmetic — the same law as `Theme::glyph`). The sober
+/// register (colour off · links off · every pipe) is byte-identical to the
+/// themeless render it replaces.
+pub(crate) fn render(findings: &[Finding], theme: Theme) -> String {
     let mut s = String::new();
     let count = |level: Level| findings.iter().filter(|f| f.level == level).count();
     let (ok, warn, fail) = (count(Level::Ok), count(Level::Warn), count(Level::Fail));
     let verdict = if fail > 0 { Level::Fail } else { Level::Ok };
-    let _ = writeln!(s, "{} {ok} ok · {warn} warn · {fail} fail", verdict.glyph());
+    let glyph = |level: Level| theme.paint(level.role(), &level.glyph().to_string());
+    let _ = writeln!(s, "{} {ok} ok · {warn} warn · {fail} fail", glyph(verdict));
     for f in findings {
-        let _ = writeln!(s, "{} {:<10} {}", f.level.glyph(), f.label, f.detail);
+        let _ = writeln!(
+            s,
+            "{} {:<LABEL_COL$} {}",
+            glyph(f.level),
+            f.label,
+            link_targets(theme, &f.detail)
+        );
         if let Some(fix) = &f.fix {
-            let _ = writeln!(s, "  fix: {fix}");
+            let _ = writeln!(s, "  fix: {}", link_targets(theme, fix));
         }
     }
     s
+}
+
+/// OSC-8-wrap the linkable targets inside ONE printed doctor line — an
+/// existing file path (`/…` or `./…` · canonicalize-gated through the
+/// [`crate::verbs::linked_path`] seam: a link that cannot open stays plain)
+/// or an `https://` URL. Token-bounded on spaces, and the printed TEXT never
+/// changes — with the `links` capability off (every pipe · `--hyperlink
+/// never`) the line is returned VERBATIM, so the sober register stays
+/// byte-frozen.
+fn link_targets(theme: Theme, text: &str) -> String {
+    if !theme.links {
+        return text.to_owned();
+    }
+    let linked: Vec<String> = text
+        .split(' ')
+        .map(|token| {
+            if token.starts_with("https://") {
+                theme.link(token, token)
+            } else if token.starts_with('/') || token.starts_with("./") {
+                crate::verbs::linked_path(theme, token)
+            } else {
+                token.to_owned()
+            }
+        })
+        .collect();
+    linked.join(" ")
 }
 
 /// One cloud-provider row (✔ key present · ⚠ unset, with the export fix).
@@ -447,9 +505,11 @@ fn redact_userinfo(url: &str) -> String {
 
 /// Diagnose the environment: build the real probe (the shared
 /// `verbs::probe` engine · PRESENCE-only · offline unless `ping`), then
-/// render the findings.
+/// render the findings. The theme comes from the global
+/// `--color`/`--hyperlink` chain (main.rs) — a piped doctor keeps its
+/// exact bytes; `--json` never colours.
 #[must_use]
-pub fn run(ping: bool, json: bool) -> VerbOutput {
+pub fn run(ping: bool, json: bool, theme: Theme) -> VerbOutput {
     let probe = crate::verbs::probe::collect(ping);
     let findings = diagnose(&probe);
     let code = exit_code(&findings);
@@ -457,7 +517,7 @@ pub fn run(ping: bool, json: bool) -> VerbOutput {
         text: if json {
             render_json(&findings)
         } else {
-            render(&findings)
+            render(&findings, theme)
         },
         code,
     }
@@ -472,6 +532,9 @@ mod tests {
 
     use super::*;
     use crate::verbs::probe::{client_probe_any, env_present, ping_addr, spawn_ping};
+
+    /// The sober register — the byte-frozen baseline every pipe reads.
+    const PLAIN: Theme = Theme::new(false, false, false);
 
     fn cloud(id: &str, var: &str, present: bool) -> ProviderProbe {
         ProviderProbe {
@@ -585,7 +648,7 @@ mod tests {
             retention: crate::verbs::trace::retention::RetentionConfig::default(),
             retention_notes: vec![],
         };
-        let text = render(&diagnose(&probe));
+        let text = render(&diagnose(&probe), PLAIN);
         assert!(text.contains("OPENAI_API_KEY"), "names the var: {text}");
         assert!(
             !text.contains("sk-"),
@@ -738,7 +801,7 @@ mod tests {
             retention: crate::verbs::trace::retention::RetentionConfig::default(),
             retention_notes: vec![],
         };
-        let text = render(&diagnose(&probe));
+        let text = render(&diagnose(&probe), PLAIN);
         assert!(text.contains("stale MCP args"), "{text}");
         assert!(text.contains("fix: nika wire cursor"), "{text}");
     }
@@ -777,7 +840,7 @@ mod tests {
         // The wired run() over the canonical catalog: local providers exist, so
         // there is never a hard Fail (exit 0) even with no keys in the test env.
         // ping=false — the default run stays fully offline, in tests too.
-        let out = run(false, false);
+        let out = run(false, false, PLAIN);
         assert_eq!(out.code, exit::OK, "the catalog always offers a path");
         assert!(out.text.contains("binary"), "renders the binary line");
         // The LLM test backend stays hidden (no `mock — key` provider row);
@@ -808,7 +871,7 @@ mod tests {
             detail: "x — KEY unset".to_owned(),
             fix: Some("export KEY=…".to_owned()),
         };
-        let text = render(&[ok.clone(), ok.clone(), warn.clone()]);
+        let text = render(&[ok.clone(), ok.clone(), warn.clone()], PLAIN);
         let first = text.lines().next().expect("verdict line");
         assert_eq!(first, "✔ 2 ok · 1 warn · 0 fail");
         assert!(text.contains("binary"), "sections unchanged: {text}");
@@ -819,7 +882,7 @@ mod tests {
             detail: "no path".to_owned(),
             fix: None,
         };
-        let red = render(&[ok, warn, fail]);
+        let red = render(&[ok, warn, fail], PLAIN);
         assert!(
             red.starts_with("✖ 1 ok · 1 warn · 1 fail"),
             "a fail flips the verdict glyph: {red}"
@@ -986,5 +1049,59 @@ mod tests {
             .find(|f| f.label == "local")
             .expect("local line");
         assert!(local.fix.is_none(), "pinged run drops the hand-off");
+    }
+
+    /// Every label `diagnose` can emit fits STRICTLY inside the fixed
+    /// [`LABEL_COL`] cell — the grid never shears (nextest school).
+    #[test]
+    fn every_label_fits_the_fixed_column() {
+        for label in [
+            "binary",
+            "config",
+            "lsp",
+            "mcp",
+            "traces",
+            "agent",
+            "provider",
+            "providers",
+            "local",
+            "ping",
+            "image",
+            "tts",
+            "pricing",
+        ] {
+            assert!(
+                label.len() <= LABEL_COL,
+                "label `{label}` ({}) exceeds LABEL_COL ({LABEL_COL})",
+                label.len()
+            );
+        }
+    }
+
+    /// Item-3 wiring: on the linked register an https target inside a
+    /// detail line rides the OSC-8 wrapper (text unchanged); the sober
+    /// register — every pipe — keeps its exact bytes, zero escapes.
+    #[test]
+    fn linked_register_wraps_https_targets_and_sober_stays_frozen() {
+        let f = vec![Finding {
+            level: Level::Ok,
+            label: "pricing".to_owned(),
+            detail: "snapshot · see https://docs.nika.sh/errors for codes".to_owned(),
+            fix: None,
+        }];
+        let sober = render(&f, PLAIN);
+        assert!(
+            !sober.contains('\x1b'),
+            "sober register is escape-free: {sober:?}"
+        );
+        let mut linked = PLAIN;
+        linked.links = true;
+        let out = render(&f, linked);
+        assert!(
+            out.contains(
+                "\x1b]8;;https://docs.nika.sh/errors\x1b\\https://docs.nika.sh/errors\x1b]8;;\x1b\\"
+            ),
+            "https target rides OSC-8: {out:?}"
+        );
     }
 }

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -11,12 +11,24 @@
 
 use nika_error::codes::{code_help, lookup};
 
+use crate::display::theme::Theme;
 use crate::verbs::VerbOutput;
 
+/// The doc-site home for the error-code registry — the ONE https target the
+/// explain surface names. Printed scheme-less (the established prose form);
+/// the OSC-8 wrapper carries the scheme.
+const DOCS_ERRORS_URL: &str = "https://docs.nika.sh/errors";
+const DOCS_ERRORS_TEXT: &str = "docs.nika.sh/errors";
+
 /// The `nika explain <code>` verb. Accepts `NIKA-440`, `NIKA-DAG-003`,
-/// or the bare forms (`440` · `DAG-003`).
+/// or the bare forms (`440` · `DAG-003`). The theme comes from the global
+/// `--color`/`--hyperlink` chain: on a TTY the doc-site reference rides an
+/// OSC-8 hyperlink; a piped explain keeps its exact bytes.
 #[must_use]
-pub fn run(wire: &str) -> VerbOutput {
+pub fn run(wire: &str, theme: Theme) -> VerbOutput {
+    // The seam (`Theme::link` → `format::osc8`): text unchanged, escapes
+    // only when the links capability resolved on.
+    let docs = theme.link(DOCS_ERRORS_URL, DOCS_ERRORS_TEXT);
     let normalized = if wire.starts_with("NIKA-") {
         wire.to_owned()
     } else {
@@ -41,7 +53,7 @@ pub fn run(wire: &str) -> VerbOutput {
                  NIKA-BUILTIN-<NAME>-001..099). Valid in `retry.on_codes:` and \
                  `on_error.on_codes:`. The specific cause is the builtin's own \
                  arg/runtime contract — see spec stdlib (builtins) · \
-                 docs.nika.sh/errors.\n"
+                 {docs}.\n"
             ));
         }
         // Per-provider runtime codes (`NIKA-PROVIDER-<NNN>`) — 001-099 are
@@ -55,14 +67,14 @@ pub fn run(wire: &str) -> VerbOutput {
                  NIKA-PROVIDER-001..099). The specific cause is provider-defined \
                  (transport · quota · auth · response shape from that provider). \
                  Valid in `retry.on_codes:` and `on_error.on_codes:` — see \
-                 spec/05-errors.md §NIKA-PROVIDER · docs.nika.sh/errors.\n"
+                 spec/05-errors.md §NIKA-PROVIDER · {docs}.\n"
             ));
         }
         return VerbOutput::file(format!(
             "unknown code `{wire}` — the registry knows NIKA-001..NIKA-9999 \
              (allocated ranges), the spec conformance codes \
              (NIKA-DAG-* · NIKA-VAR-* · …), per-builtin NIKA-BUILTIN-<NAME>-NNN \
-             and per-provider NIKA-PROVIDER-NNN codes; see docs.nika.sh/errors"
+             and per-provider NIKA-PROVIDER-NNN codes; see {docs}"
         ));
     };
     // The category/severity labels are the OWNING crate's canonical
@@ -138,6 +150,12 @@ fn is_provider_code(code: &str) -> bool {
 mod tests {
     use super::*;
     use crate::verbs::exit;
+
+    /// The sober register (links off) — the byte-frozen baseline every
+    /// machine surface reads.
+    fn run(wire: &str) -> VerbOutput {
+        super::run(wire, Theme::new(false, false, false))
+    }
 
     #[test]
     fn numeric_registry_codes_answer_exit_zero() {
@@ -258,5 +276,33 @@ mod tests {
         let out = run("NIKA-VAR-002");
         assert_eq!(out.code, exit::OK);
         assert!(out.text.contains("zero or multiple values"), "{}", out.text);
+    }
+
+    /// On the linked register the doc-site reference rides the OSC-8
+    /// wrapper (scheme in the URL · prose text unchanged); the sober
+    /// register — every pipe — keeps its exact bytes, zero escapes.
+    #[test]
+    fn doc_site_reference_links_on_the_linked_register() {
+        let mut linked = Theme::new(false, false, false);
+        linked.links = true;
+        for wire in [
+            "NIKA-BUILTIN-WRITE-001",
+            "NIKA-PROVIDER-001",
+            "NIKA-ZZZ-999",
+        ] {
+            let out = super::run(wire, linked);
+            assert!(
+                out.text.contains(
+                    "\x1b]8;;https://docs.nika.sh/errors\x1b\\docs.nika.sh/errors\x1b]8;;\x1b\\"
+                ),
+                "{wire} links the doc site: {:?}",
+                out.text
+            );
+            let sober = run(wire);
+            assert!(
+                !sober.text.contains('\x1b'),
+                "{wire} sober register is escape-free"
+            );
+        }
     }
 }

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -32,7 +32,7 @@ use crate::verbs::{VerbOutput, load_checked};
 /// like a code still routes as a file when it exists on disk — the
 /// pathological tie goes to the thing that provably exists.
 #[must_use]
-pub fn dispatch(query: &str, json: bool) -> VerbOutput {
+pub fn dispatch(query: &str, json: bool, theme: crate::display::theme::Theme) -> VerbOutput {
     let yaml_ext = Path::new(query)
         .extension()
         .is_some_and(|e| e.eq_ignore_ascii_case("yaml") || e.eq_ignore_ascii_case("yml"));
@@ -52,7 +52,7 @@ pub fn dispatch(query: &str, json: bool) -> VerbOutput {
                 .to_owned(),
         );
     }
-    super::explain::run(query)
+    super::explain::run(query, theme)
 }
 
 /// The `nika explain <file>` verb.
@@ -642,19 +642,31 @@ mod tests {
     fn dispatch_routes_codes_and_files() {
         // Codes: registry + spec + bare forms stay the teaching surface.
         for code in ["NIKA-440", "440", "DAG-003"] {
-            let out = dispatch(code, false);
+            let out = dispatch(
+                code,
+                false,
+                crate::display::theme::Theme::new(false, false, false),
+            );
             assert_eq!(out.code, exit::OK, "{code}: {}", out.text);
         }
         // A path-shaped query routes to the file narrator — missing file
         // = the loader's own error, never a "unknown code" 404.
-        let out = dispatch("no/such/dir/flow.nika.yaml", false);
+        let out = dispatch(
+            "no/such/dir/flow.nika.yaml",
+            false,
+            crate::display::theme::Theme::new(false, false, false),
+        );
         assert!(
             !out.text.contains("unknown code"),
             "paths never 404 as codes: {}",
             out.text
         );
         // The code form refuses --json loudly instead of ignoring it.
-        let out = dispatch("NIKA-440", true);
+        let out = dispatch(
+            "NIKA-440",
+            true,
+            crate::display::theme::Theme::new(false, false, false),
+        );
         assert_eq!(out.code, exit::FILE);
         assert!(out.text.contains("--json"), "{}", out.text);
     }

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -333,7 +333,7 @@ fn infer_permits_emits_a_paste_ready_boundary() {
 #[test]
 fn explain_teaches_a_registered_code_in_both_wire_forms() {
     for wire in ["NIKA-440", "440"] {
-        let out = explain::run(wire);
+        let out = explain::run(wire, PLAIN);
         assert_eq!(out.code, exit::OK, "{wire}");
         // The stable output contract: code · category · severity · slug.
         assert!(
@@ -348,7 +348,7 @@ fn explain_teaches_a_registered_code_in_both_wire_forms() {
 
 #[test]
 fn explain_refuses_an_unknown_code_exit_2() {
-    let out = explain::run("NIKA-9999");
+    let out = explain::run("NIKA-9999", PLAIN);
     assert_eq!(out.code, exit::FILE);
     assert!(out.text.contains("unknown code"));
 }


### PR DESCRIPTION
The crash-stranded teaching arc (488f3d414 + ff74d1fe0), audited against current main and re-done — two commits: what was genuinely missing, nothing that #281/#298/#305 already shipped.

## Commit 1 — doctor + explain speak the display seam
The two verbs the seam arc skipped join it — no new machinery, the existing theme/format helpers only (the welcome idiom, #305). Reimplemented against the CURRENT probe layer (the old diff predates verbs::probe — the retention rows from #311 ride the seam for free).

- **doctor**: rows carry NO durations, so the nextest discipline reduces to the status/label columns — a fixed 1-cell status glyph (Level→Role: green ok · yellow advisory · red hard-fail, semantic never decorative) + the fixed `LABEL_COL` cell, both laid out on RAW text and painted AFTER (ANSI never enters width arithmetic). `link_targets` wraps https URLs + existing paths per token (`theme.link` / `linked_path`, canonicalize-gated).
- **explain**: the doc-site reference (`docs.nika.sh/errors`, named on the builtin/provider/unknown branches) rides an OSC-8 hyperlink on the linked register; prose text unchanged. The theme threads through `explain_file::dispatch` to the code form (file form untouched).
- **The sober-register law, pinned**: every pipe / `--json` is byte-identical to the themeless render it replaces (escape-free asserted); `every_label_fits_the_fixed_column` pins the grid; the OSC-8 wrapper is asserted byte-exact on both surfaces.

Proof: 345 lib + 20 verbs_static green · clippy 0 · fn-length OK (main() shaved back under the cap via an import alias) · visual: painted TTY / frozen pipe / linked docs target verified on the built binary.

## Commit 2 — the timeout lesson reaches the scaffolded skill
The ONE line of the stranded init-teaching commit that main never got (everything else is covered by #281's live clap tree and #298): timeouts are quoted Go-durations, and local thinking models need ≥300s — they routinely think past 30s (the qwen e2e trap, lived).
