### PR TITLE
docs(cli): one word for the machine surface — projection

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -122,7 +122,7 @@ enum Command {
     /// Offline · presence-only · always exit 0 — a greeting, not a gate.
     #[command(display_order = 40)]
     Welcome {
-        /// Emit the versioned machine mirror (`welcome_version: 1`).
+        /// Emit the versioned machine projection (`welcome_version: 1`).
         #[arg(long)]
         json: bool,
         /// The whole workspace truth (every workflow audited · recent
@@ -142,7 +142,7 @@ enum Command {
         /// Omitted with exactly one workflow here → that one is audited.
         #[arg(num_args = 0..)]
         files: Vec<String>,
-        /// Emit the machine-readable report (never coloured).
+        /// Emit the versioned machine projection (`report_version: 1`).
         #[arg(long)]
         json: bool,
         /// Print an inferred `permits:` boundary instead of the report.
@@ -199,7 +199,7 @@ enum Command {
         /// An error code (`NIKA-440` · bare `440` · `DAG-003`) or a
         /// workflow file path (`*.nika.yaml` · `-` reads stdin).
         code: String,
-        /// File form only: emit the versioned machine twin
+        /// File form only: emit the versioned machine projection
         /// (`explain_version: 1` · the check report's own vocabulary).
         #[arg(long)]
         json: bool,
@@ -217,7 +217,7 @@ enum Command {
         /// 300ms cap · nothing is sent on the socket). Offline without it.
         #[arg(long)]
         ping: bool,
-        /// Emit the findings as JSON (summary + findings[] · agents/CI
+        /// Emit the machine projection (summary + findings[] — agents/CI
         /// branch on `summary.fail` instead of parsing glyphs).
         #[arg(long)]
         json: bool,


### PR DESCRIPTION
The last easy MED from the SOTA Rams audit: the `--json` help spoke **three nouns for one concept** (mirror · twin · projection) plus two off-pattern forms (« machine-readable report (never coloured) » · « as JSON »).

One voice now, catalog's form as the model: **« Emit the versioned machine projection (`<verb>_version: 1`) »** — every version key **verified on the real wire** before writing it (`welcome_version` · `report_version` · `explain_version` · `catalog_version`). `doctor` carries no version key, so its line says « machine projection » without the versioned claim — the help never promises what the wire does not carry. The lone « never coloured » caveat dies: true everywhere, said nowhere.

(`context`'s old « aggregate » phrasing was already gone — folded into `welcome --deep` by #489.)

Proof: 7 bin tests green · clippy `-D warnings` 0 · help-text only, zero behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)