### PR TITLE
fix(runtime): on_error.recover awaits a no-edge referent's terminal state (#291)

### DIFF
--- a/crates/nika-runtime/src/expr.rs
+++ b/crates/nika-runtime/src/expr.rs
@@ -139,7 +139,9 @@ impl<'a> Scope<'a> {
     /// `reference` is the AUTHOR's text — parsed exactly once by
     /// [`parse`]; the runtime values are bound as DATA by
     /// [`ScopeResolver`], never re-parsed (the injection-safe boundary ·
-    /// see module docs).
+    /// see module docs). `pub(crate)`: the recover-await classifier
+    /// probes islands through THIS seam, so park-vs-fail agrees with the
+    /// render by construction (spec 05 §recover · zero drift).
     ///
     /// # Errors
     ///
@@ -148,7 +150,7 @@ impl<'a> Scope<'a> {
     /// (NIKA-1703) for a static-grammar violation (`NIKA-VAR-005`) ·
     /// [`RuntimeError::CelEval`] (`NIKA-VAR-006`) for an evaluation type
     /// error (cross-type compare · `size()` of a scalar · …).
-    fn resolve_expr(&self, reference: &str) -> Result<Value, RuntimeError> {
+    pub(crate) fn resolve_expr(&self, reference: &str) -> Result<Value, RuntimeError> {
         let expr = parse(reference).map_err(|e| RuntimeError::from_cel(&e, reference))?;
         compute(&expr, &ScopeResolver(self)).map_err(|e| RuntimeError::from_cel(&e, reference))
     }

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -562,61 +562,19 @@ where
         };
 
         for wave in &report.waves {
-            // The wave-frozen view moves OUT for the wave (same-wave tasks
-            // never reference each other — checker law — so the pipelines
-            // read upstream records only) and back in after: the settles
-            // stream into a side map while the frozen view stays borrowed.
-            let frozen = std::mem::take(&mut records);
-            let streamed = self
-                .dispatch_settle_wave(
+            let early = self
+                .run_one_wave(
                     wave,
-                    wf,
-                    &frozen,
-                    (&vars, &env, &secrets, permits),
-                    &resume_ctx,
+                    (&workflow_name, permits),
+                    &resolve_scope,
                     &run_ledger,
-                    (&mut ok, &mut cache_hits),
                     &mut parked,
+                    (&mut records, &mut ok, &mut cache_hits),
                     stamper,
                     sink,
                 )
-                .await;
-            records = frozen;
-            let (wave_records, paused) = streamed?;
-            records.extend(wave_records);
-
-            if let Some(p) = paused {
-                emit_paused(&workflow_name, &p, stamper, sink);
-                let mut outcome =
-                    RunOutcome::new(true, std::mem::take(&mut records), BTreeMap::new());
-                outcome.cache_hits = std::mem::take(&mut cache_hits);
-                outcome.paused = Some(p);
-                return Ok(outcome.with_ledger(&run_ledger.snapshot()));
-            }
-
-            // The budget boundary: settle what ran, cancel what never
-            // started, fail the run with spent-vs-budget (NIKA-1704).
-            if run_ledger.tripped() {
-                // Parked recoveries resolve against what RAN before the
-                // abort cancels the rest — no task is left frameless.
-                recover::resolve_at_end(
-                    &resolve_scope,
-                    &mut parked,
-                    &mut records,
-                    &mut ok,
-                    &mut cache_hits,
-                    stamper,
-                    sink,
-                );
-                let outcome = abort_on_budget(
-                    wf,
-                    &workflow_name,
-                    records,
-                    cache_hits,
-                    &run_ledger.snapshot(),
-                    stamper,
-                    sink,
-                );
+                .await?;
+            if let Some(outcome) = early {
                 return Ok(outcome);
             }
         }
@@ -646,6 +604,93 @@ where
         let mut outcome = RunOutcome::new(ok, records, outputs).with_ledger(&snapshot);
         outcome.cache_hits = cache_hits;
         Ok(outcome)
+    }
+
+    /// One wave through the spine: dispatch + streamed settle, then the
+    /// two early-exit boundaries — `Some(outcome)` returns the run NOW
+    /// (a pause · the budget boundary), `None` continues to the next
+    /// wave. The wave-frozen view moves OUT for the wave (same-wave
+    /// tasks never reference each other — checker law — so the
+    /// pipelines read upstream records only) and back in after: the
+    /// settles stream into a side map while the frozen view stays
+    /// borrowed.
+    // The scope struct + accumulator trio ARE the settle surface —
+    // mirrors `dispatch_settle_wave` itself.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_one_wave(
+        &self,
+        wave: &[usize],
+        (workflow_name, permits): (&str, Option<&nika_schema::types::Permits>),
+        resolve_scope: &recover::ResolveScope<'_>,
+        run_ledger: &ledger::RunLedger,
+        parked: &mut recover::ParkedRecoveries,
+        (records, ok, cache_hits): (
+            &mut BTreeMap<String, TaskRecord>,
+            &mut bool,
+            &mut Vec<String>,
+        ),
+        stamper: &mut dyn Stamper,
+        sink: &mut dyn EventSink,
+    ) -> Result<Option<RunOutcome>, RuntimeError> {
+        let (wf, vars, env, secrets) = (
+            resolve_scope.wf,
+            resolve_scope.vars,
+            resolve_scope.env,
+            resolve_scope.secrets,
+        );
+        let frozen = std::mem::take(records);
+        let streamed = self
+            .dispatch_settle_wave(
+                wave,
+                wf,
+                &frozen,
+                (vars, env, secrets, permits),
+                resolve_scope.resume_ctx,
+                run_ledger,
+                (ok, cache_hits),
+                parked,
+                stamper,
+                sink,
+            )
+            .await;
+        *records = frozen;
+        let (wave_records, paused) = streamed?;
+        records.extend(wave_records);
+
+        if let Some(p) = paused {
+            emit_paused(workflow_name, &p, stamper, sink);
+            let mut outcome = RunOutcome::new(true, std::mem::take(records), BTreeMap::new());
+            outcome.cache_hits = std::mem::take(cache_hits);
+            outcome.paused = Some(p);
+            return Ok(Some(outcome.with_ledger(&run_ledger.snapshot())));
+        }
+
+        // The budget boundary: settle what ran, cancel what never
+        // started, fail the run with spent-vs-budget (NIKA-1704).
+        if run_ledger.tripped() {
+            // Parked recoveries resolve against what RAN before the
+            // abort cancels the rest — no task is left frameless.
+            recover::resolve_at_end(
+                resolve_scope,
+                parked,
+                records,
+                ok,
+                cache_hits,
+                stamper,
+                sink,
+            );
+            let outcome = abort_on_budget(
+                wf,
+                workflow_name,
+                std::mem::take(records),
+                std::mem::take(cache_hits),
+                &run_ledger.snapshot(),
+                stamper,
+                sink,
+            );
+            return Ok(Some(outcome));
+        }
+        Ok(None)
     }
 
     /// Resolve one wave's members, dispatch concurrently over the

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -48,6 +48,7 @@ mod jq;
 mod ledger;
 mod pause;
 mod record;
+mod recover;
 pub mod resume;
 mod retry;
 mod secret;
@@ -547,6 +548,18 @@ where
         let mut cache_hits: Vec<String> = Vec::new();
         // The spend ledger (leaf debits) + the `--max-cost-usd` gate.
         let run_ledger = ledger::RunLedger::new(self.config.max_cost_usd);
+        // Recoveries awaiting a not-yet-terminal referent (spec 05
+        // §recover step 3) — parked on the settle spine, task-id ordered.
+        // A pause exit drops them UNEMITTED (like the blocked prompt,
+        // they simply have not happened yet · they re-run on `--resume`).
+        let mut parked = recover::ParkedRecoveries::new();
+        let resolve_scope = recover::ResolveScope {
+            wf,
+            vars: &vars,
+            env: &env,
+            secrets: &secrets,
+            resume_ctx: &resume_ctx,
+        };
 
         for wave in &report.waves {
             // The wave-frozen view moves OUT for the wave (same-wave tasks
@@ -563,6 +576,7 @@ where
                     &resume_ctx,
                     &run_ledger,
                     (&mut ok, &mut cache_hits),
+                    &mut parked,
                     stamper,
                     sink,
                 )
@@ -583,6 +597,17 @@ where
             // The budget boundary: settle what ran, cancel what never
             // started, fail the run with spent-vs-budget (NIKA-1704).
             if run_ledger.tripped() {
+                // Parked recoveries resolve against what RAN before the
+                // abort cancels the rest — no task is left frameless.
+                recover::resolve_at_end(
+                    &resolve_scope,
+                    &mut parked,
+                    &mut records,
+                    &mut ok,
+                    &mut cache_hits,
+                    stamper,
+                    sink,
+                );
                 let outcome = abort_on_budget(
                     wf,
                     &workflow_name,
@@ -595,6 +620,20 @@ where
                 return Ok(outcome);
             }
         }
+
+        // Recoveries whose referents never settled on the spine (mutual
+        // recovery cycles) resolve against the FINAL records — each
+        // still-parked task reads as its PRE-recovery failed record
+        // (spec 05 · recovery never rewrites the referent's history).
+        recover::resolve_at_end(
+            &resolve_scope,
+            &mut parked,
+            &mut records,
+            &mut ok,
+            &mut cache_hits,
+            stamper,
+            sink,
+        );
 
         // Resolve the `outputs:` BEFORE the terminal frame so a typed output
         // that breaks its declared `type:` can fail the run — the output half
@@ -648,10 +687,18 @@ where
         resume_ctx: &resume::ResumeContext,
         ledger: &ledger::RunLedger,
         (ok, cache_hits): (&mut bool, &mut Vec<String>),
+        parked: &mut recover::ParkedRecoveries,
         stamper: &mut dyn Stamper,
         sink: &mut dyn EventSink,
     ) -> Result<(BTreeMap<String, TaskRecord>, Option<WorkflowPause>), RuntimeError> {
         let (vars, env, secrets, permits) = scope;
+        let resolve_scope = recover::ResolveScope {
+            wf,
+            vars,
+            env,
+            secrets,
+            resume_ctx,
+        };
         // Resolve indices up front — a bad index is a schedule breach
         // (NIKA-1701 · run abort · the one system error).
         let mut members = Vec::with_capacity(wave.len());
@@ -687,7 +734,21 @@ where
                 paused = Some(p);
                 continue;
             }
-            settle(finish, &mut wave_records, ok, cache_hits, stamper, sink);
+            // A finish whose recovery AWAITS a not-yet-terminal referent
+            // parks instead of settling (spec 05 §recover); everything
+            // else settles into the side map, then covered parks drain —
+            // the wave's terminal truth is `frozen ∪ wave_records`.
+            recover::settle_or_park(
+                finish,
+                &resolve_scope,
+                parked,
+                frozen,
+                &mut wave_records,
+                ok,
+                cache_hits,
+                stamper,
+                sink,
+            );
         }
         Ok((wave_records, paused))
     }
@@ -726,8 +787,10 @@ fn emit_paused(
 }
 
 /// Settle one task in wave order · owns the pens (stamper + sink) ·
-/// inserts the result record.
-fn settle(
+/// inserts the result record. `pub(crate)`: the recover-await spine
+/// (`recover::settle_or_park` + the drain passes) settles through THIS
+/// one site — parked stories keep the same frames as live ones.
+pub(crate) fn settle(
     finish: Finish,
     records: &mut BTreeMap<String, TaskRecord>,
     ok: &mut bool,
@@ -916,26 +979,66 @@ fn settle_ran(
             error,
             cost_usd,
             cost_unpriced,
-        } => {
-            // Billed-then-failed spend rides the failure frame — the
-            // dollars a dying task burned must never vanish with it
-            // (already ledger-debited per attempt; this is the frame's
-            // per-task truth).
-            let mut fields = vec![
-                ("task", s(id)),
-                ("note", s(&run.note)),
-                ("detail", s(&format!("{} · {}", error.code, error.message))),
-                ("duration_ms", i(duration)),
-            ];
-            push_spend_fields(&mut fields, cost_usd, cost_unpriced);
-            let ended = emit(stamper, sink, EventKind::TaskFailed, &fields);
-            record.status = TaskStatus::Failure;
-            record.ended_at = Some(ended);
-            record.error = Some(error);
-            *ok = false;
-        }
+        } => settle_failed_terminal(
+            id,
+            &run.note,
+            duration,
+            error,
+            (cost_usd, cost_unpriced),
+            &mut record,
+            ok,
+            stamper,
+            sink,
+        ),
+        // Backstop: a pending recovery parks BEFORE settle (the
+        // `recover::settle_or_park` spine) — one reaching this site
+        // settles its classification-time failure (total · no panic).
+        task::RunResult::PendingRecovery(pending) => settle_failed_terminal(
+            id,
+            &run.note,
+            duration,
+            pending.render_error,
+            (pending.failed.cost_usd, pending.failed.cost_unpriced),
+            &mut record,
+            ok,
+            stamper,
+            sink,
+        ),
     }
     record
+}
+
+/// The failure terminal — the ONE site for a settled failure's frame +
+/// record (the `Failed` arm and the pending-recovery backstop share it).
+/// Billed-then-failed spend rides the frame — the dollars a dying task
+/// burned must never vanish with it (already ledger-debited per attempt;
+/// this is the frame's per-task truth).
+// REASON: the terminal frame's field surface + the settle pens — the
+// same shape as `settle_ran` itself.
+#[allow(clippy::too_many_arguments)]
+fn settle_failed_terminal(
+    id: &str,
+    note: &str,
+    duration: i64,
+    error: TaskErrorRecord,
+    spend: (Option<f64>, Option<nika_types::cost::UnpricedReason>),
+    record: &mut TaskRecord,
+    ok: &mut bool,
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) {
+    let mut fields = vec![
+        ("task", s(id)),
+        ("note", s(note)),
+        ("detail", s(&format!("{} · {}", error.code, error.message))),
+        ("duration_ms", i(duration)),
+    ];
+    push_spend_fields(&mut fields, spend.0, spend.1);
+    let ended = emit(stamper, sink, EventKind::TaskFailed, &fields);
+    record.status = TaskStatus::Failure;
+    record.ended_at = Some(ended);
+    record.error = Some(error);
+    *ok = false;
 }
 
 /// `on_error: skip` — the ONE state where status is skipped AND the

--- a/crates/nika-runtime/src/recover.rs
+++ b/crates/nika-runtime/src/recover.rs
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `on_error.recover` await (spec 05 §recover resolution steps 2-4).
+//!
+//! A `recover: ${{ tasks.X.output }}` reference is NOT an execution-order
+//! edge: resolution happens at RECOVERY time, and a referent that is not
+//! yet terminal is AWAITED — deterministic, never a race. The await rides
+//! the EXISTING ordered settle spine (never a new scheduler) ·
+//!
+//! 1. **Classify** ([`classify_await`]) — a recover render failure whose
+//!    every failing island names a not-yet-terminal `tasks.X` root
+//!    becomes a [`PendingRecovery`]; any other unresolved root keeps the
+//!    immediate fail (the recovery fails as if `on_error:` were absent).
+//! 2. **Park** ([`settle_or_park`]) — the settle spine holds the finish
+//!    in a task-id-ordered side table; NO frame is emitted yet (the whole
+//!    story defers, so the stream keeps per-task contiguity).
+//! 3. **Retry on the spine** — after every settlement the covered parks
+//!    resolve (transitively: a resolution can cover another park) and
+//!    settle through the ONE emit site (`task_recovered` + terminal).
+//! 4. **Workflow-end** ([`resolve_at_end`]) — parks still waiting after
+//!    the last wave (mutual recovery cycles) resolve against the FINAL
+//!    records where every still-parked task reads as its PRE-recovery
+//!    FAILED record (recovery never rewrites the referent's history).
+//!    Bounded by task count — nothing hangs.
+//!
+//! Determinism: parks mutate only on the sequential settle spine, the
+//! side table is a `BTreeMap` (task-id order), and resolution consults
+//! nothing but the records — no clocks, signals or timeouts, so the
+//! event stream stays byte-identical for any wave-parallelism cap. On
+//! the streamed wave (#412) settles land in a SIDE map the caller
+//! merges after the wave, so the spine's terminal truth during the wave
+//! is `frozen-prior ∪ side-map` — both evolve only on that same spine.
+//!
+//! Boundaries (pinned by tests) · a `for_each` ITERATION never parks
+//! (the fan-out settles as one task — its collector downgrades a pending
+//! classification to the immediate render failure) · a run that PAUSES
+//! (ADR-099) drops its parks unemitted — those tasks simply have not
+//! happened yet and re-run on `--resume`, like the blocked prompt itself.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use nika_schema::raw::RawWorkflow;
+use nika_schema::types::OnErrorAction;
+use nika_tmpl::expression::{NamespaceRef, expr_refs, scan_templates};
+use serde_json::Value;
+
+use crate::expr::{self, Scope};
+use crate::record::{TaskErrorRecord, TaskRecord, TaskStatus};
+use crate::resume::ResumeContext;
+use crate::stamp::{EventSink, Stamper};
+use crate::task::{
+    FailedOutcome, Finish, RanTask, RetryStamp, RunResult, SettleAs, bind_outputs,
+    runtime_error_record, success_output,
+};
+
+/// A recovery whose render awaits not-yet-terminal referents (spec 05
+/// §recover step 3) — everything the deferred render needs, owned (the
+/// pipeline scope is gone by resolution time).
+pub(crate) struct PendingRecovery {
+    /// The attempt-loop failure `recover:` fired on — the pre-recovery
+    /// truth: its code marks `task_recovered`, its spend rides the
+    /// terminal frame, and its record is what a still-parked task reads
+    /// as in the workflow-end view.
+    pub failed: FailedOutcome,
+    /// The classification-time render failure — what a non-parking
+    /// surface (a `for_each` iteration · an undeclared awaited root)
+    /// reports instead of awaiting.
+    pub render_error: TaskErrorRecord,
+    /// The not-yet-terminal `tasks.<id>` roots the render awaits.
+    pub awaiting: BTreeSet<String>,
+    /// The task's rendered `with:` namespace.
+    pub with_ns: BTreeMap<String, Value>,
+}
+
+/// The run-scoped READ surfaces a deferred resolution needs (the records
+/// stay a separate `&mut` — they are the spine's write surface).
+#[derive(Clone, Copy)]
+pub(crate) struct ResolveScope<'a> {
+    pub wf: &'a RawWorkflow,
+    pub vars: &'a BTreeMap<String, Value>,
+    pub env: &'a BTreeMap<String, Value>,
+    pub secrets: &'a BTreeMap<String, Value>,
+    pub resume_ctx: &'a ResumeContext,
+}
+
+/// The settle spine's park table — task-id ordered (`BTreeMap`), so
+/// every drain and the workflow-end pass are deterministic.
+pub(crate) struct ParkedRecoveries {
+    entries: BTreeMap<String, Parked>,
+}
+
+/// One parked finish, fully deconstructed (total — no placeholder
+/// results, no unreachable arms at resolution time).
+struct Parked {
+    /// The task's index in `wf.tasks` — re-borrows the `RawTask` at
+    /// resolution (the recover template + the `output:` bindings).
+    task_index: usize,
+    note: String,
+    retries: Vec<RetryStamp>,
+    agent_events: Vec<crate::agent_events::StampedAgentEvent>,
+    duration_ms: u64,
+    resume: Option<crate::resume::ResumeStamp>,
+    pending: Box<PendingRecovery>,
+}
+
+impl ParkedRecoveries {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+/// Classify a recover render failure (spec 05 §recover step 3): `Some`
+/// with the awaited task ids when EVERY failing island of `template`
+/// names at least one not-yet-terminal `tasks.X` root — the render can
+/// still succeed once those referents settle. `None` keeps the immediate
+/// fail: a structural fault, or a failing island a terminal state cannot
+/// repair (an unknown namespace · a broken path INTO a terminal record).
+///
+/// Islands are probed through the render's own resolver seam
+/// ([`Scope::resolve_expr`]) so this classification cannot drift from
+/// what the render accepts.
+pub(crate) fn classify_await(template: &Value, scope: &Scope<'_>) -> Option<BTreeSet<String>> {
+    let mut leaves = Vec::new();
+    string_leaves(template, &mut leaves);
+    let mut awaiting = BTreeSet::new();
+    for leaf in leaves {
+        let Ok(islands) = scan_templates(leaf) else {
+            return None; // structural fault — no terminal state repairs it
+        };
+        for island in islands {
+            if scope.resolve_expr(&island.src).is_ok() {
+                continue;
+            }
+            let pending: Vec<String> = expr_refs(&island.expr)
+                .into_iter()
+                .filter_map(|r| match r {
+                    NamespaceRef::Tasks { id, .. } if !scope.records.contains_key(&id) => Some(id),
+                    _ => None,
+                })
+                .collect();
+            if pending.is_empty() {
+                return None; // not explained by a pending referent — fail now
+            }
+            awaiting.extend(pending);
+        }
+    }
+    (!awaiting.is_empty()).then_some(awaiting)
+}
+
+/// String leaves of a recover template, in the order the render visits
+/// them (values only — object keys are never rendered).
+fn string_leaves<'v>(value: &'v Value, out: &mut Vec<&'v str>) {
+    match value {
+        Value::String(s) => out.push(s),
+        Value::Array(items) => items.iter().for_each(|v| string_leaves(v, out)),
+        Value::Object(map) => map.values().for_each(|v| string_leaves(v, out)),
+        _ => {}
+    }
+}
+
+/// The spine's settle step: park a pending recovery, settle everything
+/// else into `live` (the wave's side map on the streamed spine), then
+/// drain every park the spine's terminal truth covers. That truth is
+/// `prior ∪ live` — the frozen prior-wave records the pipelines read
+/// PLUS this wave's settles so far (disjoint by construction: a task
+/// settles once). One call per finish — the only integration point the
+/// settle loop needs.
+// REASON: the settle surface (pens + run accumulators) + the park table —
+// mirrors `settle` itself.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn settle_or_park(
+    finish: Finish,
+    scope: &ResolveScope<'_>,
+    parked: &mut ParkedRecoveries,
+    prior: &BTreeMap<String, TaskRecord>,
+    live: &mut BTreeMap<String, TaskRecord>,
+    ok: &mut bool,
+    cache_hits: &mut Vec<String>,
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) {
+    if let Some(finish) = try_park(finish, scope, parked) {
+        crate::settle(finish, live, ok, cache_hits, stamper, sink);
+    }
+    drain_ready(scope, parked, prior, live, ok, cache_hits, stamper, sink);
+}
+
+/// Park a pending-recovery finish — `None` when parked (nothing settles
+/// yet). `Some(finish)` settles normally: either the finish untouched
+/// (not a pending recovery), or its immediate failure when an awaited
+/// root is NOT a declared task (such a root can never reach a terminal
+/// state — the recovery fails exactly as if nothing had parked · spec 05).
+fn try_park(
+    finish: Finish,
+    scope: &ResolveScope<'_>,
+    parked: &mut ParkedRecoveries,
+) -> Option<Finish> {
+    let Finish {
+        id,
+        settle: settled_as,
+        named,
+        resume,
+    } = finish;
+    let ran = match settled_as {
+        SettleAs::Ran(ran) => ran,
+        other => {
+            return Some(Finish {
+                id,
+                settle: other,
+                named,
+                resume,
+            });
+        }
+    };
+    let RanTask {
+        note,
+        retries,
+        agent_events,
+        duration_ms,
+        result,
+    } = ran;
+    let pending = match result {
+        RunResult::PendingRecovery(pending) => pending,
+        other => {
+            let ran = RanTask {
+                note,
+                retries,
+                agent_events,
+                duration_ms,
+                result: other,
+            };
+            return Some(Finish {
+                id,
+                settle: SettleAs::Ran(ran),
+                named,
+                resume,
+            });
+        }
+    };
+    let declared = |t: &String| scope.wf.tasks.iter().any(|s| s.value.id.value == *t);
+    if let Some(task_index) =
+        task_index(scope.wf, &id).filter(|_| pending.awaiting.iter().all(declared))
+    {
+        parked.entries.insert(
+            id,
+            Parked {
+                task_index,
+                note,
+                retries,
+                agent_events,
+                duration_ms,
+                resume,
+                pending,
+            },
+        );
+        return None;
+    }
+    // An awaited root that is NOT a declared task can never reach a
+    // terminal state — the recovery fails NOW, exactly as if nothing
+    // had parked (spec 05).
+    let PendingRecovery {
+        failed,
+        render_error,
+        ..
+    } = *pending;
+    let ran = RanTask {
+        note,
+        retries,
+        agent_events,
+        duration_ms,
+        result: RunResult::Failed {
+            error: render_error,
+            cost_usd: failed.cost_usd,
+            cost_unpriced: failed.cost_unpriced,
+        },
+    };
+    Some(Finish {
+        id,
+        settle: SettleAs::Ran(ran),
+        named,
+        resume,
+    })
+}
+
+/// Resolve + settle every park the spine's terminal truth covers, to a
+/// fixpoint (a resolution settles a record into `live`, which can cover
+/// another park — chains drain transitively). The truth is `prior ∪
+/// live`: the wave-frozen prior records plus the settles so far, checked
+/// clone-free; a resolution renders against `live` directly when `prior`
+/// is empty (the workflow-end shape) and against a per-resolution merged
+/// view otherwise (the rare path — the same clone-for-a-scope trade as
+/// the cleanup overlay). Resolutions settle into `live` (the wave's one
+/// write surface). Task-id order · bounded (each pass removes one entry).
+// REASON: the settle surface + the park table — same shape as settle_or_park.
+#[allow(clippy::too_many_arguments)]
+fn drain_ready(
+    scope: &ResolveScope<'_>,
+    parked: &mut ParkedRecoveries,
+    prior: &BTreeMap<String, TaskRecord>,
+    live: &mut BTreeMap<String, TaskRecord>,
+    ok: &mut bool,
+    cache_hits: &mut Vec<String>,
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) {
+    loop {
+        let ready = parked
+            .entries
+            .iter()
+            .find(|(_, p)| {
+                p.pending
+                    .awaiting
+                    .iter()
+                    .all(|t| prior.contains_key(t) || live.contains_key(t))
+            })
+            .map(|(id, _)| id.clone());
+        let Some(id) = ready else { return };
+        let Some(park) = parked.entries.remove(&id) else {
+            return;
+        };
+        let finish = if prior.is_empty() {
+            resolve_parked(id, park, scope, live)
+        } else {
+            let mut view = prior.clone();
+            view.extend(live.iter().map(|(k, v)| (k.clone(), v.clone())));
+            resolve_parked(id, park, scope, &view)
+        };
+        crate::settle(finish, live, ok, cache_hits, stamper, sink);
+    }
+}
+
+/// The workflow-end pass (spec 05 §recover step 3 tail): drain what the
+/// final records cover, then resolve the rest — mutual recovery cycles —
+/// against a FROZEN view where every still-parked task reads as its
+/// PRE-recovery FAILED record (recovery never rewrites the referent's
+/// history; both sides of a cycle see the other's failure, whatever they
+/// themselves resolve to). Settles in task-id order. Also runs before a
+/// budget abort, so no parked task is left frameless.
+// REASON: the settle surface + the park table — same shape as settle_or_park.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_at_end(
+    scope: &ResolveScope<'_>,
+    parked: &mut ParkedRecoveries,
+    records: &mut BTreeMap<String, TaskRecord>,
+    ok: &mut bool,
+    cache_hits: &mut Vec<String>,
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) {
+    // Post-merge, the run-wide records ARE the whole truth (prior empty).
+    let no_prior = BTreeMap::new();
+    drain_ready(
+        scope, parked, &no_prior, records, ok, cache_hits, stamper, sink,
+    );
+    if parked.entries.is_empty() {
+        return;
+    }
+    let mut view = records.clone();
+    for (id, park) in &parked.entries {
+        view.insert(id.clone(), failed_view_record(&park.pending.failed.record));
+    }
+    let ids: Vec<String> = parked.entries.keys().cloned().collect();
+    let mut resolved = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Some(park) = parked.entries.remove(&id) {
+            resolved.push(resolve_parked(id, park, scope, &view));
+        }
+    }
+    for finish in resolved {
+        crate::settle(finish, records, ok, cache_hits, stamper, sink);
+    }
+}
+
+/// A still-parked task as the workflow-end view reads it: its
+/// pre-recovery failure (status + the original typed error).
+fn failed_view_record(error: &TaskErrorRecord) -> TaskRecord {
+    let mut record = TaskRecord::unran(TaskStatus::Failure);
+    record.error = Some(error.clone());
+    record
+}
+
+/// Resolve one park against `view`: re-render the recover template —
+/// success takes the normal recovered path (`recovered_from` marks the
+/// original code · the failed attempts' spend rides), a render error
+/// takes the normal recovery-failed path. `output:` bindings re-evaluate
+/// over the FINAL value (the recovery substitutes the raw output BEFORE
+/// binding extraction · spec 05), and the ADR-099 resume stamp passes
+/// the same secret-leak filter the live pipeline applies.
+fn resolve_parked(
+    id: String,
+    park: Parked,
+    scope: &ResolveScope<'_>,
+    view: &BTreeMap<String, TaskRecord>,
+) -> Finish {
+    let Parked {
+        task_index,
+        note,
+        retries,
+        agent_events,
+        duration_ms,
+        resume,
+        pending,
+    } = park;
+    let PendingRecovery {
+        failed,
+        render_error,
+        awaiting: _,
+        with_ns,
+    } = *pending;
+    let FailedOutcome {
+        record,
+        cost_usd,
+        cost_unpriced,
+    } = failed;
+    let result = match recover_template(scope.wf, task_index) {
+        Some(template) => {
+            let render_scope = Scope {
+                records: view,
+                vars: scope.vars,
+                env: scope.env,
+                secrets: scope.secrets,
+                with_ns: Some(&with_ns),
+                item: None, // iterations never park (fan-out boundary)
+                index: None,
+                permits: None, // rendering performs no effect (no exec sink)
+            };
+            match expr::render_json(template, &render_scope) {
+                Ok(value) => RunResult::Success {
+                    value,
+                    tokens: None,
+                    recovered_from: Some(record.code),
+                    warning: None,
+                    cost_usd,
+                    cost_unpriced,
+                },
+                Err(err) => RunResult::Failed {
+                    error: runtime_error_record(&err),
+                    cost_usd,
+                    cost_unpriced,
+                },
+            }
+        }
+        // Total-function backstop (a park is only ever built FROM the
+        // recover arm): no template ⇒ the classification-time failure.
+        None => RunResult::Failed {
+            error: render_error,
+            cost_usd,
+            cost_unpriced,
+        },
+    };
+    let mut settled_as = SettleAs::Ran(RanTask {
+        note,
+        retries,
+        agent_events,
+        duration_ms,
+        result,
+    });
+    let named = match scope.wf.tasks.get(task_index) {
+        Some(task) => bind_outputs(&task.value, &mut settled_as),
+        None => BTreeMap::new(),
+    };
+    let resume = resume.filter(|_| {
+        success_output(&settled_as)
+            .and_then(|v| serde_json::to_string(v).ok())
+            .is_none_or(|text| !scope.resume_ctx.leaks_secret(&text))
+    });
+    Finish {
+        id,
+        settle: settled_as,
+        named,
+        resume,
+    }
+}
+
+/// The declared recover template of `wf.tasks[index]`, when it is one.
+fn recover_template(wf: &RawWorkflow, index: usize) -> Option<&Value> {
+    let on_error = wf.tasks.get(index)?.value.on_error.as_ref()?;
+    match &on_error.value.action {
+        OnErrorAction::Recover(v) => Some(&v.value),
+        _ => None,
+    }
+}
+
+/// The index of `id` in the workflow's task list.
+fn task_index(wf: &RawWorkflow, id: &str) -> Option<usize> {
+    wf.tasks.iter().position(|t| t.value.id.value == id)
+}

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -187,6 +187,13 @@ pub(crate) enum RunResult {
         cost_usd: Option<f64>,
         cost_unpriced: Option<nika_types::cost::UnpricedReason>,
     },
+    /// `on_error: recover` whose reference awaits not-yet-terminal
+    /// referents (spec 05 §recover step 3 · a recover ref is NOT an
+    /// edge): the outcome is DECIDED on the ordered settle spine once
+    /// every awaited task is terminal — parked there, never settled
+    /// here. A `for_each` iteration never parks: its collector
+    /// downgrades this to the immediate render failure.
+    PendingRecovery(Box<crate::recover::PendingRecovery>),
 }
 
 struct IterationLocals<'a> {
@@ -872,6 +879,18 @@ where
                     break;
                 }
             }
+            // An ITERATION never parks — the fan-out settles as ONE task,
+            // so a pending recovery downgrades to its immediate render
+            // failure (the recover-await boundary · pinned by tests).
+            RunResult::PendingRecovery(pending) => {
+                acc.outputs.push(Value::Null);
+                if acc.first_error.is_none() {
+                    acc.first_error = Some(pending.render_error);
+                }
+                if fail_fast {
+                    break;
+                }
+            }
         }
     }
     acc
@@ -943,8 +962,10 @@ fn resolve_collection(
 ///   not a 1702). The success VALUE is never recomputed.
 ///
 /// Returns an empty map when the task declares no `output:` (the common
-/// lane pays nothing).
-fn bind_outputs(task: &RawTask, settle: &mut SettleAs) -> BTreeMap<String, Value> {
+/// lane pays nothing). `pub(crate)`: the recover-await resolution binds
+/// over the deferred value through THIS one site (spec 05 · the recovery
+/// substitutes the raw output BEFORE binding extraction).
+pub(crate) fn bind_outputs(task: &RawTask, settle: &mut SettleAs) -> BTreeMap<String, Value> {
     if task.output.is_empty() {
         return BTreeMap::new();
     }
@@ -978,11 +999,15 @@ fn null_bindings(task: &RawTask) -> BTreeMap<String, Value> {
 
 /// The success raw output of a settled task (the value bindings extract
 /// from), or `None` when the task did not settle as a plain success.
-fn success_output(settle: &SettleAs) -> Option<&Value> {
+/// `pub(crate)`: the recover-await resolution re-applies the pipeline's
+/// binding + leak-filter steps over the deferred value.
+pub(crate) fn success_output(settle: &SettleAs) -> Option<&Value> {
     match settle {
         SettleAs::Ran(ran) => match &ran.result {
             RunResult::Success { value, .. } => Some(value),
-            RunResult::SkippedWithError { .. } | RunResult::Failed { .. } => None,
+            RunResult::SkippedWithError { .. }
+            | RunResult::Failed { .. }
+            | RunResult::PendingRecovery(_) => None,
         },
         // A cache hit IS a success — bindings extract from the
         // rehydrated output (ADR-099 · downstream parity with live).
@@ -1142,17 +1167,23 @@ fn default_gate_open(task: &RawTask, records: &BTreeMap<String, TaskRecord>) -> 
 }
 
 /// The parent's preview record for the cleanup scope (spec 03 · the
-/// cleanup sees `tasks.<parent>.status` / `.error`).
+/// cleanup sees `tasks.<parent>.status` / `.error`). A PENDING recovery
+/// previews as its pre-recovery failure: the attempts DID fail, and the
+/// deferred render has produced no value when the cleanup runs (the
+/// cleanup is task-scoped · it never awaits the spine).
 fn preview_record(ran: &RanTask) -> TaskRecord {
     let mut record = TaskRecord::unran(match ran.result {
         RunResult::Success { .. } => TaskStatus::Success,
         RunResult::SkippedWithError { .. } => TaskStatus::Skipped,
-        RunResult::Failed { .. } => TaskStatus::Failure,
+        RunResult::Failed { .. } | RunResult::PendingRecovery(_) => TaskStatus::Failure,
     });
     match &ran.result {
         RunResult::Success { value, .. } => record.output = value.clone(),
         RunResult::SkippedWithError { error, .. } | RunResult::Failed { error, .. } => {
             record.error = Some(error.clone());
+        }
+        RunResult::PendingRecovery(pending) => {
+            record.error = Some(pending.failed.record.clone());
         }
     }
     record.duration_ms = Some(ran.duration_ms);
@@ -1278,13 +1309,29 @@ fn apply_on_error(task: &RawTask, scope: &Scope<'_>, failed: FailedOutcome) -> R
                 cost_usd,
                 cost_unpriced,
             },
-            // Recovery itself failed → the task fails as if
-            // `on_error:` were absent (spec 05 §recover resolution).
-            Err(err) => RunResult::Failed {
-                error: runtime_error_record(&err),
-                cost_usd,
-                cost_unpriced,
-            },
+            // A render failure explained ONLY by not-yet-terminal task
+            // referents AWAITS them (spec 05 §recover step 3 · a recover
+            // ref is not an edge): the settle spine decides the outcome
+            // once they settle. Any other unresolved root → the task
+            // fails as if `on_error:` were absent (§recover step 4).
+            Err(err) => {
+                let render_error = runtime_error_record(&err);
+                match crate::recover::classify_await(&value.value, scope) {
+                    Some(awaiting) => {
+                        RunResult::PendingRecovery(Box::new(crate::recover::PendingRecovery {
+                            failed: FailedOutcome::new(error, cost_usd, cost_unpriced),
+                            render_error,
+                            awaiting,
+                            with_ns: scope.with_ns.cloned().unwrap_or_default(),
+                        }))
+                    }
+                    None => RunResult::Failed {
+                        error: render_error,
+                        cost_usd,
+                        cost_unpriced,
+                    },
+                }
+            }
         },
         OnErrorAction::Skip => RunResult::SkippedWithError {
             error,
@@ -1360,7 +1407,9 @@ fn render_with(
 /// out-of-subset form · …) — the identifier `tasks.X.error.code` exposes and
 /// `on_codes:` filters on — NEVER the engine-internal `nika_code()` (spec 05
 /// §142 · internal codes MUST NOT leak into workflow-visible errors).
-fn runtime_error_record(err: &RuntimeError) -> TaskErrorRecord {
+/// `pub(crate)`: the recover-await resolution maps its deferred render
+/// failure through the SAME site.
+pub(crate) fn runtime_error_record(err: &RuntimeError) -> TaskErrorRecord {
     TaskErrorRecord {
         code: err.spec_code(),
         message: err.wire_message(),

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -418,3 +418,435 @@ fn cost_unpriced_reason_rides_task_completed() {
         "snake_case wire form"
     );
 }
+
+// ─── on_error.recover awaits a no-edge referent (#291 · spec 05 §recover) ───
+//
+// A `recover: ${{ tasks.X.output }}` reference is NOT an execution-order
+// edge; resolution happens at RECOVERY time; a pending/running referent is
+// AWAITED to its terminal state (deterministic · never a race). The await
+// rides the ordered settle spine: the failing task PARKS, every subsequent
+// settlement retries covered parks, and a workflow-end pass resolves the
+// rest against the final records (a still-parked referent reads as its
+// pre-recovery FAILED record — recovery never rewrites the referent's
+// history).
+
+mod recover_await {
+    use std::num::NonZeroUsize;
+
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+    use nika_verb_agent::AgentVerb;
+    use nika_verb_exec::ExecVerb;
+    use nika_verb_invoke::InvokeVerb;
+
+    use super::*;
+
+    /// The real parse → check → run chain over mock seams (the `spec_v2`
+    /// harness idiom, exec-only — every fixture here drives the shell).
+    async fn run_yaml(
+        yaml: &str,
+        shell: MockShell,
+        cap: Option<usize>,
+    ) -> (RunOutcome, Vec<Event>) {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(report.is_clean(), "fixture passes the ladder: {report:?}");
+        let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+        let runtime = Runtime::new(
+            ExecVerb::new(Arc::new(shell)),
+            Arc::clone(&invoke),
+            nika_verb_infer::InferVerb::new(registry, "mock/echo"),
+            AgentVerb::new(
+                Arc::new(MockProvider::new("mock")),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::new(cap.and_then(NonZeroUsize::new), 0),
+        );
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let outcome = runtime
+            .run(&wf, &report, &mut stamper, &mut sink)
+            .await
+            .expect("clean run");
+        (outcome, sink.into_events())
+    }
+
+    /// Position of the FIRST frame of `kind` for `task` in the stream.
+    fn frame_at(events: &[Event], kind: EventKind, task: &str) -> usize {
+        events
+            .iter()
+            .position(|e| {
+                e.kind == kind
+                    && e.fields.iter().any(
+                        |f| matches!(&f.value, FieldValue::String(s) if f.key == "task" && s == task),
+                    )
+            })
+            .unwrap_or_else(|| panic!("no {kind:?} frame for `{task}`"))
+    }
+
+    fn recovered_code<'e>(events: &'e [Event], task: &str) -> &'e str {
+        let frame = &events[frame_at(events, EventKind::TaskRecovered, task)];
+        frame
+            .fields
+            .iter()
+            .find_map(|f| match (&f.key[..], &f.value) {
+                ("code", FieldValue::String(s)) => Some(s.as_str()),
+                _ => None,
+            })
+            .expect("task_recovered carries what it recovered FROM")
+    }
+
+    /// (a) Same-wave no-edge referent: the recovery AWAITS the referent's
+    /// terminal state and succeeds with its value — never NIKA-VAR-001,
+    /// never a race. The parked task's story (started → recovered →
+    /// completed) lands AFTER the referent settles; `output:` bindings
+    /// evaluate over the recovered value; downstream consumes it. The
+    /// stream is byte-identical for any wave-parallelism cap.
+    #[tokio::test]
+    async fn same_wave_noedge_recover_awaits_the_referent() {
+        let yaml = r#"
+nika: v1
+workflow: recover-await-same-wave
+tasks:
+  - id: risky
+    exec: { command: "exit 1" }
+    on_error:
+      recover: ${{ tasks.source.output }}
+    output:
+      v: "."
+  - id: source
+    exec: { command: "echo 99" }
+  - id: sink
+    depends_on: [risky]
+    exec: { command: "use ${{ tasks.risky.output }}" }
+"#;
+        let mut streams: Vec<Vec<Event>> = Vec::new();
+        for cap in [Some(1), Some(2), None] {
+            let shell = MockShell::new()
+                .enqueue_fail(1, "boom")
+                .enqueue_ok("99\n")
+                .enqueue_ok("used\n");
+            let (outcome, events) = run_yaml(yaml, shell, cap).await;
+
+            assert!(outcome.ok, "the recovery repaired the run (cap {cap:?})");
+            assert_eq!(outcome.records["risky"].status, TaskStatus::Success);
+            assert_eq!(outcome.records["risky"].output, Value::String("99".into()));
+            assert_eq!(
+                outcome.records["risky"].named["v"],
+                Value::String("99".into()),
+                "output: bindings evaluate over the RECOVERED value (spec 05)"
+            );
+            assert_eq!(outcome.records["sink"].status, TaskStatus::Success);
+
+            // The await is visible in the stream: the referent's terminal
+            // precedes the parked task's whole story.
+            let source_done = frame_at(&events, EventKind::TaskCompleted, "source");
+            let risky_started = frame_at(&events, EventKind::TaskStarted, "risky");
+            assert!(
+                source_done < risky_started,
+                "the parked story lands after the awaited referent settles"
+            );
+            let rec = frame_at(&events, EventKind::TaskRecovered, "risky");
+            let done = frame_at(&events, EventKind::TaskCompleted, "risky");
+            assert!(rec < done, "task_recovered inserts before the terminal");
+            assert_eq!(recovered_code(&events, "risky"), "NIKA-EXEC-001");
+            streams.push(events);
+        }
+        assert!(
+            streams.windows(2).all(|w| w[0] == w[1]),
+            "the cap never leaks into the stream (ordered-settlement law)"
+        );
+    }
+
+    /// (b) Later-wave referent + a parked-on-parked chain: A awaits B,
+    /// B awaits C (a later wave). C settles → B resolves → A resolves on
+    /// the same spine (the retry pass drains transitively). A's recovered
+    /// value is B's POST-recovery output — downstream of a recovered task
+    /// sees `status: success` + the recover value (spec 05).
+    #[tokio::test]
+    async fn later_wave_referent_resolves_transitively_on_the_spine() {
+        let yaml = r#"
+nika: v1
+workflow: recover-await-chain
+tasks:
+  - id: a
+    exec: { command: "exit 1" }
+    on_error:
+      recover: ${{ tasks.b.output }}
+  - id: b
+    exec: { command: "exit 2" }
+    on_error:
+      recover: ${{ tasks.c.output }}
+  - id: base
+    exec: { command: "echo base" }
+  - id: c
+    depends_on: [base]
+    exec: { command: "echo 42" }
+"#;
+        let shell = MockShell::new()
+            .enqueue_fail(1, "a boom")
+            .enqueue_fail(2, "b boom")
+            .enqueue_ok("base\n")
+            .enqueue_ok("42\n");
+        let (outcome, events) = run_yaml(yaml, shell, Some(1)).await;
+
+        assert!(outcome.ok);
+        assert_eq!(outcome.records["b"].status, TaskStatus::Success);
+        assert_eq!(outcome.records["b"].output, Value::String("42".into()));
+        assert_eq!(
+            outcome.records["a"].output,
+            Value::String("42".into()),
+            "a sees b's POST-recovery output (downstream-of-recovered law)"
+        );
+        let c_done = frame_at(&events, EventKind::TaskCompleted, "c");
+        let b_started = frame_at(&events, EventKind::TaskStarted, "b");
+        let a_started = frame_at(&events, EventKind::TaskStarted, "a");
+        assert!(c_done < b_started, "b resolves after c settles");
+        assert!(b_started < a_started, "the chain drains in coverage order");
+    }
+
+    /// (c) A referent skipped by `when:` reaches a terminal state whose
+    /// output is defined-null (spec 04) — the awaited recovery resolves
+    /// with `null`, it does NOT fail (the records hold what they hold).
+    #[tokio::test]
+    async fn skipped_referent_resolves_to_defined_null() {
+        let yaml = r#"
+nika: v1
+workflow: recover-await-skipped
+tasks:
+  - id: risky
+    exec: { command: "exit 1" }
+    on_error:
+      recover: ${{ tasks.source.output }}
+  - id: base
+    exec: { command: "echo base" }
+  - id: source
+    depends_on: [base]
+    when: false
+    exec: { command: "echo never" }
+"#;
+        let shell = MockShell::new()
+            .enqueue_fail(1, "boom")
+            .enqueue_ok("base\n");
+        let (outcome, events) = run_yaml(yaml, shell, Some(1)).await;
+
+        assert!(outcome.ok, "recovered-with-null is a success");
+        assert_eq!(outcome.records["risky"].status, TaskStatus::Success);
+        assert_eq!(outcome.records["risky"].output, Value::Null);
+        assert_eq!(recovered_code(&events, "risky"), "NIKA-EXEC-001");
+        let skipped = frame_at(&events, EventKind::TaskSkipped, "source");
+        let risky_started = frame_at(&events, EventKind::TaskStarted, "risky");
+        assert!(skipped < risky_started, "the skip is the awaited terminal");
+    }
+
+    /// (d) Mutual recovery (A recovers-from B, B recovers-from A, no
+    /// edges): both park, both resolve at WORKFLOW-END, and each renders
+    /// against the other's PRE-recovery FAILED record (recovery never
+    /// rewrites the referent's history) — `tasks.other.status` reads
+    /// `failure`, not the `success` both end up with.
+    #[tokio::test]
+    async fn mutual_recovery_resolves_at_workflow_end_against_failed_records() {
+        let yaml = r#"
+nika: v1
+workflow: recover-await-mutual
+tasks:
+  - id: a
+    exec: { command: "exit 1" }
+    on_error:
+      recover: ${{ tasks.b.status }}
+  - id: b
+    exec: { command: "exit 2" }
+    on_error:
+      recover: ${{ tasks.a.status }}
+"#;
+        let shell = MockShell::new()
+            .enqueue_fail(1, "a boom")
+            .enqueue_fail(2, "b boom");
+        let (outcome, events) = run_yaml(yaml, shell, Some(1)).await;
+
+        assert!(outcome.ok, "both recoveries resolve — nothing hangs");
+        for id in ["a", "b"] {
+            assert_eq!(outcome.records[id].status, TaskStatus::Success);
+            assert_eq!(
+                outcome.records[id].output,
+                Value::String("failure".into()),
+                "`{id}` sees the OTHER's pre-recovery failed state"
+            );
+            assert_eq!(recovered_code(&events, id), "NIKA-EXEC-001");
+        }
+        // Deterministic order: the end pass settles in task-id order.
+        let a_done = frame_at(&events, EventKind::TaskCompleted, "a");
+        let b_started = frame_at(&events, EventKind::TaskStarted, "b");
+        assert!(a_done < b_started, "workflow-end resolution is id-ordered");
+    }
+
+    /// (e) The await gates on « not yet terminal » ONLY: a recover whose
+    /// reference breaks INSIDE an already-terminal referent (the path,
+    /// not the task, is unresolved) keeps today's fail-fast — no park is
+    /// owed to a referent that already settled.
+    #[tokio::test]
+    async fn broken_path_into_a_terminal_referent_still_fails_fast() {
+        let yaml = r#"
+nika: v1
+workflow: recover-terminal-broken-path
+tasks:
+  - id: done
+    exec: { command: "echo ok" }
+  - id: risky
+    depends_on: [done]
+    exec: { command: "exit 1" }
+    on_error:
+      recover: ${{ tasks.done.output.missing }}
+"#;
+        let shell = MockShell::new().enqueue_ok("ok\n").enqueue_fail(1, "boom");
+        let (outcome, _events) = run_yaml(yaml, shell, Some(1)).await;
+
+        assert!(
+            !outcome.ok,
+            "the recovery failed — the task fails as-if unhandled"
+        );
+        assert_eq!(outcome.records["risky"].status, TaskStatus::Failure);
+        let error = outcome.records["risky"]
+            .error
+            .as_ref()
+            .expect("error readable");
+        assert!(
+            error.code.starts_with("NIKA-VAR-"),
+            "the render failure surfaces its spec class · got {}",
+            error.code
+        );
+    }
+
+    /// (e·unknown-name) An awaited root that is NOT a declared task can
+    /// never reach a terminal state — the park validation settles the
+    /// classification-time NIKA-VAR-001 immediately, exactly as if
+    /// nothing had parked. (Driven at the park site: `nika check`
+    /// rejects an undeclared recover ref before a run can exist, so the
+    /// runtime backstop is what this pins.)
+    #[test]
+    fn undeclared_awaited_root_fails_fast_at_the_park_site() {
+        let yaml =
+            "nika: v1\nworkflow: t\ntasks:\n  - id: risky\n    exec: { command: \"exit 1\" }\n";
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let (vars, env, secrets) = (BTreeMap::new(), BTreeMap::new(), BTreeMap::new());
+        let resume_ctx = resume::ResumeContext::of(&wf, &secrets, None);
+        let scope = crate::recover::ResolveScope {
+            wf: &wf,
+            vars: &vars,
+            env: &env,
+            secrets: &secrets,
+            resume_ctx: &resume_ctx,
+        };
+        let error = |code: &str, message: &str| TaskErrorRecord {
+            code: code.to_owned(),
+            message: message.to_owned(),
+            transient: false,
+        };
+        let pending = crate::recover::PendingRecovery {
+            failed: task::FailedOutcome {
+                record: error("NIKA-EXEC-001", "exit 1"),
+                cost_usd: None,
+                cost_unpriced: None,
+            },
+            render_error: error("NIKA-VAR-001", "unresolved reference `tasks.ghost.output`"),
+            awaiting: std::collections::BTreeSet::from(["ghost".to_owned()]),
+            with_ns: BTreeMap::new(),
+        };
+        let finish = task::Finish {
+            id: "risky".to_owned(),
+            settle: task::SettleAs::Ran(task::RanTask {
+                note: "exec · sh".to_owned(),
+                retries: Vec::new(),
+                agent_events: Vec::new(),
+                duration_ms: 0,
+                result: task::RunResult::PendingRecovery(Box::new(pending)),
+            }),
+            named: BTreeMap::new(),
+            resume: None,
+        };
+        let mut parked = crate::recover::ParkedRecoveries::new();
+        // The streamed-wave shape: prior-wave records + the wave's side
+        // map — both empty here (the downgrade needs neither).
+        let prior = BTreeMap::new();
+        let mut records = BTreeMap::new();
+        let mut ok = true;
+        let mut cache_hits = Vec::new();
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        crate::recover::settle_or_park(
+            finish,
+            &scope,
+            &mut parked,
+            &prior,
+            &mut records,
+            &mut ok,
+            &mut cache_hits,
+            &mut stamper,
+            &mut sink,
+        );
+
+        assert!(!ok, "the recovery failed — nothing parked");
+        assert_eq!(records["risky"].status, TaskStatus::Failure);
+        assert_eq!(
+            records["risky"]
+                .error
+                .as_ref()
+                .expect("error readable")
+                .code,
+            "NIKA-VAR-001"
+        );
+        assert!(
+            sink.events()
+                .iter()
+                .any(|e| e.kind == EventKind::TaskFailed),
+            "the terminal frame emitted at the park site"
+        );
+    }
+
+    /// (e·fan-out) A `for_each` iteration's recover keeps today's
+    /// immediate resolution — iterations never park (the fan-out settles
+    /// as ONE task; its recovery references resolve against the wave
+    /// records, and a pending sibling stays NIKA-VAR-001 there).
+    #[tokio::test]
+    async fn fan_out_iteration_recover_keeps_todays_fail_fast() {
+        let yaml = r#"
+nika: v1
+workflow: recover-fanout-boundary
+tasks:
+  - id: fan
+    for_each: ["x"]
+    exec: { command: "exit 1" }
+    on_error:
+      recover: ${{ tasks.source.output }}
+  - id: source
+    exec: { command: "echo 9" }
+"#;
+        let shell = MockShell::new().enqueue_fail(1, "boom").enqueue_ok("9\n");
+        let (outcome, _events) = run_yaml(yaml, shell, Some(1)).await;
+
+        assert!(!outcome.ok);
+        assert_eq!(outcome.records["fan"].status, TaskStatus::Failure);
+        assert_eq!(
+            outcome.records["fan"].error.as_ref().expect("error").code,
+            "NIKA-VAR-001",
+            "an iteration's unresolved recover ref stays fail-fast"
+        );
+        assert_eq!(outcome.records["source"].status, TaskStatus::Success);
+    }
+}


### PR DESCRIPTION
## The divergence

Spec 05 §recover resolution (normative · [`spec/05-errors.md` §"`recover:` reference resolution"](https://github.com/supernovae-st/nika-spec/blob/main/spec/05-errors.md)): a `recover: ${{ tasks.X.output }}` reference is **NOT an execution-order edge** — resolution happens at **recovery time**, and "if it is still `pending`/`running`, the engine **awaits its terminal state** before resolving (deterministic · never a race · the DAG is finite so the await always terminates)".

The engine rendered the recover expression immediately against the wave-frozen records snapshot instead: a same-wave no-edge referent was never terminal at render time, so the recovery always failed `NIKA-VAR-001` — the #402 race made visible (`nika check` green, the run dies on timing-shaped semantics).

## The design — the await rides the existing ordered settle spine (never a new scheduler)

All in a new `nika-runtime/src/recover.rs` module; the spine integration is two calls (`settle_or_park` per finish + `resolve_at_end` after the wave loop), so the per-settle streaming rework on the sister branch rebases trivially.

1. **Classify at recover time** (`classify_await`) — when the recover render fails, every failing `${{ }}` island is probed through the render's own resolver seam (`Scope::resolve_expr` — park-vs-fail cannot drift from the render) and its refs walked with nika-tmpl's own extractor (`expr_refs` — the checker's). If every failing island names at least one not-yet-terminal `tasks.X` root, the result becomes a parked `PendingRecovery { failed, render_error, awaiting: BTreeSet, with_ns }`. Any other unresolved root keeps today's fail-fast.
2. **Park it** — the settle spine holds pending recoveries in a task-id-ordered `BTreeMap` side table. Nothing is emitted yet (the whole story defers — the stream keeps per-task contiguity). An awaited root that is not a **declared** task settles its immediate failure at the park site (it can never reach a terminal state).
3. **Retry on the spine** — after every settlement, parks whose `awaiting` set is terminal-covered resolve and settle through the ONE emit site (`task_recovered` inserts before the terminal `task_completed`, exactly like a live recovery; a render error takes the normal recovery-failed path). The drain is a fixpoint: a resolution settles a record, which can cover another park — parked-on-parked chains drain in coverage order.
4. **Workflow-end resolution** — parks whose referents never settle on the spine (mutual recovery cycles) resolve against the FINAL records, where each still-parked task reads as its **pre-recovery FAILED record** (spec 05 — recovery never rewrites the referent's history). Bounded by task count; nothing hangs. The same pass runs before a budget abort, so no parked task is left frameless.

**Mutual recovery pinned (§5):** A recovers-from B, B recovers-from A, no edges → both park → both resolve at workflow-end → each side renders against the other's pre-recovery failure: `recover: ${{ tasks.other.status }}` recovers `"failure"` on both sides — never the `success` both end up with.

## Determinism

Mutations happen only on the sequential ordered settle spine; the side table is a `BTreeMap` (task-id order); resolution consults nothing but the records — no signals, no timeouts, no clocks. The same-wave test runs caps 1, 2 and wave-width and asserts **byte-identical event streams** (the ordered-settlement law extends through parking).

## Test proof

`nika-runtime --lib`: **112 passed** (7 new in `tests::recover_await`) · full `nika-runtime` incl. integration batteries: **181 passed** · `nika-cli --lib`: **290 passed** · `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

- (a) same-wave no-edge referent recovers with its value — `output:` bindings evaluate over the recovered value, downstream consumes it, cap-sweep byte-identical streams
- (b) later-wave referent + parked-on-parked chain drains transitively (A sees B's post-recovery output — the downstream-of-recovered law)
- (c) referent skipped by `when:` → terminal defined-null → recovers `null` (spec 04 records law)
- (d) mutual recovery resolves at workflow-end against pre-recovery failed records (both recover `"failure"`)
- (e) unknown-name awaited root fails fast `NIKA-VAR-001` at the park site (`nika check` already rejects it upstream — the runtime backstop is pinned) · a broken path INTO an already-terminal referent stays fail-fast · a `for_each` iteration never parks (downgrades to today's immediate render failure — the fan-out settles as one task)

**Corpus:** `nika-lab errors/recover-a-noedge` graduated back from the `divergences/` quarantine with a spec-true header (`exit 0` · recovers `99`), proven against this build (`nika check` clean · `nika run` exit 0 · `risky … recovered` · `out/errors/recover-a.json == 99`) — lab commit `e87d2a0`. The spec-repo conformance twin (`conformance/errors/recover-task-ref-no-edge.nika.yaml`, DIVERGENT class) flips to PASS automatically once a release carries this fix; its header/FINDINGS flip is a spec-repo follow-up.

**Bonus:** the shipped `showcase/t2-release-radar` state-file pattern (`recover: ${{ tasks.no_state.output }}` in the same wave) becomes correct as authored.

## Boundaries (documented + pinned)

- `for_each` iterations keep immediate resolution (parking a single iteration would hold the whole fan-out accumulation and its `on_finally` — out of scope; pinned by test).
- `on_finally` of a parked task previews the parent as its pre-recovery failure (the attempts DID fail; the deferred render has produced no value when the task-scoped cleanup runs).
- A dependent of a parked task that dispatches while the park is still waiting reads the wave-entry records (the existing gate law) — same cancelled outcome as today's instant-fail behavior; only the parked task's own verdict improves.
- A paused run (ADR-099) drops parks unemitted — like the blocked prompt, they simply have not happened yet and re-run on `--resume`.

Closes #291
Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
