### PR TITLE
feat(runtime): settles stream on the ordered spine — a kill keeps settled siblings (#412)

### DIFF
--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -549,30 +549,34 @@ where
         let run_ledger = ledger::RunLedger::new(self.config.max_cost_usd);
 
         for wave in &report.waves {
-            let finishes = self
-                .dispatch_wave(
+            // The wave-frozen view moves OUT for the wave (same-wave tasks
+            // never reference each other — checker law — so the pipelines
+            // read upstream records only) and back in after: the settles
+            // stream into a side map while the frozen view stays borrowed.
+            let frozen = std::mem::take(&mut records);
+            let streamed = self
+                .dispatch_settle_wave(
                     wave,
                     wf,
-                    &records,
+                    &frozen,
                     (&vars, &env, &secrets, permits),
                     &resume_ctx,
                     &run_ledger,
+                    (&mut ok, &mut cache_hits),
+                    stamper,
+                    sink,
                 )
-                .await?;
+                .await;
+            records = frozen;
+            let (wave_records, paused) = streamed?;
+            records.extend(wave_records);
 
-            if let Some(outcome) = self.settle_wave(
-                finishes,
-                wf,
-                &vars,
-                &env,
-                &resume_ctx,
-                &workflow_name,
-                &mut records,
-                &mut ok,
-                &mut cache_hits,
-                stamper,
-                sink,
-            ) {
+            if let Some(p) = paused {
+                emit_paused(&workflow_name, &p, stamper, sink);
+                let mut outcome =
+                    RunOutcome::new(true, std::mem::take(&mut records), BTreeMap::new());
+                outcome.cache_hits = std::mem::take(&mut cache_hits);
+                outcome.paused = Some(p);
                 return Ok(outcome.with_ledger(&run_ledger.snapshot()));
             }
 
@@ -605,22 +609,48 @@ where
         Ok(outcome)
     }
 
-    /// Resolve one wave's members + dispatch concurrently over the
-    /// wave-frozen records (checker law) · collect in submission order.
+    /// Resolve one wave's members, dispatch concurrently over the
+    /// wave-frozen records (checker law), and settle each finish AS THE
+    /// ORDERED STREAM YIELDS IT (#412): `buffered` yields in submission
+    /// order as each front future completes, so a settled task's frames
+    /// reach the sink — and the trace file — at ITS settle, not the wave
+    /// join. A `kill -9` mid-wave now keeps the resume credit of every
+    /// sibling that already settled. The total event order is unchanged
+    /// (the same sequential wave-order spine); only the timing moves
+    /// earlier — a slow EARLIER member still holds later settles (the
+    /// ordered spine's head-of-line, the price of determinism).
+    ///
+    /// Settles land in a SIDE map (the caller merges after the wave) —
+    /// the frozen view stays borrowed by the in-flight pipelines, and
+    /// same-wave tasks never reference each other, so neither the
+    /// pipelines nor the pause payload can miss a same-wave record.
+    ///
+    /// Returns the wave's settled records + `Some(pause)` iff the wave
+    /// PAUSED on a blocked `nika:prompt` (ADR-099 rider): siblings that
+    /// finished still settle (their work is journaled · they cache-hit
+    /// on resume); the blocked prompt itself never settles; the caller
+    /// emits the pause frame and stops dispatching later waves.
+    ///
     /// Budget gate: `take_while` runs when `buffered` PULLS — a tripped
     /// ledger stops NEW tasks; in-flight complete and count. The default
     /// cap (= wave width) pulls the whole wave before any debit lands:
     /// the gate stops later waves + capped fan-outs, never already-
     /// admitted same-wave siblings. Errors: NIKA-1701 schedule breach.
-    async fn dispatch_wave(
+    // The accumulator pair + the two pens ARE the settle surface —
+    // mirrors `settle` itself.
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_settle_wave(
         &self,
         wave: &[usize],
         wf: &RawWorkflow,
-        records: &BTreeMap<String, TaskRecord>,
+        frozen: &BTreeMap<String, TaskRecord>,
         scope: WaveScope<'_>,
         resume_ctx: &resume::ResumeContext,
         ledger: &ledger::RunLedger,
-    ) -> Result<Vec<Finish>, RuntimeError> {
+        (ok, cache_hits): (&mut bool, &mut Vec<String>),
+        stamper: &mut dyn Stamper,
+        sink: &mut dyn EventSink,
+    ) -> Result<(BTreeMap<String, TaskRecord>, Option<WorkflowPause>), RuntimeError> {
         let (vars, env, secrets, permits) = scope;
         // Resolve indices up front — a bad index is a schedule breach
         // (NIKA-1701 · run abort · the one system error).
@@ -636,61 +666,30 @@ where
             .config
             .wave_parallelism
             .map_or_else(|| members.len().max(1), NonZeroUsize::get);
-        Ok(
+        let mut wave_records: BTreeMap<String, TaskRecord> = BTreeMap::new();
+        let mut paused: Option<WorkflowPause> = None;
+        let mut finishes = std::pin::pin!(
             futures_util::stream::iter(members.iter().take_while(|_| !ledger.tripped()).map(
                 |&task| {
                     self.run_task_pipeline(
-                        task, records, vars, env, secrets, permits, resume_ctx, ledger,
+                        task, frozen, vars, env, secrets, permits, resume_ctx, ledger,
                     )
                 },
             ))
             .buffered(cap)
-            .collect()
-            .await,
-        )
-    }
-
-    /// Settle one wave's finishes in order — `Some(outcome)` iff the wave
-    /// PAUSED on a blocked `nika:prompt` (ADR-099 rider · PROMPT-001
-    /// under a non-interactive surface): siblings that finished still
-    /// settle (their work is journaled · they cache-hit on resume); the
-    /// blocked prompt itself never settles (no `task_failed` — it simply
-    /// has not happened yet); later waves never dispatch.
-    // The pens + the three run accumulators ARE the settle surface —
-    // mirrors `settle` itself.
-    #[allow(clippy::too_many_arguments)]
-    fn settle_wave(
-        &self,
-        finishes: Vec<Finish>,
-        wf: &RawWorkflow,
-        vars: &BTreeMap<String, Value>,
-        env: &BTreeMap<String, Value>,
-        resume_ctx: &resume::ResumeContext,
-        workflow_name: &str,
-        records: &mut BTreeMap<String, TaskRecord>,
-        ok: &mut bool,
-        cache_hits: &mut Vec<String>,
-        stamper: &mut dyn Stamper,
-        sink: &mut dyn EventSink,
-    ) -> Option<RunOutcome> {
-        let mut paused: Option<WorkflowPause> = None;
-        for finish in finishes {
+        );
+        while let Some(finish) = finishes.next().await {
             if self.pause_on_prompt
                 && paused.is_none()
                 && let Some(p) =
-                    pause::prompt_block(&finish, wf, records, vars, env, resume_ctx.markers())
+                    pause::prompt_block(&finish, wf, frozen, vars, env, resume_ctx.markers())
             {
                 paused = Some(p);
                 continue;
             }
-            settle(finish, records, ok, cache_hits, stamper, sink);
+            settle(finish, &mut wave_records, ok, cache_hits, stamper, sink);
         }
-        let p = paused?;
-        emit_paused(workflow_name, &p, stamper, sink);
-        let mut outcome = RunOutcome::new(true, std::mem::take(records), BTreeMap::new());
-        outcome.cache_hits = std::mem::take(cache_hits);
-        outcome.paused = Some(p);
-        Some(outcome)
+        Ok((wave_records, paused))
     }
 }
 

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -10,6 +10,138 @@
 
 use super::*;
 
+/// #412 test seam — the gate: a `nika:jq` call whose `expression` arg is
+/// `".gate"` polls the sink's flag (1ms yields — tokio's `sync` feature
+/// is off in this workspace, and a flag poll needs only `time`); every
+/// other call answers instantly. Bounded at 5s so a regression fails
+/// loudly, never hangs the suite.
+struct GateExecutor {
+    unblock: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl nika_kernel::tool_executor::ToolExecuteDyn for GateExecutor {
+    async fn execute(
+        &self,
+        call: nika_kernel::tool_executor::ToolCall,
+    ) -> Result<nika_kernel::tool_executor::ToolResult, nika_kernel::tool_executor::ToolExecError>
+    {
+        use std::sync::atomic::Ordering;
+        if call.input.get("expression").and_then(Value::as_str) == Some(".gate") {
+            let mut waited_ms = 0u32;
+            while !self.unblock.load(Ordering::Acquire) {
+                if waited_ms > 5_000 {
+                    return Err(nika_kernel::tool_executor::ToolExecError::NotAvailable {
+                        reason: "settles did not stream — the gate starved (#412 \
+                                 regression: frames held to the wave join)"
+                            .into(),
+                    });
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                waited_ms += 1;
+            }
+        }
+        Ok(nika_kernel::tool_executor::ToolResult::success(
+            call.id.as_str(),
+            "\"done\"",
+        ))
+    }
+}
+
+/// #412 test seam — the observer: forwards every event to a [`VecSink`]
+/// and flips the gate's flag when `fast`'s terminal frame arrives.
+struct NotifyOnFastSettle {
+    inner: VecSink,
+    unblock: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl EventSink for NotifyOnFastSettle {
+    fn emit(&mut self, event: Event) {
+        let is_fast_completed = event.kind == EventKind::TaskCompleted
+            && event.fields.iter().any(|kv| {
+                kv.key == "task" && matches!(&kv.value, FieldValue::String(s) if s == "fast")
+            });
+        if is_fast_completed {
+            self.unblock
+                .store(true, std::sync::atomic::Ordering::Release);
+        }
+        self.inner.emit(event);
+    }
+}
+
+/// #412 · settles STREAM through the ordered spine: a settled sibling's
+/// frames reach the sink at ITS settle, not the wave join. Proof by
+/// construction: `gate` (same wave, declared after `fast`) BLOCKS until
+/// the sink has seen fast's `task_completed` — join-granularity frames
+/// would starve it forever (they'd only exist after gate itself
+/// finished); the streamed spine settles fast first and unblocks the
+/// wave. A 5s timeout turns a regression into a loud failure, never a
+/// hung suite.
+#[tokio::test]
+async fn wave_settles_stream_before_the_join() {
+    use nika_kernel_mock::{MockClock, MockProvider, MockShell, MockToolDefinitionProvider};
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+    use std::sync::atomic::AtomicBool;
+
+    let yaml = "nika: v1\nworkflow: stream-settle\ntasks:\n  - id: fast\n    exec: { command: \"true\" }\n  - id: gate\n    invoke: { tool: \"nika:jq\", args: { input: [], expression: \".gate\" } }\n";
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_schema::check(&wf);
+    assert!(report.is_clean(), "fixture must check clean");
+    assert_eq!(report.waves.len(), 1, "ONE wave — the whole point");
+
+    let unblock = Arc::new(AtomicBool::new(false));
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(GateExecutor {
+        unblock: Arc::clone(&unblock),
+    })));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new().enqueue_ok("ok"))),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = NotifyOnFastSettle {
+        inner: VecSink::new(),
+        unblock,
+    };
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    assert!(outcome.ok, "both tasks settle green: {:?}", outcome.records);
+
+    // The settle ORDER is unchanged (submission order — the spine):
+    // fast's terminal frame precedes gate's.
+    let completed: Vec<&str> = sink
+        .inner
+        .events()
+        .iter()
+        .filter(|e| e.kind == EventKind::TaskCompleted)
+        .filter_map(|e| {
+            e.fields
+                .iter()
+                .find(|kv| kv.key == "task")
+                .and_then(|kv| match &kv.value {
+                    FieldValue::String(s) => Some(s.as_str()),
+                    _ => None,
+                })
+        })
+        .collect();
+    assert_eq!(completed, ["fast", "gate"], "the ordered spine holds");
+}
+
 #[test]
 fn runtime_config_default_is_wave_width_seed_zero() {
     let cfg = RuntimeConfig::default();


### PR DESCRIPTION
## What

`task_completed` used to reach the sink — and therefore the trace file — at the **wave join**: dispatch collected every finish, then settled sequentially. A `kill -9` mid-wave lost the resume credit of every sibling that had already settled on the console (the trace held `task_scheduled` only), so `--resume` re-ran finished work and re-billed finished infers — exactly the work resume exists to protect (the issue's repro + the use-case battery's independent confirmation).

`dispatch_wave` + `settle_wave` fuse into `dispatch_settle_wave`: `buffered` yields in submission order as each front future completes, and each finish settles **as it yields** — frames land at the task's settle. The trace side needed nothing: `TraceFileSink` already flushes per line; the runtime simply never handed it the frames until the join.

## Determinism

- The total event order is UNCHANGED — the same sequential submission-order spine; only the timing moves earlier. (A slow earlier member still holds later settles: head-of-line on the ordered spine is the price of determinism.)
- Settles land in a side map merged after the wave: the frozen wave view stays borrowed by in-flight pipelines, and same-wave tasks never reference each other (checker law), so neither the pipelines nor the pause payload can miss a record.
- The ADR-099 pause rider and the `--max-cost-usd` budget boundary keep their exact semantics (pause still settles finished siblings and stops later waves).

Closes #412

## Proof

`cargo test -p nika-runtime --lib` 106 passed · `-p nika-cli --lib` 290 passed · clippy-touched clean. The new pin is deadlock-shaped (`wave_settles_stream_before_the_join`): a same-wave sibling BLOCKS until the sink has seen the fast task's terminal frame — join-granularity frames would starve it (5s loud failure); the streamed spine unblocks it. The pin also asserts the settle ORDER is byte-stable (`["fast", "gate"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
