### PR TITLE
fix(cli): the plural is part of the voice

### DIFF
--- a/crates/nika-cli/src/lib.rs
+++ b/crates/nika-cli/src/lib.rs
@@ -24,6 +24,7 @@
 pub use nika_display as display;
 pub use nika_display::demo;
 pub mod registry;
+pub(crate) mod text;
 pub mod verbs;
 pub mod wires;
 

--- a/crates/nika-cli/src/text.rs
+++ b/crates/nika-cli/src/text.rs
@@ -1,0 +1,31 @@
+//! Count-noun agreement for visible strings — the operator surface
+//! reads as prose, so it never prints `1 tasks` nor the lazy `task(s)`.
+
+/// `count(3, "task")` → `3 tasks` · `count(1, "task")` → `1 task`.
+///
+/// Regular plurals only — every counted noun on the surface (task ·
+/// wave · run · finding · hint · edge · key) pluralizes with a plain
+/// `s`; an irregular noun would earn its own arm the day one exists.
+pub(crate) fn count(n: usize, noun: &str) -> String {
+    if n == 1 {
+        format!("1 {noun}")
+    } else {
+        format!("{n} {noun}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count;
+
+    #[test]
+    fn one_reads_singular_and_the_rest_plural() {
+        assert_eq!(count(1, "task"), "1 task");
+        assert_eq!(count(0, "task"), "0 tasks");
+        assert_eq!(count(3, "wave"), "3 waves");
+        // A compound noun pluralizes at its tail — the caller can pass
+        // a qualified noun and the agreement stays right.
+        assert_eq!(count(1, "more hint"), "1 more hint");
+        assert_eq!(count(4, "downstream task"), "4 downstream tasks");
+    }
+}

--- a/crates/nika-cli/src/verbs/context.rs
+++ b/crates/nika-cli/src/verbs/context.rs
@@ -263,7 +263,7 @@ fn render_human(
         let verdict = if f.clean {
             theme.paint(Role::Good, "clean")
         } else {
-            theme.paint(Role::Bad, &format!("{} finding(s)", f.findings))
+            theme.paint(Role::Bad, &crate::text::count(f.findings, "finding"))
         };
         let cost = if f.cost_is_floor {
             format!("≥ ${:.4}", f.cost_bounded_usd)
@@ -272,10 +272,10 @@ fn render_human(
         };
         let _ = writeln!(
             s,
-            "  {:<width$}  {verdict} · {} task(s) · {} wave(s) · {cost}{}",
+            "  {:<width$}  {verdict} · {} · {} · {cost}{}",
             f.path,
-            f.tasks,
-            f.waves,
+            crate::text::count(f.tasks, "task"),
+            crate::text::count(f.waves, "wave"),
             if f.permits_declared {
                 " · permits ✓".to_owned()
             } else {
@@ -294,12 +294,12 @@ fn render_human(
     let floor = if rollups.cost_is_floor { "≥" } else { "≤" };
     let _ = writeln!(
         s,
-        "{} {} clean / {} total · {floor} ${:.4} · {} run(s) recorded",
+        "{} {} clean / {} total · {floor} ${:.4} · {} recorded",
         theme.paint(Role::Strong, "rollup"),
         rollups.workflows_clean,
         rollups.workflows_total,
         rollups.cost_bounded_usd,
-        workspace.runs.len(),
+        crate::text::count(workspace.runs.len(), "run"),
     );
     let _ = writeln!(
         s,

--- a/crates/nika-cli/src/verbs/doctor.rs
+++ b/crates/nika-cli/src/verbs/doctor.rs
@@ -254,8 +254,9 @@ fn image_finding(img: &ImageProbe) -> Finding {
             format!("mock ready · {local_part} · no cloud image key set")
         } else {
             format!(
-                "mock ready · {} key(s) present · {local_part}",
-                wired.join(" · ")
+                "mock ready · {} {} present · {local_part}",
+                wired.join(" · "),
+                if wired.len() == 1 { "key" } else { "keys" }
             )
         },
         fix: None,
@@ -322,8 +323,9 @@ fn tts_finding(tts: &TtsProbe) -> Finding {
             format!("mock ready · {local_part} · no cloud speech key set")
         } else {
             format!(
-                "mock ready · {} key(s) present · {local_part}",
-                wired.join(" · ")
+                "mock ready · {} {} present · {local_part}",
+                wired.join(" · "),
+                if wired.len() == 1 { "key" } else { "keys" }
             )
         },
         fix: None,
@@ -521,8 +523,8 @@ fn local_finding(local_ids: &[&str], pinged: bool) -> Finding {
         level: Level::Ok,
         label: "local".to_owned(),
         detail: format!(
-            "{} provider(s) ({}) — no key · needs a running server",
-            local_ids.len(),
+            "{} ({}) — no key · needs a running server",
+            crate::text::count(local_ids.len(), "provider"),
             local_ids.join(" · ")
         ),
         fix: (!pinged)

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -160,8 +160,8 @@ fn dirty(path: &str, description: Option<&str>, report: &CheckReport, json: bool
     let mut s = String::new();
     let _ = writeln!(
         s,
-        "this workflow does not check clean yet — {} finding(s):",
-        report.conformance.len()
+        "this workflow does not check clean yet — {}:",
+        crate::text::count(report.conformance.len(), "finding")
     );
     for c in report.conformance.iter().take(3) {
         let _ = writeln!(s, "  [{}] {}", c.code, c.message);
@@ -282,9 +282,9 @@ fn render_human(
     );
     let _ = writeln!(
         s,
-        "  {} task(s) · {} wave(s) · checks clean",
-        doc.nodes.len(),
-        report.waves.len()
+        "  {} · {} · checks clean",
+        crate::text::count(doc.nodes.len(), "task"),
+        crate::text::count(report.waves.len(), "wave")
     );
     story_section(&mut s, doc, report);
     cost_section(&mut s, report);
@@ -388,7 +388,13 @@ fn touches_section(s: &mut String, doc: &GraphDoc, report: &CheckReport, permits
             .requirements
             .models
             .iter()
-            .map(|m| format!("{} ({} task(s))", m.model, m.tasks.len()))
+            .map(|m| {
+                format!(
+                    "{} ({})",
+                    m.model,
+                    crate::text::count(m.tasks.len(), "task")
+                )
+            })
             .collect();
         let _ = writeln!(s, "  models   {}", models.join(" · "));
     }
@@ -449,17 +455,20 @@ fn risks_section(s: &mut String, path: &str, report: &CheckReport) {
     if report.hints.len() > 3 {
         let _ = writeln!(
             s,
-            "  … +{} more hint(s) → nika check {path}",
-            report.hints.len() - 3
+            "  … +{} → nika check {path}",
+            crate::text::count(report.hints.len() - 3, "more hint")
         );
     }
     if let Some(a) = report.analysis.as_ref()
         && let Some(b) = a.blast_radius.first()
     {
+        // Noun AND verb agree — `1 downstream task never runs`.
         let _ = writeln!(
             s,
-            "  if {} fails, {} downstream task(s) never run",
-            b.task, b.blocks
+            "  if {} fails, {} never {}",
+            b.task,
+            crate::text::count(b.blocks, "downstream task"),
+            if b.blocks == 1 { "runs" } else { "run" }
         );
     }
 }
@@ -490,9 +499,10 @@ fn recorder_section(s: &mut String, traces: Option<&(usize, String)>) {
         Some((n, latest)) => {
             let _ = writeln!(
                 s,
-                "\nflight recorder\n  {n} run(s) in .nika/traces · latest:\n  \
+                "\nflight recorder\n  {} in .nika/traces · latest:\n  \
                  nika trace show {latest}\n  \
-                 nika trace verify <same file>   # prove the hash chain"
+                 nika trace verify <same file>   # prove the hash chain",
+                crate::text::count(*n, "run")
             );
         }
         None => {
@@ -592,13 +602,13 @@ mod tests {
         assert_eq!(out.code, exit::OK, "{}", out.text);
         for needle in [
             "brief-factory — fetch, summarize twice, join",
-            "4 task(s) · 3 wave(s) · checks clean",
+            "4 tasks · 3 waves · checks clean",
             "the story",
             "wave 2 — 2 in parallel",
             "asks mock/echo",
             "cost before a token is spent",
             "what it touches",
-            "mock/echo (4 task(s))",
+            "mock/echo (4 tasks)",
             "run it",
             "nika run",
             "flight recorder",
@@ -618,7 +628,7 @@ mod tests {
         // If root fails, everything downstream is named.
         assert!(
             out.text
-                .contains("if root fails, 3 downstream task(s) never run"),
+                .contains("if root fails, 3 downstream tasks never run"),
             "{}",
             out.text
         );

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -230,7 +230,10 @@ fn diff_lines(expected: &Value, actual: &Value) -> Vec<String> {
     if lines.len() > DIFF_LINE_CAP {
         let more = lines.len() - DIFF_LINE_CAP;
         lines.truncate(DIFF_LINE_CAP);
-        lines.push(format!("… and {more} more difference(s)"));
+        lines.push(format!(
+            "… and {}",
+            crate::text::count(more, "more difference")
+        ));
     }
     lines
 }

--- a/crates/nika-cli/src/verbs/trace/mod.rs
+++ b/crates/nika-cli/src/verbs/trace/mod.rs
@@ -145,8 +145,8 @@ fn render_outputs(view: &RunView, trace: &str, theme: Theme) -> String {
 /// task id is the one placeholder).
 fn totals_line(view: &RunView, trace: &str, theme: Theme) -> String {
     let mut line = format!(
-        "  {} task(s) · {}",
-        view.rows().len(),
+        "  {} · {}",
+        crate::text::count(view.rows().len(), "task"),
         fmt_wall_ms(view.elapsed_ms)
     );
     let tokens: u64 = view.rows().iter().filter_map(|r| r.tokens).sum();
@@ -433,7 +433,7 @@ fn render_flow(edges: &[FlowEdge], theme: Theme) -> String {
     }
     let arrow = crate::display::vocab::arrow(theme.ascii);
     let join = if theme.ascii { "x" } else { "×" };
-    let mut totals = format!("  {} edge(s)", edges.len());
+    let mut totals = format!("  {}", crate::text::count(edges.len(), "edge"));
     if let Some(widest) = edges
         .iter()
         .filter(|e| e.bytes.is_some())
@@ -496,7 +496,7 @@ mod tests {
             text.contains(&format!("full value: nika trace peek {trace} <task>")),
             "peek hint carries the real path: {text}"
         );
-        assert!(text.contains("5 task(s)"), "totals: {text}");
+        assert!(text.contains("5 tasks"), "totals: {text}");
         assert!(text.contains("710 tok"), "token total: {text}");
     }
 
@@ -704,7 +704,7 @@ mod tests {
             "terminal outputs edge (aligned): {text}"
         );
         assert!(
-            text.contains("2 edge(s) · widest: read_payload→audit"),
+            text.contains("2 edges · widest: read_payload→audit"),
             "totals + widest: {text}"
         );
         assert!(


### PR DESCRIPTION
## The catch

The operator surface read **three dialects at once**: the correct (`3 runs`, forecast already agreed), the wrong (`1 tasks`), and the lazy (`task(s)` — punctuation standing in for grammar, thirteen sites across five verbs).

## One voice

A count-noun helper (`text::count`, `pub(crate)`, zero public-api impact) and every visible counter in `context` · `explain` · `trace` · `test` · `doctor` now agrees in number — noun AND verb (`if root fails, 1 downstream task never runs`). Proven at the binary: `1 task · 1 wave · checks clean`.

## Deliberately NOT here

The run banner (`· 1 tasks`), check verdict line, inspect header and the display-crate twins live in files **PR #489 owns** — noted there ([comment](https://github.com/supernovae-st/nika/pull/489#issuecomment-4951827267)), taken post-merge with the same helper (promoted to `vocab` then).

Proof: nika-cli 311 lib green (helper pinned: silence rules + compound nouns) · clippy `-D warnings` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)