### PR TITLE
chore(deps): feed-rs 2.4.0 — the quick-xml DoS pair leaves the default build

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,18 +5,17 @@
 [advisories]
 ignore = [
   # RUSTSEC-2026-0194 + RUSTSEC-2026-0195 · quick-xml DoS pair (quadratic
-  # dup-attr check + unbounded NsReader namespace allocation). Two locked
-  # instances, both transitive, neither fixable by bump today (fix >=0.41.0):
-  #   · quick-xml 0.30.0 ← xcb 1.7 ← xcap 0.9.6 ← nika-screen — xcap is
-  #     FEATURE-GATED OFF by default (ADR-081 arc · headless builds) and
-  #     Linux-X11-only → the vulnerable code is not compiled in default or
-  #     release builds.
-  #   · quick-xml 0.37.5 ← feed-rs 2.3.1 ← nika-extract — feed-rs 2.3.1 is
-  #     the LATEST release (no quick-xml >=0.41 release exists upstream).
-  #     DoS-only severity (crafted-XML memory/time exhaustion · no RCE) ·
-  #     feed sources are operator-declared workflow inputs.
-  # Review: 2026-07-16 · watch https://github.com/feed-rs/feed-rs for the
-  # quick-xml bump · drop both entries the day feed-rs releases it.
+  # dup-attr check + unbounded NsReader namespace allocation · fix >=0.41.0).
+  # 2026-07-10: the DEFAULT-BUILD graph is CLEAN — feed-rs 2.4.0 shipped the
+  # quick-xml 0.41 bump (taken same-week) and nika-extract's direct sitemap
+  # parser rides 0.41.0. What remains is feature-gated OFF and never in a
+  # default or release build:
+  #   · quick-xml 0.30.0 ← xcb 1.7 ← xcap 0.9.6 ← nika-screen — the xcap
+  #     feature is OFF by default (ADR-081 arc · headless builds) and
+  #     Linux-X11-only.
+  #   · quick-xml 0.39.4 · same feature-gated screen-capture cluster.
+  # The entries stay ONLY for `--features xcap` dev builds on Linux/X11.
+  # Review: 2026-08-10 · drop when xcb/xcap cross 0.41 upstream.
   "RUSTSEC-2026-0194",
   "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,13 +1798,13 @@ dependencies = [
 
 [[package]]
 name = "feed-rs"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+checksum = "369995dae0733f1fe5ab0e3f345f6503a5f384179df5d8da333702031a131cf9"
 dependencies = [
  "chrono",
  "mediatype",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "regex",
  "serde",
  "serde_json",
@@ -2321,8 +2321,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -2707,7 +2707,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3367,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "mediatype"
-version = "0.19.20"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
 dependencies = [
  "serde",
 ]
@@ -3803,7 +3803,7 @@ dependencies = [
  "nika-kernel",
  "nika-types",
  "proptest",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "scraper",
  "serde_json",
  "thiserror 2.0.18",
@@ -5067,16 +5067,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "encoding_rs",
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -5087,10 +5077,11 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -5309,9 +5300,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5338,9 +5329,9 @@ checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -5840,9 +5831,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5990,9 +5981,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -6169,7 +6160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6780,9 +6771,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ htmd          = "0.5"    # nika-extract L1.5 — mode markdown|article HTML→Ma
 dom_smoothie  = "0.18"   # nika-extract L1.5 — mode article Readability (MIT · Article fields content+text_content verified docs.rs)
 scraper       = "0.27"   # nika-extract L1.5 — modes text|selector|metadata|links CSS-select DOM (ISC)
 feed-rs       = "2.3"    # nika-extract L1.5 — mode feed RSS/Atom/JSON-Feed normalize (MIT)
-quick-xml     = "0.40"   # nika-extract L1.5 — mode sitemap urlset+index parse (MIT)
+quick-xml     = "0.41"   # nika-extract L1.5 — mode sitemap urlset+index parse (MIT)
 encoding_rs   = "0.8"    # nika-builtin L1.5 — nika:fetch charset-aware decode for extraction modes (Apache-2.0/MIT/BSD-3 · the encoding the web actually uses · same crate reqwest text() uses)
 ego-tree      = "0.11"   # nika-extract L1.5 — scraper public tree API (Edge traversal for the text-mode walk · ISC · pinned aligned with scraper 0.27)
 uuid     = { version = "1", features = ["v7", "v4", "serde"] }   # ADR-033 UUIDv7 IDs (nika-error L0) · v4 for nika:builtin nika:uuid

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -917,7 +917,12 @@ mod tests {
     /// so the assertions pin glyphs/text, not ANSI). The render path is what
     /// the operator reads — these tests pin its exact words.
     fn checked_text(name: &str, yaml: &str, ascii: bool) -> String {
-        let dir = std::env::temp_dir().join("nika-cli-killtests");
+        // Per-PROCESS dir: two concurrent `cargo test` invocations (a CI
+        // matrix · a dev double-run) share the OS tmpdir, and a fixed
+        // name let them stomp each other's fixtures mid-read (flaked
+        // live 2026-07-10 — the same fixed-temp-name class as the
+        // check-expect mktemp collision, #376).
+        let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmp dir");
         let path = dir.join(name);
         std::fs::write(&path, yaml).expect("fixture body");
@@ -928,7 +933,12 @@ mod tests {
     /// Same fixture plumbing, full `VerbOutput` (exit-code assertions) —
     /// the `--native-strict` posture tests read `.code`.
     fn checked_output(name: &str, yaml: &str, native_strict: bool) -> VerbOutput {
-        let dir = std::env::temp_dir().join("nika-cli-killtests");
+        // Per-PROCESS dir: two concurrent `cargo test` invocations (a CI
+        // matrix · a dev double-run) share the OS tmpdir, and a fixed
+        // name let them stomp each other's fixtures mid-read (flaked
+        // live 2026-07-10 — the same fixed-temp-name class as the
+        // check-expect mktemp collision, #376).
+        let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmp dir");
         let path = dir.join(name);
         std::fs::write(&path, yaml).expect("fixture body");
@@ -982,7 +992,12 @@ mod tests {
         // The JSON surface: models_resolve false · clean false · the
         // pricing row is NULL (unpriced beats conjured — the $0.0001
         // fuzzy-match hole from the live evidence).
-        let dir = std::env::temp_dir().join("nika-cli-killtests");
+        // Per-PROCESS dir: two concurrent `cargo test` invocations (a CI
+        // matrix · a dev double-run) share the OS tmpdir, and a fixed
+        // name let them stomp each other's fixtures mid-read (flaked
+        // live 2026-07-10 — the same fixed-temp-name class as the
+        // check-expect mktemp collision, #376).
+        let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
         let path = dir.join("models-bare.nika.yaml");
         let theme = Theme::new(false, true, false);
         let out = run(path.to_str().expect("utf8 path"), true, false, None, theme);
@@ -1023,7 +1038,12 @@ mod tests {
     #[test]
     fn native_strict_json_payload_agrees_with_the_exit_code() {
         let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://acme.test\" }\n";
-        let dir = std::env::temp_dir().join("nika-cli-killtests");
+        // Per-PROCESS dir: two concurrent `cargo test` invocations (a CI
+        // matrix · a dev double-run) share the OS tmpdir, and a fixed
+        // name let them stomp each other's fixtures mid-read (flaked
+        // live 2026-07-10 — the same fixed-temp-name class as the
+        // check-expect mktemp collision, #376).
+        let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmp dir");
         let path = dir.join("native-strict-json.nika.yaml");
         std::fs::write(&path, helper).expect("fixture body");

--- a/deny.toml
+++ b/deny.toml
@@ -114,15 +114,15 @@ ignore = [
   #
   # RUSTSEC-2026-0194 + RUSTSEC-2026-0195 · quick-xml DoS pair (quadratic
   # dup-attr check + unbounded NsReader namespace allocation · fix >=0.41.0).
-  # Two locked instances, both transitive, neither bump-fixable today:
-  #   · 0.30.0 ← xcb 1.7 ← xcap 0.9.6 ← nika-screen — xcap FEATURE-GATED OFF
-  #     by default (ADR-081 · headless) + Linux-X11-only → not compiled in
-  #     default/release builds.
-  #   · 0.37.5 ← feed-rs 2.3.1 (LATEST · no quick-xml>=0.41 release upstream)
-  #     ← nika-extract. DoS-only (crafted-XML time/memory exhaustion · no
-  #     RCE) · feed sources are operator-declared workflow inputs.
-  # Review: 2026-07-16 · watch github.com/feed-rs/feed-rs · drop both the day
-  # feed-rs releases the quick-xml bump. Mirror: .cargo/audit.toml.
+  # 2026-07-10: the DEFAULT-BUILD graph is CLEAN — feed-rs 2.4.0 shipped the
+  # quick-xml 0.41 bump (taken same-week) and nika-extract's direct sitemap
+  # parser rides 0.41.0. What remains is feature-gated OFF, never in a
+  # default or release build:
+  #   · 0.30.0 ← xcb 1.7 ← xcap 0.9.6 ← nika-screen — xcap OFF by default
+  #     (ADR-081 · headless) + Linux-X11-only.
+  #   · 0.39.4 · same feature-gated screen-capture cluster.
+  # Entries stay ONLY for `--features xcap` dev builds on Linux/X11.
+  # Review: 2026-08-10 · drop when xcb/xcap cross 0.41. Mirror: .cargo/audit.toml.
   "RUSTSEC-2026-0194",
   "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
feed-rs 2.4.0 (released 2026-07-07) ships the quick-xml 0.41 bump the RUSTSEC-2026-0194/0195 ignores were waiting on — taken **six days before the allow-list own review date**. nika-extract direct sitemap parser rides 0.41.0 too (workspace pin 0.40→0.41).

**The default-build graph is clean of the advisory pair.** What remains (quick-xml 0.30.0/0.39.4) lives ONLY behind the xcap screen-capture feature (OFF by default · Linux-X11-only · never in a release build). Both mirror files (.cargo/audit.toml + deny.toml, the vector-34 sync law) re-scoped to that exact perimeter, review 2026-08-10.

Second commit: the killtests fixture dir goes per-process — two concurrent cargo-test invocations stomped each other in the shared $TMPDIR (flaked live today; same fixed-temp-name class as #376). Proven by a deliberate simultaneous double suite, 353/353 both sides.

cargo audit: **0 vulnerabilities / 759 deps** · cargo deny advisories ok · extract 136/136 · cli 353/353 ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)