### PR TITLE
docs(readme): the toolchain installs join get-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,19 @@ Prefer a guided page? Every install path, step by step: [nika.sh/install](https:
 > [latest release](https://github.com/supernovae-st/nika/releases/latest), verify
 > with `sha256sum -c SHA256SUMS --ignore-missing`, then move `nika` onto your `PATH`.
 
+Already carrying a toolchain?
+
+```sh
+# cargo — fetches the PREBUILT release tarball (no compile); the binary lands
+# as `nika-cli` until the crates.io publish — symlink the public name once:
+#   ln -sf ~/.cargo/bin/nika-cli ~/.cargo/bin/nika
+cargo binstall --git https://github.com/supernovae-st/nika nika-cli
+
+# nix — builds the exact release source via the flake (first run compiles,
+# the store caches it); `nix profile install` for a durable install
+nix run github:supernovae-st/nika
+```
+
 Your first workflow runs with **zero setup**: no model, no API key:
 
 ```sh


### PR DESCRIPTION
The README is the source of truth the site's /install page mirrors — brew, the script and the air-gapped tarball were taught; the two zero-gatekeeper paths that merged this cycle (#400 binstall metadata · #401 flake) were not.

One compact block after the air-gapped note, **honesty per path**:

- **cargo binstall** fetches the *prebuilt* release tarball (no compile) — the binary lands as `nika-cli` until the crates.io publish, the symlink one-liner is stated, not hidden.
- **nix** *builds* the exact release source via the flake (first run compiles, the store caches it) — `nix profile install` for durable installs.

Both proven live before writing (binstall dry-run on the v0.99.0 assets · the flake's own CI job on #401). The site (/install, deployed) and docs.nika.sh (#72 merged · #74 in flight) mirror the same pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)