### PR TITLE
docs(agents): kit 0.4.1 — every teaching earned by the fresh-user gauntlet

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika · Intent as Code",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,30 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.4.1 — 2026-07-12
+
+Everything in this patch was earned by a fresh-user gauntlet run
+against the released binary (real API workflows · real failures ·
+real tokens): each teaching below is a friction that actually fired.
+
+- session-context hook: an equipped repo (`nika init` wrote
+  `.cursor/rules/nika.mdc`) now gets the map at session start even
+  before its first workflow exists — that first session is exactly
+  when the map matters.
+- nika-debugging: prompts headless FAIL with
+  `NIKA-BUILTIN-PROMPT-001` (a terminal blocks, an agent's world does
+  not) — same `--resume --answer` line either way; the failed-run
+  card's own `autopsy:` line is the entry point.
+- nika-operating: the secrets taint FLOWS — every downstream sink of
+  secret-derived data needs its own `egress:` entry (worked example);
+  `host:`-scoped egress cannot be proven against an interpolated URL;
+  mock mocks the MODEL, not the tools (goldens are for hermetic
+  workflows — network truth is proven by traces).
+- nika-migration: `curl … | jq` collapses into ONE fetch task
+  (`mode: jq` + `jq:`); an API fetch needs `mode: raw`/`jq` — the
+  default `markdown` mode is for pages and escapes JSON; `nika:jq`'s
+  arg is `expression`.
+
 ## 0.4.0 — 2026-07-12
 
 The suite release: one component per use case becomes a full crew —

--- a/.agents/plugins/nika/scripts/session-context.sh
+++ b/.agents/plugins/nika/scripts/session-context.sh
@@ -28,11 +28,13 @@ else
 fi
 [ -n "$cwd" ] && [ -d "$cwd" ] && cd "$cwd" || true
 
-# Nika-enabled = a .nika/ store or any workflow file near the root.
-# Bounded probe (depth 3 · prune the heavy dirs) — this runs at every
-# session open and must stay in the milliseconds.
+# Nika-enabled = a .nika/ store, an equipped repo (`nika init` wrote
+# .cursor/rules/nika.mdc — the session right after init is exactly
+# when the map matters, before any workflow exists), or any workflow
+# file near the root. Bounded probe (depth 3 · prune the heavy dirs)
+# — this runs at every session open and must stay in the milliseconds.
 enabled=""
-if [ -d .nika ]; then
+if [ -d .nika ] || [ -f .cursor/rules/nika.mdc ]; then
   enabled=1
 else
   hit="$(find . -maxdepth 3 \( -name node_modules -o -name .git -o -name target -o -name dist \) -prune -o \( -name '*.nika.yaml' -o -name '*.nika.yml' \) -print -quit 2>/dev/null || true)"

--- a/.agents/plugins/nika/skills/nika-debugging/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-debugging/SKILL.md
@@ -29,18 +29,27 @@ a memory of the terminal scroll.
 6. **Fix minimally, rerun surgically** (below). Re-check before any
    rerun.
 
-## Paused runs (prompts and confirm gates)
+## Prompts and confirm gates (paused OR failed — same answer line)
 
-A run paused on `nika:prompt` is not failed — it is waiting. The card
-names the unanswered prompt. Resume it:
+On a terminal, `nika:prompt` blocks and waits (the run shows as
+`paused` in `nika trace ls`). Headless — which is where an agent
+lives — a prompt without a `default:` FAILS with
+`NIKA-BUILTIN-PROMPT-001` instead. Both states resolve with the same
+line:
 
 ```
 nika run <file> --resume <trace> --answer <task>=<value>
 ```
 
-Confirm gates take booleans (`--answer approve=true`). Removing a
-paused trace refuses without `--force` and names the prompt it would
-destroy — that refusal is protecting an answer, not being difficult.
+Confirm gates take booleans (`--answer approve=true`); every task the
+journal already proved is skipped as a visible cache hit, so only the
+prompt and its downstream run. Removing a paused trace refuses
+without `--force` and names the prompt it would destroy — that
+refusal is protecting an answer, not being difficult.
+
+A failed run's card prints its own forensics line (`autopsy:
+nika trace peek <trace> <task>`) — start there, it points at the
+exact failing task.
 
 ## Surgical reruns (never restart what already worked)
 

--- a/.agents/plugins/nika/skills/nika-migration/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-migration/SKILL.md
@@ -25,8 +25,9 @@ sub-second pure-shell pipelines with zero AI and zero HTTP (a
 | In the script | In the workflow |
 |---|---|
 | a step / function | one task, exactly one verb |
-| `curl` / `wget` / `fetch()` helper | `invoke:` `tool: "nika:fetch"` |
-| `jq` / `sed` on JSON | `nika:jq`, or an `output:` binding |
+| `curl` / `wget` / `fetch()` helper | `invoke:` `tool: "nika:fetch"` — **for an API, set `mode: raw` or `mode: jq`** (the default `markdown` mode is for pages and escapes JSON bodies) |
+| `curl … \| jq` in one breath | ONE fetch task: `mode: jq` + `jq: '<expression>'` — the shape rides the fetch |
+| `jq` / `sed` on JSON | `nika:jq` (arg name is `expression`), or an `output:` binding |
 | `cat` / `cp` / `mkdir` / `tee` | `nika:read` / `nika:write` (`create_dirs: true`) |
 | in-place file edits | `nika:edit` |
 | the LLM call (SDK, `curl` to an API) | `infer:` with `prompt`, `schema?`, `max_tokens` |

--- a/.agents/plugins/nika/skills/nika-operating/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-operating/SKILL.md
@@ -34,8 +34,30 @@ are data, not config — they travel with the file through PR review.
 ## Secrets (masked, declared, sunk)
 
 - Every credential rides `${{ secrets.X }}`, declared in the
-  `secrets:` block with its `egress:` sink — the engine masks it in
-  logs and refuses to send it anywhere but the declared sink.
+  `secrets:` block (`source: env` + `key: VAR_NAME`) with its
+  `egress:` sinks — the engine masks it in logs and refuses to send
+  it anywhere but the declared sinks.
+- **The taint FLOWS**: the output of a task that used a secret is
+  secret-derived, and every downstream sink it reaches needs its own
+  `egress:` entry. An authed fetch whose output feeds an `infer:`
+  declares both:
+
+  ```yaml
+  secrets:
+    gh_token:
+      source: env
+      key: GITHUB_TOKEN
+      egress:
+        - to: "nika:fetch"
+        - to: "infer"
+  ```
+
+  The checker names the exact chain when one is missing
+  (`secrets.X → tasks.A.output → tasks.B.output`).
+- A `host:`-scoped egress cannot be proven against an interpolated
+  URL (`${{ vars.repo }}` in the address) — the checker refuses
+  conservatively. Pin the URL, or drop the `host:` scope and keep
+  the tool-level sink.
 - Values come from the environment at run time; CI injects them the
   same way a shell does. Never a literal in YAML, never in a trace.
 - `nika doctor` audits the machine: binary, PATH, provider env vars.
@@ -57,8 +79,13 @@ are data, not config — they travel with the file through PR review.
   findings · 3 broken oracle. Parse `clean`, `conformance[]`,
   `pricing`, `models_resolve` from the payload.
 - Pin behavior: `nika test <file> --update` writes
-  `<file>.golden.json` from an offline mock run; `nika test <file>`
-  replays and compares — deterministic, zero keys, CI-safe.
+  `<file>.golden.json` from a mock run; `nika test <file>` replays
+  and compares — deterministic, zero model keys, CI-safe.
+- **Mock mocks the MODEL, not the tools**: a live `nika:fetch` still
+  rides the network under `nika test`, and a `secrets:` entry still
+  resolves from the environment (export a dummy in CI). Golden the
+  hermetic workflows (read · jq · write · infer); a workflow whose
+  truth lives on the network is proven by its TRACE, not a golden.
 - `--native-strict` in CI keeps `exec:` honest: any shell task an
   embedded builtin covers fails the gate (the exec ledger documents
   the survivors).


### PR DESCRIPTION
Kit 0.4.1 — a fresh-user gauntlet against the released binary (real workflows, real API failures, real spend) fed every patch. Nothing speculative; each teaching is a friction that actually fired:

- **session-context hook**: an equipped repo (`nika init` wrote `.cursor/rules/nika.mdc`) now gets the map at session start even before its first workflow exists — that first session is exactly when the map matters. (Gauntlet: post-init silence.)
- **nika-debugging**: headless, `nika:prompt` without `default:` FAILS with `NIKA-BUILTIN-PROMPT-001` (a terminal blocks; an agent has no TTY) — the resume line is identical either way; the failed card's own `autopsy:` line is the entry point. (Gauntlet: prompt run + `--resume --answer approve=true` proven, 1 cache hit.)
- **nika-operating**: secrets taint FLOWS — worked `egress:` example showing each downstream sink sanctioned (the checker names the exact chain); `host:`-scoped egress vs interpolated URLs refuses statically; **mock mocks the MODEL, not the tools** — goldens are for hermetic workflows, network truth is proven by traces. (Gauntlet: 3-leak chain resolved to clean; golden failed on live fetch then proven on a hermetic file.)
- **nika-migration**: `curl … | jq` collapses into ONE fetch task (`mode: jq` + `jq:`); an API fetch needs `mode: raw`/`jq` — the default `markdown` mode is for pages and escapes JSON bodies; `nika:jq`'s arg is `expression`. (Gauntlet: the port failed twice on exactly these, then ran at $0.00003.)

Hook regression battery re-run: equipped-repo map (T18) · empty-dir silence · vocab law · versions agree at 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
