### PR TITLE
feat(nika-cli): wire wave-2 — gemini, lmstudio, junie (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`nika wire gemini|lmstudio|junie` — wave-2 wire targets.** Three more
+  hosts join the explicit, idempotent MCP wiring (#384, sibling of #330):
+  Gemini CLI (`~/.gemini/settings.json` — the shared settings file, every
+  unrelated key preserved), LM Studio (dedicated `mcp.json`, with the real
+  macOS location honoured when the app keeps it under `~/.cache/lm-studio/`
+  — upstream docs and reality disagree, lmstudio-bug-tracker#1371), and
+  JetBrains Junie (project-scope `.junie/mcp/mcp.json`). Same laws as
+  wave 1: create-or-repair, stale-argv migration, other servers untouched,
+  `wire all` covers them. Cline stays marketplace-side by design.
 - **`cargo binstall nika-cli` resolves the prebuilt release binaries.** The
   binary crate ships `[package.metadata.binstall]` mapping every release
   asset (macos/linux × arm64/x64 · the binary at tarball root under its

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -553,7 +553,10 @@ pub nika_cli::verbs::wire::WireTarget::All
 pub nika_cli::verbs::wire::WireTarget::Claude
 pub nika_cli::verbs::wire::WireTarget::Codex
 pub nika_cli::verbs::wire::WireTarget::Cursor
+pub nika_cli::verbs::wire::WireTarget::Gemini
 pub nika_cli::verbs::wire::WireTarget::Hermes
+pub nika_cli::verbs::wire::WireTarget::Junie
+pub nika_cli::verbs::wire::WireTarget::Lmstudio
 pub nika_cli::verbs::wire::WireTarget::Opencode
 pub nika_cli::verbs::wire::WireTarget::Vscode
 pub nika_cli::verbs::wire::WireTarget::Windsurf

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -360,6 +360,9 @@ enum WireTargetArg {
     Zed,
     Opencode,
     Hermes,
+    Gemini,
+    Lmstudio,
+    Junie,
     All,
 }
 
@@ -374,6 +377,9 @@ impl From<WireTargetArg> for verbs::wire::WireTarget {
             WireTargetArg::Zed => Self::Zed,
             WireTargetArg::Opencode => Self::Opencode,
             WireTargetArg::Hermes => Self::Hermes,
+            WireTargetArg::Gemini => Self::Gemini,
+            WireTargetArg::Lmstudio => Self::Lmstudio,
+            WireTargetArg::Junie => Self::Junie,
             WireTargetArg::All => Self::All,
         }
     }

--- a/crates/nika-cli/src/verbs/wire.rs
+++ b/crates/nika-cli/src/verbs/wire.rs
@@ -25,6 +25,9 @@ pub enum WireTarget {
     Zed,
     Opencode,
     Hermes,
+    Gemini,
+    Lmstudio,
+    Junie,
     All,
 }
 
@@ -75,6 +78,9 @@ fn expand_target(target: WireTarget) -> Vec<WireTarget> {
             WireTarget::Zed,
             WireTarget::Opencode,
             WireTarget::Hermes,
+            WireTarget::Gemini,
+            WireTarget::Lmstudio,
+            WireTarget::Junie,
         ],
         other => vec![other],
     }
@@ -110,8 +116,51 @@ fn wire_one(target: WireTarget, dir: &str) -> Result<WireAction, String> {
         // least-privilege home (the repo the oracle serves).
         WireTarget::Opencode => patch_opencode(&Path::new(dir).join("opencode.json")),
         WireTarget::Hermes => patch_hermes(&home_path(&[".hermes", "config.yaml"])?),
+        // Gemini CLI reads `mcpServers` from its SHARED `settings.json`
+        // (user scope · docs/tools/mcp-server.md) — `patch_config` only
+        // touches that one key, every other setting survives. Server names
+        // must not contain underscores (upstream policy parser splits on
+        // `_`) — `nika` is safe.
+        WireTarget::Gemini => patch_cursor_like(
+            &home_path(&[".gemini", "settings.json"])?,
+            "mcpServers",
+            "gemini",
+            false,
+        ),
+        WireTarget::Lmstudio => {
+            patch_cursor_like(&lmstudio_mcp_path()?, "mcpServers", "lmstudio", false)
+        }
+        // Junie reads project-scope `.junie/mcp/mcp.json` (`mcpServers`
+        // root · junie-cli-mcp-configuration.html); the global
+        // `~/.junie/mcp/mcp.json` exists but the project file is the
+        // least-privilege home, same reasoning as OpenCode above.
+        WireTarget::Junie => patch_cursor_like(
+            &Path::new(dir).join(".junie").join("mcp").join("mcp.json"),
+            "mcpServers",
+            "junie",
+            false,
+        ),
         WireTarget::All => unreachable!("expanded before dispatch"),
     }
+}
+
+/// LM Studio documents `~/.lmstudio/mcp.json` (blog v0.3.17 · macOS+Linux ·
+/// `%USERPROFILE%\.lmstudio` on Windows), but on some macOS installs the app
+/// actually keeps it under `~/.cache/lm-studio/` (lmstudio-bug-tracker#1371,
+/// open) — writing the documented path there would wire nothing. Resolution:
+/// whichever app-created directory EXISTS wins, documented location first;
+/// neither existing falls back to the documented default (created on write).
+fn lmstudio_mcp_path() -> Result<PathBuf, String> {
+    Ok(lmstudio_mcp_path_from(&home_path(&[])?))
+}
+
+fn lmstudio_mcp_path_from(home: &Path) -> PathBuf {
+    let documented = home.join(".lmstudio");
+    let cache = home.join(".cache").join("lm-studio");
+    if !documented.is_dir() && cache.is_dir() {
+        return cache.join("mcp.json");
+    }
+    documented.join("mcp.json")
 }
 
 /// Zed reads MCP servers from `context_servers` in `settings.json`
@@ -721,6 +770,106 @@ args = ["mcp"]
         let again = patch_zed(&path).expect("wire twice");
         assert!(matches!(again, WireAction::Current(_)));
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// #384 · gemini: `mcpServers` lives inside the SHARED settings.json —
+    /// every unrelated setting survives, stale argv migrates.
+    #[test]
+    fn gemini_settings_preserves_unrelated_keys_and_migrates_stale() {
+        let dir = temp_dir("gemini");
+        let path = dir.join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "theme": "GitHub",
+  "autoAccept": false,
+  "mcpServers": {
+    "context7": { "command": "npx", "args": ["-y", "@upstash/context7-mcp"] },
+    "nika": { "command": "nika", "args": ["mcp", "serve", "--stdio"] }
+  }
+}
+"#,
+        )
+        .expect("fixture");
+
+        let action = patch_cursor_like(&path, "mcpServers", "gemini", false).expect("wire");
+        assert!(matches!(action, WireAction::Migrated(_)), "{action:?}");
+        let doc = read_json(&path).expect("json");
+        assert_eq!(doc["theme"], "GitHub", "unrelated settings preserved");
+        assert_eq!(doc["autoAccept"], false, "unrelated settings preserved");
+        assert_eq!(doc["mcpServers"]["context7"]["command"], "npx");
+        assert_eq!(doc["mcpServers"]["nika"]["args"], json!(["mcp"]));
+
+        let again = patch_cursor_like(&path, "mcpServers", "gemini", false).expect("re-run");
+        assert!(matches!(again, WireAction::Current(_)));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// #384 · lmstudio: the documented dir wins, the cache dir
+    /// (lmstudio-bug-tracker#1371) is honoured only when it is the ONLY
+    /// app-created root, and a bare home falls back to the documented
+    /// default.
+    #[test]
+    fn lmstudio_path_resolution_truth_table() {
+        let home = temp_dir("lmstudio-home");
+
+        // Bare home — documented default (created on write).
+        assert_eq!(
+            lmstudio_mcp_path_from(&home),
+            home.join(".lmstudio").join("mcp.json")
+        );
+
+        // Only the cache root exists — the app lives there, follow it.
+        std::fs::create_dir_all(home.join(".cache").join("lm-studio")).expect("cache root");
+        assert_eq!(
+            lmstudio_mcp_path_from(&home),
+            home.join(".cache").join("lm-studio").join("mcp.json")
+        );
+
+        // Documented root exists — it wins even beside the cache root.
+        std::fs::create_dir_all(home.join(".lmstudio")).expect("documented root");
+        assert_eq!(
+            lmstudio_mcp_path_from(&home),
+            home.join(".lmstudio").join("mcp.json")
+        );
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    /// #384 · lmstudio: dedicated `mcp.json` (Cursor-style `mcpServers`) —
+    /// created then idempotent at the resolved path.
+    #[test]
+    fn lmstudio_config_created_and_idempotent() {
+        let home = temp_dir("lmstudio-cfg");
+        std::fs::create_dir_all(home.join(".lmstudio")).expect("root");
+        let path = lmstudio_mcp_path_from(&home);
+
+        let action = patch_cursor_like(&path, "mcpServers", "lmstudio", false).expect("wire");
+        assert!(matches!(action, WireAction::Created(_)), "{action:?}");
+        let doc = read_json(&path).expect("json");
+        assert_eq!(doc["mcpServers"]["nika"]["command"], "nika");
+        assert_eq!(doc["mcpServers"]["nika"]["args"], json!(["mcp"]));
+
+        let again = patch_cursor_like(&path, "mcpServers", "lmstudio", false).expect("re-run");
+        assert!(matches!(again, WireAction::Current(_)));
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    /// #384 · junie: project-scope `.junie/mcp/mcp.json` — nested dirs
+    /// created, `mcpServers` root, idempotent.
+    #[test]
+    fn junie_project_config_created_nested_and_idempotent() {
+        let project = temp_dir("junie");
+        let path = project.join(".junie").join("mcp").join("mcp.json");
+
+        let action = patch_cursor_like(&path, "mcpServers", "junie", false).expect("wire");
+        assert!(matches!(action, WireAction::Created(_)), "{action:?}");
+        let doc = read_json(&path).expect("json");
+        assert_eq!(doc["mcpServers"]["nika"]["command"], "nika");
+        assert_eq!(doc["mcpServers"]["nika"]["args"], json!(["mcp"]));
+
+        let again = patch_cursor_like(&path, "mcpServers", "junie", false).expect("re-run");
+        assert!(matches!(again, WireAction::Current(_)));
+        let _ = std::fs::remove_dir_all(project);
     }
 
     #[allow(clippy::disallowed_methods)]

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -526,6 +526,53 @@ fn wire_cursor_migrates_stale_mcp_config() {
     let _ = std::fs::remove_dir_all(&home);
 }
 
+/// #384 · the wave-2 targets through the real binary: gemini + lmstudio
+/// resolve under HOME, junie under the project `--dir`.
+#[test]
+fn wire_wave2_targets_create_their_configs() {
+    let home = workspace_tmp_dir("nika-wire-wave2");
+    std::fs::create_dir_all(home.join(".lmstudio")).expect("lmstudio root");
+    let project = home.join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+
+    for target in ["gemini", "lmstudio", "junie"] {
+        let out = bin()
+            .arg("wire")
+            .arg(target)
+            .arg("--dir")
+            .arg(&project)
+            .env("HOME", &home)
+            .output()
+            .expect("binary runs");
+        assert_eq!(out.status.code(), Some(0), "wire {target} succeeds");
+        let stdout = String::from_utf8(out.stdout).expect("utf8");
+        assert!(stdout.contains("created"), "{target}: {stdout}");
+    }
+
+    for config in [
+        home.join(".gemini").join("settings.json"),
+        home.join(".lmstudio").join("mcp.json"),
+        project.join(".junie").join("mcp").join("mcp.json"),
+    ] {
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).expect("config written"))
+                .expect("valid json");
+        assert_eq!(
+            doc["mcpServers"]["nika"]["command"],
+            "nika",
+            "{}",
+            config.display()
+        );
+        assert_eq!(
+            doc["mcpServers"]["nika"]["args"],
+            serde_json::json!(["mcp"]),
+            "{}",
+            config.display()
+        );
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
 #[test]
 fn mcp_serves_initialize_and_lists_tools() {
     use std::process::Stdio;


### PR DESCRIPTION
Closes #384. Sibling of #330, rebased onto the #399 display descent (the crate-size ratchet caught the first attempt at 15054/15000 — the split made the room, exactly as designed).

## The three writers

- **gemini** — `mcpServers` lives inside the SHARED `~/.gemini/settings.json`: `patch_config` only touches that one key, every other setting survives (asserted). Upstream forbids underscores in server names (their policy parser splits on `_`) — `nika` is safe.
- **lmstudio** — the docs say `~/.lmstudio/mcp.json` but some macOS installs keep it under `~/.cache/lm-studio/` (lmstudio-bug-tracker#1371, open): writing the documented path there would wire nothing. The resolver follows whichever app-created root exists, documented location first, bare home falls back to the documented default. Pure function of home — truth-table tested.
- **junie** — project-scope `.junie/mcp/mcp.json` (`mcpServers` root), the least-privilege home, same reasoning as opencode.

All three ride the existing `patch_config` mechanics: create-or-repair · stale-argv migration · other servers untouched · `wire all` expanded. **Cline stays marketplace-side by design** (issue non-target).

Mechanisms re-verified at primary sources before implementation — parked on #384 ([comment](https://github.com/supernovae-st/nika/issues/384#issuecomment-4939198197)).

## Proof

- 4 unit tests (gemini preserve+migrate · lmstudio path truth-table · lmstudio create+idempotent · junie nested create+idempotent)
- 1 bin smoke through the real binary (3 targets · config shapes asserted)
- nika-cli lib 279 passed · bin_smoke 33 passed · clippy -D warnings clean · crate-size ratchet green post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)