### PR TITLE
feat(agents): kit 0.100.1 — the read-only promise becomes a frontmatter fact

### DIFF
--- a/.agents/plugins/nika/.claude-plugin/plugin.json
+++ b/.agents/plugins/nika/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "author": {
     "name": "SuperNovae Studio",
     "url": "https://nika.sh"

--- a/.agents/plugins/nika/.codex-plugin/plugin.json
+++ b/.agents/plugins/nika/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika · Intent as Code",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files — 4 skills, 3 subagents, 2 rules, 5 slash commands (/nika:check · /nika:explain · /nika:new · /nika:trace · /nika:permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context · check-on-edit · a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools · nika_check through nika_tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "author": "SuperNovae Studio",
   "repository": "https://github.com/supernovae-st/nika",
   "homepage": "https://nika.sh",

--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nika",
   "displayName": "Nika",
   "description": "Author, debug, operate and migrate AI workflows as checkable .nika.yaml files. Bundles 4 skills, 3 subagents, 2 rules, 5 commands (/check, /explain, /new, /trace, /permits), 3 hooks on every surface — Cursor, Claude Code and Codex (one dialect, sniffed) (session context, check-on-edit, a guard that audits before any nika run) and the read-only Nika MCP oracle (8 tools). Requires the nika binary: brew install supernovae-st/tap/nika",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "author": {
     "name": "SuperNovae Studio",
     "email": "nika@supernovae.studio"

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -3,6 +3,14 @@
 The bundle every marketplace installs (Claude Code · Codex · Cursor).
 Versions move together across all manifests (the mirror gate pins it).
 
+## 0.100.1 — 2026-07-12
+
+- The three subagents declare `readonly: true` — Cursor ENFORCES what the
+  prose always promised (« read-only oracle · it never runs the workflow »);
+  Claude Code tolerates the unknown key, live-probed first (a probe agent
+  carrying the key loads and is offered next to a control). Kit-only patch
+  on the 0.100 wave.
+
 ## 0.100.0 — 2026-07-12
 
 The galaxy shares one wave number: engine · extension · client-sdk ·

--- a/.agents/plugins/nika/agents/nika-author.md
+++ b/.agents/plugins/nika/agents/nika-author.md
@@ -1,6 +1,7 @@
 ---
 name: nika-author
 description: Writes and repairs .nika.yaml workflows with the deterministic authoring protocol. Use when the user wants repeatable AI work turned into a workflow file, asks for a .nika.yaml, or a nika check must pass. Routes intent to a template, fills the SLOT markers, then loops nika check until rc=0. Read-only oracle; it never runs the workflow.
+readonly: true
 ---
 
 # nika-author · the workflow author

--- a/.agents/plugins/nika/agents/nika-debugger.md
+++ b/.agents/plugins/nika/agents/nika-debugger.md
@@ -1,6 +1,7 @@
 ---
 name: nika-debugger
 description: Root-causes failed or paused Nika runs from their hash-chained traces. Use when nika run exited red, a run paused on a prompt and needs the exact resume line, a NIKA-XXXX runtime finding needs a cause, or a trace must be verified and explained. Evidence-first — reads .nika/traces via nika trace; proposes fixes and run lines, never executes them.
+readonly: true
 ---
 
 # nika-debugger · the run forensic

--- a/.agents/plugins/nika/agents/nika-migrator.md
+++ b/.agents/plugins/nika/agents/nika-migrator.md
@@ -1,6 +1,7 @@
 ---
 name: nika-migrator
 description: Ports an existing script, Makefile target, CI job or prompt chain to a checkable .nika.yaml workflow. Use when converting ad-hoc automation to nika, when a shell script wraps LLM/HTTP/file plumbing, or when a prompt chain in a doc should become a runnable, auditable file. Inventories side effects first, maps steps to the four verbs native-first, proves with check and a golden pin.
+readonly: true
 ---
 
 # nika-migrator · the automation porter


### PR DESCRIPTION
The three subagents' prose always promised « read-only oracle »; Cursor's `readonly:` frontmatter **enforces** it. Probe-first per the house law: a probe agent carrying the unknown key **loads and is offered by Claude Code** next to a control (live, this machine).

**Kit-only patch on the 0.100 wave** — rebased after the release train's wave alignment (63bdc62cc: kit versions ride the engine wave from 0.100 on). Manifests move to **0.100.1** together: a content change without a bump would leave per-version plugin caches serving the old bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)