### PR TITLE
docs(changelog): the evening ledger — trust battery + the rustsec pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   fix-forms for the high-traffic conformance codes (DAG-001/002/003 ·
   PARSE-002) and its footer teaches instead of reading inward (#145).
 
+- **The trust battery — and the release gate that runs it.** The
+  runs-as-evidence claims, composed into one offline battery
+  (`scripts/test/trust-battery.sh`): run→resume with visible cache
+  hits · reproduce → REPRODUCED with engine attestation · chain
+  verify · ONE tampered byte exits 2 · one dropped line exits 2 ·
+  OTLP export lands. `release.yml` plays it against the exact tarball
+  about to ship, beside the funnel — a release whose flight recorder
+  lies never uploads.
+
 ### Fixed
 
 - **gemini 2.5 dynamic thinking no longer burns structured budgets** —
@@ -60,6 +69,13 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 - **Parse-fatal `check --json` answers JSON** — the most common CI case
   emitted plain text on stdout; now ONE object (`parse_fatal: true` ·
   a `findings[]` row carrying the NIKA-PARSE code) (#331).
+
+- **The quick-xml DoS advisory pair leaves the default build**
+  (RUSTSEC-2026-0194/0195): feed-rs 2.4.0 ships the 0.41 bump (taken
+  six days before the allow-list's own review date) and the sitemap
+  parser rides 0.41 too. What remains lives only behind the
+  off-by-default screen-capture feature; `cargo audit`: 0
+  vulnerabilities across 759 dependencies.
 
 ### Changed
 


### PR DESCRIPTION
The continuous-ledger discipline (#373/#377), evening batch: **#381/#382** (the operator trust path — resume · reproduce · tamper-1-byte-exits-2 · OTLP — gated at release: a release whose flight recorder lies never uploads) and **#386** (the quick-xml advisory pair leaves the default build; `cargo audit` 0 vulnerabilities / 759 deps). The cohesion refactors and the gate-5 attestation stay out — internal quality, not release surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)