### PR TITLE
chore(release): v0.100.0 — the terminal sings and the models come home

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.3",
+  "version": "0.100.0",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika · Intent as Code",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.3",
+  "version": "0.100.0",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.5.3",
+  "version": "0.100.0",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,12 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.100.0 — 2026-07-12
+
+The galaxy shares one wave number: engine · extension · client-sdk ·
+kit ship the same version per wave from 0.100 on (0.5.3 → 0.100.0 —
+alignment only, no functional change).
+
 ## 0.5.3 — 2026-07-12
 
 The seatbelts reach Codex (issue #505 closed by a live probe, not a doc):

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,9 +129,9 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `feat/cli-wow-onboarding`                                      |
+| branch           | `chore/release-0.100.0`                                      |
 | HEAD             | `e241f1cc3` (`e241f1cc342f7c6131c1fe18b75d8837bab1deb6`)             |
-| workspace        | v0.99.0                                  |
+| workspace        | v0.100.0                                  |
 | crates (workspace)| 49                                              |
 | crates (admitted)| 47 / 42                                   |
 | crates (WIP)     | 2 — nika-chart nika-fx                                  |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+## [0.100.0](https://github.com/supernovae-st/nika/compare/v0.99.0..v0.100.0) - 2026-07-12
+
 ### Changed
 
 - **One glyph table, zero-alloc live channel** (rust-pro pass) — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,7 +3521,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nika-a11y"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "accessibility",
  "atspi",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "nika-blob"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "nika-bm25"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "nika-browser"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "chromiumoxide",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "nika-builtin"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-types",
  "proptest",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-verify"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "clap",
  "futures",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cel"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -3681,11 +3681,11 @@ dependencies = [
 
 [[package]]
 name = "nika-chart"
-version = "0.99.0"
+version = "0.100.0"
 
 [[package]]
 name = "nika-cli"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "nika-clock"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-kernel",
  "tokio",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "nika-dap"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-event",
  "nika-schema",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "nika-display"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "annotate-snippets 0.12.15",
  "anstyle",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "expect-test",
  "insta",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "nika-event"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "insta",
  "miette",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "nika-exec-runner"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-kernel",
  "nix 0.30.1",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "nika-extract"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "dom_smoothie",
  "ego-tree",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "nika-fs"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "globset",
@@ -3839,11 +3839,11 @@ dependencies = [
 
 [[package]]
 name = "nika-fx"
-version = "0.99.0"
+version = "0.100.0"
 
 [[package]]
 name = "nika-http"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "nika-infer-local"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "nika-input"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "enigo",
  "nika-kernel",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-error",
  "nika-kernel-ai",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-ai"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-core"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-mock"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-plugin"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "insta",
  "miette",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "nika-kernel-runtime"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "nika-lsp"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "lsp-server",
  "lsp-types",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "nika-mcp"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-builtin",
  "nika-catalog",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "nika-models"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "nika-ocr"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "nika-kernel",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "nika-onboard"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-bm25",
  "nika-catalog",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pack"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "include_dir",
  "sha2",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "nika-pck-manifest"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "proptest",
  "serde",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "nika-providers"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "nika-registry-client"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-kernel",
  "nika-kernel-mock",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "nika-runtime"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -4122,14 +4122,14 @@ dependencies = [
 
 [[package]]
 name = "nika-sandbox-seatbelt"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-kernel",
 ]
 
 [[package]]
 name = "nika-schema"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "nika-screen"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4170,14 +4170,14 @@ dependencies = [
 
 [[package]]
 name = "nika-tmpl"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "nika-types"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "loom",
  "proptest",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-agent"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-exec"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "miette",
  "nika-error",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-infer"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "nika-verb-invoke"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "miette",
  "nika-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version      = "0.99.0"
+version      = "0.100.0"
 edition      = "2024"
 license      = "AGPL-3.0-or-later"
 authors      = ["Thibaut Melen <thibaut@supernovae.studio>"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #
 # CI stages binaries at dist/linux/<TARGETARCH>/nika. Local build = the same
 # staging (docker arch: amd64|arm64 · release tarball arch: x64|arm64):
-#   v=0.99.0; a=arm64                    # apple-silicon/arm hosts (amd64: a=x64)
+#   v=0.100.0; a=arm64                    # apple-silicon/arm hosts (amd64: a=x64)
 #   curl -fsSLO "https://github.com/supernovae-st/nika/releases/download/v${v}/nika-linux-${a}-${v}.tar.gz"
 #   mkdir -p dist/linux/arm64 && tar -xzf "nika-linux-${a}-${v}.tar.gz" -C dist/linux/arm64 nika
 #   docker build -t nika .

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,9 +93,9 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 
 | field            | value                                          |
 |------------------|------------------------------------------------|
-| branch           | `feat/cli-wow-onboarding`                                      |
+| branch           | `chore/release-0.100.0`                                      |
 | HEAD             | `e241f1cc3` (`e241f1cc342f7c6131c1fe18b75d8837bab1deb6`)             |
-| workspace        | v0.99.0                                  |
+| workspace        | v0.100.0                                  |
 | crates (workspace)| 49                                              |
 | crates (admitted)| 47 / 42                                   |
 | crates (WIP)     | 2 — nika-chart nika-fx                                  |

--- a/crates/nika-a11y/Cargo.toml
+++ b/crates/nika-a11y/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 # thiserror + miette removed 2026-06-10: A11yError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-a11y re-exports it.
 # tokio `rt` for spawn_blocking (the !Send AXUIElement walk runs off the async

--- a/crates/nika-blob/Cargo.toml
+++ b/crates/nika-blob/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 bytes       = { workspace = true }   # kernel put/get payloads
 blake3      = { workspace = true }   # content-addressed hashing (the CAS key)
 # tokio::fs is the production storage backend; rides the workspace base

--- a/crates/nika-bm25/Cargo.toml
+++ b/crates/nika-bm25/Cargo.toml
@@ -41,9 +41,9 @@ _gate-3-green-phase = []
 # Pure-algo core uses ZERO nika-* deps · maison tokenizer (std::char) · BTreeMap (std) · f64 (std)
 
 # Kernel adapter deps · gated behind `kernel` feature
-nika-types     = { path = "../nika-types", version = "0.99.0", optional = true }
-nika-error     = { path = "../nika-error", version = "0.99.0", optional = true }
-nika-kernel    = { path = "../nika-kernel", version = "0.99.0", optional = true }
+nika-types     = { path = "../nika-types", version = "0.100.0", optional = true }
+nika-error     = { path = "../nika-error", version = "0.100.0", optional = true }
+nika-kernel    = { path = "../nika-kernel", version = "0.100.0", optional = true }
 thiserror      = { workspace = true, optional = true }
 tokio          = { workspace = true, features = ["rt"], optional = true }
 trait-variant  = { workspace = true, optional = true }

--- a/crates/nika-browser/Cargo.toml
+++ b/crates/nika-browser/Cargo.toml
@@ -17,11 +17,11 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 # The canonical SSRF IP-range oracle (`net::ip_is_blocked`) — the SAME predicate
 # nika-http gates on, so a literal private/loopback/metadata IP is refused
 # BEFORE any CDP navigate (the browser's own network stack bypasses nika-http).
-nika-types  = { path = "../nika-types", version = "0.99.0" }
+nika-types  = { path = "../nika-types", version = "0.100.0" }
 # BrowserError + DTOs live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-browser re-exports the error; no thiserror/miette dep here.
 # tokio `rt` for the per-session CDP Handler task (B.3 · chromiumoxide is

--- a/crates/nika-builtin/Cargo.toml
+++ b/crates/nika-builtin/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 tool layer.
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }   # the 3 tool seams + fs/http/clock/event effect seams
-nika-extract = { path = "../nika-extract", version = "0.99.0" }  # nika:fetch — the extract modes + page digest (L1.5→L1.5 same-layer)
-nika-fx      = { path = "../nika-fx", version = "0.99.0" }  # nika:image_fx — deterministic artistic effects (L1 pure-algo · zero-dep)
-nika-types   = { path = "../nika-types", version = "0.99.0" }    # fetch traverse bound — ONE definition with the static checker
-nika-chart   = { path = "../nika-chart", version = "0.99.0" }    # nika:chart — deterministic artifacts (zero-dep · byte-identical SVG · sha256 → trace chain)
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }   # the 3 tool seams + fs/http/clock/event effect seams
+nika-extract = { path = "../nika-extract", version = "0.100.0" }  # nika:fetch — the extract modes + page digest (L1.5→L1.5 same-layer)
+nika-fx      = { path = "../nika-fx", version = "0.100.0" }  # nika:image_fx — deterministic artistic effects (L1 pure-algo · zero-dep)
+nika-types   = { path = "../nika-types", version = "0.100.0" }    # fetch traverse bound — ONE definition with the static checker
+nika-chart   = { path = "../nika-chart", version = "0.100.0" }    # nika:chart — deterministic artifacts (zero-dep · byte-identical SVG · sha256 → trace chain)
 url           = { workspace = true }   # traverse — same-origin math + normalization (the WHATWG parse the transport uses)
 # data wave
 jaq-core      = { workspace = true }   # nika:jq — THE data language
@@ -44,15 +44,15 @@ tokio         = { workspace = true }   # spawn_blocking — jq's sync CPU eval o
 # required) — the SAME vocabulary the in-test drift guards pin to the
 # ToolDef schemas (one source, no drift). Minimal features: the builtin
 # catalog only, no provider/pricing data. L1.5→L0 downward (layering-clean).
-nika-catalog  = { path = "../nika-catalog", version = "0.99.0", default-features = false, features = ["builtins-transforms"] }
+nika-catalog  = { path = "../nika-catalog", version = "0.100.0", default-features = false, features = ["builtins-transforms"] }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.99.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.100.0" }
 # test-only: the REAL filesystem (TokioFs) — the permits.fs boundary tests
 # need a true `canonicalize` (resolves `..` + symlinks) against a /tmp scratch
 # dir; MockFs::canonicalize is a no-op, so the escape cases can only be proven
 # against the production impl. dev-only · L1.5→L1 downward (layering-clean).
-nika-fs          = { path = "../nika-fs", version = "0.99.0" }
+nika-fs          = { path = "../nika-fs", version = "0.100.0" }
 # test-only: an INDEPENDENT PNG decoder proving the mock image provider's
 # hand-rolled stored-deflate encoder emits spec-valid files (not just bytes
 # our own sniffer accepts).

--- a/crates/nika-cap/Cargo.toml
+++ b/crates/nika-cap/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.99.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
+nika-types = { path = "../nika-types", version = "0.100.0" }  # host_glob_matches — the same matcher nika-http enforces at runtime (zero drift)
 serde_json = { workspace = true }   # builtin arg-shape rules — pure data over Value (extracted 2026-07-07)
 serde      = { workspace = true }
 

--- a/crates/nika-catalog-verify/Cargo.toml
+++ b/crates/nika-catalog-verify/Cargo.toml
@@ -15,7 +15,7 @@ name = "nika-catalog-verify"
 path = "src/main.rs"
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.99.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.100.0" }
 
 clap       = { version = "4.5", features = ["derive"] }
 tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }

--- a/crates/nika-catalog/Cargo.toml
+++ b/crates/nika-catalog/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-error = { path = "../nika-error", version = "0.99.0" }
+nika-error = { path = "../nika-error", version = "0.100.0" }
 phf        = { workspace = true }
 unicase    = { workspace = true }
 thiserror  = { workspace = true }
@@ -51,7 +51,7 @@ builtins-transforms  = []
 
 [build-dependencies]
 # The TOML→Rust generator (unit-tested library · D-2026-06-10-N4 WIRE).
-nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.99.0" }
+nika-catalog-codegen = { path = "../nika-catalog-codegen", version = "0.100.0" }
 
 [dev-dependencies]
 criterion  = { workspace = true }

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -11,11 +11,11 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.99.0" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.99.0" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.99.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
-nika-error  = { path = "../nika-error", version = "0.99.0" }  # the code registry (`nika explain`)
-nika-pack   = { path = "../nika-pack", version = "0.99.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-event  = { path = "../nika-event", version = "0.100.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.100.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.100.0" } # parse + the ADR-092 check ladder (check · inspect · graph)
+nika-error  = { path = "../nika-error", version = "0.100.0" }  # the code registry (`nika explain`)
+nika-pack   = { path = "../nika-pack", version = "0.100.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde       = { workspace = true }                             # graph projection envelope (§6)
@@ -26,26 +26,26 @@ uuid        = { workspace = true }
 # the CLI — all strictly downward (L4 → L3/L2/L1.5/L1/L0). Before the run
 # verb these were dev-deps (the e2e rehearsal only); the verb makes them
 # load-bearing in src/.
-nika-kernel      = { path = "../nika-kernel", version = "0.99.0" }        # ProviderInferDyn · Secret · the seam traits
-nika-runtime     = { path = "../nika-runtime", version = "0.99.0" }       # the L3 executor (the composer drives it)
-nika-registry-client = { path = "../nika-registry-client", version = "0.99.0" }  # the L2 resolve/verify/cache half (this crate composes http + executor around it)
-nika-providers   = { path = "../nika-providers", version = "0.99.0" }     # ProviderRegistry — resolve provider/model + keys
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.99.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.99.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.99.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.99.0" }
-nika-builtin     = { path = "../nika-builtin", version = "0.99.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
-nika-fs          = { path = "../nika-fs", version = "0.99.0" }            # TokioFs — the builtin tool plane's fs effect
-nika-clock       = { path = "../nika-clock", version = "0.99.0" }         # SystemClock — backoff + timeout + the date builtin
-nika-http        = { path = "../nika-http", version = "0.99.0" }          # ReqwestHttp — the registry + fetch effect
-nika-exec-runner = { path = "../nika-exec-runner", version = "0.99.0" }   # TokioShell — the exec verb's subprocess runner
-nika-catalog     = { path = "../nika-catalog", version = "0.99.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
-nika-lsp         = { path = "../nika-lsp", version = "0.99.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
-nika-display     = { path = "../nika-display", version = "0.99.0" } # the run-comprehension surface (descended 2026-07-10 · re-exported at display::)
-nika-onboard     = { path = "../nika-onboard", version = "0.99.0" } # the founding wizard + guided first workflow (descended 2026-07-12 · adapters at verbs/{init,new}.rs)
-nika-dap         = { path = "../nika-dap", version = "0.99.0" }           # `nika dap` + the trace-forensics plane (chain · recover · otel · reproduce · store · retention — re-exported at the old verb paths)
-nika-mcp         = { path = "../nika-mcp", version = "0.99.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
-nika-models      = { path = "../nika-models", version = "0.99.0" }        # `nika model` — the local-models unit (ONE dir · Hub pull · serve glue · descended 2026-07-12)
+nika-kernel      = { path = "../nika-kernel", version = "0.100.0" }        # ProviderInferDyn · Secret · the seam traits
+nika-runtime     = { path = "../nika-runtime", version = "0.100.0" }       # the L3 executor (the composer drives it)
+nika-registry-client = { path = "../nika-registry-client", version = "0.100.0" }  # the L2 resolve/verify/cache half (this crate composes http + executor around it)
+nika-providers   = { path = "../nika-providers", version = "0.100.0" }     # ProviderRegistry — resolve provider/model + keys
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.100.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.100.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.100.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.100.0" }
+nika-builtin     = { path = "../nika-builtin", version = "0.100.0" }       # BuiltinDispatcher — the tool plane (invoke + agent tools)
+nika-fs          = { path = "../nika-fs", version = "0.100.0" }            # TokioFs — the builtin tool plane's fs effect
+nika-clock       = { path = "../nika-clock", version = "0.100.0" }         # SystemClock — backoff + timeout + the date builtin
+nika-http        = { path = "../nika-http", version = "0.100.0" }          # ReqwestHttp — the registry + fetch effect
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.100.0" }   # TokioShell — the exec verb's subprocess runner
+nika-catalog     = { path = "../nika-catalog", version = "0.100.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
+nika-lsp         = { path = "../nika-lsp", version = "0.100.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
+nika-display     = { path = "../nika-display", version = "0.100.0" } # the run-comprehension surface (descended 2026-07-10 · re-exported at display::)
+nika-onboard     = { path = "../nika-onboard", version = "0.100.0" } # the founding wizard + guided first workflow (descended 2026-07-12 · adapters at verbs/{init,new}.rs)
+nika-dap         = { path = "../nika-dap", version = "0.100.0" }           # `nika dap` + the trace-forensics plane (chain · recover · otel · reproduce · store · retention — re-exported at the old verb paths)
+nika-mcp         = { path = "../nika-mcp", version = "0.100.0" }           # `nika mcp` — the MCP server (stdio · exposes check/explain to Cursor/Claude Desktop)
+nika-models      = { path = "../nika-models", version = "0.100.0" }        # `nika model` — the local-models unit (ONE dir · Hub pull · serve glue · descended 2026-07-12)
 tokio            = { workspace = true }                                   # the bin's async entry (block the run on the executor)
 
 [features]
@@ -65,7 +65,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.99.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.100.0" }
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 expectrl = { workspace = true }   # PTY e2e · the wizard conversation is TTY-gated — unreachable

--- a/crates/nika-clock/Cargo.toml
+++ b/crates/nika-clock/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 tokio       = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/nika-dap/Cargo.toml
+++ b/crates/nika-dap/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.99.0" }   # the journal taxonomy the replayer walks
-nika-schema = { path = "../nika-schema", version = "0.99.0" }  # parse the workflow for breakpoint line-mapping
-nika-types  = { path = "../nika-types", version = "0.99.0" }   # field values on replayed frames
+nika-event  = { path = "../nika-event", version = "0.100.0" }   # the journal taxonomy the replayer walks
+nika-schema = { path = "../nika-schema", version = "0.100.0" }  # parse the workflow for breakpoint line-mapping
+nika-types  = { path = "../nika-types", version = "0.100.0" }   # field values on replayed frames
 sha2        = { workspace = true }                              # the chain primitive + source identity (one voice)
 serde      = { workspace = true }                             # protocol frames (Request derive)
 serde_json = { workspace = true }                             # DAP wire bodies + replay journal parse

--- a/crates/nika-display/Cargo.toml
+++ b/crates/nika-display/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-event  = { path = "../nika-event", version = "0.99.0" }  # the REAL event taxonomy (the fold input)
-nika-types  = { path = "../nika-types", version = "0.99.0" }  # Timestamp · KeyValue · ids
-nika-schema = { path = "../nika-schema", version = "0.99.0" } # spans the snippet painter maps
+nika-event  = { path = "../nika-event", version = "0.100.0" }  # the REAL event taxonomy (the fold input)
+nika-types  = { path = "../nika-types", version = "0.100.0" }  # Timestamp · KeyValue · ids
+nika-schema = { path = "../nika-schema", version = "0.100.0" } # spans the snippet painter maps
 annotate-snippets = { workspace = true }                       # painted spans (rustc-grade frames through the Theme seam)
 anstyle     = { workspace = true }                             # Role→Style mapping for the snippet renderer
 serde_json  = { workspace = true }                             # the shape reader parses task output JSON

--- a/crates/nika-error/Cargo.toml
+++ b/crates/nika-error/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See feedback_publish_false_foundation_strategy.md + ADR-017.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.99.0" }
+nika-types = { path = "../nika-types", version = "0.100.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-event/Cargo.toml
+++ b/crates/nika-event/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-types = { path = "../nika-types", version = "0.99.0" }
-nika-error = { path = "../nika-error", version = "0.99.0" }
+nika-types = { path = "../nika-types", version = "0.100.0" }
+nika-error = { path = "../nika-error", version = "0.100.0" }
 thiserror  = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde      = { workspace = true, optional = true }

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-extract/Cargo.toml
+++ b/crates/nika-extract/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 transformation layer.
 
 [dependencies]
-nika-types   = { path = "../nika-types", version = "0.99.0" }   # ExtractMode — the ONE closed vocabulary
+nika-types   = { path = "../nika-types", version = "0.100.0" }   # ExtractMode — the ONE closed vocabulary
 htmd         = { workspace = true }   # markdown|article — HTML→Markdown (Apache-2.0)
 dom_smoothie = { workspace = true }   # article — Readability (MIT)
 scraper      = { workspace = true }   # text|selector|metadata|links — CSS-select DOM (ISC)
@@ -25,8 +25,8 @@ miette       = { workspace = true }
 
 [dev-dependencies]
 proptest  = { workspace = true }
-nika-http   = { path = "../nika-http", version = "0.99.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }  # e2e: the http seam types the client implements
+nika-http   = { path = "../nika-http", version = "0.100.0" }   # e2e: extraction over a REAL socket (L1.5→L1 downward)
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }  # e2e: the http seam types the client implements
 tokio     = { workspace = true, features = ["rt", "macros", "net", "io-util"] }
 
 [package.metadata.lore]

--- a/crates/nika-fs/Cargo.toml
+++ b/crates/nika-fs/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 bytes       = { workspace = true }  # FsRead::read zero-copy payload (kernel trait surface)
 globset     = { workspace = true }  # FsList::glob matcher · literal_separator(true) semantics
 # tokio::fs is the production I/O backend; `fs` rides on top of the

--- a/crates/nika-http/Cargo.toml
+++ b/crates/nika-http/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.99.0" }
-nika-types   = { path = "../nika-types", version = "0.99.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
+nika-kernel  = { path = "../nika-kernel", version = "0.100.0" }
+nika-types   = { path = "../nika-types", version = "0.100.0" }   # net::host_in_allowlist — the SHARED permits.net.http glob matcher (no check↔runtime drift)
 bytes        = { workspace = true }   # kernel body payloads
 futures-core = { workspace = true }   # HttpStreamResponse body stream
 reqwest      = { workspace = true, features = ["stream"] }   # the HTTP backend (rustls · no default features) · `stream` powers send_streaming

--- a/crates/nika-input/Cargo.toml
+++ b/crates/nika-input/Cargo.toml
@@ -17,7 +17,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081", "ADR-083"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 # InputError + its derives live in nika-kernel-core (Pattern A · FCI-023bis) —
 # nika-input re-exports it; no thiserror/miette dep here.
 # tokio `rt` for spawn_blocking (the synchronous `enigo` calls run off the async

--- a/crates/nika-kernel-ai/Cargo.toml
+++ b/crates/nika-kernel-ai/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.99.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.99.0" }
+nika-error       = { path = "../nika-error", version = "0.100.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.100.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -17,7 +17,7 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.99.0" }
+nika-error    = { path = "../nika-error", version = "0.100.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-mock/Cargo.toml
+++ b/crates/nika-kernel-mock/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["proptest", "rstest"]  # dev-deps used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-kernel   = { path = "../nika-kernel", version = "0.99.0" }
-nika-error    = { path = "../nika-error", version = "0.99.0" }
+nika-kernel   = { path = "../nika-kernel", version = "0.100.0" }
+nika-error    = { path = "../nika-error", version = "0.100.0" }
 parking_lot   = { workspace = true }
 bytes         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/nika-kernel-plugin/Cargo.toml
+++ b/crates/nika-kernel-plugin/Cargo.toml
@@ -17,8 +17,8 @@ ignored = ["insta"]  # dev-dep used in #[cfg(test)] blocks
 workspace = true
 
 [dependencies]
-nika-error       = { path = "../nika-error", version = "0.99.0" }
-nika-kernel-core = { path = "../nika-kernel-core", version = "0.99.0" }
+nika-error       = { path = "../nika-error", version = "0.100.0" }
+nika-kernel-core = { path = "../nika-kernel-core", version = "0.100.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-runtime/Cargo.toml
+++ b/crates/nika-kernel-runtime/Cargo.toml
@@ -14,7 +14,7 @@ description  = "Runtime sibling of the split kernel — tool execution + agent l
 workspace = true
 
 [dependencies]
-nika-error    = { path = "../nika-error", version = "0.99.0" }
+nika-error    = { path = "../nika-error", version = "0.100.0" }
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel/Cargo.toml
+++ b/crates/nika-kernel/Cargo.toml
@@ -14,11 +14,11 @@ description  = "Trait contracts for every side effect in the Nika diamond — L0
 workspace = true
 
 [dependencies]
-nika-error          = { path = "../nika-error", version = "0.99.0" }
-nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.99.0" }
-nika-kernel-core    = { path = "../nika-kernel-core", version = "0.99.0" }
-nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.99.0" }
-nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.99.0" }
+nika-error          = { path = "../nika-error", version = "0.100.0" }
+nika-kernel-ai      = { path = "../nika-kernel-ai", version = "0.100.0" }
+nika-kernel-core    = { path = "../nika-kernel-core", version = "0.100.0" }
+nika-kernel-plugin  = { path = "../nika-kernel-plugin", version = "0.100.0" }
+nika-kernel-runtime = { path = "../nika-kernel-runtime", version = "0.100.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (driven by the `nika lsp` subcommand).
 
 [dependencies]
-nika-catalog = { path = "../nika-catalog", version = "0.99.0", features = ["builtins-transforms", "providers"] } # the tool/model vocabulary completions derive from (born-stale law: never hand-tabled)
-nika-schema = { path = "../nika-schema", version = "0.99.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
+nika-catalog = { path = "../nika-catalog", version = "0.100.0", features = ["builtins-transforms", "providers"] } # the tool/model vocabulary completions derive from (born-stale law: never hand-tabled)
+nika-schema = { path = "../nika-schema", version = "0.100.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types
 serde       = { workspace = true }                             # DeserializeOwned/Serialize bounds for the request dispatch

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -11,15 +11,15 @@ homepage.workspace     = true
 publish                = false  # Foundation crate — never on crates.io. See ADR-022.
 
 [dependencies]
-nika-schema = { path = "../nika-schema", version = "0.99.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
-nika-providers = { path = "../nika-providers", version = "0.99.0", default-features = false }  # the resolver law: every model resolves in THIS binary (#320)
-nika-error  = { path = "../nika-error", version = "0.99.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
-nika-pack   = { path = "../nika-pack", version = "0.99.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
+nika-schema = { path = "../nika-schema", version = "0.100.0" }  # parse + the ADR-092 check ladder (the `nika_check` tool)
+nika-providers = { path = "../nika-providers", version = "0.100.0", default-features = false }  # the resolver law: every model resolves in THIS binary (#320)
+nika-error  = { path = "../nika-error", version = "0.100.0" }   # code_help/lookup — numeric registry (the `nika_explain` tool)
+nika-pack   = { path = "../nika-pack", version = "0.100.0" }    # embedded canon error_codes — the spec codes (NIKA-VAR-* · NIKA-DAG-* …)
 # The embedded knowledge payloads (`nika_catalog` · `nika_tools`) — the SAME
 # versioned projections `nika catalog|tools --json` emit (one builder per
 # owning crate · zero duplication). L4→L0 / L4→L1.5, strictly downward.
-nika-catalog = { path = "../nika-catalog", version = "0.99.0", default-features = false, features = ["serde", "capabilities"] }
-nika-builtin = { path = "../nika-builtin", version = "0.99.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.100.0", default-features = false, features = ["serde", "capabilities"] }
+nika-builtin = { path = "../nika-builtin", version = "0.100.0" }
 
 serde_json  = { workspace = true }   # JSON-RPC 2.0 messages (the only wire format · no SDK)
 thiserror   = { workspace = true }   # the transport error enum

--- a/crates/nika-models/Cargo.toml
+++ b/crates/nika-models/Cargo.toml
@@ -12,8 +12,8 @@ homepage.workspace     = true
 publish                = false  # Internal L4 interface crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" } # HttpGetDyn/HttpPostDyn — the injectable transport seam (the whole pull path is mock-proven)
-nika-http   = { path = "../nika-http", version = "0.99.0" }   # ReqwestHttp — the production client (rustls · SSRF floor · per-hop redirect vetting)
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" } # HttpGetDyn/HttpPostDyn — the injectable transport seam (the whole pull path is mock-proven)
+nika-http   = { path = "../nika-http", version = "0.100.0" }   # ReqwestHttp — the production client (rustls · SSRF floor · per-hop redirect vetting)
 tokio       = { workspace = true }                            # the blocking pull seam's current-thread runtime (the registry #452 idiom)
 serde       = { workspace = true }                            # the Hub tree rows
 serde_json  = { workspace = true }                            # tree-listing parse
@@ -22,7 +22,7 @@ serde_json  = { workspace = true }                            # tree-listing par
 # `serve` boots the candle backend behind the tiny_http sidecar server.
 # Optional so the default binary keeps the lean-core contract (zero
 # inference deps); the default body teaches the build flag.
-nika-infer-local = { path = "../nika-infer-local", version = "0.99.0", optional = true }
+nika-infer-local = { path = "../nika-infer-local", version = "0.100.0", optional = true }
 
 [features]
 # Build the serve body for real: the candle backend + the loopback

--- a/crates/nika-ocr/Cargo.toml
+++ b/crates/nika-ocr/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 # thiserror + miette removed 2026-06-10: OcrError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-ocr re-exports it.
 # ocrs = pure-Rust OCR engine (detect → find lines → recognize) · rten = the

--- a/crates/nika-onboard/Cargo.toml
+++ b/crates/nika-onboard/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 [package]
 name        = "nika-onboard"
-version     = "0.99.0"
+version     = "0.100.0"
 edition     = "2024"
 rust-version = "1.88"
 license     = "AGPL-3.0-or-later"
@@ -9,17 +9,17 @@ description = "nika's onboarding surface — the founding wizard (init) and the 
 repository  = "https://github.com/supernovae-st/nika"
 
 [dependencies]
-nika-pack    = { path = "../nika-pack", version = "0.99.0" }    # templates · examples (the scaffold corpus)
-nika-bm25    = { path = "../nika-bm25", version = "0.99.0" }    # intent→template routing (the deterministic floor)
-nika-display = { path = "../nika-display", version = "0.99.0" } # theme + chrome (rail · panel · banner)
-nika-catalog = { path = "../nika-catalog", version = "0.99.0", features = ["providers"] } # the model menu (local first)
+nika-pack    = { path = "../nika-pack", version = "0.100.0" }    # templates · examples (the scaffold corpus)
+nika-bm25    = { path = "../nika-bm25", version = "0.100.0" }    # intent→template routing (the deterministic floor)
+nika-display = { path = "../nika-display", version = "0.100.0" } # theme + chrome (rail · panel · banner)
+nika-catalog = { path = "../nika-catalog", version = "0.100.0", features = ["providers"] } # the model menu (local first)
 serde_json   = { workspace = true }                              # the canvas stamp (parse + re-emit settings.json)
 
 [dev-dependencies]
 # The own-corpus ratchet: every recipe scaffold must parse AND check
 # clean — proven against the REAL ladder, test-side only (the runtime
 # audit arrives injected from the composition root).
-nika-schema = { path = "../nika-schema", version = "0.99.0" }
+nika-schema = { path = "../nika-schema", version = "0.100.0" }
 
 [package.metadata.lore]
 daemon        = "forgeron"

--- a/crates/nika-providers/Cargo.toml
+++ b/crates/nika-providers/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace     = true
 publish                = false  # Internal L1.5 service crate.
 
 [dependencies]
-nika-kernel  = { path = "../nika-kernel", version = "0.99.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.99.0", features = ["providers"] }
-nika-types   = { path = "../nika-types", version = "0.99.0" }   # the shared did-you-mean metric (MODELS rung)
+nika-kernel  = { path = "../nika-kernel", version = "0.100.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.100.0", features = ["providers"] }
+nika-types   = { path = "../nika-types", version = "0.100.0" }   # the shared did-you-mean metric (MODELS rung)
 serde_json   = { workspace = true }
 bytes        = { workspace = true }
 futures-core = { workspace = true }

--- a/crates/nika-registry-client/Cargo.toml
+++ b/crates/nika-registry-client/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace     = true
 publish                = false  # Internal L2 service crate (size-cap descent from nika-cli · D-2026-07-09-N1).
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }   # HttpGetDyn seam — the ONE injected effect
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }   # HttpGetDyn seam — the ONE injected effect
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 sha2        = { workspace = true }   # the digest verify (index-pinned sha256 · hard refuse on mismatch)
 toml_edit   = { workspace = true }   # the local pin records (pins.toml — bare refs never float · ADR-106)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.99.0" }  # MockHttp — the injected seam under test
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.100.0" }  # MockHttp — the injected seam under test
 tempfile         = { workspace = true }
 tokio            = { workspace = true }   # the tests park their own current-thread executor
 

--- a/crates/nika-runtime/Cargo.toml
+++ b/crates/nika-runtime/Cargo.toml
@@ -11,18 +11,18 @@ homepage.workspace     = true
 publish                = false  # Internal L3 orchestration crate.
 
 [dependencies]
-nika-types       = { path = "../nika-types", version = "0.99.0" }        # EventId · Timestamp · KeyValue · Value
-nika-error       = { path = "../nika-error", version = "0.99.0" }        # NIKA_1700..1703 registry constants
-nika-event       = { path = "../nika-event", version = "0.99.0" }        # Event · EventKind (the stream this crate emits)
-nika-schema      = { path = "../nika-schema", version = "0.99.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
-nika-tmpl        = { path = "../nika-tmpl", version = "0.99.0" }         # the ONE ${{ }} island lexer · shared with the checker (check⇄run parity)
-nika-catalog     = { path = "../nika-catalog", version = "0.99.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
-nika-cel         = { path = "../nika-cel", version = "0.99.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
-nika-kernel      = { path = "../nika-kernel", version = "0.99.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
-nika-verb-infer  = { path = "../nika-verb-infer", version = "0.99.0" }
-nika-verb-exec   = { path = "../nika-verb-exec", version = "0.99.0" }
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.99.0" }
-nika-verb-agent  = { path = "../nika-verb-agent", version = "0.99.0" }
+nika-types       = { path = "../nika-types", version = "0.100.0" }        # EventId · Timestamp · KeyValue · Value
+nika-error       = { path = "../nika-error", version = "0.100.0" }        # NIKA_1700..1703 registry constants
+nika-event       = { path = "../nika-event", version = "0.100.0" }        # Event · EventKind (the stream this crate emits)
+nika-schema      = { path = "../nika-schema", version = "0.100.0" }       # RawWorkflow · RawAction · CheckReport (audit-before-run)
+nika-tmpl        = { path = "../nika-tmpl", version = "0.100.0" }         # the ONE ${{ }} island lexer · shared with the checker (check⇄run parity)
+nika-catalog     = { path = "../nika-catalog", version = "0.100.0", features = ["pricing"] } # estimate_cost_for — the ONE pricing seam (floor + actual agree by construction)
+nika-cel         = { path = "../nika-cel", version = "0.100.0" }          # the cel-subset/0.1 engine behind the expr seam (parse · compute · Resolver · L0)
+nika-kernel      = { path = "../nika-kernel", version = "0.100.0" }       # ShellRunDyn · ToolExecuteDyn · ClockDyn · ai seams (hub only)
+nika-verb-infer  = { path = "../nika-verb-infer", version = "0.100.0" }
+nika-verb-exec   = { path = "../nika-verb-exec", version = "0.100.0" }
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.100.0" }
+nika-verb-agent  = { path = "../nika-verb-agent", version = "0.100.0" }
 futures-util     = { workspace = true }   # buffered(k) intra-wave concurrency + select (no executor · async rides the injected seams)
 jaq-core         = { workspace = true }   # output: named bindings — THE data language (the same jaq nika:jq runs · spec 04 §binding)
 jaq-std          = { workspace = true }   # jq stdlib filters (map · select · add …) over a binding's raw output
@@ -35,9 +35,9 @@ miette           = { workspace = true }
 uuid             = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.99.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
-nika-providers   = { path = "../nika-providers", version = "0.99.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
-nika-pack        = { path = "../nika-pack", version = "0.99.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.100.0" }  # MockClock · MockShell · MockToolExecutor · MockToolDefinitionProvider
+nika-providers   = { path = "../nika-providers", version = "0.100.0" }    # ProviderRegistry mock/echo (the tests' InferVerb seam · the composer owns it in prod)
+nika-pack        = { path = "../nika-pack", version = "0.100.0" }          # error_codes() — the spec-plane codes the runtime emits pin to the embedded canon
 bytes            = { workspace = true }   # canned HttpResponse bodies (the F1 capturing http seam)
 insta            = { workspace = true }
 proptest         = { workspace = true }

--- a/crates/nika-sandbox-seatbelt/Cargo.toml
+++ b/crates/nika-sandbox-seatbelt/Cargo.toml
@@ -20,7 +20,7 @@ adr = ["ADR-003", "ADR-095"]
 # The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only
 # builds an SBPL profile string and wraps the command argv for the OS-shipped
 # `sandbox-exec` launcher (the wrapper model · no unsafe · no FFI).
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 
 [package.metadata.lore]
 daemon        = "sentinelle"

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -20,11 +20,11 @@ publish                = false  # Foundation crate — never on crates.io. See f
 # reuse without pulling the parser; inlining them back to stay at 3 would defeat the
 # extractions + re-introduce the check⇄run scanner drift. High fan-in is intentional
 # for the schema assembler hub (ADR-027 · marker-based exemption).
-nika-error   = { path = "../nika-error", version = "0.99.0" }
-nika-catalog = { path = "../nika-catalog", version = "0.99.0" }
-nika-types   = { path = "../nika-types", version = "0.99.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
-nika-cap     = { path = "../nika-cap", version = "0.99.0" }   # the permits vocab lives here now (extracted 2026-07-03)
-nika-tmpl    = { path = "../nika-tmpl", version = "0.99.0" }   # the ${{ }} language crate (island lexer + expression grammar · check⇄run parity)
+nika-error   = { path = "../nika-error", version = "0.100.0" }
+nika-catalog = { path = "../nika-catalog", version = "0.100.0" }
+nika-types   = { path = "../nika-types", version = "0.100.0" }   # ExtractMode — fetch arg-shape rules (one closed vocabulary)
+nika-cap     = { path = "../nika-cap", version = "0.100.0" }   # the permits vocab lives here now (extracted 2026-07-03)
+nika-tmpl    = { path = "../nika-tmpl", version = "0.100.0" }   # the ${{ }} language crate (island lexer + expression grammar · check⇄run parity)
 
 thiserror  = { workspace = true }
 serde      = { workspace = true }
@@ -47,10 +47,10 @@ jsonschema = { workspace = true }
 
 [dev-dependencies]
 # the verb-theater example folds REAL engine events (the telemetry truth)
-nika-event = { path = "../nika-event", version = "0.99.0" }
+nika-event = { path = "../nika-event", version = "0.100.0" }
 # the emitted⊆registered ratchet cross-checks every statically-emittable
 # spec code against the embedded canon registry (spec/05-errors.md SSOT)
-nika-pack  = { path = "../nika-pack", version = "0.99.0" }
+nika-pack  = { path = "../nika-pack", version = "0.100.0" }
 uuid       = { workspace = true }
 insta      = { workspace = true }
 proptest   = { workspace = true }

--- a/crates/nika-screen/Cargo.toml
+++ b/crates/nika-screen/Cargo.toml
@@ -16,7 +16,7 @@ publish                = false  # Internal L1 effect crate (not a standalone cra
 adr = ["ADR-003", "ADR-081"]
 
 [dependencies]
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 # thiserror + miette removed 2026-06-10: ScreenError + its derives moved to
 # nika-kernel-core (Pattern A migration · FCI-023bis) — nika-screen re-exports it.
 bytes       = { workspace = true }  # Frame RGBA8 zero-copy payload (B.3)

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -11,12 +11,12 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate (the binary ships, the lib doesn't).
 
 [dependencies]
-nika-types      = { path = "../nika-types", version = "0.99.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
-nika-kernel      = { path = "../nika-kernel", version = "0.99.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
-nika-error       = { path = "../nika-error", version = "0.99.0" }        # NIKA_460..467 registry constants
-nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.99.0" }  # tool dispatch (same-layer L2 · spec §0.5)
-nika-bm25        = { path = "../nika-bm25", version = "0.99.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
-nika-schema      = { path = "../nika-schema", version = "0.99.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
+nika-types      = { path = "../nika-types", version = "0.100.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
+nika-kernel      = { path = "../nika-kernel", version = "0.100.0" }       # ai::provider seam · ai::tool_defs seam · runtime agent DTOs
+nika-error       = { path = "../nika-error", version = "0.100.0" }        # NIKA_460..467 registry constants
+nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.100.0" }  # tool dispatch (same-layer L2 · spec §0.5)
+nika-bm25        = { path = "../nika-bm25", version = "0.100.0" }         # deterministic per-turn tool routing (L2→L1 downward · ADR-096)
+nika-schema      = { path = "../nika-schema", version = "0.100.0" }       # agent:compose static gate (L2→L0 downward · check-before-permission)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
@@ -25,7 +25,7 @@ tokio            = { workspace = true }                                   # spaw
 futures-util     = { workspace = true }                                   # buffered — order-preserving parallel intra-turn dispatch (ADR-097)
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.99.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.100.0" }  # MockProvider · MockToolExecutor · MockToolDefinitionProvider
 proptest         = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -13,13 +13,13 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.99.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-error  = { path = "../nika-error", version = "0.100.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.99.0" }
+nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.100.0" }
 proptest = { workspace = true }
 tokio    = { workspace = true }
 

--- a/crates/nika-verb-infer/Cargo.toml
+++ b/crates/nika-verb-infer/Cargo.toml
@@ -13,10 +13,10 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-types      = { path = "../nika-types", version = "0.99.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
-nika-error     = { path = "../nika-error", version = "0.99.0" }
-nika-kernel    = { path = "../nika-kernel", version = "0.99.0" }
-nika-providers = { path = "../nika-providers", version = "0.99.0" }
+nika-types      = { path = "../nika-types", version = "0.100.0", features = ["serde"] } # SpendOnFailure (billed-then-failed spend · Cost Intelligence)
+nika-error     = { path = "../nika-error", version = "0.100.0" }
+nika-kernel    = { path = "../nika-kernel", version = "0.100.0" }
+nika-providers = { path = "../nika-providers", version = "0.100.0" }
 jsonschema     = { workspace = true }
 miette         = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/nika-verb-invoke/Cargo.toml
+++ b/crates/nika-verb-invoke/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace     = true
 publish                = false  # Internal L2 verb crate.
 
 [dependencies]
-nika-error  = { path = "../nika-error", version = "0.99.0" }
-nika-kernel = { path = "../nika-kernel", version = "0.99.0" }
+nika-error  = { path = "../nika-error", version = "0.100.0" }
+nika-kernel = { path = "../nika-kernel", version = "0.100.0" }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "nika-cap"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "nika-types",
  "serde",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "miette",
  "nika-catalog-codegen",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "nika-catalog-codegen"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "phf_codegen",
  "phf_shared",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "nika-error"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "miette",
  "nika-types",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "nika-schema"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "jaq-core",
  "jaq-json",
@@ -905,11 +905,11 @@ dependencies = [
 
 [[package]]
 name = "nika-tmpl"
-version = "0.99.0"
+version = "0.100.0"
 
 [[package]]
 name = "nika-types"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "loom",
  "serde",


### PR DESCRIPTION
## The 0.100 wave

First release of the 0.100/0.101/… line — the whole galaxy (engine · vscode · client-sdk · agents kit) aligns on the same version from this wave on.

**What 0.99 → 0.100 carries** (the folded Unreleased ledger, highlights):
- **The terminal sings** (#489) — verb band, live spinner, themed living DAG, the founding wizard (`nika init`), lazy-hands run/check.
- **Less but better: 24 verbs → 20 in six families** — `graph`/`schema`/`context`/`tools` fold into their parent doors; one colour chain (`--ascii` global, 23 twins die).
- **The sovereign models lane** — `nika model pull/list/rm` (#507), resume-honest receipts (#513), per-family serve receipts, tokenizer borrow, the proven pull→serve→infer loop.
- **The registry client descends to L2** (#512) — the illegal L4 edge dies.
- **LSP code actions** (#519) + completion uplift (#531) — check --fix renames become quickfixes in every editor; `tool:`/models/enums complete from the catalog.
- **Gauntlet fixes** — trace-store name resolution (#495), MCP explain namespace (#499), `examples run --var` (#500).

## Mechanics

- Version sweep 0.99.0 → 0.100.0: 47 files (root + 46 crate manifests incl. literal-version `nika-onboard`, both locks via `cargo update -w`, Dockerfile teaching comment, live status rows in ROADMAP/.claude/CLAUDE.md, changelog fold).
- Frozen surfaces untouched (crate-spec admission facts · doctor/banner test fixtures · pre-commit-hooks historical marker).
- On merge: tag `v0.100.0` on the squash commit → the release train (4-platform binaries · GH release · tap formula · GHCR image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
