### PR TITLE
feat(nika-lsp): the three 557 lanes — tools whitelist · task members · schema context

### DIFF
--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -144,6 +144,7 @@ pub fn nika_lsp::analysis::vocab::Entry::as_any(&self) -> &(dyn core::any::Any +
 impl<T> outref::AsOut<T> for nika_lsp::analysis::vocab::Entry where T: core::marker::Copy
 pub fn nika_lsp::analysis::vocab::Entry::as_out(&mut self) -> outref::Out<'_, T>
 pub const nika_lsp::analysis::vocab::PROVIDERS: &[nika_lsp::analysis::vocab::Entry]
+pub const nika_lsp::analysis::vocab::SCHEMA_KEYS: &[nika_lsp::analysis::vocab::Entry]
 pub const nika_lsp::analysis::vocab::TASK_FIELD_KEYS: &[nika_lsp::analysis::vocab::Entry]
 pub const nika_lsp::analysis::vocab::TOP_LEVEL_KEYS: &[nika_lsp::analysis::vocab::Entry]
 pub const nika_lsp::analysis::vocab::VERBS: &[nika_lsp::analysis::vocab::Entry]

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -59,8 +59,20 @@ pub fn completion(text: &str, offset: usize) -> Vec<CompletionItem> {
     if in_open_depends_on(text, offset) || is_template_tasks_ref(prefix) {
         return task_ids(text, scope::current_task_id(text, offset).as_deref());
     }
+    // An agent's `tools: [ … ]` whitelist — the same catalog register the
+    // singular `tool:` value gets (MCP refs stay the author's to type:
+    // the server has no MCP registry to speak from).
+    if in_open_tools_list(text, offset) {
+        return builtin_tools();
+    }
     if let Some(root) = members::template_member_root(prefix) {
         return members::member_items(text, root);
+    }
+    // `${{ tasks.<id>. }}` — the task's member facts (output · status ·
+    // error · its named bindings), BEFORE the CEL post-dot lane: a data
+    // path ends in methods, a task ref ends in members.
+    if let Some(task_id) = members::template_task_member(prefix) {
+        return members::task_member_items(text, &task_id);
     }
     if is_expression_post_dot(prefix) {
         return cel_methods();
@@ -78,7 +90,14 @@ pub fn completion(text: &str, offset: usize) -> Vec<CompletionItem> {
     if is_top_level_key(prefix) {
         return keyword_items(vocab::TOP_LEVEL_KEYS);
     }
-    if is_task_field_key(line, prefix) {
+    // Inside a `schema:` block the vocabulary is JSON Schema, never the
+    // task fields (the 557 probe: `schema:` used to offer `depends_on`).
+    // Direct children of `schema:`/`items:` get the keyset; children of
+    // `properties:` stay silent — those names belong to the author.
+    if scope::in_schema_key_position(text, offset) {
+        return keyword_items(vocab::SCHEMA_KEYS);
+    }
+    if is_task_field_key(line, prefix) && !scope::in_schema_scope(text, offset) {
         let mut items = keyword_items(vocab::TASK_FIELD_KEYS);
         items.extend(verb_items());
         return items;
@@ -138,12 +157,48 @@ fn is_model_value(prefix: &str) -> bool {
 /// opening line. The nearest `depends_on:` before the cursor must have an
 /// unbalanced `[` up to the cursor.
 fn in_open_depends_on(text: &str, offset: usize) -> bool {
+    in_open_flow_list(text, offset, "depends_on:")
+}
+
+/// Whether `offset` sits inside an unclosed agent `tools:` flow list —
+/// the default-deny register position (the singular `tool:` value lane
+/// serves invoke; THIS one serves the whitelist).
+fn in_open_tools_list(text: &str, offset: usize) -> bool {
+    in_open_flow_list(text, offset, "tools:")
+}
+
+fn in_open_flow_list(text: &str, offset: usize, key_name: &str) -> bool {
     let upto = text.get(..offset).unwrap_or("");
-    let Some(key) = upto.rfind("depends_on:") else {
+    let Some(key) = upto.rfind(key_name) else {
         return false;
     };
     let between = upto.get(key..).unwrap_or("");
-    between.matches('[').count() > between.matches(']').count()
+    if between.matches('[').count() <= between.matches(']').count() {
+        return false;
+    }
+    // The open bracket must still be THIS key's scope: an unclosed `[`
+    // abandoned upstream must not capture every later position in the
+    // file. Any non-blank line at indent ≤ the key's ends the block —
+    // deeper continuation lines (`depends_on: [\n  a,\n  <cursor>`) pass.
+    let key_line_start = upto
+        .get(..key)
+        .map_or(0, |s| s.rfind('\n').map_or(0, |i| i + 1));
+    let key_indent = upto
+        .get(key_line_start..)
+        .unwrap_or("")
+        .chars()
+        .take_while(|c| *c == ' ')
+        .count();
+    for line in between.lines().skip(1) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent <= key_indent {
+            return false;
+        }
+    }
+    true
 }
 
 /// Whether the current-line `prefix` ends in an open `${{ … tasks.` island.
@@ -611,790 +666,4 @@ fn scan_task_ids(text: &str) -> Vec<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn labels(items: &[CompletionItem]) -> Vec<String> {
-        items.iter().map(|i| i.label.clone()).collect()
-    }
-
-    fn kinds(items: &[CompletionItem]) -> Vec<CompletionItemKind> {
-        items.iter().filter_map(|i| i.kind).collect()
-    }
-
-    #[test]
-    fn current_line_returns_the_exact_line_around_the_offset() {
-        // The line slice must be EXACTLY the current line (no shift): for an
-        // offset on the third line, `current_line` is that whole line with no
-        // newline. A replaced/empty/shifted body (`""`, `"xyzzy"`, `nl-1`,
-        // `offset-nl`) would return a different slice.
-        let text = "aa\nbbbb\ncccccc";
-        // offset 5 is inside "bbbb" (line 1, starts at byte 3, ends at 7).
-        assert_eq!(current_line(text, 5), "bbbb", "the whole middle line");
-        // offset 0 → first line, offset at end → last line.
-        assert_eq!(current_line(text, 0), "aa", "first line");
-        assert_eq!(current_line(text, text.len()), "cccccc", "last line");
-        // a one-char shift in either boundary would drop a char or include a
-        // newline — assert the precise length too.
-        assert_eq!(current_line(text, 5).len(), 4, "no off-by-one in bounds");
-    }
-
-    #[test]
-    fn flow_map_close_line_suppresses_task_fields() {
-        // The cursor sits at the indent of a line whose content begins with
-        // `}` (a flow-map close). `is_task_field_key`'s guard reads the WHOLE
-        // current line via `current_line`; if that returns "" / "xyzzy" /
-        // a shifted slice, the `}` is missed and fields are wrongly offered.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    } x";
-        let cursor = text.rfind('}').expect("brace"); // caret at the indent
-        let items = completion(text, cursor);
-        assert!(
-            items.is_empty(),
-            "a `}}`-leading line is not a field position: {:?}",
-            labels(&items)
-        );
-        // CONTRAST: a normal indented ident fragment DOES offer fields — so
-        // the suppression above is the `}` guard, not a blanket empty.
-        let normal = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    de";
-        assert!(
-            !completion(normal, normal.len()).is_empty(),
-            "a normal field fragment still completes"
-        );
-    }
-
-    /// The space trigger's cost contract — ` ` is a trigger character
-    /// (capabilities.rs), so a space anywhere in running prose fires a
-    /// request; this pins that a non-value space answers EMPTY, keeping
-    /// the trigger free inside prompt blocks and plain text.
-    #[test]
-    fn a_space_in_running_prose_offers_nothing() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer:\n      prompt: |\n        Summarize the following ";
-        assert!(completion(text, text.len()).is_empty());
-    }
-
-    /// `tool: ` offers the full catalog-derived `nika:*` set — and the
-    /// count IS the catalog's (the born-stale gate: a builtin added to
-    /// the catalog appears here with zero LSP edits).
-    #[test]
-    fn tool_value_offers_exactly_the_builtin_set() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke:\n      tool: ";
-        let items = completion(text, text.len());
-        assert_eq!(items.len(), nika_catalog::all_builtins().len());
-        let got = labels(&items);
-        assert!(got.iter().all(|l| l.starts_with("nika:")), "{got:?}");
-        assert!(got.contains(&"nika:read".to_owned()));
-        assert!(got.contains(&"nika:jq".to_owned()));
-        // a partial token keeps offering (client-side filtering)
-        let text2 = format!("{text}nika:re");
-        assert!(!completion(&text2, text2.len()).is_empty());
-        // quoted form too — `tool: "nika:` is the corpus's own style
-        let text3 = format!("{text}\"nika:");
-        assert!(!completion(&text3, text3.len()).is_empty());
-    }
-
-    /// `model: ollama/` narrows to ollama's OWN catalog models; an
-    /// unknown provider falls back to the provider list (never empty).
-    #[test]
-    fn provider_slash_offers_that_providers_models() {
-        let text = "nika: v1\nmodel: ollama/";
-        let items = completion(text, text.len());
-        assert!(!items.is_empty(), "ollama has catalog models");
-        let got = labels(&items);
-        assert!(got.iter().all(|l| l.starts_with("ollama/")), "{got:?}");
-
-        let text2 = "nika: v1\nmodel: nosuch/";
-        let fallback = completion(text2, text2.len());
-        let fb = labels(&fallback);
-        assert!(
-            fb.iter().any(|l| l == "ollama/"),
-            "unknown provider → provider list: {fb:?}"
-        );
-    }
-
-    /// Closed-enum fields offer exactly the spec's vocabulary.
-    #[test]
-    fn enum_fields_offer_exactly_the_closed_sets() {
-        let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: x\n      capture: ";
-        let labels_ = labels(&completion(text, text.len()));
-        assert_eq!(labels_, vec!["text".to_owned(), "structured".to_owned()]);
-
-        let text2 = "nika: v1\ntasks:\n  - id: a\n    retry:\n      backoff_strategy: ";
-        let l2 = labels(&completion(text2, text2.len()));
-        assert_eq!(
-            l2,
-            vec![
-                "exponential".to_owned(),
-                "linear".to_owned(),
-                "fixed".to_owned()
-            ]
-        );
-
-        // the envelope value — the FIRST thing every author types
-        let text3 = "nika: ";
-        let l3 = labels(&completion(text3, text3.len()));
-        assert_eq!(l3, vec!["v1".to_owned()]);
-
-        // vars declaration types — and the same lane serves JSON-Schema
-        // `type:` lines inside `schema:` blocks
-        let text4 = "nika: v1\nvars:\n  city:\n    type: ";
-        let l4 = labels(&completion(text4, text4.len()));
-        assert_eq!(
-            l4,
-            vec![
-                "string".to_owned(),
-                "number".to_owned(),
-                "integer".to_owned(),
-                "boolean".to_owned(),
-                "array".to_owned(),
-                "object".to_owned()
-            ]
-        );
-    }
-
-    #[test]
-    fn model_value_offers_exactly_the_provider_set() {
-        let text = "nika: v1\nworkflow: w\nmodel: ";
-        let items = completion(text, text.len());
-        // EXACT label set: every provider with a trailing `/`, in canon
-        // (local-first) order — not the keyword/field/task sets.
-        assert_eq!(
-            labels(&items),
-            vec![
-                "ollama/",
-                "lmstudio/",
-                "llamacpp/",
-                "localai/",
-                "vllm/",
-                "mistral/",
-                "anthropic/",
-                "openai/",
-                "google/",
-                "deepseek/",
-                "groq/",
-                "xai/",
-                "openrouter/",
-                "huggingface/",
-                "nvidia/",
-                "mock/",
-            ],
-            "the 16-provider catalog, local-first, each suffixed with `/`"
-        );
-        // every provider item is a VALUE with a non-empty detail (the kind +
-        // detail fields, not just the label).
-        assert!(
-            items
-                .iter()
-                .all(|i| i.kind == Some(CompletionItemKind::VALUE)),
-            "providers are VALUE-kinded"
-        );
-        assert!(
-            items
-                .iter()
-                .all(|i| i.detail.as_deref().is_some_and(|d| !d.is_empty())),
-            "every provider carries its doc as detail"
-        );
-        // the ollama detail is the exact vocab doc (pins the detail field).
-        assert_eq!(
-            items[0].detail.as_deref(),
-            Some("Local models via Ollama (sovereign, open-weight)."),
-            "ollama detail is the vocab doc"
-        );
-    }
-
-    #[test]
-    fn model_value_with_a_partial_provider_still_offers_providers() {
-        // `model: ollama` (a bare provider, no whitespace after) is still a
-        // value position — providers are offered (the client filters). The
-        // `||` in is_model_value is load-bearing: `!contains(ws)` is true
-        // here so the OR short-circuits to true.
-        let text = "nika: v1\nmodel: ollama";
-        let items = completion(text, text.len());
-        assert_eq!(
-            labels(&items).first().map(String::as_str),
-            Some("ollama/"),
-            "a typed-but-incomplete provider value still offers the catalog"
-        );
-    }
-
-    #[test]
-    fn model_value_after_a_space_separated_token_offers_nothing() {
-        // `model: ollama foo` has whitespace WITHIN the value — no longer a
-        // single value position. `!after.contains(ws)` is false and
-        // `after.trim().is_empty()` is false, so `is_model_value` is false.
-        // (Deleting the `!` or flipping `||`→`&&` would mis-classify this.)
-        let text = "nika: v1\nmodel: ollama foo";
-        let items = completion(text, text.len());
-        assert!(
-            !labels(&items).iter().any(|l| l.ends_with('/')),
-            "a space-separated trailing token is not a provider value: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn depends_on_offers_exactly_the_task_ids() {
-        // The partially-typed `depends_on: [` does not parse → the scan path
-        // yields the ids with detail "task" and VARIABLE kind. EXACT set.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [";
-        let items = completion(text, text.len());
-        assert_eq!(
-            labels(&items),
-            vec!["extract"],
-            "exactly the OTHER task ids — `save` is the task being edited, \
-             and a self-dependency is a cycle the check refuses"
-        );
-        assert!(
-            items
-                .iter()
-                .all(|i| i.kind == Some(CompletionItemKind::VARIABLE)),
-            "task refs are VARIABLE-kinded"
-        );
-        assert!(
-            items.iter().all(|i| i.detail.as_deref() == Some("task")),
-            "scan-path detail is the bare `task` label"
-        );
-    }
-
-    #[test]
-    fn depends_on_in_a_parseable_doc_uses_the_verb_detail() {
-        // A FULLY VALID document with the cursor inside an open `[`: the
-        // parse path wins, so each id carries its verb in the detail
-        // (`task (exec)`) — the `!wf.tasks.is_empty()` guard + the label/
-        // kind/detail fields of the parse-path CompletionItem.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract]\n    exec: { command: \"y\" }\n";
-        let cursor = text
-            .find("depends_on: [")
-            .map(|p| p + "depends_on: [".len())
-            .expect("open bracket");
-        let items = completion(text, cursor);
-        assert_eq!(
-            labels(&items),
-            vec!["extract"],
-            "the other task ids (self excluded)"
-        );
-        assert!(
-            items
-                .iter()
-                .all(|i| i.kind == Some(CompletionItemKind::VARIABLE)),
-            "VARIABLE-kinded"
-        );
-        assert_eq!(
-            items.iter().map(|i| i.detail.clone()).collect::<Vec<_>>(),
-            vec![Some("task (exec)".to_owned())],
-            "parse path carries the verb in the detail, NOT the bare `task`"
-        );
-    }
-
-    #[test]
-    fn closed_depends_on_after_the_bracket_does_not_offer_task_ids() {
-        // The `[` is BALANCED by `]` — the cursor sits after a fully closed
-        // depends_on. `in_open_depends_on` must be FALSE (counts equal, not
-        // `>=`), so no task-id completion fires here.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract] ";
-        let items = completion(text, text.len());
-        assert!(
-            !labels(&items).iter().any(|l| l == "extract" || l == "save"),
-            "a closed depends_on offers no task ids: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn depends_on_offers_task_ids_across_lines() {
-        // a multi-line flow list: the cursor is on a continuation line, the
-        // `depends_on:` key + unclosed `[` are on PREVIOUS lines.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [\n      extract,\n      ";
-        let items = completion(text, text.len());
-        let labels = labels(&items);
-        assert!(labels.contains(&"extract".to_owned()), "{labels:?}");
-        assert!(
-            !labels.contains(&"save".to_owned()),
-            "the edited task never offers itself: {labels:?}"
-        );
-    }
-
-    #[test]
-    fn model_key_without_space_offers_envelope_keys_not_providers() {
-        // caret right after `model:` (no space) — this is the KEY, not the
-        // value. Offering `ollama/` here would glue to `model:ollama/`.
-        let text = "nika: v1\nmodel:";
-        let items = completion(text, text.len());
-        let labels = labels(&items);
-        assert!(
-            !labels.iter().any(|l| l.ends_with('/')),
-            "no provider values at the bare key: {labels:?}"
-        );
-    }
-
-    #[test]
-    fn template_tasks_dot_offers_task_ids() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use\n    exec: { command: \"echo ${{ tasks.";
-        let items = completion(text, text.len());
-        assert_eq!(
-            labels(&items),
-            vec!["extract"],
-            "the OTHER task ids — `use` is the task being edited"
-        );
-        assert!(
-            items
-                .iter()
-                .all(|i| i.kind == Some(CompletionItemKind::VARIABLE)),
-            "task refs are VARIABLE-kinded"
-        );
-    }
-
-    #[test]
-    fn template_island_without_tasks_dot_offers_nothing() {
-        // An open `${{ ` island that does NOT end with `tasks.` is not a task
-        // reference. `is_template_tasks_ref` requires BOTH `!contains("}}")`
-        // AND `ends_with("tasks.")` — flipping the `&&` to `||` would fire on
-        // any open island.
-        let text =
-            "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"echo ${{ vars.";
-        let items = completion(text, text.len());
-        assert!(
-            !labels(&items).iter().any(|l| l == "extract"),
-            "an `${{{{ vars.` island is not a tasks ref: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn top_level_offers_exactly_the_envelope_keys() {
-        let text = "nika: v1\nwo";
-        let items = completion(text, text.len());
-        // EXACT envelope-key set (the vocab order), PROPERTY-kinded, no verbs.
-        assert_eq!(
-            labels(&items),
-            vec![
-                "nika",
-                "workflow",
-                "description",
-                "model",
-                "vars",
-                "env",
-                "secrets",
-                "permits",
-                "tasks",
-                "outputs",
-            ],
-            "the 10 top-level envelope keys, in spec order"
-        );
-        assert!(
-            items
-                .iter()
-                .all(|i| i.kind == Some(CompletionItemKind::PROPERTY)),
-            "envelope keys are PROPERTY-kinded"
-        );
-        // verbs are NOT top-level keys
-        assert!(!labels(&items).contains(&"infer".to_owned()));
-    }
-
-    #[test]
-    fn top_level_non_identifier_prefix_offers_nothing() {
-        // A column-0 line with a space in the typed fragment (`wo rk`) is NOT
-        // a bare key fragment — `is_top_level_key`'s `all(ident)` is false,
-        // so no envelope keys fire. (Flipping `&&`→`||` would still offer.)
-        let text = "nika: v1\nwo rk";
-        let items = completion(text, text.len());
-        assert!(
-            items.is_empty(),
-            "a non-identifier top-level prefix offers nothing: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn top_level_after_a_colon_offers_no_keys() {
-        // Once the line has a `:` it is a VALUE position, not a key position.
-        // `is_top_level_key`'s `!typed.contains(':')` must hold. The `==` in
-        // the char predicate (`c == '_'`) and the `&&` both matter here.
-        let text = "nika: v1\nworkflow: w";
-        let items = completion(text, text.len());
-        assert!(
-            !labels(&items).contains(&"workflow".to_owned()),
-            "a `key: value` line is not a key position: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn task_field_offers_exactly_the_fields_and_verbs() {
-        // indented key position inside a task: the 12 task fields followed by
-        // the 4 verbs, in that order. EXACT set + kinds (fields PROPERTY,
-        // verbs KEYWORD).
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    de";
-        let items = completion(text, text.len());
-        assert_eq!(
-            labels(&items),
-            vec![
-                // the 12 task fields (vocab order)
-                "id",
-                "depends_on",
-                "when",
-                "for_each",
-                "max_parallel",
-                "fail_fast",
-                "retry",
-                "on_error",
-                "timeout",
-                "with",
-                "output",
-                "on_finally",
-                // then the 4 verbs
-                "infer",
-                "exec",
-                "invoke",
-                "agent",
-            ],
-            "task fields then the 4 verbs"
-        );
-        // the first 12 are PROPERTY (fields), the last 4 are KEYWORD (verbs).
-        let ks = kinds(&items);
-        assert_eq!(ks.len(), 16, "16 items, all kinded");
-        assert!(
-            ks[..12].iter().all(|k| *k == CompletionItemKind::PROPERTY),
-            "fields are PROPERTY-kinded"
-        );
-        assert!(
-            ks[12..].iter().all(|k| *k == CompletionItemKind::KEYWORD),
-            "verbs are KEYWORD-kinded"
-        );
-        // the verb items carry their doc as detail (the detail field).
-        let infer = items
-            .iter()
-            .find(|i| i.label == "infer")
-            .expect("infer item");
-        assert_eq!(
-            infer.detail.as_deref(),
-            Some(
-                "A single LLM call. Sends one prompt, returns one response \
-                 (optionally structured against a `schema:`)."
-            ),
-            "the infer verb's detail is its vocab doc"
-        );
-    }
-
-    #[test]
-    fn task_field_inside_a_flow_map_value_offers_nothing() {
-        // An indented line that has already opened a flow-map value (`{`)
-        // and contains a `:` is NOT a field position. `is_task_field_key`
-        // requires `!body.contains(':')`; the closing-`}` guard and the
-        // ident predicate also gate it.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command";
-        let items = completion(text, text.len());
-        // `command` has no colon yet, BUT the line started a flow map — it is
-        // still a bare ident fragment, so fields ARE offered here. Assert the
-        // CONVERSE boundary: once a `:` appears, nothing fires.
-        let after_colon = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: x";
-        let none = completion(after_colon, after_colon.len());
-        assert!(
-            none.is_empty(),
-            "an indented `key: value` line offers nothing: {:?}",
-            labels(&none)
-        );
-        // sanity: the flow-map-open case still parses as a field fragment.
-        let _ = items;
-    }
-
-    #[test]
-    fn task_field_fragment_with_underscore_still_completes() {
-        // The field fragment `for_` contains an underscore. `is_task_field_
-        // key`'s char predicate `c == '_' || alnum` must accept it (flipping
-        // `==` to `!=` would reject the `_` and suppress field completion).
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    for_";
-        let items = completion(text, text.len());
-        assert!(
-            labels(&items).contains(&"for_each".to_owned()),
-            "an underscore-bearing field fragment still completes: {:?}",
-            labels(&items)
-        );
-        assert!(
-            labels(&items).contains(&"on_error".to_owned()),
-            "and the rest"
-        );
-    }
-
-    /// B6 · the CEL method position: a dot PAST a data path inside an
-    /// open island completes the closed cel-subset/0.1 method set — and
-    /// the bare `tasks.` island stays task-id territory (checked first).
-    #[test]
-    fn expression_post_dot_completes_cel_methods() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.output.";
-        let items = completion(text, text.len());
-        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
-        assert!(
-            labels.contains(&"size()"),
-            "cel methods at post-path dot: {labels:?}"
-        );
-        assert!(labels.contains(&"startsWith(…)"));
-        assert_eq!(
-            items.len(),
-            4,
-            "the method set is CLOSED (parser arity table)"
-        );
-
-        // Bare `tasks.` still resolves to task IDS, never methods.
-        let bare = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    exec: { command: \"echo ${{ tasks.";
-        let ids: Vec<String> = completion(bare, bare.len())
-            .into_iter()
-            .map(|i| i.label)
-            .collect();
-        assert!(
-            ids.contains(&"a".to_owned()),
-            "task ids win on the bare root: {ids:?}"
-        );
-    }
-
-    /// B6 · the island start completes the five locked roots + item +
-    /// the two free functions — and outside any island, nothing changes.
-    #[test]
-    fn expression_start_completes_roots_and_free_functions() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ ";
-        let labels: Vec<String> = completion(text, text.len())
-            .into_iter()
-            .map(|i| i.label)
-            .collect();
-        for root in ["tasks", "vars", "env", "secrets", "with", "item"] {
-            assert!(
-                labels.contains(&root.to_owned()),
-                "missing root {root}: {labels:?}"
-            );
-        }
-        assert!(labels.contains(&"has(…)".to_owned()));
-
-        // A closed island offers nothing from the expression vocab.
-        let closed =
-            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ vars.x }} and ";
-        let after: Vec<String> = completion(closed, closed.len())
-            .into_iter()
-            .map(|i| i.label)
-            .collect();
-        assert!(
-            !after.contains(&"has(…)".to_owned()),
-            "closed island leaks: {after:?}"
-        );
-    }
-
-    #[test]
-    fn keyword_items_carry_their_doc_as_detail() {
-        // The envelope/task-field items built by `keyword_items` carry the
-        // vocab doc in their `detail` field (deleting it would default to
-        // None). Assert the exact detail on a known envelope key.
-        let text = "nika: v1\nwo";
-        let items = completion(text, text.len());
-        let tasks = items
-            .iter()
-            .find(|i| i.label == "tasks")
-            .expect("tasks key item");
-        assert_eq!(
-            tasks.detail.as_deref(),
-            Some(
-                "The task DAG. Required, non-empty. Each task runs exactly \
-                 one verb."
-            ),
-            "the envelope key carries its vocab doc as detail"
-        );
-        assert!(
-            items.iter().all(|i| i.detail.is_some()),
-            "every keyword item has a detail"
-        );
-    }
-
-    #[test]
-    fn scan_task_ids_reads_underscored_ids_in_full() {
-        // The scan-path take_while keeps `_` and alnum. An id with an
-        // underscore (`my_task`) must be read in FULL (flipping the `==` in
-        // the take_while predicate would stop at the `_`, truncating to `my`).
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: my_task\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [";
-        let items = completion(text, text.len());
-        assert_eq!(
-            labels(&items),
-            vec!["my_task"],
-            "the underscored id is read whole, not truncated to `my` \
-             (`b` is the task being edited — self excluded)"
-        );
-    }
-
-    #[test]
-    fn list_marker_id_is_a_task_field_position() {
-        // The `- ` list marker introducing a task is a field position: after
-        // stripping `- `, the body is a bare ident fragment. (`is_task_field_
-        // key` strips the `- ` marker.)
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - i";
-        let items = completion(text, text.len());
-        assert!(
-            labels(&items).contains(&"id".to_owned()),
-            "the `- ` marker line offers task fields: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn inside_a_value_offers_nothing() {
-        // cursor inside a quoted prompt value — no trigger context
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"echo ";
-        let items = completion(text, text.len());
-        // not a model/ref/key position → empty (the `command` line has a `:`
-        // and an open value)
-        assert!(
-            items.is_empty(),
-            "no spurious completions: {:?}",
-            labels(&items)
-        );
-    }
-
-    #[test]
-    fn scan_task_ids_dedups_and_reads_in_order() {
-        // The scan path reads `id:` lines in source order and dedups repeats.
-        // (`!id.is_empty() && !ids.contains(&id)` — the `&&` and the `==` in
-        // the take_while predicate both matter.) A duplicate id must appear
-        // ONCE; the order is source order.
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: first\n    exec: { command: \"x\" }\n  - id: second\n    exec: { command: \"y\" }\n  - id: first\n    exec: { command: \"z\" }\n  - id: editor\n    depends_on: [";
-        let items = completion(text, text.len());
-        assert_eq!(
-            labels(&items),
-            vec!["first", "second"],
-            "source order, deduplicated (`first` once) — and `editor`, \
-             the task being edited, excludes itself"
-        );
-    }
-
-    #[test]
-    fn completion_is_total_over_a_mid_char_offset() {
-        // The entry clamps a past-the-end offset (`offset.min(len)`) but the
-        // clamp does not land on a char BOUNDARY — a mid-multibyte offset
-        // slices `text[..offset]` mid-char and panics, which in the sync
-        // serve loop takes the WHOLE language server down. `completion` must
-        // be total over `(text, offset)`: any offset returns, never panics.
-        // (The server floors offsets via `LineIndex::offset`, so this is
-        // defence-in-depth for a public analysis primitive, not a reachable
-        // crash today — the bar for an LSP is « no input panics ».)
-        let _ = completion("é", 1); // byte 1 is inside the 2-byte 'é'
-        let _ = completion("nika: v1\n", 99_999); // far past the end
-        let doc = "nika: v1\nmodel: 🦋";
-        let _ = completion(doc, doc.len() - 1); // inside the trailing 4-byte 🦋
-    }
-
-    /// Inside `args:` of a KNOWN builtin, key position → that tool's own
-    /// argument names, catalog-derived (the born-stale law again) —
-    /// required ones sorted first and marked.
-    #[test]
-    fn fetch_args_offer_the_catalog_arg_keys() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: get\n    invoke:\n      tool: nika:fetch\n      args:\n        ";
-        let items = completion(text, text.len());
-        let fetch = nika_catalog::all_builtins()
-            .iter()
-            .find(|b| b.name == "fetch")
-            .expect("fetch in catalog");
-        assert_eq!(items.len(), fetch.args.len(), "exactly the catalog args");
-        let labels = labels(&items);
-        assert!(labels.contains(&"url:".to_owned()), "{labels:?}");
-        assert!(labels.contains(&"mode:".to_owned()), "{labels:?}");
-        // required args float first (sort_text partition: '0…' < '1…')
-        for item in &items {
-            let required = item
-                .detail
-                .as_deref()
-                .is_some_and(|d| d.starts_with("required"));
-            let sort = item.sort_text.as_deref().unwrap_or("");
-            assert_eq!(
-                sort.starts_with('0'),
-                required,
-                "sort partition mirrors required: {item:?}"
-            );
-        }
-    }
-
-    /// An UNKNOWN tool's args stay its own business — no `nika:fetch`
-    /// keys leak under an MCP tool.
-    #[test]
-    fn mcp_tool_args_do_not_leak_fetch_keys() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: gh\n    invoke:\n      tool: github.search\n      args:\n        ";
-        let labels = labels(&completion(text, text.len()));
-        assert!(
-            !labels.contains(&"url:".to_owned()),
-            "no cross-tool leak: {labels:?}"
-        );
-    }
-
-    /// `mode:` under `nika:fetch` offers the stdlib extract vocabulary —
-    /// the SET is `ExtractMode::ALL` (a mode added at L0 appears here
-    /// with zero LSP edits). Under any other tool the lane stays silent.
-    #[test]
-    fn fetch_mode_offers_the_stdlib_extract_vocabulary() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: get\n    invoke:\n      tool: nika:fetch\n      args:\n        mode: ";
-        let items = completion(text, text.len());
-        assert_eq!(items.len(), nika_types::ExtractMode::ALL.len());
-        let labels = labels(&items);
-        assert_eq!(labels[0], "markdown", "canon order — the default first");
-        assert!(labels.contains(&"jq".to_owned()), "{labels:?}");
-
-        let other = "nika: v1\nworkflow: w\ntasks:\n  - id: x\n    invoke:\n      tool: github.search\n      args:\n        mode: ";
-        assert!(
-            labels_of(other).iter().all(|l| l != "jq"),
-            "another tool's `mode:` is not the extract vocabulary"
-        );
-    }
-
-    /// `${{ vars.` offers the file's OWN declared vars. On a document
-    /// that parses (cursor mid-island, island closed), typed vars carry
-    /// type + required + description and untyped ones their default; a
-    /// mid-keystroke document that no longer parses falls back to the
-    /// block scan — names still arrive, detail goes generic.
-    #[test]
-    fn island_vars_offer_the_declared_names() {
-        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    description: target city\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }}\" }\n";
-        let cursor = text.find("${{ vars.").expect("island") + "${{ vars.".len();
-        let items = completion(text, cursor);
-        let got = labels(&items);
-        assert_eq!(got, vec!["city", "out_dir"], "{got:?}");
-        let detail = items[0].detail.as_deref().unwrap_or("");
-        assert!(
-            detail.contains("string")
-                && detail.contains("required")
-                && detail.contains("target city"),
-            "typed var detail teaches type · required · description: {detail}"
-        );
-        assert!(
-            items[1].detail.as_deref().unwrap_or("").contains("./out"),
-            "untyped var detail carries the default"
-        );
-
-        // mid-keystroke fallback: unterminated island · parse fails · the
-        // block scan still teaches the NAMES
-        let typing = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.";
-        let fallback = labels(&completion(typing, typing.len()));
-        assert_eq!(fallback, vec!["city", "out_dir"], "{fallback:?}");
-    }
-
-    /// `${{ secrets.` / `${{ env.` offer the file's own declared names.
-    #[test]
-    fn island_secrets_and_env_offer_declared_names() {
-        let text = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\nsecrets:\n  api_key:\n    source: env\n    key: MY_KEY\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ secrets.";
-        let labels_s = labels(&completion(text, text.len()));
-        assert_eq!(labels_s, vec!["api_key"], "{labels_s:?}");
-
-        let text2 = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ env.";
-        let labels_e = labels(&completion(text2, text2.len()));
-        assert_eq!(labels_e, vec!["REGION"], "{labels_e:?}");
-    }
-
-    /// The exclusion is the whole ILLEGAL set — not just self. In the
-    /// diamond a → {b, c} → d, task `b` editing a `${{ tasks.` island
-    /// may reference `a` (ancestor) and `c` (parallel) but never `d`:
-    /// a ref to d is an implicit edge d → b while d already waits on b
-    /// — the cycle the check refuses. Same law, one voice.
-    #[test]
-    fn island_tasks_exclude_the_downstream_closure() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output }}\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
-        // cursor mid-island inside task b (document parses whole)
-        let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
-        let got = labels(&completion(text, cursor));
-        assert_eq!(got, vec!["a", "c"], "ancestor + parallel only: {got:?}");
-    }
-
-    fn labels_of(text: &str) -> Vec<String> {
-        labels(&completion(text, text.len()))
-    }
-}
+mod tests;

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -1,0 +1,919 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The completion lanes, pinned — split out of `completion.rs` when the
+//! 557 lanes pushed the single file past the 1500-LOC cap (the Diamond
+//! law: split, never exempt). `use super::*` keeps every private lane
+//! reachable — same module, its own file.
+
+use super::*;
+
+fn labels(items: &[CompletionItem]) -> Vec<String> {
+    items.iter().map(|i| i.label.clone()).collect()
+}
+
+fn kinds(items: &[CompletionItem]) -> Vec<CompletionItemKind> {
+    items.iter().filter_map(|i| i.kind).collect()
+}
+
+#[test]
+fn current_line_returns_the_exact_line_around_the_offset() {
+    // The line slice must be EXACTLY the current line (no shift): for an
+    // offset on the third line, `current_line` is that whole line with no
+    // newline. A replaced/empty/shifted body (`""`, `"xyzzy"`, `nl-1`,
+    // `offset-nl`) would return a different slice.
+    let text = "aa\nbbbb\ncccccc";
+    // offset 5 is inside "bbbb" (line 1, starts at byte 3, ends at 7).
+    assert_eq!(current_line(text, 5), "bbbb", "the whole middle line");
+    // offset 0 → first line, offset at end → last line.
+    assert_eq!(current_line(text, 0), "aa", "first line");
+    assert_eq!(current_line(text, text.len()), "cccccc", "last line");
+    // a one-char shift in either boundary would drop a char or include a
+    // newline — assert the precise length too.
+    assert_eq!(current_line(text, 5).len(), 4, "no off-by-one in bounds");
+}
+
+#[test]
+fn flow_map_close_line_suppresses_task_fields() {
+    // The cursor sits at the indent of a line whose content begins with
+    // `}` (a flow-map close). `is_task_field_key`'s guard reads the WHOLE
+    // current line via `current_line`; if that returns "" / "xyzzy" /
+    // a shifted slice, the `}` is missed and fields are wrongly offered.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    } x";
+    let cursor = text.rfind('}').expect("brace"); // caret at the indent
+    let items = completion(text, cursor);
+    assert!(
+        items.is_empty(),
+        "a `}}`-leading line is not a field position: {:?}",
+        labels(&items)
+    );
+    // CONTRAST: a normal indented ident fragment DOES offer fields — so
+    // the suppression above is the `}` guard, not a blanket empty.
+    let normal = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    de";
+    assert!(
+        !completion(normal, normal.len()).is_empty(),
+        "a normal field fragment still completes"
+    );
+}
+
+/// The space trigger's cost contract — ` ` is a trigger character
+/// (capabilities.rs), so a space anywhere in running prose fires a
+/// request; this pins that a non-value space answers EMPTY, keeping
+/// the trigger free inside prompt blocks and plain text.
+#[test]
+fn a_space_in_running_prose_offers_nothing() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer:\n      prompt: |\n        Summarize the following ";
+    assert!(completion(text, text.len()).is_empty());
+}
+
+/// `tool: ` offers the full catalog-derived `nika:*` set — and the
+/// count IS the catalog's (the born-stale gate: a builtin added to
+/// the catalog appears here with zero LSP edits).
+#[test]
+fn tool_value_offers_exactly_the_builtin_set() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    invoke:\n      tool: ";
+    let items = completion(text, text.len());
+    assert_eq!(items.len(), nika_catalog::all_builtins().len());
+    let got = labels(&items);
+    assert!(got.iter().all(|l| l.starts_with("nika:")), "{got:?}");
+    assert!(got.contains(&"nika:read".to_owned()));
+    assert!(got.contains(&"nika:jq".to_owned()));
+    // a partial token keeps offering (client-side filtering)
+    let text2 = format!("{text}nika:re");
+    assert!(!completion(&text2, text2.len()).is_empty());
+    // quoted form too — `tool: "nika:` is the corpus's own style
+    let text3 = format!("{text}\"nika:");
+    assert!(!completion(&text3, text3.len()).is_empty());
+}
+
+/// `model: ollama/` narrows to ollama's OWN catalog models; an
+/// unknown provider falls back to the provider list (never empty).
+#[test]
+fn provider_slash_offers_that_providers_models() {
+    let text = "nika: v1\nmodel: ollama/";
+    let items = completion(text, text.len());
+    assert!(!items.is_empty(), "ollama has catalog models");
+    let got = labels(&items);
+    assert!(got.iter().all(|l| l.starts_with("ollama/")), "{got:?}");
+
+    let text2 = "nika: v1\nmodel: nosuch/";
+    let fallback = completion(text2, text2.len());
+    let fb = labels(&fallback);
+    assert!(
+        fb.iter().any(|l| l == "ollama/"),
+        "unknown provider → provider list: {fb:?}"
+    );
+}
+
+/// Closed-enum fields offer exactly the spec's vocabulary.
+#[test]
+fn enum_fields_offer_exactly_the_closed_sets() {
+    let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: x\n      capture: ";
+    let labels_ = labels(&completion(text, text.len()));
+    assert_eq!(labels_, vec!["text".to_owned(), "structured".to_owned()]);
+
+    let text2 = "nika: v1\ntasks:\n  - id: a\n    retry:\n      backoff_strategy: ";
+    let l2 = labels(&completion(text2, text2.len()));
+    assert_eq!(
+        l2,
+        vec![
+            "exponential".to_owned(),
+            "linear".to_owned(),
+            "fixed".to_owned()
+        ]
+    );
+
+    // the envelope value — the FIRST thing every author types
+    let text3 = "nika: ";
+    let l3 = labels(&completion(text3, text3.len()));
+    assert_eq!(l3, vec!["v1".to_owned()]);
+
+    // vars declaration types — and the same lane serves JSON-Schema
+    // `type:` lines inside `schema:` blocks
+    let text4 = "nika: v1\nvars:\n  city:\n    type: ";
+    let l4 = labels(&completion(text4, text4.len()));
+    assert_eq!(
+        l4,
+        vec![
+            "string".to_owned(),
+            "number".to_owned(),
+            "integer".to_owned(),
+            "boolean".to_owned(),
+            "array".to_owned(),
+            "object".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn model_value_offers_exactly_the_provider_set() {
+    let text = "nika: v1\nworkflow: w\nmodel: ";
+    let items = completion(text, text.len());
+    // EXACT label set: every provider with a trailing `/`, in canon
+    // (local-first) order — not the keyword/field/task sets.
+    assert_eq!(
+        labels(&items),
+        vec![
+            "ollama/",
+            "lmstudio/",
+            "llamacpp/",
+            "localai/",
+            "vllm/",
+            "mistral/",
+            "anthropic/",
+            "openai/",
+            "google/",
+            "deepseek/",
+            "groq/",
+            "xai/",
+            "openrouter/",
+            "huggingface/",
+            "nvidia/",
+            "mock/",
+        ],
+        "the 16-provider catalog, local-first, each suffixed with `/`"
+    );
+    // every provider item is a VALUE with a non-empty detail (the kind +
+    // detail fields, not just the label).
+    assert!(
+        items
+            .iter()
+            .all(|i| i.kind == Some(CompletionItemKind::VALUE)),
+        "providers are VALUE-kinded"
+    );
+    assert!(
+        items
+            .iter()
+            .all(|i| i.detail.as_deref().is_some_and(|d| !d.is_empty())),
+        "every provider carries its doc as detail"
+    );
+    // the ollama detail is the exact vocab doc (pins the detail field).
+    assert_eq!(
+        items[0].detail.as_deref(),
+        Some("Local models via Ollama (sovereign, open-weight)."),
+        "ollama detail is the vocab doc"
+    );
+}
+
+#[test]
+fn model_value_with_a_partial_provider_still_offers_providers() {
+    // `model: ollama` (a bare provider, no whitespace after) is still a
+    // value position — providers are offered (the client filters). The
+    // `||` in is_model_value is load-bearing: `!contains(ws)` is true
+    // here so the OR short-circuits to true.
+    let text = "nika: v1\nmodel: ollama";
+    let items = completion(text, text.len());
+    assert_eq!(
+        labels(&items).first().map(String::as_str),
+        Some("ollama/"),
+        "a typed-but-incomplete provider value still offers the catalog"
+    );
+}
+
+#[test]
+fn model_value_after_a_space_separated_token_offers_nothing() {
+    // `model: ollama foo` has whitespace WITHIN the value — no longer a
+    // single value position. `!after.contains(ws)` is false and
+    // `after.trim().is_empty()` is false, so `is_model_value` is false.
+    // (Deleting the `!` or flipping `||`→`&&` would mis-classify this.)
+    let text = "nika: v1\nmodel: ollama foo";
+    let items = completion(text, text.len());
+    assert!(
+        !labels(&items).iter().any(|l| l.ends_with('/')),
+        "a space-separated trailing token is not a provider value: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn depends_on_offers_exactly_the_task_ids() {
+    // The partially-typed `depends_on: [` does not parse → the scan path
+    // yields the ids with detail "task" and VARIABLE kind. EXACT set.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [";
+    let items = completion(text, text.len());
+    assert_eq!(
+        labels(&items),
+        vec!["extract"],
+        "exactly the OTHER task ids — `save` is the task being edited, \
+         and a self-dependency is a cycle the check refuses"
+    );
+    assert!(
+        items
+            .iter()
+            .all(|i| i.kind == Some(CompletionItemKind::VARIABLE)),
+        "task refs are VARIABLE-kinded"
+    );
+    assert!(
+        items.iter().all(|i| i.detail.as_deref() == Some("task")),
+        "scan-path detail is the bare `task` label"
+    );
+}
+
+#[test]
+fn depends_on_in_a_parseable_doc_uses_the_verb_detail() {
+    // A FULLY VALID document with the cursor inside an open `[`: the
+    // parse path wins, so each id carries its verb in the detail
+    // (`task (exec)`) — the `!wf.tasks.is_empty()` guard + the label/
+    // kind/detail fields of the parse-path CompletionItem.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract]\n    exec: { command: \"y\" }\n";
+    let cursor = text
+        .find("depends_on: [")
+        .map(|p| p + "depends_on: [".len())
+        .expect("open bracket");
+    let items = completion(text, cursor);
+    assert_eq!(
+        labels(&items),
+        vec!["extract"],
+        "the other task ids (self excluded)"
+    );
+    assert!(
+        items
+            .iter()
+            .all(|i| i.kind == Some(CompletionItemKind::VARIABLE)),
+        "VARIABLE-kinded"
+    );
+    assert_eq!(
+        items.iter().map(|i| i.detail.clone()).collect::<Vec<_>>(),
+        vec![Some("task (exec)".to_owned())],
+        "parse path carries the verb in the detail, NOT the bare `task`"
+    );
+}
+
+#[test]
+fn closed_depends_on_after_the_bracket_does_not_offer_task_ids() {
+    // The `[` is BALANCED by `]` — the cursor sits after a fully closed
+    // depends_on. `in_open_depends_on` must be FALSE (counts equal, not
+    // `>=`), so no task-id completion fires here.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract] ";
+    let items = completion(text, text.len());
+    assert!(
+        !labels(&items).iter().any(|l| l == "extract" || l == "save"),
+        "a closed depends_on offers no task ids: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn depends_on_offers_task_ids_across_lines() {
+    // a multi-line flow list: the cursor is on a continuation line, the
+    // `depends_on:` key + unclosed `[` are on PREVIOUS lines.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [\n      extract,\n      ";
+    let items = completion(text, text.len());
+    let labels = labels(&items);
+    assert!(labels.contains(&"extract".to_owned()), "{labels:?}");
+    assert!(
+        !labels.contains(&"save".to_owned()),
+        "the edited task never offers itself: {labels:?}"
+    );
+}
+
+#[test]
+fn model_key_without_space_offers_envelope_keys_not_providers() {
+    // caret right after `model:` (no space) — this is the KEY, not the
+    // value. Offering `ollama/` here would glue to `model:ollama/`.
+    let text = "nika: v1\nmodel:";
+    let items = completion(text, text.len());
+    let labels = labels(&items);
+    assert!(
+        !labels.iter().any(|l| l.ends_with('/')),
+        "no provider values at the bare key: {labels:?}"
+    );
+}
+
+#[test]
+fn template_tasks_dot_offers_task_ids() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use\n    exec: { command: \"echo ${{ tasks.";
+    let items = completion(text, text.len());
+    assert_eq!(
+        labels(&items),
+        vec!["extract"],
+        "the OTHER task ids — `use` is the task being edited"
+    );
+    assert!(
+        items
+            .iter()
+            .all(|i| i.kind == Some(CompletionItemKind::VARIABLE)),
+        "task refs are VARIABLE-kinded"
+    );
+}
+
+#[test]
+fn template_island_without_tasks_dot_offers_nothing() {
+    // An open `${{ ` island that does NOT end with `tasks.` is not a task
+    // reference. `is_template_tasks_ref` requires BOTH `!contains("}}")`
+    // AND `ends_with("tasks.")` — flipping the `&&` to `||` would fire on
+    // any open island.
+    let text =
+        "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"echo ${{ vars.";
+    let items = completion(text, text.len());
+    assert!(
+        !labels(&items).iter().any(|l| l == "extract"),
+        "an `${{{{ vars.` island is not a tasks ref: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn top_level_offers_exactly_the_envelope_keys() {
+    let text = "nika: v1\nwo";
+    let items = completion(text, text.len());
+    // EXACT envelope-key set (the vocab order), PROPERTY-kinded, no verbs.
+    assert_eq!(
+        labels(&items),
+        vec![
+            "nika",
+            "workflow",
+            "description",
+            "model",
+            "vars",
+            "env",
+            "secrets",
+            "permits",
+            "tasks",
+            "outputs",
+        ],
+        "the 10 top-level envelope keys, in spec order"
+    );
+    assert!(
+        items
+            .iter()
+            .all(|i| i.kind == Some(CompletionItemKind::PROPERTY)),
+        "envelope keys are PROPERTY-kinded"
+    );
+    // verbs are NOT top-level keys
+    assert!(!labels(&items).contains(&"infer".to_owned()));
+}
+
+#[test]
+fn top_level_non_identifier_prefix_offers_nothing() {
+    // A column-0 line with a space in the typed fragment (`wo rk`) is NOT
+    // a bare key fragment — `is_top_level_key`'s `all(ident)` is false,
+    // so no envelope keys fire. (Flipping `&&`→`||` would still offer.)
+    let text = "nika: v1\nwo rk";
+    let items = completion(text, text.len());
+    assert!(
+        items.is_empty(),
+        "a non-identifier top-level prefix offers nothing: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn top_level_after_a_colon_offers_no_keys() {
+    // Once the line has a `:` it is a VALUE position, not a key position.
+    // `is_top_level_key`'s `!typed.contains(':')` must hold. The `==` in
+    // the char predicate (`c == '_'`) and the `&&` both matter here.
+    let text = "nika: v1\nworkflow: w";
+    let items = completion(text, text.len());
+    assert!(
+        !labels(&items).contains(&"workflow".to_owned()),
+        "a `key: value` line is not a key position: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn task_field_offers_exactly_the_fields_and_verbs() {
+    // indented key position inside a task: the 12 task fields followed by
+    // the 4 verbs, in that order. EXACT set + kinds (fields PROPERTY,
+    // verbs KEYWORD).
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    de";
+    let items = completion(text, text.len());
+    assert_eq!(
+        labels(&items),
+        vec![
+            // the 12 task fields (vocab order)
+            "id",
+            "depends_on",
+            "when",
+            "for_each",
+            "max_parallel",
+            "fail_fast",
+            "retry",
+            "on_error",
+            "timeout",
+            "with",
+            "output",
+            "on_finally",
+            // then the 4 verbs
+            "infer",
+            "exec",
+            "invoke",
+            "agent",
+        ],
+        "task fields then the 4 verbs"
+    );
+    // the first 12 are PROPERTY (fields), the last 4 are KEYWORD (verbs).
+    let ks = kinds(&items);
+    assert_eq!(ks.len(), 16, "16 items, all kinded");
+    assert!(
+        ks[..12].iter().all(|k| *k == CompletionItemKind::PROPERTY),
+        "fields are PROPERTY-kinded"
+    );
+    assert!(
+        ks[12..].iter().all(|k| *k == CompletionItemKind::KEYWORD),
+        "verbs are KEYWORD-kinded"
+    );
+    // the verb items carry their doc as detail (the detail field).
+    let infer = items
+        .iter()
+        .find(|i| i.label == "infer")
+        .expect("infer item");
+    assert_eq!(
+        infer.detail.as_deref(),
+        Some(
+            "A single LLM call. Sends one prompt, returns one response \
+             (optionally structured against a `schema:`)."
+        ),
+        "the infer verb's detail is its vocab doc"
+    );
+}
+
+#[test]
+fn task_field_inside_a_flow_map_value_offers_nothing() {
+    // An indented line that has already opened a flow-map value (`{`)
+    // and contains a `:` is NOT a field position. `is_task_field_key`
+    // requires `!body.contains(':')`; the closing-`}` guard and the
+    // ident predicate also gate it.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command";
+    let items = completion(text, text.len());
+    // `command` has no colon yet, BUT the line started a flow map — it is
+    // still a bare ident fragment, so fields ARE offered here. Assert the
+    // CONVERSE boundary: once a `:` appears, nothing fires.
+    let after_colon = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: x";
+    let none = completion(after_colon, after_colon.len());
+    assert!(
+        none.is_empty(),
+        "an indented `key: value` line offers nothing: {:?}",
+        labels(&none)
+    );
+    // sanity: the flow-map-open case still parses as a field fragment.
+    let _ = items;
+}
+
+#[test]
+fn task_field_fragment_with_underscore_still_completes() {
+    // The field fragment `for_` contains an underscore. `is_task_field_
+    // key`'s char predicate `c == '_' || alnum` must accept it (flipping
+    // `==` to `!=` would reject the `_` and suppress field completion).
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    for_";
+    let items = completion(text, text.len());
+    assert!(
+        labels(&items).contains(&"for_each".to_owned()),
+        "an underscore-bearing field fragment still completes: {:?}",
+        labels(&items)
+    );
+    assert!(
+        labels(&items).contains(&"on_error".to_owned()),
+        "and the rest"
+    );
+}
+
+/// B6 · the CEL method position: a dot PAST a data path inside an
+/// open island completes the closed cel-subset/0.1 method set — and
+/// the bare `tasks.` island stays task-id territory (checked first).
+#[test]
+fn expression_post_dot_completes_cel_methods() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.output.";
+    let items = completion(text, text.len());
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"size()"),
+        "cel methods at post-path dot: {labels:?}"
+    );
+    assert!(labels.contains(&"startsWith(…)"));
+    assert_eq!(
+        items.len(),
+        4,
+        "the method set is CLOSED (parser arity table)"
+    );
+
+    // Bare `tasks.` still resolves to task IDS, never methods.
+    let bare = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    exec: { command: \"echo ${{ tasks.";
+    let ids: Vec<String> = completion(bare, bare.len())
+        .into_iter()
+        .map(|i| i.label)
+        .collect();
+    assert!(
+        ids.contains(&"a".to_owned()),
+        "task ids win on the bare root: {ids:?}"
+    );
+}
+
+/// B6 · the island start completes the five locked roots + item +
+/// the two free functions — and outside any island, nothing changes.
+#[test]
+fn expression_start_completes_roots_and_free_functions() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ ";
+    let labels: Vec<String> = completion(text, text.len())
+        .into_iter()
+        .map(|i| i.label)
+        .collect();
+    for root in ["tasks", "vars", "env", "secrets", "with", "item"] {
+        assert!(
+            labels.contains(&root.to_owned()),
+            "missing root {root}: {labels:?}"
+        );
+    }
+    assert!(labels.contains(&"has(…)".to_owned()));
+
+    // A closed island offers nothing from the expression vocab.
+    let closed =
+        "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ vars.x }} and ";
+    let after: Vec<String> = completion(closed, closed.len())
+        .into_iter()
+        .map(|i| i.label)
+        .collect();
+    assert!(
+        !after.contains(&"has(…)".to_owned()),
+        "closed island leaks: {after:?}"
+    );
+}
+
+#[test]
+fn keyword_items_carry_their_doc_as_detail() {
+    // The envelope/task-field items built by `keyword_items` carry the
+    // vocab doc in their `detail` field (deleting it would default to
+    // None). Assert the exact detail on a known envelope key.
+    let text = "nika: v1\nwo";
+    let items = completion(text, text.len());
+    let tasks = items
+        .iter()
+        .find(|i| i.label == "tasks")
+        .expect("tasks key item");
+    assert_eq!(
+        tasks.detail.as_deref(),
+        Some(
+            "The task DAG. Required, non-empty. Each task runs exactly \
+             one verb."
+        ),
+        "the envelope key carries its vocab doc as detail"
+    );
+    assert!(
+        items.iter().all(|i| i.detail.is_some()),
+        "every keyword item has a detail"
+    );
+}
+
+#[test]
+fn scan_task_ids_reads_underscored_ids_in_full() {
+    // The scan-path take_while keeps `_` and alnum. An id with an
+    // underscore (`my_task`) must be read in FULL (flipping the `==` in
+    // the take_while predicate would stop at the `_`, truncating to `my`).
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: my_task\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [";
+    let items = completion(text, text.len());
+    assert_eq!(
+        labels(&items),
+        vec!["my_task"],
+        "the underscored id is read whole, not truncated to `my` \
+         (`b` is the task being edited — self excluded)"
+    );
+}
+
+#[test]
+fn list_marker_id_is_a_task_field_position() {
+    // The `- ` list marker introducing a task is a field position: after
+    // stripping `- `, the body is a bare ident fragment. (`is_task_field_
+    // key` strips the `- ` marker.)
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - i";
+    let items = completion(text, text.len());
+    assert!(
+        labels(&items).contains(&"id".to_owned()),
+        "the `- ` marker line offers task fields: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn inside_a_value_offers_nothing() {
+    // cursor inside a quoted prompt value — no trigger context
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"echo ";
+    let items = completion(text, text.len());
+    // not a model/ref/key position → empty (the `command` line has a `:`
+    // and an open value)
+    assert!(
+        items.is_empty(),
+        "no spurious completions: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn scan_task_ids_dedups_and_reads_in_order() {
+    // The scan path reads `id:` lines in source order and dedups repeats.
+    // (`!id.is_empty() && !ids.contains(&id)` — the `&&` and the `==` in
+    // the take_while predicate both matter.) A duplicate id must appear
+    // ONCE; the order is source order.
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: first\n    exec: { command: \"x\" }\n  - id: second\n    exec: { command: \"y\" }\n  - id: first\n    exec: { command: \"z\" }\n  - id: editor\n    depends_on: [";
+    let items = completion(text, text.len());
+    assert_eq!(
+        labels(&items),
+        vec!["first", "second"],
+        "source order, deduplicated (`first` once) — and `editor`, \
+         the task being edited, excludes itself"
+    );
+}
+
+#[test]
+fn completion_is_total_over_a_mid_char_offset() {
+    // The entry clamps a past-the-end offset (`offset.min(len)`) but the
+    // clamp does not land on a char BOUNDARY — a mid-multibyte offset
+    // slices `text[..offset]` mid-char and panics, which in the sync
+    // serve loop takes the WHOLE language server down. `completion` must
+    // be total over `(text, offset)`: any offset returns, never panics.
+    // (The server floors offsets via `LineIndex::offset`, so this is
+    // defence-in-depth for a public analysis primitive, not a reachable
+    // crash today — the bar for an LSP is « no input panics ».)
+    let _ = completion("é", 1); // byte 1 is inside the 2-byte 'é'
+    let _ = completion("nika: v1\n", 99_999); // far past the end
+    let doc = "nika: v1\nmodel: 🦋";
+    let _ = completion(doc, doc.len() - 1); // inside the trailing 4-byte 🦋
+}
+
+/// Inside `args:` of a KNOWN builtin, key position → that tool's own
+/// argument names, catalog-derived (the born-stale law again) —
+/// required ones sorted first and marked.
+#[test]
+fn fetch_args_offer_the_catalog_arg_keys() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: get\n    invoke:\n      tool: nika:fetch\n      args:\n        ";
+    let items = completion(text, text.len());
+    let fetch = nika_catalog::all_builtins()
+        .iter()
+        .find(|b| b.name == "fetch")
+        .expect("fetch in catalog");
+    assert_eq!(items.len(), fetch.args.len(), "exactly the catalog args");
+    let labels = labels(&items);
+    assert!(labels.contains(&"url:".to_owned()), "{labels:?}");
+    assert!(labels.contains(&"mode:".to_owned()), "{labels:?}");
+    // required args float first (sort_text partition: '0…' < '1…')
+    for item in &items {
+        let required = item
+            .detail
+            .as_deref()
+            .is_some_and(|d| d.starts_with("required"));
+        let sort = item.sort_text.as_deref().unwrap_or("");
+        assert_eq!(
+            sort.starts_with('0'),
+            required,
+            "sort partition mirrors required: {item:?}"
+        );
+    }
+}
+
+/// An UNKNOWN tool's args stay its own business — no `nika:fetch`
+/// keys leak under an MCP tool.
+#[test]
+fn mcp_tool_args_do_not_leak_fetch_keys() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: gh\n    invoke:\n      tool: github.search\n      args:\n        ";
+    let labels = labels(&completion(text, text.len()));
+    assert!(
+        !labels.contains(&"url:".to_owned()),
+        "no cross-tool leak: {labels:?}"
+    );
+}
+
+/// `mode:` under `nika:fetch` offers the stdlib extract vocabulary —
+/// the SET is `ExtractMode::ALL` (a mode added at L0 appears here
+/// with zero LSP edits). Under any other tool the lane stays silent.
+#[test]
+fn fetch_mode_offers_the_stdlib_extract_vocabulary() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: get\n    invoke:\n      tool: nika:fetch\n      args:\n        mode: ";
+    let items = completion(text, text.len());
+    assert_eq!(items.len(), nika_types::ExtractMode::ALL.len());
+    let labels = labels(&items);
+    assert_eq!(labels[0], "markdown", "canon order — the default first");
+    assert!(labels.contains(&"jq".to_owned()), "{labels:?}");
+
+    let other = "nika: v1\nworkflow: w\ntasks:\n  - id: x\n    invoke:\n      tool: github.search\n      args:\n        mode: ";
+    assert!(
+        labels_of(other).iter().all(|l| l != "jq"),
+        "another tool's `mode:` is not the extract vocabulary"
+    );
+}
+
+/// `${{ vars.` offers the file's OWN declared vars. On a document
+/// that parses (cursor mid-island, island closed), typed vars carry
+/// type + required + description and untyped ones their default; a
+/// mid-keystroke document that no longer parses falls back to the
+/// block scan — names still arrive, detail goes generic.
+#[test]
+fn island_vars_offer_the_declared_names() {
+    let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    description: target city\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }}\" }\n";
+    let cursor = text.find("${{ vars.").expect("island") + "${{ vars.".len();
+    let items = completion(text, cursor);
+    let got = labels(&items);
+    assert_eq!(got, vec!["city", "out_dir"], "{got:?}");
+    let detail = items[0].detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("string") && detail.contains("required") && detail.contains("target city"),
+        "typed var detail teaches type · required · description: {detail}"
+    );
+    assert!(
+        items[1].detail.as_deref().unwrap_or("").contains("./out"),
+        "untyped var detail carries the default"
+    );
+
+    // mid-keystroke fallback: unterminated island · parse fails · the
+    // block scan still teaches the NAMES
+    let typing = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.";
+    let fallback = labels(&completion(typing, typing.len()));
+    assert_eq!(fallback, vec!["city", "out_dir"], "{fallback:?}");
+}
+
+/// `${{ secrets.` / `${{ env.` offer the file's own declared names.
+#[test]
+fn island_secrets_and_env_offer_declared_names() {
+    let text = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\nsecrets:\n  api_key:\n    source: env\n    key: MY_KEY\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ secrets.";
+    let labels_s = labels(&completion(text, text.len()));
+    assert_eq!(labels_s, vec!["api_key"], "{labels_s:?}");
+
+    let text2 = "nika: v1\nworkflow: w\nenv:\n  REGION: eu-west-1\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ env.";
+    let labels_e = labels(&completion(text2, text2.len()));
+    assert_eq!(labels_e, vec!["REGION"], "{labels_e:?}");
+}
+
+/// The exclusion is the whole ILLEGAL set — not just self. In the
+/// diamond a → {b, c} → d, task `b` editing a `${{ tasks.` island
+/// may reference `a` (ancestor) and `c` (parallel) but never `d`:
+/// a ref to d is an implicit edge d → b while d already waits on b
+/// — the cycle the check refuses. Same law, one voice.
+#[test]
+fn island_tasks_exclude_the_downstream_closure() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output }}\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
+    // cursor mid-island inside task b (document parses whole)
+    let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
+    let got = labels(&completion(text, cursor));
+    assert_eq!(got, vec!["a", "c"], "ancestor + parallel only: {got:?}");
+}
+
+fn labels_of(text: &str) -> Vec<String> {
+    labels(&completion(text, text.len()))
+}
+
+// ─── the 557 lanes: tools list · task members · schema context ─────────
+
+#[test]
+fn agent_tools_list_speaks_the_catalog() {
+    let text =
+        "nika: v1\ntasks:\n  - id: judge\n    agent:\n      prompt: \"rule\"\n      tools: [\"";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.iter().any(|l| l == "nika:fetch"),
+        "the whitelist position offers the catalog: {got:?}"
+    );
+    // a CLOSED list is not a completion position
+    let closed =
+        "nika: v1\ntasks:\n  - id: judge\n    agent:\n      tools: [\"nika:fetch\"]\n      ";
+    let after = labels(&completion(closed, closed.len()));
+    assert!(
+        !after.iter().any(|l| l == "nika:fetch"),
+        "past the closing bracket the register goes quiet: {after:?}"
+    );
+}
+
+#[test]
+fn an_abandoned_open_bracket_upstream_captures_nothing() {
+    // A `tools: ["` left unclosed must not leak the catalog into every
+    // later position — the scope dies at the first line back at (or
+    // above) the key's indent.
+    let text =
+        "nika: v1\ntasks:\n  - id: judge\n    agent:\n      tools: [\"\n      schema:\n        ";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        !got.iter().any(|l| l.starts_with("nika:")),
+        "the abandoned bracket stays in its block: {got:?}"
+    );
+}
+
+#[test]
+fn task_member_island_teaches_the_three_facts_and_the_bindings() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: gather\n    exec:\n      command: ls\n    output:\n      first_line: \".stdout\"\n  - id: use\n    depends_on: [gather]\n    when: ${{ tasks.gather.";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.contains(&"output".to_owned())
+            && got.contains(&"status".to_owned())
+            && got.contains(&"error".to_owned()),
+        "the three spec facts: {got:?}"
+    );
+    assert!(
+        got.contains(&"first_line".to_owned()),
+        "the task's own named binding rides along: {got:?}"
+    );
+    let output_detail = completion(text, text.len())
+        .into_iter()
+        .find(|i| i.label == "output")
+        .and_then(|i| i.detail)
+        .unwrap_or_default();
+    assert!(
+        output_detail.contains("exec"),
+        "verb-aware detail: {output_detail}"
+    );
+}
+
+#[test]
+fn task_member_island_survives_an_unknown_id() {
+    let text = "nika: v1\ntasks:\n  - id: a\n    exec: {command: ls}\n  - id: b\n    when: ${{ tasks.ghost.";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.contains(&"output".to_owned()) && got.contains(&"status".to_owned()),
+        "an unknown id still teaches the facts (mid-rename): {got:?}"
+    );
+}
+
+#[test]
+fn data_path_post_dot_still_ends_in_cel_methods() {
+    // `tasks.x.output.` is PAST the member — the CEL method position
+    // must keep winning there (the member lane stops at one segment).
+    let text = "nika: v1\ntasks:\n  - id: b\n    when: ${{ tasks.x.output.";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.iter().any(|l| l.starts_with("size")),
+        "past a data path the methods speak: {got:?}"
+    );
+}
+
+#[test]
+fn schema_children_speak_json_schema_not_task_fields() {
+    let text =
+        "nika: v1\ntasks:\n  - id: a\n    infer:\n      prompt: \"p\"\n      schema:\n        ";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.contains(&"required".to_owned()) && got.contains(&"properties".to_owned()),
+        "the JSON-Schema keyset: {got:?}"
+    );
+    assert!(
+        !got.contains(&"depends_on".to_owned()),
+        "the 557 probe bug — task fields must NOT leak into schema: {got:?}"
+    );
+}
+
+#[test]
+fn properties_children_belong_to_the_author() {
+    let text =
+        "nika: v1\ntasks:\n  - id: a\n    infer:\n      schema:\n        properties:\n          ";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.is_empty(),
+        "property NAMES are the author's — silence beats noise: {got:?}"
+    );
+}
+
+#[test]
+fn items_inside_a_schema_keeps_the_keyset() {
+    let text = "nika: v1\ntasks:\n  - id: a\n    infer:\n      schema:\n        properties:\n          rows:\n            items:\n              ";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.contains(&"type".to_owned()) && got.contains(&"enum".to_owned()),
+        "items: nested anywhere inside a schema speaks JSON Schema: {got:?}"
+    );
+}
+
+#[test]
+fn task_fields_survive_outside_schema() {
+    let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: ls\n  - id: b\n    ";
+    let got = labels(&completion(text, text.len()));
+    assert!(
+        got.contains(&"depends_on".to_owned()),
+        "the task-field lane is untouched outside schema: {got:?}"
+    );
+}

--- a/crates/nika-lsp/src/analysis/members.rs
+++ b/crates/nika-lsp/src/analysis/members.rs
@@ -132,3 +132,118 @@ fn scan_block_keys(text: &str, root: &str) -> Vec<String> {
     }
     keys
 }
+
+/// An open island ending in `tasks.<id>.` — the TASK member position:
+/// the per-task facts the spec names (`output` · `status` · `error`) plus
+/// the task's own named `output:` bindings (04-variables: bindings are
+/// addressed as `tasks.<id>.<binding>`).
+pub(super) fn template_task_member(prefix: &str) -> Option<String> {
+    let island = prefix.rfind("${{")?;
+    let after = prefix.get(island..).unwrap_or("");
+    if after.contains("}}") {
+        return None;
+    }
+    let t = after.trim_end();
+    let rest = t.rfind("tasks.").map(|i| &t[i + "tasks.".len()..])?;
+    let (id, tail) = rest.split_once('.')?;
+    if tail.is_empty() && !id.is_empty() && id.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return Some(id.to_owned());
+    }
+    None
+}
+
+/// The member items for one task: the three spec facts, verb-aware when
+/// the task is found, plus the task's named `output:` bindings. The open
+/// `${{` island makes the document YAML-invalid at the very moment this
+/// lane fires, so the task facts come from a LINE SCAN of its block
+/// (parse-first would be a dead branch here); an unknown id
+/// (mid-rename · scratch) still teaches the three facts — silence would
+/// read as « nothing exists here ».
+pub(super) fn task_member_items(text: &str, task_id: &str) -> Vec<CompletionItem> {
+    let scanned = scan_task_block(text, task_id);
+    let output_detail = scanned
+        .as_ref()
+        .and_then(|t| t.verb.as_deref())
+        .map_or_else(
+            || "the task's recorded output".to_owned(),
+            |verb| format!("the task's recorded output ({verb} result)"),
+        );
+    let mut items = vec![
+        member_item("output", output_detail),
+        member_item(
+            "status",
+            "success · failure · skipped · cancelled — gate `when:` on it".to_owned(),
+        ),
+        member_item(
+            "error",
+            "the typed error — populated when `on_error.skip` kept it readable".to_owned(),
+        ),
+    ];
+    if let Some(t) = scanned {
+        for name in t.bindings {
+            items.push(member_item(&name, "named `output:` binding".to_owned()));
+        }
+    }
+    items
+}
+
+struct ScannedTask {
+    verb: Option<String>,
+    bindings: Vec<String>,
+}
+
+/// Line-scan `task_id`'s block: its verb key and its `output:` binding
+/// names. The block runs from `- id: <task_id>` to the next `- ` item at
+/// the same indent (or a top-level key).
+fn scan_task_block(text: &str, task_id: &str) -> Option<ScannedTask> {
+    const VERBS: [&str; 4] = ["infer:", "exec:", "invoke:", "agent:"];
+    let mut found: Option<usize> = None; // the `- id:` line's indent
+    let mut verb = None;
+    let mut bindings = Vec::new();
+    let mut in_output = false;
+    let mut output_indent = 0;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        match found {
+            None => {
+                if let Some(rest) = trimmed.strip_prefix("- id:")
+                    && rest.split('#').next().unwrap_or("").trim() == task_id
+                {
+                    found = Some(indent);
+                }
+            }
+            Some(item_indent) => {
+                if trimmed.is_empty() {
+                    continue;
+                }
+                // the next sibling item or a shallower key ends the block
+                if indent <= item_indent && (trimmed.starts_with("- ") || !trimmed.starts_with('-'))
+                {
+                    break;
+                }
+                if in_output {
+                    if indent <= output_indent {
+                        in_output = false;
+                    } else if let Some((name, _)) = trimmed.split_once(':')
+                        && !name.is_empty()
+                        && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+                    {
+                        bindings.push(name.to_owned());
+                        continue;
+                    }
+                }
+                if verb.is_none()
+                    && let Some(v) = VERBS.iter().find(|v| trimmed.starts_with(**v))
+                {
+                    verb = Some(v.trim_end_matches(':').to_owned());
+                }
+                if trimmed.starts_with("output:") {
+                    in_output = true;
+                    output_indent = indent;
+                }
+            }
+        }
+    }
+    found.map(|_| ScannedTask { verb, bindings })
+}

--- a/crates/nika-lsp/src/analysis/scope.rs
+++ b/crates/nika-lsp/src/analysis/scope.rs
@@ -34,27 +34,33 @@ pub(super) fn enclosing_tool(text: &str, offset: usize) -> Option<String> {
     None
 }
 
-/// Whether the cursor sits at a KEY position directly inside an `args:`
-/// block — an indented bare word (no `:` typed yet) whose nearest
-/// shallower non-blank ancestor line is `args:`. Nested maps inside an
-/// argument value (a deeper ancestor that is not `args:`) stay silent.
-pub(super) fn in_args_key_position(text: &str, offset: usize) -> bool {
+/// The indent of the cursor's KEY position — `Some(indent)` when the
+/// line so far is an indented bare word (no `:` typed yet), the shared
+/// precondition of every key-completion lane.
+fn key_position_indent(text: &str, offset: usize) -> Option<usize> {
     let upto = text.get(..offset).unwrap_or("");
     let line_start = upto.rfind('\n').map_or(0, |i| i + 1);
     let prefix = &upto[line_start..];
     let typed = prefix.trim_start();
-    // A key position: nothing yet, or a bare identifier without its colon.
     if !typed.is_empty()
         && !typed
             .chars()
             .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
     {
-        return false;
+        return None;
     }
     let indent = prefix.len() - typed.len();
-    if indent == 0 {
+    (indent > 0).then_some(indent)
+}
+
+/// Whether the cursor sits at a KEY position directly inside an `args:`
+/// block — an indented bare word (no `:` typed yet) whose nearest
+/// shallower non-blank ancestor line is `args:`. Nested maps inside an
+/// argument value (a deeper ancestor that is not `args:`) stay silent.
+pub(super) fn in_args_key_position(text: &str, offset: usize) -> bool {
+    let Some(indent) = key_position_indent(text, offset) else {
         return false;
-    }
+    };
     for line in lines_upward(text, offset) {
         if line.trim().is_empty() {
             continue;
@@ -63,6 +69,81 @@ pub(super) fn in_args_key_position(text: &str, offset: usize) -> bool {
         if line_indent < indent {
             return line.trim_start().starts_with("args:");
         }
+    }
+    false
+}
+
+/// Whether the cursor sits at a KEY position whose IMMEDIATE ancestor
+/// opens a `schema:` (or a nested `items:` inside one) — the JSON-Schema
+/// vocabulary position. Direct children of `properties:` stay silent:
+/// those names belong to the author, not the spec.
+pub(super) fn in_schema_key_position(text: &str, offset: usize) -> bool {
+    let Some(indent) = key_position_indent(text, offset) else {
+        return false;
+    };
+    let mut current = indent;
+    let mut immediate = true;
+    for line in lines_upward(text, offset) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let line_indent = line.len() - line.trim_start().len();
+        if line_indent >= current {
+            continue;
+        }
+        let key = line.trim_start();
+        if immediate {
+            if key.starts_with("schema:") {
+                return true;
+            }
+            if key.starts_with("items:") {
+                // `items:` counts only when IT sits inside a schema —
+                // keep walking the chain to find out.
+                immediate = false;
+                current = line_indent;
+                continue;
+            }
+            return false;
+        }
+        if key.starts_with("schema:") {
+            return true;
+        }
+        if key.starts_with("- id:") || line_indent == 0 {
+            return false;
+        }
+        current = line_indent;
+    }
+    false
+}
+
+/// Whether the ancestor CHAIN above the cursor crosses a `schema:` key
+/// before the task boundary — anywhere inside the block, any depth. The
+/// task-field lane stays silent here (a `schema:` block speaks
+/// JSON-Schema, never `depends_on`).
+pub(super) fn in_schema_scope(text: &str, offset: usize) -> bool {
+    let upto = text.get(..offset).unwrap_or("");
+    let line_start = upto.rfind('\n').map_or(0, |i| i + 1);
+    let prefix = &upto[line_start..];
+    let mut current = prefix.len() - prefix.trim_start().len();
+    if current == 0 {
+        return false;
+    }
+    for line in lines_upward(text, offset) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let line_indent = line.len() - line.trim_start().len();
+        if line_indent >= current {
+            continue;
+        }
+        let key = line.trim_start();
+        if key.starts_with("schema:") {
+            return true;
+        }
+        if key.starts_with("- id:") || line_indent == 0 {
+            return false;
+        }
+        current = line_indent;
     }
     false
 }

--- a/crates/nika-lsp/src/analysis/vocab.rs
+++ b/crates/nika-lsp/src/analysis/vocab.rs
@@ -159,6 +159,36 @@ pub const TASK_FIELD_KEYS: &[Entry] = &[
     },
 ];
 
+/// The JSON-Schema keyset inside a `schema:` block (02-verbs: the typed
+/// response/final-message contract). Direct children of `schema:` and
+/// `items:` — `properties:` children are the AUTHOR's field names.
+pub const SCHEMA_KEYS: &[Entry] = &[
+    Entry {
+        name: "type",
+        doc: "The JSON type — the portable top level is `object`.",
+    },
+    Entry {
+        name: "required",
+        doc: "The field names the response MUST carry (`[summary]`).",
+    },
+    Entry {
+        name: "properties",
+        doc: "Field name → its schema (`summary: { type: string }`).",
+    },
+    Entry {
+        name: "items",
+        doc: "The element schema of an array.",
+    },
+    Entry {
+        name: "enum",
+        doc: "The closed value set — the model cannot invent a fifth answer.",
+    },
+    Entry {
+        name: "description",
+        doc: "Teaches the model what the field means — part of the prompt.",
+    },
+];
+
 /// The canonical LLM provider names for `model: <provider>/<name>`.
 ///
 /// MIRRORED-FROM-CANON: the 16-provider catalog (spec `canon.yaml` SSOT ·


### PR DESCRIPTION
Closes the three remaining lanes of #557 (the fourth — cycle-safe `depends_on` — shipped in #558). Every lane speaks truth the server already owned: the catalog, the document itself, the spec's keysets.

## The lanes

**1 · `tools: [ … ]` — the agent whitelist speaks the catalog.** The singular `tool:` value lane already did; the whitelist position now gets the same register (categories + args as detail). MCP refs stay the author's to type — the server has no MCP registry to speak from. *Found by the probe and fixed here:* the open-bracket detector is now **scoped** — an unclosed `[` abandoned upstream dies at the first line back at the key's indent instead of capturing every later position in the file (`in_open_depends_on` inherits the same containment; regression test pinned).

**2 · `${{ tasks.<id>. }}` — the task's member facts.** `output` (verb-aware detail: *« the task's recorded output (exec result) »*) · `status` · `error` · plus the task's own named `output:` bindings (04-variables: bindings address as `tasks.<id>.<binding>`). **Line-scanned, not parsed**: the open `${{` island makes the document YAML-invalid at the very moment this lane fires, so a parse-first branch would be dead code — the scan walks the task's block for its verb and binding names. An unknown id still teaches the three facts (mid-rename must not read as « nothing exists here »). The CEL post-dot lane keeps winning past a data path (`tasks.x.output.` → methods).

**3 · `schema:` speaks JSON Schema, never task fields.** The probe's bug: a `schema:` child position offered `depends_on`. Direct children of `schema:`/`items:` (nested at any depth) now get the keyset — `type · required · properties · items · enum · description` — and children of `properties:` stay **silent**: those names belong to the author. The task-field lane is guarded by the ancestor chain (`in_schema_scope`).

## Proof

- `cargo test -p nika-lsp --lib` — **168 green** (10 new: the three lanes · the containment regression · the properties silence · the post-dot ordering · unknown-id survival)
- `cargo clippy -p nika-lsp --all-targets` — 0 warnings · fmt clean
- Probed live over JSON-RPC on the built binary — the three positions answer (payloads mirror the issue's probes):
  - `tools: ["` → `nika:assert` · `nika:chart` · … (catalog, categorized)
  - `schema:` child → `type · required · properties · items · enum · description`
  - `tasks.gather.` → `output (exec result) · status · error · first_line` (the named binding)

Remaining #557 rows (`when:` CEL-atom composition · `for_each:` collection candidates · `skills:` pending a machine listing) stay on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
