### PR TITLE
docs: readme + authoring skill name the discovery catalogs

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -15,7 +15,12 @@ oracle; the human runs it.
    `nika examples list` · `nika examples show <slug>` ·
    `nika new --from <template> <file>.nika.yaml`
 2. **Write the file.** Envelope is always `nika: v1` +
-   `workflow: <kebab-id>` + `tasks:`.
+   `workflow: <kebab-id>` + `tasks:`. Pick models and builtins from
+   the embedded catalogs — `nika catalog` (providers · models ·
+   capabilities · which env var each needs) and `nika tools` (the
+   `nika:*` builtins an `invoke` reaches without MCP); before a run,
+   `nika inspect <file>` shows the anatomy: tasks · waves · the cost
+   floor.
 3. **Check it**: `nika check <file>` (exit 0 = clean · 2 = findings),
    then `nika check --native-strict <file>` — it fails on any
    `native-first` hint (an `exec:` a builtin covers).

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ nika run flow.nika.yaml --task hero    # regenerate ONE task + its upstream cone
 nika run flow.nika.yaml --resume .nika/traces/<run>.ndjson   # skip journaled successes
 nika run flow.nika.yaml --resume <trace> --answer approve=true  # re-arm a paused gate
 nika trace show .nika/traces/<run>.ndjson   # re-render any past run
+nika catalog                         # the embedded provider/model catalog · capabilities · env vars
+nika tools                           # the nika:* builtin catalog · what invoke reaches without MCP
 nika doctor --ping                   # are the local servers actually listening?
 ```
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -114,6 +114,11 @@ post-commit:
       run: bash scripts/hooks/activity-log.sh
 
     sequence-reminder:
+      # post-commit has no staged set · without an explicit files source the
+      # glob filters NOTHING and the reminder fired on every commit
+      # (empirical 2026-07-10 ×2 on README-only commits). The commit's own
+      # file list is the correct source.
+      files: git diff-tree --no-commit-id --name-only -r HEAD
       glob: 'memory/execution-roadmap/**/*'
       run: >
         printf '\n[reminder] execution-roadmap/ touched — update SEQUENCE.md status.\n'

--- a/scripts/hooks/activity-log.sh
+++ b/scripts/hooks/activity-log.sh
@@ -31,12 +31,11 @@ else
   LOG_FILE="${REPO_ROOT}/dx/activity-log.jsonl"
 fi
 
-# Ensure directory exists
+# Absent log dir = the log surface is retired here (memory/execution-roadmap
+# left the engine tree) — the NORMAL state, not a failure. Skip silently:
+# a warning on every commit is noise that trains people to ignore hooks.
 LOG_DIR="$(dirname "$LOG_FILE")"
-if [[ ! -d "$LOG_DIR" ]]; then
-  printf '[activity-log] warning: log directory %s not found — skipping\n' "$LOG_DIR" >&2
-  exit 0
-fi
+[[ -d "$LOG_DIR" ]] || exit 0
 
 # ---------------------------------------------------------------------------
 # Gather commit metadata


### PR DESCRIPTION
The teaching-parity ratchet (monorepo · derive fixed 2026-07-10: the awk swallowed the start-here footer as five phantom verbs, masking the real gap) flags two engine surfaces for the 0.99 discovery verbs.

- README daily commands gain `nika catalog` + `nika tools` between trace and doctor — where an author asks what models and builtins exist.
- The authoring skill (SSOT of the nika-agents engine-mirror — a hand-edit in the pack was correctly rejected by its own binary-truth gate) teaches catalog/tools at write time and `nika inspect` before a run.
- Rider: two post-commit hooks stop firing on every commit (activity-log warned on the retired memory dir; sequence-reminder had no files source in post-commit so its glob filtered nothing).

Pushed via the API route (memory-head treadmill · the shared checkout law). After merge: `python3 scripts/resync-mirror.py` in nika-agents re-pins the mirror and its teaching-parity goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)