### PR TITLE
feat(nika-schema): egress to outputs — the workflow boundary earns its valve

### DIFF
--- a/crates/nika-cli/src/verbs/new.rs
+++ b/crates/nika-cli/src/verbs/new.rs
@@ -1009,15 +1009,15 @@ mod tests {
         // secret in a fetch auth-header taints the response, exactly as a
         // secret in the body would), with no `infer`/`agent`-style prompt
         // exception and no output-declassification construct. So
-        // `api-upload-and-create` (upload+create, both secret-authed, the
-        // create response piped to `outputs:`) cannot surface its result
-        // to ANY sink — outputs, a local `nika:write`, or another tool
-        // all trip the egress. Resolving it needs a header-position
-        // exception in the taint analysis OR an output-declassification
-        // feature; both are design decisions. Until then it is the ONE
-        // documented exception: a SECOND dirty template — or this one
-        // becoming clean (the gap resolved) — fails this ratchet.
-        const KNOWN_GAP: &[&str] = &["api-upload-and-create"];
+        // EMPTY since 2026-07-10: the one former gap
+        // (`api-upload-and-create` — a secret-authed response piped to
+        // `outputs:` had NO sanctioned path) resolved via the
+        // output-declassification this ratchet's note called for:
+        // `egress: [{ to: "outputs" }]` (spec 01-envelope §egress · the
+        // owner declassifies the workflow boundary itself). Every template
+        // now passes its own audit; a dirty one fails this ratchet unless
+        // a genuine flow-model design gap is documented here.
+        const KNOWN_GAP: &[&str] = &[];
         let mut clean = 0_usize;
         for name in nika_pack::template_names() {
             let body = nika_pack::template(&name).expect("template embedded");

--- a/crates/nika-pack/pack/coverage-matrix.tsv
+++ b/crates/nika-pack/pack/coverage-matrix.tsv
@@ -1,0 +1,118 @@
+pillar	namespace	stage	covered_by
+dag	(positive)	positive-run	conformance/dag/diamond-topology.nika.yaml
+dag	(positive)	positive-run	conformance/dag/foreach-empty-skips.nika.yaml
+dag	(positive)	positive-run	conformance/dag/foreach-item-index-bindings.nika.yaml
+dag	(positive)	positive-run	conformance/dag/foreach-over-upstream-output.nika.yaml
+dag	(positive)	positive-run	conformance/dag/when-false-skips.nika.yaml
+dag	(positive)	positive-run	conformance/dag/when-has-null-semantics.nika.yaml
+dag	NIKA-CANCEL	run-fail	conformance/dag/failure-cancels-downstream.nika.yaml
+dag	NIKA-DAG	check-reject	conformance/dag/cycle-reject.nika.yaml
+dag	NIKA-DAG	check-reject	conformance/dag/recover-ref-downstream-reject.nika.yaml
+dag	NIKA-DAG	check-reject	conformance/dag/ref-without-edge-reject.nika.yaml
+dag	NIKA-DAG	check-reject	conformance/dag/undeclared-dep-reject.nika.yaml
+dag	NIKA-EXEC	run-fail	conformance/dag/failure-cancels-downstream.nika.yaml
+dag	NIKA-EXEC	run-fail	conformance/dag/failure-drains-inflight.nika.yaml
+dag	NIKA-EXEC	run-fail	conformance/dag/foreach-fail-fast-false.nika.yaml
+dag	NIKA-EXEC	run-fail	conformance/dag/foreach-fail-fast-true.nika.yaml
+envelope	(positive)	positive-run	conformance/envelope/minimal-valid-workflow.nika.yaml
+envelope	(positive)	positive-run	conformance/envelope/outputs-contract.nika.yaml
+envelope	(positive)	positive-run	conformance/envelope/secrets-infer-egress-sanctioned.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-bad-task-id.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-bad-version.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-duplicate-task-id.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-inline-secret-forbidden.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-missing-workflow-field.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-reserved-binding-name.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-task-no-verb.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-unknown-field.nika.yaml
+envelope	NIKA-PARSE	check-reject	conformance/envelope/parse-yaml-syntax-reject.nika.yaml
+envelope	NIKA-SEC	run-fail	conformance/envelope/sec-exec-array-form-blocklist.nika.yaml
+envelope	NIKA-SEC	run-fail	conformance/envelope/sec-exec-blocklist-rm-rf.nika.yaml
+envelope	NIKA-SEC	run-fail	conformance/envelope/sec-ssrf-localhost-blocked.nika.yaml
+envelope	NIKA-SEC	run-fail	conformance/envelope/sec-ssrf-metadata-blocked.nika.yaml
+envelope	NIKA-SEC	run-fail	conformance/envelope/sec-ssrf-private-range-blocked.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-agent-tool-outside-whitelist.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-empty-default-deny.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-exec-absent.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-fs-read-escape.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-fs-write-escape-absolute.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-net-absent.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/permits-tool-not-listed.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/secrets-launder-concat.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/secrets-leak-exec-sink.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/secrets-leak-infer-prompt.nika.yaml
+envelope	NIKA-SEC-gate	check-reject	conformance/envelope/secrets-two-sinks-one-sanctioned.nika.yaml
+errors	NIKA-BUILTIN	recovered	conformance/errors/foreach-recover-null-alignment.nika.yaml
+errors	NIKA-EXEC	recovered	conformance/errors/on-error-on-codes-matched.nika.yaml
+errors	NIKA-EXEC	recovered	conformance/errors/on-error-recover-downstream.nika.yaml
+errors	NIKA-EXEC	recovered	conformance/errors/on-error-recover-literal.nika.yaml
+errors	NIKA-EXEC	recovered	conformance/errors/on-error-skip-status.nika.yaml
+errors	NIKA-EXEC	recovered	conformance/errors/recover-task-ref-with-edge.nika.yaml
+errors	NIKA-EXEC	recovered	conformance/errors/retry-exhausted-then-recover.nika.yaml
+errors	NIKA-EXEC	run-fail	conformance/errors/on-error-fail-workflow.nika.yaml
+errors	NIKA-EXEC	run-fail	conformance/errors/on-error-on-codes-unmatched.nika.yaml
+errors	NIKA-EXEC	run-fail	conformance/errors/on-finally-both-paths.nika.yaml
+errors	NIKA-EXEC	run-fail	conformance/errors/retry-non-transient-single-attempt.nika.yaml
+errors	NIKA-EXEC	run-fail	conformance/errors/retry-on-codes-forces.nika.yaml
+errors	NIKA-EXEC	run-fail	conformance/errors/retry-on-codes-unmatched.nika.yaml
+errors	NIKA-TIMEOUT	recovered	conformance/errors/timeout-recovered.nika.yaml
+errors	NIKA-TIMEOUT	run-fail	conformance/errors/timeout-never-retryable.nika.yaml
+errors	NIKA-VAR	DIVERGENT	conformance/errors/recover-task-ref-no-edge.nika.yaml
+errors	NIKA-VAR	recovered	conformance/errors/error-field-canonical-code.nika.yaml
+variables	(positive)	positive-run	conformance/variables/null-membership-compare.nika.yaml
+variables	(positive)	positive-run	conformance/variables/number-continuum.nika.yaml
+variables	(positive)	positive-run	conformance/variables/typed-vars-declarations.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/arithmetic-rejected.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/jq-expression-static-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/missing-task-ref-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/static-type-error-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/unclosed-island-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/unknown-function-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/unresolved-ref-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/when-bare-ref-reject.nika.yaml
+variables	NIKA-VAR	check-reject	conformance/variables/when-string-literal-reject.nika.yaml
+variables	NIKA-VAR	either	conformance/variables/cross-type-compare-error.nika.yaml
+variables	NIKA-VAR	either	conformance/variables/foreach-non-array-either.nika.yaml
+variables	NIKA-VAR	either	conformance/variables/string-method-type-mismatch.nika.yaml
+variables	NIKA-VAR	run-fail	conformance/variables/binding-bad-syntax-error.nika.yaml
+variables	NIKA-VAR	run-fail	conformance/variables/binding-stream-error.nika.yaml
+variables	NIKA-VAR	run-fail	conformance/variables/foreach-non-array-run.nika.yaml
+variables	NIKA-VAR	run-fail	conformance/variables/typed-outputs-mismatch.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/agent-injection-contained.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/agent-pure-conversation.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/builtin-assert-positive.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/builtin-extract-inline.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/builtin-json-diff.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/builtin-validate-errors-array.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/builtin-validate-positive.nika.yaml
+verbs	(positive)	positive-run	conformance/verbs/exec-capture-convert-chain.nika.yaml
+verbs	NIKA-BUILTIN	run-fail	conformance/verbs/builtin-assert-fail.nika.yaml
+verbs	NIKA-BUILTIN	run-fail	conformance/verbs/builtin-jq-runtime-error.nika.yaml
+verbs	NIKA-BUILTIN	run-fail	conformance/verbs/builtin-validate-bad-schema.nika.yaml
+verbs	NIKA-BUILTIN	run-fail	conformance/verbs/builtin-write-runtime-gap.nika.yaml
+verbs	NIKA-EXEC	run-fail	conformance/verbs/exec-nonzero-exit.nika.yaml
+verbs	NIKA-EXEC	run-fail	conformance/verbs/exec-spawn-fail.nika.yaml
+verbs	NIKA-SEC-gate	check-reject	conformance/verbs/invoke-unknown-tool-reject.nika.yaml
+verbs	NIKA-TIMEOUT	run-fail	conformance/verbs/timeout-basic.nika.yaml
+verbs	NIKA-TIMEOUT	run-fail	conformance/verbs/timeout-per-iteration.nika.yaml
+verbs	NIKA-INFER	check-reject	EMPTY (no mock infer-namespace check reject; infer statics covered via PARSE-014/SEC-secrets)
+verbs	NIKA-INFER	run-fail	EMPTY (no mock NIKA-INFER-001/002 exemplar in lab)
+verbs	NIKA-INFER	recovered	EMPTY
+verbs	NIKA-INFER	positive-run	covered under envelope pillar (envelope/secrets-infer-egress-sanctioned.nika.yaml — run-level mock infer, upgraded 2026-07-08)
+verbs	NIKA-AGENT	run-fail	EMPTY (cr29-agent-budget-exhausted NIKA-AGENT-001 is gemini-locked; needs mock port)
+verbs	NIKA-AGENT	recovered	EMPTY
+verbs	NIKA-INVOKE	run-fail	EMPTY (runtime invoke failures surface as NIKA-BUILTIN-*; mcp: tool path has no offline exemplar)
+verbs	NIKA-INVOKE	check-reject	covered as gate verdict (verbs/invoke-unknown-tool-reject.nika.yaml — spec-05 INVOKE-001 code not surfaced by reference check; FINDINGS.md F-1)
+verbs	NIKA-BUILTIN	recovered	covered under errors pillar (errors/foreach-recover-null-alignment.nika.yaml)
+verbs	NIKA-TIMEOUT	recovered	covered under errors pillar (errors/timeout-recovered.nika.yaml)
+verbs	(positive)	exec-structured-capture	EMPTY (etl/23 machine-dependent; needs self-contained rewrite)
+verbs	(positive)	builtin-read-glob-grep-hash	EMPTY (cr04/cr17/cr18/etl-08 fixture-dependent; need in-corpus fixtures)
+dag	NIKA-DAG	run-fail	N/A-BY-DESIGN (DAG errors are static)
+envelope	NIKA-PARSE	run-fail	N/A-BY-DESIGN (parse errors are check-stage)
+envelope	NIKA-PARSE-010	check-reject	EMPTY (e31 bad-timeout-value dropped for budget; v0.2)
+envelope	NIKA-SEC	recovered	EMPTY (whether SEC blocks are on_error-recoverable is an open spec question)
+envelope	NIKA-SEC	ssrf-by-name	EMPTY (sec02 localhost-name excluded: DNS-resolution-dependent)
+envelope	NIKA-SEC	secrets-fetch-sink	EMPTY (sec27 dropped for budget; v0.2)
+errors	NIKA-BUILTIN-ASSERT	recovered	EMPTY (w06 dropped for budget; BUILTIN-recovered covered via JQ)
+variables	NIKA-VAR	recovered	partial (errors/error-field-canonical-code.nika.yaml recovers a VAR-006 args error)
+variables	NIKA-VAR	index-out-of-range	EMPTY (c12/c14 fire VAR-001 "unresolved reference"; spec code ambiguous — FINDINGS.md F-2; v0.2 after spec call)

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -24,7 +24,7 @@ templates:
   - file: templates/agent-loop.nika.yaml
     sha256_16: 305b7b4b04c2beaf
   - file: templates/api-upload-and-create.nika.yaml
-    sha256_16: 11bf108efc4f6880
+    sha256_16: eff75e74a952c137
   - file: templates/chain.nika.yaml
     sha256_16: 8f4cfd3538943b22
   - file: templates/docker-report.nika.yaml

--- a/crates/nika-pack/pack/templates/api-upload-and-create.nika.yaml
+++ b/crates/nika-pack/pack/templates/api-upload-and-create.nika.yaml
@@ -28,7 +28,8 @@ secrets:
     source: env
     key: EXAMPLE_API_KEY            # SLOT: the OS env var holding the key
     egress:
-      - to: "nika:fetch"            # the ONE sanctioned sink · default-deny otherwise
+      - to: "nika:fetch"            # the send · default-deny otherwise
+      - to: "outputs"               # the return value derives from the authed response
 
 tasks:
   - id: upload

--- a/crates/nika-schema/src/check/flow.rs
+++ b/crates/nika-schema/src/check/flow.rs
@@ -201,7 +201,12 @@ pub(super) fn analyze_flow(wf: &RawWorkflow, waves: &[Vec<usize>]) -> FlowFacts 
         }
     }
 
-    // Egress: a workflow `outputs:` entry referencing a tainted slot.
+    // Egress: a workflow `outputs:` entry referencing a tainted slot —
+    // UNLESS the owning secret declassifies the workflow boundary itself
+    // (`egress: [{ to: "outputs" }]` · spec 01-envelope §egress · the DLM
+    // owner's act, same as every sink; absent = default-deny, the report
+    // stands). Sink-only and secret-SPECIFIC: it clears nothing but THIS
+    // secret's taints reaching `outputs:` — never a send.
     for (name, decl) in &wf.outputs {
         if let Some(trace) = taint_of_refs(
             refs_in_str(decl_value(decl)),
@@ -210,6 +215,10 @@ pub(super) fn analyze_flow(wf: &RawWorkflow, waves: &[Vec<usize>]) -> FlowFacts 
             &id_of,
             &facts,
         ) {
+            let egress = egress_of.get(trace.secret.as_str()).copied().unwrap_or(&[]);
+            if egress.iter().any(|rule| rule.to == "outputs") {
+                continue;
+            }
             facts
                 .egress
                 .insert(name.value.clone(), trace.via("outputs".to_owned()));
@@ -666,6 +675,89 @@ mod tests {
             f.effect_taint(idx(&wf, "b")).is_none(),
             "infer output not tainted → downstream stays clean"
         );
+    }
+
+    #[test]
+    fn outputs_egress_declass_clears_the_boundary_report() {
+        // The api-upload class (night battery 2026-07-10): the capture
+        // stays tainted, outputs is where it LEAVES — `to: "outputs"` is
+        // the owner's declassification of the workflow boundary itself.
+        let y = "\
+nika: v1
+workflow: w
+secrets:
+  api_key:
+    source: vault
+    key: x
+    egress:
+      - to: \"nika:fetch\"
+      - to: \"outputs\"
+tasks:
+  - id: up
+    invoke:
+      tool: \"nika:fetch\"
+      args: { url: \"https://api.example.com/u\", headers: { x-api-key: \"${{ secrets.api_key }}\" } }
+outputs:
+  result: \"${{ tasks.up.output }}\"
+";
+        let (_wf, f) = facts(y);
+        assert!(
+            f.egresses().is_empty(),
+            "the declared boundary declass clears the outputs report"
+        );
+    }
+
+    #[test]
+    fn outputs_egress_stays_default_deny_without_the_rule() {
+        // Same workflow, no `to: "outputs"` — the report STANDS.
+        let y = "\
+nika: v1
+workflow: w
+secrets:
+  api_key:
+    source: vault
+    key: x
+    egress:
+      - to: \"nika:fetch\"
+tasks:
+  - id: up
+    invoke:
+      tool: \"nika:fetch\"
+      args: { url: \"https://api.example.com/u\", headers: { x-api-key: \"${{ secrets.api_key }}\" } }
+outputs:
+  result: \"${{ tasks.up.output }}\"
+";
+        let (_wf, f) = facts(y);
+        assert_eq!(f.egresses().len(), 1, "default-deny · the report stands");
+    }
+
+    #[test]
+    fn outputs_egress_never_authorizes_the_send() {
+        // `to: "outputs"` ALONE: the boundary is cleared but the SEND to
+        // nika:fetch is still an unsanctioned leak (no cross-sink grant).
+        let y = "\
+nika: v1
+workflow: w
+secrets:
+  api_key:
+    source: vault
+    key: x
+    egress:
+      - to: \"outputs\"
+tasks:
+  - id: up
+    invoke:
+      tool: \"nika:fetch\"
+      args: { url: \"https://api.example.com/u\", headers: { x-api-key: \"${{ secrets.api_key }}\" } }
+outputs:
+  result: \"${{ tasks.up.output }}\"
+";
+        let (wf, f) = facts(y);
+        assert!(
+            f.effect_leak(idx(&wf, "up")).is_some(),
+            "the send stays a leak — outputs clears only the boundary"
+        );
+        assert!(f.egresses().is_empty(), "the boundary itself is cleared");
     }
 
     #[test]


### PR DESCRIPTION
## The gap (named by the ratchet itself)

The night battery caught the embedded `api-upload-and-create` template **failing its own audit**: the capture-taint law is deliberate (the provider saw the key — its response is not provably clean), so the authed fetch output taints `outputs:` — and there was **no sanctioned path**. The `new.rs` ratchet had it documented as THE known gap, its note naming exactly this feature (*« an output-declassification feature »*) as one of the two resolutions.

## The valve (spec pair: nika-spec 5f8f96d, merged)

```yaml
egress:
  - to: "nika:fetch"   # the send
  - to: "outputs"      # the return value derived from the authed response
```

The outputs-egress scan skips taints whose owning secret declares `to: "outputs"` — the DLM owner's act beside the two existing sanction sites. Sink-only · secret-SPECIFIC · **default-deny when absent**.

## Pins

- three flow tests: declared-clears · default-deny-stands · **never-authorizes-the-send** (no cross-sink grant)
- the template re-vendors with its two rules (manifest hash follows) · **KNOWN_GAP empties** — the ratchet's own failure message demanded it; a dirty template now fails with zero exceptions
- e2e on the built binary: `new --from api-upload-and-create` → `check` **exit 0**, SECRETS ✔

Workspace **3865/3865** · clippy deny 0 · 8/8 ratchets · crate-size green (nika-schema +8 lines).