### PR TITLE
fix(schema): chart and tts join the effect classification — no more self-refusing boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`nika:chart` and `nika:tts_generate` were invisible to the effect
+  classification** — a chart/tts write outside the boundary passed the
+  static scan and failed only at runtime, and `--infer-permits` wrote a
+  boundary the run then REFUSED (the self-refusing class the analyzer
+  forbids everywhere else). Both media graduates now classify: chart's
+  permit-gated `out` write (plus its `compile_to` vega `.vl.json`
+  sibling — one shared derivation, matching the runtime byte for byte)
+  and tts's recursive `output_dir` write (the image_generate shape).
+  Escape scanning, boundary inference and the per-task graph `permits`
+  attribution all speak them now.
+
 ### Added
 
 - **`graph --format json` fills the per-task `permits` attribution** —

--- a/crates/nika-schema/src/check/infer_permits.rs
+++ b/crates/nika-schema/src/check/infer_permits.rs
@@ -27,7 +27,9 @@
 
 use std::collections::BTreeSet;
 
-use super::permits_fit::{BuiltinEffect, builtin_effect, literal_arg, static_program, url_host};
+use super::permits_fit::{
+    BuiltinEffect, builtin_effect, chart_vl_sibling, literal_arg, static_program, url_host,
+};
 use crate::raw::{RawAction, RawCommand, RawTask, RawWorkflow};
 use crate::types::{ExecPermit, FsPermits, NetPermits, Permits};
 
@@ -235,6 +237,12 @@ fn collect_builtin_effect(c: &mut Collector, id: &str, a: &crate::raw::RawInvoke
         },
         None => {}
     }
+    // The chart vega sibling is a SECOND gated write — inferred alongside
+    // the artifact (an exact-path boundary that admits the svg but not
+    // its `.vl.json` would self-refuse the very workflow it came from).
+    if let Some(vl) = chart_vl_sibling(a) {
+        c.writes.insert(vl);
+    }
 }
 
 fn build_fs(reads: BTreeSet<String>, writes: BTreeSet<String>) -> Option<FsPermits> {
@@ -327,6 +335,52 @@ mod tests {
     use crate::parser::{ParseMode, parse};
     use crate::source::FileId;
     use proptest::prelude::*;
+
+    /// The inference covers chart + tts (they were invisible — the
+    /// boundary it wrote refused the very run it came from) and the
+    /// chart vega sibling rides along.
+    #[test]
+    fn chart_and_tts_infer_their_writes() {
+        let wf = crate::parser::parse(
+            "\
+nika: v1
+workflow: t
+model: mock/echo
+tasks:
+  - id: c
+    invoke:
+      tool: \"nika:chart\"
+      args:
+        data: [{ x: \"a\", y: 1 }]
+        chart: { type: bar, x: x, y: y }
+        out: \"out/c.svg\"
+        compile_to: vega_lite
+  - id: s
+    invoke:
+      tool: \"nika:tts_generate\"
+      args:
+        text: \"hi\"
+        output_dir: \"audio\"
+",
+            crate::source::FileId::new(0),
+            crate::parser::ParseMode::Strict,
+        )
+        .expect("parse");
+        let inferred = infer(&wf);
+        let yaml = inferred.to_yaml();
+        assert!(
+            yaml.contains("out/c.svg"),
+            "chart artifact inferred: {yaml}"
+        );
+        assert!(
+            yaml.contains("out/c.vl.json"),
+            "vega sibling inferred: {yaml}"
+        );
+        assert!(
+            yaml.contains("audio/**"),
+            "tts dir inferred recursive: {yaml}"
+        );
+    }
 
     /// The per-task projector: each family flattens deterministically,
     /// dynamic exec widens, unpinnable effects project NOTHING, and a

--- a/crates/nika-schema/src/check/permits_fit.rs
+++ b/crates/nika-schema/src/check/permits_fit.rs
@@ -325,20 +325,24 @@ pub(super) fn builtin_effect(a: &RawInvokeAction) -> Option<BuiltinEffect> {
             writes: true,
             recursive: false,
         }),
-        // generated assets + the manifest land INSIDE a literal
-        // `output_dir:` — a recursive write (stdlib §Media · the provider
-        // egress rides the engine's image plane, not permits.net.http,
-        // exactly like `infer:`).
-        "nika:image_generate" => Some(BuiltinEffect::Fs {
+        // Media generators: assets (+ manifest) land INSIDE a literal
+        // `output_dir:` — a recursive write (stdlib §Media · provider
+        // egress rides the engine's media plane, not permits.net.http,
+        // exactly like `infer:`). tts follows the image_generate shape.
+        "nika:image_generate" | "nika:tts_generate" => Some(BuiltinEffect::Fs {
             path_arg: "output_dir",
             reads: false,
             writes: true,
             recursive: true,
         }),
-        // `nika:image_fx` — the WRITE side (`out:`) is the statically-
-        // checkable effect; the `input:` read is runtime-gated inside the
-        // builtin (the image edit-mode precedent · one path_arg per effect).
-        "nika:image_fx" => Some(BuiltinEffect::Fs {
+        // Single-artifact writers: the WRITE side (`out:`) is the
+        // statically-checkable effect. image_fx's `input:` read is
+        // runtime-gated inside the builtin (the image edit-mode precedent
+        // · one path_arg per effect); chart was INVISIBLE here until
+        // 2026-07-11 — the inference wrote a boundary the run then
+        // refused (the self-refusing class); its `compile_to` vega
+        // sibling rides `chart_vl_sibling`.
+        "nika:image_fx" | "nika:chart" => Some(BuiltinEffect::Fs {
             path_arg: "out",
             reads: false,
             writes: true,
@@ -346,6 +350,23 @@ pub(super) fn builtin_effect(a: &RawInvokeAction) -> Option<BuiltinEffect> {
         }),
         _ => None,
     }
+}
+
+/// `nika:chart` with `compile_to: vega_lite` writes a SECOND gated file —
+/// the `.vl.json` sibling next to the svg. One derivation, shared by the
+/// escape scan and the boundary inference, matching the runtime byte for
+/// byte (`chart.rs`: `format!("{}.vl.json", out.trim_end_matches(".svg"))`).
+/// `None` when the tool isn't chart, either arg is dynamic/absent, or the
+/// compile target isn't the closed set's `vega_lite`.
+pub(super) fn chart_vl_sibling(a: &RawInvokeAction) -> Option<String> {
+    if a.tool.value.as_str() != "nika:chart" {
+        return None;
+    }
+    if literal_arg(a, "compile_to").as_deref() != Some("vega_lite") {
+        return None;
+    }
+    let out = literal_arg(a, "out")?;
+    Some(format!("{}.vl.json", out.trim_end_matches(".svg")))
 }
 
 /// Check a builtin invoke's LITERAL fs/net effect against the boundary,
@@ -396,6 +417,19 @@ fn check_builtin_effect(
                         floor: false,
                     });
                 }
+            }
+            // The chart vega sibling is a SECOND gated write — same
+            // boundary test as the artifact itself.
+            if let Some(vl) = chart_vl_sibling(a)
+                && !permits.allows_path(&vl, true)
+            {
+                out.push(CapabilityEscape {
+                    task: id.to_owned(),
+                    category: "fs",
+                    detail: format!("`{tool}` vega sibling `{vl}` is outside permits.fs.write"),
+                    fix: Some(format!("add \"{vl}\" to permits.fs.write")),
+                    floor: false,
+                });
             }
         }
         None => {}
@@ -469,6 +503,103 @@ mod tests {
                 "url_host disagrees on {input}"
             );
         }
+    }
+
+    /// The two newest media builtins were INVISIBLE to the effect
+    /// classification: a chart/tts write outside the boundary passed the
+    /// static scan and failed at runtime, and --infer-permits wrote a
+    /// boundary the run then refused (the self-refusing class). Both
+    /// sides pin here — the sibling `.vl.json` included.
+    #[test]
+    fn chart_and_tts_writes_escape_an_empty_boundary() {
+        let escapes = escapes_of(
+            "\
+nika: v1
+workflow: t
+model: mock/echo
+permits:
+  fs: { write: [\"elsewhere/**\"] }
+  tools: [\"nika:chart\", \"nika:tts_generate\"]
+tasks:
+  - id: c
+    invoke:
+      tool: \"nika:chart\"
+      args:
+        data: [{ x: \"a\", y: 1 }]
+        chart: { type: bar, x: x, y: y }
+        out: \"out/c.svg\"
+        compile_to: vega_lite
+  - id: s
+    invoke:
+      tool: \"nika:tts_generate\"
+      args:
+        text: \"hi\"
+        output_dir: \"audio\"
+",
+        );
+        let fs: Vec<&str> = escapes
+            .iter()
+            .filter(|e| e.category == "fs")
+            .map(|e| e.detail.as_str())
+            .collect();
+        assert!(
+            fs.iter().any(|d| d.contains("out/c.svg")),
+            "chart artifact write must escape: {fs:?}"
+        );
+        assert!(
+            fs.iter().any(|d| d.contains("out/c.vl.json")),
+            "chart vega sibling write must escape: {fs:?}"
+        );
+        assert!(
+            fs.iter().any(|d| d.contains("audio")),
+            "tts output_dir write must escape: {fs:?}"
+        );
+    }
+
+    #[test]
+    fn chart_vl_sibling_derives_only_for_literal_vega_lite() {
+        let wf = parse(
+            "\
+nika: v1
+workflow: t
+model: mock/echo
+tasks:
+  - id: c
+    invoke:
+      tool: \"nika:chart\"
+      args:
+        data: [{ x: \"a\", y: 1 }]
+        chart: { type: bar, x: x, y: y }
+        out: \"out/c.svg\"
+        compile_to: vega_lite
+  - id: plain
+    invoke:
+      tool: \"nika:chart\"
+      args:
+        data: [{ x: \"a\", y: 1 }]
+        chart: { type: bar, x: x, y: y }
+        out: \"out/p.svg\"
+",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("parse");
+        let invoke_of = |id: &str| match &wf
+            .tasks
+            .iter()
+            .find(|t| t.value.id.value == id)
+            .expect("task")
+            .value
+            .action
+        {
+            crate::raw::RawAction::Invoke(a) => a,
+            other => panic!("not an invoke: {other:?}"),
+        };
+        assert_eq!(
+            chart_vl_sibling(invoke_of("c")).as_deref(),
+            Some("out/c.vl.json"),
+        );
+        assert_eq!(chart_vl_sibling(invoke_of("plain")), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Found live while probing the fresh per-task permits projection (#445): **`nika:chart` and `nika:tts_generate` were invisible to the capability walk.** Concretely:

- A chart/tts write outside the declared boundary **passed the static scan** and failed only at runtime.
- `check --infer-permits` synthesized a boundary that **refused the very workflow it came from** (proven: infer on a chart workflow omitted `out/c.svg` — the builtin's own permit-gated write) — the self-refusing class this module forbids everywhere else.

The fix:

- `nika:chart` classifies its `out` write (single artifact, exact path); the `compile_to` vega `.vl.json` sibling gets ONE shared derivation (`chart_vl_sibling`, matching the runtime byte for byte: `{out%.svg}.vl.json`) consumed by BOTH the escape scan and the boundary inference.
- `nika:tts_generate` classifies its recursive `output_dir` write (the image_generate shape).
- The per-task graph `permits` attribution (#445) speaks them for free — same walk.
- Identical match arms merged per clippy (`image_generate|tts_generate` · `image_fx|chart`).

## Proof

- Escape test pins artifact + vega sibling + tts dir against a constrained boundary; inference test pins all three paths in the emitted YAML; sibling derivation table (literal `vega_lite` only, dynamic → runtime).
- Full schema lib suite **738 green** · clippy pedantic **zero** · no public-API change (helper is `pub(super)`) — no baseline touch.
- End-to-end re-probe: `--infer-permits` on the chart workflow now emits `out/c.svg` where it was silent.

Pushed via the API-commit route (worktree `memory-head-sha` false positive — known class); pushed blobs verified to carry BOTH #445 and this fix (no clobber).

🦋 auditable before it runs