### PR TITLE
fix(invoke): the failure card's error code speaks once

### DIFF
--- a/crates/nika-verb-invoke/src/errors.rs
+++ b/crates/nika-verb-invoke/src/errors.rs
@@ -87,6 +87,17 @@ impl VerbInvokeError {
         spec_code: Option<String>,
         transient: bool,
     ) -> Self {
+        // One-voice: a builtin's content opens with its own spec code
+        // (`NIKA-BUILTIN-WRITE-001 · parent directory…`) and the failure
+        // card prints the code again as the outer prefix — strip the house
+        // `CODE · ` opener from the content so the code speaks once
+        // (caught live 2026-07-10 · duplicated code in the run's ✖ card).
+        let content = match &spec_code {
+            Some(code) => content
+                .strip_prefix(&format!("{code} · "))
+                .unwrap_or(content),
+            None => content,
+        };
         Self::ToolReportedError {
             tool: tool.into(),
             content_tail: cap_tail(content),
@@ -234,5 +245,48 @@ mod tests {
             VerbInvokeError::Dispatch { source: timeout() }.is_transient(),
             timeout().is_transient()
         );
+    }
+    /// One-voice: the coded constructor strips the house `CODE · ` opener
+    /// from the content — the failure card owns the code prefix, so the
+    /// display body must not repeat it (caught live 2026-07-10).
+    #[test]
+    fn coded_constructor_strips_its_own_code_prefix() {
+        let err = VerbInvokeError::tool_reported_coded(
+            "nika:write",
+            "NIKA-BUILTIN-WRITE-001 · parent directory `./out` does not exist",
+            Some("NIKA-BUILTIN-WRITE-001".to_owned()),
+            false,
+        );
+        let display = format!("{err}");
+        assert!(
+            !display.contains("NIKA-BUILTIN-WRITE-001"),
+            "the code must not ride the display body: {display}"
+        );
+        assert!(display.contains("parent directory `./out` does not exist"));
+    }
+
+    /// A mismatched or absent code leaves the content untouched.
+    #[test]
+    fn coded_constructor_leaves_foreign_prefixes_alone() {
+        let err = VerbInvokeError::tool_reported_coded(
+            "nika:write",
+            "NIKA-BUILTIN-FETCH-001 · some other tool's phrasing",
+            Some("NIKA-BUILTIN-WRITE-001".to_owned()),
+            false,
+        );
+        match &err {
+            VerbInvokeError::ToolReportedError { content_tail, .. } => {
+                assert!(content_tail.starts_with("NIKA-BUILTIN-FETCH-001"));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+        let plain =
+            VerbInvokeError::tool_reported("nika:jq", "NIKA-X · text-only tools keep everything");
+        match &plain {
+            VerbInvokeError::ToolReportedError { content_tail, .. } => {
+                assert!(content_tail.starts_with("NIKA-X · "));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## What

Caught live today while running a third-party repository's demo through nika (the Tapestry `contrib/` PoC): the failure card printed the spec code **twice** —

```
✖ NIKA-BUILTIN-WRITE-001 · tool `nika:write` reported an error: NIKA-BUILTIN-WRITE-001 · parent directory …
```

The builtin's error content opens with its own code and the card prints the code again as the outer prefix. `tool_reported_coded` now strips the house `CODE · ` opener from the content when `spec_code` carries that same code. Text-only tools and foreign prefixes stay untouched (one-voice: the code speaks once).

## Proof

- 21 lib tests green on nika-verb-invoke (2 new: the strip path + the leave-foreign-prefixes-alone path incl. text-only constructor).
- `cargo clippy --all-targets -- -D warnings` clean.
- Re-proven on the live probe binary: the card now reads `NIKA-BUILTIN-WRITE-001 · tool `nika:write` reported an error: parent directory …` — code once.

## Sibling finding (parked · cap-blocked)

The same session caught a meter-honesty bug in nika-cli (`── 2/2 done ──` over a ✖ row) — fix ready but **nika-cli sits at 14999/15000 prod LOC**, so any touch trips the crate-size ratchet. Filed separately with the patch inline; it lands with the registered crate-size split (the 08-01 window P0).