### PR TITLE
feat(mcp): streamable HTTP transport — the second pump over the same pure dispatch

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -299,10 +299,32 @@ enum Command {
     Dap,
     /// Run the language server over stdio (drives the editor extension).
     Lsp,
-    /// Run the MCP server over stdio (validate: check/explain · learn:
+    /// Run the MCP server (validate: check/explain · learn:
     /// schema/examples/templates/canon — the in-binary Model Context Protocol
-    /// surface for Cursor · Claude Desktop · agents).
-    Mcp,
+    /// surface for Cursor · Claude Desktop · agents). Default transport:
+    /// stdio; `--transport http` serves Streamable HTTP for managed hosts.
+    Mcp {
+        /// The wire: `stdio` (the editor/agent default) or `http`
+        /// (Streamable HTTP · POST JSON-RPC · spec 2025-11-25).
+        #[arg(long, value_enum, default_value_t = McpTransportArg::Stdio)]
+        transport: McpTransportArg,
+        /// HTTP port (with `--transport http`).
+        #[arg(long, default_value_t = 8123)]
+        port: u16,
+        /// HTTP bind address. Loopback by default — widening this exposes
+        /// the server to your network; put TLS + auth (a reverse proxy ·
+        /// `NIKA_MCP_TOKEN`) in front before you do.
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum McpTransportArg {
+    /// Newline-delimited JSON-RPC over stdin/stdout.
+    Stdio,
+    /// Streamable HTTP (POST JSON-RPC · origin-gated · loopback default).
+    Http,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -747,13 +769,11 @@ fn main() -> std::process::ExitCode {
         // The MCP server OWNS stdout (JSON-RPC) — like `lsp`, it must not go
         // through `emit`. Same server-process exit convention: 0 on a clean
         // EOF shutdown, 1 on a transport failure.
-        Command::Mcp => match nika_mcp::run_stdio() {
-            Ok(()) => verbs::exit::OK,
-            Err(err) => {
-                eprintln!("nika-cli: mcp: {err}");
-                1
-            }
-        },
+        Command::Mcp {
+            transport,
+            port,
+            bind,
+        } => mcp_verb(transport, port, &bind),
     };
     std::process::ExitCode::from(code)
 }
@@ -832,6 +852,44 @@ fn flow_verb(trace: Option<PathBuf>, workflow: Option<String>, theme: Theme) -> 
             theme,
         )),
         Err(code) => code,
+    }
+}
+
+/// `nika mcp` — serve the read-only MCP surface. stdio owns stdout
+/// (JSON-RPC); http binds first so the banner names the RESOLVED
+/// address, reads `NIKA_MCP_TOKEN` here (the crate is env-free by
+/// discipline), then serves forever.
+fn mcp_verb(transport: McpTransportArg, port: u16, bind: &str) -> u8 {
+    let served = match transport {
+        McpTransportArg::Stdio => nika_mcp::run_stdio(),
+        McpTransportArg::Http => match nika_mcp::HttpServer::bind(bind, port) {
+            Ok(server) => {
+                // The sanctioned env boundary (same seam as config_from_env):
+                // the token is operator config crossing into a server hold.
+                #[allow(clippy::disallowed_methods)]
+                let token = std::env::var("NIKA_MCP_TOKEN").ok();
+                let addr = server
+                    .addr()
+                    .map_or_else(|_| format!("{bind}:{port}"), |a| a.to_string());
+                eprintln!(
+                    "nika mcp · http://{addr}/mcp · POST JSON-RPC (MCP 2025-11-25) · origin-gated · {} · production TLS belongs to a reverse proxy",
+                    if token.is_some() {
+                        "bearer auth ON (NIKA_MCP_TOKEN)"
+                    } else {
+                        "no auth (set NIKA_MCP_TOKEN to require a bearer)"
+                    }
+                );
+                server.serve(token.as_deref())
+            }
+            Err(err) => Err(err),
+        },
+    };
+    match served {
+        Ok(()) => verbs::exit::OK,
+        Err(err) => {
+            eprintln!("nika-cli: mcp: {err}");
+            1
+        }
     }
 }
 

--- a/crates/nika-mcp/public-api.txt
+++ b/crates/nika-mcp/public-api.txt
@@ -32,4 +32,5 @@ impl<T> nika_error::traits::AsAny for nika_mcp::McpError where T: 'static
 pub fn nika_mcp::McpError::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> typenum::type_operators::Same for nika_mcp::McpError
 pub type nika_mcp::McpError::Output = T
+pub fn nika_mcp::run_http(bind: &str, port: u16) -> core::result::Result<(), nika_mcp::McpError>
 pub fn nika_mcp::run_stdio() -> core::result::Result<(), nika_mcp::McpError>

--- a/crates/nika-mcp/public-api.txt
+++ b/crates/nika-mcp/public-api.txt
@@ -32,5 +32,30 @@ impl<T> nika_error::traits::AsAny for nika_mcp::McpError where T: 'static
 pub fn nika_mcp::McpError::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> typenum::type_operators::Same for nika_mcp::McpError
 pub type nika_mcp::McpError::Output = T
-pub fn nika_mcp::run_http(bind: &str, port: u16) -> core::result::Result<(), nika_mcp::McpError>
+pub struct nika_mcp::HttpServer
+impl nika_mcp::HttpServer
+pub fn nika_mcp::HttpServer::addr(&self) -> core::result::Result<core::net::socket_addr::SocketAddr, nika_mcp::McpError>
+pub fn nika_mcp::HttpServer::bind(bind: &str, port: u16) -> core::result::Result<Self, nika_mcp::McpError>
+pub fn nika_mcp::HttpServer::serve(&self, token: core::option::Option<&str>) -> never
+impl<D> owo_colors::OwoColorize for nika_mcp::HttpServer
+impl<T, U> core::convert::Into<U> for nika_mcp::HttpServer where U: core::convert::From<T>
+pub fn nika_mcp::HttpServer::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_mcp::HttpServer where U: core::convert::Into<T>
+pub type nika_mcp::HttpServer::Error = core::convert::Infallible
+pub fn nika_mcp::HttpServer::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_mcp::HttpServer where U: core::convert::TryFrom<T>
+pub type nika_mcp::HttpServer::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_mcp::HttpServer::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_mcp::HttpServer where T: 'static + ?core::marker::Sized
+pub fn nika_mcp::HttpServer::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_mcp::HttpServer where T: ?core::marker::Sized
+pub fn nika_mcp::HttpServer::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_mcp::HttpServer where T: ?core::marker::Sized
+pub fn nika_mcp::HttpServer::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_mcp::HttpServer
+pub fn nika_mcp::HttpServer::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_mcp::HttpServer where T: 'static
+pub fn nika_mcp::HttpServer::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> typenum::type_operators::Same for nika_mcp::HttpServer
+pub type nika_mcp::HttpServer::Output = T
 pub fn nika_mcp::run_stdio() -> core::result::Result<(), nika_mcp::McpError>

--- a/crates/nika-mcp/src/http.rs
+++ b/crates/nika-mcp/src/http.rs
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The **Streamable HTTP** transport (#335) — the second pump over the
+//! same pure dispatch the stdio pump feeds.
+//!
+//! MCP spec rev 2025-11-25 §Transports allows a deliberately minimal,
+//! fully conformant shape for a read-only, stateless server, and this
+//! is exactly that shape:
+//!
+//! - `POST` with a JSON-RPC **request** → `200 · application/json`, ONE
+//!   response object (the spec's non-SSE branch — a synchronous audit
+//!   tool never streams);
+//! - `POST` with a **notification** (no `id`) → `202 Accepted`;
+//! - `GET` (the server-push stream) → `405` (explicitly legal: a server
+//!   MUST return SSE *or 405* — a read-only server has nothing to push);
+//! - `DELETE` (session end) → `405` — no `Mcp-Session-Id` is ever
+//!   assigned (a stateless server MAY simply not); one sent by a client
+//!   is ignored;
+//! - JSON-RPC **batches** are not accepted (removed from the spec in
+//!   the 2025-06-18 revision).
+//!
+//! **Security posture** (the spec's own MUSTs + house sovereignty):
+//! the `Origin` header is validated on every request (anti
+//! DNS-rebinding — absent is allowed for non-browser clients, loopback
+//! origins pass, anything else is `403`); the listener binds loopback
+//! unless the operator widens it explicitly; `NIKA_MCP_TOKEN` arms
+//! constant-time bearer auth; bodies require `Content-Length` (`411`
+//! otherwise — every first-party MCP SDK sends sized bodies) and are
+//! capped at the same 8 MiB trust-boundary ceiling the stdio pump
+//! enforces (`413` over it).
+//!
+//! **Zero new dependencies** — hand-rolled HTTP/1.1 over
+//! `std::net::TcpListener`, thread per connection, `Connection: close`
+//! per response (correct and simple; keep-alive is a measured future
+//! upgrade). The crate stays zero-async, zero-SDK — its stated
+//! discipline. Production TLS is a reverse proxy's job (documented on
+//! the CLI flag), never hand-rolled here.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+use crate::{MAX_MSG_BYTES, McpError, protocol};
+
+/// Header-section ceiling (start line + headers). Generous for real
+/// clients; a bound because the socket is a trust boundary.
+const MAX_HEAD_BYTES: usize = 16 * 1024;
+
+/// Per-connection read deadline — a stalled client releases its thread.
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// One parsed request — method · target path · lowercased header map ·
+/// raw body bytes.
+struct Request {
+    method: String,
+    target: String,
+    headers: BTreeMap<String, String>,
+    body: Vec<u8>,
+}
+
+/// A refusal the transport answers WITHOUT reaching the dispatch —
+/// status + teaching body (the HTTP twin of the stdio `-32700` line).
+#[derive(Debug)]
+struct Refusal {
+    status: u16,
+    reason: &'static str,
+    detail: String,
+}
+
+impl Refusal {
+    fn new(status: u16, reason: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            status,
+            reason,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// A bound-but-not-yet-serving MCP HTTP server. Two-step shape so the
+/// CALLER owns the operator surface: it binds (learning the resolved
+/// address — port 0 becomes real), prints its own banner through its
+/// own print discipline, reads its own env for the bearer token, then
+/// hands both to [`HttpServer::serve`]. This crate stays env-free and
+/// print-free (the workspace purity lints are the enforcement).
+pub struct HttpServer {
+    listener: TcpListener,
+}
+
+impl HttpServer {
+    /// Bind `bind:port` without serving yet.
+    ///
+    /// # Errors
+    /// Returns [`McpError::Transport`] if the listener cannot bind.
+    pub fn bind(bind: &str, port: u16) -> Result<Self, McpError> {
+        Ok(Self {
+            listener: TcpListener::bind((bind, port))?,
+        })
+    }
+
+    /// The resolved local address (a `--port 0` request becomes real here).
+    ///
+    /// # Errors
+    /// Returns [`McpError::Transport`] if the OS cannot report the address.
+    pub fn addr(&self) -> Result<std::net::SocketAddr, McpError> {
+        Ok(self.listener.local_addr()?)
+    }
+
+    /// Accept forever — SEQUENTIAL: one connection, one request, one
+    /// response (`Connection: close`), then the next. An MCP host is one
+    /// client issuing millisecond-scale audit calls; serializing them is
+    /// correct and keeps this crate free of threading (the workspace is
+    /// tokio-first and this transport is deliberately sync — a measured
+    /// upgrade if a real host ever saturates it). A failed accept is
+    /// skipped (transient), never fatal.
+    pub fn serve(&self, token: Option<&str>) -> ! {
+        loop {
+            let Ok((stream, _)) = self.listener.accept() else {
+                continue;
+            };
+            let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
+            handle_conn(stream, token);
+        }
+    }
+}
+
+/// One connection = one request = one response, then close. Transport
+/// write errors are swallowed — the client hung up; there is nobody
+/// left to tell.
+fn handle_conn(stream: TcpStream, token: Option<&str>) {
+    let mut reader = BufReader::new(match stream.try_clone() {
+        Ok(clone) => clone,
+        Err(_) => return,
+    });
+    let mut out = stream;
+    match parse_request(&mut reader) {
+        Ok(req) => {
+            let (status, reason, content_type, body) = respond(&req, token);
+            let _ = write_response(&mut out, status, reason, content_type, body.as_bytes());
+        }
+        Err(refusal) => {
+            let _ = write_response(
+                &mut out,
+                refusal.status,
+                refusal.reason,
+                "text/plain; charset=utf-8",
+                refusal.detail.as_bytes(),
+            );
+        }
+    }
+}
+
+/// Route one parsed request through the gates to the pure dispatch —
+/// returns (status · reason · content-type · body).
+fn respond(req: &Request, token: Option<&str>) -> (u16, &'static str, &'static str, String) {
+    if !origin_allowed(req.headers.get("origin").map(String::as_str)) {
+        return (
+            403,
+            "Forbidden",
+            "text/plain; charset=utf-8",
+            "origin not allowed — this endpoint serves local MCP clients, not browsers \
+             (DNS-rebinding guard, MCP spec §security)"
+                .to_owned(),
+        );
+    }
+    if !auth_ok(req.headers.get("authorization").map(String::as_str), token) {
+        return (
+            401,
+            "Unauthorized",
+            "text/plain; charset=utf-8",
+            "missing or wrong bearer — this server was started with NIKA_MCP_TOKEN set; \
+             send `Authorization: Bearer <token>`"
+                .to_owned(),
+        );
+    }
+    if req.method != "POST" {
+        // GET = the optional server-push stream (nothing to push, 405 is
+        // the spec's sanctioned answer) · DELETE = session end (stateless).
+        return (
+            405,
+            "Method Not Allowed",
+            "text/plain; charset=utf-8",
+            format!(
+                "{} unsupported — POST one JSON-RPC message to this endpoint \
+                 (read-only server: no push stream, no sessions)",
+                req.method
+            ),
+        );
+    }
+    if req.target != "/mcp" && req.target != "/" {
+        return (
+            404,
+            "Not Found",
+            "text/plain; charset=utf-8",
+            format!("no route {} — the MCP endpoint is /mcp", req.target),
+        );
+    }
+    dispatch_body(&req.body)
+}
+
+/// Parse the body as ONE JSON-RPC message and dispatch it — the exact
+/// contract the stdio pump applies per line, minus the framing.
+fn dispatch_body(body: &[u8]) -> (u16, &'static str, &'static str, String) {
+    let parsed = std::str::from_utf8(body)
+        .map_err(|e| e.to_string())
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).map_err(|e| e.to_string()));
+    let msg = match parsed {
+        Ok(msg) if msg.is_array() => {
+            // Batches left the spec in 2025-06-18 — refuse loudly rather
+            // than answering half a contract.
+            let reply = serde_json::json!({
+                "jsonrpc": "2.0", "id": serde_json::Value::Null,
+                "error": { "code": -32600,
+                    "message": "JSON-RPC batches are not part of MCP (removed 2025-06-18) — send one message per POST" }
+            });
+            return (400, "Bad Request", "application/json", reply.to_string());
+        }
+        Ok(msg) => msg,
+        Err(e) => {
+            let reply = serde_json::json!({
+                "jsonrpc": "2.0", "id": serde_json::Value::Null,
+                "error": { "code": -32700, "message": format!("parse error: {e}") }
+            });
+            return (400, "Bad Request", "application/json", reply.to_string());
+        }
+    };
+    match protocol::dispatch(&msg) {
+        Some(reply) => (200, "OK", "application/json", reply.to_string()),
+        // A notification produces no reply — 202 is the spec's word for it.
+        None => (202, "Accepted", "application/json", String::new()),
+    }
+}
+
+/// The DNS-rebinding gate: absent `Origin` (curl · SDK clients) passes;
+/// loopback origins pass; everything else is refused. A local audit
+/// server has no browser story, so there is no allowlist to configure.
+fn origin_allowed(origin: Option<&str>) -> bool {
+    let Some(origin) = origin else { return true };
+    let rest = origin
+        .strip_prefix("http://")
+        .or_else(|| origin.strip_prefix("https://"));
+    let Some(rest) = rest else { return false };
+    let host = rest.split(':').next().unwrap_or(rest);
+    matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1")
+}
+
+/// The bearer gate — armed only when the server holds a token.
+/// Constant-time comparison: an early-exit mismatch would leak the
+/// prefix length to a timing probe.
+fn auth_ok(header: Option<&str>, token: Option<&str>) -> bool {
+    let Some(token) = token else { return true };
+    let Some(sent) = header.and_then(|h| h.strip_prefix("Bearer ")) else {
+        return false;
+    };
+    let (a, b) = (sent.as_bytes(), token.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// Read one HTTP/1.1 request: start line + headers (bounded), then a
+/// `Content-Length`-sized body (bounded). Chunked bodies are refused
+/// with `411` — every first-party MCP SDK sends sized bodies, and a
+/// sized read is the bounded one.
+fn parse_request<R: BufRead>(reader: &mut R) -> Result<Request, Refusal> {
+    let start = read_head_line(reader)?;
+    let mut parts = start.split_ascii_whitespace();
+    let (Some(method), Some(target)) = (parts.next(), parts.next()) else {
+        return Err(Refusal::new(400, "Bad Request", "malformed request line"));
+    };
+    let (method, target) = (method.to_owned(), target.to_owned());
+
+    let mut headers = BTreeMap::new();
+    let mut head_budget = MAX_HEAD_BYTES.saturating_sub(start.len());
+    loop {
+        let line = read_head_line(reader)?;
+        if line.is_empty() {
+            break;
+        }
+        head_budget = head_budget.checked_sub(line.len()).ok_or_else(|| {
+            Refusal::new(
+                431,
+                "Request Header Fields Too Large",
+                "header section over 16 KiB",
+            )
+        })?;
+        if let Some((k, v)) = line.split_once(':') {
+            headers.insert(k.trim().to_ascii_lowercase(), v.trim().to_owned());
+        }
+    }
+
+    let body = read_sized_body(reader, &method, &headers)?;
+    Ok(Request {
+        method,
+        target,
+        headers,
+        body,
+    })
+}
+
+/// One CRLF-terminated head line (start line or header), bounded.
+fn read_head_line<R: BufRead>(reader: &mut R) -> Result<String, Refusal> {
+    let mut buf = Vec::new();
+    let n = reader
+        .take(MAX_HEAD_BYTES as u64 + 1)
+        .read_until(b'\n', &mut buf)
+        .map_err(|e| Refusal::new(400, "Bad Request", format!("read failed: {e}")))?;
+    if n == 0 || buf.last() != Some(&b'\n') {
+        return Err(Refusal::new(400, "Bad Request", "truncated request head"));
+    }
+    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+        buf.pop();
+    }
+    String::from_utf8(buf).map_err(|_| Refusal::new(400, "Bad Request", "non-UTF-8 request head"))
+}
+
+/// The bounded body read — `Content-Length` required on POST (411
+/// otherwise: chunked is the unbounded form), capped at the stdio
+/// pump's own 8 MiB ceiling (413 over it). Non-POST methods carry none.
+fn read_sized_body<R: BufRead>(
+    reader: &mut R,
+    method: &str,
+    headers: &BTreeMap<String, String>,
+) -> Result<Vec<u8>, Refusal> {
+    if method != "POST" {
+        return Ok(Vec::new());
+    }
+    if headers.contains_key("transfer-encoding") {
+        return Err(Refusal::new(
+            411,
+            "Length Required",
+            "chunked bodies are refused — send Content-Length (every MCP SDK does)",
+        ));
+    }
+    let len: u64 = headers
+        .get("content-length")
+        .and_then(|v| v.parse().ok())
+        .ok_or_else(|| Refusal::new(411, "Length Required", "POST needs Content-Length"))?;
+    if len > MAX_MSG_BYTES {
+        return Err(Refusal::new(
+            413,
+            "Content Too Large",
+            format!("body exceeds the {MAX_MSG_BYTES}-byte message ceiling"),
+        ));
+    }
+    let mut body = vec![0u8; usize::try_from(len).unwrap_or(usize::MAX)];
+    reader.read_exact(&mut body).map_err(|e| {
+        Refusal::new(
+            400,
+            "Bad Request",
+            format!("body shorter than declared: {e}"),
+        )
+    })?;
+    Ok(body)
+}
+
+/// One HTTP/1.1 response, `Connection: close`, flushed.
+fn write_response(
+    out: &mut impl Write,
+    status: u16,
+    reason: &str,
+    content_type: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    write!(
+        out,
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    out.write_all(body)?;
+    out.flush()
+}
+
+#[cfg(test)]
+// std::thread::spawn is workspace-disallowed in PRODUCTION (tokio-first) —
+// these tests need a real OS thread to host the blocking accept loop, the
+// exact thing the sync transport is. Test-only, deliberate.
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::disallowed_methods
+)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn parse(raw: &str) -> Result<Request, Refusal> {
+        parse_request(&mut Cursor::new(raw.as_bytes().to_vec()))
+    }
+
+    /// A well-formed sized POST parses: method · target · lowercased
+    /// headers · exact body bytes.
+    #[test]
+    fn parses_a_sized_post() {
+        let req = parse(
+            "POST /mcp HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}",
+        )
+        .expect("parses");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.target, "/mcp");
+        assert_eq!(req.headers.get("content-type").unwrap(), "application/json");
+        assert_eq!(req.body, b"{}");
+    }
+
+    /// The unbounded form is refused with the teaching 411 — chunked
+    /// AND absent Content-Length alike.
+    #[test]
+    fn chunked_and_lengthless_posts_get_411() {
+        for raw in [
+            "POST /mcp HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n",
+            "POST /mcp HTTP/1.1\r\nHost: x\r\n\r\n",
+        ] {
+            let refusal = parse(raw).err().expect("refused");
+            assert_eq!(refusal.status, 411, "{}", refusal.detail);
+        }
+    }
+
+    /// The stdio pump's 8 MiB ceiling holds on this transport too.
+    #[test]
+    fn oversize_body_gets_413() {
+        let raw = format!(
+            "POST /mcp HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+            MAX_MSG_BYTES + 1
+        );
+        let refusal = parse(&raw).err().expect("refused");
+        assert_eq!(refusal.status, 413);
+    }
+
+    /// The DNS-rebinding matrix: absent + loopback pass · foreign
+    /// origins are refused (http and https alike).
+    #[test]
+    fn origin_gate_matrix() {
+        assert!(origin_allowed(None));
+        assert!(origin_allowed(Some("http://localhost")));
+        assert!(origin_allowed(Some("http://localhost:6274")));
+        assert!(origin_allowed(Some("https://127.0.0.1:8123")));
+        assert!(!origin_allowed(Some("https://evil.example.com")));
+        assert!(!origin_allowed(Some("http://localhost.evil.com")));
+        assert!(!origin_allowed(Some("file://x")));
+    }
+
+    /// The bearer matrix: unarmed passes everything · armed requires
+    /// the exact token in the Bearer form.
+    #[test]
+    fn auth_gate_matrix() {
+        assert!(auth_ok(None, None));
+        assert!(auth_ok(Some("Bearer whatever"), None));
+        assert!(!auth_ok(None, Some("s3cret")));
+        assert!(!auth_ok(Some("Bearer wrong"), Some("s3cret")));
+        assert!(
+            !auth_ok(Some("s3cret"), Some("s3cret")),
+            "raw token without the Bearer form"
+        );
+        assert!(auth_ok(Some("Bearer s3cret"), Some("s3cret")));
+    }
+
+    /// GET answers the spec-sanctioned 405 (no push stream to offer) —
+    /// and the gates run BEFORE the method check (a foreign origin on a
+    /// GET is still 403).
+    #[test]
+    fn get_is_405_and_origin_still_gates_it() {
+        let req = parse("GET /mcp HTTP/1.1\r\nHost: x\r\n\r\n").expect("parses");
+        let (status, ..) = respond(&req, None);
+        assert_eq!(status, 405);
+        let req =
+            parse("GET /mcp HTTP/1.1\r\nOrigin: https://evil.example.com\r\n\r\n").expect("parses");
+        let (status, ..) = respond(&req, None);
+        assert_eq!(status, 403);
+    }
+
+    /// A JSON-RPC REQUEST body answers 200 + ONE application/json
+    /// object; a NOTIFICATION answers 202 with an empty body; a BATCH
+    /// answers 400 naming the 2025-06-18 removal.
+    #[test]
+    fn dispatch_shapes_request_notification_batch() {
+        let (status, _, ct, body) = dispatch_body(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#);
+        assert_eq!((status, ct), (200, "application/json"));
+        let v: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(v["id"], 1);
+
+        let (status, _, _, body) =
+            dispatch_body(br#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#);
+        assert_eq!(status, 202);
+        assert!(body.is_empty());
+
+        let (status, _, _, body) = dispatch_body(br"[]");
+        assert_eq!(status, 400);
+        assert!(body.contains("2025-06-18"), "{body}");
+    }
+
+    /// The full socket round-trip on an ephemeral port: initialize →
+    /// tools/list through a REAL `TcpStream` — the exact bytes a client
+    /// sends, the exact bytes it reads back.
+    #[test]
+    fn real_socket_round_trip() {
+        let server = HttpServer::bind("127.0.0.1", 0).expect("ephemeral bind");
+        let addr = server.addr().expect("addr");
+        std::thread::spawn(move || server.serve(None));
+
+        let reply = post(
+            addr,
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#,
+        );
+        assert!(reply.starts_with("HTTP/1.1 200"), "{reply}");
+        assert!(reply.contains("application/json"), "{reply}");
+        assert!(reply.contains("protocolVersion"), "{reply}");
+
+        let reply = post(addr, r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#);
+        assert!(reply.contains("nika_check"), "{reply}");
+    }
+
+    /// The armed server refuses a tokenless client with the teaching
+    /// 401 and accepts the exact bearer.
+    #[test]
+    fn real_socket_auth_round_trip() {
+        let server = HttpServer::bind("127.0.0.1", 0).expect("ephemeral bind");
+        let addr = server.addr().expect("addr");
+        std::thread::spawn(move || server.serve(Some("s3cret")));
+
+        let reply = post(addr, r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#);
+        assert!(reply.starts_with("HTTP/1.1 401"), "{reply}");
+
+        let reply = post_with(
+            addr,
+            r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#,
+            "Authorization: Bearer s3cret\r\n",
+        );
+        assert!(reply.starts_with("HTTP/1.1 200"), "{reply}");
+    }
+
+    fn post(addr: std::net::SocketAddr, body: &str) -> String {
+        post_with(addr, body, "")
+    }
+
+    fn post_with(addr: std::net::SocketAddr, body: &str, extra: &str) -> String {
+        let mut s = TcpStream::connect(addr).expect("connect");
+        write!(
+            s,
+            "POST /mcp HTTP/1.1\r\nHost: t\r\nContent-Type: application/json\r\n{extra}Content-Length: {}\r\n\r\n{body}",
+            body.len()
+        )
+        .expect("send");
+        let mut reply = String::new();
+        s.read_to_string(&mut reply).expect("read");
+        reply
+    }
+}

--- a/crates/nika-mcp/src/lib.rs
+++ b/crates/nika-mcp/src/lib.rs
@@ -21,8 +21,11 @@
 //! the server surface is read-only by construction. `nika run` stays the
 //! effectful path, gated and audited.
 
+mod http;
 mod protocol;
 mod tools;
+
+pub use http::HttpServer;
 
 use std::io::{BufRead, Read, Write};
 
@@ -60,7 +63,7 @@ pub fn run_stdio() -> Result<(), McpError> {
 /// A message that reaches the ceiling without a newline is refused with a
 /// `-32700`-class error and the pump stops — the stream is unrecoverable for
 /// a line protocol, and draining an unterminated line is itself unbounded.
-const MAX_MSG_BYTES: u64 = 8 * 1024 * 1024;
+pub(crate) const MAX_MSG_BYTES: u64 = 8 * 1024 * 1024;
 
 /// The transport pump over arbitrary byte streams. [`run_stdio`] wires the real
 /// stdio handles; tests drive it with in-memory buffers so every branch — a


### PR DESCRIPTION
Closes #335 — stdio-only closed the managed-MCP hosts; `protocol::dispatch` was always transport-free, so HTTP is a second pump over the same truth.

## The conformant-minimal shape (MCP rev 2025-11-25)

POST request → `200 · application/json` ONE object (the non-SSE branch) · notification → `202` · GET → `405` (the spec's own alternative to a push stream) · DELETE → `405` (stateless — no `Mcp-Session-Id` ever assigned) · batches → `400` naming their 2025-06-18 removal.

## Security (the spec's MUSTs + house sovereignty)

Origin validated on every request (anti DNS-rebinding: absent passes, loopback passes, else 403 teaching) · loopback bind default (`--bind` documents the widening risk) · `NIKA_MCP_TOKEN` arms constant-time bearer (401 teaches the form) · `Content-Length` required (411 — chunked is the unbounded form) · the stdio pump's 8 MiB ceiling holds (413).

## Zero new deps · zero discipline erosion

Hand-rolled HTTP/1.1 on `std::net`, **sequential** accept (an MCP host = one client, ms-scale audit calls; the workspace is tokio-first and this transport is deliberately sync), `Connection: close`. The crate stays **env-free and print-free** — the purity lints forced a better design than the first draft: the CLI binds first (`HttpServer::bind → addr → serve`), owns the banner, reads the token at its sanctioned env boundary.

## CLI

`nika mcp --transport http [--port 8123] [--bind 127.0.0.1]` — default stdio, byte-compatible.

## Proof

53 lib tests (parse/gate matrices · dispatch shapes · two real-socket round-trips incl. armed auth) · 9-check curl e2e on the built binary · workspace suite green · clippy -D clean · baseline: surgical sorted insert (the crate carries ubuntu-rendered io paths — the #352 platform trap, dodged).

Design plan: `dx/.claude/plans/active/sprint/2026-07-10-nika-mcp-http-transport.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)