### PR TITLE
feat(cli): examples run carries the run trio — var · no-progress · max-cost-usd

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -566,7 +566,7 @@ impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::SystemStam
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::SystemStamper
 pub type nika_cli::verbs::run::SystemStamper::Output = T
 pub fn nika_cli::verbs::run::capabilities_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_cli::verbs::run::RuntimeCapabilities
-pub fn nika_cli::verbs::run::example(slug: &str, model_override: core::option::Option<&str>, theme: nika_display::theme::Theme) -> u8
+pub fn nika_cli::verbs::run::example(slug: &str, model_override: core::option::Option<&str>, vars: &[alloc::string::String], no_progress: bool, max_cost_usd: core::option::Option<f64>, theme: nika_display::theme::Theme) -> u8
 pub fn nika_cli::verbs::run::fs_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_builtin::permits::FsBoundary
 pub fn nika_cli::verbs::run::net_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_http::NetBoundary
 pub fn nika_cli::verbs::run::production_runtime(default_model: &str, caps: nika_cli::verbs::run::RuntimeCapabilities) -> core::result::Result<nika_cli::verbs::run::ProdRuntime, nika_kernel_core::io::http::HttpError>

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -1,16 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The `nika-cli` dev binary — the seed of the `nika` verb tree.
-//!
-//! Today: the full STATIC suite (`check` · `inspect` · `graph` ·
-//! `explain` · `spec` · `schema` · `examples` · `new` · `completions`) +
-//! `trace replay|show` (the flight-recorder reader · spec §7). Everything
-//! is auditable-before-run, and the `run` verb executes a CHECKED workflow
-//! through the composed `nika-runtime` (L3) over production seams
-//! (`nika-builtin` is admitted · no mocks).
-//! Exit codes follow the locked contract (spec §4): `0` ok · `1` workflow
-//! failed · `2` file findings · `3` environment error.
+//! The `nika` binary — clap surface + dispatch over the verb tree
+//! (`nika --help` is the living list; the static suite audits before any
+//! run, `run` executes CHECKED workflows through the composed L3 runtime
+//! over production seams). Exit codes per the locked contract (spec §4):
+//! `0` ok · `1` workflow failed · `2` file findings · `3` environment.
 
 // A terminal binary's whole job is printing — the same exemption as the
 // nika-catalog-verify binary and the nika-schema check example.
@@ -406,6 +401,17 @@ enum ExamplesAction {
         /// `--model mock/echo` to preview offline (zero key · zero network).
         #[arg(long, value_name = "PROVIDER/NAME")]
         model: Option<String>,
+        /// Bind a workflow `vars:` input (repeatable) — the `nika run
+        /// --var` contract; examples with `required:` vars need it.
+        #[arg(long = "var", value_name = "KEY=VALUE")]
+        var: Vec<String>,
+        /// Plain line-by-line render — same as `nika run --no-progress`.
+        #[arg(long)]
+        no_progress: bool,
+        /// Refuse any spend past this bound BEFORE the crossing call —
+        /// the `nika run --max-cost-usd` contract.
+        #[arg(long = "max-cost-usd", value_name = "USD", value_parser = parse_budget_usd)]
+        max_cost_usd: Option<f64>,
     },
 }
 
@@ -896,9 +902,20 @@ fn examples_verb(action: Option<ExamplesAction>, plain_theme: Theme) -> u8 {
         ExamplesAction::List => emit(&verbs::pack_surface::examples_list()),
         ExamplesAction::Show { slug } => emit(&verbs::pack_surface::examples_show(&slug)),
         // The L3 run verb shipped — execute the embedded example for real.
-        ExamplesAction::Run { slug, model } => {
-            verbs::run::example(&slug, model.as_deref(), plain_theme)
-        }
+        ExamplesAction::Run {
+            slug,
+            model,
+            var,
+            no_progress,
+            max_cost_usd,
+        } => verbs::run::example(
+            &slug,
+            model.as_deref(),
+            &var,
+            no_progress,
+            max_cost_usd,
+            plain_theme,
+        ),
     }
 }
 

--- a/crates/nika-cli/src/verbs/context.rs
+++ b/crates/nika-cli/src/verbs/context.rs
@@ -2,22 +2,15 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
 //! `nika context` — the whole workspace truth in ONE call (the agent
-//! aggregate · 30s-arc W4).
+//! aggregate · 30s-arc W4). Composition ONLY: welcome's bounded walk +
+//! THE in-process check ladder (the seam MCP `nika_check` speaks) +
+//! trace-journal folds + the shared `verbs::probe` engine — no new
+//! analysis, one truth, one more renderer.
 //!
-//! Composition ONLY: the workflow inventory is the same bounded walk the
-//! welcome glance does, each file goes through THE in-process check
-//! ladder (`nika_schema::parse` + `check` — the same seam the MCP
-//! `nika_check` tool speaks), runs are folded from `.nika/traces`
-//! journal heads/tails, and the machine facts ride the shared
-//! `verbs::probe` engine. No new analysis exists here — one truth,
-//! one more renderer.
-//!
-//! The wire (`--json` · `context_version: 1` · additive-only) follows
-//! the house machine-envelope law and three field rules:
-//! FACTS never file contents · RELATIVE paths only (an absolute path
-//! leaks usernames into agent transcripts) · every array is CAPPED and
-//! says so (`workflows_capped` / `runs_capped` — silent truncation
-//! reads as « covered everything »).
+//! The wire (`--json` · `context_version: 1` · additive-only): FACTS
+//! never file contents · RELATIVE paths only (absolute paths leak
+//! usernames into agent transcripts) · every array CAPPED and says so
+//! (silent truncation reads as « covered everything »).
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;

--- a/crates/nika-cli/src/verbs/run/compose.rs
+++ b/crates/nika-cli/src/verbs/run/compose.rs
@@ -248,21 +248,13 @@ pub(crate) fn config_from_env() -> ProvidersConfig {
             config = config.with_key(provider.id, Secret::new(value));
         }
     }
-    // CLOUD endpoints honor the same override family — the locked
-    // long-tail escape hatch (D-2026-06-10-N2: « the openai+base_url
-    // hatch stays for the long tail ») finally gets its operator
-    // surface: `NIKA_<ID>_BASE_URL` points a CLOUD profile at any
-    // OpenAI-compatible endpoint (Scaleway EU · Together · Fireworks ·
-    // a corporate gateway) with ZERO catalog change. The value is the
-    // COMPLETE endpoint URL (gemini keeps its STEM contract — see
-    // `ProvidersConfig::with_base_url`), taken verbatim: no loopback
-    // normalization (that convenience grammar is the locals'). Pair it
-    // with `NIKA_<ID>_API_KEY` (the #286 ladder) so the override rides
-    // a SCOPED key — the provider's Bearer goes wherever the override
-    // points, which is exactly the operator's intent and nobody else's
-    // (both variables are theirs · sovereignty Rule 1). Live-proven
-    // against Scaleway Generative APIs 2026-07-08 (vLLM-class · EU):
-    // json_schema enforced through the openai dialect, strict tolerated.
+    // CLOUD endpoints honor the same override family (D-2026-06-10-N2
+    // long-tail hatch): `NIKA_<ID>_BASE_URL` points a cloud profile at
+    // any OpenAI-compatible endpoint, zero catalog change — the value is
+    // the COMPLETE URL taken verbatim (gemini keeps its STEM contract ·
+    // no loopback normalization, that grammar is the locals'). Pair with
+    // `NIKA_<ID>_API_KEY` (#286) so the Bearer rides a SCOPED key. Live-
+    // proven against Scaleway Generative APIs 2026-07-08 (EU · vLLM-class).
     for provider in nika_catalog::all_providers() {
         // the locals own the NEXT loop (loopback-normalized grammar) —
         // catalog rows exist for them too, so exclude by id.
@@ -273,16 +265,12 @@ pub(crate) fn config_from_env() -> ProvidersConfig {
             config = config.with_base_url(provider.id, url);
         }
     }
-    // The LOCAL servers' base URLs cross the SAME sanctioned boundary
-    // (deliberately not secrets — same rationale as NIKA_IMAGE_LOCAL_URL):
-    // `NIKA_<ID>_BASE_URL` first (ours, all 5 locals), then the server's
-    // own convention where one exists — `OLLAMA_HOST`, which the official
-    // ollama client honors and every LAN-GPU setup already exports. The
-    // engine ignoring it sent runs to 127.0.0.1 while the user's own
-    // `ollama` CLI talked to the box they configured (the user-sim
-    // finding). The convenience forms ollama documents (`host` ·
-    // `host:port` · full URL) all resolve; a bare host gets the
-    // provider's own default port, mirroring the official client.
+    // The LOCAL servers cross the SAME boundary (deliberately not
+    // secrets): `NIKA_<ID>_BASE_URL` first, then the server's own
+    // convention (`OLLAMA_HOST` — ignoring it sent runs to 127.0.0.1
+    // while the user's own CLI talked to their LAN box · user-sim
+    // finding). Ollama's convenience forms (`host` · `host:port` · full
+    // URL) all resolve; a bare host gets the provider's default port.
     for (id, conventional, default_port) in LOCAL_BASE_ENV {
         let ours = format!("NIKA_{}_BASE_URL", id.to_uppercase());
         #[allow(clippy::disallowed_methods)] // the sanctioned env boundary (see doc)

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -395,8 +395,18 @@ fn load_resume_plan(
 /// printed to stderr (#145: the offline-model nudge for infer/provider
 /// failures · the real missing dependency for an exec `program not
 /// found`) · the original exit code is returned unchanged.
+///
+/// `vars`/`no_progress`/`max_cost_usd` are the run trio verbatim — the
+/// SAME funnel serves both surfaces (F7: required-var examples run direct).
 #[must_use]
-pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
+pub fn example(
+    slug: &str,
+    model_override: Option<&str>,
+    vars: &[String],
+    no_progress: bool,
+    max_cost_usd: Option<f64>,
+    theme: Theme,
+) -> u8 {
     let Some(yaml) = nika_pack::example(slug) else {
         eprintln!("unknown example `{slug}` — `nika examples list` names the embedded set");
         return exit::FILE;
@@ -411,8 +421,7 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         eprintln!("nika run: environment: cannot stage example `{slug}`: {e}");
         return exit::ENV;
     }
-    // The example renders live on a TTY, plain when piped (no flags here).
-    let mode = if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+    let mode = if !no_progress && std::io::IsTerminal::is_terminal(&std::io::stdout()) {
         RenderMode::Live
     } else {
         RenderMode::Plain
@@ -430,7 +439,7 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         mode,
         false,
         model_override,
-        &[],
+        vars,
         None,
         // No run journal: the example is staged to a TEMP file — `.nika/
         // traces/` belongs to workspace runs (the same drive underneath,
@@ -439,7 +448,7 @@ pub fn example(slug: &str, model_override: Option<&str>, theme: Theme) -> u8 {
         // Examples always run whole (tiny by design · no scoping surface).
         None,
         false,
-        None,
+        max_cost_usd,
         // An example runs a TEMP-staged file, not a workspace run — the
         // workspace's trace store is not this invocation's to collect.
         true,
@@ -824,12 +833,9 @@ fn plan_waves(wf: &RawWorkflow, report: &CheckReport) -> Vec<Vec<String>> {
 /// bytes stay exact (the rider can only buffer its own fs error, surfaced
 /// after the run · never the exit code). The caller composes the journal
 /// (enabled or disabled) like every other seam.
-// The 8th parameter is the `--resume` summary switch — same clap-surface
-// The trailing parameters are the `--resume` summary switch + the
-// outputs-tail switch — same clap-surface idiom as `run` itself (four
-// independent flags ARE four bools, not a state machine). The workflow
-// rides as (path, parsed) — the epilogue hint teaches a command over
-// the SAME file the operator just ran.
+// Trailing bools mirror the clap surface (independent flags ARE bools,
+// not a state machine). The workflow rides as (path, parsed) — the
+// epilogue hint teaches a command over the SAME file just run.
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 async fn execute(
     runtime: &ProdRuntime,
@@ -846,14 +852,10 @@ async fn execute(
 ) -> RunVerdict {
     let mut stamper = SystemStamper::new();
     if output_json {
-        // Machine-result mode (spec 01 §export contract): the live fold is
-        // a DIAGNOSTIC → stderr; the resolved `outputs:` object is the ONE
-        // JSON object on stdout, never interleaved. This powers the v0.1
-        // sub-workflow composition `exec: nika run sub.yaml --output json`
-        // + `capture: stdout` (spec 08 §composition).
-        // `Plain` deliberately: the fold goes to stderr (a pipe in the
-        // composition path · never the live TTY redraw); the one final
-        // storyboard frame is what matters, not the animation.
+        // Machine-result mode (spec 01 §export · 08 §composition): the
+        // fold is a DIAGNOSTIC → stderr (Plain deliberately — a pipe,
+        // never the live redraw); the resolved `outputs:` object is the
+        // ONE JSON object on stdout, never interleaved.
         let mut fold = FoldSink::new(std::io::stderr().lock(), theme, RenderMode::Plain);
         fold.set_plan(plan_waves(wf, report));
         let mut tee = Tee::new(fold, trace);

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -206,26 +206,33 @@ fn the_plain_lane_narrates_cleanly_when_piped() {
     );
 }
 
-// `examples run` EXECUTES (no longer refuses). 01-hello infers against
-// `ollama/llama3.1` — a LIVE local model, NOT hermetic (the prior "mock/echo"
-// comment was stale · the example's `model:` is a real provider). So this is
-// `#[ignore]`d: it runs only where ollama serves llama3.1
-// (`cargo test -- --ignored`), and never fails an offline box or the mutation
-// baseline. No embedded example runs clean with zero external deps, so the
-// `examples run` execution path has no hermetic smoke today.
+// `examples run` EXECUTES — and carries the run trio (--var ·
+// --no-progress · --max-cost-usd · gauntlet F7 2026-07-12). The trio
+// makes a hermetic smoke POSSIBLE at last: 19-schema-retry has a
+// `required:` var (unrunnable by this surface before) and infers clean
+// under `--model mock/echo` — zero keys, zero network, the exact combo
+// the old `#[ignore = "needs a live ollama"]` excuse said couldn't exist.
 #[test]
-#[ignore = "needs a live ollama/llama3.1 — run with `cargo test -- --ignored`"]
-fn examples_run_executes_an_embedded_workflow() {
+fn examples_run_carries_the_run_trio_hermetically() {
     let out = bin()
-        .arg("examples")
-        .arg("run")
-        .arg("01-hello")
+        .args([
+            "examples",
+            "run",
+            "19-schema-retry",
+            "--model",
+            "mock/echo",
+            "--var",
+            "text=Ada met Babbage in London",
+            "--no-progress",
+            "--max-cost-usd",
+            "0.01",
+        ])
         .output()
         .expect("binary runs");
     assert_eq!(
         out.status.code(),
         Some(0),
-        "the embedded mock/echo example runs clean · stderr: {}",
+        "a required-var example runs hermetically with the trio · stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
 }


### PR DESCRIPTION
## F7 (fresh-user gauntlet 2026-07-12)

`19-schema-retry` declares a `required:` var — and `examples run` had no `--var`. The example was **unrunnable by its own surface**, and clap's `tip: to pass '--var' as a value, use '-- --var'` pointed at a trailing lane that does not exist. The gauntlet's workaround (`examples show > f.yaml && nika run f.yaml --var …`) was the teaching of a gap, not a path.

## The fix — one funnel, no mirroring

`examples run` already delegates to `run_verdict`, passing `&[]` (vars) and `None` (max-cost) hardcoded. The trio (`--var` · `--no-progress` · `--max-cost-usd`) threads through the **same funnel**, so the flags carry `run`'s exact contracts (JSON-typed vars · unknown-key refusal · plain render · pre-flight spend refusal) by construction.

## The excuse dies

`run_verb.rs` carried `#[ignore = "needs a live ollama"]` with "No embedded example runs clean with zero external deps, so the examples run execution path has no hermetic smoke today." A required-var example under `mock/echo` IS that hermetic smoke — the new trio test replaces the ignored one and runs everywhere, zero keys (8/8 green, 0 ignored).

## Wall

15000 held by trading stale/verbose comment mass, contracts kept: `main.rs` head (its "Today:" suite list predates run/init/wire/doctor — now points at `--help` as the living list) · compose.rs override-family prose (citations kept) · context.rs head. `check-crate-size.sh` green.

## Proof

`cargo test -p nika-cli --lib` 333 · `--test run_verb` 8/8 · clippy `-D warnings` 0 · wall ✓ — all in an isolated worktree/target (a sister session shares the main checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
