### PR TITLE
feat(provider): openrouter calls carry the app-attribution pair

### DIFF
--- a/crates/nika-providers/src/wire/openai_compat.rs
+++ b/crates/nika-providers/src/wire/openai_compat.rs
@@ -110,6 +110,13 @@ fn build_request(
             format!("Bearer {}", key.expose()),
         );
     }
+    if rp.profile.id == "openrouter" {
+        // OpenRouter app attribution (their optional-but-recommended pair):
+        // calls show up as `Nika` on openrouter.ai/rankings instead of an
+        // anonymous key. openrouter-only — peers may 400 on surprise headers.
+        headers.insert("http-referer".to_owned(), "https://nika.sh".to_owned());
+        headers.insert("x-title".to_owned(), "Nika".to_owned());
+    }
 
     let mut http_req = HttpRequest::post(rp.base_url.clone());
     http_req.headers = headers;
@@ -614,6 +621,47 @@ mod tests {
             "keyless local call"
         );
         assert!(sent[0].url.starts_with("http://127.0.0.1:11434"));
+    }
+
+    #[tokio::test]
+    async fn openrouter_sends_app_attribution_headers() {
+        let fake = FakeHttp::with_json(
+            200,
+            r#"{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{}}"#,
+        );
+        let rp = resolved_with(&fake, "openrouter", "sk-or-test");
+        let _ = infer(&rp, req(vec![Message::text(Role::User, "x")]))
+            .await
+            .expect("ok");
+        let sent = fake.captured();
+        assert_eq!(
+            sent[0].headers.get("http-referer").map(String::as_str),
+            Some("https://nika.sh"),
+            "openrouter app attribution · referer"
+        );
+        assert_eq!(
+            sent[0].headers.get("x-title").map(String::as_str),
+            Some("Nika"),
+            "openrouter app attribution · title"
+        );
+    }
+
+    #[tokio::test]
+    async fn attribution_headers_stay_openrouter_only() {
+        let fake = FakeHttp::with_json(
+            200,
+            r#"{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{}}"#,
+        );
+        let rp = resolved_with(&fake, "groq", "gsk-test");
+        let _ = infer(&rp, req(vec![Message::text(Role::User, "x")]))
+            .await
+            .expect("ok");
+        let sent = fake.captured();
+        assert!(
+            !sent[0].headers.contains_key("http-referer")
+                && !sent[0].headers.contains_key("x-title"),
+            "attribution is an openrouter contract, not an openai-compat one"
+        );
     }
 
     #[test]


### PR DESCRIPTION
OpenRouter's optional-but-recommended attribution headers — `HTTP-Referer: https://nika.sh` + `X-Title: Nika` — now ride every openrouter request. Runs surface as **Nika** on [openrouter.ai/rankings](https://openrouter.ai/rankings) instead of an anonymous key (the E7 finding from the meet-everywhere distribution sweep).

Scoped to the `openrouter` profile only — openai-compat peers may 400 on surprise headers. Proven both directions (TDD, RED first):
- `openrouter_sends_app_attribution_headers` — the pair present
- `attribution_headers_stay_openrouter_only` — absent on groq

`nika-providers --lib`: **141/141** · clippy deny-mode 0.

Closes #334.