### PR TITLE
ci(coherence): pack CONTENT pin + agents-mirror pin join the nightly

### DIFF
--- a/scripts/ci/ecosystem-coherence.py
+++ b/scripts/ci/ecosystem-coherence.py
@@ -98,6 +98,30 @@ def main():
     if pack and spec and pack != spec:
         FINDINGS.append(("FAIL", "pack", f"engine pack {pack} != spec {spec} — re-vendor before the next tag"))
 
+    # The VERSION pin above goes green while CONTENT drifts inside one
+    # version (proven 2026-07-09: pack canon said 9 templates, spec said
+    # 10, both files read 0.1.0-draft — the MCP oracle taught a stale
+    # shelf). Hash the vendored canon against the spec's: a pin at the
+    # wrong granularity is worse than no pin.
+    import hashlib
+    pack_canon = grab(f"{RAW}/supernovae-st/nika/main/crates/nika-pack/pack/canon.yaml", str, "pack canon")
+    spec_canon = grab(f"{RAW}/supernovae-st/nika-spec/main/canon.yaml", str, "spec canon")
+    if pack_canon and spec_canon and pack_canon != spec_canon:
+        ph = hashlib.sha256(pack_canon.encode()).hexdigest()[:12]
+        sh = hashlib.sha256(spec_canon.encode()).hexdigest()[:12]
+        FINDINGS.append(("WARN", "pack content",
+                         f"vendored canon {ph} != spec canon {sh} (same VERSION possible) — sync-pack before the next tag"))
+
+    # The marketplace mirror (nika-agents) claims byte-parity with engine
+    # main; its own gate only fires on push/PR + a daily cron. This pin
+    # gives the nightly issue the same eye (drift proven to reappear
+    # within 24h of a resync, 2026-07-09).
+    eng_skill = grab(f"{RAW}/supernovae-st/nika/main/.agents/plugins/nika/skills/nika-authoring/SKILL.md", str, "agents mirror")
+    mir_skill = grab(f"{RAW}/supernovae-st/nika-agents/main/.agents/plugins/nika/skills/nika-authoring/SKILL.md", str, "agents mirror")
+    if eng_skill and mir_skill and eng_skill != mir_skill:
+        FINDINGS.append(("WARN", "agents mirror",
+                         "nika-agents SKILL.md != engine main — the byte-parity claim drifted; resync the mirror"))
+
     vscode_repo = grab(f"{RAW}/supernovae-st/nika-vscode/main/package.json",
                        lambda t: json.loads(t)["version"], "vscode repo")
     ovsx = grab("https://open-vsx.org/api/supernovae/nika-lang",


### PR DESCRIPTION
Two additive pins in the nightly bot, both closing **false-green classes proven live** in the 2026-07-09 diamond audit:

## 1 · The pack CONTENT pin (DP0-8, bot half)

The existing `pack VERSION == spec VERSION` pin stayed green while the CONTENT drifted inside one version — the vendored pack canon said **9 templates**, the spec SSOT said **10** (`docker-report` landed spec-side), both files read `0.1.0-draft`, and the MCP oracle (`nika_canon` / `nika_template`) taught agents the stale shelf. The vendored `canon.yaml` is now **hashed against the spec's** — a mismatch WARNs `sync-pack before the next tag`. *A pin at the wrong granularity is worse than no pin* (it reads as coverage while covering nothing).

Note: this pin will — correctly — WARN on tonight's run, since the drift is live until the next re-vendor. That is the pin doing its job.

## 2 · The agents-mirror pin (A5-3, bot half)

nika-agents claims byte-parity with engine main; its own gate fires on push/PR + a daily cron, but the nightly issue had **zero eye** on it — and the drift empirically reappeared within 24h of a resync (the mirror was re-synced at 13:37 on 07-08 and had already lost two engine lines by 07-09 morning). The mirrored SKILL.md is compared byte-for-byte; mismatch WARNs.

Both WARN-tier (operator-actionable lags, not release blockers) — same class as the `vscode publish` lag. AST-validated; `grab()`'s failure path already turns an unreadable URL into a WARN finding, never a crash. The re-vendor itself rides the next engine train (issues #320/#321 pins the W8 scope).

🦋