### PR TITLE
docs(privacy): the rules index drops its operator memory slugs

### DIFF
--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -28,11 +28,8 @@ User asks you to …                    → Load rule
 
 Higher in this list wins when two docs contradict:
 
-1. `~/.claude/projects/-Users-thibaut-dev-supernovae-hq/memory/POST_AUDIT_REVISIONS.md` — supreme authority
-2. `~/.claude/projects/-Users-thibaut-dev-supernovae-hq/memory/PRE_LAUNCH_GATES.md` — 7 shadow zones
-3. `~/.claude/projects/-Users-thibaut-dev-supernovae-hq/memory/HANDOFF_PHASE_1_REVISED.md` — current execution plan
-4. `.claude/rules/*.md` (this directory) — project-specific enforcement
-5. `~/.claude/projects/-Users-thibaut-dev-supernovae-hq/memory/project_ai_velocity_north_star.md` — WHY diamond (decision filter)
+1. Studio-internal authority docs (POST_AUDIT_REVISIONS · PRE_LAUNCH_GATES · HANDOFF · the velocity north-star) — private overlay on the operator's machine (`.claude/settings.local.json` · gitignored) — supreme authority when present locally
+2. `.claude/rules/*.md` (this directory) — project-specific enforcement
 
 ## Loading philosophy
 


### PR DESCRIPTION
Sister of #343 (same leak class, missed file): `.claude/rules/INDEX.md` authority chain printed full `~/.claude/projects/<machine-slug>/memory` paths. Chain semantics preserved — studio-internal overlay wins when present locally. The elided `~/.claude/.../` pointer form used elsewhere (frozen ADRs · diamond-discipline) stays sanctioned per `scripts/hygiene/check-private-leaks.sh`.

Context: the monorepo hygiene `privacy-boundary` vector grows a **tracked-content pass** this arc (`ventures/<v>/0N-` paths + full `~/.claude/projects/` slugs) — this file was its only remaining hit across the 9 public repos. API-commit route (pre-push `memory-head-sha` race · precedent #317/#343); blob sha verified against `git hash-object` byte-parity.