### PR TITLE
fix(ci): check-expect survives concurrent hooks — portable mktemp

### DIFF
--- a/scripts/ci/check-expect.sh
+++ b/scripts/ci/check-expect.sh
@@ -26,7 +26,12 @@ fi
 
 # Python helper written to a temp script so it can be called per-file without
 # bash here-doc-in-subshell limitations.
-_PY_CHECKER="$(mktemp /tmp/check_expect_XXXXXX.py)"
+# No suffix after the Xs: BSD/macOS mktemp only randomizes TRAILING Xs, so
+# `…_XXXXXX.py` degraded to a LITERAL name — two concurrent pre-push hooks
+# (parallel worktree pushes) collided on it with `mkstemp failed: File
+# exists`, blocking whichever push ran second (observed 2026-07-10). Python
+# runs any filename; portability beats the extension.
+_PY_CHECKER="$(mktemp /tmp/check_expect_XXXXXX)"
 trap 'rm -f "$_PY_CHECKER"' EXIT
 
 cat >"$_PY_CHECKER" <<'PYEOF'


### PR DESCRIPTION
BSD/macOS `mktemp` only randomizes **trailing** Xs: the `check_expect_XXXXXX.py` template degraded to a **literal name**, so two pre-push hooks running at once (parallel worktree pushes — the exact shape of a multi-PR morning) collided with `mkstemp failed: File exists`, blocking whichever push ran second. Observed live today, twice in one push pair.

One line: drop the suffix (python runs any filename). **Proven**: 3 concurrent runs → 3 OK; the vector's verdict is unchanged (`zero .expect( in production src/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)