### PR TITLE
feat(nika-lsp): loop-scoped roots by the law — item gated, index joins

### DIFF
--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -106,7 +106,7 @@ pub fn completion_at(text: &str, offset: usize, doc_dir: Option<&Path>) -> Vec<C
         return cel_methods();
     }
     if is_expression_start(prefix) {
-        return expression_roots();
+        return expression_roots(scope::in_for_each_task(text, offset));
     }
     // A bare key inside `args:` of a KNOWN builtin — that tool's own
     // argument names, required ones floated first (catalog-derived).
@@ -357,17 +357,25 @@ fn cel_methods() -> Vec<CompletionItem> {
 
 /// Expression ROOTS (the five locked namespaces · D-N11) + the two free
 /// functions the parser accepts (`size` · `has` — a closed set there too).
-fn expression_roots() -> Vec<CompletionItem> {
+/// The loop-scoped pair (`item` · `index` — spec 04 §loop-scoped locals)
+/// appears ONLY when the enclosing task declares `for_each:` (#574):
+/// offering `item` outside a fan-out completes a reference the run
+/// cannot resolve — never offer what check refuses, island edition.
+fn expression_roots(in_for_each: bool) -> Vec<CompletionItem> {
     const ROOTS: &[(&str, &str)] = &[
         ("tasks", "an upstream task's output (`tasks.<id>.output`)"),
         ("vars", "a declared workflow var"),
         ("env", "an allowed environment value"),
         ("secrets", "a declared secret (never echoed)"),
         ("with", "this task's own `with:` aliases"),
-        ("item", "the current `for_each` element"),
+    ];
+    const LOOP_ROOTS: &[(&str, &str)] = &[
+        ("item", "the current `for_each` element (loop-scoped)"),
+        ("index", "the element's 0-based position (loop-scoped)"),
     ];
     let mut items: Vec<CompletionItem> = ROOTS
         .iter()
+        .chain(if in_for_each { LOOP_ROOTS } else { &[] })
         .map(|(name, doc)| CompletionItem {
             label: (*name).to_owned(),
             kind: Some(CompletionItemKind::VARIABLE),

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -541,8 +541,9 @@ fn expression_post_dot_completes_cel_methods() {
     );
 }
 
-/// B6 · the island start completes the five locked roots + item +
-/// the two free functions — and outside any island, nothing changes.
+/// B6 · the island start completes the five locked roots + the two
+/// free functions — the loop-scoped pair stays OUT of a non-fan-out
+/// task (its own law test below covers the gate both ways).
 #[test]
 fn expression_start_completes_roots_and_free_functions() {
     let text = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    infer: { prompt: \"${{ ";
@@ -550,7 +551,7 @@ fn expression_start_completes_roots_and_free_functions() {
         .into_iter()
         .map(|i| i.label)
         .collect();
-    for root in ["tasks", "vars", "env", "secrets", "with", "item"] {
+    for root in ["tasks", "vars", "env", "secrets", "with"] {
         assert!(
             labels.contains(&root.to_owned()),
             "missing root {root}: {labels:?}"
@@ -1112,5 +1113,27 @@ fn with_island_offers_the_enclosing_tasks_aliases() {
         got,
         vec!["article", "limit"],
         "b's aliases, never a's: {got:?}"
+    );
+}
+
+/// The loop-scoped pair rides ONLY under a `for_each:` task (spec 04
+/// §loop-scoped locals · #574): outside one, `item`/`index` would
+/// complete references the run cannot resolve.
+#[test]
+fn loop_roots_are_gated_to_for_each_tasks() {
+    let plain = "nika: v1\nworkflow: w\ntasks:\n  - id: a\n    exec: { command: [\"echo\", \"${{ ";
+    let got = labels(&completion(plain, plain.len()));
+    assert!(
+        !got.contains(&"item".to_owned()),
+        "no item outside fan-out: {got:?}"
+    );
+    assert!(!got.contains(&"index".to_owned()), "{got:?}");
+
+    let fanned = "nika: v1\nworkflow: w\nvars:\n  urls: [1, 2]\ntasks:\n  - id: a\n    for_each: \"${{ vars.urls }}\"\n    exec: { command: [\"echo\", \"${{ ";
+    let got = labels(&completion(fanned, fanned.len()));
+    assert!(got.contains(&"item".to_owned()), "{got:?}");
+    assert!(
+        got.contains(&"index".to_owned()),
+        "the missing twin joins: {got:?}"
     );
 }

--- a/crates/nika-lsp/src/analysis/scope.rs
+++ b/crates/nika-lsp/src/analysis/scope.rs
@@ -214,6 +214,23 @@ pub(super) fn enclosing_block_key(text: &str, offset: usize) -> Option<(String, 
     block.map(|(b, _)| (b, None))
 }
 
+/// Whether the task enclosing `offset` declares `for_each:` — the gate
+/// for the loop-scoped roots (`item` · `index` are alive only inside a
+/// fan-out task · spec 04 §loop-scoped locals). Line-walk like the rest
+/// of this module: scan up to the task boundary looking for the key.
+pub(super) fn in_for_each_task(text: &str, offset: usize) -> bool {
+    for line in lines_upward(text, offset) {
+        let t = line.trim_start();
+        if t.starts_with("for_each:") {
+            return true;
+        }
+        if t.starts_with("- id:") {
+            return false;
+        }
+    }
+    false
+}
+
 /// The lines strictly above `offset`'s line, nearest first.
 fn lines_upward(text: &str, offset: usize) -> impl Iterator<Item = &str> {
     let upto = text.get(..offset).unwrap_or("");


### PR DESCRIPTION
## What

Closes #574 (probed on the installed 0.103.0).

| Gap | Before | After |
|---|---|---|
| `item` in EVERY island | offered even with no `for_each:` — completes a reference the run cannot resolve (spec 04 §loop-scoped locals: alive only inside a fan-out task) | rides ONLY when the ENCLOSING task declares `for_each:` — the never-offer-what-check-refuses law, island edition |
| `index` | never offered (the spec names the pair) | the missing twin joins, same gate |

`scope::in_for_each_task` walks up to the task boundary (the module's line-walk discipline). The B6 roots pin re-laws to the five locked namespaces; the gate's own law test covers both faces (plain task → neither · fan-out task → both).

193/193 nika-lsp · clippy 0 · fn-length OK · zero new pub items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)