### PR TITLE
docs: software heritage archive badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **Software Heritage badge.** The repository is archived at Software
+  Heritage (save request accepted 2026-07-11 · the archive re-crawls on
+  its own cadence); the README badge links the archived origin — the
+  permanent, vendor-independent copy of the source.
+
 ### Fixed
 
 - **`nika:chart` and `nika:tts_generate` were invisible to the effect

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![Rust](https://img.shields.io/badge/built_in-Rust-orange.svg)](Cargo.toml)
 [![CI](https://github.com/supernovae-st/nika/actions/workflows/diamond-ci.yml/badge.svg?branch=main)](https://github.com/supernovae-st/nika/actions/workflows/diamond-ci.yml)
 [![Release](https://img.shields.io/github/v/release/supernovae-st/nika?label=release)](https://github.com/supernovae-st/nika/releases/latest)
+[![SWH](https://archive.softwareheritage.org/badge/origin/https://github.com/supernovae-st/nika/)](https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/supernovae-st/nika)
 
 Useful AI work shouldn't disappear into chats. **Nika turns repeatable AI
 work into files you can run, review, diff and share.** If you do the same


### PR DESCRIPTION
One badge after Release in the README row, linking the archived origin (save request accepted today — the permanent vendor-independent copy, coherent with the sovereignty doctrine), plus the changelog entry (new Added section above the Unreleased Fixed block). Docs-only.