### PR TITLE
feat(nika-cli): nika explain --forecast — learned truth beside the story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **`nika explain --forecast` — learned truth before a run.** Duration,
+  cost and risk priors computed from YOUR local traces (`.nika/traces/`)
+  — deterministic stats, never a model call, never the network. The
+  honesty ladder is a type: never-run says so · one run is « last run » ·
+  2-4 runs earn a min–max range · p50/p90 bands are earned at n ≥ 5
+  (Hyndman & Fan type-7, the numpy/R default). Costs compose the `≥`
+  floor whenever unpriced spend participates — absence stays a dash,
+  never `$0`. Retried-then-passed counts as flaky, never failed; cache
+  hits and other-model runs are excluded from bands and named. The
+  section auto-appears in `nika explain <file>` once 3 runs exist; the
+  flag forces it, and `--json` gains a versioned `forecast` key
+  (internally-tagged rungs — consumers tolerate unknown kinds).
+
 ## [0.98.0](https://github.com/supernovae-st/nika/compare/v0.97.0..v0.98.0) - 2026-07-08
 
 **Structured output goes native, the checker closes its gaps — and the

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -60,8 +60,8 @@ pub fn nika_cli::display::format::ColorChoice::as_any(&self) -> &(dyn core::any:
 impl<T> outref::AsOut<T> for nika_cli::display::format::ColorChoice where T: core::marker::Copy
 pub fn nika_cli::display::format::ColorChoice::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::format::ColorChoice where T: ?core::marker::Sized
-pub fn nika_cli::display::format::ColorChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::format::ColorChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::format::ColorChoice
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::format::ColorChoice
 impl<T> typenum::type_operators::Same for nika_cli::display::format::ColorChoice
@@ -115,8 +115,8 @@ pub fn nika_cli::display::format::LinkChoice::as_any(&self) -> &(dyn core::any::
 impl<T> outref::AsOut<T> for nika_cli::display::format::LinkChoice where T: core::marker::Copy
 pub fn nika_cli::display::format::LinkChoice::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::format::LinkChoice where T: ?core::marker::Sized
-pub fn nika_cli::display::format::LinkChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::format::LinkChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::LinkChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::LinkChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::format::LinkChoice
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::format::LinkChoice
 impl<T> typenum::type_operators::Same for nika_cli::display::format::LinkChoice
@@ -163,8 +163,8 @@ pub fn nika_cli::display::format::ColorEnv::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::display::format::ColorEnv where T: core::marker::Copy
 pub fn nika_cli::display::format::ColorEnv::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::format::ColorEnv where T: ?core::marker::Sized
-pub fn nika_cli::display::format::ColorEnv::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::format::ColorEnv::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorEnv::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorEnv::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::format::ColorEnv
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::format::ColorEnv
 impl<T> typenum::type_operators::Same for nika_cli::display::format::ColorEnv
@@ -236,8 +236,8 @@ pub fn nika_cli::display::state::TaskState::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::display::state::TaskState where T: core::marker::Copy
 pub fn nika_cli::display::state::TaskState::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskState where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskState
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskState
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskState
@@ -285,8 +285,8 @@ pub fn nika_cli::display::state::RunView::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::RunView where T: 'static
 pub fn nika_cli::display::state::RunView::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::RunView where T: ?core::marker::Sized
-pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::RunView
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::RunView
 impl<T> typenum::type_operators::Same for nika_cli::display::state::RunView
@@ -341,8 +341,8 @@ pub fn nika_cli::display::state::TaskRow::__clone_box(&self, _: dyn_clone::seale
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::TaskRow where T: 'static
 pub fn nika_cli::display::state::TaskRow::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskRow where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskRow
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskRow
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskRow
@@ -400,8 +400,8 @@ pub fn nika_cli::display::theme::Role::as_any(&self) -> &(dyn core::any::Any + '
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Role where T: core::marker::Copy
 pub fn nika_cli::display::theme::Role::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Role where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Role
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Role
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Role
@@ -455,8 +455,8 @@ pub fn nika_cli::display::theme::Theme::as_any(&self) -> &(dyn core::any::Any + 
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Theme where T: core::marker::Copy
 pub fn nika_cli::display::theme::Theme::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Theme where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Theme
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Theme
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Theme
@@ -484,8 +484,8 @@ pub const nika_cli::verbs::exit::WORKFLOW: u8
 pub mod nika_cli::verbs::explain
 pub fn nika_cli::verbs::explain::run(wire: &str, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::explain_file
-pub fn nika_cli::verbs::explain_file::dispatch(query: &str, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
-pub fn nika_cli::verbs::explain_file::run(path: &str, json: bool) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::explain_file::dispatch(query: &str, json: bool, forecast: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::explain_file::run(path: &str, json: bool, forecast: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::graph
 pub enum nika_cli::verbs::graph::GraphFormat
 pub nika_cli::verbs::graph::GraphFormat::Ascii
@@ -537,8 +537,8 @@ pub fn nika_cli::verbs::graph::GraphFormat::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::verbs::graph::GraphFormat where T: core::marker::Copy
 pub fn nika_cli::verbs::graph::GraphFormat::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::GraphFormat where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::GraphFormat::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::GraphFormat::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphFormat::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphFormat::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::GraphFormat
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::GraphFormat
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::GraphFormat
@@ -571,8 +571,8 @@ pub fn nika_cli::verbs::graph::Edge::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::Edge where T: 'static
 pub fn nika_cli::verbs::graph::Edge::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::Edge where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::Edge::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::Edge::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Edge::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Edge::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::Edge
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::Edge
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::Edge
@@ -604,8 +604,8 @@ pub fn nika_cli::verbs::graph::FanOut::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::FanOut where T: 'static
 pub fn nika_cli::verbs::graph::FanOut::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::FanOut where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::FanOut::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::FanOut::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::FanOut::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::FanOut::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::FanOut
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::FanOut
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::FanOut
@@ -639,8 +639,8 @@ pub fn nika_cli::verbs::graph::GraphDoc::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::GraphDoc where T: 'static
 pub fn nika_cli::verbs::graph::GraphDoc::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::GraphDoc where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::GraphDoc::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::GraphDoc::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphDoc::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphDoc::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::GraphDoc
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::GraphDoc
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::GraphDoc
@@ -678,8 +678,8 @@ pub fn nika_cli::verbs::graph::Node::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::Node where T: 'static
 pub fn nika_cli::verbs::graph::Node::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::Node where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::Node::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::Node::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Node::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Node::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::Node
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::Node
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::Node
@@ -751,15 +751,15 @@ pub fn nika_cli::verbs::run::RenderMode::as_any(&self) -> &(dyn core::any::Any +
 impl<T> outref::AsOut<T> for nika_cli::verbs::run::RenderMode where T: core::marker::Copy
 pub fn nika_cli::verbs::run::RenderMode::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::RenderMode where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RenderMode::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::RenderMode::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RenderMode::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RenderMode::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RenderMode
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RenderMode
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RenderMode
 pub type nika_cli::verbs::run::RenderMode::Output = T
 pub struct nika_cli::verbs::run::FoldSink<W: std::io::Write>
 impl<W: std::io::Write> nika_cli::verbs::run::FoldSink<W>
-pub fn nika_cli::verbs::run::FoldSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
+pub fn nika_cli::verbs::run::FoldSink<W>::into_error(self) -> core::option::Option<std::io::error::Error>
 pub fn nika_cli::verbs::run::FoldSink<W>::new(writer: W, theme: nika_cli::display::theme::Theme, mode: nika_cli::verbs::run::RenderMode) -> Self
 pub fn nika_cli::verbs::run::FoldSink<W>::print_final(&mut self)
 pub fn nika_cli::verbs::run::FoldSink<W>::set_plan(&mut self, waves: alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>)
@@ -787,15 +787,15 @@ pub fn nika_cli::verbs::run::FoldSink<W>::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::FoldSink<W> where T: 'static
 pub fn nika_cli::verbs::run::FoldSink<W>::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::FoldSink<W> where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::FoldSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::FoldSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::FoldSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::FoldSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::FoldSink<W>
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::FoldSink<W>
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::FoldSink<W>
 pub type nika_cli::verbs::run::FoldSink<W>::Output = T
 pub struct nika_cli::verbs::run::JsonSink<W: std::io::Write>
 impl<W: std::io::Write> nika_cli::verbs::run::JsonSink<W>
-pub fn nika_cli::verbs::run::JsonSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
+pub fn nika_cli::verbs::run::JsonSink<W>::into_error(self) -> core::option::Option<std::io::error::Error>
 pub fn nika_cli::verbs::run::JsonSink<W>::new(writer: W) -> Self
 impl<W: std::io::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::JsonSink<W>
 pub fn nika_cli::verbs::run::JsonSink<W>::emit(&mut self, event: nika_event::event::Event)
@@ -819,8 +819,8 @@ pub fn nika_cli::verbs::run::JsonSink<W>::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::JsonSink<W> where T: 'static
 pub fn nika_cli::verbs::run::JsonSink<W>::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::JsonSink<W> where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::JsonSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::JsonSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::JsonSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::JsonSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::JsonSink<W>
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::JsonSink<W>
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::JsonSink<W>
@@ -848,8 +848,8 @@ pub fn nika_cli::verbs::run::RecoveredTrace::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::RecoveredTrace where T: 'static
 pub fn nika_cli::verbs::run::RecoveredTrace::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::RecoveredTrace where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RecoveredTrace::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::RecoveredTrace::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RecoveredTrace::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RecoveredTrace::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RecoveredTrace
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RecoveredTrace
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RecoveredTrace
@@ -890,8 +890,8 @@ pub fn nika_cli::verbs::run::ResumeRequest::__clone_box(&self, _: dyn_clone::sea
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::ResumeRequest where T: 'static
 pub fn nika_cli::verbs::run::ResumeRequest::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::ResumeRequest where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::ResumeRequest::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::ResumeRequest::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::ResumeRequest::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::ResumeRequest::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::ResumeRequest
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::ResumeRequest
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::ResumeRequest
@@ -919,8 +919,8 @@ pub fn nika_cli::verbs::run::RuntimeCapabilities::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::RuntimeCapabilities where T: 'static
 pub fn nika_cli::verbs::run::RuntimeCapabilities::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::RuntimeCapabilities where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RuntimeCapabilities::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::RuntimeCapabilities::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RuntimeCapabilities::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RuntimeCapabilities::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RuntimeCapabilities
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RuntimeCapabilities
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RuntimeCapabilities
@@ -954,8 +954,8 @@ pub fn nika_cli::verbs::run::SystemStamper::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::SystemStamper where T: 'static
 pub fn nika_cli::verbs::run::SystemStamper::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::SystemStamper where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::SystemStamper::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::SystemStamper::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::SystemStamper::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::SystemStamper::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::SystemStamper
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::SystemStamper
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::SystemStamper
@@ -1010,8 +1010,8 @@ pub fn nika_cli::verbs::trace::manage::RmTarget::__clone_box(&self, _: dyn_clone
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::trace::manage::RmTarget where T: 'static
 pub fn nika_cli::verbs::trace::manage::RmTarget::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::trace::manage::RmTarget where T: ?core::marker::Sized
-pub fn nika_cli::verbs::trace::manage::RmTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::trace::manage::RmTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::trace::manage::RmTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::trace::manage::RmTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::trace::manage::RmTarget
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::trace::manage::RmTarget
 impl<T> typenum::type_operators::Same for nika_cli::verbs::trace::manage::RmTarget
@@ -1084,8 +1084,8 @@ pub fn nika_cli::verbs::wire::WireTarget::as_any(&self) -> &(dyn core::any::Any 
 impl<T> outref::AsOut<T> for nika_cli::verbs::wire::WireTarget where T: core::marker::Copy
 pub fn nika_cli::verbs::wire::WireTarget::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::wire::WireTarget where T: ?core::marker::Sized
-pub fn nika_cli::verbs::wire::WireTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::wire::WireTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::wire::WireTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::wire::WireTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::wire::WireTarget
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::wire::WireTarget
 impl<T> typenum::type_operators::Same for nika_cli::verbs::wire::WireTarget
@@ -1116,8 +1116,8 @@ pub fn nika_cli::verbs::VerbOutput::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::VerbOutput where T: 'static
 pub fn nika_cli::verbs::VerbOutput::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::VerbOutput where T: ?core::marker::Sized
-pub fn nika_cli::verbs::VerbOutput::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::VerbOutput::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::VerbOutput::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::VerbOutput::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::VerbOutput
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::VerbOutput
 impl<T> typenum::type_operators::Same for nika_cli::verbs::VerbOutput
@@ -1174,8 +1174,8 @@ pub fn nika_cli::display::theme::Role::as_any(&self) -> &(dyn core::any::Any + '
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Role where T: core::marker::Copy
 pub fn nika_cli::display::theme::Role::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Role where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Role
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Role
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Role
@@ -1233,8 +1233,8 @@ pub fn nika_cli::display::state::TaskState::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::display::state::TaskState where T: core::marker::Copy
 pub fn nika_cli::display::state::TaskState::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskState where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskState
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskState
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskState
@@ -1282,8 +1282,8 @@ pub fn nika_cli::display::state::RunView::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::RunView where T: 'static
 pub fn nika_cli::display::state::RunView::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::RunView where T: ?core::marker::Sized
-pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::RunView
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::RunView
 impl<T> typenum::type_operators::Same for nika_cli::display::state::RunView
@@ -1338,8 +1338,8 @@ pub fn nika_cli::display::state::TaskRow::__clone_box(&self, _: dyn_clone::seale
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::TaskRow where T: 'static
 pub fn nika_cli::display::state::TaskRow::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskRow where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskRow
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskRow
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskRow
@@ -1393,8 +1393,8 @@ pub fn nika_cli::display::theme::Theme::as_any(&self) -> &(dyn core::any::Any + 
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Theme where T: core::marker::Copy
 pub fn nika_cli::display::theme::Theme::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Theme where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Theme
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Theme
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Theme

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -60,8 +60,8 @@ pub fn nika_cli::display::format::ColorChoice::as_any(&self) -> &(dyn core::any:
 impl<T> outref::AsOut<T> for nika_cli::display::format::ColorChoice where T: core::marker::Copy
 pub fn nika_cli::display::format::ColorChoice::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::format::ColorChoice where T: ?core::marker::Sized
-pub fn nika_cli::display::format::ColorChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::format::ColorChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::format::ColorChoice
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::format::ColorChoice
 impl<T> typenum::type_operators::Same for nika_cli::display::format::ColorChoice
@@ -115,8 +115,8 @@ pub fn nika_cli::display::format::LinkChoice::as_any(&self) -> &(dyn core::any::
 impl<T> outref::AsOut<T> for nika_cli::display::format::LinkChoice where T: core::marker::Copy
 pub fn nika_cli::display::format::LinkChoice::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::format::LinkChoice where T: ?core::marker::Sized
-pub fn nika_cli::display::format::LinkChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::format::LinkChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::LinkChoice::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::LinkChoice::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::format::LinkChoice
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::format::LinkChoice
 impl<T> typenum::type_operators::Same for nika_cli::display::format::LinkChoice
@@ -163,8 +163,8 @@ pub fn nika_cli::display::format::ColorEnv::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::display::format::ColorEnv where T: core::marker::Copy
 pub fn nika_cli::display::format::ColorEnv::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::format::ColorEnv where T: ?core::marker::Sized
-pub fn nika_cli::display::format::ColorEnv::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::format::ColorEnv::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorEnv::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::format::ColorEnv::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::format::ColorEnv
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::format::ColorEnv
 impl<T> typenum::type_operators::Same for nika_cli::display::format::ColorEnv
@@ -236,8 +236,8 @@ pub fn nika_cli::display::state::TaskState::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::display::state::TaskState where T: core::marker::Copy
 pub fn nika_cli::display::state::TaskState::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskState where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskState
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskState
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskState
@@ -285,8 +285,8 @@ pub fn nika_cli::display::state::RunView::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::RunView where T: 'static
 pub fn nika_cli::display::state::RunView::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::RunView where T: ?core::marker::Sized
-pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::RunView
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::RunView
 impl<T> typenum::type_operators::Same for nika_cli::display::state::RunView
@@ -341,8 +341,8 @@ pub fn nika_cli::display::state::TaskRow::__clone_box(&self, _: dyn_clone::seale
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::TaskRow where T: 'static
 pub fn nika_cli::display::state::TaskRow::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskRow where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskRow
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskRow
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskRow
@@ -400,8 +400,8 @@ pub fn nika_cli::display::theme::Role::as_any(&self) -> &(dyn core::any::Any + '
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Role where T: core::marker::Copy
 pub fn nika_cli::display::theme::Role::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Role where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Role
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Role
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Role
@@ -455,8 +455,8 @@ pub fn nika_cli::display::theme::Theme::as_any(&self) -> &(dyn core::any::Any + 
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Theme where T: core::marker::Copy
 pub fn nika_cli::display::theme::Theme::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Theme where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Theme
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Theme
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Theme
@@ -471,8 +471,6 @@ pub fn nika_cli::verbs::check::run(path: &str, json: bool, native_strict: bool, 
 pub fn nika_cli::verbs::check::run_infer_permits(path: &str, json: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::context
 pub fn nika_cli::verbs::context::run(json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
-pub mod nika_cli::verbs::dap
-pub fn nika_cli::verbs::dap::run_stdio() -> u8
 pub mod nika_cli::verbs::doctor
 pub fn nika_cli::verbs::doctor::run(ping: bool, json: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::exit
@@ -537,8 +535,8 @@ pub fn nika_cli::verbs::graph::GraphFormat::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::verbs::graph::GraphFormat where T: core::marker::Copy
 pub fn nika_cli::verbs::graph::GraphFormat::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::GraphFormat where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::GraphFormat::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::GraphFormat::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphFormat::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphFormat::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::GraphFormat
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::GraphFormat
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::GraphFormat
@@ -571,8 +569,8 @@ pub fn nika_cli::verbs::graph::Edge::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::Edge where T: 'static
 pub fn nika_cli::verbs::graph::Edge::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::Edge where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::Edge::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::Edge::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Edge::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Edge::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::Edge
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::Edge
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::Edge
@@ -604,8 +602,8 @@ pub fn nika_cli::verbs::graph::FanOut::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::FanOut where T: 'static
 pub fn nika_cli::verbs::graph::FanOut::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::FanOut where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::FanOut::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::FanOut::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::FanOut::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::FanOut::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::FanOut
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::FanOut
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::FanOut
@@ -639,8 +637,8 @@ pub fn nika_cli::verbs::graph::GraphDoc::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::GraphDoc where T: 'static
 pub fn nika_cli::verbs::graph::GraphDoc::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::GraphDoc where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::GraphDoc::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::GraphDoc::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphDoc::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::GraphDoc::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::GraphDoc
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::GraphDoc
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::GraphDoc
@@ -678,8 +676,8 @@ pub fn nika_cli::verbs::graph::Node::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::graph::Node where T: 'static
 pub fn nika_cli::verbs::graph::Node::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::graph::Node where T: ?core::marker::Sized
-pub fn nika_cli::verbs::graph::Node::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::graph::Node::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Node::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::graph::Node::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::graph::Node
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::graph::Node
 impl<T> typenum::type_operators::Same for nika_cli::verbs::graph::Node
@@ -702,6 +700,8 @@ pub fn nika_cli::verbs::pack_surface::examples_show(slug: &str) -> nika_cli::ver
 pub fn nika_cli::verbs::pack_surface::schema() -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::pack_surface::spec(canon: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::run
+pub use nika_cli::verbs::run::RecoveredTrace
+pub use nika_cli::verbs::run::recover_events
 #[non_exhaustive] pub enum nika_cli::verbs::run::RenderMode
 pub nika_cli::verbs::run::RenderMode::Live
 pub nika_cli::verbs::run::RenderMode::Plain
@@ -751,15 +751,15 @@ pub fn nika_cli::verbs::run::RenderMode::as_any(&self) -> &(dyn core::any::Any +
 impl<T> outref::AsOut<T> for nika_cli::verbs::run::RenderMode where T: core::marker::Copy
 pub fn nika_cli::verbs::run::RenderMode::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::RenderMode where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RenderMode::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::RenderMode::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RenderMode::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RenderMode::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RenderMode
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RenderMode
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RenderMode
 pub type nika_cli::verbs::run::RenderMode::Output = T
 pub struct nika_cli::verbs::run::FoldSink<W: std::io::Write>
 impl<W: std::io::Write> nika_cli::verbs::run::FoldSink<W>
-pub fn nika_cli::verbs::run::FoldSink<W>::into_error(self) -> core::option::Option<std::io::error::Error>
+pub fn nika_cli::verbs::run::FoldSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_cli::verbs::run::FoldSink<W>::new(writer: W, theme: nika_cli::display::theme::Theme, mode: nika_cli::verbs::run::RenderMode) -> Self
 pub fn nika_cli::verbs::run::FoldSink<W>::print_final(&mut self)
 pub fn nika_cli::verbs::run::FoldSink<W>::set_plan(&mut self, waves: alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>)
@@ -787,15 +787,15 @@ pub fn nika_cli::verbs::run::FoldSink<W>::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::FoldSink<W> where T: 'static
 pub fn nika_cli::verbs::run::FoldSink<W>::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::FoldSink<W> where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::FoldSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::FoldSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::FoldSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::FoldSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::FoldSink<W>
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::FoldSink<W>
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::FoldSink<W>
 pub type nika_cli::verbs::run::FoldSink<W>::Output = T
 pub struct nika_cli::verbs::run::JsonSink<W: std::io::Write>
 impl<W: std::io::Write> nika_cli::verbs::run::JsonSink<W>
-pub fn nika_cli::verbs::run::JsonSink<W>::into_error(self) -> core::option::Option<std::io::error::Error>
+pub fn nika_cli::verbs::run::JsonSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_cli::verbs::run::JsonSink<W>::new(writer: W) -> Self
 impl<W: std::io::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::JsonSink<W>
 pub fn nika_cli::verbs::run::JsonSink<W>::emit(&mut self, event: nika_event::event::Event)
@@ -819,41 +819,12 @@ pub fn nika_cli::verbs::run::JsonSink<W>::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::JsonSink<W> where T: 'static
 pub fn nika_cli::verbs::run::JsonSink<W>::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::JsonSink<W> where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::JsonSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::JsonSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::JsonSink<W>::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::JsonSink<W>::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::JsonSink<W>
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::JsonSink<W>
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::JsonSink<W>
 pub type nika_cli::verbs::run::JsonSink<W>::Output = T
-pub struct nika_cli::verbs::run::RecoveredTrace
-pub nika_cli::verbs::run::RecoveredTrace::events: alloc::vec::Vec<nika_event::event::Event>
-pub nika_cli::verbs::run::RecoveredTrace::truncated_note: core::option::Option<alloc::string::String>
-impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::RecoveredTrace
-impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::RecoveredTrace where U: core::convert::From<T>
-pub fn nika_cli::verbs::run::RecoveredTrace::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::run::RecoveredTrace where U: core::convert::Into<T>
-pub type nika_cli::verbs::run::RecoveredTrace::Error = core::convert::Infallible
-pub fn nika_cli::verbs::run::RecoveredTrace::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::run::RecoveredTrace where U: core::convert::TryFrom<T>
-pub type nika_cli::verbs::run::RecoveredTrace::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn nika_cli::verbs::run::RecoveredTrace::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for nika_cli::verbs::run::RecoveredTrace where T: 'static + ?core::marker::Sized
-pub fn nika_cli::verbs::run::RecoveredTrace::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for nika_cli::verbs::run::RecoveredTrace where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RecoveredTrace::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::run::RecoveredTrace where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RecoveredTrace::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for nika_cli::verbs::run::RecoveredTrace
-pub fn nika_cli::verbs::run::RecoveredTrace::from(t: T) -> T
-impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::RecoveredTrace where T: 'static
-pub fn nika_cli::verbs::run::RecoveredTrace::as_any(&self) -> &(dyn core::any::Any + 'static)
-impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::RecoveredTrace where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RecoveredTrace::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::RecoveredTrace::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RecoveredTrace
-impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RecoveredTrace
-impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RecoveredTrace
-pub type nika_cli::verbs::run::RecoveredTrace::Output = T
 pub struct nika_cli::verbs::run::ResumeRequest
 pub nika_cli::verbs::run::ResumeRequest::answers: alloc::vec::Vec<alloc::string::String>
 pub nika_cli::verbs::run::ResumeRequest::from: core::option::Option<alloc::string::String>
@@ -890,8 +861,8 @@ pub fn nika_cli::verbs::run::ResumeRequest::__clone_box(&self, _: dyn_clone::sea
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::ResumeRequest where T: 'static
 pub fn nika_cli::verbs::run::ResumeRequest::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::ResumeRequest where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::ResumeRequest::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::ResumeRequest::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::ResumeRequest::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::ResumeRequest::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::ResumeRequest
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::ResumeRequest
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::ResumeRequest
@@ -919,8 +890,8 @@ pub fn nika_cli::verbs::run::RuntimeCapabilities::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::RuntimeCapabilities where T: 'static
 pub fn nika_cli::verbs::run::RuntimeCapabilities::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::RuntimeCapabilities where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::RuntimeCapabilities::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::RuntimeCapabilities::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RuntimeCapabilities::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::RuntimeCapabilities::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RuntimeCapabilities
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RuntimeCapabilities
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RuntimeCapabilities
@@ -954,8 +925,8 @@ pub fn nika_cli::verbs::run::SystemStamper::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::run::SystemStamper where T: 'static
 pub fn nika_cli::verbs::run::SystemStamper::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::run::SystemStamper where T: ?core::marker::Sized
-pub fn nika_cli::verbs::run::SystemStamper::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::run::SystemStamper::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::SystemStamper::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::run::SystemStamper::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::SystemStamper
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::SystemStamper
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::SystemStamper
@@ -965,7 +936,6 @@ pub fn nika_cli::verbs::run::example(slug: &str, model_override: core::option::O
 pub fn nika_cli::verbs::run::fs_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_builtin::permits::FsBoundary
 pub fn nika_cli::verbs::run::net_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_http::NetBoundary
 pub fn nika_cli::verbs::run::production_runtime(default_model: &str, caps: nika_cli::verbs::run::RuntimeCapabilities) -> core::result::Result<nika_cli::verbs::run::ProdRuntime, nika_kernel_core::io::http::HttpError>
-pub fn nika_cli::verbs::run::recover_events(raw: &str, label: &str) -> core::result::Result<nika_cli::verbs::run::RecoveredTrace, alloc::string::String>
 pub fn nika_cli::verbs::run::run(file: &str, json: bool, output: core::option::Option<&str>, theme: nika_cli::display::theme::Theme, mode: nika_cli::verbs::run::RenderMode, dry_run: bool, model_override: core::option::Option<&str>, vars: &[alloc::string::String], resume: core::option::Option<&nika_cli::verbs::run::ResumeRequest>, no_trace_file: bool, task_filter: core::option::Option<&str>, no_outputs: bool, max_cost_usd: core::option::Option<f64>, no_gc: bool) -> u8
 pub type nika_cli::verbs::run::ProdRuntime = nika_runtime::Runtime<nika_exec_runner::TokioShell, nika_builtin::BuiltinDispatcher<nika_fs::TokioFs, nika_http::ReqwestHttp, nika_clock::SystemClock, nika_cli::verbs::run::compose::StderrEmitter, nika_builtin::NonInteractive, nika_builtin::NoWorkflow>, nika_http::ReqwestHttp, nika_cli::verbs::run::compose::RegistryProvider<nika_http::ReqwestHttp>, nika_builtin::BuiltinDispatcher<nika_fs::TokioFs, nika_http::ReqwestHttp, nika_clock::SystemClock, nika_cli::verbs::run::compose::StderrEmitter, nika_builtin::NonInteractive, nika_builtin::NoWorkflow>, nika_clock::SystemClock>
 pub mod nika_cli::verbs::test
@@ -1010,8 +980,8 @@ pub fn nika_cli::verbs::trace::manage::RmTarget::__clone_box(&self, _: dyn_clone
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::trace::manage::RmTarget where T: 'static
 pub fn nika_cli::verbs::trace::manage::RmTarget::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::trace::manage::RmTarget where T: ?core::marker::Sized
-pub fn nika_cli::verbs::trace::manage::RmTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::trace::manage::RmTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::trace::manage::RmTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::trace::manage::RmTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::trace::manage::RmTarget
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::trace::manage::RmTarget
 impl<T> typenum::type_operators::Same for nika_cli::verbs::trace::manage::RmTarget
@@ -1084,8 +1054,8 @@ pub fn nika_cli::verbs::wire::WireTarget::as_any(&self) -> &(dyn core::any::Any 
 impl<T> outref::AsOut<T> for nika_cli::verbs::wire::WireTarget where T: core::marker::Copy
 pub fn nika_cli::verbs::wire::WireTarget::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::wire::WireTarget where T: ?core::marker::Sized
-pub fn nika_cli::verbs::wire::WireTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::wire::WireTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::wire::WireTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::wire::WireTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::wire::WireTarget
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::wire::WireTarget
 impl<T> typenum::type_operators::Same for nika_cli::verbs::wire::WireTarget
@@ -1116,8 +1086,8 @@ pub fn nika_cli::verbs::VerbOutput::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::verbs::VerbOutput where T: 'static
 pub fn nika_cli::verbs::VerbOutput::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::VerbOutput where T: ?core::marker::Sized
-pub fn nika_cli::verbs::VerbOutput::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::verbs::VerbOutput::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::VerbOutput::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::VerbOutput::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::verbs::VerbOutput
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::VerbOutput
 impl<T> typenum::type_operators::Same for nika_cli::verbs::VerbOutput
@@ -1174,8 +1144,8 @@ pub fn nika_cli::display::theme::Role::as_any(&self) -> &(dyn core::any::Any + '
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Role where T: core::marker::Copy
 pub fn nika_cli::display::theme::Role::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Role where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Role::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Role
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Role
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Role
@@ -1233,8 +1203,8 @@ pub fn nika_cli::display::state::TaskState::as_any(&self) -> &(dyn core::any::An
 impl<T> outref::AsOut<T> for nika_cli::display::state::TaskState where T: core::marker::Copy
 pub fn nika_cli::display::state::TaskState::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskState where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskState
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskState
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskState
@@ -1282,8 +1252,8 @@ pub fn nika_cli::display::state::RunView::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::RunView where T: 'static
 pub fn nika_cli::display::state::RunView::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::RunView where T: ?core::marker::Sized
-pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::RunView::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::RunView
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::RunView
 impl<T> typenum::type_operators::Same for nika_cli::display::state::RunView
@@ -1338,8 +1308,8 @@ pub fn nika_cli::display::state::TaskRow::__clone_box(&self, _: dyn_clone::seale
 impl<T> nika_error::traits::AsAny for nika_cli::display::state::TaskRow where T: 'static
 pub fn nika_cli::display::state::TaskRow::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::state::TaskRow where T: ?core::marker::Sized
-pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::state::TaskRow::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::state::TaskRow
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::state::TaskRow
 impl<T> typenum::type_operators::Same for nika_cli::display::state::TaskRow
@@ -1393,8 +1363,8 @@ pub fn nika_cli::display::theme::Theme::as_any(&self) -> &(dyn core::any::Any + 
 impl<T> outref::AsOut<T> for nika_cli::display::theme::Theme where T: core::marker::Copy
 pub fn nika_cli::display::theme::Theme::as_out(&mut self) -> outref::Out<'_, T>
 impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::display::theme::Theme where T: ?core::marker::Sized
-pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::display::theme::Theme::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_cli::display::theme::Theme
 impl<T> tracing::instrument::WithSubscriber for nika_cli::display::theme::Theme
 impl<T> typenum::type_operators::Same for nika_cli::display::theme::Theme

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -706,14 +706,7 @@ fn main() -> std::process::ExitCode {
         Command::Schema => emit(&verbs::pack_surface::schema()),
         Command::Catalog { json } => emit(&verbs::catalog::run(json)),
         Command::Tools { json } => emit(&verbs::tools::run(json)),
-        Command::Examples { action } => match action.unwrap_or(ExamplesAction::List) {
-            ExamplesAction::List => emit(&verbs::pack_surface::examples_list()),
-            ExamplesAction::Show { slug } => emit(&verbs::pack_surface::examples_show(&slug)),
-            // The L3 run verb shipped — execute the embedded example for real.
-            ExamplesAction::Run { slug, model } => {
-                verbs::run::example(&slug, model.as_deref(), plain_theme)
-            }
-        },
+        Command::Examples { action } => examples_verb(action, plain_theme),
         Command::New { from, dest, force } => emit(&verbs::new::dispatch(
             from.as_deref(),
             dest.as_deref(),
@@ -766,6 +759,18 @@ fn emit(out: &VerbOutput) -> u8 {
 
 /// Dispatch the `trace` verb family: the live renders (replay · show)
 /// plus the static readers (outputs · peek · flow).
+/// The `examples` sub-verbs — list · show · run-for-real (L3 shipped).
+fn examples_verb(action: Option<ExamplesAction>, plain_theme: Theme) -> u8 {
+    match action.unwrap_or(ExamplesAction::List) {
+        ExamplesAction::List => emit(&verbs::pack_surface::examples_list()),
+        ExamplesAction::Show { slug } => emit(&verbs::pack_surface::examples_show(&slug)),
+        // The L3 run verb shipped — execute the embedded example for real.
+        ExamplesAction::Run { slug, model } => {
+            verbs::run::example(&slug, model.as_deref(), plain_theme)
+        }
+    }
+}
+
 fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     match action {
         TraceAction::Replay(args) => trace_render(&args, true, color, link_when),

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -191,6 +191,11 @@ enum Command {
         /// (`explain_version: 1` · the check report's own vocabulary).
         #[arg(long)]
         json: bool,
+        /// File form only: include the learned-truth forecast — duration/
+        /// cost/risk priors from YOUR local traces (stats over
+        /// `.nika/traces/` · never a model call · never the network).
+        #[arg(long)]
+        forecast: bool,
     },
     /// Diagnose the environment (binary · config · provider keys · spec §8).
     /// Diagnose-only — prints the exact fix command, never mutates anything.
@@ -689,7 +694,11 @@ fn main() -> std::process::ExitCode {
         Command::Welcome { json, ascii } => {
             emit(&verbs::welcome::run(json, with_ascii(plain_theme, ascii)))
         }
-        Command::Explain { code, json } => emit(&explain_dispatch(&code, json, plain_theme)),
+        Command::Explain {
+            code,
+            json,
+            forecast,
+        } => emit(&explain_dispatch(&code, json, forecast, plain_theme)),
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json, plain_theme)),
         Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target.into(), &dir)),

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -58,12 +58,38 @@ pub fn dispatch(
                 .to_owned(),
         );
     }
+    if forecast {
+        // Same law as --json: a forecast is learned from a WORKFLOW's
+        // history — an error code has none. Refuse loudly, never ignore.
+        return VerbOutput::file(
+            "--forecast rides the FILE form (`nika explain <file> --forecast`); error codes have no run history"
+                .to_owned(),
+        );
+    }
     super::explain::run(query, theme)
 }
 
 /// The `nika explain <file>` verb.
 #[must_use]
 pub fn run(path: &str, json: bool, forecast: bool) -> VerbOutput {
+    run_with_traces(
+        path,
+        json,
+        forecast,
+        Path::new(".nika").join("traces").as_path(),
+    )
+}
+
+/// [`run`] with an explicit trace directory — the testable seam: tests
+/// stage their own recorder history; a real invocation keeps the fixed
+/// relative path the sink writes.
+#[must_use]
+pub(crate) fn run_with_traces(
+    path: &str,
+    json: bool,
+    forecast: bool,
+    traces_dir: &Path,
+) -> VerbOutput {
     let (yaml, wf, report) = match load_checked_with_source(path) {
         Ok(triple) => triple,
         Err(out) => return out,
@@ -77,8 +103,7 @@ pub fn run(path: &str, json: bool, forecast: bool) -> VerbOutput {
         return dirty(path, description.as_deref(), &report, json);
     }
     let doc = project(&wf, &report);
-    let traces_dir = Path::new(".nika").join("traces");
-    let traces = traces_glance(traces_dir.as_path());
+    let traces = traces_glance(traces_dir);
     // Learned truth rides beside the static story: gather is bounded +
     // fail-open, and skipped entirely when nothing was ever recorded
     // (the glance already knows) unless the flag asks explicitly.
@@ -88,7 +113,7 @@ pub fn run(path: &str, json: bool, forecast: bool) -> VerbOutput {
             sha256: sha256_hex(yaml.as_bytes()),
             sha256_lf: sha256_hex(lf_normal_form(&yaml).as_bytes()),
         };
-        let gathered = super::forecast::gather::gather(traces_dir.as_path(), &identity.name);
+        let gathered = super::forecast::gather::gather(traces_dir, &identity.name);
         Some(super::forecast::compute(&identity, &gathered))
     } else {
         None
@@ -719,5 +744,247 @@ mod tests {
         assert!(
             unbounded_gloss("t", None, UnboundedReason::UnknownIterations).contains("run time")
         );
+    }
+
+    // ─── the forecast surface · staged-history integration ─────────────
+    // Every case drives the REAL seam (`run_with_traces`) over traces
+    // staged through the SAME serde path the sink writes — the honesty
+    // matrix rules the plan pins, proven at the render/JSON surface.
+
+    use crate::verbs::forecast::gather::tests as fx;
+    use crate::verbs::trace::store::tests::{stage_trace, temp_store};
+    use nika_event::EventKind;
+    use nika_types::resource::Value;
+    use std::time::Duration;
+
+    const FC: &str = "nika: v1\nworkflow: fc-fix\ndescription: forecast fixture\n\nmodel: mock/echo\n\ntasks:\n  - id: fetch\n    exec: { command: \"echo x\" }\n  - id: think\n    depends_on: [fetch]\n    infer: { prompt: \"p\", max_tokens: 10 }\n";
+
+    /// One completed fc-fix run body: fetch (exec) + think (infer),
+    /// distinct durations, optional sha/model/extras.
+    fn fc_run(sha: Option<&str>, at: u64, think_ms: u64, extras: &[nika_event::Event]) -> String {
+        // Extras (retries · notes) precede think's terminal — the fold's
+        // LAST state wins, so a retry after the completion would leave
+        // the row Retrying instead of Ok.
+        let mut tasks = vec![fx::task_done("fetch", at + 10, 20, None, None)];
+        tasks.extend_from_slice(extras);
+        tasks.push(fx::task_done(
+            "think",
+            at + 40,
+            think_ms,
+            None,
+            Some("mock/echo"),
+        ));
+        fx::run_body("fc-fix", sha, at, &tasks, Some(fx::done(at + 50, None)))
+    }
+
+    #[test]
+    fn forecast_flag_forces_the_section_and_absence_stays_silent() {
+        let dir = temp_store("explain-fc-empty");
+        let path = tmp("fc-empty", FC);
+        let p = path.to_str().expect("utf8");
+        let forced = run_with_traces(p, false, true, &dir);
+        assert!(
+            forced
+                .text
+                .contains("no forecast — this workflow has never run here"),
+            "{}",
+            forced.text
+        );
+        let silent = run_with_traces(p, false, false, &dir);
+        assert!(!silent.text.contains("FORECAST"), "{}", silent.text);
+        // JSON twin: ALWAYS present under the flag (honest empty shape) ·
+        // absent without it below the auto threshold.
+        let j = run_with_traces(p, true, true, &dir);
+        let v: serde_json::Value = serde_json::from_str(&j.text).expect("parses");
+        assert_eq!(v["forecast"]["runs"]["total"], 0);
+        assert_eq!(v["forecast"]["run_duration"]["kind"], "never_ran");
+        let j2 = run_with_traces(p, true, false, &dir);
+        let v2: serde_json::Value = serde_json::from_str(&j2.text).expect("parses");
+        assert!(v2.get("forecast").is_none(), "{}", j2.text);
+        std::fs::remove_file(&path).ok();
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn ladder_rungs_render_from_staged_history() {
+        let dir = temp_store("explain-fc-ladder");
+        let path = tmp("fc-ladder", FC);
+        let p = path.to_str().expect("utf8");
+        let sha = crate::verbs::run::sha256_hex(FC.as_bytes());
+        stage_trace(
+            &dir,
+            "2026-07-08T01-00-00Z-0001.ndjson",
+            &fc_run(Some(&sha), 1_000, 100, &[]),
+            Duration::from_secs(60),
+        );
+        let one = run_with_traces(p, false, true, &dir);
+        assert!(one.text.contains("based on last 1 run "), "{}", one.text);
+        assert!(one.text.contains("last run "), "{}", one.text);
+        assert!(!one.text.contains("p90"), "{}", one.text);
+
+        for (i, ms) in [(2u64, 200u64), (3, 300)] {
+            stage_trace(
+                &dir,
+                &format!("2026-07-08T0{i}-00-00Z-000{i}.ndjson"),
+                &fc_run(Some(&sha), i * 10_000, ms, &[]),
+                Duration::from_secs(60 - i),
+            );
+        }
+        // n = 3: the section arrives UNPROMPTED (auto threshold) · range
+        // vocabulary only.
+        let auto = run_with_traces(p, false, false, &dir);
+        assert!(auto.text.contains("based on last 3 runs"), "{}", auto.text);
+        assert!(!auto.text.contains("p90"), "{}", auto.text);
+
+        for i in 4u64..=6 {
+            stage_trace(
+                &dir,
+                &format!("2026-07-08T0{i}-00-00Z-000{i}.ndjson"),
+                &fc_run(Some(&sha), i * 10_000, 100 * i, &[]),
+                Duration::from_secs(60 - i),
+            );
+        }
+        let bands = run_with_traces(p, false, true, &dir);
+        assert!(
+            bands.text.contains("based on last 6 runs"),
+            "{}",
+            bands.text
+        );
+        assert!(bands.text.contains("(p90 "), "{}", bands.text);
+        assert!(
+            bands.text.contains("low confidence (n<10)"),
+            "{}",
+            bands.text
+        );
+        std::fs::remove_file(&path).ok();
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn honesty_composition_stale_unknown_unpriced_and_retry() {
+        let dir = temp_store("explain-fc-honesty");
+        let path = tmp("fc-honesty", FC);
+        let p = path.to_str().expect("utf8");
+        let sha = crate::verbs::run::sha256_hex(FC.as_bytes());
+        // Same-hash run whose think RETRIED then completed (flaky ≠ failed).
+        let retry = fx::ev(
+            EventKind::TaskRetrying,
+            10_020,
+            &[("task", Value::string("think"))],
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T01-00-00Z-aaaa.ndjson",
+            &fc_run(Some(&sha), 10_000, 100, &[retry]),
+            Duration::from_secs(50),
+        );
+        // A stale-hash run and an unverifiable (hashless) run.
+        stage_trace(
+            &dir,
+            "2026-07-08T02-00-00Z-bbbb.ndjson",
+            &fc_run(Some("beef"), 20_000, 120, &[]),
+            Duration::from_secs(40),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T03-00-00Z-cccc.ndjson",
+            &fc_run(None, 30_000, 140, &[]),
+            Duration::from_secs(30),
+        );
+        // An unpriced think occurrence (local-model class) — ≥ composes.
+        let unpriced = fx::ev(
+            EventKind::TaskCompleted,
+            40_040,
+            &[
+                ("task", Value::string("think")),
+                ("duration_ms", Value::Int(160)),
+                ("cost_unpriced", Value::string("local_model")),
+            ],
+        );
+        let body = fx::run_body(
+            "fc-fix",
+            Some(&sha),
+            40_000,
+            &[fx::task_done("fetch", 40_010, 20, None, None), unpriced],
+            Some(fx::done(40_050, None)),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T04-00-00Z-dddd.ndjson",
+            &body,
+            Duration::from_secs(20),
+        );
+
+        let out = run_with_traces(p, false, true, &dir);
+        for needle in [
+            "1 predate the last edit",
+            "1 unverifiable",
+            "passed on retry 1/",
+            "unpriced: local_model",
+            "≥",
+        ] {
+            assert!(
+                out.text.contains(needle),
+                "missing `{needle}`:\n{}",
+                out.text
+            );
+        }
+        // fetch is exec: no cost sample and no unpriced slug — the honest
+        // dash, never an invented $. Scope to the FORECAST block: the
+        // shape section's wires line also starts with `fetch`.
+        let fc_start = out.text.find("FORECAST").expect("forecast section");
+        let fetch_row = out.text[fc_start..]
+            .lines()
+            .find(|l| l.trim_start().starts_with("fetch"))
+            .expect("fetch row renders");
+        assert!(fetch_row.contains('—'), "{fetch_row}");
+        assert!(!fetch_row.contains('$'), "{fetch_row}");
+        std::fs::remove_file(&path).ok();
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn json_twin_tags_rungs_census_and_retention_knob() {
+        let dir = temp_store("explain-fc-json");
+        let path = tmp("fc-json", FC);
+        let p = path.to_str().expect("utf8");
+        let sha = crate::verbs::run::sha256_hex(FC.as_bytes());
+        for i in 1u64..=6 {
+            stage_trace(
+                &dir,
+                &format!("2026-07-08T0{i}-00-00Z-json{i}.ndjson"),
+                &fc_run(Some(&sha), i * 10_000, 100 * i, &[]),
+                Duration::from_secs(60 - i),
+            );
+        }
+        let j = run_with_traces(p, true, true, &dir);
+        let v: serde_json::Value = serde_json::from_str(&j.text).expect("parses");
+        let fc = &v["forecast"];
+        assert_eq!(fc["run_duration"]["kind"], "bands");
+        assert_eq!(fc["runs"]["completed"], 6);
+        assert_eq!(fc["runs"]["same_hash"], 6);
+        let expected_keep = crate::verbs::trace::retention::RetentionConfig::from_env()
+            .0
+            .keep_last;
+        assert_eq!(
+            fc["window"]["retention_keep"],
+            serde_json::json!(expected_keep)
+        );
+        std::fs::remove_file(&path).ok();
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The code form refuses --forecast as loudly as --json — an error
+    /// code has no run history; silence would strand an agent.
+    #[test]
+    fn code_form_refuses_forecast_loudly() {
+        let out = dispatch(
+            "NIKA-440",
+            false,
+            true,
+            crate::display::theme::Theme::new(false, false, false),
+        );
+        assert_eq!(out.code, exit::FILE);
+        assert!(out.text.contains("--forecast"), "{}", out.text);
     }
 }

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -24,7 +24,8 @@ use std::path::Path;
 use nika_schema::check::{CheckReport, UnboundedReason};
 
 use crate::verbs::graph::{GraphDoc, Node, project};
-use crate::verbs::{VerbOutput, load_checked};
+use crate::verbs::run::{lf_normal_form, sha256_hex};
+use crate::verbs::{VerbOutput, load_checked_with_source};
 
 /// Route `explain`'s positional: an existing path or a path-shaped string
 /// (`/` · `.yaml`/`.yml` · `-`) narrates the FILE; everything else teaches
@@ -32,7 +33,12 @@ use crate::verbs::{VerbOutput, load_checked};
 /// like a code still routes as a file when it exists on disk — the
 /// pathological tie goes to the thing that provably exists.
 #[must_use]
-pub fn dispatch(query: &str, json: bool, theme: crate::display::theme::Theme) -> VerbOutput {
+pub fn dispatch(
+    query: &str,
+    json: bool,
+    forecast: bool,
+    theme: crate::display::theme::Theme,
+) -> VerbOutput {
     let yaml_ext = Path::new(query)
         .extension()
         .is_some_and(|e| e.eq_ignore_ascii_case("yaml") || e.eq_ignore_ascii_case("yml"));
@@ -42,7 +48,7 @@ pub fn dispatch(query: &str, json: bool, theme: crate::display::theme::Theme) ->
         || yaml_ext
         || Path::new(query).exists();
     if file_shaped {
-        return run(query, json);
+        return run(query, json, forecast);
     }
     if json {
         // The code form is prose-by-design (one paragraph, one voice) —
@@ -57,9 +63,9 @@ pub fn dispatch(query: &str, json: bool, theme: crate::display::theme::Theme) ->
 
 /// The `nika explain <file>` verb.
 #[must_use]
-pub fn run(path: &str, json: bool) -> VerbOutput {
-    let (wf, report) = match load_checked(path) {
-        Ok(pair) => pair,
+pub fn run(path: &str, json: bool, forecast: bool) -> VerbOutput {
+    let (yaml, wf, report) = match load_checked_with_source(path) {
+        Ok(triple) => triple,
         Err(out) => return out,
     };
     let description = wf.description.as_ref().map(|d| d.value.clone());
@@ -71,7 +77,25 @@ pub fn run(path: &str, json: bool) -> VerbOutput {
         return dirty(path, description.as_deref(), &report, json);
     }
     let doc = project(&wf, &report);
-    let traces = traces_glance(Path::new(".nika").join("traces").as_path());
+    let traces_dir = Path::new(".nika").join("traces");
+    let traces = traces_glance(traces_dir.as_path());
+    // Learned truth rides beside the static story: gather is bounded +
+    // fail-open, and skipped entirely when nothing was ever recorded
+    // (the glance already knows) unless the flag asks explicitly.
+    let fc = if forecast || traces.is_some() {
+        let identity = super::forecast::WorkflowIdentity {
+            name: doc.workflow.clone(),
+            sha256: sha256_hex(yaml.as_bytes()),
+            sha256_lf: sha256_hex(lf_normal_form(&yaml).as_bytes()),
+        };
+        let gathered = super::forecast::gather::gather(traces_dir.as_path(), &identity.name);
+        Some(super::forecast::compute(&identity, &gathered))
+    } else {
+        None
+    };
+    let fc_view = fc
+        .as_ref()
+        .filter(|r| forecast || r.runs.total >= super::forecast::AUTO_FORECAST_MIN_RUNS);
     if json {
         return VerbOutput::ok(render_json(
             path,
@@ -80,6 +104,7 @@ pub fn run(path: &str, json: bool) -> VerbOutput {
             &report,
             permits_declared,
             traces.as_ref(),
+            fc_view,
         ));
     }
     VerbOutput::ok(render_human(
@@ -89,6 +114,7 @@ pub fn run(path: &str, json: bool) -> VerbOutput {
         &report,
         permits_declared,
         traces.as_ref(),
+        fc_view,
     ))
 }
 
@@ -219,6 +245,7 @@ fn render_human(
     report: &CheckReport,
     permits_declared: bool,
     traces: Option<&(usize, String)>,
+    forecast: Option<&super::forecast::ForecastReport>,
 ) -> String {
     let mut s = String::new();
     let _ = writeln!(
@@ -238,6 +265,9 @@ fn render_human(
     cost_section(&mut s, report);
     touches_section(&mut s, doc, report, permits_declared);
     risks_section(&mut s, path, report);
+    if let Some(fc) = forecast {
+        super::forecast::render::forecast_section(&mut s, fc);
+    }
     run_section(&mut s, path, report);
     recorder_section(&mut s, traces);
     s
@@ -459,6 +489,7 @@ fn render_json(
     report: &CheckReport,
     permits_declared: bool,
     traces: Option<&(usize, String)>,
+    forecast: Option<&super::forecast::ForecastReport>,
 ) -> String {
     let wave_sizes: Vec<usize> = report.waves.iter().map(Vec::len).collect();
     let mut waves: Vec<Vec<&str>> = Vec::with_capacity(wave_sizes.len());
@@ -487,7 +518,7 @@ fn render_json(
             })
         })
         .collect();
-    serde_json::json!({
+    let mut v = serde_json::json!({
         "explain_version": 1,
         "file": path,
         "workflow": doc.workflow,
@@ -501,8 +532,15 @@ fn render_json(
         "hints": report.hints,
         "analysis": report.analysis,
         "traces": traces.map(|(n, latest)| serde_json::json!({"count": n, "latest": latest})),
-    })
-    .to_string()
+    });
+    // Under --forecast the key is ALWAYS present (an agent that asked
+    // receives the honest empty shape); without the flag, presence is
+    // gated at the auto threshold — an absent key is the deliberate
+    // "not gathered" signal, never an ambiguous null.
+    if let Some(fc) = forecast {
+        v["forecast"] = serde_json::to_value(fc).unwrap_or(serde_json::Value::Null);
+    }
+    v.to_string()
 }
 
 #[cfg(test)]
@@ -524,7 +562,7 @@ mod tests {
     #[test]
     fn narrates_the_diamond_with_cost_and_handoff() {
         let path = tmp("diamond", DIAMOND);
-        let out = run(path.to_str().expect("utf8"), false);
+        let out = run(path.to_str().expect("utf8"), false, false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
         for needle in [
@@ -569,7 +607,7 @@ mod tests {
             "floor",
             "nika: v1\nworkflow: floor-story\ntasks:\n  - id: think\n    infer: { prompt: \"x\" }\n",
         );
-        let out = run(path.to_str().expect("utf8"), false);
+        let out = run(path.to_str().expect("utf8"), false, false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
         assert!(out.text.contains("FLOOR"), "{}", out.text);
@@ -588,7 +626,7 @@ mod tests {
     #[test]
     fn json_twin_is_versioned_and_speaks_the_report_dialect() {
         let path = tmp("json", DIAMOND);
-        let out = run(path.to_str().expect("utf8"), true);
+        let out = run(path.to_str().expect("utf8"), true, false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::OK, "{}", out.text);
         let v: serde_json::Value = serde_json::from_str(&out.text).expect("parses");
@@ -611,7 +649,7 @@ mod tests {
             "dirty",
             "nika: v1\nworkflow: dirty\ntasks:\n  - id: a\n    exec: { command: \"echo x\" }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: \"echo y\" }\n",
         );
-        let out = run(path.to_str().expect("utf8"), false);
+        let out = run(path.to_str().expect("utf8"), false, false);
         std::fs::remove_file(&path).ok();
         assert_eq!(out.code, exit::FILE, "{}", out.text);
         assert!(out.text.contains("does not check clean"), "{}", out.text);
@@ -645,6 +683,7 @@ mod tests {
             let out = dispatch(
                 code,
                 false,
+                false,
                 crate::display::theme::Theme::new(false, false, false),
             );
             assert_eq!(out.code, exit::OK, "{code}: {}", out.text);
@@ -653,6 +692,7 @@ mod tests {
         // = the loader's own error, never a "unknown code" 404.
         let out = dispatch(
             "no/such/dir/flow.nika.yaml",
+            false,
             false,
             crate::display::theme::Theme::new(false, false, false),
         );
@@ -665,6 +705,7 @@ mod tests {
         let out = dispatch(
             "NIKA-440",
             true,
+            false,
             crate::display::theme::Theme::new(false, false, false),
         );
         assert_eq!(out.code, exit::FILE);

--- a/crates/nika-cli/src/verbs/forecast/gather.rs
+++ b/crates/nika-cli/src/verbs/forecast/gather.rs
@@ -1,0 +1,564 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The forecast reader — a bounded, fail-open scan of `.nika/traces/`
+//! into per-run samples. One-voice law (store.rs:8-13): every file
+//! parses through the SAME tolerant reader (`recover_events`) and the
+//! terminal state folds through the SAME classifier (`fold_facts`) —
+//! zero parallel parsers. The reader never errs: the sink is
+//! infallible, so the reader is tolerant — every skip is COUNTED,
+//! never silent.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use nika_event::{Event, EventKind};
+use nika_types::resource::Value;
+
+use crate::RunView;
+use crate::display::state::TaskState;
+use crate::verbs::run::recover_events;
+use crate::verbs::trace::retention::RetentionConfig;
+use crate::verbs::trace::store::{TraceState, fold_facts};
+
+use super::Window;
+
+/// Hard cap on directory entries examined per gather — defends against
+/// a `--no-gc` pileup: the forecast stays O(cap) whatever the history.
+pub(crate) const SCAN_CAP: usize = 200;
+
+/// The run-count window (C4 · hybrid with [`WINDOW_MS`], first reached).
+pub(crate) const WINDOW_RUNS: usize = 50;
+
+/// The age window: 30 days in milliseconds, anchored on the newest
+/// MATCHING run's `workflow_started` stamp — never on `now()`
+/// (determinism: the same trace directory always forecasts the same).
+pub(crate) const WINDOW_MS: i64 = 2_592_000_000;
+
+/// One task occurrence inside one recovered run.
+#[derive(Debug, Clone)]
+pub(crate) struct TaskSample {
+    /// The task id (the workflow's vocabulary).
+    pub id: String,
+    /// Folded terminal state for this occurrence.
+    pub state: TaskState,
+    /// The occurrence was a `task_cache_hit` rehydration — excluded
+    /// from duration/cost bands (it never ran here), counted apart.
+    pub cached: bool,
+    /// The model the run's notes named, when one did (`None` is a
+    /// clean bucket of its own — exec/invoke tasks).
+    pub model: Option<String>,
+    /// Runtime-measured wall duration (the REAL one, not stamp span).
+    pub duration_ms: Option<u64>,
+    /// Per-task realized spend, when the terminal frame carried one.
+    pub cost_usd: Option<f64>,
+    /// The task retried at least once, then reached its terminal —
+    /// C5: retried-then-completed is FLAKY, never failed.
+    pub retried: bool,
+    /// The `cost_unpriced` slug the frames carried, if any.
+    pub unpriced: Option<String>,
+}
+
+/// One recovered run, reduced to its forecast facts.
+#[derive(Debug, Clone)]
+pub(crate) struct RunSample {
+    /// Source identity from `workflow_started` — `None` when the run
+    /// predates hash stamping (the fields are OPTIONAL): bucketed
+    /// `Unknown`, never silently same/stale.
+    pub sha256: Option<String>,
+    /// The LF normal-form twin, when recorded.
+    pub sha256_lf: Option<String>,
+    /// `workflow_started` stamp (unix ms) — the window anchor.
+    pub started_ms: i64,
+    /// The run's terminal classification (`fold_facts` — one voice).
+    pub state: TraceState,
+    /// Wall-clock span folded from event stamps (ms).
+    pub elapsed_ms: u64,
+    /// The terminal frame's AUTHORITATIVE run total, when priced —
+    /// absence is absence (`None`), never a fake zero.
+    pub total_cost_usd: Option<f64>,
+    /// Per-task occurrences, in first-seen order.
+    pub tasks: Vec<TaskSample>,
+}
+
+/// Everything the reader hands `compute` — samples in newest-first
+/// order plus the accounting every skip landed in.
+#[derive(Debug, Default)]
+pub(crate) struct Gathered {
+    /// Matching runs inside the window, newest first.
+    pub samples: Vec<RunSample>,
+    /// The window accounting (caps · skips · retention knob).
+    pub window: Window,
+}
+
+/// Scan `dir` for the newest runs of `workflow_name`, bounded and
+/// fail-open. A missing directory gathers empty — gather never errs.
+pub(crate) fn gather(dir: &Path, workflow_name: &str) -> Gathered {
+    let mut out = Gathered {
+        window: Window::new(),
+        ..Gathered::default()
+    };
+    out.window.retention_keep = resolved_retention().keep_last;
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    // Filename lexico-DESC = newest first: the names embed the run's
+    // ISO stamp (content-derived), where mtime is not (a clone/rsync
+    // rewrites it) — the `traces_glance` precedent.
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_str()?.to_owned();
+            name.ends_with(".ndjson").then_some(name)
+        })
+        .collect();
+    names.sort_unstable();
+    names.reverse();
+
+    for name in names {
+        if out.window.files_examined >= SCAN_CAP || out.samples.len() >= WINDOW_RUNS {
+            break;
+        }
+        out.window.files_examined += 1;
+        // TOCTOU is a fact of life here: retention GC can race the
+        // scan — a vanished file is COUNTED unreadable, never an error.
+        let Ok(raw) = std::fs::read_to_string(dir.join(&name)) else {
+            out.window.files_unreadable += 1;
+            continue;
+        };
+        let Ok(recovered) = recover_events(&raw, &name) else {
+            out.window.files_unreadable += 1;
+            continue;
+        };
+        if recovered.truncated_note.is_some() {
+            out.window.files_truncated += 1;
+        }
+        let (run_workflow, state, _paused_task) = fold_facts(&recovered.events);
+        if run_workflow != workflow_name {
+            continue;
+        }
+        if let Some(sample) = fold_sample(&recovered.events, state) {
+            out.samples.push(sample);
+        }
+    }
+
+    // The 30-day cut, anchored on the newest MATCHING run (samples are
+    // newest-first, so the anchor is the head).
+    if let Some(anchor) = out.samples.first().map(|s| s.started_ms) {
+        let floor = anchor.saturating_sub(WINDOW_MS);
+        out.samples.retain(|s| s.started_ms >= floor);
+    }
+    out
+}
+
+/// Reduce one recovered run to its sample: the shared `RunView` fold
+/// (rows · elapsed) plus the two facts it cannot carry — per-task
+/// retry attribution (`RunView.retries` is global) and the
+/// `cost_unpriced` slug (`apply_task_completed` drops it).
+pub(crate) fn fold_sample(events: &[Event], state: TraceState) -> Option<RunSample> {
+    let mut view = RunView::new();
+    for event in events {
+        view.apply(event);
+    }
+    let started = events
+        .iter()
+        .find(|e| e.kind == EventKind::WorkflowStarted)?;
+    let started_ms = started.timestamp.unix_ms();
+    let sha256 = str_field(started, "workflow_sha256").map(str::to_owned);
+    let sha256_lf = str_field(started, "workflow_sha256_lf").map(str::to_owned);
+
+    let mut retried: BTreeSet<String> = BTreeSet::new();
+    let mut unpriced: Vec<(String, String)> = Vec::new();
+    let mut total_cost_usd = None;
+    for event in events {
+        match event.kind {
+            EventKind::TaskRetrying => {
+                if let Some(task) = str_field(event, "task") {
+                    retried.insert(task.to_owned());
+                }
+            }
+            EventKind::TaskCompleted | EventKind::TaskFailed => {
+                if let (Some(task), Some(slug)) =
+                    (str_field(event, "task"), str_field(event, "cost_unpriced"))
+                {
+                    unpriced.push((task.to_owned(), slug.to_owned()));
+                }
+            }
+            EventKind::WorkflowCompleted | EventKind::WorkflowFailed => {
+                if let Some(total) = float_field(event, "total_cost_usd") {
+                    total_cost_usd = Some(total);
+                }
+            }
+            // Dispatch/stream/checkpoint kinds carry no forecast fact;
+            // `#[non_exhaustive]` future kinds (task_recovered · #301)
+            // fold nothing rather than guessing.
+            _ => {}
+        }
+    }
+
+    let tasks = view
+        .rows()
+        .iter()
+        .map(|row| TaskSample {
+            id: row.id.clone(),
+            state: row.state,
+            cached: row.cached,
+            model: row.model.clone(),
+            duration_ms: row.wall_ms(),
+            cost_usd: row.cost_usd,
+            retried: retried.contains(&row.id),
+            unpriced: unpriced
+                .iter()
+                .find(|(task, _)| *task == row.id)
+                .map(|(_, slug)| slug.clone()),
+        })
+        .collect();
+
+    Some(RunSample {
+        sha256,
+        sha256_lf,
+        started_ms,
+        state,
+        elapsed_ms: view.elapsed_ms,
+        total_cost_usd,
+        tasks,
+    })
+}
+
+/// The active retention config — the same knobs GC enforces, so the
+/// window line can say WHY n saturates at keep-last-N.
+#[allow(clippy::disallowed_methods)] // presence+value of NON-secret config vars
+fn resolved_retention() -> RetentionConfig {
+    let (retention, _notes) = RetentionConfig::resolve(
+        std::env::var("NIKA_TRACE_KEEP").ok().as_deref(),
+        std::env::var("NIKA_TRACE_MAX_AGE_DAYS").ok().as_deref(),
+        std::env::var("NIKA_TRACE_BUDGET_MB").ok().as_deref(),
+    );
+    retention
+}
+
+/// One string field off an event (the journal's additive KV vocabulary
+/// — the store/state twins are private, ~6 lines each by design).
+fn str_field<'a>(event: &'a Event, key: &str) -> Option<&'a str> {
+    event.fields.iter().find(|kv| kv.key == key).and_then(|kv| {
+        if let Value::String(s) = &kv.value {
+            Some(s.as_str())
+        } else {
+            None
+        }
+    })
+}
+
+/// One float field off an event.
+fn float_field(event: &Event, key: &str) -> Option<f64> {
+    event.fields.iter().find(|kv| kv.key == key).and_then(|kv| {
+        if let Value::Float(f) = &kv.value {
+            Some(*f)
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::verbs::trace::store::tests::{stage_trace, temp_store};
+    use nika_types::id::EventId;
+    use nika_types::resource::KeyValue;
+    use nika_types::timestamp::Timestamp;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    /// One journal event with arbitrary KV fields (the store helper
+    /// carries exactly one string field — forecasts need several).
+    pub(crate) fn ev(kind: EventKind, ms: u64, fields: &[(&str, Value)]) -> Event {
+        let mut event = Event::new(EventId::new(Uuid::nil()), Timestamp::from_unix_ms(ms), kind);
+        for (key, value) in fields {
+            event = event.with_field(KeyValue::new(*key, value.clone()));
+        }
+        event
+    }
+
+    pub(crate) fn ndjson(events: &[Event]) -> String {
+        let mut body = String::new();
+        for e in events {
+            body.push_str(&serde_json::to_string(e).expect("event serializes"));
+            body.push('\n');
+        }
+        body
+    }
+
+    /// A complete run journal: started (with hashes) · tasks · terminal.
+    pub(crate) fn run_body(
+        workflow: &str,
+        sha: Option<&str>,
+        started_ms: u64,
+        tasks: &[Event],
+        terminal: Option<Event>,
+    ) -> String {
+        let mut events = Vec::new();
+        let mut fields = vec![("workflow", Value::string(workflow))];
+        if let Some(sha) = sha {
+            fields.push(("workflow_sha256", Value::string(sha)));
+            fields.push(("workflow_sha256_lf", Value::string(sha)));
+        }
+        events.push(ev(EventKind::WorkflowStarted, started_ms, &fields));
+        events.extend_from_slice(tasks);
+        if let Some(t) = terminal {
+            events.push(t);
+        }
+        ndjson(&events)
+    }
+
+    /// One completed-task frame with duration + optional cost/model.
+    pub(crate) fn task_done(
+        id: &str,
+        ms: u64,
+        dur: u64,
+        cost: Option<f64>,
+        model: Option<&str>,
+    ) -> Event {
+        let mut fields = vec![
+            ("task", Value::string(id)),
+            ("duration_ms", Value::Int(i64::try_from(dur).unwrap_or(0))),
+        ];
+        if let Some(c) = cost {
+            fields.push(("cost_usd", Value::Float(c)));
+        }
+        if let Some(m) = model {
+            fields.push(("note", Value::string(format!("infer · {m}"))));
+        }
+        ev(EventKind::TaskCompleted, ms, &fields)
+    }
+
+    pub(crate) fn done(ms: u64, total: Option<f64>) -> Event {
+        let mut fields = vec![("workflow", Value::string("wf"))];
+        if let Some(t) = total {
+            fields.push(("total_cost_usd", Value::Float(t)));
+        }
+        ev(EventKind::WorkflowCompleted, ms, &fields)
+    }
+
+    /// ISO-shaped trace name at a lexicographic position: `idx` orders
+    /// newest-last alphabetically, so idx 99 is the newest.
+    fn name(idx: usize) -> String {
+        format!("2026-07-08T{:02}-00-00Z-{idx:04}.ndjson", idx % 24)
+    }
+
+    #[test]
+    fn gathers_newest_first_and_matches_by_name() {
+        let dir = temp_store("forecast-gather-basic");
+        let old = run_body(
+            "wf",
+            Some("aaaa"),
+            1_000,
+            &[task_done("t", 1_010, 100, None, None)],
+            Some(done(1_020, None)),
+        );
+        let new = run_body(
+            "wf",
+            Some("aaaa"),
+            2_000,
+            &[task_done("t", 2_010, 200, None, None)],
+            Some(done(2_020, None)),
+        );
+        let other = run_body("other", Some("bbbb"), 3_000, &[], Some(done(3_010, None)));
+        stage_trace(
+            &dir,
+            "2026-07-08T01-00-00Z-0001.ndjson",
+            &old,
+            Duration::from_secs(60),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T02-00-00Z-0002.ndjson",
+            &new,
+            Duration::from_secs(30),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T03-00-00Z-0003.ndjson",
+            &other,
+            Duration::from_secs(10),
+        );
+        let g = gather(&dir, "wf");
+        assert_eq!(g.samples.len(), 2);
+        assert_eq!(g.samples[0].started_ms, 2_000); // newest first
+        assert_eq!(g.window.files_examined, 3);
+        assert_eq!(g.window.files_unreadable, 0);
+    }
+
+    #[test]
+    fn window_is_anchored_on_newest_matching_run_never_now() {
+        let dir = temp_store("forecast-gather-window");
+        // A 60-day-old pair: both far from now(), 1ms apart from each
+        // other — an anchor on now() would drop both; the per-workflow
+        // anchor keeps both.
+        let t0: u64 = 3_000_000_000; // ≫ WINDOW_MS so the cut bites
+        let within = run_body("wf", None, t0, &[], Some(done(t0 + 10, None)));
+        let anchor = run_body("wf", None, t0 + 1, &[], Some(done(t0 + 11, None)));
+        // And one BEYOND 30d before the anchor: dropped by the cut.
+        let win_ms = u64::try_from(WINDOW_MS).unwrap_or(0);
+        let ancient_ms = (t0 + 1).saturating_sub(win_ms + 1);
+        let ancient = run_body(
+            "wf",
+            None,
+            ancient_ms,
+            &[],
+            Some(done(ancient_ms + 5, None)),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T01-00-00Z-0001.ndjson",
+            &ancient,
+            Duration::from_secs(90),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T02-00-00Z-0002.ndjson",
+            &within,
+            Duration::from_secs(60),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T03-00-00Z-0003.ndjson",
+            &anchor,
+            Duration::from_secs(30),
+        );
+        let g = gather(&dir, "wf");
+        assert_eq!(g.samples.len(), 2, "the ancient run exits the window");
+        assert!(
+            g.samples
+                .iter()
+                .all(|s| s.started_ms >= i64::try_from(t0).unwrap_or(i64::MAX))
+        );
+    }
+
+    #[test]
+    fn caps_bound_the_scan() {
+        let dir = temp_store("forecast-gather-caps");
+        for idx in 0..60 {
+            let ms = 10_000 + u64::try_from(idx).unwrap_or(0);
+            let body = run_body("wf", None, ms, &[], Some(done(ms + 1, None)));
+            stage_trace(&dir, &name(idx), &body, Duration::from_secs(5));
+        }
+        let g = gather(&dir, "wf");
+        assert_eq!(g.samples.len(), WINDOW_RUNS, "K caps the collection");
+        assert!(g.window.files_examined <= SCAN_CAP);
+    }
+
+    #[test]
+    fn skips_are_counted_never_silent() {
+        let dir = temp_store("forecast-gather-skips");
+        stage_trace(
+            &dir,
+            "2026-07-08T01-00-00Z-dead.ndjson",
+            "not json at all\n",
+            Duration::from_secs(9),
+        );
+        let good = run_body("wf", None, 5_000, &[], Some(done(5_010, None)));
+        // A valid prefix + a torn tail: the prefix is USED, the tear COUNTED.
+        let torn = format!("{good}{{\"kind\":\"task_recovered\",\"torn\":");
+        stage_trace(
+            &dir,
+            "2026-07-08T02-00-00Z-torn.ndjson",
+            &torn,
+            Duration::from_secs(8),
+        );
+        let g = gather(&dir, "wf");
+        assert_eq!(g.window.files_unreadable, 1, "first-line-dead file counted");
+        assert_eq!(g.window.files_truncated, 1, "torn tail counted");
+        assert_eq!(g.samples.len(), 1, "the torn file's valid prefix is used");
+    }
+
+    #[test]
+    fn missing_dir_gathers_empty() {
+        let g = gather(Path::new("/nonexistent/nika/traces"), "wf");
+        assert!(g.samples.is_empty());
+        assert_eq!(g.window.files_examined, 0);
+    }
+
+    #[test]
+    fn per_task_facts_fold_retry_cache_unpriced_and_totals() {
+        let dir = temp_store("forecast-gather-facts");
+        let retry = ev(
+            EventKind::TaskRetrying,
+            6_005,
+            &[("task", Value::string("flaky"))],
+        );
+        let flaky_done = task_done("flaky", 6_010, 50, Some(0.01), Some("mock/echo"));
+        let cached = ev(
+            EventKind::TaskCacheHit,
+            6_012,
+            &[("task", Value::string("warm"))],
+        );
+        let unpriced = ev(
+            EventKind::TaskCompleted,
+            6_020,
+            &[
+                ("task", Value::string("local")),
+                ("duration_ms", Value::Int(30)),
+                ("cost_unpriced", Value::string("local_model")),
+            ],
+        );
+        let body = run_body(
+            "wf",
+            Some("cafe"),
+            6_000,
+            &[retry, flaky_done, cached, unpriced],
+            Some(done(6_030, Some(0.01))),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T04-00-00Z-0004.ndjson",
+            &body,
+            Duration::from_secs(3),
+        );
+        let g = gather(&dir, "wf");
+        assert_eq!(g.samples.len(), 1);
+        let run = &g.samples[0];
+        assert_eq!(run.total_cost_usd, Some(0.01));
+        assert_eq!(run.sha256.as_deref(), Some("cafe"));
+        let flaky = run
+            .tasks
+            .iter()
+            .find(|t| t.id == "flaky")
+            .expect("test value");
+        assert!(flaky.retried, "C5: retried-then-completed is flaky");
+        assert_eq!(flaky.state, TaskState::Ok);
+        assert_eq!(flaky.model.as_deref(), Some("mock/echo"));
+        let warm = run
+            .tasks
+            .iter()
+            .find(|t| t.id == "warm")
+            .expect("test value");
+        assert!(warm.cached);
+        let local = run
+            .tasks
+            .iter()
+            .find(|t| t.id == "local")
+            .expect("test value");
+        assert_eq!(local.unpriced.as_deref(), Some("local_model"));
+        assert_eq!(local.cost_usd, None, "absence is absence, never $0");
+    }
+
+    #[test]
+    fn elapsed_is_stamp_span_never_duration_sum() {
+        // Two overlapping tasks: starts 0/10 · durations 100/100 ·
+        // terminal stamps 100/110 → elapsed 110, never 200.
+        let dir = temp_store("forecast-gather-elapsed");
+        let t1 = task_done("a", 100, 100, None, None);
+        let t2 = task_done("b", 110, 100, None, None);
+        let body = run_body("wf", None, 0, &[t1, t2], Some(done(110, None)));
+        stage_trace(
+            &dir,
+            "2026-07-08T05-00-00Z-0005.ndjson",
+            &body,
+            Duration::from_secs(2),
+        );
+        let g = gather(&dir, "wf");
+        assert_eq!(g.samples[0].elapsed_ms, 110);
+    }
+}

--- a/crates/nika-cli/src/verbs/forecast/gather.rs
+++ b/crates/nika-cli/src/verbs/forecast/gather.rs
@@ -30,10 +30,13 @@ pub(crate) const SCAN_CAP: usize = 200;
 /// The run-count window (C4 · hybrid with [`WINDOW_MS`], first reached).
 pub(crate) const WINDOW_RUNS: usize = 50;
 
-/// The age window: 30 days in milliseconds, anchored on the newest
-/// MATCHING run's `workflow_started` stamp — never on `now()`
-/// (determinism: the same trace directory always forecasts the same).
-pub(crate) const WINDOW_MS: i64 = 2_592_000_000;
+/// The age window in days (C4 · the render's « / 30 days » figure).
+pub(crate) const WINDOW_DAYS: u32 = 30;
+
+/// The age window in milliseconds, anchored on the newest MATCHING
+/// run's `workflow_started` stamp — never on `now()` (determinism: the
+/// same trace directory always forecasts the same).
+pub(crate) const WINDOW_MS: i64 = WINDOW_DAYS as i64 * 86_400_000;
 
 /// One task occurrence inside one recovered run.
 #[derive(Debug, Clone)]
@@ -190,9 +193,11 @@ pub(crate) fn fold_sample(events: &[Event], state: TraceState) -> Option<RunSamp
                     total_cost_usd = Some(total);
                 }
             }
-            // Dispatch/stream/checkpoint kinds carry no forecast fact;
-            // `#[non_exhaustive]` future kinds (task_recovered · #301)
-            // fold nothing rather than guessing.
+            // Dispatch/stream/checkpoint kinds carry no forecast fact —
+            // and so do shipped kinds like `task_recovered` (#313: a
+            // resume repair marker, not a duration/cost sample). Future
+            // `#[non_exhaustive]` kinds ride the same arm: fold nothing
+            // rather than guessing.
             _ => {}
         }
     }
@@ -226,16 +231,11 @@ pub(crate) fn fold_sample(events: &[Event], state: TraceState) -> Option<RunSamp
     })
 }
 
-/// The active retention config — the same knobs GC enforces, so the
-/// window line can say WHY n saturates at keep-last-N.
-#[allow(clippy::disallowed_methods)] // presence+value of NON-secret config vars
+/// The active retention config — the same knobs GC enforces (ONE
+/// resolution path · `RetentionConfig::from_env`), so the window line
+/// can say WHY n saturates at keep-last-N.
 fn resolved_retention() -> RetentionConfig {
-    let (retention, _notes) = RetentionConfig::resolve(
-        std::env::var("NIKA_TRACE_KEEP").ok().as_deref(),
-        std::env::var("NIKA_TRACE_MAX_AGE_DAYS").ok().as_deref(),
-        std::env::var("NIKA_TRACE_BUDGET_MB").ok().as_deref(),
-    );
-    retention
+    RetentionConfig::from_env().0
 }
 
 /// One string field off an event (the journal's additive KV vocabulary
@@ -250,15 +250,19 @@ fn str_field<'a>(event: &'a Event, key: &str) -> Option<&'a str> {
     })
 }
 
-/// One float field off an event.
+/// One float field off an event — the Int arm coerces like the state
+/// fold's twin (state.rs): an integer-typed total is still a total.
 fn float_field(event: &Event, key: &str) -> Option<f64> {
-    event.fields.iter().find(|kv| kv.key == key).and_then(|kv| {
-        if let Value::Float(f) = &kv.value {
-            Some(*f)
-        } else {
-            None
-        }
-    })
+    event
+        .fields
+        .iter()
+        .find(|kv| kv.key == key)
+        .and_then(|kv| match &kv.value {
+            Value::Float(f) => Some(*f),
+            #[allow(clippy::cast_precision_loss)] // display-only magnitude
+            Value::Int(i) => Some(*i as f64),
+            _ => None,
+        })
 }
 
 #[cfg(test)]
@@ -459,18 +463,100 @@ pub(crate) mod tests {
             Duration::from_secs(9),
         );
         let good = run_body("wf", None, 5_000, &[], Some(done(5_010, None)));
-        // A valid prefix + a torn tail: the prefix is USED, the tear COUNTED.
-        let torn = format!("{good}{{\"kind\":\"task_recovered\",\"torn\":");
+        // A valid prefix + a WELL-FORMED line whose kind this binary does
+        // not know (a FUTURE engine's trace): serde refuses the LINE —
+        // truncation counted, prefix USED. (`task_recovered` stopped
+        // qualifying the day #313 shipped it — a genuinely unknown slug
+        // is the only honest fixture here.)
+        let future = format!("{good}{{\"kind\":\"zz_future_kind\",\"x\":1}}\n");
         stage_trace(
             &dir,
-            "2026-07-08T02-00-00Z-torn.ndjson",
-            &torn,
+            "2026-07-08T02-00-00Z-future.ndjson",
+            &future,
             Duration::from_secs(8),
+        );
+        // And the crash shape: a syntactically torn tail.
+        let torn = format!("{good}{{\"kind\":\"task_started\",\"torn\":");
+        stage_trace(
+            &dir,
+            "2026-07-08T03-00-00Z-torn.ndjson",
+            &torn,
+            Duration::from_secs(7),
         );
         let g = gather(&dir, "wf");
         assert_eq!(g.window.files_unreadable, 1, "first-line-dead file counted");
-        assert_eq!(g.window.files_truncated, 1, "torn tail counted");
-        assert_eq!(g.samples.len(), 1, "the torn file's valid prefix is used");
+        assert_eq!(
+            g.window.files_truncated, 2,
+            "unknown-kind line AND torn tail each counted"
+        );
+        assert_eq!(g.samples.len(), 2, "both valid prefixes are used");
+    }
+
+    /// `task_recovered` (#313) DESERIALIZES and folds nothing — the `_`
+    /// arm is load-bearing with a REAL shipped variant, never a forgery.
+    #[test]
+    fn shipped_no_fact_kinds_ride_the_wildcard_arm() {
+        let dir = temp_store("forecast-gather-recovered");
+        let repair = ev(
+            EventKind::TaskRecovered,
+            5_005,
+            &[("task", Value::string("t"))],
+        );
+        let body = run_body(
+            "wf",
+            None,
+            5_000,
+            &[repair, task_done("t", 5_010, 40, None, None)],
+            Some(done(5_020, None)),
+        );
+        stage_trace(
+            &dir,
+            "2026-07-08T06-00-00Z-0006.ndjson",
+            &body,
+            Duration::from_secs(1),
+        );
+        let g = gather(&dir, "wf");
+        assert_eq!(
+            g.window.files_truncated, 0,
+            "a shipped kind never truncates"
+        );
+        assert_eq!(g.samples.len(), 1);
+        let run = &g.samples[0];
+        assert_eq!(run.state, TraceState::Completed);
+        let t = run.tasks.iter().find(|t| t.id == "t").expect("test value");
+        assert_eq!(t.duration_ms, Some(40), "the completion sample survived");
+    }
+
+    /// The plan's retention-interaction fixture: 12 finished traces ·
+    /// default GC keeps 10 · the reader sees EXACTLY the kept window and
+    /// the report carries the knob that explains why.
+    #[test]
+    fn retention_bounds_the_window_and_the_report_names_it() {
+        use crate::verbs::trace::retention;
+        use std::time::SystemTime;
+        let dir = temp_store("forecast-gather-retention");
+        for i in 0..12u64 {
+            let ms = 100_000 + i * 1_000;
+            let body = run_body("wf", None, ms, &[], Some(done(ms + 10, None)));
+            stage_trace(
+                &dir,
+                &format!("2026-07-08T{:02}-00-00Z-{i:04}.ndjson", 1 + i),
+                &body,
+                Duration::from_secs((12 - i) * 3_600),
+            );
+        }
+        let gc = retention::collect(&dir, &RetentionConfig::default(), SystemTime::now());
+        assert!(gc.is_some(), "12 finished under keep-10 → 2 rotate");
+        let g = gather(&dir, "wf");
+        assert_eq!(
+            g.samples.len(),
+            10,
+            "the reader sees exactly the kept window"
+        );
+        assert_eq!(
+            g.window.retention_keep,
+            RetentionConfig::default().keep_last
+        );
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/forecast/math.rs
+++ b/crates/nika-cli/src/verbs/forecast/math.rs
@@ -93,7 +93,7 @@ impl Prior {
 }
 
 /// Hyndman & Fan type-7 (numpy/R default · C1) over an ASCENDING-sorted,
-/// all-finite slice. `None` on empty input; `q` outside [0,1] clamps; a
+/// all-finite slice. `None` on empty input; `q` outside `[0, 1]` clamps; a
 /// non-finite `q` refuses (never NaN out). Plain lerp — golden parity
 /// over cleverness (no `mul_add`).
 #[must_use]

--- a/crates/nika-cli/src/verbs/forecast/math.rs
+++ b/crates/nika-cli/src/verbs/forecast/math.rs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The forecast math — one exact quantile (Hyndman & Fan type-7, the
+//! numpy/R default) and the honesty ladder as a TYPE: a p50 under
+//! `BANDS_MIN_N` samples cannot be constructed, not merely not
+//! rendered. Learned truth stays learned — bands, never points; the
+//! sample count rides every rung.
+
+/// The C3 honesty ladder — the rung IS the type. The JSON twin
+/// inherits the same honesty through the `kind` tag (internally
+/// tagged · consumers tolerate unknown kinds, the law `EventKind`
+/// teaches).
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum Prior {
+    /// n = 0 — no numbers exist. « never run », never an invention.
+    NeverRan,
+    /// n = 1 — the one observation, named as such (no percentile words).
+    LastRun {
+        /// The single observed value.
+        value: f64,
+    },
+    /// 2 ≤ n < [`BANDS_MIN_N`] — honest spread only.
+    Range {
+        /// Sample count.
+        n: usize,
+        /// Smallest observation.
+        min: f64,
+        /// Largest observation.
+        max: f64,
+    },
+    /// n ≥ [`BANDS_MIN_N`] — H&F-7 bands (C1).
+    Bands {
+        /// Sample count.
+        n: usize,
+        /// Smallest observation.
+        min: f64,
+        /// Median (H&F-7).
+        p50: f64,
+        /// 90th percentile (H&F-7).
+        p90: f64,
+        /// Largest observation.
+        max: f64,
+    },
+}
+
+/// C3: percentile vocabulary is earned at n ≥ 5 (p90 ≈ max until
+/// n > 1/(1−p) — the 1/(1-p) rule).
+pub(crate) const BANDS_MIN_N: usize = 5;
+
+impl Prior {
+    /// Build the rung the sample size earns. Input must already be
+    /// finite-filtered (the caller counts the drops — C2 accounting).
+    #[must_use]
+    pub(crate) fn from_finite(values: &[f64]) -> Self {
+        let mut xs = values.to_vec();
+        xs.sort_unstable_by(f64::total_cmp);
+        match xs.as_slice() {
+            [] => Self::NeverRan,
+            [one] => Self::LastRun { value: *one },
+            [min, .., max] if xs.len() < BANDS_MIN_N => Self::Range {
+                n: xs.len(),
+                min: *min,
+                max: *max,
+            },
+            [min, .., max] => match (quantile_h7(&xs, 0.5), quantile_h7(&xs, 0.9)) {
+                (Some(p50), Some(p90)) => Self::Bands {
+                    n: xs.len(),
+                    min: *min,
+                    p50,
+                    p90,
+                    max: *max,
+                },
+                _ => Self::Range {
+                    n: xs.len(),
+                    min: *min,
+                    max: *max,
+                },
+            },
+        }
+    }
+
+    /// Sample count on any rung (render's « based on last N runs »).
+    #[must_use]
+    pub(crate) const fn n(&self) -> usize {
+        match self {
+            Self::NeverRan => 0,
+            Self::LastRun { .. } => 1,
+            Self::Range { n, .. } | Self::Bands { n, .. } => *n,
+        }
+    }
+}
+
+/// Hyndman & Fan type-7 (numpy/R default · C1) over an ASCENDING-sorted,
+/// all-finite slice. `None` on empty input; `q` outside [0,1] clamps; a
+/// non-finite `q` refuses (never NaN out). Plain lerp — golden parity
+/// over cleverness (no `mul_add`).
+#[must_use]
+pub(crate) fn quantile_h7(sorted: &[f64], q: f64) -> Option<f64> {
+    if !q.is_finite() {
+        return None;
+    }
+    let last = sorted.last().copied()?;
+    let q = q.clamp(0.0, 1.0);
+    #[allow(clippy::cast_precision_loss)] // n ≤ SCAN_CAP (200) ≪ 2^52
+    let h = (sorted.len() - 1) as f64 * q;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // 0 ≤ h ≤ n−1
+    let j = h.floor() as usize;
+    let g = h - h.floor();
+    let lo = sorted.get(j).copied()?;
+    let hi = sorted.get(j + 1).copied().unwrap_or(last);
+    Some(lo + g * (hi - lo))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Relative approx-eq (≤1e-9) — `q*(n-1)` carries ulp noise, golden
+    /// vectors NEVER assert bit-equality (§2.3).
+    fn close(a: f64, b: f64) {
+        let scale = a.abs().max(b.abs()).max(1.0);
+        assert!((a - b).abs() <= 1e-9 * scale, "{a} !~ {b}");
+    }
+
+    #[test]
+    fn golden_vectors_match_numpy_linear_default() {
+        // §2.3 pins · verified against numpy 2.4.0 method='linear'.
+        close(
+            quantile_h7(&[1.0, 2.0, 3.0, 4.0], 0.9).expect("test value"),
+            3.7,
+        );
+        for q in [0.0, 0.5, 0.9, 1.0] {
+            close(quantile_h7(&[10.0], q).expect("test value"), 10.0);
+        }
+        close(quantile_h7(&[1.0, 2.0], 0.5).expect("test value"), 1.5);
+        let five = [120.0, 150.0, 180.0, 200.0, 240.0];
+        close(quantile_h7(&five, 0.5).expect("test value"), 180.0); // exact-hit g=0
+        close(quantile_h7(&five, 0.9).expect("test value"), 224.0); // interpolation g=0.6
+    }
+
+    #[test]
+    fn quantile_edges_refuse_honestly() {
+        assert_eq!(quantile_h7(&[], 0.5), None);
+        assert_eq!(quantile_h7(&[1.0, 2.0], f64::NAN), None);
+        close(
+            quantile_h7(&[1.0, 2.0, 3.0], -1.0).expect("test value"),
+            1.0,
+        ); // clamp q=0
+        close(quantile_h7(&[1.0, 2.0, 3.0], 2.0).expect("test value"), 3.0); // clamp q=1
+    }
+
+    #[test]
+    fn ladder_rungs_are_earned_by_n() {
+        assert_eq!(Prior::from_finite(&[]), Prior::NeverRan);
+        assert_eq!(Prior::from_finite(&[7.0]), Prior::LastRun { value: 7.0 });
+        assert_eq!(
+            Prior::from_finite(&[3.0, 1.0, 2.0]),
+            Prior::Range {
+                n: 3,
+                min: 1.0,
+                max: 3.0
+            }
+        );
+        let bands = Prior::from_finite(&[240.0, 120.0, 180.0, 200.0, 150.0]);
+        let Prior::Bands {
+            n,
+            min,
+            p50,
+            p90,
+            max,
+        } = bands
+        else {
+            unreachable!("n = 5 earns bands, got {bands:?}")
+        };
+        assert_eq!(n, 5);
+        close(min, 120.0);
+        close(p50, 180.0);
+        close(p90, 224.0);
+        close(max, 240.0);
+    }
+
+    #[test]
+    fn json_twin_is_internally_tagged_per_rung() {
+        // One golden per rung — the discriminant is the contract (§4.4).
+        let never = serde_json::to_value(Prior::NeverRan).expect("test value");
+        assert_eq!(never["kind"], "never_ran");
+        let last = serde_json::to_value(Prior::LastRun { value: 3.0 }).expect("test value");
+        assert_eq!(last["kind"], "last_run");
+        assert!((last["value"].as_f64().expect("test value") - 3.0).abs() < 1e-12);
+        let range = serde_json::to_value(Prior::from_finite(&[1.0, 2.0])).expect("test value");
+        assert_eq!(range["kind"], "range");
+        assert_eq!(range["n"], 2);
+        let bands = serde_json::to_value(Prior::from_finite(&[1.0, 2.0, 3.0, 4.0, 5.0]))
+            .expect("test value");
+        assert_eq!(bands["kind"], "bands");
+        assert_eq!(bands["n"], 5);
+    }
+
+    proptest! {
+        #[test]
+        fn permutation_invariance(mut xs in proptest::collection::vec(0.0f64..1e9, 0..40)) {
+            let a = Prior::from_finite(&xs);
+            xs.reverse();
+            let b = Prior::from_finite(&xs);
+            prop_assert_eq!(a, b);
+        }
+
+        #[test]
+        fn bands_are_ordered(xs in proptest::collection::vec(0.0f64..1e9, 5..40)) {
+            if let Prior::Bands { min, p50, p90, max, .. } = Prior::from_finite(&xs) {
+                prop_assert!(min <= p50 && p50 <= p90 && p90 <= max);
+            } else {
+                prop_assert!(false, "n >= 5 must earn bands");
+            }
+        }
+
+        #[test]
+        fn quantile_monotone_in_q(xs in proptest::collection::vec(0.0f64..1e9, 1..40),
+                                  qa in 0.0f64..1.0, qb in 0.0f64..1.0) {
+            let mut s = xs;
+            s.sort_unstable_by(f64::total_cmp);
+            let (lo, hi) = if qa <= qb { (qa, qb) } else { (qb, qa) };
+            let a = quantile_h7(&s, lo).expect("test value");
+            let b = quantile_h7(&s, hi).expect("test value");
+            prop_assert!(a <= b + 1e-9 * b.abs().max(1.0));
+        }
+
+        #[test]
+        fn degenerate_n1_all_quantiles_equal(x in 0.0f64..1e9, q in 0.0f64..1.0) {
+            let v = quantile_h7(&[x], q).expect("test value");
+            prop_assert!((v - x).abs() <= f64::EPSILON * x.abs().max(1.0));
+        }
+
+        #[test]
+        fn rung_totality(n in 0usize..12) {
+            #[allow(clippy::cast_precision_loss)] // proptest n < 12
+            let xs: Vec<f64> = (0..n).map(|i| i as f64).collect();
+            let rung = Prior::from_finite(&xs);
+            let expect_n = rung.n();
+            prop_assert_eq!(expect_n, n);
+            match (n, rung) {
+                (0, Prior::NeverRan)
+                | (1, Prior::LastRun { .. })
+                | (2..=4, Prior::Range { .. })
+                | (5.., Prior::Bands { .. }) => {}
+                (n, rung) => prop_assert!(false, "n={n} earned the wrong rung {rung:?}"),
+            }
+        }
+    }
+}

--- a/crates/nika-cli/src/verbs/forecast/mod.rs
+++ b/crates/nika-cli/src/verbs/forecast/mod.rs
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika explain --forecast` — learned truth from the local trace
+//! history: duration/cost/risk priors BEFORE a run, computed
+//! deterministically from `.nika/traces/` (stats, never a model call,
+//! never the network — Rule 1). The honesty ladder is a TYPE
+//! ([`math::Prior`]): never-run says so · one run is « last run » ·
+//! 2-4 runs earn a range · bands are earned at n ≥ 5. Every skip is
+//! counted; a suggestion never outweighs a proof.
+
+pub(crate) mod gather;
+pub(crate) mod math;
+pub(crate) mod render;
+
+use std::collections::BTreeMap;
+
+use crate::display::state::TaskState;
+use crate::verbs::trace::store::TraceState;
+
+use gather::{Gathered, RunSample, TaskSample};
+use math::Prior;
+
+/// `explain <file>` includes the section unprompted once the window
+/// holds this many runs (under it, the recorder glance suffices);
+/// `--forecast` always forces.
+pub(crate) const AUTO_FORECAST_MIN_RUNS: usize = 3;
+
+/// The current file's source identity — computed ONCE by the caller
+/// (`load_checked_with_source` + `run/source_id.rs` hashes; the stdin
+/// `-` arm works for free).
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowIdentity {
+    /// The workflow name (matches `workflow_started`'s field).
+    pub name: String,
+    /// sha256 hex over the exact bytes read.
+    pub sha256: String,
+    /// sha256 hex over the LF normal form (CRLF/BOM-insensitive — an
+    /// editor re-encode must not read as an edit).
+    pub sha256_lf: String,
+}
+
+/// The gather accounting — every bound and every skip, counted.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub(crate) struct Window {
+    /// The run-count cap (policy · C4).
+    pub k: usize,
+    /// The age cap in days (policy · C4).
+    pub days: u32,
+    /// Directory entries examined (≤ `gather::SCAN_CAP`).
+    pub files_examined: usize,
+    /// GC race mid-scan · I/O refusal · dead first line.
+    pub files_unreadable: usize,
+    /// Valid prefix kept, torn tail dropped (crash · future kind).
+    pub files_truncated: usize,
+    /// NaN/inf samples filtered before sorting (C2 accounting).
+    pub nonfinite_dropped: usize,
+    /// The resolved `NIKA_TRACE_KEEP` knob — when the window saturates
+    /// at it, retention is the reason n stays small (the render names
+    /// it · information, never an error tone).
+    pub retention_keep: usize,
+}
+
+impl Window {
+    pub(crate) fn new() -> Self {
+        Self {
+            k: gather::WINDOW_RUNS,
+            days: 30,
+            files_examined: 0,
+            files_unreadable: 0,
+            files_truncated: 0,
+            nonfinite_dropped: 0,
+            retention_keep: 0,
+        }
+    }
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// How a historical run's recorded source relates to the file being
+/// explained — three states, never a silent guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShaMatch {
+    /// Either recorded hash equals the current one (raw or LF form).
+    Same,
+    /// Hashes recorded, none match — the run predates the last edit.
+    Stale,
+    /// The run recorded no source hash (optional fields) — unverifiable.
+    Unknown,
+}
+
+/// The run population census — who is in the window, by identity and
+/// by terminal state.
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
+pub(crate) struct RunCensus {
+    /// Matching runs inside the window.
+    pub total: usize,
+    /// Runs whose recorded source hash matches the current file.
+    pub same_hash: usize,
+    /// Runs recorded against an older source — counted, caveated.
+    pub stale_hash: usize,
+    /// Runs with no recorded hash — named « unverifiable », never
+    /// silently bucketed.
+    pub unknown_hash: usize,
+    /// `workflow_completed` runs (the duration sample population).
+    pub completed: usize,
+    /// `workflow_failed` runs.
+    pub failed: usize,
+    /// `workflow_cancelled` runs.
+    pub cancelled: usize,
+    /// Paused on a human gate — an obligation, not a crash; excluded
+    /// from bands, named apart.
+    pub paused: usize,
+    /// No terminal event — in flight or torn.
+    pub no_terminal: usize,
+}
+
+/// One task's learned priors across the window.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct TaskPrior {
+    /// The task id.
+    pub id: String,
+    /// Runs the task actually appeared in (≠ total when `when`-gated —
+    /// the hedge line exists for this).
+    pub ran_in_runs: usize,
+    /// Hard failures (terminal Failed) — C5: never mixed with flaky.
+    pub failed: usize,
+    /// Retried then reached Ok — FLAKY, never counted failed (C5).
+    pub passed_on_retry: usize,
+    /// Cache-hit rehydrations — excluded from bands, counted apart.
+    pub cache_hits: usize,
+    /// Occurrences on a model other than the newest occurrence's —
+    /// EXCLUDED from bands (no cross-model extrapolation), counted.
+    pub other_model: usize,
+    /// Wall-duration prior over completed, non-cached, current-model
+    /// occurrences.
+    pub duration_ms: Prior,
+    /// Realized-spend prior over the same population — `None` when no
+    /// occurrence carried a cost (absence is absence, never $0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<Prior>,
+    /// The dominant `cost_unpriced` slug, when the window carried one —
+    /// forces the `≥` floor rendering.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unpriced: Option<String>,
+}
+
+/// The forecast — learned truth, labeled as such, sample counts on
+/// every number.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ForecastReport {
+    /// The workflow name the history was matched on.
+    pub workflow: String,
+    /// The window population census.
+    pub runs: RunCensus,
+    /// The gather accounting.
+    pub window: Window,
+    /// Whole-run wall-duration prior (completed runs only).
+    pub run_duration: Prior,
+    /// Whole-run realized-spend prior — quantiles of per-run TOTALS
+    /// (never a sum of per-task p50s); `None` when no terminal carried
+    /// a priced total.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_cost: Option<Prior>,
+    /// Per-task priors, first-seen order.
+    pub tasks: Vec<TaskPrior>,
+}
+
+/// Classify one sample's recorded source against the current identity.
+fn sha_match(sample: &RunSample, id: &WorkflowIdentity) -> ShaMatch {
+    match (&sample.sha256, &sample.sha256_lf) {
+        (None, None) => ShaMatch::Unknown,
+        (raw, lf) => {
+            let same_raw = raw.as_deref() == Some(id.sha256.as_str());
+            let same_lf = lf.as_deref() == Some(id.sha256_lf.as_str());
+            if same_raw || same_lf {
+                ShaMatch::Same
+            } else {
+                ShaMatch::Stale
+            }
+        }
+    }
+}
+
+/// Push a finite sample; count the non-finite drop (C2 accounting).
+fn push_finite(values: &mut Vec<f64>, v: f64, dropped: &mut usize) {
+    if v.is_finite() {
+        values.push(v);
+    } else {
+        *dropped += 1;
+    }
+}
+
+/// Fold gathered samples into the forecast report. PURE — zero I/O,
+/// zero clock: the same gather always computes the same report.
+#[must_use]
+pub(crate) fn compute(id: &WorkflowIdentity, gathered: &Gathered) -> ForecastReport {
+    let mut window = gathered.window;
+    let mut runs = RunCensus {
+        total: gathered.samples.len(),
+        ..RunCensus::default()
+    };
+    let mut run_durations = Vec::new();
+    let mut run_costs = Vec::new();
+    for sample in &gathered.samples {
+        match sha_match(sample, id) {
+            ShaMatch::Same => runs.same_hash += 1,
+            ShaMatch::Stale => runs.stale_hash += 1,
+            ShaMatch::Unknown => runs.unknown_hash += 1,
+        }
+        match sample.state {
+            TraceState::Completed => {
+                runs.completed += 1;
+                #[allow(clippy::cast_precision_loss)] // wall ms ≪ 2^52
+                run_durations.push(sample.elapsed_ms as f64);
+            }
+            TraceState::Failed => runs.failed += 1,
+            TraceState::Cancelled => runs.cancelled += 1,
+            TraceState::Paused => runs.paused += 1,
+            TraceState::Running => runs.no_terminal += 1,
+        }
+        if let Some(total) = sample.total_cost_usd {
+            push_finite(&mut run_costs, total, &mut window.nonfinite_dropped);
+        }
+    }
+
+    let tasks = fold_tasks(&gathered.samples, &mut window.nonfinite_dropped);
+
+    ForecastReport {
+        workflow: id.name.clone(),
+        runs,
+        window,
+        run_duration: Prior::from_finite(&run_durations),
+        run_cost: (!run_costs.is_empty()).then(|| Prior::from_finite(&run_costs)),
+        tasks,
+    }
+}
+
+/// Per-task accumulation scratch (samples arrive newest-first, so the
+/// FIRST occurrence seen fixes the current model — R-modèle).
+#[derive(Default)]
+struct TaskAcc {
+    ran_in_runs: usize,
+    failed: usize,
+    passed_on_retry: usize,
+    cache_hits: usize,
+    other_model: usize,
+    model_fixed: bool,
+    current_model: Option<String>,
+    durations: Vec<f64>,
+    costs: Vec<f64>,
+    unpriced: BTreeMap<String, usize>,
+}
+
+/// Group occurrences per task id and earn each prior.
+fn fold_tasks(samples: &[RunSample], nonfinite: &mut usize) -> Vec<TaskPrior> {
+    let mut order: Vec<String> = Vec::new();
+    let mut accs: BTreeMap<String, TaskAcc> = BTreeMap::new();
+    for sample in samples {
+        for occ in &sample.tasks {
+            let acc = accs.entry(occ.id.clone()).or_insert_with(|| {
+                order.push(occ.id.clone());
+                TaskAcc::default()
+            });
+            fold_occurrence(acc, occ, nonfinite);
+        }
+    }
+    order
+        .into_iter()
+        .filter_map(|id| {
+            let acc = accs.remove(&id)?;
+            Some(TaskPrior {
+                id,
+                ran_in_runs: acc.ran_in_runs,
+                failed: acc.failed,
+                passed_on_retry: acc.passed_on_retry,
+                cache_hits: acc.cache_hits,
+                other_model: acc.other_model,
+                duration_ms: Prior::from_finite(&acc.durations),
+                cost_usd: (!acc.costs.is_empty()).then(|| Prior::from_finite(&acc.costs)),
+                unpriced: dominant(&acc.unpriced),
+            })
+        })
+        .collect()
+}
+
+/// Fold one occurrence into its task's scratch — the admission rules
+/// (cache exclusion · C5 retry split · R-modèle scoping) live HERE,
+/// in one place.
+fn fold_occurrence(acc: &mut TaskAcc, occ: &TaskSample, nonfinite: &mut usize) {
+    acc.ran_in_runs += 1;
+    if let Some(slug) = &occ.unpriced {
+        *acc.unpriced.entry(slug.clone()).or_insert(0) += 1;
+    }
+    if occ.cached {
+        acc.cache_hits += 1;
+        return; // rehydrated — never a duration/cost/failure sample
+    }
+    match occ.state {
+        TaskState::Failed => {
+            acc.failed += 1;
+            return; // task_failed carries no duration/cost sample
+        }
+        TaskState::Ok => {
+            if occ.retried {
+                acc.passed_on_retry += 1; // C5 · flaky, NEVER failed
+            }
+        }
+        // Pending/Running (torn) · Retrying (no terminal) · Skipped ·
+        // Cancelled: not a completed occurrence — no sample.
+        _ => return,
+    }
+    // R-modèle: the newest occurrence (seen first) fixes the model
+    // bucket; other models are counted out, never mixed in.
+    if !acc.model_fixed {
+        acc.model_fixed = true;
+        acc.current_model.clone_from(&occ.model);
+    }
+    if acc.current_model != occ.model {
+        acc.other_model += 1;
+        return;
+    }
+    if let Some(d) = occ.duration_ms {
+        #[allow(clippy::cast_precision_loss)] // wall ms ≪ 2^52
+        acc.durations.push(d as f64);
+    }
+    if let Some(c) = occ.cost_usd {
+        push_finite(&mut acc.costs, c, nonfinite);
+    }
+}
+
+/// The most frequent slug (ties break on `BTreeMap` order — stable).
+fn dominant(counts: &BTreeMap<String, usize>) -> Option<String> {
+    counts
+        .iter()
+        .max_by_key(|(_, n)| **n)
+        .map(|(slug, _)| slug.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gather::tests::{done, ev, run_body, task_done};
+    use super::gather::{Gathered, RunSample, TaskSample};
+    use super::*;
+    use nika_event::EventKind;
+    use nika_types::resource::Value;
+
+    fn id() -> WorkflowIdentity {
+        WorkflowIdentity {
+            name: "wf".into(),
+            sha256: "cafe".into(),
+            sha256_lf: "cafe-lf".into(),
+        }
+    }
+
+    fn sample_from(body: &str) -> RunSample {
+        let recovered = crate::verbs::run::recover_events(body, "test").expect("parses");
+        let (_, state, _) = crate::verbs::trace::store::fold_facts(&recovered.events);
+        super::gather::fold_sample(&recovered.events, state).expect("sample")
+    }
+
+    fn gathered(samples: Vec<RunSample>) -> Gathered {
+        Gathered {
+            samples,
+            window: Window::new(),
+        }
+    }
+
+    #[test]
+    fn census_buckets_same_stale_unknown_and_crlf_same() {
+        let same_raw = sample_from(&run_body(
+            "wf",
+            Some("cafe"),
+            1_000,
+            &[],
+            Some(done(1_010, None)),
+        ));
+        let stale = sample_from(&run_body(
+            "wf",
+            Some("beef"),
+            2_000,
+            &[],
+            Some(done(2_010, None)),
+        ));
+        let unknown = sample_from(&run_body("wf", None, 3_000, &[], Some(done(3_010, None))));
+        // CRLF twin: raw hash differs, LF form matches → Same.
+        let mut crlf = sample_from(&run_body(
+            "wf",
+            Some("beef"),
+            4_000,
+            &[],
+            Some(done(4_010, None)),
+        ));
+        crlf.sha256 = Some("other".into());
+        crlf.sha256_lf = Some("cafe-lf".into());
+        let report = compute(&id(), &gathered(vec![crlf, unknown, stale, same_raw]));
+        assert_eq!(report.runs.total, 4);
+        assert_eq!(report.runs.same_hash, 2, "raw-same + lf-same");
+        assert_eq!(report.runs.stale_hash, 1);
+        assert_eq!(report.runs.unknown_hash, 1);
+        assert_eq!(report.runs.completed, 4);
+    }
+
+    #[test]
+    fn run_duration_uses_completed_only_and_paused_is_named() {
+        let completed = sample_from(&run_body("wf", None, 0, &[], Some(done(100, None))));
+        let paused_body = run_body(
+            "wf",
+            None,
+            0,
+            &[],
+            Some(ev(
+                EventKind::WorkflowPaused,
+                50,
+                &[("task", Value::string("gate"))],
+            )),
+        );
+        let paused = sample_from(&paused_body);
+        let torn = sample_from(&run_body("wf", None, 0, &[], None));
+        let report = compute(&id(), &gathered(vec![completed, paused, torn]));
+        assert_eq!(report.runs.paused, 1);
+        assert_eq!(report.runs.no_terminal, 1);
+        assert_eq!(report.run_duration.n(), 1, "completed only feeds the prior");
+        assert_eq!(report.run_duration, Prior::LastRun { value: 100.0 });
+    }
+
+    #[test]
+    fn fake_zero_is_dead_all_unpriced_window_has_no_run_cost() {
+        let a = sample_from(&run_body("wf", None, 0, &[], Some(done(10, None))));
+        let b = sample_from(&run_body("wf", None, 20, &[], Some(done(30, None))));
+        let report = compute(&id(), &gathered(vec![b, a]));
+        assert_eq!(report.run_cost, None, "no priced terminal → no cost prior");
+    }
+
+    #[test]
+    fn run_cost_is_quantile_of_totals_never_task_sums() {
+        // Two runs: totals 110 and 110 — while per-task costs are
+        // 100+10 and 60+50. The prior speaks TOTALS.
+        let r1 = sample_from(&run_body(
+            "wf",
+            None,
+            0,
+            &[
+                task_done("a", 5, 10, Some(100.0), None),
+                task_done("b", 8, 10, Some(10.0), None),
+            ],
+            Some(done(10, Some(110.0))),
+        ));
+        let r2 = sample_from(&run_body(
+            "wf",
+            None,
+            20,
+            &[
+                task_done("a", 25, 10, Some(60.0), None),
+                task_done("b", 28, 10, Some(50.0), None),
+            ],
+            Some(done(30, Some(110.0))),
+        ));
+        let report = compute(&id(), &gathered(vec![r2, r1]));
+        let Some(Prior::Range { min, max, .. }) = report.run_cost else {
+            unreachable!("two priced totals earn a range, got {:?}", report.run_cost)
+        };
+        assert!((min - 110.0).abs() < 1e-9 && (max - 110.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn r_model_scopes_bands_to_the_newest_model() {
+        // Newest run on mock/echo · older run on other/model: the older
+        // occurrence is counted out, the band n shrinks to 1.
+        let newest = sample_from(&run_body(
+            "wf",
+            None,
+            100,
+            &[task_done("t", 105, 40, Some(0.02), Some("mock/echo"))],
+            Some(done(110, Some(0.02))),
+        ));
+        let older = sample_from(&run_body(
+            "wf",
+            None,
+            0,
+            &[task_done("t", 5, 400, Some(0.2), Some("other/model"))],
+            Some(done(10, Some(0.2))),
+        ));
+        let report = compute(&id(), &gathered(vec![newest, older]));
+        let t = &report.tasks[0];
+        assert_eq!(t.other_model, 1);
+        assert_eq!(t.duration_ms, Prior::LastRun { value: 40.0 });
+        assert_eq!(t.ran_in_runs, 2);
+    }
+
+    #[test]
+    fn retry_split_and_cache_exclusion_hold_at_compute_level() {
+        let flaky_run = sample_from(&run_body(
+            "wf",
+            None,
+            0,
+            &[
+                ev(EventKind::TaskRetrying, 2, &[("task", Value::string("t"))]),
+                task_done("t", 5, 30, None, None),
+            ],
+            Some(done(10, None)),
+        ));
+        let cached_run = {
+            let mut s = sample_from(&run_body("wf", None, 20, &[], Some(done(30, None))));
+            s.tasks.push(TaskSample {
+                id: "t".into(),
+                state: TaskState::Ok,
+                cached: true,
+                model: None,
+                duration_ms: Some(0),
+                cost_usd: None,
+                retried: false,
+                unpriced: None,
+            });
+            s
+        };
+        let report = compute(&id(), &gathered(vec![cached_run, flaky_run]));
+        let t = &report.tasks[0];
+        assert_eq!(t.passed_on_retry, 1, "C5: flaky, not failed");
+        assert_eq!(t.failed, 0);
+        assert_eq!(t.cache_hits, 1);
+        assert_eq!(t.duration_ms.n(), 1, "the cache hit fed no band");
+    }
+
+    #[test]
+    fn nonfinite_costs_are_dropped_and_counted() {
+        let mut s = sample_from(&run_body("wf", None, 0, &[], Some(done(10, None))));
+        s.total_cost_usd = Some(f64::NAN);
+        let report = compute(&id(), &gathered(vec![s]));
+        assert_eq!(report.run_cost, None);
+        assert_eq!(report.window.nonfinite_dropped, 1);
+    }
+}

--- a/crates/nika-cli/src/verbs/forecast/mod.rs
+++ b/crates/nika-cli/src/verbs/forecast/mod.rs
@@ -65,7 +65,7 @@ impl Window {
     pub(crate) fn new() -> Self {
         Self {
             k: gather::WINDOW_RUNS,
-            days: 30,
+            days: gather::WINDOW_DAYS,
             files_examined: 0,
             files_unreadable: 0,
             files_truncated: 0,
@@ -124,8 +124,10 @@ pub(crate) struct RunCensus {
 pub(crate) struct TaskPrior {
     /// The task id.
     pub id: String,
-    /// Runs the task actually appeared in (≠ total when `when`-gated —
-    /// the hedge line exists for this).
+    /// Runs where the task actually EXECUTED (ok · failed · torn
+    /// mid-attempt · cache-satisfied). A `when` skip or an upstream
+    /// cancellation is a decision, not a run — the when-gate hedge
+    /// (« ran in K/N runs ») depends on this split.
     pub ran_in_runs: usize,
     /// Hard failures (terminal Failed) — C5: never mixed with flaky.
     pub failed: usize,
@@ -292,27 +294,37 @@ fn fold_tasks(samples: &[RunSample], nonfinite: &mut usize) -> Vec<TaskPrior> {
 /// (cache exclusion · C5 retry split · R-modèle scoping) live HERE,
 /// in one place.
 fn fold_occurrence(acc: &mut TaskAcc, occ: &TaskSample, nonfinite: &mut usize) {
-    acc.ran_in_runs += 1;
     if let Some(slug) = &occ.unpriced {
         *acc.unpriced.entry(slug.clone()).or_insert(0) += 1;
     }
     if occ.cached {
+        // Rehydrated: the task was SATISFIED here (counts as ran for the
+        // when-gate hedge) — never a duration/cost/failure sample.
+        acc.ran_in_runs += 1;
         acc.cache_hits += 1;
-        return; // rehydrated — never a duration/cost/failure sample
+        return;
     }
     match occ.state {
         TaskState::Failed => {
+            acc.ran_in_runs += 1;
             acc.failed += 1;
             return; // task_failed carries no duration/cost sample
         }
+        // Attempted, torn before a terminal — it RAN, no sample.
+        TaskState::Running | TaskState::Retrying => {
+            acc.ran_in_runs += 1;
+            return;
+        }
         TaskState::Ok => {
+            acc.ran_in_runs += 1;
             if occ.retried {
                 acc.passed_on_retry += 1; // C5 · flaky, NEVER failed
             }
         }
-        // Pending/Running (torn) · Retrying (no terminal) · Skipped ·
-        // Cancelled: not a completed occurrence — no sample.
-        _ => return,
+        // Pending (never started) · Skipped (a `when` decision) ·
+        // Cancelled (upstream died): the task did NOT run here — a skip
+        // counting as « ran » would kill the when-gate hedge signal.
+        TaskState::Pending | TaskState::Skipped | TaskState::Cancelled => return,
     }
     // R-modèle: the newest occurrence (seen first) fixes the model
     // bucket; other models are counted out, never mixed in.

--- a/crates/nika-cli/src/verbs/forecast/render.rs
+++ b/crates/nika-cli/src/verbs/forecast/render.rs
@@ -37,7 +37,7 @@ pub(crate) fn forecast_section(s: &mut String, report: &ForecastReport) {
         .unwrap_or(4)
         .max(4);
     for task in &report.tasks {
-        let _ = writeln!(s, "{}", task_row(task, width));
+        let _ = writeln!(s, "{}", task_row(task, width, report.runs.total));
     }
     let _ = writeln!(s, "  {}", "─".repeat(width + 34));
     let _ = writeln!(s, "{}", run_line(report, width));
@@ -63,7 +63,11 @@ fn window_line(report: &ForecastReport) -> String {
     if runs.unknown_hash > 0 {
         let _ = write!(line, " · {} unverifiable", runs.unknown_hash);
     }
-    if w.retention_keep > 0 && runs.total == w.retention_keep {
+    // `>=`, never `==`: GC rides `nika run` START, so right after a run
+    // the dir holds keep+1 matching traces — the saturated-window case
+    // is the COMMON shape, not an exact hit (e2e-proven: 12 runs → 11
+    // seen · keep 10 · the annotation must still fire).
+    if w.retention_keep > 0 && runs.total >= w.retention_keep {
         let _ = write!(line, " · trace retention keeps last {}", w.retention_keep);
     }
     if w.files_unreadable > 0 {
@@ -88,14 +92,27 @@ fn window_line(report: &ForecastReport) -> String {
 }
 
 /// One task line: duration prior · cost prior · the risk notes.
-fn task_row(task: &TaskPrior, width: usize) -> String {
+fn task_row(task: &TaskPrior, width: usize, total_runs: usize) -> String {
+    // A task that RAN but never completed (failures · torn attempts ·
+    // cache-only) has no duration sample — that is a dash, NEVER the
+    // « never ran » words (it visibly ran; the failed count sits beside).
+    let duration = if matches!(task.duration_ms, Prior::NeverRan) && task.ran_in_runs > 0 {
+        "—".to_owned()
+    } else {
+        prior_cell(&task.duration_ms)
+    };
     let mut line = format!(
         "  {:width$}  {:22} {:10}",
         task.id,
-        prior_cell(&task.duration_ms),
+        duration,
         cost_cell(task.cost_usd.as_ref(), task.unpriced.is_some()),
     );
     let mut notes: Vec<String> = Vec::new();
+    // The when-gate hedge made visible (C6): the task executed in fewer
+    // runs than the window holds — say so, in run units.
+    if task.ran_in_runs < total_runs {
+        notes.push(format!("ran in {}/{} runs", task.ran_in_runs, total_runs));
+    }
     if task.failed > 0 {
         notes.push(format!("failed {}/{}", task.failed, task.ran_in_runs));
     }
@@ -132,15 +149,24 @@ fn task_row(task: &TaskPrior, width: usize) -> String {
 /// prior · what was excluded, named.
 fn run_line(report: &ForecastReport, width: usize) -> String {
     let any_unpriced = report.tasks.iter().any(|t| t.unpriced.is_some());
+    let dn = report.run_duration.n();
+    // Same dash law as the task rows: runs happened but none completed →
+    // no duration sample, never « never ran » beside a real census.
+    let duration = if matches!(report.run_duration, Prior::NeverRan) && report.runs.total > 0 {
+        "—".to_owned()
+    } else {
+        prior_cell(&report.run_duration)
+    };
     let mut line = format!(
         "  {:width$}  {:22} {:10}",
         "run",
-        prior_cell(&report.run_duration),
+        duration,
         cost_cell(report.run_cost.as_ref(), any_unpriced),
     );
     let mut notes: Vec<String> = Vec::new();
-    let dn = report.run_duration.n();
-    if dn > 0 && dn != report.runs.total {
+    // Including dn == 0: « duration from 0 completed » names why the
+    // cell is a dash — the count only stays silent when EVERY run fed it.
+    if dn != report.runs.total {
         notes.push(format!("duration from {dn} completed"));
     }
     if report.runs.failed > 0 {
@@ -311,5 +337,76 @@ mod tests {
         forecast_section(&mut s, &r);
         assert!(s.contains("1 paused run excluded"));
         assert!(!s.contains("incomplete"));
+    }
+
+    /// R-8 (e2e-proven): GC rides run START, so the post-run dir holds
+    /// keep+1 — the saturation annotation fires at `>=`, never only `==`.
+    #[test]
+    fn retention_annotation_fires_above_the_keep_knob_too() {
+        let mut r = report(11);
+        r.window.retention_keep = 10;
+        let mut s = String::new();
+        forecast_section(&mut s, &r);
+        assert!(
+            s.contains("trace retention keeps last 10"),
+            "total 11 ≥ keep 10 must name retention:\n{s}"
+        );
+    }
+
+    /// R-2: a task that ran and only FAILED shows a dash — « never ran »
+    /// beside « failed 2/2 » would be a contradiction.
+    #[test]
+    fn failed_only_task_is_a_dash_never_never_ran() {
+        let mut r = report(2);
+        r.tasks.push(TaskPrior {
+            id: "flaky".into(),
+            ran_in_runs: 2,
+            failed: 2,
+            passed_on_retry: 0,
+            cache_hits: 0,
+            other_model: 0,
+            duration_ms: Prior::NeverRan,
+            cost_usd: None,
+            unpriced: None,
+        });
+        let mut s = String::new();
+        forecast_section(&mut s, &r);
+        assert!(!s.contains("never ran"), "{s}");
+        assert!(s.contains("failed 2/2"), "{s}");
+    }
+
+    /// C6 made visible: a when-gated task names its own run count.
+    #[test]
+    fn when_gated_task_names_its_run_share() {
+        let mut r = report(3);
+        r.tasks.push(TaskPrior {
+            id: "gated".into(),
+            ran_in_runs: 1,
+            failed: 0,
+            passed_on_retry: 0,
+            cache_hits: 0,
+            other_model: 0,
+            duration_ms: Prior::LastRun { value: 40.0 },
+            cost_usd: None,
+            unpriced: None,
+        });
+        let mut s = String::new();
+        forecast_section(&mut s, &r);
+        assert!(s.contains("ran in 1/3 runs"), "{s}");
+    }
+
+    /// R-2 at run level: a census with zero completions dashes the cell
+    /// and NAMES the zero (« duration from 0 completed »).
+    #[test]
+    fn zero_completed_runs_dash_the_run_cell_and_say_why() {
+        let mut r = report(2);
+        r.runs.completed = 0;
+        r.runs.failed = 2;
+        r.run_duration = Prior::NeverRan;
+        let mut s = String::new();
+        forecast_section(&mut s, &r);
+        assert!(!s.contains("never ran"), "{s}");
+        assert!(s.contains("duration from 0 completed"), "{s}");
+        assert!(s.contains("failed 2/2"), "{s}");
     }
 }

--- a/crates/nika-cli/src/verbs/forecast/render.rs
+++ b/crates/nika-cli/src/verbs/forecast/render.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The forecast section — learned truth rendered honestly: the rung
+//! decides the vocabulary (never a percentile under n=5), `≥` composes
+//! whenever unpriced spend participates, and every exclusion is named.
+//! Plain text like the sibling explain sections (theming is R3);
+//! durations speak `fmt_wall_ms`, money speaks `fmt_cost_usd`.
+
+use std::fmt::Write as _;
+
+use crate::display::flow::fmt_wall_ms;
+use crate::display::format::fmt_cost_usd;
+
+use super::math::Prior;
+use super::{ForecastReport, TaskPrior};
+
+/// Low-confidence tag threshold: p90 ≈ max until n > 10 (1/(1−p)).
+const LOW_CONFIDENCE_N: usize = 10;
+
+/// The whole FORECAST section (the composer — one honest block).
+pub(crate) fn forecast_section(s: &mut String, report: &ForecastReport) {
+    let _ = writeln!(s);
+    if report.runs.total == 0 {
+        let _ = writeln!(
+            s,
+            "FORECAST · no forecast — this workflow has never run here"
+        );
+        return;
+    }
+    let _ = writeln!(s, "FORECAST · {}", window_line(report));
+    let width = report
+        .tasks
+        .iter()
+        .map(|t| t.id.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    for task in &report.tasks {
+        let _ = writeln!(s, "{}", task_row(task, width));
+    }
+    let _ = writeln!(s, "  {}", "─".repeat(width + 34));
+    let _ = writeln!(s, "{}", run_line(report, width));
+    let _ = writeln!(s, "  {}", hedge_line());
+}
+
+/// The « based on … » header tail: population, window bounds, identity
+/// caveats, retention note, confidence tag — information, never an
+/// error tone.
+fn window_line(report: &ForecastReport) -> String {
+    let runs = &report.runs;
+    let w = &report.window;
+    let mut line = format!(
+        "based on last {} run{} (window {} runs / {} days",
+        runs.total,
+        if runs.total == 1 { "" } else { "s" },
+        w.k,
+        w.days
+    );
+    if runs.stale_hash > 0 {
+        let _ = write!(line, " · {} predate the last edit", runs.stale_hash);
+    }
+    if runs.unknown_hash > 0 {
+        let _ = write!(line, " · {} unverifiable", runs.unknown_hash);
+    }
+    if w.retention_keep > 0 && runs.total == w.retention_keep {
+        let _ = write!(line, " · trace retention keeps last {}", w.retention_keep);
+    }
+    if w.files_unreadable > 0 {
+        let _ = write!(line, " · {} unreadable skipped", w.files_unreadable);
+    }
+    if w.files_truncated > 0 {
+        let _ = write!(
+            line,
+            " · {} torn tail{} trimmed",
+            w.files_truncated,
+            if w.files_truncated == 1 { "" } else { "s" }
+        );
+    }
+    if w.nonfinite_dropped > 0 {
+        let _ = write!(line, " · {} non-finite dropped", w.nonfinite_dropped);
+    }
+    line.push(')');
+    if report.runs.total < LOW_CONFIDENCE_N {
+        let _ = write!(line, " · low confidence (n<{LOW_CONFIDENCE_N})");
+    }
+    line
+}
+
+/// One task line: duration prior · cost prior · the risk notes.
+fn task_row(task: &TaskPrior, width: usize) -> String {
+    let mut line = format!(
+        "  {:width$}  {:22} {:10}",
+        task.id,
+        prior_cell(&task.duration_ms),
+        cost_cell(task.cost_usd.as_ref(), task.unpriced.is_some()),
+    );
+    let mut notes: Vec<String> = Vec::new();
+    if task.failed > 0 {
+        notes.push(format!("failed {}/{}", task.failed, task.ran_in_runs));
+    }
+    if task.passed_on_retry > 0 {
+        notes.push(format!(
+            "passed on retry {}/{} ⚠",
+            task.passed_on_retry, task.ran_in_runs
+        ));
+    }
+    if let Some(slug) = &task.unpriced {
+        notes.push(format!("unpriced: {slug}"));
+    }
+    if task.cache_hits > 0 {
+        notes.push(format!(
+            "{} cache hit{}",
+            task.cache_hits,
+            if task.cache_hits == 1 { "" } else { "s" }
+        ));
+    }
+    if task.other_model > 0 {
+        notes.push(format!(
+            "{} run{} on other models excluded",
+            task.other_model,
+            if task.other_model == 1 { "" } else { "s" }
+        ));
+    }
+    if !notes.is_empty() {
+        let _ = write!(line, " {}", notes.join(" · "));
+    }
+    line.trim_end().to_owned()
+}
+
+/// The whole-run line: elapsed prior over COMPLETED runs · the totals
+/// prior · what was excluded, named.
+fn run_line(report: &ForecastReport, width: usize) -> String {
+    let any_unpriced = report.tasks.iter().any(|t| t.unpriced.is_some());
+    let mut line = format!(
+        "  {:width$}  {:22} {:10}",
+        "run",
+        prior_cell(&report.run_duration),
+        cost_cell(report.run_cost.as_ref(), any_unpriced),
+    );
+    let mut notes: Vec<String> = Vec::new();
+    let dn = report.run_duration.n();
+    if dn > 0 && dn != report.runs.total {
+        notes.push(format!("duration from {dn} completed"));
+    }
+    if report.runs.failed > 0 {
+        notes.push(format!(
+            "failed {}/{}",
+            report.runs.failed, report.runs.total
+        ));
+    }
+    if report.runs.paused > 0 {
+        notes.push(format!(
+            "{} paused run{} excluded",
+            report.runs.paused,
+            if report.runs.paused == 1 { "" } else { "s" }
+        ));
+    }
+    if report.runs.no_terminal > 0 {
+        notes.push(format!("{} unfinished excluded", report.runs.no_terminal));
+    }
+    if !notes.is_empty() {
+        let _ = write!(line, " · {}", notes.join(" · "));
+    }
+    line.trim_end().to_owned()
+}
+
+/// The Argo-shaped honesty hedge — printed beside the numbers, always.
+const fn hedge_line() -> &'static str {
+    "estimates vary with `when` branches, inputs, and provider latency"
+}
+
+/// A duration prior cell — the rung decides the vocabulary (EXHAUSTIVE
+/// match: this is OUR enum, four arms, never a `_`).
+fn prior_cell(prior: &Prior) -> String {
+    match *prior {
+        Prior::NeverRan => "never ran".to_owned(),
+        Prior::LastRun { value } => format!("last run {}", fmt_wall_ms(to_ms(value))),
+        Prior::Range { min, max, .. } => {
+            format!("{}–{}", fmt_wall_ms(to_ms(min)), fmt_wall_ms(to_ms(max)))
+        }
+        Prior::Bands { p50, p90, .. } => {
+            format!(
+                "~{} (p90 {})",
+                fmt_wall_ms(to_ms(p50)),
+                fmt_wall_ms(to_ms(p90))
+            )
+        }
+    }
+}
+
+/// A cost prior cell — `≥` composes whenever unpriced spend
+/// participates; no prior AND no unpriced is an honest dash, never $0.
+fn cost_cell(prior: Option<&Prior>, unpriced: bool) -> String {
+    let floor = if unpriced { "≥ " } else { "" };
+    match prior {
+        None => {
+            if unpriced {
+                "≥ —".to_owned()
+            } else {
+                "—".to_owned()
+            }
+        }
+        Some(Prior::NeverRan) => "—".to_owned(),
+        Some(Prior::LastRun { value }) => format!("{floor}{}", fmt_cost_usd(*value)),
+        Some(Prior::Range { min, max, .. }) => {
+            format!("{floor}{}–{}", fmt_cost_usd(*min), fmt_cost_usd(*max))
+        }
+        Some(Prior::Bands { p50, p90, .. }) => {
+            format!(
+                "{floor}~{} (p90 {})",
+                fmt_cost_usd(*p50),
+                fmt_cost_usd(*p90)
+            )
+        }
+    }
+}
+
+/// f64 milliseconds → u64 for the shared formatter. Values are wall
+/// times ≪ 2^53, so the round-trip is exact; negatives clamp to zero.
+fn to_ms(v: f64) -> u64 {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let ms = v.round().max(0.0) as u64;
+    ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{RunCensus, Window};
+    use super::*;
+
+    fn report(total: usize) -> ForecastReport {
+        ForecastReport {
+            workflow: "wf".into(),
+            runs: RunCensus {
+                total,
+                same_hash: total,
+                completed: total,
+                ..RunCensus::default()
+            },
+            window: Window::new(),
+            run_duration: Prior::from_finite(
+                #[allow(clippy::cast_precision_loss)] // test sizes ≪ 2^52
+                &(0..total).map(|i| 1_000.0 + i as f64).collect::<Vec<_>>(),
+            ),
+            run_cost: None,
+            tasks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn never_run_says_so_and_invents_nothing() {
+        let mut s = String::new();
+        forecast_section(&mut s, &report(0));
+        assert!(s.contains("no forecast — this workflow has never run here"));
+        assert!(!s.contains("p90"), "no percentile vocabulary at n=0");
+    }
+
+    #[test]
+    fn one_run_speaks_last_run_never_percentiles() {
+        let mut s = String::new();
+        forecast_section(&mut s, &report(1));
+        assert!(s.contains("based on last 1 run "));
+        assert!(s.contains("last run 1.0s"));
+        assert!(!s.contains("p90"));
+        assert!(s.contains("low confidence (n<10)"));
+    }
+
+    #[test]
+    fn three_runs_earn_a_range_five_earn_bands() {
+        let mut s = String::new();
+        forecast_section(&mut s, &report(3));
+        assert!(s.contains('–'), "range dash present");
+        assert!(!s.contains("p90"));
+        let mut s5 = String::new();
+        forecast_section(&mut s5, &report(5));
+        assert!(s5.contains("(p90 "));
+        assert!(s5.contains("~1.0s"));
+    }
+
+    #[test]
+    fn floor_composes_and_absence_stays_a_dash() {
+        assert_eq!(cost_cell(None, false), "—");
+        assert_eq!(cost_cell(None, true), "≥ —");
+        let one = Prior::LastRun { value: 0.021 };
+        assert_eq!(cost_cell(Some(&one), true), "≥ $0.02");
+        assert_eq!(cost_cell(Some(&one), false), "$0.02");
+    }
+
+    #[test]
+    fn window_caveats_are_information_not_errors() {
+        let mut r = report(7);
+        r.runs.stale_hash = 2;
+        r.runs.unknown_hash = 1;
+        r.window.retention_keep = 7;
+        r.window.files_truncated = 1;
+        let mut s = String::new();
+        forecast_section(&mut s, &r);
+        assert!(s.contains("2 predate the last edit"));
+        assert!(s.contains("1 unverifiable"));
+        assert!(s.contains("trace retention keeps last 7"));
+        assert!(s.contains("1 torn tail trimmed"));
+        assert!(s.contains(hedge_line()));
+    }
+
+    #[test]
+    fn paused_is_named_paused_never_a_crash_word() {
+        let mut r = report(3);
+        r.runs.paused = 1;
+        let mut s = String::new();
+        forecast_section(&mut s, &r);
+        assert!(s.contains("1 paused run excluded"));
+        assert!(!s.contains("incomplete"));
+    }
+}

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -17,6 +17,7 @@ pub mod dap;
 pub mod doctor;
 pub mod explain;
 pub mod explain_file;
+pub(crate) mod forecast;
 pub mod graph;
 pub mod init;
 pub mod inspect;

--- a/crates/nika-cli/src/verbs/trace/store.rs
+++ b/crates/nika-cli/src/verbs/trace/store.rs
@@ -136,7 +136,7 @@ fn read_meta(path: &Path) -> Option<TraceMeta> {
 /// awaiting task): the FIRST `workflow_started` names the run; the
 /// LAST workflow-level terminal event decides the state (none →
 /// `Running`) and, when paused, names the unanswered task.
-fn fold_facts(events: &[Event]) -> (String, TraceState, Option<String>) {
+pub(crate) fn fold_facts(events: &[Event]) -> (String, TraceState, Option<String>) {
     let workflow = events
         .iter()
         .find(|e| e.kind == EventKind::WorkflowStarted)

--- a/crates/nika-cli/tests/forecast_e2e.rs
+++ b/crates/nika-cli/tests/forecast_e2e.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! Forecast e2e — the honesty ladder proven end to end: REAL runs
+//! through the REAL runtime (mock seams), their event streams written
+//! exactly as the flight recorder writes them, then `nika explain
+//! --forecast` read back through the public verb surface.
+//!
+//! CWD note: `explain` reads `.nika/traces/` relative to the working
+//! directory (the operator contract), so each test owns a tempdir and
+//! `set_current_dir`s into it. Safe under CI's nextest (process per
+//! test); this file never runs under the local `--lib` law.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use nika_event::Event;
+use nika_kernel_mock::{MockClock, MockProvider, MockShell, MockToolDefinitionProvider};
+use nika_providers::{ProviderRegistry, ProvidersConfig};
+use nika_runtime::{DeterministicStamper, Runtime, RuntimeConfig, VecSink};
+use nika_schema::{FileId, ParseMode, check, parse};
+use nika_verb_agent::AgentVerb;
+use nika_verb_exec::ExecVerb;
+use nika_verb_infer::InferVerb;
+use nika_verb_invoke::InvokeVerb;
+
+/// Two tasks · two verbs — enough DAG for a run-level elapsed and a
+/// per-task model bucket (`think` rides mock/echo · `probe` is exec).
+const WORKFLOW: &str = r#"
+nika: v1
+workflow: fc-e2e
+description: forecast ladder fixture
+
+model: mock/echo
+
+tasks:
+  - id: probe
+    exec:
+      command: "echo ready"
+
+  - id: think
+    depends_on: [probe]
+    infer:
+      prompt: "summarize the probe"
+      max_tokens: 32
+"#;
+
+/// One REAL run through the runtime — the same chain `nika run`
+/// composes, mock seams at the I/O edges only.
+async fn one_run() -> Vec<Event> {
+    let wf = parse(WORKFLOW, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    let report = check(&wf);
+    assert!(report.is_clean(), "fixture must check clean");
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(
+        nika_kernel_mock::MockToolExecutor::new(),
+    )));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new().enqueue_ok("ready\n"))),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean workflow executes");
+    assert!(outcome.ok, "the fixture run completes");
+    sink.into_events()
+}
+
+/// Write N runs into `<dir>/.nika/traces/` exactly as the recorder
+/// does (one NDJSON line per event · ISO-shaped names, newest last).
+fn stage_runs(dir: &Path, events: &[Event], n: usize) {
+    let traces = dir.join(".nika").join("traces");
+    std::fs::create_dir_all(&traces).expect("traces dir");
+    let body: String = events
+        .iter()
+        .map(|e| serde_json::to_string(e).expect("event serializes"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    for i in 0..n {
+        let name = format!("2026-07-09T{:02}-00-00Z-e2e{i}.ndjson", 1 + i);
+        std::fs::write(traces.join(name), &body).expect("trace staged");
+    }
+}
+
+/// The workflow file + the cwd dance shared by both tests.
+fn arena(events: &[Event], runs: usize) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("arena");
+    std::fs::write(dir.path().join("fc-e2e.nika.yaml"), WORKFLOW).expect("wf written");
+    stage_runs(dir.path(), events, runs);
+    std::env::set_current_dir(dir.path()).expect("cwd into arena");
+    dir
+}
+
+#[tokio::test]
+async fn six_runs_earn_bands_and_the_json_twin_tags_the_rung() {
+    let events = one_run().await;
+    let _arena = arena(&events, 6);
+
+    let out = nika_cli::verbs::explain_file::run("fc-e2e.nika.yaml", false, true);
+    for needle in [
+        "FORECAST",
+        "based on last 6 runs",
+        "(p90 ",
+        "low confidence (n<10)",
+        // The harness stamps no source hashes — the census must SAY so.
+        "6 unverifiable",
+        "estimates vary with `when` branches",
+    ] {
+        assert!(
+            out.text.contains(needle),
+            "missing `{needle}`:\n{}",
+            out.text
+        );
+    }
+    assert!(
+        !out.text.contains("predict"),
+        "banned vocabulary:\n{}",
+        out.text
+    );
+
+    let json = nika_cli::verbs::explain_file::run("fc-e2e.nika.yaml", true, true);
+    let v: serde_json::Value = serde_json::from_str(&json.text).expect("json parses");
+    assert_eq!(v["forecast"]["run_duration"]["kind"], "bands");
+    assert_eq!(v["forecast"]["runs"]["total"], 6);
+    assert_eq!(v["forecast"]["runs"]["completed"], 6);
+    assert_eq!(v["forecast"]["runs"]["unknown_hash"], 6);
+}
+
+#[tokio::test]
+async fn three_runs_stay_a_range_and_arrive_unprompted() {
+    let events = one_run().await;
+    let _arena = arena(&events, 3);
+
+    // n = 3 crosses the auto threshold: the section arrives WITHOUT the
+    // flag, and speaks range vocabulary only — never a percentile.
+    let out = nika_cli::verbs::explain_file::run("fc-e2e.nika.yaml", false, false);
+    assert!(
+        out.text.contains("based on last 3 runs"),
+        "auto-section at n=3:\n{}",
+        out.text
+    );
+    assert!(
+        !out.text.contains("p90"),
+        "no bands under n=5:\n{}",
+        out.text
+    );
+
+    let json = nika_cli::verbs::explain_file::run("fc-e2e.nika.yaml", true, false);
+    let v: serde_json::Value = serde_json::from_str(&json.text).expect("json parses");
+    assert_eq!(v["forecast"]["run_duration"]["kind"], "range");
+}


### PR DESCRIPTION
`nika explain <file>` now reads the flight-recorder history beside the
static story: duration/cost forecasts per task, an honesty ladder as a
type (the rung says HOW MUCH the number knows), and `--json` gains a
versioned `forecast` key (internally-tagged rungs — consumers tolerate
unknown kinds). Deterministic: anchored on the newest matching run's
`workflow_started` stamp, never `now()` — the same trace directory
always forecasts the same.

Also in this branch:
- `refactor(nika-cli): main under the fn cap — examples arm extracted`
- forecast hardening review batch (WINDOW_DAYS named const · float_field
  Int coercion · retention via `RetentionConfig::from_env` · `--forecast`
  refuses error-code queries loudly · `run_with_traces` testable seam),
  pinned by a real-runtime e2e (`tests/forecast_e2e.rs` — REAL runs
  through mock seams, read back through the public verb surface, CI
  nextest).

Stacked follow-up: the `nika-dap` admission PR is based on this branch —
the forecast's +947 LOC pushed nika-cli to 98.9% of its size cap, and the
split is the consequence. Merge this first.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
