### PR TITLE
fix(changelog): the conformal cite says Theorem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   A distribution-free, finite-sample upper prediction bound (split
   conformal, order-statistic form): for exchangeable runs the NEXT one
   falls at or below the k-th order statistic with probability ≥ k/(n+1),
-  exactly k/(n+1) for continuous data (arXiv:2411.11824 Thm 3.2). The
+  exactly k/(n+1) for continuous data (arXiv:2411.11824 Theorem 3.2). The
   level arrives as a rational (the f64 route mis-computes the exact
   feasibility frontier — 0.9·10 ceils to 10); nine runs earn a
   guaranteed 90% bound, nineteen earn 95%. Proven by a deterministic

--- a/crates/nika-dap/src/stats.rs
+++ b/crates/nika-dap/src/stats.rs
@@ -100,7 +100,7 @@ impl Prior {
 /// and **exactly** `k/(n+1)` when the distribution is continuous (ties
 /// only push true coverage higher — conservative, never invalid). A
 /// distribution-free THEOREM about the next run, not an estimate
-/// (Angelopoulos–Barber–Bates, CUP 2026 · arXiv:2411.11824 Thm 3.2).
+/// (Angelopoulos–Barber–Bates, CUP 2026 · arXiv:2411.11824 Theorem 3.2).
 ///
 /// Scope of the promise: « next » means the next observation drawn
 /// from the SAME population the sample was gathered from — the
@@ -262,7 +262,7 @@ mod tests {
         /// leave-one-out split is equally likely, and the k-th order
         /// statistic of the kept n covers the held-out value in
         /// EXACTLY k of the n+1 splits (continuous case ·
-        /// arXiv:2411.11824 Thm 3.2): hold out y_(j) — the kept k-th
+        /// arXiv:2411.11824 Theorem 3.2): hold out y_(j) — the kept k-th
         /// smallest is y_(k+1) when j ≤ k (covers) and y_(k) when
         /// j > k (does not). No Monte-Carlo, no seed sensitivity.
         #[test]


### PR DESCRIPTION
Main's Diamond CI is red on the typos job since #325's changelog entry landed: `Thm 3.2` reads as a typo of `Them`. Spelled out to `Theorem 3.2`.

One word, three heals: main's typos job, #338's merge-ref (its CHANGELOG inherits main), and #339 carries the same hunk (identical content — merges clean). The rust(tests) red on main's last run is an install-action 504 infra flake; the next push run clears it.