### PR TITLE
fix(runtime,display): a token-burning empty answer warns on the console (#410)

### DIFF
--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -330,6 +330,7 @@ pub nika_display::state::TaskRow::started_ms: core::option::Option<i64>
 pub nika_display::state::TaskRow::started_note: core::option::Option<alloc::string::String>
 pub nika_display::state::TaskRow::state: nika_display::state::TaskState
 pub nika_display::state::TaskRow::tokens: core::option::Option<u64>
+pub nika_display::state::TaskRow::warning: core::option::Option<alloc::string::String>
 impl nika_display::state::TaskRow
 pub fn nika_display::state::TaskRow::wall_ms(&self) -> core::option::Option<u64>
 impl core::clone::Clone for nika_display::state::TaskRow

--- a/crates/nika-display/src/render.rs
+++ b/crates/nika-display/src/render.rs
@@ -114,6 +114,7 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         ));
     }
 
+    lines.extend(warning_lines(view, theme));
     lines.push(meter_line(view, theme));
 
     // Failure card (only on a failed verdict · derives the explain hint) —
@@ -122,6 +123,29 @@ fn frame_impl(view: &RunView, theme: &Theme, tick: usize, outputs: bool) -> Vec<
         append_failure_card(&mut lines, view, theme);
     }
     lines
+}
+
+/// The OBS-E warning block (#410): one `⚠ <task> · <warning>` line per
+/// row whose terminal frame carried the non-fatal diagnostic (a thinking
+/// model that spent its budget and answered blank). Above the meter so a
+/// green verdict never buries it — the exit code stays 0, the console
+/// stops being silent about the "" feeding downstream.
+// `&Theme` to match the frame borrows that thread it here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn warning_lines(view: &RunView, theme: &Theme) -> Vec<String> {
+    let mark = if theme.ascii { "!" } else { "⚠" };
+    view.rows()
+        .iter()
+        .filter_map(|row| {
+            let warning = row.warning.as_deref()?;
+            Some(format!(
+                "  {} {} · {}",
+                theme.paint(Role::Warn, mark),
+                row.id,
+                theme.paint(Role::Warn, warning),
+            ))
+        })
+        .collect()
 }
 
 /// The footer meter: progress · live cost vs ceiling · wall clock. The
@@ -211,14 +235,16 @@ pub fn stream_settled_line(
     ))
 }
 
-/// The streamed close (#321): the meter + the failure card. The rows
-/// already spoke at their settle — the plain final print never repeats
-/// them (a captured log reads the run ONCE, top to bottom).
+/// The streamed close (#321): the OBS-E warnings (#410) + the meter +
+/// the failure card. The rows already spoke at their settle — the plain
+/// final print never repeats them (a captured log reads the run ONCE,
+/// top to bottom).
 // `&Theme` to match the sink borrow that threads it here.
 #[allow(clippy::trivially_copy_pass_by_ref)]
 #[must_use]
 pub fn stream_summary(view: &RunView, theme: &Theme) -> Vec<String> {
-    let mut lines = vec![meter_line(view, theme)];
+    let mut lines = warning_lines(view, theme);
+    lines.push(meter_line(view, theme));
     if view.verdict == Some(false) {
         append_failure_card(&mut lines, view, theme);
     }
@@ -646,6 +672,63 @@ mod tests {
                 .iter()
                 .any(|l| l.starts_with("  x  write_md") && l.contains("blocked · summarize failed")),
             "ascii blocked row (err X ≠ blocked x): {ascii:?}"
+        );
+    }
+
+    /// #410 · the OBS-E warning reaches the CONSOLE: a green run whose
+    /// infer spent tokens and answered blank must say so above the meter
+    /// (the trace alone knowing was the observability gap) — on the
+    /// final frame AND the streamed plain close, unicode and ASCII.
+    #[test]
+    fn obs_e_warning_renders_above_the_meter() {
+        use nika_event::EventKind;
+        use nika_types::resource::{KeyValue, Value};
+        let task = |n: &str| KeyValue::new("task", Value::String(n.to_owned()));
+
+        let mut view = RunView::new();
+        view.apply(&demo::bare_event(EventKind::TaskStarted, 0).with_field(task("summary")));
+        view.apply(
+            &demo::bare_event(EventKind::TaskCompleted, 5)
+                .with_field(task("summary"))
+                .with_field(KeyValue::new(
+                    "warning",
+                    Value::String(
+                        "infer consumed 512 tokens yet the visible answer is empty".to_owned(),
+                    ),
+                )),
+        );
+
+        let lines = frame(&view, &UNICODE, 0);
+        let warn_at = lines
+            .iter()
+            .position(|l| l.contains("⚠ summary · infer consumed 512 tokens"))
+            .expect("the warning line renders");
+        let meter_at = lines
+            .iter()
+            .position(|l| l.contains("done"))
+            .expect("meter present");
+        assert!(warn_at < meter_at, "warning speaks before the meter");
+
+        // The streamed plain close carries the same block (stream lane).
+        let close = stream_summary(&view, &UNICODE);
+        assert!(
+            close[0].contains("⚠ summary"),
+            "stream close leads with the warning: {close:?}"
+        );
+
+        // ASCII register swaps the glyph, keeps the fact.
+        let ascii = frame(&view, &ASCII, 0);
+        assert!(
+            ascii.iter().any(|l| l.contains("! summary · infer")),
+            "{ascii:?}"
+        );
+
+        // A warning-less run renders no ⚠ block at all.
+        let mut clean = RunView::new();
+        clean.apply(&demo::bare_event(EventKind::TaskCompleted, 5).with_field(task("ok_task")));
+        assert!(
+            !frame(&clean, &UNICODE, 0).iter().any(|l| l.contains('⚠')),
+            "no false alarm on a clean run"
         );
     }
 

--- a/crates/nika-display/src/state.rs
+++ b/crates/nika-display/src/state.rs
@@ -91,6 +91,11 @@ pub struct TaskRow {
     /// surface (` · recovered`) — a repaired success must never render
     /// byte-identical to a clean one (#319).
     pub recovered: bool,
+    /// The OBS-E non-fatal `warning` the terminal frame carried (#410 ·
+    /// the thinking model that spent its budget and answered blank) —
+    /// the task succeeded, but the console must say what the trace
+    /// knows, or a green run silently feeds "" downstream.
+    pub warning: Option<String>,
 }
 
 impl TaskRow {
@@ -319,6 +324,12 @@ impl RunView {
             if let Some(tokens) = int_field(event, "tokens") {
                 self.rows[i].tokens = u64::try_from(tokens).ok();
             }
+            // The OBS-E `warning` rider (#410) — kept on the row so the
+            // final frame can speak it (the trace alone knowing is the
+            // observability gap this closes).
+            if let Some(warning) = str_field(event, "warning") {
+                self.rows[i].warning = Some(warning.to_owned());
+            }
         }
         // Live approximation (per-task) — the terminal frame's
         // leaf-level `unpriced_calls` overwrites it at run end.
@@ -415,6 +426,7 @@ impl RunView {
                 input_hash: None,
                 cached: false,
                 recovered: false,
+                warning: None,
             });
             let i = self.rows.len() - 1;
             self.index.insert(task_id.to_owned(), i);

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -798,14 +798,22 @@ fn check_exec_permits(
 /// answer — the task completes rc=0 with `output == ""` and every
 /// downstream `${{ tasks.X.output }}` silently resolves to nothing.
 ///
-/// The signal is the **empty visible answer paired with reasoning
-/// spend**, NOT `output_tokens == 0`: the gemini wire deliberately folds
-/// `thoughtsTokenCount` INTO `output_tokens` (so a heavy-think empty
-/// answer reports `output_tokens == thoughts > 0`, see
-/// `wire::gemini::usage_from`) — keying off `output_tokens` would never
-/// fire on the very provider this guards. `reasoning_tokens` (`OpenAI`
-/// o-series) is treated the same as `thinking_tokens` (provider-agnostic
-/// · the reasoning budget is one concept across wires).
+/// The signal is the **empty visible answer paired with token spend** —
+/// under either report shape:
+///
+/// - a REPORTED reasoning split (`thinking_tokens` · anthropic
+///   extended-thinking; `reasoning_tokens` · `OpenAI` o-series; the
+///   gemini wire folds `thoughtsTokenCount` INTO `output_tokens`, so its
+///   heavy-think empty answer reports `output_tokens == thoughts > 0` —
+///   see `wire::gemini::usage_from`), or
+/// - NO split at all with `output_tokens > 0` (#410 · the ollama path
+///   strips the think block upstream and reports one undifferentiated
+///   count: 512 tokens consumed, 2 bytes visible — the exact silent
+///   footgun, previously unguarded).
+///
+/// A blank answer with ZERO tokens of any kind stays silent — nothing
+/// was spent, so this is a plain empty completion, not the thinking
+/// footgun.
 ///
 /// Non-fatal: returns the diagnostic STRING when the footgun is detected
 /// (the caller rides it on `TaskCompleted` as a `warning` field) · the
@@ -814,14 +822,25 @@ fn empty_thinking_warning(
     value: &Value,
     usage: &nika_kernel::provider::TokenUsage,
 ) -> Option<String> {
+    if !value_is_blank(value) {
+        return None;
+    }
     let reasoning = usage
         .thinking_tokens
         .unwrap_or(0)
         .saturating_add(usage.reasoning_tokens.unwrap_or(0));
-    if reasoning > 0 && value_is_blank(value) {
+    if reasoning > 0 {
         return Some(format!(
             "infer produced an empty answer · max_tokens likely too low for a thinking model \
              (reasoning consumed {reasoning} tokens)"
+        ));
+    }
+    if usage.output_tokens > 0 {
+        return Some(format!(
+            "infer consumed {} tokens yet the visible answer is empty — a thinking model may \
+             have spent the budget inside its think block (raise max_tokens, or use a no-think \
+             variant)",
+            usage.output_tokens
         ));
     }
     None
@@ -1038,13 +1057,31 @@ mod tests {
     }
 
     #[test]
-    fn obs_e_silent_when_no_reasoning_even_if_answer_blank() {
-        // A blank answer WITHOUT any reasoning spend is a different
-        // problem (an empty completion) · OBS-E only owns the thinking
-        // footgun, so it stays silent (no false alarm).
-        let usage = TokenUsage::new(7, 0); // no thinking, no reasoning
+    fn obs_e_silent_when_nothing_was_spent() {
+        // A blank answer with ZERO tokens of any kind is a plain empty
+        // completion, not the thinking footgun — silence (no false alarm).
+        let usage = TokenUsage::new(7, 0); // no output, no thinking, no reasoning
         assert!(empty_thinking_warning(&Value::String(String::new()), &usage).is_none());
         assert!(empty_thinking_warning(&Value::Null, &usage).is_none());
+    }
+
+    #[test]
+    fn obs_e_fires_on_the_unreported_split_shape() {
+        // #410 · the ollama path: the think block is stripped upstream and
+        // the wire reports ONE undifferentiated count — 512 tokens
+        // consumed, a blank visible answer, no thinking/reasoning split.
+        // The run used to stay green and silent; the warning now names it.
+        let usage = TokenUsage::new(7, 512); // output only — no split fields
+        let warn = empty_thinking_warning(&Value::String(String::new()), &usage)
+            .expect("blank answer + undifferentiated spend → warning");
+        assert!(warn.contains("512"), "reports the spend: {warn}");
+        assert!(warn.contains("max_tokens"), "names the likely fix: {warn}");
+        assert!(warn.contains("no-think"), "names the alternative: {warn}");
+        // A real answer with the same usage shape stays silent.
+        assert!(
+            empty_thinking_warning(&Value::String("Paris".to_owned()), &usage).is_none(),
+            "content is never the footgun"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Two halves close the observability gap of a thinking model that burns its whole budget inside the think block and settles green with an empty visible answer.

**The oracle broadens to the unreported-split shape.** The existing OBS-E warning keyed on `thinking_tokens`/`reasoning_tokens > 0` — but the ollama path strips the think block upstream and reports ONE undifferentiated count (the issue's repro: 512 tokens consumed, 2 bytes visible, no split fields). A blank answer now warns under either report shape; a blank answer with zero tokens of any kind stays silent (a plain empty completion, not the footgun).

**The console speaks it.** The warning already rode the trace (`warning` field on `task_completed`) — but nothing on the console hinted the inference produced nothing, and downstream tasks happily wrote empty files. The display fold now keeps the warning on the row and renders `⚠ <task> · <warning>` above the meter: final frame, streamed plain close, unicode and ASCII.

Closes #410

## Proof

`cargo clippy -p nika-runtime -p nika-display --all-targets -- -D warnings` clean · `cargo test --lib` runtime 106 + display 81 passed · new pins: `obs_e_fires_on_the_unreported_split_shape` (the exact ollama shape), `obs_e_silent_when_nothing_was_spent`, `obs_e_warning_renders_above_the_meter` (frame + stream close + ASCII + no-false-alarm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
