### PR TITLE
fix(nika-builtin): a declared write permit creates its tree (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **A declared write permit creates its tree — `nika:write` and
+  `nika:chart` agree** (#433 · use-case battery 2026-07-11). The two
+  artifact writers disagreed on a missing parent directory: chart
+  auto-created it, write refused (`create_dirs: true` required). When
+  `permits.fs.write` declares the tree (e.g. `state/**`), that permit is
+  the author's standing declaration that the tree is theirs to make — so
+  the guarded seam now creates the parent after a passing write-boundary
+  check, and BOTH writers inherit it. Purely additive: a write to a new
+  sub-directory inside a declared write permit succeeds without
+  `create_dirs`; the un-declared engine-floor corner is unchanged (write
+  keeps its safety gate, chart its seam). Option C of the #433 fork
+  (operator brainstorm).
 - **The secrets surface teaches its own fixes** (use-case battery
   2026-07-11). Three diagnostics that made the reader consult spec 01
   §egress now carry the answer: (1) an information-flow leak names the

--- a/crates/nika-builtin/src/lib.rs
+++ b/crates/nika-builtin/src/lib.rs
@@ -516,6 +516,16 @@ where
                     .enforce(self.fs.as_ref(), path, access)
                     .await?;
             }
+            // #433 option C · a declared write permit auto-creates the target
+            // tree (the permit IS the intent), so `nika:write`'s own
+            // `create_dirs` gate finds the parent present and writes — the
+            // declared-intent case now matches `nika:chart`. Only for WRITE
+            // access; a read op never materializes a directory.
+            if accesses.contains(&permits::FsAccess::Write) {
+                self.fs_boundary
+                    .ensure_write_parent(self.fs.as_ref(), path)
+                    .await;
+            }
         }
         op(self.fs.as_ref(), args).await
     }
@@ -528,6 +538,11 @@ where
             self.fs_boundary
                 .enforce(self.fs.as_ref(), out, permits::FsAccess::Write)
                 .await?;
+            // #433 option C · same declared-intent tree creation as
+            // `guarded_fs` — chart's `.vl.json` sibling shares the directory.
+            self.fs_boundary
+                .ensure_write_parent(self.fs.as_ref(), out)
+                .await;
         }
         if let Some(src) = args
             .get("data")
@@ -1045,6 +1060,68 @@ mod boundary_dispatch_tests {
             Arc::new(NoWorkflow),
         )
         .with_fs_boundary(boundary)
+    }
+
+    #[tokio::test]
+    async fn write_under_declared_permit_creates_the_subdir() {
+        // #433 option C · end-to-end through the dispatcher: a `nika:write`
+        // to a NEW sub-directory inside the declared write permit succeeds
+        // WITHOUT `create_dirs` — the permit for `allowed/**` is the intent.
+        // (Pre-fix this returned NIKA-BUILTIN-WRITE-001 « parent does not
+        // exist »; chart always auto-created — the disagreement #433 named.)
+        let root = scratch();
+        let boundary = FsBoundary::declared(vec![], vec![format!("{}/allowed/**", root.display())]);
+        let dispatcher = dispatcher_with(boundary);
+        let target = root.join("allowed/fresh/report.md");
+        let result = dispatcher
+            .execute(ToolCall::new(
+                "t",
+                "nika:write",
+                serde_json::json!({
+                    "path": target.to_string_lossy(),
+                    "content": "# under a declared tree",
+                }),
+            ))
+            .await
+            .expect("dispatches");
+        assert!(
+            !result.is_error,
+            "declared intent · no create_dirs: {}",
+            result.content
+        );
+        assert!(
+            target.exists(),
+            "the file landed in the freshly-created subdir"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn write_to_new_subdir_without_permit_still_gates() {
+        // The un-declared corner is UNCHANGED: no boundary → `nika:write`
+        // keeps its safety default (a missing parent refuses without
+        // `create_dirs`). Additive fix · nothing that gated stops gating.
+        let root = scratch();
+        let dispatcher = dispatcher_with(FsBoundary::unbounded());
+        let target = root.join("nowhere/report.md");
+        let result = dispatcher
+            .execute(ToolCall::new(
+                "t",
+                "nika:write",
+                serde_json::json!({
+                    "path": target.to_string_lossy(),
+                    "content": "x",
+                }),
+            ))
+            .await
+            .expect("dispatches");
+        assert!(result.is_error, "no permit → the safety gate still fires");
+        assert!(
+            result.content.contains("create_dirs"),
+            "the teach is intact: {}",
+            result.content
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[tokio::test]

--- a/crates/nika-builtin/src/permits.rs
+++ b/crates/nika-builtin/src/permits.rs
@@ -144,6 +144,32 @@ impl FsBoundary {
             ),
         ))
     }
+
+    /// #433 option C · create `path`'s parent directory WHEN the boundary
+    /// declares this write tree — a `permits.fs.write` glob is the author's
+    /// standing declaration that the tree is theirs to make, so the two
+    /// artifact writers (`nika:write` · `nika:chart`) agree in the case that
+    /// matters: declared-intent auto-creates, un-declared keeps each
+    /// writer's own safety default. MUST be called only AFTER a passing
+    /// [`enforce`](Self::enforce) for [`FsAccess::Write`] on this path — the
+    /// confinement is proven there, so a declared boundary reaching here
+    /// means the target is inside a write glob. No-op when no boundary is in
+    /// force (best-effort · a real fs error surfaces on the write op itself).
+    pub(crate) async fn ensure_write_parent<F: nika_kernel::io::fs::FsWriteDyn>(
+        &self,
+        fs: &F,
+        path: &str,
+    ) {
+        if !self.declared {
+            return;
+        }
+        if let Some(parent) = Path::new(path)
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+        {
+            let _ = fs.create_dir_all(parent).await;
+        }
+    }
 }
 
 /// Resolve a path to its EFFECTIVE absolute location (symlinks + `..`).
@@ -383,6 +409,41 @@ mod fs_security_tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.root);
         }
+    }
+
+    #[tokio::test]
+    async fn declared_write_tree_creates_the_parent() {
+        // #433 option C · a `permits.fs.write` glob for `allowed/**` is the
+        // author's declaration that the tree is theirs to make, so a new
+        // sub-directory under it is created (both writers inherit this via
+        // the guarded seam · uniform declared-intent behavior).
+        let s = Scratch::new();
+        let fs = TokioFs;
+        let target = s.path("allowed/newdir/x.txt");
+        let parent = s.path("allowed/newdir");
+        assert!(!std::path::Path::new(&parent).exists(), "precondition");
+        s.boundary().ensure_write_parent(&fs, &target).await;
+        assert!(
+            std::path::Path::new(&parent).exists(),
+            "the declared write tree's parent is created"
+        );
+    }
+
+    #[tokio::test]
+    async fn undeclared_boundary_creates_no_parent() {
+        // No boundary in force (engine floor) → the helper is a no-op; each
+        // writer keeps its own default (write gates on `create_dirs`, chart
+        // uses the atomic seam · the un-declared corner, unchanged).
+        let s = Scratch::new();
+        let fs = TokioFs;
+        let target = s.path("allowed/nope/y.txt");
+        FsBoundary::unbounded()
+            .ensure_write_parent(&fs, &target)
+            .await;
+        assert!(
+            !std::path::Path::new(&s.path("allowed/nope")).exists(),
+            "no boundary declared → nothing created"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #433. Option C of the fork (operator brainstorm 2026-07-11).

The two artifact writers disagreed on a missing parent directory (use-case battery): `nika:chart` auto-created it, `nika:write` refused (`NIKA-BUILTIN-WRITE-001`, `create_dirs` required). Same situation, opposite contract.

## The fix

The permit block is the intent declaration. A `permits.fs.write` glob is the author saying that tree is theirs to make, so the guarded seam creates the parent — `FsBoundary::ensure_write_parent`, called right after a passing Write `enforce`, for both `guarded_fs` and `guarded_chart`. Both writers inherit it, zero op-signature churn.

**Purely additive:** declared case → write to a new subdir inside the write permit succeeds WITHOUT `create_dirs` (the battery's W2, proven e2e); un-declared engine-floor corner unchanged (write keeps its safety gate, chart its seam).

## Proof

2 unit + 2 dispatcher e2e. nika-builtin lib 307 (+4) · clippy -D clean · `pub(crate)` helper (zero public-api surface). All 8 CI ratchets green pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)