### PR TITLE
feat(cli): registry refs on check and run — the verified pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`registry:owner/name[@version]` refs on `check` and `run`** — the
+  registry's 22 certified artifacts become consumable from the CLI:
+  `nika check registry:supernovae-st/competitor-radar` audits a
+  stranger's workflow before it ever touches your workspace, and `run`
+  rides the same seam. The resolution is the registry-v0.1 trust chain,
+  native: index → advisory MUST-refuse (`NIKA-REG-002`) → entry TOML
+  re-verification (never the index alone; disagreement refuses,
+  `NIKA-REG-005`) → raw https fetch capped at 1 MiB → sha256 must equal
+  the pinned digest or nothing is written (`NIKA-REG-003`). Verified
+  bytes cache under `~/.nika/registry/<owner>/<name>/` beside their
+  digest record — a cache hit re-verifies and runs offline; a bare ref
+  pins its version at first resolve and never floats. Nothing executes
+  at pull time: the fetched file feeds the SAME audit-before-run
+  pipeline as any local path, and a workflow's `permits:` govern its
+  run, never this CLI-level fetch (the help text says so). `--fix`
+  refuses registry refs (a digest-pinned artifact stays read-only —
+  copy it to edit). The `nika add` install verb, org indexes
+  (`--index`) and `nika.lock` stay on the ADR-106 lane (#452).
+
 - **`graph --format mermaid` paints verb identity** — nodes carry their
   verb class and the diagram ends with the SAME classDef map every
   projected docs page uses (the shared visual vocabulary: spec

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -9,6 +9,83 @@ pub use nika_cli::display
 pub use nika_cli::frame
 pub use nika_cli::frame_with_outputs
 pub use nika_cli::verdict_frame
+pub mod nika_cli::registry
+pub struct nika_cli::registry::RegistryError
+impl nika_cli::registry::RegistryError
+pub fn nika_cli::registry::RegistryError::code(&self) -> core::option::Option<&'static str>
+impl core::error::Error for nika_cli::registry::RegistryError
+impl core::fmt::Debug for nika_cli::registry::RegistryError
+pub fn nika_cli::registry::RegistryError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_cli::registry::RegistryError
+pub fn nika_cli::registry::RegistryError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::registry::RegistryError
+impl<T, U> core::convert::Into<U> for nika_cli::registry::RegistryError where U: core::convert::From<T>
+pub fn nika_cli::registry::RegistryError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::registry::RegistryError where U: core::convert::Into<T>
+pub type nika_cli::registry::RegistryError::Error = core::convert::Infallible
+pub fn nika_cli::registry::RegistryError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::registry::RegistryError where U: core::convert::TryFrom<T>
+pub type nika_cli::registry::RegistryError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::registry::RegistryError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for nika_cli::registry::RegistryError where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_cli::registry::RegistryError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_cli::registry::RegistryError where T: 'static + ?core::marker::Sized
+pub fn nika_cli::registry::RegistryError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::registry::RegistryError where T: ?core::marker::Sized
+pub fn nika_cli::registry::RegistryError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::registry::RegistryError where T: ?core::marker::Sized
+pub fn nika_cli::registry::RegistryError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::registry::RegistryError
+pub fn nika_cli::registry::RegistryError::from(t: T) -> T
+impl<T> iri_string::format::ToStringFallible for nika_cli::registry::RegistryError where T: core::fmt::Display
+pub fn nika_cli::registry::RegistryError::try_to_string(&self) -> core::result::Result<alloc::string::String, alloc::collections::TryReserveError>
+impl<T> nika_error::traits::AsAny for nika_cli::registry::RegistryError where T: 'static
+pub fn nika_cli::registry::RegistryError::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::registry::RegistryError where T: ?core::marker::Sized
+pub fn nika_cli::registry::RegistryError::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::registry::RegistryError::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::registry::RegistryError
+impl<T> tracing::instrument::WithSubscriber for nika_cli::registry::RegistryError
+impl<T> typenum::type_operators::Same for nika_cli::registry::RegistryError
+pub type nika_cli::registry::RegistryError::Output = T
+pub struct nika_cli::registry::Resolved
+pub nika_cli::registry::Resolved::coordinate: alloc::string::String
+pub nika_cli::registry::Resolved::fetched: bool
+pub nika_cli::registry::Resolved::path: std::path::PathBuf
+pub nika_cli::registry::Resolved::pinned: bool
+pub nika_cli::registry::Resolved::sha256: alloc::string::String
+impl nika_cli::registry::Resolved
+pub fn nika_cli::registry::Resolved::describe(&self) -> alloc::string::String
+impl core::fmt::Debug for nika_cli::registry::Resolved
+pub fn nika_cli::registry::Resolved::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::registry::Resolved
+impl<T, U> core::convert::Into<U> for nika_cli::registry::Resolved where U: core::convert::From<T>
+pub fn nika_cli::registry::Resolved::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::registry::Resolved where U: core::convert::Into<T>
+pub type nika_cli::registry::Resolved::Error = core::convert::Infallible
+pub fn nika_cli::registry::Resolved::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::registry::Resolved where U: core::convert::TryFrom<T>
+pub type nika_cli::registry::Resolved::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::registry::Resolved::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::registry::Resolved where T: 'static + ?core::marker::Sized
+pub fn nika_cli::registry::Resolved::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::registry::Resolved where T: ?core::marker::Sized
+pub fn nika_cli::registry::Resolved::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::registry::Resolved where T: ?core::marker::Sized
+pub fn nika_cli::registry::Resolved::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::registry::Resolved
+pub fn nika_cli::registry::Resolved::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::registry::Resolved where T: 'static
+pub fn nika_cli::registry::Resolved::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::registry::Resolved where T: ?core::marker::Sized
+pub fn nika_cli::registry::Resolved::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::registry::Resolved::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::registry::Resolved
+impl<T> tracing::instrument::WithSubscriber for nika_cli::registry::Resolved
+impl<T> typenum::type_operators::Same for nika_cli::registry::Resolved
+pub type nika_cli::registry::Resolved::Output = T
+pub fn nika_cli::registry::is_registry_ref(arg: &str) -> bool
+pub fn nika_cli::registry::resolve_blocking(arg: &str) -> core::result::Result<nika_cli::registry::Resolved, nika_cli::registry::RegistryError>
 pub mod nika_cli::verbs
 pub mod nika_cli::verbs::catalog
 pub fn nika_cli::verbs::catalog::run(json: bool) -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/src/lib.rs
+++ b/crates/nika-cli/src/lib.rs
@@ -23,6 +23,7 @@
 // every `crate::display::…` / `crate::demo` call site stays untouched.
 pub use nika_display as display;
 pub use nika_display::demo;
+pub mod registry;
 pub mod verbs;
 pub mod wires;
 

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -20,6 +20,8 @@ use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+mod registry_args;
+
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use nika_cli::display::format::{ColorChoice, ColorEnv, LinkChoice, color_enabled, links_enabled};
 use nika_cli::verbs::explain_file::dispatch as explain_dispatch;
@@ -128,16 +130,10 @@ enum Command {
     /// Audit a workflow BEFORE it runs: plan · cost ceiling · secret
     /// flows · types · tools — every finding teaches its fix.
     Check {
-        /// Workflow file(s) (`*.nika.yaml`) · `-` reads stdin · or
-        /// `registry:owner/name[@version]` — a verified pull from the
-        /// public registry: digest-checked against its pinned entry,
-        /// cached under `~/.nika/registry/` (offline afterwards), then
-        /// audited exactly like a local file. The pull happens on your
-        /// own network BEFORE any audit — a workflow's `permits:`
-        /// govern its run, never this fetch. Several files audit in
-        /// sequence (each full report · the worst exit wins — the
-        /// pre-commit/CI shape). `--json` and `--infer-permits` stay
-        /// one-file-per-call.
+        /// Workflow file(s) (`*.nika.yaml`) · `-` reads stdin · or a verified
+        /// `registry:owner/name[@version]` pull (cached + offline; workflow
+        /// `permits:` never govern the fetch) · several files audit in sequence
+        /// (worst exit wins — the CI shape) · `--json`/`--infer-permits` one-file-per-call.
         #[arg(required = true, num_args = 1..)]
         files: Vec<String>,
         /// Emit the machine-readable report (never coloured).
@@ -578,12 +574,8 @@ enum TraceAction {
 // (same as TraceArgs), not a state machine to encode.
 #[allow(clippy::struct_excessive_bools)]
 struct RunArgs {
-    /// Workflow file (`*.nika.yaml`) · or `registry:owner/name[@version]`
-    /// — a verified pull from the public registry: digest-checked against
-    /// its pinned entry, cached under `~/.nika/registry/` (offline
-    /// afterwards), then audited by the same check-before-run as any
-    /// file. The pull happens on your own network BEFORE the run — the
-    /// workflow's `permits:` govern its run, never this fetch.
+    /// Workflow file (`*.nika.yaml`) · or a `registry:owner/name[@version]`
+    /// verified pull (cached + offline; `permits:` never govern the fetch).
     file: String,
     /// Stream NDJSON events instead of the live render (CI · agents).
     #[arg(long)]
@@ -826,7 +818,7 @@ fn main() -> std::process::ExitCode {
             model,
             no_color,
             ascii,
-        } => check_verb(
+        } => registry_args::check_verb(
             &files,
             &CheckFlags {
                 json,
@@ -837,7 +829,7 @@ fn main() -> std::process::ExitCode {
             model.as_deref(),
             term_theme(color.with_no_color(no_color), ascii, link_when),
         ),
-        Command::Run(args) => registry_then_run(args, color, link_when),
+        Command::Run(args) => registry_args::registry_then_run(args, color, link_when),
         Command::Test {
             file,
             update,
@@ -909,68 +901,6 @@ fn main() -> std::process::ExitCode {
 /// Print a verb's text on the right stream and return its exit code.
 /// Findings + successes go to stdout (they ARE the product); only
 /// environment errors go to stderr.
-/// The `check` arm: registry refs resolve first (the `--fix` guard
-/// rides the same seam), then the normal multi-file dispatch.
-fn check_verb(
-    files: &[String],
-    flags: &CheckFlags,
-    fix: bool,
-    model: Option<&str>,
-    theme: Theme,
-) -> u8 {
-    match resolve_registry_args(files, fix) {
-        Ok(files) => emit(&check_dispatch(&files, flags, fix, model, theme)),
-        Err(out) => emit(&out),
-    }
-}
-
-/// The `run` arm: a registry ref resolves to its verified cache file,
-/// then the run proceeds exactly as if given that path.
-fn registry_then_run(mut args: RunArgs, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
-    match resolve_registry_arg(&args.file) {
-        Ok(file) => {
-            args.file = file;
-            run_verb(&args, color, link_when)
-        }
-        Err(out) => emit(&out),
-    }
-}
-
-/// Swap any `registry:owner/name[@version]` argument for its verified
-/// local cache file (the fetch note goes to stderr — stdout stays
-/// machine-pure) — check/run then proceed exactly as if given that
-/// path. Resolution is CLI-level and happens BEFORE any workflow is
-/// parsed: a workflow's `permits:` govern its run, never this fetch.
-fn resolve_registry_args(files: &[String], fix: bool) -> Result<Vec<String>, VerbOutput> {
-    if fix && files.iter().any(|f| nika_cli::registry::is_registry_ref(f)) {
-        return Err(VerbOutput {
-            text: "--fix rewrites a file, and a registry artifact is pinned by its \
-                   digest — editing the cache would poison it\n  fix: copy the cached \
-                   file into your workspace, edit the copy, check that"
-                .to_owned(),
-            code: verbs::exit::ENV,
-        });
-    }
-    files.iter().map(|f| resolve_registry_arg(f)).collect()
-}
-
-/// One argument through the registry seam — non-refs pass untouched.
-fn resolve_registry_arg(arg: &str) -> Result<String, VerbOutput> {
-    if !nika_cli::registry::is_registry_ref(arg) {
-        return Ok(arg.to_owned());
-    }
-    match nika_cli::registry::resolve_blocking(arg) {
-        Ok(resolved) => {
-            eprintln!("{}", resolved.describe());
-            Ok(resolved.path.to_string_lossy().into_owned())
-        }
-        Err(e) => Err(VerbOutput {
-            text: e.to_string(),
-            code: verbs::exit::ENV,
-        }),
-    }
-}
-
 fn emit(out: &VerbOutput) -> u8 {
     if out.code == verbs::exit::ENV {
         eprintln!("nika-cli: {}", out.text);

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -128,10 +128,16 @@ enum Command {
     /// Audit a workflow BEFORE it runs: plan · cost ceiling · secret
     /// flows · types · tools — every finding teaches its fix.
     Check {
-        /// Workflow file(s) (`*.nika.yaml`) · `-` reads stdin · several
-        /// files audit in sequence (each full report · the worst exit
-        /// wins — the pre-commit/CI shape). `--json` and
-        /// `--infer-permits` stay one-file-per-call.
+        /// Workflow file(s) (`*.nika.yaml`) · `-` reads stdin · or
+        /// `registry:owner/name[@version]` — a verified pull from the
+        /// public registry: digest-checked against its pinned entry,
+        /// cached under `~/.nika/registry/` (offline afterwards), then
+        /// audited exactly like a local file. The pull happens on your
+        /// own network BEFORE any audit — a workflow's `permits:`
+        /// govern its run, never this fetch. Several files audit in
+        /// sequence (each full report · the worst exit wins — the
+        /// pre-commit/CI shape). `--json` and `--infer-permits` stay
+        /// one-file-per-call.
         #[arg(required = true, num_args = 1..)]
         files: Vec<String>,
         /// Emit the machine-readable report (never coloured).
@@ -572,7 +578,12 @@ enum TraceAction {
 // (same as TraceArgs), not a state machine to encode.
 #[allow(clippy::struct_excessive_bools)]
 struct RunArgs {
-    /// Workflow file (`*.nika.yaml`).
+    /// Workflow file (`*.nika.yaml`) · or `registry:owner/name[@version]`
+    /// — a verified pull from the public registry: digest-checked against
+    /// its pinned entry, cached under `~/.nika/registry/` (offline
+    /// afterwards), then audited by the same check-before-run as any
+    /// file. The pull happens on your own network BEFORE the run — the
+    /// workflow's `permits:` govern its run, never this fetch.
     file: String,
     /// Stream NDJSON events instead of the live render (CI · agents).
     #[arg(long)]
@@ -815,21 +826,18 @@ fn main() -> std::process::ExitCode {
             model,
             no_color,
             ascii,
-        } => {
-            let theme = term_theme(color.with_no_color(no_color), ascii, link_when);
-            emit(&check_dispatch(
-                &files,
-                &CheckFlags {
-                    json,
-                    infer_permits,
-                    native_strict,
-                },
-                fix,
-                model.as_deref(),
-                theme,
-            ))
-        }
-        Command::Run(args) => run_verb(&args, color, link_when),
+        } => check_verb(
+            &files,
+            &CheckFlags {
+                json,
+                infer_permits,
+                native_strict,
+            },
+            fix,
+            model.as_deref(),
+            term_theme(color.with_no_color(no_color), ascii, link_when),
+        ),
+        Command::Run(args) => registry_then_run(args, color, link_when),
         Command::Test {
             file,
             update,
@@ -901,6 +909,68 @@ fn main() -> std::process::ExitCode {
 /// Print a verb's text on the right stream and return its exit code.
 /// Findings + successes go to stdout (they ARE the product); only
 /// environment errors go to stderr.
+/// The `check` arm: registry refs resolve first (the `--fix` guard
+/// rides the same seam), then the normal multi-file dispatch.
+fn check_verb(
+    files: &[String],
+    flags: &CheckFlags,
+    fix: bool,
+    model: Option<&str>,
+    theme: Theme,
+) -> u8 {
+    match resolve_registry_args(files, fix) {
+        Ok(files) => emit(&check_dispatch(&files, flags, fix, model, theme)),
+        Err(out) => emit(&out),
+    }
+}
+
+/// The `run` arm: a registry ref resolves to its verified cache file,
+/// then the run proceeds exactly as if given that path.
+fn registry_then_run(mut args: RunArgs, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
+    match resolve_registry_arg(&args.file) {
+        Ok(file) => {
+            args.file = file;
+            run_verb(&args, color, link_when)
+        }
+        Err(out) => emit(&out),
+    }
+}
+
+/// Swap any `registry:owner/name[@version]` argument for its verified
+/// local cache file (the fetch note goes to stderr — stdout stays
+/// machine-pure) — check/run then proceed exactly as if given that
+/// path. Resolution is CLI-level and happens BEFORE any workflow is
+/// parsed: a workflow's `permits:` govern its run, never this fetch.
+fn resolve_registry_args(files: &[String], fix: bool) -> Result<Vec<String>, VerbOutput> {
+    if fix && files.iter().any(|f| nika_cli::registry::is_registry_ref(f)) {
+        return Err(VerbOutput {
+            text: "--fix rewrites a file, and a registry artifact is pinned by its \
+                   digest — editing the cache would poison it\n  fix: copy the cached \
+                   file into your workspace, edit the copy, check that"
+                .to_owned(),
+            code: verbs::exit::ENV,
+        });
+    }
+    files.iter().map(|f| resolve_registry_arg(f)).collect()
+}
+
+/// One argument through the registry seam — non-refs pass untouched.
+fn resolve_registry_arg(arg: &str) -> Result<String, VerbOutput> {
+    if !nika_cli::registry::is_registry_ref(arg) {
+        return Ok(arg.to_owned());
+    }
+    match nika_cli::registry::resolve_blocking(arg) {
+        Ok(resolved) => {
+            eprintln!("{}", resolved.describe());
+            Ok(resolved.path.to_string_lossy().into_owned())
+        }
+        Err(e) => Err(VerbOutput {
+            text: e.to_string(),
+            code: verbs::exit::ENV,
+        }),
+    }
+}
+
 fn emit(out: &VerbOutput) -> u8 {
     if out.code == verbs::exit::ENV {
         eprintln!("nika-cli: {}", out.text);

--- a/crates/nika-cli/src/registry/mod.rs
+++ b/crates/nika-cli/src/registry/mod.rs
@@ -1,0 +1,979 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `registry:owner/name[@version]` — resolve · verify · cache (issue #452 ·
+//! the consumption half of the ADR-106 registry-client lane).
+//!
+//! A registry ref never executes anything at pull time: it RESOLVES to a
+//! verified local file under `~/.nika/registry/`, and `nika check` /
+//! `nika run` then proceed exactly as if given that path — the audit-
+//! before-run pipeline is untouched (`load_checked` reads the cached
+//! file like any other). The trust chain, per the registry-v0.1 contract
+//! (nika-spec `registry/registry-v0.1.md`):
+//!
+//! 1. **Resolve** — fetch the public index (`index.json` · contract §4) ·
+//!    match `owner/name[@version]` · newest `SemVer` wins a bare ref. A
+//!    name that resolves nowhere fails loud (`NIKA-REG-001` — the
+//!    slopsquatting guard: an LLM-suggested name must exist).
+//! 2. **Refuse on advisory** — a withdrawn version refuses BEFORE any
+//!    bytes move (`NIKA-REG-002` · contract §3 MUST-refuse).
+//! 3. **Re-verify against the ENTRY** — the index is a convenience
+//!    projection; the digest of record comes from the entry TOML itself
+//!    (contract §4: "never against the index alone"). Index/entry
+//!    disagreement refuses (`NIKA-REG-005`).
+//! 4. **Fetch + hash** — raw https fetch of `source.repo@rev:path`
+//!    (1 MiB cap) · `sha256(bytes)` MUST equal the pinned digest, else
+//!    hard refuse and NOTHING is written (`NIKA-REG-003`).
+//! 5. **Cache** — the verified bytes land under ONE canonical dir
+//!    (`~/.nika/registry/<owner>/<name>/<version>.nika.yaml`) beside a
+//!    digest record; a cache hit re-verifies and runs OFFLINE. A bare
+//!    ref writes a pin record so later bare refs never float
+//!    (ADR-106 "pin by default").
+//!
+//! The fetch happens at CLI-level resolution, BEFORE the workflow is
+//! even parsed — a workflow's `permits:` govern the run's effects, not
+//! this fetch (said in the help text too). SSRF enforcement stays on;
+//! every URL is CONSTRUCTED from charset-validated components, never
+//! taken from fetched data (closed-set law: a field the client cannot
+//! vet is refused, never interpolated).
+
+use std::path::{Path, PathBuf};
+
+use nika_kernel::http::HttpGetDyn;
+use nika_kernel::{HttpError, HttpRequest};
+
+/// The ref scheme — an argument starting with this is a registry ref.
+const SCHEME: &str = "registry:";
+/// The public index this engine speaks to in v1 (org/private indexes
+/// arrive with the `nika add` verb — ADR-106 `--index`).
+const INDEX_BASE: &str = "https://raw.githubusercontent.com/supernovae-st/nika-registry/main";
+/// Raw content host for pinned artifact bytes.
+const RAW_BASE: &str = "https://raw.githubusercontent.com";
+/// Artifact size cap (the registry-v0.1 reference cap — workflows are
+/// kilobytes of text).
+const MAX_ARTIFACT_BYTES: usize = 1024 * 1024;
+/// Index size cap (22 artifacts ≈ 30 KiB today; generous headroom).
+const MAX_INDEX_BYTES: usize = 4 * 1024 * 1024;
+/// The closed set of entry top-level keys (contract §1) — an unknown
+/// field is a smuggling channel and refuses the whole entry.
+const ENTRY_KEYS: [&str; 12] = [
+    "schema",
+    "type",
+    "name",
+    "publisher",
+    "version",
+    "description",
+    "license",
+    "spec",
+    "source",
+    "integrity",
+    "cert",
+    "signature",
+];
+/// The closed set of `[source]` keys (contract §1).
+const SOURCE_KEYS: [&str; 3] = ["repo", "rev", "path"];
+
+/// Is this CLI file argument a registry ref (`registry:…`)?
+#[must_use]
+pub fn is_registry_ref(arg: &str) -> bool {
+    arg.starts_with(SCHEME)
+}
+
+/// A parsed `registry:owner/name[@version]` ref. Owner is REQUIRED in
+/// v1 (no bare names): without a lockfile the qualified form is the
+/// only shape immune to dependency confusion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegistryRef {
+    owner: String,
+    name: String,
+    version: Option<String>,
+}
+
+impl RegistryRef {
+    fn coordinate(&self, version: &str) -> String {
+        format!("{}/{}@{}", self.owner, self.name, version)
+    }
+}
+
+// ---------------------------------------------------------------------
+// Errors — one opaque type, teaching Display, greppable NIKA-REG codes.
+// ---------------------------------------------------------------------
+
+/// A registry resolution refusal. Every message teaches its fix; the
+/// contract-allocated refusals carry a greppable `[NIKA-REG-00x]` code
+/// (also via [`RegistryError::code`]).
+#[derive(Debug)]
+pub struct RegistryError {
+    kind: ErrKind,
+}
+
+#[derive(Debug)]
+enum ErrKind {
+    /// The ref itself does not parse — teach the form.
+    BadRef { arg: String, why: String },
+    /// Nothing in the registry matches (NIKA-REG-001 · slopsquat guard).
+    NotFound { what: String, hint: String },
+    /// A matching advisory withdraws it (NIKA-REG-002 · MUST-refuse).
+    Advisory {
+        coordinate: String,
+        ids: Vec<String>,
+    },
+    /// Fetched bytes do not hash to the pinned digest (NIKA-REG-003).
+    HashMismatch {
+        coordinate: String,
+        expected: String,
+        actual: String,
+    },
+    /// A cached copy no longer matches its recorded digest (NIKA-REG-004:
+    /// a local record pins bytes; a mismatch fails, never floats).
+    CacheTampered {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    /// The registry answered in a shape this engine cannot vet
+    /// (NIKA-REG-005 · unknown schema / unknown field / index-entry drift).
+    IndexShape { why: String },
+    /// The ref names an artifact that is not a workflow.
+    NotAWorkflow { coordinate: String, kind: String },
+    /// Cache miss and the network did not answer — the honest offline story.
+    Offline { what: String, reason: String },
+    /// The registry (or the pinned source) answered a non-200.
+    FetchFailed {
+        what: String,
+        status: u16,
+        hint: String,
+    },
+    /// A body over its cap.
+    TooLarge {
+        what: String,
+        len: usize,
+        cap: usize,
+    },
+    /// Local environment failure (cache dir · runtime · TLS init).
+    Env { why: String },
+}
+
+impl RegistryError {
+    fn new(kind: ErrKind) -> Self {
+        Self { kind }
+    }
+
+    fn env(why: impl Into<String>) -> Self {
+        Self::new(ErrKind::Env { why: why.into() })
+    }
+
+    /// The contract-allocated refusal code, when this refusal has one
+    /// (`NIKA-REG-001..005` · ADR-106). Parse/transport/environment
+    /// failures carry none.
+    #[must_use]
+    pub fn code(&self) -> Option<&'static str> {
+        match &self.kind {
+            ErrKind::NotFound { .. } => Some("NIKA-REG-001"),
+            ErrKind::Advisory { .. } => Some("NIKA-REG-002"),
+            ErrKind::HashMismatch { .. } => Some("NIKA-REG-003"),
+            ErrKind::CacheTampered { .. } => Some("NIKA-REG-004"),
+            ErrKind::IndexShape { .. } => Some("NIKA-REG-005"),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn short(hex: &str) -> &str {
+            hex.get(..16).unwrap_or(hex)
+        }
+        match &self.kind {
+            ErrKind::BadRef { arg, why } => write!(
+                f,
+                "cannot read `{arg}` as a registry ref: {why}\n  form: registry:owner/name  or  registry:owner/name@1.2.0"
+            ),
+            ErrKind::NotFound { what, hint } => write!(
+                f,
+                "[NIKA-REG-001] nothing in the registry matches {what}\n  fix: {hint}"
+            ),
+            ErrKind::Advisory { coordinate, ids } => write!(
+                f,
+                "[NIKA-REG-002] {coordinate} is withdrawn by advisory {} — refusing before any bytes move\n  see advisories/ in the registry for what happened and what to do",
+                ids.join(", ")
+            ),
+            ErrKind::HashMismatch {
+                coordinate,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "[NIKA-REG-003] {coordinate}: fetched bytes do not match the pinned digest\n  entry pins sha256 {}… · fetched {}…\n  nothing was written. The source moved or the entry lies — report it to the registry.",
+                short(expected),
+                short(actual)
+            ),
+            ErrKind::CacheTampered {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "[NIKA-REG-004] the cached copy no longer matches its recorded digest\n  file: {}\n  recorded sha256 {}… · found {}…\n  fix: delete that file and re-run — it will re-fetch and re-verify",
+                path.display(),
+                short(expected),
+                short(actual)
+            ),
+            ErrKind::IndexShape { why } => write!(
+                f,
+                "[NIKA-REG-005] the registry answered in a shape this engine cannot vet: {why}\n  a schema or field the client does not understand is refused, never skipped"
+            ),
+            ErrKind::NotAWorkflow { coordinate, kind } => write!(
+                f,
+                "{coordinate} is a {kind}, not a workflow — check and run consume workflows"
+            ),
+            ErrKind::Offline { what, reason } => write!(
+                f,
+                "{what}: not in the local cache and the network did not answer ({reason})\n  an already-fetched artifact runs offline from ~/.nika/registry/ — this one has not been fetched yet"
+            ),
+            ErrKind::FetchFailed { what, status, hint } => {
+                write!(f, "{what} answered HTTP {status}\n  {hint}")
+            }
+            ErrKind::TooLarge { what, len, cap } => write!(
+                f,
+                "{what} is {len} bytes — over the {cap}-byte registry cap (workflows are kilobytes of text)"
+            ),
+            ErrKind::Env { why } => write!(f, "{why}"),
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+// ---------------------------------------------------------------------
+// Resolution result
+// ---------------------------------------------------------------------
+
+/// A resolved registry ref: the verified local file check/run consume.
+#[derive(Debug)]
+pub struct Resolved {
+    /// The cached artifact path — feed it to check/run like any file.
+    pub path: PathBuf,
+    /// `owner/name@version` as resolved.
+    pub coordinate: String,
+    /// The verified content digest (64-hex sha256).
+    pub sha256: String,
+    /// `true` when bytes moved this call; `false` on a cache hit.
+    pub fetched: bool,
+    /// `true` when a bare ref was answered by the local pin record
+    /// (no network involved in choosing the version).
+    pub pinned: bool,
+}
+
+impl Resolved {
+    /// The one/two-line stderr note the CLI prints — where the artifact
+    /// lives and that it is digest-verified (stdout stays machine-pure).
+    #[must_use]
+    pub fn describe(&self) -> String {
+        let short = self.sha256.get(..16).unwrap_or(&self.sha256);
+        if self.fetched {
+            format!(
+                "→ registry {} · fetched + digest verified (sha256 {short}…)\n  cached: {} — later runs use this copy, offline included",
+                self.coordinate,
+                self.path.display()
+            )
+        } else {
+            format!(
+                "→ registry {} · cache · digest re-verified (sha256 {short}…) · offline",
+                self.coordinate
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Index / entry / cache-record shapes
+// ---------------------------------------------------------------------
+
+/// `index.json` (contract §4) — tolerant read: the index is a derived
+/// projection and may grow fields; every load-bearing claim is
+/// re-verified against the entry + the bytes.
+#[derive(serde::Deserialize)]
+struct Index {
+    index_schema: u64,
+    #[serde(default)]
+    artifacts: Vec<IndexArtifact>,
+}
+
+#[derive(serde::Deserialize, Clone)]
+struct IndexArtifact {
+    name: String,
+    publisher: String,
+    version: String,
+    #[serde(rename = "type")]
+    kind: String,
+    sha256: String,
+    source: SourcePin,
+    #[serde(default)]
+    advisories: Vec<String>,
+}
+
+/// The full-commit content pin (contract §1 R2).
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug)]
+struct SourcePin {
+    repo: String,
+    rev: String,
+    path: String,
+}
+
+/// The cache digest record (`<version>.meta.json`) — what a cache hit
+/// re-verifies against.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Meta {
+    sha256: String,
+    coordinate: String,
+    source: SourcePin,
+}
+
+// ---------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------
+
+/// The registry client: resolve a ref to a verified, cached local file.
+/// Generic over the kernel HTTP seam — production injects `ReqwestHttp`,
+/// tests a mock (Invariant #27).
+struct RegistryClient<H> {
+    http: H,
+    cache_root: PathBuf,
+}
+
+impl<H: HttpGetDyn> RegistryClient<H> {
+    fn new(http: H, cache_root: PathBuf) -> Self {
+        Self { http, cache_root }
+    }
+
+    /// Resolve `registry:owner/name[@version]` → verified cache path.
+    ///
+    /// Order of authority: explicit version, else the local pin record
+    /// (a bare ref never floats — ADR-106), else the network's newest
+    /// `SemVer`. The cache answers before the network; a hit re-verifies
+    /// its digest record.
+    async fn resolve(&self, arg: &str) -> Result<Resolved, RegistryError> {
+        let r = parse_ref(arg)?;
+        let (version, pinned) = match &r.version {
+            Some(v) => (Some(v.clone()), false),
+            None => (self.read_pin(&r)?, true),
+        };
+        if let Some(v) = &version
+            && let Some(hit) = self.cached(&r, v, pinned)?
+        {
+            return Ok(hit);
+        }
+        let index = self.fetch_index().await?;
+        let art = select_artifact(&index, &r, version.as_deref())?;
+        let digest = self.entry_digest(&art).await?;
+        let bytes = self.fetch_artifact(&art, &digest).await?;
+        self.store(&r, &art, &digest, &bytes)
+    }
+
+    // -- cache lane ----------------------------------------------------
+
+    fn dir_of(&self, r: &RegistryRef) -> PathBuf {
+        self.cache_root.join(&r.owner).join(&r.name)
+    }
+
+    /// The pin record a bare ref wrote at its first resolve — `None`
+    /// when this name was never bare-resolved on this machine.
+    fn read_pin(&self, r: &RegistryRef) -> Result<Option<String>, RegistryError> {
+        let path = self.dir_of(r).join("pin");
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(RegistryError::env(format!(
+                    "cannot read the pin record {}: {e}",
+                    path.display()
+                )));
+            }
+        };
+        let version = raw.trim().to_owned();
+        if version_key(&version).is_none() {
+            // A pin that is not a version is a path-injection vector —
+            // refuse with the heal, never interpolate it.
+            return Err(RegistryError::env(format!(
+                "the pin record {} does not hold a version — delete it and re-run",
+                path.display()
+            )));
+        }
+        Ok(Some(version))
+    }
+
+    /// The cache probe: artifact + digest record present → re-hash the
+    /// bytes against the record (a local record pins bytes; a mismatch
+    /// fails, never floats — NIKA-REG-004). Anything missing → `None`
+    /// (the network lane heals it).
+    fn cached(
+        &self,
+        r: &RegistryRef,
+        version: &str,
+        pinned: bool,
+    ) -> Result<Option<Resolved>, RegistryError> {
+        let dir = self.dir_of(r);
+        let artifact = dir.join(format!("{version}.nika.yaml"));
+        let meta_path = dir.join(format!("{version}.meta.json"));
+        let (Ok(bytes), Ok(meta_raw)) = (std::fs::read(&artifact), std::fs::read(&meta_path))
+        else {
+            return Ok(None);
+        };
+        let Ok(meta) = serde_json::from_slice::<Meta>(&meta_raw) else {
+            return Ok(None); // an unreadable record is refetched, not trusted
+        };
+        let actual = nika_dap::source_id::sha256_hex(&bytes);
+        if actual != meta.sha256 {
+            return Err(RegistryError::new(ErrKind::CacheTampered {
+                path: artifact,
+                expected: meta.sha256,
+                actual,
+            }));
+        }
+        Ok(Some(Resolved {
+            path: artifact,
+            coordinate: r.coordinate(version),
+            sha256: actual,
+            fetched: false,
+            pinned,
+        }))
+    }
+
+    // -- network lane ----------------------------------------------------
+
+    async fn fetch_index(&self) -> Result<Index, RegistryError> {
+        let body = self
+            .get_bytes(
+                &format!("{INDEX_BASE}/index.json"),
+                "the registry index",
+                MAX_INDEX_BYTES,
+                "the registry may be unreachable or moved — see https://github.com/supernovae-st/nika-registry",
+            )
+            .await?;
+        let index: Index = serde_json::from_slice(&body).map_err(|e| {
+            RegistryError::new(ErrKind::IndexShape {
+                why: format!("index.json does not parse: {e}"),
+            })
+        })?;
+        if index.index_schema != 1 {
+            return Err(RegistryError::new(ErrKind::IndexShape {
+                why: format!(
+                    "index_schema {} — this engine speaks schema 1",
+                    index.index_schema
+                ),
+            }));
+        }
+        Ok(index)
+    }
+
+    /// The digest of record comes from the ENTRY, never the index alone
+    /// (contract §4). The entry is fetched at its CONSTRUCTED path and
+    /// cross-checked field-by-field against the index's claims — drift
+    /// between a projection and its source is treated as tampered.
+    async fn entry_digest(&self, art: &IndexArtifact) -> Result<String, RegistryError> {
+        let url = format!(
+            "{INDEX_BASE}/registry/workflows/{}/{}/{}.toml",
+            art.publisher, art.name, art.version
+        );
+        let body = self
+            .get_bytes(
+                &url,
+                "the registry entry",
+                MAX_ARTIFACT_BYTES,
+                "the index lists an entry the registry does not serve — the registry is inconsistent; report it",
+            )
+            .await?;
+        let text = String::from_utf8(body).map_err(|_| {
+            RegistryError::new(ErrKind::IndexShape {
+                why: "the entry is not UTF-8 text".to_owned(),
+            })
+        })?;
+        parse_entry(&text, art)
+    }
+
+    async fn fetch_artifact(
+        &self,
+        art: &IndexArtifact,
+        digest: &str,
+    ) -> Result<Vec<u8>, RegistryError> {
+        let coordinate = format!("{}/{}@{}", art.publisher, art.name, art.version);
+        let url = format!(
+            "{RAW_BASE}/{}/{}/{}",
+            art.source.repo, art.source.rev, art.source.path
+        );
+        let bytes = self
+            .get_bytes(
+                &url,
+                &coordinate,
+                MAX_ARTIFACT_BYTES,
+                "the pinned source is gone (the author's repo moved or rewrote history) — report it to the registry",
+            )
+            .await?;
+        let actual = nika_dap::source_id::sha256_hex(&bytes);
+        if actual != digest {
+            return Err(RegistryError::new(ErrKind::HashMismatch {
+                coordinate,
+                expected: digest.to_owned(),
+                actual,
+            }));
+        }
+        Ok(bytes)
+    }
+
+    /// One capped GET with the honest failure taxonomy: transport error
+    /// → the offline story · non-200 → what answered + the hint · over
+    /// cap → the size law.
+    async fn get_bytes(
+        &self,
+        url: &str,
+        what: &str,
+        cap: usize,
+        non_200_hint: &str,
+    ) -> Result<Vec<u8>, RegistryError> {
+        let resp = self
+            .http
+            .get(HttpRequest::get(url))
+            .await
+            .map_err(|e: HttpError| {
+                RegistryError::new(ErrKind::Offline {
+                    what: what.to_owned(),
+                    reason: e.to_string(),
+                })
+            })?;
+        if resp.status != 200 {
+            return Err(RegistryError::new(ErrKind::FetchFailed {
+                what: what.to_owned(),
+                status: resp.status,
+                hint: non_200_hint.to_owned(),
+            }));
+        }
+        if resp.body.len() > cap {
+            return Err(RegistryError::new(ErrKind::TooLarge {
+                what: what.to_owned(),
+                len: resp.body.len(),
+                cap,
+            }));
+        }
+        Ok(resp.body.to_vec())
+    }
+
+    // -- store ----------------------------------------------------------
+
+    /// Write the VERIFIED bytes + digest record (atomic: temp sibling +
+    /// rename), and the pin when the ref was bare. Nothing lands here
+    /// unless the hash already matched.
+    fn store(
+        &self,
+        r: &RegistryRef,
+        art: &IndexArtifact,
+        digest: &str,
+        bytes: &[u8],
+    ) -> Result<Resolved, RegistryError> {
+        let dir = self.dir_of(r);
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            RegistryError::env(format!(
+                "cannot create the cache dir {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let coordinate = r.coordinate(&art.version);
+        let meta = Meta {
+            sha256: digest.to_owned(),
+            coordinate: coordinate.clone(),
+            source: art.source.clone(),
+        };
+        let meta_json = serde_json::to_string_pretty(&meta)
+            .map_err(|e| RegistryError::env(format!("cannot encode the digest record: {e}")))?;
+        let artifact = dir.join(format!("{}.nika.yaml", art.version));
+        write_atomic(&artifact, bytes)?;
+        write_atomic(
+            &dir.join(format!("{}.meta.json", art.version)),
+            meta_json.as_bytes(),
+        )?;
+        if r.version.is_none() {
+            write_atomic(&dir.join("pin"), format!("{}\n", art.version).as_bytes())?;
+        }
+        Ok(Resolved {
+            path: artifact,
+            coordinate,
+            sha256: digest.to_owned(),
+            fetched: true,
+            pinned: false,
+        })
+    }
+}
+
+/// Pick the artifact a ref names, out of the index: exact version when
+/// asked, newest `SemVer` otherwise — then the refusal ladder (advisory ·
+/// type · pin shape) BEFORE any bytes move.
+fn select_artifact(
+    index: &Index,
+    r: &RegistryRef,
+    version: Option<&str>,
+) -> Result<IndexArtifact, RegistryError> {
+    let named: Vec<&IndexArtifact> = index
+        .artifacts
+        .iter()
+        .filter(|a| a.publisher == r.owner && a.name == r.name)
+        .collect();
+    if named.is_empty() {
+        return Err(RegistryError::new(ErrKind::NotFound {
+            what: format!("`{}/{}`", r.owner, r.name),
+            hint: "check the spelling against https://github.com/supernovae-st/nika-registry — a name an agent suggests must actually exist (this refusal is the guard)".to_owned(),
+        }));
+    }
+    let workflows: Vec<&IndexArtifact> = named
+        .iter()
+        .copied()
+        .filter(|a| a.kind == "workflow")
+        .collect();
+    if workflows.is_empty() {
+        // Named, but nothing runnable: teach what it IS instead.
+        let kind = named[0].kind.clone();
+        return Err(RegistryError::new(ErrKind::NotAWorkflow {
+            coordinate: format!("{}/{}", r.owner, r.name),
+            kind,
+        }));
+    }
+    let chosen: &IndexArtifact = match version {
+        Some(v) => workflows
+            .iter()
+            .copied()
+            .find(|a| a.version == v)
+            .ok_or_else(|| {
+                let mut published: Vec<&str> =
+                    workflows.iter().map(|a| a.version.as_str()).collect();
+                published.sort_unstable();
+                RegistryError::new(ErrKind::NotFound {
+                    what: format!("`{}/{}@{v}`", r.owner, r.name),
+                    hint: format!("published versions: {}", published.join(", ")),
+                })
+            })?,
+        None => workflows
+            .iter()
+            .copied()
+            .filter(|a| version_key(&a.version).is_some())
+            .max_by_key(|a| version_key(&a.version))
+            .ok_or_else(|| {
+                RegistryError::new(ErrKind::IndexShape {
+                    why: format!("no version of {}/{} parses as SemVer", r.owner, r.name),
+                })
+            })?,
+    };
+    if !chosen.advisories.is_empty() {
+        return Err(RegistryError::new(ErrKind::Advisory {
+            coordinate: format!("{}/{}@{}", r.owner, r.name, chosen.version),
+            ids: chosen.advisories.clone(),
+        }));
+    }
+    vet_pin(chosen)?;
+    Ok(chosen.clone())
+}
+
+/// The closed-set vet of everything that becomes a URL or a path — a
+/// field the client cannot vet is refused, never interpolated.
+fn vet_pin(a: &IndexArtifact) -> Result<(), RegistryError> {
+    let shape = |why: String| RegistryError::new(ErrKind::IndexShape { why });
+    if a.sha256.len() != 64 || !a.sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(shape(format!("`{}` is not a full 64-hex sha256", a.sha256)));
+    }
+    if a.source.rev.len() != 40 || !a.source.rev.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(shape(format!(
+            "`{}` is not a full 40-hex commit (tags and branches are forbidden pins)",
+            a.source.rev
+        )));
+    }
+    let repo_ok = a
+        .source
+        .repo
+        .split_once('/')
+        .is_some_and(|(owner, repo)| valid_owner(owner) && valid_repo_name(repo));
+    if !repo_ok {
+        return Err(shape(format!(
+            "`{}` is not an owner/name repo",
+            a.source.repo
+        )));
+    }
+    if !valid_source_path(&a.source.path) {
+        return Err(shape(format!(
+            "`{}` is not a plain repo-relative path",
+            a.source.path
+        )));
+    }
+    if version_key(&a.version).is_none() {
+        return Err(shape(format!("`{}` is not a SemVer version", a.version)));
+    }
+    Ok(())
+}
+
+/// Parse + vet the entry TOML (contract §1): closed key set, then the
+/// fields cross-checked against the index's claims. Returns the digest
+/// of record.
+fn parse_entry(text: &str, art: &IndexArtifact) -> Result<String, RegistryError> {
+    let shape = |why: String| RegistryError::new(ErrKind::IndexShape { why });
+    let doc: toml_edit::DocumentMut = text
+        .parse()
+        .map_err(|e| shape(format!("the entry does not parse as TOML: {e}")))?;
+    for (key, _) in doc.iter() {
+        if !ENTRY_KEYS.contains(&key) {
+            return Err(shape(format!("unknown entry field `{key}`")));
+        }
+    }
+    let str_at = |table: Option<&str>, key: &str| -> Option<String> {
+        let item = match table {
+            Some(t) => doc.get(t)?.get(key)?,
+            None => doc.get(key)?,
+        };
+        item.as_str().map(str::to_owned)
+    };
+    for (table, allowed) in [("source", &SOURCE_KEYS[..]), ("integrity", &["sha256"][..])] {
+        if let Some(entries) = doc.get(table).and_then(toml_edit::Item::as_table) {
+            for (key, _) in entries {
+                if !allowed.contains(&key) {
+                    return Err(shape(format!("unknown [{table}] field `{key}`")));
+                }
+            }
+        }
+    }
+    let claims = [
+        ("type", str_at(None, "type"), &art.kind),
+        ("name", str_at(None, "name"), &art.name),
+        ("publisher", str_at(None, "publisher"), &art.publisher),
+        ("version", str_at(None, "version"), &art.version),
+        (
+            "source.repo",
+            str_at(Some("source"), "repo"),
+            &art.source.repo,
+        ),
+        ("source.rev", str_at(Some("source"), "rev"), &art.source.rev),
+        (
+            "source.path",
+            str_at(Some("source"), "path"),
+            &art.source.path,
+        ),
+        (
+            "integrity.sha256",
+            str_at(Some("integrity"), "sha256"),
+            &art.sha256,
+        ),
+    ];
+    for (field, entry_value, index_value) in claims {
+        match entry_value {
+            Some(v) if &v == index_value => {}
+            Some(_) => {
+                return Err(shape(format!(
+                    "the index and the entry disagree on {field} — a projection that cannot be re-derived is treated as tampered"
+                )));
+            }
+            None => return Err(shape(format!("the entry is missing {field}"))),
+        }
+    }
+    // Cross-checked equal — the entry's digest IS art.sha256 now.
+    Ok(art.sha256.clone())
+}
+
+/// Atomic write: temp sibling + rename, so a torn write can never look
+/// like a verified artifact.
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), RegistryError> {
+    let io_err =
+        |e: std::io::Error| RegistryError::env(format!("cannot write {}: {e}", path.display()));
+    let tmp = path.with_extension(format!("tmp-{}", std::process::id()));
+    std::fs::write(&tmp, bytes).map_err(io_err)?;
+    std::fs::rename(&tmp, path).map_err(io_err)
+}
+
+// ---------------------------------------------------------------------
+// Ref parsing + version ordering
+// ---------------------------------------------------------------------
+
+fn parse_ref(arg: &str) -> Result<RegistryRef, RegistryError> {
+    let bad = |why: &str| {
+        RegistryError::new(ErrKind::BadRef {
+            arg: arg.to_owned(),
+            why: why.to_owned(),
+        })
+    };
+    let rest = arg
+        .strip_prefix(SCHEME)
+        .ok_or_else(|| bad("missing the `registry:` scheme"))?;
+    let (locator, version) = match rest.split_once('@') {
+        Some((l, v)) => (l, Some(v)),
+        None => (rest, None),
+    };
+    let Some((owner, name)) = locator.split_once('/') else {
+        return Err(bad(
+            "expected owner/name (the publisher is required — it is what pins WHOSE artifact you get)",
+        ));
+    };
+    if name.contains('/') {
+        return Err(bad("expected exactly owner/name — one `/`"));
+    }
+    if !valid_owner(owner) {
+        return Err(bad(
+            "the owner is a GitHub owner: letters, digits and `-`, not starting with `-`",
+        ));
+    }
+    if !valid_name(name) {
+        return Err(bad(
+            "the name is lowercase letters, digits and `-` (up to 64, starting alphanumeric)",
+        ));
+    }
+    match version {
+        Some(v) if version_key(v).is_none() => Err(bad(
+            "the version is plain SemVer, e.g. 1.2.0 or 1.2.0-rc.1 (no `v` prefix, no build metadata)",
+        )),
+        _ => Ok(RegistryRef {
+            owner: owner.to_owned(),
+            name: name.to_owned(),
+            version: version.map(str::to_owned),
+        }),
+    }
+}
+
+fn valid_owner(s: &str) -> bool {
+    !s.is_empty()
+        && !s.starts_with('-')
+        && s.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+/// GitHub repo names also allow `.` and `_` — path-safe (no separators).
+fn valid_repo_name(s: &str) -> bool {
+    !s.is_empty()
+        && s != "."
+        && s != ".."
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+}
+
+fn valid_name(s: &str) -> bool {
+    s.len() <= 64
+        && s.as_bytes()
+            .first()
+            .is_some_and(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+        && s.bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
+/// Repo-relative, no traversal, plain charset — the R2 path law.
+fn valid_source_path(s: &str) -> bool {
+    !s.is_empty()
+        && !s.starts_with('/')
+        && s.split('/').all(|seg| {
+            !seg.is_empty()
+                && seg != "."
+                && seg != ".."
+                && seg
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+        })
+}
+
+/// `SemVer`-precedence sort key (`SemVer` §11, the get.py `version_key`
+/// port): numeric core compared numerically; a STABLE release outranks
+/// any pre-release of the same core (`0.2.0` > `0.2.0-rc1`); numeric
+/// pre-release ids compare numerically and rank below alphanumeric ones.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct VersionKey {
+    core: Vec<u64>,
+    stable: bool,
+    pre: Vec<PreId>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum PreId {
+    Num(u64),
+    Alpha(String),
+}
+
+fn version_key(v: &str) -> Option<VersionKey> {
+    if v.contains('+') {
+        return None; // pin without build metadata — a pin must name ONE thing
+    }
+    let (core, pre) = match v.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (v, None),
+    };
+    let nums: Vec<u64> = core
+        .split('.')
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .ok()?;
+    if nums.len() != 3 {
+        return None;
+    }
+    let pre_ids = match pre {
+        None => Vec::new(),
+        Some("") => return None,
+        Some(pre) => pre
+            .split('.')
+            .map(|id| {
+                if id.is_empty() || !id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
+                    return None;
+                }
+                Some(match id.parse::<u64>() {
+                    Ok(n) => PreId::Num(n),
+                    Err(_) => PreId::Alpha(id.to_owned()),
+                })
+            })
+            .collect::<Option<Vec<_>>>()?,
+    };
+    Some(VersionKey {
+        core: nums,
+        stable: pre_ids.is_empty(),
+        pre: pre_ids,
+    })
+}
+
+// ---------------------------------------------------------------------
+// Production wiring (the ONE seam main.rs calls)
+// ---------------------------------------------------------------------
+
+/// Resolve a registry ref over the real network into the canonical
+/// cache (`~/.nika/registry/`), blocking the current thread — the
+/// CLI-level seam that runs BEFORE any workflow is parsed.
+///
+/// # Errors
+///
+/// Every refusal in the trust chain: a ref that does not parse, a name
+/// that resolves nowhere (`NIKA-REG-001`), an advisory withdrawal
+/// (`NIKA-REG-002`), a digest mismatch (`NIKA-REG-003` — nothing is
+/// written), a tampered cache record (`NIKA-REG-004`), a registry shape
+/// this engine cannot vet (`NIKA-REG-005`), plus the honest offline /
+/// transport / environment failures. Each message teaches its fix.
+pub fn resolve_blocking(arg: &str) -> Result<Resolved, RegistryError> {
+    let root = default_cache_root()?;
+    let http = registry_http()?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| RegistryError::env(format!("cannot start the fetch runtime: {e}")))?;
+    rt.block_on(RegistryClient::new(http, root).resolve(arg))
+}
+
+/// The registry fetch client: SSRF enforcement stays ON (public https
+/// hosts only), transport capped well under attacker-sized bodies.
+// `HttpConfig` is `#[non_exhaustive]` → field assignment, not a struct
+// literal (the same idiom as the run composer).
+#[allow(clippy::field_reassign_with_default)]
+fn registry_http() -> Result<nika_http::ReqwestHttp, RegistryError> {
+    let mut config = nika_http::HttpConfig::default();
+    config.max_response_bytes = MAX_INDEX_BYTES as u64;
+    nika_http::ReqwestHttp::with_config(config)
+        .map_err(|e| RegistryError::env(format!("cannot initialize the fetch client: {e}")))
+}
+
+/// `~/.nika/registry` — the ONE canonical cache dir (HOME/USERPROFILE,
+/// the same resolution `nika wire` uses for editor configs).
+// Env read is config-path state, not a secret — the same scoped
+// exemption as `wire.rs::home_path`.
+#[allow(clippy::disallowed_methods)]
+fn default_cache_root() -> Result<PathBuf, RegistryError> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|home| PathBuf::from(home).join(".nika").join("registry"))
+        .ok_or_else(|| RegistryError::env("cannot find HOME/USERPROFILE for the registry cache"))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/nika-cli/src/registry/mod.rs
+++ b/crates/nika-cli/src/registry/mod.rs
@@ -720,6 +720,15 @@ fn parse_entry(text: &str, art: &IndexArtifact) -> Result<String, RegistryError>
             return Err(shape(format!("unknown entry field `{key}`")));
         }
     }
+    match doc.get("schema").and_then(toml_edit::Item::as_integer) {
+        Some(1) => {}
+        Some(n) => {
+            return Err(shape(format!(
+                "entry schema {n} — this engine speaks schema 1"
+            )));
+        }
+        None => return Err(shape("the entry is missing `schema`".to_owned())),
+    }
     let str_at = |table: Option<&str>, key: &str| -> Option<String> {
         let item = match table {
             Some(t) => doc.get(t)?.get(key)?,

--- a/crates/nika-cli/src/registry/tests.rs
+++ b/crates/nika-cli/src/registry/tests.rs
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The registry-client test suite — the trust chain exercised over the
+//! mock HTTP seam (`src/<mod>/tests.rs` is the prod-LOC-exempt
+//! convention · the nika-http `src/tests.rs` precedent). `super`
+//! resolves to the registry module — semantics unchanged.
+
+use super::*;
+use nika_dap::source_id::sha256_hex;
+use nika_kernel_mock::MockHttp;
+
+const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+const BODY: &[u8] =
+    b"nika: v1\nworkflow: greet\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n";
+
+fn kind_code(err: &RegistryError) -> Option<&'static str> {
+    err.code()
+}
+
+// -- ref parsing ---------------------------------------------------
+
+#[test]
+fn detects_registry_refs() {
+    assert!(is_registry_ref("registry:acme/greet"));
+    assert!(is_registry_ref("registry:acme/greet@0.1.0"));
+    assert!(!is_registry_ref("flows/greet.nika.yaml"));
+    assert!(!is_registry_ref("Registry:acme/greet")); // exact scheme, like every CLI literal
+    assert!(!is_registry_ref("-"));
+}
+
+#[test]
+fn parses_bare_and_versioned_refs() {
+    let bare = parse_ref("registry:acme/greet").expect("bare ref parses");
+    assert_eq!(bare.owner, "acme");
+    assert_eq!(bare.name, "greet");
+    assert_eq!(bare.version, None);
+
+    let pinned = parse_ref("registry:acme-corp/my-flow@1.2.0").expect("versioned ref parses");
+    assert_eq!(pinned.owner, "acme-corp");
+    assert_eq!(pinned.name, "my-flow");
+    assert_eq!(pinned.version.as_deref(), Some("1.2.0"));
+
+    let pre = parse_ref("registry:a1/b2@1.0.0-rc.1").expect("pre-release version parses");
+    assert_eq!(pre.version.as_deref(), Some("1.0.0-rc.1"));
+}
+
+#[test]
+fn refuses_malformed_refs() {
+    // Each row: the ref + the fragment its teaching text must carry.
+    let rows: &[(&str, &str)] = &[
+        ("registry:", "owner/name"),
+        ("registry:greet", "owner/name"), // owner REQUIRED in v1
+        ("registry:acme/", "owner/name"),
+        ("registry:/greet", "owner/name"),
+        ("registry:a/b/c", "owner/name"),
+        ("registry:acme/greet@", "version"),
+        ("registry:acme/greet@1.2", "version"), // SemVer is a triple
+        ("registry:acme/greet@v1.2.0", "version"), // no v prefix
+        ("registry:acme/greet@1.2.0+meta", "version"), // pin without build metadata
+        ("registry:acme/Greet", "name"),        // contract: ^[a-z0-9][a-z0-9-]{0,63}$
+        ("registry:acme/gre_et", "name"),
+        ("registry:-acme/greet", "owner"),
+        ("registry:ac me/greet", "owner"),
+    ];
+    for (arg, teach) in rows {
+        let err = parse_ref(arg).expect_err(arg);
+        assert!(
+            kind_code(&err).is_none(),
+            "parse refusals carry no REG code: {arg}"
+        );
+        let text = err.to_string();
+        assert!(
+            text.contains(teach) && text.contains("registry:owner/name"),
+            "{arg} must teach `{teach}` + the form · got: {text}"
+        );
+    }
+}
+
+// -- version ordering ------------------------------------------------
+
+#[test]
+fn version_key_orders_by_semver_precedence() {
+    let key = |v: &str| version_key(v).expect(v);
+    assert!(key("0.10.0") > key("0.9.9"), "numeric, not lexical");
+    assert!(
+        key("0.2.0") > key("0.2.0-rc1"),
+        "stable outranks its pre-release"
+    );
+    assert!(key("0.2.0-rc2") > key("0.2.0-rc1"));
+    assert!(
+        key("0.2.0-rc.10") > key("0.2.0-rc.9"),
+        "numeric pre ids compare numerically"
+    );
+    assert!(
+        key("1.0.0-alpha") > key("1.0.0-1"),
+        "numeric ids rank below alphanumeric"
+    );
+    assert!(version_key("banana").is_none());
+    assert!(version_key("1.2").is_none());
+}
+
+// -- resolve: fixtures ------------------------------------------------
+
+fn artifact_json(
+    owner: &str,
+    name: &str,
+    version: &str,
+    kind: &str,
+    digest: &str,
+    advisories: &[&str],
+) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "publisher": owner,
+        "version": version,
+        "type": kind,
+        "sha256": digest,
+        "source": {
+            "repo": format!("{owner}/flows"),
+            "rev": REV,
+            "path": format!("flows/{name}.nika.yaml"),
+        },
+        "advisories": advisories,
+        "description": "One line.",
+        "license": "Apache-2.0",
+        "spec": "nika/v1",
+        "entry": format!("registry/workflows/{owner}/{name}/{version}.toml"),
+    })
+}
+
+fn index_json(artifacts: &[serde_json::Value]) -> String {
+    serde_json::json!({ "index_schema": 1, "artifacts": artifacts }).to_string()
+}
+
+fn entry_toml(owner: &str, name: &str, version: &str, digest: &str) -> String {
+    format!(
+        r#"schema = 1
+type = "workflow"
+name = "{name}"
+publisher = "{owner}"
+version = "{version}"
+description = "One line."
+license = "Apache-2.0"
+spec = "nika/v1"
+
+[source]
+repo = "{owner}/flows"
+rev = "{REV}"
+path = "flows/{name}.nika.yaml"
+
+[integrity]
+sha256 = "{digest}"
+"#
+    )
+}
+
+fn client(mock: MockHttp) -> (RegistryClient<MockHttp>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("cache tempdir");
+    let root = dir.path().join("registry");
+    (RegistryClient::new(mock, root), dir)
+}
+
+/// The three-response happy-path mock: index → entry → artifact.
+fn happy_mock(owner: &str, name: &str, version: &str, body: &[u8]) -> MockHttp {
+    let digest = sha256_hex(body);
+    MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[artifact_json(
+                owner,
+                name,
+                version,
+                "workflow",
+                &digest,
+                &[],
+            )]),
+        )
+        .enqueue_ok(200, entry_toml(owner, name, version, &digest))
+        .enqueue_ok(200, body.to_vec())
+}
+
+fn resolve(client: &RegistryClient<MockHttp>, arg: &str) -> Result<Resolved, RegistryError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime")
+        .block_on(client.resolve(arg))
+}
+
+// -- resolve: the trust chain ---------------------------------------
+
+#[test]
+fn fetches_verifies_and_caches_a_versioned_ref() {
+    let mock = happy_mock("acme", "greet", "0.1.0", BODY);
+    let (client, _dir) = client(mock.clone());
+
+    let got = resolve(&client, "registry:acme/greet@0.1.0").expect("resolves");
+    assert!(got.fetched);
+    assert!(!got.pinned);
+    assert_eq!(got.coordinate, "acme/greet@0.1.0");
+    assert_eq!(got.sha256, sha256_hex(BODY));
+    assert_eq!(
+        std::fs::read(&got.path).expect("cached artifact readable"),
+        BODY,
+        "the cached file is the verified bytes"
+    );
+    assert!(
+        got.path.ends_with("acme/greet/0.1.0.nika.yaml"),
+        "one canonical cache layout · got {}",
+        got.path.display()
+    );
+
+    // The URLs are CONSTRUCTED, never trusted from fetched data.
+    let urls: Vec<String> = mock.sent_requests().into_iter().map(|r| r.url).collect();
+    assert_eq!(
+        urls,
+        vec![
+            format!("{INDEX_BASE}/index.json"),
+            format!("{INDEX_BASE}/registry/workflows/acme/greet/0.1.0.toml"),
+            format!("{RAW_BASE}/acme/flows/{REV}/flows/greet.nika.yaml"),
+        ]
+    );
+
+    // No version in the ref → no pin. A versioned ref writes none.
+    assert!(
+        !client.cache_root.join("acme/greet/pin").exists(),
+        "a versioned ref pins nothing"
+    );
+}
+
+#[test]
+fn bare_ref_picks_newest_semver_and_writes_the_pin() {
+    let body_new = b"nika: v1\nworkflow: greet-new\n";
+    let d_old = sha256_hex(BODY);
+    let d_new = sha256_hex(body_new);
+    let mock = MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[
+                artifact_json("acme", "greet", "0.1.0", "workflow", &d_old, &[]),
+                artifact_json("acme", "greet", "0.2.0-rc1", "workflow", &d_new, &[]),
+                artifact_json("acme", "greet", "0.2.0", "workflow", &d_new, &[]),
+            ]),
+        )
+        .enqueue_ok(200, entry_toml("acme", "greet", "0.2.0", &d_new))
+        .enqueue_ok(200, body_new.to_vec());
+    let (client, _dir) = client(mock);
+
+    let got = resolve(&client, "registry:acme/greet").expect("bare ref resolves");
+    assert_eq!(got.coordinate, "acme/greet@0.2.0", "stable outranks rc");
+    let pin = client.cache_root.join("acme/greet/pin");
+    assert_eq!(
+        std::fs::read_to_string(&pin).expect("pin written").trim(),
+        "0.2.0",
+        "bare refs pin at resolve time — they never float"
+    );
+}
+
+#[test]
+fn tampered_bytes_refuse_and_write_nothing() {
+    let digest = sha256_hex(BODY);
+    let mock = MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[artifact_json(
+                "acme",
+                "greet",
+                "0.1.0",
+                "workflow",
+                &digest,
+                &[],
+            )]),
+        )
+        .enqueue_ok(200, entry_toml("acme", "greet", "0.1.0", &digest))
+        .enqueue_ok(200, b"nika: v1\n# tampered payload\n".to_vec());
+    let (client, _dir) = client(mock);
+
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-003"));
+    let text = err.to_string();
+    assert!(
+        text.contains("nothing was written"),
+        "teaches the refuse: {text}"
+    );
+    assert!(
+        !client.cache_root.join("acme/greet").exists(),
+        "a refused artifact leaves NO cache residue"
+    );
+}
+
+#[test]
+fn advisory_refuses_before_any_bytes_move() {
+    let digest = sha256_hex(BODY);
+    let mock = MockHttp::new().enqueue_ok(
+        200,
+        index_json(&[artifact_json(
+            "acme",
+            "greet",
+            "0.1.0",
+            "workflow",
+            &digest,
+            &["NIKA-ADV-2026-0001"],
+        )]),
+    );
+    let (client, _dir) = client(mock.clone());
+
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-002"));
+    assert!(err.to_string().contains("NIKA-ADV-2026-0001"));
+    assert_eq!(
+        mock.sent_requests().len(),
+        1,
+        "advisory refuses after the index fetch, BEFORE entry/artifact bytes"
+    );
+}
+
+#[test]
+fn cache_hit_answers_offline_and_reverifies() {
+    // Seed the cache through a real resolve…
+    let (seeded, dir) = client(happy_mock("acme", "greet", "0.1.0", BODY));
+    resolve(&seeded, "registry:acme/greet@0.1.0").expect("seed resolve");
+
+    // …then resolve again with a client whose queue is EMPTY: any
+    // request would fail, so success proves zero network.
+    let offline_mock = MockHttp::new();
+    let offline = RegistryClient::new(offline_mock.clone(), dir.path().join("registry"));
+    let got = resolve(&offline, "registry:acme/greet@0.1.0").expect("offline cache hit");
+    assert!(!got.fetched);
+    assert_eq!(got.sha256, sha256_hex(BODY));
+    assert!(
+        offline_mock.sent_requests().is_empty(),
+        "zero requests on a cache hit"
+    );
+}
+
+#[test]
+fn bare_ref_answers_offline_via_the_pin() {
+    let (seeded, dir) = client(happy_mock("acme", "greet", "0.1.0", BODY));
+    resolve(&seeded, "registry:acme/greet").expect("seed bare resolve");
+
+    let offline_mock = MockHttp::new();
+    let offline = RegistryClient::new(offline_mock.clone(), dir.path().join("registry"));
+    let got = resolve(&offline, "registry:acme/greet").expect("pin answers offline");
+    assert!(!got.fetched);
+    assert!(
+        got.pinned,
+        "the pin record chose the version, not the network"
+    );
+    assert_eq!(got.coordinate, "acme/greet@0.1.0");
+    assert!(offline_mock.sent_requests().is_empty());
+}
+
+#[test]
+fn tampered_cache_refuses_with_the_record_law() {
+    let (seeded, dir) = client(happy_mock("acme", "greet", "0.1.0", BODY));
+    let got = resolve(&seeded, "registry:acme/greet@0.1.0").expect("seed resolve");
+    std::fs::write(&got.path, "nika: v1\n# locally tampered\n").expect("tamper");
+
+    let offline = RegistryClient::new(MockHttp::new(), dir.path().join("registry"));
+    let err = resolve(&offline, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-004"));
+    assert!(
+        err.to_string().contains("delete"),
+        "teaches the heal: {err}"
+    );
+}
+
+#[test]
+fn unknown_index_schema_refuses() {
+    let mock = MockHttp::new().enqueue_ok(200, r#"{ "index_schema": 2, "artifacts": [] }"#);
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-005"));
+}
+
+#[test]
+fn unresolved_name_fails_loud() {
+    let mock = MockHttp::new().enqueue_ok(200, index_json(&[]));
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-001"), "the slopsquat guard");
+}
+
+#[test]
+fn missing_version_lists_what_exists() {
+    let digest = sha256_hex(BODY);
+    let mock = MockHttp::new().enqueue_ok(
+        200,
+        index_json(&[artifact_json(
+            "acme",
+            "greet",
+            "0.1.0",
+            "workflow",
+            &digest,
+            &[],
+        )]),
+    );
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet@9.9.9").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-001"));
+    assert!(
+        err.to_string().contains("0.1.0"),
+        "teaches the published versions: {err}"
+    );
+}
+
+#[test]
+fn non_workflow_artifacts_are_refused_with_their_kind() {
+    let digest = sha256_hex(BODY);
+    let mock = MockHttp::new().enqueue_ok(
+        200,
+        index_json(&[artifact_json(
+            "acme",
+            "greet",
+            "0.1.0",
+            "skill",
+            &digest,
+            &[],
+        )]),
+    );
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet").expect_err("must refuse");
+    assert!(kind_code(&err).is_none());
+    assert!(err.to_string().contains("skill"), "names the kind: {err}");
+}
+
+#[test]
+fn cache_miss_offline_is_honest() {
+    // Empty queue → the mock answers HttpError on the index fetch.
+    let (client, _dir) = client(MockHttp::new());
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert!(kind_code(&err).is_none());
+    let text = err.to_string();
+    assert!(
+        text.contains("cache") && text.contains("offline"),
+        "the offline story is explicit: {text}"
+    );
+}
+
+#[test]
+fn index_entry_digest_disagreement_refuses() {
+    let digest = sha256_hex(BODY);
+    let lie = sha256_hex(b"a different pin");
+    let mock = MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[artifact_json(
+                "acme",
+                "greet",
+                "0.1.0",
+                "workflow",
+                &digest,
+                &[],
+            )]),
+        )
+        .enqueue_ok(200, entry_toml("acme", "greet", "0.1.0", &lie));
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-005"));
+    assert!(err.to_string().contains("disagree"), "{err}");
+}
+
+#[test]
+fn unknown_entry_field_is_a_smuggling_channel() {
+    let digest = sha256_hex(BODY);
+    // Both channels: a top-level key the contract does not name, and
+    // a key smuggled into a known table ([integrity]).
+    let top_level = entry_toml("acme", "greet", "0.1.0", &digest)
+        .replace("[source]", "malicious = \"payload\"\n\n[source]");
+    let mut in_table = entry_toml("acme", "greet", "0.1.0", &digest);
+    in_table.push_str("smuggled = \"payload\"\n"); // appends inside [integrity]
+
+    for entry in [top_level, in_table] {
+        let mock = MockHttp::new()
+            .enqueue_ok(
+                200,
+                index_json(&[artifact_json(
+                    "acme",
+                    "greet",
+                    "0.1.0",
+                    "workflow",
+                    &digest,
+                    &[],
+                )]),
+            )
+            .enqueue_ok(200, entry);
+        let (client, _dir) = client(mock);
+        let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+        assert_eq!(kind_code(&err), Some("NIKA-REG-005"));
+    }
+}
+
+#[test]
+fn malformed_source_pins_refuse() {
+    let digest = sha256_hex(BODY);
+    let mut short_rev = artifact_json("acme", "greet", "0.1.0", "workflow", &digest, &[]);
+    short_rev["source"]["rev"] = serde_json::json!("abc123"); // tags/branches are FORBIDDEN
+    let mut traversal = artifact_json("acme", "greet", "0.1.0", "workflow", &digest, &[]);
+    traversal["source"]["path"] = serde_json::json!("../../etc/passwd");
+
+    for bad in [short_rev, traversal] {
+        let mock = MockHttp::new().enqueue_ok(200, index_json(&[bad]));
+        let (client, _dir) = client(mock);
+        let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+        assert_eq!(kind_code(&err), Some("NIKA-REG-005"));
+    }
+}
+
+#[test]
+fn oversized_artifacts_refuse() {
+    let big = vec![b'x'; MAX_ARTIFACT_BYTES + 1];
+    let digest = sha256_hex(&big);
+    let mock = MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[artifact_json(
+                "acme",
+                "greet",
+                "0.1.0",
+                "workflow",
+                &digest,
+                &[],
+            )]),
+        )
+        .enqueue_ok(200, entry_toml("acme", "greet", "0.1.0", &digest))
+        .enqueue_ok(200, big);
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert!(err.to_string().contains("cap"), "{err}");
+}
+
+#[test]
+fn entry_404_names_the_inconsistency() {
+    let digest = sha256_hex(BODY);
+    let mock = MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[artifact_json(
+                "acme",
+                "greet",
+                "0.1.0",
+                "workflow",
+                &digest,
+                &[],
+            )]),
+        )
+        .enqueue_ok(404, "404: Not Found");
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert!(err.to_string().contains("404"), "{err}");
+}
+
+#[test]
+fn describe_speaks_fetch_and_cache() {
+    let (seeded, dir) = client(happy_mock("acme", "greet", "0.1.0", BODY));
+    let fetched = resolve(&seeded, "registry:acme/greet@0.1.0").expect("seed");
+    assert!(fetched.describe().contains("fetched + digest verified"));
+    assert!(fetched.describe().contains("cached:"));
+
+    let offline = RegistryClient::new(MockHttp::new(), dir.path().join("registry"));
+    let hit = resolve(&offline, "registry:acme/greet@0.1.0").expect("hit");
+    assert!(hit.describe().contains("cache"));
+    assert!(hit.describe().contains("offline"));
+}

--- a/crates/nika-cli/src/registry/tests.rs
+++ b/crates/nika-cli/src/registry/tests.rs
@@ -492,6 +492,34 @@ fn unknown_entry_field_is_a_smuggling_channel() {
 }
 
 #[test]
+fn unknown_entry_schema_refuses() {
+    // An entry `schema` the client does not understand is refused, same
+    // closed-set law as the index's `index_schema` (ADR-106 REG-005).
+    let digest = sha256_hex(BODY);
+    let entry = entry_toml("acme", "greet", "0.1.0", &digest).replace("schema = 1", "schema = 2");
+    let mock = MockHttp::new()
+        .enqueue_ok(
+            200,
+            index_json(&[artifact_json(
+                "acme",
+                "greet",
+                "0.1.0",
+                "workflow",
+                &digest,
+                &[],
+            )]),
+        )
+        .enqueue_ok(200, entry);
+    let (client, _dir) = client(mock);
+    let err = resolve(&client, "registry:acme/greet@0.1.0").expect_err("must refuse");
+    assert_eq!(kind_code(&err), Some("NIKA-REG-005"));
+    assert!(
+        err.to_string().contains("schema 1"),
+        "teaches what it speaks: {err}"
+    );
+}
+
+#[test]
 fn malformed_source_pins_refuse() {
     let digest = sha256_hex(BODY);
     let mut short_rev = artifact_json("acme", "greet", "0.1.0", "workflow", &digest, &[]);

--- a/crates/nika-cli/src/registry_args.rs
+++ b/crates/nika-cli/src/registry_args.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `registry:` arg seam of the binary (issue #452) — swap any
+//! `registry:owner/name[@version]` file argument for its verified local
+//! cache file, then hand check/run the path exactly as if the user had
+//! typed it. A bin-side sibling of `main.rs` (the dispatcher stays a
+//! thin verb tree; this is the one arg transform it owes the registry
+//! lane). Resolution is CLI-level and happens BEFORE any workflow is
+//! parsed: a workflow's `permits:` govern its run, never this fetch.
+
+use nika_cli::registry;
+use nika_cli::verbs::{self, VerbOutput};
+
+use crate::{CheckFlags, ColorWhenArg, RunArgs, check_dispatch, emit, run_verb};
+use nika_cli::display::format::LinkChoice;
+
+/// The `check` arm: registry refs resolve first (the `--fix` guard
+/// rides the same seam), then the normal multi-file dispatch.
+pub(crate) fn check_verb(
+    files: &[String],
+    flags: &CheckFlags,
+    fix: bool,
+    model: Option<&str>,
+    theme: nika_cli::Theme,
+) -> u8 {
+    match resolve_registry_args(files, fix) {
+        Ok(files) => emit(&check_dispatch(&files, flags, fix, model, theme)),
+        Err(out) => emit(&out),
+    }
+}
+
+/// The `run` arm: a registry ref resolves to its verified cache file,
+/// then the run proceeds exactly as if given that path.
+pub(crate) fn registry_then_run(
+    mut args: RunArgs,
+    color: ColorWhenArg,
+    link_when: LinkChoice,
+) -> u8 {
+    match resolve_registry_arg(&args.file) {
+        Ok(file) => {
+            args.file = file;
+            run_verb(&args, color, link_when)
+        }
+        Err(out) => emit(&out),
+    }
+}
+
+/// Swap every registry ref among the file args for its verified cache
+/// path — non-refs pass untouched. `--fix` refuses refs BEFORE any
+/// network: a digest-pinned artifact stays read-only (rewriting the
+/// cache would poison its record).
+fn resolve_registry_args(files: &[String], fix: bool) -> Result<Vec<String>, VerbOutput> {
+    if fix && files.iter().any(|f| registry::is_registry_ref(f)) {
+        return Err(VerbOutput {
+            text: "--fix rewrites a file, and a registry artifact is pinned by its \
+                   digest — editing the cache would poison it\n  fix: copy the cached \
+                   file into your workspace, edit the copy, check that"
+                .to_owned(),
+            code: verbs::exit::ENV,
+        });
+    }
+    files.iter().map(|f| resolve_registry_arg(f)).collect()
+}
+
+/// One argument through the registry seam. The fetch note goes to
+/// stderr — the machine surfaces on stdout stay pure.
+fn resolve_registry_arg(arg: &str) -> Result<String, VerbOutput> {
+    if !registry::is_registry_ref(arg) {
+        return Ok(arg.to_owned());
+    }
+    match registry::resolve_blocking(arg) {
+        Ok(resolved) => {
+            eprintln!("{}", resolved.describe());
+            Ok(resolved.path.to_string_lossy().into_owned())
+        }
+        Err(e) => Err(VerbOutput {
+            text: e.to_string(),
+            code: verbs::exit::ENV,
+        }),
+    }
+}

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -1432,3 +1432,67 @@ fn context_aggregates_the_workspace_value_free() {
     assert!(text.contains("nika context --json"), "{text}");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// -- registry refs (issue #452) — the NETWORK-FREE half of the binary
+// contract: ref-shape refusals and the --fix guard fire at parse time,
+// before any resolution, so these tests never touch the network.
+
+#[test]
+fn registry_ref_that_cannot_parse_exits_env_and_teaches_the_form() {
+    // check side: owner is required in v1 — the refusal must teach the form.
+    let out = bin()
+        .args(["check", "registry:just-a-name"])
+        .output()
+        .expect("binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "a ref that cannot parse is an environment error, not a file finding"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("registry:owner/name"),
+        "the refusal teaches the form · stderr: {err}"
+    );
+
+    // run side rides the same seam.
+    let out = bin()
+        .args(["run", "registry:acme/Bad_Name"])
+        .output()
+        .expect("binary runs");
+    assert_eq!(out.status.code(), Some(3));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("registry:owner/name"), "stderr: {err}");
+}
+
+#[test]
+fn fix_refuses_registry_refs_before_any_network() {
+    // --fix rewrites a file; a registry artifact is pinned by its digest —
+    // editing the cache would poison it. Refused at arg-handling, network-free.
+    let out = bin()
+        .args(["check", "--fix", "registry:acme/greet"])
+        .output()
+        .expect("binary runs");
+    assert_eq!(out.status.code(), Some(3));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("digest") && err.contains("copy"),
+        "teaches WHY and the workspace-copy fix · stderr: {err}"
+    );
+}
+
+#[test]
+fn help_teaches_the_registry_form_on_check_and_run() {
+    for verb in ["check", "run"] {
+        let out = bin().args([verb, "--help"]).output().expect("binary runs");
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            text.contains("registry:owner/name"),
+            "`nika {verb} --help` teaches the registry ref · got: {text}"
+        );
+        assert!(
+            text.contains("permits"),
+            "`nika {verb} --help` says permits do not govern the fetch · got: {text}"
+        );
+    }
+}


### PR DESCRIPTION
## The gap this closes

The registry ships 22 certified artifacts (hash + oracle + engine cert, CI-re-proven) and the engine had zero way to pull them. Now:

```
nika check registry:supernovae-st/competitor-radar   # audit a stranger's workflow BEFORE it touches your machine
nika run   registry:supernovae-st/competitor-radar   # same seam — the fetched file rides the normal audit-before-run
```

Proven live against the real registry: fetch + digest verify + cache + the full check ladder on the cached file, then an offline cache-hit re-run, then a slopsquat refusal — all three paths exercised on the shipped index.

## The trust chain (what is verified, what refuses)

Resolution is CLI-level and happens BEFORE any workflow is parsed. Nothing executes at pull time — a verified file lands under `~/.nika/registry/<owner>/<name>/<version>.nika.yaml` and check/run proceed exactly as if given that path (`load_checked` untouched).

| Step | Verified | On failure |
|---|---|---|
| ref parse | `registry:owner/name[@version]` — owner required, contract charsets, plain SemVer | teaches the form (exit 3) |
| index fetch | `index.json`, `index_schema == 1`, 4 MiB cap | unknown schema refuses `[NIKA-REG-005]` |
| resolve | exact version, or newest SemVer for a bare ref (stable outranks pre-release — the get.py `version_key` semantics) | `[NIKA-REG-001]` fails loud (the slopsquatting guard) — a version miss lists what IS published |
| advisories | consulted from the index BEFORE any bytes move | `[NIKA-REG-002]` hard refuse, no override in v1 |
| type | workflows only | names the kind (`X is a skill, not a workflow`) |
| source pin vetting | rev = full 40-hex, repo/path charset-closed, no traversal — URLs are CONSTRUCTED from vetted parts, never taken from fetched data | `[NIKA-REG-005]` |
| entry re-verify | the entry TOML is fetched and cross-checked field-by-field against the index (contract §4: never the index alone); `schema` must be 1; closed key sets on top-level, `[source]`, `[integrity]` | disagreement, unknown schema or unknown field refuses `[NIKA-REG-005]` |
| bytes | raw https fetch, 1 MiB cap, `sha256(bytes)` MUST equal the pinned digest | `[NIKA-REG-003]` — **nothing is written** |
| cache hit | bytes re-hashed against the digest record on EVERY use | `[NIKA-REG-004]` with the heal (delete + re-fetch) |

Offline story: a cache hit answers with zero network (re-verified); a bare ref pins its version at first resolve (`pin` record) and never floats (ADR-106 "pin by default"); a cache miss offline says so honestly. The fetch happens outside any workflow run, so workflow `permits:` do not gate it — the help text says this explicitly on both verbs.

`--fix` refuses registry refs before any network: a digest-pinned artifact stays read-only (editing the cache would poison its record) — the refusal teaches the workspace-copy move.

## Narrow v1 — scope table

| In | Out (and where it lives) |
|---|---|
| `registry:` refs on `check` + `run` | `nika add` install-into-cwd verb (ADR-106) |
| default public index | `--index` org/private indexes (ADR-106) |
| exact `owner/name[@version]` | bare-name resolution + ambiguity rules (needs the lockfile story) |
| pin record per name (no floating bare refs) | `nika.lock` team reproducibility (ADR-106) |
| advisory hard-refuse | `--yanked-ok` override (ADR-106) |
| hash + advisory + oracle-locally (`check` IS the audit) | signature verification (registry-v0.2 `[signature]`) |
| workflows | packs / skills / agents / templates (refused with their kind) |

## ADR-106 conformance / deviations

Follows ADR-106 where it exists: index resolution + newest-SemVer, advisory MUST-refuse (REG-002), https-only 1 MiB fetch, sha256-or-nothing (REG-003), unknown-schema refuse (REG-005), name-resolves-nowhere loud (REG-001), zero install-time execution. Stricter in one place: the digest of record is re-read from the ENTRY TOML and cross-checked against the index (the contract's "never against the index alone" MUST, which ADR-106's sketch reads off the index).

Deviations, each deliberate for the consumption-only lane: surface is `registry:` refs on check/run rather than the `nika add` verb (this issue's ask; add + lockfile + `--index` stay on the ADR lane, status stays `proposed`); publisher is REQUIRED in the ref (without a lockfile, the qualified form is the only shape immune to dependency confusion — get.py refuses ambiguous bare names, we sidestep them entirely); cache is `~/.nika/registry/` + digest records rather than the nika-blob CAS + cwd workfile (REG-004 is applied to the cache record: a local record pins bytes, a mismatch fails); NIKA-REG codes appear greppable in refusal text + `RegistryError::code()` but are not yet registered in nika-error/spec 05 (additive, lands with the `nika add` spec PR).

## Test proof

- TDD: 25 lib tests written first (RED on stubs: 21 failing captured, then GREEN), over the mock kernel HTTP seam — ref grammar accept/reject table, SemVer precedence (stable > rc, numeric ids), the three-GET happy path with URL construction asserted, tamper-refuse writes nothing, advisory-before-bytes (request count pinned), offline cache hit with zero requests, bare-ref pin offline, tampered-cache refuse, unknown index schema, not-found + version listing, non-workflow kind, honest offline miss, index/entry disagreement, smuggling-channel closed sets (top-level AND in-table), unknown entry schema, source-pin vetting (short rev, traversal path), 1 MiB cap, entry 404.
- 3 binary-contract tests (network-free by construction): parse refusal teaches the form at exit 3 on both verbs, `--fix` guard fires before any resolution, `--help` teaches the ref form + the permits line.
- Suites: nika-cli `--lib` 329 passed · bin_smoke 39 passed · nika-runtime `--lib` 115 passed · fmt + clippy (`-D warnings`) clean · fn-length / crate-size / expect / unwrap gates green.
- Live e2e against the shipped registry: fetch + verify + cache + full check ladder, offline cache hit, NIKA-REG-001 refusal.

Layout note: the resolution client lives at `nika_cli::registry` (module + sibling `tests.rs`, the nika-http precedent); the CLI arg seam is a bin-side module (`src/registry_args.rs`) because `main.rs` sits at exactly the 1500-LOC wall since #482 — the dispatcher stays a thin verb tree.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
