### PR TITLE
fix(agent): a provider failure speaks one language on both verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
-- **The agent-verb battery triad** (36-workflow gauntlet on the 4th
+- **The same provider failure now speaks ONE error language on both
+  verbs** (#468): the agent loop's mid-loop provider failure surfaced
+  as a bare-numeric `NIKA-463` — outside the spec's namespace grammar,
+  so `nika check` rejected it in `on_codes:` and no retry/recover
+  filter could ever match the agent path — while `infer` surfaced the
+  same 408 as `NIKA-INFER-001`. The agent's chained failures now carry
+  the spec's shared classes on the wire: provider call → `NIKA-INFER-001`,
+  final-message `schema:` gate → `NIKA-INFER-002` (the namespace follows
+  the failure class, not the hosting verb — the spec's own `NIKA-SEC-002`
+  precedent). `retry.on_codes: [NIKA-INFER-001]` now catches provider
+  failures on BOTH verbs; the internal registry identities (463/464 ·
+  `nika explain`) are unchanged.
   verb · 2026-07-11): a standalone `nika:compose` passed `check` but
   the runtime refused it (COMPOSE-001) — the loop-only rule joins the
   one shape table both surfaces read, beside its sibling `nika:done`;

--- a/crates/nika-cli/tests/e2e_pipeline.rs
+++ b/crates/nika-cli/tests/e2e_pipeline.rs
@@ -1019,7 +1019,8 @@ async fn e2e_agent_budget_and_schema_terminals() {
     );
 
     // Schema terminal: the done result is validated against the task
-    // schema — conforming passes (Structured), violating is NIKA-464.
+    // schema — conforming passes (Structured), violating is the
+    // schema-gate verdict (wire NIKA-INFER-002).
     let schema = serde_json::json!({
         "type": "object",
         "required": ["sum"],

--- a/crates/nika-error/src/codes/registry.rs
+++ b/crates/nika-error/src/codes/registry.rs
@@ -310,14 +310,16 @@ pub const NIKA_462: NikaCode = NikaCode {
     severity: Severity::Error,
     slug: "agent-whitelist-violation",
 };
-/// NIKA-463: The provider call failed mid-loop.
+/// NIKA-463: The provider call failed mid-loop (internal identity —
+/// the wire speaks the shared spec class `NIKA-INFER-001` · #468).
 pub const NIKA_463: NikaCode = NikaCode {
     num: 463,
     category: Category::Verb,
     severity: Severity::Error,
     slug: "agent-inference",
 };
-/// NIKA-464: The agent's final message failed `schema:` validation.
+/// NIKA-464: The agent's final message failed `schema:` validation
+/// (internal identity — the wire speaks `NIKA-INFER-002` · #468).
 pub const NIKA_464: NikaCode = NikaCode {
     num: 464,
     category: Category::Verb,

--- a/crates/nika-runtime/tests/agent_telemetry.rs
+++ b/crates/nika-runtime/tests/agent_telemetry.rs
@@ -467,8 +467,8 @@ tasks:
     let report = check(&wf);
 
     // Attempt 1: routes (ToolsSelected turn 1) then the provider rate-
-    // limits → NIKA-463 transient → the runtime retries. Attempt 2:
-    // routes, reads, concludes.
+    // limits → a transient provider failure (wire NIKA-INFER-001) →
+    // the runtime retries. Attempt 2: routes, reads, concludes.
     let provider = MockProvider::new("mock")
         .enqueue_error(nika_kernel::provider::ProviderError::RateLimited {
             retry_after_ms: Some(1),

--- a/crates/nika-runtime/tests/error_one_voice.rs
+++ b/crates/nika-runtime/tests/error_one_voice.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! One-voice error battery (#468) — the same provider failure speaks
+//! the SAME wire code (`spec_code()` · `tasks.X.error.code` · what
+//! `on_codes:` matches) on every verb that surfaces it.
+//!
+//! Same floor discipline as `spec_v2.rs`: the REAL parse → check → run
+//! chain over mock seams.
+
+use std::sync::Arc;
+
+use nika_error::traits::NikaErrorCode;
+use nika_event::{Event, EventKind};
+use nika_kernel::provider::ProviderError;
+use nika_kernel_mock::{
+    MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+};
+use nika_providers::{ProviderRegistry, ProvidersConfig};
+use nika_runtime::{DeterministicStamper, RunOutcome, Runtime, RuntimeConfig, VecSink};
+use nika_schema::{FileId, ParseMode, check, parse};
+use nika_verb_agent::{AgentVerb, VerbAgentError};
+use nika_verb_exec::ExecVerb;
+use nika_verb_infer::{InferVerb, VerbInferError};
+use nika_verb_invoke::InvokeVerb;
+
+/// The 408 the issue reported live: an HTTP timeout at the provider.
+fn timeout_408() -> ProviderError {
+    ProviderError::Api {
+        status: 408,
+        message: "HTTP request timed out after 300000ms".to_owned(),
+    }
+}
+
+async fn run_agent(yaml: &str, provider: MockProvider) -> (RunOutcome, Vec<Event>) {
+    let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    let report = check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder");
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new())),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(provider),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    (outcome, sink.into_events())
+}
+
+/// #468 · the same provider 408 through both verb error surfaces must
+/// yield the same wire code — the bare-numeric `NIKA-463` was outside
+/// the spec's namespace grammar, so `nika check` rejects it in
+/// `on_codes:` and no author filter could ever match the agent path.
+#[tokio::test]
+async fn a_provider_408_speaks_one_code_on_both_verbs() {
+    let infer_err = VerbInferError::ProviderCall {
+        source: timeout_408(),
+        spend: Box::default(),
+    };
+    let agent_err = VerbAgentError::Inference {
+        source: timeout_408(),
+        spend: Box::default(),
+    };
+    assert_eq!(
+        agent_err.spec_code(),
+        infer_err.spec_code(),
+        "one provider failure · one wire language (#468)"
+    );
+    assert_eq!(agent_err.spec_code(), "NIKA-INFER-001");
+    assert_eq!(
+        agent_err.is_transient(),
+        infer_err.is_transient(),
+        "the transience verdict is the provider's on both verbs"
+    );
+
+    // The schema sibling (the issue's NIKA-464 comment): the agent's
+    // final-message schema gate is the class `NIKA-INFER-002` names.
+    let agent_schema = VerbAgentError::SchemaValidation {
+        detail: "missing field".to_owned(),
+        spend: Box::default(),
+    };
+    assert_eq!(agent_schema.spec_code(), "NIKA-INFER-002");
+
+    // Both resolve in the embedded spec canon — the table IS the truth
+    // source (a code outside it silently breaks `on_codes:` filters).
+    let canon = nika_pack::error_codes();
+    for code in [agent_err.spec_code(), agent_schema.spec_code()] {
+        assert!(
+            canon.iter().any(|row| row.code == code),
+            "{code} must resolve in the embedded spec canon"
+        );
+    }
+
+    // e2e · the wire: an agent task whose provider dies mid-loop carries
+    // the spec class at `tasks.X.error.code` (what `on_codes:` compares).
+    let yaml_fail = r#"
+nika: v1
+workflow: agent-408
+model: mock/echo
+tasks:
+  - id: stuck
+    agent:
+      prompt: "try"
+"#;
+    let (outcome, _) = run_agent(
+        yaml_fail,
+        MockProvider::new("mock").enqueue_error(timeout_408()),
+    )
+    .await;
+    let record = outcome.records["stuck"]
+        .error
+        .as_ref()
+        .expect("typed error");
+    assert_eq!(record.code, "NIKA-INFER-001", "the wire speaks the class");
+    assert!(!record.transient, "a 408 is a verdict (only 5xx/429 retry)");
+
+    // e2e · the unlock: `retry.on_codes: [NIKA-INFER-001]` now catches
+    // the agent path's provider failure (non-transient · whitelisted).
+    let yaml_retry = r#"
+nika: v1
+workflow: agent-408-retry
+model: mock/echo
+tasks:
+  - id: flaky
+    retry: { max_attempts: 2, backoff_ms: 1, backoff_strategy: fixed, jitter: false, on_codes: [NIKA-INFER-001] }
+    agent:
+      prompt: "try again"
+"#;
+    let provider = MockProvider::new("mock")
+        .enqueue_error(timeout_408())
+        .enqueue_text("recovered");
+    let (outcome, events) = run_agent(yaml_retry, provider).await;
+    assert!(
+        events.iter().any(|e| e.kind == EventKind::TaskRetrying),
+        "the on_codes whitelist matched the agent's provider failure"
+    );
+    assert!(outcome.ok, "attempt 2 recovered");
+    assert_eq!(
+        outcome.records["flaky"].output,
+        serde_json::Value::String("recovered".to_owned())
+    );
+}

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -26,9 +26,9 @@ use nika_schema::check::CheckReport;
 use nika_schema::raw::RawWorkflow;
 use nika_schema::{FileId, ParseMode, check, parse};
 use nika_types::resource::Value as FieldValue;
-use nika_verb_agent::AgentVerb;
+use nika_verb_agent::{AgentVerb, VerbAgentError};
 use nika_verb_exec::ExecVerb;
-use nika_verb_infer::InferVerb;
+use nika_verb_infer::{InferVerb, VerbInferError};
 use nika_verb_invoke::InvokeVerb;
 
 // ─── harness ─────────────────────────────────────────────────────────────
@@ -1231,6 +1231,118 @@ tasks:
     }
     assert_eq!(timeout_code, "NIKA-TIMEOUT-001");
     assert_eq!(var_code, "NIKA-VAR-006");
+}
+
+/// #468 · one voice: the same provider failure speaks the SAME wire
+/// code on both verbs. `infer` surfaces it as `NIKA-INFER-001` (spec
+/// 05's allocated provider class); the agent loop's mid-loop inference
+/// wraps the SAME `ProviderError` and must carry the SAME code — the
+/// bare-numeric `NIKA-463` is outside the spec's namespace grammar, so
+/// `nika check` rejects it in `on_codes:` and no author filter could
+/// ever match the agent path's provider failures.
+#[tokio::test]
+async fn a_provider_408_speaks_one_code_on_both_verbs() {
+    use nika_error::traits::NikaErrorCode;
+    let timeout_408 = || ProviderError::Api {
+        status: 408,
+        message: "HTTP request timed out after 300000ms".to_owned(),
+    };
+
+    // The SAME provider failure through both verb error surfaces.
+    let infer_err = VerbInferError::ProviderCall {
+        source: timeout_408(),
+        spend: Box::default(),
+    };
+    let agent_err = VerbAgentError::Inference {
+        source: timeout_408(),
+        spend: Box::default(),
+    };
+    assert_eq!(
+        agent_err.spec_code(),
+        infer_err.spec_code(),
+        "one provider failure · one wire language (#468)"
+    );
+    assert_eq!(agent_err.spec_code(), "NIKA-INFER-001");
+    assert_eq!(
+        agent_err.is_transient(),
+        infer_err.is_transient(),
+        "the transience verdict is the provider's on both verbs"
+    );
+
+    // The schema sibling (the issue's NIKA-464 comment): the agent's
+    // final-message schema gate is the class `NIKA-INFER-002` names.
+    let agent_schema = VerbAgentError::SchemaValidation {
+        detail: "missing field".to_owned(),
+        spend: Box::default(),
+    };
+    assert_eq!(agent_schema.spec_code(), "NIKA-INFER-002");
+
+    // Both resolve in the embedded spec canon — same invariant as the
+    // timeout/var pins above (a code outside the table silently breaks
+    // `on_codes:` filters).
+    let canon = nika_pack::error_codes();
+    for code in [agent_err.spec_code(), agent_schema.spec_code()] {
+        assert!(
+            canon.iter().any(|row| row.code == code),
+            "{code} must resolve in the embedded spec canon"
+        );
+    }
+
+    // e2e · the wire: an agent task whose provider dies mid-loop carries
+    // the spec class at `tasks.X.error.code` (what `on_codes:` compares).
+    let yaml_fail = r#"
+nika: v1
+workflow: agent-408
+model: mock/echo
+tasks:
+  - id: stuck
+    agent:
+      prompt: "try"
+"#;
+    let (outcome, _) = run_to_events(
+        yaml_fail,
+        MockShell::new(),
+        MockToolExecutor::new(),
+        MockProvider::new("mock").enqueue_error(timeout_408()),
+        RuntimeConfig::default(),
+    )
+    .await;
+    let record = outcome.records["stuck"]
+        .error
+        .as_ref()
+        .expect("typed error");
+    assert_eq!(record.code, "NIKA-INFER-001", "the wire speaks the class");
+    assert!(!record.transient, "a 408 is a verdict (only 5xx/429 retry)");
+
+    // e2e · the unlock: `retry.on_codes: [NIKA-INFER-001]` now catches
+    // the agent path's provider failure (non-transient · whitelisted).
+    let yaml_retry = r#"
+nika: v1
+workflow: agent-408-retry
+model: mock/echo
+tasks:
+  - id: flaky
+    retry: { max_attempts: 2, backoff_ms: 1, backoff_strategy: fixed, jitter: false, on_codes: [NIKA-INFER-001] }
+    agent:
+      prompt: "try again"
+"#;
+    let provider = MockProvider::new("mock")
+        .enqueue_error(timeout_408())
+        .enqueue_text("recovered");
+    let (outcome, events) = run_to_events(
+        yaml_retry,
+        MockShell::new(),
+        MockToolExecutor::new(),
+        provider,
+        RuntimeConfig::default(),
+    )
+    .await;
+    assert!(
+        events.iter().any(|e| e.kind == EventKind::TaskRetrying),
+        "the on_codes whitelist matched the agent's provider failure"
+    );
+    assert!(outcome.ok, "attempt 2 recovered");
+    assert_eq!(output_str(&outcome, "flaky"), "recovered");
 }
 
 // ─── 12 · the for_each when-gate scope hazard (pinned) ──────────────────

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -26,9 +26,9 @@ use nika_schema::check::CheckReport;
 use nika_schema::raw::RawWorkflow;
 use nika_schema::{FileId, ParseMode, check, parse};
 use nika_types::resource::Value as FieldValue;
-use nika_verb_agent::{AgentVerb, VerbAgentError};
+use nika_verb_agent::AgentVerb;
 use nika_verb_exec::ExecVerb;
-use nika_verb_infer::{InferVerb, VerbInferError};
+use nika_verb_infer::InferVerb;
 use nika_verb_invoke::InvokeVerb;
 
 // ─── harness ─────────────────────────────────────────────────────────────
@@ -1231,118 +1231,6 @@ tasks:
     }
     assert_eq!(timeout_code, "NIKA-TIMEOUT-001");
     assert_eq!(var_code, "NIKA-VAR-006");
-}
-
-/// #468 · one voice: the same provider failure speaks the SAME wire
-/// code on both verbs. `infer` surfaces it as `NIKA-INFER-001` (spec
-/// 05's allocated provider class); the agent loop's mid-loop inference
-/// wraps the SAME `ProviderError` and must carry the SAME code — the
-/// bare-numeric `NIKA-463` is outside the spec's namespace grammar, so
-/// `nika check` rejects it in `on_codes:` and no author filter could
-/// ever match the agent path's provider failures.
-#[tokio::test]
-async fn a_provider_408_speaks_one_code_on_both_verbs() {
-    use nika_error::traits::NikaErrorCode;
-    let timeout_408 = || ProviderError::Api {
-        status: 408,
-        message: "HTTP request timed out after 300000ms".to_owned(),
-    };
-
-    // The SAME provider failure through both verb error surfaces.
-    let infer_err = VerbInferError::ProviderCall {
-        source: timeout_408(),
-        spend: Box::default(),
-    };
-    let agent_err = VerbAgentError::Inference {
-        source: timeout_408(),
-        spend: Box::default(),
-    };
-    assert_eq!(
-        agent_err.spec_code(),
-        infer_err.spec_code(),
-        "one provider failure · one wire language (#468)"
-    );
-    assert_eq!(agent_err.spec_code(), "NIKA-INFER-001");
-    assert_eq!(
-        agent_err.is_transient(),
-        infer_err.is_transient(),
-        "the transience verdict is the provider's on both verbs"
-    );
-
-    // The schema sibling (the issue's NIKA-464 comment): the agent's
-    // final-message schema gate is the class `NIKA-INFER-002` names.
-    let agent_schema = VerbAgentError::SchemaValidation {
-        detail: "missing field".to_owned(),
-        spend: Box::default(),
-    };
-    assert_eq!(agent_schema.spec_code(), "NIKA-INFER-002");
-
-    // Both resolve in the embedded spec canon — same invariant as the
-    // timeout/var pins above (a code outside the table silently breaks
-    // `on_codes:` filters).
-    let canon = nika_pack::error_codes();
-    for code in [agent_err.spec_code(), agent_schema.spec_code()] {
-        assert!(
-            canon.iter().any(|row| row.code == code),
-            "{code} must resolve in the embedded spec canon"
-        );
-    }
-
-    // e2e · the wire: an agent task whose provider dies mid-loop carries
-    // the spec class at `tasks.X.error.code` (what `on_codes:` compares).
-    let yaml_fail = r#"
-nika: v1
-workflow: agent-408
-model: mock/echo
-tasks:
-  - id: stuck
-    agent:
-      prompt: "try"
-"#;
-    let (outcome, _) = run_to_events(
-        yaml_fail,
-        MockShell::new(),
-        MockToolExecutor::new(),
-        MockProvider::new("mock").enqueue_error(timeout_408()),
-        RuntimeConfig::default(),
-    )
-    .await;
-    let record = outcome.records["stuck"]
-        .error
-        .as_ref()
-        .expect("typed error");
-    assert_eq!(record.code, "NIKA-INFER-001", "the wire speaks the class");
-    assert!(!record.transient, "a 408 is a verdict (only 5xx/429 retry)");
-
-    // e2e · the unlock: `retry.on_codes: [NIKA-INFER-001]` now catches
-    // the agent path's provider failure (non-transient · whitelisted).
-    let yaml_retry = r#"
-nika: v1
-workflow: agent-408-retry
-model: mock/echo
-tasks:
-  - id: flaky
-    retry: { max_attempts: 2, backoff_ms: 1, backoff_strategy: fixed, jitter: false, on_codes: [NIKA-INFER-001] }
-    agent:
-      prompt: "try again"
-"#;
-    let provider = MockProvider::new("mock")
-        .enqueue_error(timeout_408())
-        .enqueue_text("recovered");
-    let (outcome, events) = run_to_events(
-        yaml_retry,
-        MockShell::new(),
-        MockToolExecutor::new(),
-        provider,
-        RuntimeConfig::default(),
-    )
-    .await;
-    assert!(
-        events.iter().any(|e| e.kind == EventKind::TaskRetrying),
-        "the on_codes whitelist matched the agent's provider failure"
-    );
-    assert!(outcome.ok, "attempt 2 recovered");
-    assert_eq!(output_str(&outcome, "flaky"), "recovered");
 }
 
 // ─── 12 · the for_each when-gate scope hazard (pinned) ──────────────────

--- a/crates/nika-verb-agent/src/errors.rs
+++ b/crates/nika-verb-agent/src/errors.rs
@@ -5,9 +5,11 @@
 //!
 //! Spec mapping (`docs/crate-specs/nika-verb-agent.md` §4): budgets are
 //! FAILURES (460 turns · 461 tokens · spec `NIKA-AGENT-001/002`), the
-//! whitelist violation is the immediate security stop (462 · not
-//! model-negotiable), provider failures chain (463), the final-message
-//! schema gate (464), parameter validation (465), and the
+//! whitelist violation is the immediate security stop (462 · spec
+//! `NIKA-SEC-002` · not model-negotiable), provider failures chain
+//! (463 · wire `NIKA-INFER-001` · the same class the `infer` verb
+//! speaks · #468), the final-message schema gate (464 · wire
+//! `NIKA-INFER-002`), parameter validation (465), and the
 //! tool-definition seam failure (466 · wraps the kernel NIKA-234).
 
 use nika_error::codes::{
@@ -59,7 +61,7 @@ pub enum VerbAgentError {
         spend: Box<SpendOnFailure>,
     },
 
-    /// A provider call failed mid-loop (NIKA-463).
+    /// A provider call failed mid-loop (NIKA-463 · wire `NIKA-INFER-001`).
     #[error("agent inference failed: {source}")]
     #[diagnostic(code(nika::verb::agent_inference))]
     Inference {
@@ -72,7 +74,8 @@ pub enum VerbAgentError {
         spend: Box<SpendOnFailure>,
     },
 
-    /// The final message failed `schema:` validation (NIKA-464).
+    /// The final message failed `schema:` validation (NIKA-464 · wire
+    /// `NIKA-INFER-002`).
     #[error("agent final message failed schema validation: {detail}")]
     #[diagnostic(code(nika::verb::agent_schema_validation))]
     SchemaValidation {
@@ -179,20 +182,26 @@ impl NikaErrorCode for VerbAgentError {
     /// filters on). `NIKA-460` → `NIKA-AGENT-001` (`max_turns`) · `NIKA-461`
     /// → `NIKA-AGENT-002` (`max_tokens`) · `NIKA-462` (non-whitelisted tool)
     /// is the security-stop `NIKA-SEC-002` (spec table `NIKA-SEC-002` ·
-    /// agent tool call outside the whitelist). The remaining variants
-    /// (`Inference` · `SchemaValidation` · `InvalidParam` · `ToolDefs` ·
-    /// `Stalled`) have no dedicated spec namespace row — they keep their
-    /// numeric wire form via the trait default.
+    /// agent tool call outside the whitelist). The loop's CHAINED
+    /// model-call failures speak the spec's shared classes — the
+    /// namespace follows the failure class, not the hosting verb (the
+    /// spec's own `NIKA-SEC-002` row is the precedent): a mid-loop
+    /// provider failure is `NIKA-INFER-001` (provider call failed · the
+    /// SAME code the `infer` verb emits · one voice · #468) and the
+    /// final-message schema gate is `NIKA-INFER-002` (structured output
+    /// failed `schema:`). The remaining variants (`InvalidParam` ·
+    /// `ToolDefs` · `Stalled`) have no spec namespace row — they keep
+    /// their numeric wire form via the trait default.
     fn spec_code(&self) -> String {
         match self {
             Self::MaxTurns { .. } => "NIKA-AGENT-001".to_owned(),
             Self::MaxTokens { .. } => "NIKA-AGENT-002".to_owned(),
             Self::WhitelistViolation { .. } => "NIKA-SEC-002".to_owned(),
-            Self::Inference { .. }
-            | Self::SchemaValidation { .. }
-            | Self::InvalidParam { .. }
-            | Self::ToolDefs { .. }
-            | Self::Stalled { .. } => self.nika_code().to_string(),
+            Self::Inference { .. } => "NIKA-INFER-001".to_owned(),
+            Self::SchemaValidation { .. } => "NIKA-INFER-002".to_owned(),
+            Self::InvalidParam { .. } | Self::ToolDefs { .. } | Self::Stalled { .. } => {
+                self.nika_code().to_string()
+            }
         }
     }
 
@@ -311,6 +320,35 @@ mod tests {
             spend: Box::default(),
         };
         assert!(!terminal.is_transient(), "a 400 is a verdict");
+    }
+
+    #[test]
+    fn chained_failures_speak_the_shared_spec_classes_on_the_wire() {
+        // #468 · one-voice: the wire code (`spec_code()` · what
+        // `on_codes:` matches and `tasks.X.error.code` carries) is the
+        // spec's shared class, never the internal registry numeral —
+        // `NIKA-463`/`NIKA-464` are outside the spec grammar and
+        // `nika check` rejects them in `on_codes:`.
+        use nika_kernel::ai::provider::ProviderError;
+        let inference = VerbAgentError::Inference {
+            source: ProviderError::Api {
+                status: 408,
+                message: "HTTP request timed out after 300000ms".to_owned(),
+            },
+            spend: Box::default(),
+        };
+        assert_eq!(inference.spec_code(), "NIKA-INFER-001");
+        let schema = VerbAgentError::SchemaValidation {
+            detail: "missing field".to_owned(),
+            spend: Box::default(),
+        };
+        assert_eq!(schema.spec_code(), "NIKA-INFER-002");
+        // Classes WITHOUT a spec row keep the numeric wire form.
+        let param = VerbAgentError::InvalidParam {
+            param: "prompt",
+            detail: "empty".to_owned(),
+        };
+        assert_eq!(param.spec_code(), "NIKA-465");
     }
 
     #[test]

--- a/crates/nika-verb-infer/src/errors.rs
+++ b/crates/nika-verb-infer/src/errors.rs
@@ -171,6 +171,35 @@ mod tests {
     }
 
     #[test]
+    fn spec_codes_match_the_wire_table() {
+        // The infer half of the one-voice contract (#468): the provider
+        // class is `NIKA-INFER-001`, the schema gate `NIKA-INFER-002` —
+        // the SAME codes the agent loop's chained failures carry.
+        let provider = VerbInferError::ProviderCall {
+            source: provider_err(),
+            spend: Box::default(),
+        };
+        assert_eq!(provider.spec_code(), "NIKA-INFER-001");
+        let resolution = VerbInferError::ModelResolution {
+            model: "ghost/model".to_owned(),
+            source: provider_err(),
+        };
+        assert_eq!(resolution.spec_code(), "NIKA-INFER-001");
+        let schema = VerbInferError::SchemaValidation {
+            attempts: 3,
+            detail: "missing field".to_owned(),
+            spend: Box::default(),
+        };
+        assert_eq!(schema.spec_code(), "NIKA-INFER-002");
+        // The upstream-reject guard has no spec row — numeric wire form.
+        let param = VerbInferError::InvalidParam {
+            param: "temperature",
+            detail: "3.5 out of 0-2".to_owned(),
+        };
+        assert_eq!(param.spec_code(), "NIKA-432");
+    }
+
+    #[test]
     fn transience_classification() {
         // Verb-local failures are never transient.
         assert!(

--- a/docs/crate-specs/nika-verb-agent.md
+++ b/docs/crate-specs/nika-verb-agent.md
@@ -10,7 +10,7 @@
 | License | `AGPL-3.0-or-later` |
 | Edition | 2024 |
 | Publish | `false` — internal L2 verb crate |
-| NIKA codes | **NIKA_460–469** in the Verb range 430–479 (infer 430-439 · exec 440-449 · invoke 450-459) · maps to spec `NIKA-AGENT-001/002` (`spec/05-errors.md:95-96`) |
+| NIKA codes | **NIKA_460–469** in the Verb range 430–479 (infer 430-439 · exec 440-449 · invoke 450-459) · wire mapping: budgets → spec `NIKA-AGENT-001/002` · whitelist → `NIKA-SEC-002` · chained provider/schema failures → the shared `NIKA-INFER-001/002` classes (#468 one-voice · `spec/05-errors.md`) |
 
 ---
 
@@ -145,8 +145,8 @@ ONLY inside an agent whitelist (the loop sentinel).
 | NIKA_460 | `MaxTurns { turns, partial_output }` | NIKA-AGENT-001 | `false` |
 | NIKA_461 | `MaxTokens { total_tokens, partial_output }` | NIKA-AGENT-002 | `false` |
 | NIKA_462 | `WhitelistViolation { tool }` | security_error (NIKA-SEC-002 family) | `false` |
-| NIKA_463 | `Inference` (wraps provider error mid-loop) | — | inherited |
-| NIKA_464 | `SchemaValidation` (final message vs schema) | — | `false` |
+| NIKA_463 | `Inference` (wraps provider error mid-loop) | NIKA-INFER-001 (shared provider class · #468) | inherited |
+| NIKA_464 | `SchemaValidation` (final message vs schema) | NIKA-INFER-002 (shared schema class · #468) | `false` |
 | NIKA_465 | `InvalidParam` (empty prompt · temp range) | — | `false` |
 
 ## §5 · Scope fences


### PR DESCRIPTION
Closes #468

## The disease

Same machine, same provider, same 408 — two error identities:

- `infer` → `NIKA-INFER-001 · provider call failed during infer: provider API error (408)…`
- `agent` → `NIKA-463 · agent inference failed: provider API error (408)…`

`NIKA-463` (and its sibling `NIKA-464`, the final-message schema gate) is **outside spec 05's namespace grammar** (`^NIKA-[A-Z]{2,9}(-[A-Z][A-Z0-9_]{1,15})?-[0-9]{3}$`). Worse than cosmetic: `nika check` **rejects** the two-segment form in `retry.on_codes` / `on_error.on_codes` (`crates/nika-schema/src/types/retry.rs::is_valid_error_code`), so the agent path's provider failures were **structurally unmatchable** — no author filter could ever catch them.

## The one voice

`VerbAgentError::spec_code()` now maps the loop's chained failures to the spec's **shared classes**:

| Variant | Wire before | Wire now |
|---|---|---|
| `Inference` (provider call failed mid-loop) | `NIKA-463` | **`NIKA-INFER-001`** |
| `SchemaValidation` (final message vs `schema:`) | `NIKA-464` | **`NIKA-INFER-002`** |

Why the shared class and not a new `NIKA-AGENT-003`:

1. **The namespace follows the failure class, not the hosting verb** — the spec's own table already does this: `NIKA-SEC-002` *is* an agent-loop failure (tool call outside the whitelist). The engine's own precedents agree: `WhitelistViolation → NIKA-SEC-002`, and infer's `ModelResolution → NIKA-INFER-001` (family mapping).
2. Spec 05's normative floor **already allocates** the exact semantics: `NIKA-INFER-001` = "provider call failed (HTTP error · provider refusal)" (`provider_error` · transient engine-assessed) and `NIKA-INFER-002` = "structured output failed `schema:` validation (after any engine-internal retries)". Zero spec change needed; both codes resolve in the embedded canon today.
3. A new `NIKA-AGENT-003` would keep the two-language disease alive with nicer syntax — an `on_codes: [NIKA-INFER-001]` transient-retry policy would *still* never see the agent path. One provider failure, one language, both verbs.

The **internal registry identities are unchanged** (`NIKA-463`/`NIKA-464` · `nika_code()` · `nika explain` still resolves both, now cross-referencing the wire form) — the fix is the agent's spec mapping site only, exactly the seam `dispatch.rs` reads (`TaskErrorRecord.code = err.spec_code()`). Verb context survives in the *message* ("agent inference failed: …"); the *code* is the class.

Not touched (honestly): `InvalidParam`(465) keeps the numeric form — infer's `InvalidParam`(432) does too, the verbs already agree (upstream-reject guards, no spec row). `ToolDefs`(466)/`Stalled`(467) are agent-only classes with no spec row and no cross-verb counterpart; giving them namespaced rows is a spec-first follow-up (`NIKA-AGENT-003+`) if wanted.

## Compat (`retry.on_codes`)

- No workflow can carry `on_codes: [NIKA-463]` today — `nika check` rejects the entry as non-canonical, so **no author filter breaks** (verified: zero hits in-repo and in the docs/spec siblings; the only `NIKA-463` prose mentions are historical CHANGELOG lines and in-crate comments naming the internal identity).
- Anything string-matching `NIKA-463` in consoles/logs will now see `NIKA-INFER-001`. Pre-1.0, one-voice wins — and this is a feature *unlock*: `retry.on_codes: [NIKA-INFER-001]` now catches provider failures on **both** verbs (proved by the new e2e test: a 408 mid-loop, non-transient, retried via the whitelist, recovered).

## Test proof (TDD — red first)

New failing test written first; red for the exact reason (`left: "NIKA-463" / right: "NIKA-INFER-001"`), then the fix, then green:

- `nika-runtime/tests/error_one_voice.rs::a_provider_408_speaks_one_code_on_both_verbs` (its own per-topic file — the loc-limits ratchet dictated the split out of spec_v2.rs, which sits at 1423/1500 LOC) — the SAME `ProviderError::Api{408}` through both verb error surfaces ⇒ same `spec_code()` (`NIKA-INFER-001`), same transience verdict; the schema sibling ⇒ `NIKA-INFER-002`; both resolve in the embedded spec canon; e2e: the wire (`tasks.X.error.code`) carries the class, and `retry.on_codes: [NIKA-INFER-001]` matches the agent path (TaskRetrying fired · attempt 2 recovered).
- `nika-verb-agent::errors::tests::chained_failures_speak_the_shared_spec_classes_on_the_wire` (the red test) + `nika-verb-infer::errors::tests::spec_codes_match_the_wire_table` (the infer half pinned from its end).

Suites: nika-verb-agent 85 · nika-verb-infer 67 · nika-error 56 · nika-runtime 115 lib + full integration suites (spec_v2 25 · error_one_voice 1) · nika-cli 294 lib + e2e_pipeline 12 — all green. `cargo fmt` clean · clippy-touched 5 crates clean (pre-commit gates all passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
