### PR TITLE
test(nika-sandbox-seatbelt): gate 5 attests measured — 96% killed, the last deferral falls

### DIFF
--- a/crates/nika-sandbox-seatbelt/src/lib.rs
+++ b/crates/nika-sandbox-seatbelt/src/lib.rs
@@ -57,7 +57,7 @@ impl SeatbeltSandbox {
     /// On any non-macOS target this is `false` (fail-closed).
     #[must_use]
     pub fn available() -> bool {
-        cfg!(target_os = "macos") && Path::new(LAUNCHER).exists()
+        available_given(cfg!(target_os = "macos"), Path::new(LAUNCHER).exists())
     }
 }
 
@@ -79,6 +79,16 @@ impl CommandSandbox for SeatbeltSandbox {
     fn backend(&self) -> &'static str {
         "seatbelt"
     }
+}
+
+/// The availability DECISION, pure — macOS AND the launcher binary both
+/// present, never either alone (fail-closed). Split from [`SeatbeltSandbox::available`]
+/// so the truth table is testable on EVERY platform: the binder reads the
+/// real world (cfg! + fs), this owns the logic — Gate 5's surviving
+/// mutants (`-> true` · `-> false` · `&& → ||`) all lived in the fused
+/// form, unkillable on any single host.
+fn available_given(is_macos: bool, launcher_exists: bool) -> bool {
+    is_macos && launcher_exists
 }
 
 /// Build the SBPL profile string from the spec (deny-default · see module doc).
@@ -293,6 +303,46 @@ const PROFILE_PREAMBLE: &str = r#"(version 1)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The availability truth table — all four rows, platform-free.
+    /// Kills Gate 5's three survivors: `-> true` (row 4 fails), `->
+    /// false` (row 1 fails), `&& → ||` (rows 2+3 fail).
+    #[test]
+    fn available_given_is_the_and_of_both_facts() {
+        assert!(available_given(true, true));
+        assert!(
+            !available_given(true, false),
+            "macOS without the launcher is UNAVAILABLE"
+        );
+        assert!(
+            !available_given(false, true),
+            "a launcher path on non-macOS is UNAVAILABLE"
+        );
+        assert!(!available_given(false, false));
+    }
+
+    /// The binder reflects THIS platform's truth (belt over the seam).
+    #[test]
+    fn available_binder_matches_the_real_world() {
+        let expected = cfg!(target_os = "macos") && Path::new(LAUNCHER).exists();
+        assert_eq!(SeatbeltSandbox::available(), expected);
+    }
+
+    /// On a macOS host with the launcher, confine PROCEEDS — the wrapped
+    /// command execs the launcher, not the original program. Kills the
+    /// `delete !` mutant (which would return Unavailable exactly here).
+    #[test]
+    fn confine_proceeds_when_available() {
+        if !SeatbeltSandbox::available() {
+            return; // linux CI: the truth-table test carries the logic
+        }
+        let spec = SandboxSpec::default();
+        let cmd = ShellCommand::new("/usr/bin/true");
+        let wrapped = SeatbeltSandbox::new()
+            .confine(&spec, cmd)
+            .expect("available host confines");
+        assert_eq!(wrapped.program, LAUNCHER);
+    }
 
     #[test]
     fn literal_prefix_extracts_the_directory_head() {

--- a/docs/crate-specs/nika-sandbox-seatbelt.md
+++ b/docs/crate-specs/nika-sandbox-seatbelt.md
@@ -57,7 +57,7 @@ and over-grant-refusal sets.
 | 2 TDD | ✅ unit (profile/escape/grant/wrap) + the adversarial jail suite |
 | 3 IMPL | ✅ no unsafe · no heavy deps (only `nika-kernel`) |
 | 4 CLIPPY 0 | ✅ |
-| 5 MUTATION ≥90% | ⏳ CI (pairs with the Linux backend arc) |
+| 5 MUTATION ≥90% | ✅ 96% killed (26/27 viable · 2026-07-10 · `check-mutation-floor.sh` — the availability decision extracted pure + the confine happy-path pinned to kill the 4 survivors) |
 | 6 PROPERTY | ✅ injection + over-grant refusal batteries |
 | 8 DOCS | ✅ module + per-fn |
 | 9 CANARY | ✅ the jail suite IS the canary (macOS) |


### PR DESCRIPTION
Vector 39 sat at 43/44 (this crate deferred since admission). The REAL floor said 84% — four survivors on ONE seam, unkillable on any single host because the availability decision was fused to cfg! + a live fs probe.

The rust-pro move (the nika-fs precedent, quoted in its own spec row): **extract the decision pure** — `available_given(is_macos, launcher_exists)` — truth-table tested platform-free (kills `-> true` · `-> false` · `&& → ||`); a belt test pins the binder to the platform truth; the cfg-gated confine happy-path asserts wrapped argv[0] IS the launcher (kills `delete !`).

**Floor re-run: 96% (26/27 viable) ≥ 90.** Spec row attests. **Vector 39: 44/44 — zero deferrals.** Public API byte-identical (the helper is private) · clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)