### PR TITLE
ci(release): the tarball passes the trust battery too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,11 @@ jobs:
           smoke="$(mktemp -d)"
           tar -xzf nika-*.tar.gz -C "$smoke"
           bash scripts/ci/funnel-e2e.sh "$smoke/nika"
+          # The operator's trust path against the SAME tarball — the
+          # runs-as-evidence claims (resume · reproduce · chain verify ·
+          # tamper/drop exit 2 · OTLP export). A release whose flight
+          # recorder lies never uploads. scripts/test/trust-battery.sh.
+          bash scripts/test/trust-battery.sh "$smoke/nika"
       - uses: actions/upload-artifact@v4
         with:
           name: nika-${{ matrix.name }}


### PR DESCRIPTION
Sequenced after #381-class battery merge (the script is on main). The funnel proves the stranger first path; the trust battery proves the OPERATOR one — resume · reproduce · chain verify · tamper/drop exit 2 · OTLP — against the SAME tarball about to ship. A release whose flight recorder lies never uploads. Tag-triggered workflow: PR CI never exercises it, the next tag does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)