### PR TITLE
docs(readme): the quickstart model answers without a think block (#428)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Yes.
 ```sh
 brew install supernovae-st/tap/nika    # or: curl -LsSf https://nika.sh/install.sh | sh
 nika examples run 01-hello --model mock/echo            # zero setup: no key, no model server
-nika examples run 01-hello --model ollama/qwen3.5:4b    # got Ollama? the same run, real + local
+nika examples run 01-hello --model ollama/llama3.2:3b   # got Ollama? the same run, real + local
+# (first run loads the model into memory — later runs are much faster)
 ```
 
 ![nika check audits the workflow (plan, cost, secrets, types), then nika run executes it locally](media/nika-hero.gif)
@@ -183,7 +184,7 @@ visible — nothing is skipped silently.
 
 The binary embeds a versioned pack of runnable examples. Browse with
 `nika examples list`, read one with `nika examples show <slug>`, preview any
-of them with `--model ollama/qwen3.5:4b` (or offline with `--model mock/echo`):
+of them with `--model ollama/llama3.2:3b` (or offline with `--model mock/echo`):
 
 | I want to… | Run | For |
 |---|---|---|


### PR DESCRIPTION
Closes #428.

A cold-reader TTFW replay found the quickstart's first real-model contact several times slower than needed: **qwen3.5 is a thinking-family model** and writes a full reasoning preamble before greeting.

## The change

The two **first-contact** suggestion sites swap to `ollama/llama3.2:3b` — already the model the README's own hero gif and transcripts run, smaller (2GB vs 3.4GB → faster first pull), and it answers a greeting directly. The cold-load parenthetical lands under the one-liner (the exact moment a first-timer might think it hung).

## What deliberately stays

The `pr-risk-review` hero's envelope default (`qwen3.5:9b`) — an in-workflow *judgment* task, not a first-run suggestion. Same exception logic the showcase convention just adopted (nika-spec#55): **thinking models where reasoning is the point, non-thinking where the budget goes to output.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)