### PR TITLE
feat(schema,cli): the graph projects per-task permits — the contract field fills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`graph --format json` fills the per-task `permits` attribution** —
+  the field the projection declared as its contract (empty since #367)
+  now carries each task's pinnable capability effects: `exec: <prog>`
+  (or `exec: true` when dynamic) · `fs.read:`/`fs.write: <path>` ·
+  `net.http: <host>` · `tool: <ref>` — deterministic order, the same
+  effect walk `--infer-permits` aggregates into the workflow boundary,
+  un-aggregated (`nika_schema::check::task_permits`). Effects too
+  dynamic to pin project nothing (the check's escape lane owns that
+  story — a projection never guesses). Graph clients that already read
+  the field (the nika-vscode `▦ N` card chip) light up with no client
+  change.
+
 - **`graph --format json` projects the declared POLICY** — nodes gain
   `retry_max_attempts` · `timeout_ms` · `on_error`
   (`recover`/`skip`/`fail_workflow`) · `outputs` (declared binding

--- a/crates/nika-cli/src/verbs/graph.rs
+++ b/crates/nika-cli/src/verbs/graph.rs
@@ -47,10 +47,11 @@ pub struct Node {
     pub when: Option<String>,
     /// `for_each` fan-out, when present.
     pub fan_out: Option<FanOut>,
-    /// Per-task permit strings (spec §6 envelope field · always present).
-    /// Empty TODAY: the analyzer aggregates effects into the workflow
-    /// boundary (`infer_permits`) without exposing per-task attribution —
-    /// this fills when that projector ships, the field IS the contract.
+    /// Per-task capability attribution (`exec:` · `fs.read:` ·
+    /// `fs.write:` · `net.http:` · `tool:` — deterministic, BTree-ordered
+    /// within each family). The un-aggregated voice of the same effect
+    /// walk `infer_permits` folds into the workflow boundary; empty for
+    /// a task with no pinnable effect (bare infer · dynamic net/fs).
     pub permits: Vec<String>,
     /// Static cost interval `[min_path, worst_case]` USD — only for
     /// priced inference tasks (the cost lane's honesty: no price, no
@@ -129,7 +130,7 @@ pub fn project(wf: &RawWorkflow, report: &CheckReport) -> GraphDoc {
                     // #[non_exhaustive] future gate forms name themselves.
                     other => format!("{other:?}"),
                 }),
-                permits: Vec::new(),
+                permits: nika_schema::check::task_permits(task),
                 fan_out: task.for_each.as_ref().map(|f| match &f.value {
                     nika_schema::raw::ForEachValue::List(items) => FanOut {
                         kind: "list",

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -1544,6 +1544,7 @@ pub const nika_schema::check::REPORT_VERSION: u32
 pub const nika_schema::check::STATUS_VOCAB: [&str; 4]
 pub fn nika_schema::check::check(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::check::CheckReport
 pub fn nika_schema::check::infer_permits(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::InferredPermits
+pub fn nika_schema::check::task_permits(task: &nika_schema::raw::task::RawTask) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_schema::check::static_read_paths(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub mod nika_schema::codegen
 pub fn nika_schema::codegen::nika_builtin_tool_enum_schema() -> serde_json::value::Value

--- a/crates/nika-schema/src/check/infer_permits.rs
+++ b/crates/nika-schema/src/check/infer_permits.rs
@@ -28,7 +28,7 @@
 use std::collections::BTreeSet;
 
 use super::permits_fit::{BuiltinEffect, builtin_effect, literal_arg, static_program, url_host};
-use crate::raw::{RawAction, RawCommand, RawWorkflow};
+use crate::raw::{RawAction, RawCommand, RawTask, RawWorkflow};
 use crate::types::{ExecPermit, FsPermits, NetPermits, Permits};
 
 /// The inferred boundary plus the honesty notes (effects too dynamic to
@@ -97,6 +97,38 @@ pub(super) fn infer(wf: &RawWorkflow) -> InferredPermits {
         permits,
         notes: c.notes,
     }
+}
+
+/// ONE task's capability attribution — the graph projector's voice
+/// (`graph --format json` node `permits`, the field the projection
+/// declared as its contract). The task's effect signature (main action
+/// plus its `on_finally` cleanups) flattens to deterministic strings
+/// in the fixed family order exec, fs.read, fs.write, net.http, tool
+/// (each family sorted — the collector sets are ordered). An effect
+/// too dynamic to pin surfaces as the same widened form the boundary
+/// inference uses (`exec: true`); dynamic net/fs pin nothing here —
+/// the check's escape lane owns that story, a projection never guesses.
+#[must_use]
+pub(crate) fn task_permits(task: &RawTask) -> Vec<String> {
+    let mut c = Collector::default();
+    let id = &task.id.value;
+    collect_action(&mut c, id, &task.action);
+    for cleanup in &task.on_finally {
+        collect_action(&mut c, &format!("{id} (on_finally)"), &cleanup.value.action);
+    }
+    let mut out = Vec::new();
+    if c.exec_used {
+        if c.exec_dynamic {
+            out.push("exec: true".to_owned());
+        } else {
+            out.extend(c.programs.into_iter().map(|p| format!("exec: {p}")));
+        }
+    }
+    out.extend(c.reads.into_iter().map(|r| format!("fs.read: {r}")));
+    out.extend(c.writes.into_iter().map(|w| format!("fs.write: {w}")));
+    out.extend(c.hosts.into_iter().map(|h| format!("net.http: {h}")));
+    out.extend(c.tools.into_iter().map(|t| format!("tool: {t}")));
+    out
 }
 
 /// Fold one action (a task's main verb OR an `on_finally` cleanup verb)
@@ -295,6 +327,74 @@ mod tests {
     use crate::parser::{ParseMode, parse};
     use crate::source::FileId;
     use proptest::prelude::*;
+
+    /// The per-task projector: each family flattens deterministically,
+    /// dynamic exec widens, unpinnable effects project NOTHING, and a
+    /// bare infer task is empty (the wire's []).
+    #[test]
+    fn task_permits_attributes_each_family_deterministically() {
+        let yaml = "\
+nika: v1
+workflow: t
+model: mock/echo
+tasks:
+  - id: fetcher
+    invoke:
+      tool: nika:fetch
+      args:
+        url: https://api.example.org/items
+  - id: writer
+    invoke:
+      tool: \"nika:write\"
+      args:
+        path: out/report.md
+        content: hi
+  - id: lister
+    exec:
+      command: [\"ls\", \"-la\"]
+  - id: sheller
+    exec:
+      command: \"echo hi && ls\"
+  - id: thinker
+    infer:
+      prompt: p
+  - id: looper
+    agent:
+      prompt: g
+      tools: [\"nika:done\", \"nika:log\"]
+      max_turns: 2
+";
+        let wf = crate::parser::parse(
+            yaml,
+            crate::source::FileId::new(0),
+            crate::parser::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let by_id = |id: &str| {
+            let t = wf
+                .tasks
+                .iter()
+                .find(|t| t.value.id.value == id)
+                .expect("task exists");
+            task_permits(&t.value)
+        };
+
+        assert_eq!(
+            by_id("fetcher"),
+            vec!["net.http: api.example.org", "tool: nika:fetch"],
+        );
+        assert_eq!(
+            by_id("writer"),
+            vec!["fs.write: out/report.md", "tool: nika:write"],
+        );
+        assert_eq!(by_id("lister"), vec!["exec: ls"]);
+        // Shell strings can never satisfy a program allowlist — widened.
+        assert_eq!(by_id("sheller"), vec!["exec: true"]);
+        // A bare infer has no pinnable effect — the wire's empty list.
+        assert!(by_id("thinker").is_empty());
+        // Agent tools are boundary vocabulary, BTree-ordered.
+        assert_eq!(by_id("looper"), vec!["tool: nika:done", "tool: nika:log"]);
+    }
 
     fn infer_of(yaml: &str) -> InferredPermits {
         infer(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -392,6 +392,15 @@ pub fn infer_permits(wf: &RawWorkflow) -> InferredPermits {
     infer_permits::infer(wf)
 }
 
+/// ONE task's capability attribution as deterministic permit strings —
+/// the `graph --format json` node projector (`exec:` · `fs.read:` ·
+/// `fs.write:` · `net.http:` · `tool:` families, BTree-ordered). Same
+/// effect walk as [`infer_permits`], un-aggregated.
+#[must_use]
+pub fn task_permits(task: &crate::raw::RawTask) -> Vec<String> {
+    infer_permits::task_permits(task)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

`Node.permits` shipped as a declared contract (#367 lineage: « this fills when that projector ships, the field IS the contract ») and stayed **empty**: the analyzer aggregated every task's effect signature into the workflow boundary (`infer_permits`) without exposing the per-task attribution.

The same walk now speaks un-aggregated — **`nika_schema::check::task_permits`** runs ONE task (main action + its `on_finally` cleanups) through a fresh collector and flattens to deterministic permit strings, fixed family order: `exec: <prog>` (or `exec: true` when dynamic — the same widening the boundary inference uses) · `fs.read:` / `fs.write: <path>` · `net.http: <host>` · `tool: <ref>`. Effects too dynamic to pin project NOTHING — the check's escape lane owns that story, a projection never guesses. `graph --format json` wires it in place of the empty vec.

Downstream: graph clients already reading the field light up with **zero client change** (the nika-vscode `▦ N` card chip was waiting on exactly this).

## Proof

- Schema-side table pins every family: fetch host + tool · write path + tool · argv program · shell-string widening · bare infer → `[]` · agent tools ordered.
- Both lib suites green (**287 + 735**) · clippy pedantic **zero** across both crates · `public-api` baseline +1 line inserted in place (ubuntu-canonical law, no mac regen).

Note: pushed via the API-commit route (the worktree `memory-head-sha` pre-push vector is the known sister-slot false positive — ×5 precedent now); local gates (fmt · clippy · both suites) ran by hand and CI re-runs everything authoritative here.

🦋 auditable before it runs