### PR TITLE
feat(release): the sovereign lane ships whole — local-infer on every target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,13 @@ jobs:
             ~/.cargo/git
             target
           key: release-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
-      - name: Build nika-cli (release · locked)
-        run: cargo build --release --locked --bin nika-cli --target ${{ matrix.target }}
+      - name: Build nika-cli (release · locked · sovereign lane whole)
+        # `local-infer` on every target (#518 ruling · option A-CPU): the
+        # shipped binary pulls AND serves — measured +2.4 MB. CPU on
+        # purpose, darwin included: candle 0.10's quantized rms-norm Metal
+        # kernel is broken, so `--features metal` ships a lane that dies
+        # at first token. Revisit when candle fixes the kernel.
+        run: cargo build --release --locked --bin nika-cli --target ${{ matrix.target }} --features local-infer
       - name: Sign + notarize (macOS)
         # Gatekeeper-trust the binary so browser-downloads do not show
         # "unidentified developer". SAFETY: continue-on-error is MANDATORY —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Added
+
+- **The sovereign lane ships whole** (#518 · the release ruling,
+  executed) — every release binary now carries `local-infer`: `nika
+  model pull` → `nika model serve` → workflow `infer` against your own
+  machine, no cloud, no external daemon, no build-from-source wall.
+  Measured +2.4 MB. CPU on every target on purpose (darwin included):
+  candle 0.10's quantized rms-norm Metal kernel is broken — a metal
+  lane would die at first token. The funnel now pins the teaching:
+  a feature-carrying binary must never utter « built without local
+  inference ».
+
 ## [0.100.0](https://github.com/supernovae-st/nika/compare/v0.99.0..v0.100.0) - 2026-07-12
 
 ### Added

--- a/scripts/ci/funnel-e2e.sh
+++ b/scripts/ci/funnel-e2e.sh
@@ -159,5 +159,22 @@ else
   say "── mcp-http leg skipped (no curl on this runner)"
 fi
 
+# 5 · the sovereign lane ships whole (#518 · release ruling A-CPU):
+# a release binary carries local-infer — it must NEVER utter the
+# build-from-source refusal. Offline: a header-only fake GGUF passes
+# model resolution; the refusal we then expect is the POST-feature
+# teaching (tokenizer), never « built without local inference ».
+if has_cmd model; then
+  run doctor-sidecar 0 -- "$BIN" doctor
+  need doctor-sidecar "local inference built in"
+  mkdir -p "$HOME_DIR/.nika/models/probe/Probe-GGUF"
+  printf 'GGUF\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+    >"$HOME_DIR/.nika/models/probe/Probe-GGUF/probe-Q8_0.gguf"
+  run serve-refusal 3 -- "$BIN" model serve --model probe/Probe-GGUF
+  if printf '%s' "$OUT" | grep -qF "built without local inference"; then
+    fail "[serve] the shipped binary lacks the sovereign lane (#518)"
+  fi
+fi
+
 say "── funnel e2e: FAILS=$FAILS"
 exit $((FAILS > 0))


### PR DESCRIPTION
## The #518 ruling, executed (option A-CPU — the measured reco)

The release matrix builds `--features local-infer` on all four targets: the shipped binary **pulls AND serves**. `nika model pull X` → `nika model serve --model X` → workflow `infer` against your own machine — no cloud, no external daemon, no build-from-source wall. CPU on darwin **on purpose**: candle 0.10's quantized rms-norm Metal kernel is broken — a metal lane dies at first token (revisit on candle fix).

## Proof (local release build · 8m40s)

- `model serve` loads the real Qwen3 GGUF and answers `/health` → `{"status":"ok"}`; teaches the workflow wire (`NIKA_LLAMACPP_BASE_URL` + `model: llamacpp/…`).
- `doctor` grows the sidecar row — `✔ sidecar · local inference built in` (a BUILD fact).
- Size: 18M → 22M on disk (debuginfo profile; #518 measured +2.4 MB stripped).

## The funnel pins it — both directions

New leg (offline · milliseconds): `doctor` must say **« local inference built in »**, and `model serve` over a header-only fake GGUF (passes resolution, fails post-feature) must refuse with the **tokenizer teaching**, never « built without local inference ».

- featured build → `FAILS=0` ✓
- 0.100.0 baseline (no feature) → `FAILS=2`, exactly the two new asserts ✓ (the gate can't lie)

Docker inherits (image = the same tarballs, never a rebuild). Closes #518 — the last release ruling. This is the 0.101 wave's headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
