### PR TITLE
fix(tmpl): one scanner vocabulary — and found counterexamples persist

### DIFF
--- a/crates/nika-tmpl/src/lib.rs
+++ b/crates/nika-tmpl/src/lib.rs
@@ -202,12 +202,22 @@ pub fn find_island_close(s: &str, from: usize) -> Option<usize> {
 /// literal) yields `None` and the caller renders textually. This preserves the
 /// runtime's historical behavior verbatim; a quote-aware widening (via
 /// [`scan_islands`]) is a deliberate future change, not part of this extraction.
+///
+/// One vocabulary, one verdict (#511): what the quote-aware scanner
+/// REFUSES, this fast path refuses too — the textual strip alone
+/// accepted `${{'{{{{}}` (an unterminated quote swallowing the closer)
+/// while [`scan_islands`] answered `Unterminated`; `Some` here now
+/// implies the scanner finds exactly one island (property-pinned).
 #[must_use]
 pub fn single_island(s: &str) -> Option<&str> {
-    let body = s.trim().strip_prefix("${{")?.strip_suffix("}}")?;
+    let trimmed = s.trim();
+    let body = trimmed.strip_prefix("${{")?.strip_suffix("}}")?;
     // A second island inside would mean `}}…${{` — reject (textual).
     if body.contains("${{") || body.contains("}}") {
         return None;
     }
-    Some(body.trim())
+    match scan_islands(trimmed) {
+        Ok(islands) if islands.len() == 1 => Some(body.trim()),
+        _ => None,
+    }
 }

--- a/crates/nika-tmpl/tests/properties.rs
+++ b/crates/nika-tmpl/tests/properties.rs
@@ -57,6 +57,18 @@ fn assert_spans_wellformed(s: &str) {
 }
 
 proptest! {
+    // Found counterexamples PERSIST (#511): the default SourceParallel
+    // walks up for a lib.rs/main.rs this integration target does not
+    // have, so every CI-found seed was lost to the log. WithSource
+    // writes `tests/proptest-regressions/` beside this file — check the
+    // file in when a failure lands and the input pins forever.
+    #![proptest_config(ProptestConfig {
+        failure_persistence: Some(Box::new(
+            proptest::test_runner::FileFailurePersistence::WithSource("proptest-regressions"),
+        )),
+        .. ProptestConfig::default()
+    })]
+
     // Arbitrary UTF-8 — the scanner must never panic and always return
     // well-formed spans or a clean Unterminated error.
     #[test]
@@ -93,6 +105,28 @@ proptest! {
             }
         }
     }
+}
+
+/// The #511 counterexample, pinned forever: an unterminated quote
+/// swallowing the closer — the textual strip said `Some("'{{{{")`
+/// while the quote-aware scan said `Unterminated`. One vocabulary,
+/// one verdict: both refuse now (the legitimate forms stay).
+#[test]
+fn issue_511_unterminated_quote_refuses_in_both_vocabularies() {
+    let s = "${{'{{{{}}";
+    assert_eq!(
+        single_island(s),
+        None,
+        "the fast path defers to the scanner"
+    );
+    assert!(scan_islands(s).is_err(), "the scanner still refuses");
+    // The everyday forms are untouched.
+    assert_eq!(single_island("${{ vars.x }}"), Some("vars.x"));
+    assert_eq!(
+        single_island("  ${{ tasks.a.output }}  "),
+        Some("tasks.a.output")
+    );
+    assert_eq!(single_island("${{ a }} tail"), None);
 }
 
 /// Exhaustive: every string of length ≤ 5 over the hostile ASCII alphabet.


### PR DESCRIPTION
Closes #511 — both sub-findings.

## 1 · The divergence dies

`single_island("${{'{{{{}}")` answered `Some("'{{{{")` while `scan_islands` answered `Unterminated` — two entry points, two definitions of an island. The fast path now **defers to the scanner**: `Some` implies `scan_islands` finds exactly one island. Its documented conservatisms stay verbatim (quoted `}}` still renders textually; the deliberate future-widening note untouched) — only the divergent acceptance dies. Downstream the runtime renders such a string textually instead of resolving a broken expression: the same verdict the checker already gave it (one voice).

## 2 · Found counterexamples pin forever

`FileFailurePersistence::SourceParallel` cannot write from an integration target (no `lib.rs` to walk to — the exact CI stderr in the issue), so every found seed was lost to the log. `WithSource("proptest-regressions")` writes beside `tests/properties.rs`; the #511 input itself is now a deterministic test (`issue_511_unterminated_quote_refuses_in_both_vocabularies`) with the everyday forms pinned untouched.

Proof: nika-tmpl 82+5+11 green (properties + the new pin) · nika-runtime 120 · nika-schema 761 · clippy `-D warnings` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)