### PR TITLE
fix(media): the tape teaches trace verify's robust shape — bare, latest

### DIFF
--- a/scripts/media/tapes/full-loop.tape
+++ b/scripts/media/tapes/full-loop.tape
@@ -55,6 +55,6 @@ Sleep 3600ms
 Type "# every run leaves a receipt — a hash-chained trace you can verify"
 Enter
 Sleep 800ms
-Type "nika trace verify .nika/traces/*.ndjson"
+Type "nika trace verify"
 Enter
 Sleep 4200ms


### PR DESCRIPTION
Gauntlet catch: `nika trace verify .nika/traces/*.ndjson` breaks the moment a SECOND trace exists (`[TRACE]` takes one file — clap: `unexpected argument`). Bare `nika trace verify` defaults to the latest trace: simpler and robust. Tape-only — the shipped GIF stays honest (its staged workdir held exactly one trace at capture); the next recut renders the better teaching. Sibling fixes landed on nika-starter's README and the hermes usecase PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)