### PR TITLE
feat(run): the epilogue seam — and the run learns to say recovered and still-running

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -259,6 +259,7 @@ pub fn nika_cli::display::state::RunView::done_count(&self) -> usize
 pub fn nika_cli::display::state::RunView::last_ts_ms(&self) -> core::option::Option<i64>
 pub fn nika_cli::display::state::RunView::new() -> Self
 pub fn nika_cli::display::state::RunView::plan(&self) -> core::option::Option<&[alloc::vec::Vec<alloc::string::String>]>
+pub fn nika_cli::display::state::RunView::recovered_count(&self) -> usize
 pub fn nika_cli::display::state::RunView::rows(&self) -> &[nika_cli::display::state::TaskRow]
 pub fn nika_cli::display::state::RunView::set_plan(&mut self, waves: alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>)
 impl core::default::Default for nika_cli::display::state::RunView
@@ -303,6 +304,7 @@ pub nika_cli::display::state::TaskRow::input_hash: core::option::Option<alloc::s
 pub nika_cli::display::state::TaskRow::model: core::option::Option<alloc::string::String>
 pub nika_cli::display::state::TaskRow::note: alloc::string::String
 pub nika_cli::display::state::TaskRow::output_json: core::option::Option<alloc::string::String>
+pub nika_cli::display::state::TaskRow::recovered: bool
 pub nika_cli::display::state::TaskRow::started_ms: core::option::Option<i64>
 pub nika_cli::display::state::TaskRow::started_note: core::option::Option<alloc::string::String>
 pub nika_cli::display::state::TaskRow::state: nika_cli::display::state::TaskState
@@ -1228,6 +1230,7 @@ pub fn nika_cli::display::state::RunView::done_count(&self) -> usize
 pub fn nika_cli::display::state::RunView::last_ts_ms(&self) -> core::option::Option<i64>
 pub fn nika_cli::display::state::RunView::new() -> Self
 pub fn nika_cli::display::state::RunView::plan(&self) -> core::option::Option<&[alloc::vec::Vec<alloc::string::String>]>
+pub fn nika_cli::display::state::RunView::recovered_count(&self) -> usize
 pub fn nika_cli::display::state::RunView::rows(&self) -> &[nika_cli::display::state::TaskRow]
 pub fn nika_cli::display::state::RunView::set_plan(&mut self, waves: alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>)
 impl core::default::Default for nika_cli::display::state::RunView
@@ -1272,6 +1275,7 @@ pub nika_cli::TaskRow::input_hash: core::option::Option<alloc::string::String>
 pub nika_cli::TaskRow::model: core::option::Option<alloc::string::String>
 pub nika_cli::TaskRow::note: alloc::string::String
 pub nika_cli::TaskRow::output_json: core::option::Option<alloc::string::String>
+pub nika_cli::TaskRow::recovered: bool
 pub nika_cli::TaskRow::started_ms: core::option::Option<i64>
 pub nika_cli::TaskRow::started_note: core::option::Option<alloc::string::String>
 pub nika_cli::TaskRow::state: nika_cli::display::state::TaskState

--- a/crates/nika-cli/src/display/flow.rs
+++ b/crates/nika-cli/src/display/flow.rs
@@ -287,14 +287,23 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
 
     let waves = wave_sizes(view).len();
     let retries_cell = format!("{} retries", view.retries);
-    let mut rows = vec![
-        format!(
-            "{}    {} tasks · {waves} waves · {retries_cell}",
-            dag_shape(view, theme),
-            view.rows().len(),
-        ),
-        totals_row(view),
-    ];
+    // The repair count (#319 · D-2026-07-08-N4) rides beside retries —
+    // only when non-zero (the verdict-count discipline: `0 retries` is
+    // a stable cell, a repair is an EVENT worth a cell only when real).
+    let recovered_cell = match view.recovered_count() {
+        0 => None,
+        n => Some(format!("{n} recovered")),
+    };
+    let mut head = format!(
+        "{}    {} tasks · {waves} waves · {retries_cell}",
+        dag_shape(view, theme),
+        view.rows().len(),
+    );
+    if let Some(cell) = &recovered_cell {
+        use std::fmt::Write as _;
+        let _ = write!(head, " · {cell}");
+    }
+    let mut rows = vec![head, totals_row(view)];
     if let Some(note) = outputs_note {
         rows.push(note.to_owned());
     }
@@ -326,11 +335,15 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
         // real retry count paints yellow. The paint lands on the FITTED
         // text AFTER the width math (escapes add zero visible cells; a
         // truncated row simply keeps its plain form).
-        let shown = if view.retries > 0 {
+        let mut shown = if view.retries > 0 {
             fitted.replace(&retries_cell, &theme.paint(Role::Warn, &retries_cell))
         } else {
             fitted
         };
+        // The repair count wears the same survived-incident yellow.
+        if let Some(cell) = &recovered_cell {
+            shown = shown.replace(cell.as_str(), &theme.paint(Role::Warn, cell));
+        }
         lines.push(format!("  {v}  {shown}{}  {v}", " ".repeat(pad)));
     }
     let bottom: String = std::iter::repeat_n(h, inner).collect();
@@ -740,6 +753,73 @@ mod tests {
         assert!(
             bare.iter().all(|w| *w == bare[0]),
             "escape-stripped alignment holds: {bare:?}"
+        );
+    }
+
+    /// #319 — the verdict card carries the repair count beside retries
+    /// when a task settled through `on_error.recover` (and NEVER grows
+    /// the cell on a clean run — the demo card above pins `0 retries`
+    /// with no `recovered` in sight).
+    #[test]
+    fn verdict_card_counts_recovered_beside_retries() {
+        let mut view = RunView::new();
+        view.apply(&ev(EventKind::TaskStarted, 0, &[("task", s("fragile"))]));
+        view.apply(&ev(
+            EventKind::TaskRecovered,
+            5,
+            &[("task", s("fragile")), ("code", s("NIKA-BUILTIN-READ-001"))],
+        ));
+        view.apply(&ev(
+            EventKind::TaskCompleted,
+            10,
+            &[("task", s("fragile")), ("duration_ms", Value::Int(1))],
+        ));
+        view.apply(&ev(EventKind::WorkflowCompleted, 20, &[]));
+
+        let lines = verdict_card(&view, &PLAIN, None);
+        let head = lines.iter().find(|l| l.contains("retries")).expect("row");
+        assert!(
+            head.contains("0 retries · 1 recovered"),
+            "the repair count rides beside retries: {head:?}"
+        );
+
+        // Colour on: the repair cell wears the survived-incident yellow
+        // and the box alignment survives the escapes.
+        let coloured = verdict_card(&view, &Theme::new(true, false, false), None);
+        let head = coloured
+            .iter()
+            .find(|l| l.contains("recovered"))
+            .expect("row");
+        assert!(
+            head.contains("\x1b[33m1 recovered\x1b[0m"),
+            "the repair count paints yellow: {head:?}"
+        );
+        let bare: Vec<usize> = coloured
+            .iter()
+            .map(|l| {
+                l.replace("\x1b[33m", "")
+                    .replace("\x1b[32m", "")
+                    .replace("\x1b[1m", "")
+                    .replace("\x1b[0m", "")
+                    .chars()
+                    .count()
+            })
+            .collect();
+        assert!(
+            bare.iter().all(|w| *w == bare[0]),
+            "escape-stripped alignment holds: {bare:?}"
+        );
+
+        // A clean run never grows the cell.
+        let mut clean = RunView::new();
+        for e in demo::success() {
+            clean.apply(&e);
+        }
+        assert!(
+            !verdict_card(&clean, &PLAIN, None)
+                .iter()
+                .any(|l| l.contains("recovered")),
+            "no repair → no cell"
         );
     }
 

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -29,25 +29,29 @@ pub fn frame_with_outputs(view: &RunView, theme: &Theme, tick: usize) -> Vec<Str
     frame_impl(view, theme, tick, true)
 }
 
-/// The one frame assembler behind both public forms.
-// `&Theme` to match the public `frame` borrow that threads it here — the
-// same one-calling-convention rationale as `task_line`.
+/// The header block (identity + ceiling + the audit-as-greeting permits
+/// line + one blank): shared by the full frame (task count = the rows)
+/// and the streamed plain narration (count from the injected plan —
+/// rows don't exist yet at the header moment). `tasks = 0` omits the
+/// count cell — a stream without a plan must not open on a lie.
+// `&Theme` to match the frame borrows that thread it here.
 #[allow(clippy::trivially_copy_pass_by_ref)]
-fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<String> {
-    let mut lines = Vec::with_capacity(view.rows().len() + 6);
-
-    // Header: identity + the statically-proven ceiling.
+fn header_lines(view: &RunView, theme: &Theme, tasks: usize) -> Vec<String> {
+    let mut lines = Vec::with_capacity(3);
+    let count = if tasks > 0 {
+        format!(" · {tasks} tasks")
+    } else {
+        String::new()
+    };
     let ceiling = view
         .ceiling_usd
         .map(|c| format!(" · ceiling ≤ {}", fmt_cost_usd(c)))
         .unwrap_or_default();
     lines.push(format!(
-        "  {} nika · {} · {} tasks{ceiling}",
+        "  {} nika · {}{count}{ceiling}",
         theme.logo(),
         theme.paint(Role::Strong, &view.workflow),
-        view.rows().len(),
     ));
-
     // The audit-as-greeting line (the trust moment, every run).
     if let Some(permits) = &view.permits {
         let mark = if theme.ascii { "OK" } else { "✓" };
@@ -58,6 +62,16 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         ));
     }
     lines.push(String::new());
+    lines
+}
+
+/// The one frame assembler behind both public forms.
+// `&Theme` to match the public `frame` borrow that threads it here — the
+// same one-calling-convention rationale as `task_line`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<String> {
+    let mut lines = Vec::with_capacity(view.rows().len() + 6);
+    lines.extend(header_lines(view, theme, view.rows().len()));
 
     // Task rows — stable order, aligned ids, notes dimmed. Time and cost
     // are first-class columns: a settled row carries its REAL wall time
@@ -100,12 +114,26 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         ));
     }
 
-    // Footer meter: progress · live cost vs ceiling · wall clock. The
-    // spend speaks the ONE cost formatter (format.rs) — the meter and the
-    // verdict card can never again disagree on the same run's dollars.
-    // The repair count rides beside `done` when non-zero (#319 · the
-    // `(N unpriced)` honesty style): a repaired run's final summary line
-    // must never read byte-identical to a clean one.
+    lines.push(meter_line(view, theme));
+
+    // Failure card (only on a failed verdict · derives the explain hint) —
+    // the SAME card the compact `--quiet` surface renders (shared helper).
+    if view.verdict == Some(false) {
+        append_failure_card(&mut lines, view, theme);
+    }
+    lines
+}
+
+/// The footer meter: progress · live cost vs ceiling · wall clock. The
+/// spend speaks the ONE cost formatter (format.rs) — the meter and the
+/// verdict card can never again disagree on the same run's dollars.
+/// The repair count rides beside `done` when non-zero (#319 · the
+/// `(N unpriced)` honesty style): a repaired run's final summary line
+/// must never read byte-identical to a clean one. Shared by the full
+/// frame and the streamed plain close (#321).
+// `&Theme` to match the frame borrows that thread it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn meter_line(view: &RunView, theme: &Theme) -> String {
     let cost = spend_meter(view);
     let repaired = match view.recovered_count() {
         0 => String::new(),
@@ -118,13 +146,73 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         view.done_count(),
         view.rows().len(),
     );
-    lines.push(format!(
-        "  {}",
-        theme.paint(Role::Dim, &pad_rule(&meter, 64))
-    ));
+    format!("  {}", theme.paint(Role::Dim, &pad_rule(&meter, 64)))
+}
 
-    // Failure card (only on a failed verdict · derives the explain hint) —
-    // the SAME card the compact `--quiet` surface renders (shared helper).
+/// The streamed header (#321 · the plain narration lane): the same
+/// identity + permits lines the frame opens with, printable the moment
+/// `workflow_started` folds. The task count prefers the injected wave
+/// plan (the run verb injects it BEFORE driving — no row exists yet at
+/// the header moment); a plan-less fold (a bare replay) falls back to
+/// the rows seen so far, and a zero count is omitted, never printed.
+// `&Theme` to match the sink borrow that threads it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+#[must_use]
+pub(crate) fn stream_header(view: &RunView, theme: &Theme) -> Vec<String> {
+    let tasks = view
+        .plan()
+        .map(|waves| waves.iter().map(Vec::len).sum())
+        .filter(|n| *n > 0)
+        .unwrap_or_else(|| view.rows().len());
+    header_lines(view, theme, tasks)
+}
+
+/// One settled row, streamed at its terminal frame (#321 · the plain
+/// narration lane): the same cells the final frame renders (glyph · id ·
+/// note · wall · spend · the repair fact · ∥ — all final by settle
+/// time) minus the table-wide note alignment (a stream cannot pad
+/// against rows that haven't spoken yet). `None` when the id names no
+/// folded row (a malformed frame renders nothing, never garbage).
+// `&Theme` to match the sink borrow that threads it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+#[must_use]
+pub(crate) fn stream_settled_line(
+    view: &RunView,
+    task: &str,
+    theme: &Theme,
+    outputs: bool,
+) -> Option<String> {
+    let (i, row) = view.rows().iter().enumerate().find(|(_, r)| r.id == task)?;
+    let id_w = view.rows().iter().map(|r| r.id.len()).max().unwrap_or(8);
+    let note = display_note(row, view);
+    let time = row_wall(row, view);
+    let time_w = time.as_ref().map_or(0, |t| t.chars().count());
+    let mark = lane_marks(view).get(i).copied().unwrap_or(false);
+    let tail = if outputs {
+        crate::display::shape::output_tail(row.output_json.as_deref(), row.tokens, theme)
+    } else {
+        None
+    };
+    Some(task_line(
+        row,
+        (view, &note),
+        theme,
+        0,
+        (id_w, note.chars().count(), time_w),
+        time.as_deref(),
+        mark,
+        tail.as_deref(),
+    ))
+}
+
+/// The streamed close (#321): the meter + the failure card. The rows
+/// already spoke at their settle — the plain final print never repeats
+/// them (a captured log reads the run ONCE, top to bottom).
+// `&Theme` to match the sink borrow that threads it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+#[must_use]
+pub(crate) fn stream_summary(view: &RunView, theme: &Theme) -> Vec<String> {
+    let mut lines = vec![meter_line(view, theme)];
     if view.verdict == Some(false) {
         append_failure_card(&mut lines, view, theme);
     }

--- a/crates/nika-cli/src/display/render.rs
+++ b/crates/nika-cli/src/display/render.rs
@@ -103,11 +103,18 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
     // Footer meter: progress · live cost vs ceiling · wall clock. The
     // spend speaks the ONE cost formatter (format.rs) — the meter and the
     // verdict card can never again disagree on the same run's dollars.
+    // The repair count rides beside `done` when non-zero (#319 · the
+    // `(N unpriced)` honesty style): a repaired run's final summary line
+    // must never read byte-identical to a clean one.
     let cost = spend_meter(view);
+    let repaired = match view.recovered_count() {
+        0 => String::new(),
+        n => format!("{n} recovered · "),
+    };
     #[allow(clippy::cast_precision_loss)] // display-only seconds
     let secs = view.elapsed_ms as f64 / 1000.0;
     let meter = format!(
-        "── {}/{} done · {cost} · elapsed {secs:.1}s ",
+        "── {}/{} done · {repaired}{cost} · elapsed {secs:.1}s ",
         view.done_count(),
         view.rows().len(),
     );
@@ -216,7 +223,7 @@ fn task_line(
         theme.paint(Role::Dim, &note),
     );
     let cost = row.cost_usd.map(|c| format!(" · {}", fmt_cost_usd(c)));
-    if time.is_none() && cost.is_none() && !mark && tail.is_none() {
+    if time.is_none() && cost.is_none() && !mark && tail.is_none() && !row.recovered {
         return line;
     }
     // Column pad computed on the RAW note (paint added escapes, the
@@ -233,6 +240,12 @@ fn task_line(
     }
     if let Some(cost) = cost {
         line.push_str(&theme.paint(Role::Dim, &cost));
+    }
+    // The repair fact (#319 · D-2026-07-08-N4): a row that settled
+    // through `on_error.recover` says so — yellow, the retry family's
+    // survived-incident colour (sober themes render it plain).
+    if row.recovered {
+        line.push_str(&theme.paint(Role::Warn, " · recovered"));
     }
     if let Some(tail) = tail {
         // Already painted by the shape module — one metadata unit.
@@ -897,6 +910,70 @@ mod tests {
         assert!(
             running.contains('▇'),
             "tokens reported → spark on the running row: {running}"
+        );
+    }
+
+    /// #319 — a repaired success SAYS so: the settled row gains
+    /// ` · recovered` and the meter line counts the repairs — while a
+    /// clean run's frame stays byte-identical (the golden tests above
+    /// pin that: the demo storyboard carries no `task_recovered`).
+    #[test]
+    fn recovered_rows_and_meter_carry_the_repair_fact() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let task = |n: &str| KeyValue::new("task", Value::String(n.to_owned()));
+
+        let mut view = RunView::new();
+        view.apply(
+            &demo::bare_event(EventKind::TaskStarted, 0)
+                .with_field(task("fragile"))
+                .with_field(KeyValue::new(
+                    "note",
+                    Value::String("invoke · nika:read".to_owned()),
+                )),
+        );
+        view.apply(
+            &demo::bare_event(EventKind::TaskRecovered, 1)
+                .with_field(task("fragile"))
+                .with_field(KeyValue::new(
+                    "code",
+                    Value::String("NIKA-BUILTIN-READ-001".to_owned()),
+                )),
+        );
+        view.apply(
+            &demo::bare_event(EventKind::TaskCompleted, 2)
+                .with_field(task("fragile"))
+                .with_field(KeyValue::new("duration_ms", Value::Int(1))),
+        );
+        view.apply(&demo::bare_event(EventKind::WorkflowCompleted, 3));
+
+        let lines = frame(&view, &UNICODE, 0);
+        let row = lines.iter().find(|l| l.contains("fragile")).expect("row");
+        assert!(
+            row.contains("1ms · recovered"),
+            "the settled line says recovered: {row}"
+        );
+        let meter = lines.iter().find(|l| l.contains("done")).expect("meter");
+        assert!(
+            meter.contains("1/1 done · 1 recovered · "),
+            "the summary line counts the repair: {meter}"
+        );
+
+        // The SUCCESS path only — no failure card grew out of the repair.
+        assert!(
+            !lines.iter().any(|l| l.contains("fix:")),
+            "a recovered success is a success: {lines:?}"
+        );
+
+        // Colour ON: the fact paints yellow (the retry family).
+        let coloured = frame(&view, &Theme::new(true, false, false), 0);
+        let painted = coloured
+            .iter()
+            .find(|l| l.contains("fragile"))
+            .expect("row");
+        assert!(
+            painted.contains("\x1b[33m · recovered\x1b[0m"),
+            "recovered paints Warn: {painted:?}"
         );
     }
 

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -440,7 +440,10 @@ fn value_of<'a>(event: &'a Event, key: &str) -> Option<&'a Value> {
         .map(|kv| &kv.value)
 }
 
-fn str_field<'a>(event: &'a Event, key: &str) -> Option<&'a str> {
+/// A string field off an event (`None` when absent or non-string) —
+/// shared with the sink layer (the plain narration + heartbeat riders
+/// address rows by the same `task` field this fold reads).
+pub(crate) fn str_field<'a>(event: &'a Event, key: &str) -> Option<&'a str> {
     match value_of(event, key) {
         Some(Value::String(s)) => Some(s.as_str()),
         _ => None,

--- a/crates/nika-cli/src/display/state.rs
+++ b/crates/nika-cli/src/display/state.rs
@@ -85,6 +85,12 @@ pub struct TaskRow {
     /// `--resume`), never by running here — the render distinguishes
     /// `↷ cache hit (resume)` from a ran-to-green row.
     pub cached: bool,
+    /// The task settled through an `on_error.recover` repair: a
+    /// `task_recovered` frame preceded its terminal (D-2026-07-08-N4
+    /// sequence · engine#313). The FACT survives to every settled
+    /// surface (` · recovered`) — a repaired success must never render
+    /// byte-identical to a clean one (#319).
+    pub recovered: bool,
 }
 
 impl TaskRow {
@@ -171,6 +177,14 @@ impl RunView {
         self.plan_waves.as_deref()
     }
 
+    /// How many rows settled through an `on_error.recover` repair —
+    /// feeds the verdict card and the final meter (the `(N unpriced)`
+    /// honesty style: a non-zero count is never silent).
+    #[must_use]
+    pub fn recovered_count(&self) -> usize {
+        self.rows.iter().filter(|r| r.recovered).count()
+    }
+
     /// How many rows reached a terminal state.
     #[must_use]
     pub fn done_count(&self) -> usize {
@@ -241,6 +255,16 @@ impl RunView {
             EventKind::TaskRetrying => {
                 self.retries = self.retries.saturating_add(1);
                 self.touch(event, TaskState::Retrying);
+            }
+            // D-2026-07-08-N4 (engine#313) — the repair frame: an
+            // `on_error.recover` fallback stood in after a failed attempt;
+            // the terminal `task_completed` follows it. The row stays
+            // in-flight (Running) — only the FACT lands, so the settled
+            // render can say ` · recovered` (#319).
+            EventKind::TaskRecovered => {
+                if let Some(i) = self.touch(event, TaskState::Running) {
+                    self.rows[i].recovered = true;
+                }
             }
             // §3.1 blocked `⊘` — a decision, not a defect (dim · never red).
             EventKind::TaskCancelled => {
@@ -379,6 +403,7 @@ impl RunView {
                 def_hash: None,
                 input_hash: None,
                 cached: false,
+                recovered: false,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);
@@ -638,6 +663,38 @@ mod tests {
         // A row that never started (skipped) keeps None.
         let skipped = view.rows().iter().find(|r| r.id == "notify_slack");
         assert_eq!(skipped.and_then(|r| r.started_note.as_deref()), None);
+    }
+
+    /// D-2026-07-08-N4 / #319 — the repair fact folds: a `task_recovered`
+    /// frame BEFORE the terminal marks the row `recovered`, the row still
+    /// settles Ok, and the view counts exactly the repaired rows. A clean
+    /// sibling stays unmarked (the byte-identical trap this kills).
+    #[test]
+    fn recovered_frame_marks_the_row_and_the_count() {
+        use nika_types::resource::{KeyValue, Value};
+        let task = |n: &str| KeyValue::new("task", Value::String(n.to_owned()));
+
+        let mut view = RunView::new();
+        view.apply(&demo::bare_event(EventKind::TaskStarted, 0).with_field(task("fragile")));
+        view.apply(
+            &demo::bare_event(EventKind::TaskRecovered, 5)
+                .with_field(task("fragile"))
+                .with_field(KeyValue::new(
+                    "code",
+                    Value::String("NIKA-BUILTIN-READ-001".to_owned()),
+                )),
+        );
+        // Mid-repair: the fact landed, the task is still in flight.
+        assert!(view.rows()[0].recovered, "the repair fact folds");
+        assert_eq!(view.rows()[0].state, TaskState::Running);
+
+        view.apply(&demo::bare_event(EventKind::TaskCompleted, 10).with_field(task("fragile")));
+        view.apply(&demo::bare_event(EventKind::TaskCompleted, 20).with_field(task("clean")));
+
+        assert_eq!(view.rows()[0].state, TaskState::Ok, "settles Ok");
+        assert!(view.rows()[0].recovered, "the fact survives the terminal");
+        assert!(!view.rows()[1].recovered, "a clean row stays unmarked");
+        assert_eq!(view.recovered_count(), 1);
     }
 
     /// The retry counter folds every `task_retrying` frame (feeds the

--- a/crates/nika-cli/src/verbs/run/budget.rs
+++ b/crates/nika-cli/src/verbs/run/budget.rs
@@ -40,7 +40,7 @@ pub(super) fn preflight(
         }
     };
     if let Some(refusal) = floor_refusal(cost.min_path_total_usd, budget) {
-        super::emit_diagnostic(&refusal, output_json);
+        super::epilogue::emit_diagnostic(&refusal, output_json);
         return Err(exit::FILE);
     }
     if cost.has_unbounded {

--- a/crates/nika-cli/src/verbs/run/epilogue.rs
+++ b/crates/nika-cli/src/verbs/run/epilogue.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The run's LAST WORDS — the human final frame (flow epilogue · resume
+//! summary) + the machine envelopes (`{"error":…}` · `{"paused":…}` ·
+//! the `outputs:` line) — one seam, so display features land here,
+//! never in the driver (`mod.rs` composes and drives; this module
+//! speaks the ending).
+
+// The epilogue IS a printing surface (the same sanctioned exemption the
+// parent module carries): the render is the run's final frame, it
+// cannot be deferred to a `VerbOutput`.
+#![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use nika_runtime::{RunOutcome, WorkflowPause};
+
+use super::resume;
+use crate::Theme;
+
+/// The `--resume` post-run summary (`resumed · N skipped · M ran live`) —
+/// printed ONLY when a resume was requested (a fresh run's surfaces stay
+/// byte-identical). Machine modes route it to stderr (stdout is the
+/// contract surface); human modes print it under the final frame.
+pub(super) fn print_resume_summary(outcome: &RunOutcome, resumed: bool, to_stderr: bool) {
+    if !resumed {
+        return;
+    }
+    let ran_live = outcome
+        .records
+        .values()
+        .filter(|r| r.started_at.is_some())
+        .count();
+    let line = resume::summary_line(outcome.cache_hits.len(), ran_live);
+    if to_stderr {
+        eprintln!("{line}");
+    } else {
+        println!("\n  {line}");
+    }
+}
+
+/// The TTY final-frame epilogue: the post-run waterfall (real durations ·
+/// real overlap · pure fold of the run's own event stream) then the
+/// shareable verdict card, its outputs note naming what left the run —
+/// closed by the explore hint. SEAM (stated, not faked): a live run
+/// writes no trace file today, so the hint teaches the two-step that
+/// works NOW (record with `--json`, then browse); when auto-trace
+/// recording ships, this collapses to the recorded path.
+pub(super) fn print_flow_epilogue(
+    view: &crate::RunView,
+    outputs: &BTreeMap<String, Value>,
+    theme: Theme,
+    file: &str,
+) {
+    for line in crate::display::flow::waterfall(view, &theme) {
+        println!("{line}");
+    }
+    let note = outputs_note(outputs);
+    for line in crate::display::flow::verdict_card(view, &theme, note.as_deref()) {
+        println!("{line}");
+    }
+    // The workflow path is CLICKABLE on link-capable terminals (OSC-8 ·
+    // file:// — the one real file in the hint; the ndjson names are the
+    // suggested two-step, not files that exist yet).
+    let file_cell = crate::verbs::linked_path(theme, file);
+    let record =
+        format!("nika run {file_cell} --json > run.ndjson · nika trace outputs run.ndjson");
+    println!(
+        "  {}",
+        crate::display::vocab::hint(theme, "explore", &record)
+    );
+}
+
+/// The card's outputs note: `outputs → key (type) · key2 (type)` — the
+/// export contract's shape at a glance (types only, never a data dump).
+/// Two keys shown, the rest counted.
+pub(super) fn outputs_note(outputs: &BTreeMap<String, Value>) -> Option<String> {
+    if outputs.is_empty() {
+        return None;
+    }
+    let mut parts: Vec<String> = outputs
+        .iter()
+        .take(2)
+        .map(|(key, value)| format!("{key} ({})", json_type_name(value)))
+        .collect();
+    if outputs.len() > 2 {
+        parts.push(format!("+{} more", outputs.len() - 2));
+    }
+    Some(format!("outputs → {}", parts.join(" · ")))
+}
+
+/// The JSON type vocabulary for the outputs pointer — names only, never
+/// values (a summary line, not a data leak into the scrollback).
+pub(super) fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// The export contract's stdout payload (spec 01 §"What leaves a run"): the
+/// resolved workflow `outputs:` as ONE JSON object on a single line. An
+/// empty map (no `outputs:` declared · or references that no longer
+/// resolve) renders `{}` — stdout is ALWAYS a single JSON object in
+/// `--output json` mode, a stable machine contract for the composition
+/// path (`exec: nika run sub --output json` + `capture: stdout`).
+pub(super) fn outputs_json_line(outputs: &BTreeMap<String, Value>) -> String {
+    serde_json::to_string(outputs).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// Route a human-readable diagnostic to the spec-correct stream: stderr in
+/// `--output json` mode (stdout MUST stay a clean JSON object · the export
+/// contract · `capture: stdout` composition), stdout in the human modes.
+/// In machine mode the failure ALSO lands on stdout as the `{"error":{…}}`
+/// envelope (F6) — the machine surface is self-sufficient, success or not.
+pub(super) fn emit_diagnostic(text: &str, output_json: bool) {
+    if output_json {
+        eprint!("{text}");
+        println!("{}", error_envelope_line(envelope_message(text)));
+    } else {
+        print!("{text}");
+    }
+}
+
+/// Print the machine failure envelope when in `--output json` mode (the
+/// ENV-class exits inside `run` share this one seam).
+pub(super) fn emit_error_envelope(message: &str, output_json: bool) {
+    if output_json {
+        println!("{}", error_envelope_line(message));
+    }
+}
+
+/// ONE `{"paused":{…}}` line — the machine pause contract (ADR-099 rider
+/// · additive beside the success/error envelopes): the prompt payload a
+/// consumer needs to deliver an answer (`--answer <task>=<value>` at
+/// resume · or a serve webhook later).
+pub(super) fn paused_envelope_line(pause: &WorkflowPause) -> String {
+    serde_json::json!({
+        "paused": {
+            "task": pause.task,
+            "mode": pause.mode,
+            "message": pause.message,
+            "choices": pause.choices,
+        }
+    })
+    .to_string()
+}
+
+/// ONE `{"error":{"code":…,"message":…}}` line — the machine failure
+/// contract (F6). `code` is the first NIKA wire code found in the message
+/// (`null` when the failure class carries none, e.g. an unreadable file).
+pub(super) fn error_envelope_line(message: &str) -> String {
+    serde_json::json!({
+        "error": { "code": first_nika_code(message), "message": message }
+    })
+    .to_string()
+}
+
+/// Best-effort wire-code extraction: the first `NIKA-…` token in a
+/// diagnostic (findings render `[NIKA-PARSE-009]` · run details lead with
+/// `NIKA-431 · …`). Never invents — no token, no code.
+pub(super) fn first_nika_code(text: &str) -> Option<&str> {
+    let start = text.find("NIKA-")?;
+    let rest = &text[start..];
+    let end = rest
+        .find(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-'))
+        .unwrap_or(rest.len());
+    let code = rest[..end].trim_end_matches('-');
+    // A bare `NIKA-` prefix with no digits is prose, not a code.
+    (code.len() > "NIKA-".len() && code.bytes().any(|b| b.is_ascii_digit())).then_some(code)
+}
+
+/// The one-line message for a findings-render envelope: the first line
+/// carrying a wire code (the render wraps it in section noise), else the
+/// first non-empty line.
+pub(super) fn envelope_message(text: &str) -> &str {
+    let mut lines = text.lines().filter(|l| !l.trim().is_empty());
+    let first = lines.next().unwrap_or(text);
+    std::iter::once(first)
+        .chain(lines)
+        .find(|l| l.contains("NIKA-"))
+        .unwrap_or(first)
+        .trim()
+}
+
+/// The failure envelope for a run that EXECUTED and failed: the first
+/// failed task row's detail (it carries the wire code), else the
+/// workflow-level detail (run-end typed-output breaches), else a stable
+/// fallback — stdout never goes silent on a machine consumer.
+pub(super) fn run_failure_envelope(view: &crate::RunView) -> String {
+    let failed = view
+        .rows()
+        .iter()
+        .find(|r| r.state == crate::TaskState::Failed);
+    let message = match failed {
+        Some(row) if row.detail.is_empty() => format!("task `{}` failed", row.id),
+        Some(row) => format!("task `{}` failed — {}", row.id, row.detail),
+        None => view
+            .workflow_detail
+            .clone()
+            .unwrap_or_else(|| "workflow failed".to_owned()),
+    };
+    error_envelope_line(&message)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::outputs_json_line;
+    use serde_json::{Value, json};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn outputs_json_line_is_one_sorted_object() {
+        let mut m: BTreeMap<String, Value> = BTreeMap::new();
+        m.insert("total".to_owned(), json!(60));
+        m.insert("count".to_owned(), json!(3));
+        // BTreeMap key order → `count` before `total`: a single line,
+        // deterministic across runs (the machine consumer can jq it).
+        assert_eq!(outputs_json_line(&m), r#"{"count":3,"total":60}"#);
+        assert!(!outputs_json_line(&m).contains('\n'));
+    }
+
+    #[test]
+    fn outputs_json_line_empty_is_braces() {
+        // No `outputs:` declared → still a JSON object on stdout.
+        assert_eq!(outputs_json_line(&BTreeMap::new()), "{}");
+    }
+
+    // ── F6 · the `--output json` machine failure envelope ────────────
+
+    /// The envelope is ONE JSON object with the `{"error":{code,message}}`
+    /// shape · the code is extracted, never invented.
+    #[test]
+    fn error_envelope_is_one_object_with_extracted_code() {
+        let line = super::error_envelope_line("task failed — NIKA-VAR-001 · unresolved reference");
+        let v: Value = serde_json::from_str(&line).expect("envelope is JSON");
+        assert_eq!(v["error"]["code"], json!("NIKA-VAR-001"));
+        assert!(
+            v["error"]["message"]
+                .as_str()
+                .expect("message is a string")
+                .contains("unresolved"),
+        );
+        assert!(!line.contains('\n'), "one line — the machine contract");
+
+        // No wire code in the failure class (unreadable file) → null, not
+        // a hallucinated code.
+        let env_line = super::error_envelope_line("cannot read wf.yaml: No such file");
+        let v: Value = serde_json::from_str(&env_line).expect("envelope is JSON");
+        assert!(v["error"]["code"].is_null());
+    }
+
+    /// Wire-code extraction: bracketed findings, leading run details,
+    /// per-builtin long codes — and NO false positive on bare prose.
+    #[test]
+    fn first_nika_code_finds_real_codes_only() {
+        assert_eq!(
+            super::first_nika_code("PARSE ✗  [NIKA-PARSE-009] two verbs"),
+            Some("NIKA-PARSE-009")
+        );
+        assert_eq!(
+            super::first_nika_code("NIKA-431 · provider API error"),
+            Some("NIKA-431")
+        );
+        assert_eq!(
+            super::first_nika_code("x NIKA-BUILTIN-JQ-001 y"),
+            Some("NIKA-BUILTIN-JQ-001")
+        );
+        assert_eq!(super::first_nika_code("the NIKA- prefix alone"), None);
+        assert_eq!(super::first_nika_code("no code here"), None);
+    }
+
+    /// A findings render condenses to the line that carries the code.
+    #[test]
+    fn envelope_message_prefers_the_code_line() {
+        let text =
+            "nika check · wf.yaml\n X CONFORM  [NIKA-CEL-001] bad when\n  verdict: 1 finding\n";
+        assert_eq!(
+            super::envelope_message(text),
+            "X CONFORM  [NIKA-CEL-001] bad when"
+        );
+        // No code anywhere → the first non-empty line.
+        assert_eq!(
+            super::envelope_message("\ncannot read x: gone\ndetail\n"),
+            "cannot read x: gone"
+        );
+    }
+
+    /// The run-failure envelope reads the folded view: the failed row's
+    /// detail (which carries the wire code) becomes the machine message.
+    #[test]
+    fn run_failure_envelope_carries_the_failed_task_detail() {
+        let mut view = crate::RunView::new();
+        for ev in crate::demo::failure() {
+            view.apply(&ev);
+        }
+        let line = super::run_failure_envelope(&view);
+        let v: Value = serde_json::from_str(&line).expect("envelope is JSON");
+        assert_eq!(v["error"]["code"], json!("NIKA-431"), "{line}");
+        assert!(
+            v["error"]["message"]
+                .as_str()
+                .expect("message present")
+                .contains("task `"),
+            "{line}"
+        );
+
+        // An empty view (nothing folded) still yields a stable envelope.
+        let empty = super::run_failure_envelope(&crate::RunView::new());
+        let v: Value = serde_json::from_str(&empty).expect("fallback is JSON");
+        assert_eq!(v["error"]["message"], json!("workflow failed"));
+    }
+}

--- a/crates/nika-cli/src/verbs/run/heartbeat.rs
+++ b/crates/nika-cli/src/verbs/run/heartbeat.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The plain-lane liveness rider (#321): while a task is in flight the
+//! run speaks on STDERR every ~10s — `still running · <task> · <n>s ·
+//! <model>` — so a piped local-model run never reads as a hang. A
+//! rider, never a surface: stdout stays the storyboard's, `--json`
+//! keeps NDJSON (it already streams), and the rider can only ever ADD
+//! stderr lines, never change an exit code.
+//!
+//! WHY the pulse is plan-driven, not event-driven (proven live on a 12s
+//! `exec` task): the runtime's single-sink fold law emits each task's
+//! whole story (`task_started … task_completed`) AT SETTLE — mid-flight
+//! the stream is structurally mute, so an in-flight registry fed by
+//! `task_started` never beats. What IS known mid-flight: the static
+//! wave plan (the scheduler's truth · injected before driving), the
+//! terminal frames as they land, and the workflow's own verb/model
+//! declarations. The current wave = the first with an unsettled member;
+//! its unsettled members are the in-flight set (wave members dispatch
+//! together — the elapsed clock opens with the wave).
+
+// The heartbeat IS a stderr surface (the same sanctioned exemption the
+// run module carries): liveness cannot be deferred to a `VerbOutput`.
+#![allow(clippy::disallowed_macros, clippy::print_stderr)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use nika_event::{Event, EventKind};
+use nika_runtime::EventSink;
+use nika_schema::raw::{RawAction, RawWorkflow};
+
+use crate::display::state::str_field;
+
+/// The heartbeat cadence (~10s per #321). Beats fire at run-global
+/// ticks for whatever is in flight past a 1s floor — a per-task
+/// `>= PERIOD` floor would starve the exact population the beat exists
+/// for (a 12s task straddles ONE tick and settles before the next).
+const PERIOD: Duration = Duration::from_secs(10);
+
+/// The pulse: everything the ticker needs to say WHO is running.
+pub(super) struct RunPulse {
+    /// The static wave plan (task ids · dispatch order) — the
+    /// scheduler's truth, the same source the ∥ lane markers speak.
+    plan: Vec<Vec<String>>,
+    /// Per-task labels in the started-note vocabulary (`infer ·
+    /// <model>` · `invoke · <tool>` · `exec`) — derived STATICALLY from
+    /// the workflow (the stream cannot say it mid-flight).
+    labels: BTreeMap<String, String>,
+    /// Terminal frames folded live (the one mid-run signal the single-
+    /// sink fold law delivers — each settle arrives when it happens).
+    settled: BTreeSet<String>,
+    /// When the CURRENT wave opened (members dispatch together; a
+    /// member settling leaves the others' clock untouched).
+    wave_opened: Instant,
+    /// The current wave index (first wave with an unsettled member).
+    wave: usize,
+}
+
+impl RunPulse {
+    /// The beat lines for this instant: every unsettled member of the
+    /// current wave in flight past the 1s floor (a sub-second overlap
+    /// with a tick is noise, not a hang).
+    fn beats(&self) -> Vec<String> {
+        let secs = self.wave_opened.elapsed().as_secs();
+        if secs < 1 {
+            return Vec::new();
+        }
+        let Some(wave) = self.plan.get(self.wave) else {
+            return Vec::new();
+        };
+        wave.iter()
+            .filter(|id| !self.settled.contains(*id))
+            .map(|id| heartbeat_line(id, secs, self.labels.get(id).map(String::as_str)))
+            .collect()
+    }
+
+    /// Fold one settle: mark the task, and when that CLOSES the current
+    /// wave, open the next unsettled one (its members dispatch now —
+    /// the elapsed clock restarts with them).
+    fn settle(&mut self, task: &str) {
+        self.settled.insert(task.to_owned());
+        let next = self
+            .plan
+            .iter()
+            .position(|wave| wave.iter().any(|id| !self.settled.contains(id)))
+            .unwrap_or(self.plan.len());
+        if next != self.wave {
+            self.wave = next;
+            self.wave_opened = Instant::now();
+        }
+    }
+}
+
+/// A fresh shared pulse (the sink folds settles · the ticker reads) —
+/// built at composition time, moments before wave 1 dispatches.
+pub(super) fn shared(
+    plan: Vec<Vec<String>>,
+    labels: BTreeMap<String, String>,
+) -> Arc<Mutex<RunPulse>> {
+    Arc::new(Mutex::new(RunPulse {
+        plan,
+        labels,
+        settled: BTreeSet::new(),
+        wave_opened: Instant::now(),
+        wave: 0,
+    }))
+}
+
+/// Per-task labels in the runtime's started-note vocabulary, derived
+/// statically: `infer`/`agent` name the model they WILL resolve (the
+/// task's own `model:` · else the effective default — a `--model`
+/// override already substituted by the caller); `invoke` names its
+/// tool; `exec` stays bare (its argv0 may be template-shaped until run
+/// time — never invent).
+pub(super) fn task_labels(wf: &RawWorkflow, default_model: &str) -> BTreeMap<String, String> {
+    wf.tasks
+        .iter()
+        .map(|t| {
+            let task = &t.value;
+            let label = match &task.action {
+                RawAction::Infer(a) => model_label(
+                    "infer",
+                    a.model.as_ref().map(|m| m.value.as_str()),
+                    default_model,
+                ),
+                RawAction::Agent(a) => model_label(
+                    "agent",
+                    a.model.as_ref().map(|m| m.value.as_str()),
+                    default_model,
+                ),
+                RawAction::Invoke(a) => format!("invoke · {}", a.tool.value),
+                RawAction::Exec(_) => "exec".to_owned(),
+                // `#[non_exhaustive]` — a FUTURE verb speaks its verb
+                // name (honest, never invented detail).
+                other => other.verb().to_owned(),
+            };
+            (task.id.value.clone(), label)
+        })
+        .collect()
+}
+
+/// `<verb> · <model>` — the task's own model wins, else the effective
+/// default; a modelless resolve stays bare (never an invented cell).
+fn model_label(verb: &str, task_model: Option<&str>, default_model: &str) -> String {
+    let model = task_model.unwrap_or(default_model);
+    if model.is_empty() {
+        verb.to_owned()
+    } else {
+        format!("{verb} · {model}")
+    }
+}
+
+/// The stream-side half: an [`EventSink`] rider folding terminal frames
+/// into the pulse. An inert handle (`None`) keeps the caller's wiring
+/// branch-free — the `TraceFileSink::disabled` idiom.
+pub(super) struct HeartbeatSink {
+    pulse: Option<Arc<Mutex<RunPulse>>>,
+}
+
+impl HeartbeatSink {
+    /// Wrap the shared pulse (`None` = permanently silent no-op).
+    pub(super) fn new(pulse: Option<Arc<Mutex<RunPulse>>>) -> Self {
+        Self { pulse }
+    }
+}
+
+impl EventSink for HeartbeatSink {
+    fn emit(&mut self, event: Event) {
+        let Some(pulse) = &self.pulse else { return };
+        // Terminal kinds ONLY — the fold law delivers these live; the
+        // started/retrying/recovered story arrives at settle anyway.
+        if !matches!(
+            event.kind,
+            EventKind::TaskCompleted
+                | EventKind::TaskFailed
+                | EventKind::TaskSkipped
+                | EventKind::TaskCancelled
+                | EventKind::TaskCacheHit
+        ) {
+            return;
+        }
+        let Some(task) = str_field(&event, "task") else {
+            return; // a terminal frame without a task settles nothing
+        };
+        // A poisoned lock = another holder panicked; the heartbeat is
+        // best-effort by contract — go silent, never propagate.
+        if let Ok(mut pulse) = pulse.lock() {
+            pulse.settle(task);
+        }
+    }
+}
+
+/// The timer half — spawned on the run's current-thread executor (it
+/// ticks whenever the driven future is at an await point, exactly the
+/// provider/subprocess wait the hang perception comes from). The caller
+/// aborts it the moment the run settles (and the executor's drop reaps
+/// it regardless — it can never outlive the run).
+pub(super) fn spawn_ticker(pulse: Arc<Mutex<RunPulse>>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(PERIOD);
+        // A long blocking stretch must not burst-fire stale beats.
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        tick.tick().await; // the immediate first tick is not a heartbeat
+        loop {
+            tick.tick().await;
+            // Collect under the lock · print after (stderr I/O never
+            // holds the pulse against the event stream).
+            let beats = match pulse.lock() {
+                Ok(pulse) => pulse.beats(),
+                Err(_) => return, // poisoned — best-effort silence
+            };
+            for line in beats {
+                eprintln!("{line}");
+            }
+        }
+    })
+}
+
+/// One heartbeat: `still running · <task> · <n>s · <model>`. The model
+/// rides bare off the `infer · <m>` / `agent · <m>` vocabulary (the
+/// issue's shape); other verbs speak their label verbatim (`invoke ·
+/// nika:fetch` — WHAT is running is the point); a labelless task stays
+/// two-celled, never invents.
+fn heartbeat_line(task: &str, secs: u64, label: Option<&str>) -> String {
+    let mut line = format!("still running · {task} · {secs}s");
+    if let Some(label) = label {
+        let what = label
+            .strip_prefix("infer · ")
+            .or_else(|| label.strip_prefix("agent · "))
+            .unwrap_or(label);
+        if !what.is_empty() {
+            line.push_str(" · ");
+            line.push_str(what);
+        }
+    }
+    line
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::demo;
+    use nika_types::resource::{KeyValue, Value};
+
+    fn task(n: &str) -> KeyValue {
+        KeyValue::new("task", Value::String(n.to_owned()))
+    }
+
+    /// An instant `secs` in the past — ages the wave clock without
+    /// sleeping (checked: the process epoch has minutes of headroom).
+    fn aged(secs: u64) -> Instant {
+        Instant::now()
+            .checked_sub(Duration::from_secs(secs))
+            .expect("epoch headroom")
+    }
+
+    /// The issue's exact shape: the model rides bare (the `infer · `
+    /// prefix strips), other verbs speak their label verbatim, and a
+    /// labelless task never grows an invented cell.
+    #[test]
+    fn heartbeat_line_speaks_the_model_or_the_verb() {
+        assert_eq!(
+            heartbeat_line("think", 15, Some("infer · ollama/qwen3.5:4b")),
+            "still running · think · 15s · ollama/qwen3.5:4b"
+        );
+        assert_eq!(
+            heartbeat_line("scout", 31, Some("agent · mock/echo")),
+            "still running · scout · 31s · mock/echo"
+        );
+        assert_eq!(
+            heartbeat_line("fetch", 12, Some("invoke · nika:fetch")),
+            "still running · fetch · 12s · invoke · nika:fetch"
+        );
+        assert_eq!(
+            heartbeat_line("bare", 10, None),
+            "still running · bare · 10s"
+        );
+    }
+
+    /// The labels derive from the WORKFLOW (the stream is mute
+    /// mid-flight): the task's own model wins · the effective default
+    /// fills modelless infer/agent · invoke names its tool · exec
+    /// stays bare.
+    #[test]
+    fn task_labels_speak_the_static_truth() {
+        let yaml = "nika: v1\nworkflow: t\nmodel: ollama/qwen3.5:4b\ntasks:\n  - id: think\n    infer: { prompt: hi }\n  - id: pinned\n    infer: { prompt: hi, model: \"mock/echo\" }\n  - id: fetch\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://example.com\" } }\n  - id: build\n    exec: { command: \"sleep 1\" }\n";
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let labels = task_labels(&wf, "ollama/qwen3.5:4b");
+        assert_eq!(labels["think"], "infer · ollama/qwen3.5:4b");
+        assert_eq!(labels["pinned"], "infer · mock/echo", "task model wins");
+        assert_eq!(labels["fetch"], "invoke · nika:fetch");
+        assert_eq!(labels["build"], "exec");
+    }
+
+    /// The pulse walks the plan: wave 1's unsettled members beat; a
+    /// settle that CLOSES the wave opens the next (fresh clock); the
+    /// exhausted plan beats nothing. Every terminal kind settles; an
+    /// inert sink folds nothing.
+    #[test]
+    fn pulse_beats_the_current_waves_unsettled_members() {
+        let plan = vec![
+            vec!["nap".to_owned(), "twin".to_owned()],
+            vec!["after".to_owned()],
+        ];
+        let labels: BTreeMap<String, String> =
+            [("after".to_owned(), "infer · mock/echo".to_owned())].into();
+        let pulse = shared(plan, labels);
+        let mut sink = HeartbeatSink::new(Some(Arc::clone(&pulse)));
+
+        // Age the wave clock past the 1s floor without sleeping.
+        pulse.lock().expect("unpoisoned").wave_opened = aged(11);
+        let beats = pulse.lock().expect("unpoisoned").beats();
+        assert_eq!(
+            beats,
+            vec![
+                "still running · nap · 11s".to_owned(),
+                "still running · twin · 11s".to_owned(),
+            ],
+            "wave 1 in flight — both members beat"
+        );
+
+        // One sibling settles — the wave stays open, the other beats on.
+        sink.emit(demo::bare_event(EventKind::TaskCompleted, 5).with_field(task("twin")));
+        let beats = pulse.lock().expect("unpoisoned").beats();
+        assert_eq!(beats.len(), 1, "the settled sibling went quiet");
+        assert!(beats[0].contains("nap"), "{beats:?}");
+
+        // The wave closes — the next opens with a FRESH clock (under
+        // the floor → quiet), then ages into its own beat.
+        sink.emit(demo::bare_event(EventKind::TaskFailed, 6).with_field(task("nap")));
+        assert!(
+            pulse.lock().expect("unpoisoned").beats().is_empty(),
+            "a just-opened wave is under the 1s floor"
+        );
+        pulse.lock().expect("unpoisoned").wave_opened = aged(12);
+        let beats = pulse.lock().expect("unpoisoned").beats();
+        assert_eq!(
+            beats,
+            vec!["still running · after · 12s · mock/echo".to_owned()],
+            "wave 2 beats with its static model label"
+        );
+
+        // The plan exhausts — silence.
+        sink.emit(demo::bare_event(EventKind::TaskSkipped, 7).with_field(task("after")));
+        assert!(pulse.lock().expect("unpoisoned").beats().is_empty());
+
+        // The inert handle folds nothing (the non-Plain lanes' shape).
+        let mut inert = HeartbeatSink::new(None);
+        inert.emit(demo::bare_event(EventKind::TaskCompleted, 8).with_field(task("ghost")));
+    }
+}

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -39,6 +39,7 @@ pub use stamp::SystemStamper;
 
 mod budget;
 mod epilogue;
+mod heartbeat;
 mod scope;
 pub(crate) use nika_dap::source_id::{lf_normal_form, sha256_hex};
 use scope::scope_to_task;
@@ -199,7 +200,6 @@ pub fn run(
         Ok(rt) => rt,
         Err(code) => return code,
     };
-    let trace = trace_sink(no_trace_file);
     rt.block_on(execute(
         &runtime,
         (file, &wf),
@@ -209,8 +209,9 @@ pub fn run(
         theme,
         mode,
         resume.is_some(),
-        trace,
+        trace_sink(no_trace_file),
         !no_outputs,
+        model_override,
     ))
 }
 
@@ -702,6 +703,7 @@ async fn execute(
     resumed: bool,
     trace: TraceFileSink,
     outputs: bool,
+    model_override: Option<&str>,
 ) -> u8 {
     let mut stamper = SystemStamper::new();
     if output_json {
@@ -769,10 +771,9 @@ async fn execute(
             &mut stamper,
             file,
             theme,
-            mode,
-            resumed,
+            (mode, resumed, outputs),
             trace,
-            outputs,
+            model_override,
         )
         .await
     }
@@ -783,6 +784,8 @@ async fn execute(
 /// are peers, not one long body). Storytelling surfaces get the flow
 /// epilogue + the spec §3.3 `trace:` pointer; `--quiet` keeps its
 /// compact-card promise.
+// The mode/resumed/outputs trio rides as one tuple — the same
+// clap-surface idiom as `execute` itself (three independent switches).
 #[allow(clippy::too_many_arguments)]
 async fn execute_fold_lane(
     runtime: &ProdRuntime,
@@ -791,22 +794,42 @@ async fn execute_fold_lane(
     stamper: &mut SystemStamper,
     file: &str,
     theme: Theme,
-    mode: RenderMode,
-    resumed: bool,
+    (mode, resumed, outputs): (RenderMode, bool, bool),
     trace: TraceFileSink,
-    outputs: bool,
+    model_override: Option<&str>,
 ) -> u8 {
+    let plan = plan_waves(wf, report);
     let mut fold = FoldSink::new(std::io::stdout().lock(), theme, mode);
-    fold.set_plan(plan_waves(wf, report));
+    fold.set_plan(plan.clone());
     // The shape tails ride the INTERACTIVE surface only (`Live` = TTY):
     // the piped/`--no-progress`/`--quiet` registers keep their exact
     // bytes — CI logs and scripts never grow tails.
     if mode == RenderMode::Live && outputs {
         fold.show_outputs(true);
     }
-    let mut tee = Tee::new(fold, trace);
+    // #321 — the plain lane's stderr liveness rider (`still running ·
+    // <task> · <n>s · <model>` every ~10s): a piped local-model run
+    // must never read as a hang. Plain ONLY — Live already repaints ·
+    // Quiet promised compactness · the machine lanes stream NDJSON. An
+    // inert handle keeps one code path (the disabled-journal idiom).
+    let pulse = (mode == RenderMode::Plain).then(|| {
+        // The EFFECTIVE default model (the same substitution
+        // composed_runtime made): the beat's static labels must name
+        // what will actually resolve, `--model` override included.
+        let default_model =
+            model_override.unwrap_or_else(|| wf.model.as_ref().map_or("", |m| m.value.as_str()));
+        heartbeat::shared(plan, heartbeat::task_labels(wf, default_model))
+    });
+    let ticker = pulse.clone().map(heartbeat::spawn_ticker);
+    let beat = heartbeat::HeartbeatSink::new(pulse);
+    let mut tee = Tee::new(Tee::new(fold, beat), trace);
     let (code, outcome) = drive(runtime, wf, report, stamper, &mut tee).await;
-    let (mut sink, trace) = tee.into_parts();
+    // The run settled — the rider must not speak over the epilogue.
+    if let Some(ticker) = &ticker {
+        ticker.abort();
+    }
+    let (inner, trace) = tee.into_parts();
+    let (mut sink, _beat) = inner.into_parts();
     // `Live` painted in place during the run; `Plain`/`Quiet` folded
     // silently · print the ONE final frame now.
     if mode != RenderMode::Live {

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -38,6 +38,7 @@ use sink::{TraceNote, surface_trace};
 pub use stamp::SystemStamper;
 
 mod budget;
+mod epilogue;
 mod scope;
 pub(crate) use nika_dap::source_id::{lf_normal_form, sha256_hex};
 use scope::scope_to_task;
@@ -50,7 +51,7 @@ use std::io::Write as _;
 use serde_json::Value;
 
 use nika_runtime::resume::ResumePlan;
-use nika_runtime::{EventSink, RunOutcome, Runtime, Stamper, WorkflowPause};
+use nika_runtime::{EventSink, RunOutcome, Runtime, Stamper};
 use nika_schema::check::CheckReport;
 use nika_schema::raw::RawWorkflow;
 
@@ -142,7 +143,7 @@ pub fn run(
         Err(out) => {
             // Machine mode: diagnostics ride stderr so a `capture: stdout`
             // consumer never mistakes them for the JSON result.
-            emit_diagnostic(&refusal_text(&out), output_json);
+            epilogue::emit_diagnostic(&refusal_text(&out), output_json);
             return out.code;
         }
     };
@@ -226,7 +227,7 @@ fn executor(output_json: bool) -> Result<tokio::runtime::Runtime, u8> {
         .map_err(|e| {
             let message = format!("cannot start the async executor: {e}");
             eprintln!("nika run: environment: {message}");
-            emit_error_envelope(&message, output_json);
+            epilogue::emit_error_envelope(&message, output_json);
             exit::ENV
         })
 }
@@ -258,7 +259,7 @@ fn resume_setup(
     let answers = resume::parse_answers(resume.map_or(&[][..], |r| r.answers.as_slice()), wf)
         .map_err(|message| {
             eprintln!("nika run: {message}");
-            emit_error_envelope(&message, output_json);
+            epilogue::emit_error_envelope(&message, output_json);
             exit::ENV
         })?;
     Ok(ResumeSetup { plan, answers })
@@ -280,7 +281,7 @@ fn load_resume_plan(
     let label = req.trace.display().to_string();
     let refuse = |message: String| {
         eprintln!("nika run: {message}");
-        emit_error_envelope(&message, output_json);
+        epilogue::emit_error_envelope(&message, output_json);
         exit::ENV
     };
     let raw = std::fs::read_to_string(&req.trace)
@@ -539,7 +540,7 @@ fn composed_runtime(
         }
         Err(e) => {
             eprintln!("nika run: environment: {e}");
-            emit_error_envelope(&e.to_string(), output_json);
+            epilogue::emit_error_envelope(&e.to_string(), output_json);
             Err(exit::ENV)
         }
     }
@@ -609,7 +610,7 @@ fn validated_var_overrides(
 ) -> Result<std::collections::BTreeMap<String, serde_json::Value>, u8> {
     parse_var_overrides(vars, wf).map_err(|message| {
         eprintln!("nika run: {message}");
-        emit_error_envelope(&message, output_json);
+        epilogue::emit_error_envelope(&message, output_json);
         exit::ENV
     })
 }
@@ -632,7 +633,7 @@ fn scoped_clean_gate(
     let (wf, report) = apply_task_scope(wf, report, task_filter, output_json)?;
     if !report.is_clean() {
         let out = crate::verbs::check::run(file, json, false, None, theme);
-        emit_diagnostic(&out.text, output_json);
+        epilogue::emit_diagnostic(&out.text, output_json);
         return Err(out.code);
     }
     Ok((wf, report))
@@ -658,7 +659,7 @@ fn apply_task_scope(
             Ok((sub, sub_report))
         }
         Err(msg) => {
-            emit_diagnostic(&msg, output_json);
+            epilogue::emit_diagnostic(&msg, output_json);
             Err(exit::ENV)
         }
     }
@@ -719,22 +720,22 @@ async fn execute(
         let (mut sink, trace) = tee.into_parts();
         sink.print_final();
         surface_trace(trace, TraceNote::Stderr, None);
-        print_resume_summary(&outcome, resumed, true);
+        epilogue::print_resume_summary(&outcome, resumed, true);
         // Built BEFORE the sink is consumed — the failure envelope reads
         // the folded view (the failed row's detail carries the wire code).
         // A PAUSED run gets its own additive envelope (`{"paused":{…}}` ·
         // ADR-099 rider · run state `paused` in the report vocabulary).
         let verdict_line = if code == exit::PAUSED {
-            outcome.paused.as_ref().map(paused_envelope_line)
+            outcome.paused.as_ref().map(epilogue::paused_envelope_line)
         } else if code != exit::OK {
-            Some(run_failure_envelope(sink.view()))
+            Some(epilogue::run_failure_envelope(sink.view()))
         } else {
             None
         };
         if let Some(e) = sink.into_error() {
             let message = format!("render failed: {e}");
             eprintln!("nika run: {message}");
-            println!("{}", error_envelope_line(&message));
+            println!("{}", epilogue::error_envelope_line(&message));
             return exit::ENV;
         }
         // stdout is ALWAYS one self-sufficient JSON object (F6): the
@@ -744,7 +745,7 @@ async fn execute(
         // human-gate pause.
         match verdict_line {
             Some(line) => println!("{line}"),
-            None => println!("{}", outputs_json_line(&outcome.outputs)),
+            None => println!("{}", epilogue::outputs_json_line(&outcome.outputs)),
         }
         code
     } else if json {
@@ -758,7 +759,7 @@ async fn execute(
             eprintln!("nika run: stream write failed: {e}");
             return exit::ENV;
         }
-        print_resume_summary(&outcome, resumed, true);
+        epilogue::print_resume_summary(&outcome, resumed, true);
         code
     } else {
         execute_fold_lane(
@@ -815,7 +816,7 @@ async fn execute_fold_lane(
     // time waterfall + the outputs pointer (design §2c). The sober
     // registers stay untouched — CI logs never grow chart art.
     if mode == RenderMode::Live {
-        print_flow_epilogue(sink.view(), &outcome.outputs, theme, file);
+        epilogue::print_flow_epilogue(sink.view(), &outcome.outputs, theme, file);
     }
     // The spec §3.3 final-frame pointer (`trace: …`) — under the frame
     // on the storytelling surfaces.
@@ -834,96 +835,12 @@ async fn execute_fold_lane(
         },
         failed_task.as_deref(),
     );
-    print_resume_summary(&outcome, resumed, false);
+    epilogue::print_resume_summary(&outcome, resumed, false);
     if let Some(e) = sink.into_error() {
         eprintln!("nika run: render failed: {e}");
         return exit::ENV;
     }
     code
-}
-
-/// The `--resume` post-run summary (`resumed · N skipped · M ran live`) —
-/// printed ONLY when a resume was requested (a fresh run's surfaces stay
-/// byte-identical). Machine modes route it to stderr (stdout is the
-/// contract surface); human modes print it under the final frame.
-fn print_resume_summary(outcome: &RunOutcome, resumed: bool, to_stderr: bool) {
-    if !resumed {
-        return;
-    }
-    let ran_live = outcome
-        .records
-        .values()
-        .filter(|r| r.started_at.is_some())
-        .count();
-    let line = resume::summary_line(outcome.cache_hits.len(), ran_live);
-    if to_stderr {
-        eprintln!("{line}");
-    } else {
-        println!("\n  {line}");
-    }
-}
-
-/// The TTY final-frame epilogue: the post-run waterfall (real durations ·
-/// real overlap · pure fold of the run's own event stream) then the
-/// shareable verdict card, its outputs note naming what left the run —
-/// closed by the explore hint. SEAM (stated, not faked): a live run
-/// writes no trace file today, so the hint teaches the two-step that
-/// works NOW (record with `--json`, then browse); when auto-trace
-/// recording ships, this collapses to the recorded path.
-fn print_flow_epilogue(
-    view: &crate::RunView,
-    outputs: &BTreeMap<String, Value>,
-    theme: Theme,
-    file: &str,
-) {
-    for line in crate::display::flow::waterfall(view, &theme) {
-        println!("{line}");
-    }
-    let note = outputs_note(outputs);
-    for line in crate::display::flow::verdict_card(view, &theme, note.as_deref()) {
-        println!("{line}");
-    }
-    // The workflow path is CLICKABLE on link-capable terminals (OSC-8 ·
-    // file:// — the one real file in the hint; the ndjson names are the
-    // suggested two-step, not files that exist yet).
-    let file_cell = crate::verbs::linked_path(theme, file);
-    let record =
-        format!("nika run {file_cell} --json > run.ndjson · nika trace outputs run.ndjson");
-    println!(
-        "  {}",
-        crate::display::vocab::hint(theme, "explore", &record)
-    );
-}
-
-/// The card's outputs note: `outputs → key (type) · key2 (type)` — the
-/// export contract's shape at a glance (types only, never a data dump).
-/// Two keys shown, the rest counted.
-fn outputs_note(outputs: &BTreeMap<String, Value>) -> Option<String> {
-    if outputs.is_empty() {
-        return None;
-    }
-    let mut parts: Vec<String> = outputs
-        .iter()
-        .take(2)
-        .map(|(key, value)| format!("{key} ({})", json_type_name(value)))
-        .collect();
-    if outputs.len() > 2 {
-        parts.push(format!("+{} more", outputs.len() - 2));
-    }
-    Some(format!("outputs → {}", parts.join(" · ")))
-}
-
-/// The JSON type vocabulary for the outputs pointer — names only, never
-/// values (a summary line, not a data leak into the scrollback).
-fn json_type_name(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "boolean",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
-    }
 }
 
 /// Run the workflow through a sink + map the outcome to an exit code.
@@ -978,21 +895,6 @@ where
     }
 }
 
-/// The export contract's stdout payload (spec 01 §"What leaves a run"): the
-/// resolved workflow `outputs:` as ONE JSON object on a single line. An
-/// empty map (no `outputs:` declared · or references that no longer
-/// resolve) renders `{}` — stdout is ALWAYS a single JSON object in
-/// `--output json` mode, a stable machine contract for the composition
-/// path (`exec: nika run sub --output json` + `capture: stdout`).
-fn outputs_json_line(outputs: &BTreeMap<String, Value>) -> String {
-    serde_json::to_string(outputs).unwrap_or_else(|_| "{}".to_owned())
-}
-
-/// Route a human-readable diagnostic to the spec-correct stream: stderr in
-/// `--output json` mode (stdout MUST stay a clean JSON object · the export
-/// contract · `capture: stdout` composition), stdout in the human modes.
-/// In machine mode the failure ALSO lands on stdout as the `{"error":{…}}`
-/// envelope (F6) — the machine surface is self-sufficient, success or not.
 /// The run journal (spec §3.3) — composed like the other seams;
 /// `execute` receives the sink, never a flag.
 fn trace_sink(no_trace_file: bool) -> TraceFileSink {
@@ -1003,120 +905,12 @@ fn trace_sink(no_trace_file: bool) -> TraceFileSink {
     }
 }
 
-fn emit_diagnostic(text: &str, output_json: bool) {
-    if output_json {
-        eprint!("{text}");
-        println!("{}", error_envelope_line(envelope_message(text)));
-    } else {
-        print!("{text}");
-    }
-}
-
-/// Print the machine failure envelope when in `--output json` mode (the
-/// ENV-class exits inside `run` share this one seam).
-fn emit_error_envelope(message: &str, output_json: bool) {
-    if output_json {
-        println!("{}", error_envelope_line(message));
-    }
-}
-
-/// ONE `{"paused":{…}}` line — the machine pause contract (ADR-099 rider
-/// · additive beside the success/error envelopes): the prompt payload a
-/// consumer needs to deliver an answer (`--answer <task>=<value>` at
-/// resume · or a serve webhook later).
-fn paused_envelope_line(pause: &WorkflowPause) -> String {
-    serde_json::json!({
-        "paused": {
-            "task": pause.task,
-            "mode": pause.mode,
-            "message": pause.message,
-            "choices": pause.choices,
-        }
-    })
-    .to_string()
-}
-
-/// ONE `{"error":{"code":…,"message":…}}` line — the machine failure
-/// contract (F6). `code` is the first NIKA wire code found in the message
-/// (`null` when the failure class carries none, e.g. an unreadable file).
-fn error_envelope_line(message: &str) -> String {
-    serde_json::json!({
-        "error": { "code": first_nika_code(message), "message": message }
-    })
-    .to_string()
-}
-
-/// Best-effort wire-code extraction: the first `NIKA-…` token in a
-/// diagnostic (findings render `[NIKA-PARSE-009]` · run details lead with
-/// `NIKA-431 · …`). Never invents — no token, no code.
-fn first_nika_code(text: &str) -> Option<&str> {
-    let start = text.find("NIKA-")?;
-    let rest = &text[start..];
-    let end = rest
-        .find(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-'))
-        .unwrap_or(rest.len());
-    let code = rest[..end].trim_end_matches('-');
-    // A bare `NIKA-` prefix with no digits is prose, not a code.
-    (code.len() > "NIKA-".len() && code.bytes().any(|b| b.is_ascii_digit())).then_some(code)
-}
-
-/// The one-line message for a findings-render envelope: the first line
-/// carrying a wire code (the render wraps it in section noise), else the
-/// first non-empty line.
-fn envelope_message(text: &str) -> &str {
-    let mut lines = text.lines().filter(|l| !l.trim().is_empty());
-    let first = lines.next().unwrap_or(text);
-    std::iter::once(first)
-        .chain(lines)
-        .find(|l| l.contains("NIKA-"))
-        .unwrap_or(first)
-        .trim()
-}
-
-/// The failure envelope for a run that EXECUTED and failed: the first
-/// failed task row's detail (it carries the wire code), else the
-/// workflow-level detail (run-end typed-output breaches), else a stable
-/// fallback — stdout never goes silent on a machine consumer.
-fn run_failure_envelope(view: &crate::RunView) -> String {
-    let failed = view
-        .rows()
-        .iter()
-        .find(|r| r.state == crate::TaskState::Failed);
-    let message = match failed {
-        Some(row) if row.detail.is_empty() => format!("task `{}` failed", row.id),
-        Some(row) => format!("task `{}` failed — {}", row.id, row.detail),
-        None => view
-            .workflow_detail
-            .clone()
-            .unwrap_or_else(|| "workflow failed".to_owned()),
-    };
-    error_envelope_line(&message)
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use super::{RenderMode, exit, offline_tip_applies, outputs_json_line, run, scope_to_task};
+    use super::{RenderMode, exit, offline_tip_applies, run, scope_to_task};
     use crate::Theme;
-    use serde_json::{Value, json};
-    use std::collections::BTreeMap;
-
-    #[test]
-    fn outputs_json_line_is_one_sorted_object() {
-        let mut m: BTreeMap<String, Value> = BTreeMap::new();
-        m.insert("total".to_owned(), json!(60));
-        m.insert("count".to_owned(), json!(3));
-        // BTreeMap key order → `count` before `total`: a single line,
-        // deterministic across runs (the machine consumer can jq it).
-        assert_eq!(outputs_json_line(&m), r#"{"count":3,"total":60}"#);
-        assert!(!outputs_json_line(&m).contains('\n'));
-    }
-
-    #[test]
-    fn outputs_json_line_empty_is_braces() {
-        // No `outputs:` declared → still a JSON object on stdout.
-        assert_eq!(outputs_json_line(&BTreeMap::new()), "{}");
-    }
+    use serde_json::json;
 
     /// The offline-hint policy (pure · the heart of the UX decision). The
     /// tip fires ONLY when a non-mock example FAILED with no `--model`
@@ -1308,91 +1102,6 @@ mod tests {
             exit::ENV,
             "malformed --var pair is refused"
         );
-    }
-
-    // ── F6 · the `--output json` machine failure envelope ────────────
-
-    /// The envelope is ONE JSON object with the `{"error":{code,message}}`
-    /// shape · the code is extracted, never invented.
-    #[test]
-    fn error_envelope_is_one_object_with_extracted_code() {
-        let line = super::error_envelope_line("task failed — NIKA-VAR-001 · unresolved reference");
-        let v: Value = serde_json::from_str(&line).expect("envelope is JSON");
-        assert_eq!(v["error"]["code"], json!("NIKA-VAR-001"));
-        assert!(
-            v["error"]["message"]
-                .as_str()
-                .expect("message is a string")
-                .contains("unresolved"),
-        );
-        assert!(!line.contains('\n'), "one line — the machine contract");
-
-        // No wire code in the failure class (unreadable file) → null, not
-        // a hallucinated code.
-        let env_line = super::error_envelope_line("cannot read wf.yaml: No such file");
-        let v: Value = serde_json::from_str(&env_line).expect("envelope is JSON");
-        assert!(v["error"]["code"].is_null());
-    }
-
-    /// Wire-code extraction: bracketed findings, leading run details,
-    /// per-builtin long codes — and NO false positive on bare prose.
-    #[test]
-    fn first_nika_code_finds_real_codes_only() {
-        assert_eq!(
-            super::first_nika_code("PARSE ✗  [NIKA-PARSE-009] two verbs"),
-            Some("NIKA-PARSE-009")
-        );
-        assert_eq!(
-            super::first_nika_code("NIKA-431 · provider API error"),
-            Some("NIKA-431")
-        );
-        assert_eq!(
-            super::first_nika_code("x NIKA-BUILTIN-JQ-001 y"),
-            Some("NIKA-BUILTIN-JQ-001")
-        );
-        assert_eq!(super::first_nika_code("the NIKA- prefix alone"), None);
-        assert_eq!(super::first_nika_code("no code here"), None);
-    }
-
-    /// A findings render condenses to the line that carries the code.
-    #[test]
-    fn envelope_message_prefers_the_code_line() {
-        let text =
-            "nika check · wf.yaml\n X CONFORM  [NIKA-CEL-001] bad when\n  verdict: 1 finding\n";
-        assert_eq!(
-            super::envelope_message(text),
-            "X CONFORM  [NIKA-CEL-001] bad when"
-        );
-        // No code anywhere → the first non-empty line.
-        assert_eq!(
-            super::envelope_message("\ncannot read x: gone\ndetail\n"),
-            "cannot read x: gone"
-        );
-    }
-
-    /// The run-failure envelope reads the folded view: the failed row's
-    /// detail (which carries the wire code) becomes the machine message.
-    #[test]
-    fn run_failure_envelope_carries_the_failed_task_detail() {
-        let mut view = crate::RunView::new();
-        for ev in crate::demo::failure() {
-            view.apply(&ev);
-        }
-        let line = super::run_failure_envelope(&view);
-        let v: Value = serde_json::from_str(&line).expect("envelope is JSON");
-        assert_eq!(v["error"]["code"], json!("NIKA-431"), "{line}");
-        assert!(
-            v["error"]["message"]
-                .as_str()
-                .expect("message present")
-                .contains("task `"),
-            "{line}"
-        );
-
-        // An empty view (nothing folded) still yields a stable envelope.
-        let empty = super::run_failure_envelope(&crate::RunView::new());
-        let v: Value = serde_json::from_str(&empty).expect("fallback is JSON");
-        assert_eq!(v["error"]["message"], json!("workflow failed"));
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -19,6 +19,8 @@ use nika_runtime::EventSink;
 use nika_types::timestamp::Timestamp;
 use uuid::Uuid;
 
+use crate::display::render::{stream_header, stream_settled_line, stream_summary};
+use crate::display::state::str_field;
 use crate::{RunView, Theme, frame, frame_with_outputs, verdict_frame};
 
 // The chain primitive + genesis tag live in the forensics crate — the
@@ -428,13 +430,16 @@ impl<W: Write> FoldSink<W> {
 
     /// Print the final frame once (the `Plain`/`Quiet` lanes · the caller
     /// calls this after the run · a no-op buffered error stays buffered).
-    /// `Quiet` paints the compact verdict card; `Plain` the full storyboard.
+    /// `Quiet` paints the compact verdict card; `Plain` CLOSES its
+    /// narration (#321 — the rows spoke at settle · the meter + the
+    /// failure card end the story, never a repeated storyboard).
     pub fn print_final(&mut self) {
         if self.error.is_some() {
             return;
         }
         let lines = match self.mode {
             RenderMode::Quiet => verdict_frame(&self.view, &self.theme),
+            RenderMode::Plain => stream_summary(&self.view, &self.theme),
             _ if self.outputs => frame_with_outputs(&self.view, &self.theme, 0),
             _ => frame(&self.view, &self.theme, 0),
         };
@@ -486,6 +491,35 @@ impl<W: Write> FoldSink<W> {
         self.last_lines = lines.len();
         self.writer.flush()
     }
+
+    /// The plain narration (#321): the header the moment the workflow
+    /// starts, one storyboard line the moment each task settles — the
+    /// SAME content the final frame would show, streamed (zero cursor
+    /// control · a piped consumer sees progress when it happens, and a
+    /// local-model run never reads as a hang). Non-narrating events
+    /// write nothing (no flush churn on dispatch/checkpoint frames).
+    fn narrate(&mut self, event: &Event) -> std::io::Result<()> {
+        use nika_event::EventKind;
+        let lines: Vec<String> = match event.kind {
+            EventKind::WorkflowStarted => stream_header(&self.view, &self.theme),
+            EventKind::TaskCompleted
+            | EventKind::TaskFailed
+            | EventKind::TaskSkipped
+            | EventKind::TaskCancelled
+            | EventKind::TaskCacheHit => str_field(event, "task")
+                .and_then(|task| stream_settled_line(&self.view, task, &self.theme, self.outputs))
+                .into_iter()
+                .collect(),
+            _ => Vec::new(),
+        };
+        if lines.is_empty() {
+            return Ok(());
+        }
+        for line in &lines {
+            writeln!(self.writer, "{line}")?;
+        }
+        self.writer.flush()
+    }
 }
 
 impl<W: Write> EventSink for FoldSink<W> {
@@ -494,12 +528,15 @@ impl<W: Write> EventSink for FoldSink<W> {
             return;
         }
         self.view.apply(&event);
-        // Only `Live` repaints in place; `Plain`/`Quiet` fold silently (the
-        // caller prints one final frame) — never leak cursor escapes into a
-        // captured log.
-        if self.mode == RenderMode::Live
-            && let Err(e) = self.repaint()
-        {
+        // `Live` repaints in place (TTY cursor control) · `Plain`
+        // narrates at settle (#321 · zero escapes) · `Quiet` folds
+        // silently for the compact final card.
+        let painted = match self.mode {
+            RenderMode::Live => self.repaint(),
+            RenderMode::Plain => self.narrate(&event),
+            _ => Ok(()),
+        };
+        if let Err(e) = painted {
             self.error = Some(e);
         }
     }
@@ -561,13 +598,24 @@ mod tests {
         assert!(!text.contains('\x1b'), "--json carries zero ANSI escapes");
     }
 
+    /// #321 — the plain lane NARRATES: the header at workflow start, one
+    /// storyboard line at each settle, the meter as the close — top to
+    /// bottom ONCE (no repeated frame) · zero cursor escapes (the
+    /// CI-capture contract) · a piped consumer sees progress live.
     #[test]
-    fn fold_sink_non_interactive_folds_silent_then_prints_one_frame() {
+    fn fold_sink_plain_narrates_at_settle_then_closes_with_the_meter() {
         let theme = Theme::new(false, true, false);
         let mut buf = Vec::new();
         {
-            // Plain: no per-event repaint · one final storyboard frame.
             let mut sink = FoldSink::new(&mut buf, theme, RenderMode::Plain);
+            // The run verb injects the plan BEFORE driving — the streamed
+            // header counts from it (rows don't exist at header time).
+            sink.set_plan(vec![
+                vec!["fetch_top".to_owned()],
+                vec!["extract_ai".to_owned()],
+                vec!["summarize".to_owned()],
+                vec!["write_md".to_owned(), "notify_slack".to_owned()],
+            ]);
             for ev in demo::success() {
                 sink.emit(ev);
             }
@@ -576,8 +624,32 @@ mod tests {
             assert!(sink.into_error().is_none());
         }
         let text = String::from_utf8(buf).expect("utf8");
-        // Exactly ONE frame · the storyboard rows · ZERO cursor escapes.
-        assert!(text.contains("fetch_top"), "the run painted: {text}");
+        let lines: Vec<&str> = text.lines().collect();
+        // The header opens the story, plan-counted, permits greeting next.
+        assert!(
+            lines[0].contains("veille-news · 5 tasks"),
+            "header first, counted from the plan: {}",
+            lines[0]
+        );
+        assert!(lines[1].contains("permits"), "the greeting: {}", lines[1]);
+        // One line per settled task, in SETTLE order, exactly once each.
+        assert_eq!(
+            text.matches("fetch_top").count(),
+            1,
+            "a row speaks once — never a repeated storyboard: {text}"
+        );
+        let fetch = lines.iter().position(|l| l.contains("fetch_top"));
+        let write = lines.iter().position(|l| l.contains("write_md"));
+        let meter = lines.iter().position(|l| l.contains("done"));
+        assert!(
+            fetch < write && write < meter,
+            "settle order, then the meter closes: {text}"
+        );
+        assert!(
+            lines[meter.expect("meter")].contains("5/5 done"),
+            "the close counts the run: {text}"
+        );
+        // ZERO cursor escapes — the CI-capture contract survives.
         assert!(
             !text.contains('\x1b'),
             "non-interactive lane leaks no ANSI: {text}"

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -176,8 +176,9 @@ fn an_infer_workflow_runs_over_mock_echo_without_network() {
 }
 
 #[test]
-fn the_live_lane_paints_one_clean_frame_when_piped() {
-    // Non-TTY (piped): the fold degrades to a single final frame · ZERO
+fn the_plain_lane_narrates_cleanly_when_piped() {
+    // Non-TTY (piped): the fold NARRATES (#321 — header at start · one
+    // storyboard line per settle · the meter as the close) with ZERO
     // cursor escapes in the captured output (the CI-capture contract).
     let wf = fixture("ok2.nika.yaml", OK_EXEC);
     let out = bin()


### PR DESCRIPTION
Closes #319 · Closes #321 — the pre-0.99 display pair, riding the module split both issues asked for first.

## 1 · The epilogue seam (`refactor` · byte-identical)

`run/mod.rs` sat 13 lines from the 1500 cap. The run's LAST WORDS — the human final frame (`print_flow_epilogue` · `print_resume_summary` · `outputs_note` · `json_type_name`) + the machine envelopes (`emit_diagnostic` · `emit_error_envelope` · `paused_envelope_line` · `error_envelope_line` · `first_nika_code` · `envelope_message` · `run_failure_envelope` · `outputs_json_line`) — moved whole into a new **`run/epilogue.rs`** (`pub(super)` · their tests ride along · budget.rs's one call-site updated). `trace_sink` stays in the driver — it is run-START composition, not epilogue. **Pure move, byte-identical behavior**: function bodies verbatim; the one comment artifact (a fused doc above `trace_sink`) split back to its two owners. `run/mod.rs` 1487 → 1196 lines; display features now land in the seam, never the driver — which is exactly what the next two commits do.

## 2 · #319 — a recovered success says so

`task_recovered` ships (D-2026-07-08-N4, engine#313) but the engine's own display never consumed it — a repaired success rendered **byte-identical** to a clean one. Three touches, the issue's exact list:

- **storyboard row** — `✔  fragile  invoke · nika:read  0ms · recovered` (fold: `TaskRow.recovered` + the `TaskRecovered` arm; render: the settled line's new cell, Warn — the retry family's survived-incident yellow)
- **final meter** — `── 2/2 done · 1 recovered · ≥ $0.00 (1 unpriced) · elapsed 0.0s` (the `(N unpriced)` honesty-style precedent: a non-zero count is never silent — landed in the shared meter composition so every lane and `trace show` speak it; the issue's "run epilogue summary line", placed in `display/render.rs` rather than `epilogue.rs` because the meter is the frame renderer's line, shared by all lanes)
- **verdict card** — `◆ ⇉ ◆    2 tasks · 2 waves · 0 retries · 1 recovered` (beside retries, only when non-zero, same Warn discipline · `trace show` reads the same card)

The failure-card path is untouched (this is the SUCCESS path). A clean run's frames stay byte-identical — the goldens pin it, and a live `on_error.recover` run proves all three surfaces.

## 3 · #321 — plain mode narrates at settle + the stderr heartbeat

Piped runs printed **0 bytes until the final frame** — the scaffold's local-model default read as « it hangs ». Two halves:

- **Narration (stdout)**: Plain now streams the storyboard — header the moment the workflow starts (task count from the injected wave plan), one row line the moment each task settles (the same cells the final frame renders — all final by settle time), and the close is the meter + failure card, never a repeated frame. nextest-school: rows in settle order, summary last.
- **Heartbeat (stderr)**: `still running · nap · 10s · exec` every ~10s while a task is in flight. **Plan-driven, not event-driven** — the empirical find of this PR: the runtime's single-sink fold law emits each task's whole story (`task_started … task_completed`) AT SETTLE, so mid-flight the stream is structurally mute; an event-fed in-flight registry beats zero times (proven live on a 12s task). The pulse instead walks the static wave plan + live terminal frames, and the model cell derives statically from the workflow (`--model` override substituted). Plain lane only; aborted at settle; can only ever add stderr lines.

## Lanes proven live (debug build, this branch)

- `--json`: 12s run → stdout = NDJSON only (every line parses) · **stderr = 0 bytes** (no heartbeat, no narration — the lane never constructs either)
- `--output json`: stdout = **exactly one JSON object** (the F6 contract) · the narrated fold rides stderr, its existing diagnostic surface
- TTY (pty capture): in-place repaint · output tails · waterfall · verdict card · explore hint — untouched
- `on_error.recover` run: row + meter + `trace show` card all say recovered; a clean run shows none of it

## Gates

- `cargo test --workspace --lib` — 44/44 crate suites ok (nika-cli 350)
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `bash scripts/hooks/run-ci-ratchets.sh` — all 8 (fn-length caught `run` at 107 mid-arc; recomposed to the pre-existing 100)
- integration: run_verb (32) · e2e_pipeline (12) · resume_e2e (4) · bin_smoke (7) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
