### PR TITLE
feat(nika-lsp): the file teaches itself — args, modes, members, self, cards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3977,6 +3977,7 @@ dependencies = [
  "lsp-types",
  "nika-catalog",
  "nika-schema",
+ "nika-types",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -12,6 +12,7 @@ publish                = false  # Internal L4 interface crate (driven by the `ni
 
 [dependencies]
 nika-catalog = { path = "../nika-catalog", version = "0.101.0", features = ["builtins-transforms", "providers"] } # the tool/model vocabulary completions derive from (born-stale law: never hand-tabled)
+nika-types   = { path = "../nika-types", version = "0.101.0" }  # ExtractMode::ALL — the mode: lane derives from the L0 vocabulary
 nika-schema = { path = "../nika-schema", version = "0.101.0" }  # parse + the ADR-092 check ladder + RawWorkflow (the analysis source)
 lsp-server  = { workspace = true }                             # sync stdio JSON-RPC message loop
 lsp-types   = { workspace = true }                             # LSP 3.17 protocol types

--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -51,6 +51,7 @@ impl<T> nika_error::traits::AsAny for nika_lsp::analysis::document::Document whe
 pub fn nika_lsp::analysis::document::Document::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub mod nika_lsp::analysis::hover
 pub fn nika_lsp::analysis::hover::hover(text: &str, offset: usize) -> core::option::Option<lsp_types::hover::Hover>
+pub mod nika_lsp::analysis::members
 pub mod nika_lsp::analysis::position
 pub struct nika_lsp::analysis::position::LineIndex
 impl nika_lsp::analysis::position::LineIndex
@@ -90,6 +91,7 @@ impl<T> dyn_clone::DynClone for nika_lsp::analysis::position::LineIndex where T:
 pub fn nika_lsp::analysis::position::LineIndex::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_lsp::analysis::position::LineIndex where T: 'static
 pub fn nika_lsp::analysis::position::LineIndex::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub mod nika_lsp::analysis::scope
 pub mod nika_lsp::analysis::symbols
 pub fn nika_lsp::analysis::symbols::document_symbols(text: &str) -> alloc::vec::Vec<lsp_types::document_symbols::DocumentSymbol>
 pub mod nika_lsp::analysis::vocab

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -25,6 +25,8 @@
 use lsp_types::{CompletionItem, CompletionItemKind};
 use nika_schema::{FileId, ParseMode, parse};
 
+use super::members;
+use super::scope;
 use super::vocab::{self, Entry};
 
 /// Compute completion items for the cursor at `offset` in `text`.
@@ -45,17 +47,33 @@ pub fn completion(text: &str, offset: usize) -> Vec<CompletionItem> {
     if is_tool_value(prefix) {
         return builtin_tools();
     }
+    // `mode:` inside a `nika:fetch` block — the stdlib extract vocabulary
+    // (L0-derived). Contextual: a `mode:` argument of some OTHER tool
+    // (an MCP tool with its own vocabulary) stays silent.
+    if is_extract_mode_value(text, offset, prefix) {
+        return extract_mode_items();
+    }
     if let Some(items) = enum_values(prefix) {
         return items;
     }
     if in_open_depends_on(text, offset) || is_template_tasks_ref(prefix) {
-        return task_ids(text);
+        return task_ids(text, scope::current_task_id(text, offset).as_deref());
+    }
+    if let Some(root) = members::template_member_root(prefix) {
+        return members::member_items(text, root);
     }
     if is_expression_post_dot(prefix) {
         return cel_methods();
     }
     if is_expression_start(prefix) {
         return expression_roots();
+    }
+    // A bare key inside `args:` of a KNOWN builtin — that tool's own
+    // argument names, required ones floated first (catalog-derived).
+    if scope::in_args_key_position(text, offset)
+        && let Some(items) = builtin_arg_keys(text, offset)
+    {
+        return items;
     }
     if is_top_level_key(prefix) {
         return keyword_items(vocab::TOP_LEVEL_KEYS);
@@ -409,6 +427,82 @@ fn enum_values(prefix: &str) -> Option<Vec<CompletionItem>> {
     None
 }
 
+/// `mode: ` inside a `nika:fetch` invoke block — one token typed at most.
+fn is_extract_mode_value(text: &str, offset: usize, prefix: &str) -> bool {
+    let trimmed = prefix.trim_start();
+    let Some(rest) = trimmed.strip_prefix("mode:") else {
+        return false;
+    };
+    let Some(after) = rest.strip_prefix(' ') else {
+        return false;
+    };
+    if after.contains(char::is_whitespace) && !after.trim().is_empty() {
+        return false;
+    }
+    scope::enclosing_tool(text, offset).as_deref() == Some("nika:fetch")
+}
+
+/// The stdlib extract-mode vocabulary — the SET is `ExtractMode::ALL`
+/// (nika-types L0 · closed at stdlib v0.1), so a mode added there
+/// appears here with zero LSP edits; the one-line prose is local.
+fn extract_mode_items() -> Vec<CompletionItem> {
+    use nika_types::ExtractMode as M;
+    fn doc(m: M) -> &'static str {
+        match m {
+            M::Markdown => "HTML → cleaned Markdown (the content default)",
+            M::Article => "readability article body → Markdown",
+            M::Text => "tags stripped · plain text",
+            M::Selector => "raw HTML of the `selector:` matches",
+            M::Jq => "JSON body · a `jq:` expression applied",
+            M::Metadata => "meta tags · OpenGraph · canonical · lang",
+            M::Links => "every <a href> as an absolute URL",
+            M::Feed => "RSS · Atom · JSON Feed → normalized object",
+            M::Sitemap => "sitemap.xml → URL entries",
+            _ => "the decoded body verbatim",
+        }
+    }
+    M::ALL
+        .iter()
+        .map(|m| CompletionItem {
+            label: m.as_str().to_owned(),
+            kind: Some(CompletionItemKind::ENUM_MEMBER),
+            detail: Some(doc(*m).to_owned()),
+            ..CompletionItem::default()
+        })
+        .collect()
+}
+
+/// The argument names of the enclosing block's builtin — catalog-derived
+/// (born-stale law), required ones sorted first and marked. `None` when
+/// the enclosing `tool:` is absent, unknown, or not a `nika:*` builtin
+/// (an MCP tool's args are its own business — silence beats noise).
+fn builtin_arg_keys(text: &str, offset: usize) -> Option<Vec<CompletionItem>> {
+    let tool = scope::enclosing_tool(text, offset)?;
+    let short = tool.strip_prefix("nika:")?;
+    let b = nika_catalog::all_builtins()
+        .iter()
+        .find(|b| b.name == short)?;
+    Some(
+        b.args
+            .iter()
+            .map(|arg| {
+                let required = b.required.contains(arg);
+                CompletionItem {
+                    label: format!("{arg}:"),
+                    kind: Some(CompletionItemKind::FIELD),
+                    detail: Some(if required {
+                        format!("required · {tool} argument")
+                    } else {
+                        format!("{tool} argument")
+                    }),
+                    sort_text: Some(format!("{}{arg}", if required { '0' } else { '1' })),
+                    ..CompletionItem::default()
+                }
+            })
+            .collect(),
+    )
+}
+
 fn providers() -> Vec<CompletionItem> {
     vocab::PROVIDERS
         .iter()
@@ -454,15 +548,18 @@ fn keyword_items(table: &[Entry]) -> Vec<CompletionItem> {
 /// [` with nothing after it does not parse as YAML), so ids are read from
 /// a robust line scan for `id:` declarations rather than a full parse —
 /// the parse path would yield nothing exactly when completion is needed.
-fn task_ids(text: &str) -> Vec<CompletionItem> {
+fn task_ids(text: &str, exclude: Option<&str>) -> Vec<CompletionItem> {
     // Prefer the parser's authoritative ids (with verb detail) when the
-    // document parses; fall back to the line scan otherwise.
+    // document parses; fall back to the line scan otherwise. The task
+    // being edited is EXCLUDED — a self-dependency is a cycle the check
+    // would refuse, so offering it teaches an error.
     if let Ok(wf) = parse(text, FileId::new(0), ParseMode::Lenient)
         && !wf.tasks.is_empty()
     {
         return wf
             .tasks
             .iter()
+            .filter(|t| Some(t.value.id.value.as_str()) != exclude)
             .map(|t| CompletionItem {
                 label: t.value.id.value.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),
@@ -473,6 +570,7 @@ fn task_ids(text: &str) -> Vec<CompletionItem> {
     }
     scan_task_ids(text)
         .into_iter()
+        .filter(|id| Some(id.as_str()) != exclude)
         .map(|id| CompletionItem {
             label: id,
             kind: Some(CompletionItemKind::VARIABLE),
@@ -735,8 +833,9 @@ mod tests {
         let items = completion(text, text.len());
         assert_eq!(
             labels(&items),
-            vec!["extract", "save"],
-            "exactly the two task ids in source order"
+            vec!["extract"],
+            "exactly the OTHER task ids — `save` is the task being edited, \
+             and a self-dependency is a cycle the check refuses"
         );
         assert!(
             items
@@ -762,7 +861,11 @@ mod tests {
             .map(|p| p + "depends_on: [".len())
             .expect("open bracket");
         let items = completion(text, cursor);
-        assert_eq!(labels(&items), vec!["extract", "save"], "the task ids");
+        assert_eq!(
+            labels(&items),
+            vec!["extract"],
+            "the other task ids (self excluded)"
+        );
         assert!(
             items
                 .iter()
@@ -771,10 +874,7 @@ mod tests {
         );
         assert_eq!(
             items.iter().map(|i| i.detail.clone()).collect::<Vec<_>>(),
-            vec![
-                Some("task (exec)".to_owned()),
-                Some("task (exec)".to_owned())
-            ],
+            vec![Some("task (exec)".to_owned())],
             "parse path carries the verb in the detail, NOT the bare `task`"
         );
     }
@@ -801,7 +901,10 @@ mod tests {
         let items = completion(text, text.len());
         let labels = labels(&items);
         assert!(labels.contains(&"extract".to_owned()), "{labels:?}");
-        assert!(labels.contains(&"save".to_owned()));
+        assert!(
+            !labels.contains(&"save".to_owned()),
+            "the edited task never offers itself: {labels:?}"
+        );
     }
 
     #[test]
@@ -823,8 +926,8 @@ mod tests {
         let items = completion(text, text.len());
         assert_eq!(
             labels(&items),
-            vec!["extract", "use"],
-            "the workflow task ids"
+            vec!["extract"],
+            "the OTHER task ids — `use` is the task being edited"
         );
         assert!(
             items
@@ -1101,8 +1204,9 @@ mod tests {
         let items = completion(text, text.len());
         assert_eq!(
             labels(&items),
-            vec!["my_task", "b"],
-            "the underscored id is read whole, not truncated to `my`"
+            vec!["my_task"],
+            "the underscored id is read whole, not truncated to `my` \
+             (`b` is the task being edited — self excluded)"
         );
     }
 
@@ -1140,12 +1244,13 @@ mod tests {
         // (`!id.is_empty() && !ids.contains(&id)` — the `&&` and the `==` in
         // the take_while predicate both matter.) A duplicate id must appear
         // ONCE; the order is source order.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: first\n    exec: { command: \"x\" }\n  - id: second\n    exec: { command: \"y\" }\n  - id: first\n    depends_on: [";
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: first\n    exec: { command: \"x\" }\n  - id: second\n    exec: { command: \"y\" }\n  - id: first\n    exec: { command: \"z\" }\n  - id: editor\n    depends_on: [";
         let items = completion(text, text.len());
         assert_eq!(
             labels(&items),
             vec!["first", "second"],
-            "source order, deduplicated — `first` appears once"
+            "source order, deduplicated (`first` once) — and `editor`, \
+             the task being edited, excludes itself"
         );
     }
 
@@ -1163,5 +1268,113 @@ mod tests {
         let _ = completion("nika: v1\n", 99_999); // far past the end
         let doc = "nika: v1\nmodel: 🦋";
         let _ = completion(doc, doc.len() - 1); // inside the trailing 4-byte 🦋
+    }
+
+    /// Inside `args:` of a KNOWN builtin, key position → that tool's own
+    /// argument names, catalog-derived (the born-stale law again) —
+    /// required ones sorted first and marked.
+    #[test]
+    fn fetch_args_offer_the_catalog_arg_keys() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: get\n    invoke:\n      tool: nika:fetch\n      args:\n        ";
+        let items = completion(text, text.len());
+        let fetch = nika_catalog::all_builtins()
+            .iter()
+            .find(|b| b.name == "fetch")
+            .expect("fetch in catalog");
+        assert_eq!(items.len(), fetch.args.len(), "exactly the catalog args");
+        let labels = labels(&items);
+        assert!(labels.contains(&"url:".to_owned()), "{labels:?}");
+        assert!(labels.contains(&"mode:".to_owned()), "{labels:?}");
+        // required args float first (sort_text partition: '0…' < '1…')
+        for item in &items {
+            let required = item
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.starts_with("required"));
+            let sort = item.sort_text.as_deref().unwrap_or("");
+            assert_eq!(
+                sort.starts_with('0'),
+                required,
+                "sort partition mirrors required: {item:?}"
+            );
+        }
+    }
+
+    /// An UNKNOWN tool's args stay its own business — no `nika:fetch`
+    /// keys leak under an MCP tool.
+    #[test]
+    fn mcp_tool_args_do_not_leak_fetch_keys() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: gh\n    invoke:\n      tool: github.search\n      args:\n        ";
+        let labels = labels(&completion(text, text.len()));
+        assert!(
+            !labels.contains(&"url:".to_owned()),
+            "no cross-tool leak: {labels:?}"
+        );
+    }
+
+    /// `mode:` under `nika:fetch` offers the stdlib extract vocabulary —
+    /// the SET is `ExtractMode::ALL` (a mode added at L0 appears here
+    /// with zero LSP edits). Under any other tool the lane stays silent.
+    #[test]
+    fn fetch_mode_offers_the_stdlib_extract_vocabulary() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: get\n    invoke:\n      tool: nika:fetch\n      args:\n        mode: ";
+        let items = completion(text, text.len());
+        assert_eq!(items.len(), nika_types::ExtractMode::ALL.len());
+        let labels = labels(&items);
+        assert_eq!(labels[0], "markdown", "canon order — the default first");
+        assert!(labels.contains(&"jq".to_owned()), "{labels:?}");
+
+        let other = "nika: v1\nworkflow: w\ntasks:\n  - id: x\n    invoke:\n      tool: github.search\n      args:\n        mode: ";
+        assert!(
+            labels_of(other).iter().all(|l| l != "jq"),
+            "another tool's `mode:` is not the extract vocabulary"
+        );
+    }
+
+    /// `${{ vars.` offers the file's OWN declared vars. On a document
+    /// that parses (cursor mid-island, island closed), typed vars carry
+    /// type + required + description and untyped ones their default; a
+    /// mid-keystroke document that no longer parses falls back to the
+    /// block scan — names still arrive, detail goes generic.
+    #[test]
+    fn island_vars_offer_the_declared_names() {
+        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    description: target city\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }}\" }\n";
+        let cursor = text.find("${{ vars.").expect("island") + "${{ vars.".len();
+        let items = completion(text, cursor);
+        let got = labels(&items);
+        assert_eq!(got, vec!["city", "out_dir"], "{got:?}");
+        let detail = items[0].detail.as_deref().unwrap_or("");
+        assert!(
+            detail.contains("string")
+                && detail.contains("required")
+                && detail.contains("target city"),
+            "typed var detail teaches type · required · description: {detail}"
+        );
+        assert!(
+            items[1].detail.as_deref().unwrap_or("").contains("./out"),
+            "untyped var detail carries the default"
+        );
+
+        // mid-keystroke fallback: unterminated island · parse fails · the
+        // block scan still teaches the NAMES
+        let typing = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.";
+        let fallback = labels(&completion(typing, typing.len()));
+        assert_eq!(fallback, vec!["city", "out_dir"], "{fallback:?}");
+    }
+
+    /// `${{ secrets.` / `${{ env.` offer the file's own declared names.
+    #[test]
+    fn island_secrets_and_env_offer_declared_names() {
+        let text = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\nsecrets:\n  api_key:\n    source: env\n    env: MY_KEY\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ secrets.";
+        let labels_s = labels(&completion(text, text.len()));
+        assert_eq!(labels_s, vec!["api_key"], "{labels_s:?}");
+
+        let text2 = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ env.";
+        let labels_e = labels(&completion(text2, text2.len()));
+        assert_eq!(labels_e, vec!["REGION"], "{labels_e:?}");
+    }
+
+    fn labels_of(text: &str) -> Vec<String> {
+        labels(&completion(text, text.len()))
     }
 }

--- a/crates/nika-lsp/src/analysis/hover.rs
+++ b/crates/nika-lsp/src/analysis/hover.rs
@@ -23,7 +23,102 @@ use super::vocab::{self, Entry};
 /// or `${{ tasks.X }}`) showing the target task's verb.
 #[must_use]
 pub fn hover(text: &str, offset: usize) -> Option<Hover> {
-    vocab_hover(text, offset).or_else(|| task_ref_hover(text, offset))
+    value_card_hover(text, offset)
+        .or_else(|| vocab_hover(text, offset))
+        .or_else(|| task_ref_hover(text, offset))
+}
+
+/// Hover on a `tool:` or `model:` VALUE — the catalog card for that
+/// builtin (category · args · required) or that model (context/output
+/// windows). Line-based: the value spans past `word_at`'s identifier
+/// alphabet (`nika:jq` · `ollama/qwen3.5:4b`), so the span is the
+/// scalar after the key, quotes and comment shed.
+fn value_card_hover(text: &str, offset: usize) -> Option<Hover> {
+    let (key, value, start, end) = keyed_value_at(text, offset)?;
+    let body = match key {
+        "tool" => builtin_card(value)?,
+        "model" => model_card(value)?,
+        _ => return None,
+    };
+    let index = LineIndex::new(text);
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: body,
+        }),
+        range: Some(Range::new(index.position(start), index.position(end))),
+    })
+}
+
+/// The `key` and value span of the cursor's line, when the cursor sits
+/// INSIDE the value of a `key: value` line.
+fn keyed_value_at(text: &str, offset: usize) -> Option<(&str, &str, usize, usize)> {
+    let line_start = text.get(..offset)?.rfind('\n').map_or(0, |i| i + 1);
+    let line_end = text
+        .get(offset..)
+        .and_then(|rest| rest.find('\n'))
+        .map_or(text.len(), |i| offset + i);
+    let line = text.get(line_start..line_end)?;
+    let colon = line.find(':')?;
+    let key = line.get(..colon)?.trim_start().trim_start_matches("- ");
+    let after = line.get(colon + 1..)?;
+    let shed = after.split('#').next().unwrap_or("");
+    let value = shed.trim().trim_matches('"').trim_matches('\'');
+    if value.is_empty() {
+        return None;
+    }
+    let value_start = line_start + colon + 1 + shed.len() - shed.trim_start().len()
+        + usize::from(shed.trim_start().starts_with('"') || shed.trim_start().starts_with('\''));
+    let value_end = value_start + value.len();
+    (offset >= value_start && offset <= value_end).then_some((key, value, value_start, value_end))
+}
+
+/// The catalog card for a `nika:*` builtin.
+fn builtin_card(value: &str) -> Option<String> {
+    let short = value.strip_prefix("nika:")?;
+    let b = nika_catalog::all_builtins()
+        .iter()
+        .find(|b| b.name == short)?;
+    let args = if b.args.is_empty() {
+        "none".to_owned()
+    } else {
+        b.args
+            .iter()
+            .map(|a| format!("`{a}`"))
+            .collect::<Vec<_>>()
+            .join(" · ")
+    };
+    let mut body = format!(
+        "**`nika:{}`** — _{:?} builtin_\n\nargs: {args}",
+        b.name, b.category
+    );
+    if !b.required.is_empty() {
+        use std::fmt::Write as _;
+        let _ = write!(
+            body,
+            "\nrequired: {}",
+            b.required
+                .iter()
+                .map(|a| format!("`{a}`"))
+                .collect::<Vec<_>>()
+                .join(" · ")
+        );
+    }
+    Some(body)
+}
+
+/// The catalog card for a `provider/model` address.
+fn model_card(value: &str) -> Option<String> {
+    let (prov, model) = value.split_once('/')?;
+    let provider = nika_catalog::all_providers()
+        .iter()
+        .find(|p| p.id == prov)?;
+    let m = provider.models.iter().find(|m| m.model == model)?;
+    Some(format!(
+        "**`{prov}/{model}`** — _catalog model_\n\ncontext {}k tokens · output {}k tokens",
+        m.context_window_tokens / 1000,
+        m.max_output_tokens / 1000
+    ))
 }
 
 /// Hover for a language-vocabulary token (a verb or an envelope/task key).
@@ -289,5 +384,40 @@ mod tests {
         let after = yaml.find("exec").expect("verb") + "exec".len();
         let h = hover(yaml, after).expect("hover");
         assert!(body(&h).contains("**`exec`**"));
+    }
+
+    /// Hover on a `tool:` value → the catalog card (category · args ·
+    /// required) — derived, so a builtin's card can never lag its truth.
+    #[test]
+    fn hover_on_tool_value_shows_the_builtin_card() {
+        let text = "nika: v1\ntasks:\n  - id: a\n    invoke:\n      tool: nika:jq\n      args: { expression: \".\" }\n";
+        let offset = text.find("nika:jq").expect("tool value") + 3;
+        let h = hover(text, offset).expect("a card");
+        let b = body(&h);
+        assert!(b.contains("nika:jq"), "{b}");
+        assert!(b.contains("`expression`"), "args listed: {b}");
+        assert!(b.contains("required"), "required set named: {b}");
+    }
+
+    /// Hover on a `model:` value → the model card with its windows.
+    #[test]
+    fn hover_on_model_value_shows_the_catalog_windows() {
+        let text = "nika: v1\nmodel: ollama/llama3.2:3b\n";
+        let offset = text.find("ollama/").expect("model value") + 4;
+        let h = hover(text, offset).expect("a card");
+        let b = body(&h);
+        assert!(b.contains("ollama/llama3.2:3b"), "{b}");
+        assert!(b.contains("context") && b.contains("output"), "{b}");
+    }
+
+    /// An unknown tool or model stays silent — no invented card.
+    #[test]
+    fn hover_on_unknown_tool_or_model_stays_silent() {
+        let text = "nika: v1\ntasks:\n  - id: a\n    invoke:\n      tool: github.search\n";
+        let offset = text.find("github.search").expect("value") + 3;
+        assert!(hover(text, offset).is_none());
+        let text2 = "nika: v1\nmodel: nosuch/model-x\n";
+        let off2 = text2.find("nosuch/").expect("value") + 2;
+        assert!(hover(text2, off2).is_none());
     }
 }

--- a/crates/nika-lsp/src/analysis/members.rs
+++ b/crates/nika-lsp/src/analysis/members.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `${{ vars. / secrets. / env. }}` member lanes — the workflow's
+//! OWN declarations offered at the island, parse-first with a line-scan
+//! fallback for mid-keystroke documents (the `scan_task_ids` spirit).
+
+use lsp_types::{CompletionItem, CompletionItemKind};
+use nika_schema::{FileId, ParseMode, parse};
+
+/// An open island ending in `vars.` / `secrets.` / `env.` — the member
+/// position for the workflow's OWN declarations.
+pub(super) fn template_member_root(prefix: &str) -> Option<&'static str> {
+    let island = prefix.rfind("${{")?;
+    let after = prefix.get(island..).unwrap_or("");
+    if after.contains("}}") {
+        return None;
+    }
+    let t = after.trim_end();
+    for root in ["vars", "secrets", "env"] {
+        if t.ends_with(&format!("{root}.")) {
+            return Some(root);
+        }
+    }
+    None
+}
+
+/// The file's own declared members for one island root — a lenient parse
+/// of the document itself, so the workflow teaches its own names. A
+/// mid-keystroke document that no longer parses falls back to a line
+/// scan of the block (same spirit as `scan_task_ids`).
+pub(super) fn member_items(text: &str, root: &str) -> Vec<CompletionItem> {
+    let Ok(wf) = parse(text, FileId::new(0), ParseMode::Lenient) else {
+        return scan_block_keys(text, root)
+            .into_iter()
+            .map(|name| {
+                member_item(
+                    &name,
+                    match root {
+                        "vars" => "var".to_owned(),
+                        "secrets" => "secret · masked, never echoed".to_owned(),
+                        _ => "env · non-sensitive runtime config".to_owned(),
+                    },
+                )
+            })
+            .collect();
+    };
+    let mut items = Vec::new();
+    match root {
+        "vars" => {
+            for (name, decl) in &wf.vars {
+                let detail = match decl {
+                    nika_schema::VarDecl::Typed {
+                        r#type,
+                        required,
+                        description,
+                        ..
+                    } => {
+                        let mut d = format!("var · {type}");
+                        if *required {
+                            d.push_str(" · required");
+                        }
+                        if let Some(desc) = description {
+                            d.push_str(" — ");
+                            d.push_str(desc);
+                        }
+                        d
+                    }
+                    nika_schema::VarDecl::Untyped(v) => format!("var · default {v}"),
+                    // #[non_exhaustive] upstream — an unknown future form
+                    // still names itself a var.
+                    _ => "var".to_owned(),
+                };
+                items.push(member_item(&name.value, detail));
+            }
+        }
+        "secrets" => {
+            for (name, _) in &wf.secrets {
+                items.push(member_item(
+                    &name.value,
+                    "secret · masked, never echoed".to_owned(),
+                ));
+            }
+        }
+        _ => {
+            for (name, _) in &wf.env {
+                items.push(member_item(
+                    &name.value,
+                    "env · non-sensitive runtime config".to_owned(),
+                ));
+            }
+        }
+    }
+    items
+}
+
+fn member_item(name: &str, detail: String) -> CompletionItem {
+    CompletionItem {
+        label: name.to_owned(),
+        kind: Some(CompletionItemKind::VARIABLE),
+        detail: Some(detail),
+        ..CompletionItem::default()
+    }
+}
+
+/// The immediate child keys of a top-level `vars:` / `secrets:` / `env:`
+/// block, by line shape — the fallback when the document mid-keystroke
+/// no longer parses.
+fn scan_block_keys(text: &str, root: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut in_block = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        if indent == 0 {
+            in_block = trimmed.trim_end() == format!("{root}:");
+            continue;
+        }
+        if !in_block || trimmed.is_empty() {
+            continue;
+        }
+        // an immediate child: exactly one indent step, `name:` shape
+        if indent == 2
+            && let Some((name, _)) = trimmed.split_once(':')
+            && !name.is_empty()
+            && name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
+            keys.push(name.to_owned());
+        }
+    }
+    keys
+}

--- a/crates/nika-lsp/src/analysis/mod.rs
+++ b/crates/nika-lsp/src/analysis/mod.rs
@@ -17,6 +17,8 @@ pub mod definition;
 pub mod diagnostics;
 pub mod document;
 pub mod hover;
+pub mod members;
 pub mod position;
+pub mod scope;
 pub mod symbols;
 pub mod vocab;

--- a/crates/nika-lsp/src/analysis/scope.rs
+++ b/crates/nika-lsp/src/analysis/scope.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Upward block scanning — the completion lanes that depend on WHERE the
+//! cursor sits (which task · which `tool:` · inside `args:`) share these
+//! line-walk primitives. Same v0.1 register as the rest of the analysis:
+//! robust line heuristics over a full AST, silence beats noise.
+
+/// The id of the task whose block encloses `offset` — the nearest
+/// preceding `- id:` line. `None` above the first task.
+pub(super) fn current_task_id(text: &str, offset: usize) -> Option<String> {
+    for line in lines_upward(text, offset) {
+        let t = line.trim_start();
+        if let Some(rest) = t.strip_prefix("- id:") {
+            return Some(unquote(rest).to_owned());
+        }
+    }
+    None
+}
+
+/// The `tool:` value of the invoke block enclosing `offset`, when the
+/// enclosing task declares one — the scan stops at the task boundary
+/// (`- id:`) so a PREVIOUS task's tool never leaks into this one.
+pub(super) fn enclosing_tool(text: &str, offset: usize) -> Option<String> {
+    for line in lines_upward(text, offset) {
+        let t = line.trim_start();
+        if let Some(rest) = t.strip_prefix("tool:") {
+            return Some(unquote(rest).to_owned());
+        }
+        if t.starts_with("- id:") {
+            return None;
+        }
+    }
+    None
+}
+
+/// Whether the cursor sits at a KEY position directly inside an `args:`
+/// block — an indented bare word (no `:` typed yet) whose nearest
+/// shallower non-blank ancestor line is `args:`. Nested maps inside an
+/// argument value (a deeper ancestor that is not `args:`) stay silent.
+pub(super) fn in_args_key_position(text: &str, offset: usize) -> bool {
+    let upto = text.get(..offset).unwrap_or("");
+    let line_start = upto.rfind('\n').map_or(0, |i| i + 1);
+    let prefix = &upto[line_start..];
+    let typed = prefix.trim_start();
+    // A key position: nothing yet, or a bare identifier without its colon.
+    if !typed.is_empty()
+        && !typed
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+    {
+        return false;
+    }
+    let indent = prefix.len() - typed.len();
+    if indent == 0 {
+        return false;
+    }
+    for line in lines_upward(text, offset) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let line_indent = line.len() - line.trim_start().len();
+        if line_indent < indent {
+            return line.trim_start().starts_with("args:");
+        }
+    }
+    false
+}
+
+/// The lines strictly above `offset`'s line, nearest first.
+fn lines_upward(text: &str, offset: usize) -> impl Iterator<Item = &str> {
+    let upto = text.get(..offset).unwrap_or("");
+    let line_start = upto.rfind('\n').map_or(0, |i| i + 1);
+    text.get(..line_start)
+        .unwrap_or("")
+        .lines()
+        .rev()
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+/// A scalar value with optional YAML quotes and trailing comment shed.
+fn unquote(rest: &str) -> &str {
+    let v = rest.split('#').next().unwrap_or("").trim();
+    v.trim_matches('"').trim_matches('\'')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOC: &str = "nika: v1\nworkflow: w\ntasks:\n  - id: fetch_article\n    invoke:\n      tool: nika:fetch\n      args:\n        url: \"https://x\"\n        \n  - id: second\n    exec:\n      command: ls\n";
+
+    #[test]
+    fn current_task_is_the_nearest_id_above() {
+        let in_args = DOC.find("url:").expect("url line");
+        assert_eq!(
+            current_task_id(DOC, in_args).as_deref(),
+            Some("fetch_article")
+        );
+        let in_second = DOC.find("command:").expect("command line");
+        assert_eq!(current_task_id(DOC, in_second).as_deref(), Some("second"));
+        assert_eq!(current_task_id(DOC, 0), None);
+    }
+
+    #[test]
+    fn enclosing_tool_stops_at_the_task_boundary() {
+        let in_args = DOC.find("url:").expect("url line");
+        assert_eq!(enclosing_tool(DOC, in_args).as_deref(), Some("nika:fetch"));
+        // the second task declares no tool — the first task's must not leak
+        let in_second = DOC.find("command:").expect("command line");
+        assert_eq!(enclosing_tool(DOC, in_second), None);
+    }
+
+    #[test]
+    fn args_key_position_wants_the_args_ancestor() {
+        // the blank-indented line inside args: IS a key position
+        let blank = DOC.find("\n        \n").expect("blank args line") + 9;
+        assert!(in_args_key_position(DOC, blank));
+        // a value position (after `url: `) is not
+        let after_url = DOC.find("url:").expect("url") + "url: ".len();
+        assert!(!in_args_key_position(DOC, after_url));
+        // a task-field key position (ancestor is the task item, not args:)
+        let field = DOC.find("invoke:").expect("invoke line");
+        assert!(!in_args_key_position(DOC, field));
+    }
+
+    #[test]
+    fn quotes_and_comments_shed_from_scalar_values() {
+        let doc = "tasks:\n  - id: a\n    invoke:\n      tool: \"nika:jq\"  # data\n      args:\n        x: 1\n";
+        let in_args = doc.find("x: 1").expect("x line");
+        assert_eq!(enclosing_tool(doc, in_args).as_deref(), Some("nika:jq"));
+    }
+}


### PR DESCRIPTION
## What

The SOTA wave — five lanes where the LSP answers from the SSOT instead of silence. Every SET is derived (the born-stale law); only the one-line prose is local.

| Lane | Source of truth |
|---|---|
| **args keys** — bare key inside `args:` of a known builtin → that tool's OWN argument names, required floated first & marked | `nika_catalog::all_builtins()` (args + required) |
| **extract modes** — `mode:` under `nika:fetch` → the stdlib vocabulary, `jq` included | `nika_types::ExtractMode::ALL` (L0) |
| **island members** — `${{ vars. / secrets. / env.` → the file's OWN declarations; typed vars teach type · required · description | the document itself (parse-first, line-scan fallback mid-keystroke) |
| **self-filter** — `depends_on:` / `${{ tasks.` exclude the task being edited | a self-dependency is a cycle the check refuses — never offer what check rejects |
| **hover cards** — `tool:` → builtin card (category · args · required) · `model:` → catalog windows (ctx/out) | catalog again, at rest |

## The context machinery

New `analysis/scope.rs`: upward block scanner (enclosing `tool:` · current task · args-key position) — the #541 refusal of `mode:` ("two vocabularies, needs context") is closed by CONTEXT, not by guessing: the lane checks the enclosing tool, and an MCP tool's args stay its own business (law-tested: no cross-tool leak).

New `analysis/members.rs`: the island member lanes (keeps completion.rs under the 1500 wall).

## Proof

152/152 nika-lsp lib · clippy -D warnings 0 · probed live over JSON-RPC: args-keys (10, catalog count) · modes (canon order, `markdown` first) · vars with details · self-filter · both hover cards — 6/6 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
