### PR TITLE
feat(schema,cli): --fix heals dependency and reference renames — convergence

### DIFF
--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -90,6 +90,14 @@ pub fn run(path: &str, native_strict: bool, model: Option<&str>, theme: Theme) -
                         renames.push((a.arg.clone(), s.clone(), "arg"));
                     }
                 }
+                // Conformance renames (typed `offending`/`suggestion` —
+                // unknown depends_on target · unresolved `${{ }}` ref,
+                // both fully qualified so a splice keeps the namespace).
+                for v in &report.conformance {
+                    if let (Some(o), Some(s)) = (&v.offending, &v.suggestion) {
+                        renames.push((o.clone(), s.clone(), "ref"));
+                    }
+                }
                 renames.sort();
                 renames.dedup();
                 for (old, new, kind) in renames {
@@ -176,9 +184,15 @@ fn splice(
     kind: &'static str,
     repairs: &mut Vec<Repair>,
 ) -> bool {
-    // One entry per (old, new, kind) — a token skipped in round N must
-    // not re-log every later round.
-    if repairs.iter().any(|r| r.old == old && r.kind == kind) {
+    // An APPLIED token never re-applies. A SKIPPED one stays retryable:
+    // an earlier round's splice can make it unique (the two-site case —
+    // `buidl` in `depends_on` is ambiguous while `tasks.buidl` exists;
+    // once the reference heals, the dependency token stands alone and
+    // the next round heals it too). Convergence, not one-shot.
+    if repairs
+        .iter()
+        .any(|r| r.applied && r.old == old && r.kind == kind)
+    {
         return false;
     }
     let sites = word_sites(source, old);
@@ -188,12 +202,19 @@ fn splice(
     } else {
         false
     };
-    repairs.push(Repair {
-        old: old.to_owned(),
-        new: new.to_owned(),
-        kind,
-        applied,
-    });
+    // One log row per (old, kind): a retry that succeeds UPGRADES its
+    // earlier skip row (the summary reports final outcomes, not rounds).
+    if let Some(row) = repairs.iter_mut().find(|r| r.old == old && r.kind == kind) {
+        row.applied = row.applied || applied;
+        new.clone_into(&mut row.new);
+    } else {
+        repairs.push(Repair {
+            old: old.to_owned(),
+            new: new.to_owned(),
+            kind,
+            applied,
+        });
+    }
     applied
 }
 
@@ -330,6 +351,59 @@ mod tests {
             out.text
         );
         assert_ne!(out.code, exit::OK, "the structural finding still reds");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn dep_and_ref_renames_converge_across_rounds() {
+        // The two-site convergence case the retryable-skip design exists
+        // for: `buidl` occurs TWICE (bare in depends_on · inside the
+        // `tasks.buidl` reference), so the dependency rename is ambiguous
+        // in round 1 — but the fully-qualified reference rename
+        // (`tasks.buidl` → `tasks.build`) is unique, applies, and leaves
+        // the bare token standing alone for round 2. Both heal; a
+        // one-shot skip would have left the file half-repaired.
+        let dir = std::env::temp_dir().join(format!("nika-fix-conv-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let path = dir.join("two-site.nika.yaml");
+        std::fs::write(
+            &path,
+            "nika: v1\nworkflow: w\nvars: { topic: \"x\" }\ntasks:\n  - id: build\n    invoke: { tool: \"nika:log\", args: { message: \"building ${{ vars.topik }}\" } }\n  - id: ship\n    depends_on: [buidl]\n    invoke: { tool: \"nika:log\", args: { message: \"${{ tasks.buidl.output }}\" } }\n",
+        )
+        .expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let healed = std::fs::read_to_string(&path).expect("re-read");
+        assert!(
+            healed.contains("depends_on: [build]"),
+            "dep healed: {healed}"
+        );
+        assert!(
+            healed.contains("tasks.build.output"),
+            "ref healed: {healed}"
+        );
+        assert!(
+            healed.contains("vars.topic"),
+            "vars ref healed too: {healed}"
+        );
+        assert!(!healed.contains("buidl") && !healed.contains("topik"));
+        assert!(
+            out.text.contains("ref `tasks.buidl` → `tasks.build`"),
+            "{}",
+            out.text
+        );
+        assert!(out.text.contains("ref `buidl` → `build`"), "{}", out.text);
+        assert!(
+            out.text.contains("ref `vars.topik` → `vars.topic`"),
+            "{}",
+            out.text
+        );
+        assert!(!out.text.contains("skipped"), "no residual skip rows");
+        assert_eq!(out.code, exit::OK, "clean after convergence: {}", out.text);
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -502,8 +502,10 @@ pub fn nika_schema::check::CheckReport::as_any(&self) -> &(dyn core::any::Any + 
 pub nika_schema::check::ConformanceViolation::code: alloc::string::String
 pub nika_schema::check::ConformanceViolation::docs_url: alloc::string::String
 pub nika_schema::check::ConformanceViolation::message: alloc::string::String
+pub nika_schema::check::ConformanceViolation::offending: core::option::Option<alloc::string::String>
 pub nika_schema::check::ConformanceViolation::severity: nika_schema::check::FindingSeverity
 pub nika_schema::check::ConformanceViolation::span: core::option::Option<nika_schema::check::ByteSpan>
+pub nika_schema::check::ConformanceViolation::suggestion: core::option::Option<alloc::string::String>
 impl core::clone::Clone for nika_schema::check::ConformanceViolation
 pub fn nika_schema::check::ConformanceViolation::clone(&self) -> nika_schema::check::ConformanceViolation
 impl core::cmp::Eq for nika_schema::check::ConformanceViolation
@@ -1775,6 +1777,7 @@ pub nika_schema::error::SchemaError::YamlSyntax
 pub nika_schema::error::SchemaError::YamlSyntax::message: alloc::string::String
 pub nika_schema::error::SchemaError::YamlSyntax::span: core::option::Option<nika_schema::Span>
 impl nika_schema::error::SchemaError
+pub fn nika_schema::error::SchemaError::rename_repair(&self) -> core::option::Option<(alloc::string::String, alloc::string::String)>
 pub fn nika_schema::error::SchemaError::span(&self) -> core::option::Option<nika_schema::Span>
 pub fn nika_schema::error::SchemaError::validation(message: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn nika_schema::error::SchemaError::validation_at(message: impl core::convert::Into<alloc::string::String>, span: nika_schema::Span) -> Self
@@ -5795,6 +5798,7 @@ pub nika_schema::SchemaError::YamlSyntax
 pub nika_schema::SchemaError::YamlSyntax::message: alloc::string::String
 pub nika_schema::SchemaError::YamlSyntax::span: core::option::Option<nika_schema::Span>
 impl nika_schema::error::SchemaError
+pub fn nika_schema::error::SchemaError::rename_repair(&self) -> core::option::Option<(alloc::string::String, alloc::string::String)>
 pub fn nika_schema::error::SchemaError::span(&self) -> core::option::Option<nika_schema::Span>
 pub fn nika_schema::error::SchemaError::validation(message: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn nika_schema::error::SchemaError::validation_at(message: impl core::convert::Into<alloc::string::String>, span: nika_schema::Span) -> Self
@@ -6484,8 +6488,10 @@ pub fn nika_schema::check::CheckReport::as_any(&self) -> &(dyn core::any::Any + 
 pub nika_schema::ConformanceViolation::code: alloc::string::String
 pub nika_schema::ConformanceViolation::docs_url: alloc::string::String
 pub nika_schema::ConformanceViolation::message: alloc::string::String
+pub nika_schema::ConformanceViolation::offending: core::option::Option<alloc::string::String>
 pub nika_schema::ConformanceViolation::severity: nika_schema::check::FindingSeverity
 pub nika_schema::ConformanceViolation::span: core::option::Option<nika_schema::check::ByteSpan>
+pub nika_schema::ConformanceViolation::suggestion: core::option::Option<alloc::string::String>
 impl core::clone::Clone for nika_schema::check::ConformanceViolation
 pub fn nika_schema::check::ConformanceViolation::clone(&self) -> nika_schema::check::ConformanceViolation
 impl core::cmp::Eq for nika_schema::check::ConformanceViolation

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -139,6 +139,20 @@ pub struct ConformanceViolation {
     /// editors surface the code as a clickable link. Additive:
     /// `report_version` stays 1.
     pub docs_url: String,
+    /// The exact offending source token, when the violation is a
+    /// RENAME-shaped defect (`buidl` for an unknown dependency ·
+    /// `tasks.buidl` for an unresolved reference) — paired with
+    /// [`Self::suggestion`], this is the machine-applicable half the
+    /// human message already renders as « did you mean ___? ». The
+    /// `--fix` repair loop splices exactly this token. Additive:
+    /// `report_version` stays 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offending: Option<String>,
+    /// The typed rename target (`build` · `tasks.build`) — present only
+    /// when the deterministic did-you-mean asserted one (silence past
+    /// the threshold, as everywhere). Additive: `report_version` stays 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestion: Option<String>,
 }
 
 /// The static pre-flight report — everything `nika check` learns without
@@ -320,6 +334,10 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
                 .map(|e| {
                     let code = e.spec_code().to_string();
                     let docs_url = format!("{ERROR_DOCS_BASE}/{code}");
+                    let (offending, suggestion) = match e.rename_repair() {
+                        Some((o, s)) => (Some(o), Some(s)),
+                        None => (None, None),
+                    };
                     ConformanceViolation {
                         code,
                         message: e.to_string(),
@@ -329,6 +347,8 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
                         }),
                         severity: FindingSeverity::Error,
                         docs_url,
+                        offending,
+                        suggestion,
                     }
                 })
                 .collect(),

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -446,6 +446,32 @@ pub enum SchemaError {
 }
 
 impl SchemaError {
+    /// The machine-applicable RENAME this error teaches, as the exact
+    /// `(offending source token, replacement)` pair — `Some` only for the
+    /// rename-shaped variants whose deterministic did-you-mean asserted a
+    /// target (`buidl` → `build` for an unknown dependency · `tasks.buidl`
+    /// → `tasks.build` for an unresolved reference, both sides fully
+    /// qualified so a splice never strips the namespace). This is the
+    /// typed half the human message renders as « did you mean ___? » —
+    /// the `--fix` repair loop and any agent loop consume it without
+    /// scraping prose.
+    #[must_use]
+    pub fn rename_repair(&self) -> Option<(String, String)> {
+        match self {
+            Self::UnknownDependency {
+                to,
+                suggestion: Some(s),
+                ..
+            } => Some((to.clone(), s.clone())),
+            Self::UnresolvedNamespaceRef {
+                reference,
+                suggestion: Some(s),
+                ..
+            } => Some((reference.clone(), s.clone())),
+            _ => None,
+        }
+    }
+
     /// The source span of this error, when one is attached — the ONE
     /// uniform surface diagnostics renderers (the check report · the
     /// future LSP) read spans through. `Cycle` has no single span (a

--- a/typos.toml
+++ b/typos.toml
@@ -41,6 +41,8 @@ requierd   = "requierd"
 filesytem  = "filesytem"
 BUIL       = "BUIL"
 markdwon   = "markdwon"  # extract-mode typo rung fixture (nika-types suggest/extract tests)
+buidl      = "buidl"     # dep/ref rename fixture (rename_repair docs + --fix convergence tests)
+topik      = "topik"     # vars-ref rename fixture (--fix convergence test)
 # French (the studio writes franglais — these are real French words, not typos)
 raison     = "raison"
 raisons    = "raisons"


### PR DESCRIPTION
Sequel to #434: the dep/ref typo class carried **typed** suggestions in `SchemaError` but lost them at the report boundary (`ConformanceViolation` was message-only) — `--fix` couldn't touch `depends_on: [buidl]` or `${{ tasks.buidl.output }}`, the two most structural renames a new user makes.

**The typed half now travels**: `SchemaError::rename_repair()` exposes the `(offending, replacement)` pair — refs stay **fully qualified** (`tasks.buidl`→`tasks.build`, a splice never strips the namespace) — and `ConformanceViolation` gains additive `offending`/`suggestion` fields (`report_version` stays 1, serde-skipped when absent).

**The convergence upgrade**: a *skipped* token stays retryable across rounds (an applied one never re-applies). The signature case is exactly why — `buidl` occurs twice (bare in `depends_on` · inside the ref), the bare rename is ambiguous round 1; the qualified ref rename IS unique, applies, and leaves the bare token standing alone for round 2. One log row per token — a retry that succeeds upgrades its skip row (final outcomes, not rounds).

Real demo (3 renames · 2 rounds · 0 residual skips):
```
$ nika check refs-demo.nika.yaml --fix
 ✔ FIX  ref `buidl` → `build`
 ✔ FIX  ref `tasks.buidl` → `tasks.build`
 ✔ FIX  ref `vars.topik` → `vars.topic`
 ✔ FIX  3 repairs applied · re-audit below
 … clean audit … rc=0
```

Gates: schema 734 · cli 288 (two-site convergence e2e pinned) · clippy `-D warnings` 0 · fmt clean · public-api **+6 strictly additive**. API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)