### PR TITLE
docs: agent-surface round 2 — bare-metal install lane + context7.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`llms-install.md` gains the bare-metal lane · `context7.json` steers
+  the retrieval surface.** The install runbook now covers the box with no
+  package manager: release tarball + `SHA256SUMS` verify, with version
+  discovery via the releases web redirect instead of the GitHub API
+  (anonymous `api.github.com` rate-limits to 403 in shared/CI
+  environments — hit live while proving this lane; the whole flow was
+  then proven curl-only end to end). `context7.json` is the owner config
+  Context7 reads when the repo is indexed: it points parsing at the
+  teaching surfaces (docs · examples · spec pointers, engine internals
+  excluded) and rides four authoring rules along every retrieval — the
+  check-first loop, provider/model form, unpriced-never-free, and
+  never-invent-builtins.
+
 - **`llms.txt` lists `llms-install.md`.** The agent on-ramp's « Start
   here » now includes the install runbook — an agent landing on the raw
   repo finds the install lane before the authoring contract.

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Nika",
+  "description": "Intent-as-code workflow engine for AI: reviewable YAML DAGs, statically checked (schema, permits, cost floor) before execution, tamper-evident traces after. Single Rust binary.",
+  "folders": [],
+  "excludeFolders": ["crates", "fuzz", "media", "scripts"],
+  "excludeFiles": [],
+  "rules": [
+    "Workflows are .nika.yaml files: envelope `nika: v1`, four verbs (infer, exec, invoke, agent); everything callable is a tool under invoke",
+    "Run `nika check <file>` before handing a workflow to anyone — exit 0 is the bar, and the diagnostics name the exact fix",
+    "Models are provider/model form (ollama/llama3.2:3b local-first, mock/echo for offline preview); local models are unpriced, never call them free",
+    "Never invent nika:* builtins or providers — `nika tools` and `nika catalog` list the canonical sets"
+  ]
+}

--- a/llms-install.md
+++ b/llms-install.md
@@ -30,6 +30,24 @@ nix profile install github:supernovae-st/nika
 # one-shot, no install: nix run github:supernovae-st/nika -- --version
 ```
 
+**No package manager (bare Linux/macOS box):** fetch the release
+tarball and verify it against `SHA256SUMS` — auditable, no `curl | sh`.
+Discover the version via the web redirect, NOT the GitHub API (anonymous
+`api.github.com` calls rate-limit to 403 in shared/CI environments; the
+redirect never does):
+
+```sh
+V=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/supernovae-st/nika/releases/latest); V=${V##*/tag/}
+T=linux-x64   # or: linux-arm64 · macos-arm64 · macos-x64
+curl -fsSLO "https://github.com/supernovae-st/nika/releases/download/$V/nika-$T-${V#v}.tar.gz"
+curl -fsSLO "https://github.com/supernovae-st/nika/releases/download/$V/SHA256SUMS"
+grep "nika-$T-${V#v}.tar.gz" SHA256SUMS | sha256sum -c -   # macOS: shasum -a 256 -c -
+tar -xzf "nika-$T-${V#v}.tar.gz"
+install -d ~/.local/bin && install -m 755 nika ~/.local/bin/nika   # any PATH dir works
+```
+
+Refuse to proceed if the checksum line does not print `OK`.
+
 **Windows:** not shipped yet. Say so plainly — do not improvise a build.
 
 ## 2 · Verify (always, before reporting success)


### PR DESCRIPTION
Two agent-surface files, both field-proven before writing. Docs-only; auto-squash intended.

## llms-install.md — the bare-metal lane

The runbook had a dead-end: a Linux box with no brew, no cargo, no nix had no agent lane. Added the explicit fetch + SHA256SUMS verify + install flow, with the version-discovery trap encoded: anonymous api.github.com rate-limits to 403 (hit live while proving this) — the releases web redirect is the no-auth discovery path. Whole lane proven curl-only end to end just now: redirect resolved v0.99.0, checksum printed OK, extracted binary ran `nika 0.99.0`. The macOS/Linux checksum-tool split (shasum -a 256 vs sha256sum) is noted inline. "Refuse to proceed if the checksum line does not print OK" is the agent-grade instruction.

## context7.json — the retrieval-surface owner config

Context7 (context7.com) indexes public repos so coding agents retrieve current docs; a root context7.json is their robots.txt-like owner config ($schema included, editor-validated). Ours points parsing at the teaching surfaces (docs, examples, spec pointers — crates/fuzz/media/scripts excluded so 14 crates of Rust internals don't drown the authoring signal) and rides four authoring rules along every retrieval: check-first loop, provider/model form, unpriced-never-free, never-invent-builtins. The web-form registration on context7.com/add-library is a separate operator step; this file makes whatever gets indexed correct.

Verification: JSON parses (python -m json.tool), schema field enables editor validation, every rule statement checked against the shipped binary's actual surfaces (nika check / nika tools / nika catalog exist and behave as stated).
