### PR TITLE
feat(nika-lsp): code actions — the --fix engine reaches every editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **LSP code actions — the `--fix` engine in every editor**: the language
+  server now answers `textDocument/codeAction` with quickfix renames
+  built from the checker's typed `offending`/`suggestion` pairs (unknown
+  fields · tools · args · rename-shaped conformance findings). Same
+  discipline as `nika check --fix`: did-you-mean only, unique-token
+  only — an ambiguous or suggestion-less finding offers nothing. One
+  fix engine, projected; VS Code, Cursor, zed, helix and neovim get the
+  one-click repair the terminal already had.
+
 ### Fixed
 
 - **`on_error.recover` awaits a no-edge referent's terminal state**

--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -1,5 +1,7 @@
 pub mod nika_lsp
 pub mod nika_lsp::analysis
+pub mod nika_lsp::analysis::code_action
+pub fn nika_lsp::analysis::code_action::code_actions(uri: &lsp_types::uri::Uri, text: &str, index: &nika_lsp::analysis::position::LineIndex, range: lsp_types::Range) -> alloc::vec::Vec<lsp_types::code_action::CodeActionOrCommand>
 pub mod nika_lsp::analysis::completion
 pub fn nika_lsp::analysis::completion::completion(text: &str, offset: usize) -> alloc::vec::Vec<lsp_types::completion::CompletionItem>
 pub mod nika_lsp::analysis::definition

--- a/crates/nika-lsp/src/analysis/code_action.rs
+++ b/crates/nika-lsp/src/analysis/code_action.rs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `textDocument/codeAction` — the `check --fix` repair engine, projected.
+//!
+//! ONE fix engine, two surfaces: the CLI's `nika check --fix` splices the
+//! checker's typed rename suggestions (`offending`/`suggestion` pairs);
+//! this module projects the SAME pairs as LSP quickfixes, so every editor
+//! (VS Code · Cursor · zed · helix · neovim) gets the one-click repair the
+//! terminal already had. No second brain: the suggestions come from the
+//! identical `parse` + `check` ladder the diagnostics run.
+//!
+//! Discipline (mirrors `--fix`):
+//! - **typed did-you-mean only** — a finding without a `suggestion` offers
+//!   nothing (silence beats a wrong guess).
+//! - **unique-token only** — the edit targets the offending token's ONE
+//!   occurrence (identifier-boundary checked); an ambiguous token offers
+//!   nothing, exactly like the CLI skip-with-a-note.
+//! - **pure** — `(text, range) -> actions`; the server shell owns I/O.
+
+use lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Range, TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+};
+use nika_schema::{FileId, ParseMode, SchemaError};
+
+use super::position::LineIndex;
+
+/// One machine-applicable rename: the offending token and its repair.
+struct Rename {
+    offending: String,
+    suggestion: String,
+    kind: &'static str,
+}
+
+/// Compute the quickfixes for `range` — every typed rename whose offending
+/// token sits (uniquely) on a line the range touches.
+#[must_use]
+pub fn code_actions(
+    uri: &Uri,
+    text: &str,
+    index: &LineIndex,
+    range: Range,
+) -> Vec<CodeActionOrCommand> {
+    renames(text)
+        .into_iter()
+        .filter_map(|r| to_action(uri, text, index, range, &r))
+        .collect()
+}
+
+/// The typed rename set for this document — the exact pairs `--fix`
+/// splices, in the same precedence (parse-fatal first, then the report).
+fn renames(text: &str) -> Vec<Rename> {
+    match nika_schema::parse(text, FileId::new(0), ParseMode::Strict) {
+        Err(SchemaError::UnknownField {
+            field,
+            suggestion: Some(to),
+            ..
+        }) => vec![Rename {
+            offending: field,
+            suggestion: to,
+            kind: "field",
+        }],
+        Err(_) => Vec::new(),
+        Ok(wf) => {
+            let report = nika_schema::check(&wf);
+            let mut out = Vec::new();
+            for v in &report.conformance {
+                if let (Some(o), Some(s)) = (&v.offending, &v.suggestion) {
+                    out.push(Rename {
+                        offending: o.clone(),
+                        suggestion: s.clone(),
+                        kind: "reference",
+                    });
+                }
+            }
+            for t in &report.unknown_tools {
+                if let Some(s) = &t.suggestion {
+                    out.push(Rename {
+                        offending: t.tool.clone(),
+                        suggestion: s.clone(),
+                        kind: "tool",
+                    });
+                }
+            }
+            for a in &report.unknown_args {
+                if let Some(s) = &a.suggestion {
+                    out.push(Rename {
+                        offending: a.arg.clone(),
+                        suggestion: s.clone(),
+                        kind: "arg",
+                    });
+                }
+            }
+            out
+        }
+    }
+}
+
+/// Project one rename to a quickfix — `None` when the token is absent,
+/// ambiguous, or off the requested range.
+fn to_action(
+    uri: &Uri,
+    text: &str,
+    index: &LineIndex,
+    range: Range,
+    rename: &Rename,
+) -> Option<CodeActionOrCommand> {
+    let start = find_unique_token(text, &rename.offending)?;
+    let edit_range = byte_range(index, start, start + rename.offending.len());
+    if edit_range.start.line > range.end.line || edit_range.end.line < range.start.line {
+        return None; // the lightbulb is elsewhere
+    }
+    let edit = TextEdit {
+        range: edit_range,
+        new_text: rename.suggestion.clone(),
+    };
+    // `document_changes` (not the Uri-keyed map): the house bans HashMap
+    // and a Uri key is a mutable-key-type lint — the versioned-edit shape
+    // is also what modern clients prefer.
+    let doc_edit = TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: uri.clone(),
+            version: None,
+        },
+        edits: vec![OneOf::Left(edit)],
+    };
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!(
+            "Rename {} `{}` to `{}`",
+            rename.kind, rename.offending, rename.suggestion
+        ),
+        kind: Some(CodeActionKind::QUICKFIX),
+        is_preferred: Some(true),
+        edit: Some(WorkspaceEdit {
+            document_changes: Some(DocumentChanges::Edits(vec![doc_edit])),
+            ..WorkspaceEdit::default()
+        }),
+        ..CodeAction::default()
+    }))
+}
+
+/// The byte offset of `token`'s single identifier-bounded occurrence —
+/// `None` on zero or several (the `--fix` unique-by-the-gate discipline).
+fn find_unique_token(text: &str, token: &str) -> Option<usize> {
+    if token.is_empty() {
+        return None;
+    }
+    let boundary = |c: Option<char>| c.is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+    let mut found: Option<usize> = None;
+    let mut from = 0;
+    while let Some(pos) = text[from..].find(token) {
+        let at = from + pos;
+        let before = text[..at].chars().next_back();
+        let after = text[at + token.len()..].chars().next();
+        if boundary(before) && boundary(after) {
+            if found.is_some() {
+                return None; // ambiguous — never guess
+            }
+            found = Some(at);
+        }
+        from = at + token.len();
+    }
+    found
+}
+
+/// A byte span as an LSP range through the document's line index.
+fn byte_range(index: &LineIndex, start: usize, end: usize) -> Range {
+    Range {
+        start: index.position(start),
+        end: index.position(end),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WHOLE: Range = Range {
+        start: lsp_types::Position {
+            line: 0,
+            character: 0,
+        },
+        end: lsp_types::Position {
+            line: 999,
+            character: 0,
+        },
+    };
+
+    fn uri() -> Uri {
+        "file:///wf.nika.yaml".parse().expect("static uri")
+    }
+
+    fn actions(text: &str) -> Vec<CodeActionOrCommand> {
+        code_actions(&uri(), text, &LineIndex::new(text), WHOLE)
+    }
+
+    fn first_edit(action: &CodeActionOrCommand) -> &TextEdit {
+        let CodeActionOrCommand::CodeAction(a) = action else {
+            panic!("quickfix expected");
+        };
+        let Some(DocumentChanges::Edits(edits)) =
+            a.edit.as_ref().unwrap().document_changes.as_ref()
+        else {
+            panic!("document_changes expected");
+        };
+        let OneOf::Left(edit) = &edits[0].edits[0] else {
+            panic!("plain edit expected");
+        };
+        edit
+    }
+
+    /// The one-voice proof: the REAL checker's typed suggestion becomes a
+    /// quickfix whose edit slices exactly the offending token.
+    #[test]
+    fn an_unknown_dependency_offers_the_did_you_mean_rename() {
+        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: gather\n    exec: { command: \"true\" }\n  - id: think\n    depends_on: [gathr]\n    exec: { command: \"true\" }\n";
+        let acts = actions(text);
+        assert_eq!(acts.len(), 1, "one typed rename");
+        let edit = first_edit(&acts[0]);
+        assert_eq!(edit.new_text, "gather");
+        let line = text.lines().nth(edit.range.start.line as usize).unwrap();
+        let s = edit.range.start.character as usize;
+        let e = edit.range.end.character as usize;
+        assert_eq!(&line[s..e], "gathr", "the edit slices the offending token");
+    }
+
+    /// A finding with no suggestion offers NOTHING (silence beats a guess).
+    #[test]
+    fn no_suggestion_means_no_action() {
+        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: \"${{ tasks.zzzzzz.output }}\" }\n";
+        // `zzzzzz` is nowhere near any declared name — no did-you-mean.
+        assert!(actions(text).is_empty());
+    }
+
+    /// An ambiguous token (two identifier-bounded occurrences) is skipped —
+    /// the CLI's unique-by-the-gate discipline, mirrored.
+    #[test]
+    fn ambiguous_tokens_are_never_touched() {
+        assert_eq!(find_unique_token("a gathr b gathr", "gathr"), None);
+        assert_eq!(find_unique_token("x gathr y", "gathr"), Some(2));
+        assert_eq!(
+            find_unique_token("gathrer gathr", "gathr"),
+            Some("gathrer ".len()),
+            "substring hits are not occurrences"
+        );
+    }
+
+    /// The lightbulb only lights where the finding lives.
+    #[test]
+    fn actions_off_the_requested_range_stay_silent() {
+        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: gather\n    exec: { command: \"true\" }\n  - id: think\n    depends_on: [gathr]\n    exec: { command: \"true\" }\n";
+        let top = Range {
+            start: lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+            end: lsp_types::Position {
+                line: 1,
+                character: 0,
+            },
+        };
+        assert!(code_actions(&uri(), text, &LineIndex::new(text), top).is_empty());
+    }
+}

--- a/crates/nika-lsp/src/analysis/mod.rs
+++ b/crates/nika-lsp/src/analysis/mod.rs
@@ -11,6 +11,7 @@
 //! [`server`](crate::run_stdio) loop is the thin transport shell that
 //! drives these.
 
+pub mod code_action;
 pub mod completion;
 pub mod definition;
 pub mod diagnostics;

--- a/crates/nika-lsp/src/capabilities.rs
+++ b/crates/nika-lsp/src/capabilities.rs
@@ -15,8 +15,8 @@
 //! tokens, …) is simply left `None`.
 
 use lsp_types::{
-    CompletionOptions, OneOf, PositionEncodingKind, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind,
+    CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CompletionOptions, OneOf,
+    PositionEncodingKind, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
 };
 
 /// The capabilities advertised in the initialize response.
@@ -34,6 +34,12 @@ pub fn server_capabilities() -> ServerCapabilities {
         }),
         definition_provider: Some(OneOf::Left(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
+        // v0.2 surface: quickfix-only — the `check --fix` rename engine
+        // projected (one fix engine, every editor).
+        code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
+            code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+            ..CodeActionOptions::default()
+        })),
         ..ServerCapabilities::default()
     }
 }
@@ -84,9 +90,14 @@ mod tests {
     }
 
     #[test]
-    fn out_of_scope_features_are_absent() {
+    fn scope_pins_hold_v02_in_the_rest_out() {
         let caps = server_capabilities();
-        assert!(caps.code_action_provider.is_none());
+        // v0.2: quickfix-only code actions (the --fix engine projected).
+        let Some(CodeActionProviderCapability::Options(opts)) = caps.code_action_provider else {
+            panic!("code actions advertise as Options");
+        };
+        assert_eq!(opts.code_action_kinds, Some(vec![CodeActionKind::QUICKFIX]));
+        // still out of scope:
         assert!(caps.inlay_hint_provider.is_none());
         assert!(caps.semantic_tokens_provider.is_none());
     }

--- a/crates/nika-lsp/src/lib.rs
+++ b/crates/nika-lsp/src/lib.rs
@@ -26,11 +26,13 @@
 //! drives it. v0.1 is single-file, full-reparse-on-change, UTF-16
 //! positions.
 //!
-//! # Scope (v0.1, LOCKED)
+//! # Scope
 //!
-//! In: diagnostics, hover, completion, document symbols, definition. Out
-//! (deferred to v0.8X): code actions, inlay hints, semantic tokens, model
-//! catalog intelligence, `${{ }}` expression intelligence, multi-file /
+//! v0.1 (LOCKED): diagnostics, hover, completion, document symbols,
+//! definition. v0.2 adds **code actions** (quickfix-only — the
+//! `check --fix` typed-rename engine projected; one fix engine, every
+//! editor). Still out: inlay hints, semantic tokens, model catalog
+//! intelligence, `${{ }}` expression intelligence, multi-file /
 //! includes / incremental reparse.
 
 // Tests may use `unwrap`/`expect`/`panic`-class assertions freely (the

--- a/crates/nika-lsp/src/server.rs
+++ b/crates/nika-lsp/src/server.rs
@@ -39,7 +39,7 @@ use lsp_types::notification::{
     Notification as NotificationTrait, PublishDiagnostics,
 };
 use lsp_types::request::{
-    Completion, GotoDefinition, HoverRequest, Request as RequestTrait, Shutdown,
+    CodeActionRequest, Completion, GotoDefinition, HoverRequest, Request as RequestTrait, Shutdown,
 };
 use lsp_types::{
     CompletionParams, CompletionResponse, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
@@ -49,7 +49,7 @@ use lsp_types::{
 
 use crate::analysis::diagnostics;
 use crate::analysis::document::Document;
-use crate::analysis::{completion, definition, hover, symbols};
+use crate::analysis::{code_action, completion, definition, hover, symbols};
 use crate::capabilities::server_capabilities;
 use crate::error::LspError;
 
@@ -199,6 +199,15 @@ fn handle_request(req: Request, docs: &Docs) -> Response {
                 doc.text(),
                 offset,
             )))
+        }),
+        CodeActionRequest::METHOD => respond(id, req, |p: lsp_types::CodeActionParams| {
+            let doc = docs.get(uri_key(&p.text_document.uri))?;
+            Some(code_action::code_actions(
+                &p.text_document.uri,
+                doc.text(),
+                doc.line_index(),
+                p.range,
+            ))
         }),
         GotoDefinition::METHOD => respond(id, req, |p: GotoDefinitionParams| {
             let pos = p.text_document_position_params;

--- a/docs/crate-specs/nika-lsp.md
+++ b/docs/crate-specs/nika-lsp.md
@@ -42,7 +42,7 @@ ships — zero extension change.
 | **Go-to-definition** | ✅ | a task ref (`depends_on:` item or `${{ tasks.X }}`) at the cursor → the task's `id` span |
 | **`$/cancelRequest`** (base protocol) | ✅ | the serve loop drains everything already queued into one batch and answers a request cancelled BEFORE it was computed with `-32800 RequestCancelled` — a fast-typing burst no longer computes stale results the client already discarded |
 | Expression intelligence inside `${{ }}` | 🟡 | CEL completion inside `${{ }}` islands shipped (PR #170) · expression hover stays client-side meanwhile |
-| Code actions / quick fixes | ❌ v0.8X | (the check ladder already carries the fix form in the message) |
+| Code actions / quick fixes | ✅ v0.2 (shipped 2026-07-12) | quickfix-only — the `check --fix` typed-rename engine (`offending`/`suggestion`) projected; unique-token + did-you-mean-only discipline mirrored |
 | Inlay hints · semantic tokens · code lens | ❌ v0.8X | |
 | Model catalog hover/compat (`model_intel`) | ❌ v0.8X | |
 | Multi-file / includes · incremental reparse | ❌ v0.8X | (v0.1 is single-file, full-reparse-on-change) |


### PR DESCRIPTION
## The `--fix` engine reaches every editor

The v0.1 LSP scope deferred code actions to v0.8X — at 0.99, the planned evolution ships. `textDocument/codeAction` answers **quickfix renames built from the checker's typed `offending`/`suggestion` pairs**: unknown fields (parse), unknown tools, unknown args, and rename-shaped conformance findings (unresolved refs · unknown dependencies).

**One fix engine, two surfaces** — these are the exact pairs `nika check --fix` splices, under the same discipline:
- **did-you-mean only** — a suggestion-less finding offers nothing (silence beats a wrong guess);
- **unique-token only** — identifier-boundary checked; an ambiguous token offers nothing (the CLI's skip-with-a-note, mirrored).

Pure module in the analysis brain (`(text, range) → actions`); the server shell routes; capabilities advertise quickfix-only. `WorkspaceEdit` rides `document_changes` (versioned-edit shape — the house bans HashMap, and a `Uri` key is a mutable-key-type lint).

## Proof

- **Real-checker tests** (4 pins): the did-you-mean rename slices exactly the offending token · no suggestion = no action · ambiguity never guesses (incl. substring traps) · off-range stays silent. Scope-pin test learns v0.2 (inlay hints/semantic tokens still out).
- **E2E over JSON-RPC** against the built server: initialize advertises `codeActionProvider`, `codeAction` answers `Rename reference `gathr` to `gather`` with the edit at the exact range.
- 136 lib tests · clippy `-D warnings` zero · LOC wall green · crate spec row flipped (✅ v0.2) · CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
