### PR TITLE
fix(agents): kit 0.5.3 — the seatbelts reach Codex, one manifest line

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
-  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.2",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.5.3",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -1,13 +1,14 @@
 {
   "name": "nika",
   "displayName": "Nika · Intent as Code",
-  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks in both dialects — Cursor and Claude Code (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.2",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.5.3",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",
   "license": "AGPL-3.0-or-later",
   "skills": "./skills/",
   "commands": "./commands/",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/claude-hooks.json"
 }

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "nika",
   "displayName": "Nika",
-  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks in both dialects — Cursor and Claude Code (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.2",
+  "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
+  "version": "0.5.3",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,25 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.5.3 — 2026-07-12
+
+The seatbelts reach Codex (issue #505 closed by a live probe, not a doc):
+
+- `.codex-plugin/plugin.json` now declares `"hooks"` — Codex prefers that
+  manifest over `.claude-plugin/plugin.json` when both exist, so the field's
+  absence silently shadowed the three hooks on the one surface that needed
+  its own manifest. One line, three seatbelts.
+- The probe that earned it (headless `codex exec`, payloads dumped verbatim):
+  Codex emits the **Claude Code dialect exactly** — `hook_event_name`,
+  `tool_name: "Bash"`, `tool_input.command`, `tool_response` — and honors the
+  same output envelopes (`permissionDecision: deny` blocks with the reason
+  relayed to the model; SessionStart `additionalContext` is injected as
+  context). The kit's scripts run UNCHANGED; behavioral proof: guard-run
+  denied a red `nika run` and the model quoted NIKA-VAR-001 verbatim.
+- Codex notes: hooks ride the `[features] hooks = true` flag (or
+  `--enable hooks`), and a first interactive run asks to trust new hooks —
+  both are Codex-side gates, not kit config.
+
 ## 0.5.2 — 2026-07-12
 
 Two teachings earned by the night's deep-e2e (each caught live before

--- a/.agents/plugins/nika/scripts/check-on-edit.sh
+++ b/.agents/plugins/nika/scripts/check-on-edit.sh
@@ -3,7 +3,8 @@
 # *.nika.yaml, run the audit so findings reach the agent immediately
 # (the file is the contract; check is the oracle).
 #
-# ONE script, TWO dialects (sniffed from stdin — `hook_event_name` is
+# ONE script, TWO dialects, THREE surfaces (Codex emits the Claude Code
+# dialect verbatim — live-proven 2026-07-12). Sniffed from stdin — `hook_event_name` is
 # Claude Code's, absent from Cursor's):
 #   Cursor (afterFileEdit): file_path at the payload root; findings go
 #     to STDERR (the hook log) and stdout stays `{}` — never a veto.

--- a/.agents/plugins/nika/scripts/guard-run.sh
+++ b/.agents/plugins/nika/scripts/guard-run.sh
@@ -3,7 +3,8 @@
 # `nika run`, audit the workflow. Check is the gate the language is
 # built on; an agent must not be able to skip it by accident.
 #
-# ONE script, TWO dialects (sniffed from stdin — `hook_event_name` is
+# ONE script, TWO dialects, THREE surfaces (Codex emits the Claude Code
+# dialect verbatim — live-proven 2026-07-12). Sniffed from stdin — `hook_event_name` is
 # Claude Code's, absent from Cursor's):
 #   Cursor  (docs/agent/hooks · beforeShellExecution): in {command, cwd}
 #     → out {"permission":"allow"|"deny", agent_message/user_message}.


### PR DESCRIPTION
Kit 0.4.1 — a fresh-user gauntlet against the released binary (real workflows, real API failures, real spend) fed every patch. Nothing speculative; each teaching is a friction that actually fired:

- **session-context hook**: an equipped repo (`nika init` wrote `.cursor/rules/nika.mdc`) now gets the map at session start even before its first workflow exists — that first session is exactly when the map matters. (Gauntlet: post-init silence.)
- **nika-debugging**: headless, `nika:prompt` without `default:` FAILS with `NIKA-BUILTIN-PROMPT-001` (a terminal blocks; an agent has no TTY) — the resume line is identical either way; the failed card's own `autopsy:` line is the entry point. (Gauntlet: prompt run + `--resume --answer approve=true` proven, 1 cache hit.)
- **nika-operating**: secrets taint FLOWS — worked `egress:` example showing each downstream sink sanctioned (the checker names the exact chain); `host:`-scoped egress vs interpolated URLs refuses statically; **mock mocks the MODEL, not the tools** — goldens are for hermetic workflows, network truth is proven by traces. (Gauntlet: 3-leak chain resolved to clean; golden failed on live fetch then proven on a hermetic file.)
- **nika-migration**: `curl … | jq` collapses into ONE fetch task (`mode: jq` + `jq:`); an API fetch needs `mode: raw`/`jq` — the default `markdown` mode is for pages and escapes JSON bodies; `nika:jq`'s arg is `expression`. (Gauntlet: the port failed twice on exactly these, then ran at $0.00003.)

Hook regression battery re-run: equipped-repo map (T18) · empty-dir silence · vocab law · versions agree at 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
