### PR TITLE
feat(agents): the plugin becomes a suite — every use case gets its crew (0.4.0)

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
-  "description": "Author AI workflows as checkable .nika.yaml files — the nika-authoring skill, the nika-author subagent, the language rule, three slash commands (/nika:check · /nika:explain · /nika:new), a check-on-edit hook and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.3.0",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.4.0",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "nika",
   "displayName": "Nika · Intent as Code",
-  "description": "Author AI workflows as checkable .nika.yaml files — the nika-authoring skill, the nika-author subagent, the language rule, three slash commands (/nika:check · /nika:explain · /nika:new), a check-on-edit hook and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.3.0",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.4.0",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "nika",
   "displayName": "Nika",
-  "description": "Author AI workflows as checkable .nika.yaml files. Bundles the nika-authoring skill, the nika-author subagent, the language rule, three commands (/check, /explain, /new), a check-on-edit hook and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.3.0",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.4.0",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,32 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.4.0 — 2026-07-12
+
+The suite release: one component per use case becomes a full crew —
+an agent with this bundle authors, debugs, operates and migrates
+workflows on its own.
+
+- Three new skills: `nika-debugging` (trace forensics · resume lines ·
+  surgical reruns), `nika-operating` (spend caps · permits · secrets ·
+  model swaps · CI goldens · OTLP export), `nika-migration` (scripts
+  and prompt chains → workflows, mapping table + parity protocol).
+- Two new subagents: `nika-debugger` (evidence-first run forensics
+  from the hash-chained trace) and `nika-migrator` (inventory →
+  native-first mapping → check loop → golden pin).
+- Two new commands: `/nika:trace` (verdict · root cause · tamper
+  check · the exact resume line) and `/nika:permits` (infer and paste
+  the tightest boundary).
+- The delegation rule: teaches the agent WHEN to propose a workflow
+  (repeatable · multi-step · spend-bound AI work) and which bundled
+  surface to reach for.
+- Two new Cursor hooks, both fail-open: `sessionStart` injects the
+  nika map when the workspace has workflows (surfaces · laws · where
+  traces live); `beforeShellExecution` denies a `nika run` on a file
+  with live check findings — the denial carries the findings, so the
+  agent repairs and reruns (audit-before-run, structurally
+  unskippable).
+
 ## 0.3.0 — 2026-07-12
 
 - Cursor first-class: the `.cursor-plugin/plugin.json` manifest (logo ·

--- a/.agents/plugins/nika/README.md
+++ b/.agents/plugins/nika/README.md
@@ -7,7 +7,8 @@
 Teach your agent to hand repeatable work to
 [Nika](https://github.com/supernovae-st/nika): a plain-text
 `.nika.yaml` workflow it can **check before a token is spent** and
-**verify after**. One `Add` installs the full bundle.
+**verify after**. One `Add` installs the full bundle — your agent
+learns to author, debug, operate and migrate workflows on its own.
 
 ```sh
 brew install supernovae-st/tap/nika   # the binary first; the plugin invokes it
@@ -18,10 +19,19 @@ brew install supernovae-st/tap/nika   # the binary first; the plugin invokes it
 | Component | What it does |
 |---|---|
 | `nika-authoring` skill | the author → check → repair loop, taught step by step |
+| `nika-debugging` skill | run forensics: trace ls → show → outputs → verify · resume lines · surgical reruns |
+| `nika-operating` skill | day-2 hardening: spend caps · permits · secrets · model swaps · CI goldens · OTLP export |
+| `nika-migration` skill | convert scripts, CI jobs and prompt chains to workflows — mapping table + parity protocol |
 | `nika-author` subagent | routes an intent to a template, fills the `# SLOT:` markers, loops `nika check` until rc=0 — read-only, never runs the workflow |
+| `nika-debugger` subagent | root-causes a failed or paused run from its hash-chained trace, hands back the exact resume line |
+| `nika-migrator` subagent | ports existing automation: inventory → native-first mapping → check loop → golden pin |
 | language rule | the 4-verb surface (`infer` · `exec` · `invoke` · `agent`), auto-loaded on `*.nika.yaml` |
+| delegation rule | teaches the agent WHEN to propose a workflow (repeatable · multi-step · spend-bound AI work) and which bundled surface to reach for |
 | `/nika:check` · `/nika:explain` · `/nika:new` | audit a file · explain a finding code · scaffold from a template |
+| `/nika:trace` · `/nika:permits` | read a run's flight recorder (verdict · root cause · resume line) · infer and paste the tightest permits boundary |
+| session-context hook | a workspace with workflows greets the agent with the full nika map at session start (surfaces · laws · where traces live) |
 | check-on-edit hook | every agent edit to a `*.nika.yaml` is audited immediately (findings in the hook log; never blocks the edit) |
+| guard-run hook | `nika run` on a file that fails `nika check` is denied with the findings — the audit-before-run law, structurally unskippable |
 | MCP oracle (8 tools) | `nika_check` · `nika_explain` · `nika_schema` · `nika_examples` · `nika_template` · `nika_canon` · `nika_catalog` · `nika_tools` — read-only, by design |
 
 <p align="center">
@@ -35,7 +45,8 @@ brew install supernovae-st/tap/nika   # the binary first; the plugin invokes it
 2. fill every `# SLOT:` marker — touch nothing else
 3. `nika check` — findings carry `NIKA-XXXX` codes with fix hints
 4. repair, re-check, until `rc=0`
-5. the human runs it: `nika run <file>`
+5. the human runs it: `nika run <file>` — and the trace proves it
+   (`nika trace verify`)
 
 No plugin store to audit on the workflow side either: everything
 callable is a tool under `invoke:`, and the engine ships its own
@@ -46,8 +57,13 @@ callable is a tool under `invoke:`, and the engine ships its own
 - **macOS GUI PATH**: Cursor may not inherit your shell PATH — if the
   MCP oracle does not start, launch Cursor from a terminal once
   (`open -a Cursor`) or ensure `nika` is reachable from GUI apps.
-- **Windows**: the check-on-edit hook is a bash script; without a bash
-  on PATH it fails open (the edit always proceeds — hooks never block).
+- **Windows**: the hooks are bash scripts; without a bash on PATH they
+  fail open (edits and runs always proceed — hooks never brick a
+  machine).
+- Every hook fails open by design: a missing binary, an unreadable
+  file or a broken oracle never blocks you. The ONLY deny is a
+  `nika run` on a file with live check findings — and the denial
+  carries the findings, so the agent repairs and reruns by itself.
 - Everything the oracle answers is read-only by design: the plugin can
   audit and teach, only YOU run workflows.
 

--- a/.agents/plugins/nika/agents/nika-debugger.md
+++ b/.agents/plugins/nika/agents/nika-debugger.md
@@ -1,0 +1,48 @@
+---
+name: nika-debugger
+description: Root-causes failed or paused Nika runs from their hash-chained traces. Use when nika run exited red, a run paused on a prompt and needs the exact resume line, a NIKA-XXXX runtime finding needs a cause, or a trace must be verified and explained. Evidence-first — reads .nika/traces via nika trace; proposes fixes and run lines, never executes them.
+---
+
+# nika-debugger · the run forensic
+
+You explain what a run DID, from its journal, and hand back the
+smallest fix. You never guess beyond the trace and you never rerun
+anything yourself.
+
+## The protocol (follow exactly)
+
+1. **Locate.** `nika trace ls` — pick the named trace, or the `★`
+   newest of the workflow in question. No trace? Say so: a run that
+   never started leaves no journal, so the problem is upstream
+   (binary, file path, check refusal).
+2. **Read.** `nika trace show <trace>` for the verdict card, then
+   `nika trace outputs <trace>` to walk per-task verb · duration ·
+   tokens · preview. The FIRST red task is the root cause;
+   downstream reds are fallout — say which is which.
+3. **Verify.** `nika trace verify <trace>` — exit 0 intact · 2
+   broken chain (say so prominently: the journal was altered) · 3
+   pre-chain. Cite the trace path in your report.
+4. **Decode.** Every finding code goes through
+   `nika explain NIKA-XXXX` — fold its cause · category · fix-form
+   into the diagnosis, never paraphrase from memory.
+5. **Cross-check the file.** `nika check <file>` (or the `nika_check`
+   MCP tool) — model resolution, permits, env expectations. A run
+   failure often becomes a check finding once you know where to look.
+6. **Hand off.** Report: root-cause task · the finding and its
+   teaching · the minimal fix (a file edit, an env var, a widened
+   permit — one thing) · the exact next command for the human:
+   - paused → `nika run <file> --resume <trace> --answer <task>=<value>`
+   - fixed upstream → `nika run <file> --from <task-id>`
+   - one flaky task → `nika run <file> --task <task-id>`
+
+## Hard lines
+
+- Never `nika run` — you propose the line, the human executes.
+- Never edit a trace, never delete a paused trace, never touch a
+  `.golden.json` to make red green (`nika test <file> --update` is
+  the human's deliberate move after an INTENTIONAL change).
+- The trace proves engine behavior; provider-side failures (an
+  outage, a model regression) are hypotheses — label them as such.
+- A missing binary is a stop: say
+  `brew install supernovae-st/tap/nika`, do not reconstruct runs
+  from memory.

--- a/.agents/plugins/nika/agents/nika-migrator.md
+++ b/.agents/plugins/nika/agents/nika-migrator.md
@@ -1,0 +1,59 @@
+---
+name: nika-migrator
+description: Ports an existing script, Makefile target, CI job or prompt chain to a checkable .nika.yaml workflow. Use when converting ad-hoc automation to nika, when a shell script wraps LLM/HTTP/file plumbing, or when a prompt chain in a doc should become a runnable, auditable file. Inventories side effects first, maps steps to the four verbs native-first, proves with check and a golden pin.
+---
+
+# nika-migrator · the automation porter
+
+You re-declare an existing automation's intent as a `.nika.yaml` the
+checker can audit. The source is the spec; the check is the oracle;
+parity is the proof.
+
+## The protocol (follow exactly)
+
+1. **Read the source completely** before writing anything. Inventory
+   in four lists: inputs (args, env, files read) · outputs (files,
+   stdout, API writes) · side effects (deploys, sends, deletes) ·
+   credentials. A guard clause in the source is INTENT — port it.
+2. **Route.** Pick the outer shape from the embedded templates
+   (`nika new --from '?'` prints the living list): chain · fanout ·
+   gate-and-act · etl-state · agent-loop · human-gated-ship.
+   `nika new --from <template> <file>.nika.yaml`, then fill the
+   `# SLOT:` markers.
+3. **Map native-first.** The order is `invoke: nika:*` →
+   `invoke: mcp:<server>/<tool>` → `exec:` last. HTTP → `nika:fetch` ·
+   JSON shaping → `nika:jq` or an `output:` binding · file plumbing →
+   `nika:read`/`nika:write` · LLM calls → `infer:` with `max_tokens` ·
+   loops → `for_each:` · conditionals → `when:` · parameters →
+   `vars:` + `${{ env.KEY }}` · credentials → `${{ secrets.X }}`
+   declared with an `egress:` sink. Every task that reads another's
+   output declares `depends_on`.
+4. **Guard the irreversible.** Any step the source author would have
+   hovered over before hitting enter (deploy · publish · send · rm)
+   gets a `nika:prompt` confirm gate before it.
+5. **Check-loop under mock.** `model: mock/echo` while shaping;
+   `nika check <file>` after every change until rc=0, then
+   `--native-strict`. Every surviving `exec:` (git, build tools, a
+   CLI with no MCP surface) gets its exec-ledger row in the header
+   comment.
+6. **Declare the boundary.** `nika check <file> --infer-permits` →
+   paste the `permits:` block in. The script trusted its author; the
+   workflow is default-deny.
+7. **Hand off with parity.** Report: the mapping (source step →
+   task) · what stayed `exec:` and why · the parity plan (run old
+   and new on the same input once, compare artifacts, then
+   `nika test <file> --update` pins the golden) · the run line with
+   its spend cap. The human runs both sides and retires the script.
+
+## Hard lines
+
+- Never delete or edit the source automation — retirement is the
+  human's call, after parity.
+- Never wrap the old script (`exec: bash old.sh`) and call it a
+  migration — that is the exact anti-pattern (`native-first/005`).
+- Never run the workflow; propose the line (`nika run` is the
+  human's move). Your oracle is read-only: check · explain · schema ·
+  examples · template · catalog · tools.
+- Secrets become declared secrets AT PORT TIME, never "TODO later".
+- A missing binary is a stop:
+  `brew install supernovae-st/tap/nika`.

--- a/.agents/plugins/nika/commands/permits.md
+++ b/.agents/plugins/nika/commands/permits.md
@@ -1,0 +1,26 @@
+---
+description: Infer and paste the tightest permits boundary — the workflow's declared blast radius, default-deny from then on
+argument-hint: <file.nika.yaml>
+allowed-tools: Bash(nika check:*), Read, Edit
+---
+
+Declare the blast radius — permits are data in the file, reviewable
+in a diff, default-deny once declared.
+
+Target: `$ARGUMENTS` (no argument? `Glob` for `*.nika.yaml` — one
+match runs, several ask).
+
+1. `nika check $ARGUMENTS --infer-permits` — the engine prints the
+   tightest `permits:` block the workflow actually needs (hosts ·
+   paths · tools), derived from the tasks, not guessed.
+2. Paste the block into the file. If a `permits:` block already
+   exists, diff the two and narrate what widened or narrowed —
+   a widening is a conscious decision, name what the new task
+   touches.
+3. `nika check $ARGUMENTS` — must stay clean with the boundary in
+   place. A permits finding here means a task reaches outside the
+   declared boundary: either the task is wrong or the boundary is —
+   ask which was intended, never silently widen.
+4. Close by narrating the boundary in one breath: which hosts it may
+   call, which paths it may touch, which tools it may invoke — and
+   that everything else is now refused at run time.

--- a/.agents/plugins/nika/commands/trace.md
+++ b/.agents/plugins/nika/commands/trace.md
@@ -1,0 +1,34 @@
+---
+description: Read a run's flight recorder — verdict, failing task, tamper check, and the exact resume line if paused
+argument-hint: [trace-or-workflow]
+allowed-tools: Bash(nika trace:*), Bash(nika explain:*), Read, Glob
+---
+
+Read the journal, not a memory of the terminal — `.nika/traces/` is
+the only truth about what a run did.
+
+Target: `$ARGUMENTS` (no argument? `nika trace ls` and take the `★`
+newest — say which one you picked).
+
+1. `nika trace show <trace>` — the verdict card. Then
+   `nika trace outputs <trace>` — per-task verb · duration · tokens ·
+   bounded preview. The FIRST red task is the root cause; downstream
+   reds are fallout.
+2. `nika trace verify <trace>` — exit 0 chain intact · 2 broken (the
+   journal was altered — report this FIRST) · 3 pre-chain.
+3. Report in this order:
+   - **Verdict** — completed · failed at `<task>` · paused on
+     `<prompt>`.
+   - **Root cause** — the failing task, its finding code decoded via
+     `nika explain NIKA-XXXX` (fold the teaching in, never
+     paraphrase from memory).
+   - **Integrity** — chain intact or not.
+   - **Next command** — paused:
+     `nika run <file> --resume <trace> --answer <task>=<value>`
+     (confirm gates take booleans) · fixed upstream:
+     `nika run <file> --from <task-id>` · one flaky task:
+     `nika run <file> --task <task-id>`.
+4. Never re-run anything yourself — `nika trace replay` re-renders
+   (never re-executes) if the human wants to watch it again; the run
+   line is theirs. Dashboards? `nika trace export <trace>` emits
+   OTLP/JSON lines any OTel viewer reads.

--- a/.agents/plugins/nika/hooks/cursor-hooks.json
+++ b/.agents/plugins/nika/hooks/cursor-hooks.json
@@ -1,8 +1,18 @@
 {
   "hooks": {
+    "sessionStart": [
+      {
+        "command": "./scripts/session-context.sh"
+      }
+    ],
     "afterFileEdit": [
       {
         "command": "./scripts/check-on-edit.sh"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "./scripts/guard-run.sh"
       }
     ]
   }

--- a/.agents/plugins/nika/rules/nika-delegation.mdc
+++ b/.agents/plugins/nika/rules/nika-delegation.mdc
@@ -1,0 +1,47 @@
+---
+description: When the user describes repeatable, multi-step or scheduled AI work (a prompt chain, an automation, a pipeline, "do this every time"), propose authoring it as a Nika workflow instead of ad-hoc scripting — and route to the bundled nika skills, subagents and MCP tools
+alwaysApply: false
+---
+
+# Nika delegation — when to reach for a workflow
+
+This project has the Nika toolchain installed. Nika turns repeatable
+AI work into ONE `.nika.yaml` file: audited before it runs
+(`nika check`), bounded while it runs (cost cap · permits · masked
+secrets), proven after it runs (hash-chained trace).
+
+## Reach for a workflow when the user asks for
+
+- a prompt chain or multi-step AI task they will run more than once
+- automation around LLM calls (fetch → infer → write, summarize
+  every X, watch-then-act)
+- anything with a spend concern, an approval step, or an audit need
+- converting an existing script/CI job that wraps AI or HTTP plumbing
+
+Do NOT reach for it for one-shot questions, interactive exploration,
+or pure code edits.
+
+## How to delegate (the bundled surfaces)
+
+- **Author**: the `nika-author` subagent (or the `nika-authoring`
+  skill) — template-first, check-loop until rc=0.
+- **Debug a run**: the `nika-debugger` subagent (or `nika-debugging`)
+  — trace-first forensics, exact resume line.
+- **Port a script**: the `nika-migrator` subagent (or
+  `nika-migration`) — inventory, native-first mapping, parity pin.
+- **Harden for production**: the `nika-operating` skill — spend caps,
+  permits, secrets, CI goldens, OTLP export.
+- **Quick oracle, no shell**: the read-only MCP tools — `nika_check` ·
+  `nika_explain` · `nika_schema` · `nika_examples` · `nika_template` ·
+  `nika_canon` · `nika_catalog` · `nika_tools`.
+
+## The laws that always apply
+
+- `nika check <file>` must pass before ANY run is proposed — never
+  hand over a file that does not check clean.
+- Running is the human's move: propose the `nika run` line (with
+  `--max-cost-usd` when spend matters), never execute it unasked.
+- Cost honesty: report the ceiling (`≤ $X`) or name why it is a
+  floor; a local model is "unpriced", never "free".
+- Missing binary: `brew install supernovae-st/tap/nika` — never
+  improvise YAML from memory when the oracle is unavailable.

--- a/.agents/plugins/nika/scripts/guard-run.sh
+++ b/.agents/plugins/nika/scripts/guard-run.sh
@@ -49,6 +49,10 @@ case "$cmd" in *--resume*) allow ;; esac
 
 # The workflow file: first *.nika.yaml / *.nika.yml token in the command.
 file=""
+# set -f: the unquoted expansion must split into words WITHOUT
+# globbing (a literal `nika run *.nika.yaml` would otherwise expand
+# against the hook's own cwd).
+set -f
 for word in $cmd; do
   case "$word" in
     *.nika.yaml | *.nika.yml)
@@ -57,6 +61,7 @@ for word in $cmd; do
       ;;
   esac
 done
+set +f
 [ -n "$file" ] || allow
 
 # Resolve relative to the payload cwd; unfindable file fails open

--- a/.agents/plugins/nika/scripts/guard-run.sh
+++ b/.agents/plugins/nika/scripts/guard-run.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# guard-run — the execution seatbelt: before the agent shells out a
+# `nika run`, audit the workflow. Check is the gate the language is
+# built on; an agent must not be able to skip it by accident.
+#
+# Cursor hook contract (docs/agent/hooks · beforeShellExecution):
+# input is JSON on STDIN ({command, cwd, sandbox}); stdout is the
+# JSON permission response ({"permission":"allow"|"deny", plus
+# agent_message/user_message on deny). Exit 0 always — the JSON
+# carries the decision.
+#
+# Deny is TEACHING, not punishment: the agent_message carries the
+# findings so the agent repairs and reruns — the check loop becomes
+# structurally unskippable. Everything else fails open: a missing
+# binary, a file we cannot find, a broken oracle (exit 3) must never
+# block the human's terminal.
+set -euo pipefail
+
+input="$(cat)"
+
+allow() {
+  printf '{"permission":"allow"}\n'
+  exit 0
+}
+
+# command + cwd from the stdin JSON — python3 when present, sed fallback.
+if command -v python3 >/dev/null 2>&1; then
+  cmd="$(printf '%s' "$input" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("command", ""))
+except Exception:
+    print("")' 2>/dev/null || true)"
+  cwd="$(printf '%s' "$input" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("cwd", ""))
+except Exception:
+    print("")' 2>/dev/null || true)"
+else
+  cmd="$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  cwd="$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+
+# Only `nika run …` is gated — every other command flows.
+printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])nika[[:space:]]+run([[:space:]]|$)' || allow
+
+# A resumed run replays an already-audited plan from its trace; the
+# gate is for fresh runs of the file as it stands now.
+case "$cmd" in *--resume*) allow ;; esac
+
+# The workflow file: first *.nika.yaml / *.nika.yml token in the command.
+file=""
+for word in $cmd; do
+  case "$word" in
+    *.nika.yaml | *.nika.yml)
+      file="$word"
+      break
+      ;;
+  esac
+done
+[ -n "$file" ] || allow
+
+# Resolve relative to the payload cwd; unfindable file fails open
+# (the run itself will name the real error better than we can).
+case "$file" in
+  /*) ;;
+  *) [ -n "$cwd" ] && file="$cwd/$file" ;;
+esac
+[ -f "$file" ] || allow
+command -v nika >/dev/null 2>&1 || allow
+
+set +e
+findings="$(nika check "$file" --color never 2>&1)"
+rc=$?
+set -e
+
+# rc 0 = clean → run flows. rc 2 = findings → deny and teach.
+# Anything else (3 = broken oracle) fails open.
+if [ "$rc" -ne 2 ]; then
+  allow
+fi
+
+findings="$(printf '%s' "$findings" | head -c 2000)"
+
+if command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$findings" | python3 -c '
+import json, sys
+findings = sys.stdin.read()
+msg = ("nika check failed on this workflow - repair the findings, "
+       "re-run nika check until it passes, then run again.\n\n" + findings)
+print(json.dumps({
+    "permission": "deny",
+    "agent_message": msg,
+    "user_message": "nika run blocked: the workflow does not pass nika check yet.",
+}))'
+else
+  # No python3: a fixed, pre-escaped message (never interpolate raw
+  # findings into JSON by hand).
+  printf '{"permission":"deny","agent_message":"nika check failed on this workflow - run nika check on the file, repair the findings it names, then run again.","user_message":"nika run blocked: the workflow does not pass nika check yet."}\n'
+fi
+exit 0

--- a/.agents/plugins/nika/scripts/session-context.sh
+++ b/.agents/plugins/nika/scripts/session-context.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# session-context — the omniscience seed: when a session opens in a
+# workspace that uses Nika, hand the agent the map once, up front —
+# which surfaces exist (MCP tools · subagents · skills · commands),
+# which laws bind (check before run · cost honesty), where runs
+# live (.nika/traces/).
+#
+# Cursor hook contract (docs/agent/hooks · sessionStart): input is
+# JSON on STDIN; the response's "additional_context" string joins the
+# session's initial context. Exit 0 always; a workspace without Nika
+# gets silence ({}), never noise.
+#
+# The context string is STATIC — fixed content, hand-escaped once,
+# zero interpolation (nothing user-controlled can break the JSON).
+set -euo pipefail
+
+input="$(cat)"
+
+# Workspace root: the payload cwd when present, else where Cursor ran us.
+if command -v python3 >/dev/null 2>&1; then
+  cwd="$(printf '%s' "$input" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("cwd", ""))
+except Exception:
+    print("")' 2>/dev/null || true)"
+else
+  cwd="$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+[ -n "$cwd" ] && [ -d "$cwd" ] && cd "$cwd" || true
+
+# Nika-enabled = a .nika/ store or any workflow file near the root.
+# Bounded probe (depth 3 · prune the heavy dirs) — this runs at every
+# session open and must stay in the milliseconds.
+enabled=""
+if [ -d .nika ]; then
+  enabled=1
+else
+  hit="$(find . -maxdepth 3 \( -name node_modules -o -name .git -o -name target -o -name dist \) -prune -o \( -name '*.nika.yaml' -o -name '*.nika.yml' \) -print -quit 2>/dev/null || true)"
+  [ -n "$hit" ] && enabled=1
+fi
+
+if [ -z "$enabled" ]; then
+  printf '{}\n'
+  exit 0
+fi
+
+printf '%s\n' '{"additional_context":"This workspace uses Nika (nika.sh): repeatable AI work lives in .nika.yaml workflow files, audited BEFORE they run (nika check), cost-bounded while they run, hash-chain traced after (.nika/traces/). Laws: (1) nika check <file> must pass before proposing any run; running is the human'"'"'s move (propose the nika run line, with --max-cost-usd when spend matters). (2) Cost honesty: report the ceiling; a local model is unpriced, never free. Installed surfaces: read-only MCP oracle (nika_check, nika_explain, nika_schema, nika_examples, nika_template, nika_canon, nika_catalog, nika_tools) · subagents nika-author (write a workflow), nika-debugger (root-cause a run from its trace), nika-migrator (port a script) · skills nika-authoring, nika-debugging, nika-operating, nika-migration · commands /nika:check /nika:explain /nika:new /nika:trace /nika:permits. CLI: nika check|run|trace|graph|explain|inspect|new|examples|catalog|tools|doctor. When the user describes repeatable or multi-step AI work, propose a Nika workflow."}'
+exit 0

--- a/.agents/plugins/nika/skills/nika-debugging/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-debugging/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: nika-debugging
+description: Diagnose and repair failed, paused or suspicious Nika runs from their traces (.nika/traces). Use when nika run exited red, a run paused on a prompt, a NIKA-XXXX runtime finding needs a root cause, a trace must be read or tamper-verified, or a fixed workflow needs a surgical partial rerun.
+---
+
+# Debugging Nika runs
+
+Every run writes a hash-chained journal to `.nika/traces/`. That journal
+is the ONLY truth about what happened — debug from the trace, never from
+a memory of the terminal scroll.
+
+## The forensic loop (evidence first)
+
+1. **Locate the run**: `nika trace ls` — age · size · workflow ·
+   terminal state (completed/failed/paused) · `★` marks the newest
+   trace of each workflow (the resume candidate).
+2. **Read the card**: `nika trace show <trace>` — the final verdict,
+   the waves, per-task outcome. `nika trace replay <trace>` re-renders
+   the run live (replay = re-render, NEVER re-execute).
+3. **Find the failing task**: `nika trace outputs <trace>` — verb ·
+   duration · tokens · a bounded preview per task (full value:
+   `nika trace peek`). The first red task is the root; everything
+   downstream is fallout.
+4. **Decode the finding**: `nika explain NIKA-XXXX` teaches the cause ·
+   category · fix-form of any code the trace carries.
+5. **Re-audit the file**: `nika check <file>` — a run that failed often
+   fails again at check once you know what to look for (a model that no
+   longer resolves, a missing env var, a permits violation).
+6. **Fix minimally, rerun surgically** (below). Re-check before any
+   rerun.
+
+## Paused runs (prompts and confirm gates)
+
+A run paused on `nika:prompt` is not failed — it is waiting. The card
+names the unanswered prompt. Resume it:
+
+```
+nika run <file> --resume <trace> --answer <task>=<value>
+```
+
+Confirm gates take booleans (`--answer approve=true`). Removing a
+paused trace refuses without `--force` and names the prompt it would
+destroy — that refusal is protecting an answer, not being difficult.
+
+## Surgical reruns (never restart what already worked)
+
+- `nika run <file> --from <task-id>` — rerun from one task onward,
+  keeping upstream results.
+- `nika run <file> --task <task-id>` — rerun exactly one task.
+- After an intentional behavior change, refresh the pin:
+  `nika test <file> --update` rewrites the golden from an offline mock
+  run — never hand-edit a `.golden.json` to make red green.
+
+## Common root causes (check these before anything exotic)
+
+- **Model does not resolve**: `nika check <file> --json` →
+  `models_resolve` says whether every `model:` runs in THIS binary;
+  `nika catalog` names the env var each provider needs.
+- **Missing credential**: secrets ride `${{ secrets.X }}` /
+  `${{ env.KEY }}` — the trace shows the task, the shell shows the
+  env. `nika doctor` audits the machine side.
+- **Timeout too tight**: local providers need `timeout: "300s"` or
+  more — thinking models routinely think past 30s.
+- **Permits violation**: the run was blocked by its own declared
+  boundary — read the finding, then either the task is wrong or the
+  boundary is (widen it consciously, never delete it).
+- **Cost cap hit**: `--max-cost-usd` blocks BEFORE the call that would
+  cross the cap — that is the feature working, not a bug. Raise the
+  cap deliberately or shrink the task.
+
+## Tamper evidence
+
+`nika trace verify <trace>` checks the hash chain: any edited,
+inserted, dropped or reordered line breaks every hash after it.
+Exit 0 intact · 2 broken · 3 unchained (pre-chain journal). Cite the
+trace in any report — a verified chain is proof, prose is not.
+
+## Honesty lines
+
+- The trace tells you what the engine did. It cannot tell you WHY a
+  provider returned garbage — a provider-side outage or a model
+  regression is named as a hypothesis, never asserted as fact.
+- Never edit a trace. Never delete a paused trace to "clean up".
+- If the binary is missing: `brew install supernovae-st/tap/nika` —
+  do not reconstruct runs from memory.

--- a/.agents/plugins/nika/skills/nika-migration/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-migration/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: nika-migration
+description: Convert existing automation — shell scripts, Python glue, Makefile targets, CI jobs, prompt chains in docs — into checkable .nika.yaml workflows. Use when a script wraps LLM calls or HTTP/file plumbing, a prompt chain lives in a README or notebook, or ad-hoc automation needs audit, cost bounds and replayable traces.
+---
+
+# Migrating existing automation to Nika
+
+A script runs; a workflow is **audited before it runs, bounded while
+it runs, and proven after it runs**. Migration is not translation —
+it is re-declaring the intent so the checker can see it.
+
+## When to migrate (and when not to)
+
+Migrate when the automation: calls an LLM anywhere · chains
+HTTP/file/JSON steps around AI output · is repeated (cron, CI, "run
+this every release") · needs a cost bound or an audit trail · is
+handed to someone else to run.
+
+Do NOT migrate: one-shot commands · interactive debugging sessions ·
+sub-second pure-shell pipelines with zero AI and zero HTTP (a
+`Makefile` that only compiles code is already in its best form).
+
+## The mapping table
+
+| In the script | In the workflow |
+|---|---|
+| a step / function | one task, exactly one verb |
+| `curl` / `wget` / `fetch()` helper | `invoke:` `tool: "nika:fetch"` |
+| `jq` / `sed` on JSON | `nika:jq`, or an `output:` binding |
+| `cat` / `cp` / `mkdir` / `tee` | `nika:read` / `nika:write` (`create_dirs: true`) |
+| in-place file edits | `nika:edit` |
+| the LLM call (SDK, `curl` to an API) | `infer:` with `prompt`, `schema?`, `max_tokens` |
+| an agent loop (retry-until-good) | `agent:` with `tools` allowlist + `max_turns` |
+| `for item in …` | `for_each:` fan-out |
+| `if <condition>` | a `when:` gate |
+| `$1`, `$ENV_VAR` parameters | `vars:` + `--var key=value` · `${{ env.KEY }}` |
+| `API_KEY=…` literals | `${{ secrets.X }}` + `secrets:` block with its `egress:` sink |
+| step B reads step A's output | `${{ tasks.A.output }}` + `depends_on: [A]` |
+| the irreversible step (deploy, send, publish) | a confirm gate before it (`nika:prompt`) — human answers at run time |
+| what no builtin/MCP covers (git, build tools) | `exec:` + a row in the exec ledger |
+
+## The port protocol
+
+1. **Read the source completely.** Inventory: inputs · outputs · side
+   effects · credentials · the failure the author feared (that guard
+   clause is the intent — keep it).
+2. **Route to a template**: `nika new --from '?'` lists the embedded
+   set; pick the OUTER shape (chain · fanout · gate-and-act ·
+   etl-state · agent-loop · human-gated-ship) and instantiate with
+   `nika new --from <template> <file>.nika.yaml`.
+3. **Map with the table.** Native-first is the law: `invoke: nika:*`
+   → `invoke: mcp:<server>/<tool>` → `exec:` last. Every surviving
+   `exec:` gets its ledger row (task · command · why no native path ·
+   unlock that removes it).
+4. **Shape under mock**: `model: mock/echo` while the structure
+   settles — `nika check <file>` after every change, repair from the
+   diagnostics until exit 0, then `--native-strict`.
+5. **Declare the boundary**: `nika check <file> --infer-permits` →
+   paste the `permits:` block. The script trusted its author; the
+   workflow trusts nobody by default.
+6. **Prove parity once**: run the old script and
+   `nika run <file> --model mock/echo` (or a local model) side by
+   side on the same input; compare the artifacts. Then pin:
+   `nika test <file> --update` writes the golden.
+7. **Hand off honestly**: the workflow file + the golden + the run
+   line (`nika run <file> --var … --max-cost-usd <n>`). The human
+   decides when the old script retires — never delete it yourself.
+
+## Traps
+
+- Porting a helper script by wrapping it (`exec: node helper.mjs`) is
+  not a migration — that is `native-first/005`. Unbundle the helper
+  into fetch/jq/read/write tasks.
+- A prompt chain in a doc usually hides implicit state ("then take
+  the output and…") — make every handoff an explicit
+  `${{ tasks.X.output }}` reference so the checker can trace it.
+- Scripts swallow errors (`|| true`); workflows should not. If the
+  source ignored a failure, ask whether that was intent or debt —
+  default to letting the task fail loudly.
+- Credentials in the script's environment become DECLARED secrets
+  with sinks — the engine masks them; the script never did.

--- a/.agents/plugins/nika/skills/nika-operating/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-operating/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: nika-operating
+description: Operate Nika workflows day-2 — spend caps, permits boundaries, secrets, model swaps (cloud/local), CI wiring, trace export. Use when hardening a working workflow for production, wiring it into CI or a scheduler, capping cost, tightening the permits boundary, swapping models, or exporting traces to OpenTelemetry.
+---
+
+# Operating Nika workflows
+
+Authoring makes a file pass `nika check`. Operating makes it safe to
+run unattended: bounded spend, a declared blast radius, masked
+credentials, a model you chose, and a journal you can export.
+
+## Spend (the envelope is part of the contract)
+
+- `nika check <file>` prints the cost BEFORE any token: `≤ $X` is a
+  ceiling · `≥ $X FLOOR` means at least one task is unbounded — fix
+  the reason (a missing `max_tokens`, an uncataloged model, an
+  expression fan-out), never ship a floor to production.
+- Cap the run: `nika run <file> --max-cost-usd <n>` blocks BEFORE the
+  call that would cross the cap.
+- A local model is **unpriced compute, not free** — say "unpriced",
+  never "$0".
+
+## Permits (declare the blast radius)
+
+```
+nika check <file> --infer-permits
+```
+
+prints the tightest `permits:` block the workflow needs — paste it
+into the file. From then on the boundary is default-deny: a new host,
+path or tool must be added consciously, in a reviewable diff. Permits
+are data, not config — they travel with the file through PR review.
+
+## Secrets (masked, declared, sunk)
+
+- Every credential rides `${{ secrets.X }}`, declared in the
+  `secrets:` block with its `egress:` sink — the engine masks it in
+  logs and refuses to send it anywhere but the declared sink.
+- Values come from the environment at run time; CI injects them the
+  same way a shell does. Never a literal in YAML, never in a trace.
+- `nika doctor` audits the machine: binary, PATH, provider env vars.
+
+## Models (a one-line swap, both directions)
+
+- Models are `provider/name`. `nika catalog` is the embedded registry:
+  providers · models · capabilities · which env var each needs.
+- Shape with `mock/echo` (offline, deterministic, zero keys). Prove
+  structure first, spend later.
+- Sovereignty path: `--model ollama/<model>` runs local — same file,
+  same check, same trace. Give local providers `timeout: "300s"`+.
+- The file does not hardcode a vendor: swapping cloud↔local is a
+  `--model` flag or one line in the YAML, never a rewrite.
+
+## CI (the check is the gate, the golden is the pin)
+
+- Gate every PR: `nika check <file> --json` — exit 0 clean · 2
+  findings · 3 broken oracle. Parse `clean`, `conformance[]`,
+  `pricing`, `models_resolve` from the payload.
+- Pin behavior: `nika test <file> --update` writes
+  `<file>.golden.json` from an offline mock run; `nika test <file>`
+  replays and compares — deterministic, zero keys, CI-safe.
+- `--native-strict` in CI keeps `exec:` honest: any shell task an
+  embedded builtin covers fails the gate (the exec ledger documents
+  the survivors).
+- Schedule with the scheduler you already have (cron · CI · a
+  systemd timer): the engine is a binary, the workflow is a file,
+  `--var key=value` carries the parameters.
+
+## Observability (the journal is exportable, not captive)
+
+- `nika trace export <trace>` projects the journal to OTLP/JSON
+  lines — drag into Jaeger UI (≥1.60) or POST to any OTLP/HTTP
+  endpoint. Local file, zero collector, zero vendor.
+- `nika trace ls` shows the store; retention never collects the `★`
+  newest trace of each workflow. `nika trace rm --older-than <dur>`
+  prunes deliberately.
+- Audits cite `nika trace verify <trace>` (hash-chain intact), never
+  a log screenshot.
+
+## Production checklist
+
+1. `nika check <file>` — clean, ceiling not floor.
+2. `nika check <file> --native-strict` — exec ledger complete.
+3. `permits:` pasted from `--infer-permits` — default-deny.
+4. Secrets in `secrets:` with sinks — env-injected, never literal.
+5. Golden pinned (`nika test <file> --update`, committed).
+6. Spend cap on the run line (`--max-cost-usd`).
+7. Trace store known (`.nika/traces/`) — export wired if anyone
+   watches dashboards.


### PR DESCRIPTION
## The suite release — 0.4.0

One component per use case becomes a full crew. An agent with the bundle installed authors, debugs, operates and migrates workflows on its own — the "omniscient" install.

| Use case | Skill | Subagent | Command | Hook |
|---|---|---|---|---|
| Author | nika-authoring | nika-author | /check /explain /new | check-on-edit |
| Debug a run | **nika-debugging** | **nika-debugger** | **/trace** | |
| Operate day-2 | **nika-operating** | | **/permits** | **guard-run** |
| Migrate scripts | **nika-migration** | **nika-migrator** | | |
| Omniscience | | | | **session-context** + delegation rule |

### The two new hooks (Cursor · both fail-open)

- **sessionStart** — a workspace with workflows greets the agent with the nika map once, up front: surfaces (MCP tools · subagents · skills · commands), laws (check-before-run · cost honesty), where traces live. Static JSON, zero interpolation, 31ms.
- **beforeShellExecution** — a `nika run` on a file with live check findings is **denied, with the findings in the deny message**, so the agent repairs and reruns by itself. Audit-before-run becomes structurally unskippable. `--resume` flows (replays an already-audited plan); missing binary/file and a broken oracle (rc 3) fail open.

### Truth discipline

- Every taught command probed against the installed binary before writing: `trace peek/export/rm --older-than` · `run --resume/--from/--task` · `check --json/--infer-permits/--native-strict` · `test --update`.
- Hook contracts re-fetched from cursor.com/docs/agent/hooks (stdin `{command, cwd}` → `{"permission", "agent_message"}` · sessionStart `additional_context`) — not assumed.
- Hook battery 16/16 local: allow/deny matrix (chained commands · abs/rel paths · substring false-positives) · JSON validity on real multiline findings containing quotes · malformed stdin · the no-python3 fallback literal parsed.

### Versions

All three manifests (`.cursor-plugin` · `.claude-plugin` · `.codex-plugin`) move together to **0.4.0**; CHANGELOG + README component table updated. Mirror resync to nika-agents follows the merge (the nightly parity pin will otherwise flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
