### PR TITLE
docs(adr): adr-030 flips accepted under the merged-code rule

### DIFF
--- a/docs/adr/adr-030-memory-frame-trust.md
+++ b/docs/adr/adr-030-memory-frame-trust.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-030
 title: "MemoryFrameRef.trust reservation (Shield gate seed)"
-status: proposed
+status: accepted
 date: "2026-04-17"
 phase: "Phase D — Wave 4A R2"
 deciders: ["@ThibautMelen"]
@@ -18,35 +18,76 @@ fci: ["FCI-035"]
 inv: []
 shadow_zones: []
 nika_codes: ["NIKA-380", "NIKA-381", "NIKA-389"]
-timeline: "v0.81.0-alpha.4, Wave 4A R2 seed (prose pending Phase C)"
+timeline: "v0.81.0-alpha.4, Wave 4A R2 seed · prose authored + accepted 2026-07-12 (merged-code rule)"
 follow_ups:
-  - "Flesh out full rationale + alternatives during Phase C ADR prose sweep"
-  - "Pin trust-default policy (UNTRUSTED vs TRUSTED) in the prose version"
+  - "Populate `trust` from real ingest provenance when the Connectome recall path ships (the field is wired, the writer is not)"
 ---
 
 # ADR-030: MemoryFrameRef.trust reservation (Shield gate seed)
 
-> **STUB — prose pending Phase C.** Decision is load-bearing in code; this
-> file exists so vector 19 (adr-orphan-proposed) can surface it at day 31
-> and force full prose authoring.
+Status flipped `proposed → accepted` 2026-07-12 under the merged-code
+rule (the #474 ADR ruling): the decision is load-bearing in shipped
+code — `MemoryFrameRef.trust` exists, defaults safely, and rides the
+serde wire today. An ADR whose decision the workspace already executes
+does not stay "proposed"; the prose below documents what IS.
 
 ## Context
 
-Wave 4A R2 (commit `41e8a1467`, 2026-04-17) adds `trust: TrustLevel` as a
-reserved field on `MemoryFrameRef` (re-exported from `nika-kernel` via
-`nika-types`). The field lets Shield (NIKA-380..389) gate every recall by
-the trust level of the source memory frame without a v0.95+ breaking
-change.
+Wave 4A R2 (commit `41e8a1467`, 2026-04-17) added `trust: TrustLevel`
+as a reserved field on `MemoryFrameRef` so that Shield (the
+NIKA-380..389 code family) can gate every recall by the trust level of
+the source memory frame **without a breaking change** when real recall
+arrives. Per ADR-028 (forward-compat reservation policy), the field
+ships years before its writer: reserving the slot is cheap; retrofitting
+it onto a `#[non_exhaustive]` struct consumed across layers is not.
 
-## Decision (preliminary)
+The trust model this seeds is **sticky taint**: trust is assigned at
+ingest and never upgrades on recall — a frame that entered the store
+untrusted can never launder itself into a trusted context by being
+remembered.
 
-`MemoryFrameRef.trust` defaults to `TrustLevel::UNTRUSTED` (safe-by-default
-per ADR-033 rev.2). Field is `#[non_exhaustive]`-protected and populated by
-the memory store impl when real recall arrives in v0.95 Cortex. Shield
-downstream reads the field to decide spotlight / block / allow. Full
-rationale (trust lattice propagation, default inversion justification,
-migration path for pre-v0.95 stubs) to be authored during Phase C ADR
-sweep before v0.90.
+## Decision
+
+- `MemoryFrameRef` carries `pub trust: crate::trust::TrustLevel`
+  (`nika-types/src/memory.rs` — re-exported through `nika-kernel`).
+- **Wire default**: when the field is absent on the wire, serde fills
+  `TrustLevel::UNTRUSTED` (50) via `default_trust_untrusted()` — a
+  legacy or unknown-origin frame is conservatively untrusted, keeping
+  new-consumer/old-producer AND old-consumer/new-producer strictly
+  fail-safe.
+- **No language-level `Default`**: `TrustLevel` deliberately does NOT
+  implement `Default` (removed in Wave 3 · P1-2 rust-security). A
+  blanket `default()` returning UNTRUSTED (50) sits ABOVE SANDBOXED
+  (10) in the lattice — a silent inversion of safe-by-default for any
+  capability gate written as `is_at_least(SANDBOXED)`. Trust must be a
+  deliberate construction at every call site; only the serde
+  wire-compat path carries a default, and that one is scoped, named,
+  and documented at the field.
+- The lattice itself (SANDBOXED 10 < UNTRUSTED 50 < TRUSTED 150 <
+  ELEVATED 200 < SYSTEM 255 · `meet`/`join`/`is_at_least`) is ADR-033's
+  decision; this ADR consumes it.
+
+## Alternatives considered
+
+- **`Option<TrustLevel>`** — rejected: an absent trust level forces
+  every reader to invent a policy at the read site; the whole point is
+  ONE conservative policy at the boundary.
+- **Defaulting to TRUSTED for engine-internal frames** — rejected: the
+  writer (real ingest) does not exist yet, so nothing can vouch for
+  provenance; safe-by-default (ADR-033 rev.2) wins until it does.
+- **Deferring the field to the Connectome era** — rejected per ADR-028:
+  adding a field later to a serialized, cross-layer struct is the
+  exact breaking change the reservation policy exists to prevent.
+
+## Empirical validation (what makes this "merged code")
+
+- `nika-types/src/memory.rs` — the field, its serde default fn, and the
+  constructor defaulting to UNTRUSTED, all shipped and exercised by the
+  crate's serde round-trip tests.
+- `nika-types/src/trust.rs` — the lattice with the no-`Default`
+  invariant documented at the impl site.
+- The `#[non_exhaustive]` + `new()` discipline (FCI invariant #19)
+  holds on both types, so the v0.95+ writer lands without a major.
 
 ## See also
 

--- a/docs/adr/adr-092-nika-check-program-analysis-ladder.md
+++ b/docs/adr/adr-092-nika-check-program-analysis-ladder.md
@@ -80,7 +80,7 @@ The ranked roadmap (the rest of the ladder · sequenced, not vapor):
 | # | Capability | Research basis | Moat | Status |
 |---|---|---|---|---|
 | 1 | **IFC taint-trace** (non-interference) | Denning 1976 · Jif · FlowCaml · LIO | ⭐⭐⭐ | ✅ shipped (`check/flow.rs`) |
-| 2 | **Capability inference** (`--infer-permits`) | E-lang object-capabilities · Koka effects | ⭐⭐⭐ | ✅ shipped (`check/infer_permits.rs`) |
+| 2 | **Capability inference** (`--infer-permits`) | E-lang object-capabilities · Koka effects | ⭐⭐⭐ | ✅ shipped (`check/permits_infer.rs`) |
 | 3 | **Unified FlowFacts IR** | rust-analyzer HIR · single annotated pass | ⭐⭐ (enabler) | ✅ shipped (taint slice) |
 | 4 | **Dataflow schema typing** — `${{ tasks.A.output.field }}` type-checked transitively vs A's schema | bidirectional type inference | ⭐⭐⭐ | ✅ shipped (`check/schema_typing.rs`) |
 | 5 | **Symbolic cost intervals** — `[min,max]` over retry/agent-turns/`when:` branches; input-token bounds | RAML (Hoffmann) · WCET | ⭐⭐ | ✅ shipped (structural slice — retry × fan-out × `when:` gates; input-token side stays out per the output-ceiling convention) |
@@ -128,7 +128,7 @@ design, not a leak; the model response is not a verbatim echo).
 
 - `crates/nika-schema/src/check/` -- the shipped `nika check` (mod/cost/secrets/permits_fit)
 - `crates/nika-schema/src/check/flow.rs` -- the IFC engine (this ADR · ladder #1+#3)
-- `crates/nika-schema/src/check/infer_permits.rs` -- capability inference (ladder #2 ·
+- `crates/nika-schema/src/check/permits_infer.rs` -- capability inference (ladder #2 ·
   `infer_permits()` + `InferredPermits::to_yaml()` · sound-by-honesty notes ·
   round-trip property: the inferred block re-checks clean)
 - `crates/nika-schema/src/check/permits_fit.rs` -- `static_program` + `builtin_effect`


### PR DESCRIPTION
Two of the hygiene board's yellows settle (found re-verifying the board after the memory pointer said RED — fresh main is actually 34 green / 5 yellow / 0 red):

## ADR-030 — the board's oldest orphan (85 days proposed)

Verified **load-bearing before the flip** (the #474 rule — no flip without per-ADR proof): `MemoryFrameRef.trust` ships with the scoped serde default (`default_trust_untrusted` — legacy frames conservatively untrusted, both serde-compat directions fail-safe), and `TrustLevel` deliberately carries **no language-level `Default`** (removed Wave 3 P1-2: a blanket UNTRUSTED(50) sits *above* SANDBOXED(10) — a silent safe-by-default inversion for `is_at_least(SANDBOXED)` gates). The prose replaces the stub and documents what IS: sticky taint · the wire default · the no-Default invariant · the alternatives and why each lost. `adr-orphan-proposed`'s worst case drops 85d → 58d (the remaining 11 need their own per-ADR proofs — deliberately not bulk-flipped).

## ADR-092 — two dead evidence paths

`check/infer_permits.rs` → the module is `check/permits_infer.rs`. Both citations corrected; **`adr-evidence-paths` goes YELLOW → GREEN** (167 paths verified).

Proof: `check-adr-schema` 67 ADRs 0 errors · `check-adr-evidence` OK 167 · both vectors re-run on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)