### PR TITLE
feat(cli): graph mermaid paints verb identity — spec-parity classDefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`graph --format mermaid` paints verb identity** — nodes carry their
+  verb class and the diagram ends with the SAME classDef map every
+  projected docs page uses (the shared visual vocabulary: spec
+  `design/tokens.yaml`, vendored into the pack as `design-tokens.yaml`
+  and exposed via `nika_pack::design_tokens()`). Byte-parity with the
+  spec's showcase projector (`fill = color + 22` alpha · only drawn
+  verbs get a classDef); a parity test pins the renderer's consts to
+  the vendored tokens, so a spec-side hue change stays red engine-side
+  until the table follows. Terminal output untouched — chrome remains
+  ANSI-16 semantic (#464).
+
 - **`nika wire` wave-3a: `claude-desktop` + `qwen`** (#449). Claude
   Desktop was the double gap — a different app with a different config
   file than Claude Code's `~/.claude.json`: the writer targets

--- a/crates/nika-cli/src/verbs/graph.rs
+++ b/crates/nika-cli/src/verbs/graph.rs
@@ -219,7 +219,24 @@ fn action_facts(
     }
 }
 
-/// Mermaid renderer — derives from the projection, labels carry the verb.
+/// The 4 verb hues — the shared visual vocabulary (spec `design/tokens.yaml`,
+/// vendored in the pack as `design-tokens.yaml`). Hand-written consts, NOT a
+/// runtime parse (L-grain: zero yaml in the render path) — the parity test
+/// below pins them against `nika_pack::design_tokens()`, so a spec-side hue
+/// change fails `cargo test` here until this table follows. Terminal output
+/// never uses these (nika-display is ANSI-16 semantic by doctrine); they
+/// exist for the HEX surfaces: mermaid classDefs, byte-parity with the
+/// spec's showcase projector (`fill = color + "22"` alpha).
+const VERB_COLORS: [(&str, &str); 4] = [
+    ("infer", "#5b8cff"),
+    ("exec", "#ff7a3c"),
+    ("invoke", "#22d3ee"),
+    ("agent", "#b07bff"),
+];
+
+/// Mermaid renderer — derives from the projection, labels carry the verb,
+/// verb identity paints the node (the same classDef map every projected
+/// docs diagram uses — one visual language on every surface).
 #[must_use]
 pub fn to_mermaid(doc: &GraphDoc) -> String {
     let mut out = String::from("graph TD\n");
@@ -232,13 +249,22 @@ pub fn to_mermaid(doc: &GraphDoc) -> String {
             .unwrap_or_default();
         let _ = writeln!(
             out,
-            "  {id}[\"{id} · {verb}{detail}\"]",
+            "  {id}[\"{id} · {verb}{detail}\"]:::{verb}",
             id = node.id,
             verb = node.verb
         );
     }
     for edge in &doc.edges {
         let _ = writeln!(out, "  {} --> {}", edge.from, edge.to);
+    }
+    // Only the classDefs of verbs actually drawn (the spec projector's rule).
+    for (verb, color) in VERB_COLORS {
+        if doc.nodes.iter().any(|n| n.verb == verb) {
+            let _ = writeln!(
+                out,
+                "  classDef {verb} fill:{color}22,stroke:{color},color:{color}"
+            );
+        }
     }
     out
 }
@@ -364,6 +390,54 @@ mod tests {
         let report = nika_schema::check(&wf);
         let doc = project(&wf, &report);
         (to_mermaid(&doc), to_dot(&doc))
+    }
+
+    /// The hand-written [`VERB_COLORS`] table must MATCH the vendored
+    /// design-tokens (spec `design/tokens.yaml` → pack `design-tokens.yaml`)
+    /// — the shared visual vocabulary is spec-first: a hue change lands
+    /// there, re-vendors, and THIS test stays red until the table follows.
+    #[test]
+    fn verb_colors_match_the_pack_design_tokens() {
+        let tokens = nika_pack::design_tokens();
+        assert!(
+            !tokens.is_empty(),
+            "pack carries design-tokens.yaml (sync-pack.sh vendored it)"
+        );
+        for (verb, color) in VERB_COLORS {
+            let section = tokens
+                .split(&format!("  {verb}:\n"))
+                .nth(1)
+                .expect("tokens carry every verb section");
+            let pinned = section
+                .lines()
+                .find_map(|l| l.trim().strip_prefix("color: \""))
+                .and_then(|rest| rest.split('"').next())
+                .expect("verb section carries a color");
+            assert_eq!(
+                color, pinned,
+                "VERB_COLORS.{verb} drifted from the pack design-tokens"
+            );
+        }
+    }
+
+    /// Mermaid nodes carry their verb class and the classDef map is the
+    /// SAME derivation the spec's showcase projector emits (fill = color +
+    /// `22` alpha) — one visual language on every rendered surface. Only
+    /// verbs actually drawn get a classDef.
+    #[test]
+    fn mermaid_paints_verb_identity() {
+        let (mermaid, _) = renders(
+            "nika: v1\nworkflow: paint\nmodel: mock/echo\ntasks:\n  - id: a\n    infer: { prompt: \"p\", max_tokens: 5 }\n",
+        );
+        assert!(mermaid.contains(":::infer"), "node classed:\n{mermaid}");
+        assert!(
+            mermaid.contains("classDef infer fill:#5b8cff22,stroke:#5b8cff,color:#5b8cff"),
+            "spec-parity classDef:\n{mermaid}"
+        );
+        assert!(
+            !mermaid.contains("classDef exec"),
+            "undrawn verbs stay classless:\n{mermaid}"
+        );
     }
 
     /// A model with chars special to mermaid (`"` `]`) or dot (`"`) must be

--- a/crates/nika-pack/pack/design-tokens.yaml
+++ b/crates/nika-pack/pack/design-tokens.yaml
@@ -1,0 +1,81 @@
+# design/tokens.yaml — the nika SHARED visual vocabulary · SSOT v1
+#
+# THIS FILE IS THE SOURCE for every cross-repo design value: the 4 verb
+# colors, the severity pair, the brand core, and each concept's per-surface
+# icon binding. Every other surface is a PROJECTION:
+#
+#   nika.sh    src/design-tokens.generated.ts   (scripts/design-projector.py)
+#   nika-vscode src/design-tokens.generated.ts  (idem · sibling checkout)
+#   nika-docs  docs.json theme colors           (parity-checked, not rewritten)
+#   nika-spec  showcase-projector MERMAID map   (read directly, same repo)
+#   nika engine · the pack vendors this file    (sync-pack.sh · engine consts)
+#
+# Surfaces are heterogeneous (React SVG · vscode codicons · Mintlify
+# fontawesome · terminal glyphs) — so "the same icon everywhere" is ONE
+# concept row carrying its per-surface binding, all pinned here. A naive
+# same-file-everywhere would be false coherence.
+#
+# Law: values change HERE first, then re-project (--write) and re-check
+# (--check, wired in CI). Every value below is the CURRENT shipping value
+# canonized 2026-07-11 — consolidation, not redesign. The terminal is
+# deliberately ABSENT: engine chrome is ANSI-16 semantic by doctrine
+# (nika-display theme.rs · the user's terminal theme decides those hues).
+
+version: 1
+
+brand:
+  glyph: "🦋"
+  # The served asset canon (marks · logo lockups · tiles · glyph-16 · the
+  # machine-readable icon ontology icons.json/.ttl). Vendor FROM here —
+  # sync contents, never rename (the vscode icons/README.md contract).
+  assets: "https://nika.sh/brand/"
+  color:
+    bg: "#08090b"             # the dark surface (website --v4-bg == docs bg dark)
+    accent: "#4f86ff"         # THE accent (blue) · website --v4-accent
+    accent_strong: "#2f6bff"  # website --v4-accent-strong == docs primary/dark
+    accent_bright: "#8db4ff"  # website --v4-accent-bright == docs light
+    mark:
+      ice: "#9fd0ff"          # nika-mark-dark.svg fill (dark surfaces)
+      glow: "#cfe6ff"         # nika-mark-glow.svg (tiny sizes · WebGL)
+      ink: "#04050d"          # nika-mark-light.svg fill (light surfaces)
+
+# The 4 verbs — locked forever (spec/02-verbs.md). codicon + glyph are the
+# SHIPPED vscode bindings (workflowTree ThemeIcons · the ◇▷◆✦ unicode set);
+# fa is the Mintlify binding; icon is the nika.sh ontology id (icons.json).
+verbs:
+  infer:
+    color: "#5b8cff"
+    codicon: "sparkle"
+    fa: "sparkles"
+    glyph: "◇"
+    icon: "ai-magic/sparkle"
+  exec:
+    color: "#ff7a3c"
+    codicon: "terminal"
+    fa: "terminal"
+    glyph: "▷"
+    icon: "console"
+  invoke:
+    color: "#22d3ee"
+    codicon: "plug"
+    fa: "plug"
+    glyph: "◆"
+    icon: "api-connection"
+  agent:
+    color: "#b07bff"
+    codicon: "robot"
+    fa: "robot"
+    glyph: "✦"
+    icon: "agent-graph"
+
+# The severity pair shared by run verdicts across surfaces (website run/morph
+# css · vscode run-state · docs). warn stays surface-local today (no cross-
+# repo consumer pins a shared warn yet — add it the day two surfaces need it).
+severity:
+  ok: "#34d399"
+  fail: "#ff5d5d"
+
+rules:
+  # Mermaid classDef fill = verb color + this alpha suffix. Derived at
+  # projection time, never stored as a 5th value per verb.
+  mermaid_fill_alpha: "22"

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -134,7 +134,7 @@ The following are **deferred** to stdlib v0.x or beyond ·
 - Memory subsystem APIs (the engine's memory subsystem · the Connectome · separate stdlib version)
 - Workflow include/import (single-file workflows only in v0.1)
 - Macros / templates (no preprocessing layer)
-- 24 media builtins (`pdf_extract` · `chart` · `qr_validate` · etc. · stdlib v0.x)
+- 22 media builtins (`pdf_extract` · `ocr` · `qr_validate` · etc. · stdlib v0.x)
 - Persistent jobs · scheduled execution (runtime concern · daemon at v0.3)
 - Streaming output (deferred)
 - Multi-workflow orchestration (deferred)

--- a/crates/nika-pack/pack/spec/08-out-of-scope.md
+++ b/crates/nika-pack/pack/spec/08-out-of-scope.md
@@ -157,14 +157,14 @@ tasks: ...
 
 **Why deferred** · scheduling is an engine-runtime concern · not a language concern. A conformant engine handles cron at runtime · workflows themselves stay schedule-agnostic.
 
-### Trace retention · lifted by ADR-100 (proposed)
+### Trace retention · lifted by ADR-100
 
 > `.nika/traces/` is bounded by default (keep-last-N · age cap · size
 > budget) with two absolute exemptions — a `paused` trace (a pending human
 > gate) and each workflow's newest trace (the standing resume candidate) —
 > and a one-line visible report whenever collection removes anything ·
-> [ADR-100](../adr/adr-100-trace-retention.md). CLI surface (`nika trace
-> ls|rm`) and config wiring land with the engine arc.
+> [ADR-100](../adr/adr-100-trace-retention.md). The CLI surface (`nika trace
+> ls|rm`) and config wiring landed with the engine arc.
 
 ### Workflow checkpointing / resumption
 
@@ -177,7 +177,7 @@ checkpoint:
 
 **Why deferred** · persistence is an engine-runtime concern. A conformant engine handles this internally · workflows don't declare it.
 
-> **Lifted at the durable-lite tier · [ADR-099](../adr/adr-099-durable-lite-run-resume.md) (proposed · 2026-07-05)** ·
+> **Lifted at the durable-lite tier · [ADR-099](../adr/adr-099-durable-lite-run-resume.md) (accepted · 2026-07-05 · shipped)** ·
 > `nika run --resume <trace>` re-executes from the run's own NDJSON trace
 > (content-addressed per-task skip · every skip a **visible** `task.cache_hit`
 > event · `--from <task_id>` override) — the trace IS the checkpoint · CLI +
@@ -277,13 +277,17 @@ agents:
 
 ## Tooling extensibility · STDLIB v0.x
 
-### 24 media builtins
+### 22 media builtins
 
-`pdf_extract` · `svg_render` · `chart` · `phash` · `compare` · `optimize` · `provenance` · `qr_validate` · `thumbhash` · `dominant_color` · `image_diff` · `import` · `thumbnail` · `provenance_verify` · `text_extract` · `ocr` · `transcribe` · `tts` · `mediainfo` · `dimensions` · `colorize` · `palette_extract` · `qr_generate` · `barcode`
+`pdf_extract` · `svg_render` · `phash` · `compare` · `optimize` · `provenance` · `qr_validate` · `thumbhash` · `dominant_color` · `image_diff` · `import` · `thumbnail` · `provenance_verify` · `text_extract` · `ocr` · `transcribe` · `mediainfo` · `dimensions` · `colorize` · `palette_extract` · `qr_generate` · `barcode`
 
-**Why deferred** · 24 builtins is a third of the total builtin surface · they target a specific audience (media pipelines). Splitting them into stdlib v0.x reduces v0.1 scope by ~40% without losing core capability.
+**Why deferred** · 22 builtins would nearly double the total builtin surface · they target a specific audience (media pipelines). Splitting them into stdlib v0.x keeps v0.1 scope lean without losing core capability.
 
-The reference engine ships them (opt-in feature flag) but they don't count toward Stdlib v0.1 conformance.
+Rows graduate one at a time, as counted stdlib builtins, when they pass the
+admission razors: `chart` (§Media graduate #4 · 2026-07-09) and `tts`
+(shipped as `tts_generate` · §Audio · 2026-07-05) already left this list —
+see [canon.yaml](../canon.yaml) + [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md).
+The rows above remain unshipped and don't count toward Stdlib v0.1 conformance.
 
 ### Pluggable provider adapters
 
@@ -372,11 +376,11 @@ or a non-goal, with the line that says whose job it is.
 
 | # | Horizon | Posture | The one-paragraph answer |
 |---|---|---|---|
-| H1 | Durable execution (checkpoint · resume · replay) | **OUT · durable-lite tier lifted by ADR-099 (proposed)** | A v0.1 run is a single OS process with in-memory state · crash = re-run from the top · `retry:` is in-process only. The **durable-lite tier** (crash-resume + re-run-from-a-node from the run's own trace · visible `task.cache_hit` · zero author-facing determinism constraints) is lifted by [ADR-099](../adr/adr-099-durable-lite-run-resume.md) · CLI + trace only. Idempotency keys + the full durable-execution waypoint (retries that survive a restart · at-least-once dedup) stay deferred (§Persistence · v0.2+) · until then durability beyond `--resume` is the **host's responsibility** (run under a supervisor · make side-effecting tools idempotent via their own args). |
+| H1 | Durable execution (checkpoint · resume · replay) | **OUT · durable-lite tier lifted by ADR-099** | A v0.1 run is a single OS process with in-memory state · crash = re-run from the top · `retry:` is in-process only. The **durable-lite tier** (crash-resume + re-run-from-a-node from the run's own trace · visible `task.cache_hit` · zero author-facing determinism constraints) is lifted by [ADR-099](../adr/adr-099-durable-lite-run-resume.md) · CLI + trace only. Idempotency keys + the full durable-execution waypoint (retries that survive a restart · at-least-once dedup) stay deferred (§Persistence · v0.2+) · until then durability beyond `--resume` is the **host's responsibility** (run under a supervisor · make side-effecting tools idempotent via their own args). |
 | H2 | Streaming between tasks | **OUT** | Tasks are synchronous · a dependent reads the **final assembled value** (§Streaming). Engines MAY stream provider tokens internally/to the user. A between-task stream changes what an *edge* delivers: a future additive edge semantic, never a verb ([02 closure](./02-verbs.md#the-closure-argument--why-no-case-forces-a-5th-verb)). Pub/sub listeners · NEVER in the finite-DAG v1. |
 | H3 | Multimodal artifacts (typed image/audio/video) | **PARTIAL** | v0.1 values are strings · JSON values · and **opaque bytes pass-through** (tool-determined · [02 §invoke output](./02-verbs.md#what--tasksidoutput--holds--per-verb) · `infer.vision` takes file/url refs). No typed media payloads · no content-addressing in the language. Both arrive with the deferred media builtins (stdlib v0.x · §Tooling extensibility). Addressing (e.g. blake3) is engine detail, not language surface. |
 | H4 | Agent-of-agents (sub-agents · budget propagation · trust inheritance) | **PARTIAL** | The `agent:` verb is a **single loop** with per-task budgets (`max_turns` · `max_tokens_total` · normative · [02 §agent](./02-verbs.md)) and a default-deny tool whitelist. Budgets do NOT propagate across tasks (each declares its own). Multi-agent topology · §Advanced agent features (expressible today as multiple `agent:` tasks + explicit `with:` hand-off). Run-recursion is bounded by the §composition recursion guard. |
-| H5 | Human-in-the-loop (approval gates) | **IN** | `nika:prompt` (blocking confirm with `default:` for non-interactive mode) plus `nika:notify` (fire-and-forget). Pause-state is **live** (the run keeps a process while blocked) · **durable pause ships with [ADR-099](../adr/adr-099-durable-lite-run-resume.md)'s `--resume`** (proposed · a non-interactive default-less blocked `nika:prompt` journals `workflow.paused` + exits cleanly · resume re-arms it) · time-bound it with the task-level `timeout:`. ONE construct · a tool under `invoke:` · forever. |
+| H5 | Human-in-the-loop (approval gates) | **IN** | `nika:prompt` (blocking confirm with `default:` for non-interactive mode) plus `nika:notify` (fire-and-forget). Pause-state is **live** (the run keeps a process while blocked) · **durable pause shipped with [ADR-099](../adr/adr-099-durable-lite-run-resume.md)'s `--resume`** (a non-interactive default-less blocked `nika:prompt` journals `workflow.paused` + exits cleanly · resume re-arms it) · time-bound it with the task-level `timeout:`. ONE construct · a tool under `invoke:` · forever. |
 | H6 | Evals in-language (asserts · LLM-judge · golden runs) | **PARTIAL** | v0.1 ships the pieces · `schema:` (per-task structured-output gate · auto-retry) · `nika:assert` (fail-fast CEL guard) · `nika:validate` (JSON Schema over data). An LLM-judge is an `infer:` task with a verdict `schema:`, no dedicated builtin needed. Golden-run testing reuses the conformance fixture shape (input + expected output on `mock/`). Declarative in-file eval blocks · deferred. |
 | H7 | Cost governance (budgets in €/tokens) | **PARTIAL** | Reading IS in-language · `nika:inspect view: cost` (running cost). Enforcement is NOT · hard caps are engine config (§Observability · `budget:` blocks deferred v0.2). The `agent:` budgets (`max_tokens_total`) are the one normative in-language cap today. |
 | H8 | Model routing / fallback chains | **PARTIAL** | The language surface is ONE field · explicit `model:` per task (+ `vars` parameterization: one workflow, any backend). Provider-side routing exists TODAY via `openrouter/…` (gateway fallback). Declarative capability-based routing in YAML ("any vision model under $X") · deferred · it must not create a second way to pick a model. |

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -40,10 +40,10 @@
 | Data | 8 | `jq` (THE data language) + 7 capabilities jq can't express (json_diff · validate · json_merge_patch · convert · uuid · date · hash) |
 | Introspection | 2 | Self-awareness · `inspect` (runtime state · 4 views) · `compose` (static check of a drafted workflow · agent loops only) |
 | Network | 2 | fetch (HTTP+extraction) · notify (alerts out) |
-| Media | 3 | `chart` (§Media #3 · deterministic/attested · 2026-07-09) · `image_generate` (§Media · 2026-07-05) · `tts_generate` (§Audio · same day) — the REST of the media class stays deferred to stdlib v0.x |
-| **Total v0.1** | **26** | |
+| Media | 4 | `chart` (§Media #4 · deterministic/attested · 2026-07-09) · `image_generate` (§Media · 2026-07-05) · `image_fx` (§Media #3 · deterministic ops chain · 2026-07-09) · `tts_generate` (§Audio · 2026-07-05) — the REST of the media class stays deferred to stdlib v0.x |
+| **Total v0.1** | **<!-- canon:builtins -->27<!-- /canon -->** | |
 
-A Stdlib v0.1-compliant engine MUST ship these 26.
+A Stdlib v0.1-compliant engine MUST ship these <!-- canon:builtins -->27<!-- /canon -->.
 
 ---
 

--- a/crates/nika-pack/public-api.txt
+++ b/crates/nika-pack/public-api.txt
@@ -36,6 +36,7 @@ pub unsafe fn nika_pack::ErrorCodeRow::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_pack::ErrorCodeRow
 pub fn nika_pack::ErrorCodeRow::from(t: T) -> T
 pub fn nika_pack::canon() -> &'static str
+pub fn nika_pack::design_tokens() -> &'static str
 pub fn nika_pack::doc(path: &str) -> core::option::Option<&'static str>
 pub fn nika_pack::doc_paths() -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_pack::error_codes() -> alloc::vec::Vec<nika_pack::ErrorCodeRow>

--- a/crates/nika-pack/scripts/sync-pack.sh
+++ b/crates/nika-pack/scripts/sync-pack.sh
@@ -36,5 +36,9 @@ cp "${SPEC}"/stdlib/*.md "${DEST}/stdlib/"
 # the egress-to-outputs arc) — without this line every re-sync silently
 # DELETED it (the rm -rf + copy-list pattern's blind spot).
 cp "${SPEC}/conformance/coverage-matrix.tsv" "${DEST}/"
+# The shared visual vocabulary (spec design/tokens.yaml · the design SSOT ·
+# #464): verb colors + severity + brand core. graph's mermaid classDefs
+# derive from it at build time. Same blind-spot law as the line above.
+cp "${SPEC}/design/tokens.yaml" "${DEST}/design-tokens.yaml"
 
 echo "pack synced from ${SPEC} → ${DEST} (version $(cat "${DEST}/VERSION"))"

--- a/crates/nika-pack/src/lib.rs
+++ b/crates/nika-pack/src/lib.rs
@@ -53,6 +53,15 @@ pub fn canon() -> &'static str {
     file_str("canon.yaml").unwrap_or("")
 }
 
+/// The shared visual vocabulary (`design-tokens.yaml` — the spec's
+/// `design/tokens.yaml`, vendored): verb colors · severity · brand core.
+/// `graph --format mermaid` derives its classDefs from it; a parity test
+/// pins the renderer's hand-written consts against this file.
+#[must_use]
+pub fn design_tokens() -> &'static str {
+    file_str("design-tokens.yaml").unwrap_or("")
+}
+
 /// One row of the canon's `error_codes` registry — the spec's normative
 /// floor (`spec/05-errors.md` · projector-emitted flow-style rows).
 /// Output-only: constructed solely by [`error_codes`].


### PR DESCRIPTION
The design-tokens arc reaches the engine (#464, seams a+b of three):

- **(a) pack vendoring** — `sync-pack.sh` copies the spec's `design/tokens.yaml` → pack `design-tokens.yaml` (same blind-spot law as the coverage matrix: the cp line is mandatory forever). Exposed via `nika_pack::design_tokens()`. The re-vendor also catches the pack up to merged spec surfaces (builtins image_fx category row · agent-offline note · overview prose).
- **(b) mermaid verb identity** — `graph --format mermaid` nodes gain `:::verb` classes and the diagram ends with the SAME classDef map every projected docs page carries (`fill = color + 22` alpha · only drawn verbs emitted) — one visual language from docs diagrams to CLI output.

**The seam discipline**: the renderer keeps hand-written consts — zero yaml parse in the render path (L-grain); the **parity test** pins them to the vendored tokens, so a spec-side hue change fails `cargo test` engine-side until the table follows. Negative-tested (one-hex nudge → red). Terminal chrome untouched: `nika-display` stays ANSI-16 semantic by doctrine.

Seam (c) — nika-chart `svg.rs` THEME_STYLE de-dup vs `palette.rs` — stays open on #464 (nika-chart is WIP/un-admitted).

Proof: clippy 0 · graph lib tests 5/5 (2 new) · pack integrity green · external `verbs_static` suite green.

Part of #464 (do not auto-close — seam c remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)