### PR TITLE
docs(readme): the showcase example passes its own audit — hold for post-v0.99 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ ceiling, secret flows, types, tool args), then runs it:
 ```text
 $ nika check brief.nika.yaml
  ✔ PLAN     2 wave(s) · 2 task(s) · max parallelism 1
+      wave 1 fetch_notes (exec · sh -c)
+      wave 2 brief (infer · ollama/llama3.2:3b)
  ✔ SECRETS  no information-flow escapes
  ✔ TYPES    every deep output reference fits its declared shape
  ✔ TOOLS    every nika: tool names a canonical builtin
  ✔ ARGS     every invoke arg key is declared + every required arg is present
  ✔ SCHEMA   every authored schema: is satisfiable
- ✔ clean — audited before a single token was spent
+ ✔ audited · 2 task(s) · 2 wave(s) · permits none · est ≥$0.0000
 
 $ nika run brief.nika.yaml
   🦋 nika · daily-brief · 2 tasks
@@ -79,9 +81,12 @@ tasks:
       capture: structured
 
   - id: assess                        # infer: structured LLM judgment
-    with: { patch: ${{ tasks.diff.output.stdout }} }
+    depends_on: [diff]
+    with:
+      patch: ${{ tasks.diff.output.stdout }}
     infer:
       prompt: "Risk-assess this diff (secrets, breaking changes, missing tests). Be terse.\n${{ with.patch }}"
+      max_tokens: 300
       schema:
         type: object
         required: [risk]
@@ -89,10 +94,12 @@ tasks:
           risk: { type: string, enum: [low, medium, high] }
 
   - id: comment                       # invoke: the only write, gated on the verdict
+    depends_on: [assess]
     when: ${{ tasks.assess.output.risk == 'high' }}
     invoke:
       tool: "mcp:github/pr-comment"
-      args: { body: ${{ tasks.assess.output }} }
+      args:
+        body: ${{ tasks.assess.output }}
 ```
 
 ## Check before it runs


### PR DESCRIPTION
> ⏸️ **HOLD — merge AFTER the v0.99.0 tag.** The release ceremony targets the exact QA'd commit on main; this docs-only PR must not move main under it. Land it with the post-tag batch.

## The showcase example passes its own audit (B4 · one voice site↔README)

The README's whole pitch is « audited before a single token is spent » — and its showcase workflow failed that audit three ways (verified with `nika 0.98.0` on the fence extracted verbatim):

1. **NIKA-PARSE-001** — the `${{ }}` interpolations inside YAML *flow mappings* (`{ patch: ${{ … }} }`) don't parse: the braces close the flow mapping early. Fixed with block-style `with:`/`args:` — the exact style of `examples/pr-risk-review.nika.yaml`.
2. **NIKA-DAG-003 ×3** — `assess` reads `tasks.diff` and `comment` reads `tasks.assess` without `depends_on` (the depends_on law).
3. **Unbounded COST** — `assess` carried no `max_tokens`, on the very file whose caption says the cost is known before it runs.

The extracted fence now proves: `✔ audited · 3 task(s) · 3 wave(s)`.

Same one-voice pass on the quickstart transcript: the closing line becomes the binary's real form (`✔ audited · 2 task(s) · …` — the previous `✔ clean — audited before a single token was spent` line doesn't exist in any nika version), and the real per-wave PLAN detail lines join it.

Docs-only · README.md +10/−3 · rebased on `3d90001b9` (#361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
