### PR TITLE
docs: agent-facing metadata — llms-install · CITATION.cff · ADOPTERS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,19 @@
+# Adopters
+
+Projects and teams running nika workflows in the wild. Add yourself
+with a one-line PR: name, public link, one sentence on what nika runs
+for you. The only bar is real usage with a public link.
+
+| Who | What nika runs |
+|---|---|
+| [SuperNovae Studio](https://github.com/supernovae-st) | The studio's own launch ops run on nika daily — a community release radar, a full-funnel traffic ledger, and a dependency release radar — plus [nika-site-audit](https://github.com/supernovae-st/nika-site-audit), the site-audit workflow that ships with receipts. |
+
+## Badge
+
+Runs with nika? Say it:
+
+[![runs with nika](https://img.shields.io/badge/runs%20with-nika-0ea5e9)](https://github.com/supernovae-st/nika)
+
+```markdown
+[![runs with nika](https://img.shields.io/badge/runs%20with-nika-0ea5e9)](https://github.com/supernovae-st/nika)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **Agent-facing repo metadata: `llms-install.md` · `CITATION.cff` ·
+  `ADOPTERS.md`.** `llms-install.md` is the install runbook written FOR
+  an AI agent (the file Cline-class installers read): package-manager
+  paths only in the agent lane — brew · `cargo binstall --git` · nix —
+  each checksum-verified by its own flow, the shell script stays the
+  human lane (the same line the skill-guard hardening drew). Verify ·
+  prove offline (`nika examples run 01-hello --model mock/echo`) · wire
+  MCP · uninstall clean. `CITATION.cff` makes GitHub's « Cite this
+  repository » box work and is the metadata Zenodo reads at archive
+  time — version/date deliberately not hand-written (releases stamp
+  them); CITATIONS.md keeps crediting the research Nika builds on — the
+  two files answer different questions. `ADOPTERS.md` seeds the public
+  adopters table (one-line-PR invitation · « runs with nika » badge).
+
 - **`nika check` audits several files in one call.** `nika check a.nika.yaml
   b.nika.yaml …` runs the full per-file ladder on each (every report keeps
   its own header), no stop-at-first — a broken file mid-list exits with the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+# GitHub reads this file for « Cite this repository »; Zenodo reads it at
+# archive time. The research Nika itself builds on is credited in CITATIONS.md.
+# Version/date are stamped by releases (see CHANGELOG.md), not hand-written here.
+cff-version: 1.2.0
+message: "If you use Nika in your work, please cite this repository."
+type: software
+title: "Nika"
+abstract: "Intent-as-code workflow engine for AI: reviewable YAML DAGs, statically checked (schema, permits, cost floor) before execution, tamper-evident traces after. Single Rust binary."
+authors:
+  - name: "SuperNovae Studio"
+    city: "Paris"
+    country: "FR"
+    website: "https://nika.sh"
+repository-code: "https://github.com/supernovae-st/nika"
+url: "https://nika.sh"
+license: AGPL-3.0-or-later
+keywords:
+  - workflow-engine
+  - ai-agents
+  - llm-orchestration
+  - static-analysis
+  - mcp
+  - rust

--- a/llms-install.md
+++ b/llms-install.md
@@ -1,0 +1,81 @@
+# Installing Nika — a runbook for AI agents
+
+You are an agent installing the `nika` binary for a human. Take the
+first path that matches the machine, verify, stop. Every command below
+is non-interactive and idempotent. Prefer the package-manager paths —
+they verify checksums for you; the shell install script is the human
+lane (guided page: <https://nika.sh/install>), not the agent lane.
+
+## 1 · Install
+
+**macOS / Linux with Homebrew (preferred):**
+
+```sh
+brew install supernovae-st/tap/nika
+```
+
+**Any machine with a Rust toolchain (prebuilt download, no compile):**
+
+```sh
+cargo binstall --git https://github.com/supernovae-st/nika nika-cli
+```
+
+(`cargo install cargo-binstall` first if missing. The crate is named
+`nika-cli`; the installed binary is `nika`.)
+
+**Nix (builds the pinned release source via the flake):**
+
+```sh
+nix profile install github:supernovae-st/nika
+# one-shot, no install: nix run github:supernovae-st/nika -- --version
+```
+
+**Windows:** not shipped yet. Say so plainly — do not improvise a build.
+
+## 2 · Verify (always, before reporting success)
+
+```sh
+nika --version   # prints the installed release
+nika welcome     # 30 seconds: what nika is + what it sees here · offline
+nika doctor      # providers · PATH · what this machine can run
+```
+
+`nika: command not found` right after a brew install usually means the
+shell needs a PATH refresh — open a new shell before diagnosing deeper.
+
+## 3 · Prove it works (zero keys, zero network)
+
+```sh
+nika examples run 01-hello --model mock/echo
+```
+
+Exit 0 with a rendered run = the install is good. If Ollama is present,
+the same run works fully local:
+
+```sh
+nika examples run 01-hello --model ollama/qwen3.5:4b
+```
+
+## 4 · Wire nika as an MCP server (optional)
+
+`nika mcp` speaks MCP on stdio — read-only authoring tools (check ·
+explain · examples · catalog · …). For known clients, wiring is one
+idempotent command: `nika wire --help` lists the supported hosts.
+Manual shape for anything else:
+
+```json
+{ "mcpServers": { "nika": { "command": "nika", "args": ["mcp"] } } }
+```
+
+## 5 · Uninstall (leave the machine clean)
+
+```sh
+brew uninstall nika    # if installed via brew — cargo/nix undo their own
+rm -rf ~/.nika         # traces + caches · ask the human before deleting
+```
+
+## After install — authoring
+
+Read [`AGENTS.md`](AGENTS.md), the authoring contract for agents. The
+short form: `nika check <file>` before every handoff — exit 0 is the
+bar, and the diagnostics teach the exact fix when it is not.


### PR DESCRIPTION
Three root metadata files, all agent/machine-facing, plus their changelog entry. Wave-4 distribution rails (private map: beyond-listings wave 4).

## What

- **llms-install.md** — the install runbook written FOR an AI agent. This is the exact file the Cline marketplace validates ("can the AI install it from README + llms-install.md alone") and the general artifact any agent-installer reads. Agent lane = package managers only (brew · cargo binstall --git · nix), each verifying checksums in its own flow; the shell script stays the human lane — same line the skill-guard hardening drew (v1.0.0 -> v1.0.1 precedent). Windows: honest "not shipped yet".
- **CITATION.cff** — makes GitHub's "Cite this repository" box work; Zenodo reads it at archive time (the DOI chain: cff -> Zenodo toggle -> DOI per release -> the first independent reference Wikidata accepts). Version/date deliberately omitted — releases stamp them, prose never hand-writes live numbers. CITATIONS.md (research credits) answers a different question; the two cross-reference.
- **ADOPTERS.md** — public adopters table seeded with our own dogfood (the three daily launch-ops workflows + nika-site-audit), one-line-PR invitation, "runs with nika" badge. Also the path to the "more than one contributor / real usage" bars several directories gate on.

## Verification

- Every command quoted exists in README today and was verified against the released binary paths (brew line · binstall --git form proven in #400 · nix flake form proven in #401 · 01-hello mock run · nika welcome/doctor).
- No new claims, no counts, no version numbers hand-written anywhere.
- Docs-only PR — no code paths touched.

## Unlocks

Cline marketplace submission (gated on llms-install.md) · Zenodo/DOI chain · adopters/contributors bar progress.
