### PR TITLE
feat(cli): explain fix-forms — four more high-traffic codes teach the edit

### DIFF
--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -144,6 +144,28 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
             "every workflow starts with three lines — `nika: v1`, \
              `workflow: <name>`, and a non-empty `tasks:` list",
         ),
+        "NIKA-PARSE-001" => Some(
+            "the YAML itself is broken — check the pointed line for a missing \
+             `:`, a stray tab (YAML forbids tabs), or unbalanced quotes; if \
+             line 1 is blamed, a copier may have de-commented the \
+             `# yaml-language-server:` modeline",
+        ),
+        "NIKA-PARSE-005" => Some(
+            "the field is not part of the closed v1 envelope — check the \
+             spelling against `nika schema` (the did-you-mean in the finding \
+             usually names it); custom metadata belongs in `description:`",
+        ),
+        "NIKA-PARSE-019" => Some(
+            "the field's YAML SHAPE is wrong (a string where a list goes, a \
+             list where a map goes) — `tasks:` is a LIST of `- id:` entries, \
+             and the finding names the field whose shape to fix",
+        ),
+        "NIKA-VAR-006" => Some(
+            "the expression mixes types — `when:` must be boolean-shaped, \
+             `for_each:` must reference an ARRAY (a `.output` of a `schema:` \
+             task with `type: array`, or a literal list), and comparisons \
+             need both sides the same type",
+        ),
         _ => None,
     }
 }


### PR DESCRIPTION
The #145 long tail, next slice (same pattern as DAG-001/002/003 · PARSE-002): the failure states WHAT, the fix-form states the EDIT.

- **PARSE-001**: the three real YAML breakers (missing colon · tab · quotes) + the de-commented-modeline trap when line 1 is blamed (the 0.99 cause-namer's sibling on the teaching surface).
- **PARSE-005**: check spelling against `nika schema`; custom metadata belongs in `description:`.
- **PARSE-019**: the shape law — `tasks:` is a LIST of `- id:` entries.
- **VAR-006**: `when:` is boolean-shaped · `for_each:` references an ARRAY · comparisons need matching types.

**Proof**: 23 explain unit tests green · 5-check e2e on the built binary (4 new + DAG-003 regression) · clippy -D clean.

Keeps #145 open for the remaining tail (canon-side content is spec work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)