### PR TITLE
feat(nika-chart): the design pass — per-mode palettes, quantized cells, capped bars

### DIFF
--- a/crates/nika-chart/examples/demo.rs
+++ b/crates/nika-chart/examples/demo.rs
@@ -213,10 +213,16 @@ fn cost_per_provider() -> (ChartSpec, Vec<Row>) {
                 n(0.0035 + x * 0.00022 + if i % 4 == 0 { 0.0012 } else { 0.0 }),
             ),
         ]));
+        // Third series: another CLOUD provider — local runs are UNPRICED,
+        // never plotted as $0 (the cost-honesty law: a flat line at zero
+        // would teach the exact conjured-price class the engine refuses).
         rows.push(row(&[
             ("run", n(x)),
-            ("provider", s("ollama")),
-            ("usd", n(0.0002)),
+            ("provider", s("mistral")),
+            (
+                "usd",
+                n(0.0018 + x * 0.00012 + if i % 5 == 0 { 0.0006 } else { 0.0 }),
+            ),
         ]));
     }
     (spec, rows)

--- a/crates/nika-chart/src/palette.rs
+++ b/crates/nika-chart/src/palette.rs
@@ -1,10 +1,19 @@
 //! Embedded palettes (zero-dep · operator lock « pas de dépendances »).
 //!
-//! · Categorical: Okabe-Ito CVD-safe set (jfly.uni-koeln.de/color · web
-//!   resource, no DOI exists) — series order starts at blue.
+//! · Categorical: Okabe-Ito CVD-safe hues, PER-MODE steps — dark mode is a
+//!   selected palette (its own steps validated against the dark surface),
+//!   never an automatic flip. Both sets pass the six computable checks
+//!   (lightness band L 0.43–0.77 light / 0.48–0.67 dark · chroma ≥ 0.1 ·
+//!   adjacent CVD ΔE ≥ 12 [worst pair 20.7] · contrast vs surface) — run,
+//!   never eyeballed. Light differs from canonical Okabe-Ito in ONE slot:
+//!   #F0E442 (yellow · 1.29:1 on white, invisible as a thin mark) re-steps
+//!   to #A08C00 within the same hue.
 //! · Sequential: viridis 10-anchor LUT (`SciPy` 2015 talk · no paper) · sRGB
 //!   lerp between anchors (Lab-space lerp = v1.5 refinement).
-//! · Diverging: Moreland cool-warm 3-anchor (ISVC 2009) for `delta` (midpoint 0).
+//! · Diverging: Moreland cool-warm 3-anchor (ISVC 2009) for `delta` — the
+//!   midpoint must read as « nothing », so it is per-mode too (light gray on
+//!   light · near-surface graphite on dark; a WHITE midpoint on a dark
+//!   surface makes « no change » the loudest thing on the chart).
 
 #![allow(
     clippy::cast_possible_truncation,
@@ -13,23 +22,45 @@
     clippy::cast_possible_wrap,
     clippy::many_single_char_names
 )] // color ramp lerp (r/g/b/t idiom)
-/// Okabe-Ito series colors (black reserved for text · yellow last — weak on white).
-const OKABE_ITO: [&str; 7] = [
+/// Okabe-Ito hues stepped for the LIGHT surface (#ffffff) — black reserved
+/// for text · the gold slot last (weakest identity work).
+pub const CATEGORICAL_LIGHT: [&str; 7] = [
     "#0072B2", // blue
     "#E69F00", // orange
     "#009E73", // bluish green
     "#D55E00", // vermilion
     "#CC79A7", // reddish purple
     "#56B4E9", // sky blue
-    "#F0E442", // yellow
+    "#A08C00", // gold (Okabe-Ito yellow re-stepped into the lightness band)
+];
+
+/// The SAME seven hues stepped for the DARK surface (#0f1318) — every slot
+/// ≥ 3:1 against it (strict, no relief needed in dark).
+pub const CATEGORICAL_DARK: [&str; 7] = [
+    "#1E88CF", // blue
+    "#BC8100", // orange
+    "#009E73", // bluish green
+    "#D55E00", // vermilion
+    "#C05E93", // reddish purple
+    "#3E9BD6", // sky blue
+    "#A39500", // gold
 ];
 
 /// Categorical color for series index (cycles past 7 — the lint upstream
-/// warns at >8 categories per CHT §3ter).
+/// warns at >8 categories per CHT §3ter). LIGHT step — the single-document
+/// SVG swaps to [`CATEGORICAL_DARK`] via its `<style>` classes; PNG and
+/// Vega-Lite (single-mode surfaces) render this set.
 #[must_use]
 pub fn categorical(i: usize) -> &'static str {
-    let idx = i % OKABE_ITO.len();
-    OKABE_ITO.get(idx).copied().unwrap_or("#0072B2")
+    let idx = i % CATEGORICAL_LIGHT.len();
+    CATEGORICAL_LIGHT.get(idx).copied().unwrap_or("#0072B2")
+}
+
+/// Dark-mode step for the same series index (parity with [`categorical`]).
+#[must_use]
+pub fn categorical_dark(i: usize) -> &'static str {
+    let idx = i % CATEGORICAL_DARK.len();
+    CATEGORICAL_DARK.get(idx).copied().unwrap_or("#1E88CF")
 }
 
 /// Viridis anchors (matplotlib canonical 10-stop).
@@ -48,6 +79,11 @@ const VIRIDIS: [(u8, u8, u8); 10] = [
 
 /// Moreland cool-warm anchors (RGB 59,76,192 · 221,221,221 · 180,4,38).
 const COOLWARM: [(u8, u8, u8); 3] = [(59, 76, 192), (221, 221, 221), (180, 4, 38)];
+
+/// Cool-warm re-anchored for the DARK surface: the arms lift toward
+/// legibility on #0f1318 and the midpoint drops to near-surface graphite —
+/// « no change » must recede, not glow.
+const COOLWARM_DARK: [(u8, u8, u8); 3] = [(110, 139, 239), (58, 65, 73), (226, 91, 99)];
 
 fn lerp_channel(a: u8, b: u8, t: f64) -> u8 {
     let v = (f64::from(a) + (f64::from(b) - f64::from(a)) * t).round();
@@ -80,6 +116,41 @@ pub fn viridis(t: f64) -> String {
 #[must_use]
 pub fn coolwarm(t: f64) -> String {
     ramp(&COOLWARM, t)
+}
+
+/// Dark-mode diverging ramp (near-surface midpoint · lifted arms).
+#[must_use]
+pub fn coolwarm_dark(t: f64) -> String {
+    ramp(&COOLWARM_DARK, t)
+}
+
+/// Heatmap cells and their legend share ONE quantized scale — this many
+/// discrete bins (the legend already swore « never a gradient »; the cells
+/// keep the same promise, and the bin index doubles as the per-mode CSS
+/// class so ONE document renders both themes).
+pub const DIVERGING_BINS: usize = 8;
+
+/// Quantize t ∈ `[0,1]` onto the shared diverging bins → bin index.
+#[must_use]
+pub fn diverging_bin(t: f64) -> usize {
+    let t = t.clamp(0.0, 1.0);
+    ((t * DIVERGING_BINS as f64) as usize).min(DIVERGING_BINS - 1)
+}
+
+/// The LIGHT fill for a diverging bin (bin midpoint sampled on the ramp).
+#[must_use]
+pub fn diverging_bin_light(bin: usize) -> String {
+    coolwarm(bin_center(bin))
+}
+
+/// The DARK fill for a diverging bin.
+#[must_use]
+pub fn diverging_bin_dark(bin: usize) -> String {
+    coolwarm_dark(bin_center(bin))
+}
+
+fn bin_center(bin: usize) -> f64 {
+    (bin.min(DIVERGING_BINS - 1) as f64 + 0.5) / DIVERGING_BINS as f64
 }
 
 /// Chrome constants (one place · one voice).

--- a/crates/nika-chart/src/render.rs
+++ b/crates/nika-chart/src/render.rs
@@ -171,14 +171,19 @@ pub fn bar(
 
     let zero_y = ys.map(0.0);
     for (i, v) in vals.iter().enumerate() {
-        let (x, w) = band.slot(i);
+        let (sx, sw) = band.slot(i);
+        // Mark spec: a bar never fills its slot — cap the mark and let the
+        // band's leftover be air (thick saturated blocks read loud). 48
+        // viewBox units = 24 displayed px on the 2× grid.
+        let w = sw.min(48.0);
+        let x = sx + (sw - w) / 2.0;
         let yv = ys.map(*v);
-        let (top, h) = if yv <= zero_y {
-            (yv, zero_y - yv)
+        let (top, h, up) = if yv <= zero_y {
+            (yv, zero_y - yv, true)
         } else {
-            (zero_y, yv - zero_y)
+            (zero_y, yv - zero_y, false)
         };
-        svg.rect(x, top, w, h.max(0.0), palette::categorical(0), None);
+        svg.bar(x, top, w, h.max(0.0), palette::categorical(0), up);
         // Value label above the bar when it fits.
         let vl = fmt::label(*v, spec.y.semantic);
         if metrics::measure(&vl, 10.0) <= band.step_width() {
@@ -491,20 +496,36 @@ pub fn scatter(
     Ok(svg.close())
 }
 
-/// Normalized ramp color for a heatmap cell value.
-fn heat_color(v: f64, min: f64, max: f64, sem: Semantic) -> String {
+/// A heatmap fill, quantized onto the legend's own bins — cells and legend
+/// share ONE scale (the legend swore « never a gradient »; the cells keep
+/// the same promise).
+enum HeatFill {
+    /// Diverging (delta) — the bin index IS the per-mode CSS class.
+    Div(usize),
+    /// Sequential (viridis · perceptually uniform, legible on both
+    /// surfaces) — a quantized inline fill.
+    Seq(String),
+}
+
+fn heat_fill(v: f64, min: f64, max: f64, sem: Semantic) -> HeatFill {
     if sem == Semantic::Delta {
         let m = min.abs().max(max.abs());
-        if m <= 0.0 {
-            return palette::coolwarm(0.5);
-        }
-        palette::coolwarm(0.5 + v / (2.0 * m))
+        let t = if m <= 0.0 { 0.5 } else { 0.5 + v / (2.0 * m) };
+        HeatFill::Div(palette::diverging_bin(t))
     } else {
         let span = max - min;
-        if span <= 0.0 {
-            return palette::viridis(0.5);
-        }
-        palette::viridis((v - min) / span)
+        let t = if span <= 0.0 { 0.5 } else { (v - min) / span };
+        let bin = palette::diverging_bin(t); // same bin count · shared law
+        HeatFill::Seq(palette::viridis(
+            (bin as f64 + 0.5) / palette::DIVERGING_BINS as f64,
+        ))
+    }
+}
+
+fn paint_cell(svg: &mut Svg, x: f64, y: f64, w: f64, h: f64, fill: &HeatFill) {
+    match fill {
+        HeatFill::Div(bin) => svg.cell_bin(x, y, w, h, *bin),
+        HeatFill::Seq(hex) => svg.cell_soft(x, y, w, h, hex),
     }
 }
 
@@ -524,10 +545,11 @@ fn heat_legend(svg: &mut Svg, frame: &Frame, vmin: f64, vmax: f64, sem: Semantic
         None,
     );
     lx += metrics::measure(&min_l, 10.0) + 6.0;
-    for i in 0..7 {
-        let tt = f64::from(i) / 6.0;
+    // One swatch per shared bin — the exact classes/fills the cells wear.
+    for bin in 0..palette::DIVERGING_BINS {
+        let tt = (bin as f64 + 0.5) / palette::DIVERGING_BINS as f64;
         let v = vmin + tt * (vmax - vmin);
-        svg.cell(lx, ly - 7.0, 14.0, 9.0, &heat_color(v, vmin, vmax, sem));
+        paint_cell(svg, lx, ly - 7.0, 14.0, 9.0, &heat_fill(v, vmin, vmax, sem));
         lx += 14.0;
     }
     lx += 6.0;
@@ -580,12 +602,13 @@ pub fn heatmap(
         let xi = xcats.iter().position(|c| c == x).unwrap_or(0);
         let yi = ycats.iter().position(|c| c == y).unwrap_or(0);
         if filled.insert((xi, yi)) {
-            svg.cell(
+            paint_cell(
+                &mut svg,
                 frame.x0 + cw * (xi as f64),
                 frame.y0 + ch * (yi as f64),
                 cw,
                 ch,
-                &heat_color(*v, vmin, vmax, val_ch.semantic),
+                &heat_fill(*v, vmin, vmax, val_ch.semantic),
             );
         }
     }

--- a/crates/nika-chart/src/svg.rs
+++ b/crates/nika-chart/src/svg.rs
@@ -7,11 +7,14 @@
 //! Rect/cell edges are rounded independently (x0=px(x) · x1=px(x+w) ·
 //! w=x1−x0) so adjacent cells share an edge — seam-free without overlap.
 //!
-//! THEME SEAM (one colour seam): chrome constants map to CSS classes backed
-//! by an embedded `<style>` with a `prefers-color-scheme: dark` block —
-//! light is the base (the documented degradation for @media-blind rasterers
-//! like resvg per §12bis) · SAME bytes render light and dark. Series colors
-//! stay inline (Okabe-Ito is CVD-safe on both).
+//! THEME SEAM (one colour seam): chrome constants, series slots and
+//! diverging bins ALL map to CSS classes backed by an embedded `<style>`
+//! with a `prefers-color-scheme: dark` block — light is the base (the
+//! documented degradation for @media-blind rasterers like resvg per
+//! §12bis) · SAME bytes render light and dark. Dark is a SELECTED palette
+//! (its own steps, six-check validated against #0f1318) — the original
+//! « Okabe-Ito is CVD-safe on both » premise was refuted by the computable
+//! checks (4 slots out of the dark lightness band · yellow 1.29:1 on white).
 //!
 //! All emission goes through `write!` into one buffer (no intermediate
 //! `format!` allocations · perf law) · attributes in fixed hand-written
@@ -53,28 +56,77 @@ fn ratio(o: f64) -> String {
     }
 }
 
-/// Light values mirror `palette` chrome constants · dark values are fixed
-/// constants of the artifact contract.
+/// Light values mirror `palette` constants · dark values are the SELECTED
+/// dark steps (per-mode palettes, never an automatic flip — the six-check
+/// validator fails a single shared set on one surface or the other). Series
+/// fills (`s0..s6`), series strokes (`l0..l6`) and diverging bins
+/// (`d0..d7`) ride the same media query as the chrome, so ONE byte-stable
+/// document renders both themes. A `test` guards this block against
+/// palette drift (the BOTH-lists law, color edition).
 const THEME_STYLE: &str = "<style>.bg{fill:#ffffff}.ink{fill:#1a1a1a}.ink2{fill:#555555}\
 .grid{stroke:#e6e6e6}.axis{stroke:#9a9a9a}.nodata{fill:#eceef0}\
+.s0{fill:#0072B2}.s1{fill:#E69F00}.s2{fill:#009E73}.s3{fill:#D55E00}\
+.s4{fill:#CC79A7}.s5{fill:#56B4E9}.s6{fill:#A08C00}\
+.l0{stroke:#0072B2}.l1{stroke:#E69F00}.l2{stroke:#009E73}.l3{stroke:#D55E00}\
+.l4{stroke:#CC79A7}.l5{stroke:#56B4E9}.l6{stroke:#A08C00}\
+.d0{fill:#4F5EC4}.d1{fill:#7882CB}.d2{fill:#A0A7D2}.d3{fill:#C9CBD9}\
+.d4{fill:#D8C2C6}.d5{fill:#CE8C98}.d6{fill:#C3556B}.d7{fill:#B91F3D}\
 @media(prefers-color-scheme:dark){.bg{fill:#0f1318}.ink{fill:#e6e6e6}.ink2{fill:#9aa4ad}\
-.grid{stroke:#262c33}.axis{stroke:#57616b}.nodata{fill:#1c2127}}</style>\n";
+.grid{stroke:#262c33}.axis{stroke:#57616b}.nodata{fill:#1c2127}\
+.s0{fill:#1E88CF}.s1{fill:#BC8100}.s2{fill:#009E73}.s3{fill:#D55E00}\
+.s4{fill:#C05E93}.s5{fill:#3E9BD6}.s6{fill:#A39500}\
+.l0{stroke:#1E88CF}.l1{stroke:#BC8100}.l2{stroke:#009E73}.l3{stroke:#D55E00}\
+.l4{stroke:#C05E93}.l5{stroke:#3E9BD6}.l6{stroke:#A39500}\
+.d0{fill:#6882DA}.d1{fill:#5B6FB1}.d2{fill:#4E5D87}.d3{fill:#414A5E}\
+.d4{fill:#4F444C}.d5{fill:#794B53}.d6{fill:#A35159}.d7{fill:#CD5860}}</style>\n";
+
+/// Shared cell geometry: a 2px-displayed surface gap per side (the gap does
+/// the separating) with guards for tiny cells.
+fn cell_inset(x: f64, y: f64, w: f64, h: f64) -> (i64, i64, i64, i64) {
+    const GAP: f64 = 2.0; // per side
+    let gx = GAP.min(w / 4.0);
+    let gy = GAP.min(h / 4.0);
+    (
+        px(x + gx),
+        px(y + gy),
+        px((w - 2.0 * gx).max(0.0)),
+        px((h - 2.0 * gy).max(0.0)),
+    )
+}
 
 fn fill_class(color: &str) -> Option<&'static str> {
     match color {
         palette::BG => Some("bg"),
         palette::INK => Some("ink"),
         palette::INK_SOFT => Some("ink2"),
-        _ => None,
+        _ => series_fill_class(color),
     }
+}
+
+/// Series colors translate to per-mode classes — call sites keep passing
+/// `palette::categorical(i)` (the light step) and the document carries both.
+fn series_fill_class(color: &str) -> Option<&'static str> {
+    const S: [&str; 7] = ["s0", "s1", "s2", "s3", "s4", "s5", "s6"];
+    palette::CATEGORICAL_LIGHT
+        .iter()
+        .position(|c| *c == color)
+        .and_then(|i| S.get(i).copied())
 }
 
 fn stroke_class(color: &str) -> Option<&'static str> {
     match color {
         palette::GRID => Some("grid"),
         palette::AXIS => Some("axis"),
-        _ => None,
+        _ => series_stroke_class(color),
     }
+}
+
+fn series_stroke_class(color: &str) -> Option<&'static str> {
+    const L: [&str; 7] = ["l0", "l1", "l2", "l3", "l4", "l5", "l6"];
+    palette::CATEGORICAL_LIGHT
+        .iter()
+        .position(|c| *c == color)
+        .and_then(|i| L.get(i).copied())
 }
 
 #[must_use]
@@ -241,10 +293,18 @@ impl Svg {
             }
             let _ = write!(self.buf, "{},{}", px(*x), px(*y));
         }
+        self.buf.push_str("\" fill=\"none\"");
+        match series_stroke_class(stroke) {
+            Some(c) => {
+                let _ = write!(self.buf, " class=\"{c}\"");
+            }
+            None => {
+                let _ = write!(self.buf, " stroke=\"{stroke}\"");
+            }
+        }
         let _ = write!(
             self.buf,
-            "\" fill=\"none\" stroke=\"{stroke}\" stroke-width=\"{}\" \
-             stroke-linejoin=\"round\" stroke-linecap=\"round\"",
+            " stroke-width=\"{}\" stroke-linejoin=\"round\" stroke-linecap=\"round\"",
             px(width)
         );
         if let Some((a, b)) = dash {
@@ -279,15 +339,91 @@ impl Svg {
     pub fn dot(&mut self, cx: f64, cy: f64, r: f64, fill: &str, opacity: Option<f64>) {
         let _ = write!(
             self.buf,
-            "<circle cx=\"{}\" cy=\"{}\" r=\"{}\" fill=\"{fill}\"",
+            "<circle cx=\"{}\" cy=\"{}\" r=\"{}\"",
             px(cx),
             px(cy),
             px(r)
         );
+        match fill_class(fill) {
+            Some(c) => {
+                let _ = write!(self.buf, " class=\"{c}\"");
+            }
+            None => {
+                let _ = write!(self.buf, " fill=\"{fill}\"");
+            }
+        }
         if let Some(o) = opacity {
             let _ = write!(self.buf, " fill-opacity=\"{}\"", ratio(o));
         }
         self.buf.push_str("/>\n");
+    }
+
+    /// A bar with a ROUNDED data-end and a SQUARE baseline end (the mark
+    /// spec: the shape says which end carries the value). `up` = the data
+    /// end is the top edge (positive bars); negatives round the bottom.
+    #[allow(clippy::many_single_char_names)] // geometry signature (x y w h r)
+    pub fn bar(&mut self, x: f64, y: f64, w: f64, h: f64, fill: &str, up: bool) {
+        let r = 8.0_f64.min(w / 2.0).min(h); // 4px at the 2× viewBox · never past half-width
+        if r <= 0.0 || h <= 0.0 {
+            self.rect(x, y, w, h.max(0.0), fill, None);
+            return;
+        }
+        let (x0, x1) = (px(x), px(x + w));
+        let (y0, y1) = (px(y), px(y + h));
+        self.buf.push_str("<path d=\"");
+        if up {
+            // Baseline (bottom) square · top corners rounded.
+            let _ = write!(
+                self.buf,
+                "M{x0} {y1}V{} Q{x0} {y0} {} {y0}H{} Q{x1} {y0} {x1} {}V{y1}Z",
+                px(y + r),
+                px(x + r),
+                px(x + w - r),
+                px(y + r)
+            );
+        } else {
+            // Baseline (top) square · bottom corners rounded.
+            let _ = write!(
+                self.buf,
+                "M{x0} {y0}V{} Q{x0} {y1} {} {y1}H{} Q{x1} {y1} {x1} {}V{y0}Z",
+                px(y + h - r),
+                px(x + r),
+                px(x + w - r),
+                px(y + h - r)
+            );
+        }
+        self.buf.push('"');
+        match fill_class(fill) {
+            Some(c) => {
+                let _ = write!(self.buf, " class=\"{c}\"");
+            }
+            None => {
+                let _ = write!(self.buf, " fill=\"{fill}\"");
+            }
+        }
+        self.buf.push_str("/>\n");
+    }
+
+    /// A quantized diverging heatmap cell — the bin index IS the style
+    /// (`.d0..d7` carry per-mode fills), inset by a surface gap and gently
+    /// rounded (the gap does the separating; never a stroke).
+    pub fn cell_bin(&mut self, x: f64, y: f64, w: f64, h: f64, bin: usize) {
+        let (gx, gy, ww, hh) = cell_inset(x, y, w, h);
+        let _ = write!(
+            self.buf,
+            "<rect x=\"{gx}\" y=\"{gy}\" width=\"{ww}\" height=\"{hh}\" rx=\"3\" class=\"d{}\"/>\n",
+            bin.min(crate::palette::DIVERGING_BINS - 1)
+        );
+    }
+
+    /// A sequential heatmap cell — same inset/rounding geometry, quantized
+    /// inline fill (viridis is legible on both surfaces unchanged).
+    pub fn cell_soft(&mut self, x: f64, y: f64, w: f64, h: f64, fill: &str) {
+        let (gx, gy, ww, hh) = cell_inset(x, y, w, h);
+        let _ = write!(
+            self.buf,
+            "<rect x=\"{gx}\" y=\"{gy}\" width=\"{ww}\" height=\"{hh}\" rx=\"3\" fill=\"{fill}\"/>\n",
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -345,6 +481,77 @@ mod tests {
     #[test]
     fn escapes_all_specials() {
         assert_eq!(escape("a<b>&\"c'"), "a&lt;b&gt;&amp;&quot;c&apos;");
+    }
+
+    /// The BOTH-lists law, color edition: `THEME_STYLE` is hand-written —
+    /// every palette step must appear in it, light rules BEFORE the dark
+    /// media block and dark rules INSIDE it, or a palette edit silently
+    /// desynchronizes the artifact from the validated sets.
+    #[test]
+    fn theme_style_carries_both_validated_palettes() {
+        let dark_at = THEME_STYLE
+            .find("@media(prefers-color-scheme:dark)")
+            .expect("dark block present");
+        let (light, dark) = THEME_STYLE.split_at(dark_at);
+        for (i, (l, d)) in palette::CATEGORICAL_LIGHT
+            .iter()
+            .zip(palette::CATEGORICAL_DARK)
+            .enumerate()
+        {
+            assert!(light.contains(&format!(".s{i}{{fill:{l}}}")), "light s{i}");
+            assert!(
+                light.contains(&format!(".l{i}{{stroke:{l}}}")),
+                "light l{i}"
+            );
+            assert!(dark.contains(&format!(".s{i}{{fill:{d}}}")), "dark s{i}");
+            assert!(dark.contains(&format!(".l{i}{{stroke:{d}}}")), "dark l{i}");
+        }
+        for bin in 0..palette::DIVERGING_BINS {
+            let l = palette::diverging_bin_light(bin);
+            let d = palette::diverging_bin_dark(bin);
+            assert!(
+                light.contains(&format!(".d{bin}{{fill:{l}}}")),
+                "light d{bin}"
+            );
+            assert!(
+                dark.contains(&format!(".d{bin}{{fill:{d}}}")),
+                "dark d{bin}"
+            );
+        }
+    }
+
+    #[test]
+    fn series_colors_become_classes_never_inline() {
+        let mut svg = Svg::open(100, 100, "t", None);
+        svg.rect(0.0, 0.0, 10.0, 10.0, palette::categorical(1), None);
+        svg.polyline(
+            &[(0.0, 0.0), (5.0, 5.0)],
+            palette::categorical(2),
+            1.0,
+            None,
+        );
+        svg.dot(4.0, 4.0, 2.0, palette::categorical(0), None);
+        svg.bar(0.0, 0.0, 10.0, 20.0, palette::categorical(0), true);
+        svg.cell_bin(0.0, 0.0, 20.0, 20.0, 7);
+        let out = svg.close();
+        assert!(out.contains("class=\"s1\"") && out.contains("class=\"l2\""));
+        assert!(out.contains("class=\"s0\"") && out.contains("class=\"d7\""));
+        for c in palette::CATEGORICAL_LIGHT {
+            assert!(
+                !out.replace(THEME_STYLE, "").contains(c),
+                "series hex {c} leaked inline — per-mode classes are the contract"
+            );
+        }
+    }
+
+    #[test]
+    fn bar_rounds_the_data_end_only() {
+        let mut svg = Svg::open(100, 100, "t", None);
+        svg.bar(10.0, 10.0, 20.0, 30.0, palette::categorical(0), true);
+        let out = svg.close();
+        // One path, two quadratic corners, square baseline (Z closes flat).
+        assert!(out.contains("<path d=\"M20 80V"), "starts at the baseline");
+        assert_eq!(out.matches(" Q").count(), 2, "exactly two rounded corners");
     }
 
     #[test]

--- a/crates/nika-chart/tests/golden.rs
+++ b/crates/nika-chart/tests/golden.rs
@@ -41,7 +41,7 @@ fn golden_bar_sha256_is_pinned() {
     let (spec, rows) = bar_fixture();
     let a = nika_chart::compile(&spec, &rows).expect("compile");
     assert_eq!(
-        a.sha256, "2cc3a7f6d775db460b9dff3271e2ade8d23a7f3067406adf25e67c8f5206df59",
+        a.sha256, "83670bc4f7d2ac98e9ac909b375666732bc79435a6bda7f060701f5d2f460e1c",
         "byte drift detected — the attestation property broke"
     );
 }


### PR DESCRIPTION
## The review that forced this

A vision + validator design review of the merged `nika:chart` renderer, run against the six computable palette checks (lightness band · chroma floor · CVD separation · contrast — **run, never eyeballed**) plus a two-mode raster inspection of every chart type.

**The founding premise fell.** `svg.rs` documented *« Series colors stay inline (Okabe-Ito is CVD-safe on both) »* — the validator refuted it: **4 slots outside the dark lightness band** (L 0.48–0.67) and the yellow at **1.29:1 on white** (invisible as a thin mark).

## What ships

| Change | Rule it enforces |
|---|---|
| **Per-mode categorical palettes** — same 7 Okabe-Ito hues, dark gets its own steps (ALL six checks green vs `#0f1318`; light re-steps one slot: yellow → gold `#A08C00`) | dark mode is *selected*, never an automatic flip |
| **Series → CSS classes** (`s0..s6` fills · `l0..l6` strokes) through the existing `prefers-color-scheme` seam — call sites unchanged, ONE byte-stable document renders both themes | one colour seam |
| **BOTH-lists-style drift-guard test** — every palette step must appear in `THEME_STYLE`, light before the media block, dark inside it (it already caught 2 rounding off-by-ones during authoring) | the style block can't desync from the validated sets |
| **Heatmap cells quantize onto the legend's own 8 bins** (`d0..d7`), 2px surface gap + soft rounding — and the diverging midpoint goes near-surface graphite in dark | the legend swore « never a gradient »; cells keep the same promise · « no change » must recede, not glow |
| **Bars cap at 24 displayed px, rounded data-end, square baseline** | thin marks — thick saturated blocks read loud |
| **Demo doctrine fix**: third provider becomes mistral (cloud) | local runs are UNPRICED, never plotted as $0 — a flat zero line teaches the exact conjured-price class the engine refuses |

## Proof

- `nika-chart`: 89 lib + goldens + fuzz **green** · clippy deny-mode **0** · `nika-builtin` chart suite green
- Golden re-pinned twice — the tamper-detector fired on each intentional byte change (nominal)
- Vision re-pass on the regenerated gallery, both modes (light forced by media-block strip, dark by system)