### PR TITLE
fix(cli,schema): a typed --var override honors its declared type

### DIFF
--- a/crates/nika-cli/src/verbs/run/inputs.rs
+++ b/crates/nika-cli/src/verbs/run/inputs.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `--var KEY=VALUE` input seam — parse, key-validate, type-honor.
+//!
+//! Extracted from `run/mod.rs` (2026-07-11 · the input gauntlet's
+//! type-coercion fix pushed the file past the 1500-LOC ratchet): the
+//! run-time input surface is one coherent unit — the raw pairs in, the
+//! validated `BTreeMap<String, Value>` out, the declared `vars:` block
+//! the sole authority on both keys and types.
+
+use std::collections::BTreeMap;
+
+use nika_schema::raw::RawWorkflow;
+use nika_schema::types::VarDecl;
+use serde_json::Value;
+
+use super::epilogue;
+use crate::verbs::exit;
+
+/// Parse the repeatable `--var KEY=VALUE` overrides and validate every
+/// key against the workflow's declared `vars:` — an unknown key is
+/// refused with the declared set (a typo'd override silently doing
+/// nothing would be the worst outcome). A TYPED var's declared `type:`
+/// DRIVES the value parse (spec 01 §vars · « the engine validate
+/// inputs »): `--var count=notanumber` on an `integer` input is refused
+/// up front, and a `string` var takes the raw text verbatim (`--var
+/// name=5` is the string `"5"`). An UNTYPED var keeps the JSON-or-string
+/// guess: `--var limit=5` the number `5`, `--var topic=news` the string.
+pub(super) fn parse_var_overrides(
+    pairs: &[String],
+    wf: &RawWorkflow,
+) -> Result<BTreeMap<String, Value>, String> {
+    let mut overrides = BTreeMap::new();
+    for pair in pairs {
+        let (key, raw) = match pair.split_once('=') {
+            Some((k, v)) if !k.trim().is_empty() => (k.trim(), v),
+            _ => return Err(format!("--var expects KEY=VALUE, got `{pair}`")),
+        };
+        let Some((_, decl)) = wf.vars.iter().find(|(k, _)| k.value == key) else {
+            let declared: Vec<&str> = wf.vars.iter().map(|(k, _)| k.value.as_str()).collect();
+            return Err(if declared.is_empty() {
+                format!("--var {key}: this workflow declares no `vars:`")
+            } else {
+                format!(
+                    "--var {key}: unknown var — the workflow declares: {}",
+                    declared.join(" · ")
+                )
+            });
+        };
+        let value = match decl {
+            // The declared type drives the parse (spec-mandated input
+            // validation) — a mismatch is refused with the type + value.
+            VarDecl::Typed { r#type, .. } => r#type
+                .coerce_cli(raw)
+                .map_err(|why| format!("--var {key}: {why}"))?,
+            // Untyped var (or a future non-exhaustive variant): the
+            // JSON-or-string guess — no declared type to honor, the
+            // historical behavior + the safe default for an unknown form.
+            _ => {
+                serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()))
+            }
+        };
+        overrides.insert(key.to_owned(), value);
+    }
+    Ok(overrides)
+}
+
+/// [`parse_var_overrides`] mapped to the ENV-class refusal the caller
+/// returns — the message rides stderr + the machine error envelope.
+pub(super) fn validated_var_overrides(
+    vars: &[String],
+    wf: &RawWorkflow,
+    output_json: bool,
+) -> Result<BTreeMap<String, Value>, u8> {
+    parse_var_overrides(vars, wf).map_err(|message| {
+        eprintln!("nika run: {message}");
+        epilogue::emit_error_envelope(&message, output_json);
+        exit::ENV
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    fn parse(yaml: &str) -> RawWorkflow {
+        nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses")
+    }
+
+    use super::*;
+
+    #[test]
+    fn parse_var_overrides_types_json_else_string() {
+        let wf = parse(
+            "nika: v1\nworkflow: t\nvars:\n  topic: { type: string, required: true }\n  limit: { type: integer, default: 3 }\n  flags: [\"a\"]\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+        );
+
+        // string verbatim · integer typed · untyped JSON-guess (array).
+        let overrides = parse_var_overrides(
+            &[
+                "topic=quantum news".to_owned(),
+                "limit=5".to_owned(),
+                "flags=[\"x\",\"y\"]".to_owned(),
+            ],
+            &wf,
+        )
+        .expect("valid overrides");
+        assert_eq!(overrides["topic"], json!("quantum news"));
+        assert_eq!(overrides["limit"], json!(5));
+        assert_eq!(overrides["flags"], json!(["x", "y"]));
+
+        // The unknown-key refusal NAMES the declared set (actionable).
+        let err = parse_var_overrides(&["ghost=1".to_owned()], &wf).expect_err("unknown key");
+        assert!(err.contains("ghost"), "{err}");
+        assert!(err.contains("topic"), "lists the declared vars: {err}");
+
+        // `=` in the VALUE is preserved (split_once · key=v=w).
+        let eq = parse_var_overrides(&["topic=a=b".to_owned()], &wf).expect("value may carry '='");
+        assert_eq!(eq["topic"], json!("a=b"));
+    }
+
+    #[test]
+    fn typed_var_overrides_honor_the_declared_type() {
+        // Input gauntlet (2026-07-11): a declared `type:` is the input
+        // CONTRACT — the CLI value must honor it, not be embedded
+        // type-blind (`count=notanumber` used to ride through as a string).
+        let wf = parse(
+            "nika: v1\nworkflow: t\nvars:\n  count: { type: integer, required: true }\n  ratio: { type: number, default: 1.0 }\n  on: { type: boolean, default: false }\n  name: { type: string, required: true }\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+        );
+
+        // The type DRIVES the parse — well-typed values land as their type.
+        let ok = parse_var_overrides(
+            &[
+                "count=42".to_owned(),
+                "ratio=2.5".to_owned(),
+                "on=true".to_owned(),
+                "name=5".to_owned(), // a STRING var takes the raw text verbatim
+            ],
+            &wf,
+        )
+        .expect("well-typed overrides");
+        assert_eq!(ok["count"], json!(42));
+        assert_eq!(ok["ratio"], json!(2.5));
+        assert_eq!(ok["on"], json!(true));
+        assert_eq!(ok["name"], json!("5"), "string var never JSON-coerces");
+
+        // A mismatch is refused UP FRONT, naming the type + the value.
+        for (bad, want) in [
+            ("count=notanumber", "an integer"),
+            ("ratio=lots", "a number"),
+            ("on=maybe", "a boolean"),
+        ] {
+            let err = parse_var_overrides(&[bad.to_owned()], &wf).expect_err("type mismatch");
+            assert!(
+                err.contains(want) && err.contains(bad.split('=').next_back().unwrap()),
+                "{err}"
+            );
+        }
+    }
+}

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -55,6 +55,7 @@ use nika_runtime::resume::ResumePlan;
 use nika_runtime::{EventSink, RunOutcome, Runtime, Stamper};
 use nika_schema::check::CheckReport;
 use nika_schema::raw::RawWorkflow;
+use nika_schema::types::VarDecl;
 
 use crate::Theme;
 use crate::verbs::exit;
@@ -580,22 +581,24 @@ fn dry_run_payload(
 /// Parse the repeatable `--var KEY=VALUE` overrides and validate every
 /// key against the workflow's declared `vars:` — an unknown key is
 /// refused with the declared set (a typo'd override silently doing
-/// nothing would be the worst outcome). Values parse as JSON when they
-/// parse (numbers · booleans · arrays · quoted strings), else ride as
-/// plain strings: `--var topic=news` is the string `"news"`,
-/// `--var limit=5` the number `5`.
+/// nothing would be the worst outcome). A TYPED var's declared `type:`
+/// DRIVES the value parse (spec 01 §vars · « the engine validate
+/// inputs »): `--var count=notanumber` on an `integer` input is refused
+/// up front, and a `string` var takes the raw text verbatim (`--var
+/// name=5` is the string `"5"`). An UNTYPED var keeps the JSON-or-string
+/// guess: `--var limit=5` the number `5`, `--var topic=news` the string.
 fn parse_var_overrides(
     pairs: &[String],
     wf: &RawWorkflow,
 ) -> Result<BTreeMap<String, Value>, String> {
-    let declared: Vec<&str> = wf.vars.iter().map(|(k, _)| k.value.as_str()).collect();
     let mut overrides = BTreeMap::new();
     for pair in pairs {
         let (key, raw) = match pair.split_once('=') {
             Some((k, v)) if !k.trim().is_empty() => (k.trim(), v),
             _ => return Err(format!("--var expects KEY=VALUE, got `{pair}`")),
         };
-        if !declared.contains(&key) {
+        let Some((_, decl)) = wf.vars.iter().find(|(k, _)| k.value == key) else {
+            let declared: Vec<&str> = wf.vars.iter().map(|(k, _)| k.value.as_str()).collect();
             return Err(if declared.is_empty() {
                 format!("--var {key}: this workflow declares no `vars:`")
             } else {
@@ -604,9 +607,20 @@ fn parse_var_overrides(
                     declared.join(" · ")
                 )
             });
-        }
-        let value =
-            serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()));
+        };
+        let value = match decl {
+            // The declared type drives the parse (spec-mandated input
+            // validation) — a mismatch is refused with the type + value.
+            VarDecl::Typed { r#type, .. } => r#type
+                .coerce_cli(raw)
+                .map_err(|why| format!("--var {key}: {why}"))?,
+            // Untyped var (or a future non-exhaustive variant): the
+            // JSON-or-string guess — no declared type to honor, the
+            // historical behavior + the safe default for an unknown form.
+            _ => {
+                serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()))
+            }
+        };
         overrides.insert(key.to_owned(), value);
     }
     Ok(overrides)
@@ -1430,6 +1444,49 @@ mod tests {
         let eq = super::parse_var_overrides(&["topic=a=b".to_owned()], &wf)
             .expect("value may carry '='");
         assert_eq!(eq["topic"], json!("a=b"));
+    }
+
+    #[test]
+    fn typed_var_overrides_honor_the_declared_type() {
+        // Stateful/input gauntlet (2026-07-11): a declared `type:` is the
+        // input CONTRACT — the CLI value must honor it, not be embedded
+        // type-blind (`count=notanumber` used to ride through as a string).
+        let wf = nika_schema::parse(
+            "nika: v1\nworkflow: t\nvars:\n  count: { type: integer, required: true }\n  ratio: { type: number, default: 1.0 }\n  on: { type: boolean, default: false }\n  name: { type: string, required: true }\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+
+        // The type DRIVES the parse — well-typed values land as their type.
+        let ok = super::parse_var_overrides(
+            &[
+                "count=42".to_owned(),
+                "ratio=2.5".to_owned(),
+                "on=true".to_owned(),
+                "name=5".to_owned(), // a STRING var takes the raw text verbatim
+            ],
+            &wf,
+        )
+        .expect("well-typed overrides");
+        assert_eq!(ok["count"], json!(42));
+        assert_eq!(ok["ratio"], json!(2.5));
+        assert_eq!(ok["on"], json!(true));
+        assert_eq!(ok["name"], json!("5"), "string var never JSON-coerces");
+
+        // A mismatch is refused UP FRONT, naming the type + the value.
+        for (bad, want) in [
+            ("count=notanumber", "an integer"),
+            ("ratio=lots", "a number"),
+            ("on=maybe", "a boolean"),
+        ] {
+            let err = super::parse_var_overrides(&[bad.to_owned()], &wf)
+                .expect_err("type mismatch refused");
+            assert!(
+                err.contains(want) && err.contains(bad.split('=').next_back().unwrap()),
+                "{err}"
+            );
+        }
     }
     /// `--task` scope · the diamond proves ancestors-only semantics: the
     /// target + transitive upstream survive · siblings and downstream drop

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -22,6 +22,7 @@
 #![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
 
 mod compose;
+mod inputs;
 pub(crate) use compose::config_from_env;
 mod resume;
 mod sink;
@@ -55,7 +56,6 @@ use nika_runtime::resume::ResumePlan;
 use nika_runtime::{EventSink, RunOutcome, Runtime, Stamper};
 use nika_schema::check::CheckReport;
 use nika_schema::raw::RawWorkflow;
-use nika_schema::types::VarDecl;
 
 use crate::Theme;
 use crate::verbs::exit;
@@ -228,7 +228,7 @@ fn run_verdict(
             Ok(pair) => pair,
             Err(code) => return RunVerdict::bare(code),
         };
-    let overrides = match validated_var_overrides(vars, &wf, output_json) {
+    let overrides = match inputs::validated_var_overrides(vars, &wf, output_json) {
         Ok(map) => map,
         Err(code) => return RunVerdict::bare(code),
     };
@@ -578,54 +578,6 @@ fn dry_run_payload(
     })
 }
 
-/// Parse the repeatable `--var KEY=VALUE` overrides and validate every
-/// key against the workflow's declared `vars:` — an unknown key is
-/// refused with the declared set (a typo'd override silently doing
-/// nothing would be the worst outcome). A TYPED var's declared `type:`
-/// DRIVES the value parse (spec 01 §vars · « the engine validate
-/// inputs »): `--var count=notanumber` on an `integer` input is refused
-/// up front, and a `string` var takes the raw text verbatim (`--var
-/// name=5` is the string `"5"`). An UNTYPED var keeps the JSON-or-string
-/// guess: `--var limit=5` the number `5`, `--var topic=news` the string.
-fn parse_var_overrides(
-    pairs: &[String],
-    wf: &RawWorkflow,
-) -> Result<BTreeMap<String, Value>, String> {
-    let mut overrides = BTreeMap::new();
-    for pair in pairs {
-        let (key, raw) = match pair.split_once('=') {
-            Some((k, v)) if !k.trim().is_empty() => (k.trim(), v),
-            _ => return Err(format!("--var expects KEY=VALUE, got `{pair}`")),
-        };
-        let Some((_, decl)) = wf.vars.iter().find(|(k, _)| k.value == key) else {
-            let declared: Vec<&str> = wf.vars.iter().map(|(k, _)| k.value.as_str()).collect();
-            return Err(if declared.is_empty() {
-                format!("--var {key}: this workflow declares no `vars:`")
-            } else {
-                format!(
-                    "--var {key}: unknown var — the workflow declares: {}",
-                    declared.join(" · ")
-                )
-            });
-        };
-        let value = match decl {
-            // The declared type drives the parse (spec-mandated input
-            // validation) — a mismatch is refused with the type + value.
-            VarDecl::Typed { r#type, .. } => r#type
-                .coerce_cli(raw)
-                .map_err(|why| format!("--var {key}: {why}"))?,
-            // Untyped var (or a future non-exhaustive variant): the
-            // JSON-or-string guess — no declared type to honor, the
-            // historical behavior + the safe default for an unknown form.
-            _ => {
-                serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()))
-            }
-        };
-        overrides.insert(key.to_owned(), value);
-    }
-    Ok(overrides)
-}
-
 /// Compose the production runtime for one run — extracted so `run` stays
 /// under the fn-length cap without losing the composition story.
 ///
@@ -787,24 +739,6 @@ fn example_tip(
     None
 }
 
-/// The static wave plan as task ids (the check report's schedule) —
-/// injected into the display fold so the ∥ lane markers and the DAG-shape
-/// glyph speak the scheduler's truth, not a reconstruction.
-/// `--var` overrides (F4), parsed + validated BEFORE any work: an
-/// unknown key refuses loudly (a typo'd override silently doing nothing
-/// would be the worst outcome) · the operator-input exit class (3).
-fn validated_var_overrides(
-    vars: &[String],
-    wf: &RawWorkflow,
-    output_json: bool,
-) -> Result<std::collections::BTreeMap<String, serde_json::Value>, u8> {
-    parse_var_overrides(vars, wf).map_err(|message| {
-        eprintln!("nika run: {message}");
-        epilogue::emit_error_envelope(&message, output_json);
-        exit::ENV
-    })
-}
-
 /// The `--task` scope + the clean gate, fused (both run before any
 /// effect): the WHOLE-FILE report gates first — the `--task` help's
 /// promise (« findings stay whole-file faithful »): a file must be sound
@@ -868,6 +802,9 @@ fn apply_task_scope(
     }
 }
 
+/// The static wave plan as task ids (the check report's schedule) —
+/// injected into the display fold so the ∥ lane markers and the DAG-shape
+/// glyph speak the scheduler's truth, not a reconstruction.
 fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
     report
         .waves
@@ -1411,83 +1348,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parse_var_overrides_types_json_else_string() {
-        let wf = nika_schema::parse(
-            "nika: v1\nworkflow: t\nvars:\n  topic: { type: string, required: true }\n  limit: { type: integer, default: 3 }\n  flags: [\"a\"]\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
-            nika_schema::FileId::new(0),
-            nika_schema::ParseMode::Strict,
-        )
-        .expect("fixture parses");
-
-        // JSON-if-parses: numbers · arrays land typed; bare words as strings.
-        let overrides = super::parse_var_overrides(
-            &[
-                "topic=quantum news".to_owned(),
-                "limit=5".to_owned(),
-                "flags=[\"x\",\"y\"]".to_owned(),
-            ],
-            &wf,
-        )
-        .expect("valid overrides");
-        assert_eq!(overrides["topic"], json!("quantum news"));
-        assert_eq!(overrides["limit"], json!(5));
-        assert_eq!(overrides["flags"], json!(["x", "y"]));
-
-        // The unknown-key refusal NAMES the declared set (actionable).
-        let err = super::parse_var_overrides(&["ghost=1".to_owned()], &wf)
-            .expect_err("unknown key refused");
-        assert!(err.contains("ghost"), "{err}");
-        assert!(err.contains("topic"), "lists the declared vars: {err}");
-
-        // `=` in the VALUE is preserved (split_once · key=v=w).
-        let eq = super::parse_var_overrides(&["topic=a=b".to_owned()], &wf)
-            .expect("value may carry '='");
-        assert_eq!(eq["topic"], json!("a=b"));
-    }
-
-    #[test]
-    fn typed_var_overrides_honor_the_declared_type() {
-        // Stateful/input gauntlet (2026-07-11): a declared `type:` is the
-        // input CONTRACT — the CLI value must honor it, not be embedded
-        // type-blind (`count=notanumber` used to ride through as a string).
-        let wf = nika_schema::parse(
-            "nika: v1\nworkflow: t\nvars:\n  count: { type: integer, required: true }\n  ratio: { type: number, default: 1.0 }\n  on: { type: boolean, default: false }\n  name: { type: string, required: true }\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
-            nika_schema::FileId::new(0),
-            nika_schema::ParseMode::Strict,
-        )
-        .expect("fixture parses");
-
-        // The type DRIVES the parse — well-typed values land as their type.
-        let ok = super::parse_var_overrides(
-            &[
-                "count=42".to_owned(),
-                "ratio=2.5".to_owned(),
-                "on=true".to_owned(),
-                "name=5".to_owned(), // a STRING var takes the raw text verbatim
-            ],
-            &wf,
-        )
-        .expect("well-typed overrides");
-        assert_eq!(ok["count"], json!(42));
-        assert_eq!(ok["ratio"], json!(2.5));
-        assert_eq!(ok["on"], json!(true));
-        assert_eq!(ok["name"], json!("5"), "string var never JSON-coerces");
-
-        // A mismatch is refused UP FRONT, naming the type + the value.
-        for (bad, want) in [
-            ("count=notanumber", "an integer"),
-            ("ratio=lots", "a number"),
-            ("on=maybe", "a boolean"),
-        ] {
-            let err = super::parse_var_overrides(&[bad.to_owned()], &wf)
-                .expect_err("type mismatch refused");
-            assert!(
-                err.contains(want) && err.contains(bad.split('=').next_back().unwrap()),
-                "{err}"
-            );
-        }
-    }
     /// `--task` scope · the diamond proves ancestors-only semantics: the
     /// target + transitive upstream survive · siblings and downstream drop
     /// · outputs clear (they may read unscoped tasks).

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -4222,6 +4222,7 @@ pub nika_schema::types::var_decl::VarType::Number
 pub nika_schema::types::var_decl::VarType::Object
 pub nika_schema::types::var_decl::VarType::String
 impl nika_schema::types::var_decl::VarType
+pub fn nika_schema::types::var_decl::VarType::coerce_cli(self, raw: &str) -> core::result::Result<serde_json::value::Value, alloc::string::String>
 pub fn nika_schema::types::var_decl::VarType::from_str_opt(s: &str) -> core::option::Option<Self>
 impl core::clone::Clone for nika_schema::types::var_decl::VarType
 pub fn nika_schema::types::var_decl::VarType::clone(&self) -> nika_schema::types::var_decl::VarType
@@ -4884,6 +4885,7 @@ pub nika_schema::types::VarType::Number
 pub nika_schema::types::VarType::Object
 pub nika_schema::types::VarType::String
 impl nika_schema::types::var_decl::VarType
+pub fn nika_schema::types::var_decl::VarType::coerce_cli(self, raw: &str) -> core::result::Result<serde_json::value::Value, alloc::string::String>
 pub fn nika_schema::types::var_decl::VarType::from_str_opt(s: &str) -> core::option::Option<Self>
 impl core::clone::Clone for nika_schema::types::var_decl::VarType
 pub fn nika_schema::types::var_decl::VarType::clone(&self) -> nika_schema::types::var_decl::VarType
@@ -6065,6 +6067,7 @@ pub nika_schema::VarType::Number
 pub nika_schema::VarType::Object
 pub nika_schema::VarType::String
 impl nika_schema::types::var_decl::VarType
+pub fn nika_schema::types::var_decl::VarType::coerce_cli(self, raw: &str) -> core::result::Result<serde_json::value::Value, alloc::string::String>
 pub fn nika_schema::types::var_decl::VarType::from_str_opt(s: &str) -> core::option::Option<Self>
 impl core::clone::Clone for nika_schema::types::var_decl::VarType
 pub fn nika_schema::types::var_decl::VarType::clone(&self) -> nika_schema::types::var_decl::VarType

--- a/crates/nika-schema/src/types/var_decl.rs
+++ b/crates/nika-schema/src/types/var_decl.rs
@@ -49,6 +49,52 @@ impl VarType {
             _ => None,
         }
     }
+
+    /// Coerce a CLI `--var KEY=VALUE` raw string into a JSON value that
+    /// HONORS this declared type — the declared type DRIVES the parse, it
+    /// does not merely validate a type-blind JSON guess. A `string` var
+    /// takes the raw text verbatim (`--var name=5` is the string `"5"`,
+    /// never the number 5); the scalar types parse their own lexical form
+    /// and reject anything else (`--var count=notanumber` on an `integer`
+    /// input is refused UP FRONT, not silently embedded); `array`/`object`
+    /// JSON-parse and shape-check.
+    ///
+    /// # Errors
+    ///
+    /// A one-line message naming the expected type + the offending value,
+    /// ready for the CLI's `--var <key>: …` frame.
+    pub fn coerce_cli(self, raw: &str) -> Result<serde_json::Value, String> {
+        use serde_json::Value;
+        let wrong = |want: &str| format!("expects {want}, got `{raw}`");
+        match self {
+            // A string takes the raw text verbatim — CLI values are strings
+            // by nature, so a `string` input never surprises the caller.
+            Self::String => Ok(Value::String(raw.to_owned())),
+            Self::Integer => raw
+                .parse::<i64>()
+                .map(|n| Value::Number(n.into()))
+                .map_err(|_| wrong("an integer")),
+            Self::Number => raw
+                .parse::<f64>()
+                .ok()
+                .and_then(serde_json::Number::from_f64)
+                .map(Value::Number)
+                .ok_or_else(|| wrong("a number")),
+            Self::Boolean => match raw {
+                "true" => Ok(Value::Bool(true)),
+                "false" => Ok(Value::Bool(false)),
+                _ => Err(wrong("a boolean (`true` or `false`)")),
+            },
+            Self::Array => match serde_json::from_str::<Value>(raw) {
+                Ok(v @ Value::Array(_)) => Ok(v),
+                _ => Err(wrong("a JSON array (e.g. `[1,2]`)")),
+            },
+            Self::Object => match serde_json::from_str::<Value>(raw) {
+                Ok(v @ Value::Object(_)) => Ok(v),
+                _ => Err(wrong("a JSON object (e.g. `{\"k\":1}`)")),
+            },
+        }
+    }
 }
 
 impl fmt::Display for VarType {
@@ -118,6 +164,40 @@ mod tests {
     fn untyped_holds_value() {
         let v = VarDecl::Untyped(serde_json::json!("./output"));
         assert!(matches!(v, VarDecl::Untyped(ref val) if val == "./output"));
+    }
+
+    #[test]
+    fn coerce_cli_lets_the_declared_type_drive() {
+        use serde_json::json;
+        // string · verbatim, never JSON-coerced (`5` stays "5").
+        assert_eq!(VarType::String.coerce_cli("5").unwrap(), json!("5"));
+        assert_eq!(
+            VarType::String.coerce_cli("hi there").unwrap(),
+            json!("hi there")
+        );
+        // integer · whole numbers only (5.5 and words rejected).
+        assert_eq!(VarType::Integer.coerce_cli("42").unwrap(), json!(42));
+        assert!(VarType::Integer.coerce_cli("5.5").is_err());
+        assert!(VarType::Integer.coerce_cli("notanumber").is_err());
+        // number · any finite float; NaN/inf have no JSON form → rejected.
+        assert_eq!(VarType::Number.coerce_cli("2.5").unwrap(), json!(2.5));
+        assert_eq!(VarType::Number.coerce_cli("7").unwrap(), json!(7.0));
+        assert!(VarType::Number.coerce_cli("NaN").is_err());
+        // boolean · exactly true|false.
+        assert_eq!(VarType::Boolean.coerce_cli("true").unwrap(), json!(true));
+        assert_eq!(VarType::Boolean.coerce_cli("false").unwrap(), json!(false));
+        assert!(VarType::Boolean.coerce_cli("maybe").is_err());
+        // array/object · JSON-parse AND shape-check (a bare number is neither).
+        assert_eq!(VarType::Array.coerce_cli("[1,2]").unwrap(), json!([1, 2]));
+        assert!(VarType::Array.coerce_cli("{}").is_err());
+        assert_eq!(
+            VarType::Object.coerce_cli(r#"{"k":1}"#).unwrap(),
+            json!({"k": 1})
+        );
+        assert!(VarType::Object.coerce_cli("[1]").is_err());
+        // the message names the type + the offending value.
+        let err = VarType::Integer.coerce_cli("nope").unwrap_err();
+        assert!(err.contains("integer") && err.contains("nope"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
**Input gauntlet** — the run-time surface the 147 authoring battery never touched. `--var` validated the KEY (unknown keys refused with the declared set) but **not the value's type**:

```
# workflow declares  count: { type: integer }
$ nika run w.yaml --var count=notanumber   →  rc=0 · « hi bob xnotanumber »  (!)
```

The raw string rode straight into the interpolation, only maybe exploding later IF it reached a typed context (a when-gate gave `NIKA-VAR-006`). The declared `type:` is the workflow's **input contract** (spec 01 §vars · « the engine validate inputs »); it must gate the value.

`VarType::coerce_cli` (nika-schema · L0 · pure) lets the declared type **drive** the parse: a `string` var takes the raw text verbatim (`--var name=5` is `"5"`, never the number — the old JSON-guess would surprise the caller), scalars parse their own lexical form and reject up front, `array`/`object` JSON-parse + shape-check. Untyped vars keep the historical guess. The refusal names type + value:

```
nika run: --var count: expects an integer, got `notanumber`
nika run: --var verbose: expects a boolean (`true` or `false`), got `maybe`
```

Gates: schema 740 (coerce over all 6 types + reject shapes) · cli 294 (typed lands as its type · string verbatim · mismatch refused · untyped guess preserved) · clippy `-D warnings` 0 · public-api +1 additive · e2e verified. API route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)