### PR TITLE
feat(release): official ghcr docker image — multi-arch, verified

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,45 @@ jobs:
             --verify-tag \
             artifacts/nika-*.tar.gz artifacts/SHA256SUMS
 
+  docker:
+    name: docker image (ghcr)
+    needs: release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout only — this job never writes the repo
+      packages: write # push ghcr.io/supernovae-st/nika
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Smoke the amd64 image before any push
+        run: |
+          set -euo pipefail
+          docker buildx build --load \
+            --platform linux/amd64 \
+            --build-arg "NIKA_VERSION=${VERSION}" \
+            -f docker/Dockerfile -t nika-smoke .
+          docker run --rm nika-smoke --version | grep -F "${VERSION}"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build + push multi-arch
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            NIKA_VERSION=${{ env.VERSION }}
+          tags: |
+            ghcr.io/supernovae-st/nika:${{ env.VERSION }}
+            ghcr.io/supernovae-st/nika:latest
+
   bump-formula:
     name: bump homebrew tap
     needs: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   its own cadence); the README badge links the archived origin — the
   permanent, vendor-independent copy of the source.
 
+- **Official Docker image on GHCR** — the release workflow now builds and
+  pushes `ghcr.io/supernovae-st/nika` (multi-arch linux/amd64 + linux/arm64 ·
+  tags `latest` + semver, smoke-tested before any push). The image carries
+  the checksum-verified release binary on debian-slim with a non-root user;
+  the entrypoint is the whole CLI — `docker run --rm ghcr.io/supernovae-st/nika
+  --version`, and `docker run -i --rm ghcr.io/supernovae-st/nika mcp` serves
+  the read-only MCP oracle. Standalone-buildable from the repo:
+  `docker build -f docker/Dockerfile --build-arg NIKA_VERSION=<v> .` (#442)
+
 ### Fixed
 
 - **`nika:chart` and `nika:tts_generate` were invisible to the effect
@@ -30,7 +39,6 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   Escape scanning, boundary inference and the per-task graph `permits`
   attribution all speak them now.
 
-### Added
 
 - **`graph --format json` fills the per-task `permits` attribution** —
   the field the projection declared as its contract (empty since #367)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#
+# The official nika image (#442) — the RELEASE binary, checksum-verified,
+# multi-arch (linux/amd64 + linux/arm64). Built and pushed to
+# `ghcr.io/supernovae-st/nika` by the release workflow; standalone-buildable
+# too (the same ARG-download pattern the nika-agents kit proved in CI):
+#
+#   docker build -f docker/Dockerfile --build-arg NIKA_VERSION=0.99.0 -t nika .
+#   docker run --rm nika --version
+#   docker run -i --rm nika mcp          # the read-only MCP oracle (stdio)
+#
+# Base: debian-slim, NOT distroless — the `exec:` verb and shell-form
+# commands need a shell + coreutils; the oracle lane never uses them but
+# the image entrypoint is the WHOLE binary (`nika`), per the issue.
+FROM debian:12-slim AS fetch
+ARG NIKA_VERSION
+ARG TARGETARCH
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+RUN set -eu; \
+    test -n "${NIKA_VERSION}" || { echo "NIKA_VERSION build-arg is required" >&2; exit 1; }; \
+    case "${TARGETARCH}" in \
+      amd64) A=x64 ;; \
+      arm64) A=arm64 ;; \
+      *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    T="nika-linux-${A}-${NIKA_VERSION}.tar.gz"; \
+    cd /tmp; \
+    curl -fsSL -O "https://github.com/supernovae-st/nika/releases/download/v${NIKA_VERSION}/${T}"; \
+    curl -fsSL -O "https://github.com/supernovae-st/nika/releases/download/v${NIKA_VERSION}/SHA256SUMS"; \
+    grep " ${T}\$" SHA256SUMS | sha256sum -c -; \
+    tar -xzf "${T}" -C /usr/local/bin nika; \
+    chmod +x /usr/local/bin/nika
+
+FROM debian:12-slim
+# ca-certificates: rustls needs CA roots for `nika:fetch` + provider calls.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --create-home --uid 10001 nika
+COPY --from=fetch /usr/local/bin/nika /usr/local/bin/nika
+USER nika
+WORKDIR /home/nika
+LABEL org.opencontainers.image.source="https://github.com/supernovae-st/nika" \
+      org.opencontainers.image.description="nika — Intent as Code · the workflow language for AI. One file, 4 verbs, one binary. Entrypoint is the whole CLI; `docker run -i --rm <img> mcp` serves the read-only MCP oracle." \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later"
+ENTRYPOINT ["nika"]
+CMD ["--help"]


### PR DESCRIPTION
Closes #442 — the triple unlock (Dokploy/Coolify/Railway templates · Docker MCP Registry lane · plain docker-compose users), all blocked on an official image existing.

**The image** (`docker/Dockerfile`): the kit-proven ARG-download pattern promoted engine-side — a fetch stage curls the release tarball for `TARGETARCH`, verifies it against `SHA256SUMS`, and the runtime is debian-12-slim + ca-certificates + a non-root user. debian-slim, not distroless: the `exec:` verb needs a shell; the entrypoint is the whole CLI per the issue (`docker run -i --rm ghcr.io/supernovae-st/nika mcp` serves the MCP oracle).

**The workflow** (`release.yml` +`docker` job): hangs on `needs.release` (assets published by then) · **smoke-tests the amd64 image against the version string BEFORE any push** · buildx multi-arch (linux/amd64 + linux/arm64) · GHCR push with `GITHUB_TOKEN` under job-scoped `packages: write` (top-level perms untouched). Tags `latest` + semver.

Standalone-buildable: `docker build -f docker/Dockerfile --build-arg NIKA_VERSION=0.99.0 .`

First tagged release proves the GHCR lane end-to-end; then the Dokploy/Coolify/MCP-Registry listings unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)