### PR TITLE
fix(hygiene): vector 9 follows the org storefront — canonical tap name + the two new repos

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -55,7 +55,7 @@ change. `brew install supernovae-st/tap/nika` then pulls the new version.
 
 ## 3. One-time secret for the auto-formula-bump
 
-Create a fine-grained PAT with **contents:write** on `supernovae-st/homebrew-nika`,
+Create a fine-grained PAT with **contents:write** on `supernovae-st/homebrew-tap`,
 then add it to the engine repo:
 
 ```bash

--- a/scripts/hygiene/check-org-readme.sh
+++ b/scripts/hygiene/check-org-readme.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Vector 9: Org profile README mentions all 6 canonical repos.
+# Vector 9: Org profile README mentions every canonical public repo.
 set -u
 if ! command -v gh >/dev/null; then
   echo "gh not installed"
@@ -13,9 +13,10 @@ content="$(gh api repos/supernovae-st/.github/contents/profile/README.md --jq .c
 }
 
 missing=""
-# homebrew-tap was RENAMED homebrew-nika (2026-07-02 · GitHub redirects both);
-# nika-spec/nika-docs/nika-vscode joined the canonical set with the profile refresh.
-for repo in nika nika.sh nika-client nika-spec nika-docs nika-vscode homebrew-nika nika-site-audit; do
+# homebrew-nika was RENAMED homebrew-tap (canonical per api .full_name · GitHub
+# redirects the old name); nika-agents + nika-registry joined the profile with
+# the 2026-07-09 storefront-truth pass (.github#1).
+for repo in nika nika.sh nika-client nika-spec nika-docs nika-vscode nika-agents nika-registry homebrew-tap nika-site-audit; do
   echo "$content" | grep -q "$repo" || missing="${missing}${repo} "
 done
 
@@ -23,5 +24,5 @@ if [ -n "$missing" ]; then
   echo "missing from profile: ${missing}"
   exit 1
 fi
-echo "OK (all 6 repos listed)"
+echo "OK (all canonical repos listed)"
 exit 0


### PR DESCRIPTION
The storefront-truth pass ([supernovae-st/.github#1](https://github.com/supernovae-st/.github/pull/1)) replaced `homebrew-nika` with the canonical `homebrew-tap` on the org profile and added `nika-agents` + `nika-registry` — **vector 9 still grepped for the old tap name and would have gone RED on its next run** (self-inflicted, caught by the same-day truth sweep).

- repo list → the 10 canonical repos (`homebrew-tap` + the two new ones)
- the comment stops stating the rename **backwards** (`homebrew-nika` → `homebrew-tap` per `api .full_name`; GitHub redirects the old name)
- `RELEASING.md` scopes the formula-bump PAT on the canonical repo name

**Proven green against the live profile before pushing** (`OK (all canonical repos listed)`). Pre-push suite green (ratchets · hygiene · clippy · tests).

🦋 Signed: Nika