### PR TITLE
feat(init): the binary carries the seatbelts — Cursor equipped fully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **`nika init` equips Cursor FULLY** (#509) — Cursor's local plugin
+  loader consumes MCP + skills only, so the binary now carries the
+  rest at project scope: the three kit subagents
+  (`.cursor/agents/nika-{author,debugger,migrator}.md`), the
+  WHEN-to-delegate rule (`.cursor/rules/nika-delegation.mdc`), and the
+  three hook seatbelts (`.cursor/hooks.json` +
+  `.cursor/hooks-nika/{session-context,check-on-edit,guard-run}.sh`,
+  exec bit stamped at write). Every body is `include_str!` from the
+  kit — one living writer, byte parity by construction; a test pins
+  the hooks manifest structurally to the kit's (same events, same
+  scripts). Scaffold grows 7 → 15 targets; `--force` semantics
+  unchanged.
+
 ### Changed
 
 - **One glyph table, zero-alloc live channel** (rust-pro pass) — the

--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -196,6 +196,79 @@ const AGENT_SKILL: &str = include_str!(concat!(
     "/../../.agents/plugins/nika/skills/nika-authoring/SKILL.md"
 ));
 
+/// The three kit subagents, delivered PROJECT-side (`.cursor/agents/`) —
+/// Cursor's local plugin loader consumes MCP + skills only (#509), so the
+/// binary carries the rest. `include_str!` from the kit: one living writer,
+/// byte parity by construction. Cursor also reads `.claude/agents/` and
+/// `.codex/agents/`, so `.cursor/agents/` serves every client that looks.
+const CURSOR_AGENT_AUTHOR: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/agents/nika-author.md"
+));
+const CURSOR_AGENT_DEBUGGER: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/agents/nika-debugger.md"
+));
+const CURSOR_AGENT_MIGRATOR: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/agents/nika-migrator.md"
+));
+
+/// The WHEN-to-delegate rule — routes repeatable AI work to a workflow
+/// and names the bundled surfaces (skills · subagents · MCP tools).
+const CURSOR_DELEGATION_RULE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/rules/nika-delegation.mdc"
+));
+
+/// The three seatbelt scripts, kit VERBATIM — they sniff the hook dialect
+/// themselves and self-silence outside nika contexts, so the same bytes
+/// serve plugin and project scope. `write_file` stamps the exec bit.
+const HOOK_SESSION_CONTEXT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/scripts/session-context.sh"
+));
+const HOOK_CHECK_ON_EDIT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/scripts/check-on-edit.sh"
+));
+const HOOK_GUARD_RUN: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/scripts/guard-run.sh"
+));
+
+/// `.cursor/hooks.json` — the seatbelts wired at PROJECT scope. The kit's
+/// own manifest points `./scripts/…` (plugin-relative); this one points
+/// `./.cursor/hooks-nika/…` (workspace-relative). A test pins structural
+/// parity (same events, same script basenames) so the two cannot drift.
+const CURSOR_HOOKS_JSON: &str = r#"{
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "./.cursor/hooks-nika/session-context.sh"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "./.cursor/hooks-nika/check-on-edit.sh"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "./.cursor/hooks-nika/guard-run.sh"
+      }
+    ]
+  }
+}
+"#;
+
+/// The kit's own hooks manifest — test-only anchor for the parity pin.
+#[cfg(test)]
+const KIT_CURSOR_HOOKS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/hooks/cursor-hooks.json"
+));
+
 /// The scaffolded agent guide, exposed for the bin-side parity test —
 /// a verb the binary ships and the guide never names is a verb a wired
 /// agent will never reach (found stale 2026-07-05: the scaffold taught
@@ -208,12 +281,23 @@ pub fn agents_md() -> &'static str {
 
 /// The scaffold set · (relative path, body). The ONE source of what `init`
 /// writes — `plan` and the docs both read it.
-pub(super) fn targets() -> [(&'static str, &'static str); 7] {
+pub(super) fn targets() -> [(&'static str, &'static str); 15] {
     [
         (".vscode/settings.json", VSCODE_SETTINGS),
         ("AGENTS.md", AGENTS_MD),
         (".cursor/rules/nika.mdc", CURSOR_RULES),
+        (".cursor/rules/nika-delegation.mdc", CURSOR_DELEGATION_RULE),
         (".cursor/mcp.json", CURSOR_MCP),
+        (".cursor/agents/nika-author.md", CURSOR_AGENT_AUTHOR),
+        (".cursor/agents/nika-debugger.md", CURSOR_AGENT_DEBUGGER),
+        (".cursor/agents/nika-migrator.md", CURSOR_AGENT_MIGRATOR),
+        (".cursor/hooks.json", CURSOR_HOOKS_JSON),
+        (
+            ".cursor/hooks-nika/session-context.sh",
+            HOOK_SESSION_CONTEXT,
+        ),
+        (".cursor/hooks-nika/check-on-edit.sh", HOOK_CHECK_ON_EDIT),
+        (".cursor/hooks-nika/guard-run.sh", HOOK_GUARD_RUN),
         (".agents/skills/nika-authoring/SKILL.md", AGENT_SKILL),
         (".github/copilot-instructions.md", COPILOT_INSTRUCTIONS),
         ("CLAUDE.md", CLAUDE_MD),
@@ -362,23 +446,96 @@ mod tests {
         }
     }
 
-    /// The scaffold table stays complete — six briefs, every family
-    /// present (schema wiring · contract · per-client briefs · skill).
+    /// The scaffold table stays complete — every family present (schema
+    /// wiring · contract · per-client briefs · skill · Cursor full equip:
+    /// subagents + delegation rule + hook seatbelts, #509).
     #[test]
     fn targets_names_every_brief_family() {
         let t = targets();
-        assert_eq!(t.len(), 7);
+        assert_eq!(t.len(), 15);
         let paths: Vec<&str> = t.iter().map(|(p, _)| *p).collect();
         for expected in [
             ".vscode/settings.json",
             "AGENTS.md",
             ".cursor/rules/nika.mdc",
+            ".cursor/rules/nika-delegation.mdc",
             ".cursor/mcp.json",
+            ".cursor/agents/nika-author.md",
+            ".cursor/agents/nika-debugger.md",
+            ".cursor/agents/nika-migrator.md",
+            ".cursor/hooks.json",
+            ".cursor/hooks-nika/session-context.sh",
+            ".cursor/hooks-nika/check-on-edit.sh",
+            ".cursor/hooks-nika/guard-run.sh",
             ".agents/skills/nika-authoring/SKILL.md",
             ".github/copilot-instructions.md",
             "CLAUDE.md",
         ] {
             assert!(paths.contains(&expected), "{expected} missing");
+        }
+    }
+
+    /// The project hooks manifest mirrors the kit's — same events, same
+    /// script basenames — only the path prefix differs (workspace vs
+    /// plugin scope). If the kit grows a seatbelt, this fails until the
+    /// project manifest carries it too.
+    #[test]
+    fn project_hooks_manifest_mirrors_the_kit() {
+        let ours: serde_json::Value =
+            serde_json::from_str(CURSOR_HOOKS_JSON).expect("project manifest parses");
+        let kit: serde_json::Value =
+            serde_json::from_str(KIT_CURSOR_HOOKS).expect("kit manifest parses");
+        let events = |v: &serde_json::Value| -> Vec<(String, String)> {
+            let hooks = v["hooks"].as_object().expect("hooks object");
+            let mut out: Vec<(String, String)> = hooks
+                .iter()
+                .map(|(event, entries)| {
+                    let cmd = entries[0]["command"].as_str().expect("command");
+                    let basename = cmd.rsplit('/').next().expect("basename");
+                    (event.clone(), basename.to_owned())
+                })
+                .collect();
+            out.sort();
+            out
+        };
+        assert_eq!(events(&ours), events(&kit));
+        // and every referenced script is itself a scaffold target
+        let t = targets();
+        for (_, basename) in events(&ours) {
+            let rel = format!(".cursor/hooks-nika/{basename}");
+            assert!(
+                t.iter().any(|(p, _)| *p == rel),
+                "{rel} referenced by hooks.json but not scaffolded"
+            );
+        }
+    }
+
+    /// The delivered subagents and rule are real briefs, not stubs —
+    /// each carries its frontmatter contract.
+    #[test]
+    fn cursor_agents_and_rule_carry_frontmatter() {
+        for (name, body) in [
+            ("nika-author", CURSOR_AGENT_AUTHOR),
+            ("nika-debugger", CURSOR_AGENT_DEBUGGER),
+            ("nika-migrator", CURSOR_AGENT_MIGRATOR),
+        ] {
+            assert!(body.starts_with("---"), "{name}: frontmatter opens");
+            assert!(body.contains("name:"), "{name}: names itself");
+            assert!(body.contains("description:"), "{name}: describes itself");
+        }
+        assert!(CURSOR_DELEGATION_RULE.starts_with("---"));
+        assert!(CURSOR_DELEGATION_RULE.contains("description:"));
+        // seatbelt scripts are bash with a shebang — write_file's exec
+        // bit is what makes them spawnable
+        for (name, body) in [
+            ("session-context", HOOK_SESSION_CONTEXT),
+            ("check-on-edit", HOOK_CHECK_ON_EDIT),
+            ("guard-run", HOOK_GUARD_RUN),
+        ] {
+            assert!(
+                body.starts_with("#!/usr/bin/env bash"),
+                "{name}: shebang present"
+            );
         }
     }
 }

--- a/crates/nika-onboard/src/founding.rs
+++ b/crates/nika-onboard/src/founding.rs
@@ -358,7 +358,19 @@ fn write_file(path: &str, body: &str) -> std::io::Result<()> {
     {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, body)
+    std::fs::write(path, body)?;
+    // Hook scripts must be spawnable the moment they land — Cursor execs
+    // them directly (#509). Unix-only: Windows has no bit and bash hooks
+    // fail open there anyway.
+    #[cfg(unix)]
+    if Path::new(path)
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("sh"))
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -526,7 +538,7 @@ mod tests {
     #[test]
     fn plan_creates_both_when_nothing_exists() {
         let p = plan(".", &|_| false, false);
-        assert_eq!(p.len(), 7);
+        assert_eq!(p.len(), 15);
         assert!(p.iter().all(|a| matches!(a, Action::Create { .. })));
         // Schema wiring + agent guide + per-client briefs are the targets.
         let paths: Vec<&str> = p
@@ -538,6 +550,8 @@ mod tests {
         assert!(paths.iter().any(|p| p.ends_with("settings.json")));
         assert!(paths.iter().any(|p| p.ends_with("AGENTS.md")));
         assert!(paths.iter().any(|p| p.ends_with("nika.mdc")));
+        assert!(paths.iter().any(|p| p.ends_with("hooks.json")));
+        assert!(paths.iter().any(|p| p.ends_with("guard-run.sh")));
         assert!(
             paths
                 .iter()
@@ -549,6 +563,33 @@ mod tests {
                 .any(|p| p.ends_with(".github/copilot-instructions.md"))
         );
         assert!(paths.iter().any(|p| p.ends_with("CLAUDE.md")));
+    }
+
+    /// A scaffolded hook script lands spawnable — Cursor execs it
+    /// directly, so the write itself must carry the bit (unix).
+    #[cfg(unix)]
+    #[test]
+    fn scaffolded_hook_scripts_are_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = std::env::temp_dir().join(format!("nika-execbit-{}", std::process::id()));
+        let dir = tmp.to_string_lossy().into_owned();
+        let rows = apply_briefs(&dir, true, None);
+        let mode = std::fs::metadata(tmp.join(".cursor/hooks-nika/guard-run.sh"))
+            .expect("guard-run.sh written")
+            .permissions()
+            .mode();
+        let plain = std::fs::metadata(tmp.join(".cursor/hooks.json"))
+            .expect("hooks.json written")
+            .permissions()
+            .mode();
+        std::fs::remove_dir_all(&tmp).ok();
+        assert!(
+            rows.iter()
+                .all(|(_, o)| !matches!(o, BriefOutcome::Failed(_))),
+            "all briefs land"
+        );
+        assert_eq!(mode & 0o111, 0o111, "script carries the exec bit");
+        assert_eq!(plain & 0o111, 0, "manifest stays a plain file");
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes #509. Cursor's local plugin loader consumes **MCP + skills only** — agents/rules/hooks in the manifest are ignored, and the marketplace one-Add is submission-gated. Every non-marketplace user was under-equipped. The universal vehicle we own end-to-end is the binary: `nika init` grows **eight Cursor-side targets (7 → 15)**.

| Target | Source |
|---|---|
| `.cursor/agents/nika-{author,debugger,migrator}.md` | kit subagents, `include_str!` — one living writer |
| `.cursor/rules/nika-delegation.mdc` | kit WHEN-to-delegate rule, same pattern |
| `.cursor/hooks.json` | project-scoped manifest (`./.cursor/hooks-nika/…` paths) |
| `.cursor/hooks-nika/{session-context,check-on-edit,guard-run}.sh` | kit **verbatim** — dialect-sniffing, self-silencing outside nika contexts |

## The three laws in the diff

1. **One living writer** — every agent/rule/script body is `include_str!` from `.agents/plugins/nika/` (the CURSOR_RULES precedent): byte parity by construction, zero duplication.
2. **Structural parity pin** — the project hooks manifest can't drift from the kit's: a test asserts same events + same script basenames, and that every referenced script is itself a scaffold target. A kit seatbelt the project misses fails the build.
3. **Spawnable at write** — `write_file` stamps the exec bit on `.sh` (unix; Windows has no bit and bash hooks fail open there anyway). Test pins `guard-run.sh & 0o111 == 0o111` and `hooks.json & 0o111 == 0`.

## Proven live

```
$ nika init --yes          # fresh dir
15 × ✔ created (recap byte-shape #158 intact)
$ echo '{"hook_event_name":"beforeShellExecution","command":"ls"}' | ./.cursor/hooks-nika/guard-run.sh
{}                         # fail-open outside a nika context — self-silencing proven
```

59 nika-onboard lib · 275 nika-cli lib · 5 init_smoke · 11 wizard_pty — all green · clippy -D warnings 0 · LOC gates OK.

**Kit follow-up (0.5.x, separate):** `readonly: true` frontmatter on the three agents once Claude Code tolerance is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
