### PR TITLE
fix(agents): kit 0.5.1 — the map survives a subdir session

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika · Intent as Code",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks in both dialects — Cursor and Claude Code (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,13 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.5.1 — 2026-07-12
+
+- session-context: a session opened in a SUBDIR of the workspace now
+  gets the map — the script resolves the git toplevel before probing
+  the workspace markers (proven lost from `src/deep/`; non-git dirs
+  keep the old behavior, silence stays silent).
+
 ## 0.5.0 — 2026-07-12
 
 Hooks parity: the three seatbelts reach Claude Code (they were

--- a/.agents/plugins/nika/scripts/session-context.sh
+++ b/.agents/plugins/nika/scripts/session-context.sh
@@ -34,6 +34,12 @@ else
   cwd="$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
 fi
 [ -n "$cwd" ] && [ -d "$cwd" ] && cd "$cwd" || true
+# A session opened in a SUBDIR of the workspace must still get the map
+# (proven lost 2026-07-12): resolve the git toplevel when there is one —
+# the workspace markers (.nika/ · .cursor/rules/nika.mdc · *.nika.yaml)
+# live at the root. Not a git repo → stay where we are (old behavior).
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$root" ] && [ -d "$root" ] && cd "$root" || true
 
 # Nika-enabled = a .nika/ store, an equipped repo (`nika init` wrote
 # .cursor/rules/nika.mdc — the session right after init is exactly


### PR DESCRIPTION
Friction hunt: a session opened in `src/deep/` of a nika workspace got **no context** — the probe only looked at cwd. The script now resolves the git toplevel before probing the workspace markers (`.nika/` · `.cursor/rules/nika.mdc` · `*.nika.yaml`); non-git dirs keep the old behavior.

Battery: subdir map served in BOTH dialects · non-git silence intact · monorepo-root timing unchanged (47ms measured). Manifests move to 0.5.1.

(Also probed this pass: the 'NIKA-VAR-001 twice' in the E2E deny = fixture artifact — two real references, two findings with distinct spans, not a product dup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)