### PR TITLE
fix(schema,types,http,browser): SSRF floor speaks at check — one static host oracle

### DIFF
--- a/crates/nika-browser/src/cdp.rs
+++ b/crates/nika-browser/src/cdp.rs
@@ -255,13 +255,15 @@ pub(crate) fn validate_absolute_url(url: &str) -> Result<(), BrowserError> {
                 reason: format!("URL {url:?} targets non-public IP {v6} — refused (SSRF)"),
             });
         }
-        Some(url::Host::Domain(d))
-            if d.eq_ignore_ascii_case("localhost")
-                || d.rsplit_once('.')
-                    .is_some_and(|(_, last)| last.eq_ignore_ascii_case("localhost")) =>
-        {
+        // The shared static host oracle: the `localhost` family (RFC 6761)
+        // PLUS the cloud-metadata hostnames (`metadata.google.internal` ·
+        // `metadata.goog`) — the names class was open here before the
+        // oracle hoist (only the IP forms were gated).
+        Some(url::Host::Domain(d)) if nika_types::net::host_is_blocked(d) => {
             return Err(BrowserError::NavigationFailed {
-                reason: format!("URL {url:?} targets loopback host {d:?} — refused (SSRF)"),
+                reason: format!(
+                    "URL {url:?} targets loopback/metadata host {d:?} — refused (SSRF)"
+                ),
             });
         }
         _ => {}
@@ -497,6 +499,10 @@ mod tests {
             "http://[::ffff:169.254.169.254]/x", // IPv4-mapped metadata smuggling
             "http://localhost/x",          // loopback hostname
             "http://api.localhost/x",      // *.localhost
+            // Metadata NAMES — open before the shared-oracle hoist (only
+            // the IP forms were gated; Chrome would have resolved these).
+            "http://metadata.google.internal/computeMetadata/v1/",
+            "http://Metadata.Goog./x",
             // WHATWG normalizes these integer/short IPv4 forms to Host::Ipv4 —
             // the classic decimal/hex/short-form SSRF encodings all fold to
             // 127.0.0.1 and hit the oracle (would slip a naive string check).

--- a/crates/nika-http/src/ssrf.rs
+++ b/crates/nika-http/src/ssrf.rs
@@ -31,29 +31,7 @@
 //! through a translation gateway. (Teredo `2001::/32` obfuscates the
 //! client v4 by XOR; it is dead in practice and not special-cased.)
 
-use std::net::IpAddr;
-
 use nika_kernel::HttpError;
-
-/// True HOSTNAME strings that are always blocked (loopback alias ·
-/// cloud metadata). IP literals — dotted v4, bracketed v6 — do NOT
-/// belong here: `url::Url::host_str()` strips v6 brackets and the
-/// literal-IP parse branch below is authoritative for every address
-/// form (review swarm P2 · 2026-06-10: the former `"[::1]"`/`"[::]"`/
-/// `"0.0.0.0"` entries were unreachable or redundant dead code).
-/// Comparison is case-insensitive and trailing-dot-normalized
-/// (`localhost.` is the absolute-FQDN spelling of `localhost`).
-const BLOCKED_HOSTNAMES: &[&str] = &[
-    "localhost",
-    // Cloud metadata NAMES only. The metadata IP 169.254.169.254 does
-    // NOT belong here: url::Url canonicalizes every IPv4 spelling, so
-    // the literal-IP branch below is the AUTHORITATIVE guard for that
-    // address class (link-local) — a string entry would be unreachable
-    // dead code misleading maintainers about which layer defends it
-    // (review swarm P0 · 2026-06-12).
-    "metadata.google.internal",
-    "metadata.goog",
-];
 
 /// Statically vet a URL before any network activity.
 ///
@@ -105,28 +83,15 @@ pub(crate) fn check_url(raw: &str) -> Result<url::Url, HttpError> {
             url: raw.to_string(),
         });
     }
-    // Strip the absolute-FQDN trailing dot so `localhost.` fails fast
-    // in the static layer (it would still be caught by DNS-resolve).
-    let host_lower = host.trim_end_matches('.').to_ascii_lowercase();
-
-    if BLOCKED_HOSTNAMES.iter().any(|b| host_lower == *b) {
-        return Err(HttpError::SsrfBlocked {
-            url: raw.to_string(),
-        });
-    }
-
-    // Literal IP in the authority — the single, authoritative oracle.
-    // EMPIRICAL (url 2.x · verified 2026-06-10): `host_str()` keeps the
-    // brackets for IPv6 (`"[::1]"`) and canonicalizes every IPv4 spelling
-    // — decimal `2130706433`, octal `0177.0.0.1`, hex — to dotted form.
-    // So we strip the v6 brackets and parse ONCE: that catches dotted v4
-    // AND bracketed v6 literals. (A bare `host.parse()` would miss v6
-    // because of the brackets — the brackets-stripped parse is the only
-    // form that handles both.)
-    let literal = host.trim_start_matches('[').trim_end_matches(']');
-    if let Ok(ip) = literal.parse::<IpAddr>()
-        && ip_is_blocked(ip)
-    {
+    // The single static host oracle (`nika_types::net`): the `localhost`
+    // family + cloud-metadata names + the literal-IP ranges, shared with
+    // the browser navigate gate AND the `nika check` floor-parity pass so
+    // no surface can drift. EMPIRICAL (url 2.x · verified 2026-06-10):
+    // `host_str()` keeps the brackets for IPv6 (`"[::1]"`) and
+    // canonicalizes every IPv4 spelling — decimal `2130706433`, octal
+    // `0177.0.0.1`, hex — to dotted form; the oracle strips brackets and
+    // parses ONCE, so it covers every authority form this layer sees.
+    if nika_types::net::host_is_blocked(host) {
         return Err(HttpError::SsrfBlocked {
             url: raw.to_string(),
         });
@@ -146,7 +111,7 @@ pub(crate) use nika_types::net::ip_is_blocked;
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
 
     use super::*;
 
@@ -157,6 +122,12 @@ mod tests {
         assert!(check_url("http://localhost/api").is_err());
         assert!(check_url("http://127.0.0.1/api").is_err());
         assert!(check_url("http://0.0.0.0/api").is_err());
+        // RFC 6761: the whole `.localhost` TLD is loopback — blocked
+        // statically since the oracle hoist (previously caught one layer
+        // later, at DNS-resolve).
+        assert!(check_url("http://api.localhost/api").is_err());
+        // …but `localhost` as a NON-last label is a real public name.
+        assert!(check_url("http://localhost.example.com/api").is_ok());
     }
 
     #[test]

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -351,6 +351,7 @@ pub fn nika_schema::check::ByteSpan::as_out(&mut self) -> outref::Out<'_, T>
 pub nika_schema::check::CapabilityEscape::category: &'static str
 pub nika_schema::check::CapabilityEscape::detail: alloc::string::String
 pub nika_schema::check::CapabilityEscape::fix: core::option::Option<alloc::string::String>
+pub nika_schema::check::CapabilityEscape::floor: bool
 pub nika_schema::check::CapabilityEscape::task: alloc::string::String
 impl core::clone::Clone for nika_schema::CapabilityEscape
 pub fn nika_schema::CapabilityEscape::clone(&self) -> nika_schema::CapabilityEscape
@@ -6330,6 +6331,7 @@ pub fn nika_schema::check::ByteSpan::as_out(&mut self) -> outref::Out<'_, T>
 pub nika_schema::CapabilityEscape::category: &'static str
 pub nika_schema::CapabilityEscape::detail: alloc::string::String
 pub nika_schema::CapabilityEscape::fix: core::option::Option<alloc::string::String>
+pub nika_schema::CapabilityEscape::floor: bool
 pub nika_schema::CapabilityEscape::task: alloc::string::String
 impl core::clone::Clone for nika_schema::CapabilityEscape
 pub fn nika_schema::CapabilityEscape::clone(&self) -> nika_schema::CapabilityEscape

--- a/crates/nika-schema/src/check/findings.rs
+++ b/crates/nika-schema/src/check/findings.rs
@@ -102,8 +102,16 @@ pub(super) fn collect(report: &CheckReport) -> Vec<UnifiedFinding> {
                 None => format!("{} (task `{}`)", c.detail, c.task),
             },
         );
-        f.code = Some("NIKA-SEC-004".to_owned());
-        f.docs_url = Some(format!("{}/NIKA-SEC-004", super::ERROR_DOCS_BASE));
+        // The wire code the RUN would emit for the same violation: the
+        // always-on SSRF floor speaks NIKA-SEC-005, the declared permits
+        // boundary NIKA-SEC-004 (spec 05-errors) — check≡run down to the code.
+        let code = if c.floor {
+            "NIKA-SEC-005"
+        } else {
+            "NIKA-SEC-004"
+        };
+        f.code = Some(code.to_owned());
+        f.docs_url = Some(format!("{}/{code}", super::ERROR_DOCS_BASE));
         f.task = Some(c.task.clone());
         out.push(f);
     }

--- a/crates/nika-schema/src/check/infer_permits.rs
+++ b/crates/nika-schema/src/check/infer_permits.rs
@@ -150,6 +150,21 @@ fn collect_builtin_effect(c: &mut Collector, id: &str, a: &crate::raw::RawInvoke
     match builtin_effect(a) {
         Some(BuiltinEffect::Net { url_arg }) => {
             match literal_arg(a, url_arg).as_deref().and_then(url_host) {
+                // A floor-blocked host is NEVER inferred into the grants:
+                // the always-on SSRF floor (NIKA-SEC-005) refuses it
+                // regardless of `permits:`, so the entry would be inert —
+                // and the escape scanner would immediately flag the block
+                // this inference just wrote (a self-refusing suggestion,
+                // the same class as suggesting a program allowlist for a
+                // shell string). Honesty note instead of a silent drop.
+                Some(host) if nika_types::net::host_is_blocked(&host) => {
+                    c.notes.push(format!(
+                        "task `{id}` fetches `{host}` — the always-on SSRF floor \
+                         (NIKA-SEC-005) refuses loopback/private/link-local/metadata \
+                         targets, so no `permits.net.http` entry can admit it; not \
+                         inferred (point the task at a public host)"
+                    ));
+                }
                 Some(host) => {
                     c.hosts.insert(host);
                 }
@@ -555,5 +570,22 @@ mod tests {
             parse(&full, FileId::new(0), ParseMode::Strict).is_ok(),
             "the empty mapping form parses"
         );
+    }
+
+    #[test]
+    fn floor_blocked_host_is_never_inferred_into_the_grants() {
+        // A loopback fetch must NOT synthesize `net.http: ["127.0.0.1"]`
+        // — the floor refuses it regardless, so the entry would be inert
+        // and the escape scanner would flag the block this inference just
+        // wrote (a self-refusing suggestion). Public hosts still infer;
+        // the floored one becomes an honesty note.
+        let r = infer_of(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"http://127.0.0.1:9/x\" } }\n  - id: b\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/x\" } }\n",
+        );
+        let net = r.permits.net.as_ref().expect("public host infers net");
+        assert_eq!(net.http, vec!["api.example.com".to_owned()]);
+        assert_eq!(r.notes.len(), 1, "{:?}", r.notes);
+        assert!(r.notes[0].contains("SSRF floor"), "{}", r.notes[0]);
+        assert!(r.notes[0].contains("`127.0.0.1`"), "{}", r.notes[0]);
     }
 }

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -285,11 +285,15 @@ impl CheckReport {
     pub fn extra_conformance_codes(&self) -> Vec<SpecCode> {
         let builtin = SpecCode::new("BUILTIN", 1, SpecCategory::ValidationError);
         let mut codes = Vec::new();
-        codes.extend(
-            self.capability_escapes
-                .iter()
-                .map(|_| SpecCode::new("SEC", 4, SpecCategory::SecurityError)),
-        );
+        codes.extend(self.capability_escapes.iter().map(|e| {
+            // Floor escapes carry the code the run would emit (SEC-005 ·
+            // the always-on SSRF floor); boundary escapes stay SEC-004.
+            SpecCode::new(
+                "SEC",
+                if e.floor { 5 } else { 4 },
+                SpecCategory::SecurityError,
+            )
+        }));
         codes.extend(self.unknown_tools.iter().map(|_| builtin));
         codes.extend(self.unknown_args.iter().map(|_| builtin));
         codes.extend(self.missing_args.iter().map(|_| builtin));

--- a/crates/nika-schema/src/check/permits_fit.rs
+++ b/crates/nika-schema/src/check/permits_fit.rs
@@ -45,18 +45,26 @@ pub struct CapabilityEscape {
     /// contains the entry. One idiom = the agent repair loop
     /// pattern-matches once and converges (e2e-tested).
     pub fix: Option<String>,
+    /// True when the escape is the always-on SSRF floor (`NIKA-SEC-005` ·
+    /// spec 05-errors: independent of `permits:`), not the declared
+    /// boundary (`NIKA-SEC-004`). A floor escape never carries a grant
+    /// `fix` — no permits entry can admit the target; the repair is
+    /// pointing the task at a public host. Additive (`#[non_exhaustive]`).
+    pub floor: bool,
 }
 
-/// Scan a workflow for capability escapes. Empty when no `permits:` block
-/// is declared (absent = today's behavior, nothing to enforce). Walks every
-/// task's main action AND its `on_finally:` cleanup actions — a cleanup
-/// runs under the same boundary (and ALWAYS runs, so a blind spot there
-/// breaks every run, not just the failure path).
+/// Scan a workflow for capability escapes. The declared-boundary checks
+/// run only under a `permits:` block (absent = today's behavior, nothing
+/// to enforce); the SSRF-floor parity check runs UNCONDITIONALLY — the
+/// floor itself is independent of `permits:` (spec 05-errors
+/// `NIKA-SEC-005`), so a literal fetch to a floor-blocked target is a
+/// check-time truth with or without a boundary. Walks every task's main
+/// action AND its `on_finally:` cleanup actions — a cleanup runs under
+/// the same boundary (and ALWAYS runs, so a blind spot there breaks
+/// every run, not just the failure path).
 #[must_use]
 pub(super) fn scan_escapes(wf: &RawWorkflow) -> Vec<CapabilityEscape> {
-    let Some(permits) = wf.permits.as_ref().map(|p| &p.value) else {
-        return Vec::new();
-    };
+    let permits = wf.permits.as_ref().map(|p| &p.value);
     let mut escapes = Vec::new();
     for task in &wf.tasks {
         let id = &task.value.id.value;
@@ -70,12 +78,47 @@ pub(super) fn scan_escapes(wf: &RawWorkflow) -> Vec<CapabilityEscape> {
             );
         }
     }
+    // Dead grants: a literal `permits.net.http` entry the floor always
+    // refuses can never take effect — the runtime blocks the target
+    // before the allowlist is even consulted. Flagged at the ENTRY (its
+    // own yaml site) so the author learns the grant is inert even when
+    // every task URL is dynamic. Globs are skipped: `*.internal.example`
+    // may match public names, and glob-vs-floor inclusion is DNS
+    // knowledge the static pass does not have.
+    if let Some(net) = permits.and_then(|p| p.net.as_ref()) {
+        for entry in &net.http {
+            if !entry.contains('*') && nika_types::net::host_is_blocked(entry) {
+                escapes.push(CapabilityEscape {
+                    task: "permits".to_owned(),
+                    category: "net",
+                    detail: format!(
+                        "permits.net.http entry `{entry}` can never take effect — the \
+                         always-on SSRF floor (NIKA-SEC-005) refuses loopback/private/\
+                         link-local/metadata targets regardless of `permits:`; remove \
+                         the entry"
+                    ),
+                    fix: None,
+                    floor: true,
+                });
+            }
+        }
+    }
     escapes
 }
 
 /// Check one action (a task's main verb OR an `on_finally` cleanup verb)
-/// against the boundary.
-fn check_action(id: &str, action: &RawAction, permits: &Permits, out: &mut Vec<CapabilityEscape>) {
+/// against the boundary. The floor half runs even with no `permits:`
+/// declared; the boundary half needs one.
+fn check_action(
+    id: &str,
+    action: &RawAction,
+    permits: Option<&Permits>,
+    out: &mut Vec<CapabilityEscape>,
+) {
+    if let RawAction::Invoke(a) = action {
+        check_net_floor(id, a, out);
+    }
+    let Some(permits) = permits else { return };
     match action {
         RawAction::Exec(a) => check_exec(id, &a.command, permits, out),
         RawAction::Invoke(a) => {
@@ -100,6 +143,38 @@ fn check_action(id: &str, action: &RawAction, permits: &Permits, out: &mut Vec<C
     }
 }
 
+/// The check≡run SSRF-floor parity pass (battery finding F3 · issue #395):
+/// a literal net-egress URL whose host the always-on floor refuses can
+/// NEVER succeed at run — `check` blessing it was a false green. Fires on
+/// the same static knowledge the runtime's static layer has (the
+/// `localhost` family · metadata names · literal-IP ranges, via the ONE
+/// `nika_types::net::host_is_blocked` oracle `nika-http` enforces with);
+/// a public DNS name that resolves privately stays the runtime
+/// `GuardedResolver`'s half. No grant `fix` — permits cannot override the
+/// floor, so the repair is the URL itself.
+fn check_net_floor(id: &str, a: &RawInvokeAction, out: &mut Vec<CapabilityEscape>) {
+    let Some(BuiltinEffect::Net { url_arg }) = builtin_effect(a) else {
+        return;
+    };
+    if let Some(host) = literal_arg(a, url_arg).as_deref().and_then(url_host)
+        && nika_types::net::host_is_blocked(&host)
+    {
+        let tool = a.tool.value.as_str();
+        out.push(CapabilityEscape {
+            task: id.to_owned(),
+            category: "net",
+            detail: format!(
+                "`{tool}` host `{host}` is refused by the always-on SSRF floor \
+                 (NIKA-SEC-005): loopback/private/link-local/metadata targets are \
+                 unreachable regardless of `permits:` — point the task at a \
+                 public host"
+            ),
+            fix: None,
+            floor: true,
+        });
+    }
+}
+
 /// Record a tool-surface escape (`invoke`/`agent` tool outside the grant).
 ///
 /// When the tool is a `nika:`-prefixed name that is NOT a canonical
@@ -116,6 +191,7 @@ fn escapes_tool(id: &str, surface: &str, tool: &str, out: &mut Vec<CapabilityEsc
         category: "tools",
         detail: format!("{surface} tool `{tool}` is outside permits.tools"),
         fix: (!is_phantom_builtin).then(|| format!("add \"{tool}\" to permits.tools")),
+        floor: false,
     });
 }
 
@@ -140,6 +216,7 @@ fn check_exec(id: &str, command: &RawCommand, permits: &Permits, out: &mut Vec<C
                 }
                 RawCommand::Shell(_) => None,
             },
+            floor: false,
         });
         return;
     }
@@ -160,6 +237,7 @@ fn check_exec(id: &str, command: &RawCommand, permits: &Permits, out: &mut Vec<C
                 // No machine fix: widening the permit would not make the
                 // string form verifiable; the fix is rewriting the command.
                 fix: None,
+                floor: false,
             });
             return;
         }
@@ -171,6 +249,7 @@ fn check_exec(id: &str, command: &RawCommand, permits: &Permits, out: &mut Vec<C
                 category: "exec",
                 detail: format!("program `{program}` is outside permits.exec allowlist"),
                 fix: Some(format!("add \"{program}\" to permits.exec")),
+                floor: false,
             });
         }
     }
@@ -281,7 +360,11 @@ fn check_builtin_effect(
     let tool = a.tool.value.as_str();
     match builtin_effect(a) {
         Some(BuiltinEffect::Net { url_arg }) => {
+            // A floor-blocked host is already flagged by `check_net_floor`
+            // (and the grant fix would be a lie — no entry can admit it),
+            // so the boundary escape fires only for floor-clean hosts.
             if let Some(host) = literal_arg(a, url_arg).as_deref().and_then(url_host)
+                && !nika_types::net::host_is_blocked(&host)
                 && !permits.allows_host(&host)
             {
                 out.push(CapabilityEscape {
@@ -289,6 +372,7 @@ fn check_builtin_effect(
                     category: "net",
                     detail: format!("`{tool}` host `{host}` is outside permits.net.http"),
                     fix: Some(format!("add \"{host}\" to permits.net.http")),
+                    floor: false,
                 });
             }
         }
@@ -309,6 +393,7 @@ fn check_builtin_effect(
                         category: "fs",
                         detail: format!("`{tool}` path `{path}` is outside permits.{cat}"),
                         fix: Some(format!("add \"{path}\" to permits.{cat}")),
+                        floor: false,
                     });
                 }
             }
@@ -463,12 +548,19 @@ mod tests {
     #[test]
     fn ipv6_bracket_host_is_extracted_not_mangled() {
         // `https://[::1]:8080/x` — the host is `::1`, not `[` (the first-`:`
-        // split bug). Bracket-free in permits, symmetric both sides.
-        let ok = "nika: v1\nworkflow: w\npermits: { tools: [\"nika:fetch\"], net: { http: [\"::1\"] }, exec: false }\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://[::1]:8080/x\" } }\n";
-        assert!(escapes_of(ok).is_empty(), "::1 is granted");
-        let bad = "nika: v1\nworkflow: w\npermits: { tools: [\"nika:fetch\"], net: { http: [\"api.x.com\"] }, exec: false }\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://[::1]:8080/x\" } }\n";
-        let e = escapes_of(bad);
-        assert_eq!(e.len(), 1);
+        // split bug). Bracket-free in permits, symmetric both sides. Since
+        // the floor-parity pass (F3 · issue #395), a granted `::1` is no
+        // longer a false green: BOTH the inert grant entry and the task get
+        // the floor escape — the extraction still reads `::1` in each detail.
+        let granted = "nika: v1\nworkflow: w\npermits: { tools: [\"nika:fetch\"], net: { http: [\"::1\"] }, exec: false }\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://[::1]:8080/x\" } }\n";
+        let e = escapes_of(granted);
+        assert_eq!(e.len(), 2, "the grant is inert AND the task is floored");
+        assert!(e.iter().all(|esc| esc.floor && esc.fix.is_none()));
+        assert!(e.iter().all(|esc| esc.detail.contains("`::1`")), "{e:?}");
+        let ungranted = "nika: v1\nworkflow: w\npermits: { tools: [\"nika:fetch\"], net: { http: [\"api.x.com\"] }, exec: false }\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://[::1]:8080/x\" } }\n";
+        let e = escapes_of(ungranted);
+        assert_eq!(e.len(), 1, "floor escape only — never the grant fix");
+        assert!(e[0].floor);
         assert!(e[0].detail.contains("`::1`"), "detail: {}", e[0].detail);
     }
 
@@ -775,5 +867,168 @@ tasks:
             "no machine fix — widening the permit would not make the \
              string form verifiable"
         );
+    }
+}
+
+#[cfg(test)]
+mod floor_parity {
+    use super::*;
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    fn escapes(yaml: &str) -> Vec<CapabilityEscape> {
+        scan_escapes(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+    }
+
+    #[test]
+    fn granted_loopback_fetch_is_no_longer_a_false_green() {
+        // THE battery-F3 repro (issue #395): `permits.net.http:
+        // ["127.0.0.1"]` + a literal fetch to it — check said rc=0, run
+        // always NIKA-SEC-005. Now check tells the truth at BOTH yaml
+        // sites: the inert grant entry and the floored task.
+        let y = r#"nika: v1
+workflow: w
+permits:
+  net: { http: ["127.0.0.1"] }
+  tools: ["nika:fetch"]
+tasks:
+  - id: probe
+    invoke: { tool: "nika:fetch", args: { url: "http://127.0.0.1:8080/api" } }
+"#;
+        let e = escapes(y);
+        assert_eq!(e.len(), 2, "entry + task: {e:?}");
+        assert!(e.iter().all(|esc| esc.floor && esc.fix.is_none()));
+        let task = e
+            .iter()
+            .find(|esc| esc.task == "probe")
+            .expect("task escape");
+        assert!(task.detail.contains("NIKA-SEC-005"), "{}", task.detail);
+        assert!(task.detail.contains("public host"), "{}", task.detail);
+        let entry = e
+            .iter()
+            .find(|esc| esc.task == "permits")
+            .expect("entry escape");
+        assert!(
+            entry.detail.contains("never take effect"),
+            "{}",
+            entry.detail
+        );
+    }
+
+    #[test]
+    fn floor_fires_without_any_permits_block() {
+        // The floor is permits-INDEPENDENT — the seam existed with no
+        // boundary declared too (check blessed, run always refused).
+        let y = r#"nika: v1
+workflow: w
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "http://localhost:3000/x" } }
+"#;
+        let e = escapes(y);
+        assert_eq!(e.len(), 1, "{e:?}");
+        assert!(e[0].floor);
+        assert!(e[0].detail.contains("`localhost`"), "{}", e[0].detail);
+        // …and a public fetch with no permits stays clean (today's law).
+        let clean = r#"nika: v1
+workflow: w
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "https://api.example.com/x" } }
+"#;
+        assert!(escapes(clean).is_empty());
+    }
+
+    #[test]
+    fn metadata_ip_gets_the_floor_teaching_not_a_grant_fix() {
+        // Outside permits AND floor-blocked: the old path would have said
+        // « add "169.254.169.254" to permits.net.http » — a lie (the grant
+        // cannot help). The floor escape must be the ONLY finding.
+        let y = r#"nika: v1
+workflow: w
+permits:
+  net: { http: ["api.x.com"] }
+  tools: ["nika:fetch"]
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "http://169.254.169.254/latest/meta-data/" } }
+"#;
+        let e = escapes(y);
+        assert_eq!(e.len(), 1, "{e:?}");
+        assert!(e[0].floor);
+        assert!(e[0].fix.is_none(), "a grant fix here would be a lie");
+    }
+
+    #[test]
+    fn dead_grant_is_flagged_even_when_unused() {
+        // Entry-level truth: the grant is inert whether or not a static
+        // URL exercises it (a dynamic URL to it still floors at run).
+        let y = r#"nika: v1
+workflow: w
+permits:
+  net: { http: ["localhost", "api.x.com"] }
+  tools: ["nika:fetch"]
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "https://api.x.com/x" } }
+"#;
+        let e = escapes(y);
+        assert_eq!(e.len(), 1, "{e:?}");
+        assert_eq!(e[0].task, "permits");
+        assert!(e[0].floor);
+        assert!(e[0].detail.contains("`localhost`"), "{}", e[0].detail);
+    }
+
+    #[test]
+    fn glob_entries_and_public_hosts_stay_silent() {
+        // A glob may match public names — glob-vs-floor inclusion is DNS
+        // knowledge the static pass does not have. Never flagged.
+        let y = r#"nika: v1
+workflow: w
+permits:
+  net: { http: ["*.internal.example", "*.localhost"] }
+  tools: ["nika:fetch"]
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "https://api.internal.example/x" } }
+"#;
+        assert!(escapes(y).is_empty(), "globs are never floor-classified");
+    }
+
+    #[test]
+    fn webhook_notify_to_private_target_floors() {
+        // The floor speaks for every Net-classified builtin — webhook
+        // notify rides the same nika-http boundary as fetch.
+        let y = r#"nika: v1
+workflow: w
+tasks:
+  - id: t
+    invoke: { tool: "nika:notify", args: { channel: "webhook", target: "http://10.0.0.8/hook", message: "hi" } }
+"#;
+        let e = escapes(y);
+        assert_eq!(e.len(), 1, "{e:?}");
+        assert!(e[0].floor);
+        assert!(e[0].detail.contains("`10.0.0.8`"), "{}", e[0].detail);
+    }
+
+    #[test]
+    fn localhost_family_and_dynamic_urls_split_static_vs_runtime() {
+        // `api.localhost` is loopback BY STRUCTURE (RFC 6761) → static.
+        let family = r#"nika: v1
+workflow: w
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "http://api.localhost/x" } }
+"#;
+        assert_eq!(escapes(family).len(), 1, "the localhost FAMILY floors");
+        // A dynamic URL is invisible statically — the runtime floor owns it.
+        let dynamic = r#"nika: v1
+workflow: w
+vars: { target: "http://127.0.0.1/x" }
+tasks:
+  - id: t
+    invoke: { tool: "nika:fetch", args: { url: "${{ vars.target }}" } }
+"#;
+        assert!(escapes(dynamic).is_empty(), "dynamic = runtime concern");
     }
 }

--- a/crates/nika-types/public-api.txt
+++ b/crates/nika-types/public-api.txt
@@ -1651,6 +1651,7 @@ pub const nika_types::net::MAX_TRAVERSE_PAGES: u64
 pub const nika_types::net::MULTIPART_PART_KEYS: [&str; 5]
 pub fn nika_types::net::host_glob_matches(glob: &str, host: &str) -> bool
 pub fn nika_types::net::host_in_allowlist(allowlist: &[alloc::string::String], host: &str) -> bool
+pub fn nika_types::net::host_is_blocked(host: &str) -> bool
 pub fn nika_types::net::ip_is_blocked(ip: core::net::ip_addr::IpAddr) -> bool
 pub mod nika_types::prelude
 #[non_exhaustive] pub enum nika_types::prelude::BudgetDirective

--- a/crates/nika-types/src/net.rs
+++ b/crates/nika-types/src/net.rs
@@ -107,6 +107,46 @@ pub fn ip_is_blocked(ip: core::net::IpAddr) -> bool {
     }
 }
 
+/// True HOSTNAME strings the SSRF floor always refuses (cloud metadata).
+/// The `localhost` FAMILY (`localhost` + any `*.localhost` label · RFC 6761
+/// reserves the TLD as loopback) is matched structurally in
+/// [`host_is_blocked`], and IP literals do NOT belong here — the literal-IP
+/// parse there is authoritative for every address form (a string entry for
+/// either class would be unreachable dead code · review swarm P2/P0
+/// 2026-06-10/12).
+const BLOCKED_HOSTNAMES: &[&str] = &["metadata.google.internal", "metadata.goog"];
+
+/// The single STATIC SSRF host oracle: `true` when `host` — a hostname or a
+/// literal IP in any spelling (dotted v4 · bracketed or bare v6) — is a
+/// target the always-on SSRF floor refuses (`NIKA-SEC-005`): the `localhost`
+/// family (RFC 6761), a cloud-metadata hostname, or a literal address
+/// [`ip_is_blocked`] classifies as non-public. Case-insensitive and
+/// trailing-dot-normalized (`localhost.` is the absolute-FQDN spelling of
+/// `localhost`). Every egress boundary funnels its STATIC host knowledge
+/// through this one predicate — the http effect (`nika-http`'s `check_url`),
+/// the browser navigate gate (`nika-browser`), and the `nika check` floor
+/// parity pass (`nika-schema`) — so check and run cannot drift. A DNS name
+/// that merely RESOLVES to a private address is invisible statically; the
+/// runtime `GuardedResolver` owns that half.
+#[must_use]
+pub fn host_is_blocked(host: &str) -> bool {
+    let trimmed = host.trim_end_matches('.');
+    let last_label = trimmed.rsplit('.').next().unwrap_or(trimmed);
+    if last_label.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    if BLOCKED_HOSTNAMES
+        .iter()
+        .any(|b| trimmed.eq_ignore_ascii_case(b))
+    {
+        return true;
+    }
+    let literal = trimmed.trim_start_matches('[').trim_end_matches(']');
+    literal
+        .parse::<core::net::IpAddr>()
+        .is_ok_and(ip_is_blocked)
+}
+
 /// The v4 address a transition-format v6 embeds in two segments (NAT64
 /// `64:ff9b::a.b.c.d` in segments 6+7 · 6to4 `2002:a.b:c.d::` in segments 1+2).
 fn embedded_v4(hi: u16, lo: u16) -> core::net::Ipv4Addr {
@@ -271,6 +311,44 @@ mod tests {
         ] {
             let ip: IpAddr = s.parse().expect("ip");
             assert!(!ip_is_blocked(ip), "{s} is public, must be admitted");
+        }
+    }
+
+    #[test]
+    fn host_oracle_blocks_names_and_literals_in_every_spelling() {
+        for h in [
+            "localhost",
+            "LOCALHOST",
+            "localhost.",    // absolute-FQDN spelling
+            "api.localhost", // RFC 6761: the TLD is loopback
+            "a.b.localhost",
+            "metadata.google.internal",
+            "Metadata.Goog.",
+            "127.0.0.1",
+            "0.0.0.0",
+            "10.0.0.1",
+            "169.254.169.254", // cloud metadata IP
+            "::1",
+            "[::1]", // bracketed spelling (URL authority form)
+            "[fe80::1]",
+            "100.100.100.200", // CGN (Alibaba metadata)
+        ] {
+            assert!(host_is_blocked(h), "{h} must be floor-blocked");
+        }
+    }
+
+    #[test]
+    fn host_oracle_admits_public_hosts_and_stays_silent_on_globs() {
+        for h in [
+            "api.example.com",
+            "example.com.", // trailing-dot public FQDN
+            "8.8.8.8",
+            "[2606:4700:4700::1111]",
+            "localhost.example.com", // `localhost` as a NON-last label is a real name
+            "*.github.com",          // a permits glob is not a host — never classified
+            "",
+        ] {
+            assert!(!host_is_blocked(h), "{h} must not be floor-blocked");
         }
     }
 }


### PR DESCRIPTION
Closes the actionable half of #395 — battery finding **F3**, the last of the 147-workflow gauntlet's three.

**The seam**: `permits.net.http: ["127.0.0.1"]` + a literal fetch to it → `nika check` rc=0, `nika run` always `NIKA-SEC-005`. The always-on floor is permits-independent, so check was blessing a workflow that can never succeed. The static host knowledge was also split three ways (http: private hostname blocklist · browser: localhost-family but no metadata names · checker: nothing).

**One oracle** — `nika_types::net::host_is_blocked` (L0 · no_std) = localhost FAMILY (RFC 6761) + metadata names + the literal-IP ranges:

| Surface | Change |
|---|---|
| `nika-http` `check_url` | folds its two static branches into the one call (suite-pinned · gains `*.localhost` statically, same verdict one layer earlier) |
| `nika-browser` navigate | Domain arm → oracle — **closes the metadata-NAME class** that was open (only IPs were gated) |
| `nika-schema` check | new floor-parity pass: literal fetch/webhook URL the floor refuses → escape with the **run's own wire code** `NIKA-SEC-005` (additive `CapabilityEscape.floor` field), fires with or without `permits:`; a floor-blocked `net.http` entry → dead-grant escape. Never a grant `fix` (no entry can admit the target) |
| `infer_permits` | stops synthesizing floor-blocked hosts (honesty note) — keeps the round-trip property vs the new pass |

Dynamic URLs / DNS-resolving-private stay the runtime `GuardedResolver`'s half.

The spec's own `conformance/envelope/sec-ssrf-*` attack fixtures are exactly this shape — spec-side PR updates their `run-fail` → `check-reject` rows + 01-envelope §permits enforcement prose (follows).

**Gates**: types 232 · http 49 · browser 30 · schema 733 · builtin 303 · clippy `-D warnings` 0 · fmt clean · public-api strictly additive (types +1 fn · schema +1 field, `non_exhaustive` Gate-12 safe). Pushed via the API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)