### PR TITLE
chore(pack): vendor the template comment diet (spec 5c78e4572)

### DIFF
--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -34,9 +34,9 @@ templates:
   - file: templates/fanout.nika.yaml
     sha256_16: 4b9e949062b555a1
   - file: templates/gate-and-act.nika.yaml
-    sha256_16: 00db7679539f3b23
+    sha256_16: b1532d0fc09cb82e
   - file: templates/human-gated-ship.nika.yaml
-    sha256_16: 8a0675f074eecb75
+    sha256_16: 45cd7789e3c974e1
   - file: templates/media-asset-pack.nika.yaml
     sha256_16: 1958bcdaac3dd2b9
   - file: templates/website-brief.nika.yaml

--- a/crates/nika-pack/pack/templates/agent-loop.nika.yaml
+++ b/crates/nika-pack/pack/templates/agent-loop.nika.yaml
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · agent-loop · plan with a fast model, execute with a
-# family: agentic
-# budgeted agent, validate the typed result.
-# The default shape for open-ended work (research · review · triage).
+# TEMPLATE · agent-loop · plan fast → execute with a leashed agent → validate the typed result.
 #
-# Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
-# Three leashes (pattern 5 + 8 · NEVER ship an unleashed agent) ·
-#   tools:    default-deny · grant the MINIMUM · nika:done ends cleanly
-#   max_turns + max_tokens_total · the worst case is bounded
-#   schema:   the final message is TYPED · prose is not a contract
-
+#   [plan]────▶[execute]─────▶[confirm]
+#   infer       agent·leashed  nika:assert
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: agent-loop-template       # SLOT: kebab-case workflow id
 description: "plan → budgeted agent → typed result"   # SLOT

--- a/crates/nika-pack/pack/templates/api-upload-and-create.nika.yaml
+++ b/crates/nika-pack/pack/templates/api-upload-and-create.nika.yaml
@@ -2,19 +2,10 @@
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
 # TEMPLATE · api-upload-and-create · upload a file → create a resource from it.
-# family: ops
-# The shape for « call a product API: multipart upload, then a JSON create ».
 #
-# Instantiate (agents · deterministic) ·
-#   1. Copy this file · rename per the job (kebab-case).
-#   2. Fill every `# SLOT:` line · delete slot comments when filled.
-#   3. Validate · `nika check <file>` (or conformance/runner.py validate).
-#   4. Repair using the error's fix line · re-check until valid.
-# Native-first · the upload is fetch `multipart:` (file parts ride the
-# permits.fs READ boundary); auth rides a masked secrets header; the
-# create is fetch JSON; extraction is the mode/jq pairing. Zero exec ·
-# no upload helper script.
-
+#   [upload]────▶[create]
+#   nika:fetch    nika:fetch
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: api-upload-and-create-template  # SLOT: kebab-case workflow id
 description: "upload → create → result"   # SLOT: one honest sentence

--- a/crates/nika-pack/pack/templates/chain.nika.yaml
+++ b/crates/nika-pack/pack/templates/chain.nika.yaml
@@ -2,17 +2,10 @@
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
 # TEMPLATE · chain · gather facts → one model step → persist.
-# family: sequential
-# The default shape for « take real data, produce words, save them ».
 #
-# Instantiate (agents · deterministic) ·
-#   1. Copy this file · rename per the job (kebab-case).
-#   2. Fill every `# SLOT:` line · delete slot comments when filled.
-#   3. Validate · `nika check <file>` (or conformance/runner.py validate).
-#   4. Repair using the error's fix line · re-check until valid.
-# Rules the validator enforces · one verb per task · snake_case ids ·
-# every ${{ tasks.X }} reference REQUIRES depends_on: [X] (NIKA-DAG-003).
-
+#   [gather]────▶[think]────▶[persist]
+#   nika:read     infer       nika:write
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: chain-template            # SLOT: kebab-case workflow id
 description: "gather → think → persist"   # SLOT: one honest sentence

--- a/crates/nika-pack/pack/templates/docker-report.nika.yaml
+++ b/crates/nika-pack/pack/templates/docker-report.nika.yaml
@@ -1,22 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · docker-report: read a system's real state via a pinned CLI,
-# family: ops
-# have a model explain it, keep the report as a file. The audited-ops
-# shape: argv-array exec (a provable `permits.exec` allowlist — a shell
-# string can smuggle any program through a pipe, so the checker refuses
-# to bless one), reads fan out in parallel, one model call, one artifact.
-# Swap `docker` for any product CLI (kubectl · gh · terraform · psql).
-#
-# Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
-#
-# EXEC LEDGER · (the native-first law: every surviving exec names why)
-# | task | command          | why no native path               | unlock that removes it |
-# | ps   | docker ps        | product CLI · no MCP surface yet | a docker MCP server    |
-# | df   | docker system df | same                             | same                   |
-# Needs · a running docker daemon (the report reads YOUR containers).
-
+# TEMPLATE · docker-report · read real state via a pinned CLI → explain it → keep the report.
+#   [ps]────┐
+#   [df]────┴──▶[diagnose]────▶[keep]
+#   exec ×2      infer          nika:write
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: docker-report-template    # SLOT: kebab-case workflow id
 description: "read the daemon's state · explain it · keep the report"   # SLOT

--- a/crates/nika-pack/pack/templates/etl-state.nika.yaml
+++ b/crates/nika-pack/pack/templates/etl-state.nika.yaml
@@ -2,15 +2,10 @@
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
 # TEMPLATE · etl-state · incremental data job with a state file.
-# family: ops
-# The default shape for « only the NEW » jobs (feeds · exports · syncs)
-# and for batch pipelines that must survive bad input.
-#
-# Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
-# Two load-bearing moves ·
-#   on_error: recover:   bad data is DATA · the pipeline lives
-#   state read→diff→write   you only process what changed
-
+#   [previous]──┬──▶[delta]──when ≠∅──▶[process]
+#   [fresh]─────┤    json_diff           nika:jq
+#               └──▶[save_state]
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: etl-state-template        # SLOT: kebab-case workflow id
 description: "read state · fetch fresh · diff · process the delta · save state"   # SLOT

--- a/crates/nika-pack/pack/templates/fanout.nika.yaml
+++ b/crates/nika-pack/pack/templates/fanout.nika.yaml
@@ -1,18 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · fanout: discover a collection, process every item in
-# family: parallel
-# parallel (with a leash), merge the results.
-# The default shape for « N pages / N files / N records » jobs.
+# TEMPLATE · fanout · discover a collection → process every item in parallel → merge.
 #
-# Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
-# The leash (pattern 4 · ALWAYS set all three) ·
-#   max_parallel  cap concurrency (APIs rate-limit · GPUs thrash)
-#   fail_fast: false + on_error recover: null: one bad item yields null
-#     at its index (order preserved) · the batch lives · filter downstream
-#   per-iteration retry/timeout · the flaky world is normal
-
+#   [discover]──▶[process ∥×N]───▶[survivors]──▶[merge]
+#   nika:glob     for_each·infer    nika:jq        infer
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: fanout-template           # SLOT: kebab-case workflow id
 description: "discover N items · process in parallel · merge"   # SLOT

--- a/crates/nika-pack/pack/templates/gate-and-act.nika.yaml
+++ b/crates/nika-pack/pack/templates/gate-and-act.nika.yaml
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · gate-and-act: check a condition, act only when it holds.
-# family: gated
-# The default shape for monitors, alerts and threshold jobs. Often
-# needs ZERO model calls (pattern 1 · deterministic core).
+# TEMPLATE · gate-and-act · check a condition, act only when it holds.
 #
-# Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
-# Gate semantics (pick the right one · pattern 6) ·
-#   when:        SKIP gate · routing, not failure
-#   nika:assert  FAIL gate · the run is wrong, stop loudly
-#   nika:prompt  HUMAN gate · blocks until a person decides
-
+#   [check]────when(cond)────▶[act]
+#   nika:fetch                 nika:notify
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: gate-and-act-template     # SLOT: kebab-case workflow id
 description: "watch a value · act only when the condition holds"   # SLOT
@@ -45,6 +39,7 @@ tasks:
 
   - id: act
     depends_on: [check]
+    # when: is a SKIP gate — routing, not failure (a skipped task is not an error)
     when: ${{ tasks.check.value > vars.threshold }}   # SLOT: the CEL condition
     invoke:
       tool: "nika:notify"           # SLOT: the action · notify / write / exec

--- a/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
+++ b/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
@@ -1,22 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# TEMPLATE · human-gated-ship: gates in parallel, a human signs,
-# family: gated
-# the action ships, evidence always lands.
-# The default shape for anything irreversible (deploys · sends · publishes).
-#
-# Needs · TEAM_WEBHOOK_URL (the record's landing) — and a human: the
-# prompt PAUSES the run; answer and resume with
-#   nika run --resume <trace> --answer human=yes
-#
-# Instantiate · copy → fill `# SLOT:` → `nika check` → repair → re-check.
-# The contract (patterns 6 + 9) ·
-#   nothing irreversible happens before nika:prompt returns true
-#   the assert makes a RED gate terminal · the act fails LOUDLY (default
-#   capture) · a terminal `when: true` task records EVERY outcome
-#   (acted · refused · failed): the always-pattern
-
+# TEMPLATE · human-gated-ship · gates in parallel → a human signs → ship · evidence always lands.
+#   [check_a]─┐                             ┌──▶[act]──▶[record]
+#   [check_b]─┴─▶[gates]──▶[human ⏸]──yes──┘    exec     nika:notify (always)
+#   exec ×2       assert     nika:prompt
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: human-gated-ship-template  # SLOT: kebab-case workflow id
 description: "verify in parallel · human GO · act · record"   # SLOT
@@ -57,6 +46,8 @@ tasks:
   - id: human
     depends_on: [gates]
     invoke:
+      # the prompt PAUSES the run (exit 4 · not a failure) — answer and resume:
+      #   nika run --resume <trace> --answer human=yes
       tool: "nika:prompt"
       args:
         message: "All gates GREEN. Proceed?"   # SLOT: the decision, fully informed

--- a/crates/nika-pack/pack/templates/media-asset-pack.nika.yaml
+++ b/crates/nika-pack/pack/templates/media-asset-pack.nika.yaml
@@ -2,17 +2,10 @@
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
 # TEMPLATE · media-asset-pack · brief → generate assets → manifest.
-# family: content
-# The shape for « generate image (or audio) assets from a creative brief ».
 #
-# Instantiate (agents · deterministic) ·
-#   1. Copy this file · rename per the job (kebab-case).
-#   2. Fill every `# SLOT:` line · delete slot comments when filled.
-#   3. Validate · `nika check <file>` (or conformance/runner.py validate).
-#   4. Repair using the error's fix line · re-check until valid.
-# Native-first · generation is `nika:image_generate` (no provider curl ·
-# no OpenAI helper script); the manifest is `nika:jq` + `nika:write`.
-
+#   [brief]──▶[render]────────────▶[manifest]──▶[persist]
+#   infer      nika:image_generate  nika:jq       nika:write
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: media-asset-pack-template # SLOT: kebab-case workflow id
 description: "brief → render → manifest"  # SLOT: one honest sentence

--- a/crates/nika-pack/pack/templates/website-brief.nika.yaml
+++ b/crates/nika-pack/pack/templates/website-brief.nika.yaml
@@ -2,17 +2,10 @@
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
 # TEMPLATE · website-brief · crawl a site → understand it → persist the brief.
-# family: content
-# The shape for « understand a site (domain · theme · assets) from a URL ».
 #
-# Instantiate (agents · deterministic) ·
-#   1. Copy this file · rename per the job (kebab-case).
-#   2. Fill every `# SLOT:` line · delete slot comments when filled.
-#   3. Validate · `nika check <file>` (or conformance/runner.py validate).
-#   4. Repair using the error's fix line · re-check until valid.
-# Native-first · the crawl is `traverse:` (no curl · no helper script);
-# the brief is one typed infer; the persist is `nika:write`. Zero exec.
-
+#   [crawl_site]────▶[brief]────▶[persist]
+#   nika:fetch        infer       nika:write
+# Green as-is · `nika check <file>` · fill the `# SLOT:` lines · repair from the fix lines · re-check.
 nika: v1
 workflow: website-brief-template    # SLOT: kebab-case workflow id
 description: "crawl → brief → persist"   # SLOT: one honest sentence


### PR DESCRIPTION
Vendors nika-spec#70 via `sync-pack.sh` — every embedded template's header drops from 13-19 prose lines to **≤6**: the `# TEMPLATE` tagline (one line everywhere — `nika new`'s inventory no longer truncates the five that wrapped), **the DAG as ASCII wire-art**, one protocol line leading with the quick win. Displaced teachings live inline at the point they govern.

`nika new` scaffolds now open on the shape, not a prose wall. 275 nika-cli tests + pack suite green against the new pack.

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)