### PR TITLE
fix(cli): the first screen speaks user — help voice, explain fix-forms, check points at explain

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -125,7 +125,8 @@ enum Command {
         #[arg(long)]
         ascii: bool,
     },
-    /// Static pre-flight: the ADR-092 ladder (audit BEFORE run).
+    /// Audit a workflow BEFORE it runs: plan · cost ceiling · secret
+    /// flows · types · tools — every finding teaches its fix.
     Check {
         /// Workflow file (`*.nika.yaml`) · `-` reads stdin.
         file: String,
@@ -152,7 +153,7 @@ enum Command {
         #[arg(long)]
         ascii: bool,
     },
-    /// Execute a CHECKED workflow through the L3 runtime (live render).
+    /// Run a workflow (the same audit runs first · live render).
     Run(RunArgs),
     /// Golden test: run under the MOCK provider (offline · deterministic)
     /// and compare the typed `outputs:` against `<file>.golden.json`.
@@ -202,7 +203,7 @@ enum Command {
         #[arg(long)]
         forecast: bool,
     },
-    /// Diagnose the environment (binary · config · provider keys · spec §8).
+    /// Diagnose this machine (binary · config · provider keys · local models).
     /// Diagnose-only — prints the exact fix command, never mutates anything.
     Doctor {
         /// TCP-probe the local provider ports (loopback/configured only ·
@@ -280,7 +281,7 @@ enum Command {
         #[arg(long)]
         force: bool,
     },
-    /// Generate shell completions from the clap tree (spec §9).
+    /// Generate shell completions (bash · zsh · fish · elvish · powershell).
     Completions {
         /// Target shell.
         #[arg(value_enum)]

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -12,7 +12,7 @@
 
 use std::fmt::Write as _;
 
-use nika_schema::check::{CheckReport, UnboundedReason};
+use nika_schema::check::{CheckReport, ConformanceViolation, UnboundedReason};
 use nika_schema::infer_permits;
 use nika_schema::raw::{RawAction, RawWorkflow};
 use nika_schema::types::VarDecl;
@@ -231,6 +231,34 @@ fn mark(theme: Theme, ok: bool) -> String {
     theme.paint(role, if theme.ascii { asc } else { uni })
 }
 
+/// One CONFORM finding: the ✖ row, the offline+online fix pointer (the
+/// rustc `--explain` move — the same affordance `run` failures print,
+/// #145 P2 · one teaching voice on both surfaces), and the source frame
+/// when the finding carries a span (rustc-grade caret · the CONFORM row
+/// above stays grep-stable).
+fn conformance_row(out: &mut String, c: &ConformanceViolation, source: &str, path: &str, t: Theme) {
+    let _ = writeln!(
+        out,
+        " {} {}  [{}] {}",
+        mark(t, false),
+        t.paint(Role::Strong, "CONFORM"),
+        c.code,
+        c.message
+    );
+    let _ = writeln!(
+        out,
+        "   {}",
+        t.paint(
+            Role::Dim,
+            &format!("fix: nika explain {} · {}", c.code, c.docs_url)
+        )
+    );
+    if let Some(span) = c.span {
+        let frame = crate::display::snippet::paint_span(source, path, span, t);
+        let _ = writeln!(out, "{frame}");
+    }
+}
+
 /// Render the human report — every section present, grep-stable keywords.
 fn render(
     report: &CheckReport,
@@ -250,22 +278,7 @@ fn render(
     );
 
     for c in &report.conformance {
-        let _ = writeln!(
-            out,
-            " {} {}  [{}] {}",
-            mark(t, false),
-            t.paint(Role::Strong, "CONFORM"),
-            c.code,
-            c.message
-        );
-        // The rustc `--explain` move: every code links its own page.
-        let _ = writeln!(out, "   {}", t.paint(Role::Dim, &c.docs_url));
-        // …and span-carrying findings frame the offending source line
-        // (rustc-grade caret · the CONFORM row above stays grep-stable).
-        if let Some(span) = c.span {
-            let frame = crate::display::snippet::paint_span(source, path, span, t);
-            let _ = writeln!(out, "{frame}");
-        }
+        conformance_row(&mut out, c, source, path, t);
     }
 
     plan(&mut out, report, wf, t);

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -103,8 +103,8 @@ fn canon_row(code: &str) -> Option<String> {
         .unwrap_or_default();
     Some(format!(
         "{code} · {category} · transient: {transient}\n\n  {failure}\n\n{fix}\
-         spec conformance code — emitted by `nika check`; prose home: \
-         spec/05-errors.md (embedded canon `error_codes` is the SSOT row).\n",
+         full docs: https://nika.sh/errors/{code} — `nika check` catches \
+         this before a run ever starts.\n",
         category = row.category,
         transient = row.transient,
         failure = row.failure,
@@ -121,6 +121,28 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
             "an unbound workflow var is supplied on the CLI — `nika run <file> \
              --var <key>=<value>` (repeatable) — or given a `default:` in the \
              workflow `vars:` block",
+        ),
+        // The high-traffic conformance codes whose fix is one obvious
+        // YAML edit teach it concretely (#145 P1 — the failure states
+        // WHAT, this states the edit; the canon row never carries
+        // per-CLI affordances, so the fix-form lives here).
+        "NIKA-DAG-001" => Some(
+            "break the loop — one task in the cycle must drop its \
+             `depends_on` on the other (a task can never wait on itself, \
+             directly or through a chain)",
+        ),
+        "NIKA-DAG-002" => Some(
+            "the `depends_on:` entry names a task that does not exist — \
+             match it to a declared task `id:` (check for a typo first)",
+        ),
+        "NIKA-DAG-003" => Some(
+            "declare the edge the reference implies — add `depends_on: \
+             [<that task>]` to the task whose template reads \
+             `tasks.<that task>.output`",
+        ),
+        "NIKA-PARSE-002" => Some(
+            "every workflow starts with three lines — `nika: v1`, \
+             `workflow: <name>`, and a non-empty `tasks:` list",
         ),
         _ => None,
     }
@@ -176,7 +198,16 @@ mod tests {
         );
         assert!(out.text.contains("NIKA-DAG-003"));
         assert!(out.text.contains("validation_error"));
-        assert!(out.text.contains("spec/05-errors.md"));
+        assert!(
+            out.text.contains("https://nika.sh/errors/NIKA-DAG-003"),
+            "the footer links the code's own page:\n{}",
+            out.text
+        );
+        assert!(
+            out.text.contains("depends_on"),
+            "the fix-form states the concrete YAML edit (#145 P1):\n{}",
+            out.text
+        );
     }
 
     #[test]


### PR DESCRIPTION
Probed #145 against the released 0.99.0: the P0 rescue tip and the bare-`nika` footer shipped in earlier arcs — three findings survived verbatim. This closes them (string-level, one teaching voice):

- **--help de-jargoned (P0)**: "the ADR-092 ladder" → "Audit a workflow BEFORE it runs: plan · cost ceiling · secret flows · types · tools"; "the L3 runtime", "spec §8", "the clap tree" likewise. A newcomer's first screen carries zero engine-internal vocabulary.
- **check ✖ gains the run affordance (P2)**: every conformance finding prints `fix: nika explain <CODE> · <docs url>` — the same offline pointer run failures always had.
- **explain teaches instead of reading inward (P1)**: the "embedded canon error_codes is the SSOT row" closer becomes "full docs: https://nika.sh/errors/<CODE> — nika check catches this before a run ever starts", and `cli_fix_hint` grows the high-traffic conformance codes whose fix is one obvious YAML edit (DAG-001/002/003 · PARSE-002). The canon row still states the FAILURE; the fix-form lives CLI-side with the affordance itself.

**Proof**: 11-check e2e battery on the built binary (3 fixes + negative jargon grep + 4 non-regressions incl. the dead-ollama rescue tip) · workspace lib suite green · clippy clean · `render` split (`conformance_row`) keeps the fn-length ratchet green.

**Partial on #145**: the long-tail per-code fix-forms stay open — canon-side content is spec work, tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)