### PR TITLE
chore(ci): the spec pin becomes a file — one mechanism across the estate

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -73,20 +73,19 @@ jobs:
       # repo's fixtures — locally a sibling ../spec checkout, here an
       # explicit NIKA_SPEC_DIR. Tests-leg only: the full battery (the
       # 2026-07-06 flip) is the first CI consumer these suites ever had.
+      # The conformance pin lives in SPEC_PIN at the repo root — ONE
+      # mechanism across the estate (file + heal bot, the vscode/registry
+      # pattern). PINNED, not floating: a floating default branch reddens
+      # every engine branch the moment a spec change merges ahead of its
+      # engine cascade — the cross-repo drift class. spec-pin-heal.yml
+      # advances the pin by PR; this CI judges at the pin.
       - name: Checkout nika-spec (conformance fixtures · tests leg)
         if: matrix.job == 'tests'
-        uses: actions/checkout@v4
-        with:
-          repository: supernovae-st/nika-spec
-          # PINNED, not floating: a floating default branch reddens
-          # every engine branch the moment a spec change merges ahead
-          # of its engine cascade — the cross-repo drift class. Bump
-          # the pin WITH each engine-side spec cascade (the sync-pack
-          # train). Current pin = spec#78 (argv|shell + gate algebra):
-          # the engine speaks argv (its #570) — the gate-algebra half
-          # (the /003 lint rescope) is the named remaining cascade.
-          ref: 12157ad949e75859c0cc41806c73876887871fac
-          path: nika-spec
+        run: |
+          set -euo pipefail
+          pin="$(grep -v '^#' SPEC_PIN | head -1 | tr -d '[:space:]')"
+          git clone --filter=blob:none https://github.com/supernovae-st/nika-spec "$GITHUB_WORKSPACE/nika-spec"
+          git -C "$GITHUB_WORKSPACE/nika-spec" checkout --detach "$pin"
       - name: Run rust job
         env:
           NIKA_SPEC_DIR: ${{ github.workspace }}/nika-spec

--- a/.github/workflows/spec-pin-heal.yml
+++ b/.github/workflows/spec-pin-heal.yml
@@ -1,0 +1,50 @@
+name: spec-pin-heal
+
+# The pin advances itself: daily, if nika-spec main moved past SPEC_PIN,
+# bump the pin and open ONE idempotent PR — the Diamond CI (conformance
+# fixtures checked out at the new pin) judges. Never a direct push. The
+# vendored pack has its own heal lane (pack-resync); this lane moves only
+# the pin the tests leg checks out. The healed file lives at the repo
+# root, never under .github/workflows/, so GITHUB_TOKEN can push it.
+# SECURITY: no github.event data is interpolated.
+
+on:
+  schedule:
+    - cron: '51 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  heal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: The pin follows the spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --filter=blob:none https://github.com/supernovae-st/nika-spec ../spec
+          head="$(git -C ../spec rev-parse HEAD)"
+          pin="$(grep -v '^#' SPEC_PIN | head -1 | tr -d '[:space:]')"
+          if [ "$head" = "$pin" ]; then echo "pin current ($pin) — nothing to heal"; exit 0; fi
+          python3 - "$head" <<'PYEOF'
+          import io, re, sys
+          s = io.open('SPEC_PIN', encoding='utf-8').read()
+          s = re.sub(r'^[0-9a-f]{40}$', sys.argv[1], s, count=1, flags=re.M)
+          io.open('SPEC_PIN', 'w', encoding='utf-8').write(s)
+          PYEOF
+          git add SPEC_PIN
+          git config user.name "nika-release[bot]"
+          git config user.email "nika@supernovae.studio"
+          git checkout -B bot/spec-pin
+          git commit -m "chore(spec-pin): the tests leg follows the spec — $(git -C ../spec rev-parse --short HEAD)"
+          git push -f origin bot/spec-pin
+          gh pr create --head bot/spec-pin \
+            --title "chore(spec-pin): the tests leg follows the spec" \
+            --body "Automated pin advance (spec-pin-heal). The Diamond CI conformance leg judges at the new pin; merge on green." \
+            2>/dev/null || echo "PR already open — refreshed"

--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,0 +1,4 @@
+# The nika-spec commit this repo's conformance fixtures + CI are proven at.
+# Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
+# tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
+12157ad949e75859c0cc41806c73876887871fac


### PR DESCRIPTION
## The residue (PL-008)

Three spec pins lived under **two mechanisms**: vscode and the registry carry a \`SPEC_PIN\` file advanced by a heal bot; the engine hardcoded the commit inline at \`diamond-ci.yml\`.

## The fix — the engine joins the file pattern

- **\`SPEC_PIN\`** at the repo root (same \`12157ad\` pin, unchanged — zero behavior delta today)
- **\`diamond-ci.yml\`** tests-leg checkout now reads the file (blob-less clone + detached checkout at the pin) — the pedagogical comment about the cross-repo drift class is preserved
- **\`spec-pin-heal.yml\`** (new): daily, if nika-spec main moved past the pin, bump \`SPEC_PIN\` and open ONE idempotent PR (\`bot/spec-pin\`) — the Diamond CI conformance leg judges at the new pin; never a direct push

Deploy-key lesson honored by construction: the healed file lives at the repo **root**, never under \`.github/workflows/\`, so \`GITHUB_TOKEN\` can push it. Pack vendoring keeps its own lane (pack-resync) — this lane moves only the pin the tests leg checks out.

## Verification

- The pin value is byte-identical to the previous inline \`ref:\` — the tests leg checks out the same commit
- Diamond CI on this PR IS the proof (the new checkout path runs on this very PR)

Zero-residue ledger **PL-008** · W0 of the v1 refonte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)