### PR TITLE
docs(llms-install): the gh extension lane joins the agent runbook

### DIFF
--- a/llms-install.md
+++ b/llms-install.md
@@ -30,6 +30,13 @@ nix profile install github:supernovae-st/nika
 # one-shot, no install: nix run github:supernovae-st/nika -- --version
 ```
 
+**GitHub CLI present (Actions runners · Codespaces · agents with `gh`):**
+
+```sh
+gh extension install supernovae-st/gh-nika
+gh nika --version   # pass-through to a PATH nika, else a one-time checksum-verified release fetch
+```
+
 **No package manager (bare Linux/macOS box):** fetch the release
 tarball and verify it against `SHA256SUMS` — auditable, no `curl | sh`.
 Discover the version via the web redirect, NOT the GitHub API (anonymous


### PR DESCRIPTION
One install block in the agent runbook: [gh-nika](https://github.com/supernovae-st/gh-nika) (v1.0.0 tagged today — pass-through to a PATH `nika`, else a one-time SHA256SUMS-verified release fetch; CI covers shellcheck/shfmt + both lanes live). The everywhere docs map and the constellation table already carry it; the runbook agents actually read was the missing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)