### PR TITLE
docs(kit): 0.5.2 — the night's teachings reach the authoring skill

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika · Intent as Code",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks in both dialects — Cursor and Claude Code (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,19 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.5.2 — 2026-07-12
+
+Two teachings earned by the night's deep-e2e (each caught live before
+it was written down):
+
+- authoring: the `outputs:` binding law — bind `${{ tasks.<id>.output }}`,
+  never the bare task (the ENVELOPE: status + timestamps → `nika test`
+  goldens drift red on every run · the engine now teaches it at check
+  time as `[envelope-output]`, the skill says it at write time).
+- authoring: the sovereign lane joined the run step — `nika model pull`
+  → `nika model serve` (qwen3-family GGUFs; the banner prints the exact
+  wiring), beside the ollama route.
+
 ## 0.5.1 — 2026-07-12
 
 - session-context: a session opened in a SUBDIR of the workspace now

--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -34,7 +34,10 @@ oracle; the human runs it.
    not pass `nika check`** — and pass `--native-strict` too, unless
    every remaining `exec:` is in the exec ledger (below).
 6. The human (or CI) runs it: `nika run <file>`. Preview offline with
-   `--model mock/echo`; run locally with `--model ollama/<model>`.
+   `--model mock/echo`; run locally with `--model ollama/<model>` —
+   or fully in-binary: `nika model pull <owner/repo-GGUF>` then
+   `nika model serve --model <id>` (qwen3-family GGUFs today; the
+   serve banner prints the exact env + `model:` line workflows use).
    Inputs ride `--var key=value` (repeatable · unknown keys refused);
    a run paused on a `nika:prompt` resumes with
    `nika run <file> --resume <trace> --answer <task>=<value>`
@@ -111,6 +114,11 @@ Every surviving `exec:` gets a row in the workflow's header comment:
 
 - References: `${{ tasks.<id>.output }}` · `${{ vars.x }}` ·
   `${{ env.KEY }}` · `${{ secrets.X }}` (never inline a credential).
+- In `outputs:` bind `${{ tasks.<id>.output }}` — never the bare
+  `${{ tasks.<id> }}`: that binds the ENVELOPE (status + timestamps),
+  so `nika test` goldens drift red on every run. `nika check` teaches
+  this as `[envelope-output]`; fix the binding, never re-baseline
+  around it.
 - A task that reads another task's output MUST declare it in
   `depends_on: [<id>]`.
 - Models are `provider/name` (`ollama/llama3.2:3b` local-first ·


### PR DESCRIPTION
Two lessons earned live by the deep-e2e, written where agents read them (each teaching in this kit is earned by a real friction — the kit law):

- **The `outputs:` binding law** — bind `${{ tasks.<id>.output }}`, never the bare task: the bare form binds the ENVELOPE (status + timestamps), so `nika test` goldens drift red on every run. The engine now teaches it at check time (`[envelope-output]`, #524); the skill says it at WRITE time, before the trap is typed. Fix the binding, never re-baseline around it.
- **The sovereign lane joins the run step** — `nika model pull` → `nika model serve` beside the ollama route (qwen3-family; the banner prints the exact wiring). The skill predated the whole lane (#146/#521/#525).

The debugging skill needed nothing: its « autopsy: nika trace peek » line was written to the promise, and #520 made the engine keep it.

Kit 0.5.2 across the three manifests + changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)