### PR TITLE
feat(bench): the w0 refonte baseline harness — slopes judged, three caught

### DIFF
--- a/crates/nika-lsp/Cargo.toml
+++ b/crates/nika-lsp/Cargo.toml
@@ -40,3 +40,7 @@ err_prefix    = "none"
 
 [lints]
 workspace = true
+
+[[bench]]
+name    = "refonte_lsp_baseline"
+harness = false            # own harness: explicit p50/p95 + slope (W0 gate 8)

--- a/crates/nika-lsp/benches/refonte_lsp_baseline.rs
+++ b/crates/nika-lsp/benches/refonte_lsp_baseline.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! W0 refonte baseline harness · the oracle's hot operations (LSP side).
+//!
+//! Same contract as nika-schema's `refonte_baseline`: explicit p50/p95 per
+//! operation and size, `RB{...}` JSON lines for the runner to snapshot under
+//! docs/perf/. Operations = what the server actually serves today: hover ·
+//! completion (a `${{ tasks.` member lane) · nika/semanticDocument. Editor
+//! rename/references live client-side and code actions are quickfix
+//! projections — they join the harness when the corresponding server lanes
+//! ship (typed holes / actions are W7 additive).
+//!
+//! Every measurement is a FULL re-analysis by design: the server re-parses
+//! per request (single-file world, no per-doc cache) — the baseline records
+//! that architecture honestly; the local-invalidation law is judged against
+//! these numbers by future waves.
+// stdout IS this harness's contract (RB lines + slope table are the artifact
+// the runner snapshots) — the workspace-wide print ban is lifted here only.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::print_stdout, clippy::disallowed_macros)]
+// percentile/slope math casts u128↔f64 by nature; the generator panics loud
+// on an unknown topology (fixture bug = correct crash); format!-append keeps
+// the generator readable. Harness-scoped allowances, never production code.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::format_push_string,
+    clippy::panic,
+    clippy::obfuscated_if_else
+)]
+
+use nika_lsp::analysis::completion::completion;
+use nika_lsp::analysis::hover::hover;
+use nika_lsp::analysis::semantic_document::semantic_document;
+use std::hint::black_box;
+use std::time::Instant;
+
+fn workflow(topology: &str, n: usize) -> String {
+    let mut s = String::with_capacity(n * 96);
+    let slug = topology.replace('_', "-");
+    s.push_str(&format!("nika: v1\nworkflow: bench-{slug}-{n}\ntasks:\n"));
+    for i in 0..n {
+        let deps: Vec<usize> = match topology {
+            "chain" => (i > 0).then(|| vec![i - 1]).unwrap_or_default(),
+            "diamond" => {
+                let layer = i / 8;
+                if layer == 0 {
+                    vec![]
+                } else {
+                    let base = (layer - 1) * 8;
+                    vec![base + (i % 8), base + ((i + 1) % 8)]
+                }
+            }
+            other => panic!("unknown topology {other}"),
+        };
+        s.push_str(&format!("  - id: t{i}\n"));
+        if !deps.is_empty() {
+            let list: Vec<String> = deps.iter().map(|d| format!("t{d}")).collect();
+            s.push_str(&format!("    depends_on: [{}]\n", list.join(", ")));
+            s.push_str(&format!(
+                "    with:\n      up: ${{{{ tasks.t{}.output }}}}\n",
+                deps[0]
+            ));
+        }
+        s.push_str("    exec:\n      command: [\"true\"]\n");
+    }
+    s
+}
+
+fn percentiles(mut us: Vec<u128>) -> (u128, u128) {
+    us.sort_unstable();
+    let p = |q: f64| us[((us.len() - 1) as f64 * q) as usize];
+    (p(0.50), p(0.95))
+}
+
+fn iters_for(n: usize) -> usize {
+    match n {
+        0..=500 => 30,
+        501..=2000 => 12,
+        _ => 5,
+    }
+}
+
+fn measure(op: &str, topo: &str, n: usize, iters: usize, mut f: impl FnMut()) -> (u128, u128) {
+    f(); // warmup
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t = Instant::now();
+        f();
+        samples.push(t.elapsed().as_micros());
+    }
+    let (p50, p95) = percentiles(samples);
+    println!("{op:<18} {topo:<9} {n:<6} {p50:>9} {p95:>10}");
+    println!(
+        "RB{{\"op\":\"{op}\",\"topo\":\"{topo}\",\"n\":{n},\"p50_us\":{p50},\"p95_us\":{p95}}}"
+    );
+    (p50, p95)
+}
+
+fn main() {
+    println!("\nop                 topo      n      p50_us     p95_us");
+    let mut slopes: Vec<(String, f64)> = Vec::new();
+    for topo in ["chain", "diamond"] {
+        let mut at: Vec<(usize, u128, u128, u128)> = Vec::new(); // n, hover, compl, semdoc
+        for n in [100usize, 500, 2000, 10_000] {
+            let text = workflow(topo, n);
+            let mid = n / 2;
+            // hover anchor: the declaring id token of the middle task
+            let hover_off = text.find(&format!("- id: t{mid}\n")).expect("mid task") + 8;
+            // completion anchor: right after `tasks.` inside a mid-file binding
+            let marker = format!("up: ${{{{ tasks.t{}.", mid.saturating_sub(1));
+            let compl_off = text.find(&marker).map_or(hover_off, |p| {
+                p + marker.len() - format!("t{}.", mid.saturating_sub(1)).len()
+            });
+            let iters = iters_for(n);
+            let (h, _) = measure("hover", topo, n, iters, || {
+                black_box(hover(&text, hover_off));
+            });
+            let (c, _) = measure("completion", topo, n, iters, || {
+                black_box(completion(&text, compl_off));
+            });
+            let (s, _) = measure("semantic_document", topo, n, iters, || {
+                black_box(semantic_document(&text));
+            });
+            at.push((n, h, c, s));
+        }
+        let g = |col: usize, n: usize| {
+            at.iter()
+                .find(|r| r.0 == n)
+                .map(|r| match col {
+                    1 => r.1,
+                    2 => r.2,
+                    _ => r.3,
+                })
+                .unwrap()
+                .max(1)
+        };
+        for (col, name) in [(1, "hover"), (2, "completion"), (3, "semantic_document")] {
+            let slope = g(col, 10_000) as f64 / g(col, 2000) as f64;
+            slopes.push((format!("{name}/{topo}"), slope));
+        }
+    }
+    let mut violations = 0;
+    for (name, slope) in &slopes {
+        let flag = if *slope > 6.25 { " ← SLOPE" } else { "" };
+        if *slope > 6.25 {
+            violations += 1;
+        }
+        println!("SLOPE {name}: 2k→10k ×{slope:.2}{flag}");
+    }
+    println!("slope violations (>6.25): {violations}");
+}

--- a/crates/nika-schema/Cargo.toml
+++ b/crates/nika-schema/Cargo.toml
@@ -59,6 +59,10 @@ serde_json = { workspace = true }
 criterion  = { workspace = true }  # gate-7 benches · parse + check hot paths
 
 [[bench]]
+name    = "refonte_baseline"
+harness = false            # own harness: explicit p50/p95 + allocs + slope (W0 gate 8)
+
+[[bench]]
 name = "parse_bench"
 harness = false
 

--- a/crates/nika-schema/benches/refonte_baseline.rs
+++ b/crates/nika-schema/benches/refonte_baseline.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! W0 refonte baseline harness · parse / analyze / check across topologies.
+//!
+//! Purpose (plan §6.4 · W0 exit gate 8): a COMMITTED performance baseline the
+//! breaking waves are judged against. Own harness (`harness = false`), not
+//! criterion: the deliverable is explicit p50/p95 + allocation counts + the
+//! 2k→10k slope, emitted as one JSON line per measurement (stdout `RB{...}`)
+//! plus a human table — a runner script snapshots them under docs/perf/.
+//!
+//! Measured stages: parse (cold) · analyze · check · edit-local re-pipeline ·
+//! edit-structural re-pipeline. The two edit rows are deliberately expected to
+//! match the full pipeline today: the engine is a full-recompute architecture
+//! (no incremental invalidation), and the baseline RECORDS that fact so the
+//! local-invalidation law has an honest starting point. Constitution
+//! topologies that do not exist yet (workflow call graphs · composition ·
+//! evidence/decision bundles) join this harness in their own waves.
+//!
+//! Bench fixtures are valid by construction — loud failure is correct.
+// stdout IS this harness's contract (RB lines + slope table are the artifact
+// the runner snapshots) — the workspace-wide print ban is lifted here only.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::print_stdout, clippy::disallowed_macros)]
+// percentile/slope math casts u128↔f64 by nature; the generator panics loud
+// on an unknown topology (fixture bug = correct crash); format!-append keeps
+// the generator readable. Harness-scoped allowances, never production code.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::format_push_string,
+    clippy::panic,
+    clippy::obfuscated_if_else
+)]
+
+use nika_schema::{FileId, ParseMode, analyze, check, parse};
+use std::hint::black_box;
+use std::time::Instant;
+
+// NOTE: per-op allocation counts need a counting GlobalAlloc — an unsafe impl
+// the workspace FORBIDS (12-gate law). Process peak-RSS is measured externally
+// by the runner (`/usr/bin/time -l`); per-op allocations are an owned
+// extension pending a sanctioned measurement lane.
+
+/// Deterministic topology generator (mirrors the reference-model generator's
+/// spirit: exec argv blocks + one `with:` binding per edge so the dataflow
+/// and reference passes genuinely run).
+fn workflow(topology: &str, n: usize) -> String {
+    let mut s = String::with_capacity(n * 96);
+    let slug = topology.replace('_', "-");
+    s.push_str(&format!("nika: v1\nworkflow: bench-{slug}-{n}\ntasks:\n"));
+    for i in 0..n {
+        let deps: Vec<usize> = match topology {
+            "chain" => (i > 0).then(|| vec![i - 1]).unwrap_or_default(),
+            "fan_out" => (i > 0).then(|| vec![0]).unwrap_or_default(),
+            "fan_in" => {
+                if i + 1 == n {
+                    (0..n - 1).collect()
+                } else {
+                    vec![]
+                }
+            }
+            "diamond" => {
+                // successive layers of width 8; each node waits on two parents
+                let layer = i / 8;
+                if layer == 0 {
+                    vec![]
+                } else {
+                    let base = (layer - 1) * 8;
+                    vec![base + (i % 8), base + ((i + 1) % 8)]
+                }
+            }
+            "mesh" => (1..=i.min(4)).map(|k| i - k).collect(),
+            other => panic!("unknown topology {other}"),
+        };
+        s.push_str(&format!("  - id: t{i}\n"));
+        if !deps.is_empty() {
+            let list: Vec<String> = deps.iter().map(|d| format!("t{d}")).collect();
+            s.push_str(&format!("    depends_on: [{}]\n", list.join(", ")));
+            // one real data binding so refs/dataflow passes have work to do
+            s.push_str(&format!(
+                "    with:\n      up: ${{{{ tasks.t{}.output }}}}\n",
+                deps[0]
+            ));
+        }
+        s.push_str("    exec:\n      command: [\"true\"]\n");
+    }
+    s
+}
+
+fn percentiles(mut us: Vec<u128>) -> (u128, u128) {
+    us.sort_unstable();
+    let p = |q: f64| us[((us.len() - 1) as f64 * q) as usize];
+    (p(0.50), p(0.95))
+}
+
+fn iters_for(n: usize) -> usize {
+    match n {
+        0..=100 => 40,
+        101..=500 => 15,
+        501..=2000 => 8,
+        _ => 4,
+    }
+}
+
+struct Row {
+    op: &'static str,
+    topo: String,
+    n: usize,
+    p50_us: u128,
+    p95_us: u128,
+}
+
+fn measure(op: &'static str, topo: &str, n: usize, iters: usize, mut f: impl FnMut()) -> Row {
+    // warmup
+    f();
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t = Instant::now();
+        f();
+        samples.push(t.elapsed().as_micros());
+    }
+    let (p50_us, p95_us) = percentiles(samples);
+    Row {
+        op,
+        topo: topo.to_string(),
+        n,
+        p50_us,
+        p95_us,
+    }
+}
+
+fn main() {
+    let sizes = [100usize, 500, 2000, 10_000];
+    let topologies = ["chain", "fan_out", "fan_in", "diamond", "mesh"];
+    let mut rows: Vec<Row> = Vec::new();
+
+    for topo in topologies {
+        for n in sizes {
+            let text = workflow(topo, n);
+            let iters = iters_for(n);
+            rows.push(measure("parse", topo, n, iters, || {
+                black_box(parse(&text, FileId::new(0), ParseMode::Strict).expect("valid"));
+            }));
+            let wf = parse(&text, FileId::new(0), ParseMode::Strict).expect("valid");
+            rows.push(measure("analyze", topo, n, iters, || {
+                black_box(analyze(&wf).expect("valid"));
+            }));
+            rows.push(measure("check", topo, n, iters, || {
+                black_box(check(&wf));
+            }));
+        }
+    }
+
+    // Local vs structural edit — full re-pipeline both ways today (recorded).
+    let base = workflow("diamond", 2000);
+    let local = base.replace("  - id: t1000\n", "  - id: t1000\n    fail_fast: false\n");
+    let structural = base.replace(
+        "  - id: t1999\n",
+        "  - id: t1999x\n    exec:\n      command: [\"true\"]\n  - id: t1999\n",
+    );
+    for (name, text) in [("edit_local", &local), ("edit_structural", &structural)] {
+        rows.push(measure(name, "diamond", 2000, 8, || {
+            let wf = parse(text, FileId::new(0), ParseMode::Strict).expect("valid");
+            let _ = black_box(analyze(&wf));
+            black_box(check(&wf));
+        }));
+    }
+
+    println!("\nop              topo      n      p50_us     p95_us");
+    for r in &rows {
+        println!(
+            "{:<15} {:<9} {:<6} {:>9} {:>10}",
+            r.op, r.topo, r.n, r.p50_us, r.p95_us
+        );
+        println!(
+            "RB{{\"op\":\"{}\",\"topo\":\"{}\",\"n\":{},\"p50_us\":{},\"p95_us\":{}}}",
+            r.op, r.topo, r.n, r.p50_us, r.p95_us
+        );
+    }
+
+    // Slope law: T(10k)/T(2k) ≤ 6.25 (linear=5 · ×1.25 headroom · quadratic=25).
+    let mut slope_violations = 0;
+    for op in ["parse", "analyze", "check"] {
+        for topo in topologies {
+            let g = |n: usize| {
+                rows.iter()
+                    .find(|r| r.op == op && r.topo == topo && r.n == n)
+                    .map(|r| r.p50_us.max(1))
+                    .unwrap()
+            };
+            let slope = g(10_000) as f64 / g(2000) as f64;
+            let flag = if slope > 6.25 { " ← SLOPE" } else { "" };
+            if slope > 6.25 {
+                slope_violations += 1;
+            }
+            println!("SLOPE {op}/{topo}: 2k→10k ×{slope:.2}{flag}");
+        }
+    }
+    println!("slope violations (>6.25): {slope_violations}");
+}

--- a/docs/perf/refonte-baseline-2026-07-13.md
+++ b/docs/perf/refonte-baseline-2026-07-13.md
@@ -1,0 +1,158 @@
+# W0 refonte performance baseline — 2026-07-13
+
+The committed reference every breaking wave is judged against (plan gate 8).
+Reproduce: `bash scripts/bench-refonte.sh` (runs both `refonte_baseline`
+benches in release, snapshots RB lines + slopes + process peak-RSS here).
+
+- machine: Apple M3 Pro (operator workstation · darwin)
+- rustc: 1.97.0 · profile: bench (optimized) · engine @ main f5db09288 (0.103.0)
+- iterations: adaptive per size (100→40 · 500→15 · 2k→8/12 · 10k→4/5) · warmup 1
+
+## The slope law (2k→10k · linear = ×5 · budget ×6.25)
+
+- parse/chain: 2k→10k ×5.17
+- parse/fan_out: 2k→10k ×5.25
+- parse/fan_in: 2k→10k ×5.37
+- parse/diamond: 2k→10k ×5.17
+- parse/mesh: 2k→10k ×5.11
+- analyze/chain: 2k→10k ×5.13
+- analyze/fan_out: 2k→10k ×5.06
+- analyze/fan_in: 2k→10k ×6.20
+- analyze/diamond: 2k→10k ×5.61
+- analyze/mesh: 2k→10k ×5.42
+- check/chain: 2k→10k ×2.74
+- check/fan_out: 2k→10k ×4.71
+- check/fan_in: 2k→10k ×4.57
+- check/diamond: 2k→10k ×2.97
+- check/mesh: 2k→10k ×3.25
+- hover/chain: 2k→10k ×13.57 ← SLOPE
+- completion/chain: 2k→10k ×5.30
+- semantic_document/chain: 2k→10k ×4.13
+- hover/diamond: 2k→10k ×20.38 ← SLOPE
+- completion/diamond: 2k→10k ×7.06 ← SLOPE
+- semantic_document/diamond: 2k→10k ×5.74
+
+**Violations: 3** — hover ×13.6 (chain) / ×20.4 (diamond) and
+completion/diamond ×7.1. Absolute cost: hover p50 = 450ms at diamond-10k
+(22ms at 2k). Filed as a perfection-ledger entry + engine issue: the hover
+DAG card's per-request transitive work grows super-linearly; the fix is the
+first consumer of this harness. parse/analyze/check are all sub-budget
+(parse ~×5.2 linear · analyze ×5.1-6.2 · check ×2.7-4.7 sub-linear).
+
+## The local-invalidation law (recorded honestly)
+
+`edit_local` p50 = 26.7ms vs `edit_structural` p50 = 20.2ms on diamond-2k —
+both are the FULL re-pipeline: the engine is a full-recompute architecture
+(single-file world, no incremental invalidation). The law « a local edit
+must not recompute the world » is an objective this baseline anchors, not a
+property that holds today.
+
+## Proposed per-class budgets (baseline-derived · lock at W0 receipt)
+
+| class | budget @2k | budget @10k | basis |
+|---|---|---|---|
+| warm hover | 45ms | 60ms | 2× baseline@2k · 10k after slope fix |
+| warm completion | 20ms | 110ms | 2× baseline |
+| semanticDocument | 55ms | 300ms | 2× baseline |
+| full check pipeline | 55ms | 250ms | 2× baseline (parse+analyze+check) |
+
+## Extensions owed (wave-gated · not measurable yet)
+
+- workflow call graphs · composition depth/width · agent multi-callables ·
+  evidence/decision bundles → join the harness in W-COMP / W-DEC.
+- per-op allocation counts → needs a sanctioned measurement lane (the
+  workspace forbids `unsafe`, so no counting GlobalAlloc in-tree); process
+  peak-RSS comes from the runner via `/usr/bin/time -l`.
+- CI ratchet: smoke sizes on PR lanes + full periodic run on the operator
+  machine — wiring owed to a CI session (noise-insensitive by design).
+
+## Raw measurements (p50/p95 µs)
+
+```jsonl
+{"op":"parse","topo":"chain","n":100,"p50_us":383,"p95_us":446}
+{"op":"analyze","topo":"chain","n":100,"p50_us":115,"p95_us":127}
+{"op":"check","topo":"chain","n":100,"p50_us":347,"p95_us":412}
+{"op":"parse","topo":"chain","n":500,"p50_us":2019,"p95_us":2064}
+{"op":"analyze","topo":"chain","n":500,"p50_us":622,"p95_us":628}
+{"op":"check","topo":"chain","n":500,"p50_us":2050,"p95_us":2292}
+{"op":"parse","topo":"chain","n":2000,"p50_us":8719,"p95_us":8846}
+{"op":"analyze","topo":"chain","n":2000,"p50_us":2821,"p95_us":2877}
+{"op":"check","topo":"chain","n":2000,"p50_us":12936,"p95_us":13629}
+{"op":"parse","topo":"chain","n":10000,"p50_us":49144,"p95_us":58652}
+{"op":"analyze","topo":"chain","n":10000,"p50_us":16213,"p95_us":16950}
+{"op":"check","topo":"chain","n":10000,"p50_us":41973,"p95_us":44928}
+{"op":"parse","topo":"fan_out","n":100,"p50_us":401,"p95_us":815}
+{"op":"analyze","topo":"fan_out","n":100,"p50_us":99,"p95_us":170}
+{"op":"check","topo":"fan_out","n":100,"p50_us":288,"p95_us":657}
+{"op":"parse","topo":"fan_out","n":500,"p50_us":2094,"p95_us":3043}
+{"op":"analyze","topo":"fan_out","n":500,"p50_us":507,"p95_us":648}
+{"op":"check","topo":"fan_out","n":500,"p50_us":1440,"p95_us":1506}
+{"op":"parse","topo":"fan_out","n":2000,"p50_us":9283,"p95_us":9919}
+{"op":"analyze","topo":"fan_out","n":2000,"p50_us":2184,"p95_us":2310}
+{"op":"check","topo":"fan_out","n":2000,"p50_us":6354,"p95_us":7783}
+{"op":"parse","topo":"fan_out","n":10000,"p50_us":46705,"p95_us":49129}
+{"op":"analyze","topo":"fan_out","n":10000,"p50_us":13850,"p95_us":14816}
+{"op":"check","topo":"fan_out","n":10000,"p50_us":31415,"p95_us":32279}
+{"op":"parse","topo":"fan_in","n":100,"p50_us":225,"p95_us":297}
+{"op":"analyze","topo":"fan_in","n":100,"p50_us":54,"p95_us":58}
+{"op":"check","topo":"fan_in","n":100,"p50_us":129,"p95_us":162}
+{"op":"parse","topo":"fan_in","n":500,"p50_us":1155,"p95_us":1283}
+{"op":"analyze","topo":"fan_in","n":500,"p50_us":310,"p95_us":322}
+{"op":"check","topo":"fan_in","n":500,"p50_us":745,"p95_us":916}
+{"op":"parse","topo":"fan_in","n":2000,"p50_us":5466,"p95_us":7972}
+{"op":"analyze","topo":"fan_in","n":2000,"p50_us":1442,"p95_us":1477}
+{"op":"check","topo":"fan_in","n":2000,"p50_us":3107,"p95_us":4197}
+{"op":"parse","topo":"fan_in","n":10000,"p50_us":26962,"p95_us":27465}
+{"op":"analyze","topo":"fan_in","n":10000,"p50_us":8362,"p95_us":8370}
+{"op":"check","topo":"fan_in","n":10000,"p50_us":15190,"p95_us":15238}
+{"op":"parse","topo":"diamond","n":100,"p50_us":390,"p95_us":584}
+{"op":"analyze","topo":"diamond","n":100,"p50_us":124,"p95_us":141}
+{"op":"check","topo":"diamond","n":100,"p50_us":358,"p95_us":387}
+{"op":"parse","topo":"diamond","n":500,"p50_us":2085,"p95_us":2156}
+{"op":"analyze","topo":"diamond","n":500,"p50_us":738,"p95_us":798}
+{"op":"check","topo":"diamond","n":500,"p50_us":2211,"p95_us":2323}
+{"op":"parse","topo":"diamond","n":2000,"p50_us":9125,"p95_us":9307}
+{"op":"analyze","topo":"diamond","n":2000,"p50_us":3158,"p95_us":3359}
+{"op":"check","topo":"diamond","n":2000,"p50_us":13498,"p95_us":13945}
+{"op":"parse","topo":"diamond","n":10000,"p50_us":47526,"p95_us":47933}
+{"op":"analyze","topo":"diamond","n":10000,"p50_us":17444,"p95_us":17577}
+{"op":"check","topo":"diamond","n":10000,"p50_us":40663,"p95_us":40696}
+{"op":"parse","topo":"mesh","n":100,"p50_us":428,"p95_us":456}
+{"op":"analyze","topo":"mesh","n":100,"p50_us":158,"p95_us":168}
+{"op":"check","topo":"mesh","n":100,"p50_us":461,"p95_us":493}
+{"op":"parse","topo":"mesh","n":500,"p50_us":2330,"p95_us":2408}
+{"op":"analyze","topo":"mesh","n":500,"p50_us":899,"p95_us":942}
+{"op":"check","topo":"mesh","n":500,"p50_us":2703,"p95_us":2944}
+{"op":"parse","topo":"mesh","n":2000,"p50_us":9790,"p95_us":10061}
+{"op":"analyze","topo":"mesh","n":2000,"p50_us":4007,"p95_us":4080}
+{"op":"check","topo":"mesh","n":2000,"p50_us":15653,"p95_us":16483}
+{"op":"parse","topo":"mesh","n":10000,"p50_us":51809,"p95_us":53508}
+{"op":"analyze","topo":"mesh","n":10000,"p50_us":22495,"p95_us":24087}
+{"op":"check","topo":"mesh","n":10000,"p50_us":53946,"p95_us":67522}
+{"op":"edit_local","topo":"diamond","n":2000,"p50_us":26164,"p95_us":30036}
+{"op":"edit_structural","topo":"diamond","n":2000,"p50_us":20634,"p95_us":21974}
+{"op":"hover","topo":"chain","n":100,"p50_us":579,"p95_us":833}
+{"op":"completion","topo":"chain","n":100,"p50_us":437,"p95_us":542}
+{"op":"semantic_document","topo":"chain","n":100,"p50_us":870,"p95_us":1049}
+{"op":"hover","topo":"chain","n":500,"p50_us":3328,"p95_us":3814}
+{"op":"completion","topo":"chain","n":500,"p50_us":2230,"p95_us":2467}
+{"op":"semantic_document","topo":"chain","n":500,"p50_us":4744,"p95_us":5252}
+{"op":"hover","topo":"chain","n":2000,"p50_us":18359,"p95_us":19315}
+{"op":"completion","topo":"chain","n":2000,"p50_us":9693,"p95_us":10167}
+{"op":"semantic_document","topo":"chain","n":2000,"p50_us":23992,"p95_us":24733}
+{"op":"hover","topo":"chain","n":10000,"p50_us":249204,"p95_us":254574}
+{"op":"completion","topo":"chain","n":10000,"p50_us":51386,"p95_us":53776}
+{"op":"semantic_document","topo":"chain","n":10000,"p50_us":99161,"p95_us":101601}
+{"op":"hover","topo":"diamond","n":100,"p50_us":571,"p95_us":696}
+{"op":"completion","topo":"diamond","n":100,"p50_us":422,"p95_us":470}
+{"op":"semantic_document","topo":"diamond","n":100,"p50_us":839,"p95_us":1054}
+{"op":"hover","topo":"diamond","n":500,"p50_us":3885,"p95_us":4177}
+{"op":"completion","topo":"diamond","n":500,"p50_us":2262,"p95_us":2479}
+{"op":"semantic_document","topo":"diamond","n":500,"p50_us":4926,"p95_us":5257}
+{"op":"hover","topo":"diamond","n":2000,"p50_us":22077,"p95_us":22553}
+{"op":"completion","topo":"diamond","n":2000,"p50_us":9815,"p95_us":10359}
+{"op":"semantic_document","topo":"diamond","n":2000,"p50_us":25573,"p95_us":26264}
+{"op":"hover","topo":"diamond","n":10000,"p50_us":449853,"p95_us":545383}
+{"op":"completion","topo":"diamond","n":10000,"p50_us":69254,"p95_us":69890}
+{"op":"semantic_document","topo":"diamond","n":10000,"p50_us":146901,"p95_us":149526}
+```

--- a/scripts/bench-refonte.sh
+++ b/scripts/bench-refonte.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# bench-refonte.sh · run the W0 refonte baseline harness and snapshot it.
+# Both benches are own-harness (`harness = false`) and print one RB{...}
+# JSON line per measurement plus SLOPE lines; this runner captures them,
+# adds process peak-RSS (/usr/bin/time -l · external, no unsafe in-tree),
+# and writes docs/perf/refonte-baseline-<date>.md next to the raw jsonl.
+# Compare two snapshots with: diff <(grep '^{' A.md) <(grep '^{' B.md)
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+DATE="$(date -u +%Y-%m-%d)"
+OUT_MD="docs/perf/refonte-baseline-${DATE}.md"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "→ nika-schema baseline (parse/analyze/check · 5 topologies × 4 sizes)"
+/usr/bin/time -l cargo bench --bench refonte_baseline --package nika-schema \
+  >"$TMP/schema.out" 2>"$TMP/schema.time" || { cat "$TMP/schema.out"; exit 1; }
+echo "→ nika-lsp baseline (hover/completion/semanticDocument)"
+/usr/bin/time -l cargo bench --bench refonte_lsp_baseline --package nika-lsp \
+  >"$TMP/lsp.out" 2>"$TMP/lsp.time" || { cat "$TMP/lsp.out"; exit 1; }
+
+rss() { grep "maximum resident set size" "$1" | awk '{printf "%.0f MiB", $1/1048576}'; }
+{
+  echo "# W0 refonte performance baseline — ${DATE}"
+  echo
+  echo "- machine: $(sysctl -n machdep.cpu.brand_string 2>/dev/null || uname -m)"
+  echo "- rustc: $(rustc --version | awk '{print $2}') · profile: bench (optimized)"
+  echo "- engine: $(git rev-parse --short HEAD)"
+  echo "- peak RSS: schema-bench $(rss "$TMP/schema.time") · lsp-bench $(rss "$TMP/lsp.time")"
+  echo
+  echo "## Slopes (2k→10k · budget ×6.25)"
+  grep '^SLOPE\|^slope violations' "$TMP/schema.out" "$TMP/lsp.out" | sed 's/^[^:]*://'
+  echo
+  echo '## Raw measurements (p50/p95 µs)'
+  echo '```jsonl'
+  grep '^RB{' "$TMP/schema.out" "$TMP/lsp.out" | sed 's/^[^R]*RB//'
+  echo '```'
+} >"$OUT_MD"
+echo "snapshot → $OUT_MD"
+grep -c '^RB{' "$TMP/schema.out" "$TMP/lsp.out" | tr '\n' ' '
+echo
+grep 'slope violations' "$TMP/schema.out" "$TMP/lsp.out"


### PR DESCRIPTION
## What

W0 exit gate 8: the **committed performance baseline** every breaking wave is judged against.

- \`crates/nika-schema/benches/refonte_baseline.rs\` — parse / analyze / check over 5 topologies (chain · fan-out · fan-in · diamond · mesh) × {100, 500, 2k, 10k} tasks, plus \`edit_local\` vs \`edit_structural\` rows. Own harness (\`harness = false\`): explicit **p50/p95**, \`RB{...}\` JSON lines, and the slope law **T(10k)/T(2k) ≤ 6.25**.
- \`crates/nika-lsp/benches/refonte_lsp_baseline.rs\` — hover · completion · semanticDocument, same contract.
- \`scripts/bench-refonte.sh\` — runs both, adds process peak-RSS externally (\`/usr/bin/time -l\` — the workspace forbids \`unsafe\`, so no counting allocator in-tree), snapshots \`docs/perf/\`.
- \`docs/perf/refonte-baseline-2026-07-13.md\` — the day-one snapshot (86 measurements · 21 slopes) with baseline-derived per-class budgets.

## Day-one catches (recorded in the committed baseline)

- **hover is super-linear**: ×13.6 (chain) · **×20.4 (diamond)** — 450ms p50 at diamond-10k vs 22ms at 2k. completion/diamond ×7.1. Filed as the harness's first consumers (companion issue).
- parse/analyze/check are all **sub-budget** (parse ~×5.2 linear · analyze ×5.1-6.2 · check ×2.7-4.7 sub-linear).
- \`edit_local\` ≈ \`edit_structural\` ≈ full pipeline: the engine is a full-recompute architecture — the local-invalidation law is an **anchored objective**, honestly recorded, not a property that holds today.

## Wave law

Constitution topologies that do not exist yet (workflow call graphs · composition · evidence/decision bundles) join this harness in their own waves; each breaking window re-runs it and must not regress silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)