### PR TITLE
fix(schema,cli,lsp): an unknown arg teaches the declared vocabulary

### DIFF
--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -429,12 +429,17 @@ fn arg_rows(report: &CheckReport) -> Vec<String> {
         .unknown_args
         .iter()
         .map(|u| {
-            format!(
-                "`{}` (task `{}`) has no `{}` arg{}",
-                u.tool,
-                u.task,
-                u.arg,
+            // With a suggestion the fix is the rename; without one (a
+            // wrong-name-entirely miss — `extract` for fetch's `mode`),
+            // the closed declared set is the teaching.
+            let teach = if u.suggestion.is_some() {
                 fix_clause(u.suggestion.as_deref())
+            } else {
+                format!(" — declared: {}", u.declared.join(" · "))
+            };
+            format!(
+                "`{}` (task `{}`) has no `{}` arg{teach}",
+                u.tool, u.task, u.arg,
             )
         })
         .collect();

--- a/crates/nika-lsp/src/analysis/diagnostics.rs
+++ b/crates/nika-lsp/src/analysis/diagnostics.rs
@@ -24,6 +24,7 @@
 //! secret egresses) carry no task name and render at the document origin.
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range};
 use nika_schema::check::ByteSpan;
@@ -107,6 +108,10 @@ fn push_tool_findings(
         );
         if let Some(s) = &a.suggestion {
             push_did_you_mean(&mut msg, s);
+        } else {
+            // No honest guess (wrong-name-entirely) — the closed declared
+            // set is the teaching, same voice as check/findings.
+            let _ = write!(msg, " — declared: {}", a.declared.join(" · "));
         }
         diags.push(error_diag(
             task_range(index, task_spans, &a.task),

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -1444,6 +1444,7 @@ impl<T> nika_error::traits::AsAny for nika_schema::check::UnifiedFinding where T
 pub fn nika_schema::check::UnifiedFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::check::UnknownArg
 pub nika_schema::check::UnknownArg::arg: alloc::string::String
+pub nika_schema::check::UnknownArg::declared: alloc::vec::Vec<alloc::string::String>
 pub nika_schema::check::UnknownArg::suggestion: core::option::Option<alloc::string::String>
 pub nika_schema::check::UnknownArg::task: alloc::string::String
 pub nika_schema::check::UnknownArg::tool: alloc::string::String

--- a/crates/nika-schema/src/check/findings.rs
+++ b/crates/nika-schema/src/check/findings.rs
@@ -181,9 +181,14 @@ fn fold_tools(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
                     "`{}` is not an arg of `{}` (task `{}`) — did you mean `{s}`?",
                     a.arg, a.tool, a.task
                 ),
+                // No honest guess (a wrong-name-entirely miss) — the
+                // closed declared set IS the teaching.
                 None => format!(
-                    "`{}` is not an arg of `{}` (task `{}`)",
-                    a.arg, a.tool, a.task
+                    "`{}` is not an arg of `{}` (task `{}`) — declared: {}",
+                    a.arg,
+                    a.tool,
+                    a.task,
+                    a.declared.join(" · ")
                 ),
             },
         );

--- a/crates/nika-schema/src/check/tools.rs
+++ b/crates/nika-schema/src/check/tools.rs
@@ -101,9 +101,18 @@ pub struct UnknownArg {
     /// The undeclared arg key as written (`data`).
     pub arg: String,
     /// The nearest declared arg key, when one is close enough (`input`
-    /// for `inpit`) — the machine-applicable fix. `None` when the typo is
-    /// too far for an honest guess (silence beats a wrong suggestion).
+    /// for `inpit` · edit distance) or unambiguously abbreviated (`expr`
+    /// for `expression` · unique-prefix) — the machine-applicable fix.
+    /// `None` when no honest guess exists (silence beats a wrong
+    /// suggestion) — then [`Self::declared`] is the teaching.
     pub suggestion: Option<String>,
+    /// The builtin's FULL declared arg vocabulary (catalog order). The
+    /// renderer's fallback teaching when no suggestion is honest: a
+    /// wrong-name-entirely miss (`extract` for fetch's `mode` · `left`
+    /// for `json_diff`'s `before` — the battery's own author-errors) is
+    /// answered by the closed set itself, not a guess. Additive
+    /// (`#[non_exhaustive]`).
+    pub declared: Vec<String>,
 }
 
 /// Scan every `invoke` call (main verbs AND `on_finally` cleanups) for
@@ -148,13 +157,34 @@ fn collect_args(site: &str, action: &RawAction, out: &mut Vec<UnknownArg>) {
         if builtin.args.contains(&key.as_str()) {
             continue;
         }
-        let suggestion = did_you_mean(key, builtin.args.iter().copied()).map(str::to_owned);
+        // Suggestion ladder: edit-distance first (typos: `inpit`), then
+        // unique-prefix (abbreviations: `expr` → `expression` — distance 6,
+        // invisible to the metric, but an unambiguous author intent).
+        let suggestion = did_you_mean(key, builtin.args.iter().copied())
+            .or_else(|| unique_prefix_match(key, builtin.args))
+            .map(str::to_owned);
         out.push(UnknownArg {
             task: site.to_owned(),
             tool: a.tool.value.clone(),
             arg: key.clone(),
             suggestion,
+            declared: builtin.args.iter().map(|&s| s.to_owned()).collect(),
         });
+    }
+}
+
+/// The one declared key the unknown key unambiguously abbreviates —
+/// `Some` only when EXACTLY one candidate starts with it (two matches =
+/// ambiguous = silence) and the abbreviation is substantial (≥3 chars:
+/// a 1-2 char key prefixes half the vocabulary by accident).
+fn unique_prefix_match<'a>(key: &str, declared: &[&'a str]) -> Option<&'a str> {
+    if key.chars().count() < 3 {
+        return None;
+    }
+    let mut hits = declared.iter().filter(|d| d.starts_with(key));
+    match (hits.next(), hits.next()) {
+        (Some(&only), None) => Some(only),
+        _ => None,
     }
 }
 
@@ -335,6 +365,52 @@ mod tests {
         assert_eq!(f.len(), 1, "{f:?}");
         assert_eq!(f[0].arg, "inpit");
         assert_eq!(f[0].suggestion.as_deref(), Some("input"));
+    }
+
+    #[test]
+    fn abbreviated_arg_gets_the_unique_prefix_fix() {
+        // The battery's own author-error: `expr` for `nika:jq` — edit
+        // distance 6 (invisible to the metric) but an unambiguous
+        // abbreviation of exactly one declared key.
+        let f = arg_findings_of(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    invoke: { tool: \"nika:jq\", args: { expr: \".\", input: 1 } }\n",
+        );
+        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f[0].arg, "expr");
+        assert_eq!(f[0].suggestion.as_deref(), Some("expression"));
+    }
+
+    #[test]
+    fn wrong_name_entirely_carries_the_declared_vocabulary() {
+        // The other battery author-error class: `left`/`right` for
+        // `nika:json_diff` (`before`/`after`) — no lexical similarity, so
+        // no guess; the finding carries the closed declared set instead.
+        let f = arg_findings_of(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    invoke: { tool: \"nika:json_diff\", args: { left: { a: 1 }, right: { a: 2 } } }\n",
+        );
+        assert_eq!(f.len(), 2, "{f:?}");
+        for u in &f {
+            assert_eq!(u.suggestion, None, "no honest guess for {}", u.arg);
+            assert!(
+                u.declared.iter().any(|d| d == "before") && u.declared.iter().any(|d| d == "after"),
+                "declared vocabulary teaches the real keys: {:?}",
+                u.declared
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_rule_is_unique_and_substantial_only() {
+        // Two-candidate ambiguity → silence (never a coin-flip guess).
+        assert_eq!(unique_prefix_match("pa", &["path", "pattern"]), None);
+        assert_eq!(unique_prefix_match("pat", &["path", "pattern"]), None);
+        // Substantial + unique → the fix.
+        assert_eq!(
+            unique_prefix_match("expr", &["expression", "input"]),
+            Some("expression")
+        );
+        // Too short to assert intent, even when unique.
+        assert_eq!(unique_prefix_match("ex", &["expression", "input"]), None);
     }
 
     #[test]


### PR DESCRIPTION
Third teaching-diagnostic from the 147-workflow gauntlet (sibling of #394/#397). Four of the battery's own author-errors were wrong **arg** names — `extract`→fetch's `mode` · `expr`→jq's `expression` · `left`/`right`→json_diff's `before`/`after` — and the finding stopped at the unknown key's name.

**Before / after** (real CLI output):
```
✖ ARGS  `nika:fetch` (task `a`) has no `extract` arg
✖ ARGS  `nika:fetch` (task `a`) has no `extract` arg — declared: url · method · headers · body · form · multipart · traverse · mode · selector · jq

✖ ARGS  `nika:jq` (task `a`) has no `expr` arg
✖ ARGS  `nika:jq` (task `a`) has no `expr` arg · fix: did you mean `expression`?
```

Two honest upgrades, zero guessing:
- **Unique-prefix rung** after edit-distance in the suggestion ladder (`expr` is distance 6 from `expression` — invisible to the metric, unambiguous as an abbreviation). Fires only on exactly-one match + 3-plus chars; ambiguity (`pat` vs `path`/`pattern`) stays silent.
- **`UnknownArg.declared`** (additive field): the no-guess arm teaches the closed declared set instead of stopping at the name — one voice across CLI panel, `findings[]` machine list, LSP diagnostics.

Gates: schema 736 (4 battery cases pinned) · lsp 276 · cli 132 · clippy `-D warnings` 0 · fmt clean · public-api +1 additive. API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)