### PR TITLE
feat(cli): nika model serve — the sidecar launch surface (adr-091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   ride `wire all`. Cline/Continue remain on #449 (wave-3b — variant
   paths and YAML-list shapes verified first).
 
+- **`nika model serve` — the sovereign sidecar's launch surface** (the
+  ADR-091/093 rung `nika model pull` (#146) sequences after). A build
+  with `--features local-infer` serves a Qwen3-family GGUF as a
+  loopback OpenAI-compatible server, in the foreground (Ctrl-C stops
+  it · one generation at a time): `nika model serve --model
+  <path.gguf> [--tokenizer <path>] [--port 8712] [--model-id <id>]` —
+  the tokenizer defaults to `tokenizer.json` beside the weights, the
+  id to the file stem. Zero new dispatch seam: a workflow reaches it
+  through the existing local base-URL lane (`export
+  NIKA_LLAMACPP_BASE_URL=http://127.0.0.1:8712` · `model:
+  llamacpp/<id>`). The DEFAULT binary keeps the subcommand and refuses
+  with the build recipe (exit 3 · zero inference deps linked), and
+  `nika doctor` gains a `sidecar` row exactly when the feature is
+  built in.
+
 - **An exact loopback literal in `permits.net.http` clears the SSRF
   floor for that host** (#395 · the ADR-092 secrets-`egress:`
   precedent: the owner's explicit act, co-located with the boundary).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,6 +3701,7 @@ dependencies = [
  "nika-exec-runner",
  "nika-fs",
  "nika-http",
+ "nika-infer-local",
  "nika-kernel",
  "nika-kernel-mock",
  "nika-lsp",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -46,6 +46,20 @@ nika-dap         = { path = "../nika-dap", version = "0.99.0" }           # `nik
 nika-mcp         = { path = "../nika-mcp", version = "0.99.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
+# ── the sovereign local-inference launch surface (ADR-091/093) — OFF by default ─
+# `nika model serve` boots the candle backend behind the tiny_http sidecar
+# server. Optional so the default binary keeps the lean-core contract
+# (zero inference deps); the subcommand's default body teaches the build flag.
+nika-infer-local = { path = "../nika-infer-local", version = "0.99.0", optional = true }
+
+[features]
+# Build `nika model serve` for real: the candle backend + the loopback
+# OpenAI-compat server (ADR-091 · ADR-093). Off by default.
+local-infer = ["dep:nika-infer-local", "nika-infer-local/local-infer", "nika-infer-local/server"]
+# Apple-GPU kernels for the local backend (macOS only — CI's Linux
+# feature-matrix excludes this name, keep them aligned).
+metal       = ["local-infer", "nika-infer-local/metal"]
+
 [[bin]]
 name = "nika-cli"
 path = "src/main.rs"

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -245,6 +245,9 @@ pub fn nika_cli::verbs::init::agents_md() -> &'static str
 pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool, theme: nika_display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::inspect
 pub fn nika_cli::verbs::inspect::run(path: &str, ascii: bool) -> nika_cli::verbs::VerbOutput
+pub mod nika_cli::verbs::model
+pub const nika_cli::verbs::model::DEFAULT_PORT: u16
+pub fn nika_cli::verbs::model::serve(gguf: &std::path::Path, tokenizer: core::option::Option<&std::path::Path>, port: u16, model_id: core::option::Option<&str>) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::new
 pub fn nika_cli::verbs::new::dispatch(from: core::option::Option<&str>, dest: core::option::Option<&str>, force: bool, theme: nika_display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub fn nika_cli::verbs::new::run(template: &str, dest: core::option::Option<&str>, force: bool) -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -250,6 +250,11 @@ enum Command {
         #[arg(long, default_value = ".")]
         dir: String,
     },
+    /// Local models — serve one on this machine (no cloud, no external daemon).
+    Model {
+        #[command(subcommand)]
+        action: ModelAction,
+    },
     /// The embedded spec identity (`--canon` prints the SSOT).
     Spec {
         /// Print the canon.yaml single source of truth.
@@ -398,6 +403,26 @@ impl From<WireTargetArg> for verbs::wire::WireTarget {
             WireTargetArg::All => Self::All,
         }
     }
+}
+
+#[derive(Subcommand)]
+enum ModelAction {
+    /// Serve a GGUF model — an OpenAI-compatible foreground server on
+    /// 127.0.0.1 (Ctrl-C stops it · the banner says how workflows reach it).
+    Serve {
+        /// The model weights (a Qwen3-family `.gguf` file).
+        #[arg(long, value_name = "PATH.gguf")]
+        model: PathBuf,
+        /// The tokenizer file (default: `tokenizer.json` beside the model).
+        #[arg(long, value_name = "PATH")]
+        tokenizer: Option<PathBuf>,
+        /// Loopback port to listen on.
+        #[arg(long, default_value_t = verbs::model::DEFAULT_PORT)]
+        port: u16,
+        /// The model id responses report (default: the model file's name).
+        #[arg(long, value_name = "ID")]
+        model_id: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -831,6 +856,7 @@ fn main() -> std::process::ExitCode {
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json, plain_theme)),
         Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target.into(), &dir)),
+        Command::Model { action } => model_verb(action),
         Command::Spec { canon } => emit(&verbs::pack_surface::spec(canon)),
         Command::Schema => emit(&verbs::pack_surface::schema()),
         Command::Catalog { json } => emit(&verbs::catalog::run(json)),
@@ -882,6 +908,22 @@ fn emit(out: &VerbOutput) -> u8 {
         println!("{}", out.text.trim_end());
     }
     out.code
+}
+
+/// The `model` sub-verbs — a healthy `serve` never returns, so `emit` only prints refusals.
+fn model_verb(action: ModelAction) -> u8 {
+    let ModelAction::Serve {
+        model,
+        tokenizer,
+        port,
+        model_id,
+    } = action;
+    emit(&verbs::model::serve(
+        &model,
+        tokenizer.as_deref(),
+        port,
+        model_id.as_deref(),
+    ))
 }
 
 /// Dispatch the `trace` verb family: the live renders (replay · show)

--- a/crates/nika-cli/src/verbs/doctor.rs
+++ b/crates/nika-cli/src/verbs/doctor.rs
@@ -112,6 +112,7 @@ pub(crate) fn diagnose(probe: &Probe) -> Vec<Finding> {
             .to_owned(),
         fix: None,
     });
+    out.extend(sidecar_finding());
 
     for client in &probe.clients {
         out.push(client_finding(client));
@@ -164,6 +165,30 @@ pub(crate) fn diagnose(probe: &Probe) -> Vec<Finding> {
     }
 
     out
+}
+
+/// The sovereign sidecar lane (ADR-091) — a row ONLY when this binary was
+/// built with it (a BUILD fact · presence, never a probe): the default
+/// build's doctor stays byte-identical, so the row set is per-axis (a
+/// `Vec`, not an `Option` — the arity depends on the compile). The
+/// models-dir row arrives with `nika model pull`, which DEFINES the one
+/// canonical dir.
+fn sidecar_finding() -> Vec<Finding> {
+    #[cfg(feature = "local-infer")]
+    {
+        vec![Finding {
+            level: Level::Ok,
+            label: "sidecar".to_owned(),
+            detail: "local inference built in — `nika model serve --model <path.gguf>` \
+                     (loopback · OpenAI-compatible)"
+                .to_owned(),
+            fix: None,
+        }]
+    }
+    #[cfg(not(feature = "local-infer"))]
+    {
+        Vec::new()
+    }
 }
 
 /// The image plane (`nika:image_generate`) — mock always works; this
@@ -775,6 +800,33 @@ mod tests {
 
     /// Each severity prints a DISTINCT glyph — a `Default::default()` mutant
     /// (the null char `'\0'`) would erase the level cue the operator scans for.
+    /// The sidecar row is a BUILD fact: present exactly when this binary
+    /// carries the `local-infer` feature, absent otherwise — the default
+    /// doctor stays byte-identical.
+    #[test]
+    fn sidecar_row_tracks_the_build_feature() {
+        let probe = Probe {
+            version: "0.99.0".to_owned(),
+            config_path: None,
+            providers: vec![local("ollama")],
+            clients: vec![],
+            image: ImageProbe::default(),
+            tts: TtsProbe::default(),
+            local_pings: Vec::new(),
+            pricing: PricingProbe::default(),
+            retention: crate::verbs::trace::retention::RetentionConfig::default(),
+            retention_notes: vec![],
+        };
+        let sidecar = diagnose(&probe).into_iter().find(|f| f.label == "sidecar");
+        if cfg!(feature = "local-infer") {
+            let row = sidecar.expect("built with local-infer — the row must appear");
+            assert_eq!(row.level, Level::Ok);
+            assert!(row.detail.contains("nika model serve"), "{}", row.detail);
+        } else {
+            assert!(sidecar.is_none(), "default build carries no sidecar row");
+        }
+    }
+
     #[test]
     fn level_glyphs_are_distinct() {
         assert_eq!(Level::Ok.glyph(), '✔');
@@ -1061,6 +1113,7 @@ mod tests {
             "config",
             "lsp",
             "mcp",
+            "sidecar",
             "traces",
             "agent",
             "provider",

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -114,6 +114,9 @@ builtins. Copy, fill, check.
 ## Servers (stdio · for editors and agent clients)
 `nika lsp` (language server) · `nika mcp` (MCP: check/explain/schema/examples
 as tools) · `nika completions <shell>` generates shell completions.
+`nika model serve --model <path.gguf>` serves a local model on loopback
+(OpenAI-compatible · needs a `local-infer` build — the default binary
+prints the build recipe).
 
 ## Discipline
 - Every effect is gated by `permits:` (default-deny · `nika check --infer-permits`

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod forecast;
 pub mod graph;
 pub mod init;
 pub mod inspect;
+pub mod model;
 pub mod new;
 pub mod pack_surface;
 pub(crate) mod probe;

--- a/crates/nika-cli/src/verbs/model.rs
+++ b/crates/nika-cli/src/verbs/model.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika model serve` — the sovereign local-inference launch surface
+//! (ADR-091 · ADR-093).
+//!
+//! FOREGROUND by design: the process the operator (or a workflow's `exec`
+//! task, or the future L3 supervisor) starts, watches and stops. The v1
+//! contract is deliberately narrow — one loopback `tiny_http` server over
+//! one loaded GGUF, one generation at a time, Ctrl-C ends it. Process
+//! supervision (spawn/health/restart) is the runtime layer's job per
+//! ADR-091 §isolation; this verb is the rung below it.
+//!
+//! The served endpoint is reached over the EXISTING `OpenAiCompat` wire
+//! (zero new dispatch seam): point any keyless local profile's base URL at
+//! it (`NIKA_LLAMACPP_BASE_URL=http://127.0.0.1:<port>`) and a workflow's
+//! `model: llamacpp/<id>` lands on the sidecar.
+//!
+//! The whole surface is feature-gated (`local-infer` · off by default —
+//! the default binary links zero inference deps): the SUBCOMMAND always
+//! exists so the tree teaches it, the default BODY refuses with the build
+//! recipe (exit `3` · environment class).
+
+// The healthy path prints a banner then serves for the process' whole
+// life — output DURING a blocking serve cannot be deferred through
+// `VerbOutput`. The same sanctioned exemption `run` and `main.rs` carry.
+#![allow(clippy::disallowed_macros, clippy::print_stderr)]
+
+use std::path::Path;
+// `PathBuf` rides only the feature/test axes (`ServePlan` · fixtures).
+#[cfg(any(feature = "local-infer", test))]
+use std::path::PathBuf;
+
+use crate::verbs::{VerbOutput, exit};
+
+/// The default loopback port (`nika mcp` owns 8123; this stays clear of
+/// the 5 external local servers' defaults: 11434 · 1234 · 8080 · 8000).
+pub const DEFAULT_PORT: u16 = 8712;
+
+/// Serve `gguf` (Qwen3 family · v1 loader scope) in the foreground on
+/// loopback `port`. `tokenizer` defaults to `tokenizer.json` beside the
+/// GGUF (the layout a Hugging Face repo download produces); `model_id`
+/// (the id responses report) defaults to the GGUF file stem.
+///
+/// Returns ONLY on refusal (missing file · unreadable model · bind
+/// failure · a build without the feature) — a healthy server runs until
+/// the process ends (Ctrl-C). Refusals are environment-class (exit `3`).
+#[must_use]
+pub fn serve(
+    gguf: &Path,
+    tokenizer: Option<&Path>,
+    port: u16,
+    model_id: Option<&str>,
+) -> VerbOutput {
+    #[cfg(feature = "local-infer")]
+    {
+        serve_local(gguf, tokenizer, port, model_id)
+    }
+    #[cfg(not(feature = "local-infer"))]
+    {
+        let _ = (gguf, tokenizer, port, model_id);
+        feature_stub()
+    }
+}
+
+/// The resolved boot inputs: every path verified present, the id named.
+#[cfg(any(feature = "local-infer", test))]
+#[derive(Debug, PartialEq, Eq)]
+struct ServePlan {
+    gguf: PathBuf,
+    tokenizer: PathBuf,
+    model_id: String,
+}
+
+/// Resolve + verify the boot inputs BEFORE any load: a wrong path must
+/// refuse with the exact fix, not a parse failure deep in the loader.
+#[cfg(any(feature = "local-infer", test))]
+fn plan(
+    gguf: &Path,
+    tokenizer: Option<&Path>,
+    model_id: Option<&str>,
+) -> Result<ServePlan, VerbOutput> {
+    if !gguf.is_file() {
+        return Err(VerbOutput {
+            text: format!(
+                "model serve: no model file at {}\n  fix: point --model at a \
+                 Qwen3-family .gguf (download one from the Hugging Face Hub \
+                 — its tokenizer.json goes beside it)\n",
+                gguf.display()
+            ),
+            code: exit::ENV,
+        });
+    }
+    let tokenizer =
+        tokenizer.map_or_else(|| gguf.with_file_name("tokenizer.json"), Path::to_path_buf);
+    if !tokenizer.is_file() {
+        return Err(VerbOutput {
+            text: format!(
+                "model serve: no tokenizer at {}\n  fix: download the model \
+                 repo's tokenizer.json beside the GGUF, or name one with \
+                 --tokenizer <path>\n",
+                tokenizer.display()
+            ),
+            code: exit::ENV,
+        });
+    }
+    Ok(ServePlan {
+        model_id: model_id.map_or_else(|| derive_model_id(gguf), str::to_owned),
+        gguf: gguf.to_path_buf(),
+        tokenizer,
+    })
+}
+
+/// The id responses report when `--model-id` is absent: the GGUF file
+/// stem (`qwen3-4b-instruct-q4_k_m.gguf` → `qwen3-4b-instruct-q4_k_m`).
+#[cfg(any(feature = "local-infer", test))]
+fn derive_model_id(gguf: &Path) -> String {
+    gguf.file_stem()
+        .map_or_else(|| "local".to_owned(), |s| s.to_string_lossy().into_owned())
+}
+
+/// The default build's honest refusal: name the feature and the build
+/// recipe — never pretend the lane is one flag away at runtime.
+#[cfg(any(not(feature = "local-infer"), test))]
+fn feature_stub() -> VerbOutput {
+    VerbOutput {
+        text: "model serve: this binary was built without local inference \
+               (the default build links zero inference dependencies)\n  \
+               fix: build from source with the feature — cargo build -p \
+               nika-cli --features local-infer   (Apple GPU: --features \
+               metal)\n"
+            .to_owned(),
+        code: exit::ENV,
+    }
+}
+
+/// Load the GGUF, bind loopback, announce, serve until the process ends.
+#[cfg(feature = "local-infer")]
+fn serve_local(
+    gguf: &Path,
+    tokenizer: Option<&Path>,
+    port: u16,
+    model_id: Option<&str>,
+) -> VerbOutput {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    let plan = match plan(gguf, tokenizer, model_id) {
+        Ok(plan) => plan,
+        Err(refusal) => return refusal,
+    };
+    eprintln!(
+        "nika model serve · loading {} (a first load reads the whole file)",
+        plan.gguf.display()
+    );
+    let backend = match nika_infer_local::CandleBackend::load_qwen3(
+        &plan.gguf,
+        &plan.tokenizer,
+        &plan.model_id,
+    ) {
+        Ok(backend) => backend,
+        Err(err) => {
+            return VerbOutput {
+                text: format!(
+                    "model serve: {err}\n  fix: the v1 loader serves \
+                         Qwen3-family GGUFs with their tokenizer.json — \
+                         check both files\n"
+                ),
+                code: exit::ENV,
+            };
+        }
+    };
+    // Loopback ONLY (ADR-093: no TLS · no auth · the operator owns the
+    // port) — widening the bind is the supervisor era's decision, not v1's.
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let handle = match nika_infer_local::serve(Arc::new(backend), addr) {
+        Ok(handle) => handle,
+        Err(err) => {
+            return VerbOutput {
+                text: format!(
+                    "model serve: {err}\n  fix: another process may own the \
+                     port — pick one with --port <n>\n"
+                ),
+                code: exit::ENV,
+            };
+        }
+    };
+    let bound = handle.addr();
+    eprintln!(
+        "nika model serve · http://{bound}/v1/chat/completions · {} · \
+         loopback only · one generation at a time · Ctrl-C stops",
+        plan.model_id
+    );
+    eprintln!(
+        "  reach it from a workflow: export NIKA_LLAMACPP_BASE_URL=http://{bound} \
+         then model: llamacpp/{}",
+        plan.model_id
+    );
+    // The handle must outlive the park (dropping it stops the server).
+    // Ctrl-C ends the foreground process — the v1 lifecycle contract.
+    let _serving = handle;
+    loop {
+        std::thread::park();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The doctor tests' exact fixture idiom (CARGO_TARGET_TMPDIR is unset
+    // for lib unit tests — fall back beside the build dir).
+    #[allow(clippy::disallowed_methods)]
+    fn temp_dir(name: &str) -> PathBuf {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
+            || {
+                std::env::current_dir()
+                    .expect("current dir")
+                    .join("target")
+                    .join("tmp")
+            },
+            PathBuf::from,
+        );
+        let dir = base.join(format!("nika-model-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        dir
+    }
+
+    #[test]
+    fn plan_refuses_a_missing_gguf_with_the_fix() {
+        let dir = temp_dir("missing-gguf");
+        let refusal = plan(&dir.join("nope.gguf"), None, None).expect_err("must refuse");
+        assert_eq!(refusal.code, exit::ENV);
+        assert!(refusal.text.contains("no model file"), "{}", refusal.text);
+        assert!(refusal.text.contains("--model"), "{}", refusal.text);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn plan_defaults_to_the_sibling_tokenizer_and_the_file_stem_id() {
+        let dir = temp_dir("sibling");
+        let gguf = dir.join("qwen3-4b-instruct-q4_k_m.gguf");
+        std::fs::write(&gguf, b"stub").expect("fixture");
+        std::fs::write(dir.join("tokenizer.json"), b"{}").expect("fixture");
+        let plan = plan(&gguf, None, None).expect("resolves");
+        assert_eq!(plan.tokenizer, dir.join("tokenizer.json"));
+        assert_eq!(plan.model_id, "qwen3-4b-instruct-q4_k_m");
+        assert_eq!(plan.gguf, gguf);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn plan_refuses_a_missing_tokenizer_naming_both_fixes() {
+        let dir = temp_dir("no-tokenizer");
+        let gguf = dir.join("model.gguf");
+        std::fs::write(&gguf, b"stub").expect("fixture");
+        let refusal = plan(&gguf, None, None).expect_err("must refuse");
+        assert_eq!(refusal.code, exit::ENV);
+        assert!(refusal.text.contains("tokenizer.json"), "{}", refusal.text);
+        assert!(refusal.text.contains("--tokenizer"), "{}", refusal.text);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn plan_honors_explicit_tokenizer_and_model_id() {
+        let dir = temp_dir("explicit");
+        let gguf = dir.join("weights.gguf");
+        let tok = dir.join("tok.json");
+        std::fs::write(&gguf, b"stub").expect("fixture");
+        std::fs::write(&tok, b"{}").expect("fixture");
+        let resolved = plan(&gguf, Some(&tok), Some("qwen3")).expect("resolves");
+        assert_eq!(resolved.tokenizer, tok);
+        assert_eq!(resolved.model_id, "qwen3");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn the_stub_names_the_feature_and_exits_environment() {
+        let out = feature_stub();
+        assert_eq!(out.code, exit::ENV);
+        assert!(out.text.contains("local-infer"), "{}", out.text);
+        assert!(out.text.contains("cargo build"), "{}", out.text);
+    }
+
+    /// The REAL serve path refuses a missing model file cleanly — the
+    /// documented no-fixture e2e (a live-model boot is a manual step).
+    #[cfg(feature = "local-infer")]
+    #[test]
+    fn serve_refuses_a_missing_model_before_binding_anything() {
+        let dir = temp_dir("serve-missing");
+        let out = serve(&dir.join("absent.gguf"), None, DEFAULT_PORT, None);
+        assert_eq!(out.code, exit::ENV);
+        assert!(out.text.contains("no model file"), "{}", out.text);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// A present-but-invalid GGUF exercises the loader's typed refusal
+    /// through the real feature-on path (no model fixture in the repo).
+    #[cfg(feature = "local-infer")]
+    #[test]
+    fn serve_refuses_a_garbage_gguf_with_the_loader_error() {
+        let dir = temp_dir("serve-garbage");
+        let gguf = dir.join("junk.gguf");
+        std::fs::write(&gguf, b"not a gguf").expect("fixture");
+        std::fs::write(dir.join("tokenizer.json"), b"{}").expect("fixture");
+        let out = serve(&gguf, None, DEFAULT_PORT, None);
+        assert_eq!(out.code, exit::ENV);
+        assert!(out.text.contains("Qwen3-family"), "{}", out.text);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -506,6 +506,44 @@ fn doctor_diagnoses_the_environment_and_exits_zero() {
     );
 }
 
+/// The `model serve` launch surface (ADR-091) through the real binary:
+/// the required flag refuses at parse time, the port default (8712 —
+/// clear of `nika mcp`'s 8123) is a help-visible contract, and the
+/// no-model refusal is honest PER BUILD AXIS — the default binary
+/// teaches the `local-infer` build recipe, a feature build reaches the
+/// real path resolver (both exit 3, environment class).
+#[test]
+fn model_serve_pins_its_surface_and_refuses_honestly() {
+    let out = bin()
+        .args(["model", "serve"])
+        .output()
+        .expect("binary runs");
+    assert_ne!(out.status.code(), Some(0), "a bare form must refuse");
+    let err = String::from_utf8(out.stderr).expect("utf8");
+    assert!(err.contains("--model"), "names the required flag: {err}");
+
+    let out = bin()
+        .args(["model", "serve", "--help"])
+        .output()
+        .expect("binary runs");
+    let help = String::from_utf8(out.stdout).expect("utf8");
+    assert!(help.contains("8712"), "the port default is visible: {help}");
+
+    let out = bin()
+        .args(["model", "serve", "--model", "absent.gguf"])
+        .output()
+        .expect("binary runs");
+    assert_eq!(out.status.code(), Some(3), "environment-class refusal");
+    let err = String::from_utf8(out.stderr).expect("utf8");
+    #[cfg(not(feature = "local-infer"))]
+    {
+        assert!(err.contains("local-infer"), "teaches the feature: {err}");
+        assert!(err.contains("cargo build"), "prints the recipe: {err}");
+    }
+    #[cfg(feature = "local-infer")]
+    assert!(err.contains("no model file"), "the real resolver: {err}");
+}
+
 #[test]
 fn init_scaffolds_a_repo_and_is_idempotent() {
     let dir = workspace_tmp_dir("nika-init-smoke");


### PR DESCRIPTION
## The ADR-091 launch surface — the rung that unblocks #146

ADR-091 + ADR-093 were accepted with an explicit gap: `nika-infer-local` is admitted (candle backend proven on a real GGUF, tiny_http server round-trip proven over `MockBackend`) but **nothing can start it** — no `[[bin]]`, no CLI lane, zero inbound deps. ADR-091 §sub-decisions names this exact follow-up: *"the launch surface (the L3 supervisor that spawns/monitors the sidecar + the CLI lane) is this ADR's `enables`, tracked by #146"*.

This PR ships the smallest honest launch surface: **`nika model serve`**.

```
nika model serve --model qwen3-4b-instruct-q4_k_m.gguf [--tokenizer <path>] [--port 8712] [--model-id <id>]
```

### Why foreground-first (the supervisor ladder's bottom rung)

ADR-093's follow-up puts the subprocess supervisor (spawn/health/restart) at the runtime layer (L3) per ADR-091 §isolation. That supervisor needs something to spawn — a process whose lifecycle an owner can hold. A **foreground serve** is that process: the operator (or a workflow's `exec` task, or the future L3 supervisor) starts it, watches it, Ctrl-C ends it. No daemon magic, no pid files, no premature process supervision — and when the supervisor arrives it spawns exactly this, unchanged. Closing "nothing can start it" without building the ladder's top rung first.

### The shape

- **`nika model serve`** — the `nika model` family is #146's own proposal (`pull` · `list` · `rm` land there); `serve` is its natural sibling and the family reads as one surface: pull a model, serve a model.
- **Loopback only, hardcoded** (ADR-093: no TLS · no auth · loopback by design). Port default 8712 — clear of `nika mcp` (8123) and the 5 external local servers' defaults. `--port` for collisions; no `--bind` (widening is the supervisor era's decision).
- **Boot inputs**: the candle loader (`CandleBackend::load_qwen3`) needs a Qwen3-family GGUF **and** its `tokenizer.json`. `--tokenizer` defaults to the sibling `tokenizer.json` (the layout a Hub download produces); `--model-id` defaults to the GGUF file stem. Every missing input refuses with the exact fix before any load (exit 3, environment class).
- **Feature-gated, one public API on both axes**: the subcommand always exists (the tree teaches it; the scaffolded AGENTS.md names it), the **body** is `#[cfg]`-swapped — the default binary refuses with the build recipe (`cargo build -p nika-cli --features local-infer` · Apple GPU: `--features metal`). `nika-cli` gains the two forwarding features; `metal` reuses the exact name diamond-ci's Linux feature-matrix already excludes.
- **Zero new dispatch seam** (ADR-091's own promise): the banner and the help teach the existing lane — `export NIKA_LLAMACPP_BASE_URL=http://127.0.0.1:8712` then `model: llamacpp/<id>`. No provider-registry change; the ADR-093 `local` profile row can land with #146.
- **`nika doctor`** gains the ADR-091-promised row — presence-only: a `sidecar` line appears exactly when the binary carries `local-infer`. The **models-dir** part of that row is deliberately deferred to `nika model pull` (#146), which *defines* the one canonical dir — pre-defining it in doctor is the exact two-dir pull/load mismatch the issue warns about (the brouillon-era regression).

### Narrower than the design where honesty demanded it

- No `/v1/models` probe test — the server exposes `POST /v1/chat/completions` + `GET /health` only (ADR-093 v1 surface); its full HTTP round-trip over `MockBackend` is already pinned in `crates/nika-infer-local/tests/server_http.rs`.
- The live-model e2e (real GGUF → 200) stays a **documented manual step** — no fixture models in the repo. The feature-on path is tested through its honest refusals instead (see below).

### Test proof

Default axis (`cargo test -p nika-cli -p nika-infer-local --lib`): **300 + 53 green** —
- clap surface: `model serve` parses minimal + full forms, defaults pinned (`port 8712` · sibling tokenizer · stem id); a bare `model serve` refuses naming `--model`.
- plan resolution: sibling-tokenizer default · explicit overrides · missing-GGUF and missing-tokenizer refusals carry the exact fix, exit 3.
- the feature stub names `local-infer` + the build command, exit 3.
- doctor: the `sidecar` row tracks the build feature (absent on default — the default doctor stays byte-identical).

Feature axis (`cargo test -p nika-cli --features local-infer --lib`): the REAL `serve()` path refuses a missing model file cleanly, and a present-but-garbage GGUF surfaces the loader's typed refusal (`GGUF parse failed` → exit 3) — the no-fixture e2e of the boot path.

Validation: `cargo fmt` · `cargo clippy -p nika-cli --all-targets -- -D warnings` green on **both** axes · `cargo build -p nika-cli --features local-infer` green · `crates/nika-cli/public-api.txt` regenerated with the pinned cargo-public-api 0.51.0.

(Local note: `tests/forecast_e2e.rs` fails identically at `origin/main` with this diff stashed — pre-existing local-env artifact, untouched by this PR.)

### What this unblocks

#146 (`nika model pull`) sequences directly after: acquisition UX (hf-hub download · the ONE canonical models dir · quant selection) now has a serve lane to hand models to, and `nika doctor`'s models-dir row lands with the dir's definition.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
