### PR TITLE
feat(dist): flake.nix — nix run resolves the release binary (#388)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,40 @@
+# The flake's prover (#388): the authoring machines carry no nix, so this
+# job IS the proof the derivation builds — same trust model as the linux
+# leg of release.yml. Runs only when the flake inputs can change. No
+# github.event.* interpolation anywhere in run: (workflow-injection safe
+# by construction — static commands, paths trigger).
+name: nix
+
+on:
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - Cargo.lock
+      - .github/workflows/nix.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: nix build (flake)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - name: Flake eval
+        run: nix flake check --no-build --print-build-logs
+      - name: Build the package
+        run: nix build .#nika --print-build-logs
+      - name: Smoke the binary
+        run: |
+          set -euo pipefail
+          ./result/bin/nika --version
+          out="$(./result/bin/nika --version)"
+          case "$out" in
+            nika\ *) echo "version line ok: $out" ;;
+            *) echo "unexpected version line: $out" >&2; exit 1 ;;
+          esac

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ media/.frames/
 # execute; journals are artifacts, never sources (the editor watches them,
 # git must not).
 .nika/
+
+# nix build output symlinks (flake.nix)
+result
+result-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`nix run github:supernovae-st/nika` — the flake install path.** A
+  root `flake.nix` builds the exact release binary (`--bin nika-cli`,
+  locked, renamed to its public name) on the four release platforms —
+  zero gatekeeper, no queue, the 2026 Rust-CLI canon (helix · atuin ·
+  jujutsu all ship one). The derivation needs zero native build inputs
+  (the operator crate's dep tree is pure Rust + rustls) and skips tests
+  by design — diamond-ci gates every merge; a dedicated `nix.yml` job
+  proves the build on every PR touching the flake or the lockfile
+  (#388). Pairs with the binstall metadata (#383): together they cover
+  the two big « install without brew » crowds.
 - **`nika mcp --transport http` — the Streamable HTTP transport.** The
   managed-MCP hosts stdio closed on get their wire: POST-only,
   conformant-minimal per MCP rev 2025-11-25 (single

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#
+# `nix run github:supernovae-st/nika` — the zero-gatekeeper install path
+# (#388). Builds the same binary the release ships: `--bin nika-cli`,
+# `--locked`, renamed to its public name `nika` (release.yml does the same
+# rename at packaging — the seed-crate bin name is reserved for the L5
+# composition root).
+#
+# Tests do NOT run here (`doCheck = false`): the full battery gates every
+# merge in diamond-ci; the flake is an INSTALL path, not a second CI. The
+# build itself is proven by .github/workflows/nix.yml on every PR that
+# touches this file or the lockfile.
+{
+  description = "nika — the sovereign workflow engine for AI (4 verbs · audit-before-run · traces as receipts)";
+
+  inputs = {
+    # unstable: the workspace MSRV (rust-version in Cargo.toml) moves with
+    # the toolchain; the stable channel's rustc lags too far behind it.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        nika = pkgs.rustPlatform.buildRustPackage {
+          pname = "nika";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
+          src = self;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # The operator-surface crate only — its dep tree is pure Rust
+          # (rustls, no openssl/pkg-config), which is why this derivation
+          # needs zero nativeBuildInputs; release.yml builds the same crate
+          # on a bare runner with no apt step.
+          buildAndTestSubdir = "crates/nika-cli";
+
+          doCheck = false;
+
+          postInstall = ''
+            mv $out/bin/nika-cli $out/bin/nika
+          '';
+
+          meta = {
+            description = "The sovereign workflow engine for AI";
+            homepage = "https://nika.sh";
+            license = nixpkgs.lib.licenses.agpl3Plus;
+            mainProgram = "nika";
+          };
+        };
+        default = nika;
+      });
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${self.packages.${pkgs.system}.nika}/bin/nika";
+        };
+      });
+    };
+}


### PR DESCRIPTION
Closes #388.

Nix users had no zero-gatekeeper path: no flake, and the nixpkgs queue is a human-review funnel. The root flake builds the exact binary the release ships (`--bin nika-cli`, locked, renamed to its public name at install — release.yml does the same rename at packaging).

## Shape (each choice pinned by a probe)

- `buildAndTestSubdir` on the operator crate — the workspace root is virtual; `cargo install --path .` would refuse it.
- **Zero nativeBuildInputs** — release.yml builds the same crate on a bare runner with no apt step (rustls, no openssl/pkg-config); the desktop libs in diamond-ci belong to full-workspace crates the flake does not build.
- `doCheck = false` — the battery gates merges in diamond-ci; the flake is an install path, not a second CI.
- nixpkgs-unstable input — the workspace MSRV tracks recent toolchains; stable-channel rustc lags it.
- No `flake.lock` committed — the authoring machine carries no nix; consumers resolve the input fresh, and a follow-up `nix flake lock` commit can pin one.

## The prover

`.github/workflows/nix.yml` (Determinate installer → `nix flake check --no-build` → `nix build .#nika` → version-line smoke) fires on every PR touching the flake, the lockfile or itself — **this PR's own run is the empirical proof**, same trust model as the linux release leg. Static commands only, no event interpolation.

Pairs with #383 (binstall, merged): together they cover the two big « install without brew » crowds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)