### PR TITLE
fix: the V-arc findings — the stranger's first path holds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,17 @@ jobs:
           tarball="nika-${ASSET_NAME}-${version}.tar.gz"
           tar -czf "${tarball}" -C "${stage}" nika
           shasum -a 256 "${tarball}" | tee "${tarball}.sha256"
+      - name: Funnel e2e (gate before upload)
+        # The stranger's first path, played against the TARBALL that is
+        # about to ship (untarred into a clean HOME · offline · content
+        # asserts, never bare exit codes) — the deno pattern: a broken
+        # first-run never uploads. scripts/ci/funnel-e2e.sh is the spec.
+        # No workflow inputs reach the script: it takes one local path.
+        run: |
+          set -euo pipefail
+          smoke="$(mktemp -d)"
+          tar -xzf nika-*.tar.gz -C "$smoke"
+          bash scripts/ci/funnel-e2e.sh "$smoke/nika"
       - uses: actions/upload-artifact@v4
         with:
           name: nika-${{ matrix.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **The missing-input trap is taught at check time** — `nika check`
+  prints an `[inputs]` HINT when a `nika:read` path that resolves
+  statically (a literal, or one `${{ vars.X }}` with a literal default)
+  does not exist here; never an error — the file may appear at run
+  time, and anything dynamic is never guessed
+  (`nika_schema::check::static_read_paths`, the pure half).
+- **The release tarball is funnel-gated** — `scripts/ci/funnel-e2e.sh`
+  plays the stranger's first path against the EXACT tarball about to
+  ship (clean HOME · offline · content asserts); a broken first-run
+  never uploads.
+
+### Fixed
+
+- **Fold verdicts are terminal kinds only** — a journal truncated after
+  its opening line no longer surfaces `workflow_started` as if the
+  crashed run had reached a state; `nika context` reads it as
+  honestly-unknown.
+
 ## [0.98.0](https://github.com/supernovae-st/nika/compare/v0.97.0..v0.98.0) - 2026-07-08
 
 **Structured output goes native, the checker closes its gaps — and the

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -299,6 +299,22 @@ fn hints_and_verdict(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t
             h.advice
         );
     }
+    // The stranger's first trap (V-arc F1): statically-resolvable
+    // `nika:read` paths that do not exist HERE — a hint, never an
+    // error (the file may appear at run time). Analysis is
+    // nika-schema's; only the filesystem question lives at this edge.
+    for (task, path) in nika_schema::check::static_read_paths(wf)
+        .into_iter()
+        .filter(|(_, p)| !std::path::Path::new(p).exists())
+    {
+        hint_count += 1;
+        let _ = writeln!(
+            out,
+            " {} {}     [inputs] `{task}` reads `{path}` which does not exist here — create it (or point its var elsewhere) · the run would fail at that wave",
+            t.paint(Role::Accent, "↳"),
+            t.paint(Role::Strong, "HINT"),
+        );
+    }
     let inputs = required_inputs(wf);
     if !inputs.is_empty() {
         hint_count += 1;
@@ -615,6 +631,29 @@ pub fn run_infer_permits(path: &str, json: bool) -> VerbOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_read_files_flags_static_literal_and_var_default() {
+        let dir = std::env::temp_dir().join(format!("nika-lint-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap_or(());
+        let present = dir.join("present.txt");
+        std::fs::write(&present, "x").expect("fixture");
+        let yaml = format!(
+            "nika: v1\nworkflow: w\nvars:\n  src: \"{missing}\"\ntasks:\n  - id: a\n    invoke:\n      tool: \"nika:read\"\n      args: {{ path: \"${{{{ vars.src }}}}\" }}\n  - id: b\n    invoke:\n      tool: \"nika:read\"\n      args: {{ path: \"{present}\" }}\n  - id: c\n    invoke:\n      tool: \"nika:read\"\n      args: {{ path: \"${{{{ tasks.a.output }}}}\" }}\n",
+            missing = dir.join("missing.txt").display(),
+            present = present.display(),
+        );
+        let wf = parse_wf(&yaml);
+        let flagged: Vec<(String, String)> = nika_schema::check::static_read_paths(&wf)
+            .into_iter()
+            .filter(|(_, p)| !std::path::Path::new(p).exists())
+            .collect();
+        // `a` via var default → flagged · `b` exists → silent ·
+        // `c` dynamic (task ref) → the lint never guesses.
+        assert_eq!(flagged.len(), 1, "{flagged:?}");
+        assert_eq!(flagged[0].0, "a");
+        let _ = std::fs::remove_file(&present);
+    }
 
     #[test]
     fn pricing_section_rates_known_null_unknown() {

--- a/crates/nika-event/src/fold.rs
+++ b/crates/nika-event/src/fold.rs
@@ -107,7 +107,16 @@ pub fn fold_one(path: &Path) -> RunFact {
         .as_ref()
         .and_then(|t| t.get("kind"))
         .and_then(|k| k.as_str())
-        .filter(|k| k.starts_with("workflow_"))
+        // TERMINAL kinds only — a journal truncated after its opening
+        // line must fold to `None` (honestly unknown), never surface
+        // `workflow_started` as if a crashed run had reached a state
+        // (the V-arc e2e caught exactly that).
+        .filter(|k| {
+            matches!(
+                *k,
+                "workflow_completed" | "workflow_failed" | "workflow_paused"
+            )
+        })
         .map(str::to_owned);
     let cost_usd = tail
         .as_ref()
@@ -123,5 +132,58 @@ pub fn fold_one(path: &Path) -> RunFact {
         verdict,
         cost_usd,
         unpriced_calls,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncated_journal_folds_to_unknown_verdict() {
+        let dir = std::env::temp_dir().join(format!(
+            "nika-fold-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().map_or(0, str::len)
+        ));
+        std::fs::create_dir_all(&dir).unwrap_or(());
+        let path = dir.join("truncated.ndjson");
+        // A journal cut after its OPENING event — the exact V-arc repro:
+        // the head kind starts with `workflow_` but is NOT terminal.
+        std::fs::write(
+            &path,
+            "{\"kind\":\"workflow_started\",\"fields\":[{\"key\":\"workflow\",\"value\":\"demo\"}]}\n",
+        )
+        .expect("fixture write");
+        let fact = fold_one(&path);
+        assert_eq!(fact.workflow.as_deref(), Some("demo"));
+        assert_eq!(
+            fact.verdict, None,
+            "opening event must never read as a verdict"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn completed_tail_folds_to_terminal_verdict() {
+        let dir = std::env::temp_dir().join(format!(
+            "nika-fold-ok-{}-{}",
+            std::process::id(),
+            std::thread::current().name().map_or(0, str::len)
+        ));
+        std::fs::create_dir_all(&dir).unwrap_or(());
+        let path = dir.join("done.ndjson");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"kind\":\"workflow_started\",\"fields\":[{\"key\":\"workflow\",\"value\":\"demo\"}]}\n",
+                "{\"kind\":\"workflow_completed\",\"fields\":[{\"key\":\"total_cost_usd\",\"value\":0.5}]}\n",
+            ),
+        )
+        .expect("fixture write");
+        let fact = fold_one(&path);
+        assert_eq!(fact.verdict.as_deref(), Some("workflow_completed"));
+        assert_eq!(fact.cost_usd, Some(0.5));
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -1409,6 +1409,7 @@ pub const nika_schema::check::REPORT_VERSION: u32
 pub const nika_schema::check::STATUS_VOCAB: [&str; 4]
 pub fn nika_schema::check::check(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::check::CheckReport
 pub fn nika_schema::check::infer_permits(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::InferredPermits
+pub fn nika_schema::check::static_read_paths(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub mod nika_schema::codegen
 pub fn nika_schema::codegen::nika_builtin_tool_enum_schema() -> serde_json::value::Value
 pub mod nika_schema::error

--- a/crates/nika-schema/src/check/hints.rs
+++ b/crates/nika-schema/src/check/hints.rs
@@ -50,7 +50,7 @@ use std::collections::BTreeSet;
 
 use crate::expression::{Expr, Literal, RelOp, scan_templates, task_output_paths};
 use crate::raw::{RawAction, RawTask, RawWorkflow};
-use crate::types::{CaptureMode, OnErrorAction};
+use crate::types::{CaptureMode, OnErrorAction, VarDecl};
 
 /// One advisory improvement with its concrete unlock.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -552,6 +552,60 @@ fn visit_json(value: &serde_json::Value, visit: &mut dyn FnMut(&str)) {
         }
         serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
     }
+}
+
+/// Resolve an invoke arg to a STATIC string when it is a plain literal
+/// or a single `${{ vars.X }}` whose declaration carries a literal
+/// default — the two shapes a scaffold ships. Anything dynamic (task
+/// refs · env · concatenations) resolves to `None`: analysis never
+/// guesses.
+fn static_string_arg(wf: &RawWorkflow, value: &serde_json::Value) -> Option<String> {
+    let s = value.as_str()?;
+    let trimmed = s.trim();
+    if !trimmed.contains("${{") {
+        return Some(trimmed.to_owned());
+    }
+    let inner = trimmed.strip_prefix("${{")?.strip_suffix("}}")?.trim();
+    let var = inner.strip_prefix("vars.")?;
+    if var.contains(['.', '[']) {
+        return None;
+    }
+    wf.vars.iter().find_map(|(name, decl)| {
+        if name.value != var {
+            return None;
+        }
+        let default = match decl {
+            VarDecl::Untyped(v) => Some(v),
+            VarDecl::Typed { default, .. } => default.as_ref(),
+        };
+        default.and_then(|d| d.as_str()).map(str::to_owned)
+    })
+}
+
+/// Every `nika:read` whose `path` arg resolves STATICALLY — the pure
+/// half of the missing-input lint (V-arc F1 2026-07-09): the analyzer
+/// names the (task · path) pairs, the CALLER decides what existence
+/// means on its side of the I/O boundary (the CLI checks the local
+/// filesystem; a server might check an artifact store).
+#[must_use]
+pub fn static_read_paths(wf: &RawWorkflow) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for task in &wf.tasks {
+        let RawAction::Invoke(invoke) = &task.value.action else {
+            continue;
+        };
+        if invoke.tool.value != "nika:read" {
+            continue;
+        }
+        let Some(args) = &invoke.args else { continue };
+        let Some(path_val) = args.value.get("path") else {
+            continue;
+        };
+        if let Some(path) = static_string_arg(wf, path_val) {
+            out.push((task.value.id.value.clone(), path));
+        }
+    }
+    out
 }
 
 fn hint(kind: &'static str, task: &str, advice: String) -> Hint {

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -52,6 +52,7 @@ pub use certificate::{Bound, CertTerm, RunCertificate};
 pub use cost::{CostCeiling, TaskCost, UnboundedReason};
 pub use flow::{FlowFacts, TaintTrace};
 pub use hints::Hint;
+pub use hints::static_read_paths;
 pub use infer_permits::InferredPermits;
 pub use permits_fit::CapabilityEscape;
 pub use reach::{GateFinding, GateFindingKind, STATUS_VOCAB};

--- a/scripts/ci/funnel-e2e.sh
+++ b/scripts/ci/funnel-e2e.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# funnel-e2e · the stranger's first path, played against a BUILT binary.
+#
+# Release-gate version of the V-arc deep e2e (2026-07-09): structural
+# asserts only — sections exist · promised commands exist in the clap
+# tree · JSON envelope versions · stable semantic needles (FLOOR ·
+# unpriced) · exit codes. Never whole transcripts (those live in docs,
+# re-captured by hand per the RELEASED law).
+#
+# Runs OFFLINE in a throwaway HOME (no keys · no configs · TERM=dumb).
+# Usage: funnel-e2e.sh <nika-binary>
+set -euo pipefail
+BIN="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+HOME_DIR="$ROOT/home"
+WS="$ROOT/ws"
+mkdir -p "$HOME_DIR" "$WS"
+cd "$WS"
+FAILS=0
+say() { printf '%s\n' "$*"; }
+fail() {
+  say "FAIL $*"
+  FAILS=$((FAILS + 1))
+}
+run() { # run <name> <expected-exit> -- cmd...
+  local name="$1" want="$2"
+  shift 2
+  [ "$1" = "--" ] && shift
+  set +e
+  OUT=$(env -i HOME="$HOME_DIR" PATH=/usr/bin:/bin TERM=dumb "$@" 2>&1)
+  local got=$?
+  set -e
+  if [ "$got" -ne "$want" ]; then
+    fail "[$name] exit=$got want=$want"
+    printf '%s\n' "$OUT" | head -6 | sed 's/^/    /'
+    return 1
+  fi
+}
+need() { printf '%s' "$OUT" | grep -qF "$2" || fail "[$1] missing: $2"; }
+
+HELP=$(env -i HOME="$HOME_DIR" PATH=/usr/bin:/bin TERM=dumb "$BIN" --help 2>&1)
+has_cmd() { printf '%s' "$HELP" | grep -Eq "^[[:space:]]+$1([[:space:]]|$)"; }
+
+say "── funnel e2e · $("$BIN" --version)"
+
+# 1 · the mirror: sections + every arrow-promised command exists
+run welcome 0 -- "$BIN" welcome
+need welcome "this machine"
+need welcome "start here"
+for c in $(printf '%s' "$OUT" | grep -oE '→ nika [a-z-]+' | awk '{print $3}' | sort -u); do
+  has_cmd "$c" || fail "[welcome] promises 'nika $c' — clap tree lacks it"
+done
+FIRST=$(printf '%s' "$OUT" | grep -oE 'nika examples run [a-z0-9-]+ --model mock/echo' | head -1)
+[ -n "$FIRST" ] || fail "[welcome] no offline first command promised"
+# shellcheck disable=SC2086 # the promise is played verbatim, word-split intended
+[ -n "$FIRST" ] && run first-promise 0 -- "$BIN" ${FIRST#nika }
+run welcome-json 0 -- "$BIN" welcome --json
+need welcome-json '"welcome_version"'
+# sovereignty canary: a key VALUE must never surface
+OUT=$(env -i HOME="$HOME_DIR" PATH=/usr/bin:/bin TERM=dumb OPENAI_API_KEY=sk-CANARY-9911 "$BIN" welcome --json 2>&1)
+printf '%s' "$OUT" | grep -q "sk-CANARY-9911" && fail "[welcome] key VALUE leaked"
+
+# 2 · scaffold → audit (the inputs trap is TAUGHT) → provision → run → story → verify
+run new-from 0 -- "$BIN" new --from chain first.nika.yaml
+[ -f first.nika.yaml ] || fail "[new] no file created"
+run check 0 -- "$BIN" check first.nika.yaml
+need check "audited"
+need check "[inputs]" # the scaffold's ./input.txt trap is taught BEFORE the run
+echo demo >input.txt
+run run-mock 0 -- "$BIN" run first.nika.yaml --model mock/echo
+TRACE=$(find .nika/traces -name '*.ndjson' 2>/dev/null | sort | tail -1)
+[ -n "$TRACE" ] || fail "[run] no trace recorded"
+if has_cmd explain; then
+  run explain-file 0 -- "$BIN" explain first.nika.yaml
+  need explain-file "FLOOR"
+  need explain-file "unpriced"
+  need explain-file "flight recorder"
+  need explain-file "$(basename "$TRACE")"
+fi
+run verify 0 -- "$BIN" trace verify "$TRACE"
+
+# 3 · the workspace aggregate (when the binary carries it)
+if has_cmd context; then
+  run context-json 0 -- "$BIN" context --json
+  need context-json '"context_version"'
+  need context-json '"rollups"'
+  # a journal truncated after its opening line folds to verdict null
+  head -1 "$TRACE" >.nika/traces/zz-truncated.ndjson
+  run context-trunc 0 -- "$BIN" context --json
+  printf '%s' "$OUT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+runs = [r for r in d["workspace"]["runs"] if "zz-truncated" in r["trace"]]
+assert runs, "truncated journal missing from runs"
+assert runs[0]["verdict"] is None, f"opening event read as verdict: {runs[0]}"
+' || fail "[context-trunc] crashed-run fold not honest"
+fi
+
+# 4 · agent briefing: every taught verb exists
+run init 0 -- "$BIN" init
+[ -f AGENTS.md ] || fail "[init] no AGENTS.md"
+run init-again 0 -- "$BIN" init
+for c in $(grep -oE '`nika [a-z-]+' AGENTS.md | awk '{print $2}' | tr -d '`' | sort -u); do
+  has_cmd "$c" || fail "[agents-md] teaches 'nika $c' — clap tree lacks it"
+done
+
+# 5 · doctor diagnoses offline · broken files fail WITH a code
+run doctor 0 -- "$BIN" doctor
+# shellcheck disable=SC2016 # the ${{ }} island must reach the file UNEXPANDED
+printf 'nika: v1\nworkflow: broken\nmodel: mock/echo\ntasks:\n  - id: a\n    exec: { command: "echo ${{ tasks.ghost.output }}" }\n' >broken.nika.yaml
+set +e
+OUT=$(env -i HOME="$HOME_DIR" PATH=/usr/bin:/bin TERM=dumb "$BIN" check broken.nika.yaml 2>&1)
+GOT=$?
+set -e
+[ "$GOT" -eq 0 ] && fail "[broken] invalid workflow checked clean"
+printf '%s' "$OUT" | grep -qE "NIKA-[A-Z0-9-]+[0-9]" || fail "[broken] no error code in voice"
+
+say "── funnel e2e: FAILS=$FAILS"
+exit $((FAILS > 0))


### PR DESCRIPTION
Three findings from the 2026-07-09 V-arc deep e2e (the stranger's first
path against a built binary), each with its regression pinned:

1. **The missing-input trap is taught at check time** — the scaffolded
   chain workflow reads `./input.txt` and the first `nika run` died on it
   AFTER a clean `nika check`. New `nika_schema::check::static_read_paths`
   (the pure half: literal paths or one-`${{ vars.X }}`-with-literal-default;
   dynamic never guessed) + a filesystem HINT at the CLI edge — never an
   error, the file may legitimately appear at run time.
2. **Fold verdicts are terminal kinds only** — a journal truncated after
   its opening line surfaced `workflow_started` as if the crashed run had
   reached a state. Terminal kinds (completed · failed · paused) or
   honestly-unknown `None`.
3. **funnel-e2e gates the release tarball** — the deno pattern: the
   stranger's path replayed against the EXACT tarball about to ship
   (clean HOME · offline · content asserts, never bare exit codes); a
   broken first-run never uploads.

Tests: 350 (schema) + 9 (event) + 791 (cli) green · clippy 0 ·
public-api.txt regenerated (+1 fn) · shellcheck + shfmt clean.

**The gate proven differential**: funnel-e2e ran against BOTH binaries —
`FAILS=0` on this branch, `FAILS=2` on main, and the two failures are
exactly the two engine fixes this PR ships (`[inputs]` hint · truncated
fold). The gate detects what it claims to gate, nothing else.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
