### PR TITLE
fix(schema): the parse lane joins the native-first/005 inventory (#475)

### DIFF
--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -134,6 +134,7 @@ pub(crate) fn classify(command: &RawCommand) -> Option<(&'static str, String)> {
                 "`{head}` runs a helper script — inventory it: \
                  HTTP calls → `nika:fetch` (uploads: `multipart:` · crawls: `traverse:`) · \
                  file I/O → `nika:read`/`nika:write` · JSON shaping → `nika:jq` · \
+                 YAML/TOML/CSV in or out → `nika:convert` (then `nika:jq`) · \
                  a product API → wrap it as an MCP server (`mcp:<server>/<tool>`); \
                  keep `exec:` only for a genuine subprocess and record it in the exec ledger"
             ),
@@ -298,6 +299,10 @@ mod tests {
         ));
         assert!(h.advice.contains("native-first/005"), "{h:?}");
         assert!(h.advice.contains("exec ledger"), "{h:?}");
+        // #475 · the parse lane is IN the inventory: the single most
+        // common reason a helper survives it is "my input is YAML/CSV/
+        // TOML" — a hole here becomes an exec in a user's boundary.
+        assert!(h.advice.contains("nika:convert"), "{h:?}");
     }
 
     #[test]


### PR DESCRIPTION
One clause in the 005 exec-helper hint: `YAML/TOML/CSV in or out → nika:convert (then nika:jq)` — the single most common reason a helper script survives the inventory (the dogfood evidence: a real python sidecar whose only irreducible job was YAML→JSON). The test pins the lane so the inventory cannot regrow the hole.

Spec-side row: [nika-spec#64](https://github.com/supernovae-st/nika-spec/pull/64) — **merged**. The vendored pack mirror picks it up at the next vendoring train (mirror law: fixed at the SSOT, never in the pack).

Proof: `cargo test -p nika-schema --lib` green (the 005 pin asserts `nika:convert`).

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)