### PR TITLE
fix(display): the plural voice reaches the band — one vocabulary

### DIFF
--- a/crates/nika-cli/src/text.rs
+++ b/crates/nika-cli/src/text.rs
@@ -1,31 +1,12 @@
-//! Count-noun agreement for visible strings — the operator surface
-//! reads as prose, so it never prints `1 tasks` nor the lazy `task(s)`.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-/// `count(3, "task")` → `3 tasks` · `count(1, "task")` → `1 task`.
-///
-/// Regular plurals only — every counted noun on the surface (task ·
-/// wave · run · finding · hint · edge · key) pluralizes with a plain
-/// `s`; an irregular noun would earn its own arm the day one exists.
+//! Count-noun agreement — a thin delegate to the ONE vocabulary
+//! (`display::vocab::count`), kept so the crate's 13+ call sites read
+//! `crate::text::count` without a display path in every verb.
+
+/// See [`crate::display::vocab::count`] — `1 task` · `3 tasks` ·
+/// `2 retries` (consonant+y → ies) · compound nouns at the tail.
 pub(crate) fn count(n: usize, noun: &str) -> String {
-    if n == 1 {
-        format!("1 {noun}")
-    } else {
-        format!("{n} {noun}s")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::count;
-
-    #[test]
-    fn one_reads_singular_and_the_rest_plural() {
-        assert_eq!(count(1, "task"), "1 task");
-        assert_eq!(count(0, "task"), "0 tasks");
-        assert_eq!(count(3, "wave"), "3 waves");
-        // A compound noun pluralizes at its tail — the caller can pass
-        // a qualified noun and the agreement stays right.
-        assert_eq!(count(1, "more hint"), "1 more hint");
-        assert_eq!(count(4, "downstream task"), "4 downstream tasks");
-    }
+    crate::display::vocab::count(n, noun)
 }

--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -550,14 +550,15 @@ fn audited_line(report: &CheckReport, wf: &RawWorkflow, hints: usize, t: Theme) 
         "none"
     };
     let floor = crate::display::vocab::at_least(t.ascii);
-    let hint_word = if hints == 1 { "hint" } else { "hints" };
     let mark = if t.ascii { "ok" } else { "✔" };
     t.paint(
         Role::Good,
         &format!(
-            "{mark} audited · {tasks} task(s) · {} wave(s) · permits {permits} · est {floor}${:.4} · {hints} {hint_word}",
-            report.waves.len(),
+            "{mark} audited · {} · {} · permits {permits} · est {floor}${:.4} · {}",
+            crate::text::count(tasks, "task"),
+            crate::text::count(report.waves.len(), "wave"),
             report.cost.min_path_total_usd,
+            crate::text::count(hints, "hint"),
         ),
     )
 }
@@ -629,10 +630,11 @@ fn plan(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
         .unwrap_or_default();
     let _ = writeln!(
         out,
-        " {} {}     {} wave(s) · {tasks} task(s) · max parallelism {max_par}{width_note}",
+        " {} {}     {} · {} · max parallelism {max_par}{width_note}",
         mark(t, true),
         t.paint(Role::Strong, "PLAN"),
-        report.waves.len(),
+        crate::text::count(report.waves.len(), "wave"),
+        crate::text::count(tasks, "task"),
     );
     // The membership — WHAT dispatches WHEN (the dry-run answer: check
     // is the dry-run; this line is what `run` will do, wave by wave).
@@ -1414,9 +1416,7 @@ mod tests {
         let yaml = "nika: v1\nworkflow: card\nmodel: mock/echo\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo bye\" }\n";
         let text = checked_text("audited-card.nika.yaml", yaml, false);
         assert!(
-            text.contains(
-                "✔ audited · 2 task(s) · 2 wave(s) · permits none · est ≥$0.0000 · 1 hint"
-            ),
+            text.contains("✔ audited · 2 tasks · 2 waves · permits none · est ≥$0.0000 · 1 hint"),
             "the audited card line: {text}"
         );
         let ascii = checked_text("audited-card-ascii.nika.yaml", yaml, true);

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -79,10 +79,10 @@ pub fn run(path: &str, theme: Theme) -> VerbOutput {
     };
 
     let mut out = format!(
-        "{} · {} tasks · {} waves · {ceiling}\n",
+        "{} · {} · {} · {ceiling}\n",
         theme.paint(Role::Strong, &doc.workflow),
-        doc.nodes.len(),
-        report.waves.len(),
+        crate::text::count(doc.nodes.len(), "task"),
+        crate::text::count(report.waves.len(), "wave"),
     );
     // The pinch set (DagAnalysis · « nothing else runs while these
     // run ») — drawn ON the graph, not only said under it: the P1 of

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -235,9 +235,7 @@ fn check_clean_file_exits_0_with_grep_stable_sections() {
     // The clean verdict is the audited card line: what was proven, at a
     // glance (tasks · waves · permits state · cost floor · hint count).
     assert!(
-        out.text.contains("audited ·")
-            && out.text.contains("wave(s)")
-            && out.text.contains("permits"),
+        out.text.contains("audited ·") && out.text.contains("wave") && out.text.contains("permits"),
         "the audited card line closes a clean report: {}",
         out.text
     );

--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -495,6 +495,7 @@ pub const nika_display::theme::SPINNER: [char; 10]
 pub mod nika_display::vocab
 pub fn nika_display::vocab::arrow(ascii: bool) -> &'static str
 pub fn nika_display::vocab::at_least(ascii: bool) -> &'static str
+pub fn nika_display::vocab::count(n: usize, noun: &str) -> alloc::string::String
 pub fn nika_display::vocab::hint(theme: nika_display::theme::Theme, label: &str, command: &str) -> alloc::string::String
 pub mod nika_display::wires
 pub struct nika_display::wires::WireGraph

--- a/crates/nika-display/src/flow.rs
+++ b/crates/nika-display/src/flow.rs
@@ -304,7 +304,7 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
     let title_raw = format!("{h} nika {mark_raw} {} ", view.workflow);
 
     let waves = wave_sizes(view).len();
-    let retries_cell = format!("{} retries", view.retries);
+    let retries_cell = crate::vocab::count(view.retries as usize, "retry");
     // The repair count (#319 · D-2026-07-08-N4) rides beside retries —
     // only when non-zero (the verdict-count discipline: `0 retries` is
     // a stable cell, a repair is an EVENT worth a cell only when real).
@@ -313,9 +313,10 @@ pub fn verdict_card(view: &RunView, theme: &Theme, outputs_note: Option<&str>) -
         n => Some(format!("{n} recovered")),
     };
     let mut head = format!(
-        "{}    {} tasks · {waves} waves · {retries_cell}",
+        "{}    {} · {} · {retries_cell}",
         dag_shape(view, theme),
-        view.rows().len(),
+        crate::vocab::count(view.rows().len(), "task"),
+        crate::vocab::count(waves, "wave"),
     );
     if let Some(cell) = &recovered_cell {
         use std::fmt::Write as _;
@@ -750,10 +751,10 @@ mod tests {
         }
         retried.apply(&ev(EventKind::WorkflowCompleted, 9_000, &[]));
         let lines = verdict_card(&retried, &coloured, None);
-        let totals = lines.iter().find(|l| l.contains("retries")).expect("row");
+        let totals = lines.iter().find(|l| l.contains("retry")).expect("row");
         assert!(
-            totals.contains("\x1b[33m1 retries\x1b[0m"),
-            "a real retry count paints yellow: {totals:?}"
+            totals.contains("\x1b[33m1 retry\x1b[0m"),
+            "a real retry count paints yellow, singular agreed: {totals:?}"
         );
         // The box still closes at one visible column: strip the escapes
         // and every border row measures the same width.

--- a/crates/nika-display/src/render.rs
+++ b/crates/nika-display/src/render.rs
@@ -107,7 +107,7 @@ fn map_node(row: Option<&TaskRow>, id: &str, theme: Theme, tick: usize, with_id:
 fn header_lines(view: &RunView, theme: Theme, tasks: usize) -> Vec<String> {
     let mut lines = Vec::with_capacity(3);
     let count = if tasks > 0 {
-        format!(" · {tasks} tasks")
+        format!(" · {}", crate::vocab::count(tasks, "task"))
     } else {
         String::new()
     };
@@ -562,10 +562,10 @@ pub fn verdict_frame(view: &RunView, theme: &Theme) -> Vec<String> {
     #[allow(clippy::cast_precision_loss)] // display-only seconds
     let secs = view.elapsed_ms as f64 / 1000.0;
     lines.push(format!(
-        "  {} {} · {} tasks · {secs:.1}s · {cost}",
+        "  {} {} · {} · {secs:.1}s · {cost}",
         glyph,
         theme.paint(Role::Strong, &view.workflow),
-        view.rows().len(),
+        crate::vocab::count(view.rows().len(), "task"),
     ));
 
     // Errors always (spec §3.5) — the same failure card the full frame emits,

--- a/crates/nika-display/src/vocab.rs
+++ b/crates/nika-display/src/vocab.rs
@@ -33,6 +33,30 @@ pub fn hint(theme: Theme, label: &str, command: &str) -> String {
     theme.paint(Role::Dim, &format!("{label}: {command}"))
 }
 
+/// Count-noun agreement: `count(3, "task")` → `3 tasks` · `count(1,
+/// "task")` → `1 task` — the surface reads as prose, never `1 tasks`
+/// nor the lazy `task(s)`. Two rules cover the band's whole noun set
+/// (task · wave · run · retry · edge · finding): consonant+`y` → `ies`
+/// (`1 retry` · `2 retries`), else a plain `s`. A compound noun
+/// pluralizes at its tail (`4 downstream tasks`).
+#[must_use]
+pub fn count(n: usize, noun: &str) -> String {
+    if n == 1 {
+        return format!("1 {noun}");
+    }
+    let ies = noun.ends_with('y')
+        && !noun
+            .chars()
+            .rev()
+            .nth(1)
+            .is_some_and(|c| matches!(c, 'a' | 'e' | 'i' | 'o' | 'u'));
+    if ies {
+        format!("{n} {}ies", &noun[..noun.len() - 1])
+    } else {
+        format!("{n} {noun}s")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -46,6 +70,19 @@ mod tests {
         assert_eq!(arrow(true), "->");
         assert_eq!(at_least(false), "≥");
         assert_eq!(at_least(true), ">=");
+    }
+
+    /// One reads singular, the rest plural — noun tail included, and
+    /// consonant+y takes `ies` (`retries`) while vowel+y stays (`days`).
+    #[test]
+    fn count_agrees_in_number() {
+        assert_eq!(count(1, "task"), "1 task");
+        assert_eq!(count(0, "task"), "0 tasks");
+        assert_eq!(count(3, "wave"), "3 waves");
+        assert_eq!(count(1, "downstream task"), "1 downstream task");
+        assert_eq!(count(1, "retry"), "1 retry");
+        assert_eq!(count(0, "retry"), "0 retries");
+        assert_eq!(count(2, "day"), "2 days");
     }
 
     /// The hint form is fixed: `label: command`, dim as one unit.


### PR DESCRIPTION
## The #516 promise, due since #489 merged

The hero banner read **« · 1 tasks »**, the check verdict and PLAN lines spoke the lazy **« task(s) · wave(s) »**, inspect and the gantt totals counted blind — all in files #489 owned, deliberately left and [noted there](https://github.com/supernovae-st/nika/pull/489#issuecomment-4951827267).

## One vocabulary, both crates

`count()` moves to its true home — **`display::vocab`**, beside `arrow`/`hint` — and earns its first irregular arm the day one exists: consonant+`y` → `ies` (`1 retry · 2 retries`, vowel+y stays `days`). `nika-cli::text::count` becomes the thin delegate; banner · verdict frame · gantt totals · check verdict + PLAN · inspect header all agree in number.

Proven at the binary:
```
 ✔ PLAN     1 wave · 1 task · max parallelism 1
 ✔ audited · 1 task · 1 wave · permits none · est ≥$0.0000 · 0 hints
  🦋 nika · solo · 1 task
solo · 1 task · 1 wave · ≥ $0.0000 (floor — unbounded tasks)
```

Proof: nika-display 99 · nika-cli 275 lib + 22 verbs_static + **38 bin_smoke** green · clippy `-D warnings` 0 · `vocab::count` baseline row added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)