### PR TITLE
fix(builtin): the headless prompt dead-end teaches both exits

### DIFF
--- a/crates/nika-builtin/src/core_tools.rs
+++ b/crates/nika-builtin/src/core_tools.rs
@@ -165,9 +165,17 @@ fn default_or_fail(
                 format!("`default:` must be {type_hint} for this mode (got {raw}) — {remedy}"),
             )
         }),
+        // Teach BOTH exits from the headless dead-end (stateful gauntlet
+        // 2026-07-11): the stdlib contract fails here by design (never
+        // hang), but the message named neither route — an author could not
+        // learn that `default:` unblocks headless runs or that the machine
+        // surfaces pause durably instead of failing.
         None => Err(BuiltinFailure::new(
             code,
-            "non-interactive and no `default:` — cannot answer without a human",
+            "non-interactive and no `default:` — cannot answer without a human · \
+             either declare `default:` (headless runs answer with it) or run \
+             with `--json`/`--output json` (the run pauses durably · resume \
+             with `--resume <trace> --answer <task>=<value>`)",
         )),
     }
 }
@@ -446,7 +454,19 @@ mod tests {
             &NonInteractive,
             &args(serde_json::json!({ "message": "ok?" })),
         );
-        assert!(matches!(fail, Err(f) if f.code == "NIKA-BUILTIN-PROMPT-001"));
+        // The headless dead-end teaches BOTH exits (stateful gauntlet
+        // 2026-07-11): declare `default:` OR run on a machine surface that
+        // pauses durably (`--resume … --answer`).
+        assert!(matches!(&fail, Err(f) if f.code == "NIKA-BUILTIN-PROMPT-001"));
+        let msg = match fail {
+            Err(f) => f.message,
+            Ok(_) => unreachable!("headless prompt without default must fail"),
+        };
+        assert!(msg.contains("declare `default:`"), "{msg}");
+        assert!(
+            msg.contains("--resume") && msg.contains("--answer"),
+            "{msg}"
+        );
 
         // a real human picks the first choice (exercises string_choices + the choice arm).
         let picked = prompt(


### PR DESCRIPTION
**Stateful gauntlet** (pause/resume machinery e2e): the durable-gate loop is solid — machine surfaces pause rc=4 + `{"paused":{…}}` envelope · `--resume --answer` completes · answerless resume re-pauses idempotently · `answer=false` skips the when-gated downstream.

**The seam is the plain surface.** A headless run hitting a default-less `nika:prompt` fails PROMPT-001 by normative design (never hang), but the message named **neither exit**:

```
avant  non-interactive and no `default:` — cannot answer without a human
après  … · either declare `default:` (headless runs answer with it) or run with
       `--json`/`--output json` (the run pauses durably · resume with
       `--resume <trace> --answer <task>=<value>`)
```

An author who was promised « a paused run resumes with `--resume` » (every scaffold teaches it) couldn't learn why the pause never happened — ADR-099 binds the rider to machine surfaces only — nor that `default:` unblocks headless runs.

Gates: builtin 307 (fail-branch pins both routes) · clippy `-D warnings` 0 · fmt clean · e2e verified on the built CLI. Single-file, message-only. API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)