### PR TITLE
fix(kit): the new command frontmatter parses — invalid yaml dies at the source

### DIFF
--- a/.agents/plugins/nika/commands/new.md
+++ b/.agents/plugins/nika/commands/new.md
@@ -1,6 +1,6 @@
 ---
 description: Scaffold a workflow from an embedded template, then audit it clean
-argument-hint: [template] [file.nika.yaml]
+argument-hint: "[template] [file.nika.yaml]"
 allowed-tools: Bash(nika new:*), Bash(nika examples:*), Bash(nika check:*), Read, Edit
 ---
 


### PR DESCRIPTION
`argument-hint: [template] [file.nika.yaml]` = two juxtaposed flow sequences → invalid YAML. CC's lenient parser shrugs; any strict consumer drops the whole block. Quoted, both agree.

This file is the **engine-mirror source** for the kit (`agents/mirror.json` pins its bytes) — agents#115 resyncs once this lands. Only file in the `.agents` tree with the class (frontmatter sweep run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)