### PR TITLE
fix(nika-lsp): the island speaks DAG-003 — declared edges, the carve-out, the free block

### DIFF
--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -92,6 +92,7 @@ impl<T> dyn_clone::DynClone for nika_lsp::analysis::position::LineIndex where T:
 pub fn nika_lsp::analysis::position::LineIndex::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_lsp::analysis::position::LineIndex where T: 'static
 pub fn nika_lsp::analysis::position::LineIndex::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub mod nika_lsp::analysis::refs
 pub mod nika_lsp::analysis::scope
 pub mod nika_lsp::analysis::symbols
 pub fn nika_lsp::analysis::symbols::document_symbols(text: &str) -> alloc::vec::Vec<lsp_types::document_symbols::DocumentSymbol>

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -26,6 +26,7 @@ use lsp_types::{CompletionItem, CompletionItemKind};
 use nika_schema::{FileId, ParseMode, parse};
 
 use super::members;
+use super::refs;
 use super::scope;
 use super::vocab::{self, Entry};
 
@@ -56,7 +57,7 @@ pub fn completion(text: &str, offset: usize) -> Vec<CompletionItem> {
     if let Some(items) = enum_values(prefix) {
         return items;
     }
-    if in_open_depends_on(text, offset) || is_template_tasks_ref(prefix) {
+    if in_open_depends_on(text, offset) {
         return task_ids(text, scope::current_task_id(text, offset).as_deref());
     }
     // An agent's `tools: [ … ]` whitelist — the same catalog register the
@@ -64,6 +65,9 @@ pub fn completion(text: &str, offset: usize) -> Vec<CompletionItem> {
     // the server has no MCP registry to speak from).
     if in_open_tools_list(text, offset) {
         return builtin_tools();
+    }
+    if is_template_tasks_ref(prefix) {
+        return refs::island_task_refs(text, offset);
     }
     if let Some(root) = members::template_member_root(prefix) {
         return members::member_items(text, root);
@@ -603,7 +607,7 @@ fn keyword_items(table: &[Entry]) -> Vec<CompletionItem> {
 /// [` with nothing after it does not parse as YAML), so ids are read from
 /// a robust line scan for `id:` declarations rather than a full parse —
 /// the parse path would yield nothing exactly when completion is needed.
-fn task_ids(text: &str, exclude: Option<&str>) -> Vec<CompletionItem> {
+pub(super) fn task_ids(text: &str, exclude: Option<&str>) -> Vec<CompletionItem> {
     // Prefer the parser's authoritative ids (with verb detail) when the
     // document parses; fall back to the line scan otherwise. The
     // exclusion is the editing task's whole ILLEGAL set — itself plus

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -322,12 +322,12 @@ fn model_key_without_space_offers_envelope_keys_not_providers() {
 
 #[test]
 fn template_tasks_dot_offers_task_ids() {
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use\n    exec: { command: \"echo ${{ tasks.";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use\n    depends_on: [extract]\n    exec: { command: \"echo ${{ tasks.";
     let items = completion(text, text.len());
     assert_eq!(
         labels(&items),
         vec!["extract"],
-        "the OTHER task ids — `use` is the task being edited"
+        "the DECLARED edge — DAG-003 accepts nothing else"
     );
     assert!(
         items
@@ -528,8 +528,9 @@ fn expression_post_dot_completes_cel_methods() {
         "the method set is CLOSED (parser arity table)"
     );
 
-    // Bare `tasks.` still resolves to task IDS, never methods.
-    let bare = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    exec: { command: \"echo ${{ tasks.";
+    // Bare `tasks.` still resolves to task IDS, never methods —
+    // and only the DECLARED edges (DAG-003): b waits on a, so a.
+    let bare = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.";
     let ids: Vec<String> = completion(bare, bare.len())
         .into_iter()
         .map(|i| i.label)
@@ -772,18 +773,50 @@ fn island_secrets_and_env_offer_declared_names() {
     assert_eq!(labels_e, vec!["REGION"], "{labels_e:?}");
 }
 
-/// The exclusion is the whole ILLEGAL set — not just self. In the
-/// diamond a → {b, c} → d, task `b` editing a `${{ tasks.` island
-/// may reference `a` (ancestor) and `c` (parallel) but never `d`:
-/// a ref to d is an implicit edge d → b while d already waits on b
-/// — the cycle the check refuses. Same law, one voice.
+/// A task-field island offers ONLY the declared edges — DAG-003
+/// (probed at the binary): even a transitive ancestor or a parallel
+/// task is refused without its own `depends_on` entry. In the
+/// diamond a → {b, c} → d, task `b`'s island offers exactly `a`.
 #[test]
-fn island_tasks_exclude_the_downstream_closure() {
+fn island_tasks_offer_only_the_declared_edges() {
     let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output }}\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
     // cursor mid-island inside task b (document parses whole)
     let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
     let got = labels(&completion(text, cursor));
-    assert_eq!(got, vec!["a", "c"], "ancestor + parallel only: {got:?}");
+    assert_eq!(got, vec!["a"], "declared edges only: {got:?}");
+    let items = completion(text, cursor);
+    assert!(
+        items[0]
+            .detail
+            .as_deref()
+            .unwrap_or("")
+            .contains("declared dependency"),
+        "{items:?}"
+    );
+}
+
+/// The recover carve-out (spec 05 · DAG-003 exempt · DAG-004 binds):
+/// a `recover:` island offers everything except the task itself and
+/// its downstream closure — the deadlock set.
+#[test]
+fn recover_island_offers_the_dag004_legal_set() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: cached\n    exec: { command: \"echo fallback\" }\n  - id: live\n    exec:\n      command: \"false\"\n    on_error:\n      recover: \"${{ tasks.cached.output }}\"\n  - id: after\n    depends_on: [live]\n    exec: { command: \"x\" }\n";
+    let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
+    let got = labels(&completion(text, cursor));
+    assert_eq!(
+        got,
+        vec!["cached"],
+        "not itself · not `after` (deadlock): {got:?}"
+    );
+}
+
+/// A workflow-level `outputs:` island is not inside any task — every
+/// task is legal there (probed green at the binary).
+#[test]
+fn outputs_island_offers_every_task() {
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"y\" }\noutputs:\n  first: \"${{ tasks.";
+    let got = labels(&completion(text, text.len()));
+    assert_eq!(got, vec!["a", "b"], "outside a task, all ids: {got:?}");
 }
 
 fn labels_of(text: &str) -> Vec<String> {

--- a/crates/nika-lsp/src/analysis/mod.rs
+++ b/crates/nika-lsp/src/analysis/mod.rs
@@ -20,6 +20,7 @@ pub mod graph;
 pub mod hover;
 pub mod members;
 pub mod position;
+pub mod refs;
 pub mod scope;
 pub mod symbols;
 pub mod vocab;

--- a/crates/nika-lsp/src/analysis/refs.rs
+++ b/crates/nika-lsp/src/analysis/refs.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `${{ tasks.` island lane — routed by the law that judges each
+//! context (DAG-003 declared edges · the recover carve-out · workflow
+//! `outputs:` freedom). The completion dispatch calls in; the shared
+//! `task_ids` builder stays in `completion`.
+
+use lsp_types::{CompletionItem, CompletionItemKind};
+use nika_schema::{FileId, ParseMode, parse};
+
+use super::completion::task_ids;
+use super::scope;
+
+/// A `${{ tasks.` island routes by the law that judges it (probed at
+/// the binary, 2026-07-13) ·
+/// - a task's NORMAL field: DAG-003 accepts only the task's DIRECT
+///   `depends_on` — even a transitive ancestor is refused, so the
+///   lane offers exactly the declared edges;
+/// - a `recover:` value: exempt from DAG-003 (the spec 05 carve-out),
+///   bounded by DAG-004 instead — everything except itself and its
+///   downstream closure (the deadlock set);
+/// - outside any task (workflow `outputs:`): every task is legal.
+pub(super) fn island_task_refs(text: &str, offset: usize) -> Vec<CompletionItem> {
+    let Some(editing) = scope::current_task_id(text, offset) else {
+        return task_ids(text, None);
+    };
+    if scope::in_recover_value(text, offset) {
+        return task_ids(text, Some(&editing));
+    }
+    direct_dep_items(text, &editing)
+}
+
+/// The editing task's declared `depends_on`, as completion items with
+/// verb details — parse-first; a mid-keystroke document falls back to
+/// an upward line scan of the task block. No deps declared → empty
+/// (silence beats teaching a DAG-003).
+fn direct_dep_items(text: &str, editing: &str) -> Vec<CompletionItem> {
+    if let Ok(wf) = parse(text, FileId::new(0), ParseMode::Lenient) {
+        let verbs: std::collections::BTreeMap<&str, &'static str> = wf
+            .tasks
+            .iter()
+            .map(|t| (t.value.id.value.as_str(), t.value.action.verb()))
+            .collect();
+        if let Some(task) = wf.tasks.iter().find(|t| t.value.id.value == editing) {
+            return task
+                .value
+                .depends_on
+                .iter()
+                .map(|d| CompletionItem {
+                    label: d.value.clone(),
+                    kind: Some(CompletionItemKind::VARIABLE),
+                    detail: Some(verbs.get(d.value.as_str()).map_or_else(
+                        || "declared dependency".to_owned(),
+                        |v| format!("task ({v}) · declared dependency"),
+                    )),
+                    ..CompletionItem::default()
+                })
+                .collect();
+        }
+    }
+    scan_direct_deps(text, editing)
+        .into_iter()
+        .map(|id| CompletionItem {
+            label: id,
+            kind: Some(CompletionItemKind::VARIABLE),
+            detail: Some("declared dependency".to_owned()),
+            ..CompletionItem::default()
+        })
+        .collect()
+}
+
+/// Line-scan fallback: the `depends_on: [...]` items of the task block
+/// named `editing` (mid-keystroke documents keep their edges).
+fn scan_direct_deps(text: &str, editing: &str) -> Vec<String> {
+    let mut in_task = false;
+    let mut deps = Vec::new();
+    for line in text.lines() {
+        let t = line.trim_start();
+        if let Some(rest) = t.strip_prefix("- id:") {
+            in_task = rest.split('#').next().unwrap_or("").trim() == editing;
+            continue;
+        }
+        if in_task && let Some(rest) = t.strip_prefix("depends_on:") {
+            let inner = rest.trim().trim_start_matches('[').trim_end_matches(']');
+            deps.extend(
+                inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').trim_matches('\''))
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned),
+            );
+        }
+    }
+    deps
+}

--- a/crates/nika-lsp/src/analysis/scope.rs
+++ b/crates/nika-lsp/src/analysis/scope.rs
@@ -14,8 +14,28 @@ pub(super) fn current_task_id(text: &str, offset: usize) -> Option<String> {
         if let Some(rest) = t.strip_prefix("- id:") {
             return Some(unquote(rest).to_owned());
         }
+        // A column-0 key above us means we left the tasks block — a
+        // workflow-level `outputs:`/`vars:` island is NOT inside the
+        // last task that happens to sit above it.
+        if !t.is_empty() && line.len() == t.len() {
+            return None;
+        }
     }
     None
+}
+
+/// Whether the cursor's line is a `recover:` value — the DAG-003
+/// carve-out (spec 05 §recover): refs there are NOT edges, only the
+/// DAG-004 no-downstream law binds. Line-based like the rest of v0.1
+/// (a multi-line block-scalar recover value is out of this heuristic's
+/// reach — silence there, never a wrong set).
+pub(super) fn in_recover_value(text: &str, offset: usize) -> bool {
+    let upto = text.get(..offset).unwrap_or("");
+    let line_start = upto.rfind('\n').map_or(0, |i| i + 1);
+    upto.get(line_start..)
+        .unwrap_or("")
+        .trim_start()
+        .starts_with("recover:")
 }
 
 /// The `tool:` value of the invoke block enclosing `offset`, when the


### PR DESCRIPTION
## What

A socratic pass on my own #558 **against the binary** found the island lane teaching errors. The completion offered "ancestor + parallel" tasks in `${{ tasks.` islands — both **refused** by check.

## Probed truths (at the binary, 2026-07-13)

| Probe | Verdict |
|---|---|
| `b` references `tasks.a` without `depends_on: [a]` | ✖ NIKA-DAG-003 |
| `c → b → a`, c references `tasks.a` (transitive ancestor) | ✖ NIKA-DAG-003 — the law is *declared edges*, not *no cycle* |
| `recover: "${{ tasks.cached.output }}"` without an edge | ✔ green — the spec 05 carve-out |
| workflow-level `outputs:` referencing any task | ✔ green |

## The router (`analysis/refs.rs`)

Each island context routes by the law that judges it:

- **task field** → the task's declared `depends_on` **exactly** (verb + "declared dependency" in the detail). Zero deps → **empty**: edge-first authoring — silence beats teaching a DAG-003.
- **`recover:` value** → all − {self} − downstream closure (the DAG-004 deadlock set).
- **outside any task** (workflow `outputs:`) → all ids. `current_task_id` now stops at column-0 lines, so an `outputs:` island no longer inherits the last task above it.

`depends_on: [` **keeps** the #558 anti-cycle law — correct there: an edge to an ancestor is redundant-but-legal; an edge downstream is the cycle.

## Proof

Three pins rewritten to the binary-probed law + three new law tests (edges · carve-out · free block) · 161/161 · clippy 0 · probed live over JSON-RPC 3/3 (`['a']` · `['cached']` · `['a','b']`) · completion.rs back under the 1500 wall.

The lesson, banked: *"never offer what check refuses" is proven at the binary per context — the law I imagined (anti-cycle) was laxer than the real one (declared edges).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
