### PR TITLE
feat(lsp): server-side rename — the map key renames everywhere at once

### DIFF
--- a/crates/nika-lsp/src/analysis/definition.rs
+++ b/crates/nika-lsp/src/analysis/definition.rs
@@ -187,7 +187,7 @@ fn template_task_target(text: &str, offset: usize) -> Option<String> {
 /// The byte ranges `[start, end)` of every `${{ … }}` island in `text`
 /// (`start` is just past `${{`, `end` is at the closing `}}`). Honors the
 /// `\${{` literal escape and quote-aware close detection.
-fn islands(text: &str) -> Vec<(usize, usize)> {
+pub(super) fn islands(text: &str) -> Vec<(usize, usize)> {
     let bytes = text.as_bytes();
     let mut out = Vec::new();
     let mut i = 0usize;
@@ -255,7 +255,7 @@ fn find_close(bytes: &[u8], from: usize) -> Option<usize> {
 
 /// The byte offset just past an identifier starting at `start` (CEL ids
 /// are `[A-Za-z_][A-Za-z0-9_]*` · matches the `snake_case` task-id grammar).
-fn ident_end(bytes: &[u8], start: usize) -> usize {
+pub(super) fn ident_end(bytes: &[u8], start: usize) -> usize {
     let mut i = start;
     while let Some(&b) = bytes.get(i) {
         if b == b'_' || b.is_ascii_alphanumeric() {
@@ -270,7 +270,7 @@ fn ident_end(bytes: &[u8], start: usize) -> usize {
 /// Whether `offset` falls within the token a `span` anchors, given the
 /// token's byte length. A point span (`start == end`) is widened to
 /// `[start, start + token_len)`; a real range uses its own end.
-fn token_span_contains(span: Span, token_len: usize, offset: u32) -> bool {
+pub(super) fn token_span_contains(span: Span, token_len: usize, offset: u32) -> bool {
     let end = if span.end.0 > span.start.0 {
         span.end.0
     } else {
@@ -281,7 +281,7 @@ fn token_span_contains(span: Span, token_len: usize, offset: u32) -> bool {
 
 /// The LSP range over the token a point/real span anchors, widened to the
 /// token byte length so the jump target highlights the whole id.
-fn token_range(index: &LineIndex, span: Span, token_len: usize) -> Range {
+pub(super) fn token_range(index: &LineIndex, span: Span, token_len: usize) -> Range {
     let start = span.start.0 as usize;
     let end = if span.end.0 > span.start.0 {
         span.end.0 as usize

--- a/crates/nika-lsp/src/analysis/mod.rs
+++ b/crates/nika-lsp/src/analysis/mod.rs
@@ -22,6 +22,7 @@ mod islands;
 pub mod members;
 pub mod position;
 pub mod refs;
+pub mod rename;
 pub mod scope;
 pub mod semantic_document;
 mod skills;

--- a/crates/nika-lsp/src/analysis/rename.rs
+++ b/crates/nika-lsp/src/analysis/rename.rs
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Server-side rename for task identities (single-file · the W1 map).
+//!
+//! A task's identity is its map KEY (W1 « the map »), and a rename must
+//! move every site that speaks it, atomically ·
+//!
+//! 1. the declaring key token (`old:` → `new:`),
+//! 2. every `depends_on:` entry naming it,
+//! 3. every `tasks.<old>` chain inside a `${{ … }}` island — the same
+//!    document-level byte-scan discipline (and the same comment
+//!    tolerance) as the [`definition`](super::definition) lane, so the
+//!    two features agree on what a reference IS.
+//!
+//! `prepareRename` answers only on those three site shapes; `rename`
+//! validates the new name against the task-id grammar
+//! (`[a-z][a-z0-9_]*`) and refuses collisions with existing ids — the
+//! refusal is a request ERROR carrying the teaching, never a silent
+//! no-op edit.
+
+use std::collections::BTreeSet;
+
+use lsp_types::{
+    DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier, Range, TextDocumentEdit,
+    TextEdit, Uri, WorkspaceEdit,
+};
+use nika_schema::raw::RawWorkflow;
+use nika_schema::{FileId, ParseMode, parse};
+
+use super::definition::{ident_end, islands, token_range, token_span_contains};
+use super::position::LineIndex;
+
+/// The token range + current id under `offset`, when it is a renameable
+/// task-identity site (key · `depends_on` entry · `tasks.<id>` island
+/// ref). `None` anywhere else — the client greys the gesture out.
+#[must_use]
+pub fn prepare(text: &str, offset: usize) -> Option<(Range, String)> {
+    let wf = parse(text, FileId::new(0), ParseMode::Lenient).ok()?;
+    let index = LineIndex::new(text);
+    site_at(&wf, text, offset).map(|site| {
+        let range = site_lsp_range(&index, &site);
+        (range, site.id)
+    })
+}
+
+/// Rename the task identity under `offset` to `new_name` across every
+/// site. `Ok` is the single-document [`WorkspaceEdit`].
+///
+/// # Errors
+///
+/// The human-readable refusal the client shows: not an identity site ·
+/// unparseable document · same name · grammar violation · collision ·
+/// ghost (the id defines no task).
+pub fn rename(
+    uri: &Uri,
+    text: &str,
+    offset: usize,
+    new_name: &str,
+) -> Result<WorkspaceEdit, String> {
+    let wf = parse(text, FileId::new(0), ParseMode::Lenient)
+        .map_err(|e| format!("rename needs a parseable document: {e}"))?;
+    let site = site_at(&wf, text, offset).ok_or_else(|| {
+        "not a task identity (key · depends_on entry · tasks.<id> ref)".to_owned()
+    })?;
+    let old = site.id;
+    if new_name == old {
+        return Err(format!("`{old}` already is the name"));
+    }
+    if !valid_task_id(new_name) {
+        return Err(format!(
+            "`{new_name}` is not a task id — snake_case: [a-z][a-z0-9_]*"
+        ));
+    }
+    let ids: BTreeSet<&str> = wf.tasks.iter().map(|t| t.value.id.value.as_str()).collect();
+    if ids.contains(new_name) {
+        return Err(format!("a task named `{new_name}` already exists"));
+    }
+    if !ids.contains(old.as_str()) {
+        return Err(format!(
+            "`{old}` names no task in this document — rename the definition, not a ghost"
+        ));
+    }
+
+    let index = LineIndex::new(text);
+    let mut edits: Vec<TextEdit> = Vec::new();
+    // 1 · the declaring key token
+    for task in &wf.tasks {
+        if task.value.id.value == old {
+            edits.push(TextEdit {
+                range: token_range(&index, task.value.id.span, old.len()),
+                new_text: new_name.to_owned(),
+            });
+        }
+        // 2 · every depends_on entry naming it
+        for dep in &task.value.depends_on {
+            if dep.value == old {
+                edits.push(TextEdit {
+                    range: token_range(&index, dep.span, old.len()),
+                    new_text: new_name.to_owned(),
+                });
+            }
+        }
+    }
+    // 3 · every `tasks.<old>` chain inside an island
+    for (start, end) in island_ref_sites(text, &old) {
+        edits.push(TextEdit {
+            range: Range::new(index.position(start), index.position(end)),
+            new_text: new_name.to_owned(),
+        });
+    }
+    edits.sort_by_key(|e| (e.range.start.line, e.range.start.character));
+    edits.dedup_by(|a, b| a.range == b.range);
+
+    // documentChanges (not the `changes` map): no HashMap in the payload
+    // path, and the versioned-document shape every modern client speaks.
+    Ok(WorkspaceEdit {
+        document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+            text_document: OptionalVersionedTextDocumentIdentifier {
+                uri: uri.clone(),
+                version: None,
+            },
+            edits: edits.into_iter().map(OneOf::Left).collect(),
+        }])),
+        ..WorkspaceEdit::default()
+    })
+}
+
+/// One renameable site: the id it names plus its exact byte range.
+struct Site {
+    id: String,
+    start: usize,
+    end: usize,
+    /// A parser span site (key/dep) carries its span-derived range via
+    /// bytes already; island sites too — one shape serves both.
+    _kind: SiteKind,
+}
+
+enum SiteKind {
+    Key,
+    Dep,
+    IslandRef,
+}
+
+fn site_lsp_range(index: &LineIndex, site: &Site) -> Range {
+    Range::new(index.position(site.start), index.position(site.end))
+}
+
+/// Resolve the renameable site under `offset` — key first (the
+/// declaration outranks a same-byte ref), then `depends_on` entries,
+/// then island refs.
+fn site_at(wf: &RawWorkflow, text: &str, offset: usize) -> Option<Site> {
+    let off = u32::try_from(offset).unwrap_or(u32::MAX);
+    for task in &wf.tasks {
+        let id = &task.value.id;
+        if token_span_contains(id.span, id.value.len(), off) {
+            let start = id.span.start.0 as usize;
+            return Some(Site {
+                id: id.value.clone(),
+                start,
+                end: start + id.value.len(),
+                _kind: SiteKind::Key,
+            });
+        }
+        for dep in &task.value.depends_on {
+            if token_span_contains(dep.span, dep.value.len(), off) {
+                let start = dep.span.start.0 as usize;
+                return Some(Site {
+                    id: dep.value.clone(),
+                    start,
+                    end: start + dep.value.len(),
+                    _kind: SiteKind::Dep,
+                });
+            }
+        }
+    }
+    island_ref_at(text, offset)
+}
+
+/// The `tasks.<id>` island ref under `offset`, with the id's byte range
+/// (cursor anywhere from the `tasks.` keyword through the id).
+fn island_ref_at(text: &str, offset: usize) -> Option<Site> {
+    let bytes = text.as_bytes();
+    for (island_start, island_end) in islands(text) {
+        let inner = text.get(island_start..island_end)?;
+        let mut search_from = 0usize;
+        while let Some(rel) = inner.get(search_from..)?.find("tasks.") {
+            let kw_at = island_start + search_from + rel;
+            let mid_ident = kw_at > 0
+                && bytes
+                    .get(kw_at - 1)
+                    .is_some_and(|b| *b == b'_' || b.is_ascii_alphanumeric());
+            if !mid_ident {
+                let id_start = kw_at + "tasks.".len();
+                let id_end = ident_end(bytes, id_start);
+                if id_end > id_start && (kw_at..id_end).contains(&offset) {
+                    return text.get(id_start..id_end).map(|id| Site {
+                        id: id.to_owned(),
+                        start: id_start,
+                        end: id_end,
+                        _kind: SiteKind::IslandRef,
+                    });
+                }
+            }
+            search_from = (search_from + rel + "tasks.".len()).min(inner.len());
+        }
+    }
+    None
+}
+
+/// Every `tasks.<old>` id byte range across every island — the edit set
+/// for site shape 3.
+fn island_ref_sites(text: &str, old: &str) -> Vec<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    for (island_start, island_end) in islands(text) {
+        let Some(inner) = text.get(island_start..island_end) else {
+            continue;
+        };
+        let mut search_from = 0usize;
+        while let Some(rel) = inner.get(search_from..).and_then(|s| s.find("tasks.")) {
+            let kw_at = island_start + search_from + rel;
+            let mid_ident = kw_at > 0
+                && bytes
+                    .get(kw_at - 1)
+                    .is_some_and(|b| *b == b'_' || b.is_ascii_alphanumeric());
+            if !mid_ident {
+                let id_start = kw_at + "tasks.".len();
+                let id_end = ident_end(bytes, id_start);
+                if id_end > id_start && text.get(id_start..id_end) == Some(old) {
+                    out.push((id_start, id_end));
+                }
+            }
+            search_from = (search_from + rel + "tasks.".len()).min(inner.len());
+        }
+    }
+    out
+}
+
+/// The task-id grammar (spec 03 §id · `snake_case` · CEL-safe).
+fn valid_task_id(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(|c| c.is_ascii_lowercase())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    const DOC: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  fetch:\n    exec: { command: [\"curl\"] }\n  digest:\n    depends_on: [fetch]\n    infer: { prompt: \"sum ${{ tasks.fetch.output }}\", max_tokens: 10 }\n  save:\n    depends_on: [digest, fetch]\n    exec: { command: [\"tee\", \"${{ tasks.digest.output }}\", \"${{ tasks.fetch.output }}\"] }\n";
+
+    fn uri() -> Uri {
+        Uri::from_str("file:///w.nika.yaml").expect("uri")
+    }
+
+    fn edits(we: &WorkspaceEdit) -> Vec<TextEdit> {
+        let Some(DocumentChanges::Edits(docs)) = we.document_changes.as_ref() else {
+            panic!("documentChanges edits");
+        };
+        docs[0]
+            .edits
+            .iter()
+            .map(|e| match e {
+                OneOf::Left(t) => t.clone(),
+                OneOf::Right(a) => a.text_edit.clone(),
+            })
+            .collect()
+    }
+
+    fn apply(text: &str, mut es: Vec<TextEdit>) -> String {
+        // apply bottom-up so earlier byte offsets stay valid
+        let index = LineIndex::new(text);
+        es.sort_by_key(|e| std::cmp::Reverse((e.range.start.line, e.range.start.character)));
+        let mut out = text.to_owned();
+        for e in es {
+            let s = index.offset(e.range.start);
+            let t = index.offset(e.range.end);
+            out.replace_range(s..t, &e.new_text);
+        }
+        out
+    }
+
+    #[test]
+    fn rename_from_the_key_moves_every_site() {
+        // rename `fetch` → `pull` from its declaring key: the key, TWO
+        // depends_on entries, TWO island refs — five edits, one truth.
+        let at = DOC.find("\n  fetch:").expect("key") + 3;
+        let we = rename(&uri(), DOC, at, "pull").expect("renames");
+        let es = edits(&we);
+        assert_eq!(es.len(), 5, "key + 2 deps + 2 island refs: {es:?}");
+        let after = apply(DOC, es);
+        assert!(!after.contains("fetch"), "no site left behind: {after}");
+        assert!(after.contains("\n  pull:"), "the key moved");
+        assert!(after.contains("depends_on: [pull]"), "digest's dep moved");
+        assert!(
+            after.contains("depends_on: [digest, pull]"),
+            "save's dep moved"
+        );
+        assert!(
+            after.contains("${{ tasks.pull.output }}"),
+            "island refs moved"
+        );
+        // the renamed document still parses — the edit set is coherent
+        assert!(
+            nika_schema::parse(&after, FileId::new(0), ParseMode::Strict).is_ok(),
+            "renamed doc parses strict: {after}"
+        );
+    }
+
+    #[test]
+    fn rename_from_a_dep_and_from_an_island_ref_agree_with_the_key() {
+        let from_key = {
+            let at = DOC.find("\n  fetch:").expect("key") + 3;
+            apply(DOC, edits(&rename(&uri(), DOC, at, "pull").expect("ok")))
+        };
+        let from_dep = {
+            let at = DOC.find("[fetch]").expect("dep") + 1;
+            apply(DOC, edits(&rename(&uri(), DOC, at, "pull").expect("ok")))
+        };
+        let from_ref = {
+            let at = DOC.find("tasks.fetch").expect("ref") + "tasks.".len();
+            apply(DOC, edits(&rename(&uri(), DOC, at, "pull").expect("ok")))
+        };
+        assert_eq!(from_key, from_dep, "dep site → same document");
+        assert_eq!(from_key, from_ref, "island site → same document");
+    }
+
+    #[test]
+    fn refusals_teach_grammar_collision_and_ghost() {
+        let at = DOC.find("\n  fetch:").expect("key") + 3;
+        assert!(
+            rename(&uri(), DOC, at, "Bad-Name")
+                .expect_err("grammar")
+                .contains("snake_case"),
+            "grammar refusal teaches the shape"
+        );
+        assert!(
+            rename(&uri(), DOC, at, "digest")
+                .expect_err("collision")
+                .contains("already exists"),
+            "collision refusal names the conflict"
+        );
+        // a ghost dep site: rename refuses (rename the definition, not a ghost)
+        let ghost_doc = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    depends_on: [ghost]\n    exec: { command: [\"x\"] }\n";
+        let at = ghost_doc.find("ghost").expect("ghost") + 1;
+        assert!(
+            rename(&uri(), ghost_doc, at, "real")
+                .expect_err("ghost")
+                .contains("ghost"),
+            "ghost refusal names it"
+        );
+    }
+
+    #[test]
+    fn prepare_answers_on_the_three_sites_and_nowhere_else() {
+        let index = LineIndex::new(DOC);
+        // key site
+        let key_at = DOC.find("\n  digest:").expect("key") + 3;
+        let (range, id) = prepare(DOC, key_at).expect("key prepares");
+        assert_eq!(id, "digest");
+        assert_eq!(
+            index.offset(range.start),
+            key_at,
+            "range anchors the key token"
+        );
+        // dep site
+        let dep_at = DOC.find("[digest, fetch]").expect("deps") + 1;
+        assert_eq!(prepare(DOC, dep_at).expect("dep prepares").1, "digest");
+        // island site
+        let ref_at = DOC.find("tasks.digest").expect("ref") + "tasks.".len();
+        assert_eq!(prepare(DOC, ref_at).expect("ref prepares").1, "digest");
+        // a verb keyword is NOT a renameable site
+        let verb_at = DOC.find("infer:").expect("verb");
+        assert!(prepare(DOC, verb_at).is_none(), "verb keyword refuses");
+        // the workflow id is NOT a task identity
+        let wf_at = DOC.find("id: w").expect("wf id") + 4;
+        assert!(prepare(DOC, wf_at).is_none(), "workflow id refuses");
+    }
+
+    #[test]
+    fn verb_named_task_renames_only_identity_sites() {
+        // a task NAMED `invoke` (the census trap): the verb KEY of another
+        // task must not be touched — only identity sites move.
+        let doc = "nika: v1\nworkflow:\n  id: w\ntasks:\n  invoke:\n    exec: { command: [\"x\"] }\n  b:\n    depends_on: [invoke]\n    invoke:\n      tool: \"nika:read\"\n      args: { path: \"${{ tasks.invoke.output }}\" }\n";
+        let at = doc.find("\n  invoke:").expect("key") + 3;
+        let we = rename(&uri(), doc, at, "caller").expect("renames");
+        let after = apply(doc, edits(&we));
+        assert!(after.contains("\n  caller:"), "identity key moved");
+        assert!(after.contains("depends_on: [caller]"), "dep moved");
+        assert!(after.contains("tasks.caller.output"), "ref moved");
+        assert!(
+            after.contains("\n    invoke:\n      tool:"),
+            "task b's VERB key untouched: {after}"
+        );
+    }
+
+    #[test]
+    fn same_name_refuses_and_unparseable_refuses() {
+        let at = DOC.find("\n  fetch:").expect("key") + 3;
+        assert!(rename(&uri(), DOC, at, "fetch").is_err(), "no-op refused");
+        assert!(
+            rename(&uri(), "nika: v1\nworkflow: [bad\n", 0, "x").is_err(),
+            "unparseable refused with a message"
+        );
+    }
+}

--- a/crates/nika-lsp/src/capabilities.rs
+++ b/crates/nika-lsp/src/capabilities.rs
@@ -16,7 +16,8 @@
 
 use lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CompletionOptions, OneOf,
-    PositionEncodingKind, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    PositionEncodingKind, RenameOptions, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, WorkDoneProgressOptions,
 };
 
 /// The capabilities advertised in the initialize response.
@@ -44,6 +45,13 @@ pub fn server_capabilities() -> ServerCapabilities {
         }),
         definition_provider: Some(OneOf::Left(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
+        // W1: a task's identity is its map key — server-side rename moves
+        // the key + every depends_on entry + every `tasks.<id>` island ref
+        // atomically. prepareRename gates the gesture to identity sites.
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        })),
         // v0.2 surface: quickfix-only — the `check --fix` rename engine
         // projected (one fix engine, every editor).
         code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
@@ -129,6 +137,11 @@ mod tests {
             panic!("code actions advertise as Options");
         };
         assert_eq!(opts.code_action_kinds, Some(vec![CodeActionKind::QUICKFIX]));
+        // W1: rename with prepare support (the map key is the identity).
+        let Some(OneOf::Right(rename)) = caps.rename_provider else {
+            panic!("rename advertises as Options with prepare");
+        };
+        assert_eq!(rename.prepare_provider, Some(true));
         // still out of scope:
         assert!(caps.inlay_hint_provider.is_none());
         assert!(caps.semantic_tokens_provider.is_none());

--- a/crates/nika-lsp/src/server.rs
+++ b/crates/nika-lsp/src/server.rs
@@ -49,7 +49,9 @@ use lsp_types::{
 
 use crate::analysis::diagnostics;
 use crate::analysis::document::Document;
-use crate::analysis::{code_action, completion, definition, hover, semantic_document, symbols};
+use crate::analysis::{
+    code_action, completion, definition, hover, rename, semantic_document, symbols,
+};
 use crate::capabilities::server_capabilities;
 use crate::error::LspError;
 
@@ -220,6 +222,23 @@ fn handle_request(req: Request, docs: &Docs) -> Response {
                 p.range,
             ))
         }),
+        "textDocument/prepareRename" => {
+            respond(id, req, |p: lsp_types::TextDocumentPositionParams| {
+                let doc = docs.get(uri_key(&p.text_document.uri))?;
+                let offset = doc.line_index().offset(p.position);
+                rename::prepare(doc.text(), offset).map(|(range, placeholder)| {
+                    lsp_types::PrepareRenameResponse::RangeWithPlaceholder { range, placeholder }
+                })
+            })
+        }
+        "textDocument/rename" => respond_fallible(id, req, |p: lsp_types::RenameParams| {
+            let pos = p.text_document_position;
+            let doc = docs
+                .get(uri_key(&pos.text_document.uri))
+                .ok_or_else(|| "document not open".to_owned())?;
+            let offset = doc.line_index().offset(pos.position);
+            rename::rename(&pos.text_document.uri, doc.text(), offset, &p.new_name)
+        }),
         GotoDefinition::METHOD => respond(id, req, |p: GotoDefinitionParams| {
             let pos = p.text_document_position_params;
             let uri = pos.text_document.uri;
@@ -367,6 +386,32 @@ fn send(connection: &Connection, msg: Message) -> Result<(), LspError> {
 }
 
 /// The document-map key for a URI (its canonical string form).
+/// Like [`respond`], for handlers whose refusal carries a MESSAGE the
+/// client must show (LSP rename: an invalid new name is a request error,
+/// never a silent no-op edit).
+fn respond_fallible<P, R, F>(id: RequestId, req: Request, handler: F) -> Response
+where
+    P: serde::de::DeserializeOwned,
+    R: serde::Serialize,
+    F: FnOnce(P) -> Result<R, String>,
+{
+    let method = req.method.clone();
+    match req.extract::<P>(&method) {
+        Ok((_id, params)) => match handler(params) {
+            Ok(result) => Response::new_ok(id, result),
+            Err(message) => Response::new_err(id, INVALID_PARAMS, message),
+        },
+        Err(ExtractError::JsonError { method, error }) => Response::new_err(
+            id,
+            INVALID_PARAMS,
+            format!("invalid params for {method}: {error}"),
+        ),
+        Err(ExtractError::MethodMismatch(_)) => {
+            Response::new_err(id, INTERNAL_ERROR, "internal method mismatch".to_owned())
+        }
+    }
+}
+
 fn uri_key(uri: &Uri) -> &str {
     uri.as_str()
 }
@@ -852,6 +897,28 @@ mod canary {
         );
     }
 
+    /// W1 rename over the wire: prepare (14) · rename (15) · refusal (16).
+    fn queue_rename_requests(client: &Connection, hello_uri: &Uri, key_pos: Position) {
+        request(
+            client,
+            14,
+            "textDocument/prepareRename",
+            at(hello_uri, key_pos),
+        );
+        for (id, name) in [(15, "salute"), (16, "Bad-Name")] {
+            request(
+                client,
+                id,
+                "textDocument/rename",
+                lsp_types::RenameParams {
+                    text_document_position: at(hello_uri, key_pos),
+                    new_name: name.to_owned(),
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                },
+            );
+        }
+    }
+
     /// Run the server over the pre-queued conversation in a scoped thread
     /// (joins before the scope returns — no detached thread), then drain
     /// the buffered replies.
@@ -931,6 +998,8 @@ mod canary {
         let dep_pos = idx.position(hello.rfind("greet").expect("dep ref") + 1);
         queue_hello_requests(&client, &hello_uri, verb_pos, dep_pos);
         queue_model_completion(&client);
+        let key_pos = idx.position(hello.find("\n  greet:").expect("key") + 3);
+        queue_rename_requests(&client, &hello_uri, key_pos);
 
         // shutdown / exit (queued last — the server returns after exit)
         request(&client, 99, "shutdown", serde_json::Value::Null);
@@ -976,6 +1045,26 @@ mod canary {
         assert!(
             completion.to_string().contains("ollama/"),
             "completion: {completion}"
+        );
+        // prepareRename answers the key token + placeholder
+        let prep = response(14).result.clone().expect("prepare result");
+        assert!(prep.to_string().contains("greet"), "prepare: {prep}");
+        // rename returns a WorkspaceEdit moving the key + the dep + the ref
+        let ws = response(15).result.clone().expect("rename result");
+        let ws_str = ws.to_string();
+        assert!(ws_str.contains("salute"), "rename edit: {ws_str}");
+        assert_eq!(
+            ws_str.matches("salute").count(),
+            3,
+            "key + depends_on + island ref — three edits: {ws_str}"
+        );
+        // an invalid new name is a request ERROR carrying the teaching
+        let refusal = response(16);
+        let err = refusal.error.as_ref().expect("rename refusal is an error");
+        assert!(
+            err.message.contains("snake_case"),
+            "the refusal teaches the grammar: {}",
+            err.message
         );
     }
 


### PR DESCRIPTION
## W1 · server-side rename — the map key renames everywhere at once

The deliverable the map form makes honest: a task's identity IS its key, so `textDocument/rename` moves every site that speaks it in ONE `WorkspaceEdit` —

1. the declaring key token,
2. every `depends_on:` entry,
3. every `tasks.<id>` chain inside a `${{ }}` island (the definition lane's byte-scan discipline, shared `pub(super)` so the two features agree on what a reference IS).

`prepareRename` gates the gesture to the three identity-site shapes (token range + placeholder). A refusal is a **request error carrying the teaching** — grammar (`[a-z][a-z0-9_]*`), collision, ghost, no-op — served by the new `respond_fallible` arm; never a silent empty edit. Payload ships as `documentChanges` (versioned-document shape).

### Proofs
- rename-from-key / from-dep / from-island-ref produce **byte-identical documents** that re-parse STRICT
- the verb-named-task trap (a task named `invoke`) moves only identity sites — the sibling VERB key untouched
- lifecycle wire test drives prepare + rename + the grammar refusal over JSON-RPC (3 edits · `-32602` teaches `snake_case`)
- nika-lsp 199 green · clippy `-D warnings` clean · fn-length/crate-size ratchets green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
