### PR TITLE
docs: llms.txt on-ramp lists the install runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`llms.txt` lists `llms-install.md`.** The agent on-ramp's « Start
+  here » now includes the install runbook — an agent landing on the raw
+  repo finds the install lane before the authoring contract.
+
 - **Agent-facing repo metadata: `llms-install.md` · `CITATION.cff` ·
   `ADOPTERS.md`.** `llms-install.md` is the install runbook written FOR
   an AI agent (the file Cline-class installers read): package-manager

--- a/llms.txt
+++ b/llms.txt
@@ -5,6 +5,7 @@
 ## Start here
 
 - [AGENTS.md](AGENTS.md): The cross-tool agent operating manual (Claude Code, Cursor, Aider, Codex). Hard rules, the 12-gate admission, tooling to run. Read this first.
+- [llms-install.md](llms-install.md): Installing the `nika` binary — the agent-lane runbook (package-manager paths only · verify · prove offline · wire MCP · uninstall clean).
 - [README.md](README.md): User-facing overview and current state.
 - [DIAMOND.md](DIAMOND.md): The Diamond rewrite philosophy — why an orphan-branch rebuild, CRAFT-not-extraction.
 - [ROADMAP.md](ROADMAP.md): The real-semver plan toward the 1.0 launch, the crate sequence (dep-ordered), the tag scheme. Run `bash scripts/refresh-status.sh` for the live canonical state (no volatile counts are hardcoded in docs).


### PR DESCRIPTION
One line in the Start-here section: the agent on-ramp now points at llms-install.md (shipped in 436) before the authoring contract — an agent reading llms.txt cold finds the install lane first. Plus the changelog entry. Docs-only; auto-squash intended (path-filtered checks make docs PRs merge immediately — deliberate here).