### PR TITLE
fix(types,providers,schema,cap): one did-you-mean metric, every closed namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4036,6 +4036,7 @@ dependencies = [
  "jsonschema",
  "nika-catalog",
  "nika-kernel",
+ "nika-types",
  "proptest",
  "serde_json",
  "tokio",

--- a/crates/nika-cap/src/shape.rs
+++ b/crates/nika-cap/src/shape.rs
@@ -353,11 +353,14 @@ fn check_fetch_shape(args: Option<&serde_json::Value>, out: &mut Vec<String>) {
                 match raw.parse::<ExtractMode>() {
                     Ok(parsed) => Some(parsed),
                     Err(unknown) => {
-                        // ONE hint table for both voices (the L0 error owns
-                        // it) — check and runtime teach the same route.
+                        // ONE suggestion ladder for both voices (the L0
+                        // error owns it) — check and runtime teach the
+                        // same route: typo-of-a-real-mode first (the
+                        // rename is the fix), wrong-concept hint second.
                         let hint = unknown
-                            .hint()
-                            .map(|h| format!(" · {h}"))
+                            .suggestion()
+                            .map(|m| format!(" · did you mean `{m}`?"))
+                            .or_else(|| unknown.hint().map(|h| format!(" · {h}")))
                             .unwrap_or_default();
                         out.push(format!(
                             "`mode: {raw}` is not a stdlib v0.1 extract mode — the set \

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -303,15 +303,15 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RenderMode
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RenderMode
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RenderMode
 pub type nika_cli::verbs::run::RenderMode::Output = T
-pub struct nika_cli::verbs::run::FoldSink<W: std::io::Write>
-impl<W: std::io::Write> nika_cli::verbs::run::FoldSink<W>
+pub struct nika_cli::verbs::run::FoldSink<W: core::io::write::Write>
+impl<W: core::io::write::Write> nika_cli::verbs::run::FoldSink<W>
 pub fn nika_cli::verbs::run::FoldSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_cli::verbs::run::FoldSink<W>::new(writer: W, theme: nika_display::theme::Theme, mode: nika_cli::verbs::run::RenderMode) -> Self
 pub fn nika_cli::verbs::run::FoldSink<W>::print_final(&mut self)
 pub fn nika_cli::verbs::run::FoldSink<W>::set_plan(&mut self, waves: alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>)
 pub fn nika_cli::verbs::run::FoldSink<W>::show_outputs(&mut self, on: bool)
 pub fn nika_cli::verbs::run::FoldSink<W>::view(&self) -> &nika_display::state::RunView
-impl<W: std::io::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::FoldSink<W>
+impl<W: core::io::write::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::FoldSink<W>
 pub fn nika_cli::verbs::run::FoldSink<W>::emit(&mut self, event: nika_event::event::Event)
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::FoldSink<W>
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::FoldSink<W> where U: core::convert::From<T>
@@ -339,11 +339,11 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::FoldSink<W>
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::FoldSink<W>
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::FoldSink<W>
 pub type nika_cli::verbs::run::FoldSink<W>::Output = T
-pub struct nika_cli::verbs::run::JsonSink<W: std::io::Write>
-impl<W: std::io::Write> nika_cli::verbs::run::JsonSink<W>
+pub struct nika_cli::verbs::run::JsonSink<W: core::io::write::Write>
+impl<W: core::io::write::Write> nika_cli::verbs::run::JsonSink<W>
 pub fn nika_cli::verbs::run::JsonSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_cli::verbs::run::JsonSink<W>::new(writer: W) -> Self
-impl<W: std::io::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::JsonSink<W>
+impl<W: core::io::write::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::JsonSink<W>
 pub fn nika_cli::verbs::run::JsonSink<W>::emit(&mut self, event: nika_event::event::Event)
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::JsonSink<W>
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::JsonSink<W> where U: core::convert::From<T>

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -13,6 +13,7 @@ publish                = false  # Internal L1.5 service crate.
 [dependencies]
 nika-kernel  = { path = "../nika-kernel", version = "0.99.0" }
 nika-catalog = { path = "../nika-catalog", version = "0.99.0", features = ["providers"] }
+nika-types   = { path = "../nika-types", version = "0.99.0" }   # the shared did-you-mean metric (MODELS rung)
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -186,12 +186,21 @@ pub fn resolve_refusal(model: &str) -> Option<String> {
              {} runnable providers)",
             CANONICAL_IDS.len()
         )),
-        Some((provider, _)) if !CANONICAL_IDS.contains(&provider) => Some(format!(
-            "provider `{provider}` does not resolve in THIS binary \
-             ({} runnable — `nika doctor` names them); a cataloged \
-             vendor is not a runnable one",
-            CANONICAL_IDS.len()
-        )),
+        Some((provider, _)) if !CANONICAL_IDS.contains(&provider) => {
+            // The shared did-you-mean metric (nika-types::suggest — the
+            // same threshold the parser/checker suggest with): `antropic`
+            // is ONE edit from the most-used provider id, and the rename
+            // is the whole fix. Silence past the threshold, as everywhere.
+            let guess = nika_types::suggest::did_you_mean(provider, CANONICAL_IDS)
+                .map(|p| format!(" — did you mean `{p}`?"))
+                .unwrap_or_default();
+            Some(format!(
+                "provider `{provider}` does not resolve in THIS binary \
+                 ({} runnable — `nika doctor` names them); a cataloged \
+                 vendor is not a runnable one{guess}",
+                CANONICAL_IDS.len()
+            ))
+        }
         Some(_) => None,
     }
 }
@@ -317,9 +326,22 @@ mod tests {
         // cataloged-but-unresolvable provider — the azure class
         let azure = resolve_refusal("azure/gpt-4o").expect("azure refused");
         assert!(azure.contains("`azure`") && azure.contains("not a runnable one"));
+        // azure is far from every canonical id — no guess appended
+        assert!(!azure.contains("did you mean"), "{azure}");
         // every canonical provider clears, inner slashes included
         assert!(resolve_refusal("mock/echo").is_none());
         assert!(resolve_refusal("huggingface/Qwen/Qwen3.5-9B:groq").is_none());
+    }
+
+    #[test]
+    fn provider_typo_gets_the_rename() {
+        // The sweep's mute surface (2026-07-11): `antropic` is ONE edit
+        // from the most-used provider id — the refusal now carries the
+        // rename, through the SAME shared metric as the parser/checker.
+        let typo = resolve_refusal("antropic/claude-sonnet-4-6").expect("typo refused");
+        assert!(typo.contains("did you mean `anthropic`?"), "{typo}");
+        let gemni = resolve_refusal("gemni/gemini-2.5-flash").expect("typo refused");
+        assert!(gemni.contains("did you mean `gemini`?"), "{gemni}");
     }
 
     use super::*;

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -431,8 +431,14 @@ fn parse_on_error(
         return Ok(None);
     };
     let Some(on_error_map) = node.as_mapping() else {
+        // A scalar here is usually the action name typed bare
+        // (`on_error: recover`) — teach the mapping SHAPE and the closed
+        // action vocabulary, not just the type mismatch.
         return Err(SchemaError::BadOnError {
-            reason: "`on_error` must be a mapping".to_owned(),
+            reason: "`on_error` must be a mapping carrying exactly one action — \
+                     `recover:` · `skip: true` · `fail_workflow: true` \
+                     (e.g. `on_error: { skip: true }`)"
+                .to_owned(),
             span: cx.span(node.span()),
         });
     };
@@ -1058,6 +1064,27 @@ tasks:
             wf.tasks[1].value.on_error.as_ref().expect("b").value.action,
             OnErrorAction::FailWorkflow
         ));
+    }
+
+    #[test]
+    fn on_error_scalar_teaches_the_mapping_shape() {
+        // The sweep's third mute surface (2026-07-11): `on_error: recover`
+        // typed bare said only « must be a mapping » — the reason now
+        // carries the closed action vocabulary AND a paste-able example.
+        let yaml = "\
+tasks:
+  - id: t
+    exec: { command: echo }
+    on_error: recover
+";
+        let err = parse_strict(yaml).expect_err("scalar on_error refused");
+        let msg = err.to_string();
+        assert!(msg.contains("exactly one action"), "{msg}");
+        assert!(
+            msg.contains("`recover:`") && msg.contains("`skip: true`"),
+            "{msg}"
+        );
+        assert!(msg.contains("on_error: { skip: true }"), "{msg}");
     }
 
     #[test]

--- a/crates/nika-schema/src/suggest.rs
+++ b/crates/nika-schema/src/suggest.rs
@@ -1,42 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! Deterministic « did you mean » — the suggestion core every check
-//! report shares (rustc's diagnostic model · no LLM, no heuristics that
-//! vary run-to-run).
+//! Deterministic « did you mean » — the checker's suggestion surface.
 //!
-//! Distance is **Damerau-Levenshtein** (optimal string alignment): one
-//! edit = insert · delete · substitute · transpose-adjacent. Transposition
-//! matters because the dominant real-world typo class in field/tool names
-//! is swapped letters (`sumary` → wait, that's a delete — `nmae` → `name`
-//! IS a transposition). The acceptance threshold is rustc's:
-//! `max(len/3, 1)` — short names tolerate 1 edit, long names scale, and
-//! anything farther is silence (a WRONG suggestion is worse than none).
+//! The METRIC (Damerau-Levenshtein OSA + the rustc `max(len/3, 1)`
+//! threshold) lives in [`nika_types::suggest`] — hoisted 2026-07-11 (the
+//! `ip_is_blocked` precedent) so the closed-namespace surfaces OUTSIDE
+//! this crate (the provider resolver's MODELS rung · the extract-mode
+//! typo rung) suggest with the SAME semantics as the parser/checker.
+//! This module re-exports it verbatim for the in-crate callers and keeps
+//! the render-side clause helper (schema-only vocabulary).
 
-/// The best near-match for `target` among `candidates`, when one is
-/// close enough to assert. Ties break to the lexicographically smallest
-/// candidate (full determinism — input order never changes the answer).
-pub(crate) fn did_you_mean<'a, I>(target: &str, candidates: I) -> Option<&'a str>
-where
-    I: IntoIterator<Item = &'a str>,
-{
-    let threshold = (target.chars().count() / 3).max(1);
-    let mut best: Option<(usize, &str)> = None;
-    for candidate in candidates {
-        if candidate == target {
-            continue; // an exact match is not a suggestion
-        }
-        let d = damerau_levenshtein(target, candidate);
-        if d > threshold {
-            continue;
-        }
-        best = match best {
-            Some((bd, bc)) if (d, candidate) >= (bd, bc) => Some((bd, bc)),
-            _ => Some((d, candidate)),
-        };
-    }
-    best.map(|(_, c)| c)
-}
+pub(crate) use nika_types::suggest::{damerau_levenshtein, did_you_mean};
 
 /// Render a suggestion clause (`" — did you mean ___?"`) or empty.
 /// A suggestion carrying spaces is a TEACHING sentence (e.g. the modeline
@@ -51,135 +26,33 @@ pub(crate) fn suggestion_clause(suggestion: Option<&str>) -> String {
     })
 }
 
-/// Damerau-Levenshtein distance (optimal string alignment variant) —
-/// the classic O(n·m) dynamic program over chars, with the adjacent-
-/// transposition case. Unicode-correct (per-char, not per-byte).
-pub(crate) fn damerau_levenshtein(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    if a.is_empty() {
-        return b.len();
-    }
-    if b.is_empty() {
-        return a.len();
-    }
-
-    // three rolling rows: i-2, i-1, i
-    let mut prev2: Vec<usize> = vec![0; b.len() + 1];
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut curr: Vec<usize> = vec![0; b.len() + 1];
-
-    for i in 1..=a.len() {
-        curr[0] = i;
-        for j in 1..=b.len() {
-            let cost = usize::from(a[i - 1] != b[j - 1]);
-            let mut d = (prev[j] + 1) // deletion
-                .min(curr[j - 1] + 1) // insertion
-                .min(prev[j - 1] + cost); // substitution
-            // adjacent transposition (ab ↔ ba)
-            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
-                d = d.min(prev2[j - 2] + 1);
-            }
-            curr[j] = d;
-        }
-        std::mem::swap(&mut prev2, &mut prev);
-        std::mem::swap(&mut prev, &mut curr);
-    }
-    prev[b.len()]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::*;
-
-    proptest! {
-        // Metric-space axioms — a distance that violates these would make
-        // did_you_mean rank suggestions nonsensically. Inputs bounded so
-        // the O(n·m) DP stays fast.
-        #[test]
-        fn distance_is_a_pseudometric(
-            a in "\\PC{0,40}",
-            b in "\\PC{0,40}",
-            c in "\\PC{0,40}",
-        ) {
-            // identity
-            prop_assert_eq!(damerau_levenshtein(&a, &a), 0);
-            // symmetry
-            prop_assert_eq!(damerau_levenshtein(&a, &b), damerau_levenshtein(&b, &a));
-            // triangle inequality
-            prop_assert!(
-                damerau_levenshtein(&a, &c)
-                    <= damerau_levenshtein(&a, &b) + damerau_levenshtein(&b, &c)
-            );
-            // bounded by the longer length (per-char edits)
-            let max_len = a.chars().count().max(b.chars().count());
-            prop_assert!(damerau_levenshtein(&a, &b) <= max_len);
-        }
-
-        // did_you_mean NEVER invents a candidate and NEVER returns the
-        // exact target — the two invariants the agent loop relies on.
-        #[test]
-        fn did_you_mean_only_ever_returns_a_real_non_exact_candidate(
-            target in "[a-z_]{1,16}",
-            candidates in prop::collection::vec("[a-z_]{1,16}", 0..8),
-        ) {
-            let refs: Vec<&str> = candidates.iter().map(String::as_str).collect();
-            if let Some(hit) = did_you_mean(&target, refs.iter().copied()) {
-                prop_assert!(candidates.iter().any(|c| c == hit), "invented `{hit}`");
-                prop_assert_ne!(hit, target.as_str(), "exact match is not a suggestion");
-            }
-        }
-    }
 
     #[test]
-    fn distance_basics() {
-        assert_eq!(damerau_levenshtein("summary", "summary"), 0);
-        assert_eq!(damerau_levenshtein("sumary", "summary"), 1); // delete
-        assert_eq!(damerau_levenshtein("nmae", "name"), 1); // transpose
-        assert_eq!(damerau_levenshtein("titel", "title"), 1); // transpose
-        assert_eq!(damerau_levenshtein("", "abc"), 3);
-        assert_eq!(damerau_levenshtein("kitten", "sitting"), 3);
-    }
-
-    #[test]
-    fn unicode_is_per_char_not_per_byte() {
-        // é is 2 bytes — a byte-based DP would count 2 edits.
-        assert_eq!(damerau_levenshtein("café", "cafe"), 1);
-    }
-
-    #[test]
-    fn osa_variant_is_pinned() {
-        // THE distinguisher: full Damerau-Levenshtein gives 2 for
-        // "ca"→"abc" (transpose then insert INTO the transposed pair);
-        // optimal string alignment gives 3 (no edit-within-transposition).
-        // The doc contracts OSA — pin it so a refactor can't silently
-        // change which variant ships.
-        assert_eq!(damerau_levenshtein("ca", "abc"), 3);
-        assert_eq!(damerau_levenshtein("abc", "ca"), 3);
-    }
-
-    #[test]
-    fn did_you_mean_respects_the_threshold() {
+    fn reexport_keeps_the_checker_semantics() {
+        // The consumer pin: the hoist must not change what THIS crate's
+        // callers observe (threshold · tie-break · exact-match silence ·
+        // the OSA variant).
         let keys = ["summary", "highlights", "impact"];
         assert_eq!(did_you_mean("sumary", keys), Some("summary"));
-        assert_eq!(did_you_mean("highlihgts", keys), Some("highlights"));
-        // far from everything → silence, never a wrong guess
         assert_eq!(did_you_mean("zzzzzz", keys), None);
-        // short target: threshold 1 — `impct` is 1 away, suggested
-        assert_eq!(did_you_mean("impct", keys), Some("impact"));
-    }
-
-    #[test]
-    fn ties_break_lexicographically_deterministic() {
-        // both 1 edit away from `bd` — `ad` < `cd` wins, whatever the
-        // candidate iteration order.
-        assert_eq!(did_you_mean("bd", ["cd", "ad"]), Some("ad"));
-        assert_eq!(did_you_mean("bd", ["ad", "cd"]), Some("ad"));
-    }
-
-    #[test]
-    fn exact_match_is_not_a_suggestion() {
         assert_eq!(did_you_mean("summary", ["summary"]), None);
+        assert_eq!(did_you_mean("bd", ["cd", "ad"]), Some("ad"));
+        assert_eq!(damerau_levenshtein("ca", "abc"), 3);
+    }
+
+    #[test]
+    fn clause_renders_key_vs_prose() {
+        assert_eq!(
+            suggestion_clause(Some("summary")),
+            " — did you mean `summary`?"
+        );
+        assert_eq!(
+            suggestion_clause(Some("compute it in a jq task")),
+            " — compute it in a jq task"
+        );
+        assert_eq!(suggestion_clause(None), "");
     }
 }

--- a/crates/nika-types/public-api.txt
+++ b/crates/nika-types/public-api.txt
@@ -688,6 +688,7 @@ impl<T> serde_core::de::DeserializeOwned for nika_types::extract::ExtractMode wh
 pub nika_types::extract::UnknownExtractMode::input: alloc::string::String
 impl nika_types::extract::UnknownExtractMode
 pub fn nika_types::extract::UnknownExtractMode::hint(&self) -> core::option::Option<&'static str>
+pub fn nika_types::extract::UnknownExtractMode::suggestion(&self) -> core::option::Option<&'static str>
 impl core::clone::Clone for nika_types::extract::UnknownExtractMode
 pub fn nika_types::extract::UnknownExtractMode::clone(&self) -> nika_types::extract::UnknownExtractMode
 impl core::cmp::Eq for nika_types::extract::UnknownExtractMode
@@ -4028,6 +4029,9 @@ pub unsafe fn nika_types::schema::TraceFormatVersion::clone_to_uninit(&self, des
 impl<T> core::convert::From<T> for nika_types::schema::TraceFormatVersion
 pub fn nika_types::schema::TraceFormatVersion::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_types::schema::TraceFormatVersion where T: for<'de> serde_core::de::Deserialize<'de>
+pub mod nika_types::suggest
+pub fn nika_types::suggest::damerau_levenshtein(a: &str, b: &str) -> usize
+pub fn nika_types::suggest::did_you_mean<'a, I>(target: &str, candidates: I) -> core::option::Option<&'a str> where I: core::iter::traits::collect::IntoIterator<Item = &'a str>
 pub mod nika_types::timestamp
 #[non_exhaustive] pub struct nika_types::timestamp::Timestamp
 pub nika_types::timestamp::Timestamp::unix_ns: i64

--- a/crates/nika-types/src/extract.rs
+++ b/crates/nika-types/src/extract.rs
@@ -106,6 +106,17 @@ pub struct UnknownExtractMode {
 }
 
 impl UnknownExtractMode {
+    /// The canonical mode this input is a TYPO of, when one is close
+    /// enough to assert (`markdwon` → `markdown`) — the shared
+    /// [`crate::suggest::did_you_mean`] metric over [`ExtractMode::ALL`],
+    /// so this surface suggests with the same threshold semantics as the
+    /// parser/checker. Distinct from [`Self::hint`]: a typo names the
+    /// right mode wrong; a hint answers the WRONG-CONCEPT miss (`json`).
+    #[must_use]
+    pub fn suggestion(&self) -> Option<&'static str> {
+        crate::suggest::did_you_mean(&self.input, ExtractMode::ALL.map(ExtractMode::as_str))
+    }
+
     /// A route hint for the empirically-common wrong guesses — the
     /// new-user battery (2026-07-10) hit `json` twice: the set is closed
     /// by the one-data-language law (jq replaced `JSONPath`), so the error
@@ -140,7 +151,11 @@ impl fmt::Display for UnknownExtractMode {
              (extract-modes-v0.1.md)",
             self.input
         )?;
-        if let Some(hint) = self.hint() {
+        // A typo of a real mode outranks the wrong-concept table — the
+        // rename IS the fix; the hint would answer a question not asked.
+        if let Some(mode) = self.suggestion() {
+            write!(f, " · did you mean `{mode}`?")?;
+        } else if let Some(hint) = self.hint() {
             write!(f, " · {hint}")?;
         }
         Ok(())
@@ -252,5 +267,29 @@ mod hint_tests {
         assert!(plain.contains("the stdlib v0.1 set is closed"));
         assert!(!plain.contains(" · for"), "{plain}");
         assert!(e("banana").hint().is_none());
+    }
+
+    /// The typo rung (sweep 2026-07-11 · `markdwon` answered mutely):
+    /// a near-miss of a real mode gets the rename, and it OUTRANKS the
+    /// wrong-concept hint (the rename is the fix — a route hint would
+    /// answer a question not asked). The two rungs never collide:
+    /// every hint-table input (`json` · `html` · `rss`…) is past the
+    /// metric threshold from every canonical mode name.
+    #[test]
+    fn typo_of_a_real_mode_gets_the_rename() {
+        let e = |s: &str| UnknownExtractMode {
+            input: s.to_owned(),
+        };
+        assert_eq!(e("markdwon").suggestion(), Some("markdown"));
+        let msg = e("markdwon").to_string();
+        assert!(msg.contains("did you mean `markdown`?"), "{msg}");
+        assert_eq!(e("selectr").suggestion(), Some("selector"));
+        // the hint-table inputs stay on their semantic rung
+        for concept in ["json", "html", "rss", "atom", "xml"] {
+            assert_eq!(e(concept).suggestion(), None, "{concept} is not a typo");
+            assert!(e(concept).hint().is_some(), "{concept} keeps its route");
+        }
+        // far from everything → base message only
+        assert_eq!(e("banana").suggestion(), None);
     }
 }

--- a/crates/nika-types/src/lib.rs
+++ b/crates/nika-types/src/lib.rs
@@ -51,6 +51,7 @@ pub mod extract;
 pub mod memory;
 pub mod net;
 pub mod role;
+pub mod suggest;
 pub mod timestamp;
 pub mod token_usage;
 

--- a/crates/nika-types/src/suggest.rs
+++ b/crates/nika-types/src/suggest.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Deterministic « did you mean » — the ONE suggestion metric every
+//! closed-namespace surface shares (rustc's diagnostic model · no LLM,
+//! no heuristics that vary run-to-run).
+//!
+//! Hoisted from `nika_schema::suggest` (the `ip_is_blocked` precedent:
+//! one predicate in the L0 leaf, every boundary consumes it) so the
+//! surfaces OUTSIDE the schema checker — the provider resolver's
+//! MODELS rung (`nika-providers`), the extract-mode teaching
+//! (`ExtractMode`), and any future closed set — suggest with the SAME
+//! threshold semantics as the parser/checker. Two metrics would drift;
+//! a drifted threshold is a surface that guesses where its sibling
+//! stays silent.
+//!
+//! Distance is **Damerau-Levenshtein** (optimal string alignment): one
+//! edit = insert · delete · substitute · transpose-adjacent.
+//! Transposition matters because the dominant real-world typo class in
+//! field/tool names is swapped letters (`nmae` → `name`). The
+//! acceptance threshold is rustc's: `max(len/3, 1)` — short names
+//! tolerate 1 edit, long names scale, and anything farther is silence
+//! (a WRONG suggestion is worse than none). Pure · `no_std` + alloc.
+
+use alloc::vec::Vec;
+
+/// The best near-match for `target` among `candidates`, when one is
+/// close enough to assert. Ties break to the lexicographically smallest
+/// candidate (full determinism — input order never changes the answer).
+#[must_use]
+pub fn did_you_mean<'a, I>(target: &str, candidates: I) -> Option<&'a str>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let threshold = (target.chars().count() / 3).max(1);
+    let mut best: Option<(usize, &str)> = None;
+    for candidate in candidates {
+        if candidate == target {
+            continue; // an exact match is not a suggestion
+        }
+        let d = damerau_levenshtein(target, candidate);
+        if d > threshold {
+            continue;
+        }
+        best = match best {
+            Some((bd, bc)) if (d, candidate) >= (bd, bc) => Some((bd, bc)),
+            _ => Some((d, candidate)),
+        };
+    }
+    best.map(|(_, c)| c)
+}
+
+/// Damerau-Levenshtein distance (optimal string alignment variant) —
+/// the classic O(n·m) dynamic program over chars, with the adjacent-
+/// transposition case. Unicode-correct (per-char, not per-byte).
+#[must_use]
+pub fn damerau_levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+
+    // three rolling rows: i-2, i-1, i
+    let mut prev2: Vec<usize> = alloc::vec![0; b.len() + 1];
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = alloc::vec![0; b.len() + 1];
+
+    for i in 1..=a.len() {
+        curr[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            let mut d = (prev[j] + 1) // deletion
+                .min(curr[j - 1] + 1) // insertion
+                .min(prev[j - 1] + cost); // substitution
+            // adjacent transposition (ab ↔ ba)
+            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                d = d.min(prev2[j - 2] + 1);
+            }
+            curr[j] = d;
+        }
+        core::mem::swap(&mut prev2, &mut prev);
+        core::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        // Metric-space axioms — a distance that violates these would make
+        // did_you_mean rank suggestions nonsensically. Inputs bounded so
+        // the O(n·m) DP stays fast.
+        #[test]
+        fn distance_is_a_pseudometric(
+            a in "\\PC{0,40}",
+            b in "\\PC{0,40}",
+            c in "\\PC{0,40}",
+        ) {
+            // identity
+            prop_assert_eq!(damerau_levenshtein(&a, &a), 0);
+            // symmetry
+            prop_assert_eq!(damerau_levenshtein(&a, &b), damerau_levenshtein(&b, &a));
+            // triangle inequality
+            prop_assert!(
+                damerau_levenshtein(&a, &c)
+                    <= damerau_levenshtein(&a, &b) + damerau_levenshtein(&b, &c)
+            );
+            // bounded by the longer length (per-char edits)
+            let max_len = a.chars().count().max(b.chars().count());
+            prop_assert!(damerau_levenshtein(&a, &b) <= max_len);
+        }
+
+        // did_you_mean NEVER invents a candidate and NEVER returns the
+        // exact target — the two invariants the agent loop relies on.
+        #[test]
+        fn did_you_mean_only_ever_returns_a_real_non_exact_candidate(
+            target in "[a-z_]{1,16}",
+            candidates in prop::collection::vec("[a-z_]{1,16}", 0..8),
+        ) {
+            let refs: Vec<&str> = candidates.iter().map(alloc::string::String::as_str).collect();
+            if let Some(hit) = did_you_mean(&target, refs.iter().copied()) {
+                prop_assert!(candidates.iter().any(|c| c == hit), "invented `{hit}`");
+                prop_assert_ne!(hit, target.as_str(), "exact match is not a suggestion");
+            }
+        }
+    }
+
+    #[test]
+    fn distance_basics() {
+        assert_eq!(damerau_levenshtein("summary", "summary"), 0);
+        assert_eq!(damerau_levenshtein("sumary", "summary"), 1); // delete
+        assert_eq!(damerau_levenshtein("nmae", "name"), 1); // transpose
+        assert_eq!(damerau_levenshtein("titel", "title"), 1); // transpose
+        assert_eq!(damerau_levenshtein("", "abc"), 3);
+        assert_eq!(damerau_levenshtein("kitten", "sitting"), 3);
+    }
+
+    #[test]
+    fn unicode_is_per_char_not_per_byte() {
+        // é is 2 bytes — a byte-based DP would count 2 edits.
+        assert_eq!(damerau_levenshtein("café", "cafe"), 1);
+    }
+
+    #[test]
+    fn osa_variant_is_pinned() {
+        // THE distinguisher: full Damerau-Levenshtein gives 2 for
+        // "ca"→"abc" (transpose then insert INTO the transposed pair);
+        // optimal string alignment gives 3 (no edit-within-transposition).
+        // The doc contracts OSA — pin it so a refactor can't silently
+        // change which variant ships.
+        assert_eq!(damerau_levenshtein("ca", "abc"), 3);
+        assert_eq!(damerau_levenshtein("abc", "ca"), 3);
+    }
+
+    #[test]
+    fn did_you_mean_respects_the_threshold() {
+        let keys = ["summary", "highlights", "impact"];
+        assert_eq!(did_you_mean("sumary", keys), Some("summary"));
+        assert_eq!(did_you_mean("highlihgts", keys), Some("highlights"));
+        // far from everything → silence, never a wrong guess
+        assert_eq!(did_you_mean("zzzzzz", keys), None);
+        // short target: threshold 1 — `impct` is 1 away, suggested
+        assert_eq!(did_you_mean("impct", keys), Some("impact"));
+    }
+
+    #[test]
+    fn ties_break_lexicographically_deterministic() {
+        // both 1 edit away from `bd` — `ad` < `cd` wins, whatever the
+        // candidate iteration order.
+        assert_eq!(did_you_mean("bd", ["cd", "ad"]), Some("ad"));
+        assert_eq!(did_you_mean("bd", ["ad", "cd"]), Some("ad"));
+    }
+
+    #[test]
+    fn exact_match_is_not_a_suggestion() {
+        assert_eq!(did_you_mean("summary", ["summary"]), None);
+    }
+
+    #[test]
+    fn the_two_new_consumer_namespaces_suggest() {
+        // The sweep's two mute surfaces, now teaching through the SAME
+        // metric: the provider rung and the extract-mode typo rung.
+        assert_eq!(
+            did_you_mean("antropic", ["anthropic", "openai", "gemini"]),
+            Some("anthropic")
+        );
+        assert_eq!(
+            did_you_mean("markdwon", ["markdown", "article", "text"]),
+            Some("markdown")
+        );
+    }
+}

--- a/typos.toml
+++ b/typos.toml
@@ -40,6 +40,7 @@ titel      = "titel"
 requierd   = "requierd"
 filesytem  = "filesytem"
 BUIL       = "BUIL"
+markdwon   = "markdwon"  # extract-mode typo rung fixture (nika-types suggest/extract tests)
 # French (the studio writes franglais — these are real French words, not typos)
 raison     = "raison"
 raisons    = "raisons"


### PR DESCRIPTION
The Socratic sweep after #408: **is did-you-mean uniform across every closed naming surface a new user typos?** Ten e2e probes against the built binary — seven already teach (verb fields · retry fields · `depends_on` · `tasks./vars.` refs · envelope keys incl. the dangerous `permit`→`permits` · fetch-mode wrong-concept). **Three answered mutely**, now fixed:

| Probe | Before | After |
|---|---|---|
| `model: antropic/…` | named the refusal, no rename | `… not a runnable one — did you mean \`anthropic\`?` |
| `mode: markdwon` | closed set listed, no rename (#397 covered wrong-CONCEPT, not typos) | `… (extract-modes-v0.1.md) · did you mean \`markdown\`?` |
| `on_error: recover` (bare scalar) | « must be a mapping » | `… carrying exactly one action — \`recover:\` · \`skip: true\` · \`fail_workflow: true\` (e.g. …)` |

**The structural fix first**: the metric (Damerau-Levenshtein OSA + rustc `max(len/3,1)` threshold) hoists `nika_schema::suggest` → `nika_types::suggest` (pub · no_std+alloc · the `ip_is_blocked` precedent from #403). Schema re-exports verbatim with a consumer pin freezing threshold/tie-break/OSA semantics. Both mute surfaces consume the SAME metric — two thresholds would drift, and a drifted threshold is one surface guessing where its sibling stays silent.

- `resolve_refusal` (nika-providers) — shared by CLI MODELS rung + MCP `nika_check` **by construction** (one law, one fn)
- `UnknownExtractMode::suggestion()` (additive · mode names are `'static`): typo rung **outranks** the wrong-concept hint (the rename IS the fix) · both voices (runtime Display + nika-cap check) ride one ladder · rungs proven collision-free (every hint-table input is past-threshold from every mode name)

Gates: types 242 (metric axioms moved in · typo-rung + collision pins) · providers 148 · schema 731 · cap 21 · clippy `-D warnings` 0 · public-api types +4 strictly additive, providers unchanged. API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)