### PR TITLE
test(onboard): two guards for the Cursor equip — kit parity · exec-bit pin

### DIFF
--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -243,6 +243,14 @@ const HOOK_GUARD_RUN: &str = include_str!(concat!(
 /// `.cursor/hooks.json` — the project-level hook wiring. Commands point
 /// at the scripts the SAME scaffold writes (project-relative), never at
 /// a plugin root; a parity test walks each command back to `targets()`.
+/// The kit's own hooks manifest — test-only anchor: the project manifest
+/// below must mirror it structurally or the build fails.
+#[cfg(test)]
+const KIT_CURSOR_HOOKS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../.agents/plugins/nika/hooks/cursor-hooks.json"
+));
+
 const CURSOR_HOOKS_JSON: &str = r#"{
   "hooks": {
     "sessionStart": [
@@ -484,6 +492,45 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The project manifest mirrors the KIT's — same events, same script
+    /// basenames, only the path prefix differs (workspace vs plugin
+    /// scope). The sibling test above checks internal consistency; this
+    /// one checks the SOURCE: a seatbelt added to the kit that the
+    /// project manifest misses fails here, not silently in the field.
+    #[test]
+    fn project_hooks_manifest_mirrors_the_kit() {
+        let ours: serde_json::Value =
+            serde_json::from_str(CURSOR_HOOKS_JSON).expect("project manifest parses");
+        let kit: serde_json::Value =
+            serde_json::from_str(KIT_CURSOR_HOOKS).expect("kit manifest parses");
+        let shape = |v: &serde_json::Value| -> Vec<(String, String)> {
+            let mut out: Vec<(String, String)> = v["hooks"]
+                .as_object()
+                .expect("hooks object")
+                .iter()
+                .flat_map(|(event, entries)| {
+                    entries
+                        .as_array()
+                        .expect("entry array")
+                        .iter()
+                        .map(|e| {
+                            let cmd = e["command"].as_str().expect("command string");
+                            let base = cmd.rsplit('/').next().expect("basename");
+                            (event.clone(), base.to_owned())
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            out.sort();
+            out
+        };
+        assert_eq!(
+            shape(&ours),
+            shape(&kit),
+            "project hooks.json drifted from the kit manifest"
+        );
     }
 
     /// The subagents keep their kit identity — Cursor matches them by

--- a/crates/nika-onboard/src/founding.rs
+++ b/crates/nika-onboard/src/founding.rs
@@ -708,4 +708,32 @@ mod tests {
         assert!(out.text.contains("skipped"), "{}", out.text);
         std::fs::remove_dir_all(&tmp).ok();
     }
+
+    /// The exec-bit stamp survives refactors — Cursor spawns the
+    /// seatbelt scripts directly, so a write path that loses the bit
+    /// ships dead hooks to every fresh repo (unix).
+    #[cfg(unix)]
+    #[test]
+    fn scaffolded_hook_scripts_are_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = std::env::temp_dir().join(format!("nika-execbit-{}", std::process::id()));
+        let dir = tmp.to_string_lossy().into_owned();
+        let rows = apply_briefs(&dir, true, None);
+        let mode = std::fs::metadata(tmp.join(".cursor/hooks-nika/guard-run.sh"))
+            .expect("guard-run.sh written")
+            .permissions()
+            .mode();
+        let plain = std::fs::metadata(tmp.join(".cursor/hooks.json"))
+            .expect("hooks.json written")
+            .permissions()
+            .mode();
+        std::fs::remove_dir_all(&tmp).ok();
+        assert!(
+            rows.iter()
+                .all(|(_, o)| !matches!(o, BriefOutcome::Failed(_))),
+            "all briefs land"
+        );
+        assert_eq!(mode & 0o111, 0o111, "script carries the exec bit");
+        assert_eq!(plain & 0o111, 0, "manifest stays a plain file");
+    }
 }


### PR DESCRIPTION
## What

#535 shipped the #509 implementation (the race — #536 carried the same impl, closed as duplicate). These are the **two regression guards** the race left behind. Tests only, zero production-code change.

## The two guards

1. **`project_hooks_manifest_mirrors_the_kit`** — the existing sibling test checks *internal* consistency (manifest → scaffolded paths) and pins "three seatbelts" as a literal. This one checks the **source**: same events + same script basenames as the kit's own `cursor-hooks.json` (test-only `include_str!`). A seatbelt added to the kit that the project manifest misses now **fails the build** instead of drifting silently in the field.
2. **`scaffolded_hook_scripts_are_executable`** — the exec-bit stamp exists in `write_file` but nothing pinned it; a refactor that loses the bit ships dead hooks to every fresh repo. Pins `guard-run.sh & 0o111 == 0o111` **and** `hooks.json & 0o111 == 0` (unix).

60/60 nika-onboard lib · clippy -D warnings 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
