### PR TITLE
feat(nika-lsp): the envelope and the vars complete themselves — enums round 2

### DIFF
--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -344,10 +344,19 @@ fn provider_models(prefix: &str) -> Option<Vec<CompletionItem>> {
     (!items.is_empty()).then_some(items)
 }
 
-/// Closed-enum field values (`capture:` · `backoff_strategy:`) — the
-/// schema's own vocabulary, offered where the spec closes the set.
+/// Closed-enum field values (`nika:` · `capture:` · `backoff_strategy:` ·
+/// `type:`) — the schema's own vocabulary, offered where the spec closes
+/// the set. Output-side enums (finding severity · permits source) are
+/// engine-stamped, never authored — they do not belong here.
 fn enum_values(prefix: &str) -> Option<Vec<CompletionItem>> {
     const ENUMS: &[(&str, &[(&str, &str)])] = &[
+        (
+            "nika:",
+            &[(
+                "v1",
+                "the envelope — a single version marker, frozen forever",
+            )],
+        ),
         (
             "capture:",
             &[
@@ -361,6 +370,20 @@ fn enum_values(prefix: &str) -> Option<Vec<CompletionItem>> {
                 ("exponential", "1s · 2s · 4s … (the retry default)"),
                 ("linear", "1s · 2s · 3s … steady climb"),
                 ("fixed", "the same delay every attempt"),
+            ],
+        ),
+        // `vars:` declarations (spec 01-envelope §vars) — the same six
+        // words double as the JSON-Schema `type:` vocabulary inside
+        // `schema:` blocks, so one lane serves both authoring sites.
+        (
+            "type:",
+            &[
+                ("string", "a UTF-8 string"),
+                ("number", "any JSON number"),
+                ("integer", "a JSON integer"),
+                ("boolean", "true or false"),
+                ("array", "a JSON array"),
+                ("object", "a JSON object"),
             ],
         ),
     ];
@@ -589,6 +612,27 @@ mod tests {
                 "exponential".to_owned(),
                 "linear".to_owned(),
                 "fixed".to_owned()
+            ]
+        );
+
+        // the envelope value — the FIRST thing every author types
+        let text3 = "nika: ";
+        let l3 = labels(&completion(text3, text3.len()));
+        assert_eq!(l3, vec!["v1".to_owned()]);
+
+        // vars declaration types — and the same lane serves JSON-Schema
+        // `type:` lines inside `schema:` blocks
+        let text4 = "nika: v1\nvars:\n  city:\n    type: ";
+        let l4 = labels(&completion(text4, text4.len()));
+        assert_eq!(
+            l4,
+            vec![
+                "string".to_owned(),
+                "number".to_owned(),
+                "integer".to_owned(),
+                "boolean".to_owned(),
+                "array".to_owned(),
+                "object".to_owned()
             ]
         );
     }


### PR DESCRIPTION
## What

#531 follow-through — two more closed sets join the enum completion lane, both probed live over JSON-RPC:

| Site | Offers |
|---|---|
| `nika: ` | `v1` — the FIRST key every author types, answered with the only legal value (frozen forever) |
| `type: ` | `string · number · integer · boolean · array · object` — the vars-declaration vocabulary (spec 01-envelope §vars); the same six words double as JSON-Schema's `type:` inside `schema:` blocks, so one lane serves both authoring sites |

## Deliberately NOT added — the corpus as witness

- **`source:`** — ambiguous in the wild: `07-for-each-locales` declares a var literally named `source`. Needs block context (inside `secrets:`), not a line prefix.
- **`mode:`** — two vocabularies: the corpus writes `mode: jq`, the schema enum says `jmespath`. Offering the wrong set is worse than offering none; waits for the extract SSOT.
- **finding severity / permits source** — engine-STAMPED output enums (`Serialize`-only), never authored. They do not belong in a completion lane.

## Proof

Law test extended with exact-set asserts for both lanes · 139/139 nika-lsp lib · clippy -D warnings 0 · live JSON-RPC probe: envelope → `[v1]`, type → the six in spec order · zero new pub items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
