### PR TITLE
feat(cli): bare trace show/verify/outputs/flow read the workspace latest

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -988,6 +988,7 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::trace::manage::RmTa
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::trace::manage::RmTarget
 impl<T> typenum::type_operators::Same for nika_cli::verbs::trace::manage::RmTarget
 pub type nika_cli::verbs::trace::manage::RmTarget::Output = T
+pub fn nika_cli::verbs::trace::manage::latest() -> core::option::Option<std::path::PathBuf>
 pub fn nika_cli::verbs::trace::manage::ls(theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::trace::manage::parse_older_than(raw: &str) -> core::result::Result<core::time::Duration, alloc::string::String>
 pub fn nika_cli::verbs::trace::manage::rm(target: &nika_cli::verbs::trace::manage::RmTarget, force: bool, theme: nika_cli::display::theme::Theme) -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -17,7 +17,7 @@
 #![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
 
 use std::io::{IsTerminal, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -422,8 +422,8 @@ enum TraceAction {
     /// Browse per-task outputs: verb · duration · tokens · bounded
     /// preview (full value: `trace peek`).
     Outputs {
-        /// Trace NDJSON path (one `nika-event` Event per line).
-        trace: PathBuf,
+        /// Trace NDJSON path (default: the workspace's latest trace).
+        trace: Option<PathBuf>,
         /// Force the ASCII glyph theme.
         #[arg(long)]
         ascii: bool,
@@ -449,8 +449,8 @@ enum TraceAction {
     /// inserted, dropped or reordered line breaks every hash after it.
     /// Exit 0 intact · 2 broken · 3 unchained (pre-chain journal).
     Verify {
-        /// Trace NDJSON path (one `nika-event` Event per line).
-        trace: PathBuf,
+        /// Trace NDJSON path (default: the workspace's latest trace).
+        trace: Option<PathBuf>,
     },
     /// Is this run reproducible? Compare a recorded journal against a
     /// fresh one and classify every task: reproduced · nondeterministic
@@ -483,11 +483,12 @@ enum TraceAction {
     /// sizes (plan bindings from the workflow file × sizes from the
     /// trace).
     Flow {
-        /// Trace NDJSON path (one `nika-event` Event per line).
-        trace: PathBuf,
+        /// Trace NDJSON path (default: the workspace's latest trace —
+        /// `nika trace flow <workflow>` alone reads the last run).
+        trace: Option<PathBuf>,
         /// The workflow file the run executed (`*.nika.yaml`) — the
         /// trace records values, the definition records the bindings.
-        workflow: String,
+        workflow: Option<String>,
         /// Force the ASCII glyph theme.
         #[arg(long)]
         ascii: bool,
@@ -782,6 +783,57 @@ fn examples_verb(action: Option<ExamplesAction>, plain_theme: Theme) -> u8 {
     }
 }
 
+/// Name the bare-form pick on stderr — the receipt names its subject.
+fn announce_latest(path: &Path) {
+    eprintln!(
+        "nika-cli: reading {} (the workspace latest)",
+        path.display()
+    );
+}
+
+/// The bare form of a static trace reader: no path → the workspace's
+/// latest trace, named on stderr · zero traces → the teaching error,
+/// exit 3 (ADR-098 environment).
+fn resolve_trace(given: Option<PathBuf>) -> Result<PathBuf, u8> {
+    if let Some(path) = given {
+        return Ok(path);
+    }
+    if let Some(path) = verbs::trace::manage::latest() {
+        announce_latest(&path);
+        return Ok(path);
+    }
+    eprintln!(
+        "nika-cli: no traces in .nika/traces yet — run a workflow first, or pass a trace path"
+    );
+    Err(verbs::exit::ENV)
+}
+
+/// `nika trace flow` — two positionals, both optional to clap (a
+/// required one may not follow an optional one): one arg IS the
+/// workflow and the trace defaults, matching the bare-form contract.
+fn flow_verb(trace: Option<PathBuf>, workflow: Option<String>, theme: Theme) -> u8 {
+    let (trace, workflow) = match (trace, workflow) {
+        (trace, Some(workflow)) => (trace, workflow),
+        (Some(only), None) if only.extension().and_then(|e| e.to_str()) != Some("ndjson") => {
+            (None, only.to_string_lossy().into_owned())
+        }
+        _ => {
+            eprintln!(
+                "nika-cli: trace flow needs the workflow file — `nika trace flow [trace] <workflow.nika.yaml>` (the trace records values, the definition records the bindings)"
+            );
+            return verbs::exit::ENV;
+        }
+    };
+    match resolve_trace(trace) {
+        Ok(path) => emit(&verbs::trace::flow(
+            &path.to_string_lossy(),
+            &workflow,
+            theme,
+        )),
+        Err(code) => code,
+    }
+}
+
 fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     match action {
         TraceAction::Replay(args) => trace_render(&args, true, color, link_when),
@@ -828,14 +880,19 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
             ascii,
             no_color,
         } => {
+            let trace = match resolve_trace(trace) {
+                Ok(path) => path,
+                Err(code) => return code,
+            };
             let mut theme = term_theme(color.with_no_color(no_color), ascii, link_when);
             // The dur column's bracket accents: TTY comfort only.
             theme.accents = std::io::stdout().is_terminal();
             emit(&verbs::trace::outputs(&trace.to_string_lossy(), theme))
         }
-        TraceAction::Verify { trace } => {
-            emit(&verbs::trace_verify::verify(&trace.to_string_lossy()))
-        }
+        TraceAction::Verify { trace } => match resolve_trace(trace) {
+            Ok(path) => emit(&verbs::trace_verify::verify(&path.to_string_lossy())),
+            Err(code) => code,
+        },
         TraceAction::Reproduce { recorded, fresh } => emit(&verbs::trace_reproduce::reproduce(
             &recorded.to_string_lossy(),
             &fresh.to_string_lossy(),
@@ -868,11 +925,11 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
             workflow,
             ascii,
             no_color,
-        } => emit(&verbs::trace::flow(
-            &trace.to_string_lossy(),
-            &workflow,
+        } => flow_verb(
+            trace,
+            workflow,
             term_theme(color.with_no_color(no_color), ascii, link_when),
-        )),
+        ),
     }
 }
 
@@ -1062,10 +1119,24 @@ fn load_events(args: &TraceArgs) -> Result<Vec<Event>, String> {
     if args.demo_fail {
         return Ok(nika_cli::demo::failure());
     }
-    let Some(path) = &args.trace else {
-        return Err("no trace given — pass a .ndjson path or --demo / --demo-fail".to_owned());
+    let path = match &args.trace {
+        Some(path) => path.clone(),
+        // Bare form: the workspace's latest trace (same contract as
+        // verify/outputs/flow).
+        None => match verbs::trace::manage::latest() {
+            Some(path) => {
+                announce_latest(&path);
+                path
+            }
+            None => {
+                return Err("no trace given and no traces in .nika/traces yet — run a \
+                            workflow first, pass a .ndjson path, or try --demo"
+                    .to_owned());
+            }
+        },
     };
-    let raw = std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let raw =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     recover_events(&raw, &path.display().to_string())
 }
 

--- a/crates/nika-cli/src/verbs/trace/manage.rs
+++ b/crates/nika-cli/src/verbs/trace/manage.rs
@@ -180,6 +180,21 @@ pub fn parse_older_than(raw: &str) -> Result<Duration, String> {
     Ok(Duration::from_secs(seconds))
 }
 
+/// The workspace's most recent trace (mtime · name tie-break) — what a
+/// bare static reader (`show` · `verify` · `outputs` · `flow`) means:
+/// the first thing typed after a run should not demand the path the
+/// run card just printed. `None` when the store is empty or absent —
+/// the caller keeps its teaching error, never a conjured path.
+#[must_use]
+pub fn latest() -> Option<PathBuf> {
+    latest_in(Path::new(store::TRACE_DIR))
+}
+
+/// The dir-injected core (tests point it at a staged store).
+pub(crate) fn latest_in(dir: &Path) -> Option<PathBuf> {
+    store::scan(dir).into_iter().next().map(|meta| meta.path)
+}
+
 /// `nika trace rm` — explicit removal from the workspace store.
 #[must_use]
 pub fn rm(target: &RmTarget, force: bool, theme: Theme) -> VerbOutput {
@@ -308,6 +323,38 @@ mod tests {
 
     fn plain() -> Theme {
         Theme::new(false, false, false)
+    }
+
+    /// Bare-form resolution picks the NEWEST trace by mtime — the run
+    /// just finished is the one meant, even when an older file sorts
+    /// first alphabetically.
+    #[test]
+    fn latest_picks_the_newest_by_mtime_not_by_name() {
+        let dir = temp_store("latest-newest");
+        stage_trace(
+            &dir,
+            "aaa-old.ndjson",
+            &ndjson(&run_events("old", Some(EventKind::WorkflowCompleted))),
+            Duration::from_secs(3_600),
+        );
+        let newest = stage_trace(
+            &dir,
+            "zzz-new.ndjson",
+            &ndjson(&run_events("new", Some(EventKind::WorkflowCompleted))),
+            Duration::from_secs(60),
+        );
+        assert_eq!(latest_in(&dir), Some(newest));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// An empty or absent store resolves to None — the caller keeps its
+    /// teaching error, never a conjured path.
+    #[test]
+    fn latest_answers_none_on_an_empty_or_missing_store() {
+        let dir = temp_store("latest-empty");
+        assert_eq!(latest_in(&dir), None);
+        assert_eq!(latest_in(&dir.join("never-created")), None);
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     /// The ls table: one row per trace (newest first) · age · size ·


### PR DESCRIPTION
Closes #345 — the engine half of the funnel's last-step fix.

## What

- Bare `trace show` / `verify` / `outputs` resolve to the newest `.nika/traces/` trace (mtime · name tie-break — the store scan's own order), printing one stderr line naming the pick: the receipt names its subject.
- `trace flow <workflow>` (one arg) reads the last run against that definition. A lone `.ndjson` arg keeps teaching the two-arg form (clap can't put a required positional after an optional one, so the runtime disambiguates).
- Zero traces keeps the exit-3 teaching error on every surface; explicit-path forms are unchanged and silent.

## Why

Probed on 0.98.0: the first thing a user or agent types after a run is `nika trace show` — and it sat on the LAST step of the funnel demanding the path the run card just printed. Every teaching surface (delegation skill, docs quickstart, hermes page) grew `<trace>` boilerplate to route around it. The surfaces were fixed; this closes the engine half.

## Proof

- `manage::latest()` over the existing newest-first store scan — dir-injected core, 2 new unit tests (mtime beats name · empty/missing store → None).
- 12-check e2e battery on the built binary: bare verify/show/outputs pick the newest (content-asserted `yo` vs `hi`) · flow 1-arg/2-arg/0-arg/ndjson-only · explicit forms silent + unchanged · zero-trace exit 3 ×2.
- Workspace lib suite green · clippy -D warnings clean · public-api baseline: one sorted-position line insert (`manage::latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)