### PR TITLE
fix(ci): the schema public-api baseline re-sits on the ubuntu render

### DIFF
--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -1546,8 +1546,8 @@ pub const nika_schema::check::REPORT_VERSION: u32
 pub const nika_schema::check::STATUS_VOCAB: [&str; 4]
 pub fn nika_schema::check::check(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::check::CheckReport
 pub fn nika_schema::check::infer_permits(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_schema::InferredPermits
-pub fn nika_schema::check::task_permits(task: &nika_schema::raw::task::RawTask) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_schema::check::static_read_paths(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
+pub fn nika_schema::check::task_permits(task: &nika_schema::raw::task::RawTask) -> alloc::vec::Vec<alloc::string::String>
 pub mod nika_schema::codegen
 pub fn nika_schema::codegen::nika_builtin_tool_enum_schema() -> serde_json::value::Value
 pub mod nika_schema::error


### PR DESCRIPTION
## What

#445's hand-inserted `task_permits` baseline line sat ONE sort position early (before `static_read_paths` — ubuntu's cargo-public-api orders it after), so the API-freeze `diff` job went red on main with **identical content at a different line**. Baseline-only fix: the file becomes the byte-for-byte copy of the `public-api-actual` artifact from the main dispatch run (29152591197), per the workflow's own regeneration law — baselines are canonical on the ubuntu runner, never a local mac render.

Verified before shipping: nika-schema is the ONLY drifted baseline across all 40+ crates in the artifact (the #440 nika-cli hand-insert was position-correct).

## Lesson banked

Hand-inserting is fine for FIELD lines inside a struct block (stable neighborhood); for a top-level `pub fn` the sort neighborhood is the whole module — take the artifact copy instead.

🦋 auditable before it runs