### PR TITLE
docs(crate-specs): the teaching surfaces say graph_format 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ layers.nika-catalog-codegen = "L0"
 layers.nika-catalog-verify = "L4"
 layers.nika-schema = "L0"
 layers.nika-lints = "L0"
-# nika-graph · the canonical graph projection (graph_format: 1 · spec 03
+# nika-graph · the canonical graph projection (graph_format: 2 · spec 03
 # §graph-projection) · split from nika-schema 2026-07-13 (the crate-size
 # cap · the nika-dap/nika-models precedents) — one projector, every surface.
 layers.nika-graph = "L0"

--- a/crates/nika-graph/Cargo.toml
+++ b/crates/nika-graph/Cargo.toml
@@ -5,7 +5,7 @@ version     = "0.103.0"
 edition     = "2024"
 rust-version = "1.88"
 license     = "AGPL-3.0-or-later"
-description = "nika's canonical graph projection — graph_format: 1 (spec 03 §graph-projection): ONE projector for every surface (CLI inspect · LSP semanticDocument · future canvases)"
+description = "nika's canonical graph projection — graph_format: 2, typed edges (spec 03 §graph projection): ONE projector for every surface (CLI inspect · LSP semanticDocument · future canvases)"
 repository  = "https://github.com/supernovae-st/nika"
 
 [dependencies]

--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -169,11 +169,11 @@ the trace path (the flight recorder IS the crash report, owned by the user)
 ## 6. The graph projector (one projector · N renderers)
 
 `nika graph --json` is the canonical projection; mermaid/dot/ASCII/webview
-all derive from it. Versioned envelope (`graph_format: 1`):
+all derive from it. Versioned envelope (`graph_format: 2` · typed edges):
 
 ```json
 {
-  "graph_format": 1,
+  "graph_format": 2,
   "workflow": "veille-news",
   "nodes": [
     {"id": "fetch_top", "verb": "invoke", "tool": "nika:fetch",

--- a/docs/crate-specs/nika-graph.md
+++ b/docs/crate-specs/nika-graph.md
@@ -7,7 +7,8 @@ with the workspace train.
 ## What it is
 
 ONE projector: `project(&RawWorkflow, &CheckReport) -> GraphDoc` — the
-versioned `graph_format: 1` document (spec 03 §graph-projection). Every
+versioned `graph_format: 2` document (spec 03 §graph projection format 2 ·
+typed edges). Every
 surface that draws or reasons about a workflow graph consumes THIS
 document, never a private re-derivation:
 
@@ -19,7 +20,8 @@ document, never a private re-derivation:
 
 ## The shape (wire contract · additive, spec-first)
 
-`GraphDoc { graph_format: 1, workflow, nodes[], edges[] }` — nodes are
+`GraphDoc { graph_format: 2, workflow, nodes[], edges[] }` — edges are
+typed `{from, to, kind, predicate?, binding?}` — nodes are
 topologically sorted (wave order · stable layouts); `Node` carries the
 static facts only (verb · tool · resolved model · when · fan_out ·
 permits attribution · cost interval · retry/timeout/on_error · declared

--- a/docs/crate-specs/nika-lsp.md
+++ b/docs/crate-specs/nika-lsp.md
@@ -56,7 +56,7 @@ reads the advertisement instead of probing blind.
 
 | Method | Params | Result | Capability |
 |---|---|---|---|
-| `nika/semanticDocument` | `{ "uri": … }` (a `TextDocumentIdentifier`) | `{ graph, reason?, spans }` (typed: `SemanticDocument`) — `graph` is the canonical `graph_format: 1` projection VERBATIM (`nika-graph::project` · the same bytes `nika inspect --format json` prints) · `reason` appears ONLY when `graph` is null (`"parse"` · `"findings"` — one word, the diagnostics lane carries the details) · `spans` maps task ids to their declaring token ranges | `experimental.nika.semanticDocument.graphFormat: 1` |
+| `nika/semanticDocument` | `{ "uri": … }` (a `TextDocumentIdentifier`) | `{ graph, reason?, spans }` (typed: `SemanticDocument`) — `graph` is the canonical `graph_format: 2` projection VERBATIM (`nika-graph::project` · the same bytes `nika inspect --format json` prints) · `reason` appears ONLY when `graph` is null (`"parse"` · `"findings"` — one word, the diagnostics lane carries the details) · `spans` maps task ids to their declaring token ranges | `experimental.nika.semanticDocument.graphFormat: 2` |
 
 Measured (debug build · 500-task document · hot): hover 16 ms ·
 completion 15 ms · semanticDocument 33 ms — the <50 ms budget holds

--- a/docs/crate-specs/nika-mcp.md
+++ b/docs/crate-specs/nika-mcp.md
@@ -28,7 +28,7 @@ analysis:
 - **`nika_check`** — statically audit a `*.nika.yaml` (schema · DAG · CEL ·
   effects · permits · cost) and return the full check report, or a clean
   verdict. Auditable before a token is spent.
-- **`nika_inspect`** — project the DAG as the canonical `graph_format: 1`
+- **`nika_inspect`** — project the DAG as the canonical `graph_format: 2`
   document (`nika-graph::project` VERBATIM — byte-equal with `nika inspect
   --format json` and the LSP's `nika/semanticDocument.graph`, both
   law-pinned). Findings → `{"graph": null, "reason": "findings"}` — never a


### PR DESCRIPTION
The census W2 judge (`census.sh` §w2 dead forms) caught six live teachings still speaking `graph_format: 1` after the #588 window: the four crate-spec docs and the two Cargo descriptions. Docs-only — the producers and consumers all moved in #588; these teach what they emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)