### PR TITLE
feat(agents): kit 0.5.0 — the three seatbelts reach Claude Code

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
-  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.4.2",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.5.0",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"
@@ -16,5 +16,6 @@
     "ai-workflows",
     "agent",
     "audit"
-  ]
+  ],
+  "hooks": "./hooks/claude-hooks.json"
 }

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "nika",
   "displayName": "Nika · Intent as Code",
-  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.4.2",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.5.0",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "nika",
   "displayName": "Nika",
-  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.4.2",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks in both dialects — Cursor and Claude Code (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.5.0",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,27 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.5.0 — 2026-07-12
+
+Hooks parity: the three seatbelts reach Claude Code (they were
+Cursor-only — `claude plugin details` inventoried Hooks (0), found by
+the completeness audit).
+
+- ONE script per concern, TWO dialects, sniffed from stdin
+  (`hook_event_name` is Claude Code's): session-context serves
+  `hookSpecificOutput.additionalContext` on SessionStart · guard-run
+  answers PreToolUse (matcher Bash) with `permissionDecision: deny` +
+  the findings as the reason — and `{}` (no opinion) on pass, never
+  "allow", which would skip the user's own permission prompt ·
+  check-on-edit answers PostToolUse (Edit|Write|MultiEdit) with
+  findings on stderr + exit 2, the documented feedback channel.
+- `hooks/claude-hooks.json` (`${CLAUDE_PLUGIN_ROOT}` paths) wired via an
+  explicit `hooks` field in the Claude Code manifest — symmetric with
+  Cursor's explicit `cursor-hooks.json`, no auto-discovery ambiguity
+  in either direction.
+- Battery: 12 two-dialect cases (deny shapes · no-opinion pass ·
+  context envelopes · edit feedback rc contracts · non-nika silence).
+
 ## 0.4.2 — 2026-07-12
 
 Deep-verify patch — each fix is a gap found by checking the kit

--- a/.agents/plugins/nika/README.md
+++ b/.agents/plugins/nika/README.md
@@ -29,9 +29,9 @@ brew install supernovae-st/tap/nika   # the binary first; the plugin invokes it
 | delegation rule | teaches the agent WHEN to propose a workflow (repeatable · multi-step · spend-bound AI work) and which bundled surface to reach for |
 | `/nika:check` · `/nika:explain` · `/nika:new` | audit a file · explain a finding code · scaffold from a template |
 | `/nika:trace` · `/nika:permits` | read a run's flight recorder (verdict · root cause · resume line) · infer and paste the tightest permits boundary |
-| session-context hook | a workspace with workflows greets the agent with the full nika map at session start (surfaces · laws · where traces live) |
+| session-context hook | a workspace with workflows greets the agent with the full nika map at session start (surfaces · laws · where traces live) — Cursor **and** Claude Code dialects |
 | check-on-edit hook | every agent edit to a `*.nika.yaml` is audited immediately (findings in the hook log; never blocks the edit) |
-| guard-run hook | `nika run` on a file that fails `nika check` is denied with the findings — the audit-before-run law, structurally unskippable |
+| guard-run hook | `nika run` on a file that fails `nika check` is denied with the findings — the audit-before-run law, structurally unskippable (Cursor `beforeShellExecution` · Claude Code `PreToolUse`) |
 | MCP oracle (8 tools) | `nika_check` · `nika_explain` · `nika_schema` · `nika_examples` · `nika_template` · `nika_canon` · `nika_catalog` · `nika_tools` — read-only, by design |
 
 <p align="center">

--- a/.agents/plugins/nika/hooks/claude-hooks.json
+++ b/.agents/plugins/nika/hooks/claude-hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-context.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-run.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-on-edit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.agents/plugins/nika/scripts/check-on-edit.sh
+++ b/.agents/plugins/nika/scripts/check-on-edit.sh
@@ -1,24 +1,38 @@
 #!/usr/bin/env bash
 # check-on-edit — the plugin's seatbelt: after the agent edits a
-# *.nika.yaml, run the audit so findings land in the hook log
-# immediately (the file is the contract; check is the oracle).
+# *.nika.yaml, run the audit so findings reach the agent immediately
+# (the file is the contract; check is the oracle).
 #
-# Cursor hook contract (docs/agent/hooks): input is JSON on STDIN
-# (afterFileEdit carries file_path + edits); stdout is the JSON
-# response; the afterFileEdit matcher filters by TOOL type, not by
-# filename — so the extension filter lives HERE. Exit 0 always: an
-# audit finding is the repair loop's next step, never an edit veto.
+# ONE script, TWO dialects (sniffed from stdin — `hook_event_name` is
+# Claude Code's, absent from Cursor's):
+#   Cursor (afterFileEdit): file_path at the payload root; findings go
+#     to STDERR (the hook log) and stdout stays `{}` — never a veto.
+#   Claude Code (PostToolUse · matcher Edit|Write|MultiEdit): file_path
+#     at tool_input.file_path; findings go to STDERR + exit 2 — the
+#     documented feedback channel (the tool already ran, so exit 2 is
+#     non-blocking here: Claude SEES the findings and repairs).
 #
 # Capability-honest: no nika binary means no verdict, never a failure.
 set -euo pipefail
 
 input="$(cat)"
 
-# file_path from the stdin JSON — python3 when present, sed fallback.
+cc=""
+case "$input" in *hook_event_name*) cc=1 ;; esac
+
+done_quiet() {
+  printf '{}\n'
+  exit 0
+}
+
+# file_path from the stdin JSON — python3 when present, sed fallback
+# (both dialects carry exactly one "file_path" key, so the flat
+# fallback matches either nesting).
 if command -v python3 >/dev/null 2>&1; then
   file="$(printf '%s' "$input" | python3 -c 'import json,sys
 try:
-    print(json.load(sys.stdin).get("file_path", ""))
+    d = json.load(sys.stdin)
+    print(d.get("file_path") or d.get("tool_input", {}).get("file_path", ""))
 except Exception:
     print("")' 2>/dev/null || true)"
 else
@@ -27,20 +41,29 @@ fi
 
 case "$file" in
   *.nika.yaml | *.nika.yml) ;;
-  *)
-    printf '{}\n'
-    exit 0
-    ;;
+  *) done_quiet ;;
 esac
 
 if [ ! -f "$file" ] || ! command -v nika >/dev/null 2>&1; then
   # Missing file or binary: nothing to audit (the skill teaches the
   # install line) — stay silent and let the edit flow.
-  printf '{}\n'
-  exit 0
+  done_quiet
 fi
 
-# Findings go to STDERR (the hook log); stdout stays valid JSON for
-# the hook protocol. A red check never blocks the edit.
-nika check "$file" --color never >&2 || true
+set +e
+findings="$(nika check "$file" --color never 2>&1)"
+rc=$?
+set -e
+
+if [ "$rc" -ne 2 ]; then
+  # Clean (0) or broken oracle (3): nothing to teach — silence.
+  done_quiet
+fi
+
+printf '%s\n' "$findings" | head -c 2000 >&2
+if [ -n "$cc" ]; then
+  # PostToolUse exit 2 = stderr fed to Claude, edit already applied.
+  exit 2
+fi
 printf '{}\n'
+exit 0

--- a/.agents/plugins/nika/scripts/guard-run.sh
+++ b/.agents/plugins/nika/scripts/guard-run.sh
@@ -3,31 +3,45 @@
 # `nika run`, audit the workflow. Check is the gate the language is
 # built on; an agent must not be able to skip it by accident.
 #
-# Cursor hook contract (docs/agent/hooks · beforeShellExecution):
-# input is JSON on STDIN ({command, cwd, sandbox}); stdout is the
-# JSON permission response ({"permission":"allow"|"deny", plus
-# agent_message/user_message on deny). Exit 0 always — the JSON
-# carries the decision.
+# ONE script, TWO dialects (sniffed from stdin — `hook_event_name` is
+# Claude Code's, absent from Cursor's):
+#   Cursor  (docs/agent/hooks · beforeShellExecution): in {command, cwd}
+#     → out {"permission":"allow"|"deny", agent_message/user_message}.
+#   Claude Code (hooks.md · PreToolUse · matcher Bash): in
+#     {hook_event_name, tool_name, tool_input:{command}, cwd} → deny is
+#     {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#     "permissionDecision":"deny","permissionDecisionReason":…}}; the
+#     no-opinion pass is `{}` — NEVER "allow", which would skip the
+#     user's own permission prompt (the hook teaches, it never widens).
 #
-# Deny is TEACHING, not punishment: the agent_message carries the
-# findings so the agent repairs and reruns — the check loop becomes
-# structurally unskippable. Everything else fails open: a missing
-# binary, a file we cannot find, a broken oracle (exit 3) must never
-# block the human's terminal.
+# Deny is TEACHING, not punishment: the reason carries the findings so
+# the agent repairs and reruns — the check loop becomes structurally
+# unskippable. Everything else fails open: a missing binary, a file we
+# cannot find, a broken oracle (exit 3) must never block a terminal.
 set -euo pipefail
 
 input="$(cat)"
 
+cc=""
+case "$input" in *hook_event_name*) cc=1 ;; esac
+
 allow() {
-  printf '{"permission":"allow"}\n'
+  if [ -n "$cc" ]; then
+    printf '{}\n' # no opinion — the user's permission flow proceeds
+  else
+    printf '{"permission":"allow"}\n'
+  fi
   exit 0
 }
 
-# command + cwd from the stdin JSON — python3 when present, sed fallback.
+# command + cwd from the stdin JSON — python3 when present, sed fallback
+# (in a Bash PreToolUse payload the only "command" key is
+# tool_input.command, so the flat fallback matches both dialects).
 if command -v python3 >/dev/null 2>&1; then
   cmd="$(printf '%s' "$input" | python3 -c 'import json,sys
 try:
-    print(json.load(sys.stdin).get("command", ""))
+    d = json.load(sys.stdin)
+    print(d.get("command") or d.get("tool_input", {}).get("command", ""))
 except Exception:
     print("")' 2>/dev/null || true)"
   cwd="$(printf '%s' "$input" | python3 -c 'import json,sys
@@ -87,19 +101,31 @@ fi
 findings="$(printf '%s' "$findings" | head -c 2000)"
 
 if command -v python3 >/dev/null 2>&1; then
-  printf '%s' "$findings" | python3 -c '
-import json, sys
+  # env on the CONSUMER: `VAR=x cmd1 | cmd2` binds VAR to cmd1 only.
+  printf '%s' "$findings" | CC="$cc" python3 -c '
+import json, os, sys
 findings = sys.stdin.read()
 msg = ("nika check failed on this workflow - repair the findings, "
        "re-run nika check until it passes, then run again.\n\n" + findings)
-print(json.dumps({
-    "permission": "deny",
-    "agent_message": msg,
-    "user_message": "nika run blocked: the workflow does not pass nika check yet.",
-}))'
+if os.environ.get("CC"):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": msg,
+    }}))
+else:
+    print(json.dumps({
+        "permission": "deny",
+        "agent_message": msg,
+        "user_message": "nika run blocked: the workflow does not pass nika check yet.",
+    }))'
 else
   # No python3: a fixed, pre-escaped message (never interpolate raw
   # findings into JSON by hand).
-  printf '{"permission":"deny","agent_message":"nika check failed on this workflow - run nika check on the file, repair the findings it names, then run again.","user_message":"nika run blocked: the workflow does not pass nika check yet."}\n'
+  if [ -n "$cc" ]; then
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"nika check failed on this workflow - run nika check on the file, repair the findings it names, then run again."}}\n'
+  else
+    printf '{"permission":"deny","agent_message":"nika check failed on this workflow - run nika check on the file, repair the findings it names, then run again.","user_message":"nika run blocked: the workflow does not pass nika check yet."}\n'
+  fi
 fi
 exit 0

--- a/.agents/plugins/nika/scripts/session-context.sh
+++ b/.agents/plugins/nika/scripts/session-context.sh
@@ -16,7 +16,14 @@ set -euo pipefail
 
 input="$(cat)"
 
-# Workspace root: the payload cwd when present, else where Cursor ran us.
+# Dialect sniff: `hook_event_name` is Claude Code's (SessionStart);
+# Cursor's sessionStart payload has no such field. Same map, two
+# envelope shapes (Cursor: additional_context · Claude Code:
+# hookSpecificOutput.additionalContext).
+cc=""
+case "$input" in *hook_event_name*) cc=1 ;; esac
+
+# Workspace root: the payload cwd when present, else where the host ran us.
 if command -v python3 >/dev/null 2>&1; then
   cwd="$(printf '%s' "$input" | python3 -c 'import json,sys
 try:
@@ -46,5 +53,13 @@ if [ -z "$enabled" ]; then
   exit 0
 fi
 
-printf '%s\n' '{"additional_context":"This workspace uses Nika (nika.sh): repeatable AI work lives in .nika.yaml workflow files, audited BEFORE they run (nika check), cost-bounded while they run, hash-chain traced after (.nika/traces/). Laws: (1) nika check <file> must pass before proposing any run; running is the human'"'"'s move (propose the nika run line, with --max-cost-usd when spend matters). (2) Cost honesty: report the ceiling; a local model is unpriced, never free. Installed surfaces: read-only MCP oracle (nika_check, nika_explain, nika_schema, nika_examples, nika_template, nika_canon, nika_catalog, nika_tools) · subagents nika-author (write a workflow), nika-debugger (root-cause a run from its trace), nika-migrator (port a script) · skills nika-authoring, nika-debugging, nika-operating, nika-migration · commands check, explain, new, trace, permits (slash-prefixed per your client). CLI: nika check|run|trace|graph|explain|inspect|new|examples|catalog|tools|doctor. When the user describes repeatable or multi-step AI work, propose a Nika workflow."}'
+# The map is STATIC — fixed content, hand-escaped once, zero
+# interpolation. Both envelopes carry the SAME text.
+map='This workspace uses Nika (nika.sh): repeatable AI work lives in .nika.yaml workflow files, audited BEFORE they run (nika check), cost-bounded while they run, hash-chain traced after (.nika/traces/). Laws: (1) nika check <file> must pass before proposing any run; running is the human'"'"'s move (propose the nika run line, with --max-cost-usd when spend matters). (2) Cost honesty: report the ceiling; a local model is unpriced, never free. Installed surfaces: read-only MCP oracle (nika_check, nika_explain, nika_schema, nika_examples, nika_template, nika_canon, nika_catalog, nika_tools) · subagents nika-author (write a workflow), nika-debugger (root-cause a run from its trace), nika-migrator (port a script) · skills nika-authoring, nika-debugging, nika-operating, nika-migration · commands check, explain, new, trace, permits (slash-prefixed per your client). CLI: nika check|run|trace|graph|explain|inspect|new|examples|catalog|tools|doctor. When the user describes repeatable or multi-step AI work, propose a Nika workflow.'
+
+if [ -n "$cc" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$map"
+else
+  printf '{"additional_context":"%s"}\n' "$map"
+fi
 exit 0


### PR DESCRIPTION
## The hole (completeness audit 2026-07-12)

`claude plugin details nika@nika` inventoried **Hooks (0)** — the three seatbelts (omniscience map · audit-before-run guard · check-on-edit) were **Cursor-only**. Claude Code has the same primitives; the parity was buildable.

## The design — one script per concern, two dialects

Dialect sniffed from stdin (`hook_event_name` is Claude Code's, absent from Cursor's):

| Concern | Cursor | Claude Code |
|---|---|---|
| session map | `sessionStart` → `{"additional_context"}` | `SessionStart` → `hookSpecificOutput.additionalContext` |
| audit-before-run | `beforeShellExecution` → `permission: allow/deny` | `PreToolUse` (matcher `Bash`) → `permissionDecision: deny` + findings as reason · **`{}` no-opinion on pass** — never `allow`, which would skip the user's own permission prompt |
| check-on-edit | `afterFileEdit` → findings on stderr, `{}` out | `PostToolUse` (`Edit\|Write\|MultiEdit`) → findings on stderr + **exit 2** (the documented feedback channel; the edit already ran) |

`hooks/claude-hooks.json` (`${CLAUDE_PLUGIN_ROOT}` paths) rides an explicit `hooks` field in the Claude Code manifest — symmetric with Cursor's explicit `cursor-hooks.json`, zero auto-discovery ambiguity in either direction (the 0.3.0 collision class, now the design).

## Truth discipline

- Contracts fetched from the docs (`hooks.md` · `plugins-reference.md` — stdin schemas, permissionDecision values, exit-code semantics, `${CLAUDE_PLUGIN_ROOT}`), never assumed.
- Battery **12/12 two-dialect**: deny shapes both sides · no-opinion pass · context envelopes · edit-feedback rc contracts (2 on red, 0 clean) · non-nika silence · malformed stdin. The one red on the way (G4) caught the `VAR=x cmd1 | cmd2` env-binding trap — env moved to the consumer.
- The staleness ladder proven live this arc: `claude plugin marketplace update nika` + `claude plugin update nika@nika` → 0.1.0 → 0.4.2 with full inventory (this PR ships 0.5.0 through the same path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
