### PR TITLE
feat(dist): .pre-commit-hooks.yaml — nika check as a pre-commit hook (#407)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,22 @@
+# The pre-commit framework manifest (#407) — makes `nika check` consumable
+# as a hook (https://pre-commit.com). Consumers pin a tagged release:
+#
+#   repos:
+#     - repo: https://github.com/supernovae-st/nika
+#       rev: v0.99.0   # first tag carrying this file: the NEXT release
+#       hooks:
+#         - id: nika-check
+#
+# `language: script` (not `system`) because `nika check` audits ONE file
+# per call while pre-commit passes every staged match in one argv — the
+# wrapper fans out and keeps the worst exit. The `nika` binary itself is
+# assumed on PATH (brew/tarball/binstall/nix), the same trade actionlint's
+# system hook takes.
+- id: nika-check
+  name: nika check
+  description: >-
+    Statically audit .nika.yaml workflows (DAG, types, permits, secret
+    flows, cost floor) before they land — audit-before-run at commit time.
+  entry: scripts/hooks/pre-commit-nika-check.sh
+  language: script
+  files: '\.nika\.yaml$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`.pre-commit-hooks.yaml` — `nika check` as a pre-commit hook.** The
+  standard manifest the [pre-commit](https://pre-commit.com) framework
+  reads from a hooked repo (actionlint · shellcheck-py · ruff all ship
+  one): every hooked repo audits its staged `*.nika.yaml` at commit
+  time. `language: script` with a fan-out wrapper because `nika check`
+  audits ONE file per call (its report is a per-file contract) while
+  pre-commit passes every staged match in one argv — each failing file
+  reports in the same run and the worst spec-§4 exit survives (proven
+  against the released binary: a broken file mid-list exits 2, the
+  files after it still audit). The `nika` binary is assumed on PATH,
+  the same trade actionlint's system hook takes. Unblocks the
+  pre-commit.com listing once tagged (#407).
 - **`nika wire gemini|lmstudio|junie` — wave-2 wire targets.** Three more
   hosts join the explicit, idempotent MCP wiring (#384, sibling of #330):
   Gemini CLI (`~/.gemini/settings.json` — the shared settings file, every

--- a/scripts/hooks/pre-commit-nika-check.sh
+++ b/scripts/hooks/pre-commit-nika-check.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Consumer: the pre-commit FRAMEWORK (pre-commit.com) — NOT this repo's
+# lefthook (its scripts live beside this one). `.pre-commit-hooks.yaml` at
+# the repo root points here.
+#
+# pre-commit passes every staged `*.nika.yaml` as argv in ONE invocation;
+# `nika check` audits ONE file per call (its report — human and --json —
+# is a per-file contract). The hook fans out and keeps going so EVERY
+# failing file reports in the same run, and the worst exit survives
+# (spec §4 ladder: 3 environment > 2 findings > 1).
+set -u
+
+worst=0
+for f in "$@"; do
+  nika check "$f"
+  rc=$?
+  if [ "$rc" -gt "$worst" ]; then
+    worst=$rc
+  fi
+done
+exit "$worst"


### PR DESCRIPTION
Closes #407.

The standard manifest the [pre-commit](https://pre-commit.com) framework reads from a hooked repo — every hooked repo audits its staged `*.nika.yaml` at commit time.

## The one design point (probe-pinned before writing)

`nika check` takes exactly **one** `<FILE>` (clap refuses a second — verified on the released 0.99.0) while pre-commit passes every staged match in one argv, and the framework has no per-file knob. So **`language: script` with a POSIX fan-out wrapper** instead of the issue's `language: system` sketch:

- each failing file reports in the same run (no stop-at-first),
- the worst spec-§4 exit survives (3 environment > 2 findings),
- proven live: three files with a broken one in the **middle** → rc=2 and the file after it still audited,
- shellcheck + house shfmt clean.

The variadic-`<FILE>` alternative (teaching `check` many files) was deliberately **not** taken: it changes the check CLI contract (`--json` is a per-file `report_version: 1` object) and the cli arg surface has active work in flight (#408). The wrapper delivers the hook today; variadic can supersede it engine-side later if ever wanted.

## Consumer shape (once tagged)

```yaml
repos:
  - repo: https://github.com/supernovae-st/nika
    rev: <next tag>
    hooks:
      - id: nika-check
```

The `nika` binary is assumed on PATH (brew/tarball/binstall/nix) — the same trade actionlint's hook takes. The pre-commit.com **listing** PR is gated on this file reaching a tag; it rides the next release, disclosed + ledgered like the other listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)