### PR TITLE
docs(adr): the wave-4a stubs earn their prose — three more flips

### DIFF
--- a/docs/adr/adr-031-recall-query-tenant-keyspace.md
+++ b/docs/adr/adr-031-recall-query-tenant-keyspace.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-031
 title: "RecallQuery.tenant reservation (multi-tenant keyspace seed)"
-status: proposed
+status: accepted
 date: "2026-04-17"
 phase: "Phase D — Wave 4A R3"
 deciders: ["@ThibautMelen"]
@@ -10,7 +10,7 @@ affects_crates: ["nika-types", "nika-kernel"]
 affects_layers: ["L0", "L0.5"]
 supersedes: []
 superseded_by: []
-related: ["ADR-028", "ADR-033", "ADR-034"]
+related: ["ADR-028", "ADR-030", "ADR-033", "ADR-034"]
 requires: ["ADR-028", "ADR-033"]
 enables: []
 amends: []
@@ -18,41 +18,75 @@ fci: ["FCI-035"]
 inv: []
 shadow_zones: []
 nika_codes: []
-timeline: "v0.81.0-alpha.4, Wave 4A R3 seed (prose pending Phase C)"
+timeline: "v0.81.0-alpha.4, Wave 4A R3 seed · prose authored + accepted 2026-07-12 (merged-code rule)"
 follow_ups:
-  - "Flesh out full rationale + alternatives during Phase C ADR prose sweep"
-  - "Define tenant-scoping semantics (required vs. default vs. wildcard) in the prose version"
+  - "Populate `tenant` from the execution context when multi-tenant recall ships (the field and the scoped constructor are wired; the writer is not)"
 ---
 
 # ADR-031: RecallQuery.tenant reservation (multi-tenant keyspace seed)
 
-> **STUB — prose pending Phase C.** Decision is load-bearing in code; this
-> file exists so vector 19 (adr-orphan-proposed) can surface it at day 31
-> and force full prose authoring.
+Status flipped `proposed → accepted` 2026-07-12 under the merged-code
+rule (the #474 ADR ruling): the decision is load-bearing in shipped
+code — `RecallQuery.tenant` exists, is mandatory, and every recall
+scope flows through it. The prose documents what IS, including where
+the shipped shape deliberately hardened beyond the original seed.
 
 ## Context
 
-Wave 4A R3 (commit `41e8a1467`, 2026-04-17) adds `tenant: Option<TenantId>`
-as a reserved field on `RecallQuery` (re-exported from `nika-kernel` via
-`nika-types`). The field lets v0.95 Cortex scope every recall by tenant
-without breaking consumers that ship at v0.8x with a single-tenant
-assumption.
+Wave 4A R3 (commit `41e8a1467`, 2026-04-17) reserved a tenant keyspace
+on `RecallQuery` so multi-tenant recall can ship later without a
+breaking change (ADR-028 reservation policy). The reservation exists so
+that a v0.8x consumer compiled against a single-tenant world keeps
+working the day a multi-tenant host arrives — and so that cross-tenant
+reads are structurally impossible rather than policy-forbidden.
 
-## Decision (preliminary)
+## Decision
 
-`RecallQuery.tenant` is `Option<TenantId>` where `None` = "use
-`TenantId::default_tenant()` (single-tenant mode)". When v0.95 multi-tenant
-support ships, the field becomes populated by the verb runtime from the
-execution context. Memory store impls MUST scope recall by this field to
-prevent cross-tenant read. Shield consumes the field to gate compliance
-(Category::Tenant rules). Full rationale (required vs. optional, wildcard
-semantics, tenant-ID format, migration path for single-tenant deployments)
-to be authored during Phase C ADR sweep before v0.90.
+- `RecallQuery` carries `pub tenant: TenantId`
+  (`nika-kernel-ai/src/memory.rs` — re-exported through `nika-kernel`)
+  — **mandatory, not `Option`**. The original seed sketched
+  `Option<TenantId>` with `None` = default; the shipped shape hardened:
+  an optional tenant invites every store impl to invent its own `None`
+  policy, which is exactly how cross-tenant leaks are born. Instead:
+  - `RecallQuery::new(…)` scopes to `TenantId::default_tenant()` —
+    single-tenant deployments use it and never think about the field;
+  - `RecallQuery::scoped(tenant, …)` is the multi-tenant constructor;
+  - every recall MUST scope by the field (the struct doc states the
+    contract; store impls return only same-tenant frames).
+- The struct is `#[non_exhaustive]` with constructor discipline
+  (FCI invariant #19), so later filters (the `observed_after/_before`
+  temporal pair rode in on the same shape) land without a major.
+
+## Alternatives considered
+
+- **`Option<TenantId>`, `None` = default tenant** (the seed's sketch) —
+  rejected at hardening: per-impl `None` policies are the leak vector;
+  a mandatory field with a defaulting constructor gives the same
+  single-tenant ergonomics with ONE policy instead of N.
+- **Tenant as a store-construction parameter only** — rejected: it
+  forces one store instance per tenant (hosts want pooled stores) and
+  removes the per-query audit trail.
+- **No reservation until multi-tenant ships** — rejected per ADR-028:
+  adding a mandatory field to a serialized, cross-layer query type
+  later is the breaking change the policy exists to prevent.
+
+## Empirical validation (what makes this "merged code")
+
+- `nika-kernel-ai/src/memory.rs` — the field with its mandatory-scope
+  contract in the struct docs, `new()` defaulting to
+  `TenantId::default_tenant()` (line 113), `scoped()` for multi-tenant
+  hosts (line 119).
+- `TenantId` lives beside the provider types (ADR-033's family) and
+  serializes with the query.
+- The mock kernel exercises the same shape — recall tests construct
+  queries through the defaulting constructor.
 
 ## See also
 
 - ADR-028 — Forward-compat reservation policy (this ADR is an instance).
-- ADR-033 — `TenantId` newtype + `default_tenant()` constant.
+- ADR-030 — `MemoryFrameRef.trust` (the sibling Wave 4A reservation —
+  trust gates what a recall may spotlight; tenant gates what it may see).
+- ADR-033 — `TenantId` newtype + `default_tenant()`.
 - ADR-034 — `MemoryStore::recall` signature (tenant flows through).
 - FCI-035 addendum — Wave 4A/4B reservation catalog.
 

--- a/docs/adr/adr-032-wasm-plugin-context.md
+++ b/docs/adr/adr-032-wasm-plugin-context.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-032
 title: "WasmPluginError OutOfFuel + Trap + PluginCallContext reservation"
-status: proposed
+status: accepted
 date: "2026-04-17"
 phase: "Phase D — Wave 4A R4"
 deciders: ["@ThibautMelen"]
@@ -10,7 +10,7 @@ affects_crates: ["nika-kernel", "nika-kernel-mock"]
 affects_layers: ["L0.5"]
 supersedes: []
 superseded_by: []
-related: ["ADR-020", "ADR-028", "ADR-033"]
+related: ["ADR-020", "ADR-028", "ADR-030", "ADR-033"]
 requires: ["ADR-020", "ADR-028"]
 enables: []
 amends: ["ADR-020"]
@@ -18,50 +18,82 @@ fci: ["FCI-035"]
 inv: []
 shadow_zones: []
 nika_codes: ["NIKA-700", "NIKA-701", "NIKA-702", "NIKA-703", "NIKA-704"]
-timeline: "v0.81.0-alpha.4, Wave 4A R4 seed (prose pending Phase C)"
+timeline: "v0.81.0-alpha.4, Wave 4A R4 seed · prose authored + accepted 2026-07-12 (merged-code rule)"
 follow_ups:
-  - "Flesh out full rationale + alternatives during Phase C ADR prose sweep"
-  - "Pin TrapKind enum closed vs. #[non_exhaustive] + discriminator strategy"
-  - "Decide caller_trust vs plugin_trust lattice propagation semantics in prose"
+  - "Wire real wasmtime fuel metering + trap mapping when the wasm host lands (v0.100 horizon) — the shapes are reserved, the engine is not"
 ---
 
 # ADR-032: WasmPluginError OutOfFuel + Trap + PluginCallContext reservation
 
-> **STUB — prose pending Phase C.** Decision is load-bearing in code; this
-> file exists so vector 19 (adr-orphan-proposed) can surface it at day 31
-> and force full prose authoring.
+Status flipped `proposed → accepted` 2026-07-12 under the merged-code
+rule (the #474 ADR ruling): all three reservations ship in
+`crates/nika-kernel-plugin/src/wasm.rs` (the kernel's plugin member —
+the ADR predates the kernel descent; `nika-kernel` re-exports). The
+stub's two open follow-ups were RESOLVED in the shipped code; the
+prose records those resolutions.
 
 ## Context
 
-Wave 4A R4 (commit `368820e42`, 2026-04-17) extends the WASM plugin stubs
-shipped under ADR-020 with three additive reservations in
-`crates/nika-kernel-plugin/src/wasm.rs`:
+Wave 4A R4 (commit `368820e42`, 2026-04-17) extended the WASM plugin
+stubs shipped under ADR-020 with three additive reservations, so the
+v0.100 wasmtime integration lands without breaking every v0.8x plugin
+consumer: a fuel-cancellation error, a structured trap surface, and a
+per-call context that carries trust + budgets.
 
-1. `WasmPluginError::OutOfFuel { fuel_consumed }` — fuel-based cancellation
-   variant, complementing the wall-clock `Timeout` variant.
-2. `WasmPluginError::Trap { kind: TrapKind }` — runtime trap surface
-   (out-of-memory, stack overflow, unreachable, division by zero, ...).
-3. `PluginCallContext { cancel, caller_trust, plugin_trust }` — per-call
-   context DTO replacing the previous bare-cancel argument; carries the
-   trust lattice of both the caller and the plugin for Shield gating.
+## Decision
 
-## Decision (preliminary)
+All three shapes are `#[non_exhaustive]`, shipped in
+`nika-kernel-plugin/src/wasm.rs`:
 
-All three additions are `#[non_exhaustive]`. The `TrapKind` enum is
-`#[non_exhaustive]` as well so wasmtime and wasmer can contribute
-engine-specific variants without breaking v0.8x consumers. `PluginCallContext`
-is the replacement for future `PluginCall` callsite evolution; the existing
-`cancel: CancelCtx` trait-method parameter continues to work during the
-transition. Full rationale (dual-timeout policy rationale, trap taxonomy,
-trust propagation model, fuel-budget default) to be authored during Phase
-C ADR sweep before v0.90.
+1. **`WasmPluginError::OutOfFuel { consumed, budget }`** — fuel-based
+   cancellation beside the wall-clock `Timeout`. The seed sketched a
+   single `fuel_consumed`; the shipped shape carries BOTH sides of the
+   ledger — an error that says how much was spent but not what was
+   allowed teaches nothing.
+2. **`WasmPluginError::Trap { kind: TrapKind }`** — guest-level aborts
+   (unreachable · divide-by-zero · stack overflow · …) distinct from
+   host errors. **Follow-up resolved**: `TrapKind` is
+   `#[non_exhaustive]`, mirroring wasmtime's `TrapCode` taxonomy at the
+   nika layer — engine-specific variants land without a major AND
+   without a direct wasmtime dep in L0.5.
+3. **`PluginCallContext { trust, input_trust, cancel, fuel_budget,
+   wall_timeout_ms }`** — the per-call DTO replacing the bare-cancel
+   argument. **Follow-up resolved**: the seed's `caller_trust` /
+   `plugin_trust` pair became `input_trust` (propagated from the verb
+   that constructed the call) and `trust` (granted to the plugin's
+   OUTPUT — lower than `input_trust` by host policy: plugin output is
+   always untrusted data regardless of what it was given, the ADR-030
+   sticky-taint model applied at the plugin boundary). Both budget
+   knobs ride the context (`None` = unmetered), so the dual-timeout
+   policy (fuel + wall) is per-call, not global.
+
+## Alternatives considered
+
+- **Single timeout (wall-clock only)** — rejected: wall time cannot
+  distinguish a slow host from a hot guest loop; fuel is deterministic
+  per-op and survives host load. Both ship.
+- **Closed `TrapKind` enum** — rejected (the stub's open question):
+  wasmtime/wasmer taxonomies evolve; a closed enum turns every new trap
+  class into a major.
+- **Trust pair as caller/plugin** (the seed's sketch) — rejected at
+  hardening: what gates downstream consumption is the trust of the
+  OUTPUT, not the identity of the caller; input/output naming states
+  the dataflow directly.
+
+## Empirical validation (what makes this "merged code")
+
+- `nika-kernel-plugin/src/wasm.rs` — `OutOfFuel` (line ~146), `Trap` +
+  `TrapKind` (lines ~162-192, with `Display`), `PluginCallContext`
+  (line ~217) with the untrusted-default constructor.
+- The reservations are exercised by the plugin trait's mock host in
+  `nika-kernel-mock` (the ADR-020 test seam).
 
 ## See also
 
-- ADR-020 — WASM plugin boundary + Sandbox. This ADR amends ADR-020's
-  trait surface with three additive reservations.
+- ADR-020 — WASM plugin boundary + Sandbox (amended by this ADR).
 - ADR-028 — Forward-compat reservation policy (this ADR is an instance).
-- ADR-033 — `TrustLevel` type used by `PluginCallContext`.
+- ADR-030 — sticky-taint trust model (applied here at the plugin edge).
+- ADR-033 — `TrustLevel` lattice used by `PluginCallContext`.
 - FCI-035 addendum — Wave 4A/4B reservation catalog.
 - NIKA-700..749 — WASM plugin error code range (reserved v0.80).
 

--- a/docs/adr/adr-035-telemetry-seams.md
+++ b/docs/adr/adr-035-telemetry-seams.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-035
 title: "Telemetry seams: SpanGuard parent_span_id + SpanRef (OTel-ready)"
-status: proposed
+status: accepted
 date: "2026-04-17"
 phase: "Phase D — Wave 4B #1"
 deciders: ["@ThibautMelen"]
@@ -18,52 +18,73 @@ fci: ["FCI-035"]
 inv: []
 shadow_zones: []
 nika_codes: ["NIKA-800", "NIKA-801", "NIKA-802", "NIKA-803", "NIKA-804"]
-timeline: "v0.81.0-alpha.4, Wave 4B #1 seed (prose pending Phase C)"
+timeline: "v0.81.0-alpha.4, Wave 4B #1 seed · prose authored + accepted 2026-07-12 (merged-code rule)"
 follow_ups:
-  - "Flesh out full rationale + alternatives during Phase C ADR prose sweep"
-  - "Finalise SpanRef vs SpanContext (OTel term) naming when nika-observability-otel lands v0.100"
-  - "Verify W3C trace-context inject/extract bridges cleanly off this surface"
+  - "Finalise SpanRef vs SpanContext (OTel term) naming when an OTel bridge crate lands — note the OTLP need was meanwhile served by `nika trace export` (nika-dap/src/otel.rs), projection-side"
 ---
 
 # ADR-035: Telemetry seams: SpanGuard parent_span_id + SpanRef (OTel-ready)
 
-> **STUB — prose pending Phase C.** Decision is load-bearing in code; this
-> file exists so vector 19 (adr-orphan-proposed) can surface it at day 31
-> and force full prose authoring.
+Status flipped `proposed → accepted` 2026-07-12 under the merged-code
+rule (the #474 ADR ruling): both reservations ship in
+`crates/nika-kernel-core/src/infra/trace.rs` (the kernel's core member
+— the ADR predates the kernel descent; `nika-kernel` re-exports).
 
 ## Context
 
-Wave 4B #1 (commit `861f09bc9`, 2026-04-17) extends the kernel telemetry
-types at `crates/nika-kernel-core/src/infra/trace.rs` with two additive
-reservations:
+Wave 4B #1 (commit `861f09bc9`, 2026-04-17) extended the kernel
+telemetry types with two additive reservations so span identity can
+travel — across await points, channels, spawned tasks — without a
+thread-local stack (which the tokio runtime breaks) and without
+cloning a live guard.
 
-1. `SpanGuard.parent_span_id: Option<SpanId>` — explicit parent link so
-   nested spans can be stitched into a tree without relying on a
-   thread-local stack (which the tokio runtime breaks).
-2. `SpanRef { trace_id, span_id }` — lightweight copyable handle that lets
-   callers propagate span identity across channel boundaries (tokio::mpsc
-   SendError consumers, spawned tasks, cross-process IPC) without cloning
-   the full `SpanGuard`.
+## Decision
 
-Both additions are designed to bridge into OpenTelemetry's
-`SpanContext` at v0.100 without any v0.8x-breaking change.
+Both shapes ship in `nika-kernel-core/src/infra/trace.rs`:
 
-## Decision (preliminary)
+1. **`SpanGuard.parent_span_id: Option<SpanId>`** — the explicit
+   parent link. Nested spans stitch into a tree by data, not by
+   ambient state: the module doc states the law (« parent_span_id
+   threads parent→child links »), and the field is `Option` because a
+   root span honestly has no parent — this is the one place an absent
+   value IS the semantics, not a policy hole.
+2. **`SpanRef { trace_id, span_id }`** — the lightweight copyable
+   handle (with `::new()`, FCI #19) for propagating span identity
+   across boundaries where a `SpanGuard` cannot go: channel payloads,
+   spawn captures, cross-process IPC. The shape deliberately mirrors
+   OTel's `SpanContext` so a future bridge is a field-for-field map.
 
-`SpanGuard` gains `parent_span_id: Option<SpanId>` behind
-`#[non_exhaustive]`. `SpanRef` is a new `#[non_exhaustive]` struct with
-a `::new()` constructor and `Copy`-able inner IDs. The types intentionally
-mirror OTel's `SpanContext` shape so the v0.100 `nika-observability-otel`
-crate can implement a zero-copy bridge. Full rationale (tree-stitching
-rationale, W3C trace-context compatibility, SpanRef vs SpanContext naming,
-copy semantics, ID-gen ownership) to be authored during Phase C ADR sweep
-before v0.90.
+Both are `#[non_exhaustive]` — OTel's `TraceFlags`/`TraceState` can
+join `SpanRef` later without a major.
+
+## Alternatives considered
+
+- **Thread-local span stack** — rejected: tokio task migration breaks
+  ambient parenting; the explicit field survives every executor.
+- **Clone the `SpanGuard` across boundaries** — rejected: a guard's
+  Drop is its END event; two owners means double-close or leaked
+  spans. A `Copy`-able ref carries identity without lifecycle.
+- **Adopt the `opentelemetry` crate types directly in L0.5** —
+  rejected: the kernel stays zero-heavy-deps; mirroring the SHAPE
+  keeps the bridge zero-copy while the dependency stays out.
+
+## Empirical validation (what makes this "merged code")
+
+- `nika-kernel-core/src/infra/trace.rs` — `SpanRef` (line ~21, with
+  constructor), `parent_span_id: Option<SpanId>` on `SpanGuard`
+  (line ~49), module-doc law at the top.
+- The OTel direction the reservation aimed at materialized
+  projection-side meanwhile: `nika trace export`
+  (`nika-dap/src/otel.rs`) projects recorded journals to OTLP/JSON —
+  consuming the same span-identity vocabulary these types reserved.
 
 ## See also
 
 - ADR-028 — Forward-compat reservation policy (this ADR is an instance).
-- ADR-034 — `TracerProvider` trait that will emit `SpanRef` instances.
+- ADR-034 — the tracer trait family that emits these shapes.
 - FCI-035 addendum — Wave 4A/4B reservation catalog.
-- NIKA-800..819 — Observability / telemetry error code range (reserved v0.80).
+- NIKA-800..819 — Observability / telemetry error code range (reserved
+  v0.80).
+- `nika trace export` — the shipped OTLP projection (journal-side).
 
 🦋


### PR DESCRIPTION
Continuation of #540 (ADR-030): the three remaining 85-day stubs, each **verified at the code before its flip** (the #474 rule), each prose recording where the shipped shape HARDENED past its seed:

- **ADR-031** — `RecallQuery.tenant` is **mandatory** (not the seed's `Option`): per-impl `None` policies are the cross-tenant leak vector; `new()` defaults to `default_tenant` (memory.rs:113), `scoped()` is the multi-tenant door (:119).
- **ADR-032** — `OutOfFuel {consumed, budget}` carries both ledger sides; the seed's caller/plugin trust pair became **input/OUTPUT trust** (plugin output always untrusted — ADR-030 sticky taint at the plugin edge); `TrapKind` `#[non_exhaustive]` resolves the stub's open follow-up.
- **ADR-035** — `parent_span_id` threads the span tree by data (tokio breaks ambient parenting); `SpanRef` mirrors OTel `SpanContext` for the zero-copy bridge; the OTLP need meanwhile shipped projection-side (`nika trace export`).

**Deliberately NOT flipped** (the same rule, other direction): ADR-036 (its open questions — cadence formula · resolver 3 · `rust-version` fields — are neither resolved nor built; only the pre-existing toolchain pin lives) and the memory-stack designs 039-042/078-081 (their crates are not in the workspace yet — honestly proposed is their correct state).

`adr-orphan-proposed`: **12 → 9** · `check-adr-schema` 67 ADRs 0 errors · `check-adr-evidence` 167 paths OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)