### PR TITLE
feat(cli): nika model pull/list/rm — one models dir by construction

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -132,8 +132,8 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | branch           | `chore/release-0.99.0`                                      |
 | HEAD             | `3d90001b9` (`3d90001b9d3efdc29fc9fce810ecd74476551acd`)             |
 | workspace        | v0.99.0                                  |
-| crates (workspace)| 46                                              |
-| crates (admitted)| 44 / 42                                   |
+| crates (workspace)| 47                                              |
+| crates (admitted)| 45 / 42                                   |
 | crates (WIP)     | 2 — nika-chart nika-fx                                  |
 | L0               | 12                                              |
 | L0.5             | 6                                              |
@@ -141,7 +141,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | L1.5             | 4                                              |
 | L2               | 4                                              |
 | L3               | 1                                              |
-| L4               | 6                                              |
+| L4               | 7                                              |
 | lib tests        | 3875 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,36 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **`nika model pull/list/rm` — first-class Hugging Face acquisition for
+  the native path** ([#146](https://github.com/supernovae-st/nika/issues/146)):
+  one command from the Hub to a sovereign in-process run. `pull
+  owner/repo[:QUANT]` resolves the repo's file tree first (sizes BEFORE
+  any byte moves; 2 GiB and over confirms, `--yes` for CI), streams the
+  GGUF over the house `nika-http` seam (rustls · SSRF floor · per-hop
+  redirect vetting — no `hf-hub`/`ureq` second HTTP stack), resumes an
+  interrupted transfer from its `.part` via `Range:`, and brings
+  `tokenizer.json` along — the exact sibling layout the serve loader
+  wants. ONE canonical models dir (`~/.nika/models/<owner>/<repo>/`):
+  the downloader and the resolver share it by construction (the
+  brouillon-era pull/load two-dir mismatch cannot re-happen), so `nika
+  model serve --model owner/repo[:QUANT]` now resolves pulled ids (and
+  bare file stems) — a real path still passes straight through.
+  `list` prints the dir once with id · size · file rows; `rm` reclaims
+  a whole repo or one quant (sweeping a gguf-empty dir) and refuses a
+  no-match WITH the installed list as the teaching surface. `HF_TOKEN`
+  authenticates gated repos (the Hub answers 401 for missing repos too
+  — the refusal names both lanes). `nika doctor` grows the models row:
+  dir + count + bytes once anything is pulled (any build), and a
+  teach-pull advisory on a sidecar build with nothing to serve. The
+  fetch is CLI-level, like `registry:` pulls — a workflow's `permits:`
+  never govern it. Acquisition only: the candle runtime owns
+  loading/generation (ADR-091/093). The whole unit ships as the
+  `nika-models` member (store · pull · serve glue) per D-2026-07-09-N1
+  — `nika-cli` sat at 14,958 of the 15,000 prod-LOC cap and keeps thin
+  exit-contract adapters at the unchanged public paths (the
+  `nika-onboard`/`nika-display`/`nika-dap` descents' wall, the same
+  house way).
+
 - **The one earned ask: welcome + init grow the community line** (#498 —
   the traction baseline showed installs running 2.5x ahead of stars
   because the product never asks). `nika welcome`'s footer gains a third

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,11 +3701,11 @@ dependencies = [
  "nika-exec-runner",
  "nika-fs",
  "nika-http",
- "nika-infer-local",
  "nika-kernel",
  "nika-kernel-mock",
  "nika-lsp",
  "nika-mcp",
+ "nika-models",
  "nika-pack",
  "nika-providers",
  "nika-runtime",
@@ -3994,6 +3994,20 @@ dependencies = [
  "proptest",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nika-models"
+version = "0.99.0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "nika-http",
+ "nika-infer-local",
+ "nika-kernel",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members  = ["crates/nika-types", "crates/nika-error", "crates/nika-catalog", "crates/nika-catalog-codegen", "crates/nika-catalog-verify", "crates/nika-chart", "crates/nika-kernel", "crates/nika-kernel-ai", "crates/nika-kernel-core", "crates/nika-kernel-runtime", "crates/nika-kernel-plugin", "crates/nika-kernel-mock", "crates/nika-schema", "crates/nika-bm25", "crates/nika-screen", "crates/nika-event", "crates/nika-extract", "crates/nika-exec-runner", "crates/nika-sandbox-seatbelt", "crates/nika-blob", "crates/nika-clock", "crates/nika-fs", "crates/nika-fx", "crates/nika-http", "crates/nika-ocr", "crates/nika-a11y", "crates/nika-input", "crates/nika-browser", "crates/nika-pack", "crates/nika-providers", "crates/nika-infer-local", "crates/nika-verb-infer", "crates/nika-verb-exec", "crates/nika-verb-invoke", "crates/nika-verb-agent", "crates/nika-builtin", "crates/nika-cel", "crates/nika-runtime", "crates/nika-cli", "crates/nika-lsp", "crates/nika-mcp", "crates/nika-dap", "crates/nika-display", "crates/nika-cap", "crates/nika-pck-manifest", "crates/nika-tmpl"]
+members  = ["crates/nika-types", "crates/nika-error", "crates/nika-catalog", "crates/nika-catalog-codegen", "crates/nika-catalog-verify", "crates/nika-chart", "crates/nika-kernel", "crates/nika-kernel-ai", "crates/nika-kernel-core", "crates/nika-kernel-runtime", "crates/nika-kernel-plugin", "crates/nika-kernel-mock", "crates/nika-schema", "crates/nika-bm25", "crates/nika-screen", "crates/nika-event", "crates/nika-extract", "crates/nika-exec-runner", "crates/nika-sandbox-seatbelt", "crates/nika-blob", "crates/nika-clock", "crates/nika-fs", "crates/nika-fx", "crates/nika-http", "crates/nika-ocr", "crates/nika-a11y", "crates/nika-input", "crates/nika-browser", "crates/nika-pack", "crates/nika-providers", "crates/nika-infer-local", "crates/nika-verb-infer", "crates/nika-verb-exec", "crates/nika-verb-invoke", "crates/nika-verb-agent", "crates/nika-builtin", "crates/nika-cel", "crates/nika-runtime", "crates/nika-cli", "crates/nika-lsp", "crates/nika-mcp", "crates/nika-dap", "crates/nika-display", "crates/nika-models", "crates/nika-cap", "crates/nika-pck-manifest", "crates/nika-tmpl"]
 # Excluded so cargo does not try to descend into untracked main-leftover
 # manifests under crates/ (the orphan working tree carries them but they
 # are not part of the diamond workspace).
@@ -49,6 +49,10 @@ layers.nika-cli = "L4"
 # crate-size cap · the nika-cap precedent).
 layers.nika-dap = "L4"
 layers.nika-display = "L4"
+# nika-models · the local-models unit (ONE canonical dir · Hub pull · serve
+# glue) · split from nika-cli's verbs/model 2026-07-12 (the crate-size cap ·
+# the nika-onboard/nika-display precedents).
+layers.nika-models = "L4"
 layers.nika-lsp = "L4"
 # nika-mcp · the in-binary MCP server (announce floor `nika mcp`) · hand-rolled
 # newline-delimited JSON-RPC 2.0 over stdio (serde_json only · zero SDK) ·

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,8 +96,8 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | branch           | `chore/release-0.99.0`                                      |
 | HEAD             | `3d90001b9` (`3d90001b9d3efdc29fc9fce810ecd74476551acd`)             |
 | workspace        | v0.99.0                                  |
-| crates (workspace)| 46                                              |
-| crates (admitted)| 44 / 42                                   |
+| crates (workspace)| 47                                              |
+| crates (admitted)| 45 / 42                                   |
 | crates (WIP)     | 2 — nika-chart nika-fx                                  |
 | L0               | 12                                              |
 | L0.5             | 6                                              |
@@ -105,7 +105,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | L1.5             | 4                                              |
 | L2               | 4                                              |
 | L3               | 1                                              |
-| L4               | 6                                              |
+| L4               | 7                                              |
 | lib tests        | 3875 passed, 0 failed                              |
 | clippy           | 0 warnings                              |
 

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -44,21 +44,17 @@ nika-lsp         = { path = "../nika-lsp", version = "0.99.0" }           # `nik
 nika-display     = { path = "../nika-display", version = "0.99.0" } # the run-comprehension surface (descended 2026-07-10 · re-exported at display::)
 nika-dap         = { path = "../nika-dap", version = "0.99.0" }           # `nika dap` + the trace-forensics plane (chain · recover · otel · reproduce · store · retention — re-exported at the old verb paths)
 nika-mcp         = { path = "../nika-mcp", version = "0.99.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-models      = { path = "../nika-models", version = "0.99.0" }        # `nika model` — the local-models unit (ONE dir · Hub pull · serve glue · descended 2026-07-12)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
-
-# ── the sovereign local-inference launch surface (ADR-091/093) — OFF by default ─
-# `nika model serve` boots the candle backend behind the tiny_http sidecar
-# server. Optional so the default binary keeps the lean-core contract
-# (zero inference deps); the subcommand's default body teaches the build flag.
-nika-infer-local = { path = "../nika-infer-local", version = "0.99.0", optional = true }
 
 [features]
 # Build `nika model serve` for real: the candle backend + the loopback
-# OpenAI-compat server (ADR-091 · ADR-093). Off by default.
-local-infer = ["dep:nika-infer-local", "nika-infer-local/local-infer", "nika-infer-local/server"]
+# OpenAI-compat server (ADR-091 · ADR-093) — forwarded to the descended
+# local-models member. Off by default (the lean-core contract).
+local-infer = ["nika-models/local-infer"]
 # Apple-GPU kernels for the local backend (macOS only — CI's Linux
 # feature-matrix excludes this name, keep them aligned).
-metal       = ["local-infer", "nika-infer-local/metal"]
+metal       = ["local-infer", "nika-models/metal"]
 
 [[bin]]
 name = "nika-cli"

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -323,6 +323,12 @@ pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool, theme: nika
 pub mod nika_cli::verbs::inspect
 pub fn nika_cli::verbs::inspect::run(path: &str, ascii: bool) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::model
+pub mod nika_cli::verbs::model::pull
+pub fn nika_cli::verbs::model::pull::run(arg: &str, yes: bool) -> nika_cli::verbs::VerbOutput
+pub mod nika_cli::verbs::model::store
+pub fn nika_cli::verbs::model::store::list() -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::model::store::resolve_serve_model(arg: &str) -> core::result::Result<std::path::PathBuf, nika_cli::verbs::VerbOutput>
+pub fn nika_cli::verbs::model::store::rm(id: &str) -> nika_cli::verbs::VerbOutput
 pub const nika_cli::verbs::model::DEFAULT_PORT: u16
 pub fn nika_cli::verbs::model::serve(gguf: &std::path::Path, tokenizer: core::option::Option<&std::path::Path>, port: u16, model_id: core::option::Option<&str>) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::new

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -15,6 +15,7 @@ use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+mod model_args;
 mod registry_args;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -248,10 +249,11 @@ enum Command {
         #[arg(long, default_value = ".")]
         dir: String,
     },
-    /// Local models — serve one on this machine (no cloud, no external daemon).
+    /// Local models — pull from the Hugging Face Hub, serve on this
+    /// machine, list/rm the disk (ONE models dir · no external daemon).
     Model {
         #[command(subcommand)]
-        action: ModelAction,
+        action: model_args::ModelAction,
     },
     /// The embedded spec identity (`--canon` prints the SSOT).
     Spec {
@@ -362,26 +364,6 @@ impl From<GraphFormatArg> for verbs::graph::GraphFormat {
             GraphFormatArg::Ascii => Self::Ascii,
         }
     }
-}
-
-#[derive(Subcommand)]
-enum ModelAction {
-    /// Serve a GGUF model — an OpenAI-compatible foreground server on
-    /// 127.0.0.1 (Ctrl-C stops it · the banner says how workflows reach it).
-    Serve {
-        /// The model weights (a Qwen3-family `.gguf` file).
-        #[arg(long, value_name = "PATH.gguf")]
-        model: PathBuf,
-        /// The tokenizer file (default: `tokenizer.json` beside the model).
-        #[arg(long, value_name = "PATH")]
-        tokenizer: Option<PathBuf>,
-        /// Loopback port to listen on.
-        #[arg(long, default_value_t = verbs::model::DEFAULT_PORT)]
-        port: u16,
-        /// The model id responses report (default: the model file's name).
-        #[arg(long, value_name = "ID")]
-        model_id: Option<String>,
-    },
 }
 
 #[derive(Subcommand)]
@@ -824,7 +806,7 @@ fn main() -> std::process::ExitCode {
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json, plain_theme)),
         Command::Init { dir, force, yes } => emit(&verbs::init::run(&dir, force, yes, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target, &dir)),
-        Command::Model { action } => model_verb(action),
+        Command::Model { action } => model_args::model_verb(action),
         Command::Spec { canon } => emit(&verbs::pack_surface::spec(canon)),
         Command::Schema => emit(&verbs::pack_surface::schema()),
         Command::Catalog { json } => emit(&verbs::catalog::run(json)),
@@ -876,22 +858,6 @@ fn emit(out: &VerbOutput) -> u8 {
         println!("{}", out.text.trim_end());
     }
     out.code
-}
-
-/// The `model` sub-verbs — a healthy `serve` never returns, so `emit` only prints refusals.
-fn model_verb(action: ModelAction) -> u8 {
-    let ModelAction::Serve {
-        model,
-        tokenizer,
-        port,
-        model_id,
-    } = action;
-    emit(&verbs::model::serve(
-        &model,
-        tokenizer.as_deref(),
-        port,
-        model_id.as_deref(),
-    ))
 }
 
 /// Dispatch the `trace` verb family: the live renders (replay · show)

--- a/crates/nika-cli/src/model_args.rs
+++ b/crates/nika-cli/src/model_args.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `nika model` clap family — a bin-side sibling of `main.rs` (the
+//! `registry_args.rs` convention): the dispatcher stays a thin verb
+//! tree, and the model family grows HERE, not at main.rs' 1500-line
+//! wall. Verb bodies live in the library (`verbs::model`) so every
+//! surface stays testable as a library call.
+
+use clap::Subcommand;
+
+use crate::emit;
+use nika_cli::verbs;
+
+#[derive(Subcommand)]
+pub(crate) enum ModelAction {
+    /// Serve a GGUF model — an OpenAI-compatible foreground server on
+    /// 127.0.0.1 (Ctrl-C stops it · the banner says how workflows reach it).
+    Serve {
+        /// The model: a `.gguf` path, or a pulled id — `owner/repo[:QUANT]`
+        /// or a file stem, resolved against the models dir (`nika model list`).
+        #[arg(long, value_name = "PATH|ID")]
+        model: String,
+        /// The tokenizer file (default: `tokenizer.json` beside the model).
+        #[arg(long, value_name = "PATH")]
+        tokenizer: Option<std::path::PathBuf>,
+        /// Loopback port to listen on.
+        #[arg(long, default_value_t = verbs::model::DEFAULT_PORT)]
+        port: u16,
+        /// The model id responses report (default: the model file's name).
+        #[arg(long, value_name = "ID")]
+        model_id: Option<String>,
+    },
+    /// Download a GGUF from the Hugging Face Hub into the ONE models dir
+    /// (`~/.nika/models` — the same dir `serve --model <id>` resolves, by
+    /// construction). Size prints BEFORE downloading; 2 GiB and over
+    /// confirms (`--yes` for CI). An interrupted pull resumes from its
+    /// `.part`. `HF_TOKEN` authenticates gated repos. This fetch is
+    /// CLI-level, like `registry:` pulls — a workflow's `permits:` never
+    /// govern it.
+    Pull {
+        /// The Hub model: `owner/repo[:QUANT]` — default quant `Q4_K_M`
+        /// when the repo tags one.
+        #[arg(value_name = "OWNER/REPO[:QUANT]")]
+        model: String,
+        /// Skip the size confirmation (CI · scripts).
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+    /// What's on disk: id · size · file per GGUF — the ONE models dir
+    /// printed once at top.
+    List,
+    /// Remove a pulled model: `owner/repo` removes every quant (and the
+    /// tokenizer beside them) · `owner/repo:QUANT` one file. A no-match
+    /// refuses, listing what IS there.
+    Rm {
+        /// The id to remove (`owner/repo[:QUANT]`, or a file stem from `list`).
+        #[arg(value_name = "ID")]
+        id: String,
+    },
+}
+
+/// The `model` sub-verbs — a healthy `serve` never returns, so `emit` only prints refusals.
+pub(crate) fn model_verb(action: ModelAction) -> u8 {
+    match action {
+        ModelAction::Serve {
+            model,
+            tokenizer,
+            port,
+            model_id,
+        } => {
+            // By-id resolution against the ONE models dir (`pull` writes
+            // it, this reads it) — a real path passes straight through.
+            match verbs::model::store::resolve_serve_model(&model) {
+                Ok(path) => emit(&verbs::model::serve(
+                    &path,
+                    tokenizer.as_deref(),
+                    port,
+                    model_id.as_deref(),
+                )),
+                Err(refusal) => emit(&refusal),
+            }
+        }
+        ModelAction::Pull { model, yes } => emit(&verbs::model::pull::run(&model, yes)),
+        ModelAction::List => emit(&verbs::model::store::list()),
+        ModelAction::Rm { id } => emit(&verbs::model::store::rm(&id)),
+    }
+}

--- a/crates/nika-cli/src/verbs/doctor.rs
+++ b/crates/nika-cli/src/verbs/doctor.rs
@@ -26,7 +26,7 @@ use std::fmt::Write as _;
 // this module's tests (and historical importers) keep their names.
 use crate::display::theme::{Role, Theme};
 pub(crate) use crate::verbs::probe::{
-    ClientProbe, ImageProbe, PingState, PricingProbe, Probe, ProviderProbe, TtsProbe,
+    ClientProbe, ImageProbe, ModelsProbe, PingState, PricingProbe, Probe, ProviderProbe, TtsProbe,
 };
 use crate::verbs::{VerbOutput, exit};
 
@@ -113,6 +113,7 @@ pub(crate) fn diagnose(probe: &Probe) -> Vec<Finding> {
         fix: None,
     });
     out.extend(sidecar_finding());
+    out.extend(models_finding(&probe.models));
 
     for client in &probe.clients {
         out.push(client_finding(client));
@@ -170,9 +171,9 @@ pub(crate) fn diagnose(probe: &Probe) -> Vec<Finding> {
 /// The sovereign sidecar lane (ADR-091) — a row ONLY when this binary was
 /// built with it (a BUILD fact · presence, never a probe): the default
 /// build's doctor stays byte-identical, so the row set is per-axis (a
-/// `Vec`, not an `Option` — the arity depends on the compile). The
-/// models-dir row arrives with `nika model pull`, which DEFINES the one
-/// canonical dir.
+/// `Vec`, not an `Option` — the arity depends on the compile). Its
+/// models-dir half lives in [`models_finding`] (issue #146 closed the
+/// deferral this note used to carry).
 fn sidecar_finding() -> Vec<Finding> {
     #[cfg(feature = "local-infer")]
     {
@@ -183,6 +184,40 @@ fn sidecar_finding() -> Vec<Finding> {
                      (loopback · OpenAI-compatible)"
                 .to_owned(),
             fix: None,
+        }]
+    }
+    #[cfg(not(feature = "local-infer"))]
+    {
+        Vec::new()
+    }
+}
+
+/// The models-dir half of the sidecar lane (issue #146 — the deferral
+/// `sidecar_finding` documented): the dir + count once anything is
+/// pulled (ANY build — acquisition is not feature-gated), and a teach
+/// row on a sidecar build with nothing to serve. A default build with
+/// zero pulls stays byte-identical.
+fn models_finding(models: &ModelsProbe) -> Vec<Finding> {
+    if models.count > 0 {
+        let root = models.root.as_deref().unwrap_or("~/.nika/models");
+        return vec![Finding {
+            level: Level::Ok,
+            label: "models".to_owned(),
+            detail: format!(
+                "{root} — {} GGUF · {} (`nika model list`)",
+                models.count,
+                nika_models::store::human_size(models.bytes)
+            ),
+            fix: None,
+        }];
+    }
+    #[cfg(feature = "local-infer")]
+    {
+        vec![Finding {
+            level: Level::Warn,
+            label: "models".to_owned(),
+            detail: "none pulled yet — the sidecar has nothing to serve".to_owned(),
+            fix: Some("nika model pull Qwen/Qwen3-4B-Instruct-2507-GGUF".to_owned()),
         }]
     }
     #[cfg(not(feature = "local-infer"))]
@@ -600,6 +635,7 @@ mod tests {
     #[test]
     fn key_present_is_ok_and_exits_zero() {
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.81.0".to_owned(),
             config_path: Some("~/.nika/config.toml".to_owned()),
             providers: vec![cloud("anthropic", "ANTHROPIC_API_KEY", true)],
@@ -626,6 +662,7 @@ mod tests {
         // An unset cloud key is advisory — exit stays 0 (a local provider is a
         // valid path · doctor cannot know which provider the user needs).
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.81.0".to_owned(),
             config_path: None,
             providers: vec![
@@ -663,6 +700,7 @@ mod tests {
         // The probe carries only a bool — there is no field a value could ride.
         // Assert the rendered report carries the VAR NAME, never a value.
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.81.0".to_owned(),
             config_path: None,
             providers: vec![cloud("openai", "OPENAI_API_KEY", false)],
@@ -687,6 +725,7 @@ mod tests {
         // A broken/empty catalog — no cloud key AND no local server: the real
         // "cannot infer" environment error (spec §4 ENV).
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.81.0".to_owned(),
             config_path: None,
             providers: vec![cloud("anthropic", "ANTHROPIC_API_KEY", false)],
@@ -706,6 +745,7 @@ mod tests {
     #[test]
     fn local_provider_alone_is_a_usable_path_exit_zero() {
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.81.0".to_owned(),
             config_path: None,
             providers: vec![local("ollama"), local("vllm")],
@@ -806,6 +846,7 @@ mod tests {
     #[test]
     fn sidecar_row_tracks_the_build_feature() {
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.99.0".to_owned(),
             config_path: None,
             providers: vec![local("ollama")],
@@ -827,6 +868,52 @@ mod tests {
         }
     }
 
+    /// The models row (issue #146 · the sidecar's dir+count half): pulled
+    /// models list on ANY build; an empty store rows only on a sidecar
+    /// build (teaching pull) — the default doctor stays byte-identical.
+    #[test]
+    fn models_row_reports_the_dir_and_count_once_pulled() {
+        let with_models = ModelsProbe {
+            root: Some("/home/x/.nika/models".to_owned()),
+            count: 2,
+            bytes: 3 * 1024 * 1024 * 1024,
+        };
+        let rows = models_finding(&with_models);
+        assert_eq!(rows.len(), 1, "pulled models row on EVERY build");
+        assert_eq!(rows[0].level, Level::Ok);
+        assert_eq!(rows[0].label, "models");
+        assert!(
+            rows[0].detail.contains("/home/x/.nika/models"),
+            "{}",
+            rows[0].detail
+        );
+        assert!(rows[0].detail.contains("2 GGUF"), "{}", rows[0].detail);
+        assert!(rows[0].detail.contains("3.0 GiB"), "{}", rows[0].detail);
+        assert!(
+            rows[0].detail.contains("nika model list"),
+            "{}",
+            rows[0].detail
+        );
+    }
+
+    #[test]
+    fn empty_models_store_teaches_pull_only_on_a_sidecar_build() {
+        let rows = models_finding(&ModelsProbe::default());
+        if cfg!(feature = "local-infer") {
+            assert_eq!(rows.len(), 1, "sidecar build with nothing to serve warns");
+            assert_eq!(rows[0].level, Level::Warn);
+            assert!(
+                rows[0]
+                    .fix
+                    .as_deref()
+                    .is_some_and(|f| f.contains("nika model pull")),
+                "{rows:?}"
+            );
+        } else {
+            assert!(rows.is_empty(), "default build + zero pulls = no row");
+        }
+    }
+
     #[test]
     fn level_glyphs_are_distinct() {
         assert_eq!(Level::Ok.glyph(), '✔');
@@ -837,6 +924,7 @@ mod tests {
     #[test]
     fn client_probe_reports_stale_wiring_with_a_wire_fix() {
         let probe = Probe {
+            models: ModelsProbe::default(),
             version: "0.90.0".to_owned(),
             config_path: None,
             providers: vec![local("ollama")],
@@ -1048,6 +1136,7 @@ mod tests {
     #[test]
     fn local_line_hands_off_to_ping_and_ping_lines_render() {
         let base = Probe {
+            models: ModelsProbe::default(),
             version: "0.0.0".to_owned(),
             config_path: None,
             providers: vec![ProviderProbe {
@@ -1076,6 +1165,7 @@ mod tests {
         );
 
         let pinged = Probe {
+            models: ModelsProbe::default(),
             local_pings: vec![
                 (
                     "ollama".to_owned(),

--- a/crates/nika-cli/src/verbs/model.rs
+++ b/crates/nika-cli/src/verbs/model.rs
@@ -1,50 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! `nika model serve` — the sovereign local-inference launch surface
-//! (ADR-091 · ADR-093).
-//!
-//! FOREGROUND by design: the process the operator (or a workflow's `exec`
-//! task, or the future L3 supervisor) starts, watches and stops. The v1
-//! contract is deliberately narrow — one loopback `tiny_http` server over
-//! one loaded GGUF, one generation at a time, Ctrl-C ends it. Process
-//! supervision (spawn/health/restart) is the runtime layer's job per
-//! ADR-091 §isolation; this verb is the rung below it.
-//!
-//! The served endpoint is reached over the EXISTING `OpenAiCompat` wire
-//! (zero new dispatch seam): point any keyless local profile's base URL at
-//! it (`NIKA_LLAMACPP_BASE_URL=http://127.0.0.1:<port>`) and a workflow's
-//! `model: llamacpp/<id>` lands on the sidecar.
-//!
-//! The whole surface is feature-gated (`local-infer` · off by default —
-//! the default binary links zero inference deps): the SUBCOMMAND always
-//! exists so the tree teaches it, the default BODY refuses with the build
-//! recipe (exit `3` · environment class).
-
-// The healthy path prints a banner then serves for the process' whole
-// life — output DURING a blocking serve cannot be deferred through
-// `VerbOutput`. The same sanctioned exemption `run` and `main.rs` carry.
-#![allow(clippy::disallowed_macros, clippy::print_stderr)]
+//! `nika model` — thin adapters over the descended `nika-models` unit
+//! (serve · pull · list · rm · issue #146). The member owns the logic
+//! (the ONE models dir · Hub acquisition · the sidecar launch glue) and
+//! speaks plain strings; THIS file owns what the texts MEAN on the verb
+//! tree — receipts exit `0`, refusals exit `3` (environment class).
+//! Split 2026-07-12 per D-2026-07-09-N1 (the 15k prod-LOC crate cap —
+//! the `nika-onboard`/`nika-display` precedents).
 
 use std::path::Path;
-// `PathBuf` rides only the feature/test axes (`ServePlan` · fixtures).
-#[cfg(any(feature = "local-infer", test))]
-use std::path::PathBuf;
 
 use crate::verbs::{VerbOutput, exit};
 
 /// The default loopback port (`nika mcp` owns 8123; this stays clear of
 /// the 5 external local servers' defaults: 11434 · 1234 · 8080 · 8000).
-pub const DEFAULT_PORT: u16 = 8712;
+pub const DEFAULT_PORT: u16 = nika_models::serve::DEFAULT_PORT;
 
-/// Serve `gguf` (Qwen3 family · v1 loader scope) in the foreground on
-/// loopback `port`. `tokenizer` defaults to `tokenizer.json` beside the
-/// GGUF (the layout a Hugging Face repo download produces); `model_id`
-/// (the id responses report) defaults to the GGUF file stem.
-///
-/// Returns ONLY on refusal (missing file · unreadable model · bind
-/// failure · a build without the feature) — a healthy server runs until
-/// the process ends (Ctrl-C). Refusals are environment-class (exit `3`).
+/// Serve a GGUF in the foreground on loopback `port` — returns ONLY on
+/// refusal (a healthy server runs until Ctrl-C); the whole surface is
+/// feature-gated `local-infer` (the default body teaches the recipe).
 #[must_use]
 pub fn serve(
     gguf: &Path,
@@ -52,155 +27,66 @@ pub fn serve(
     port: u16,
     model_id: Option<&str>,
 ) -> VerbOutput {
-    #[cfg(feature = "local-infer")]
-    {
-        serve_local(gguf, tokenizer, port, model_id)
+    env(nika_models::serve::serve(gguf, tokenizer, port, model_id))
+}
+
+/// The models-dir store: by-id resolution · list · rm.
+pub mod store {
+    use std::path::PathBuf;
+
+    use super::{VerbOutput, env, ok};
+
+    /// Resolve `serve --model <arg>`: paths pass through (`serve` owns
+    /// the missing-path verdict per build axis — the bin_smoke-pinned
+    /// #482 contract); ids resolve against the ONE models dir.
+    ///
+    /// # Errors
+    ///
+    /// An exit-3 refusal on the id lane only — a miss lists what IS
+    /// installed (the teaching surface), an ambiguous id the exact ids.
+    pub fn resolve_serve_model(arg: &str) -> Result<PathBuf, VerbOutput> {
+        nika_models::store::resolve_serve_model(arg).map_err(env)
     }
-    #[cfg(not(feature = "local-infer"))]
-    {
-        let _ = (gguf, tokenizer, port, model_id);
-        feature_stub()
+
+    /// `nika model list` — the dir once at top, then id · size · file.
+    #[must_use]
+    pub fn list() -> VerbOutput {
+        ok(nika_models::store::list())
+    }
+
+    /// `nika model rm <id>` — reclaim a repo or one quant; a no-match
+    /// refuses with the installed list.
+    #[must_use]
+    pub fn rm(id: &str) -> VerbOutput {
+        nika_models::store::rm(id).map_or_else(env, ok)
     }
 }
 
-/// The resolved boot inputs: every path verified present, the id named.
-#[cfg(any(feature = "local-infer", test))]
-#[derive(Debug, PartialEq, Eq)]
-struct ServePlan {
-    gguf: PathBuf,
-    tokenizer: PathBuf,
-    model_id: String,
-}
+/// The Hub acquisition (`nika model pull`).
+pub mod pull {
+    use super::{VerbOutput, env, ok};
 
-/// Resolve + verify the boot inputs BEFORE any load: a wrong path must
-/// refuse with the exact fix, not a parse failure deep in the loader.
-#[cfg(any(feature = "local-infer", test))]
-fn plan(
-    gguf: &Path,
-    tokenizer: Option<&Path>,
-    model_id: Option<&str>,
-) -> Result<ServePlan, VerbOutput> {
-    if !gguf.is_file() {
-        return Err(VerbOutput {
-            text: format!(
-                "model serve: no model file at {}\n  fix: point --model at a \
-                 Qwen3-family .gguf (download one from the Hugging Face Hub \
-                 — its tokenizer.json goes beside it)\n",
-                gguf.display()
-            ),
-            code: exit::ENV,
-        });
+    /// `nika model pull <owner/repo[:QUANT]>` — receipts (and the
+    /// operator's clean abort) exit `0`, refusals `3`.
+    #[must_use]
+    pub fn run(arg: &str, yes: bool) -> VerbOutput {
+        nika_models::pull::run(arg, yes).map_or_else(env, ok)
     }
-    let tokenizer =
-        tokenizer.map_or_else(|| gguf.with_file_name("tokenizer.json"), Path::to_path_buf);
-    if !tokenizer.is_file() {
-        return Err(VerbOutput {
-            text: format!(
-                "model serve: no tokenizer at {}\n  fix: download the model \
-                 repo's tokenizer.json beside the GGUF, or name one with \
-                 --tokenizer <path>\n",
-                tokenizer.display()
-            ),
-            code: exit::ENV,
-        });
-    }
-    Ok(ServePlan {
-        model_id: model_id.map_or_else(|| derive_model_id(gguf), str::to_owned),
-        gguf: gguf.to_path_buf(),
-        tokenizer,
-    })
 }
 
-/// The id responses report when `--model-id` is absent: the GGUF file
-/// stem (`qwen3-4b-instruct-q4_k_m.gguf` → `qwen3-4b-instruct-q4_k_m`).
-#[cfg(any(feature = "local-infer", test))]
-fn derive_model_id(gguf: &Path) -> String {
-    gguf.file_stem()
-        .map_or_else(|| "local".to_owned(), |s| s.to_string_lossy().into_owned())
-}
-
-/// The default build's honest refusal: name the feature and the build
-/// recipe — never pretend the lane is one flag away at runtime.
-#[cfg(any(not(feature = "local-infer"), test))]
-fn feature_stub() -> VerbOutput {
+/// A receipt on the success stream (exit `0`).
+fn ok(text: String) -> VerbOutput {
     VerbOutput {
-        text: "model serve: this binary was built without local inference \
-               (the default build links zero inference dependencies)\n  \
-               fix: build from source with the feature — cargo build -p \
-               nika-cli --features local-infer   (Apple GPU: --features \
-               metal)\n"
-            .to_owned(),
-        code: exit::ENV,
+        text,
+        code: exit::OK,
     }
 }
 
-/// Load the GGUF, bind loopback, announce, serve until the process ends.
-#[cfg(feature = "local-infer")]
-fn serve_local(
-    gguf: &Path,
-    tokenizer: Option<&Path>,
-    port: u16,
-    model_id: Option<&str>,
-) -> VerbOutput {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use std::sync::Arc;
-
-    let plan = match plan(gguf, tokenizer, model_id) {
-        Ok(plan) => plan,
-        Err(refusal) => return refusal,
-    };
-    eprintln!(
-        "nika model serve · loading {} (a first load reads the whole file)",
-        plan.gguf.display()
-    );
-    let backend = match nika_infer_local::CandleBackend::load_qwen3(
-        &plan.gguf,
-        &plan.tokenizer,
-        &plan.model_id,
-    ) {
-        Ok(backend) => backend,
-        Err(err) => {
-            return VerbOutput {
-                text: format!(
-                    "model serve: {err}\n  fix: the v1 loader serves \
-                         Qwen3-family GGUFs with their tokenizer.json — \
-                         check both files\n"
-                ),
-                code: exit::ENV,
-            };
-        }
-    };
-    // Loopback ONLY (ADR-093: no TLS · no auth · the operator owns the
-    // port) — widening the bind is the supervisor era's decision, not v1's.
-    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    let handle = match nika_infer_local::serve(Arc::new(backend), addr) {
-        Ok(handle) => handle,
-        Err(err) => {
-            return VerbOutput {
-                text: format!(
-                    "model serve: {err}\n  fix: another process may own the \
-                     port — pick one with --port <n>\n"
-                ),
-                code: exit::ENV,
-            };
-        }
-    };
-    let bound = handle.addr();
-    eprintln!(
-        "nika model serve · http://{bound}/v1/chat/completions · {} · \
-         loopback only · one generation at a time · Ctrl-C stops",
-        plan.model_id
-    );
-    eprintln!(
-        "  reach it from a workflow: export NIKA_LLAMACPP_BASE_URL=http://{bound} \
-         then model: llamacpp/{}",
-        plan.model_id
-    );
-    // The handle must outlive the park (dropping it stops the server).
-    // Ctrl-C ends the foreground process — the v1 lifecycle contract.
-    let _serving = handle;
-    loop {
-        std::thread::park();
+/// A teaching refusal on stderr (exit `3` · environment class).
+fn env(text: String) -> VerbOutput {
+    VerbOutput {
+        text,
+        code: exit::ENV,
     }
 }
 
@@ -208,105 +94,19 @@ fn serve_local(
 mod tests {
     use super::*;
 
-    // The doctor tests' exact fixture idiom (CARGO_TARGET_TMPDIR is unset
-    // for lib unit tests — fall back beside the build dir).
-    #[allow(clippy::disallowed_methods)]
-    fn temp_dir(name: &str) -> PathBuf {
-        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
-            || {
-                std::env::current_dir()
-                    .expect("current dir")
-                    .join("target")
-                    .join("tmp")
-            },
-            PathBuf::from,
-        );
-        let dir = base.join(format!("nika-model-{name}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("temp dir");
-        dir
-    }
-
+    /// The adapter's ONE job: receipts ride exit 0, refusals exit 3 —
+    /// the member's strings keep their teaching text verbatim.
     #[test]
-    fn plan_refuses_a_missing_gguf_with_the_fix() {
-        let dir = temp_dir("missing-gguf");
-        let refusal = plan(&dir.join("nope.gguf"), None, None).expect_err("must refuse");
+    fn the_adapter_maps_strings_onto_the_locked_exit_contract() {
+        let refusal = pull::run("not-a-ref", true);
         assert_eq!(refusal.code, exit::ENV);
-        assert!(refusal.text.contains("no model file"), "{}", refusal.text);
-        assert!(refusal.text.contains("--model"), "{}", refusal.text);
-        let _ = std::fs::remove_dir_all(dir);
-    }
+        assert!(refusal.text.contains("owner/repo"), "{}", refusal.text);
 
-    #[test]
-    fn plan_defaults_to_the_sibling_tokenizer_and_the_file_stem_id() {
-        let dir = temp_dir("sibling");
-        let gguf = dir.join("qwen3-4b-instruct-q4_k_m.gguf");
-        std::fs::write(&gguf, b"stub").expect("fixture");
-        std::fs::write(dir.join("tokenizer.json"), b"{}").expect("fixture");
-        let plan = plan(&gguf, None, None).expect("resolves");
-        assert_eq!(plan.tokenizer, dir.join("tokenizer.json"));
-        assert_eq!(plan.model_id, "qwen3-4b-instruct-q4_k_m");
-        assert_eq!(plan.gguf, gguf);
-        let _ = std::fs::remove_dir_all(dir);
-    }
+        let listed = store::list();
+        assert_eq!(listed.code, exit::OK);
+        assert!(listed.text.contains("models ·"), "{}", listed.text);
 
-    #[test]
-    fn plan_refuses_a_missing_tokenizer_naming_both_fixes() {
-        let dir = temp_dir("no-tokenizer");
-        let gguf = dir.join("model.gguf");
-        std::fs::write(&gguf, b"stub").expect("fixture");
-        let refusal = plan(&gguf, None, None).expect_err("must refuse");
-        assert_eq!(refusal.code, exit::ENV);
-        assert!(refusal.text.contains("tokenizer.json"), "{}", refusal.text);
-        assert!(refusal.text.contains("--tokenizer"), "{}", refusal.text);
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn plan_honors_explicit_tokenizer_and_model_id() {
-        let dir = temp_dir("explicit");
-        let gguf = dir.join("weights.gguf");
-        let tok = dir.join("tok.json");
-        std::fs::write(&gguf, b"stub").expect("fixture");
-        std::fs::write(&tok, b"{}").expect("fixture");
-        let resolved = plan(&gguf, Some(&tok), Some("qwen3")).expect("resolves");
-        assert_eq!(resolved.tokenizer, tok);
-        assert_eq!(resolved.model_id, "qwen3");
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn the_stub_names_the_feature_and_exits_environment() {
-        let out = feature_stub();
-        assert_eq!(out.code, exit::ENV);
-        assert!(out.text.contains("local-infer"), "{}", out.text);
-        assert!(out.text.contains("cargo build"), "{}", out.text);
-    }
-
-    /// The REAL serve path refuses a missing model file cleanly — the
-    /// documented no-fixture e2e (a live-model boot is a manual step).
-    #[cfg(feature = "local-infer")]
-    #[test]
-    fn serve_refuses_a_missing_model_before_binding_anything() {
-        let dir = temp_dir("serve-missing");
-        let out = serve(&dir.join("absent.gguf"), None, DEFAULT_PORT, None);
-        assert_eq!(out.code, exit::ENV);
-        assert!(out.text.contains("no model file"), "{}", out.text);
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    /// A present-but-invalid GGUF exercises the loader's typed refusal
-    /// through the real feature-on path (no model fixture in the repo).
-    #[cfg(feature = "local-infer")]
-    #[test]
-    fn serve_refuses_a_garbage_gguf_with_the_loader_error() {
-        let dir = temp_dir("serve-garbage");
-        let gguf = dir.join("junk.gguf");
-        std::fs::write(&gguf, b"not a gguf").expect("fixture");
-        std::fs::write(dir.join("tokenizer.json"), b"{}").expect("fixture");
-        let out = serve(&gguf, None, DEFAULT_PORT, None);
-        assert_eq!(out.code, exit::ENV);
-        assert!(out.text.contains("Qwen3-family"), "{}", out.text);
-        let _ = std::fs::remove_dir_all(dir);
+        let missing = store::rm("absent/never-pulled-model");
+        assert_eq!(missing.code, exit::ENV);
     }
 }

--- a/crates/nika-cli/src/verbs/probe.rs
+++ b/crates/nika-cli/src/verbs/probe.rs
@@ -45,7 +45,14 @@ pub(crate) struct Probe {
     /// Knob values that would not parse (each fell back LOUDLY to its
     /// default — a typo'd knob silently doing nothing is hidden magic).
     pub retention_notes: Vec<String>,
+    /// The ONE models dir (`~/.nika/models` · issue #146) — presence facts
+    /// only, observed once here so `diagnose` stays pure.
+    pub models: ModelsProbe,
 }
+
+// The models-dir facts live with their store (the descended member) —
+// re-exported so `doctor`'s diagnosis keeps one import surface.
+pub(crate) use nika_models::ModelsProbe;
 
 /// The pricing-catalog facts — all derived from the vendored snapshot
 /// (zero network · the born-stale law keeps counts read-time-derived).
@@ -135,6 +142,7 @@ pub(crate) fn collect(ping: bool) -> Probe {
         pricing: pricing_probe(),
         retention,
         retention_notes,
+        models: nika_models::models_probe(),
     };
     if ping {
         let local_pings = nika_providers::probe::collect_local_pings(

--- a/crates/nika-cli/src/verbs/welcome.rs
+++ b/crates/nika-cli/src/verbs/welcome.rs
@@ -340,6 +340,7 @@ mod tests {
 
     fn synthetic_probe() -> Probe {
         Probe {
+            models: crate::verbs::probe::ModelsProbe::default(),
             version: "0.0.0-test".to_owned(),
             config_path: None,
             providers: vec![
@@ -474,6 +475,7 @@ mod tests {
             stale: false,
         };
         Probe {
+            models: crate::verbs::probe::ModelsProbe::default(),
             version: "0.98.0".to_owned(),
             config_path: None,
             providers: ["ollama", "lmstudio", "llamacpp", "localai", "vllm"]

--- a/crates/nika-models/Cargo.toml
+++ b/crates/nika-models/Cargo.toml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+name          = "nika-models"
+description   = "The local-models unit — the ONE canonical models dir (store · by-id resolver), the Hugging Face Hub acquisition (pull · size-confirm · Range resume · gated-repo teach), and the candle sidecar launch glue (serve · ADR-091/093). Layer L4 — split from nika-cli's verbs/model 2026-07-12 (the crate-size cap · the nika-onboard/nika-display precedents): the downloader and the resolver share one root by construction, so the brouillon-era pull/load two-dir mismatch cannot re-happen."
+version.workspace      = true
+edition.workspace      = true
+license.workspace      = true
+authors.workspace      = true
+rust-version.workspace = true
+repository.workspace   = true
+homepage.workspace     = true
+publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
+
+[dependencies]
+nika-kernel = { path = "../nika-kernel", version = "0.99.0" } # HttpGetDyn/HttpPostDyn — the injectable transport seam (the whole pull path is mock-proven)
+nika-http   = { path = "../nika-http", version = "0.99.0" }   # ReqwestHttp — the production client (rustls · SSRF floor · per-hop redirect vetting)
+tokio       = { workspace = true }                            # the blocking pull seam's current-thread runtime (the registry #452 idiom)
+serde       = { workspace = true }                            # the Hub tree rows
+serde_json  = { workspace = true }                            # tree-listing parse
+
+# ── the sovereign local-inference launch surface (ADR-091/093) — OFF by default ─
+# `serve` boots the candle backend behind the tiny_http sidecar server.
+# Optional so the default binary keeps the lean-core contract (zero
+# inference deps); the default body teaches the build flag.
+nika-infer-local = { path = "../nika-infer-local", version = "0.99.0", optional = true }
+
+[features]
+# Build the serve body for real: the candle backend + the loopback
+# OpenAI-compat server (ADR-091 · ADR-093). Off by default.
+local-infer = ["dep:nika-infer-local", "nika-infer-local/local-infer", "nika-infer-local/server"]
+# Apple-GPU kernels for the local backend (macOS only — CI's Linux
+# feature-matrix excludes this name, keep them aligned).
+metal       = ["local-infer", "nika-infer-local/metal"]
+
+[dev-dependencies]
+bytes        = { workspace = true }   # canned chunks for the pull streaming double
+futures-core = { workspace = true }   # the Stream impl on that double (src polls the kernel
+                                      # body via the trait-object's own methods · no lib dep)
+
+[package.metadata.lore]
+daemon        = "forgeron"
+archetype     = "kodama-quartermaster"
+spirit_role   = "le magasinier des poids — un seul entrepôt (~/.nika/models), le puller et le résolveur y lisent la même vérité"
+voice_pattern = "spoken"
+layer         = "L4"
+err_prefix    = "none"
+
+[lints]
+workspace = true

--- a/crates/nika-models/public-api.txt
+++ b/crates/nika-models/public-api.txt
@@ -1,0 +1,61 @@
+pub mod nika_models
+pub mod nika_models::pull
+pub fn nika_models::pull::run(arg: &str, yes: bool) -> core::result::Result<alloc::string::String, alloc::string::String>
+pub mod nika_models::serve
+pub const nika_models::serve::DEFAULT_PORT: u16
+pub fn nika_models::serve::serve(gguf: &std::path::Path, tokenizer: core::option::Option<&std::path::Path>, port: u16, model_id: core::option::Option<&str>) -> alloc::string::String
+pub mod nika_models::store
+pub fn nika_models::store::human_size(bytes: u64) -> alloc::string::String
+pub fn nika_models::store::list() -> alloc::string::String
+pub fn nika_models::store::models_root() -> core::result::Result<std::path::PathBuf, alloc::string::String>
+pub fn nika_models::store::resolve_serve_model(arg: &str) -> core::result::Result<std::path::PathBuf, alloc::string::String>
+pub fn nika_models::store::rm(id: &str) -> core::result::Result<alloc::string::String, alloc::string::String>
+pub struct nika_models::ModelsProbe
+pub nika_models::ModelsProbe::bytes: u64
+pub nika_models::ModelsProbe::count: usize
+pub nika_models::ModelsProbe::root: core::option::Option<alloc::string::String>
+impl core::clone::Clone for nika_models::ModelsProbe
+pub fn nika_models::ModelsProbe::clone(&self) -> nika_models::ModelsProbe
+impl core::cmp::Eq for nika_models::ModelsProbe
+impl core::cmp::PartialEq for nika_models::ModelsProbe
+pub fn nika_models::ModelsProbe::eq(&self, other: &nika_models::ModelsProbe) -> bool
+impl core::default::Default for nika_models::ModelsProbe
+pub fn nika_models::ModelsProbe::default() -> nika_models::ModelsProbe
+impl core::fmt::Debug for nika_models::ModelsProbe
+pub fn nika_models::ModelsProbe::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_models::ModelsProbe
+impl<D> owo_colors::OwoColorize for nika_models::ModelsProbe
+impl<Q, K> equivalent::Equivalent<K> for nika_models::ModelsProbe where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_models::ModelsProbe::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_models::ModelsProbe where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_models::ModelsProbe::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_models::ModelsProbe where U: core::convert::From<T>
+pub fn nika_models::ModelsProbe::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_models::ModelsProbe where U: core::convert::Into<T>
+pub type nika_models::ModelsProbe::Error = core::convert::Infallible
+pub fn nika_models::ModelsProbe::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_models::ModelsProbe where U: core::convert::TryFrom<T>
+pub type nika_models::ModelsProbe::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_models::ModelsProbe::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_models::ModelsProbe where T: core::clone::Clone
+pub type nika_models::ModelsProbe::Owned = T
+pub fn nika_models::ModelsProbe::clone_into(&self, target: &mut T)
+pub fn nika_models::ModelsProbe::to_owned(&self) -> T
+impl<T> core::any::Any for nika_models::ModelsProbe where T: 'static + ?core::marker::Sized
+pub fn nika_models::ModelsProbe::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_models::ModelsProbe where T: ?core::marker::Sized
+pub fn nika_models::ModelsProbe::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_models::ModelsProbe where T: ?core::marker::Sized
+pub fn nika_models::ModelsProbe::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_models::ModelsProbe where T: core::clone::Clone
+pub unsafe fn nika_models::ModelsProbe::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_models::ModelsProbe
+pub fn nika_models::ModelsProbe::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_models::ModelsProbe where T: 'static
+pub fn nika_models::ModelsProbe::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_models::ModelsProbe where T: ?core::marker::Sized
+pub fn nika_models::ModelsProbe::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_models::ModelsProbe::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_models::ModelsProbe
+impl<T> tracing::instrument::WithSubscriber for nika_models::ModelsProbe
+pub fn nika_models::models_probe() -> nika_models::ModelsProbe

--- a/crates/nika-models/src/lib.rs
+++ b/crates/nika-models/src/lib.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika-models` — the local-models unit (issue #146 · ADR-091/093).
+//!
+//! One crate, one law: the ONE canonical models dir
+//! (`~/.nika/models/<owner>/<repo>/`). The DOWNLOADER ([`pull`]) and the
+//! RESOLVER ([`store`] — what `nika model serve --model <id>` reads)
+//! share the root by construction, so the brouillon-era pull/load
+//! two-dir mismatch cannot re-happen. [`serve`] is the candle sidecar
+//! launch glue the CLI adapts (feature-gated `local-infer` — the
+//! default build's body teaches the recipe).
+//!
+//! Split from `nika-cli`'s `verbs/model` 2026-07-12 per D-2026-07-09-N1
+//! (the 15k prod-LOC crate cap — the `nika-onboard`/`nika-display`
+//! precedents): the composition root keeps thin `VerbOutput` adapters;
+//! this member owns the logic and speaks plain `Result<String, String>`
+//! (`Ok` = receipt · `Err` = an environment-class refusal that teaches
+//! its fix).
+
+// Test fixtures expect/unwrap freely — the nika-http/nika-cli idiom.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod pull;
+pub mod serve;
+pub mod store;
+
+/// The canonical models dir's presence facts — what `nika doctor`'s
+/// models row reads (observed once, so the diagnosis stays pure).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModelsProbe {
+    /// The dir (`None` when HOME/USERPROFILE cannot resolve).
+    pub root: Option<String>,
+    /// GGUFs on disk under it.
+    pub count: usize,
+    /// Their cumulative bytes.
+    pub bytes: u64,
+}
+
+/// Observe the ONE models dir (count + bytes · `~/.nika/models`).
+#[must_use]
+pub fn models_probe() -> ModelsProbe {
+    match store::models_root() {
+        Ok(root) => {
+            let items = store::installed(&root);
+            ModelsProbe {
+                root: Some(root.display().to_string()),
+                count: items.len(),
+                bytes: items.iter().map(|m| m.size).sum(),
+            }
+        }
+        Err(_) => ModelsProbe::default(),
+    }
+}

--- a/crates/nika-models/src/pull.rs
+++ b/crates/nika-models/src/pull.rs
@@ -1,0 +1,1014 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika model pull` — first-class Hugging Face acquisition for the
+//! native path (issue #146).
+//!
+//! One command from the Hub to a sovereign in-process run: resolve the
+//! repo's file tree (sizes BEFORE any download), choose the GGUF
+//! (`Q4_K_M` default · explicit via `:TAG`), stream it into the ONE
+//! canonical models dir ([`crate::store`]), and bring `tokenizer.json`
+//! along — the exact sibling layout `nika model serve` loads.
+//!
+//! # Why the HOUSE http seam, not the `hf-hub` crate (decision · honest)
+//!
+//! `hf-hub` was evaluated and NOT taken, on three architectural refusals
+//! (not a licence failure):
+//! 1. **Layer discipline** — `deny.toml` layer-bans `reqwest` to its
+//!    wrappers so every outbound byte rides `nika-http`'s four-layer
+//!    SSRF defense; `hf-hub` embeds its OWN `ureq` stack, a second HTTP
+//!    path around that seam.
+//! 2. **Testability** — `hf-hub` accepts no client injection; the
+//!    kernel `HttpGetDyn`/`HttpPostDyn` traits make this whole module
+//!    mockable (the `registry::` #452 precedent).
+//! 3. **The one-dir law** — `hf-hub` imposes its snapshot cache layout
+//!    (`models--owner--repo/snapshots/<rev>/…`); this issue exists
+//!    because pull and load once read DIFFERENT dirs, so the downloader
+//!    writes the resolver's layout directly.
+//!
+//! Resume rides a `<file>.part` + `Range:` request (the Hub serves
+//! ranges); an interrupted pull re-runs from where it stopped. The
+//! fetch is CLI-level, like `registry:` pulls — a workflow's `permits:`
+//! never govern it. `HF_TOKEN` (when set) authenticates gated repos;
+//! `nika-http` strips the header on the cross-origin CDN redirect (the
+//! signed URL carries its own grant).
+
+// Progress DURING a blocking download cannot be deferred through the
+// returned receipt — the same sanctioned exemption `serve` carries.
+#![allow(clippy::disallowed_macros, clippy::print_stderr)]
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use nika_kernel::http::{HttpGetDyn, HttpPostDyn, HttpRequest, HttpStreamResponse};
+
+use crate::store::{self, ModelRef};
+
+/// The Hugging Face Hub origin (metadata + `resolve/` downloads; the
+/// CDN hop arrives as a redirect `nika-http` re-vets per hop).
+const HUB: &str = "https://huggingface.co";
+
+/// The Hub default quant (the issue's lock): picked when the repo tags
+/// one and no explicit `:TAG` was given.
+pub(crate) const DEFAULT_QUANT: &str = "Q4_K_M";
+
+/// Sizes at or above this confirm before downloading (`--yes` bypasses).
+pub(crate) const CONFIRM_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// One file row of the Hub tree listing (`GET api/models/<repo>/tree/main`).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub(crate) struct TreeEntry {
+    /// `"file"` or `"directory"` — only files are candidates.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// The path inside the repo (top-level GGUF convention).
+    pub path: String,
+    /// Size in bytes (the confirm gate reads it BEFORE any download).
+    #[serde(default)]
+    pub size: u64,
+}
+
+/// The confirm-gate verdict over a size (pure — the prompt I/O lives in
+/// the blocking seam).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConfirmGate {
+    /// Under the threshold, or explicitly `--yes`.
+    Proceed,
+    /// Over the threshold on a terminal: ask.
+    Prompt,
+    /// Over the threshold, no terminal, no `--yes`: refuse (the CI shape).
+    RefuseNeedsYes,
+}
+
+/// Gate a download of `size` bytes: `yes` bypasses, small sizes pass,
+/// big sizes prompt on a terminal and refuse in a pipe.
+pub(crate) fn confirm_gate(size: u64, yes: bool, interactive: bool) -> ConfirmGate {
+    if yes || size < CONFIRM_BYTES {
+        ConfirmGate::Proceed
+    } else if interactive {
+        ConfirmGate::Prompt
+    } else {
+        ConfirmGate::RefuseNeedsYes
+    }
+}
+
+/// Parse the tree listing JSON into file rows (directories drop here).
+pub(crate) fn parse_tree(body: &[u8], repo_id: &str) -> Result<Vec<TreeEntry>, Refusal> {
+    let entries: Vec<TreeEntry> = serde_json::from_slice(body).map_err(|e| {
+        refuse(format!(
+            "model pull: the Hub's file listing for {repo_id} did not parse ({e})\n  fix: \
+             check the id on huggingface.co — `owner/repo`, exactly\n"
+        ))
+    })?;
+    Ok(entries.into_iter().filter(|e| e.kind == "file").collect())
+}
+
+/// Choose THE GGUF the ref names: explicit `:TAG` matches its quant
+/// (case-insensitively); no tag prefers [`DEFAULT_QUANT`], then a
+/// repo's single GGUF; every miss refuses LISTING the quants that exist.
+pub(crate) fn choose_gguf<'a>(
+    entries: &'a [TreeEntry],
+    mref: &ModelRef,
+) -> Result<&'a TreeEntry, Refusal> {
+    let ggufs: Vec<&TreeEntry> = entries
+        .iter()
+        .filter(|e| e.path.to_ascii_lowercase().ends_with(".gguf"))
+        .collect();
+    if ggufs.is_empty() {
+        return Err(refuse(format!(
+            "model pull: {} has no GGUF file\n  fix: pick a GGUF repo (quantized mirrors \
+             usually end in -GGUF — search \"{} gguf\" on huggingface.co)\n",
+            mref.repo_id(),
+            mref.name
+        )));
+    }
+    if let Some(tag) = &mref.quant {
+        return pick_tagged(&ggufs, mref, tag);
+    }
+    let defaults: Vec<&TreeEntry> = ggufs
+        .iter()
+        .copied()
+        .filter(|e| entry_matches_tag(e, DEFAULT_QUANT))
+        .collect();
+    if let [one] = defaults[..] {
+        return Ok(one);
+    }
+    if defaults.len() > 1 {
+        return Err(quant_menu(mref, &defaults, None));
+    }
+    if let [one] = ggufs[..] {
+        return Ok(one);
+    }
+    Err(quant_menu(mref, &ggufs, None))
+}
+
+/// The explicit-`:TAG` arm of [`choose_gguf`].
+fn pick_tagged<'a>(
+    ggufs: &[&'a TreeEntry],
+    mref: &ModelRef,
+    tag: &str,
+) -> Result<&'a TreeEntry, Refusal> {
+    let matches: Vec<&TreeEntry> = ggufs
+        .iter()
+        .copied()
+        .filter(|e| entry_matches_tag(e, tag))
+        .collect();
+    match matches[..] {
+        [one] => Ok(one),
+        [] => Err(quant_menu(mref, ggufs, Some(tag))),
+        _ => Err(quant_menu(mref, &matches, Some(tag))),
+    }
+}
+
+/// Does a tree entry's file name answer to a quant tag?
+fn entry_matches_tag(e: &TreeEntry, tag: &str) -> bool {
+    let file = file_name(&e.path);
+    store::quant_of(file).is_some_and(|q| q.eq_ignore_ascii_case(tag))
+        || file
+            .to_ascii_lowercase()
+            .contains(&tag.to_ascii_lowercase())
+}
+
+/// The pick-a-quant refusal: each candidate as its exact pull command.
+fn quant_menu(mref: &ModelRef, ggufs: &[&TreeEntry], asked: Option<&str>) -> Refusal {
+    let head = match asked {
+        Some(tag) => format!(
+            "model pull: `{tag}` does not name exactly one GGUF of {}",
+            mref.repo_id()
+        ),
+        None => format!(
+            "model pull: {} ships several GGUFs and none is the {DEFAULT_QUANT} default",
+            mref.repo_id()
+        ),
+    };
+    let mut text = format!("{head} — the menu:\n");
+    for e in ggufs {
+        let file = file_name(&e.path);
+        let tag = store::quant_of(file).unwrap_or_else(|| file.to_owned());
+        let _ = writeln!(
+            text,
+            "    nika model pull {}:{tag}  ·  {}",
+            mref.repo_id(),
+            store::human_size(e.size)
+        );
+    }
+    refuse(text)
+}
+
+/// The repo's top-level `tokenizer.json`, when it ships one.
+pub(crate) fn tokenizer_entry(entries: &[TreeEntry]) -> Option<&TreeEntry> {
+    entries.iter().find(|e| e.path == "tokenizer.json")
+}
+
+/// The file name of a repo path (`sub/dir/w.gguf` → `w.gguf`) — the
+/// basename ONLY ever reaches the disk (repo paths are remote input).
+fn file_name(repo_path: &str) -> &str {
+    repo_path.rsplit('/').next().unwrap_or(repo_path)
+}
+
+/// The Hub acquisition client over the injected kernel http seam.
+pub(crate) struct Puller<H> {
+    http: H,
+    root: PathBuf,
+    token: Option<String>,
+    progress: bool,
+}
+
+impl<H: HttpGetDyn + HttpPostDyn> Puller<H> {
+    pub(crate) fn new(http: H, root: PathBuf, token: Option<String>, progress: bool) -> Self {
+        Self {
+            http,
+            root,
+            token,
+            progress,
+        }
+    }
+
+    /// Fetch the repo's file tree (`path` + `size` per file) — the
+    /// metadata the size print + confirm gate read BEFORE any download.
+    pub(crate) async fn tree(&self, mref: &ModelRef) -> Result<Vec<TreeEntry>, Refusal> {
+        let url = format!("{HUB}/api/models/{}/{}/tree/main", mref.owner, mref.name);
+        let mut request = HttpRequest::get(url);
+        request.headers = self.auth_headers();
+        let response = self
+            .http
+            .get(request)
+            .await
+            .map_err(|e| transport_refusal(&mref.repo_id(), &e))?;
+        match response.status {
+            200 => parse_tree(&response.body, &mref.repo_id()),
+            401 | 403 => Err(gated_refusal(
+                &mref.repo_id(),
+                response.status,
+                self.token.is_some(),
+            )),
+            404 => Err(refuse(format!(
+                "model pull: {} is not on the Hub (404)\n  fix: check the id — owner/repo, \
+                 exactly as huggingface.co spells it\n",
+                mref.repo_id()
+            ))),
+            status => Err(refuse(format!(
+                "model pull: the Hub answered {status} for {}\n  fix: try again shortly — or \
+                 open huggingface.co/{} in a browser\n",
+                mref.repo_id(),
+                mref.repo_id()
+            ))),
+        }
+    }
+
+    /// Stream one repo file into the model's dir. Resumes a `<file>.part`
+    /// via `Range:` (206 appends · 200 restarts) and renames into place
+    /// only when the byte count matches the tree's declared size.
+    pub(crate) async fn download(
+        &self,
+        mref: &ModelRef,
+        entry: &TreeEntry,
+    ) -> Result<PathBuf, Refusal> {
+        let file = file_name(&entry.path);
+        let dir = mref.dir(&self.root);
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            refuse(format!(
+                "model pull: cannot create {} ({e})\n  fix: check permissions on the models dir\n",
+                dir.display()
+            ))
+        })?;
+        let dest = dir.join(file);
+        let part = part_path(&dest);
+        let resume_from = std::fs::metadata(&part).map_or(0, |m| m.len());
+
+        let mut request = HttpRequest::get(format!(
+            "{HUB}/{}/{}/resolve/main/{}",
+            mref.owner, mref.name, entry.path
+        ));
+        request.headers = self.auth_headers();
+        if resume_from > 0 {
+            // The Hub serves ranges — an interrupted pull re-runs from
+            // where it stopped instead of re-paying the gigabytes.
+            request
+                .headers
+                .insert("range".to_owned(), format!("bytes={resume_from}-"));
+            eprintln!("  resuming {file} at {}", store::human_size(resume_from));
+        }
+        let response = self
+            .http
+            .send_streaming(request)
+            .await
+            .map_err(|e| transport_refusal(&mref.repo_id(), &e))?;
+        let (out, start) = begin_write(
+            response.status,
+            &part,
+            resume_from,
+            &mref.repo_id(),
+            self.token.is_some(),
+            file,
+        )?;
+        let written = self.drain(response, out, &part, start, entry.size).await?;
+        if written != entry.size {
+            return Err(refuse(format!(
+                "model pull: got {} of {} for {file}\n  fix: re-run the pull — it resumes \
+                 from where this stopped (the .part stays)\n",
+                store::human_size(written),
+                store::human_size(entry.size)
+            )));
+        }
+        std::fs::rename(&part, &dest).map_err(|e| {
+            refuse(format!(
+                "model pull: cannot move {} into place ({e})\n  fix: check the models dir\n",
+                part.display()
+            ))
+        })?;
+        Ok(dest)
+    }
+
+    /// Write the stream to the `.part` file, ticking progress; returns
+    /// the total byte count (resume start included).
+    async fn drain(
+        &self,
+        response: HttpStreamResponse,
+        mut out: std::fs::File,
+        part: &Path,
+        start: u64,
+        total: u64,
+    ) -> Result<u64, Refusal> {
+        let mut body = response.body;
+        let mut written = start;
+        let mut last_tick = start;
+        while let Some(item) = std::future::poll_fn(|cx| body.as_mut().poll_next(cx)).await {
+            let chunk = item.map_err(|e| {
+                refuse(format!(
+                    "model pull: the transfer broke mid-stream ({e})\n  fix: re-run the pull \
+                     — it resumes from the .part\n"
+                ))
+            })?;
+            out.write_all(&chunk).map_err(|e| {
+                refuse(format!(
+                    "model pull: cannot write {} ({e})\n  fix: check disk space\n",
+                    part.display()
+                ))
+            })?;
+            written = written.saturating_add(chunk.len() as u64);
+            if self.progress && written.saturating_sub(last_tick) >= PROGRESS_EVERY {
+                eprint!(
+                    "\r  {} / {}",
+                    store::human_size(written),
+                    store::human_size(total)
+                );
+                last_tick = written;
+            }
+        }
+        if self.progress && last_tick > start {
+            eprintln!(
+                "\r  {} / {}",
+                store::human_size(written),
+                store::human_size(total)
+            );
+        }
+        out.sync_all().map_err(|e| {
+            refuse(format!(
+                "model pull: cannot flush {} ({e})\n  fix: check disk space\n",
+                part.display()
+            ))
+        })?;
+        Ok(written)
+    }
+
+    /// `Authorization: Bearer` rides only when `HF_TOKEN` is set —
+    /// `nika-http` strips it on the cross-origin CDN redirect.
+    fn auth_headers(&self) -> BTreeMap<String, String> {
+        let mut headers = BTreeMap::new();
+        if let Some(token) = &self.token {
+            headers.insert("authorization".to_owned(), format!("Bearer {token}"));
+        }
+        headers
+    }
+}
+
+/// Progress tick granularity (stderr TTY only).
+const PROGRESS_EVERY: u64 = 64 * 1024 * 1024;
+
+/// Open the `.part` per the server's answer: `200` restarts from zero
+/// (the server ignored/refused the range), `206` appends; auth/missing
+/// statuses refuse with their teach.
+fn begin_write(
+    status: u16,
+    part: &Path,
+    resume_from: u64,
+    repo_id: &str,
+    has_token: bool,
+    file: &str,
+) -> Result<(std::fs::File, u64), Refusal> {
+    let open_refusal = |e: std::io::Error| {
+        refuse(format!(
+            "model pull: cannot write {} ({e})\n  fix: check permissions/disk on the models dir\n",
+            part.display()
+        ))
+    };
+    match status {
+        200 => Ok((std::fs::File::create(part).map_err(open_refusal)?, 0)),
+        206 => Ok((
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(part)
+                .map_err(open_refusal)?,
+            resume_from,
+        )),
+        401 | 403 => Err(gated_refusal(repo_id, status, has_token)),
+        404 => Err(refuse(format!(
+            "model pull: {file} is gone from the repo (404)\n  fix: re-run `nika model pull \
+             {repo_id}` — the tree may have moved under you\n"
+        ))),
+        s => Err(refuse(format!(
+            "model pull: the Hub answered {s} for {file}\n  fix: try again shortly\n"
+        ))),
+    }
+}
+
+/// The access teach — a 401/403 is an ACCESS answer, not a bug. The Hub
+/// hides existence: a MISSING repo also answers 401 (verified live
+/// 2026-07-12), so the teach names the typo lane BEFORE the token lane.
+fn gated_refusal(repo_id: &str, status: u16, has_token: bool) -> Refusal {
+    let fix = if has_token {
+        "check the id spelling first — then the token's scope (read) and that your \
+         account accepted the repo's licence"
+    } else {
+        "check the id spelling first (a repo that does not exist answers 401 too); if \
+         it IS gated, accept its licence on huggingface.co and export HF_TOKEN=<your \
+         token> (Settings → Access Tokens · read scope)"
+    };
+    refuse(format!(
+        "model pull: the Hub refuses {repo_id} ({status} — gated, private, or no such \
+         repo)\n  fix: {fix}\n"
+    ))
+}
+
+/// A network-level refusal — the resume note keeps an interrupted pull cheap.
+fn transport_refusal(repo_id: &str, e: &nika_kernel::http::HttpError) -> Refusal {
+    refuse(format!(
+        "model pull: cannot reach the Hub for {repo_id} ({e})\n  fix: check the network — an \
+         interrupted pull resumes from its .part\n"
+    ))
+}
+
+/// `<dest>.part` — the in-flight download beside its final name.
+fn part_path(dest: &Path) -> PathBuf {
+    let mut os = dest.as_os_str().to_owned();
+    os.push(".part");
+    PathBuf::from(os)
+}
+
+/// `nika model pull <owner/repo[:QUANT]>` — the production blocking seam
+/// (parse → tree → choose → confirm → download GGUF + tokenizer).
+/// `Ok` is the receipt (or the operator's clean abort); `Err` is an
+/// environment-class refusal the CLI maps to exit `3`.
+///
+/// # Errors
+///
+/// Every refusal teaches its fix: a malformed ref, a HOME-less machine,
+/// an unreachable/gated/absent repo, a quant menu, the over-threshold
+/// no-terminal confirm, or a broken/short transfer (the `.part` stays).
+pub fn run(arg: &str, yes: bool) -> Result<String, Refusal> {
+    let mref = store::parse_model_ref(arg)?;
+    let root = store::models_root()?;
+    pull_over_network(&mref, &root, arg, yes)
+}
+
+/// The full network flow (`Ok` = receipt/abort · `Err` = refusal).
+fn pull_over_network(
+    mref: &ModelRef,
+    root: &Path,
+    arg: &str,
+    yes: bool,
+) -> Result<String, Refusal> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            refuse(format!(
+                "model pull: cannot start the fetch runtime ({e})\n"
+            ))
+        })?;
+    let token = hf_token();
+    let interactive = interactive_terminal();
+
+    // Metadata first (sizes BEFORE any download) — default transport caps.
+    let meta = Puller::new(house_http(None)?, root.to_path_buf(), token.clone(), false);
+    let entries = runtime.block_on(meta.tree(mref))?;
+    let entry = choose_gguf(&entries, mref)?.clone();
+    let tokenizer = tokenizer_entry(&entries).cloned();
+    let file = file_name(&entry.path).to_owned();
+    let dest = mref.dir(root).join(&file);
+
+    // The size prints BEFORE anything downloads (the issue's lock).
+    eprintln!(
+        "{} · {file} · {}",
+        mref.repo_id(),
+        store::human_size(entry.size)
+    );
+    let mut already = false;
+    if std::fs::metadata(&dest).is_ok_and(|m| m.len() == entry.size) {
+        already = true;
+        eprintln!("  already present — nothing to download");
+    } else {
+        match confirm_gate(entry.size, yes, interactive) {
+            ConfirmGate::Proceed => {}
+            ConfirmGate::Prompt => {
+                if !prompt_proceed(entry.size)? {
+                    return Ok("aborted — nothing downloaded".to_owned());
+                }
+            }
+            ConfirmGate::RefuseNeedsYes => {
+                return Err(refuse(format!(
+                    "model pull: {file} is {} — over the {} confirm threshold, and no \
+                     terminal to ask\n  fix: re-run with --yes (the CI shape)\n",
+                    store::human_size(entry.size),
+                    store::human_size(CONFIRM_BYTES)
+                )));
+            }
+        }
+        let puller = Puller::new(
+            house_http(Some(&entry))?,
+            root.to_path_buf(),
+            token.clone(),
+            interactive,
+        );
+        runtime.block_on(puller.download(mref, &entry))?;
+    }
+    // tokenizer.json beside the GGUF — the sibling layout `serve` loads.
+    let tokenizer_note = match tokenizer {
+        Some(tok) => {
+            let tok_dest = mref.dir(root).join(file_name(&tok.path));
+            if std::fs::metadata(&tok_dest).is_err() {
+                let side = Puller::new(house_http(None)?, root.to_path_buf(), token, false);
+                runtime.block_on(side.download(mref, &tok))?;
+            }
+            String::new()
+        }
+        None => "\n  note: the repo ships no tokenizer.json — `nika model serve` needs one \
+                 beside the GGUF (name yours with --tokenizer <path>)"
+            .to_owned(),
+    };
+    Ok(receipt(arg, mref, &dest, already, &tokenizer_note))
+}
+
+/// The pull receipt: where it landed + the exact next commands.
+fn receipt(arg: &str, mref: &ModelRef, dest: &Path, already: bool, tokenizer_note: &str) -> String {
+    let verb = if already { "present" } else { "pulled" };
+    format!(
+        "{verb} {}\n  {}\n  serve it: nika model serve --model {arg}\n  manage:   nika \
+         model list · nika model rm {arg}{tokenizer_note}",
+        mref.repo_id(),
+        dest.display()
+    )
+}
+
+/// The house transport (`nika-http` — rustls · SSRF floor · manual
+/// redirects): default caps for metadata, a body-sized cap for the GGUF
+/// stream (a body larger than the DECLARED size is a tamper signal).
+// `HttpConfig` is `#[non_exhaustive]` → field assignment, not a struct
+// literal (the registry seam's exact idiom).
+#[allow(clippy::field_reassign_with_default)]
+fn house_http(stream_of: Option<&TreeEntry>) -> Result<nika_http::ReqwestHttp, Refusal> {
+    let mut config = nika_http::HttpConfig::default();
+    if let Some(entry) = stream_of {
+        config.max_response_bytes = entry.size.saturating_add(64 * 1024 * 1024);
+    }
+    nika_http::ReqwestHttp::with_config(config).map_err(|e| {
+        refuse(format!(
+            "model pull: cannot initialize the fetch client ({e})\n"
+        ))
+    })
+}
+
+/// `HF_TOKEN` — the sanctioned env boundary (the `NIKA_MCP_TOKEN` seam):
+/// operator config crossing into a client hold, read once, never printed.
+#[allow(clippy::disallowed_methods)]
+fn hf_token() -> Option<String> {
+    std::env::var("HF_TOKEN").ok().filter(|t| !t.is_empty())
+}
+
+/// Both ends of a conversation present? (the prompt needs stdin AND a
+/// visible question).
+fn interactive_terminal() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+/// Ask on stderr, read one line from stdin — `y`/`yes` proceeds.
+fn prompt_proceed(size: u64) -> Result<bool, Refusal> {
+    eprint!("  download {}? [y/N] ", store::human_size(size));
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line).map_err(|e| {
+        refuse(format!(
+            "model pull: cannot read the confirmation ({e})\n  fix: re-run with --yes\n"
+        ))
+    })?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+/// A teaching refusal — the CLI adapter maps it to the environment
+/// exit class (`3`).
+pub(crate) type Refusal = String;
+
+/// The semantic marker: every `refuse(...)` site is a refusal, never a
+/// receipt (the identity keeps the sites greppable).
+fn refuse(text: String) -> Refusal {
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+    use std::task::{Context, Poll};
+
+    use bytes::Bytes;
+    use futures_core::Stream;
+    use nika_kernel::http::{HttpError, HttpResponse, HttpStreamResponse};
+
+    use super::*;
+
+    fn entry(kind: &str, path: &str, size: u64) -> TreeEntry {
+        TreeEntry {
+            kind: kind.to_owned(),
+            path: path.to_owned(),
+            size,
+        }
+    }
+
+    fn mref(arg: &str) -> ModelRef {
+        store::parse_model_ref(arg).expect("test ref parses")
+    }
+
+    // The model-serve tests' exact fixture idiom.
+    #[allow(clippy::disallowed_methods)]
+    fn temp_root(name: &str) -> PathBuf {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
+            || {
+                std::env::current_dir()
+                    .expect("current dir")
+                    .join("target")
+                    .join("tmp")
+            },
+            PathBuf::from,
+        );
+        let dir = base.join(format!("nika-pull-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp root");
+        dir
+    }
+
+    // -- the injectable seam double (GET queue + streaming queue) -----
+
+    /// A canned streaming body.
+    struct ChunkStream(VecDeque<Result<Bytes, HttpError>>);
+
+    impl Stream for ChunkStream {
+        type Item = Result<Bytes, HttpError>;
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.0.pop_front())
+        }
+    }
+
+    /// One canned `send_streaming` answer.
+    struct CannedStream {
+        status: u16,
+        content_length: Option<u64>,
+        chunks: Vec<Bytes>,
+    }
+
+    /// The house-seam double: `get` answers from one queue,
+    /// `send_streaming` from another; every request is recorded (the
+    /// `MockHttp` idiom — that mock does not stream, hence this one).
+    #[derive(Default)]
+    struct StreamHttp {
+        gets: Mutex<VecDeque<Result<HttpResponse, HttpError>>>,
+        streams: Mutex<VecDeque<CannedStream>>,
+        requests: Mutex<Vec<HttpRequest>>,
+    }
+
+    impl StreamHttp {
+        fn get_ok(self, status: u16, body: &str) -> Self {
+            self.gets
+                .lock()
+                .expect("gets")
+                .push_back(Ok(HttpResponse::new(
+                    status,
+                    BTreeMap::new(),
+                    Bytes::copy_from_slice(body.as_bytes()),
+                    String::new(),
+                )));
+            self
+        }
+
+        fn stream_ok(self, status: u16, content_length: Option<u64>, chunks: &[&[u8]]) -> Self {
+            self.streams
+                .lock()
+                .expect("streams")
+                .push_back(CannedStream {
+                    status,
+                    content_length,
+                    chunks: chunks.iter().map(|c| Bytes::copy_from_slice(c)).collect(),
+                });
+            self
+        }
+
+        fn sent(&self) -> Vec<HttpRequest> {
+            self.requests.lock().expect("requests").clone()
+        }
+    }
+
+    impl HttpGetDyn for StreamHttp {
+        async fn get(&self, request: HttpRequest) -> Result<HttpResponse, HttpError> {
+            self.requests.lock().expect("requests").push(request);
+            self.gets
+                .lock()
+                .expect("gets")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    Err(HttpError::Other {
+                        reason: "StreamHttp: get queue exhausted".into(),
+                    })
+                })
+        }
+    }
+
+    impl HttpPostDyn for StreamHttp {
+        async fn post(&self, request: HttpRequest) -> Result<HttpResponse, HttpError> {
+            self.requests.lock().expect("requests").push(request);
+            Err(HttpError::Other {
+                reason: "StreamHttp: pull never POSTs".into(),
+            })
+        }
+
+        async fn send_streaming(
+            &self,
+            request: HttpRequest,
+        ) -> Result<HttpStreamResponse, HttpError> {
+            self.requests.lock().expect("requests").push(request);
+            let canned = self
+                .streams
+                .lock()
+                .expect("streams")
+                .pop_front()
+                .ok_or_else(|| HttpError::Other {
+                    reason: "StreamHttp: stream queue exhausted".into(),
+                })?;
+            let chunks: VecDeque<Result<Bytes, HttpError>> =
+                canned.chunks.into_iter().map(Ok).collect();
+            Ok(HttpStreamResponse::new(
+                canned.status,
+                BTreeMap::new(),
+                String::new(),
+                canned.content_length,
+                Box::pin(ChunkStream(chunks)),
+            ))
+        }
+    }
+
+    // -- tree parse + choice -------------------------------------------
+
+    #[test]
+    fn parse_tree_keeps_files_drops_directories() {
+        let body = br#"[
+            {"type":"file","oid":"a","size":9,"path":"model-q4_k_m.gguf"},
+            {"type":"directory","oid":"b","size":0,"path":"assets"},
+            {"type":"file","oid":"c","size":3,"path":"tokenizer.json"}
+        ]"#;
+        let entries = parse_tree(body, "u/m").expect("parses");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].path, "model-q4_k_m.gguf");
+        assert_eq!(entries[0].size, 9);
+    }
+
+    #[test]
+    fn parse_tree_refuses_non_json_with_the_repo_named() {
+        let refusal = parse_tree(b"<html>rate limited</html>", "u/m").expect_err("refuses");
+        assert!(refusal.contains("u/m"), "{refusal}");
+    }
+
+    #[test]
+    fn choose_prefers_the_default_quant_then_the_single_gguf() {
+        let entries = [
+            entry("file", "model-Q4_K_M.gguf", 100),
+            entry("file", "model-Q8_0.gguf", 200),
+            entry("file", "tokenizer.json", 3),
+        ];
+        let chosen = choose_gguf(&entries, &mref("u/m")).expect("default quant");
+        assert_eq!(chosen.path, "model-Q4_K_M.gguf");
+
+        let single = [
+            entry("file", "weights-F16.gguf", 50),
+            entry("file", "README.md", 1),
+        ];
+        let chosen = choose_gguf(&single, &mref("u/m")).expect("single gguf");
+        assert_eq!(chosen.path, "weights-F16.gguf");
+    }
+
+    #[test]
+    fn choose_honors_an_explicit_tag_case_insensitively() {
+        let entries = [
+            entry("file", "model-Q4_K_M.gguf", 100),
+            entry("file", "model-Q8_0.gguf", 200),
+        ];
+        let chosen = choose_gguf(&entries, &mref("u/m:q8_0")).expect("tag matches");
+        assert_eq!(chosen.path, "model-Q8_0.gguf");
+    }
+
+    #[test]
+    fn choose_refuses_listing_the_quants_that_exist() {
+        // Several GGUFs, none the default → the refusal lists the menu.
+        let entries = [
+            entry("file", "model-Q5_K_M.gguf", 100),
+            entry("file", "model-Q8_0.gguf", 200),
+        ];
+        let refusal = choose_gguf(&entries, &mref("u/m")).expect_err("ambiguous");
+        assert!(refusal.contains("Q5_K_M"), "{refusal}");
+        assert!(refusal.contains("Q8_0"), "{refusal}");
+        assert!(refusal.contains(":Q5_K_M"), "teach the tag form: {refusal}");
+
+        // An explicit tag that matches nothing → same teaching shape.
+        let refusal = choose_gguf(&entries, &mref("u/m:Q2_K")).expect_err("no such tag");
+        assert!(refusal.contains("Q2_K"), "{refusal}");
+        assert!(refusal.contains("Q5_K_M"), "{refusal}");
+
+        // No GGUF at all → say so (this repo is not a GGUF repo).
+        let none = [entry("file", "model.safetensors", 100)];
+        let refusal = choose_gguf(&none, &mref("u/m")).expect_err("no gguf");
+        assert!(refusal.contains("no GGUF"), "{refusal}");
+    }
+
+    #[test]
+    fn tokenizer_rides_along_when_the_repo_ships_one() {
+        let entries = [
+            entry("file", "model-Q4_K_M.gguf", 100),
+            entry("file", "tokenizer.json", 3),
+        ];
+        assert_eq!(
+            tokenizer_entry(&entries).map(|e| e.path.as_str()),
+            Some("tokenizer.json")
+        );
+        assert!(tokenizer_entry(&entries[..1]).is_none());
+    }
+
+    // -- the confirm gate (pure) ---------------------------------------
+
+    #[test]
+    fn confirm_gate_prompts_big_sizes_and_refuses_them_in_pipes() {
+        assert_eq!(
+            confirm_gate(CONFIRM_BYTES - 1, false, false),
+            ConfirmGate::Proceed
+        );
+        assert_eq!(
+            confirm_gate(CONFIRM_BYTES, true, false),
+            ConfirmGate::Proceed
+        );
+        assert_eq!(
+            confirm_gate(CONFIRM_BYTES, false, true),
+            ConfirmGate::Prompt
+        );
+        assert_eq!(
+            confirm_gate(CONFIRM_BYTES, false, false),
+            ConfirmGate::RefuseNeedsYes
+        );
+    }
+
+    // -- the download path (over the injected seam) ---------------------
+
+    #[tokio::test]
+    async fn tree_hits_the_hub_api_with_the_bearer_when_a_token_rides() {
+        let http =
+            StreamHttp::default().get_ok(200, r#"[{"type":"file","size":1,"path":"a.gguf"}]"#);
+        let root = temp_root("tree-auth");
+        let puller = Puller::new(http, root.clone(), Some("hf_secret".to_owned()), false);
+        let entries = puller.tree(&mref("u/m")).await.expect("tree resolves");
+        assert_eq!(entries.len(), 1);
+        let sent = puller.http.sent();
+        assert_eq!(sent.len(), 1);
+        assert!(
+            sent[0]
+                .url
+                .contains("huggingface.co/api/models/u/m/tree/main"),
+            "{}",
+            sent[0].url
+        );
+        assert_eq!(
+            sent[0].headers.get("authorization").map(String::as_str),
+            Some("Bearer hf_secret")
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn tree_translates_401_into_the_hf_token_teach() {
+        let http = StreamHttp::default().get_ok(401, r#"{"error":"gated"}"#);
+        let root = temp_root("tree-gated");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let refusal = puller.tree(&mref("u/m")).await.expect_err("gated refuses");
+        assert!(refusal.contains("HF_TOKEN"), "{refusal}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_streams_into_the_canonical_dir_and_renames() {
+        let http = StreamHttp::default().stream_ok(200, Some(9), &[b"hello ", b"wor", b""]);
+        let root = temp_root("dl-happy");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let dest = puller
+            .download(&mref("u/m"), &entry("file", "w-q4_k_m.gguf", 9))
+            .await
+            .expect("download completes");
+        assert_eq!(dest, root.join("u").join("m").join("w-q4_k_m.gguf"));
+        assert_eq!(std::fs::read(&dest).expect("dest"), b"hello wor");
+        assert!(
+            !root.join("u").join("m").join("w-q4_k_m.gguf.part").exists(),
+            "the .part renamed into place"
+        );
+        // No token → no authorization header leaves this machine.
+        let sent = puller.http.sent();
+        assert!(!sent[0].headers.contains_key("authorization"));
+        assert!(
+            sent[0]
+                .url
+                .contains("huggingface.co/u/m/resolve/main/w-q4_k_m.gguf"),
+            "{}",
+            sent[0].url
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_resumes_a_part_file_with_a_range_request() {
+        let http = StreamHttp::default().stream_ok(206, Some(5), &[b"world"]);
+        let root = temp_root("dl-resume");
+        let dir = root.join("u").join("m");
+        std::fs::create_dir_all(&dir).expect("dir");
+        std::fs::write(dir.join("w.gguf.part"), b"hello").expect("part fixture");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let dest = puller
+            .download(&mref("u/m"), &entry("file", "w.gguf", 10))
+            .await
+            .expect("resume completes");
+        assert_eq!(std::fs::read(&dest).expect("dest"), b"helloworld");
+        assert!(!dir.join("w.gguf.part").exists(), ".part renamed away");
+        let sent = puller.http.sent();
+        assert_eq!(
+            sent[0].headers.get("range").map(String::as_str),
+            Some("bytes=5-"),
+            "the resume rides a Range header"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_restarts_when_the_server_answers_200_to_a_resume() {
+        let http = StreamHttp::default().stream_ok(200, Some(5), &[b"fresh"]);
+        let root = temp_root("dl-restart");
+        let dir = root.join("u").join("m");
+        std::fs::create_dir_all(&dir).expect("dir");
+        std::fs::write(dir.join("w.gguf.part"), b"stale-part").expect("part fixture");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let dest = puller
+            .download(&mref("u/m"), &entry("file", "w.gguf", 5))
+            .await
+            .expect("restart completes");
+        assert_eq!(std::fs::read(&dest).expect("dest"), b"fresh");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_keeps_the_part_and_teaches_resume_on_a_short_stream() {
+        let http = StreamHttp::default().stream_ok(200, Some(10), &[b"only4"]);
+        let root = temp_root("dl-short");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let refusal = puller
+            .download(&mref("u/m"), &entry("file", "w.gguf", 10))
+            .await
+            .expect_err("short stream refuses");
+        assert!(refusal.contains("re-run"), "{refusal}");
+        assert!(
+            root.join("u").join("m").join("w.gguf.part").exists(),
+            "the .part STAYS for the resume"
+        );
+        assert!(!root.join("u").join("m").join("w.gguf").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_translates_403_into_the_gated_teach() {
+        let http = StreamHttp::default().stream_ok(403, None, &[]);
+        let root = temp_root("dl-gated");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let refusal = puller
+            .download(&mref("u/m"), &entry("file", "w.gguf", 5))
+            .await
+            .expect_err("403 refuses");
+        assert!(refusal.contains("HF_TOKEN"), "{refusal}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/crates/nika-models/src/serve.rs
+++ b/crates/nika-models/src/serve.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika model serve` — the sovereign local-inference launch glue
+//! (ADR-091 · ADR-093): boot the candle sidecar over one GGUF —
+//! [`crate::pull`]/[`crate::store`] acquire and manage the GGUFs it
+//! serves, over the ONE canonical models dir both sides share by
+//! construction.
+//!
+//! FOREGROUND by design: the process the operator (or a workflow's `exec`
+//! task, or the future L3 supervisor) starts, watches and stops. The v1
+//! contract is deliberately narrow — one loopback `tiny_http` server over
+//! one loaded GGUF, one generation at a time, Ctrl-C ends it. Process
+//! supervision (spawn/health/restart) is the runtime layer's job per
+//! ADR-091 §isolation; this verb is the rung below it.
+//!
+//! The served endpoint is reached over the EXISTING `OpenAiCompat` wire
+//! (zero new dispatch seam): point any keyless local profile's base URL at
+//! it (`NIKA_LLAMACPP_BASE_URL=http://127.0.0.1:<port>`) and a workflow's
+//! `model: llamacpp/<id>` lands on the sidecar.
+//!
+//! The whole surface is feature-gated (`local-infer` · off by default —
+//! the default binary links zero inference deps): the SUBCOMMAND always
+//! exists so the tree teaches it, the default BODY refuses with the build
+//! recipe (exit `3` · environment class).
+
+// The healthy path prints a banner then serves for the process' whole
+// life — output DURING a blocking serve cannot be deferred through a
+// returned value. The same sanctioned exemption the CLI's run carries.
+#![allow(clippy::disallowed_macros, clippy::print_stderr)]
+
+use std::path::Path;
+// `PathBuf` rides only the feature/test axes (`ServePlan` · fixtures).
+#[cfg(any(feature = "local-infer", test))]
+use std::path::PathBuf;
+
+/// The default loopback port (`nika mcp` owns 8123; this stays clear of
+/// the 5 external local servers' defaults: 11434 · 1234 · 8080 · 8000).
+pub const DEFAULT_PORT: u16 = 8712;
+
+/// Serve `gguf` (Qwen3 family · v1 loader scope) in the foreground on
+/// loopback `port`. `tokenizer` defaults to `tokenizer.json` beside the
+/// GGUF (the layout a Hugging Face repo download produces); `model_id`
+/// (the id responses report) defaults to the GGUF file stem.
+///
+/// Returns ONLY on refusal (missing file · unreadable model · bind
+/// failure · a build without the feature) — a healthy server runs until
+/// the process ends (Ctrl-C). The refusal is a teaching text the CLI
+/// maps to the environment exit class (`3`).
+#[must_use]
+pub fn serve(gguf: &Path, tokenizer: Option<&Path>, port: u16, model_id: Option<&str>) -> String {
+    #[cfg(feature = "local-infer")]
+    {
+        serve_local(gguf, tokenizer, port, model_id)
+    }
+    #[cfg(not(feature = "local-infer"))]
+    {
+        let _ = (gguf, tokenizer, port, model_id);
+        feature_stub()
+    }
+}
+
+/// The resolved boot inputs: every path verified present, the id named.
+#[cfg(any(feature = "local-infer", test))]
+#[derive(Debug, PartialEq, Eq)]
+struct ServePlan {
+    gguf: PathBuf,
+    tokenizer: PathBuf,
+    model_id: String,
+}
+
+/// Resolve + verify the boot inputs BEFORE any load: a wrong path must
+/// refuse with the exact fix, not a parse failure deep in the loader.
+#[cfg(any(feature = "local-infer", test))]
+fn plan(
+    gguf: &Path,
+    tokenizer: Option<&Path>,
+    model_id: Option<&str>,
+) -> Result<ServePlan, String> {
+    if !gguf.is_file() {
+        return Err(format!(
+            "model serve: no model file at {}\n  fix: point --model at a \
+             Qwen3-family .gguf — nika model pull <owner/repo> fetches one \
+             (its tokenizer.json lands beside it)\n",
+            gguf.display()
+        ));
+    }
+    let tokenizer =
+        tokenizer.map_or_else(|| gguf.with_file_name("tokenizer.json"), Path::to_path_buf);
+    if !tokenizer.is_file() {
+        return Err(format!(
+            "model serve: no tokenizer at {}\n  fix: download the model \
+             repo's tokenizer.json beside the GGUF, or name one with \
+             --tokenizer <path>\n",
+            tokenizer.display()
+        ));
+    }
+    Ok(ServePlan {
+        model_id: model_id.map_or_else(|| derive_model_id(gguf), str::to_owned),
+        gguf: gguf.to_path_buf(),
+        tokenizer,
+    })
+}
+
+/// The id responses report when `--model-id` is absent: the GGUF file
+/// stem (`qwen3-4b-instruct-q4_k_m.gguf` → `qwen3-4b-instruct-q4_k_m`).
+#[cfg(any(feature = "local-infer", test))]
+fn derive_model_id(gguf: &Path) -> String {
+    gguf.file_stem()
+        .map_or_else(|| "local".to_owned(), |s| s.to_string_lossy().into_owned())
+}
+
+/// The default build's honest refusal: name the feature and the build
+/// recipe — never pretend the lane is one flag away at runtime.
+#[cfg(any(not(feature = "local-infer"), test))]
+fn feature_stub() -> String {
+    "model serve: this binary was built without local inference \
+     (the default build links zero inference dependencies)\n  \
+     fix: build from source with the feature — cargo build -p \
+     nika-cli --features local-infer   (Apple GPU: --features \
+     metal)\n"
+        .to_owned()
+}
+
+/// Load the GGUF, bind loopback, announce, serve until the process ends.
+#[cfg(feature = "local-infer")]
+fn serve_local(gguf: &Path, tokenizer: Option<&Path>, port: u16, model_id: Option<&str>) -> String {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    let plan = match plan(gguf, tokenizer, model_id) {
+        Ok(plan) => plan,
+        Err(refusal) => return refusal,
+    };
+    eprintln!(
+        "nika model serve · loading {} (a first load reads the whole file)",
+        plan.gguf.display()
+    );
+    let backend = match nika_infer_local::CandleBackend::load_qwen3(
+        &plan.gguf,
+        &plan.tokenizer,
+        &plan.model_id,
+    ) {
+        Ok(backend) => backend,
+        Err(err) => {
+            return format!(
+                "model serve: {err}\n  fix: the v1 loader serves \
+                 Qwen3-family GGUFs with their tokenizer.json — \
+                 check both files\n"
+            );
+        }
+    };
+    // Loopback ONLY (ADR-093: no TLS · no auth · the operator owns the
+    // port) — widening the bind is the supervisor era's decision, not v1's.
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let handle = match nika_infer_local::serve(Arc::new(backend), addr) {
+        Ok(handle) => handle,
+        Err(err) => {
+            return format!(
+                "model serve: {err}\n  fix: another process may own the \
+                 port — pick one with --port <n>\n"
+            );
+        }
+    };
+    let bound = handle.addr();
+    eprintln!(
+        "nika model serve · http://{bound}/v1/chat/completions · {} · \
+         loopback only · one generation at a time · Ctrl-C stops",
+        plan.model_id
+    );
+    eprintln!(
+        "  reach it from a workflow: export NIKA_LLAMACPP_BASE_URL=http://{bound} \
+         then model: llamacpp/{}",
+        plan.model_id
+    );
+    // The handle must outlive the park (dropping it stops the server).
+    // Ctrl-C ends the foreground process — the v1 lifecycle contract.
+    let _serving = handle;
+    loop {
+        std::thread::park();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The doctor tests' exact fixture idiom (CARGO_TARGET_TMPDIR is unset
+    // for lib unit tests — fall back beside the build dir).
+    #[allow(clippy::disallowed_methods)]
+    fn temp_dir(name: &str) -> PathBuf {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
+            || {
+                std::env::current_dir()
+                    .expect("current dir")
+                    .join("target")
+                    .join("tmp")
+            },
+            PathBuf::from,
+        );
+        let dir = base.join(format!("nika-model-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        dir
+    }
+
+    #[test]
+    fn plan_refuses_a_missing_gguf_with_the_fix() {
+        let dir = temp_dir("missing-gguf");
+        let refusal = plan(&dir.join("nope.gguf"), None, None).expect_err("must refuse");
+        assert!(refusal.contains("no model file"), "{refusal}");
+        assert!(refusal.contains("--model"), "{refusal}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn plan_defaults_to_the_sibling_tokenizer_and_the_file_stem_id() {
+        let dir = temp_dir("sibling");
+        let gguf = dir.join("qwen3-4b-instruct-q4_k_m.gguf");
+        std::fs::write(&gguf, b"stub").expect("fixture");
+        std::fs::write(dir.join("tokenizer.json"), b"{}").expect("fixture");
+        let plan = plan(&gguf, None, None).expect("resolves");
+        assert_eq!(plan.tokenizer, dir.join("tokenizer.json"));
+        assert_eq!(plan.model_id, "qwen3-4b-instruct-q4_k_m");
+        assert_eq!(plan.gguf, gguf);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn plan_refuses_a_missing_tokenizer_naming_both_fixes() {
+        let dir = temp_dir("no-tokenizer");
+        let gguf = dir.join("model.gguf");
+        std::fs::write(&gguf, b"stub").expect("fixture");
+        let refusal = plan(&gguf, None, None).expect_err("must refuse");
+        assert!(refusal.contains("tokenizer.json"), "{refusal}");
+        assert!(refusal.contains("--tokenizer"), "{refusal}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn plan_honors_explicit_tokenizer_and_model_id() {
+        let dir = temp_dir("explicit");
+        let gguf = dir.join("weights.gguf");
+        let tok = dir.join("tok.json");
+        std::fs::write(&gguf, b"stub").expect("fixture");
+        std::fs::write(&tok, b"{}").expect("fixture");
+        let resolved = plan(&gguf, Some(&tok), Some("qwen3")).expect("resolves");
+        assert_eq!(resolved.tokenizer, tok);
+        assert_eq!(resolved.model_id, "qwen3");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn the_stub_names_the_feature_and_teaches_the_recipe() {
+        let out = feature_stub();
+        assert!(out.contains("local-infer"), "{out}");
+        assert!(out.contains("cargo build"), "{out}");
+    }
+
+    /// The REAL serve path refuses a missing model file cleanly — the
+    /// documented no-fixture e2e (a live-model boot is a manual step).
+    #[cfg(feature = "local-infer")]
+    #[test]
+    fn serve_refuses_a_missing_model_before_binding_anything() {
+        let dir = temp_dir("serve-missing");
+        let out = serve(&dir.join("absent.gguf"), None, DEFAULT_PORT, None);
+        assert!(out.contains("no model file"), "{out}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// A present-but-invalid GGUF exercises the loader's typed refusal
+    /// through the real feature-on path (no model fixture in the repo).
+    #[cfg(feature = "local-infer")]
+    #[test]
+    fn serve_refuses_a_garbage_gguf_with_the_loader_error() {
+        let dir = temp_dir("serve-garbage");
+        let gguf = dir.join("junk.gguf");
+        std::fs::write(&gguf, b"not a gguf").expect("fixture");
+        std::fs::write(dir.join("tokenizer.json"), b"{}").expect("fixture");
+        let out = serve(&gguf, None, DEFAULT_PORT, None);
+        assert!(out.contains("Qwen3-family"), "{out}");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/nika-models/src/store.rs
+++ b/crates/nika-models/src/store.rs
@@ -1,0 +1,856 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ONE canonical models dir (issue #146) — `~/.nika/models/<owner>/<repo>/`.
+//!
+//! The RESOLVER (`nika model serve --model <id>`) and the DOWNLOADER
+//! (`nika model pull`) share this root BY CONSTRUCTION: both call
+//! [`models_root`], so the brouillon-era pull/load two-dir mismatch
+//! (`model pull` wrote one dir, inference read another) cannot re-happen.
+//! Same `HOME`/`USERPROFILE` resolution as the registry cache
+//! (`~/.nika/registry/`) and `nika wire`'s editor configs.
+//!
+//! Layout: one directory per Hub repo, holding its GGUF(s) and the
+//! `tokenizer.json` the serve loader wants beside them — exactly what a
+//! repo download produces. Refusals are plain `String`s that teach
+//! their fix — the CLI adapter maps them to its exit contract.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+/// A parsed model reference: `owner/repo[:QUANT]` — the ONE grammar
+/// `pull`, `serve --model`, and `rm` all speak.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelRef {
+    pub owner: String,
+    pub name: String,
+    /// The quant tag after `:` (`Q4_K_M` · `Q8_0` · `F16` …), verbatim.
+    pub quant: Option<String>,
+}
+
+impl ModelRef {
+    /// The Hub id (`owner/repo`) — also the installed model's list id.
+    pub(crate) fn repo_id(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+
+    /// This model's directory under the canonical root.
+    pub(crate) fn dir(&self, root: &Path) -> PathBuf {
+        root.join(&self.owner).join(&self.name)
+    }
+}
+
+/// One GGUF on disk under the canonical root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InstalledGguf {
+    /// `owner/repo` (the two directory levels under the root).
+    pub repo_id: String,
+    /// The GGUF file name (`qwen3-4b-instruct-q4_k_m.gguf`).
+    pub file_name: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// Absolute path to the GGUF.
+    pub path: PathBuf,
+}
+
+impl InstalledGguf {
+    /// The file stem — the id `serve` reports in responses.
+    pub(crate) fn stem(&self) -> &str {
+        self.file_name
+            .strip_suffix(".gguf")
+            .unwrap_or(&self.file_name)
+    }
+
+    /// The quant tag parsed from the file name (`Q4_K_M`), when one reads.
+    pub(crate) fn quant(&self) -> Option<String> {
+        quant_of(&self.file_name)
+    }
+
+    /// The exact id to hand `serve --model` / `rm`: `owner/repo:QUANT`
+    /// when a quant reads from the file name, else the file stem.
+    pub(crate) fn serve_id(&self) -> String {
+        match self.quant() {
+            Some(q) => format!("{}:{q}", self.repo_id),
+            None => self.stem().to_owned(),
+        }
+    }
+}
+
+/// Parse `owner/repo[:QUANT]`. Every refusal teaches the form.
+pub(crate) fn parse_model_ref(arg: &str) -> Result<ModelRef, String> {
+    let (repo, quant) = match arg.split_once(':') {
+        Some((repo, tag)) => {
+            if tag.is_empty() || !tag.chars().all(quant_char) {
+                return Err(refuse_ref(arg, "the quant tag reads wrong"));
+            }
+            (repo, Some(tag.to_owned()))
+        }
+        None => (arg, None),
+    };
+    let Some((owner, name)) = repo.split_once('/') else {
+        return Err(refuse_ref(arg, "missing the owner/repo slash"));
+    };
+    if !valid_segment(owner) || !valid_segment(name) {
+        return Err(refuse_ref(arg, "owner and repo are Hub path segments"));
+    }
+    Ok(ModelRef {
+        owner: owner.to_owned(),
+        name: name.to_owned(),
+        quant,
+    })
+}
+
+/// One Hub path segment: non-empty · starts alphanumeric · then
+/// alphanumerics plus `.` `_` `-` (a second `/` fails the char check).
+fn valid_segment(s: &str) -> bool {
+    s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// One quant-tag character (`Q4_K_M` · `IQ4_XS` · `F16`).
+fn quant_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')
+}
+
+/// The canonical models root: `~/.nika/models` (HOME/USERPROFILE — the
+/// registry-cache + `nika wire` resolution).
+///
+/// # Errors
+///
+/// A teaching refusal when neither HOME nor USERPROFILE resolves.
+// Env read is config-path state, not a secret — the same scoped
+// exemption as `wire.rs::home_path` and the registry's cache root.
+#[allow(clippy::disallowed_methods)]
+pub fn models_root() -> Result<PathBuf, String> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|home| PathBuf::from(home).join(".nika").join("models"))
+        .ok_or_else(|| {
+            "model: cannot find HOME/USERPROFILE for the models dir\n  fix: set HOME — \
+             the one canonical dir is ~/.nika/models\n"
+                .to_owned()
+        })
+}
+
+/// Every GGUF under the root (`<root>/<owner>/<repo>/*.gguf`), sorted by
+/// repo id then file name. Unreadable directories are skipped, never fatal.
+pub(crate) fn installed(root: &Path) -> Vec<InstalledGguf> {
+    let mut out = Vec::new();
+    for (owner, owner_path) in subdirs(root) {
+        for (repo, repo_path) in subdirs(&owner_path) {
+            for (file_name, path, size) in files(&repo_path) {
+                if is_gguf(&file_name) {
+                    out.push(InstalledGguf {
+                        repo_id: format!("{owner}/{repo}"),
+                        file_name,
+                        size,
+                        path,
+                    });
+                }
+            }
+        }
+    }
+    out.sort_by(|a, b| {
+        (a.repo_id.as_str(), a.file_name.as_str()).cmp(&(b.repo_id.as_str(), b.file_name.as_str()))
+    });
+    out
+}
+
+/// Named subdirectories of `dir` (missing/unreadable → empty).
+fn subdirs(dir: &Path) -> Vec<(String, PathBuf)> {
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in read.flatten() {
+        let path = entry.path();
+        if path.is_dir()
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+        {
+            out.push((name.to_owned(), path.clone()));
+        }
+    }
+    out
+}
+
+/// Named plain files of `dir` with sizes (missing/unreadable → empty).
+fn files(dir: &Path) -> Vec<(String, PathBuf, u64)> {
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in read.flatten() {
+        let path = entry.path();
+        if let Ok(meta) = entry.metadata()
+            && meta.is_file()
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+        {
+            out.push((name.to_owned(), path.clone(), meta.len()));
+        }
+    }
+    out
+}
+
+/// The quant tag read from a GGUF file name (`model-Q4_K_M.gguf` →
+/// `Q4_K_M`) — the LAST `-`/`.`-separated segment that reads as a quant
+/// (quants sit at the tail by Hub convention). Uppercased.
+pub(crate) fn quant_of(file_name: &str) -> Option<String> {
+    let stem = file_name.strip_suffix(".gguf").unwrap_or(file_name);
+    stem.split(['-', '.'])
+        .filter(|seg| is_quant_token(seg))
+        .next_back()
+        .map(str::to_uppercase)
+}
+
+/// Does one file-name segment read as a quant (`q4_k_m` · `iq4_xs` ·
+/// `f16`)? A `q`/`iq` prefix must be followed by a DIGIT — `qwen3` is a
+/// model family, not a quant.
+fn is_quant_token(seg: &str) -> bool {
+    let s = seg.to_ascii_lowercase();
+    if matches!(s.as_str(), "f16" | "f32" | "bf16") {
+        return true;
+    }
+    s.strip_prefix("iq")
+        .or_else(|| s.strip_prefix('q'))
+        .is_some_and(|rest| {
+            rest.chars().next().is_some_and(|c| c.is_ascii_digit())
+                && rest.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        })
+}
+
+/// Human-readable byte size (`4.2 GiB` · `812.0 MiB` · `42 B`).
+#[must_use]
+pub fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["KiB", "MiB", "GiB", "TiB"];
+    if bytes < 1024 {
+        return format!("{bytes} B");
+    }
+    #[allow(clippy::cast_precision_loss)] // display rounding only
+    let mut value = bytes as f64;
+    let mut unit = "B";
+    for next in UNITS {
+        if value < 1024.0 {
+            break;
+        }
+        value /= 1024.0;
+        unit = next;
+    }
+    format!("{value:.1} {unit}")
+}
+
+/// Resolve `nika model serve --model <arg>`: paths (existing OR merely
+/// path-shaped) pass through — `serve` owns the missing-path verdict
+/// per build axis (the bin_smoke-pinned #482 contract); anything
+/// id-shaped resolves against the canonical models dir
+/// (`owner/repo[:QUANT]` or a bare file stem). The production seam.
+///
+/// # Errors
+///
+/// A teaching refusal on the id lane only — a miss lists what IS
+/// installed, an ambiguous id lists the exact ids to pick from.
+pub fn resolve_serve_model(arg: &str) -> Result<PathBuf, String> {
+    if Path::new(arg).is_file() || path_shaped(arg) {
+        // Pre-root passthrough: a path arg must reach `serve` even on
+        // a machine where HOME cannot resolve.
+        return Ok(PathBuf::from(arg));
+    }
+    let root = models_root()?;
+    resolve_at(&root, arg)
+}
+
+/// [`resolve_serve_model`] over an explicit root (the testable core).
+pub(crate) fn resolve_at(root: &Path, arg: &str) -> Result<PathBuf, String> {
+    if Path::new(arg).is_file() {
+        return Ok(PathBuf::from(arg));
+    }
+    if path_shaped(arg) {
+        // A path-shaped arg flows THROUGH even when missing: `serve`
+        // owns that verdict PER BUILD AXIS (the default build teaches
+        // the `local-infer` recipe, a feature build's plan() names the
+        // missing file) — the bin_smoke-pinned #482 contract. Refusing
+        // here would shadow the build-recipe teach.
+        return Ok(PathBuf::from(arg));
+    }
+    let items = installed(root);
+    if arg.contains('/') {
+        let mref = parse_model_ref(arg)?;
+        return resolve_ref(&items, &mref);
+    }
+    // A bare file stem — the id `serve` reports in responses.
+    let matches: Vec<&InstalledGguf> = items
+        .iter()
+        .filter(|m| m.stem().eq_ignore_ascii_case(arg))
+        .collect();
+    match matches[..] {
+        [one] => Ok(one.path.clone()),
+        [] => Err(missing_refusal(arg, &items)),
+        _ => Err(pick_refusal(
+            &format!("`{arg}` names several pulled files"),
+            &matches,
+        )),
+    }
+}
+
+/// Resolve a parsed `owner/repo[:QUANT]` against what is installed.
+fn resolve_ref(items: &[InstalledGguf], mref: &ModelRef) -> Result<PathBuf, String> {
+    let repo: Vec<&InstalledGguf> = items
+        .iter()
+        .filter(|m| m.repo_id == mref.repo_id())
+        .collect();
+    if repo.is_empty() {
+        return Err(missing_refusal(&mref.repo_id(), items));
+    }
+    match &mref.quant {
+        Some(tag) => {
+            let matches: Vec<&InstalledGguf> = repo
+                .iter()
+                .copied()
+                .filter(|m| quant_matches(m, tag))
+                .collect();
+            match matches[..] {
+                [one] => Ok(one.path.clone()),
+                [] => Err(pick_refusal(
+                    &format!("{} has no `{tag}` locally", mref.repo_id()),
+                    &repo,
+                )),
+                _ => Err(pick_refusal(
+                    &format!("`{tag}` matches several files of {}", mref.repo_id()),
+                    &matches,
+                )),
+            }
+        }
+        None => match repo[..] {
+            [one] => Ok(one.path.clone()),
+            _ => Err(pick_refusal(
+                &format!("{} has several GGUFs — pick one", mref.repo_id()),
+                &repo,
+            )),
+        },
+    }
+}
+
+/// Does an installed GGUF answer to a quant tag (case-insensitive —
+/// parsed quant first, file-name substring as the fallback)?
+fn quant_matches(m: &InstalledGguf, tag: &str) -> bool {
+    m.quant().is_some_and(|q| q.eq_ignore_ascii_case(tag))
+        || m.file_name
+            .to_ascii_lowercase()
+            .contains(&tag.to_ascii_lowercase())
+}
+
+/// Does a file name carry the `.gguf` extension (any case)?
+fn is_gguf(name: &str) -> bool {
+    Path::new(name)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
+}
+
+/// Does the argument read as a file path rather than a model id?
+fn path_shaped(arg: &str) -> bool {
+    is_gguf(arg) || arg.starts_with('.') || arg.starts_with('/') || arg.starts_with('~')
+}
+
+/// The pick-one refusal: `head`, then each candidate as its exact
+/// `owner/repo:QUANT` id with its size.
+fn pick_refusal(head: &str, candidates: &[&InstalledGguf]) -> String {
+    let mut text = format!("model: {head}:\n");
+    for m in candidates {
+        let _ = writeln!(text, "    {}  ·  {}", m.serve_id(), human_size(m.size));
+    }
+    text.push_str("  fix: name one id exactly (nika model list shows them all)\n");
+    text
+}
+
+/// The no-match refusal — the installed LIST is the teaching surface.
+fn missing_refusal(what: &str, items: &[InstalledGguf]) -> String {
+    let mut text = format!("model: no local model matches `{what}`\n");
+    if items.is_empty() {
+        text.push_str(
+            "  nothing pulled yet — nika model pull <owner/repo> (e.g. nika model pull \
+             Qwen/Qwen3-4B-Instruct-2507-GGUF)\n",
+        );
+    } else {
+        text.push_str("  installed:\n");
+        for m in items {
+            let _ = writeln!(text, "    {}  ·  {}", m.serve_id(), human_size(m.size));
+        }
+        let _ = writeln!(text, "  pull it: nika model pull {what}");
+    }
+    text
+}
+
+/// `nika model list` — the production seam. Never fails: an empty
+/// store is a teaching line, a HOME-less machine gets the root refusal
+/// text (informational either way).
+#[must_use]
+pub fn list() -> String {
+    match models_root() {
+        Ok(root) => list_at(&root),
+        Err(refusal) => refusal,
+    }
+}
+
+/// [`list`] over an explicit root (the testable core).
+pub(crate) fn list_at(root: &Path) -> String {
+    let items = installed(root);
+    // The ONE dir, printed once at top — resolver and downloader both
+    // read it, so what lists here is what `serve --model <id>` finds.
+    let mut text = format!("models · {}\n", root.display());
+    if items.is_empty() {
+        text.push_str(
+            "  none yet — nika model pull <owner/repo> (e.g. nika model pull \
+             Qwen/Qwen3-4B-Instruct-2507-GGUF)",
+        );
+        return text;
+    }
+    let id_width = items.iter().map(|m| m.serve_id().len()).max().unwrap_or(0);
+    for m in &items {
+        let _ = writeln!(
+            text,
+            "  {:<id_width$}  ·  {:>9}  ·  {}",
+            m.serve_id(),
+            human_size(m.size),
+            m.file_name,
+        );
+    }
+    text.push_str("\nserve one: nika model serve --model <id>  ·  reclaim: nika model rm <id>");
+    text
+}
+
+/// `nika model rm <id>` — the production seam.
+///
+/// # Errors
+///
+/// A teaching refusal: a no-match lists what IS installed, an
+/// ambiguous id lists the exact ids, a filesystem failure names it.
+pub fn rm(id: &str) -> Result<String, String> {
+    rm_at(&models_root()?, id)
+}
+
+/// [`rm`] over an explicit root (the testable core).
+pub(crate) fn rm_at(root: &Path, id: &str) -> Result<String, String> {
+    let items = installed(root);
+    match find_rm_target(root, &items, id)? {
+        RmTarget::Repo(dir, repo_id) => remove_repo(&dir, &repo_id),
+        RmTarget::File(gguf) => remove_gguf_and_sweep(&gguf),
+    }
+}
+
+/// What `rm <id>` names: a whole repo dir, or one GGUF.
+enum RmTarget {
+    Repo(PathBuf, String),
+    File(InstalledGguf),
+}
+
+/// Resolve the removal target — a no-match refuses with the installed
+/// list as the teaching surface.
+fn find_rm_target(root: &Path, items: &[InstalledGguf], id: &str) -> Result<RmTarget, String> {
+    if id.contains('/') {
+        let mref = parse_model_ref(id)?;
+        return match &mref.quant {
+            // `owner/repo` reclaims the whole model dir (every quant +
+            // the tokenizer beside them).
+            None => {
+                let dir = mref.dir(root);
+                if dir.is_dir() {
+                    Ok(RmTarget::Repo(dir, mref.repo_id()))
+                } else {
+                    Err(missing_refusal(id, items))
+                }
+            }
+            // `owner/repo:QUANT` reclaims that one file.
+            Some(tag) => {
+                let matches: Vec<&InstalledGguf> = items
+                    .iter()
+                    .filter(|m| m.repo_id == mref.repo_id() && quant_matches(m, tag))
+                    .collect();
+                match matches[..] {
+                    [one] => Ok(RmTarget::File(one.clone())),
+                    [] => Err(missing_refusal(id, items)),
+                    _ => Err(pick_refusal(
+                        &format!("`{tag}` matches several files of {}", mref.repo_id()),
+                        &matches,
+                    )),
+                }
+            }
+        };
+    }
+    // A bare file stem from `list`.
+    let matches: Vec<&InstalledGguf> = items
+        .iter()
+        .filter(|m| m.stem().eq_ignore_ascii_case(id))
+        .collect();
+    match matches[..] {
+        [one] => Ok(RmTarget::File(one.clone())),
+        [] => Err(missing_refusal(id, items)),
+        _ => Err(pick_refusal(
+            &format!("`{id}` names several pulled files"),
+            &matches,
+        )),
+    }
+}
+
+/// Remove a whole model dir, reporting the bytes it held.
+fn remove_repo(dir: &Path, repo_id: &str) -> Result<String, String> {
+    let held = files(dir);
+    let freed: u64 = held.iter().map(|(_, _, size)| size).sum();
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => {
+            prune_owner_level(dir);
+            Ok(format!(
+                "removed {repo_id} ({} file(s) · freed {})",
+                held.len(),
+                human_size(freed)
+            ))
+        }
+        Err(e) => Err(format!(
+            "model rm: cannot remove {} ({e})\n  fix: check permissions\n",
+            dir.display()
+        )),
+    }
+}
+
+/// Remove one GGUF; when it was the repo's last, sweep the dir (an
+/// orphan tokenizer serves nothing).
+fn remove_gguf_and_sweep(gguf: &InstalledGguf) -> Result<String, String> {
+    if let Err(e) = std::fs::remove_file(&gguf.path) {
+        return Err(format!(
+            "model rm: cannot remove {} ({e})\n  fix: check permissions\n",
+            gguf.path.display()
+        ));
+    }
+    let mut text = format!(
+        "removed {} (freed {})",
+        gguf.path.display(),
+        human_size(gguf.size)
+    );
+    if let Some(dir) = gguf.path.parent()
+        && !files(dir).iter().any(|(name, ..)| is_gguf(name))
+    {
+        let _ = std::fs::remove_dir_all(dir);
+        prune_owner_level(dir);
+        text.push_str("\n  (the repo's last GGUF — its dir swept, tokenizer with it)");
+    }
+    Ok(text)
+}
+
+/// Best-effort prune of a now-empty `<owner>` level (fails silently
+/// when other repos remain — exactly what `remove_dir` gives).
+fn prune_owner_level(repo_dir: &Path) {
+    if let Some(owner) = repo_dir.parent() {
+        let _ = std::fs::remove_dir(owner);
+    }
+}
+
+/// A ref refusal that teaches the grammar.
+fn refuse_ref(arg: &str, why: &str) -> String {
+    format!(
+        "model: `{arg}` is not a model reference ({why})\n  fix: the form is \
+         owner/repo[:QUANT] — e.g. Qwen/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The model-serve tests' exact fixture idiom (CARGO_TARGET_TMPDIR is
+    // unset for lib unit tests — fall back beside the build dir).
+    #[allow(clippy::disallowed_methods)]
+    fn temp_root(name: &str) -> PathBuf {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
+            || {
+                std::env::current_dir()
+                    .expect("current dir")
+                    .join("target")
+                    .join("tmp")
+            },
+            PathBuf::from,
+        );
+        let dir = base.join(format!("nika-models-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp root");
+        dir
+    }
+
+    /// Lay one fake GGUF (with content = `size` bytes) under the root.
+    fn plant(root: &Path, owner: &str, repo: &str, file: &str, size: usize) -> PathBuf {
+        let dir = root.join(owner).join(repo);
+        std::fs::create_dir_all(&dir).expect("model dir");
+        let path = dir.join(file);
+        std::fs::write(&path, vec![0u8; size]).expect("gguf fixture");
+        path
+    }
+
+    // -- ref grammar ------------------------------------------------
+
+    #[test]
+    fn parses_bare_and_quant_refs() {
+        let bare = parse_model_ref("Qwen/Qwen3-4B-Instruct-2507-GGUF").expect("bare parses");
+        assert_eq!(bare.owner, "Qwen");
+        assert_eq!(bare.name, "Qwen3-4B-Instruct-2507-GGUF");
+        assert_eq!(bare.quant, None);
+        assert_eq!(bare.repo_id(), "Qwen/Qwen3-4B-Instruct-2507-GGUF");
+
+        let tagged = parse_model_ref("unsloth/gpt-oss-20b-GGUF:Q4_K_M").expect("quant parses");
+        assert_eq!(tagged.quant.as_deref(), Some("Q4_K_M"));
+
+        let dotted = parse_model_ref("bartowski/Llama-3.2-1B:IQ4_XS").expect("dots parse");
+        assert_eq!(dotted.name, "Llama-3.2-1B");
+        assert_eq!(dotted.quant.as_deref(), Some("IQ4_XS"));
+    }
+
+    #[test]
+    fn refuses_malformed_refs_teaching_the_form() {
+        // Each row: the bad ref — every refusal must teach the grammar.
+        for bad in [
+            "",
+            "no-slash",
+            "/repo",
+            "owner/",
+            "a/b/c",
+            "owner/repo:",
+            "owner/repo:Q4:Q5",
+            "ow ner/repo",
+            "owner/re po",
+            "owner/repo:Q4 K M",
+            "-owner/repo",
+            ".owner/repo",
+        ] {
+            let refusal = parse_model_ref(bad).expect_err(bad);
+            assert!(
+                refusal.contains("owner/repo"),
+                "`{bad}` must teach the form · got: {refusal}"
+            );
+        }
+    }
+
+    // -- quant + size rendering --------------------------------------
+
+    #[test]
+    fn quant_reads_from_hub_convention_file_names() {
+        assert_eq!(
+            quant_of("qwen3-4b-instruct-q4_k_m.gguf").as_deref(),
+            Some("Q4_K_M")
+        );
+        assert_eq!(quant_of("model.Q8_0.gguf").as_deref(), Some("Q8_0"));
+        assert_eq!(quant_of("Llama-3.2-1B-F16.gguf").as_deref(), Some("F16"));
+        assert_eq!(
+            quant_of("gpt-oss-20b-IQ4_XS.gguf").as_deref(),
+            Some("IQ4_XS")
+        );
+        // The LAST matching segment wins (quants sit at the tail).
+        assert_eq!(
+            quant_of("q3-family-model-Q4_K_M.gguf").as_deref(),
+            Some("Q4_K_M")
+        );
+        // A plain name carries no quant — and `qwen3` must not read as one.
+        assert_eq!(quant_of("qwen3-tokenizer.gguf"), None);
+    }
+
+    #[test]
+    fn human_size_speaks_binary_units() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(2048), "2.0 KiB");
+        assert_eq!(human_size(4 * 1024 * 1024 * 1024), "4.0 GiB");
+        assert_eq!(human_size(2_890_000_000), "2.7 GiB");
+    }
+
+    // -- installed walk ----------------------------------------------
+
+    #[test]
+    fn installed_walks_two_levels_ggufs_only_sorted() {
+        let root = temp_root("walk");
+        plant(&root, "qwen", "b-repo", "model-q4_k_m.gguf", 8);
+        plant(&root, "qwen", "a-repo", "model-q8_0.gguf", 4);
+        plant(&root, "acme", "z", "z-f16.gguf", 2);
+        // Non-GGUF siblings and stray top-level files never list.
+        plant(&root, "qwen", "a-repo", "tokenizer.json", 1);
+        std::fs::write(root.join("stray.gguf"), b"x").expect("stray");
+
+        let items = installed(&root);
+        let ids: Vec<String> = items
+            .iter()
+            .map(|m| format!("{}/{}", m.repo_id, m.file_name))
+            .collect();
+        assert_eq!(
+            ids,
+            [
+                "acme/z/z-f16.gguf",
+                "qwen/a-repo/model-q8_0.gguf",
+                "qwen/b-repo/model-q4_k_m.gguf",
+            ]
+        );
+        assert_eq!(items[0].size, 2);
+        assert_eq!(items[2].stem(), "model-q4_k_m");
+        assert_eq!(items[2].quant().as_deref(), Some("Q4_K_M"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn installed_on_a_missing_root_is_empty_never_fatal() {
+        let root = temp_root("empty");
+        let missing = root.join("never-created");
+        assert!(installed(&missing).is_empty());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // -- by-id resolution (the serve seam) ---------------------------
+
+    #[test]
+    fn resolve_passes_an_existing_file_through() {
+        let root = temp_root("passthrough");
+        let gguf = plant(&root, "q", "r", "weights.gguf", 4);
+        let resolved = resolve_at(&root, &gguf.to_string_lossy()).expect("path passes");
+        assert_eq!(resolved, gguf);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_finds_the_single_gguf_by_repo_id() {
+        let root = temp_root("by-id");
+        let gguf = plant(&root, "Qwen", "Qwen3-4B-GGUF", "qwen3-4b-q4_k_m.gguf", 4);
+        let resolved = resolve_at(&root, "Qwen/Qwen3-4B-GGUF").expect("resolves");
+        assert_eq!(resolved, gguf);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_picks_the_quant_among_several() {
+        let root = temp_root("quant-pick");
+        plant(&root, "u", "m", "m-q4_k_m.gguf", 4);
+        let q8 = plant(&root, "u", "m", "m-q8_0.gguf", 8);
+        let resolved = resolve_at(&root, "u/m:Q8_0").expect("quant resolves");
+        assert_eq!(resolved, q8);
+        // Case-insensitive tag.
+        let lower = resolve_at(&root, "u/m:q8_0").expect("lowercase tag resolves");
+        assert_eq!(lower, q8);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_refuses_ambiguity_listing_the_quants() {
+        let root = temp_root("ambiguous");
+        plant(&root, "u", "m", "m-q4_k_m.gguf", 4);
+        plant(&root, "u", "m", "m-q8_0.gguf", 8);
+        let refusal = resolve_at(&root, "u/m").expect_err("must refuse");
+        assert!(refusal.contains("Q4_K_M"), "{refusal}");
+        assert!(refusal.contains("Q8_0"), "{refusal}");
+        assert!(refusal.contains("u/m:"), "{refusal}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_refuses_a_missing_model_teaching_what_is_there() {
+        let root = temp_root("missing");
+        plant(&root, "here", "now", "now-q4_k_m.gguf", 4);
+        let refusal = resolve_at(&root, "absent/model").expect_err("must refuse");
+        assert!(
+            refusal.contains("here/now"),
+            "the refusal lists what IS there · got: {refusal}"
+        );
+        assert!(refusal.contains("nika model pull"), "{refusal}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_teaches_pull_when_nothing_is_installed() {
+        let root = temp_root("nothing");
+        let refusal = resolve_at(&root, "absent/model").expect_err("must refuse");
+        assert!(refusal.contains("nika model pull"), "{refusal}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_finds_a_bare_stem_and_passes_a_path_shaped_miss_through() {
+        let root = temp_root("stem");
+        let gguf = plant(&root, "u", "m", "qwen3-4b-q4_k_m.gguf", 4);
+        let resolved = resolve_at(&root, "qwen3-4b-q4_k_m").expect("stem resolves");
+        assert_eq!(resolved, gguf);
+        // A path-shaped argument flows THROUGH even when missing —
+        // `serve` owns that verdict per build axis (default build =
+        // the local-infer recipe · feature build = plan()'s missing-
+        // file teach; the bin_smoke-pinned #482 contract).
+        let passed = resolve_at(&root, "./missing/file.gguf").expect("path miss passes through");
+        assert_eq!(passed, PathBuf::from("./missing/file.gguf"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // -- list ---------------------------------------------------------
+
+    #[test]
+    fn list_prints_the_dir_once_with_id_quant_size_rows() {
+        let root = temp_root("list");
+        plant(&root, "u", "m", "m-q4_k_m.gguf", 2048);
+        let out = list_at(&root);
+        assert!(
+            out.contains(&root.display().to_string()),
+            "the dir prints once at top · got: {out}"
+        );
+        assert!(out.contains("u/m"), "{out}");
+        assert!(out.contains("Q4_K_M"), "{out}");
+        assert!(out.contains("2.0 KiB"), "{out}");
+        assert!(out.contains("nika model serve"), "{out}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn list_when_empty_teaches_pull() {
+        let root = temp_root("list-empty");
+        let out = list_at(&root);
+        assert!(out.contains("nika model pull"), "{out}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // -- rm -------------------------------------------------------------
+
+    #[test]
+    fn rm_by_repo_id_removes_the_whole_model_dir() {
+        let root = temp_root("rm-repo");
+        plant(&root, "u", "m", "m-q4_k_m.gguf", 4);
+        plant(&root, "u", "m", "m-q8_0.gguf", 8);
+        plant(&root, "u", "m", "tokenizer.json", 1);
+        let out = rm_at(&root, "u/m").expect("removes");
+        assert!(!root.join("u").join("m").exists(), "dir removed");
+        assert!(out.contains("freed"), "{out}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rm_by_quant_removes_one_gguf_keeping_the_rest() {
+        let root = temp_root("rm-quant");
+        plant(&root, "u", "m", "m-q4_k_m.gguf", 4);
+        let q8 = plant(&root, "u", "m", "m-q8_0.gguf", 8);
+        rm_at(&root, "u/m:Q8_0").expect("removes");
+        assert!(!q8.exists(), "the named quant is gone");
+        assert!(root.join("u").join("m").join("m-q4_k_m.gguf").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rm_sweeps_the_dir_when_the_last_gguf_leaves() {
+        let root = temp_root("rm-sweep");
+        plant(&root, "u", "m", "m-q4_k_m.gguf", 4);
+        plant(&root, "u", "m", "tokenizer.json", 1);
+        rm_at(&root, "u/m:Q4_K_M").expect("removes");
+        assert!(
+            !root.join("u").join("m").exists(),
+            "a gguf-empty model dir sweeps (the orphan tokenizer with it)"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rm_refuses_a_no_match_with_the_list_as_the_teaching_surface() {
+        let root = temp_root("rm-miss");
+        plant(&root, "here", "now", "now-q4_k_m.gguf", 4);
+        let refusal = rm_at(&root, "absent/model").expect_err("must refuse");
+        assert!(
+            refusal.contains("here/now"),
+            "the refusal lists what IS there · got: {refusal}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,8 @@ wrappers = [
   "nika-input",            # L1 write-side effect (M2.4): tokio `rt` for spawn_blocking — the sync `enigo` OS-event synthesis runs off the async runtime (worker-local · CANCEL SAFETY contract · same pattern as nika-a11y) · B.3 wires enigo
   "nika-browser",          # L1 web effect (M2.5): tokio `rt` for the per-session CDP Handler task — chromiumoxide is async-native (NO spawn_blocking) · B.3 wires chromiumoxide
   "nika-providers",
-  "nika-infer-local",      # L1.5 candle sidecar (ADR-091): tokio for the local-inference worker        # L1.5 provider layer (s8.5): tokio dev-dep for #[tokio::test] async wire-adapter tests (transport itself rides the injected kernel http effect · zero runtime tokio dep)
+  "nika-infer-local",      # L1.5 candle sidecar (ADR-091): tokio for the local-inference worker
+  "nika-models",           # L4 local-models unit (descended from nika-cli 2026-07-12): current-thread runtime blocks the Hub pull on the nika-http seam (the registry #452 idiom)        # L1.5 provider layer (s8.5): tokio dev-dep for #[tokio::test] async wire-adapter tests (transport itself rides the injected kernel http effect · zero runtime tokio dep)
   "nika-verb-infer",       # L2 verb (s9): tokio dev-dep for #[tokio::test] run() tests over the mock registry (zero runtime tokio dep · transport inherited from the resolved provider)
   "nika-verb-exec",        # L2 verb (s10): tokio dev-dep for #[tokio::test] run() tests over MockShell (zero runtime tokio dep · subprocess owned by the injected runner)
   "nika-verb-invoke",      # L2 verb (s11): tokio dev-dep for #[tokio::test] run() tests over an inline mock ToolExecute (zero runtime tokio dep · dispatch owned by the injected executor)

--- a/docs/architecture/crate-layer-registry.md
+++ b/docs/architecture/crate-layer-registry.md
@@ -150,7 +150,7 @@ flags. They obey the same 12-gate admission as any other crate.
 | L1.5 | Provider wire adapters — between effects and verbs | via L1 http seam | L0, L0.5, L1 | `nika-providers` (14/14 wire · in-crate mock), `nika-infer-local` (candle sidecar · ADR-091) |
 | L2 | Verbs + domain services — orchestrates L1 impls behind kernel traits | via L1 traits only | L0, L0.5, L1, L1.5 | `nika-pck`, `nika-verb-*`, `nika-policy` (s8 · design locked), `nika-connectome` (the Connectome orchestrator), `nika-observability`, `nika-builtin-{github,cloud,workspace}` |
 | L3 | Runtime + policy + sandbox — enforces execution contracts | via L2 | L0..L2 | `nika-runtime`, `nika-shield`, `nika-wasm-host` (v0.100), `nika-sandbox` (v0.100) |
-| L4 | Interfaces — transport/UI surface, libraries only | via L3 | L0..L3 | `nika-cli`, `nika-dap`, `nika-display`, `nika-daemon`, `nika-serve`, `nika-mcp`, `nika-lsp`, `nika-sdk`, `nika-catalog-verify` |
+| L4 | Interfaces — transport/UI surface, libraries only | via L3 | L0..L3 | `nika-cli`, `nika-dap`, `nika-display`, `nika-models`, `nika-daemon`, `nika-serve`, `nika-mcp`, `nika-lsp`, `nika-sdk`, `nika-catalog-verify` |
 | L5 | The binary — sole `[[bin]]` composition root | via L4 | L0..L4 | `nika` (<500 LOC) |
 
 ### Forward compatibility

--- a/docs/crate-specs/nika-models.md
+++ b/docs/crate-specs/nika-models.md
@@ -1,0 +1,59 @@
+# Crate spec — `nika-models`
+
+| | |
+|---|---|
+| Status | **ADMITTED 2026-07-12** — Gate 1 authored at the split (a descent, not a greenfield: the unit landed test-first in `nika-cli` the same arc — issue #146 — and descended the day it was born). |
+| Layer | L4 — interface crate (the local-models unit: store · Hub acquisition · sidecar launch glue) |
+| Design | ONE law, one crate: the canonical models dir (`~/.nika/models/<owner>/<repo>/`). `store` owns the dir (by-id resolution for `serve --model` · `list` · `rm` · the `owner/repo[:QUANT]` grammar); `pull` acquires from the Hugging Face Hub over the injected kernel http seam (tree metadata FIRST — sizes before bytes · `Q4_K_M` default quant · ≥2 GiB confirm · `.part` + `Range:` resume · `HF_TOKEN` for gated repos · `tokenizer.json` rides along); `serve` is the candle sidecar boot glue (ADR-091/093 · feature-gated `local-infer`). The downloader and the resolver share the root by construction — the brouillon-era pull/load two-dir mismatch cannot re-happen. Outcomes are plain strings (`Ok` receipt · `Err` teaching refusal); the parent's thin adapters own the exit contract. |
+| LOC budget | the 15k-prod workspace ratchet governs (≤1,500/file · ≤100/fn as everywhere) — admitted at ~1.5k prod src; the parent `nika-cli` returns under the wall it crossed at 16,298 |
+| File cap | ≤1,500 LOC each (max at admission: `pull.rs`) |
+| Function cap | ≤100 lines each |
+| Crate version | tracks workspace (`0.99.0` at admission) |
+| License | `AGPL-3.0-or-later` |
+| Edition | 2024 |
+| Publish | `false` — internal L4 interface crate, same stance as `nika-cli` |
+| Extraction source | `crates/nika-cli/src/verbs/model/{store,pull,mod→serve}.rs` (git-mv, history preserved). `nika-cli` keeps thin `VerbOutput` adapters at the OLD public paths (`verbs::model::{serve, store::{resolve_serve_model,list,rm}, pull::run}` + `DEFAULT_PORT`) — the public-api baseline lines stay true verbatim. Per D-2026-07-09-N1 the descent is ONE architectural unit in TWO members — this crate spec names the parentage; the unit stays `nika-cli`'s. Precedent: `nika-onboard` (2026-07-12) · `nika-display` (2026-07-10) · `nika-dap` (2026-07-09), the same wall. |
+| NIKA codes | **none** — an acquisition/store surface: refusals are CLI teaching texts (exit `3` via the parent's adapter), never workflow-error codes (the one-voice model stays upstream) |
+
+---
+
+## 1. Purpose
+
+`nika-models` is the **local-models unit**: everything between a
+Hugging Face repo id and a GGUF the candle sidecar can serve. The store
+logic is pure disk (temp-root tested); the Hub client is generic over
+the kernel `HttpGetDyn`/`HttpPostDyn` traits (the whole network path is
+mock-proven — resume, restart, short-stream, auth); the only production
+transport is `nika-http` (rustls · SSRF floor · per-hop redirect
+vetting — no second HTTP stack, the reason `hf-hub` was refused).
+
+## 2. Why a crate (and why now)
+
+`nika-cli` sat at **14,958/15,000 prod LOC** when issue #146 landed its
++1,340: the wall the `nika-onboard`/`nika-display`/`nika-dap` descents
+each hit. The model unit was the newest coherent surface and the least
+entangled cut: three modules, one law, zero inverse edges (the parent
+consumes; nothing here reads the parent). The `local-infer`/`metal`
+features forward through the parent unchanged.
+
+## 3. Public API (the adapter's consumption surface)
+
+- `store::{models_root, resolve_serve_model, list, rm, human_size}`
+- `pull::run`
+- `serve::{serve, DEFAULT_PORT}`
+- `ModelsProbe` + `models_probe()` (the `nika doctor` models row)
+
+Everything else is `pub(crate)` — the grammar, the walk, the quant
+parse, the Puller and its refusal builders stay internal.
+
+## 4. Tests
+
+38 lib tests at admission: the ref grammar (+12 malformed-teach rows) ·
+quant parsing · by-id resolution (passthrough / single / quant-pick /
+ambiguity / miss-teaches-list / path-shaped flow-through per the
+bin_smoke-pinned #482 contract) · list/rm on temp roots (repo rm ·
+quant rm · last-gguf sweep) · tree parse · GGUF choice (default / tag /
+menu refusals) · the confirm gate · the streamed download over an
+injected seam double (happy · resume-`Range` · 200-restart ·
+short-stream-keeps-part · 401/403 teach · bearer on/off). The serve
+boot path keeps its per-axis tests (`local-infer` on/off).

--- a/scripts/ci/public-api-coverage-baseline.txt
+++ b/scripts/ci/public-api-coverage-baseline.txt
@@ -90,3 +90,5 @@ nika-dap
 nika-display
 nika-pck-manifest
 nika-tmpl
+# --- 2026-07-12: the local-models descent (issue #146 · the 15k wall — nika-onboard/display/dap precedents) ---
+nika-models


### PR DESCRIPTION
One command from the Hub to a sovereign in-process run — the acquisition half the sidecar (ADR-091/093, #482) was waiting for.

## The unit ships as a member: `crates/nika-models` (the 15k wall, the house way)

`nika-cli` sat at 14,958/15,000 prod LOC when this feature's +1,340 landed — the exact wall the `nika-onboard` (#489 arc) / `nika-display` / `nika-dap` descents each hit. Per D-2026-07-09-N1 the unit descends: **store · pull · serve glue become `nika-models` (L4)**, and `nika-cli` keeps thin exit-contract adapters at the UNCHANGED public paths (`verbs::model::{serve, store::*, pull::run}` — the public-api baseline lines stay true verbatim; the member speaks plain `Ok(receipt)/Err(refusal)` strings, the adapter owns what they mean on the verb tree: `0`/`3`). Post-descent `nika-cli` = **14,937 prod LOC — 21 UNDER its pre-feature baseline** (serve descended too), so this PR composes with the sister descents instead of racing them.

Member ceremony, complete (the nika-onboard checklist): workspace member + `layers.nika-models = "L4"` (layering gate: 47/47) · `docs/crate-specs/nika-models.md` · crate-layer-registry L4 row · public-api coverage floor cohort line + `crates/nika-models/public-api.txt` · `deny.toml` tokio wrapper row · lore metadata (forgeron · quartermaster) · the ROADMAP/.claude/CLAUDE.md status blocks re-project (47 workspace · 45 admitted · L4=7).

## The ONE-dir law (the issue's core lesson)

`~/.nika/models/<owner>/<repo>/` — the downloader (`model pull`) and the resolver (`model serve --model <id>`) share the root **by construction**: both call the same `store::models_root()` (HOME/USERPROFILE, the `~/.nika/registry/` + `nika wire` resolution). The brouillon-era pull/load two-dir mismatch cannot re-happen — there is exactly one function that knows the dir.

- `nika model pull owner/repo[:QUANT]` — tree metadata FIRST (sizes before any byte moves), GGUF streamed to `<file>.part` → renamed into place only when the byte count matches the declared size, `tokenizer.json` brought along (the exact sibling layout the serve loader wants).
- `nika model serve --model owner/repo[:QUANT]` — by-id resolution against that dir (bare file stems work too; a real path passes straight through untouched). Ambiguity refuses with the exact ids; a miss refuses **with the installed list as the teaching surface**.
- `nika model list` — the dir printed once at top, then `id · size · file` per GGUF.
- `nika model rm <id>` — `owner/repo` reclaims every quant (tokenizer with it) · `owner/repo:QUANT` one file (sweeping a gguf-empty dir) · no-match refuses listing what IS there.

## Quant · confirm · token

- **Quant**: default `Q4_K_M` when the repo tags one; single-GGUF repos resolve bare; otherwise the refusal is a **menu of exact pull commands** (`nika model pull u/m:Q5_K_M · 4.7 GiB`). Explicit `:TAG` matches case-insensitively.
- **Confirm**: size prints BEFORE downloading; ≥ 2 GiB prompts on a terminal and **refuses teaching `--yes` in a pipe** (the CI shape).
- **Resume**: an interrupted pull re-runs from its `.part` via `Range:` (206 appends · a 200 answer restarts honestly); a short stream keeps the `.part` and says so.
- **`HF_TOKEN`**: authenticates gated repos on both the tree call and the download; `nika-http` strips the header on the cross-origin CDN redirect (the signed URL carries its own grant). Live finding baked into the teach: the Hub answers **401 for repos that don't exist** (existence hidden), so the access refusal names the typo lane before the token lane.

## Why the house seam and not `hf-hub` (dependency diligence, honest)

`hf-hub` was evaluated and NOT taken — three architectural refusals, not a licence failure:

1. **Layer discipline** — `deny.toml` layer-bans `reqwest` to its wrappers so every outbound byte rides `nika-http`'s four-layer SSRF defense; `hf-hub` embeds its own `ureq` stack, a second HTTP path around that seam.
2. **Testability** — `hf-hub` accepts no client injection; over the kernel `HttpGetDyn`/`HttpPostDyn` traits the whole pull path is mock-proven (the `registry::` #452 precedent), including resume/restart/short-stream/auth-header cases.
3. **The one-dir law itself** — `hf-hub` imposes its snapshot cache layout (`models--owner--repo/snapshots/<rev>/…`), the exact two-layout split this issue exists to kill.

`cargo deny check`: advisories / bans / licenses / sources **ok** (zero new external crates — `bytes` + `futures-core` join as dev-deps for the streaming test double, both already workspace members).

## Doctor

The models row closes #482's deliberate deferral: `✔ models <dir> — N GGUF · X GiB ("nika model list")` on **any** build once something is pulled; a `local-infer` build with nothing to serve gets a teach-pull advisory; a default build with zero pulls stays byte-identical.

## Scope boundary

Acquisition UX only — the candle runtime owns loading/generation (ADR-091/093). The fetch is CLI-level, like `registry:` pulls: a workflow's `permits:` never govern it (the help says so).

## Proof

- **TDD**: red-first suite — ref grammar (parse + 12 malformed-teach rows) · quant parsing · by-id resolution (passthrough / single / quant-pick / ambiguity / miss-teaches-list / path-shaped flow-through per the bin_smoke-pinned #482 per-build-axis contract) · list/rm on temp roots (repo rm · quant rm · last-gguf sweep) · tree parse · GGUF choice (default / tag / menu refusals) · confirm gate · streamed download over an injected seam double (happy · resume-Range · 200-restart · short-stream-keeps-part · 401/403 teach · bearer on/off).
- **Tests**: `nika-models` 38 lib (40 with `local-infer`) · `nika-cli` 331 lib + 6 bin + 39 bin_smoke + the full integration surface green · clippy `-D warnings` clean on both feature axes, both crates.
- **Gates run locally**: crate-size (`OK all crates <= 15000`) · layering (47/47) · crate-gates(nika-models) · dead-code · expect · fn-length · loc-limits · public-api coverage (46 locks) · status-claims-sync · `cargo deny` (advisories/bans/licenses/sources ok) · `cargo machete` clean.
- **Live-probed** against the real Hub: the tree lane works end-to-end (SSRF chain green); smoke-tested list/rm/serve-by-id/doctor against a scratch HOME through the real binary.
- **public-api baseline**: `nika-cli`'s six new lib lines spliced in the tool's canonical order (additive only — the adapters keep the signatures verbatim); `nika-models` gets its own lock.
- **main.rs headroom**: the first commit descends the model clap family to a bin-side `model_args.rs` (the `registry_args.rs` convention) — the family grows there, never at the wall.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
