### PR TITLE
fix(tmpl,cel): arithmetic in a guard teaches jq — both voices

### DIFF
--- a/crates/nika-cel/src/lexer.rs
+++ b/crates/nika-cel/src/lexer.rs
@@ -83,6 +83,23 @@ pub(crate) fn lex(src: &str) -> Result<Vec<Token>, CelError> {
             b'\'' | b'"' => lex_string(src, &mut i)?,
             b'-' | b'0'..=b'9' => lex_number(bytes, &mut i)?,
             b if b.is_ascii_alphabetic() || b == b'_' => lex_ident_or_keyword(bytes, &mut i),
+            // Binary arithmetic is outside the cel-subset/0.1 boolean-guard
+            // grammar — teach WHERE it belongs (a `nika:jq` task) with the
+            // SAME voice as the check-side lexer (`nika-tmpl` · one-voice
+            // parity: a workflow run without `check` first must learn the
+            // identical lesson). `-` opens a numeric literal above; its
+            // binary form lands in `lex_number`'s no-digit path.
+            b'+' | b'*' | b'/' | b'%' => {
+                return Err(CelError::static_err(
+                    format!(
+                        "arithmetic operator `{}` — `${{{{ … }}}}` is a boolean guard, not a \
+                         calculator (cel-subset/0.1): compute the value in a `nika:jq` task \
+                         and gate on `tasks.<id>.output`",
+                        b as char
+                    ),
+                    (start, start + 1),
+                ));
+            }
             other => {
                 return Err(CelError::static_err(
                     format!("unexpected character `{}`", other as char),
@@ -194,8 +211,12 @@ fn lex_number(bytes: &[u8], i: &mut usize) -> Result<Tok, CelError> {
         }
     }
     if *i == digits_start {
+        // A `-` that never opened a numeric literal is a binary-minus
+        // attempt — the same arithmetic teaching as the dispatch arm.
         return Err(CelError::static_err(
-            "expected a number",
+            "arithmetic operator `-` — `${{ … }}` is a boolean guard, not a \
+             calculator (cel-subset/0.1): compute the value in a `nika:jq` task \
+             and gate on `tasks.<id>.output`",
             (start, (*i).max(start + 1)),
         ));
     }
@@ -416,5 +437,23 @@ mod tests {
         );
         // Escapes still compose with multibyte content.
         assert_eq!(kinds(r"'é\n☃'"), vec![Tok::Str("é\n☃".into())]);
+    }
+
+    #[test]
+    fn binary_arithmetic_teaches_jq() {
+        // One-voice parity with the check-side lexer (`nika-tmpl`): every
+        // arithmetic operator surfaces the boolean-guard teaching (routes
+        // to `nika:jq`), never a raw `unexpected character` — a run
+        // launched without `check` first learns the identical lesson.
+        for expr in ["a + b", "a * b", "a / b", "a % b", "a - b"] {
+            let err = lex(expr).expect_err(expr);
+            let msg = err.to_string();
+            assert!(
+                msg.contains("arithmetic operator") && msg.contains("nika:jq"),
+                "`{expr}` → {msg}"
+            );
+        }
+        // A negative numeric literal is NOT arithmetic — it still lexes.
+        assert!(lex("-5 < 0").is_ok(), "negative literal must lex");
     }
 }

--- a/crates/nika-tmpl/public-api.txt
+++ b/crates/nika-tmpl/public-api.txt
@@ -58,6 +58,9 @@ pub unsafe fn nika_tmpl::expression::Expr::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_tmpl::expression::Expr
 pub fn nika_tmpl::expression::Expr::from(t: T) -> T
 #[non_exhaustive] pub enum nika_tmpl::expression::ExprError
+pub nika_tmpl::expression::ExprError::ArithmeticUnsupported
+pub nika_tmpl::expression::ExprError::ArithmeticUnsupported::offset: usize
+pub nika_tmpl::expression::ExprError::ArithmeticUnsupported::op: char
 pub nika_tmpl::expression::ExprError::ChainedRelation
 pub nika_tmpl::expression::ExprError::ChainedRelation::offset: usize
 pub nika_tmpl::expression::ExprError::EmptyExpression

--- a/crates/nika-tmpl/src/expression/error.rs
+++ b/crates/nika-tmpl/src/expression/error.rs
@@ -82,6 +82,21 @@ pub enum ExprError {
         /// The maximum nesting depth the parser admits.
         limit: usize,
     },
+
+    /// A binary arithmetic operator (`+` · `-` · `*` · `/` · `%`) — the
+    /// v0.1 CEL subset is a BOOLEAN guard grammar (comparisons · `&&`/`||`
+    /// · `!` · `size` · member access), never a calculator (spec `03-dag.md`
+    /// §CEL-subset). A distinct teaching variant so a new user who writes
+    /// `${{ vars.a + vars.b > 5 }}` learns WHERE arithmetic belongs (a
+    /// `nika:jq` task) instead of reading a raw `unexpected character`
+    /// tokenizer error · mirrors [`Self::UnknownFunction`]'s « `size` is
+    /// the only v0.1 callable » teaching.
+    ArithmeticUnsupported {
+        /// The offending operator.
+        op: char,
+        /// Byte offset relative to the expression start.
+        offset: usize,
+    },
 }
 
 impl fmt::Display for ExprError {
@@ -118,6 +133,12 @@ impl fmt::Display for ExprError {
             Self::TooDeep { offset, limit } => write!(
                 f,
                 "expression nests too deeply at offset {offset} (limit {limit})"
+            ),
+            Self::ArithmeticUnsupported { op, offset } => write!(
+                f,
+                "arithmetic operator `{op}` at offset {offset} — `${{{{ … }}}}` is a boolean \
+                 guard, not a calculator (v0.1 CEL subset): compute the value in a `nika:jq` \
+                 task and gate on `tasks.<id>.output`"
             ),
         }
     }

--- a/crates/nika-tmpl/src/expression/error.rs
+++ b/crates/nika-tmpl/src/expression/error.rs
@@ -219,4 +219,18 @@ mod tests {
             assert_eq!(err.to_string(), expected);
         }
     }
+
+    /// The teaching rendering is pinned byte-exact — the `${{{{`→`${{`
+    /// format-escape is the classic silent break, and the message IS the
+    /// product (it must name the jq route and the guard nature verbatim).
+    #[test]
+    fn arithmetic_display_teaches_the_jq_route() {
+        let err = ExprError::ArithmeticUnsupported { op: '+', offset: 7 };
+        assert_eq!(
+            err.to_string(),
+            "arithmetic operator `+` at offset 7 — `${{ … }}` is a boolean guard, \
+             not a calculator (v0.1 CEL subset): compute the value in a `nika:jq` \
+             task and gate on `tasks.<id>.output`"
+        );
+    }
 }

--- a/crates/nika-tmpl/src/expression/lexer.rs
+++ b/crates/nika-tmpl/src/expression/lexer.rs
@@ -126,6 +126,17 @@ pub(super) fn tokenize(src: &str) -> Result<Vec<Token>, ExprError> {
                 });
                 i += len;
             }
+            // Binary arithmetic (`+` · `*` · `/` · `%`) is outside the v0.1
+            // CEL boolean-guard subset · a distinct teaching error routes the
+            // user to `nika:jq` instead of a raw `unexpected character`. `-`
+            // opens a numeric literal above, so its binary-minus case is
+            // caught inside `lex_number` (a `-` not followed by a digit).
+            b'+' | b'*' | b'/' | b'%' => {
+                return Err(ExprError::ArithmeticUnsupported {
+                    op: bytes[i] as char,
+                    offset: i,
+                });
+            }
             b'A'..=b'Z' | b'a'..=b'z' | b'_' => {
                 let (kind, len) = lex_ident(src, i);
                 tokens.push(Token {
@@ -220,8 +231,10 @@ fn lex_number(src: &str, start: usize) -> Result<(TokenKind, usize), ExprError> 
     if bytes[i] == b'-' {
         i += 1;
         if !bytes.get(i).copied().is_some_and(|b| b.is_ascii_digit()) {
-            return Err(ExprError::UnexpectedChar {
-                ch: '-',
+            // `-` not opening a numeric literal is a binary-minus attempt —
+            // arithmetic is outside the v0.1 CEL guard subset (teach `nika:jq`).
+            return Err(ExprError::ArithmeticUnsupported {
+                op: '-',
                 offset: start,
             });
         }
@@ -441,10 +454,26 @@ mod tests {
     }
 
     #[test]
-    fn lex_bare_minus_errors() {
-        // No arithmetic in the subset — `-` only opens a numeric literal.
-        let err = tokenize("a - b").expect_err("bare minus");
-        assert!(matches!(err, ExprError::UnexpectedChar { ch: '-', .. }));
+    fn lex_binary_arithmetic_teaches_jq() {
+        // No arithmetic in the CEL guard subset — every binary operator a
+        // new user reaches for surfaces the teaching variant (routes to
+        // `nika:jq`), never a raw `unexpected character`. `-` opens a
+        // numeric literal, so its binary form (not digit-led) lands here too.
+        for (expr, op, offset) in [
+            ("a + b", '+', 2),
+            ("a * b", '*', 2),
+            ("a / b", '/', 2),
+            ("a % b", '%', 2),
+            ("a - b", '-', 2),
+        ] {
+            let err = tokenize(expr).expect_err(expr);
+            assert!(
+                matches!(err, ExprError::ArithmeticUnsupported { op: o, offset: off } if o == op && off == offset),
+                "`{expr}` → {err:?}"
+            );
+        }
+        // A negative numeric literal is NOT arithmetic — it still lexes.
+        assert!(tokenize("-5 < 0").is_ok(), "negative literal must lex");
     }
 
     #[test]


### PR DESCRIPTION
From the pre-release new-user gauntlet (96-workflow battery · offline · mock/echo): writing `when: ${{ vars.a + vars.b > 5 }}` — the single most natural thing a new user tries — answered with the raw tokenizer error `unexpected character '+' at offset 7`. Grammatically true, teaching nothing.

The CEL v0.1 subset is a boolean guard by design (03-dag §CEL-subset). The user's actual question is WHERE arithmetic belongs, so both lexers now say it (the `UnknownFunction` « size is the only v0.1 callable » precedent):

```
arithmetic operator `+` — ${{ … }} is a boolean guard, not a calculator
(v0.1 CEL subset): compute the value in a nika:jq task and gate on tasks.<id>.output
```

- Covers `+ - * / %` (binary minus lands via lex_number's no-digit path · negative literals still lex — pinned).
- `nika-tmpl` grows the `#[non_exhaustive]` `ArithmeticUnsupported` variant (additive · Gate-12 safe) — the check voice.
- `nika-cel` speaks the identical lesson — a run launched without `check` first learns the same thing (one-voice parity).
- Tests: tmpl 81 · cel 59 · schema 725 (re-export consumer) green · clippy -D warnings 0 · e2e proven on the built CLI for `+` and `*`.

Pushed via the API route (memory-head treadmill · shared checkout law).

🤖 Generated with [Claude Code](https://claude.com/claude-code)