### PR TITLE
fix(nika-cli): the scoped run honours the whole-file audit (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`nika run --task` honours the whole-file audit it promises.** The
+  help says « the full workflow still audits (findings stay whole-file
+  faithful) » — empirically the scoped re-check REPLACED the full report
+  before the clean gate looked, so a PERMITS violation or a conformance
+  error in a branch outside the target's ancestor cone neither printed
+  nor blocked: the scoped run exited 0 over a file `nika check` refuses.
+  The whole-file gate now fires BEFORE scoping (same findings rendering,
+  same exit 2 as the unscoped run — a file must be sound even to
+  regenerate one block), and the scoped re-check still gates after the
+  cut (#411).
 - **Teaching diagnostics from the 147-workflow new-user gauntlet** —
   arithmetic in a `${{ }}` guard teaches the route instead of the raw
   tokenizer error: `+ - * / %` → « `${{ }}` is a boolean guard, not a

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -303,15 +303,15 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::RenderMode
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::RenderMode
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::RenderMode
 pub type nika_cli::verbs::run::RenderMode::Output = T
-pub struct nika_cli::verbs::run::FoldSink<W: std::io::Write>
-impl<W: std::io::Write> nika_cli::verbs::run::FoldSink<W>
+pub struct nika_cli::verbs::run::FoldSink<W: core::io::write::Write>
+impl<W: core::io::write::Write> nika_cli::verbs::run::FoldSink<W>
 pub fn nika_cli::verbs::run::FoldSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_cli::verbs::run::FoldSink<W>::new(writer: W, theme: nika_display::theme::Theme, mode: nika_cli::verbs::run::RenderMode) -> Self
 pub fn nika_cli::verbs::run::FoldSink<W>::print_final(&mut self)
 pub fn nika_cli::verbs::run::FoldSink<W>::set_plan(&mut self, waves: alloc::vec::Vec<alloc::vec::Vec<alloc::string::String>>)
 pub fn nika_cli::verbs::run::FoldSink<W>::show_outputs(&mut self, on: bool)
 pub fn nika_cli::verbs::run::FoldSink<W>::view(&self) -> &nika_display::state::RunView
-impl<W: std::io::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::FoldSink<W>
+impl<W: core::io::write::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::FoldSink<W>
 pub fn nika_cli::verbs::run::FoldSink<W>::emit(&mut self, event: nika_event::event::Event)
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::FoldSink<W>
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::FoldSink<W> where U: core::convert::From<T>
@@ -339,11 +339,11 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::FoldSink<W>
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::FoldSink<W>
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::FoldSink<W>
 pub type nika_cli::verbs::run::FoldSink<W>::Output = T
-pub struct nika_cli::verbs::run::JsonSink<W: std::io::Write>
-impl<W: std::io::Write> nika_cli::verbs::run::JsonSink<W>
+pub struct nika_cli::verbs::run::JsonSink<W: core::io::write::Write>
+impl<W: core::io::write::Write> nika_cli::verbs::run::JsonSink<W>
 pub fn nika_cli::verbs::run::JsonSink<W>::into_error(self) -> core::option::Option<core::io::error::Error>
 pub fn nika_cli::verbs::run::JsonSink<W>::new(writer: W) -> Self
-impl<W: std::io::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::JsonSink<W>
+impl<W: core::io::write::Write> nika_runtime::stamp::EventSink for nika_cli::verbs::run::JsonSink<W>
 pub fn nika_cli::verbs::run::JsonSink<W>::emit(&mut self, event: nika_event::event::Event)
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::JsonSink<W>
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::JsonSink<W> where U: core::convert::From<T>

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -683,10 +683,17 @@ fn validated_var_overrides(
 }
 
 /// The `--task` scope + the clean gate, fused (both run before any
-/// effect): scope to the target's ancestor cone when requested (the
-/// sub-DAG re-checks so plan/waves/cost describe exactly what runs) ·
-/// then refuse a dirty report with the SAME findings `nika check`
-/// renders (locked rendering · exit 2 · stderr in machine mode).
+/// effect): the WHOLE-FILE report gates first — the `--task` help's
+/// promise (« findings stay whole-file faithful »): a file must be sound
+/// even to regenerate one block, so an out-of-cone finding refuses the
+/// scoped run exactly like the unscoped one (#411 — the scoped re-check
+/// used to REPLACE the full report before the gate looked, and findings
+/// outside the ancestor cone vanished). Only then scope to the target's
+/// ancestor cone (the sub-DAG re-checks so plan/waves/cost describe
+/// exactly what runs), and gate the scoped report too (a cut that
+/// orphans a reference must refuse, not run). Dirty either way renders
+/// the SAME findings `nika check` does (locked rendering · exit 2 ·
+/// stderr in machine mode).
 #[allow(clippy::too_many_arguments)]
 fn scoped_clean_gate(
     wf: RawWorkflow,
@@ -697,6 +704,11 @@ fn scoped_clean_gate(
     theme: Theme,
     output_json: bool,
 ) -> Result<(RawWorkflow, CheckReport), u8> {
+    if !report.is_clean() {
+        let out = crate::verbs::check::run(file, json, false, None, theme);
+        epilogue::emit_diagnostic(&out.text, output_json);
+        return Err(out.code);
+    }
     let (wf, report) = apply_task_scope(wf, report, task_filter, output_json)?;
     if !report.is_clean() {
         let out = crate::verbs::check::run(file, json, false, None, theme);
@@ -707,8 +719,9 @@ fn scoped_clean_gate(
 }
 
 /// Apply the `--task` scope when requested (the regenerate-one-block
-/// move). The FULL workflow audited already (whole-file spans · faithful
-/// findings) — the sub-DAG RE-CHECKS here so the plan/waves/cost describe
+/// move). The FULL workflow gated clean already (whole-file spans ·
+/// faithful findings — `scoped_clean_gate` refuses BEFORE this cut) —
+/// the sub-DAG RE-CHECKS here so the plan/waves/cost describe
 /// exactly what will run. Scoping happens before any effect; an unknown
 /// id refuses on the diagnostic surface with the environment exit class.
 fn apply_task_scope(

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -158,6 +158,92 @@ fn run_invalid_dag_exits_two_not_one() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// #411 · the `--task` help's promise made executable: « the full
+/// workflow still audits (findings stay whole-file faithful) ». A
+/// PERMITS violation in a branch OUTSIDE the target's ancestor cone
+/// refuses the scoped run (exit 2, the finding printed) exactly like
+/// the unscoped one — and a clean file still scopes and runs at 0.
+#[test]
+fn run_task_scope_still_audits_the_whole_file() {
+    let dir = workspace_tmp_dir("nika-bin-run-task-411");
+    let poisoned = r#"
+nika: v1
+workflow: i411
+permits:
+  exec: ["echo"]
+tasks:
+  - id: fetch_data
+    exec: { command: ["echo", "data"] }
+  - id: render_page
+    depends_on: [fetch_data]
+    exec: { command: ["echo", "page"] }
+  - id: compress
+    exec: { command: ["tar", "--version"] }
+"#;
+    let wf = write_fixture(&dir, "poisoned.nika.yaml", poisoned);
+
+    let out = bin()
+        .arg("run")
+        .arg(&wf)
+        .arg("--task")
+        .arg("render_page")
+        .arg("--no-progress")
+        .output()
+        .expect("binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "the out-of-cone PERMITS finding refuses the scoped run · stdout: {} · stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let all = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        all.contains("tar"),
+        "the finding names the out-of-cone program: {all}"
+    );
+
+    let clean = r#"
+nika: v1
+workflow: i411-clean
+permits:
+  exec: ["echo"]
+tasks:
+  - id: fetch_data
+    exec: { command: ["echo", "data"] }
+  - id: render_page
+    depends_on: [fetch_data]
+    exec: { command: ["echo", "page"] }
+  - id: compress
+    exec: { command: ["echo", "z"] }
+"#;
+    let ok = write_fixture(&dir, "clean.nika.yaml", clean);
+    let out = bin()
+        .arg("run")
+        .arg(&ok)
+        .arg("--task")
+        .arg("render_page")
+        .arg("--no-progress")
+        .output()
+        .expect("binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a clean file still scopes and runs · stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(
+        !stdout.contains("compress"),
+        "the scope held — the independent branch never ran: {stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn run_dry_run_executes_zero_effects() {
     // spec §10 `--dry-run` · "plan only · zero effects". The proof: FAILING


### PR DESCRIPTION
Closes #411.

The `--task` help promises « the full workflow still audits (findings stay whole-file faithful) » — empirically false on 0.99.0: in `scoped_clean_gate` the sub-DAG re-check **replaced** the full-file report before the clean gate looked at it, so any finding outside the target's ancestor cone (a PERMITS violation, a conformance error) vanished and the scoped run exited 0 over a file `nika check` refuses. The doc comment on `apply_task_scope` even claimed « The FULL workflow audited already » — describing a gate that never fired.

## The fix (the issue's option 1)

An ordering move: the **whole-file gate fires first** (same findings rendering, same exit 2 as the unscoped run — a file must be sound even to regenerate one block, which is audit-before-run made literal), then the scope cuts, then the scoped report gates too (a cut that orphans a reference must refuse, not run). Unscoped behavior unchanged — the gate order was already full-report for `task_filter=None`.

## Proof

Repro pinned **pre-fix** on the built main binary: poisoned independent branch (`tar` outside `permits.exec`) → `check` exit 2 with the finding · `run --task render_page` exit 0, zero mention. Post-fix the same scenario exits 2 and names `tar`; the clean twin still scopes and runs at 0 with the independent branch never executed — both encoded as a bin_smoke test through the real binary.

nika-cli lib 280 · bin_smoke 34 · clippy -D warnings clean. Trust battery FAILS=0 against the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)