### PR TITLE
feat(http,schema): an exact loopback literal in permits clears the ssrf floor for that host (#395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **An exact loopback literal in `permits.net.http` clears the SSRF
+  floor for that host** (#395 · the ADR-092 secrets-`egress:`
+  precedent: the owner's explicit act, co-located with the boundary).
+  Qualifying literals: `localhost` · a `127.x.y.z` v4 literal · `::1`
+  (bracketed `[::1]` accepted) — NEVER a glob, never the `*.localhost`
+  family, never RFC1918/link-local/CGN/metadata (those stay
+  floor-blocked even when named). The clearing is exact-host and
+  host-level (ports don't participate in permits): a permitted
+  `localhost` reaches its own resolved `127.0.0.1`/`::1`, while a
+  rebind of that name to any other blocked range, a redirect hop to an
+  un-permitted floor host, and a public DNS name resolving to loopback
+  (`mylocal.dev` → `127.0.0.1`) all still refuse — the declassification
+  is the literal in the file, never the resolution. check≡run same-PR:
+  the floor-parity pass stops flagging the permitted literal
+  (NIKA-SEC-005) and the dead-grant flag skips it; the clearing is
+  stated instead — an informational line in the PERMITS panel and a
+  `permits.notes` entry in the JSON report. `--infer-permits` still
+  NEVER writes a loopback grant (the explicit act stays the author's);
+  its honesty note now teaches the opt-in.
+
 - **`nika check --fix` — the in-binary repair loop.** The ladder's typed
   did-you-mean suggestions become one keystroke (the `clippy --fix` /
   `eslint --fix` shape): typo'd fields (`promt:`), tools (`nika:raed`),

--- a/crates/nika-builtin/src/permits.rs
+++ b/crates/nika-builtin/src/permits.rs
@@ -38,7 +38,9 @@ pub(crate) const SEC_DENIED: &str = "NIKA-SEC-004";
 /// The spec-canonical code for an SSRF block — a `nika:fetch`/`nika:notify`
 /// URL resolving to a loopback/private/link-local/metadata target (the
 /// always-on engine floor · `05-errors.md` · `security_error` · never
-/// retryable, never fed back to an `agent:` model · independent of `permits:`).
+/// retryable, never fed back to an `agent:` model · independent of
+/// `permits:` with ONE carve-out: an exact loopback literal in
+/// `permits.net.http` declassifies the floor for that host only · #395).
 pub(crate) const SEC_SSRF: &str = "NIKA-SEC-005";
 
 /// Which direction of `permits.fs` an op needs.

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -799,6 +799,7 @@ fn permits(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
             t.paint(Role::Strong, "PERMITS"),
             t.paint(Role::Dim, "body fits the declared boundary")
         );
+        loopback_declassification_lines(out, wf, t);
         return;
     }
     for e in &report.capability_escapes {
@@ -827,6 +828,37 @@ fn permits(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
             e.task,
             e.detail,
         );
+    }
+}
+
+/// The loopback-declassification statement (#395), one dim line per
+/// exact loopback literal in the declared `net.http`: a green panel must
+/// TEACH that the always-on SSRF floor is cleared for that host by the
+/// author's explicit permit — silence would hide a security-relevant
+/// clearing. Informational only (never a finding — the clearing is the
+/// declared intent working as designed); the JSON twin rides
+/// `report.permits.notes`.
+fn loopback_declassification_lines(out: &mut String, wf: &RawWorkflow, t: Theme) {
+    let Some(permits) = wf.permits.as_ref() else {
+        return;
+    };
+    let Some(net) = permits.value.net.as_ref() else {
+        return;
+    };
+    for entry in &net.http {
+        if nika_types::net::is_exact_loopback_literal(entry) {
+            let _ = writeln!(
+                out,
+                "   {}",
+                t.paint(
+                    Role::Dim,
+                    &format!(
+                        "`{entry}` — exact loopback literal: the explicit permit \
+                         clears the always-on SSRF floor (NIKA-SEC-005) for that host"
+                    )
+                ),
+            );
+        }
     }
 }
 
@@ -1050,6 +1082,45 @@ mod tests {
         let mut clean_out = String::new();
         permits(&mut clean_out, &clean_report, &clean, theme);
         assert!(clean_out.contains("no boundary declared"), "{clean_out}");
+    }
+
+    /// The #395 admitting direction, through the CLI render: the battery
+    /// local-watch repro (`permits.net.http: ["127.0.0.1"]` + a literal
+    /// fetch to it) is GREEN — no NIKA-SEC-005, no dead-grant flag — and
+    /// the panel TEACHES the clearing with the informational line.
+    #[test]
+    fn permitted_loopback_literal_renders_green_with_the_teaching_line() {
+        let wf = parse_wf(
+            "nika: v1\nworkflow: local-watch\npermits:\n  net: { http: [\"127.0.0.1\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"http://127.0.0.1:8971/price.json\" } }\n",
+        );
+        let report = nika_schema::check(&wf);
+        assert!(
+            report.capability_escapes.is_empty(),
+            "the exact literal declassifies: {:?}",
+            report.capability_escapes
+        );
+        let theme = Theme::new(false, true, false);
+        let mut out = String::new();
+        permits(&mut out, &report, &wf, theme);
+        assert!(
+            out.contains("body fits the declared boundary"),
+            "green panel: {out}"
+        );
+        assert!(
+            out.contains("exact loopback literal") && out.contains("`127.0.0.1`"),
+            "the teaching line renders: {out}"
+        );
+        // …and a boundary with no loopback literal renders NO such line.
+        let plain = parse_wf(
+            "nika: v1\nworkflow: w\npermits:\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/x\" } }\n",
+        );
+        let plain_report = nika_schema::check(&plain);
+        let mut plain_out = String::new();
+        permits(&mut plain_out, &plain_report, &plain, theme);
+        assert!(
+            !plain_out.contains("exact loopback literal"),
+            "no loopback grant → no line: {plain_out}"
+        );
     }
 
     /// A `required: true` input with no `default:` is what the operator MUST

--- a/crates/nika-http/src/lib.rs
+++ b/crates/nika-http/src/lib.rs
@@ -44,6 +44,16 @@
 //!    per-request `follow_redirects` works, and a public host can not
 //!    bounce the client into private space.
 //!
+//! The ONE narrow carve-out (issue #395 · ADR-092 egress precedent): an
+//! EXACT loopback literal in the declared `permits.net.http`
+//! (`localhost` · `127.x.y.z` · `::1`/`[::1]` — never a glob, never
+//! RFC1918/link-local/metadata) is the author's declassification and
+//! clears the floor for THAT host only, across all four layers: the
+//! static vet skips the block for the exact host, and the resolve layers
+//! admit the LOOPBACK addresses of that permitted NAME only (a rebind to
+//! any other blocked range, or a redirect to an un-permitted floor host,
+//! still refuses).
+//!
 //! # Response size caps
 //!
 //! `max_response_bytes` (default 64 MiB) activates the kernel's
@@ -119,7 +129,25 @@ pub enum NetBoundary {
     /// host outside it fails [`HttpError::HostNotAllowed`] (→ `NIKA-SEC-004`).
     /// An EMPTY list admits nothing (a `permits:` block present but omitting
     /// `net` = no outbound network).
+    ///
+    /// An EXACT loopback literal among the entries (`localhost` ·
+    /// `127.x.y.z` · `::1`/`[::1]`) is ALSO the author's SSRF-floor
+    /// declassification for that host (issue #395 · ADR-092 egress
+    /// precedent) — never a glob, never RFC1918/link-local/metadata (those
+    /// stay floor-blocked even when named).
     Declared(Vec<String>),
+}
+
+impl NetBoundary {
+    /// The declared glob list — empty for [`NetBoundary::Unbounded`]. The
+    /// ONE slice the floor declassification, the allowlist, and the
+    /// guarded resolver all read.
+    fn globs(&self) -> &[String] {
+        match self {
+            Self::Declared(globs) => globs,
+            Self::Unbounded => &[],
+        }
+    }
 }
 
 /// Configuration for [`ReqwestHttp`].
@@ -213,7 +241,14 @@ fn check_net_allowlist(boundary: &NetBoundary, url: &url::Url) -> Result<(), Htt
             host: url.as_str().to_owned(),
         });
     };
-    if nika_types::net::host_in_allowlist(globs, &host) {
+    // A qualifying loopback literal admits its host too (#395): the glob
+    // matcher knows nothing of the `[::1]` authority spelling, and an
+    // entry that CLEARS the floor for a host but then failed the
+    // allowlist would be check-green + run-refused — the drift class this
+    // carve-out closes. Loopback-exact only; it widens nothing else.
+    if nika_types::net::host_in_allowlist(globs, &host)
+        || nika_types::net::loopback_declassified(globs, &host)
+    {
         Ok(())
     } else {
         Err(HttpError::HostNotAllowed { host })
@@ -252,8 +287,13 @@ impl ReqwestHttp {
             // HttpConfig field — never ambient (crate docs · layer 3).
             .no_proxy();
         if config.ssrf == SsrfMode::Enforce {
-            // Layer 3: range-check INSIDE the connect path.
-            builder = builder.dns_resolver(std::sync::Arc::new(GuardedResolver));
+            // Layer 3: range-check INSIDE the connect path. The resolver
+            // carries the declared `permits.net.http` so a permitted exact
+            // loopback literal (#395) clears its OWN resolution at the
+            // connect path too — per resolved NAME, never per address class.
+            builder = builder.dns_resolver(std::sync::Arc::new(GuardedResolver {
+                net_permits: std::sync::Arc::new(config.net.globs().to_vec()),
+            }));
         }
         let inner = builder.build().map_err(|e| HttpError::Other {
             reason: format!("failed to build HTTP client: {e}"),
@@ -274,7 +314,9 @@ impl ReqwestHttp {
             SsrfMode::Disabled => url::Url::parse(raw).map_err(|e| HttpError::Other {
                 reason: format!("invalid URL: {e}"),
             })?,
-            SsrfMode::Enforce => ssrf::check_url(raw)?,
+            // The declared permits ride into the static floor check: an
+            // exact loopback literal among them declassifies its host (#395).
+            SsrfMode::Enforce => ssrf::check_url(raw, self.config.net.globs())?,
         };
         // 2. The workflow's DECLARED permits.net.http boundary (NIKA-SEC-004),
         //    on EVERY hop (this fn runs once per redirect), holding even under
@@ -289,7 +331,7 @@ impl ReqwestHttp {
         // 3. DNS-resolve guard (Enforce only) — every resolved address
         //    range-checked, AFTER the host cleared the declared boundary.
         if self.config.ssrf == SsrfMode::Enforce {
-            resolve_guard(&parsed).await?;
+            resolve_guard(&parsed, self.config.net.globs()).await?;
         }
         Ok(parsed)
     }
@@ -575,11 +617,21 @@ enum ResolveVerdict {
 /// Classify resolved addresses: `Private` if ANY is in a blocked range,
 /// else `AllPublic` (≥1) or `Empty` (none). Pure — the testable core of
 /// the DNS-resolve SSRF layer.
-fn classify_resolved(addrs: impl IntoIterator<Item = std::net::SocketAddr>) -> ResolveVerdict {
+///
+/// `allow_loopback` is the #395 declassification verdict for the NAME
+/// being resolved (its host is a permitted exact loopback literal): it
+/// admits the LOOPBACK CLASS ONLY — a permitted `localhost` must reach
+/// its resolved `127.0.0.1`/`::1`, while a rebind of the same name to
+/// RFC1918/metadata still refuses.
+fn classify_resolved(
+    addrs: impl IntoIterator<Item = std::net::SocketAddr>,
+    allow_loopback: bool,
+) -> ResolveVerdict {
     let mut any = false;
     for addr in addrs {
         any = true;
-        if ssrf::ip_is_blocked(addr.ip()) {
+        let ip = addr.ip();
+        if ssrf::ip_is_blocked(ip) && !(allow_loopback && ip.is_loopback()) {
             return ResolveVerdict::Private;
         }
     }
@@ -597,16 +649,25 @@ fn classify_resolved(addrs: impl IntoIterator<Item = std::net::SocketAddr>) -> R
 /// to land. Resolution itself is `tokio::net::lookup_host` (the system
 /// resolver, same as reqwest's default `GaiResolver`) under
 /// [`DNS_RESOLVE_TIMEOUT`].
-#[derive(Debug, Clone, Copy, Default)]
-struct GuardedResolver;
+#[derive(Debug, Clone, Default)]
+struct GuardedResolver {
+    /// The workflow's declared `permits.net.http` entries — read ONLY for
+    /// the exact-loopback declassification (#395): loopback addresses are
+    /// admitted iff the NAME being resolved is itself a permitted exact
+    /// loopback literal (`loopback_declassified` · per-name, so a redirect
+    /// hop or rebound public name gets no clearance from someone else's
+    /// grant). Empty = no boundary = today's strict floor.
+    net_permits: std::sync::Arc<Vec<String>>,
+}
 
 impl reqwest::dns::Resolve for GuardedResolver {
     fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
         let host = name.as_str().to_owned();
+        let allow_loopback = nika_types::net::loopback_declassified(&self.net_permits, &host);
         Box::pin(async move {
             // Port 0 — reqwest substitutes the URL's effective port
             // (`dns_resolver` contract · verified docs.rs 2026-06-12).
-            match guarded_lookup(&host, 0).await {
+            match guarded_lookup(&host, 0, allow_loopback).await {
                 Ok(addrs) => Ok(Box::new(addrs.into_iter()) as reqwest::dns::Addrs),
                 Err(e) => Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>), // box-dyn-ok(vendor-seam): reqwest::dns::Resolving's error slot REQUIRES this exact type — the typed HttpError rides inside and is recovered by find_http_error
             }
@@ -615,11 +676,17 @@ impl reqwest::dns::Resolve for GuardedResolver {
 }
 
 /// One guarded DNS resolution — system lookup under
-/// [`DNS_RESOLVE_TIMEOUT`], EVERY returned address range-checked.
-/// Shared by the advisory layer ([`resolve_guard`]) and the
-/// enforcement layer ([`GuardedResolver`]): one logic, two seams
-/// (review lens 2 · P3-1 dedupe).
-async fn guarded_lookup(host: &str, port: u16) -> Result<Vec<std::net::SocketAddr>, HttpError> {
+/// [`DNS_RESOLVE_TIMEOUT`], EVERY returned address range-checked
+/// (loopback admitted only under the caller's `allow_loopback`
+/// declassification verdict for THIS host · #395). Shared by the
+/// advisory layer ([`resolve_guard`]) and the enforcement layer
+/// ([`GuardedResolver`]): one logic, two seams (review lens 2 ·
+/// P3-1 dedupe).
+async fn guarded_lookup(
+    host: &str,
+    port: u16,
+    allow_loopback: bool,
+) -> Result<Vec<std::net::SocketAddr>, HttpError> {
     let lookup = tokio::time::timeout(DNS_RESOLVE_TIMEOUT, tokio::net::lookup_host((host, port)))
         .await
         .map_err(|_| HttpError::Timeout {
@@ -629,7 +696,7 @@ async fn guarded_lookup(host: &str, port: u16) -> Result<Vec<std::net::SocketAdd
             reason: format!("DNS resolution failed for {host}: {e}"),
         })?;
     let addrs: Vec<std::net::SocketAddr> = lookup.collect();
-    match classify_resolved(addrs.iter().copied()) {
+    match classify_resolved(addrs.iter().copied(), allow_loopback) {
         ResolveVerdict::AllPublic => Ok(addrs),
         ResolveVerdict::Private => Err(HttpError::SsrfBlocked {
             url: host.to_owned(),
@@ -645,8 +712,10 @@ async fn guarded_lookup(host: &str, port: u16) -> Result<Vec<std::net::SocketAdd
 ///
 /// This is the ADVISORY layer (crate docs · layer 2): it fail-fasts
 /// with a typed error before any connection attempt. The ENFORCEMENT
-/// is [`GuardedResolver`] inside the connect path.
-async fn resolve_guard(parsed: &url::Url) -> Result<(), HttpError> {
+/// is [`GuardedResolver`] inside the connect path. `net_permits` is the
+/// declared `permits.net.http` — both layers derive the SAME per-name
+/// loopback-declassification verdict from it (#395).
+async fn resolve_guard(parsed: &url::Url, net_permits: &[String]) -> Result<(), HttpError> {
     let Some(host) = parsed.host_str() else {
         return Err(HttpError::Other {
             reason: format!("URL has no host: {parsed}"),
@@ -658,9 +727,10 @@ async fn resolve_guard(parsed: &url::Url) -> Result<(), HttpError> {
     }
 
     let port = parsed.port_or_known_default().unwrap_or(80);
+    let allow_loopback = nika_types::net::loopback_declassified(net_permits, bare);
     // A Private verdict re-labels with the FULL url (the advisory layer
     // has it; the resolver only sees the bare host).
-    match guarded_lookup(bare, port).await {
+    match guarded_lookup(bare, port, allow_loopback).await {
         Ok(_) => Ok(()),
         Err(HttpError::SsrfBlocked { .. }) => Err(HttpError::SsrfBlocked {
             url: parsed.to_string(),

--- a/crates/nika-http/src/ssrf.rs
+++ b/crates/nika-http/src/ssrf.rs
@@ -39,12 +39,21 @@ use nika_kernel::HttpError;
 /// twice (parse-once discipline; the redirect loop re-enters here for
 /// every hop).
 ///
+/// `net_permits` is the workflow's declared `permits.net.http` list
+/// (empty when no boundary is declared): an EXACT loopback literal in it
+/// (`localhost` · `127.x.y.z` · `::1`/`[::1]` — never a glob, never
+/// RFC1918/link-local/metadata) is the author's declassification (issue
+/// #395 · the ADR-092 secrets-`egress:` precedent) and clears the floor
+/// for THAT host only, via the shared
+/// [`nika_types::net::loopback_declassified`] predicate — the same one
+/// the `nika check` floor-parity pass reads, so check and run agree.
+///
 /// # Errors
 ///
 /// [`HttpError::SsrfBlocked`] for non-http(s) schemes, blocked
 /// hostnames, and literal IPs in private ranges; [`HttpError::Other`]
 /// for unparseable URLs.
-pub(crate) fn check_url(raw: &str) -> Result<url::Url, HttpError> {
+pub(crate) fn check_url(raw: &str, net_permits: &[String]) -> Result<url::Url, HttpError> {
     let parsed = url::Url::parse(raw).map_err(|e| {
         // A bracketed IPv6 literal carrying a zone-id (`[fe80::1%25eth0]`)
         // is REJECTED by the WHATWG parser — but it addresses a
@@ -91,7 +100,14 @@ pub(crate) fn check_url(raw: &str) -> Result<url::Url, HttpError> {
     // canonicalizes every IPv4 spelling — decimal `2130706433`, octal
     // `0177.0.0.1`, hex — to dotted form; the oracle strips brackets and
     // parses ONCE, so it covers every authority form this layer sees.
-    if nika_types::net::host_is_blocked(host) {
+    //
+    // The ONE carve-out (#395): an exact loopback literal in the declared
+    // `permits.net.http` declassifies the floor for that host — the
+    // predicate normalizes brackets/case the same way the oracle does, and
+    // never clears anything outside the loopback class.
+    if nika_types::net::host_is_blocked(host)
+        && !nika_types::net::loopback_declassified(net_permits, host)
+    {
         return Err(HttpError::SsrfBlocked {
             url: raw.to_string(),
         });
@@ -114,6 +130,85 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use super::*;
+
+    /// The un-permitted spelling every pre-#395 vector pins: no declared
+    /// boundary → no declassification possible (`check_url`'s second
+    /// argument is the declared `permits.net.http`; empty = today's floor).
+    fn check_url(raw: &str) -> Result<url::Url, HttpError> {
+        super::check_url(raw, &[])
+    }
+
+    fn permits(entries: &[&str]) -> Vec<String> {
+        entries.iter().map(|e| (*e).to_string()).collect()
+    }
+
+    // ─── the loopback declassification (issue #395) ──────────────────
+
+    #[test]
+    fn permitted_exact_loopback_literal_clears_the_floor_for_that_host() {
+        // The author's explicit act (ADR-092 egress precedent): the exact
+        // literal in `permits.net.http` clears the floor for THAT host —
+        // in each qualifying spelling, port-independent (host-level).
+        for (entry, url) in [
+            ("127.0.0.1", "http://127.0.0.1:8971/price.json"),
+            ("localhost", "http://localhost:3000/api"),
+            ("::1", "http://[::1]:8080/x"),
+            ("[::1]", "http://[::1]/x"),
+            ("127.1.2.3", "http://127.1.2.3/x"),
+        ] {
+            let p = permits(&[entry]);
+            assert!(
+                super::check_url(url, &p).is_ok(),
+                "`{entry}` must clear {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn declassification_is_exact_never_cross_host() {
+        // `localhost` clears `localhost` ONLY — the literal in the file,
+        // never what it resolves to; 127/8 neighbours are distinct hosts.
+        let p = permits(&["localhost"]);
+        assert!(super::check_url("http://127.0.0.1/x", &p).is_err());
+        let p = permits(&["127.0.0.1"]);
+        assert!(super::check_url("http://localhost/x", &p).is_err());
+        assert!(super::check_url("http://127.0.0.2/x", &p).is_err());
+        // The `.localhost` FAMILY never clears — an exact literal has no
+        // subdomains (RFC 6761 reserves the TLD, but a subdomain names an
+        // arbitrary service; the bare name is the vocabulary).
+        let p = permits(&["localhost"]);
+        assert!(super::check_url("http://api.localhost/x", &p).is_err());
+    }
+
+    #[test]
+    fn never_list_hosts_stay_blocked_even_when_named_in_permits() {
+        // RFC1918 · link-local/metadata · CGN · metadata NAMES · the
+        // unspecified addresses · glob entries: NEVER declassifiable.
+        for (entry, url) in [
+            ("10.0.0.1", "http://10.0.0.1/x"),
+            ("172.16.0.1", "http://172.16.0.1/x"),
+            ("192.168.1.1", "http://192.168.1.1/admin"),
+            (
+                "169.254.169.254",
+                "http://169.254.169.254/latest/meta-data/",
+            ),
+            (
+                "metadata.google.internal",
+                "http://metadata.google.internal/x",
+            ),
+            ("fe80::1", "http://[fe80::1]/x"),
+            ("100.100.100.200", "http://100.100.100.200/x"),
+            ("0.0.0.0", "http://0.0.0.0/x"),
+            ("::ffff:127.0.0.1", "http://[::ffff:127.0.0.1]/x"),
+            ("64:ff9b::7f00:1", "http://[64:ff9b::7f00:1]/x"),
+            ("*.localhost", "http://api.localhost/x"),
+        ] {
+            let p = permits(&[entry]);
+            let err =
+                super::check_url(url, &p).expect_err(&format!("`{entry}` must NOT clear {url}"));
+            assert!(matches!(err, HttpError::SsrfBlocked { .. }), "{url}: {err}");
+        }
+    }
 
     // ─── brouillon parity vectors (Gate 10) ──────────────────────────
 

--- a/crates/nika-http/src/tests.rs
+++ b/crates/nika-http/src/tests.rs
@@ -157,7 +157,10 @@ fn classify_resolved_flags_any_private_address() {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 80),
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
     ];
-    assert!(matches!(classify_resolved(mixed), ResolveVerdict::Private));
+    assert!(matches!(
+        classify_resolved(mixed, false),
+        ResolveVerdict::Private
+    ));
 }
 
 #[test]
@@ -168,7 +171,7 @@ fn classify_resolved_all_public_passes() {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 443),
     ];
     assert!(matches!(
-        classify_resolved(public),
+        classify_resolved(public, false),
         ResolveVerdict::AllPublic
     ));
 }
@@ -176,7 +179,7 @@ fn classify_resolved_all_public_passes() {
 #[test]
 fn classify_resolved_empty_is_empty() {
     assert!(matches!(
-        classify_resolved(std::iter::empty()),
+        classify_resolved(std::iter::empty(), false),
         ResolveVerdict::Empty
     ));
 }
@@ -189,7 +192,44 @@ fn classify_resolved_blocks_rebind_to_metadata_ip() {
         IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
         80,
     )];
-    assert!(matches!(classify_resolved(rebind), ResolveVerdict::Private));
+    assert!(matches!(
+        classify_resolved(rebind, false),
+        ResolveVerdict::Private
+    ));
+}
+
+#[test]
+fn classify_resolved_allow_loopback_clears_loopback_only() {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    // The #395 declassification at the RESOLVED layer: when the request's
+    // host is a permitted exact loopback literal, its resolved LOOPBACK
+    // addresses are admitted (a permitted `localhost` must reach its
+    // 127.0.0.1/::1)…
+    let loopback = vec![
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80),
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 80),
+    ];
+    assert!(matches!(
+        classify_resolved(loopback.clone(), true),
+        ResolveVerdict::AllPublic
+    ));
+    // …without the declassification the same set refuses (today's law)…
+    assert!(matches!(
+        classify_resolved(loopback, false),
+        ResolveVerdict::Private
+    ));
+    // …and the clearing is the LOOPBACK CLASS ONLY: a rebind of the
+    // permitted name to metadata/RFC1918 still refuses.
+    for private in [
+        Ipv4Addr::new(169, 254, 169, 254),
+        Ipv4Addr::new(10, 0, 0, 5),
+    ] {
+        let rebind = vec![SocketAddr::new(IpAddr::V4(private), 80)];
+        assert!(
+            matches!(classify_resolved(rebind, true), ResolveVerdict::Private),
+            "{private} must stay blocked even under allow_loopback"
+        );
+    }
 }
 
 #[test]
@@ -280,11 +320,54 @@ async fn guarded_resolver_blocks_localhost_and_serves_public() {
     // must refuse to hand it to the transport. (`Addrs` is not
     // Debug — go through `.err()` instead of `expect_err`.)
     let name = reqwest::dns::Name::from_str("localhost").expect("valid name");
-    let err = GuardedResolver
+    let err = GuardedResolver::default()
         .resolve(name)
         .await
         .err()
         .expect("localhost must be blocked by the guarded resolver");
+    let http = err
+        .downcast_ref::<HttpError>()
+        .expect("the resolver emits the kernel error type");
+    assert!(matches!(http, HttpError::SsrfBlocked { .. }), "{http}");
+}
+
+#[tokio::test]
+async fn guarded_resolver_clears_a_permitted_localhost_name() {
+    use reqwest::dns::Resolve;
+    use std::str::FromStr;
+
+    // The exact literal `localhost` in `permits.net.http` (#395): the
+    // resolver admits the loopback addresses it resolves to — the permit
+    // must clear the resolved 127.0.0.1/::1, or the grant would be a lie
+    // at the connect path (layer 3).
+    let resolver = GuardedResolver {
+        net_permits: std::sync::Arc::new(vec!["localhost".to_owned()]),
+    };
+    let name = reqwest::dns::Name::from_str("localhost").expect("valid name");
+    assert!(
+        resolver.resolve(name).await.is_ok(),
+        "the permitted exact literal must clear its own resolution"
+    );
+}
+
+#[tokio::test]
+async fn guarded_resolver_declassification_is_exact_per_name() {
+    use reqwest::dns::Resolve;
+    use std::str::FromStr;
+
+    // Permits name `127.0.0.1` — the RESOLVED name `localhost` is a
+    // DIFFERENT host: still refused. The declassification is the literal
+    // in the file (per-name), never the loopback class wholesale — the
+    // `mylocal.dev`-resolves-to-127.0.0.1 case rides this same seam.
+    let resolver = GuardedResolver {
+        net_permits: std::sync::Arc::new(vec!["127.0.0.1".to_owned()]),
+    };
+    let name = reqwest::dns::Name::from_str("localhost").expect("valid name");
+    let err = resolver
+        .resolve(name)
+        .await
+        .err()
+        .expect("an un-permitted loopback NAME stays blocked");
     let http = err
         .downcast_ref::<HttpError>()
         .expect("the resolver emits the kernel error type");
@@ -307,6 +390,22 @@ async fn enforce_mode_blocks_loopback_end_to_end() {
     }
 }
 
+#[test]
+fn bracketed_loopback_entry_admits_its_host_at_the_declared_boundary() {
+    // `[::1]` — the URL-authority spelling of `::1`. As a plain glob it
+    // matches nothing (permits are written bare), but as a qualifying
+    // loopback literal (#395) it must ALSO admit its host at the declared
+    // boundary — otherwise the entry would clear the floor and then fail
+    // NIKA-SEC-004: check-green + run-refused, the exact drift class this
+    // issue exists to close.
+    let b = NetBoundary::Declared(vec!["[::1]".to_owned()]);
+    let u = url::Url::parse("http://[::1]:8080/p").expect("valid url");
+    assert!(check_net_allowlist(&b, &u).is_ok());
+    // …and it admits ONLY its host — the boundary stays default-deny.
+    let pub_u = url::Url::parse("https://api.example.com/p").expect("valid url");
+    assert!(check_net_allowlist(&b, &pub_u).is_err());
+}
+
 #[tokio::test]
 async fn disabled_mode_still_builds_a_working_client() {
     // SsrfMode::Disabled wires the DEFAULT resolver — the build path
@@ -325,8 +424,11 @@ async fn disabled_mode_still_builds_a_working_client() {
     }
 }
 
-/// Loopback e2e over REAL sockets — `SsrfMode::Disabled` everywhere here:
-/// the targets ARE loopback (the SSRF layers have their own tests above).
+/// Loopback e2e over REAL sockets — `SsrfMode::Disabled` for the transport
+/// suites (the targets ARE loopback; the SSRF layers have their own tests
+/// above), plus the `Enforce`+declassification suite (#395): the ONE lawful
+/// way an enforcing client reaches a loopback socket is the author's exact
+/// literal in `permits.net.http`.
 mod e2e {
     use super::*;
 
@@ -390,6 +492,74 @@ mod e2e {
             "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len()
         )
+    }
+
+    /// An ENFORCING client whose boundary declares the exact literal —
+    /// the #395 declassification shape, used by the suite below.
+    fn enforcing_client(entries: &[&str]) -> ReqwestHttp {
+        let mut config = HttpConfig::new(); // SsrfMode::Enforce
+        config.net = NetBoundary::Declared(entries.iter().map(|e| (*e).to_string()).collect());
+        ReqwestHttp::with_config(config).expect("client builds")
+    }
+
+    #[tokio::test]
+    async fn enforce_with_permitted_loopback_literal_reaches_a_real_local_server() {
+        // THE issue-#395 e2e: SSRF Enforce + `permits.net.http:
+        // ["127.0.0.1"]` — the author's explicit act clears the floor for
+        // that host, and the request lands on a REAL loopback socket
+        // (previously only `SsrfMode::Disabled` could).
+        let addr = serve(vec![ok_response("local fixture")]).await;
+        let resp = enforcing_client(&["127.0.0.1"])
+            .get(HttpRequest::get(format!("http://{addr}/price.json")))
+            .await
+            .expect("the permitted exact literal clears the floor");
+        assert_eq!(resp.status, 200);
+        assert_eq!(resp.body.as_ref(), b"local fixture");
+    }
+
+    #[tokio::test]
+    async fn enforce_permitted_loopback_redirect_within_the_host_lands() {
+        // Both hops are the permitted host (different ports — permits are
+        // host-level): the per-hop re-vet clears each one.
+        let dest = serve(vec![ok_response("arrived")]).await;
+        let hop = serve(vec![format!(
+            "HTTP/1.1 302 Found\r\nLocation: http://{dest}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )])
+        .await;
+        let resp = enforcing_client(&["127.0.0.1"])
+            .get(HttpRequest::get(format!("http://{hop}/start")))
+            .await
+            .expect("both hops are the permitted host");
+        assert_eq!(resp.body.as_ref(), b"arrived");
+    }
+
+    #[tokio::test]
+    async fn enforce_redirect_to_unpermitted_floor_host_refuses() {
+        // A permitted 127.0.0.1 server bounces to `localhost` — NOT
+        // permitted: the per-hop re-vet refuses (the declassification
+        // clears ONE exact host, it never travels with the request).
+        let hop = serve(vec![
+            "HTTP/1.1 302 Found\r\nLocation: http://localhost:9/x\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .to_owned(),
+        ])
+        .await;
+        let err = enforcing_client(&["127.0.0.1"])
+            .get(HttpRequest::get(format!("http://{hop}/start")))
+            .await
+            .expect_err("the hop target is floor-blocked and unpermitted");
+        assert!(matches!(err, HttpError::SsrfBlocked { .. }), "{err}");
+    }
+
+    #[tokio::test]
+    async fn enforce_unpermitted_loopback_stays_blocked_under_a_declared_boundary() {
+        // A declared boundary WITHOUT the loopback literal: the floor
+        // holds — and it speaks SEC-005's SsrfBlocked (the floor gates
+        // before the allowlist), with zero network activity.
+        let err = enforcing_client(&["api.example.com"])
+            .get(HttpRequest::get("http://127.0.0.1:9/x"))
+            .await
+            .expect_err("no declassifying literal → the floor holds");
+        assert!(matches!(err, HttpError::SsrfBlocked { .. }), "{err}");
     }
 
     #[tokio::test]

--- a/crates/nika-schema/src/check/effective.rs
+++ b/crates/nika-schema/src/check/effective.rs
@@ -51,7 +51,10 @@ pub struct EffectivePermits {
     /// paths · tools), independent of what is declared.
     pub needed: Permits,
     /// Effects too dynamic to pin statically (a computed host, a
-    /// templated path) — the inference's honesty notes, verbatim.
+    /// templated path) — the inference's honesty notes, verbatim — plus
+    /// the loopback-declassification statements (#395): each exact
+    /// loopback literal in the declared `net.http`, stated affirmatively
+    /// so a green check TEACHES that the SSRF floor is cleared for it.
     pub notes: Vec<String>,
 }
 
@@ -60,6 +63,22 @@ pub struct EffectivePermits {
 pub(super) fn collect(wf: &RawWorkflow) -> EffectivePermits {
     let inferred = permits_infer::infer(wf);
     let declared = wf.permits.as_ref().map(|p| p.value.clone());
+    let mut notes = inferred.notes;
+    // The loopback declassification, stated (#395 · ADR-092 egress
+    // precedent): the exact literal is the author's explicit act — the
+    // note is the informational surface that replaces the pre-#395
+    // dead-grant/floor findings for these entries.
+    if let Some(net) = declared.as_ref().and_then(|p| p.net.as_ref()) {
+        for entry in &net.http {
+            if nika_types::net::is_exact_loopback_literal(entry) {
+                notes.push(format!(
+                    "permits.net.http entry `{entry}` is an exact loopback literal — \
+                     the explicit permit clears the always-on SSRF floor \
+                     (NIKA-SEC-005) for that host only"
+                ));
+            }
+        }
+    }
     EffectivePermits {
         source: if declared.is_some() {
             PermitsSource::Declared
@@ -68,7 +87,7 @@ pub(super) fn collect(wf: &RawWorkflow) -> EffectivePermits {
         },
         declared,
         needed: inferred.permits,
-        notes: inferred.notes,
+        notes,
     }
 }
 
@@ -135,6 +154,28 @@ mod tests {
             !report.notes.is_empty(),
             "the un-pinnable fetch is named: {:?}",
             report.notes
+        );
+    }
+
+    /// An exact loopback literal in the declared boundary is STATED
+    /// (#395): the informational note names the entry and the clearing —
+    /// and an ordinary public grant stays silent.
+    #[test]
+    fn loopback_declassification_is_stated_as_a_note() {
+        let report = collect(&wf(
+            "nika: v1\nworkflow: w\npermits: { net: { http: [\"127.0.0.1\", \"api.x.com\"] }, tools: [\"nika:fetch\"], exec: false }\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"http://127.0.0.1:8971/price.json\" } }\n",
+        ));
+        let loopback: Vec<&String> = report
+            .notes
+            .iter()
+            .filter(|n| n.contains("exact loopback literal"))
+            .collect();
+        assert_eq!(loopback.len(), 1, "one note per qualifying entry");
+        assert!(loopback[0].contains("`127.0.0.1`"), "{}", loopback[0]);
+        assert!(loopback[0].contains("NIKA-SEC-005"), "{}", loopback[0]);
+        assert!(
+            !loopback[0].contains("api.x.com"),
+            "public grants are not loopback-stated"
         );
     }
 }

--- a/crates/nika-schema/src/check/permits_fit.rs
+++ b/crates/nika-schema/src/check/permits_fit.rs
@@ -84,10 +84,17 @@ pub(super) fn scan_escapes(wf: &RawWorkflow) -> Vec<CapabilityEscape> {
     // own yaml site) so the author learns the grant is inert even when
     // every task URL is dynamic. Globs are skipped: `*.internal.example`
     // may match public names, and glob-vs-floor inclusion is DNS
-    // knowledge the static pass does not have.
+    // knowledge the static pass does not have. An EXACT loopback literal
+    // is skipped too (#395): it now TAKES effect — the author's explicit
+    // declassification clears the floor for that host — so it is no
+    // longer dead; the affirmative statement rides `EffectivePermits::
+    // notes`. RFC1918/link-local/metadata entries stay dead-flagged.
     if let Some(net) = permits.and_then(|p| p.net.as_ref()) {
         for entry in &net.http {
-            if !entry.contains('*') && nika_types::net::host_is_blocked(entry) {
+            if !entry.contains('*')
+                && nika_types::net::host_is_blocked(entry)
+                && !nika_types::net::is_exact_loopback_literal(entry)
+            {
                 escapes.push(CapabilityEscape {
                     task: "permits".to_owned(),
                     category: "net",
@@ -106,6 +113,16 @@ pub(super) fn scan_escapes(wf: &RawWorkflow) -> Vec<CapabilityEscape> {
     escapes
 }
 
+/// The declared `permits.net.http` entries — empty when no `permits:`
+/// block (or no `net:`) is declared. The slice the floor-parity pass
+/// feeds [`nika_types::net::loopback_declassified`], mirroring what the
+/// runtime hands `nika-http` (`NetBoundary::globs`).
+fn net_http(permits: Option<&Permits>) -> &[String] {
+    permits
+        .and_then(|p| p.net.as_ref())
+        .map_or(&[], |n| &n.http)
+}
+
 /// Check one action (a task's main verb OR an `on_finally` cleanup verb)
 /// against the boundary. The floor half runs even with no `permits:`
 /// declared; the boundary half needs one.
@@ -116,7 +133,7 @@ fn check_action(
     out: &mut Vec<CapabilityEscape>,
 ) {
     if let RawAction::Invoke(a) = action {
-        check_net_floor(id, a, out);
+        check_net_floor(id, a, permits, out);
     }
     let Some(permits) = permits else { return };
     match action {
@@ -151,13 +168,23 @@ fn check_action(
 /// `nika_types::net::host_is_blocked` oracle `nika-http` enforces with);
 /// a public DNS name that resolves privately stays the runtime
 /// `GuardedResolver`'s half. No grant `fix` — permits cannot override the
-/// floor, so the repair is the URL itself.
-fn check_net_floor(id: &str, a: &RawInvokeAction, out: &mut Vec<CapabilityEscape>) {
+/// floor, so the repair is the URL itself. The ONE carve-out (#395 ·
+/// same-PR as the runtime's): an EXACT loopback literal in the declared
+/// `permits.net.http` declassifies the floor for that host — the shared
+/// `loopback_declassified` predicate `nika-http` enforces with, so the
+/// escape stops firing exactly where the run stops refusing.
+fn check_net_floor(
+    id: &str,
+    a: &RawInvokeAction,
+    permits: Option<&Permits>,
+    out: &mut Vec<CapabilityEscape>,
+) {
     let Some(BuiltinEffect::Net { url_arg }) = builtin_effect(a) else {
         return;
     };
     if let Some(host) = literal_arg(a, url_arg).as_deref().and_then(url_host)
         && nika_types::net::host_is_blocked(&host)
+        && !nika_types::net::loopback_declassified(net_http(permits), &host)
     {
         let tool = a.tool.value.as_str();
         out.push(CapabilityEscape {
@@ -381,9 +408,12 @@ fn check_builtin_effect(
     let tool = a.tool.value.as_str();
     match builtin_effect(a) {
         Some(BuiltinEffect::Net { url_arg }) => {
-            // A floor-blocked host is already flagged by `check_net_floor`
-            // (and the grant fix would be a lie — no entry can admit it),
-            // so the boundary escape fires only for floor-clean hosts.
+            // A floor-blocked host never gets a boundary escape: either it
+            // is already flagged by `check_net_floor` (and the grant fix
+            // would be a lie — no ordinary entry can admit it), or it is
+            // DECLASSIFIED by an exact loopback literal (#395) — and that
+            // same entry admits the host at the runtime boundary too
+            // (`check_net_allowlist`), so there is nothing to escape.
             if let Some(host) = literal_arg(a, url_arg).as_deref().and_then(url_host)
                 && !nika_types::net::host_is_blocked(&host)
                 && !permits.allows_host(&host)
@@ -680,14 +710,15 @@ tasks:
     fn ipv6_bracket_host_is_extracted_not_mangled() {
         // `https://[::1]:8080/x` — the host is `::1`, not `[` (the first-`:`
         // split bug). Bracket-free in permits, symmetric both sides. Since
-        // the floor-parity pass (F3 · issue #395), a granted `::1` is no
-        // longer a false green: BOTH the inert grant entry and the task get
-        // the floor escape — the extraction still reads `::1` in each detail.
+        // the declassification (#395), a granted `::1` is the author's
+        // explicit act: check is GREEN (and the run reaches the host).
         let granted = "nika: v1\nworkflow: w\npermits: { tools: [\"nika:fetch\"], net: { http: [\"::1\"] }, exec: false }\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://[::1]:8080/x\" } }\n";
-        let e = escapes_of(granted);
-        assert_eq!(e.len(), 2, "the grant is inert AND the task is floored");
-        assert!(e.iter().all(|esc| esc.floor && esc.fix.is_none()));
-        assert!(e.iter().all(|esc| esc.detail.contains("`::1`")), "{e:?}");
+        assert!(
+            escapes_of(granted).is_empty(),
+            "the exact `::1` literal declassifies its host"
+        );
+        // UNGRANTED, the floor holds — and the extraction still reads the
+        // bare `::1` in the escape detail (the bug this test pins).
         let ungranted = "nika: v1\nworkflow: w\npermits: { tools: [\"nika:fetch\"], net: { http: [\"api.x.com\"] }, exec: false }\ntasks:\n  - id: t\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://[::1]:8080/x\" } }\n";
         let e = escapes_of(ungranted);
         assert_eq!(e.len(), 1, "floor escape only — never the grant fix");
@@ -1012,11 +1043,13 @@ mod floor_parity {
     }
 
     #[test]
-    fn granted_loopback_fetch_is_no_longer_a_false_green() {
-        // THE battery-F3 repro (issue #395): `permits.net.http:
-        // ["127.0.0.1"]` + a literal fetch to it — check said rc=0, run
-        // always NIKA-SEC-005. Now check tells the truth at BOTH yaml
-        // sites: the inert grant entry and the floored task.
+    fn permitted_exact_loopback_literal_declassifies_the_floor() {
+        // THE battery-F3 workflow (issue #395 · the local-watch repro):
+        // `permits.net.http: ["127.0.0.1"]` + a literal fetch to it. The
+        // exact literal is now the author's declassification (ADR-092
+        // egress precedent) — check is GREEN and, same-PR, the run
+        // reaches the host: the two surfaces agree in the ADMITTING
+        // direction, not just the refusing one.
         let y = r#"nika: v1
 workflow: w
 permits:
@@ -1026,24 +1059,79 @@ tasks:
   - id: probe
     invoke: { tool: "nika:fetch", args: { url: "http://127.0.0.1:8080/api" } }
 "#;
-        let e = escapes(y);
-        assert_eq!(e.len(), 2, "entry + task: {e:?}");
-        assert!(e.iter().all(|esc| esc.floor && esc.fix.is_none()));
-        let task = e
-            .iter()
-            .find(|esc| esc.task == "probe")
-            .expect("task escape");
-        assert!(task.detail.contains("NIKA-SEC-005"), "{}", task.detail);
-        assert!(task.detail.contains("public host"), "{}", task.detail);
-        let entry = e
-            .iter()
-            .find(|esc| esc.task == "permits")
-            .expect("entry escape");
         assert!(
-            entry.detail.contains("never take effect"),
-            "{}",
-            entry.detail
+            escapes(y).is_empty(),
+            "the exact literal clears entry AND task"
         );
+        // Every qualifying spelling declassifies — `localhost` and the
+        // v6 loopback in both its bare and URL-authority forms.
+        for (entry, url) in [
+            ("localhost", "http://localhost:3000/x"),
+            ("::1", "https://[::1]:8080/x"),
+            ("[::1]", "https://[::1]/x"),
+        ] {
+            let y = format!(
+                "nika: v1\nworkflow: w\npermits: {{ net: {{ http: [\"{entry}\"] }}, \
+                 tools: [\"nika:fetch\"], exec: false }}\ntasks:\n  - id: t\n    \
+                 invoke: {{ tool: \"nika:fetch\", args: {{ url: \"{url}\" }} }}\n"
+            );
+            assert!(
+                escapes(&y).is_empty(),
+                "`{entry}` must clear {url}: {:?}",
+                escapes(&y)
+            );
+        }
+    }
+
+    #[test]
+    fn declassification_is_exact_never_cross_host() {
+        // `localhost` permitted · `127.0.0.1` fetched: the declassification
+        // is the literal in the file, NEVER what it resolves to — the task
+        // floor escape stays (and the entry, being live for ITS host, is
+        // not dead-flagged).
+        let y = r#"nika: v1
+workflow: w
+permits:
+  net: { http: ["localhost"] }
+  tools: ["nika:fetch"]
+tasks:
+  - id: probe
+    invoke: { tool: "nika:fetch", args: { url: "http://127.0.0.1:8080/api" } }
+"#;
+        let e = escapes(y);
+        assert_eq!(e.len(), 1, "the task floors, the entry is live: {e:?}");
+        assert_eq!(e[0].task, "probe");
+        assert!(e[0].floor && e[0].fix.is_none());
+    }
+
+    #[test]
+    fn never_list_grants_stay_dead_and_their_fetches_stay_floored() {
+        // RFC1918 · metadata name · link-local: naming them in permits
+        // declassifies NOTHING — the entry is still a dead grant and the
+        // fetch still floors (2 escapes each, the pre-#395 shape).
+        for (entry, url) in [
+            ("10.0.0.5", "http://10.0.0.5/x"),
+            ("192.168.1.1", "http://192.168.1.1/admin"),
+            (
+                "169.254.169.254",
+                "http://169.254.169.254/latest/meta-data/",
+            ),
+            (
+                "metadata.google.internal",
+                "http://metadata.google.internal/x",
+            ),
+            ("fe80::1", "http://[fe80::1]/x"),
+            ("api.localhost", "http://api.localhost/x"),
+        ] {
+            let y = format!(
+                "nika: v1\nworkflow: w\npermits: {{ net: {{ http: [\"{entry}\"] }}, \
+                 tools: [\"nika:fetch\"], exec: false }}\ntasks:\n  - id: t\n    \
+                 invoke: {{ tool: \"nika:fetch\", args: {{ url: \"{url}\" }} }}\n"
+            );
+            let e = escapes(&y);
+            assert_eq!(e.len(), 2, "`{entry}`: dead entry + floored task: {e:?}");
+            assert!(e.iter().all(|esc| esc.floor && esc.fix.is_none()));
+        }
     }
 
     #[test]
@@ -1092,12 +1180,14 @@ tasks:
 
     #[test]
     fn dead_grant_is_flagged_even_when_unused() {
-        // Entry-level truth: the grant is inert whether or not a static
-        // URL exercises it (a dynamic URL to it still floors at run).
+        // Entry-level truth: an RFC1918 grant is inert whether or not a
+        // static URL exercises it (a dynamic URL to it still floors at
+        // run) — while the loopback literal beside it is LIVE (#395·the
+        // declassification) and must not be dead-flagged.
         let y = r#"nika: v1
 workflow: w
 permits:
-  net: { http: ["localhost", "api.x.com"] }
+  net: { http: ["10.0.0.5", "localhost", "api.x.com"] }
   tools: ["nika:fetch"]
 tasks:
   - id: t
@@ -1107,7 +1197,7 @@ tasks:
         assert_eq!(e.len(), 1, "{e:?}");
         assert_eq!(e[0].task, "permits");
         assert!(e[0].floor);
-        assert!(e[0].detail.contains("`localhost`"), "{}", e[0].detail);
+        assert!(e[0].detail.contains("`10.0.0.5`"), "{}", e[0].detail);
     }
 
     #[test]

--- a/crates/nika-schema/src/check/permits_infer.rs
+++ b/crates/nika-schema/src/check/permits_infer.rs
@@ -191,13 +191,28 @@ fn collect_builtin_effect(c: &mut Collector, id: &str, a: &crate::raw::RawInvoke
                 // this inference just wrote (a self-refusing suggestion,
                 // the same class as suggesting a program allowlist for a
                 // shell string). Honesty note instead of a silent drop.
+                // A LOOPBACK host is declassifiable (#395) — but only by
+                // the AUTHOR's hand: the explicit act stays explicit, so
+                // the inference still never writes it; the note teaches
+                // the opt-in instead.
                 Some(host) if nika_types::net::host_is_blocked(&host) => {
-                    c.notes.push(format!(
-                        "task `{id}` fetches `{host}` — the always-on SSRF floor \
-                         (NIKA-SEC-005) refuses loopback/private/link-local/metadata \
-                         targets, so no `permits.net.http` entry can admit it; not \
-                         inferred (point the task at a public host)"
-                    ));
+                    let note = if nika_types::net::is_exact_loopback_literal(&host) {
+                        format!(
+                            "task `{id}` fetches `{host}` — the always-on SSRF floor \
+                             (NIKA-SEC-005) refuses it unless YOU declassify it: \
+                             writing the exact literal `{host}` into \
+                             `permits.net.http` is the owner's explicit act, so it \
+                             is never inferred"
+                        )
+                    } else {
+                        format!(
+                            "task `{id}` fetches `{host}` — the always-on SSRF floor \
+                             (NIKA-SEC-005) refuses loopback/private/link-local/metadata \
+                             targets, so no `permits.net.http` entry can admit it; not \
+                             inferred (point the task at a public host)"
+                        )
+                    };
+                    c.notes.push(note);
                 }
                 Some(host) => {
                     c.hosts.insert(host);
@@ -729,10 +744,10 @@ tasks:
     #[test]
     fn floor_blocked_host_is_never_inferred_into_the_grants() {
         // A loopback fetch must NOT synthesize `net.http: ["127.0.0.1"]`
-        // — the floor refuses it regardless, so the entry would be inert
-        // and the escape scanner would flag the block this inference just
-        // wrote (a self-refusing suggestion). Public hosts still infer;
-        // the floored one becomes an honesty note.
+        // — even though the exact literal WOULD declassify the floor
+        // (#395): the explicit act must stay the author's, so the
+        // inference keeps its hands off and the note TEACHES the opt-in.
+        // Public hosts still infer.
         let r = infer_of(
             "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"http://127.0.0.1:9/x\" } }\n  - id: b\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/x\" } }\n",
         );
@@ -741,5 +756,30 @@ tasks:
         assert_eq!(r.notes.len(), 1, "{:?}", r.notes);
         assert!(r.notes[0].contains("SSRF floor"), "{}", r.notes[0]);
         assert!(r.notes[0].contains("`127.0.0.1`"), "{}", r.notes[0]);
+        assert!(
+            r.notes[0].contains("explicit act"),
+            "the loopback note teaches the opt-in: {}",
+            r.notes[0]
+        );
+    }
+
+    #[test]
+    fn non_loopback_floor_note_never_teaches_the_opt_in() {
+        // The never-list keeps the pre-#395 wording: no entry can admit a
+        // metadata/RFC1918 target, so the note must NOT hint one.
+        let r = infer_of(
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke: { tool: \"nika:fetch\", args: { url: \"http://169.254.169.254/latest/meta-data/\" } }\n",
+        );
+        assert_eq!(r.notes.len(), 1, "{:?}", r.notes);
+        assert!(
+            r.notes[0].contains("no `permits.net.http` entry can admit it"),
+            "{}",
+            r.notes[0]
+        );
+        assert!(
+            !r.notes[0].contains("explicit act"),
+            "never-list targets get no opt-in hint: {}",
+            r.notes[0]
+        );
     }
 }

--- a/crates/nika-types/public-api.txt
+++ b/crates/nika-types/public-api.txt
@@ -1654,6 +1654,8 @@ pub fn nika_types::net::host_glob_matches(glob: &str, host: &str) -> bool
 pub fn nika_types::net::host_in_allowlist(allowlist: &[alloc::string::String], host: &str) -> bool
 pub fn nika_types::net::host_is_blocked(host: &str) -> bool
 pub fn nika_types::net::ip_is_blocked(ip: core::net::ip_addr::IpAddr) -> bool
+pub fn nika_types::net::is_exact_loopback_literal(entry: &str) -> bool
+pub fn nika_types::net::loopback_declassified(allowlist: &[alloc::string::String], host: &str) -> bool
 pub mod nika_types::prelude
 #[non_exhaustive] pub enum nika_types::prelude::BudgetDirective
 pub nika_types::prelude::BudgetDirective::Cost

--- a/crates/nika-types/src/net.rs
+++ b/crates/nika-types/src/net.rs
@@ -147,6 +147,65 @@ pub fn host_is_blocked(host: &str) -> bool {
         .is_ok_and(ip_is_blocked)
 }
 
+/// The loopback identity an exact literal can carry — the CLOSED
+/// declassification vocabulary of the SSRF floor (issue #395).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopbackLiteral {
+    /// The bare `localhost` name (RFC 6761) — never the `*.localhost`
+    /// family (a subdomain names an arbitrary service).
+    Localhost,
+    /// A literal loopback address — v4 `127.0.0.0/8` or v6 `::1`.
+    Ip(core::net::IpAddr),
+}
+
+/// Classify an EXACT loopback literal, `None` for everything else. Same
+/// normalization as [`host_is_blocked`] (trailing FQDN dot · v6 authority
+/// brackets · ASCII case), so the two predicates read one host language.
+/// Globs are excluded structurally: a `*` can neither equal `localhost`
+/// nor parse as an address.
+fn exact_loopback(entry: &str) -> Option<LoopbackLiteral> {
+    let trimmed = entry.trim_end_matches('.');
+    if trimmed.eq_ignore_ascii_case("localhost") {
+        return Some(LoopbackLiteral::Localhost);
+    }
+    let literal = trimmed.trim_start_matches('[').trim_end_matches(']');
+    let ip = literal.parse::<core::net::IpAddr>().ok()?;
+    // `is_loopback` is EXACT: v4 127/8, v6 `::1` — never the unspecified
+    // addresses, never a mapped/NAT64 wrapper smuggling 127.x (those parse
+    // as non-loopback v6 and stay floor-blocked).
+    ip.is_loopback().then_some(LoopbackLiteral::Ip(ip))
+}
+
+/// True when `entry` is an EXACT loopback literal — the bare `localhost`
+/// name, a `127.0.0.0/8` v4 literal, or the v6 loopback `::1` (bracketed
+/// or bare). The closed vocabulary an author may DECLASSIFY the SSRF
+/// floor with (issue #395 · the ADR-092 secrets-`egress:` precedent: the
+/// owner's explicit act, co-located with the boundary). NEVER a glob,
+/// NEVER the `*.localhost` family, NEVER RFC1918 / link-local / CGN /
+/// metadata — those stay floor-blocked even when named in permits.
+#[must_use]
+pub fn is_exact_loopback_literal(entry: &str) -> bool {
+    exact_loopback(entry).is_some()
+}
+
+/// True when `host` is cleared from the SSRF floor by an exact loopback
+/// literal in the declared `permits.net.http` allowlist (issue #395).
+/// EXACT host comparison — never a glob, prefix, or subnet: `localhost`
+/// clears `localhost` only (not `127.0.0.1` — the declassification is
+/// the literal in the file, never what it resolves to), `127.0.0.1`
+/// clears `127.0.0.1` only. Both sides must be loopback: a non-loopback
+/// host is never declassifiable, so RFC1918/metadata grants stay inert.
+/// Every floor surface reads THIS one predicate — the http static vet
+/// (`nika-http`), the resolved-address guard's name check, and the
+/// `nika check` floor-parity pass — so check and run cannot drift.
+#[must_use]
+pub fn loopback_declassified(allowlist: &[String], host: &str) -> bool {
+    let Some(target) = exact_loopback(host) else {
+        return false;
+    };
+    allowlist.iter().any(|e| exact_loopback(e) == Some(target))
+}
+
 /// The v4 address a transition-format v6 embeds in two segments (NAT64
 /// `64:ff9b::a.b.c.d` in segments 6+7 · 6to4 `2002:a.b:c.d::` in segments 1+2).
 fn embedded_v4(hi: u16, lo: u16) -> core::net::Ipv4Addr {
@@ -350,5 +409,95 @@ mod tests {
         ] {
             assert!(!host_is_blocked(h), "{h} must not be floor-blocked");
         }
+    }
+
+    #[test]
+    fn exact_loopback_literal_is_the_closed_declassification_vocabulary() {
+        // The qualifying set (issue #395): the bare `localhost` name, a
+        // 127.0.0.0/8 v4 literal, the v6 loopback `::1` (bracketed or
+        // bare — the URL-authority spelling included).
+        for e in [
+            "localhost",
+            "LOCALHOST",
+            "localhost.", // absolute-FQDN spelling
+            "127.0.0.1",
+            "127.5.6.7", // any exact 127/8 literal
+            "::1",
+            "[::1]",
+            "0:0:0:0:0:0:0:1", // the expanded spelling of ::1
+        ] {
+            assert!(is_exact_loopback_literal(e), "{e} must qualify");
+        }
+    }
+
+    #[test]
+    fn never_list_and_globs_never_qualify_as_loopback_literals() {
+        // The NEVER list: globs, the `*.localhost` FAMILY (an exact literal
+        // only — a subdomain reaches arbitrary services), RFC1918,
+        // link-local/metadata, CGN, the unspecified addresses, NAT64/mapped
+        // wrappers SMUGGLING loopback, and plain public hosts.
+        for e in [
+            "*.localhost",
+            "*",
+            "api.localhost", // the RFC 6761 family is NOT the bare name
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254", // cloud metadata IP
+            "metadata.google.internal",
+            "fe80::1",
+            "fc00::1",
+            "100.100.100.200",  // CGN (Alibaba metadata)
+            "0.0.0.0",          // unspecified is NOT loopback
+            "::",               // v6 unspecified
+            "::ffff:127.0.0.1", // mapped wrapper — not the ::1 literal
+            "64:ff9b::7f00:1",  // NAT64 wrapper smuggling 127.0.0.1
+            "2130706433",       // decimal spelling — not an exact literal
+            "127.0.0.1:8080",   // a host:port is not a host literal
+            "example.com",
+            "",
+        ] {
+            assert!(!is_exact_loopback_literal(e), "{e} must NOT qualify");
+        }
+    }
+
+    #[test]
+    fn declassification_clears_the_exact_host_only() {
+        let perm = |entries: &[&str]| -> vec::Vec<String> {
+            entries.iter().map(|e| (*e).to_string()).collect()
+        };
+        // The exact literal clears ITS host — in any equivalent spelling
+        // pair (case · brackets · FQDN dot), and on no other host.
+        assert!(loopback_declassified(&perm(&["127.0.0.1"]), "127.0.0.1"));
+        assert!(loopback_declassified(&perm(&["localhost"]), "localhost"));
+        assert!(loopback_declassified(&perm(&["LOCALHOST"]), "localhost."));
+        assert!(loopback_declassified(&perm(&["[::1]"]), "::1"));
+        assert!(loopback_declassified(&perm(&["::1"]), "[::1]"));
+        // Exact means EXACT: `localhost` is not `127.0.0.1` (the
+        // declassification is the literal in the file, never what it
+        // resolves to), and 127/8 neighbours are distinct hosts.
+        assert!(!loopback_declassified(&perm(&["localhost"]), "127.0.0.1"));
+        assert!(!loopback_declassified(&perm(&["127.0.0.1"]), "localhost"));
+        assert!(!loopback_declassified(&perm(&["127.0.0.1"]), "127.0.0.2"));
+        // A non-loopback HOST is never declassifiable — even when the list
+        // names it (the never-list holds from the host side too).
+        assert!(!loopback_declassified(&perm(&["10.0.0.1"]), "10.0.0.1"));
+        assert!(!loopback_declassified(
+            &perm(&["169.254.169.254"]),
+            "169.254.169.254"
+        ));
+        // The `*.localhost` family: neither a glob ENTRY nor a family HOST
+        // ever participates.
+        assert!(!loopback_declassified(
+            &perm(&["*.localhost"]),
+            "api.localhost"
+        ));
+        assert!(!loopback_declassified(
+            &perm(&["api.localhost"]),
+            "api.localhost"
+        ));
+        // Empty list declassifies nothing.
+        let empty: vec::Vec<String> = vec![];
+        assert!(!loopback_declassified(&empty, "localhost"));
     }
 }


### PR DESCRIPTION
## The design (operator-approved shape · the #395 design half)

An **exact loopback literal** in `permits.net.http` counts as the author's declassification and clears the always-on SSRF floor for **that host only** — the ADR-092 secrets `egress:` precedent: the owner's explicit act, co-located with the boundary.

- **Qualifying literals**: `localhost` (bare name) · `127.x.y.z` exact v4 literals · `::1` (bracketed `[::1]` authority spelling accepted).
- **The never-list**: globs, the `*.localhost` family, RFC1918 (10.x · 172.16-31.x · 192.168.x), link-local (169.254.x · fe80::), CGN, metadata names/IPs — those stay floor-blocked even when named; their entries stay dead-grant-flagged.
- **Exact host, host-level**: `localhost` does not clear `127.0.0.1`; `127.0.0.1` does not clear `127.0.0.2`; ports do not participate in permits.

## Rebind / redirect coverage

One predicate (`nika_types::net::{is_exact_loopback_literal, loopback_declassified}`) feeds every seam: the static vet (`check_url`), the declared-boundary admission (`check_net_allowlist`), the advisory resolve guard, the connect-path `GuardedResolver`, and the `nika check` floor-parity pass.

- A permitted `localhost` reaches its **own** resolved `127.0.0.1`/`::1` — the resolver clears the **loopback class only, per resolved name**: a rebind of the permitted name to RFC1918/metadata still refuses.
- A DNS name that is not a qualifying literal (`mylocal.dev` → `127.0.0.1`) still refuses — the declassification is the literal in the file, never the resolution.
- Every redirect hop re-vets: a bounce from a permitted host to any un-permitted floor host refuses (`NIKA-SEC-005`).

## check≡run in the SAME PR

- The floor-parity pass stops flagging the permitted exact literal (no `NIKA-SEC-005` task escape, no dead-grant entry flag) exactly where the run stops refusing — proven in both directions by an e2e: an **enforcing** client with the `127.0.0.1` permit reaching a **real loopback socket**.
- The clearing is **stated**, not silently un-flagged: a dim informational line in the green PERMITS panel + a `permits.notes` entry in the JSON report.
- `--infer-permits` still never writes a loopback grant (an explicit act stays explicit); its honesty note now teaches the manual opt-in for qualifying hosts and keeps the old wording for the never-list.
- The browser navigate gate is deliberately **unchanged** (narrower than the design allows): it does not consume `permits.net.http` and has no per-connection resolver guard yet, so its entry floor stays absolute.

## Files

- `crates/nika-types/src/net.rs` — the closed classifier (`is_exact_loopback_literal` · `loopback_declassified`) + never-list vectors.
- `crates/nika-http/src/ssrf.rs` — `check_url` gains the declared-permits parameter; declassification at the oracle seam.
- `crates/nika-http/src/lib.rs` — `NetBoundary::globs()` · allowlist admission for the declassifying entry · `resolve_guard`/`guarded_lookup`/`classify_resolved` thread the per-name loopback verdict · `GuardedResolver` carries the permits.
- `crates/nika-http/src/tests.rs` — resolver + e2e suite (Enforce reaching a real local server · same-host redirect lands · bounce to un-permitted floor host refuses).
- `crates/nika-schema/src/check/permits_fit.rs` — floor-parity + dead-grant carve-out (battery-F3 repro flips to green).
- `crates/nika-schema/src/check/effective.rs` — the affirmative `permits.notes` statement.
- `crates/nika-schema/src/check/infer_permits.rs` — the opt-in-teaching honesty note.
- `crates/nika-cli/src/verbs/check.rs` — the PERMITS panel teaching line.
- `crates/nika-builtin/src/permits.rs` — `SEC_SSRF` doc names the carve-out.
- `CHANGELOG.md` — Unreleased entry.

Spec half (same arc): supernovae-st/nika-spec#60 — 01-envelope normative carve-out, 05-errors row, the localhost attack fixture drops its now-lawful grant.

Validation: `cargo fmt` clean · `clippy --all-targets -- -D warnings` clean (nika-types · nika-http · nika-schema · nika-cli) · lib tests **245 + 60 + 742 + 291 = 1338 green**.

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
