### PR TITLE
feat(hygiene): vector 9 gains counts parity — the vitrine tracks canon.yaml

### DIFF
--- a/scripts/hygiene/check-org-readme.sh
+++ b/scripts/hygiene/check-org-readme.sh
@@ -24,5 +24,25 @@ if [ -n "$missing" ]; then
   echo "missing from profile: ${missing}"
   exit 1
 fi
-echo "OK (all canonical repos listed)"
+
+# Counts parity · the profile quotes canon.yaml and MUST track it (the
+# 2026-07-09 storefront drift: « 14 providers, 23 builtin tools » lived on
+# the page for weeks while canon said 16/25 · stress-to-ratchet graduation,
+# ≥3 same-class incidents that day). canon.yaml is the SSOT — when a count
+# moves there, this goes RED until the vitrine follows.
+canon="$(curl -fsSL --max-time 15 https://raw.githubusercontent.com/supernovae-st/nika-spec/main/canon.yaml 2>/dev/null)"
+if [ -n "$canon" ]; then
+  verbs="$(echo "$canon" | awk '/^counts:/{f=1} f && /^  verbs:/{print $2; exit}')"
+  providers="$(echo "$canon" | awk '/^counts:/{f=1} f && /^  providers:/{print $2; exit}')"
+  builtins="$(echo "$canon" | awk '/^counts:/{f=1} f && /^  builtins:/{print $2; exit}')"
+  expected="${verbs} verbs, ${providers} providers, ${builtins} builtin tools"
+  if ! echo "$content" | grep -q "$expected"; then
+    echo "counts drift: profile lacks \"$expected\" (canon.yaml is the SSOT)"
+    exit 1
+  fi
+else
+  echo "warn: canon.yaml unreachable — counts parity skipped"
+fi
+
+echo "OK (all canonical repos listed · counts match canon)"
 exit 0


### PR DESCRIPTION
**Stress-to-ratchet graduation** — the counts-drift class fired 3+ times on 2026-07-09 alone: the org profile said *« 14 providers, 23 builtin tools »* for weeks while canon said 16/25 (fixed in supernovae-st/.github#1), with sibling drift in the docs and CONTRIBUTING tables.

Vector 9 now:
1. fetches `canon.yaml` (the SSOT) from the spec repo,
2. extracts `verbs` / `providers` / `builtins` from the `counts:` block,
3. asserts the exact phrase (`4 verbs, 16 providers, 25 builtin tools`) on the org profile.

A count moving in canon → **RED here until the vitrine follows** — the org-level twin of the site's builtins↔icons gate. `canon.yaml` unreachable degrades to a warn (no false RED offline).

**Proven**: green live against today's profile + a poisoned-phrase negative test exits 1. Pre-push suite green.

🦋 Signed: Nika