### PR TITLE
fix(models): the receipt speaks per-family — no false serve promise

### DIFF
--- a/crates/nika-models/public-api.txt
+++ b/crates/nika-models/public-api.txt
@@ -1,4 +1,6 @@
 pub mod nika_models
+pub mod nika_models::gguf
+pub fn nika_models::gguf::sniff_architecture(path: &std::path::Path) -> core::option::Option<alloc::string::String>
 pub mod nika_models::pull
 pub fn nika_models::pull::run(arg: &str, yes: bool) -> core::result::Result<alloc::string::String, alloc::string::String>
 pub mod nika_models::serve
@@ -58,4 +60,5 @@ pub fn nika_models::ModelsProbe::and<P, B, E>(self, other: P) -> tower_http::fol
 pub fn nika_models::ModelsProbe::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_models::ModelsProbe
 impl<T> tracing::instrument::WithSubscriber for nika_models::ModelsProbe
+pub const nika_models::SERVE_FAMILY: &str
 pub fn nika_models::models_probe() -> nika_models::ModelsProbe

--- a/crates/nika-models/src/gguf.rs
+++ b/crates/nika-models/src/gguf.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! A header-only GGUF sniff — `general.architecture` in one buffered
+//! read, kilobytes into a multi-gigabyte file.
+//!
+//! ADVISORY by construction: every failure path (not a GGUF · a future
+//! version · a pathological header) answers `None`, never an error —
+//! the callers (the pull receipt's per-family serve line · `serve`'s
+//! fast pre-load refusal) degrade to their family-blind behavior. The
+//! authoritative check stays in the loader (`nika-infer-local`
+//! validates the same key at load); this sniff exists so a WRONG
+//! family teaches in milliseconds, not after a full-file read.
+
+use std::io::Read;
+use std::path::Path;
+
+/// `GGUF` little-endian magic.
+const MAGIC: u32 = 0x4655_4747;
+/// KV pairs scanned before giving up (the convention puts
+/// `general.architecture` first; 64 tolerates exotic writers).
+const MAX_KVS: u64 = 64;
+/// Longest key/string value read (spec strings are short).
+const MAX_STR: u64 = 4096;
+/// Longest array skipped element-by-element before giving up.
+const MAX_ARRAY: u64 = 65536;
+
+/// The GGUF's declared `general.architecture` (`qwen3` · `llama` · …),
+/// or `None` when the file does not sniff as a GGUF v2/v3 header that
+/// carries one within the first [`MAX_KVS`] pairs.
+#[must_use]
+pub fn sniff_architecture(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut r = std::io::BufReader::new(file);
+    if u32_le(&mut r)? != MAGIC {
+        return None;
+    }
+    let version = u32_le(&mut r)?;
+    if !(2..=3).contains(&version) {
+        return None;
+    }
+    let _tensor_count = u64_le(&mut r)?;
+    let kv_count = u64_le(&mut r)?.min(MAX_KVS);
+    for _ in 0..kv_count {
+        let key = string(&mut r)?;
+        let value_type = u32_le(&mut r)?;
+        if key == "general.architecture" {
+            // The spec types it string (8); anything else is malformed
+            // enough to stay unknown.
+            return if value_type == 8 {
+                string(&mut r)
+            } else {
+                None
+            };
+        }
+        skip_value(&mut r, value_type, 0)?;
+    }
+    None
+}
+
+/// Skip one value of the given GGUF type. `None` = unskippable
+/// (unknown future type · cap breach · crafted nesting) — the caller
+/// gives up.
+fn skip_value(r: &mut impl Read, value_type: u32, depth: u8) -> Option<()> {
+    match value_type {
+        0 | 1 | 7 => skip_bytes(r, 1),
+        2 | 3 => skip_bytes(r, 2),
+        4..=6 => skip_bytes(r, 4),
+        10..=12 => skip_bytes(r, 8),
+        8 => {
+            let len = u64_le(r)?;
+            if len > MAX_STR {
+                return None;
+            }
+            skip_bytes(r, len)
+        }
+        9 => {
+            // Arrays nest (element type 9) — the depth cap keeps a
+            // crafted header from recursing the stack away.
+            if depth >= 2 {
+                return None;
+            }
+            let elem_type = u32_le(r)?;
+            let count = u64_le(r)?;
+            if count > MAX_ARRAY {
+                return None;
+            }
+            for _ in 0..count {
+                skip_value(r, elem_type, depth + 1)?;
+            }
+            Some(())
+        }
+        _ => None,
+    }
+}
+
+fn u32_le(r: &mut impl Read) -> Option<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).ok()?;
+    Some(u32::from_le_bytes(b))
+}
+
+fn u64_le(r: &mut impl Read) -> Option<u64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b).ok()?;
+    Some(u64::from_le_bytes(b))
+}
+
+/// A GGUF string: u64 length + that many UTF-8 bytes.
+fn string(r: &mut impl Read) -> Option<String> {
+    let len = u64_le(r)?;
+    if len > MAX_STR {
+        return None;
+    }
+    #[allow(clippy::cast_possible_truncation)] // len ≤ MAX_STR (4096)
+    let mut buf = vec![0u8; len as usize];
+    r.read_exact(&mut buf).ok()?;
+    String::from_utf8(buf).ok()
+}
+
+fn skip_bytes(r: &mut impl Read, n: u64) -> Option<()> {
+    std::io::copy(&mut r.take(n), &mut std::io::sink())
+        .ok()
+        .filter(|&copied| copied == n)
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sniff_architecture;
+    use std::io::Write as _;
+
+    /// Build a minimal GGUF v3 header with the given KV pairs.
+    fn gguf(kvs: &[(&str, u32, Vec<u8>)]) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&super::MAGIC.to_le_bytes());
+        b.extend_from_slice(&3u32.to_le_bytes());
+        b.extend_from_slice(&0u64.to_le_bytes()); // tensors
+        b.extend_from_slice(&(kvs.len() as u64).to_le_bytes());
+        for (key, value_type, value) in kvs {
+            b.extend_from_slice(&(key.len() as u64).to_le_bytes());
+            b.extend_from_slice(key.as_bytes());
+            b.extend_from_slice(&value_type.to_le_bytes());
+            b.extend_from_slice(value);
+        }
+        b
+    }
+
+    fn gguf_string(s: &str) -> Vec<u8> {
+        let mut v = (s.len() as u64).to_le_bytes().to_vec();
+        v.extend_from_slice(s.as_bytes());
+        v
+    }
+
+    fn stage(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("nika-gguf-sniff-{name}"));
+        let mut f = std::fs::File::create(&path).expect("stage");
+        f.write_all(bytes).expect("write");
+        path
+    }
+
+    #[test]
+    fn finds_the_architecture_first_or_later() {
+        let first = stage(
+            "first.gguf",
+            &gguf(&[("general.architecture", 8, gguf_string("llama"))]),
+        );
+        assert_eq!(sniff_architecture(&first).as_deref(), Some("llama"));
+
+        // Buried behind a string, a u32, and a string-array — the skip
+        // walk earns its keep.
+        let mut arr = 8u32.to_le_bytes().to_vec();
+        arr.extend_from_slice(&2u64.to_le_bytes());
+        arr.extend_from_slice(&gguf_string("a"));
+        arr.extend_from_slice(&gguf_string("bb"));
+        let later = stage(
+            "later.gguf",
+            &gguf(&[
+                ("general.name", 8, gguf_string("SmolLM2")),
+                ("general.file_type", 4, 7u32.to_le_bytes().to_vec()),
+                ("tokenizer.ggml.tokens", 9, arr),
+                ("general.architecture", 8, gguf_string("qwen3")),
+            ]),
+        );
+        assert_eq!(sniff_architecture(&later).as_deref(), Some("qwen3"));
+        let _ = std::fs::remove_file(first);
+        let _ = std::fs::remove_file(later);
+    }
+
+    #[test]
+    fn refuses_to_guess_on_anything_else() {
+        let not_gguf = stage("not.gguf", b"MZ\x90\x00 definitely not a gguf");
+        assert_eq!(sniff_architecture(&not_gguf), None);
+        // v99: a future header this sniffer does not understand.
+        let mut future = super::MAGIC.to_le_bytes().to_vec();
+        future.extend_from_slice(&99u32.to_le_bytes());
+        let future = stage("future.gguf", &future);
+        assert_eq!(sniff_architecture(&future), None);
+        // No architecture key at all.
+        let keyless = stage(
+            "keyless.gguf",
+            &gguf(&[("general.name", 8, gguf_string("x"))]),
+        );
+        assert_eq!(sniff_architecture(&keyless), None);
+        for p in [not_gguf, future, keyless] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+}

--- a/crates/nika-models/src/lib.rs
+++ b/crates/nika-models/src/lib.rs
@@ -21,9 +21,14 @@
 // Test fixtures expect/unwrap freely — the nika-http/nika-cli idiom.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+pub mod gguf;
 pub mod pull;
 pub mod serve;
 pub mod store;
+
+/// The one GGUF family the v1 serve loader reads (mirrors the loader's
+/// own `SUPPORTED_ARCH` validation in `nika-infer-local`).
+pub const SERVE_FAMILY: &str = "qwen3";
 
 /// The canonical models dir's presence facts — what `nika doctor`'s
 /// models row reads (observed once, so the diagnosis stays pure).

--- a/crates/nika-models/src/pull.rs
+++ b/crates/nika-models/src/pull.rs
@@ -568,7 +568,9 @@ fn pull_over_network(
 /// The pull receipt: where it landed + the exact next commands. A
 /// resumed transfer says so (`resumed at <offset>`) — the receipt is
 /// the surface scripts and logs read, and a resume must not read like
-/// a fresh pull (the live-Hub pin asserts this).
+/// a fresh pull (the live-Hub pin asserts this). The serve line speaks
+/// per-family: promising `nika model serve` on a GGUF the v1 loader
+/// refuses (llama · phi · …) would be a false receipt.
 fn receipt(
     arg: &str,
     mref: &ModelRef,
@@ -584,8 +586,19 @@ fn receipt(
     } else {
         "pulled".to_owned()
     };
+    // Advisory sniff: an unknown family (None — exotic writer · future
+    // header) keeps the promise; only a POSITIVE other-family read
+    // rewords it (the loader still validates at load).
+    let serve_line = match crate::gguf::sniff_architecture(dest) {
+        Some(arch) if arch != crate::SERVE_FAMILY => format!(
+            "serve:    `{arch}`-family GGUF — `nika model serve` is {}-only today; \
+             point your local runner at the file above (ollama · llama.cpp · lmstudio)",
+            crate::SERVE_FAMILY
+        ),
+        _ => format!("serve it: nika model serve --model {arg}"),
+    };
     format!(
-        "{verb} {}\n  {}\n  serve it: nika model serve --model {arg}\n  manage:   nika \
+        "{verb} {}\n  {}\n  {serve_line}\n  manage:   nika \
          model list · nika model rm {arg}{tokenizer_note}",
         mref.repo_id(),
         dest.display()
@@ -660,6 +673,48 @@ mod tests {
     use nika_kernel::http::{HttpError, HttpResponse, HttpStreamResponse};
 
     use super::*;
+
+    /// The receipt's serve line speaks per-family: a llama GGUF at the
+    /// destination stops the `serve it:` promise (the v1 loader would
+    /// refuse it) and points at a local runner instead; an absent or
+    /// unsniffable file keeps the promise (advisory only).
+    #[test]
+    fn receipt_serve_line_speaks_per_family() {
+        let root = temp_root("receipt-family");
+        let mr = mref("u/m");
+        let dir = mr.dir(&root);
+        std::fs::create_dir_all(&dir).expect("dir");
+        let dest = dir.join("w.gguf");
+        // A minimal GGUF v3 header declaring general.architecture=llama.
+        let mut b = 0x4655_4747u32.to_le_bytes().to_vec();
+        b.extend_from_slice(&3u32.to_le_bytes());
+        b.extend_from_slice(&0u64.to_le_bytes());
+        b.extend_from_slice(&1u64.to_le_bytes());
+        let key = b"general.architecture";
+        b.extend_from_slice(&(key.len() as u64).to_le_bytes());
+        b.extend_from_slice(key);
+        b.extend_from_slice(&8u32.to_le_bytes());
+        b.extend_from_slice(&5u64.to_le_bytes());
+        b.extend_from_slice(b"llama");
+        std::fs::write(&dest, &b).expect("gguf fixture");
+
+        let text = receipt("u/m", &mr, &dest, false, 0, "");
+        assert!(text.contains("`llama`-family GGUF"), "family note: {text}");
+        assert!(
+            !text.contains("serve it: nika model serve"),
+            "no false promise: {text}"
+        );
+        assert!(text.contains("nika model rm u/m"), "manage stays: {text}");
+
+        // Unsniffable (not a GGUF) → advisory keeps the promise.
+        std::fs::write(&dest, b"not a gguf").expect("overwrite");
+        let text = receipt("u/m", &mr, &dest, false, 0, "");
+        assert!(
+            text.contains("serve it: nika model serve --model u/m"),
+            "promise kept on unknown: {text}"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
 
     fn entry(kind: &str, path: &str, size: u64) -> TreeEntry {
         TreeEntry {

--- a/crates/nika-models/src/serve.rs
+++ b/crates/nika-models/src/serve.rs
@@ -132,6 +132,21 @@ fn serve_local(gguf: &Path, tokenizer: Option<&Path>, port: u16, model_id: Optio
         Ok(plan) => plan,
         Err(refusal) => return refusal,
     };
+    // The header sniff refuses a wrong family in MILLISECONDS — the
+    // loader's authoritative validation of the same key would first
+    // read the whole multi-GiB file. Same wire as the loader's refusal;
+    // an unknown sniff (None) falls through to it.
+    if let Some(arch) = crate::gguf::sniff_architecture(&plan.gguf)
+        && arch != crate::SERVE_FAMILY
+    {
+        return format!(
+            "model serve: this loader handles `{}` GGUFs · got `{arch}` \
+             (load via the matching family loader)\n  fix: the v1 loader \
+             serves Qwen3-family GGUFs with their tokenizer.json — check \
+             both files\n",
+            crate::SERVE_FAMILY
+        );
+    }
     eprintln!(
         "nika model serve · loading {} (a first load reads the whole file)",
         plan.gguf.display()


### PR DESCRIPTION
## The catch ([#518](https://github.com/supernovae-st/nika/issues/518) probe, finding 1)

`model pull bartowski/SmolLM2-135M-Instruct-GGUF` (llama family) printed **`serve it: nika model serve --model …`** — a command the v1 qwen3-only loader refuses, and refuses only AFTER reading the whole multi-GiB file.

## Per-family voice, milliseconds honesty

A header-only GGUF sniff (`gguf::sniff_architecture` — std-only, kilobytes read, depth-capped skip walk, **advisory**: every parse doubt answers `None`) feeds two surfaces:

- **the pull receipt**: other family → `serve:    `llama`-family GGUF — `nika model serve` is qwen3-only today; point your local runner at the file above (ollama · llama.cpp · lmstudio)`; unknown → the promise stays.
- **`model serve`**: a wrong family refuses in **milliseconds** with the loader's own wire, instead of after a full-file read. The loader's authoritative validation is untouched (defense in depth).

Proof: nika-models 41 lib green (sniffer: first/buried/array-skip · not-a-GGUF/v99/keyless → None · receipt per-family pin) · clippy `-D warnings` 0 on **both** feature shapes (default + `local-infer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)