### PR TITLE
fix(workspace): unreachable earns its gate — and the mirror loses its traversal edge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ expect_used    = "warn"
 panic          = "deny"
 todo           = "warn"
 unimplemented  = "warn"
+unreachable    = "warn"
 dbg_macro      = "deny"
 # Iterating a HashMap/HashSet is ordering-nondeterminism by construction —
 # poison for an engine whose outputs, manifests and goldens must be

--- a/crates/nika-builtin/src/lib.rs
+++ b/crates/nika-builtin/src/lib.rs
@@ -26,7 +26,15 @@
 //! reaching this crate MEANS the call came from a standalone `invoke:`.
 
 #![forbid(unsafe_code)]
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable
+    )
+)]
 
 pub(crate) mod chart;
 pub mod core_tools;

--- a/crates/nika-cel/src/compute.rs
+++ b/crates/nika-cel/src/compute.rs
@@ -261,7 +261,10 @@ fn eval_rel(
         RelOp::Eq => equals(&a, &b, span)?,
         RelOp::Ne => !equals(&a, &b, span)?,
         RelOp::Lt | RelOp::Le | RelOp::Gt | RelOp::Ge => order(op, &a, &b, span)?,
-        RelOp::In => unreachable!("handled above"),
+        // In is dispatched to `membership` before this match — a
+        // fall-through here is a dispatcher regression, fail loud.
+        #[allow(clippy::unreachable, reason = "In handled by the dispatcher above")]
+        RelOp::In => unreachable!("RelOp::In must be dispatched to membership"),
     };
     Ok(Value::Bool(result))
 }
@@ -341,7 +344,11 @@ fn order(op: RelOp, a: &Value, b: &Value, span: (usize, usize)) -> Result<bool, 
         RelOp::Le => ord.is_le(),
         RelOp::Gt => ord.is_gt(),
         RelOp::Ge => ord.is_ge(),
-        _ => unreachable!(),
+        #[allow(
+            clippy::unreachable,
+            reason = "order() is only called for the four ordering ops"
+        )]
+        _ => unreachable!("order() called with a non-ordering RelOp"),
     })
 }
 

--- a/crates/nika-chart/examples/fuzz_deep.rs
+++ b/crates/nika-chart/examples/fuzz_deep.rs
@@ -3,6 +3,7 @@
 //! specs; every case must either compile cleanly (then double-render
 //! byte-eq) or fail with a TYPED error. Panics = the only real failure.
 #![allow(
+    clippy::unreachable,
     clippy::expect_used,
     clippy::unwrap_used,
     clippy::indexing_slicing,

--- a/crates/nika-chart/tests/fuzz_lite.rs
+++ b/crates/nika-chart/tests/fuzz_lite.rs
@@ -3,6 +3,7 @@
 //! specs; every case must either compile cleanly (then double-render
 //! byte-eq) or fail with a TYPED error. Panics = the only real failure.
 #![allow(
+    clippy::unreachable,
     clippy::expect_used,
     clippy::unwrap_used,
     clippy::indexing_slicing,

--- a/crates/nika-cli/src/lib.rs
+++ b/crates/nika-cli/src/lib.rs
@@ -16,7 +16,10 @@
 //! later own that name as a <500-LOC wrapper over this surface.
 
 #![forbid(unsafe_code)]
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)
+)]
 
 // The display surface DESCENDED to `nika-display` (2026-07-10 · the 15k
 // wall · nika-dap/nika-cap precedent) — re-exported at the old paths so

--- a/crates/nika-cli/src/verbs/graph.rs
+++ b/crates/nika-cli/src/verbs/graph.rs
@@ -140,8 +140,11 @@ pub fn project(wf: &RawWorkflow, report: &CheckReport) -> GraphDoc {
                         kind: "expression",
                         count: None,
                     },
+                    #[allow(
+                        clippy::unreachable,
+                        reason = "non_exhaustive future variant — enum and projector ship together; fail loud beats silently-wrong output"
+                    )]
                     other => {
-                        // #[non_exhaustive]: refuse silently-wrong output.
                         unreachable!("unknown for_each form: {other:?}")
                     }
                 }),
@@ -155,8 +158,10 @@ pub fn project(wf: &RawWorkflow, report: &CheckReport) -> GraphDoc {
                     OnErrorAction::Recover(_) => "recover",
                     OnErrorAction::Skip => "skip",
                     OnErrorAction::FailWorkflow => "fail_workflow",
-                    // #[non_exhaustive]: refuse silently-wrong output (the
-                    // for_each precedent — enum and binary ship together).
+                    #[allow(
+                        clippy::unreachable,
+                        reason = "non_exhaustive future variant — enum and projector ship together; fail loud beats silently-wrong output"
+                    )]
                     other => unreachable!("unknown on_error action: {other:?}"),
                 }),
                 outputs: task.output.iter().map(|(k, _)| k.value.clone()).collect(),
@@ -213,8 +218,10 @@ fn action_facts(
                 .map(|m| m.value.clone())
                 .or_else(|| default_model.map(str::to_owned)),
         ),
-        // #[non_exhaustive]: a future verb must teach this projector its
-        // name before it can be drawn.
+        #[allow(
+            clippy::unreachable,
+            reason = "non_exhaustive future verb — it must teach this projector its name before it can be drawn"
+        )]
         other => unreachable!("unknown verb: {other:?}"),
     }
 }

--- a/crates/nika-cli/src/verbs/wire.rs
+++ b/crates/nika-cli/src/verbs/wire.rs
@@ -149,7 +149,11 @@ fn wire_one(target: WireTarget, dir: &str) -> Result<WireAction, String> {
             "junie",
             false,
         ),
-        WireTarget::All => unreachable!("expanded before dispatch"),
+        #[allow(
+            clippy::unreachable,
+            reason = "All is expanded to concrete targets before dispatch"
+        )]
+        WireTarget::All => unreachable!("WireTarget::All must be expanded before dispatch"),
     }
 }
 

--- a/crates/nika-dap/src/lib.rs
+++ b/crates/nika-dap/src/lib.rs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
-#![cfg_attr(test, allow(clippy::expect_used, clippy::panic, clippy::unwrap_used))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unwrap_used,
+        clippy::unreachable
+    )
+)]
 
 //! `nika dap` — the Debug Adapter Protocol server (replay sessions).
 //!

--- a/crates/nika-models/src/pull.rs
+++ b/crates/nika-models/src/pull.rs
@@ -204,8 +204,19 @@ pub(crate) fn tokenizer_entry(entries: &[TreeEntry]) -> Option<&TreeEntry> {
 
 /// The file name of a repo path (`sub/dir/w.gguf` → `w.gguf`) — the
 /// basename ONLY ever reaches the disk (repo paths are remote input).
+/// A basename carrying `\\` or spelling `..` is REJECTED to a fixed
+/// name: on Windows `Path::join` treats `\\` as a separator, so a
+/// crafted tree entry like `x\\..\\evil.gguf` (ends `.gguf`, no `/`)
+/// would otherwise escape the models dir. Unix never splits on `\\`,
+/// so the same law on both platforms costs nothing and closes the
+/// mirror-controlled traversal edge.
 fn file_name(repo_path: &str) -> &str {
-    repo_path.rsplit('/').next().unwrap_or(repo_path)
+    let base = repo_path.rsplit('/').next().unwrap_or(repo_path);
+    if base.contains('\\') || base == ".." {
+        "rejected-remote-name"
+    } else {
+        base
+    }
 }
 
 /// Does a remote-supplied string shape as a Hub `owner/repo` id?
@@ -779,6 +790,19 @@ mod tests {
     use super::*;
 
     // -- the tokenizer borrow (base_model fallback) ----------------------
+
+    /// The basename law holds on remote tree paths: `/` splits, a
+    /// backslash basename (the Windows `Path::join` separator — the
+    /// mirror-controlled traversal edge) rejects to a fixed name, and
+    /// `..` never reaches a join.
+    #[test]
+    fn file_name_takes_the_basename_and_rejects_traversal_shapes() {
+        assert_eq!(file_name("sub/dir/w.gguf"), "w.gguf");
+        assert_eq!(file_name("w.gguf"), "w.gguf");
+        assert_eq!(file_name("x\\..\\evil.gguf"), "rejected-remote-name");
+        assert_eq!(file_name("a/.."), "rejected-remote-name");
+        assert_eq!(file_name("tokenizer.json"), "tokenizer.json");
+    }
 
     #[test]
     fn valid_repo_id_admits_hub_ids_and_drops_crafted_ones() {


### PR DESCRIPTION
SOTA hardening sweep — the two real findings (everything else came back clean: 0 unwrap/expect/panic outside tests across 517 files · 0 unsafe · every remote parse size-capped · all wire arithmetic saturating):

## The gate gap

`clippy::unreachable` is a restriction lint (allow-by-default) — neither the lint table nor `-D warnings` saw the 6 `unreachable!` in production src. The house law said zero; nothing enforced it. **`unreachable = "warn"` joins the workspace lint table** (promoted to deny by the CI wrapper, like todo/unimplemented). The six sites earn documented carve-outs:

- nika-cel's two dispatcher-regression arms — the bare `unreachable!()` now carries a message (an arm that fires mute teaches nothing);
- the four `non_exhaustive` future-variant arms in graph/wire — fail-loud beats silently-wrong output, the `reason=` states it.

Test scope rides the existing per-crate `cfg_attr` allow blocks (nika-cli · nika-dap · nika-builtin) + the two fuzz-harness file headers — no per-site noise.

## The traversal edge

`nika-models` `file_name()` split on `/` only — but Windows `Path::join` also splits on backslash, so a crafted Hub tree entry like `x\..\evil.gguf` (ends `.gguf`, contains no `/`) would escape the models dir on a Windows home (`USERPROFILE` is supported). A basename carrying `\` or spelling `..` rejects to a fixed name — same law both platforms, **pinned** (traversal shapes reject · honest basenames pass).

Proof: workspace clippy `-D warnings` **0** under the new gate · nika-cel 58 + nika-models 46 + nika-cli 275 + nika-chart 92 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)