### PR TITLE
feat(pack): the vendoring lane materializes — sync-pack.sh + pack-resync heal

### DIFF
--- a/.github/workflows/pack-resync.yml
+++ b/.github/workflows/pack-resync.yml
@@ -1,0 +1,43 @@
+name: pack-resync
+
+# The embedded pack follows the spec without the operator-scratch dance:
+# lib.rs promised scripts/sync-pack.sh since the crate's birth; the SSOT
+# sweep (2026-07-13) materialized it and found the pack ALREADY stale in
+# two files the coherence bot's canon-hash probe was blind to. Daily:
+# clone spec@main, run the ONE vendoring lane, open ONE idempotent PR on
+# drift — the 12-gate CI (pack integrity tests included) judges, never a
+# direct push. SECURITY: no github.event data reaches the shell.
+
+on:
+  schedule:
+    - cron: '45 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  heal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: The pack follows the spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 https://github.com/supernovae-st/nika-spec ../spec
+          bash scripts/sync-pack.sh ../spec
+          git add crates/nika-pack/pack
+          if git diff --cached --quiet; then echo "pack current — nothing to resync"; exit 0; fi
+          git config user.name "nika-release[bot]"
+          git config user.email "nika@supernovae.studio"
+          git checkout -B bot/pack-resync
+          git commit -m "chore(pack): the pack follows the spec — $(git -C ../spec rev-parse --short HEAD) (pack-resync)"
+          git push -f origin bot/pack-resync
+          gh pr create --head bot/pack-resync \
+            --title "chore(pack): the pack follows the spec" \
+            --body "Automated vendoring (pack-resync · scripts/sync-pack.sh). The 12-gate CI + pack integrity tests judge; merge on green." \
+            2>/dev/null || echo "PR already open — refreshed"

--- a/crates/nika-pack/pack/design-tokens.yaml
+++ b/crates/nika-pack/pack/design-tokens.yaml
@@ -88,6 +88,30 @@ status:
   retrying: "#e0b071"
   muted: "#5a606b"
 
+# The provider PRESENTATION order (operator lock 2026-06-12): wherever a
+# surface lists or exemplifies the catalog (pickers · docs · quickstarts),
+# local & open-weight lead, then Mistral (EU · open-weight), then the
+# rest — cloud incumbents never the first suggestion. Functional code
+# (adapters · pinned e2e) is exempt: this binds the TEACHING surface.
+# A provider absent from this list ranks after it, alphabetically.
+presentation:
+  providers_order:
+    - ollama
+    - lmstudio
+    - llamacpp
+    - localai
+    - vllm
+    - mistral
+    - groq
+    - deepseek
+    - openrouter
+    - huggingface
+    - nvidia
+    - anthropic
+    - openai
+    - google
+    - xai
+
 rules:
   # Mermaid classDef fill = verb color + this alpha suffix. Derived at
   # projection time, never stored as a 5th value per verb.

--- a/crates/nika-pack/pack/spec/03-dag.md
+++ b/crates/nika-pack/pack/spec/03-dag.md
@@ -824,6 +824,66 @@ the author records it in the **exec ledger** (task · command · why no
 native path · the unlock that would remove it) — the workflow header
 comment is the conventional home.
 
+## Graph projection (`graph_format: 1`)
+
+The DAG has ONE canonical machine-readable view: the **graph document**
+a conforming implementation emits for a *checked* workflow (the
+reference engine: `nika graph <file> --format json`; the MCP surface
+mirrors it). Clients — editor canvases, graph renderers, agents —
+consume THIS document, never a private re-parse of the YAML. Without a
+valid DAG there is no projection: the document is defined only for a
+workflow whose conformance report is clean.
+
+```json
+{
+  "graph_format": 1,
+  "workflow": "release-notes",
+  "nodes": [
+    {
+      "id": "gather", "verb": "invoke", "tool": "nika:read",
+      "when": null, "fan_out": null,
+      "permits": ["fs.read:README.md"], "cost_interval": null
+    },
+    {
+      "id": "think", "verb": "infer", "model": "mistral/mistral-small",
+      "when": null, "fan_out": null, "permits": [],
+      "cost_interval": [0.0002, 0.0031],
+      "timeout_ms": 60000, "outputs": ["summary"]
+    }
+  ],
+  "edges": [ { "from": "gather", "to": "think", "kind": "depends_on" } ]
+}
+```
+
+**The envelope.** `graph_format` versions the document. Evolution is
+**additive only**: new fields and new edge `kind` values may appear in
+the SAME format number; readers MUST ignore fields and edge kinds they
+do not know (fold-tolerance — the same law the run stream follows). A
+`graph_format` bump marks a breaking reshape, and a reader MUST refuse
+a format it does not speak rather than guess.
+
+**Nodes are topologically sorted** in wave order, and the order is
+stable across runs of the projector — stable input, stable layout.
+
+**Node fields.** `id` and `verb` (one of the four) are always present.
+Three field families follow, and their absence rules are part of the
+wire contract:
+
+| Presence | Fields | Rule |
+|---|---|---|
+| always | `id` · `verb` · `permits` | `permits` may be empty — per-task capability attribution (`exec:` · `fs.read:` · `fs.write:` · `net.http:` · `tool:` families, deterministic order), the un-aggregated voice of the same effect walk `infer_permits` folds into the workflow boundary |
+| present-as-null when undeclared | `when` · `fan_out` · `cost_interval` | `when` carries the gate source (`"true"`/`"false"` literal or the CEL island) · `fan_out` is `{ "kind": "list" \| "expression" }` with `count` only for the literal-list form · `cost_interval` is `[min_path, worst_case]` USD for **priced inference tasks only** (no price, no interval — never a fabricated 0) |
+| absent when undeclared | `tool` · `model` · `retry_max_attempts` · `timeout_ms` · `on_error` · `outputs` | declared POLICY, projected so clients read it here instead of re-parsing YAML: `tool` for `invoke` tasks · `model` as resolved `provider/name` (task override else workflow default) · `retry.max_attempts` (05) · `timeout:` as parsed milliseconds (unambiguous where the source string is not) · `on_error:` action (`recover` · `skip` · `fail_workflow`) · declared `output:` binding names in source order (04) |
+
+**Edges** carry `from` · `to` · `kind`. The `kind` enum is CLOSED —
+`depends_on` today; new kinds arrive additively with the spec, and
+unknown kinds fall under the reader-tolerance rule.
+
+**The static law.** The graph document describes the workflow as
+WRITTEN — it never carries run state (no statuses, no live costs, no
+durations). Run truth lives in the run stream and the trace; a client
+that paints run state onto this graph joins the two by task `id`.
+
 ## Forward-compat
 
 v1 ships with these task fields · `id` · `depends_on` · `when` · `for_each` · `max_parallel` · `fail_fast` · `retry` · `on_error` · `timeout` · `on_finally` · `with` · `output` · plus the verb selector. Additional fields may be added in minor bumps (additive only). (Output *shape* is per-verb · not a task field · see [02-verbs.md](./02-verbs.md#what--tasksidoutput--holds--per-verb).)

--- a/scripts/sync-pack.sh
+++ b/scripts/sync-pack.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# sync-pack.sh — vendor the spec pack into crates/nika-pack/pack/, the
+# ONE deterministic lane (lib.rs has promised this script since the
+# crate's birth; until 2026-07-13 it lived in operator scratch — a
+# phantom the SSOT sweep materialized).
+#
+#   bash scripts/sync-pack.sh <path-to-nika-spec-checkout>
+#
+# The mapping IS the contract — additions to the pack are deliberate
+# edits HERE, never ad-hoc copies:
+#   VERSION · QUICKSTART.md · canon.yaml          ← spec root
+#   coverage-matrix.tsv                            ← conformance/
+#   design-tokens.yaml · design-motion.yaml        ← design/{tokens,motion}.yaml
+#   spec/ · schemas/ · examples/ · templates/      ← whole dirs (adds+deletes flow)
+#   stdlib/*.md ONLY                               ← the two YAML SSOTs
+#     (verb-starters · authoring-shapes) deliberately stay OUT: they
+#     project through their own generator lanes, never the pack.
+#
+# Byte-copy, then the integrity tests judge (a drifted pack fails
+# `cargo test -p nika-pack`, not a user).
+set -euo pipefail
+SPEC="${1:?usage: sync-pack.sh <nika-spec-checkout>}"
+cd "$(dirname "$0")/.."
+PACK=crates/nika-pack/pack
+[ -f "$SPEC/VERSION" ] || { echo "sync-pack: $SPEC is not a nika-spec checkout" >&2; exit 2; }
+
+cp "$SPEC/VERSION"                          "$PACK/VERSION"
+cp "$SPEC/QUICKSTART.md"                    "$PACK/QUICKSTART.md"
+cp "$SPEC/canon.yaml"                       "$PACK/canon.yaml"
+cp "$SPEC/conformance/coverage-matrix.tsv"  "$PACK/coverage-matrix.tsv"
+cp "$SPEC/design/tokens.yaml"               "$PACK/design-tokens.yaml"
+cp "$SPEC/design/motion.yaml"               "$PACK/design-motion.yaml"
+
+# READMEs are repo navigation, not pack content — the vendored state
+# has never carried them (verified against the #533 tree).
+for d in spec schemas examples templates; do
+  rsync -a --delete --exclude='README.md' "$SPEC/$d/" "$PACK/$d/"
+done
+
+rsync -a --delete --include='*.md' --exclude='*' "$SPEC/stdlib/" "$PACK/stdlib/"
+
+echo "sync-pack: vendored from $(git -C "$SPEC" rev-parse --short HEAD 2>/dev/null || echo '?') — review the diff, the integrity tests judge"


### PR DESCRIPTION
**The phantom script becomes real**: `lib.rs` has promised `scripts/sync-pack.sh` since the crate's birth — it lived in operator scratch. It lands committed, mapping-as-contract (root files · `conformance/coverage-matrix.tsv` · `design/{tokens,motion}.yaml` · four whole dirs minus READMEs · `stdlib/*.md` only — the two YAML SSOTs deliberately OUT, they project through their own generator lanes).

**And its first run caught real drift** the coherence bot's canon-hash probe is blind to: `design-tokens.yaml` missing `presentation.providers_order` (the SAME drift the website leg had this morning) and `spec/03-dag.md` 60 lines behind (the graph_format contract). The resync rides this PR.

**`pack-resync.yml`** (daily + dispatch) keeps it healed: idempotent PR, the 12-gate CI + pack integrity tests judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)