### PR TITLE
feat(cli): trace verify takes the glob — per-file verdicts, worst-of exit

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -568,6 +568,7 @@ pub mod nika_cli::verbs::trace_reproduce
 pub fn nika_cli::verbs::trace_reproduce::reproduce(recorded: &str, fresh: &str) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::trace_verify
 pub fn nika_cli::verbs::trace_verify::verify(trace: &str) -> nika_cli::verbs::VerbOutput
+pub fn nika_cli::verbs::trace_verify::verify_many(traces: &[std::path::PathBuf]) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::welcome
 pub fn nika_cli::verbs::welcome::run(json: bool, theme: nika_display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::wire

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -470,8 +470,10 @@ enum TraceAction {
     /// inserted, dropped or reordered line breaks every hash after it.
     /// Exit 0 intact · 2 broken · 3 unchained (pre-chain journal).
     Verify {
-        /// Trace NDJSON path (default: the workspace's latest trace).
-        trace: Option<PathBuf>,
+        /// Trace NDJSON path(s) — a shell glob (`.nika/traces/*.ndjson`)
+        /// just works: each file verifies under its own header, the
+        /// worst exit survives (default: the workspace's latest trace).
+        traces: Vec<PathBuf>,
     },
     /// Is this run reproducible? Compare a recorded journal against a
     /// fresh one and classify every task: reproduced · nondeterministic
@@ -1027,10 +1029,18 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
             theme.accents = std::io::stdout().is_terminal();
             emit(&verbs::trace::outputs(&trace.to_string_lossy(), theme))
         }
-        TraceAction::Verify { trace } => match resolve_trace(trace) {
-            Ok(path) => emit(&verbs::trace_verify::verify(&path.to_string_lossy())),
-            Err(code) => code,
-        },
+        TraceAction::Verify { mut traces } => {
+            if traces.len() > 1 {
+                emit(&verbs::trace_verify::verify_many(&traces))
+            } else {
+                // Zero or one: the existing voice, byte-stable (bare
+                // form resolves the latest · one arg resolves handles).
+                match resolve_trace(traces.pop()) {
+                    Ok(path) => emit(&verbs::trace_verify::verify(&path.to_string_lossy())),
+                    Err(code) => code,
+                }
+            }
+        }
         TraceAction::Reproduce { recorded, fresh } => emit(&verbs::trace_reproduce::reproduce(
             &recorded.to_string_lossy(),
             &fresh.to_string_lossy(),

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -974,6 +974,19 @@ fn mcp_verb(transport: McpTransportArg, port: u16, bind: &str) -> u8 {
     }
 }
 
+/// `nika trace verify [TRACES…]` — several paths (the shell glob) go
+/// per-file/worst-of; zero or one keeps the existing voice byte-stable
+/// (bare form resolves the latest · one arg resolves store handles).
+fn verify_verb(mut traces: Vec<PathBuf>) -> u8 {
+    if traces.len() > 1 {
+        return emit(&verbs::trace_verify::verify_many(&traces));
+    }
+    match resolve_trace(traces.pop()) {
+        Ok(path) => emit(&verbs::trace_verify::verify(&path.to_string_lossy())),
+        Err(code) => code,
+    }
+}
+
 fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -> u8 {
     match action {
         TraceAction::Replay(args) => trace_render(&args, true, color, link_when),
@@ -1029,18 +1042,7 @@ fn trace_verb(action: TraceAction, color: ColorWhenArg, link_when: LinkChoice) -
             theme.accents = std::io::stdout().is_terminal();
             emit(&verbs::trace::outputs(&trace.to_string_lossy(), theme))
         }
-        TraceAction::Verify { mut traces } => {
-            if traces.len() > 1 {
-                emit(&verbs::trace_verify::verify_many(&traces))
-            } else {
-                // Zero or one: the existing voice, byte-stable (bare
-                // form resolves the latest · one arg resolves handles).
-                match resolve_trace(traces.pop()) {
-                    Ok(path) => emit(&verbs::trace_verify::verify(&path.to_string_lossy())),
-                    Err(code) => code,
-                }
-            }
-        }
+        TraceAction::Verify { traces } => verify_verb(traces),
         TraceAction::Reproduce { recorded, fresh } => emit(&verbs::trace_reproduce::reproduce(
             &recorded.to_string_lossy(),
             &fresh.to_string_lossy(),

--- a/crates/nika-cli/src/verbs/trace_verify.rs
+++ b/crates/nika-cli/src/verbs/trace_verify.rs
@@ -54,6 +54,33 @@ pub fn verify(trace: &str) -> VerbOutput {
     }
 }
 
+/// The variadic form (`nika trace verify .nika/traces/*.ndjson` — the
+/// glob muscle memory types): each file verifies under its own header,
+/// no stop-at-first, and the worst exit survives — the `check`
+/// multi-file law, one voice across verbs. Store handles resolve
+/// exactly as the single form does.
+#[must_use]
+pub fn verify_many(traces: &[std::path::PathBuf]) -> VerbOutput {
+    let mut blocks = Vec::with_capacity(traces.len());
+    let mut worst = super::exit::OK;
+    for path in traces {
+        let resolved = super::trace::manage::resolve_store_handle(path);
+        let out = verify(&resolved.to_string_lossy());
+        let mut block = format!("{}\n", resolved.display());
+        for line in out.text.lines() {
+            block.push_str("  ");
+            block.push_str(line);
+            block.push('\n');
+        }
+        blocks.push(block);
+        worst = worst.max(out.code);
+    }
+    VerbOutput {
+        text: blocks.join("\n"),
+        code: worst,
+    }
+}
+
 // The walk + its verdict live in the forensics crate (one genesis tag ·
 // one hash primitive · the sink imports the SAME constant) — re-exported
 // here so every `super::trace_verify::walk` consumer reads unchanged.
@@ -69,4 +96,72 @@ fn short(hex: &str) -> String {
 /// field must never drive the operator's terminal).
 pub(crate) fn sanitize(s: &str) -> String {
     s.chars().filter(|c| !c.is_control()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nika_dap::chain::CHAIN_GENESIS;
+    use nika_dap::source_id::sha256_hex;
+
+    /// Build a chained journal the way the sink does (the nika-dap
+    /// chain-test idiom).
+    fn chained(kinds: &[&str]) -> String {
+        let mut chain = sha256_hex(CHAIN_GENESIS);
+        let mut out = String::new();
+        for kind in kinds {
+            let mut v = serde_json::json!({
+                "id": {"uuid": "01912345-0000-7000-8000-000000000001"},
+                "timestamp": 1000, "kind": kind, "run": null,
+                "correlation": null, "fields": []
+            });
+            v["chain"] = serde_json::Value::String(chain.clone());
+            let line = serde_json::to_string(&v).expect("test json");
+            chain = sha256_hex(line.as_bytes());
+            out.push_str(&line);
+            out.push('\n');
+        }
+        out
+    }
+
+    fn stage(name: &str, raw: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("nika-verify-many-{name}"));
+        std::fs::write(&path, raw).expect("stage");
+        path
+    }
+
+    /// The glob form: every file gets its own header + verdict, the
+    /// verify never stops at the first failure, and the worst exit
+    /// survives (2 FILE from the tampered journal beats the intact 0).
+    #[test]
+    fn verify_many_reports_per_file_and_exits_worst_of() {
+        let intact = stage(
+            "intact.ndjson",
+            &chained(&["workflow_started", "task_completed"]),
+        );
+        // Tamper a MIDDLE line — the next line's recorded chain breaks.
+        // (An edited FINAL line is exactly what only the externally
+        // anchored head can catch — the module doc's whole point.)
+        let mut tampered_raw =
+            chained(&["workflow_started", "task_completed", "workflow_completed"]);
+        tampered_raw = tampered_raw.replacen("task_completed", "task_failedxx", 1);
+        let tampered = stage("tampered.ndjson", &tampered_raw);
+
+        let out = verify_many(&[intact.clone(), tampered.clone()]);
+        assert_eq!(out.code, super::super::exit::FILE, "worst-of: {}", out.text);
+        assert!(
+            out.text.contains("nika-verify-many-intact.ndjson"),
+            "first header: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("nika-verify-many-tampered.ndjson"),
+            "second header (no stop-at-first): {}",
+            out.text
+        );
+        assert!(out.text.contains("OK — 2 events"), "{}", out.text);
+        assert!(out.text.contains("BROKEN at line"), "{}", out.text);
+        let _ = std::fs::remove_file(intact);
+        let _ = std::fs::remove_file(tampered);
+    }
 }


### PR DESCRIPTION
Closes #523 — the gauntlet's worst failure shape: `nika trace verify .nika/traces/*.ndjson` works on run one (glob → one file), then betrays on run two.

## The check multi-file law, one voice across verbs

`[TRACE]` goes variadic: each file verifies under its own header, **no stop-at-first**, worst spec-§4 exit survives. Zero/one argument keep the existing voice **byte-stable** (bare form still resolves the latest · store handles resolve as before · the bin_smoke single-arg pin untouched).

Proven live — the exact issue repro:
```
$ nika run g.nika.yaml   # twice
$ nika trace verify .nika/traces/*.ndjson
.nika/traces/2026-07-12T18-15-12Z-3e68.ndjson
  OK — 5 events · chain intact · head ce00f4b8…
.nika/traces/2026-07-12T18-15-12Z-c7d6.ndjson
  OK — 5 events · chain intact · head 4c6ce98a…
$? = 0
```

Pinned: per-file blocks + worst-of on an intact/tampered pair — tampered in the **middle**, because an edited *final* line is exactly what only the externally anchored head can catch (the module doc's whole point; the first draft of the pin proved it by failing).

Proof: nika-cli 315 lib green · clippy `-D warnings` 0 · crate-size gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)