### PR TITLE
docs(readme): brand header — the lockup hotlinks the canonical kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+  <a href="https://nika.sh">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://nika.sh/brand/nika-logo-dark.svg">
+      <img src="https://nika.sh/brand/nika-logo-light.svg" alt="Nika" width="220">
+    </picture>
+  </a>
+</p>
+
 # Nika
 
 > **Intent as Code.** The workflow language for AI: one file, 4 verbs,


### PR DESCRIPTION
Theme-aware Nika lockup at the top of the README, hotlinking `nika.sh/brand/` — the canonical brand kit (supernovae-st/nika.sh#50). Zero local asset copies in the engine by design; the image renders once the site PR deploys.

Pre-push hooks green: ci-ratchets · engine-hygiene · clippy · rust-tests.

🦋 Signed: Nika