### PR TITLE
feat(check): the report states the affirmative permits contract

### DIFF
--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -147,6 +147,55 @@ impl<T> nika_error::traits::AsAny for nika_schema::GateFindingKind where T: 'sta
 pub fn nika_schema::GateFindingKind::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> outref::AsOut<T> for nika_schema::GateFindingKind where T: core::marker::Copy
 pub fn nika_schema::GateFindingKind::as_out(&mut self) -> outref::Out<'_, T>
+#[non_exhaustive] pub enum nika_schema::check::PermitsSource
+pub nika_schema::check::PermitsSource::Declared
+pub nika_schema::check::PermitsSource::Floor
+impl core::clone::Clone for nika_schema::check::PermitsSource
+pub fn nika_schema::check::PermitsSource::clone(&self) -> nika_schema::check::PermitsSource
+impl core::cmp::Eq for nika_schema::check::PermitsSource
+impl core::cmp::PartialEq for nika_schema::check::PermitsSource
+pub fn nika_schema::check::PermitsSource::eq(&self, other: &nika_schema::check::PermitsSource) -> bool
+impl core::fmt::Debug for nika_schema::check::PermitsSource
+pub fn nika_schema::check::PermitsSource::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_schema::check::PermitsSource
+impl core::marker::StructuralPartialEq for nika_schema::check::PermitsSource
+impl serde_core::ser::Serialize for nika_schema::check::PermitsSource
+pub fn nika_schema::check::PermitsSource::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::PermitsSource
+impl<Q, K> equivalent::Equivalent<K> for nika_schema::check::PermitsSource where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::PermitsSource::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::PermitsSource where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_schema::check::PermitsSource where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_schema::check::PermitsSource::equivalent(&self, key: &K) -> bool
+pub fn nika_schema::check::PermitsSource::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_schema::check::PermitsSource where U: core::convert::From<T>
+pub fn nika_schema::check::PermitsSource::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::PermitsSource where U: core::convert::Into<T>
+pub type nika_schema::check::PermitsSource::Error = core::convert::Infallible
+pub fn nika_schema::check::PermitsSource::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::PermitsSource where U: core::convert::TryFrom<T>
+pub type nika_schema::check::PermitsSource::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::PermitsSource::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::PermitsSource where T: core::clone::Clone
+pub type nika_schema::check::PermitsSource::Owned = T
+pub fn nika_schema::check::PermitsSource::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::PermitsSource::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::PermitsSource where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::PermitsSource::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::PermitsSource where T: ?core::marker::Sized
+pub fn nika_schema::check::PermitsSource::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::PermitsSource where T: ?core::marker::Sized
+pub fn nika_schema::check::PermitsSource::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::PermitsSource where T: core::clone::Clone
+pub unsafe fn nika_schema::check::PermitsSource::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::PermitsSource
+pub fn nika_schema::check::PermitsSource::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::PermitsSource where T: core::clone::Clone
+pub fn nika_schema::check::PermitsSource::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::PermitsSource where T: 'static
+pub fn nika_schema::check::PermitsSource::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_schema::check::PermitsSource where T: core::marker::Copy
+pub fn nika_schema::check::PermitsSource::as_out(&mut self) -> outref::Out<'_, T>
 #[non_exhaustive] pub enum nika_schema::check::UnboundedReason
 pub nika_schema::check::UnboundedReason::NoPrice
 pub nika_schema::check::UnboundedReason::NoTokenLimit
@@ -401,6 +450,7 @@ pub nika_schema::check::CheckReport::cost: nika_schema::CostCeiling
 pub nika_schema::check::CheckReport::gate_findings: alloc::vec::Vec<nika_schema::GateFinding>
 pub nika_schema::check::CheckReport::hints: alloc::vec::Vec<nika_schema::Hint>
 pub nika_schema::check::CheckReport::missing_args: alloc::vec::Vec<nika_schema::check::MissingArg>
+pub nika_schema::check::CheckReport::permits: nika_schema::check::EffectivePermits
 pub nika_schema::check::CheckReport::report_version: u32
 pub nika_schema::check::CheckReport::requirements: nika_schema::check::Requirements
 pub nika_schema::check::CheckReport::schema_findings: alloc::vec::Vec<nika_schema::SchemaTypeFinding>
@@ -574,6 +624,44 @@ impl<T> dyn_clone::DynClone for nika_schema::check::DagAnalysis where T: core::c
 pub fn nika_schema::check::DagAnalysis::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_schema::check::DagAnalysis where T: 'static
 pub fn nika_schema::check::DagAnalysis::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_schema::check::EffectivePermits
+pub nika_schema::check::EffectivePermits::declared: core::option::Option<nika_cap::permits::Permits>
+pub nika_schema::check::EffectivePermits::needed: nika_cap::permits::Permits
+pub nika_schema::check::EffectivePermits::notes: alloc::vec::Vec<alloc::string::String>
+pub nika_schema::check::EffectivePermits::source: nika_schema::check::PermitsSource
+impl core::clone::Clone for nika_schema::check::EffectivePermits
+pub fn nika_schema::check::EffectivePermits::clone(&self) -> nika_schema::check::EffectivePermits
+impl core::fmt::Debug for nika_schema::check::EffectivePermits
+pub fn nika_schema::check::EffectivePermits::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for nika_schema::check::EffectivePermits
+pub fn nika_schema::check::EffectivePermits::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::EffectivePermits
+impl<T, U> core::convert::Into<U> for nika_schema::check::EffectivePermits where U: core::convert::From<T>
+pub fn nika_schema::check::EffectivePermits::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::EffectivePermits where U: core::convert::Into<T>
+pub type nika_schema::check::EffectivePermits::Error = core::convert::Infallible
+pub fn nika_schema::check::EffectivePermits::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::EffectivePermits where U: core::convert::TryFrom<T>
+pub type nika_schema::check::EffectivePermits::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::EffectivePermits::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::EffectivePermits where T: core::clone::Clone
+pub type nika_schema::check::EffectivePermits::Owned = T
+pub fn nika_schema::check::EffectivePermits::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::EffectivePermits::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::EffectivePermits where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::EffectivePermits::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::EffectivePermits where T: ?core::marker::Sized
+pub fn nika_schema::check::EffectivePermits::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::EffectivePermits where T: ?core::marker::Sized
+pub fn nika_schema::check::EffectivePermits::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::EffectivePermits where T: core::clone::Clone
+pub unsafe fn nika_schema::check::EffectivePermits::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::EffectivePermits
+pub fn nika_schema::check::EffectivePermits::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::EffectivePermits where T: core::clone::Clone
+pub fn nika_schema::check::EffectivePermits::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::EffectivePermits where T: 'static
+pub fn nika_schema::check::EffectivePermits::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::check::FlowFacts
 impl nika_schema::check::FlowFacts
 pub fn nika_schema::check::FlowFacts::effect_leak(&self, task: usize) -> core::option::Option<&nika_schema::check::TaintTrace>
@@ -6298,6 +6386,7 @@ pub nika_schema::CheckReport::cost: nika_schema::CostCeiling
 pub nika_schema::CheckReport::gate_findings: alloc::vec::Vec<nika_schema::GateFinding>
 pub nika_schema::CheckReport::hints: alloc::vec::Vec<nika_schema::Hint>
 pub nika_schema::CheckReport::missing_args: alloc::vec::Vec<nika_schema::check::MissingArg>
+pub nika_schema::CheckReport::permits: nika_schema::check::EffectivePermits
 pub nika_schema::CheckReport::report_version: u32
 pub nika_schema::CheckReport::requirements: nika_schema::check::Requirements
 pub nika_schema::CheckReport::schema_findings: alloc::vec::Vec<nika_schema::SchemaTypeFinding>

--- a/crates/nika-schema/src/check/effective.rs
+++ b/crates/nika-schema/src/check/effective.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The AFFIRMATIVE permits statement — what this workflow is ALLOWED to
+//! touch, stated positively on every report (#346).
+//!
+//! Violations were always first-class (`capability_escapes` ·
+//! `secret_leaks` · `secret_egresses`) but a GREEN check said nothing a
+//! consumer could render: the nika-action comment derived tool lists
+//! from graph labels (lossy) because the report carried no grants. This
+//! module states the contract both ways — the boundary in force (the
+//! declared `permits:` block, or the engine floor when none is
+//! declared) AND the tightest boundary the body statically needs (the
+//! SAME derivation `nika check --infer-permits` prints — one inference,
+//! two consumers).
+
+use serde::Serialize;
+
+use super::infer_permits;
+use crate::raw::RawWorkflow;
+use crate::types::Permits;
+
+/// Where the effective boundary comes from. `lowercase` on the wire.
+/// Additive: `report_version` stays 1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum PermitsSource {
+    /// A `permits:` block is declared — the checker fits every effect
+    /// against it and the runtime enforces it (default-deny).
+    Declared,
+    /// No boundary declared — the engine floor only (masking · taint ·
+    /// the sandbox defaults), no per-workflow allowlist.
+    Floor,
+}
+
+/// The effective grants + the derived need, on every report — consumers
+/// render the positive contract on a green check instead of
+/// reconstructing it lossily; violations stay in `capability_escapes` /
+/// `secret_*`. Additive: `report_version` stays 1.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct EffectivePermits {
+    /// Where the boundary in force comes from.
+    pub source: PermitsSource,
+    /// The declared `permits:` block, spec-shaped (`None` on
+    /// [`PermitsSource::Floor`]).
+    pub declared: Option<Permits>,
+    /// The TIGHTEST boundary the body statically needs — the
+    /// `--infer-permits` derivation (exec programs · net hosts · fs
+    /// paths · tools), independent of what is declared.
+    pub needed: Permits,
+    /// Effects too dynamic to pin statically (a computed host, a
+    /// templated path) — the inference's honesty notes, verbatim.
+    pub notes: Vec<String>,
+}
+
+/// State the affirmative contract for one workflow (total — a
+/// half-broken workflow still states what it declares and needs).
+pub(super) fn collect(wf: &RawWorkflow) -> EffectivePermits {
+    let inferred = infer_permits::infer(wf);
+    let declared = wf.permits.as_ref().map(|p| p.value.clone());
+    EffectivePermits {
+        source: if declared.is_some() {
+            PermitsSource::Declared
+        } else {
+            PermitsSource::Floor
+        },
+        declared,
+        needed: inferred.permits,
+        notes: inferred.notes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn wf(yaml: &str) -> RawWorkflow {
+        parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses")
+    }
+
+    /// No `permits:` block → the floor, stated as such: `declared` is
+    /// null on the wire and the derived need still names what the body
+    /// touches (the renderer's affirmative line).
+    #[test]
+    fn floor_states_the_source_and_still_derives_the_need() {
+        let report = collect(&wf(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.github.com/repos\" } }\n",
+        ));
+        assert_eq!(report.source, PermitsSource::Floor);
+        assert!(report.declared.is_none());
+        let json = serde_json::to_value(&report).expect("serializes");
+        assert_eq!(json["source"], "floor");
+        assert_eq!(json["declared"], serde_json::Value::Null);
+        let hosts = json["needed"]["net"]["http"]
+            .as_array()
+            .expect("derived hosts");
+        assert!(
+            hosts.iter().any(|h| h == "api.github.com"),
+            "the need names the host: {json}"
+        );
+    }
+
+    /// A declared block rides the report spec-shaped, and the derived
+    /// need stays independent of it (declared wide · needed tight).
+    #[test]
+    fn declared_boundary_rides_beside_the_derived_need() {
+        let report = collect(&wf(
+            "nika: v1\nworkflow: w\npermits: { exec: false, net: { http: [\"api.github.com\", \"example.com\"] } }\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.github.com/repos\" } }\n",
+        ));
+        assert_eq!(report.source, PermitsSource::Declared);
+        let json = serde_json::to_value(&report).expect("serializes");
+        assert_eq!(json["source"], "declared");
+        let declared_hosts = json["declared"]["net"]["http"]
+            .as_array()
+            .expect("declared hosts");
+        assert_eq!(declared_hosts.len(), 2, "the grant is stated as written");
+        let needed_hosts = json["needed"]["net"]["http"]
+            .as_array()
+            .expect("needed hosts");
+        assert_eq!(needed_hosts.len(), 1, "the need stays tight: {json}");
+    }
+
+    /// A dynamic effect (templated URL) lands in `notes` — stated
+    /// honesty, never a silently-missing grant.
+    #[test]
+    fn dynamic_effects_surface_as_notes() {
+        let report = collect(&wf(
+            "nika: v1\nworkflow: w\nvars:\n  host: { type: string, default: \"https://x.dev\" }\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"${{ vars.host }}\" } }\n",
+        ));
+        assert!(
+            !report.notes.is_empty(),
+            "the un-pinnable fetch is named: {:?}",
+            report.notes
+        );
+    }
+}

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -31,6 +31,7 @@ mod analysis;
 mod certificate;
 mod cost;
 mod declass;
+mod effective;
 mod flow;
 mod hints;
 mod infer_permits;
@@ -50,6 +51,7 @@ use crate::raw::RawWorkflow;
 pub use analysis::{DagAnalysis, TaskBlast};
 pub use certificate::{Bound, CertTerm, RunCertificate};
 pub use cost::{CostCeiling, TaskCost, UnboundedReason};
+pub use effective::{EffectivePermits, PermitsSource};
 pub use flow::{FlowFacts, TaintTrace};
 pub use hints::Hint;
 pub use hints::static_read_paths;
@@ -168,6 +170,14 @@ pub struct CheckReport {
     /// are degree-1 polynomials in the `for_each` collection sizes.
     /// Additive: `report_version` stays 1.
     pub certificate: RunCertificate,
+    /// The AFFIRMATIVE permits statement — the boundary in force (the
+    /// declared `permits:` block or the engine floor) AND the tightest
+    /// boundary the body statically needs (the `--infer-permits`
+    /// derivation) — so consumers render the positive contract on a
+    /// green check instead of reconstructing it from graph labels;
+    /// violations stay in `capability_escapes` / `secret_*`. Additive:
+    /// `report_version` stays 1.
+    pub permits: EffectivePermits,
     /// What this workflow needs from its caller BEFORE any token is
     /// spent — models per task · declared secrets (facts, no values) ·
     /// env reads vs env defines · required vars. Declaration truth
@@ -333,6 +343,7 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         cost: cost::ceiling(wf),
         certificate: certificate::certify(wf),
         requirements: requirements::collect(wf),
+        permits: effective::collect(wf),
         secret_leaks: secrets::scan_leaks(wf, &flow),
         secret_egresses: secrets::scan_egresses(&flow),
         capability_escapes: permits_fit::scan_escapes(wf),


### PR DESCRIPTION
Closes #346 — consumers can finally render the POSITIVE contract on a green check.

## What

`check --json` gains a `permits` object:
- `source`: `declared` (a `permits:` block is in force) or `floor` (engine defaults only)
- `declared`: the authored block, spec-shaped (`null` on floor)
- `needed`: the TIGHTEST boundary the body statically needs — the SAME derivation `--infer-permits` prints (one inference, two consumers)
- `notes`: effects too dynamic to pin (the inference's honesty notes, verbatim)

Violations stay where they were (`capability_escapes` / `secret_leaks` / `secret_egresses`) — this is the affirmative half the nika-action renderer had to reconstruct lossily from graph labels.

## Additive — `report_version` stays 1

Per the report's own discipline (written on every field): additive keys never bump. The issue's version-2 framing predates that law; consumers that don't read the key are untouched, and the action's version-1 fixture pins stay valid.

## Proof

3 unit tests (floor-derives · declared-beside-needed · dynamic-notes) · e2e: the wire carries the key (`source: floor`, `needed.exec`, the shell-string honesty note) · workspace lib suite green · clippy clean · API baseline +89 additive lines regenerated at the CI tool version (platform-safe: no io types).

Rebased on the #365 descent (this is the work that hit the 15k wall and triggered it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)