### PR TITLE
feat(nika-lsp): references resolve like the graph reads — closure, jumps, cards

### DIFF
--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -49,6 +49,7 @@ impl<T> dyn_clone::DynClone for nika_lsp::analysis::document::Document where T: 
 pub fn nika_lsp::analysis::document::Document::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_lsp::analysis::document::Document where T: 'static
 pub fn nika_lsp::analysis::document::Document::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub mod nika_lsp::analysis::graph
 pub mod nika_lsp::analysis::hover
 pub fn nika_lsp::analysis::hover::hover(text: &str, offset: usize) -> core::option::Option<lsp_types::hover::Hover>
 pub mod nika_lsp::analysis::members

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -550,16 +550,22 @@ fn keyword_items(table: &[Entry]) -> Vec<CompletionItem> {
 /// the parse path would yield nothing exactly when completion is needed.
 fn task_ids(text: &str, exclude: Option<&str>) -> Vec<CompletionItem> {
     // Prefer the parser's authoritative ids (with verb detail) when the
-    // document parses; fall back to the line scan otherwise. The task
-    // being edited is EXCLUDED — a self-dependency is a cycle the check
-    // would refuse, so offering it teaches an error.
+    // document parses; fall back to the line scan otherwise. The
+    // exclusion is the editing task's whole ILLEGAL set — itself plus
+    // its downstream closure: a reference downstream is a cycle (a
+    // template ref is an implicit edge) or a recover deadlock (DAG-004),
+    // and completion never offers what check refuses. The scan fallback
+    // (no graph) honestly degrades to excluding self alone.
     if let Ok(wf) = parse(text, FileId::new(0), ParseMode::Lenient)
         && !wf.tasks.is_empty()
     {
+        let illegal: Vec<&str> = exclude.map_or_else(Vec::new, |id| {
+            super::graph::illegal_reference_targets(&wf, id)
+        });
         return wf
             .tasks
             .iter()
-            .filter(|t| Some(t.value.id.value.as_str()) != exclude)
+            .filter(|t| !illegal.contains(&t.value.id.value.as_str()))
             .map(|t| CompletionItem {
                 label: t.value.id.value.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),
@@ -1365,13 +1371,27 @@ mod tests {
     /// `${{ secrets.` / `${{ env.` offer the file's own declared names.
     #[test]
     fn island_secrets_and_env_offer_declared_names() {
-        let text = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\nsecrets:\n  api_key:\n    source: env\n    env: MY_KEY\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ secrets.";
+        let text = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\nsecrets:\n  api_key:\n    source: env\n    key: MY_KEY\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ secrets.";
         let labels_s = labels(&completion(text, text.len()));
         assert_eq!(labels_s, vec!["api_key"], "{labels_s:?}");
 
         let text2 = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ env.";
         let labels_e = labels(&completion(text2, text2.len()));
         assert_eq!(labels_e, vec!["REGION"], "{labels_e:?}");
+    }
+
+    /// The exclusion is the whole ILLEGAL set — not just self. In the
+    /// diamond a → {b, c} → d, task `b` editing a `${{ tasks.` island
+    /// may reference `a` (ancestor) and `c` (parallel) but never `d`:
+    /// a ref to d is an implicit edge d → b while d already waits on b
+    /// — the cycle the check refuses. Same law, one voice.
+    #[test]
+    fn island_tasks_exclude_the_downstream_closure() {
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output }}\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
+        // cursor mid-island inside task b (document parses whole)
+        let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
+        let got = labels(&completion(text, cursor));
+        assert_eq!(got, vec!["a", "c"], "ancestor + parallel only: {got:?}");
     }
 
     fn labels_of(text: &str) -> Vec<String> {

--- a/crates/nika-lsp/src/analysis/definition.rs
+++ b/crates/nika-lsp/src/analysis/definition.rs
@@ -30,15 +30,78 @@ use super::position::LineIndex;
 #[must_use]
 pub fn definition(uri: &Uri, text: &str, offset: usize) -> Option<Location> {
     let wf = parse(text, FileId::new(0), ParseMode::Lenient).ok()?;
+    let index = LineIndex::new(text);
+    // member refs (`${{ vars.X }}` · `secrets.X` · `env.X`) jump to
+    // their declaration — the parser's own name spans.
+    if let Some((span, len)) = member_decl_target(&wf, text, offset) {
+        return Some(Location::new(uri.clone(), token_range(&index, span, len)));
+    }
     let id_spans = id_span_table(&wf);
     let target_id =
         depends_on_target(&wf, offset).or_else(|| template_task_target(text, offset))?;
     let (span, id_len) = id_spans.get(target_id.as_str())?;
-    let index = LineIndex::new(text);
     Some(Location::new(
         uri.clone(),
         token_range(&index, *span, *id_len),
     ))
+}
+
+/// If `offset` sits on a `vars.X` / `secrets.X` / `env.X` member inside
+/// an island, return the DECLARATION's name span (+ byte length). The
+/// same byte-scan discipline as [`template_task_target`], generalized
+/// over the three declaring roots.
+fn member_decl_target(wf: &RawWorkflow, text: &str, offset: usize) -> Option<(Span, usize)> {
+    let (root, name) = template_member_at(text, offset)?;
+    match root {
+        "vars" => wf
+            .vars
+            .iter()
+            .find(|(n, _)| n.value == name)
+            .map(|(n, _)| (n.span, n.value.len())),
+        "secrets" => wf
+            .secrets
+            .iter()
+            .find(|(n, _)| n.value == name)
+            .map(|(n, _)| (n.span, n.value.len())),
+        _ => wf
+            .env
+            .iter()
+            .find(|(n, _)| n.value == name)
+            .map(|(n, _)| (n.span, n.value.len())),
+    }
+}
+
+/// The `(root, member)` under `offset` when the cursor sits on a
+/// `vars.<ident>` / `secrets.<ident>` / `env.<ident>` run inside an
+/// island — cursor anywhere from the root keyword through the member.
+pub(crate) fn template_member_at(text: &str, offset: usize) -> Option<(&'static str, String)> {
+    let bytes = text.as_bytes();
+    for (island_start, island_end) in islands(text) {
+        if !(island_start..island_end).contains(&offset) {
+            continue;
+        }
+        let inner = text.get(island_start..island_end)?;
+        for root in ["vars", "secrets", "env"] {
+            let needle = format!("{root}.");
+            let mut search_from = 0usize;
+            while let Some(rel) = inner.get(search_from..)?.find(&needle) {
+                let kw_at = island_start + search_from + rel;
+                let mid_ident = kw_at > 0
+                    && bytes
+                        .get(kw_at - 1)
+                        .is_some_and(|b| *b == b'_' || *b == b'.' || b.is_ascii_alphanumeric());
+                if !mid_ident {
+                    let m_start = kw_at + needle.len();
+                    let m_end = ident_end(bytes, m_start);
+                    if m_end > m_start && (kw_at..m_end).contains(&offset) {
+                        return text.get(m_start..m_end).map(|m| (root, m.to_owned()));
+                    }
+                }
+                search_from = (search_from + rel + needle.len()).min(inner.len());
+            }
+        }
+    }
+    None
 }
 
 /// The task referenced under `offset` (a `depends_on:` item or a
@@ -682,5 +745,35 @@ mod tests {
             definition(&uri(), yaml, at).is_none(),
             "mid-ident match rejected"
         );
+    }
+
+    /// `${{ vars.X }}` jumps to the `X:` declaration under `vars:` —
+    /// and the same lane serves `secrets.` / `env.`. An undeclared
+    /// member resolves nowhere (no invented target).
+    #[test]
+    fn member_ref_jumps_to_its_declaration() {
+        let text = "nika: v1\nworkflow: w\nvars:\n  city: \"paris\"\nenv:\n  REGION: eu\nsecrets:\n  api_key:\n    source: env\n    key: K\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }} ${{ env.REGION }} ${{ secrets.api_key }}\" }\n";
+        let uri: Uri = "file:///w.nika.yaml".parse().expect("uri");
+        let decl_line = |needle: &str| {
+            let at = text.find(needle).expect(needle);
+            u32::try_from(text[..at].matches('\n').count()).expect("line fits")
+        };
+        for (ref_needle, decl_needle) in [
+            ("vars.city", "  city:"),
+            ("env.REGION", "  REGION:"),
+            ("secrets.api_key", "  api_key:"),
+        ] {
+            let at = text.find(ref_needle).expect(ref_needle) + ref_needle.len() - 2;
+            let loc = definition(&uri, text, at).expect(ref_needle);
+            assert_eq!(
+                loc.range.start.line,
+                decl_line(decl_needle),
+                "{ref_needle} lands on its declaration line"
+            );
+        }
+        // undeclared member → nothing
+        let at = text.find("vars.city").expect("ref");
+        let miss = text.replace("vars.city", "vars.ghost");
+        assert!(definition(&uri, &miss, at + 7).is_none());
     }
 }

--- a/crates/nika-lsp/src/analysis/graph.rs
+++ b/crates/nika-lsp/src/analysis/graph.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Shared graph reads over the explicit `depends_on` edges — the same
+//! edge set the engine's own `analyze` schedules with. Presentation
+//! math only: findings about the graph stay in the check ladder.
+
+use nika_schema::raw::RawWorkflow;
+
+/// The ids downstream of `id` — { t : id →⁺ t }, BFS over the explicit
+/// reverse edges. `id` itself is NOT in the set.
+pub(super) fn downstream_ids<'a>(wf: &'a RawWorkflow, id: &str) -> Vec<&'a str> {
+    let mut seen: Vec<&'a str> = Vec::new();
+    let mut queue: Vec<&str> = vec![id];
+    while let Some(cur) = queue.pop() {
+        for t in &wf.tasks {
+            if t.value.depends_on.iter().any(|d| d.value == cur) {
+                let child = t.value.id.value.as_str();
+                if !seen.contains(&child) {
+                    seen.push(child);
+                    queue.push(child);
+                }
+            }
+        }
+    }
+    seen
+}
+
+/// The ids task `id` may legally REFERENCE — everything except itself
+/// and its downstream closure. Referencing downstream creates a cycle
+/// (a template ref is an implicit edge) or, in `recover:`, a deadlock
+/// (DAG-004): either way the check refuses it, so completion never
+/// offers it.
+pub(super) fn illegal_reference_targets<'a>(wf: &'a RawWorkflow, id: &'a str) -> Vec<&'a str> {
+    let mut set = downstream_ids(wf, id);
+    set.push(id);
+    set
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nika_schema::{FileId, ParseMode, parse};
+
+    // the diamond: a → {b, c} → d
+    const DIAMOND: &str = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
+
+    #[test]
+    fn downstream_of_the_root_is_everything_else() {
+        let wf = parse(DIAMOND, FileId::new(0), ParseMode::Lenient).expect("parses");
+        let mut down = downstream_ids(&wf, "a");
+        down.sort_unstable();
+        assert_eq!(down, vec!["b", "c", "d"]);
+        assert!(downstream_ids(&wf, "d").is_empty(), "terminal task");
+    }
+
+    #[test]
+    fn illegal_targets_are_self_plus_closure() {
+        let wf = parse(DIAMOND, FileId::new(0), ParseMode::Lenient).expect("parses");
+        let mut illegal = illegal_reference_targets(&wf, "b");
+        illegal.sort_unstable();
+        // b may not reference itself nor d (which waits on b) — a and c
+        // stay legal (ancestor · parallel-independent).
+        assert_eq!(illegal, vec!["b", "d"]);
+    }
+}

--- a/crates/nika-lsp/src/analysis/hover.rs
+++ b/crates/nika-lsp/src/analysis/hover.rs
@@ -25,8 +25,74 @@ use super::vocab::{self, Entry};
 pub fn hover(text: &str, offset: usize) -> Option<Hover> {
     value_card_hover(text, offset)
         .or_else(|| task_decl_hover(text, offset))
+        .or_else(|| member_ref_hover(text, offset))
         .or_else(|| vocab_hover(text, offset))
         .or_else(|| task_ref_hover(text, offset))
+}
+
+/// Hover on a `${{ vars.X / secrets.X / env.X }}` member — the
+/// declaration's card, without leaving the line. Same resolver as
+/// go-to-definition; same prose the completion detail teaches.
+fn member_ref_hover(text: &str, offset: usize) -> Option<Hover> {
+    let (root, name) = super::definition::template_member_at(text, offset)?;
+    let wf = nika_schema::parse(
+        text,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Lenient,
+    )
+    .ok()?;
+    let body = match root {
+        "vars" => {
+            let (_, decl) = wf.vars.iter().find(|(n, _)| n.value == name)?;
+            match decl {
+                nika_schema::VarDecl::Typed {
+                    r#type,
+                    required,
+                    default,
+                    description,
+                } => {
+                    use std::fmt::Write as _;
+                    let mut b = format!("**`vars.{name}`** — _{type}_");
+                    if *required {
+                        b.push_str(" · required");
+                    }
+                    if let Some(d) = default {
+                        let _ = write!(b, " · default `{d}`");
+                    }
+                    if let Some(desc) = description {
+                        let _ = write!(b, "\n\n{desc}");
+                    }
+                    b
+                }
+                nika_schema::VarDecl::Untyped(v) => {
+                    format!("**`vars.{name}`** — _var_\n\ndefault `{v}`")
+                }
+                _ => format!("**`vars.{name}`** — _var_"),
+            }
+        }
+        "secrets" => {
+            wf.secrets.iter().find(|(n, _)| n.value == name)?;
+            format!("**`secrets.{name}`** — _secret_\n\nmasked · never echoed · taint-tracked")
+        }
+        _ => {
+            let (_, value) = wf.env.iter().find(|(n, _)| n.value == name)?;
+            format!(
+                "**`env.{name}`** — _env_\n\nnon-sensitive runtime config · `{}`",
+                value.value
+            )
+        }
+    };
+    let range = word_at(text, offset).map(|(_, start, end)| {
+        let index = LineIndex::new(text);
+        Range::new(index.position(start), index.position(end))
+    });
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: body,
+        }),
+        range,
+    })
 }
 
 /// Hover on a task DECLARATION (`- id: X`) — the task's place in the
@@ -94,23 +160,10 @@ fn dag_card(wf: &nika_schema::raw::RawWorkflow, id: &str) -> Option<String> {
     Some(body)
 }
 
-/// |{ t : id →⁺ t }| — the size of the transitive closure downstream of
-/// `id`, BFS over the explicit reverse edges.
+/// |{ t : id →⁺ t }| — the one BFS lives in [`super::graph`]; the card
+/// only needs the count.
 fn downstream_reach(wf: &nika_schema::raw::RawWorkflow, id: &str) -> usize {
-    let mut seen: Vec<&str> = Vec::new();
-    let mut queue: Vec<&str> = vec![id];
-    while let Some(cur) = queue.pop() {
-        for t in &wf.tasks {
-            if t.value.depends_on.iter().any(|d| d.value == cur) {
-                let child = t.value.id.value.as_str();
-                if !seen.contains(&child) {
-                    seen.push(child);
-                    queue.push(child);
-                }
-            }
-        }
-    }
-    seen.len()
+    super::graph::downstream_ids(wf, id).len()
 }
 
 fn code_list(ids: &[&str]) -> String {
@@ -570,5 +623,23 @@ mod tests {
     fn hover_on_task_decl_in_a_cycle_stays_silent() {
         let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [b]\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"x\" }\n";
         assert!(hover(text, text.find("- id: a").expect("a") + 7).is_none());
+    }
+
+    /// Hover on island members — the declaration's card: typed var
+    /// (type · required · default · description) · secret (masked line)
+    /// · env (its value).
+    #[test]
+    fn hover_on_member_refs_shows_the_declaration_cards() {
+        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    default: paris\n    description: target city\nenv:\n  REGION: eu\nsecrets:\n  api_key:\n    source: env\n    key: K\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }} ${{ env.REGION }} ${{ secrets.api_key }}\" }\n";
+        let h = hover(text, text.find("vars.city").expect("ref") + 6).expect("var card");
+        let b = body(&h);
+        assert!(
+            b.contains("string") && b.contains("required") && b.contains("target city"),
+            "{b}"
+        );
+        let h = hover(text, text.find("secrets.api_key").expect("ref") + 9).expect("secret card");
+        assert!(body(&h).contains("never echoed"), "{}", body(&h));
+        let h = hover(text, text.find("env.REGION").expect("ref") + 5).expect("env card");
+        assert!(body(&h).contains("`eu`"), "{}", body(&h));
     }
 }

--- a/crates/nika-lsp/src/analysis/mod.rs
+++ b/crates/nika-lsp/src/analysis/mod.rs
@@ -16,6 +16,7 @@ pub mod completion;
 pub mod definition;
 pub mod diagnostics;
 pub mod document;
+pub mod graph;
 pub mod hover;
 pub mod members;
 pub mod position;


### PR DESCRIPTION
## What

Three reinforcements on the references — one voice with the engine's own math, zero new findings invented (the check ladder stays the judge).

### 1 · Closure exclusion (the theorem)

The `${{ tasks.` and `depends_on:` lanes now exclude the editing task's whole **illegal set**: `{X} ∪ {t : X →⁺ t}`. A reference downstream is an implicit edge that closes a cycle (normal fields) or a recover deadlock (DAG-004) — either way the check refuses it, so completion never offers it.

Diamond `a → {b,c} → d`, editing `b`: offered exactly `{a, c}` — ancestor and parallel. The one BFS lives in the new `analysis/graph.rs`; the DAG card's reach count delegates to it (**the duplicate BFS dies**). Scan fallback (unparseable mid-keystroke doc) honestly degrades to excluding self alone.

### 2 · Go-to-definition for members

`${{ vars.X }}` · `secrets.X` · `env.X` jump to their declaration — the parser's own name spans, the task-ref byte-scan discipline generalized over the three declaring roots. Undeclared member → no invented target.

### 3 · Hover cards for members

The declaration answers at rest: typed var (type · required · default · description) · secret (*masked · never echoed*) · env (its value). Same resolver as the jump.

## Test-doc honesty

The secret fixtures wrote `source: env` + `env: K` — a shape the parser **refuses** (missing `key:`); an earlier members test passed only through the scan fallback. Fixed to `key:` so the law tests exercise the parse path.

## Proof

159/159 nika-lsp lib · clippy -D warnings 0 · probed live over JSON-RPC: closure `{a,c}` · member jump lands on the declaration line · member card carries type/required/description · zero new pub items outside `analysis::graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
