### PR TITLE
feat(mcp): nika_check carries the MODELS rung — the third lane closes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,8 +129,8 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `fix/effective-model-floor`                                      |
-| HEAD             | `a2788443e` (`a2788443ebbd5a916555ca66bfca2d080fa80a4a`)             |
+| branch           | `feat/mcp-models-rung`                                      |
+| HEAD             | `233f1d6b8` (`233f1d6b881b891c78fb5b05b0d0274426eaf3e8`)             |
 | workspace        | v0.98.0                                  |
 | crates (workspace)| 45                                              |
 | crates (admitted)| 43 / 42                                   |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,7 @@ dependencies = [
  "nika-catalog",
  "nika-error",
  "nika-pack",
+ "nika-providers",
  "nika-schema",
  "proptest",
  "serde_json",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,8 +93,8 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `fix/effective-model-floor`                                      |
-| HEAD             | `a2788443e` (`a2788443ebbd5a916555ca66bfca2d080fa80a4a`)             |
+| branch           | `feat/mcp-models-rung`                                      |
+| HEAD             | `233f1d6b8` (`233f1d6b881b891c78fb5b05b0d0274426eaf3e8`)             |
 | workspace        | v0.98.0                                  |
 | crates (workspace)| 45                                              |
 | crates (admitted)| 43 / 42                                   |

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -159,24 +159,10 @@ fn unresolvable_models(report: &nika_schema::check::CheckReport) -> Vec<ModelFin
         .models
         .iter()
         .filter_map(|m| {
-            let why = match m.model.split_once('/') {
-                None => format!(
-                    "`{}` is a bare model id — the contract is `<provider>/<model>` \
-                     (pick the provider that serves it; `nika doctor` names the \
-                     {} runnable providers)",
-                    m.model,
-                    nika_providers::CANONICAL_IDS.len()
-                ),
-                Some((provider, _)) if !nika_providers::CANONICAL_IDS.contains(&provider) => {
-                    format!(
-                        "provider `{provider}` does not resolve in THIS binary \
-                         ({} runnable — `nika doctor` names them); a cataloged \
-                         vendor is not a runnable one",
-                        nika_providers::CANONICAL_IDS.len()
-                    )
-                }
-                Some(_) => return None,
-            };
+            // The ONE law, shared with the MCP lane (#320 follow-up:
+            // the two machine surfaces consult the same fn beside the
+            // resolver — they cannot drift apart again).
+            let why = nika_providers::resolve_refusal(&m.model)?;
             Some(ModelFinding {
                 model: m.model.clone(),
                 tasks: m.tasks.clone(),

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -12,6 +12,7 @@ publish                = false  # Foundation crate — never on crates.io. See A
 
 [dependencies]
 nika-schema = { path = "../nika-schema", version = "0.98.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-providers = { path = "../nika-providers", version = "0.98.0", default-features = false }  # the resolver law: every model resolves in THIS binary (#320)
 nika-error  = { path = "../nika-error", version = "0.98.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
 nika-pack   = { path = "../nika-pack", version = "0.98.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 # The embedded knowledge payloads (`nika_catalog` · `nika_tools`) — the SAME

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -153,7 +153,19 @@ fn check(args: &Value) -> Result<String, String> {
     )
     .map_err(|e| format!("PARSE ✗ {e}"))?;
     let report = nika_schema::check(&wf);
-    if report.is_clean() {
+    // The MODELS rung, MCP lane (#320 repro 3): the schema ladder alone
+    // audited a hallucinated model green — cross every requirement against
+    // the RESOLVER law shared with the CLI rung (nika-providers).
+    let model_findings: Vec<Value> = report
+        .requirements
+        .models
+        .iter()
+        .filter_map(|m| {
+            nika_providers::resolve_refusal(&m.model)
+                .map(|why| serde_json::json!({ "model": m.model, "tasks": m.tasks, "why": why }))
+        })
+        .collect();
+    if report.is_clean() && model_findings.is_empty() {
         return Ok("✔ clean — audited before a single token was spent".to_owned());
     }
     // `is_clean()` checks TEN finding surfaces (conformance · secret leaks +
@@ -161,7 +173,20 @@ fn check(args: &Value) -> Result<String, String> {
     // /unknown args · gate findings) — render the FULL structured report so the
     // MCP client sees EVERY finding (the prior code listed only `conformance`,
     // dropping 9 classes · a model can parse the JSON + repair from it).
-    let detail = serde_json::to_string_pretty(&report)
+    let mut payload = serde_json::to_value(&report)
+        .map_err(|e| format!("check report serialization failed: {e}"))?;
+    if let Some(obj) = payload.as_object_mut() {
+        // The same keys the CLI --json lane carries — the two machine
+        // lanes must not disagree (the is_clean mirror law).
+        obj.insert(
+            "models_resolve".to_owned(),
+            Value::Bool(model_findings.is_empty()),
+        );
+        if !model_findings.is_empty() {
+            obj.insert("model_findings".to_owned(), Value::Array(model_findings));
+        }
+    }
+    let detail = serde_json::to_string_pretty(&payload)
         .map_err(|e| format!("check report serialization failed: {e}"))?;
     // A DIRTY workflow is an `Err` so the dispatcher flags `isError: true`:
     // the model then SEES the findings AND the harness triggers its repair
@@ -256,6 +281,37 @@ fn explain(args: &Value) -> Result<String, String> {
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// #320 repro 3, closed: a hallucinated model over the MCP lane was
+    /// the LAST surface still auditing green — the rung now reds it with
+    /// the same payload keys the CLI --json lane carries.
+    #[test]
+    fn check_reds_a_bare_model_id_with_the_shared_rung() {
+        let yaml = "nika: v1\nworkflow: m\ntasks:\n  - id: think\n    infer: { prompt: hi, max_tokens: 10, model: \"gpt-5-turbo\" }\n";
+        let err = check(&serde_json::json!({ "workflow": yaml })).expect_err("dirty");
+        assert!(err.contains("\"models_resolve\": false"), "{err}");
+        assert!(
+            err.contains("gpt-5-turbo") && err.contains("bare model id"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn check_reds_a_cataloged_but_unresolvable_provider() {
+        let yaml = "nika: v1\nworkflow: m\ntasks:\n  - id: think\n    infer: { prompt: hi, max_tokens: 10, model: \"azure/gpt-4o\" }\n";
+        let err = check(&serde_json::json!({ "workflow": yaml })).expect_err("dirty");
+        assert!(
+            err.contains("`azure` does not resolve") || err.contains("provider `azure`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn check_stays_clean_when_every_model_resolves() {
+        let yaml = "nika: v1\nworkflow: m\ntasks:\n  - id: think\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n";
+        let ok = check(&serde_json::json!({ "workflow": yaml })).expect("clean");
+        assert!(ok.contains("clean"), "{ok}");
+    }
 
     #[test]
     fn catalog_lists_the_validate_and_learn_tools() {

--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -164,6 +164,7 @@ pub fn nika_providers::profile::Profile::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::profile::Profile where T: 'static
 pub fn nika_providers::profile::Profile::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub const nika_providers::profile::CANONICAL_IDS: [&str; 16]
+pub fn nika_providers::profile::resolve_refusal(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::profile::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>
 pub mod nika_providers::registry
 pub struct nika_providers::registry::NoHttp
@@ -537,4 +538,5 @@ pub async fn nika_providers::registry::ResolvedProvider<H>::infer(&self, request
 impl<TraitVariantBlanketType> nika_kernel_ai::provider::ProviderStream for nika_providers::registry::ResolvedProvider<H> where TraitVariantBlanketType: nika_kernel_ai::provider::ProviderStreamDyn
 pub async fn nika_providers::registry::ResolvedProvider<H>::infer_stream(&self, request: nika_kernel_ai::provider::InferRequest) -> core::result::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::provider::InferEvent, nika_kernel_ai::provider::ProviderError>> + core::marker::Send)>>, nika_kernel_ai::provider::ProviderError>
 pub const nika_providers::CANONICAL_IDS: [&str; 16]
+pub fn nika_providers::resolve_refusal(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>

--- a/crates/nika-providers/src/lib.rs
+++ b/crates/nika-providers/src/lib.rs
@@ -49,5 +49,5 @@ mod sse;
 mod test_support;
 pub mod wire;
 
-pub use profile::{CANONICAL_IDS, Profile, WireFormat, seed};
+pub use profile::{CANONICAL_IDS, Profile, WireFormat, resolve_refusal, seed};
 pub use registry::{NoHttp, ProviderRegistry, ProvidersConfig, ResolvedProvider};

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -171,6 +171,31 @@ pub const CANONICAL_IDS: [&str; 16] = [
     "mock",
 ];
 
+/// The MODELS-rung law (#320): why a `<provider>/<model>` string cannot
+/// resolve in THIS binary — `None` when it can. Lives beside the resolver
+/// (the set it interrogates is [`CANONICAL_IDS`]) and is shared by every
+/// audit surface (CLI check · MCP `nika_check`): a hallucinated model
+/// must red the audit on EVERY lane, never only one — the vendor catalog
+/// advertising a provider does not make it runnable (the azure class).
+#[must_use]
+pub fn resolve_refusal(model: &str) -> Option<String> {
+    match model.split_once('/') {
+        None => Some(format!(
+            "`{model}` is a bare model id — the contract is `<provider>/<model>` \
+             (pick the provider that serves it; `nika doctor` names the \
+             {} runnable providers)",
+            CANONICAL_IDS.len()
+        )),
+        Some((provider, _)) if !CANONICAL_IDS.contains(&provider) => Some(format!(
+            "provider `{provider}` does not resolve in THIS binary \
+             ({} runnable — `nika doctor` names them); a cataloged \
+             vendor is not a runnable one",
+            CANONICAL_IDS.len()
+        )),
+        Some(_) => None,
+    }
+}
+
 /// The 10 cloud rows (catalog-backed) + the in-process mock.
 ///
 /// gemini's `base_url` is a STEM (`…/v1beta`) — the s8.6 adapter appends
@@ -284,6 +309,19 @@ pub fn seed() -> Vec<Profile> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn resolve_refusal_names_the_two_classes_and_clears_the_runnable() {
+        // bare id — teaches the contract
+        let bare = resolve_refusal("gpt-5-turbo").expect("bare id refused");
+        assert!(bare.contains("bare model id") && bare.contains("16 runnable"));
+        // cataloged-but-unresolvable provider — the azure class
+        let azure = resolve_refusal("azure/gpt-4o").expect("azure refused");
+        assert!(azure.contains("`azure`") && azure.contains("not a runnable one"));
+        // every canonical provider clears, inner slashes included
+        assert!(resolve_refusal("mock/echo").is_none());
+        assert!(resolve_refusal("huggingface/Qwen/Qwen3.5-9B:groq").is_none());
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
The socratic re-probe of #353 found the hole its issue's repro 3 named: MCP `nika_check` calls `nika_schema::check` directly — the CLI rung never covered it. The law moves beside the resolver (`nika_providers::resolve_refusal`), the MCP lane crosses every requirement, findings red the tool with the same `models_resolve`/`model_findings` keys as the CLI lane. Pinned both classes + inner-slash clearance; providers baseline updated surgically (platform-canonical law). 142/142 · 44/44 · clippy 0. Follow-up: nika-cli dedups onto the shared law.