### PR TITLE
feat(nika-cli): the one earned ask — welcome + init grow the community line

### DIFF
--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -280,9 +280,7 @@ pub(crate) fn render(lines: &[(char, String)]) -> String {
 /// beginner walk: « you init and… sit there ») — an onboarding surface
 /// must hand over to the next command. Golden path: offline proof in
 /// 10s → scaffold → audit-before-tokens. Byte-stable additively: the
-/// #158 lines never change (scripts grep them); the community footer
-/// joined 2026-07-12 — init is a once-per-repo ceremony, the honest
-/// place for the one ask (working commands stay marketing-free).
+/// #158 lines never change; the community footer appends (2026-07-12).
 const NEXT_BLOCK: &str = "next ·\n  nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n  nika new                                       # your first workflow — guided on a terminal\n  nika new --from chain my-first.nika.yaml       # the same, scriptable\n  nika check my-first.nika.yaml                  # audit before a single token\n\nopen source · a star on github.com/supernovae-st/nika helps others find nika";
 
 /// Scaffold `dir` (default `.`). Creates parent dirs as needed. A write

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -279,9 +279,11 @@ pub(crate) fn render(lines: &[(char, String)]) -> String {
 /// The beginner's next move · init used to end SILENTLY (the 2026-07-05
 /// beginner walk: « you init and… sit there ») — an onboarding surface
 /// must hand over to the next command. Golden path: offline proof in
-/// 10s → scaffold → audit-before-tokens. Byte-stable: this is the exact
-/// non-interactive shape scripts have seen since #158.
-const NEXT_BLOCK: &str = "next ·\n  nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n  nika new                                       # your first workflow — guided on a terminal\n  nika new --from chain my-first.nika.yaml       # the same, scriptable\n  nika check my-first.nika.yaml                  # audit before a single token";
+/// 10s → scaffold → audit-before-tokens. Byte-stable additively: the
+/// #158 lines never change (scripts grep them); the community footer
+/// joined 2026-07-12 — init is a once-per-repo ceremony, the honest
+/// place for the one ask (working commands stay marketing-free).
+const NEXT_BLOCK: &str = "next ·\n  nika examples run 01-hello --model mock/echo   # offline proof · zero keys\n  nika new                                       # your first workflow — guided on a terminal\n  nika new --from chain my-first.nika.yaml       # the same, scriptable\n  nika check my-first.nika.yaml                  # audit before a single token\n\nopen source · a star on github.com/supernovae-st/nika helps others find nika";
 
 /// Scaffold `dir` (default `.`). Creates parent dirs as needed. A write
 /// failure is the one environment error (`exit 3`); everything else is `0`.

--- a/crates/nika-cli/src/verbs/welcome.rs
+++ b/crates/nika-cli/src/verbs/welcome.rs
@@ -24,9 +24,7 @@ use crate::verbs::probe::{Probe, ProviderProbe};
 use crate::verbs::{VerbOutput, probe};
 
 /// The three next moves — the SAME golden path the bare-`nika` footer and
-/// `init`'s hand-off teach (one story across every lost-user surface).
-/// Comments stay ≤26 chars: the widest command pads to 45 and the whole
-/// row must live inside 80 columns (the width nobody configures).
+/// `init`'s hand-off teach. Comments ≤26 chars: rows live inside 80 cols.
 const START: [(&str, &str); 3] = [
     (
         "nika examples run 01-hello --model mock/echo",
@@ -265,9 +263,7 @@ fn start_section(s: &mut String, theme: Theme) {
         .map(|(cmd, _)| cmd.chars().count())
         .max()
         .unwrap_or(0);
-    // The gh/bun law (2026 survey): exactly ONE next command carries the
-    // maximum visual weight — the first row is the thing to run NOW, the
-    // other two stay plain (a journey, not a menu of equals).
+    // gh/bun law: ONE next command carries the weight (a journey, not a menu).
     for (i, (cmd, why)) in START.iter().enumerate() {
         let painted = if i == 0 {
             theme.paint(Role::Strong, &format!("{cmd:<width$}"))
@@ -287,25 +283,12 @@ fn start_section(s: &mut String, theme: Theme) {
         theme.paint(
             Role::Dim,
             &format!(
-                "learn: {} · docs: {}",
+                "learn: {} · docs: {} · ⭐ {}",
                 theme.link("https://nika.sh", "nika.sh"),
                 theme.link("https://docs.nika.sh", "docs.nika.sh"),
-            )
-        )
-    );
-    // The community line — welcome is the ONE first-contact surface, so
-    // the ask lives here (once, dim, honest) and never on working
-    // commands: check/run stay marketing-free by doctrine.
-    let _ = writeln!(
-        s,
-        "{}",
-        theme.paint(
-            Role::Dim,
-            &format!(
-                "open source · a star on {} helps others find nika",
                 theme.link(
                     "https://github.com/supernovae-st/nika",
-                    "github.com/supernovae-st/nika",
+                    "github.com/supernovae-st/nika"
                 ),
             )
         )
@@ -446,7 +429,7 @@ mod tests {
             "not briefed → nika init",
             "mock/echo",
             "learn: nika.sh",
-            "helps others find nika",
+            "github.com/supernovae-st/nika",
         ] {
             assert!(text.contains(needle), "missing `{needle}`:\n{text}");
         }

--- a/crates/nika-cli/src/verbs/welcome.rs
+++ b/crates/nika-cli/src/verbs/welcome.rs
@@ -293,6 +293,23 @@ fn start_section(s: &mut String, theme: Theme) {
             )
         )
     );
+    // The community line — welcome is the ONE first-contact surface, so
+    // the ask lives here (once, dim, honest) and never on working
+    // commands: check/run stay marketing-free by doctrine.
+    let _ = writeln!(
+        s,
+        "{}",
+        theme.paint(
+            Role::Dim,
+            &format!(
+                "open source · a star on {} helps others find nika",
+                theme.link(
+                    "https://github.com/supernovae-st/nika",
+                    "github.com/supernovae-st/nika",
+                ),
+            )
+        )
+    );
 }
 
 /// Cloud keys: how many of the key-requiring providers have one PRESENT
@@ -429,6 +446,7 @@ mod tests {
             "not briefed → nika init",
             "mock/echo",
             "learn: nika.sh",
+            "helps others find nika",
         ] {
             assert!(text.contains(needle), "missing `{needle}`:\n{text}");
         }


### PR DESCRIPTION
## What

The traction baseline (2026-07-12) named the conversion gap: **739 release-asset downloads in two days vs 26 stars** — usage runs ahead of social proof because the product never asks, anywhere.

One dim line joins the two first-contact ceremonies (and only them):

- `nika welcome` footer: `open source · a star on github.com/supernovae-st/nika helps others find nika` (themed, OSC-8 link, Role::Dim)
- `nika init` NEXT_BLOCK tail: same line, plain (flows through both the interactive-declined and non-interactive paths)

## Doctrine held

- Working commands (check · run · diagnostics) stay marketing-free — the ask lives at earned, once-per-surface moments only.
- NEXT_BLOCK byte-stability refined to **additive**: the #158 lines scripts grep are untouched; the footer appends.
- JSON outputs untouched (no marketing in machine surfaces).

## Proof

- 333 nika-cli lib tests green (the welcome mirror test pins the new needle) · clippy `-D warnings` clean
- Both surfaces run against the built binary — the line renders in welcome and in a scratch-dir `init --yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)