### PR TITLE
fix(cli): the budget guard holds on both doors

### DIFF
--- a/crates/nika-cli/src/examples_args.rs
+++ b/crates/nika-cli/src/examples_args.rs
@@ -51,8 +51,11 @@ pub(crate) enum ExamplesAction {
         #[arg(long)]
         no_progress: bool,
         /// Refuse to start if the static cost floor exceeds this (USD);
-        /// metered spend aborts past it mid-run.
-        #[arg(long, value_name = "USD")]
+        /// metered spend aborts past it mid-run. Same guard, same
+        /// parser as `nika run` — a NaN/inf here would silently disarm
+        /// the budget (every comparison false), the exact class the
+        /// parser exists to kill.
+        #[arg(long, value_name = "USD", value_parser = crate::parse_budget_usd)]
         max_cost_usd: Option<f64>,
     },
 }

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -579,7 +579,7 @@ struct RunArgs {
 /// or `inf` would make every comparison false and silently DISARM the
 /// guard the operator believes is armed (the exact silent-no-protection
 /// class the budget exists to kill).
-fn parse_budget_usd(raw: &str) -> Result<f64, String> {
+pub(crate) fn parse_budget_usd(raw: &str) -> Result<f64, String> {
     let value: f64 = raw.parse().map_err(|e| format!("not a number: {e}"))?;
     if !value.is_finite() || value < 0.0 {
         return Err(format!(
@@ -1285,6 +1285,53 @@ mod tests {
     /// agent will never reach (inherited from the stalled 2026-07-05
     /// field-fixes branch: the scaffold then taught zero of the new
     /// train). Derived from the tree itself so it can never lag again.
+    /// The budget guard is ONE guard on both doors: `run` and
+    /// `examples run` share `parse_budget_usd`, so a NaN/inf (which
+    /// silently disarms every comparison) refuses at parse time on
+    /// BOTH — the drift where one door validated and the other let
+    /// the disarmed value through is pinned shut.
+    #[test]
+    fn the_budget_guard_holds_on_both_doors() {
+        for argv in [
+            vec!["nika", "run", "wf.nika.yaml", "--max-cost-usd", "nan"],
+            vec![
+                "nika",
+                "examples",
+                "run",
+                "01-hello",
+                "--max-cost-usd",
+                "nan",
+            ],
+            vec!["nika", "run", "wf.nika.yaml", "--max-cost-usd", "inf"],
+            vec![
+                "nika",
+                "examples",
+                "run",
+                "01-hello",
+                "--max-cost-usd",
+                "-1",
+            ],
+        ] {
+            assert!(
+                Cli::try_parse_from(&argv).is_err(),
+                "{argv:?} must refuse at parse time"
+            );
+        }
+        for argv in [
+            vec!["nika", "run", "wf.nika.yaml", "--max-cost-usd", "0.05"],
+            vec![
+                "nika",
+                "examples",
+                "run",
+                "01-hello",
+                "--max-cost-usd",
+                "0.05",
+            ],
+        ] {
+            assert!(Cli::try_parse_from(&argv).is_ok(), "{argv:?} must parse");
+        }
+    }
+
     #[test]
     fn the_scaffolded_agents_md_teaches_the_live_clap_tree() {
         let agents = nika_cli::verbs::init::agents_md();


### PR DESCRIPTION
## The catch (SOTA Rams audit · flag-twin validation-drift class · HIGH)

`nika run` guards `--max-cost-usd` with `parse_budget_usd` — a NaN/inf makes every comparison false and **silently disarms** the guard (the parser's own doc names this class). `nika examples run` declared the same flag as a bare `Option<f64>`:

```
$ nika examples run 01-hello --model mock/echo --max-cost-usd nan
⚠ --max-cost-usd NaN: … the budget bounds METERED spend only …
  ✔  greet  infer · mock/echo  0ms          ← ran, guard disarmed
$ nika run wf.yaml --max-cost-usd nan
error: invalid value 'nan' … (got nan)      ← refused
```

## One guard, both doors

`parse_budget_usd` goes `pub(crate)`, `examples_args` attaches it, and a parse-time pin holds nan/inf/-1 refused + 0.05 accepted on BOTH surfaces forever. Proven live post-fix: `examples run … nan` → `error: invalid value`.

Proof: 7 bin tests green (incl. the both-doors pin) · clippy `-D warnings` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)