### PR TITLE
feat(nika-cli): binstall metadata — the release assets resolve (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`cargo binstall nika-cli` resolves the prebuilt release binaries.** The
+  binary crate ships `[package.metadata.binstall]` mapping every release
+  asset (macos/linux × arm64/x64 · the binary at tarball root under its
+  public name) onto binstall's resolver — the Rust-native fast path now
+  fetches the published tarball instead of silently falling back to a
+  source build; verification rides the per-release `SHA256SUMS` (#383).
+  Proven live against the v0.99.0 assets on two targets.
 - **`nika mcp --transport http` — the Streamable HTTP transport.** The
   managed-MCP hosts stdio closed on get their wire: POST-only,
   conformant-minimal per MCP rev 2025-11-25 (single

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -71,3 +71,25 @@ err_prefix    = "none"
 
 [lints]
 workspace = true
+
+# cargo-binstall resolution (#383). The release tarball carries the binary
+# under its PUBLIC name (`nika`, renamed at packaging — release.yml), and the
+# asset names use macos/linux × arm64/x64 rather than target triples, so the
+# bin-dir and every pkg-url are spelled explicitly — binstall's default
+# heuristics miss the assets and silently fall back to a source build.
+# Verification rides the per-release SHA256SUMS.
+[package.metadata.binstall]
+pkg-fmt = "tgz"
+bin-dir = "nika{ binary-ext }"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/nika-macos-arm64-{ version }.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/nika-macos-x64-{ version }.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/nika-linux-x64-{ version }.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/nika-linux-arm64-{ version }.tar.gz"


### PR DESCRIPTION
Closes #383.

`cargo binstall` could not resolve our prebuilt binaries: no `[package.metadata.binstall]`, and the release asset names (macos/linux × arm64/x64) do not match binstall's target-triple heuristics — the Rust-native fast path silently fell back to a source build.

## What

- `[package.metadata.binstall]` on the binary crate: `pkg-fmt = tgz`, `bin-dir = nika{ binary-ext }` — the tarball carries the binary under its PUBLIC name (release.yml renames `nika-cli` → `nika` at packaging and stages it at tarball root), so the `{ bin }` placeholder would look for `nika-cli` and miss.
- Four exact-target overrides mapping each asset name — `{ target-arch }` yields `aarch64`/`x86_64`, never our `arm64`/`x64`, so a single generic `pkg-url` cannot work.
- CHANGELOG Unreleased entry.

## Proof (live, against the shipped v0.99.0 assets)

- `cargo binstall nika-cli --manifest-path crates/nika-cli --dry-run` → resolved the aarch64-apple-darwin override, downloaded the real tarball from the v0.99.0 release, found the binary via bin-dir, would install. RC=0.
- `--targets x86_64-unknown-linux-gnu --dry-run` → resolved + downloaded the linux-x64 asset. RC=0.

Metadata only — zero runtime impact. Verification rides the per-release `SHA256SUMS`. Pairs with the future crates.io publish; until then `--git` installs read the same stanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)