### PR TITLE
perf(lsp): the downstream walk goes one-pass — hover sheds its ×20 slope

### DIFF
--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -695,9 +695,10 @@ pub(super) fn task_ids(text: &str, exclude: Option<&str>) -> Vec<CompletionItem>
     if let Ok(wf) = parse(text, FileId::new(0), ParseMode::Lenient)
         && !wf.tasks.is_empty()
     {
-        let illegal: Vec<&str> = exclude.map_or_else(Vec::new, |id| {
-            super::graph::illegal_reference_targets(&wf, id)
-        });
+        let illegal: std::collections::BTreeSet<&str> = exclude
+            .map_or_else(std::collections::BTreeSet::new, |id| {
+                super::graph::illegal_reference_targets(&wf, id)
+            });
         return wf
             .tasks
             .iter()

--- a/crates/nika-lsp/src/analysis/graph.rs
+++ b/crates/nika-lsp/src/analysis/graph.rs
@@ -6,34 +6,50 @@
 //! math only: findings about the graph stay in the check ladder.
 
 use nika_schema::raw::RawWorkflow;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-/// The ids downstream of `id` — { t : id →⁺ t }, BFS over the explicit
-/// reverse edges. `id` itself is NOT in the set.
+/// The ids downstream of `id` — { t : id →⁺ t }, ONE reverse-adjacency
+/// build + ONE BFS = O(V+E). `id` itself is NOT in the set.
+///
+/// The previous shape re-scanned every task per queue pop with a
+/// `Vec::contains` visited check — O(V²·d) — and was the ×20 hover
+/// slope the W0 baseline caught on diamond-10k (engine#579; the same
+/// lesson the vscode client learned in its #101, now applied
+/// server-side).
 pub(super) fn downstream_ids<'a>(wf: &'a RawWorkflow, id: &str) -> Vec<&'a str> {
-    let mut seen: Vec<&'a str> = Vec::new();
-    let mut queue: Vec<&str> = vec![id];
-    while let Some(cur) = queue.pop() {
-        for t in &wf.tasks {
-            if t.value.depends_on.iter().any(|d| d.value == cur) {
-                let child = t.value.id.value.as_str();
-                if !seen.contains(&child) {
-                    seen.push(child);
-                    queue.push(child);
+    let mut children: BTreeMap<&str, Vec<&'a str>> = BTreeMap::new();
+    for t in &wf.tasks {
+        let child = t.value.id.value.as_str();
+        for d in &t.value.depends_on {
+            children.entry(d.value.as_str()).or_default().push(child);
+        }
+    }
+    let mut seen: BTreeSet<&'a str> = BTreeSet::new();
+    let mut order: Vec<&'a str> = Vec::new();
+    let mut queue: VecDeque<&str> = VecDeque::from([id]);
+    while let Some(cur) = queue.pop_front() {
+        if let Some(kids) = children.get(cur) {
+            for &kid in kids {
+                if seen.insert(kid) {
+                    order.push(kid);
+                    queue.push_back(kid);
                 }
             }
         }
     }
-    seen
+    order
 }
 
 /// The ids task `id` may legally REFERENCE — everything except itself
 /// and its downstream closure. Referencing downstream creates a cycle
 /// (a template ref is an implicit edge) or, in `recover:`, a deadlock
 /// (DAG-004): either way the check refuses it, so completion never
-/// offers it.
-pub(super) fn illegal_reference_targets<'a>(wf: &'a RawWorkflow, id: &'a str) -> Vec<&'a str> {
-    let mut set = downstream_ids(wf, id);
-    set.push(id);
+/// offers it. A set, because every caller filters candidates through
+/// membership tests (`contains` must be O(log V), not O(V) — `BTree` by
+/// workspace law: std hash types are disallowed for determinism).
+pub(super) fn illegal_reference_targets<'a>(wf: &'a RawWorkflow, id: &'a str) -> BTreeSet<&'a str> {
+    let mut set: BTreeSet<&'a str> = downstream_ids(wf, id).into_iter().collect();
+    set.insert(id);
     set
 }
 
@@ -57,7 +73,7 @@ mod tests {
     #[test]
     fn illegal_targets_are_self_plus_closure() {
         let wf = parse(DIAMOND, FileId::new(0), ParseMode::Lenient).expect("parses");
-        let mut illegal = illegal_reference_targets(&wf, "b");
+        let mut illegal: Vec<&str> = illegal_reference_targets(&wf, "b").into_iter().collect();
         illegal.sort_unstable();
         // b may not reference itself nor d (which waits on b) — a and c
         // stay legal (ancestor · parallel-independent).

--- a/crates/nika-lsp/src/analysis/islands.rs
+++ b/crates/nika-lsp/src/analysis/islands.rs
@@ -59,9 +59,11 @@ fn doc_view(text: &str, offset: usize) -> DocView {
                 (name.value.clone(), is_array)
             })
             .collect();
-        let illegal: Vec<&str> = current
+        let illegal: std::collections::BTreeSet<&str> = current
             .as_deref()
-            .map_or_else(Vec::new, |id| graph::illegal_reference_targets(&wf, id));
+            .map_or_else(std::collections::BTreeSet::new, |id| {
+                graph::illegal_reference_targets(&wf, id)
+            });
         let upstream = wf
             .tasks
             .iter()


### PR DESCRIPTION
## The catch (W0 baseline harness, first run)

hover was super-linear — **×20.4 on diamond (450ms p50 @10k vs 22ms @2k)**, completion/diamond ×7.1 (\`docs/perf/refonte-baseline-2026-07-13.md\`).

## Root cause

\`analysis/graph.rs::downstream_ids\` re-scanned **every task per queue pop** with a \`Vec::contains\` visited check — O(V²·d). \`illegal_reference_targets\` (completion's exclusion set) called it, then call sites did \`Vec::contains\` per candidate — another quadratic on top.

## The fix

One reverse-adjacency build + one BFS = O((V+E)·log V) (**BTree types by workspace law** — std hash types are disallowed for determinism). The illegal set returns a \`BTreeSet\` so membership tests are logarithmic. Same lesson the vscode client learned in its \`descendantsOf\` pass (#101) — now applied server-side.

## Measured (committed harness · \`cargo bench --bench refonte_lsp_baseline -p nika-lsp\`)

| op | topo @10k | before | after | slope before → after |
|---|---|---|---|---|
| hover | diamond | **450ms** | **65ms** | ×20.4 → **×5.27** ✓ |
| hover | chain | 249ms | 60ms | ×13.6 → **×5.35** ✓ |
| completion | diamond | 69ms | 45ms | ×7.1 → **×5.15** ✓ |

**Zero slope violations remain.** The committed baseline keeps the BEFORE numbers as the finding's initial proof; the next periodic run records the new floor.

193 lib tests green · clippy clean · fmt clean. Fixes #579 · perfection-ledger PL-035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)