### PR TITLE
feat(nika-lsp): the pause after the colon answers itself — space joins the triggers

### DIFF
--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -558,6 +558,16 @@ mod tests {
         );
     }
 
+    /// The space trigger's cost contract — ` ` is a trigger character
+    /// (capabilities.rs), so a space anywhere in running prose fires a
+    /// request; this pins that a non-value space answers EMPTY, keeping
+    /// the trigger free inside prompt blocks and plain text.
+    #[test]
+    fn a_space_in_running_prose_offers_nothing() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer:\n      prompt: |\n        Summarize the following ";
+        assert!(completion(text, text.len()).is_empty());
+    }
+
     /// `tool: ` offers the full catalog-derived `nika:*` set — and the
     /// count IS the catalog's (the born-stale gate: a builtin added to
     /// the catalog appears here with zero LSP edits).

--- a/crates/nika-lsp/src/capabilities.rs
+++ b/crates/nika-lsp/src/capabilities.rs
@@ -27,9 +27,19 @@ pub fn server_capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
         hover_provider: Some(true.into()),
         completion_provider: Some(CompletionOptions {
-            // auto-trigger on `.` (for `tasks.`), `/` (for `provider/`) and
-            // `[` (for `depends_on: [`) — plus the normal identifier triggers
-            trigger_characters: Some(vec![".".to_owned(), "/".to_owned(), "[".to_owned()]),
+            // auto-trigger on `.` (for `tasks.`), `/` (for `provider/`),
+            // `[` (for `depends_on: [`) and ` ` — the pause after a value
+            // colon (`tool: ` · `model: ` · `capture: `) is the exact
+            // moment an author asks "what goes here?", and clients only
+            // re-pop on word characters, so without the space trigger
+            // every value lane waits for a manual ctrl+space. Non-value
+            // spaces answer with an empty list (pinned cheap by test).
+            trigger_characters: Some(vec![
+                ".".to_owned(),
+                "/".to_owned(),
+                "[".to_owned(),
+                " ".to_owned(),
+            ]),
             ..CompletionOptions::default()
         }),
         definition_provider: Some(OneOf::Left(true)),
@@ -75,17 +85,22 @@ mod tests {
     }
 
     #[test]
-    fn completion_advertises_the_dot_slash_and_bracket_trigger_characters() {
-        // The completion provider must declare `.`, `/` and `[` as trigger
-        // characters (for `tasks.`, `provider/` and `depends_on: [`).
+    fn completion_advertises_the_trigger_characters() {
+        // `.` (tasks.), `/` (provider/), `[` (depends_on: [) and ` ` —
+        // the pause after a value colon, where every value lane lives.
         // Dropping the field would silently disable trigger-character
         // completion in clients.
         let caps = server_capabilities();
         let completion = caps.completion_provider.expect("completion provider");
         assert_eq!(
             completion.trigger_characters,
-            Some(vec![".".to_owned(), "/".to_owned(), "[".to_owned()]),
-            "exactly `.`, `/` and `[` as triggers"
+            Some(vec![
+                ".".to_owned(),
+                "/".to_owned(),
+                "[".to_owned(),
+                " ".to_owned(),
+            ]),
+            "exactly `.`, `/`, `[` and ` ` as triggers"
         );
     }
 


### PR DESCRIPTION
## What

Every value lane the LSP now owns (`tool: ` · `model: ` · `capture: ` · `nika: ` · `type: `) fires on the space after the colon — but clients only auto-pop on **word characters**, so the exact moment an author pauses to ask "what goes here?" showed nothing until a manual ctrl+space. ` ` joins the trigger characters (`.` `/` `[`) and fills that dead moment. Zero client change needed — trigger chars ride the initialize response.

## The cost contract

A space fires a request from anywhere, including prompt blocks — so the promise is pinned:

- **probed first**: completion mid-`prompt: |` prose → `[]`
- **then locked**: `a_space_in_running_prose_offers_nothing` law test

The trigger is free where it doesn't teach.

140/140 nika-lsp lib · clippy -D warnings 0 · zero new pub items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
