### PR TITLE
chore(nika-catalog): the openai showcase seats leave 2024 — gpt-5.2 and gpt-5-mini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   (absolute patterns errored before); the SEC-004 refusal now names the
   real walk root.
 
+### Changed
+
+- **The openai showcase seats leave 2024** — the catalog's two openai
+  showcase models are now `gpt-5.2` (default) and `gpt-5-mini` (cheap),
+  matching the live API's current family and the spec's teaching
+  surface (both already priced + capability-mapped; `gpt-4o` and every
+  other live id keeps working verbatim through provider pass-through —
+  proven with a live `openai/gpt-5.2` run, 780ms · $0.000098).
+
 ### Added
 
 - **Pre-generated shell completions ride the release tarballs** (#487)

--- a/crates/nika-catalog/data/llm-providers.toml
+++ b/crates/nika-catalog/data/llm-providers.toml
@@ -49,24 +49,24 @@ env_var = "OPENAI_API_KEY"
 # classic user keys (sk-). Order matters — sk-proj- is checked first since
 # it is more specific.
 key_prefixes = ["sk-proj-", "sk-"]
-default_model = "gpt-4o"
-cheap_model = "gpt-4o-mini"
+default_model = "gpt-5.2"
+cheap_model = "gpt-5-mini"
 requires_key = true
-description = "GPT-4, GPT-4o, and other OpenAI models."
+description = "GPT-5.x, the o-series, and other OpenAI models."
 api_dialect = "openai-chat"
 tags = ["code-execution", "frontier", "function-calling", "image-gen", "prompt-caching", "realtime", "streaming", "vision"]
 
 [[providers.models]]
-id = "gpt-4o"
-model = "gpt-4o"
-context_window_tokens = 128000
-max_output_tokens = 16384
+id = "gpt-5.2"
+model = "gpt-5.2"
+context_window_tokens = 272000
+max_output_tokens = 128000
 
 [[providers.models]]
-id = "gpt-4o-mini"
-model = "gpt-4o-mini"
-context_window_tokens = 128000
-max_output_tokens = 16384
+id = "gpt-5-mini"
+model = "gpt-5-mini"
+context_window_tokens = 272000
+max_output_tokens = 128000
 
 [[providers]]
 id = "mistral"


### PR DESCRIPTION
## What

The catalog's two openai **showcase seats** move from 2024 (`gpt-4o` / `gpt-4o-mini`) to the live API's current family: `gpt-5.2` (default) + `gpt-5-mini` (cheap), with the 5.x context/output windows (272k/128k). Description follows.

Found while battery-testing the whole spec corpus live: the teaching hints say `swap for openai/gpt-5.2` while `nika catalog` still showcased 2024 — the only stale layer was the showcase (pricing + capabilities already know the whole 5.x family).

## Truth checks

- Live API `/v1/models` enumerated: the family runs `gpt-5` → `gpt-5.6`; both new seats exist and are the current stable flagship/cheap pair.
- **Pass-through proven live**: `nika run … --model openai/gpt-5.2` → 780ms · $0.000098 (priced by the existing `gpt-5.2-chat-latest`-era rows); `gpt-4o` and every live id keep working verbatim — the seats are a showcase, never an allowlist.
- Spec side updated first (same-day nika-spec PR #66 second commit): `providers-v0.1.md` openai example + Models line.
- Azure seats untouched (deployment names are tenant-chosen; `gpt-4o` deployments remain common).
- `cargo test -p nika-catalog --lib` 259 green · `-p nika-cli --lib` 332 green (remaining `gpt-4o` refs are pass-through test fixtures, not showcases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
