### PR TITLE
fix(providers): the error speaks operator, not rustdoc

### DIFF
--- a/crates/nika-providers/src/registry.rs
+++ b/crates/nika-providers/src/registry.rs
@@ -176,8 +176,8 @@ where
     /// `ProviderError::Other` on a malformed model string (no `/`), an
     /// unknown provider id, or a cloud profile resolved without an http
     /// effect; `ProviderError::AuthFailed` when the profile requires a key
-    /// and none was injected (the message prints the env ladder + the
-    /// `with_key` alternative).
+    /// and none was injected — the message prints the env ladder (operator
+    /// voice); embedders inject via [`ProvidersConfig::with_key`].
     pub fn resolve(&self, model: &str) -> Result<ResolvedProvider<H>, ProviderError> {
         let Some((provider_id, model_rest)) = model.split_once('/') else {
             return Err(ProviderError::Other {

--- a/crates/nika-providers/src/registry.rs
+++ b/crates/nika-providers/src/registry.rs
@@ -208,10 +208,11 @@ where
         let key = self.config.keys.get(profile.id).cloned();
         if profile.requires_key && key.is_none() {
             let ladder = profile.env_candidates();
+            // Operator voice only — the embedder's road (`ProvidersConfig::
+            // with_key`) lives in rustdoc, never in a rendered error.
             return Err(ProviderError::AuthFailed {
                 reason: format!(
-                    "no API key for '{}' · set one of [{}] (e.g. `export {}=…`) or inject via \
-                     ProvidersConfig::with_key",
+                    "no API key for '{}' · set one of [{}] (e.g. `export {}=…`)",
                     profile.id,
                     ladder.join(", "),
                     ladder.last().map_or("", String::as_str),


### PR DESCRIPTION
## The catch (first-failure probe, at the binary)

A fresh user's first failure card said: *« set one of [NIKA_MISTRAL_API_KEY, MISTRAL_API_KEY] (e.g. `export MISTRAL_API_KEY=…`) **or inject via ProvidersConfig::with_key** »* — a Rust symbol on the operator surface. A CLI user cannot act on it; an embedder was never going to learn the API from an error string.

## One voice per audience

The rendered error keeps exactly what an operator can act on (env ladder + export line). The embedder's road stays where embedders read: the module rustdoc (`registry.rs` header · `lib.rs` overview) — both already say it.

Proof: nika-providers 148 lib green · clippy `-D warnings` 0. No test pinned the dropped tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)