### PR TITLE
feat(check): unified findings[] — one loop, and parse-fatal --json stays JSON

### DIFF
--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -34,6 +34,11 @@ pub fn run(
 ) -> VerbOutput {
     let (source, wf, report) = match load_checked_with_source(path) {
         Ok(triple) => triple,
+        // Parse-fatal + `--json` (#331's papercut): the machine mode
+        // stays machine-parseable — ONE JSON error object on stdout
+        // (parse_fatal + a findings[] row shaped like the report's own),
+        // never the plain-text refusal an agent's json parse chokes on.
+        Err(out) if json => return parse_fatal_json(&out),
         Err(out) => return out,
     };
     // `--model m` previews the RUN override's static envelope (#342): the
@@ -83,6 +88,43 @@ pub fn run(
         VerbOutput::ok(text)
     } else {
         VerbOutput::file(text)
+    }
+}
+
+/// The parse-fatal machine verdict (#331): a file the parser refuses
+/// never reaches the report, but a `--json` consumer still gets JSON —
+/// `parse_fatal: true`, `clean: false`, and ONE findings[] row carrying
+/// the spec code the plain-text voice prints (`PARSE ✗ [CODE] …`). The
+/// exit code (2 file · 3 env) rides unchanged.
+fn parse_fatal_json(out: &VerbOutput) -> VerbOutput {
+    let text = out.text.trim();
+    // The plain voice is `PARSE ✗  [NIKA-…] message` — recover the code;
+    // an env-class refusal (unreadable file) has no code and stays codeless.
+    let code = text
+        .split_once('[')
+        .and_then(|(_, rest)| rest.split_once(']'))
+        .map(|(code, _)| code.to_owned());
+    let message = text.split_once("] ").map_or(text, |(_, m)| m).to_owned();
+    let mut finding = serde_json::json!({
+        "kind": "parse",
+        "gate": "PARSE",
+        "severity": "error",
+        "message": message,
+    });
+    if let Some(c) = &code {
+        finding["code"] = serde_json::json!(c);
+        finding["docs_url"] =
+            serde_json::json!(format!("{}/{c}", nika_schema::check::ERROR_DOCS_BASE));
+    }
+    let payload = serde_json::json!({
+        "report_version": nika_schema::check::REPORT_VERSION,
+        "parse_fatal": true,
+        "clean": false,
+        "findings": [finding],
+    });
+    VerbOutput {
+        text: format!("{payload:#}"),
+        code: out.code,
     }
 }
 

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -447,6 +447,7 @@ pub nika_schema::check::CheckReport::capability_escapes: alloc::vec::Vec<nika_sc
 pub nika_schema::check::CheckReport::certificate: nika_schema::RunCertificate
 pub nika_schema::check::CheckReport::conformance: alloc::vec::Vec<nika_schema::check::ConformanceViolation>
 pub nika_schema::check::CheckReport::cost: nika_schema::CostCeiling
+pub nika_schema::check::CheckReport::findings: alloc::vec::Vec<nika_schema::check::UnifiedFinding>
 pub nika_schema::check::CheckReport::gate_findings: alloc::vec::Vec<nika_schema::GateFinding>
 pub nika_schema::check::CheckReport::hints: alloc::vec::Vec<nika_schema::Hint>
 pub nika_schema::check::CheckReport::missing_args: alloc::vec::Vec<nika_schema::check::MissingArg>
@@ -1398,6 +1399,48 @@ impl<T> dyn_clone::DynClone for nika_schema::TaskCost where T: core::clone::Clon
 pub fn nika_schema::TaskCost::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_schema::TaskCost where T: 'static
 pub fn nika_schema::TaskCost::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_schema::check::UnifiedFinding
+pub nika_schema::check::UnifiedFinding::code: core::option::Option<alloc::string::String>
+pub nika_schema::check::UnifiedFinding::docs_url: core::option::Option<alloc::string::String>
+pub nika_schema::check::UnifiedFinding::gate: &'static str
+pub nika_schema::check::UnifiedFinding::kind: &'static str
+pub nika_schema::check::UnifiedFinding::message: alloc::string::String
+pub nika_schema::check::UnifiedFinding::severity: nika_schema::check::FindingSeverity
+pub nika_schema::check::UnifiedFinding::span: core::option::Option<nika_schema::check::ByteSpan>
+pub nika_schema::check::UnifiedFinding::task: core::option::Option<alloc::string::String>
+impl core::clone::Clone for nika_schema::check::UnifiedFinding
+pub fn nika_schema::check::UnifiedFinding::clone(&self) -> nika_schema::check::UnifiedFinding
+impl core::fmt::Debug for nika_schema::check::UnifiedFinding
+pub fn nika_schema::check::UnifiedFinding::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for nika_schema::check::UnifiedFinding
+pub fn nika_schema::check::UnifiedFinding::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_schema::check::UnifiedFinding
+impl<T, U> core::convert::Into<U> for nika_schema::check::UnifiedFinding where U: core::convert::From<T>
+pub fn nika_schema::check::UnifiedFinding::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_schema::check::UnifiedFinding where U: core::convert::Into<T>
+pub type nika_schema::check::UnifiedFinding::Error = core::convert::Infallible
+pub fn nika_schema::check::UnifiedFinding::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_schema::check::UnifiedFinding where U: core::convert::TryFrom<T>
+pub type nika_schema::check::UnifiedFinding::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_schema::check::UnifiedFinding::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_schema::check::UnifiedFinding where T: core::clone::Clone
+pub type nika_schema::check::UnifiedFinding::Owned = T
+pub fn nika_schema::check::UnifiedFinding::clone_into(&self, target: &mut T)
+pub fn nika_schema::check::UnifiedFinding::to_owned(&self) -> T
+impl<T> core::any::Any for nika_schema::check::UnifiedFinding where T: 'static + ?core::marker::Sized
+pub fn nika_schema::check::UnifiedFinding::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_schema::check::UnifiedFinding where T: ?core::marker::Sized
+pub fn nika_schema::check::UnifiedFinding::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_schema::check::UnifiedFinding where T: ?core::marker::Sized
+pub fn nika_schema::check::UnifiedFinding::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_schema::check::UnifiedFinding where T: core::clone::Clone
+pub unsafe fn nika_schema::check::UnifiedFinding::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_schema::check::UnifiedFinding
+pub fn nika_schema::check::UnifiedFinding::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_schema::check::UnifiedFinding where T: core::clone::Clone
+pub fn nika_schema::check::UnifiedFinding::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_schema::check::UnifiedFinding where T: 'static
+pub fn nika_schema::check::UnifiedFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::check::UnknownArg
 pub nika_schema::check::UnknownArg::arg: alloc::string::String
 pub nika_schema::check::UnknownArg::suggestion: core::option::Option<alloc::string::String>
@@ -6383,6 +6426,7 @@ pub nika_schema::CheckReport::capability_escapes: alloc::vec::Vec<nika_schema::C
 pub nika_schema::CheckReport::certificate: nika_schema::RunCertificate
 pub nika_schema::CheckReport::conformance: alloc::vec::Vec<nika_schema::check::ConformanceViolation>
 pub nika_schema::CheckReport::cost: nika_schema::CostCeiling
+pub nika_schema::CheckReport::findings: alloc::vec::Vec<nika_schema::check::UnifiedFinding>
 pub nika_schema::CheckReport::gate_findings: alloc::vec::Vec<nika_schema::GateFinding>
 pub nika_schema::CheckReport::hints: alloc::vec::Vec<nika_schema::Hint>
 pub nika_schema::CheckReport::missing_args: alloc::vec::Vec<nika_schema::check::MissingArg>

--- a/crates/nika-schema/src/check/findings.rs
+++ b/crates/nika-schema/src/check/findings.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The UNIFIED findings list (#331) — every finding class, one shape,
+//! one loop.
+//!
+//! A failing report scatters findings across ten sibling keys and only
+//! `clean: bool` aggregates — a consumer had to hardcode the key list,
+//! and a new class broke every consumer SILENTLY. `findings[]` is the
+//! aggregation: the per-class keys stay (the typed surface), this is
+//! the renderable one. The completeness ratchet lives in this module's
+//! tests: `is_clean() ⇔ findings().is_empty()` is asserted per class,
+//! so an eleventh finding class that forgets to join the fold turns a
+//! test red instead of a consumer blind.
+
+use serde::Serialize;
+
+use super::ByteSpan;
+use super::{CheckReport, FindingSeverity};
+
+/// One finding, class-erased: the stable discriminator is [`Self::kind`]
+/// (a closed slug set — additive only), the ladder section is
+/// [`Self::gate`] (the same grep-stable keyword the human render
+/// prints), and `code`/`docs_url` ride ONLY when a canonical spec code
+/// exists for the class (the analysis-native classes are report-only by
+/// design — a conjured code would 404).
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct UnifiedFinding {
+    /// The class slug (`conformance` · `secret_leak` · `secret_egress` ·
+    /// `capability_escape` · `schema_type` · `gate` · `unknown_tool` ·
+    /// `unknown_arg` · `missing_arg` · `schema_lint`).
+    pub kind: &'static str,
+    /// The ladder section the human render files this under.
+    pub gate: &'static str,
+    /// Engine-stamped severity (every class is a run-blocker today).
+    pub severity: FindingSeverity,
+    /// The canonical spec code, when the class carries one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    /// The per-code docs page (rides with `code`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docs_url: Option<String>,
+    /// The human row — same wording family as the rendered report.
+    pub message: String,
+    /// The offending task, when the finding names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    /// The source byte range, when the finding carries one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<ByteSpan>,
+}
+
+impl UnifiedFinding {
+    fn new(kind: &'static str, gate: &'static str, message: String) -> Self {
+        Self {
+            kind,
+            gate,
+            severity: FindingSeverity::Error,
+            code: None,
+            docs_url: None,
+            message,
+            task: None,
+            span: None,
+        }
+    }
+}
+
+/// Fold every class into the one list — conformance first (the ladder's
+/// own order), then the analysis classes in render order.
+pub(super) fn collect(report: &CheckReport) -> Vec<UnifiedFinding> {
+    let mut out = Vec::new();
+    for c in &report.conformance {
+        let mut f = UnifiedFinding::new("conformance", "CONFORM", c.message.clone());
+        f.code = Some(c.code.clone());
+        f.docs_url = Some(c.docs_url.clone());
+        f.span = c.span;
+        out.push(f);
+    }
+    for l in &report.secret_leaks {
+        let mut f = UnifiedFinding::new(
+            "secret_leak",
+            "SECRETS",
+            format!("leak into {} (task `{}`) — {}", l.sink, l.task, l.trace),
+        );
+        f.task = Some(l.task.clone());
+        out.push(f);
+    }
+    for e in &report.secret_egresses {
+        out.push(UnifiedFinding::new(
+            "secret_egress",
+            "SECRETS",
+            format!("EGRESS via outputs.{} — {}", e.output, e.trace),
+        ));
+    }
+    for c in &report.capability_escapes {
+        let mut f = UnifiedFinding::new(
+            "capability_escape",
+            "PERMITS",
+            match &c.fix {
+                Some(fix) => format!("{} (task `{}`) — fix: {}", c.detail, c.task, fix),
+                None => format!("{} (task `{}`)", c.detail, c.task),
+            },
+        );
+        f.code = Some("NIKA-SEC-004".to_owned());
+        f.docs_url = Some(format!("{}/NIKA-SEC-004", super::ERROR_DOCS_BASE));
+        f.task = Some(c.task.clone());
+        out.push(f);
+    }
+    for s in &report.schema_findings {
+        out.push(UnifiedFinding::new(
+            "schema_type",
+            "TYPES",
+            format!("{} — {} ({})", s.reference, s.detail, s.site),
+        ));
+    }
+    for g in &report.gate_findings {
+        let mut f = UnifiedFinding::new(
+            "gate",
+            "GATES",
+            match &g.fix {
+                Some(fix) => format!("{} (task `{}`) — fix: {}", g.detail, g.task, fix),
+                None => format!("{} (task `{}`)", g.detail, g.task),
+            },
+        );
+        f.task = Some(g.task.clone());
+        f.span = g.span;
+        out.push(f);
+    }
+    fold_tools(report, &mut out);
+    for l in &report.schema_lints {
+        let mut f = UnifiedFinding::new(
+            "schema_lint",
+            "SCHEMA",
+            format!("{} — {} (task `{}`)", l.path, l.detail, l.task),
+        );
+        f.task = Some(l.task.clone());
+        out.push(f);
+    }
+    out
+}
+
+/// The three tool-contract classes (all BUILTIN-coded, TOOLS/ARGS gates).
+fn fold_tools(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
+    let builtin_code = || Some("NIKA-BUILTIN-001".to_owned());
+    let builtin_url = || Some(format!("{}/NIKA-BUILTIN-001", super::ERROR_DOCS_BASE));
+    for t in &report.unknown_tools {
+        let mut f = UnifiedFinding::new(
+            "unknown_tool",
+            "TOOLS",
+            match &t.suggestion {
+                Some(s) => format!(
+                    "`{}` names no canonical builtin (task `{}`) — did you mean `{s}`?",
+                    t.tool, t.task
+                ),
+                None => format!(
+                    "`{}` names no canonical builtin (task `{}`)",
+                    t.tool, t.task
+                ),
+            },
+        );
+        f.code = builtin_code();
+        f.docs_url = builtin_url();
+        f.task = Some(t.task.clone());
+        out.push(f);
+    }
+    for a in &report.unknown_args {
+        let mut f = UnifiedFinding::new(
+            "unknown_arg",
+            "ARGS",
+            match &a.suggestion {
+                Some(s) => format!(
+                    "`{}` is not an arg of `{}` (task `{}`) — did you mean `{s}`?",
+                    a.arg, a.tool, a.task
+                ),
+                None => format!(
+                    "`{}` is not an arg of `{}` (task `{}`)",
+                    a.arg, a.tool, a.task
+                ),
+            },
+        );
+        f.code = builtin_code();
+        f.docs_url = builtin_url();
+        f.task = Some(a.task.clone());
+        out.push(f);
+    }
+    for m in &report.missing_args {
+        let mut f = UnifiedFinding::new(
+            "missing_arg",
+            "ARGS",
+            format!("`{}` requires arg `{}` (task `{}`)", m.tool, m.arg, m.task),
+        );
+        f.code = builtin_code();
+        f.docs_url = builtin_url();
+        f.task = Some(m.task.clone());
+        out.push(f);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn report(yaml: &str) -> crate::check::CheckReport {
+        crate::check(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses"))
+    }
+
+    /// THE completeness ratchet: `is_clean()` and `findings.is_empty()`
+    /// are the same statement — a new finding class that updates
+    /// `is_clean` but forgets the fold turns this red (per-class
+    /// fixtures below make the direction concrete).
+    #[test]
+    fn clean_report_has_zero_findings() {
+        let r = report(
+            "nika: v1\nworkflow: ok\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"x\"] }\n",
+        );
+        assert!(r.is_clean());
+        assert!(r.findings.is_empty(), "{:#?}", r.findings);
+    }
+
+    /// Per-class: every dirty fixture must surface in findings[] AND
+    /// flip `is_clean` — the equivalence, exercised from the dirty side.
+    #[test]
+    fn each_dirty_class_lands_in_findings_with_its_gate() {
+        let cases: Vec<(&str, &str, &str)> = vec![
+            (
+                // conformance: unresolved reference
+                "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ tasks.ghost.output }}\", max_tokens: 9 }\n",
+                "conformance",
+                "CONFORM",
+            ),
+            (
+                // capability escape: exec outside a declared boundary
+                "nika: v1\nworkflow: w\npermits: { exec: false }\ntasks:\n  - id: a\n    exec: { command: [\"cargo\", \"x\"] }\n",
+                "capability_escape",
+                "PERMITS",
+            ),
+            (
+                // unknown tool (typo'd builtin)
+                "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke: { tool: \"nika:raed\", args: { path: \"./x\" } }\n",
+                "unknown_tool",
+                "TOOLS",
+            ),
+            (
+                // missing required arg
+                "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke: { tool: \"nika:write\", args: { path: \"./x\" } }\n",
+                "missing_arg",
+                "ARGS",
+            ),
+        ];
+        for (yaml, kind, gate) in cases {
+            let r = report(yaml);
+            assert!(!r.is_clean(), "fixture must be dirty for {kind}");
+            let hit = r
+                .findings
+                .iter()
+                .find(|f| f.kind == kind)
+                .unwrap_or_else(|| panic!("{kind} missing from findings: {:#?}", r.findings));
+            assert_eq!(hit.gate, gate);
+        }
+    }
+
+    /// The canonical-code law: conformance + escapes + tool-contract
+    /// classes carry a code AND its docs url; analysis-native classes
+    /// carry neither (a conjured code would 404).
+    #[test]
+    fn codes_ride_only_where_canonical() {
+        let r = report(
+            "nika: v1\nworkflow: w\npermits: { exec: false }\ntasks:\n  - id: a\n    exec: { command: [\"cargo\", \"x\"] }\n",
+        );
+        let escape = r
+            .findings
+            .iter()
+            .find(|f| f.kind == "capability_escape")
+            .expect("escape");
+        assert_eq!(escape.code.as_deref(), Some("NIKA-SEC-004"));
+        assert_eq!(
+            escape.docs_url.as_deref(),
+            Some("https://nika.sh/errors/NIKA-SEC-004")
+        );
+        assert_eq!(escape.task.as_deref(), Some("a"));
+    }
+
+    /// The wire shape: absent optionals are ABSENT (never null) — the
+    /// consumer's loop reads {kind, gate, severity, message} on every
+    /// row and the rest only when present.
+    #[test]
+    fn serialization_skips_absent_optionals() {
+        let r = report(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ tasks.ghost.output }}\", max_tokens: 9 }\n",
+        );
+        let json = serde_json::to_value(&r.findings).expect("serializes");
+        let row = &json[0];
+        assert_eq!(row["kind"], "conformance");
+        assert_eq!(row["severity"], "error");
+        assert!(row.get("task").is_none(), "absent, not null: {row}");
+        assert!(row.get("code").is_some());
+    }
+}

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -32,6 +32,7 @@ mod certificate;
 mod cost;
 mod declass;
 mod effective;
+mod findings;
 mod flow;
 mod hints;
 mod infer_permits;
@@ -52,6 +53,7 @@ pub use analysis::{DagAnalysis, TaskBlast};
 pub use certificate::{Bound, CertTerm, RunCertificate};
 pub use cost::{CostCeiling, TaskCost, UnboundedReason};
 pub use effective::{EffectivePermits, PermitsSource};
+pub use findings::UnifiedFinding;
 pub use flow::{FlowFacts, TaintTrace};
 pub use hints::Hint;
 pub use hints::static_read_paths;
@@ -234,6 +236,12 @@ pub struct CheckReport {
     /// guarantee. NEVER fail the check ([`CheckReport::is_clean`]
     /// ignores them).
     pub hints: Vec<Hint>,
+    /// Every finding, class-erased into ONE renderable list (#331) —
+    /// the per-class keys above stay (the typed surface); a consumer
+    /// loops this instead of hardcoding ten key names. Empty ⇔
+    /// [`CheckReport::is_clean`] (the completeness ratchet in
+    /// `findings::tests`). Additive: `report_version` stays 1.
+    pub findings: Vec<UnifiedFinding>,
     /// The scheduler-independent DAG read — exact width (Dilworth) with
     /// a witness antichain, pinch points, per-task failure blast radius.
     /// `None` when conformance fails (no valid order) OR the workflow
@@ -337,7 +345,7 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
     let mut hints = hints::scan_hints(wf);
     hints.extend(native_first::scan(wf));
     hints.extend(dag_read.conflicts);
-    CheckReport {
+    let mut report = CheckReport {
         report_version: REPORT_VERSION,
         conformance,
         cost: cost::ceiling(wf),
@@ -358,7 +366,12 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         hints,
         waves: topo_waves,
         analysis: dag_read.analysis,
-    }
+        findings: Vec::new(),
+    };
+    // The class-erased list folds the FINISHED report (one truth, read
+    // back) — every consumer (CLI --json · MCP nika_check) gets it free.
+    report.findings = findings::collect(&report);
+    report
 }
 
 /// Infer the TIGHTEST `permits:` block the workflow actually needs —


### PR DESCRIPTION
Closes #331 — the third rail of the machine-consumer rung (#346 permits · #332 plan · this).

## findings[]

Every finding class, erased into ONE shape a consumer loops — `{kind, gate, severity, message}` on every row, `code`/`docs_url` **only where a canonical spec code exists** (conformance's own · NIKA-SEC-004 on capability escapes · NIKA-BUILTIN-001 on the tool-contract trio; the analysis-native classes stay codeless — a conjured code would 404), `task`/`span` when carried. The fold lives in **nika-schema** and rides the serialized report: the CLI `--json` AND the MCP `nika_check` lane get it free. Per-class keys stay (the typed surface).

## The completeness ratchet

`is_clean() ⇔ findings.is_empty()`, pinned per-class from the dirty side — an eleventh finding class that forgets the fold turns a **test** red instead of a **consumer** blind. The exact silent-failure mode the issue named, made structural.

## Parse-fatal --json speaks JSON

The most common CI case emitted plain text on stdout. Now: ONE JSON object (`parse_fatal: true`, `clean: false`, a findings[] row carrying the NIKA-PARSE code + docs_url) — exit code unchanged, human voice unchanged.

## Additive — report_version stays 1

The discipline written on every report field (same call as #367); version-pinned consumers survive.

**Proof**: 5 unit (ratchet · per-class gates · canonical-code law · absent-not-null) · 6-check e2e on the built binary · workspace suite green · clippy clean · +44 additive baseline lines · fn-length/crate-size green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)