### PR TITLE
fix(nika-mcp): explain teaches the runtime namespaces — one voice with the CLI

### DIFF
--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -41,34 +41,12 @@ pub fn run(wire: &str, theme: Theme) -> VerbOutput {
         if let Some(text) = canon_row(&normalized) {
             return VerbOutput::ok(text);
         }
-        // Per-builtin runtime codes (`NIKA-BUILTIN-<NAME>-<NNN>`) are emitted
-        // by builtins at runtime and ARE valid in `on_codes:` — but they are
-        // runtime diagnostics, not spec-conformance rows, so the canon table
-        // does not carry each one. Recognize the namespace and teach what it
-        // IS (better than a flat "unknown code"), pointing to the contract.
-        if let Some(name) = builtin_code_name(&normalized) {
-            return VerbOutput::ok(format!(
-                "{normalized} · builtin · runtime error from the `nika:{name}` builtin\n\n  \
-                 A per-builtin runtime diagnostic (each builtin owns \
-                 NIKA-BUILTIN-<NAME>-001..099). Valid in `retry.on_codes:` and \
-                 `on_error.on_codes:`. The specific cause is the builtin's own \
-                 arg/runtime contract — see spec stdlib (builtins) · \
-                 {docs}.\n"
-            ));
-        }
-        // Per-provider runtime codes (`NIKA-PROVIDER-<NNN>`) — 001-099 are
-        // allocated PER PROVIDER (spec 05-errors.md §NIKA-PROVIDER) and ARE
-        // valid in `on_codes:`. The meaning is provider-defined, so (like the
-        // per-builtin namespace) teach what it IS, not a flat "unknown code".
-        if is_provider_code(&normalized) {
-            return VerbOutput::ok(format!(
-                "{normalized} · provider · a provider-adapter runtime error\n\n  \
-                 A per-provider diagnostic (each provider adapter owns \
-                 NIKA-PROVIDER-001..099). The specific cause is provider-defined \
-                 (transport · quota · auth · response shape from that provider). \
-                 Valid in `retry.on_codes:` and `on_error.on_codes:` — see \
-                 spec/05-errors.md §NIKA-PROVIDER · {docs}.\n"
-            ));
+        // Runtime namespaces (per-builtin `NIKA-BUILTIN-<NAME>-<NNN>` ·
+        // per-provider `NIKA-PROVIDER-<NNN>`) have no per-code registry
+        // row — the shared teaching lives in `nika-error::codes` so the
+        // MCP explain tool answers with the SAME text (one voice).
+        if let Some(text) = nika_error::codes::namespace_help(&normalized, &docs) {
+            return VerbOutput::ok(text);
         }
         return VerbOutput::file(format!(
             "unknown code `{wire}` — the registry knows NIKA-001..NIKA-9999 \
@@ -168,26 +146,6 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
         ),
         _ => None,
     }
-}
-
-/// Parse a per-builtin runtime code `NIKA-BUILTIN-<NAME>-<NNN>` to the builtin
-/// name (`write` · `fetch` · `json_merge_patch` · …), or `None` if the wire is
-/// not that shape. The generic `NIKA-BUILTIN-001` (no name) is a canon row and
-/// is resolved before this is reached.
-fn builtin_code_name(code: &str) -> Option<String> {
-    let rest = code.strip_prefix("NIKA-BUILTIN-")?;
-    let (name, num) = rest.rsplit_once('-')?;
-    (num.len() == 3 && num.bytes().all(|b| b.is_ascii_digit()) && !name.is_empty())
-        .then(|| name.to_ascii_lowercase())
-}
-
-/// Recognize a per-provider runtime code `NIKA-PROVIDER-<NNN>` (001-099 are
-/// allocated PER PROVIDER per spec 05-errors.md). There is no single canon
-/// row — the meaning is provider-defined — so explain teaches the namespace
-/// rather than 404-ing a code that is valid in `on_codes:`.
-fn is_provider_code(code: &str) -> bool {
-    code.strip_prefix("NIKA-PROVIDER-")
-        .is_some_and(|num| num.len() == 3 && num.bytes().all(|b| b.is_ascii_digit()))
 }
 
 #[cfg(test)]

--- a/crates/nika-error/public-api.txt
+++ b/crates/nika-error/public-api.txt
@@ -523,6 +523,8 @@ pub fn nika_error::codes::code_help(code: nika_error::codes::NikaCode) -> &'stat
 pub fn nika_error::codes::code_help(code: nika_error::codes::NikaCode) -> &'static str
 pub fn nika_error::codes::lookup(wire: &str) -> core::option::Option<nika_error::codes::NikaCode>
 pub fn nika_error::codes::lookup(wire: &str) -> core::option::Option<nika_error::codes::NikaCode>
+pub fn nika_error::codes::namespace_help(code: &str, docs: &str) -> core::option::Option<alloc::string::String>
+pub fn nika_error::codes::namespace_help(code: &str, docs: &str) -> core::option::Option<alloc::string::String>
 pub mod nika_error::core_error
 #[non_exhaustive] pub enum nika_error::core_error::CoreError
 pub nika_error::core_error::CoreError::Internal
@@ -870,6 +872,7 @@ pub const nika_error::prelude::codes::NIKA_800: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_999: nika_error::codes::NikaCode
 pub fn nika_error::prelude::codes::code_help(code: nika_error::codes::NikaCode) -> &'static str
 pub fn nika_error::prelude::codes::lookup(wire: &str) -> core::option::Option<nika_error::codes::NikaCode>
+pub fn nika_error::prelude::codes::namespace_help(code: &str, docs: &str) -> core::option::Option<alloc::string::String>
 #[non_exhaustive] pub enum nika_error::prelude::Category
 pub nika_error::prelude::Category::A11y
 pub nika_error::prelude::Category::Audio

--- a/crates/nika-error/src/codes.rs
+++ b/crates/nika-error/src/codes.rs
@@ -339,9 +339,69 @@ pub fn lookup(wire: &str) -> Option<NikaCode> {
     ALL.iter().copied().find(|c| c.num == num)
 }
 
+/// The namespace teaching for runtime codes with no per-code registry row —
+/// per-builtin `NIKA-BUILTIN-<NAME>-<NNN>` and per-provider
+/// `NIKA-PROVIDER-<NNN>` (001-099 allocated per owner · spec 05-errors.md).
+/// Both are valid in `on_codes:`, so EVERY explain surface (CLI · MCP)
+/// teaches what the namespace IS instead of 404-ing — one voice, one text.
+/// `docs` is the caller's rendering of the error-docs reference (a themed
+/// OSC-8 link on a TTY · plain text over MCP).
+#[must_use]
+pub fn namespace_help(code: &str, docs: &str) -> Option<String> {
+    if let Some(name) = builtin_code_name(code) {
+        return Some(format!(
+            "{code} · builtin · runtime error from the `nika:{name}` builtin\n\n  \
+             A per-builtin runtime diagnostic (each builtin owns \
+             NIKA-BUILTIN-<NAME>-001..099). Valid in `retry.on_codes:` and \
+             `on_error.on_codes:`. The specific cause is the builtin's own \
+             arg/runtime contract — see spec stdlib (builtins) · \
+             {docs}.\n"
+        ));
+    }
+    is_provider_code(code).then(|| {
+        format!(
+            "{code} · provider · a provider-adapter runtime error\n\n  \
+             A per-provider diagnostic (each provider adapter owns \
+             NIKA-PROVIDER-001..099). The specific cause is provider-defined \
+             (transport · quota · auth · response shape from that provider). \
+             Valid in `retry.on_codes:` and `on_error.on_codes:` — see \
+             spec/05-errors.md §NIKA-PROVIDER · {docs}.\n"
+        )
+    })
+}
+
+/// Recognize `NIKA-BUILTIN-<NAME>-<NNN>` and return the builtin's lowercase
+/// name (`NIKA-BUILTIN-FETCH-001` → `fetch`).
+fn builtin_code_name(code: &str) -> Option<String> {
+    let rest = code.strip_prefix("NIKA-BUILTIN-")?;
+    let (name, num) = rest.rsplit_once('-')?;
+    (num.len() == 3 && num.bytes().all(|b| b.is_ascii_digit()) && !name.is_empty())
+        .then(|| name.to_ascii_lowercase())
+}
+
+/// Recognize `NIKA-PROVIDER-<NNN>` (exactly three digits).
+fn is_provider_code(code: &str) -> bool {
+    code.strip_prefix("NIKA-PROVIDER-")
+        .is_some_and(|num| num.len() == 3 && num.bytes().all(|b| b.is_ascii_digit()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The one-voice namespace teaching both explain surfaces consume:
+    /// builtin and provider codes teach, everything else stays `None`
+    /// (the caller keeps its own unknown-code finding).
+    #[test]
+    fn namespace_help_teaches_builtin_and_provider_codes() {
+        let b = namespace_help("NIKA-BUILTIN-FETCH-001", "docs").expect("builtin namespace");
+        assert!(b.contains("`nika:fetch` builtin") && b.contains("on_codes"));
+        let p = namespace_help("NIKA-PROVIDER-042", "docs").expect("provider namespace");
+        assert!(p.contains("provider-adapter") && p.contains("docs"));
+        assert!(namespace_help("NIKA-VAR-001", "docs").is_none());
+        assert!(namespace_help("NIKA-BUILTIN-FETCH-1", "docs").is_none());
+        assert!(namespace_help("NIKA-PROVIDER-1042", "docs").is_none());
+    }
 
     #[test]
     fn category_and_severity_as_str_match_the_serde_wire_form() {

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -271,9 +271,20 @@ fn explain(args: &Value) -> Result<String, String> {
             row.category, row.transient, row.failure
         ));
     }
+    // 3 · the runtime namespaces (per-builtin `NIKA-BUILTIN-<NAME>-<NNN>` ·
+    //     per-provider `NIKA-PROVIDER-<NNN>`) — valid in `on_codes:` and
+    //     emitted by failed runs, so the agent debugging a trace over MCP
+    //     gets the SAME teaching the CLI gives (one voice · shared text in
+    //     `nika-error::codes`). Gauntlet 2026-07-12: the CLI taught
+    //     NIKA-BUILTIN-PROMPT-001 while this tool said "unknown code".
+    if let Some(text) = nika_error::codes::namespace_help(&normalized, "docs.nika.sh/errors") {
+        return Ok(text);
+    }
     Err(format!(
-        "unknown code `{code}` — the registry knows NIKA-001..9999 + the spec \
-         codes (NIKA-VAR-* · NIKA-DAG-* · …); see docs.nika.sh/errors"
+        "unknown code `{code}` — the registry knows NIKA-001..9999, the spec \
+         codes (NIKA-VAR-* · NIKA-DAG-* · …), per-builtin \
+         NIKA-BUILTIN-<NAME>-NNN and per-provider NIKA-PROVIDER-NNN codes; \
+         see docs.nika.sh/errors"
     ))
 }
 
@@ -411,6 +422,22 @@ mod tests {
     #[test]
     fn explain_an_unknown_code_is_a_tool_error() {
         assert!(execute("nika_explain", &json!({ "code": "NIKA-GHOST-999" })).is_err());
+    }
+
+    /// One voice with the CLI (gauntlet 2026-07-12): a failed run's
+    /// per-builtin / per-provider code must TEACH over MCP too — the
+    /// agent debugging a trace calls this tool, not the terminal.
+    #[test]
+    fn explain_teaches_the_runtime_namespaces_like_the_cli() {
+        let b = execute(
+            "nika_explain",
+            &json!({ "code": "NIKA-BUILTIN-PROMPT-001" }),
+        )
+        .expect("builtin namespace teaches");
+        assert!(b.contains("`nika:prompt` builtin") && b.contains("on_codes"));
+        let p = execute("nika_explain", &json!({ "code": "NIKA-PROVIDER-007" }))
+            .expect("provider namespace teaches");
+        assert!(p.contains("provider-adapter"));
     }
 
     #[test]


### PR DESCRIPTION
## The one-voice gap (gauntlet 2026-07-12, debugging pass)

A failed run carries `NIKA-BUILTIN-PROMPT-001`. The CLI `nika explain` teaches it (namespace teaching). The MCP `nika_explain` — the surface an agent actually calls mid-debug — answered **"unknown code"**. Two explain surfaces, two answers: the exact drift class the one-voice model exists to prevent. (Probed against a FRESH `nika mcp` server over JSON-RPC, not the session-stale one.)

## The fix

The namespace teaching (per-builtin `NIKA-BUILTIN-<NAME>-<NNN>` · per-provider `NIKA-PROVIDER-<NNN>`) moves DOWN to `nika-error::codes::namespace_help` — the registry's own crate — and both surfaces consume it: the CLI keeps its themed OSC-8 docs link, MCP passes the plain text. The CLI-local helpers are deleted (−50 lines there). One text, one home.

## Proof

- `nika-error`: namespace matrix test (teaches builtin + provider · `None` on spec codes and malformed digits — `FETCH-1`, `PROVIDER-1042` stay unknown).
- `nika-mcp`: parity test pinning that the agent lane teaches what the CLI teaches (`NIKA-BUILTIN-PROMPT-001` · `NIKA-PROVIDER-007`).
- Suites green: nika-error 57 · nika-mcp 54 · nika-cli explain 22 · clippy `-D warnings` 0 across all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
