### PR TITLE
feat(agents): the plugin grows its three slash commands

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
-  "description": "Author AI workflows as checkable .nika.yaml files — the nika-authoring skill + the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.1.0",
+  "description": "Author AI workflows as checkable .nika.yaml files — the nika-authoring skill, three slash commands (/nika:check · /nika:explain · /nika:new) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.2.0",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"
@@ -9,5 +9,12 @@
   "homepage": "https://docs.nika.sh",
   "repository": "https://github.com/supernovae-st/nika",
   "license": "AGPL-3.0-or-later",
-  "keywords": ["nika", "workflow", "yaml", "ai-workflows", "agent", "audit"]
+  "keywords": [
+    "nika",
+    "workflow",
+    "yaml",
+    "ai-workflows",
+    "agent",
+    "audit"
+  ]
 }

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "nika",
   "displayName": "Nika · Intent as Code",
-  "description": "Author AI workflows as checkable .nika.yaml files. Bundles the nika-authoring skill (author → check → repair loop) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.1.0",
+  "description": "Author AI workflows as checkable .nika.yaml files. Bundles the nika-authoring skill (author → check → repair loop), three slash commands (check · explain · new) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.2.0",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",
   "license": "AGPL-3.0-or-later",
   "skills": "./skills/",
+  "commands": "./commands/",
   "mcpServers": "./.mcp.json"
 }

--- a/.agents/plugins/nika/commands/check.md
+++ b/.agents/plugins/nika/commands/check.md
@@ -1,0 +1,29 @@
+---
+description: Audit a .nika.yaml workflow before it runs — findings with their NIKA-XXXX codes, cost envelope, permits
+argument-hint: <file.nika.yaml>
+allowed-tools: Bash(nika check:*), Bash(nika explain:*), Read, Glob
+---
+
+Audit the workflow **before** any run — check is the oracle, the file is
+the contract.
+
+Target: `$ARGUMENTS` (no argument? `Glob` for `*.nika.yaml` — one match
+runs, several ask).
+
+1. Run `nika check $ARGUMENTS --json` and read the payload, not the
+   prose: `clean` is the verdict · `conformance[]` carries the findings ·
+   `pricing` carries the rates (a `null` rate is UNKNOWN, never $0) ·
+   `models_resolve` (0.99+) says every `model:` runs in THIS binary.
+2. Summarize what the payload says, in this order:
+   - **Verdict** — clean, or N findings.
+   - **Findings** — one line each: `NIKA-XXXX · task <id> · <message>`,
+     with the fix the diagnostic teaches. Unknown code? Run
+     `nika explain NIKA-XXXX` and fold its teaching in.
+   - **Cost** — the ceiling (`≤ $X`) or the floor (`≥ $X FLOOR` — name
+     WHY it is unbounded: missing `max_tokens`, uncataloged model,
+     expression fan-out). A local model is **unpriced, never free**.
+   - **Permits** — declared boundary, or « engine floor only »
+     (suggest `nika check $ARGUMENTS --infer-permits` to write one).
+3. Exit code 2 with findings is the NORMAL red path — repair from the
+   diagnostics and re-check. Never hand the human a file that does not
+   pass. Only report a broken oracle (exit 3) as an error.

--- a/.agents/plugins/nika/commands/explain.md
+++ b/.agents/plugins/nika/commands/explain.md
@@ -1,0 +1,21 @@
+---
+description: Narrate a workflow (waves · cost · touches · how to run) or teach a NIKA-XXXX error code
+argument-hint: <file.nika.yaml | NIKA-XXXX>
+allowed-tools: Bash(nika explain:*), Read
+---
+
+Explain `$ARGUMENTS` — the same command narrates both shapes:
+
+- **A workflow file** → `nika explain $ARGUMENTS` tells the run story
+  BEFORE it happens: the waves (what runs in parallel), the cost
+  envelope (ceiling or floor — with the honest reason when unbounded),
+  what the run will touch (files · network · tools), and how to run it.
+  Relay that narration; add `--forecast` when the file has run before
+  (the typed honesty ladder over recorded durations).
+- **An error code** (`NIKA-XXXX`) → `nika explain $ARGUMENTS` teaches
+  the class: what it means, why the engine refuses, the canonical fix.
+  Every code also has its page at `https://nika.sh/errors/NIKA-XXXX`.
+
+Ground every claim in the command's output — the narration is computed
+from the file, never from memory of it. If the target is ambiguous
+(no file, no code shape), say what you need instead of guessing.

--- a/.agents/plugins/nika/commands/new.md
+++ b/.agents/plugins/nika/commands/new.md
@@ -1,0 +1,25 @@
+---
+description: Scaffold a workflow from an embedded template, then audit it clean
+argument-hint: [template] [file.nika.yaml]
+allowed-tools: Bash(nika new:*), Bash(nika examples:*), Bash(nika check:*), Read, Edit
+---
+
+Scaffold from a template, never from scratch — then audit until clean.
+
+Arguments: `$ARGUMENTS` (template + destination; either may be missing).
+
+1. No template named? `nika examples list` and pick the closest to the
+   user's intent (say which and why, one line). No destination? Derive a
+   kebab-case `<name>.nika.yaml` from the intent.
+2. `nika new --from <template> <file>` — the scriptable scaffold.
+3. Adapt the file to the user's actual task: envelope stays `nika: v1` +
+   `workflow: <kebab-id>` · exactly ONE verb per task · prefer
+   `invoke:` builtins over `exec:` (native-first) · every `infer:`
+   carries `max_tokens` (the cost ceiling depends on it) · templated
+   inputs ride `vars:` with `--var key=value` at run time.
+4. `nika check <file>` — repair from the diagnostics until exit 0, then
+   `nika check <file> --native-strict` (any remaining `exec:` needs its
+   ledger entry). **Never hand the human a file that does not pass.**
+5. Close with the run lines: `nika run <file> --model mock/echo`
+   (offline preview · zero keys) and the real form with their model —
+   plus `--max-cost-usd <n>` when spend matters.


### PR DESCRIPTION
## #341 — marketplace installs get first-class verbs

| Command | What it does |
|---|---|
| `/nika:check` | audit-before-run: findings with their NIKA-XXXX codes (folds `nika explain <code>` teaching), the cost envelope (**unpriced never free** · floor names its reason), permits — reads the `--json` payload, not the prose |
| `/nika:explain` | the narration (waves · cost · touches · how to run · `--forecast` when a history exists) — or the teaching of an error code, same command both shapes |
| `/nika:new` | scaffold from a template (`nika new --from`), adapt (one verb per task · native-first · `max_tokens` always), audit until clean — **never hand the human a failing file** |

## The mirror law honored

Born HERE under `.agents/plugins/nika/` — the marketplace repo (supernovae-st/nika-agents) re-syncs byte-identical; a kit-side addition would break the identity contract (the constraint the issue pins). Both manifests bump **0.2.0**; the codex manifest declares `./commands/` in its existing explicit-path style.

Version-honest: `models_resolve` is named as 0.99+ (the MODELS rung rides the open train).

Doc-only surface (`.agents/`) — zero overlap with the crate-size train.

Closes #341.