### PR TITLE
feat(cli): the machine dry-run form — one versioned plan object

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -530,9 +530,11 @@ struct RunArgs {
     #[arg(long, conflicts_with_all = ["no_progress", "json", "output"])]
     quiet: bool,
     /// Plan only — show the static plan and execute ZERO effects (spec §10).
-    /// A human plan preview · refused with the `--json`/`--output` machine
-    /// modes (no machine dry-run form yet · would silently corrupt stdout).
-    #[arg(long, conflicts_with_all = ["json", "output"])]
+    /// With `--json`: ONE versioned plan object (`plan_version: 1` — waves ·
+    /// cost ceiling · permits · requirements) instead of the human preview.
+    /// `--output` stays refused (an outputs export of a run that never
+    /// executed would be a lie).
+    #[arg(long, conflicts_with = "output")]
     dry_run: bool,
     /// Override the workflow's envelope `model:` (`<provider>/<name>`).
     /// Resolved through the SAME path as an envelope model — a bad id

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -162,7 +162,7 @@ pub fn run(
 
     // ── Dry-run (spec §10 · "plan only · zero effects") ─────────────
     if dry_run {
-        return render_dry_run(file, theme.ascii);
+        return dry_run_verdict(file, &wf, &report, json, theme.ascii);
     }
 
     // ── `--max-cost-usd` preflight — BEFORE any spend (budget.rs) ──
@@ -438,6 +438,72 @@ fn render_dry_run(file: &str, ascii: bool) -> u8 {
     }
     println!("\n  dry-run · plan only · no effects executed");
     exit::OK
+}
+
+/// The dry-run fork: the human preview, or the #332 machine plan.
+fn dry_run_verdict(
+    file: &str,
+    wf: &RawWorkflow,
+    report: &nika_schema::check::CheckReport,
+    json: bool,
+    ascii: bool,
+) -> u8 {
+    if json {
+        dry_run_json(file, wf, report)
+    } else {
+        render_dry_run(file, ascii)
+    }
+}
+
+/// `--dry-run --json` (#332): ONE versioned plan object on stdout — what
+/// the run WOULD do, projected from the SAME report the audit already
+/// computed (waves resolved to task ids · per-task verb/model · the cost
+/// ceiling · the affirmative permits · the caller requirements). CI and
+/// PR renderers read this instead of composing `check --json` +
+/// `explain --json` and reconstructing the plan client-side.
+/// `plan_version` follows the check-report discipline: additive keys
+/// never bump it.
+fn dry_run_json(file: &str, wf: &RawWorkflow, report: &nika_schema::check::CheckReport) -> u8 {
+    println!("{:#}", dry_run_payload(file, wf, report));
+    exit::OK
+}
+
+/// The pure projection behind [`dry_run_json`] (unit-pinned): waves
+/// resolved from indices to task ids, one `{id, verb}` row per task,
+/// and the report's own cost/permits/requirements objects verbatim.
+fn dry_run_payload(
+    file: &str,
+    wf: &RawWorkflow,
+    report: &nika_schema::check::CheckReport,
+) -> serde_json::Value {
+    let ids: Vec<&str> = wf.tasks.iter().map(|t| t.value.id.value.as_str()).collect();
+    let waves: Vec<Vec<&str>> = report
+        .waves
+        .iter()
+        .map(|w| w.iter().filter_map(|&i| ids.get(i).copied()).collect())
+        .collect();
+    let tasks: Vec<serde_json::Value> = wf
+        .tasks
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "id": t.value.id.value,
+                "verb": t.value.action.verb(),
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "plan_version": 1,
+        "workflow": wf.workflow.as_ref().map(|w| w.value.as_str()),
+        "file": file,
+        "dry_run": true,
+        "effects_executed": false,
+        "waves": waves,
+        "tasks": tasks,
+        "cost": report.cost,
+        "permits": report.permits,
+        "requirements": report.requirements,
+    })
 }
 
 /// Parse the repeatable `--var KEY=VALUE` overrides and validate every
@@ -931,9 +997,33 @@ fn trace_sink(no_trace_file: bool) -> TraceFileSink {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use super::{RenderMode, exit, offline_tip_applies, run, scope_to_task};
+    use super::{RenderMode, dry_run_payload, exit, offline_tip_applies, run, scope_to_task};
     use crate::Theme;
     use serde_json::json;
+
+    /// The #332 plan object: waves resolve indices → task ids, one
+    /// `{id, verb}` row per task, the report's cost/permits/requirements
+    /// ride verbatim, and `effects_executed` states the contract.
+    #[test]
+    fn dry_run_payload_projects_the_versioned_plan() {
+        let yaml = "nika: v1\nworkflow: demo\nmodel: mock/echo\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"x\"] }\n  - id: b\n    depends_on: [a]\n    infer: { prompt: \"go ${{ tasks.a.output }}\", max_tokens: 10 }\n\noutputs:\n  out: \"${{ tasks.b.output }}\"\n";
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::source::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        let p = dry_run_payload("demo.nika.yaml", &wf, &report);
+        assert_eq!(p["plan_version"], 1);
+        assert_eq!(p["workflow"], "demo");
+        assert_eq!(p["waves"], json!([["a"], ["b"]]));
+        assert_eq!(p["tasks"][0]["verb"], "exec");
+        assert_eq!(p["tasks"][1]["verb"], "infer");
+        assert_eq!(p["effects_executed"], false);
+        assert_eq!(p["permits"]["source"], "floor");
+        assert!(p["cost"].is_object() && p["requirements"].is_object());
+    }
 
     /// The offline-hint policy (pure · the heart of the UX decision). The
     /// tip fires ONLY when a non-mock example FAILED with no `--model`

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -243,14 +243,17 @@ fn run_no_progress_emits_no_ansi() {
 
 #[test]
 fn run_human_flags_conflict_with_machine_modes() {
-    // The render/plan flags are HUMAN surfaces · clap REFUSES them alongside
+    // The render flags are HUMAN surfaces · clap REFUSES them alongside
     // the `--json`/`--output json` machine modes, so a parsed-but-ignored flag
     // can never silently corrupt the `capture: stdout` JSON contract.
+    // `--dry-run` left this list in #332: with `--json` it IS a machine
+    // surface (the versioned plan object) — only `--output` still refuses
+    // it (an outputs export of a run that never executed would be a lie).
     let dir = std::env::temp_dir().join(format!("nika-bin-conflict-{}", std::process::id()));
     std::fs::create_dir_all(&dir).expect("tmp dir");
     let wf = write_fixture(&dir, "ok.nika.yaml", VALID);
 
-    for human in ["--dry-run", "--quiet", "--no-progress"] {
+    for human in ["--quiet", "--no-progress"] {
         let out = bin()
             .arg("run")
             .arg(&wf)
@@ -269,6 +272,45 @@ fn run_human_flags_conflict_with_machine_modes() {
             "clap names the {human}/--json conflict: {stderr}"
         );
     }
+
+    // --dry-run + --json: the #332 plan object (exit 0 · plan_version 1 ·
+    // zero effects — no trace dir appears).
+    let out = bin()
+        .arg("run")
+        .arg(&wf)
+        .arg("--dry-run")
+        .arg("--json")
+        .current_dir(&dir)
+        .output()
+        .expect("binary runs");
+    assert!(
+        out.status.success(),
+        "--dry-run --json is the machine plan: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let plan: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout is ONE JSON object");
+    assert_eq!(plan["plan_version"], 1);
+    assert_eq!(plan["effects_executed"], false);
+    assert!(
+        !dir.join(".nika").exists(),
+        "a dry run never writes the trace store"
+    );
+
+    // --dry-run + --output json: still a usage error.
+    let out = bin()
+        .arg("run")
+        .arg(&wf)
+        .arg("--dry-run")
+        .arg("--output")
+        .arg("json")
+        .output()
+        .expect("binary runs");
+    assert!(
+        !out.status.success(),
+        "--dry-run + --output must stay refused, got {:?}",
+        out.status.code()
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 


### PR DESCRIPTION
Closes #332 — the help's own "no machine dry-run form yet" gets its form.

`nika run <file> --dry-run --json` emits ONE plan object on stdout (`plan_version: 1` — additive keys never bump, the check-report discipline):

- `waves` resolved from indices to task IDS (the renderable form)
- one `{id, verb}` row per task
- the report's own `cost` / `permits` (#346's affirmative contract) / `requirements` **verbatim** — one audit, one projection, zero client-side reconstruction

The audit still gates it: a dirty workflow gets the check report on the existing refusal path (exit 2), distinguishable by key (`report_version` vs `plan_version`). Zero effects proven (no `.nika/traces/` written) · the human `--dry-run` is byte-unchanged · `--dry-run --output json` stays refused (an outputs export of a run that never executed would be a lie).

**Proof**: unit-pinned payload projection · 10-check e2e battery on the built binary (shape · declared permits with derived need · no-trace-file · human form · clap refusal) · workspace lib suite green · clippy clean · fn-length (`run()` re-slimmed via `dry_run_verdict`) + crate-size ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)