### PR TITLE
docs(adr): three statuses speak the merged code — 029/091/093 accepted

### DIFF
--- a/docs/adr/adr-029-embedding-spec-reservation.md
+++ b/docs/adr/adr-029-embedding-spec-reservation.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-029
 title: "EmbeddingSpec value-type reservation (Cortex seed)"
-status: proposed
+status: accepted
 date: "2026-04-17"
 phase: "Phase D — Wave 4A R1"
 deciders: ["@ThibautMelen"]
@@ -18,34 +18,67 @@ fci: ["FCI-035"]
 inv: []
 shadow_zones: []
 nika_codes: []
-timeline: "v0.81.0-alpha.4, Wave 4A R1 seed (prose pending Phase C)"
+timeline: "v0.81.0-alpha.4, Wave 4A R1 seed · prose authored + accepted 2026-07-11"
 follow_ups:
-  - "Flesh out full rationale + alternatives during Phase C ADR prose sweep"
-  - "Decide final field set once first embedding provider (v0.95) is prototyped"
+  - "Re-read the field set when the first embedding provider prototypes (the #[non_exhaustive] reservation absorbs additive evolution — ADR-028)"
 ---
 
 # ADR-029: EmbeddingSpec value-type reservation (Cortex seed)
 
-> **STUB — prose pending Phase C.** Decision is load-bearing in code; this
-> file exists so vector 19 (adr-orphan-proposed) can surface it at day 31
-> and force full prose authoring.
+> Accepted 2026-07-11 (operator-delegated ADR ruling): the decision has
+> been load-bearing in code since v0.81 and the reservation held its
+> shape for three months — a `proposed` status no longer described
+> reality. This prose replaces the Phase-C stub.
 
 ## Context
 
-Wave 4A R1 (commit `001ae0b6f`, 2026-04-17) adds the `EmbeddingSpec` value
-type to `nika-types` at `crates/nika-types/src/embedding.rs` as a
-forward-compat reservation for v0.95 Cortex. The type captures the
-(dim, provider, model, dtype, schema) tuple that Cortex will need for
-vector index rehydration and cross-provider embedding portability.
+The memory/Connectome era needs embedding storage whose index layout and
+distance kernel are decided by three axes — **dim**, **dtype**, **metric** —
+plus the model identity that produced the vector. The embedding landscape
+moves monthly (Matryoshka truncation; 256→3072 dims; f32/f16/bf16/i8/binary
+dtypes; cosine/dot/euclidean/hamming metrics), so whatever type we reserve
+must be able to grow fields without a breaking-change migration.
 
-## Decision (preliminary)
+Wave 4A R1 (commit `001ae0b6f`, 2026-04-17) added `EmbeddingSpec` to
+`nika-types` (`crates/nika-types/src/embedding.rs`) as that reservation,
+per the ADR-028 forward-compat reservation policy.
 
-`EmbeddingSpec` ships in `nika-types` at v0.81 with `#[non_exhaustive]`
-and a `::new()` constructor. Field shape pinned in the commit body of
-`001ae0b6f` and in the `FCI-035` addendum of
+## Decision
+
+`EmbeddingSpec` ships in `nika-types` (L0) as `#[non_exhaustive]` with a
+`::new()` constructor, carrying the (dim, dtype, metric, model_id) tuple:
+
+- **dim / dtype / metric** — exactly what HNSW/BM25/RRF backends need to
+  pick index layout and distance kernel.
+- **model_id optional** — catalog-free consumers (tests, tools) construct
+  a spec without materialising a provider name.
+- **`#[non_exhaustive]` + `new()`** — additive field evolution stays
+  non-breaking by construction (INV-019 idiom); the reservation absorbs
+  the monthly landscape drift instead of chasing it.
+
+Field shape pinned in the commit body of `001ae0b6f` and in the FCI-035
+addendum of
 [`docs/architecture/forward-compat-invariants.md`](../architecture/forward-compat-invariants.md).
-Full rationale + alternatives to be authored during Phase C ADR sweep
-before v0.90.
+`EmbeddingProvider` (ADR-034, L0.5) consumes the spec.
+
+## Alternatives considered
+
+- **No reservation — add the type when the first provider lands.** Rejected:
+  the Connectome consumers (index rehydration · cross-provider portability)
+  would then force a breaking L0 change mid-era; ADR-028 exists precisely
+  to pay this cost early and additively.
+- **A wider spec (normalization · truncation · pooling fields now).**
+  Rejected: speculative fields rot; `#[non_exhaustive]` makes adding them
+  when a real provider needs them a patch-level change.
+- **String-typed axes.** Rejected: dim/dtype/metric are closed vocabularies
+  the kernel must match on — typed enums keep the distance-kernel dispatch
+  total.
+
+## Empirical validation (why accepted now)
+
+Three months in production shape: the type is consumed, the field set never
+needed a change, and zero migrations were forced on dependents. The
+reservation did exactly what ADR-028 promised.
 
 ## See also
 

--- a/docs/adr/adr-091-nika-infer-local-candle-sidecar.md
+++ b/docs/adr/adr-091-nika-infer-local-candle-sidecar.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-091
 title: "Sovereign local inference · nika-infer-local · pure-Rust candle sidecar, OpenAI-compat reuse, no rig / no mistral.rs"
-status: proposed
+status: accepted
 date: 2026-06-11
 phase: "Phase 2 · post-v0.81 announce ladder"
 deciders: ["@ThibautMelen"]
@@ -89,18 +89,27 @@ lifecycle + cancellation (CANCEL SAFETY) · sequential request queue v1
 load · typed errors (model-not-found · OOM · context-overflow · gen-timeout).
 Default model: **Qwen3** (BFCL tool-calling + NVIDIA SLM-agents thesis).
 
-## Open sub-decisions (operator ruling pending · recommended defaults shown)
+## Sub-decisions — RULED 2026-07-11 (operator-delegated · the recommended defaults lock)
 
-- **Structured output v1** → recommend **retry-loop** (generate → validate vs
-  schema → re-prompt with the error; the exact pattern the `eval/` harness
-  already proves) · **logit-masking / GBNF** (guaranteed-valid first token,
-  the real SOTA) deferred to v2.
-- **Embeddings in the same sidecar** → recommend **YES (v1.1)**: candle serves
-  embeddings (bge/e5), making the Connectome/memory stack 100% sovereign Rust.
-  A large lever; sequence after chat-completion lands.
-- **Crate boundary vs reserved `nika-vision-local`** (ADR-081, NIKA-1500..1599)
-  → recommend `nika-infer-local` = text (+ embeddings later); `nika-vision-local`
-  stays separate (heavy vision deps); align NIKA code ranges at scaffold.
+Accepted with the ADR: the crate was admitted conformant to this design, so
+a `proposed` status no longer described reality (same-day precedent: the
+ADR-099/100 status realignment).
+
+- **Structured output v1 = retry-loop** (generate → validate vs schema →
+  re-prompt with the error; the exact pattern the `eval/` harness already
+  proves) · logit-masking / GBNF (guaranteed-valid first token, the real
+  SOTA) stays v2.
+- **Embeddings in the same sidecar = YES, at v1.1** (candle serves bge/e5 —
+  the Connectome/memory stack becomes 100% sovereign Rust). Sequenced
+  strictly after chat-completion proves stable.
+- **Crate boundary**: `nika-infer-local` = text (+ embeddings at v1.1);
+  `nika-vision-local` (ADR-081 · NIKA-1500..1599) stays a separate crate —
+  heavy vision deps never enter the text sidecar.
+
+**What acceptance does NOT ship**: the launch surface (the L3 supervisor
+that spawns/monitors the sidecar + the CLI lane) is this ADR's `enables`,
+tracked by #146 (`nika model pull` sequences after it) — per ADR-093's
+follow-up, the supervisor lives at the runtime layer.
 
 ## Alternatives rejected
 

--- a/docs/adr/adr-093-infer-local-http-server-tiny-http.md
+++ b/docs/adr/adr-093-infer-local-http-server-tiny-http.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-093
 title: "nika-infer-local HTTP server · tiny_http for the v1 sidecar endpoint"
-status: proposed
+status: accepted
 date: 2026-06-11
 phase: "Phase 2 · post-v0.81 announce ladder"
 deciders: ["@ThibautMelen"]


### PR DESCRIPTION
## The socratic rule (proved 3× today)

**What flips an ADR from proposed to accepted — the passage of time, or the fact that its code is merged and load-bearing?** The merged code decides. A `proposed` whose decision is executed is a lying status (same class as this morning's ADR-099/100 realignment); a `proposed` whose code is not built is honest and STAYS.

## The three flips (each with its empirical proof)

- **ADR-029** — `EmbeddingSpec` shipped at v0.81 (`crates/nika-types/src/embedding.rs`), consumed by ADR-034, field set stable 3 months. The Phase-C stub gains its real prose (rationale + alternatives + empirical validation) and accepts. **Vector 19's one stale flag returns green.**
- **ADR-091** — `nika-infer-local` was admitted conformant to the design (candle · feature-gated · Metal+CPU · no rig / no mistral.rs). The three open sub-decisions rule to their recommended defaults per the operator's delegated ADR ruling (2026-07-11): retry-loop v1 · embeddings v1.1 YES · text/vision crate split. **Acceptance does not ship the launch surface** — that is the ADR's `enables`, tracked by #146.
- **ADR-093** — the tiny_http sidecar endpoint is `server.rs` in the admitted crate. Same class, accepts.

## What deliberately does NOT flip

The remaining 16 proposed ADRs (the 030-042 memory/Connectome reservations, 078-081, 092, 098, 106) — their code is either unbuilt or unproven-by-this-pass; each future flip requires its own per-ADR empirical proof, not a sweep.

## Verification

`scripts/adr/validate.sh` status enum carries `accepted` · evidence paths cited by the new 029 prose exist on main · frontmatter fields untouched beyond `status`/`timeline`/`follow_ups`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)