### PR TITLE
feat(onboard): init equips Cursor fully — the binary carries the seatbelts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+- `nika init` equips Cursor FULLY, project-side — the binary carries what
+  the local plugin loader drops (it consumes MCP + skills only): the three
+  kit subagents land in `.cursor/agents/`, the delegation rule in
+  `.cursor/rules/`, and the three seatbelt hooks in `.cursor/hooks.json` +
+  `.cursor/hooks-nika/` (exec bit set on unix). All bodies `include_str!`
+  from the kit — one source, byte parity by construction; parity tests walk
+  every hooks.json command back to the scaffold table (#509).
+
 ### Changed
 
 - **One glyph table, zero-alloc live channel** (rust-pro pass) — the

--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -196,6 +196,68 @@ const AGENT_SKILL: &str = include_str!(concat!(
     "/../../.agents/plugins/nika/skills/nika-authoring/SKILL.md"
 ));
 
+/// `.cursor/agents/nika-*.md` — the three kit subagents, project-side.
+/// Cursor's LOCAL plugin loader consumes MCP + skills ONLY (agents in a
+/// local plugin manifest are ignored; the marketplace path processes the
+/// full manifest but is submission-gated) — so the binary carries them
+/// into the repo, where Cursor's project discovery (`.cursor/agents/`)
+/// DOES read them. `include_str!` from the kit: one source, byte parity
+/// by construction (the `AGENT_SKILL` precedent).
+const CURSOR_AGENT_AUTHOR: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/agents/nika-author.md"
+));
+const CURSOR_AGENT_DEBUGGER: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/agents/nika-debugger.md"
+));
+const CURSOR_AGENT_MIGRATOR: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/agents/nika-migrator.md"
+));
+
+/// `.cursor/rules/nika-delegation.mdc` — WHEN to hand a job to which
+/// subagent (the kit's delegation rule, same one-source law).
+const CURSOR_DELEGATION: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/rules/nika-delegation.mdc"
+));
+
+/// `.cursor/hooks-nika/*.sh` — the three seatbelts, verbatim from the
+/// kit. The scripts sniff their dialect from stdin and self-silence
+/// outside nika contexts, so carrying them project-side is safe by the
+/// same proof that ships them in the plugin.
+const HOOK_SESSION_CONTEXT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/scripts/session-context.sh"
+));
+const HOOK_CHECK_ON_EDIT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/scripts/check-on-edit.sh"
+));
+const HOOK_GUARD_RUN: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/scripts/guard-run.sh"
+));
+
+/// `.cursor/hooks.json` — the project-level hook wiring. Commands point
+/// at the scripts the SAME scaffold writes (project-relative), never at
+/// a plugin root; a parity test walks each command back to `targets()`.
+const CURSOR_HOOKS_JSON: &str = r#"{
+  "hooks": {
+    "sessionStart": [
+      { "command": "./.cursor/hooks-nika/session-context.sh" }
+    ],
+    "afterFileEdit": [
+      { "command": "./.cursor/hooks-nika/check-on-edit.sh" }
+    ],
+    "beforeShellExecution": [
+      { "command": "./.cursor/hooks-nika/guard-run.sh" }
+    ]
+  }
+}
+"#;
+
 /// The scaffolded agent guide, exposed for the bin-side parity test —
 /// a verb the binary ships and the guide never names is a verb a wired
 /// agent will never reach (found stale 2026-07-05: the scaffold taught
@@ -208,12 +270,23 @@ pub fn agents_md() -> &'static str {
 
 /// The scaffold set · (relative path, body). The ONE source of what `init`
 /// writes — `plan` and the docs both read it.
-pub(super) fn targets() -> [(&'static str, &'static str); 7] {
+pub(super) fn targets() -> [(&'static str, &'static str); 15] {
     [
         (".vscode/settings.json", VSCODE_SETTINGS),
         ("AGENTS.md", AGENTS_MD),
         (".cursor/rules/nika.mdc", CURSOR_RULES),
+        (".cursor/rules/nika-delegation.mdc", CURSOR_DELEGATION),
         (".cursor/mcp.json", CURSOR_MCP),
+        (".cursor/agents/nika-author.md", CURSOR_AGENT_AUTHOR),
+        (".cursor/agents/nika-debugger.md", CURSOR_AGENT_DEBUGGER),
+        (".cursor/agents/nika-migrator.md", CURSOR_AGENT_MIGRATOR),
+        (".cursor/hooks.json", CURSOR_HOOKS_JSON),
+        (
+            ".cursor/hooks-nika/session-context.sh",
+            HOOK_SESSION_CONTEXT,
+        ),
+        (".cursor/hooks-nika/check-on-edit.sh", HOOK_CHECK_ON_EDIT),
+        (".cursor/hooks-nika/guard-run.sh", HOOK_GUARD_RUN),
         (".agents/skills/nika-authoring/SKILL.md", AGENT_SKILL),
         (".github/copilot-instructions.md", COPILOT_INSTRUCTIONS),
         ("CLAUDE.md", CLAUDE_MD),
@@ -362,23 +435,75 @@ mod tests {
         }
     }
 
-    /// The scaffold table stays complete — six briefs, every family
-    /// present (schema wiring · contract · per-client briefs · skill).
+    /// The scaffold table stays complete — every family present (schema
+    /// wiring · contract · per-client briefs · skill · Cursor project
+    /// equipment: subagents + delegation + the three seatbelts).
     #[test]
     fn targets_names_every_brief_family() {
         let t = targets();
-        assert_eq!(t.len(), 7);
+        assert_eq!(t.len(), 15);
         let paths: Vec<&str> = t.iter().map(|(p, _)| *p).collect();
         for expected in [
             ".vscode/settings.json",
             "AGENTS.md",
             ".cursor/rules/nika.mdc",
+            ".cursor/rules/nika-delegation.mdc",
             ".cursor/mcp.json",
+            ".cursor/agents/nika-author.md",
+            ".cursor/agents/nika-debugger.md",
+            ".cursor/agents/nika-migrator.md",
+            ".cursor/hooks.json",
+            ".cursor/hooks-nika/session-context.sh",
+            ".cursor/hooks-nika/check-on-edit.sh",
+            ".cursor/hooks-nika/guard-run.sh",
             ".agents/skills/nika-authoring/SKILL.md",
             ".github/copilot-instructions.md",
             "CLAUDE.md",
         ] {
             assert!(paths.contains(&expected), "{expected} missing");
         }
+    }
+
+    /// Every command in the project hooks wiring resolves to a script the
+    /// SAME scaffold writes — a hooks.json naming a path init does not
+    /// create would be a dead seatbelt on every fresh repo.
+    #[test]
+    fn project_hooks_point_at_scaffolded_scripts() {
+        let paths: Vec<&str> = targets().iter().map(|(p, _)| *p).collect();
+        let wiring: serde_json::Value =
+            serde_json::from_str(CURSOR_HOOKS_JSON).expect("hooks.json parses");
+        let hooks = wiring["hooks"].as_object().expect("hooks object");
+        assert_eq!(hooks.len(), 3, "three seatbelts, no more, no fewer");
+        for (event, entries) in hooks {
+            for entry in entries.as_array().expect("entry array") {
+                let cmd = entry["command"].as_str().expect("command string");
+                let rel = cmd.strip_prefix("./").unwrap_or(cmd);
+                assert!(
+                    paths.contains(&rel),
+                    "{event} points at {rel}, which the scaffold never writes"
+                );
+            }
+        }
+    }
+
+    /// The subagents keep their kit identity — Cursor matches them by
+    /// frontmatter `name:`, and a renamed kit agent must fail HERE, not
+    /// silently in every scaffolded repo.
+    #[test]
+    fn cursor_subagents_carry_their_kit_names() {
+        for (body, name) in [
+            (CURSOR_AGENT_AUTHOR, "nika-author"),
+            (CURSOR_AGENT_DEBUGGER, "nika-debugger"),
+            (CURSOR_AGENT_MIGRATOR, "nika-migrator"),
+        ] {
+            assert!(
+                body.contains(&format!("name: {name}")),
+                "{name} frontmatter drifted from the kit"
+            );
+        }
+        assert!(
+            CURSOR_DELEGATION.contains("nika-author"),
+            "the delegation rule must route to the subagents it ships with"
+        );
     }
 }

--- a/crates/nika-onboard/src/founding.rs
+++ b/crates/nika-onboard/src/founding.rs
@@ -351,14 +351,25 @@ fn rel_to(dir: &str, path: &str) -> String {
         .map_or_else(|_| path.to_owned(), |p| p.to_string_lossy().into_owned())
 }
 
-/// Create any missing parent dirs, then write the file.
+/// Create any missing parent dirs, then write the file. Shell scripts
+/// (the scaffolded hooks) get the exec bit on unix — Cursor spawns them
+/// directly; on Windows bash hooks fail open anyway, so nothing to set.
 fn write_file(path: &str, body: &str) -> std::io::Result<()> {
     if let Some(parent) = Path::new(path).parent()
         && !parent.as_os_str().is_empty()
     {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, body)
+    std::fs::write(path, body)?;
+    #[cfg(unix)]
+    if std::path::Path::new(path)
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("sh"))
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -526,7 +537,7 @@ mod tests {
     #[test]
     fn plan_creates_both_when_nothing_exists() {
         let p = plan(".", &|_| false, false);
-        assert_eq!(p.len(), 7);
+        assert_eq!(p.len(), 15);
         assert!(p.iter().all(|a| matches!(a, Action::Create { .. })));
         // Schema wiring + agent guide + per-client briefs are the targets.
         let paths: Vec<&str> = p


### PR DESCRIPTION
Cursor's LOCAL plugin loader consumes **MCP + skills only** — agents/rules/hooks in a local manifest are silently ignored, and the marketplace path that processes them is submission-gated. The one vehicle we own end to end is the binary.

**`nika init` grows 7 → 15 targets**, all Cursor-side bodies `include_str!` from the kit (one source, byte parity by construction):
- `.cursor/agents/nika-{author,debugger,migrator}.md` — project discovery DOES read these
- `.cursor/rules/nika-delegation.mdc` — WHEN to hand a job to which subagent
- `.cursor/hooks.json` + `.cursor/hooks-nika/*.sh` — the three seatbelts verbatim (dialect-sniffing, self-silencing), exec bit on unix

**Three new pins**: plan count · a parity walk from every hooks.json command back to the scaffold table (a dead-path seatbelt fails in CI, not in every fresh repo) · the kit frontmatter names Cursor matches on.

**E2E proven**: 15/15 created fresh · re-run 15/15 skipped (`--force` unchanged) · scaffolded script answers the cursor dialect · agents byte-identical to the kit. 58 onboard tests green, clippy clean.

Kit follow-up (journaled, out of scope): `readonly: true` frontmatter once Claude Code tolerance is verified.

Closes #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)