### PR TITLE
feat(release): official multi-arch docker image on ghcr (#442)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# The image COPYs a staged release binary — only dist/ enters the build
+# context (keeps `docker build` from shipping the source tree + target/).
+*
+!dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,3 +271,54 @@ jobs:
             git commit -m "nika ${VERSION}"
             git push
           fi
+
+  docker:
+    # The official multi-arch image (#442) — one image unblocks Dokploy /
+    # Coolify / Railway templates + the Docker MCP Registry. Fed from the
+    # SAME linux tarball artifacts the release ships (never a rebuild), so
+    # the image binary is bit-identical to the published tarballs the funnel
+    # e2e + trust battery already gated. `needs: release` keeps the image
+    # behind the published release: an image never precedes its tarballs.
+    # SECURITY: the only run: step reads VERSION through env: (tag-derived,
+    # cf the header contract) — no event text reaches a shell.
+    # NB: a workflow_dispatch re-run of an OLD tag re-points `latest` at it
+    # (same semantics as the formula bump) — dispatch old tags knowingly.
+    name: docker image (ghcr)
+    needs: release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout the Dockerfile
+      packages: write # push to ghcr.io — scoped to THIS job only
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Stage per-arch binaries into the build context
+        # Docker arch names (amd64 · arm64) ≠ release tarball arch names
+        # (x64 · arm64) — the mapping happens HERE, once; the Dockerfile
+        # just COPYs dist/linux/${TARGETARCH}/nika.
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/linux/amd64 dist/linux/arm64
+          tar -xzf "artifacts/nika-linux-x64-${VERSION}.tar.gz" -C dist/linux/amd64 nika
+          tar -xzf "artifacts/nika-linux-arm64-${VERSION}.tar.gz" -C dist/linux/arm64 nika
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Build + push (linux/amd64 · linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ needs.release.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Nika — official image (ghcr.io/supernovae-st/nika · linux/amd64 + linux/arm64)
+#
+# Built on the release train (.github/workflows/release.yml `docker` job) from
+# the SAME tarball binaries the GitHub release ships — never a rebuild. The
+# base mirrors the proven MCP-lane image (nika-agents integrations/mcp/
+# Dockerfile · in-container oracle probed in CI): ubuntu:24.04 matches the
+# glibc of the release build runners (the linux-arm64 lane builds on
+# ubuntu-24.04-arm — a smaller-glibc base would strand that binary). TLS
+# roots are compiled into the binary (rustls + webpki-roots), so no
+# ca-certificates layer is needed for `infer:`/`fetch` HTTPS.
+#
+# Lanes this image targets: `nika check` · `nika run` · `nika mcp`. `exec:`
+# tasks get the base's shell + coreutils and nothing more — extend the image
+# (`FROM ghcr.io/supernovae-st/nika` + apt-get) when a workflow shells out
+# to heavier tools.
+#
+# CI stages binaries at dist/linux/<TARGETARCH>/nika. Local build = the same
+# staging (docker arch: amd64|arm64 · release tarball arch: x64|arm64):
+#   v=0.99.0; a=arm64                    # apple-silicon/arm hosts (amd64: a=x64)
+#   curl -fsSLO "https://github.com/supernovae-st/nika/releases/download/v${v}/nika-linux-${a}-${v}.tar.gz"
+#   mkdir -p dist/linux/arm64 && tar -xzf "nika-linux-${a}-${v}.tar.gz" -C dist/linux/arm64 nika
+#   docker build -t nika .
+#
+# Run:  docker run --rm -v "$PWD:/work" -w /work ghcr.io/supernovae-st/nika check flow.nika.yaml
+# MCP:  docker run -i --rm ghcr.io/supernovae-st/nika mcp
+
+FROM ubuntu:24.04
+ARG TARGETARCH
+LABEL org.opencontainers.image.source="https://github.com/supernovae-st/nika" \
+      org.opencontainers.image.description="Nika — the workflow language for AI. One YAML file: check it, run it, trace it." \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later"
+COPY dist/linux/${TARGETARCH}/nika /usr/local/bin/nika
+ENTRYPOINT ["nika"]

--- a/README.md
+++ b/README.md
@@ -318,6 +318,18 @@ cargo binstall --git https://github.com/supernovae-st/nika nika-cli
 nix run github:supernovae-st/nika
 ```
 
+Deploying to containers (Dokploy · Coolify · Railway · any PaaS)?
+
+```sh
+# docker — the official multi-arch image (ghcr · linux/amd64 + linux/arm64),
+# built on the release train from the same verified release binaries;
+# mount your workdir to check/run workflows
+docker run --rm -v "$PWD:/work" -w /work ghcr.io/supernovae-st/nika check hello.nika.yaml
+
+# the MCP lane (stdio JSON-RPC) — wire it into any MCP client config
+docker run -i --rm ghcr.io/supernovae-st/nika mcp
+```
+
 Your first workflow runs with **zero setup**: no model, no API key:
 
 ```sh


### PR DESCRIPTION
## What

The release train gains a `docker` job: on tag push, after the linux tarballs exist, it downloads the release artifacts, stages the per-arch binaries, and buildx-pushes `ghcr.io/supernovae-st/nika:{latest,<semver>}` for linux/amd64 + linux/arm64. `packages: write` is scoped to that job only; GITHUB_TOKEN — no new secret.

- Root `Dockerfile`: **ubuntu:24.04** base (the shipped arm64 release binary requires GLIBC_2.39 — probed from the actual asset; bookworm-slim's 2.36 would strand arm64), `ENTRYPOINT ["nika"]`, OCI labels including `image.source` for GHCR repo-linking. Shape reused from the CI-proven nika-agents MCP Dockerfile.
- `.dockerignore` allowlists `dist/` only.
- README gains the container lane (workdir-mounted `check` · `docker run -i … mcp`).

## The triple unlock (distribution research §G/§H)

One image unblocks: Dokploy compose templates · Coolify service templates · Railway template + open-source kickback · the Docker MCP Registry server.yaml lane (policy re-check at PR time — the registry path is distinct from the GPL-blocked Catalog).

## Proven vs first-tag

Validated locally: workflow YAML + actionlint clean · the real `nika-linux-arm64-0.99.0.tar.gz` downloaded — artifact naming and single-binary tar layout match the staging step exactly. Not provable without a daemon/tag: the `docker build` itself and the GHCR push — the first release tag proves both. One-time operator step after: flip the GHCR package to public visibility.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)