### PR TITLE
feat(models): the pull receipt speaks the resume — plus the live-hub pin

### DIFF
--- a/crates/nika-models/src/pull.rs
+++ b/crates/nika-models/src/pull.rs
@@ -261,11 +261,14 @@ impl<H: HttpGetDyn + HttpPostDyn> Puller<H> {
     /// Stream one repo file into the model's dir. Resumes a `<file>.part`
     /// via `Range:` (206 appends · 200 restarts) and renames into place
     /// only when the byte count matches the tree's declared size.
+    /// Returns the landing path + the byte offset the transfer resumed
+    /// from (`0` = a fresh pull) — the receipt tells the truth about
+    /// what happened (a resumed pull must not read like a fresh one).
     pub(crate) async fn download(
         &self,
         mref: &ModelRef,
         entry: &TreeEntry,
-    ) -> Result<PathBuf, Refusal> {
+    ) -> Result<(PathBuf, u64), Refusal> {
         let file = file_name(&entry.path);
         let dir = mref.dir(&self.root);
         std::fs::create_dir_all(&dir).map_err(|e| {
@@ -319,7 +322,7 @@ impl<H: HttpGetDyn + HttpPostDyn> Puller<H> {
                 part.display()
             ))
         })?;
-        Ok(dest)
+        Ok((dest, start))
     }
 
     /// Write the stream to the `.part` file, ticking progress; returns
@@ -508,6 +511,7 @@ fn pull_over_network(
         store::human_size(entry.size)
     );
     let mut already = false;
+    let mut resumed_from: u64 = 0;
     if std::fs::metadata(&dest).is_ok_and(|m| m.len() == entry.size) {
         already = true;
         eprintln!("  already present — nothing to download");
@@ -534,7 +538,8 @@ fn pull_over_network(
             token.clone(),
             interactive,
         );
-        runtime.block_on(puller.download(mref, &entry))?;
+        let (_, from) = runtime.block_on(puller.download(mref, &entry))?;
+        resumed_from = from;
     }
     // tokenizer.json beside the GGUF — the sibling layout `serve` loads.
     let tokenizer_note = match tokenizer {
@@ -542,7 +547,7 @@ fn pull_over_network(
             let tok_dest = mref.dir(root).join(file_name(&tok.path));
             if std::fs::metadata(&tok_dest).is_err() {
                 let side = Puller::new(house_http(None)?, root.to_path_buf(), token, false);
-                runtime.block_on(side.download(mref, &tok))?;
+                let _ = runtime.block_on(side.download(mref, &tok))?;
             }
             String::new()
         }
@@ -550,12 +555,35 @@ fn pull_over_network(
                  beside the GGUF (name yours with --tokenizer <path>)"
             .to_owned(),
     };
-    Ok(receipt(arg, mref, &dest, already, &tokenizer_note))
+    Ok(receipt(
+        arg,
+        mref,
+        &dest,
+        already,
+        resumed_from,
+        &tokenizer_note,
+    ))
 }
 
-/// The pull receipt: where it landed + the exact next commands.
-fn receipt(arg: &str, mref: &ModelRef, dest: &Path, already: bool, tokenizer_note: &str) -> String {
-    let verb = if already { "present" } else { "pulled" };
+/// The pull receipt: where it landed + the exact next commands. A
+/// resumed transfer says so (`resumed at <offset>`) — the receipt is
+/// the surface scripts and logs read, and a resume must not read like
+/// a fresh pull (the live-Hub pin asserts this).
+fn receipt(
+    arg: &str,
+    mref: &ModelRef,
+    dest: &Path,
+    already: bool,
+    resumed_from: u64,
+    tokenizer_note: &str,
+) -> String {
+    let verb = if already {
+        "present".to_owned()
+    } else if resumed_from > 0 {
+        format!("pulled (resumed at {})", store::human_size(resumed_from))
+    } else {
+        "pulled".to_owned()
+    };
     format!(
         "{verb} {}\n  {}\n  serve it: nika model serve --model {arg}\n  manage:   nika \
          model list · nika model rm {arg}{tokenizer_note}",
@@ -919,10 +947,11 @@ mod tests {
         let http = StreamHttp::default().stream_ok(200, Some(9), &[b"hello ", b"wor", b""]);
         let root = temp_root("dl-happy");
         let puller = Puller::new(http, root.clone(), None, false);
-        let dest = puller
+        let (dest, resumed_from) = puller
             .download(&mref("u/m"), &entry("file", "w-q4_k_m.gguf", 9))
             .await
             .expect("download completes");
+        assert_eq!(resumed_from, 0, "a fresh pull reports no resume offset");
         assert_eq!(dest, root.join("u").join("m").join("w-q4_k_m.gguf"));
         assert_eq!(std::fs::read(&dest).expect("dest"), b"hello wor");
         assert!(
@@ -950,10 +979,11 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("dir");
         std::fs::write(dir.join("w.gguf.part"), b"hello").expect("part fixture");
         let puller = Puller::new(http, root.clone(), None, false);
-        let dest = puller
+        let (dest, resumed_from) = puller
             .download(&mref("u/m"), &entry("file", "w.gguf", 10))
             .await
             .expect("resume completes");
+        assert_eq!(resumed_from, 5, "the 206 resume reports its offset");
         assert_eq!(std::fs::read(&dest).expect("dest"), b"helloworld");
         assert!(!dir.join("w.gguf.part").exists(), ".part renamed away");
         let sent = puller.http.sent();
@@ -973,10 +1003,11 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("dir");
         std::fs::write(dir.join("w.gguf.part"), b"stale-part").expect("part fixture");
         let puller = Puller::new(http, root.clone(), None, false);
-        let dest = puller
+        let (dest, resumed_from) = puller
             .download(&mref("u/m"), &entry("file", "w.gguf", 5))
             .await
             .expect("restart completes");
+        assert_eq!(resumed_from, 0, "a 200 restart is not a resume");
         assert_eq!(std::fs::read(&dest).expect("dest"), b"fresh");
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/nika-models/tests/live_hub.rs
+++ b/crates/nika-models/tests/live_hub.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ONE live-Hub pin (`#[ignore]` — network + ~100 MiB · run it with
+//! `cargo test -p nika-models --test live_hub -- --ignored`).
+//!
+//! The mocked suite proves the logic; THIS proves the couple: the real
+//! Hub's tree API shape, the raw download host, the redirect chain and
+//! the Range/206 resume behavior are third-party surfaces that move
+//! without notice — when they do, this test names the break before a
+//! user does (first proven live 2026-07-12: pull → one-dir layout →
+//! missing-tokenizer note → resume at 56.7 MiB → rm sweep).
+//!
+//! One test on purpose (the essential-only law): every leg rides the
+//! same pulled bytes — five downloads would prove nothing more.
+
+// A test binary panics by design — the house test exemption.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::path::PathBuf;
+
+/// The corpus repo: bartowski's smallest instruct GGUF (~100 MiB
+/// `Q4_K_M` · no `tokenizer.json` — which ALSO pins the advisory note).
+const REPO: &str = "bartowski/SmolLM2-135M-Instruct-GGUF";
+const GGUF: &str = "SmolLM2-135M-Instruct-Q4_K_M.gguf";
+
+fn repo_dir() -> PathBuf {
+    nika_models::store::models_root()
+        .expect("HOME resolves on a dev machine")
+        .join("bartowski")
+        .join("SmolLM2-135M-Instruct-GGUF")
+}
+
+/// Best-effort cleanup — the test must be re-runnable and leave no
+/// hundred-megabyte residue behind (pass or fail).
+fn cleanup() {
+    let _ = std::fs::remove_dir_all(repo_dir());
+}
+
+#[test]
+#[ignore = "network + ~100 MiB — the live Hub couple; run explicitly with --ignored"]
+fn the_hub_couple_holds_end_to_end() {
+    cleanup();
+
+    // ── 1 · pull: default quant resolves · size prints BEFORE bytes ──
+    let receipt = nika_models::pull::run(REPO, true).unwrap_or_else(|e| {
+        cleanup();
+        panic!("live pull refused: {e}");
+    });
+    assert!(receipt.contains("pulled"), "{receipt}");
+    assert!(
+        receipt.contains("no tokenizer.json"),
+        "this corpus repo ships none — the advisory note is part of the contract: {receipt}"
+    );
+
+    // ── 2 · one-dir law: the file is where list/rm/serve look ──
+    let gguf = repo_dir().join(GGUF);
+    assert!(gguf.is_file(), "the one canonical dir holds the GGUF");
+    let full_len = gguf.metadata().map(|m| m.len()).unwrap_or(0);
+    assert!(
+        full_len > 50 * 1024 * 1024,
+        "a real model, not an error page"
+    );
+
+    // ── 3 · resume: truncate to a prefix as the interrupted .part ·
+    //        the re-pull must APPEND (Range/206), never restart ──
+    let part = repo_dir().join(format!("{GGUF}.part"));
+    let bytes = std::fs::read(&gguf).unwrap_or_else(|e| {
+        cleanup();
+        panic!("read back: {e}");
+    });
+    let half = bytes.len() / 2;
+    if std::fs::write(&part, &bytes[..half]).is_err() {
+        cleanup();
+        panic!("staging the .part failed");
+    }
+    let _ = std::fs::remove_file(&gguf);
+    let receipt = nika_models::pull::run(REPO, true).unwrap_or_else(|e| {
+        cleanup();
+        panic!("resume pull refused: {e}");
+    });
+    assert!(
+        receipt.contains("resumed at"),
+        "the receipt must speak the resume (a resumed pull must not read \
+         like a fresh one): {receipt}"
+    );
+    let resumed_len = gguf.metadata().map(|m| m.len()).unwrap_or(0);
+    assert_eq!(resumed_len, full_len, "the resumed file is byte-complete");
+
+    // ── 4 · leave the machine as found ──
+    cleanup();
+    assert!(!repo_dir().exists(), "no residue");
+}


### PR DESCRIPTION
## The socratic catch (2026-07-12 · the HF-couple pass)

The mocked suite proves the logic; nothing proved the COUPLE against the real Hub. The first live gauntlet surfaced a real gap: **a resumed pull's receipt read byte-identical to a fresh one** (the resume fact lived only on a stderr progress line — the receipt is what scripts and logs read).

## The fix

`download()` returns the offset `begin_write` actually honored (**0 on a 200 restart — returning the requested offset would lie**); the receipt says `pulled (resumed at N)`. Unit pins: fresh=0 · 206=offset · 200-restart=0.

## The Rams pin (one essential live test)

`tests/live_hub.rs` — `#[ignore]`, run explicitly: `cargo test -p nika-models --test live_hub -- --ignored`. One ~100 MiB corpus pull (bartowski/SmolLM2-135M), every leg on the same bytes: size-before-bytes · one-dir law · missing-tokenizer advisory · **truncated-.part resume proven live at 50.3 MiB** · byte-complete result · zero residue pass-or-fail. Proven green twice on the real Hub tonight; the TDD loop caught both the product gap and its own wrong-surface assertion.

Proof: nika-models 38 lib green · clippy `-D warnings` 0 · live pin 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)