### PR TITLE
feat(cli): a paused run teaches its exact resume command

### DIFF
--- a/crates/nika-cli/src/verbs/run/epilogue.rs
+++ b/crates/nika-cli/src/verbs/run/epilogue.rs
@@ -153,6 +153,28 @@ pub(super) fn paused_envelope_line(pause: &WorkflowPause) -> String {
     .to_string()
 }
 
+/// The stderr resume teaching a PAUSED machine run prints beside its
+/// trace anchor — the pause sibling of the failure lane's `autopsy:`
+/// line (stateful gauntlet 2026-07-11: the pause had everything the
+/// command needs — file · trace · task · mode — and printed none of it).
+/// The `<value>` placeholder speaks the mode's own answer shape.
+pub(super) fn resume_hint_line(
+    file: &str,
+    trace: &std::path::Path,
+    pause: &WorkflowPause,
+) -> String {
+    let value = match pause.mode.as_str() {
+        "confirm" => "true|false".to_owned(),
+        "choice" if !pause.choices.is_empty() => pause.choices.join("|"),
+        _ => "\"<text>\"".to_owned(),
+    };
+    format!(
+        "resume: nika run {file} --resume {} --answer {}={value}",
+        trace.display(),
+        pause.task,
+    )
+}
+
 /// ONE `{"error":{"code":…,"message":…}}` line — the machine failure
 /// contract (F6). `code` is the first NIKA wire code found in the message
 /// (`null` when the failure class carries none, e.g. an unreadable file).
@@ -317,5 +339,35 @@ mod tests {
         let empty = super::run_failure_envelope(&crate::RunView::new());
         let v: Value = serde_json::from_str(&empty).expect("fallback is JSON");
         assert_eq!(v["error"]["message"], json!("workflow failed"));
+    }
+
+    #[test]
+    fn resume_hint_speaks_each_modes_answer_shape() {
+        // The pause sibling of `autopsy:` (stateful gauntlet 2026-07-11):
+        // the taught command must be paste-able — file · trace · task ·
+        // and a value placeholder in the MODE's own answer shape.
+        use nika_runtime::WorkflowPause;
+        let trace = std::path::Path::new(".nika/traces/t.ndjson");
+        let confirm = WorkflowPause::new("approve".into(), "confirm".into(), None, vec![]);
+        assert_eq!(
+            super::resume_hint_line("gate.nika.yaml", trace, &confirm),
+            "resume: nika run gate.nika.yaml --resume .nika/traces/t.ndjson \
+             --answer approve=true|false"
+        );
+        let choice = WorkflowPause::new(
+            "pick".into(),
+            "choice".into(),
+            None,
+            vec!["alpha".into(), "beta".into()],
+        );
+        assert_eq!(
+            super::resume_hint_line("w.yaml", trace, &choice),
+            "resume: nika run w.yaml --resume .nika/traces/t.ndjson \
+             --answer pick=alpha|beta"
+        );
+        let input = WorkflowPause::new("name".into(), "input".into(), None, vec![]);
+        assert!(
+            super::resume_hint_line("w.yaml", trace, &input).ends_with("--answer name=\"<text>\"")
+        );
     }
 }

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -909,7 +909,12 @@ async fn execute(
         let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
         let (mut sink, trace) = tee.into_parts();
         sink.print_final();
-        surface_trace(trace, TraceNote::Stderr, None);
+        let trace_path = surface_trace(trace, TraceNote::Stderr, None);
+        // A paused run teaches its exact resume command on stderr — the
+        // pause sibling of the failure lane's `autopsy:` line.
+        if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
+            eprintln!("nika run: {}", epilogue::resume_hint_line(file, p, pause));
+        }
         epilogue::print_resume_summary(&outcome, resumed, true);
         // Built BEFORE the sink is consumed — the failure envelope reads
         // the folded view (the failed row's detail carries the wire code).
@@ -947,7 +952,10 @@ async fn execute(
         let (sink, trace) = tee.into_parts();
         // stdout stays NDJSON verbatim (byte-identical with or without the
         // journal) — the trace note rides on stderr here.
-        surface_trace(trace, TraceNote::Stderr, None);
+        let trace_path = surface_trace(trace, TraceNote::Stderr, None);
+        if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
+            eprintln!("nika run: {}", epilogue::resume_hint_line(file, p, pause));
+        }
         if let Some(e) = sink.into_error() {
             eprintln!("nika run: stream write failed: {e}");
             return RunVerdict::bare(exit::ENV);
@@ -1043,7 +1051,7 @@ async fn execute_fold_lane(
         .iter()
         .find(|r| r.state == crate::TaskState::Failed)
         .map(|r| r.id.clone());
-    surface_trace(
+    let _ = surface_trace(
         trace,
         if mode == RenderMode::Quiet {
             TraceNote::Silent

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -995,7 +995,11 @@ pub(super) enum TraceNote {
 /// contract: journaling is a rider, a broken rider is a note, not a
 /// failure). An fs error goes to stderr with the path when one was opened;
 /// a written journal prints its `trace:` pointer per [`TraceNote`].
-pub(super) fn surface_trace(mut trace: TraceFileSink, note: TraceNote, autopsy: Option<&str>) {
+pub(super) fn surface_trace(
+    mut trace: TraceFileSink,
+    note: TraceNote,
+    autopsy: Option<&str>,
+) -> Option<std::path::PathBuf> {
     // Durability BEFORE advertisement: the anchor must describe bytes
     // that survive a power loss (flush reaches the page cache only).
     trace.finalize();
@@ -1014,11 +1018,9 @@ pub(super) fn surface_trace(mut trace: TraceFileSink, note: TraceNote, autopsy: 
             ),
             None => eprintln!("nika run: trace file: {e} — the run itself is unaffected"),
         }
-        return;
+        return None;
     }
-    let Some(path) = path else {
-        return; // disabled · or a run that emitted zero events
-    };
+    let path = path?; // disabled · or a run that emitted zero events
     let anchor = anchor_line(&path, count, &head);
     match note {
         TraceNote::Stdout => {
@@ -1038,6 +1040,9 @@ pub(super) fn surface_trace(mut trace: TraceFileSink, note: TraceNote, autopsy: 
         }
         TraceNote::Silent => {}
     }
+    // The published path rides back so a PAUSED machine lane can teach
+    // the exact resume command over it (the pause sibling of `autopsy:`).
+    Some(path)
 }
 
 /// The advertised anchor: the FULL 64-hex chain head — byte-exact parity


### PR DESCRIPTION
Stateful gauntlet finding 2 (sibling of #471): a FAILED run teaches its forensics (`autopsy:` — peek · replay · F5), but a PAUSED run printed only the trace anchor + envelope — **the one state whose whole point is « come back with an answer » never named the command to come back with**, though it holds everything needed (file · trace · task · mode).

Both machine lanes (`--json` · `--output json` — the only surfaces that pause, per ADR-099) now print the pause sibling of autopsy on stderr:

```
nika run: resume: nika run gate.nika.yaml --resume .nika/traces/….ndjson --answer approve=true|false
```

The `<value>` placeholder speaks each mode's own answer shape (confirm → `true|false` · choice → the actual choices joined · input → `"<text>"`). **stdout stays byte-identical** — NDJSON verbatim on `--json`, the one envelope object on `--output json`; `surface_trace` returns the published path (TTY lane discards it explicitly).

Full e2e truth table proved this session: pause rc=4 · `--resume --answer` completes rc=0 · answerless resume re-pauses idempotently rc=4 · `answer=false` skips the when-gated downstream.

Gates: cli 293 (three mode shapes pinned) · clippy `-D warnings` 0 · fmt clean · e2e verified. API route (treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)