### PR TITLE
fix(types,cap): unknown extract mode teaches the canonical route

### DIFF
--- a/crates/nika-cap/src/shape.rs
+++ b/crates/nika-cap/src/shape.rs
@@ -349,14 +349,23 @@ fn check_fetch_shape(args: Option<&serde_json::Value>, out: &mut Vec<String>) {
         Some(serde_json::Value::String(raw)) => {
             if raw.contains("${{") {
                 None // templated — the pairing is unknowable statically
-            } else if let Ok(parsed) = raw.parse::<ExtractMode>() {
-                Some(parsed)
             } else {
-                out.push(format!(
-                    "`mode: {raw}` is not a stdlib v0.1 extract mode — the set \
-                         is closed: {EXTRACT_MODE_NAMES} (extract-modes-v0.1.md)"
-                ));
-                return;
+                match raw.parse::<ExtractMode>() {
+                    Ok(parsed) => Some(parsed),
+                    Err(unknown) => {
+                        // ONE hint table for both voices (the L0 error owns
+                        // it) — check and runtime teach the same route.
+                        let hint = unknown
+                            .hint()
+                            .map(|h| format!(" · {h}"))
+                            .unwrap_or_default();
+                        out.push(format!(
+                            "`mode: {raw}` is not a stdlib v0.1 extract mode — the set \
+                         is closed: {EXTRACT_MODE_NAMES} (extract-modes-v0.1.md){hint}"
+                        ));
+                        return;
+                    }
+                }
             }
         }
         Some(_) => {

--- a/crates/nika-types/public-api.txt
+++ b/crates/nika-types/public-api.txt
@@ -686,6 +686,8 @@ pub fn nika_types::extract::ExtractMode::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_types::extract::ExtractMode where T: for<'de> serde_core::de::Deserialize<'de>
 #[non_exhaustive] pub struct nika_types::extract::UnknownExtractMode
 pub nika_types::extract::UnknownExtractMode::input: alloc::string::String
+impl nika_types::extract::UnknownExtractMode
+pub fn nika_types::extract::UnknownExtractMode::hint(&self) -> core::option::Option<&'static str>
 impl core::clone::Clone for nika_types::extract::UnknownExtractMode
 pub fn nika_types::extract::UnknownExtractMode::clone(&self) -> nika_types::extract::UnknownExtractMode
 impl core::cmp::Eq for nika_types::extract::UnknownExtractMode

--- a/crates/nika-types/src/extract.rs
+++ b/crates/nika-types/src/extract.rs
@@ -105,6 +105,33 @@ pub struct UnknownExtractMode {
     pub input: String,
 }
 
+impl UnknownExtractMode {
+    /// A route hint for the empirically-common wrong guesses — the
+    /// new-user battery (2026-07-10) hit `json` twice: the set is closed
+    /// by the one-data-language law (jq replaced `JSONPath`), so the error
+    /// must TEACH the canonical route instead of only naming the enum
+    /// (the arithmetic-diagnostic precedent). Evidence-based rows only ·
+    /// `None` for inputs with no obvious intent.
+    #[must_use]
+    pub fn hint(&self) -> Option<&'static str> {
+        match self.input.as_str() {
+            "json" => Some(
+                "for a parsed JSON response use `mode: jq` with `jq: \".\"` \
+                 (jq is the one data language)",
+            ),
+            "html" => Some(
+                "for the raw page use `mode: raw` · for one element use \
+                 `mode: selector`",
+            ),
+            "xml" | "rss" | "atom" => Some(
+                "for RSS/Atom/JSON-Feed use `mode: feed` · for arbitrary XML \
+                 use `mode: raw`",
+            ),
+            _ => None,
+        }
+    }
+}
+
 impl fmt::Display for UnknownExtractMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -112,7 +139,11 @@ impl fmt::Display for UnknownExtractMode {
             "unknown extract mode `{}` — the stdlib v0.1 set is closed: {EXTRACT_MODE_NAMES} \
              (extract-modes-v0.1.md)",
             self.input
-        )
+        )?;
+        if let Some(hint) = self.hint() {
+            write!(f, " · {hint}")?;
+        }
+        Ok(())
     }
 }
 
@@ -194,5 +225,32 @@ mod tests {
         let back: ExtractMode = serde_json::from_str("\"article\"").expect("deserialize");
         assert_eq!(back, ExtractMode::Article);
         assert!(serde_json::from_str::<ExtractMode>("\"llm-txt\"").is_err());
+    }
+}
+#[cfg(test)]
+mod hint_tests {
+    use super::*;
+
+    /// The did-you-mean table teaches the canonical route for the
+    /// measured wrong guesses (battery 2026-07-10 · `json` twice) and
+    /// stays silent on inputs with no obvious intent — the closed-set
+    /// framing must never speculate.
+    #[test]
+    fn hint_teaches_measured_guesses_only() {
+        let e = |s: &str| UnknownExtractMode {
+            input: s.to_owned(),
+        };
+        let json = e("json").to_string();
+        assert!(
+            json.contains("mode: jq") && json.contains("one data language"),
+            "{json}"
+        );
+        assert!(e("html").to_string().contains("mode: selector"));
+        assert!(e("rss").to_string().contains("mode: feed"));
+        // no speculation · the base closed-set message stands alone
+        let plain = e("banana").to_string();
+        assert!(plain.contains("the stdlib v0.1 set is closed"));
+        assert!(!plain.contains(" · for"), "{plain}");
+        assert!(e("banana").hint().is_none());
     }
 }


### PR DESCRIPTION
Second teaching-diagnostic from the 147-workflow new-user gauntlet (sibling of #394). `mode: json` — the single most common fetch intent, a parsed JSON API response — answered with the closed-enum list and no route (I hit it twice in the battery, as a fresh user would).

The set is closed by the one-data-language law (jq replaced JSONPath), so the answer is NOT an eleventh mode — it's the error teaching the route:

```
unknown extract mode `json` — the stdlib v0.1 set is closed: markdown, article,
text, selector, jq, metadata, links, feed, sitemap, raw (extract-modes-v0.1.md)
· for a parsed JSON response use `mode: jq` with `jq: "."` (jq is the one data language)
```

- `UnknownExtractMode` (L0 nika-types) grows an evidence-based `hint()` table (json · html · xml/rss/atom — anything else stays silent, never speculate) and Display appends it.
- The check-side voice (nika-cap `shape.rs`) consumes the SAME table — check ≡ runtime teaching (one-voice parity, same as #394).
- public-api snapshot: +2 strictly additive lines (the impl + the method).
- Tests: types 230 (hint pins incl. the no-speculation negative) · cap 21 · clippy `-D warnings` 0 · fmt clean.

Pushed via the API route (memory-head treadmill · shared checkout law).

🤖 Generated with [Claude Code](https://claude.com/claude-code)