### PR TITLE
fix(cap,schema,cli): the agent-verb battery triad — compose parity, VAR-005 routes, explainable PERMITS

### DIFF
--- a/crates/nika-cap/src/shape.rs
+++ b/crates/nika-cap/src/shape.rs
@@ -36,6 +36,16 @@ pub fn builtin_shape_findings(tool: &str, args: Option<&serde_json::Value>) -> V
              (02-verbs.md §loop semantics · NIKA-BUILTIN-DONE-001)"
                 .to_owned(),
         ),
+        // The done sentinel's sibling (agent battery A3 · 2026-07-11): the
+        // runtime refuses a standalone `nika:compose` (COMPOSE-001) but the
+        // check blessed it — the same check≡run seam class as the SSRF
+        // floor. Both loop-only builtins (ADR-096) now refuse at check.
+        "nika:compose" => out.push(
+            "is the agent-loop sub-workflow spawner — valid ONLY inside an \
+             `agent:` tools whitelist · never a standalone invoke \
+             (02-verbs.md §loop semantics · NIKA-BUILTIN-COMPOSE-001)"
+                .to_owned(),
+        ),
         "nika:wait" => {
             let has = |key: &str| -> bool {
                 matches!(args, Some(serde_json::Value::Object(map)) if map.contains_key(key))

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -807,9 +807,20 @@ fn permits(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
             .as_deref()
             .map(|f| format!(" · fix: {f}"))
             .unwrap_or_default();
+        // The wire code leads the row (agent battery A2 · 2026-07-11):
+        // CONFORM rows print `[NIKA-…]` and teach `nika explain <CODE>`;
+        // the PERMITS rows printed only the category, so the one panel
+        // whose findings are security-graded was the one panel a user
+        // could not ask the engine to explain. Same code the findings[]
+        // machine list stamps (floor → SEC-005 · boundary → SEC-004).
+        let code = if e.floor {
+            "NIKA-SEC-005"
+        } else {
+            "NIKA-SEC-004"
+        };
         let _ = writeln!(
             out,
-            " {} {}  [{}] task `{}` · {}{fix}",
+            " {} {}  [{code} · {}] task `{}` · {}{fix}",
             mark(t, false),
             t.paint(Role::Strong, "PERMITS"),
             e.category,
@@ -1018,6 +1029,13 @@ mod tests {
         assert!(
             out.contains("NIKA-SEC-005"),
             "the wire code names it: {out}"
+        );
+        // A2 (agent battery 2026-07-11): the code LEADS the row in
+        // bracket position — `[NIKA-SEC-005 · net]` — so the PERMITS
+        // panel is explainable like every CONFORM row (`nika explain`).
+        assert!(
+            out.contains("[NIKA-SEC-005 · net]"),
+            "the code leads the row: {out}"
         );
         assert!(
             !out.contains("no boundary declared"),

--- a/crates/nika-schema/src/analyzer/builtin_shape.rs
+++ b/crates/nika-schema/src/analyzer/builtin_shape.rs
@@ -88,6 +88,10 @@ mod tests {
         // contracts: the `done` sentinel · the `wait` XOR · `fetch` pairings.
         let cases = [
             ("{}", "nika:done", true), // standalone · always the sentinel error
+            // A3 (agent battery 2026-07-11): compose is done's sibling —
+            // the runtime refused it (COMPOSE-001), the check blessed it.
+            ("{}", "nika:compose", true),
+            (r#"{ workflow_yaml: "nika: v1" }"#, "nika:compose", true),
             (
                 r#"{ duration: "5s", until: "2026-12-01T00:00:00Z" }"#,
                 "nika:wait",
@@ -473,6 +477,15 @@ mod tests {
                 false, // provider/model support is runtime business
             ),
         ]);
+    }
+
+    #[test]
+    fn compose_in_agent_whitelist_is_legal() {
+        // The positive direction of the A3 row: granting nika:compose to
+        // an agent loop is exactly what ADR-096 blesses.
+        let agent = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    agent:\n      \
+                     prompt: \"go\"\n      tools: [\"nika:compose\", \"nika:done\"]\n";
+        assert!(!has_shape_error(agent, "nika:compose"));
     }
 
     #[test]

--- a/crates/nika-schema/src/analyzer/mod.rs
+++ b/crates/nika-schema/src/analyzer/mod.rs
@@ -753,6 +753,19 @@ tasks:
             |e| matches!(e, SchemaError::WhenNotBoolean { reason, .. } if reason.contains("boolean")),
             "when not boolean-shaped",
         );
+        // A1 (agent battery 2026-07-11): the teaching names all three
+        // shape routes — the BOOL route leads (a bare flag reference is
+        // the most natural thing this rule rejects, and the old
+        // examples applied to a bool would trade VAR-005 for the rule-4
+        // no-coercion type error).
+        assert_has(
+            &errors,
+            |e| {
+                matches!(e, SchemaError::WhenNotBoolean { reason, .. }
+                if reason.contains("== true") && reason.contains("> 0") && reason.contains("!= \"\""))
+            },
+            "the teaching names the bool · number · string routes",
+        );
     }
 
     #[test]

--- a/crates/nika-schema/src/analyzer/scan.rs
+++ b/crates/nika-schema/src/analyzer/scan.rs
@@ -303,12 +303,20 @@ fn check_single_island(
         return;
     }
     if require_boolean && !is_boolean_shaped(&islands[0].expr) {
+        // The teaching routes by DECLARED shape (agent battery A1 ·
+        // 2026-07-11): the old examples (`> 0` · `!= ""`) applied to a
+        // declared BOOLEAN would trade VAR-005 for a type error (rule 4 ·
+        // no implicit coercion) — the bool route leads, since a bare flag
+        // reference is the most natural thing this rule rejects.
         errors.push(SchemaError::WhenNotBoolean {
             field: field.to_owned(),
             task: task.to_owned(),
             reason: format!(
-                "`{}` is not boolean-shaped — use an explicit comparison (e.g. `… > 0` · `… != \"\"`)",
-                islands[0].src
+                "`{src}` is not boolean-shaped — the shape rule (cel-subset/0.1) wants \
+                 an explicit relation or boolean operator: a boolean reads \
+                 `{src} == true` (or `!{src}`) · a number `{src} > 0` · a string \
+                 `{src} != \"\"`",
+                src = islands[0].src
             ),
             span: Some(value.span),
         });


### PR DESCRIPTION
A **36-workflow battery on the 4th verb** (run/permits/error/edge families · mock/echo offline): does the offline-deterministic promise hold for `agent:`? **29/36 passed outright** — 1-turn termination, 5-agent chains, `for_each` fan-out + `max_parallel`, downstream refs, structured-output schema, retry/timeout/on_error composition. Of 7 surprises, 4 were author-errors the product taught. **Three product findings, fixed:**

| | Finding | Fix |
|---|---|---|
| **A3** | check≡run seam (the F3/SSRF class again): standalone `nika:compose` passed check, runtime refuses (COMPOSE-001) — sibling `nika:done` refused on BOTH | compose joins the shape table in nika-cap (the ONE table both surfaces read) · truth-table rows + positive pin (granted to an agent whitelist stays legal · ADR-096) |
| **A1** | VAR-005 taught a route that would not survive: « use an explicit comparison (`> 0`) » on a DECLARED BOOLEAN trades VAR-005 for the rule-4 no-coercion type error | teaching routes by shape — bool leads (`x == true` · `!x`), number/string follow |
| **A2** | PERMITS was the one panel you couldn't `nika explain` (CONFORM leads with `[NIKA-…]`; PERMITS printed only the category) | the wire code leads the row: `[NIKA-SEC-004 · tools]` · floor `[NIKA-SEC-005 · net]` — same code `findings[]` stamps |

**Re-verdict vs the fixed binary: 36/36 PASS · 0 SURPRISE** (7 EXPECTs flipped to proven truths · the mcp probe renamed to the lazy-resolution law it demonstrates).

Gates: cap 21 · schema 736 (A1 route pin · A3 rows+positive) · cli 290 (A2 bracket pin) · clippy `-D warnings` 0 · fmt clean · zero public-API change. API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)