### PR TITLE
feat(proof): W6 « la preuve » — semantic hash · nika.lock · assert: v1 · receipt_format:1 (the LAST pre-1.0 wave)

### DIFF
--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-9ff0779c7c303d41a542b574185f35d9470669e5
+a57195347264eaf522599ecd49cec8e16ebbbcd1

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -51,9 +51,9 @@ counts:
   providers: 16
   extract_modes: 9
   templates: 10
-  error_namespaces: 19
+  error_namespaces: 21
   error_categories: 12
-  error_codes: 80
+  error_codes: 82
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -224,10 +224,11 @@ templates:
 # matching "fetch is a builtin, not a verb" D-N18 · prior count 15 → 14).
 # spec/05-errors.md is the prose home (matches at 15 · NIKA-TYPE joined at W3 · cascade complete 2026-07-14).
 error_namespaces:
-  count: 19
+  count: 21
   reference: spec/05-errors.md
   items:
     - NIKA-AGENT
+    - NIKA-ASSERT
     - NIKA-BUILTIN
     - NIKA-CANCEL
     - NIKA-COMP
@@ -236,6 +237,7 @@ error_namespaces:
     - NIKA-IMPL
     - NIKA-INFER
     - NIKA-INVOKE
+    - NIKA-LOCK
     - NIKA-MCP
     - NIKA-DECIDE
     - NIKA-PARSE
@@ -273,7 +275,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 80
+  count: 82
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }
@@ -361,6 +363,8 @@ error_codes:
     - { code: NIKA-SEC-007, category: security_error, transient: "false", failure: "secret egress — a tainted value reaches the workflow boundary (outputs:) · the diagnostic carries the taint path (spec 10 · the to: outputs sanction in 01 §egress)" }
     - { code: NIKA-TIMEOUT-001, category: timeout_error, transient: "false", failure: "task (or for_each iteration) exceeded timeout:" }
     - { code: NIKA-CANCEL-001, category: cancelled, transient: "false", failure: "task cancelled (workflow failure gate · user cancellation)" }
+    - { code: NIKA-ASSERT-001, category: validation_error, transient: "false", failure: "an assert: claims a level the evidence does not support (a StaticProof the IR cannot decide · a mis-leveled obligation · spec 15)" }
+    - { code: NIKA-LOCK-001, category: validation_error, transient: "false", failure: "a dependency resolved that nika.lock does not pin, or a hand-edited lock digest does not match (pin-by-default · the lock's own hash catches the edit · spec 15)" }
     - { code: NIKA-BUILTIN-001, category: validation_error, transient: "false", failure: "builtin invoke violates its statically-checkable arg contract (e.g. nika:fetch without url: · nika:jq arg shape)" }
     - { code: NIKA-BUILTIN-DONE-001, category: validation_error, transient: "false", failure: "nika:done invoked outside an agent: loop" }
 

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -166,6 +166,7 @@ outputs:                              # what the workflow returns · symmetric t
 | [12 gateway](./12-gateway.md) | The gateway contracts · Deployment Bundle · ExecutionBackend (capabilities · lowering · readback) · AgentRuntimeAdapter (FidelityReport · AuthorityDelta) · the separation laws |
 | [13 outcomes](./13-outcomes.md) | The Outcome IR · TerminalClass × Cause × Payload · the normative transition table (one source: canon) · `trace_format: 2` |
 | [14 composition](./14-composition.md) | Workflow calling workflow · `invoke: workflow:` (tagged union) · the CallableContract · the ten composition laws · the trace forest |
+| [15 proof](./15-proof.md) | The proof layer · the semantic hash (H = H(domain ‖ version ‖ JCS(IR))) · `nika.lock` (pin by default) · `assert:` (StaticProof · TraceVerified · Unknown) · the one receipt |
 
 **Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/): **<!-- canon:providers -->16<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->28<!-- /canon --> builtins** (6 core · 5 file · 8 data · 2 network · 2 introspection · 4 media).
 

--- a/crates/nika-pack/pack/spec/05-errors.md
+++ b/crates/nika-pack/pack/spec/05-errors.md
@@ -153,6 +153,8 @@ these from this file alone.
 | `NIKA-POLICY-001` | a hard `policy:` rule is violated (`require.human_gate_before` · `forbid.exec_after` · `allow.providers` · `limits.max_tasks`) — the diagnostic names rule + task + witness · check-time, before any token ([10 §policy](./10-authority.md#the-policy-block--optional--named-workflow-law)) | `security_error` | false |
 | `NIKA-TIMEOUT-001` | task (or for_each iteration) exceeded `timeout:` | `timeout_error` | false |
 | `NIKA-CANCEL-001` | task cancelled (workflow failure gate · user cancellation) | `cancelled` | false |
+| `NIKA-ASSERT-001` | an `assert:` claims a level the evidence does not support (a `StaticProof` the IR cannot decide · a mis-leveled obligation · [15 §assert](./15-proof.md#assert--the-authors-obligations-normative)) | `validation_error` | false |
+| `NIKA-LOCK-001` | a dependency resolved that `nika.lock` does not pin, or a hand-edited lock digest does not match ([15 §lock](./15-proof.md#nikalock--the-single-lock-normative--f7)) | `validation_error` | false |
 | `NIKA-BUILTIN-001` | builtin `invoke:` violates its statically-checkable arg contract (e.g. `nika:fetch` without `url:` · `nika:jq` arg shape) | `validation_error` | false |
 | `NIKA-BUILTIN-DONE-001` | `nika:done` invoked outside an `agent:` loop | `validation_error` | false |
 

--- a/crates/nika-pack/pack/spec/15-proof.md
+++ b/crates/nika-pack/pack/spec/15-proof.md
@@ -1,0 +1,187 @@
+# 15 · Proof
+
+> Everything before this chapter made a workflow *checkable*. This
+> chapter makes a run *provable and portable*: a **canonical semantic
+> identity** (the hash of what the workflow MEANS, not how it is
+> spelled), a **single lock** that pins every dependency by digest,
+> **assertions** the author writes and the engine judges at an honest
+> level, and **one receipt** into which the certificate, the trace
+> verdict, the assertions, and the lock digest all fold — so the
+> Decision Receipt (11) and the registry certificate become
+> *instances* of one shape, never three.
+>
+> This is the last pre-1.0 chapter. It closes the loop the language
+> opened: `nika: v1` in, a signed honest proof out.
+
+---
+
+## The semantic hash (normative · G13)
+
+A workflow's identity is the hash of its **desugared, versioned
+Semantic IR** — never the source YAML text, never a reordered map:
+
+```
+H_semantic = H( domain ‖ format_version ‖ JCS(SemanticIR) )
+```
+
+- **The Semantic IR** is the source after: parsing finished · sugar
+  lowered · normative defaults expanded · types normalized (chapter 09
+  canonical forms) · graphs made explicit (the derived edges of 03) ·
+  references resolved · units normalized (durations → ns, sizes →
+  bytes) · Unicode NFC · keys sorted · spans and comments removed. Two
+  files that MEAN the same workflow lower to the **same** IR; two files
+  that mean different workflows do not.
+- **JCS** is RFC 8785 (JSON Canonicalization Scheme) — the one byte
+  encoding. It fixes number handling explicitly (JCS alone serializes
+  numbers as ES6 doubles, which would collapse distinct integers; the
+  IR carries integers as strings where that matters, the chapter-09
+  and chapter-05 precedent).
+- **Domain separation is strict.** Every hash names its domain so a
+  value can never be reinterpreted across roles:
+  `source · canonical · semantic · plan · trace · artifact · receipt`.
+  A trace-domain hash never collides usefully with a semantic-domain
+  hash even over identical bytes.
+- **Merkle by task** — each task's semantic subtree hashes
+  independently (seed: the ResumeKey's JCS+blake3 definition hash,
+  generalized); the workflow hash commits to the task hashes, and a
+  composed child (14) folds in as a subtree. A proof of the whole
+  contains a proof of each part.
+- **`canonical()` is idempotent**: `canonical(canonical(x)) ==
+  canonical(x)` — property-pinned.
+- **The correct property** (never overstated): semantically-different
+  programs produce different canonical encodings. Collision resistance
+  of the underlying hash is a **cryptographic assumption**, stated as
+  such — not a promise this spec makes.
+
+Cache and resume are **re-keyed semantically**: a result is reused iff
+the semantic identity matches — the same law the composition cache
+(14 §law 10) was waiting on.
+
+## `nika.lock` · *the single lock (normative · F7)*
+
+One lockfile pins everything a run resolves, by **digest**:
+
+```yaml
+# nika.lock · generated · never hand-edited
+lock_format: 1
+providers:                      # every model pinned by content digest
+  "anthropic/claude-…": { digest: "blake3:…" }
+tools:                          # builtin + MCP surface versions
+registry:                       # every registry: ref pinned owner/name@version + digest
+policy:                         # the resolved policy decisions (10)
+model_select:                   # `model: { select: {require, prefer} }` materialized
+```
+
+- **Pin by default**: a run resolves ONLY what the lock pins; an
+  unpinned dependency is a refusal (`NIKA-LOCK-001`). Nothing floats.
+- The lock is generated (`nika lock`), never authored — hand-editing a
+  digest is a lie the check catches (the lock's own hash covers it).
+- It unifies the prior manifest lock + the pin-by-default rule into one
+  file — the local boundary of the same supply chain the gateway (12)
+  and the distribution work extend.
+
+## `assert:` · *the author's obligations (normative)*
+
+A task or workflow declares assertions the engine judges — distinct
+from `nika:assert` (the single-condition fail-fast builtin): `assert:`
+is a **closed vocabulary of properties**, each judged at an honest
+level:
+
+```yaml
+assert:
+  - no_secret_egress                       # no secret reaches an unsanctioned sink (10)
+  - eventually: { task: deploy, state: success }
+  - before: { first: gate, second: deploy }
+  - bounded: { task: crawl, max_iterations: 100 }
+  - resource: { cost_usd: { max: 5.00 } }
+```
+
+| Property | What it claims |
+|---|---|
+| `no_secret_egress` | the flow laws of [10](./10-authority.md) hold across the whole run |
+| `eventually{task,state}` | the named task reaches the named terminal state (the Outcome of [13](./13-outcomes.md)) |
+| `before{first,second}` | an ordering law on the derived graph (03) |
+| `bounded{task,max_iterations}` | a `for_each`/agent loop stays under its cap |
+| `resource{cost_usd:{max}}` | the symbolic certificate's cost bound (05) holds |
+
+**The three levels (claim ≤ evidence · normative)**:
+
+- **`StaticProof`** — decidable at `nika check` on the graph/IR (an
+  ordering law, a static bound). The strongest, and only claimable when
+  the check genuinely decides it.
+- **`TraceVerified`** — decided by `nika trace verify` against a
+  completed run's trace (13 · the Outcome IR). What only the trace can
+  see is judged there, never optimistically promoted to `StaticProof`.
+- **`Unknown`** — honestly unresolved (a property no static check and
+  no available trace settles). Never dressed up.
+
+`nika trace verify` learns to judge assertions: it reports each
+assertion with its achieved level, and a `StaticProof` claim that the
+IR cannot actually decide is itself a refusal (`NIKA-ASSERT-001` — an
+assertion mis-leveled). Bounded/statistical assertions stay LAB
+(calibrated research · never presented as a guarantee).
+
+## `receipt_format: 1` · *the one receipt (normative)*
+
+A run's receipt folds four things into one shape:
+
+```
+receipt = (
+  certificate     # the check certificate (05 · attempts · effects · cost bound)
+  trace_verdict   # the trace-verify result (13 Outcome + chain integrity)
+  assertions      # each assert: judged with its level
+  lock_digest     # the nika.lock digest this run resolved under
+)
+```
+
+- The [Decision Receipt](./11-decision.md) and the registry certificate
+  become **instances** of this shape — one voice, three surfaces.
+- Receipts come in a PUBLIC and a PRIVATE form linked by digests (the
+  [11 §receipt](./11-decision.md) discipline): a proof can be shown
+  without exposing sensitive evidence.
+- The receipt is domain-separated (`receipt` domain) and Merkle-linked
+  to the semantic hash it proves: given a receipt you can verify it
+  proves *this* workflow and no other.
+
+## Distribution (normative note · the local boundary · G35)
+
+A distributable pack ships as an OCI content-addressed artifact with
+Sigstore signatures, in-toto/SLSA attestations, an SBOM, an admission
+policy, and transparency — one voice with the gateway's backend
+attestations ([12](./12-gateway.md)). **`nika.lock` and the local
+receipt are the LOCAL ends of that same chain**; the OCI/signature
+machinery is the distribution window's own work. Signing proves origin,
+never safety ([12](./12-gateway.md) separation laws).
+
+## Errors (the `NIKA-LOCK` / `NIKA-ASSERT` namespaces · new here)
+
+| Code | Category | Meaning |
+|---|---|---|
+| `NIKA-LOCK-001` | `validation_error` | a dependency resolved that the lock does not pin, or a hand-edited lock digest does not match (pin-by-default · the lock's own hash catches the edit) |
+| `NIKA-ASSERT-001` | `validation_error` | an `assert:` claims a level the evidence does not support (a `StaticProof` the IR cannot decide · a mis-leveled obligation) |
+
+## One obvious way (normative for linters)
+
+- A cache/resume key is the semantic hash — never the file path, never
+  the source bytes (14 §law 10, generalized here).
+- A dependency is pinned in `nika.lock` — a floating version in a
+  workflow is a refusal, not a warning.
+- An assertion states the level it earns — `StaticProof` is a claim
+  the check must be able to keep.
+
+## What v1 deliberately does not do
+
+- **No OCI/signature machinery in the language.** Distribution is a
+  dedicated window; the spec pins the local boundary (lock + receipt).
+- **No statistical/bounded assertion levels shipped.** They stay LAB —
+  a calibrated confidence is never a proof.
+- **No hand-authored lock.** The lock is generated; editing it is a
+  refusal.
+
+## Related
+
+- [05 · Errors](./05-errors.md) — the certificate the receipt folds in
+- [10 · Authority](./10-authority.md) — `no_secret_egress` · the pin chain
+- [11 · Decision](./11-decision.md) — the Decision Receipt, now an instance
+- [13 · Outcomes](./13-outcomes.md) — the Outcome `nika trace verify` reads
+- [14 · Composition](./14-composition.md) — the semantic cache this hash unblocks

--- a/crates/nika-pck-manifest/public-api.txt
+++ b/crates/nika-pck-manifest/public-api.txt
@@ -1,4 +1,131 @@
 pub mod nika_pck_manifest
+pub mod nika_pck_manifest::nika_lock
+#[non_exhaustive] pub struct nika_pck_manifest::nika_lock::LockPin
+pub nika_pck_manifest::nika_lock::LockPin::digest: alloc::string::String
+impl nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::new(digest: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::clone(&self) -> nika_pck_manifest::nika_lock::LockPin
+impl core::cmp::Eq for nika_pck_manifest::nika_lock::LockPin
+impl core::cmp::PartialEq for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::eq(&self, other: &nika_pck_manifest::nika_lock::LockPin) -> bool
+impl core::fmt::Debug for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::nika_lock::LockPin
+impl serde_core::ser::Serialize for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::nika_lock::LockPin where U: core::convert::From<T>
+pub fn nika_pck_manifest::nika_lock::LockPin::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::nika_lock::LockPin where U: core::convert::Into<T>
+pub type nika_pck_manifest::nika_lock::LockPin::Error = core::convert::Infallible
+pub fn nika_pck_manifest::nika_lock::LockPin::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::nika_lock::LockPin where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::nika_lock::LockPin::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::nika_lock::LockPin::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::nika_lock::LockPin where T: core::clone::Clone
+pub type nika_pck_manifest::nika_lock::LockPin::Owned = T
+pub fn nika_pck_manifest::nika_lock::LockPin::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::nika_lock::LockPin::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::nika_lock::LockPin where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockPin::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::nika_lock::LockPin where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockPin::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::nika_lock::LockPin where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockPin::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::nika_lock::LockPin where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::nika_lock::LockPin::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::nika_lock::LockPin where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::nika_lock::LockRefusal
+pub nika_pck_manifest::nika_lock::LockRefusal::code: &'static str
+pub nika_pck_manifest::nika_lock::LockRefusal::message: alloc::string::String
+impl core::clone::Clone for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::clone(&self) -> nika_pck_manifest::nika_lock::LockRefusal
+impl core::cmp::Eq for nika_pck_manifest::nika_lock::LockRefusal
+impl core::cmp::PartialEq for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::eq(&self, other: &nika_pck_manifest::nika_lock::LockRefusal) -> bool
+impl core::fmt::Debug for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::nika_lock::LockRefusal
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::nika_lock::LockRefusal where U: core::convert::From<T>
+pub fn nika_pck_manifest::nika_lock::LockRefusal::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::nika_lock::LockRefusal where U: core::convert::Into<T>
+pub type nika_pck_manifest::nika_lock::LockRefusal::Error = core::convert::Infallible
+pub fn nika_pck_manifest::nika_lock::LockRefusal::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::nika_lock::LockRefusal where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::nika_lock::LockRefusal::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::nika_lock::LockRefusal::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::nika_lock::LockRefusal where T: core::clone::Clone
+pub type nika_pck_manifest::nika_lock::LockRefusal::Owned = T
+pub fn nika_pck_manifest::nika_lock::LockRefusal::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::nika_lock::LockRefusal::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_pck_manifest::nika_lock::LockRefusal where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_pck_manifest::nika_lock::LockRefusal where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::nika_lock::LockRefusal where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::nika_lock::LockRefusal where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::nika_lock::LockRefusal where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::nika_lock::LockRefusal::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::from(t: T) -> T
+#[non_exhaustive] pub struct nika_pck_manifest::nika_lock::NikaLock
+pub nika_pck_manifest::nika_lock::NikaLock::lock_format: u32
+pub nika_pck_manifest::nika_lock::NikaLock::model_select: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub nika_pck_manifest::nika_lock::NikaLock::policy: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub nika_pck_manifest::nika_lock::NikaLock::providers: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_pck_manifest::nika_lock::LockPin>
+pub nika_pck_manifest::nika_lock::NikaLock::registry: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_pck_manifest::nika_lock::LockPin>
+pub nika_pck_manifest::nika_lock::NikaLock::tools: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_pck_manifest::nika_lock::LockPin>
+impl nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::new() -> Self
+pub fn nika_pck_manifest::nika_lock::NikaLock::pinned(&self) -> alloc::collections::btree::set::BTreeSet<&str>
+pub fn nika_pck_manifest::nika_lock::NikaLock::validate(&self, resolved: &alloc::collections::btree::set::BTreeSet<alloc::string::String>) -> core::result::Result<(), nika_pck_manifest::nika_lock::LockRefusal>
+impl core::clone::Clone for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::clone(&self) -> nika_pck_manifest::nika_lock::NikaLock
+impl core::cmp::Eq for nika_pck_manifest::nika_lock::NikaLock
+impl core::cmp::PartialEq for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::eq(&self, other: &nika_pck_manifest::nika_lock::NikaLock) -> bool
+impl core::default::Default for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::default() -> Self
+impl core::fmt::Debug for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::nika_lock::NikaLock
+impl serde_core::ser::Serialize for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::nika_lock::NikaLock where U: core::convert::From<T>
+pub fn nika_pck_manifest::nika_lock::NikaLock::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::nika_lock::NikaLock where U: core::convert::Into<T>
+pub type nika_pck_manifest::nika_lock::NikaLock::Error = core::convert::Infallible
+pub fn nika_pck_manifest::nika_lock::NikaLock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::nika_lock::NikaLock where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::nika_lock::NikaLock::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::nika_lock::NikaLock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::nika_lock::NikaLock where T: core::clone::Clone
+pub type nika_pck_manifest::nika_lock::NikaLock::Owned = T
+pub fn nika_pck_manifest::nika_lock::NikaLock::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::nika_lock::NikaLock::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::nika_lock::NikaLock where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::NikaLock::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::nika_lock::NikaLock where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::NikaLock::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::nika_lock::NikaLock where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::NikaLock::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::nika_lock::NikaLock where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::nika_lock::NikaLock::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::nika_lock::NikaLock where T: for<'de> serde_core::de::Deserialize<'de>
+pub const nika_pck_manifest::nika_lock::LOCK_FORMAT: u32
+pub const nika_pck_manifest::nika_lock::NIKA_LOCK_001: &str
 #[non_exhaustive] pub enum nika_pck_manifest::ArtifactKind
 pub nika_pck_manifest::ArtifactKind::AgentPreset
 pub nika_pck_manifest::ArtifactKind::BenchSuite
@@ -353,6 +480,82 @@ pub unsafe fn nika_pck_manifest::LockEntry::clone_to_uninit(&self, dest: *mut u8
 impl<T> core::convert::From<T> for nika_pck_manifest::LockEntry
 pub fn nika_pck_manifest::LockEntry::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::LockEntry where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::LockPin
+pub nika_pck_manifest::LockPin::digest: alloc::string::String
+impl nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::new(digest: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::clone(&self) -> nika_pck_manifest::nika_lock::LockPin
+impl core::cmp::Eq for nika_pck_manifest::nika_lock::LockPin
+impl core::cmp::PartialEq for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::eq(&self, other: &nika_pck_manifest::nika_lock::LockPin) -> bool
+impl core::fmt::Debug for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::nika_lock::LockPin
+impl serde_core::ser::Serialize for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::nika_lock::LockPin where U: core::convert::From<T>
+pub fn nika_pck_manifest::nika_lock::LockPin::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::nika_lock::LockPin where U: core::convert::Into<T>
+pub type nika_pck_manifest::nika_lock::LockPin::Error = core::convert::Infallible
+pub fn nika_pck_manifest::nika_lock::LockPin::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::nika_lock::LockPin where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::nika_lock::LockPin::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::nika_lock::LockPin::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::nika_lock::LockPin where T: core::clone::Clone
+pub type nika_pck_manifest::nika_lock::LockPin::Owned = T
+pub fn nika_pck_manifest::nika_lock::LockPin::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::nika_lock::LockPin::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::nika_lock::LockPin where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockPin::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::nika_lock::LockPin where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockPin::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::nika_lock::LockPin where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockPin::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::nika_lock::LockPin where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::nika_lock::LockPin::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::nika_lock::LockPin
+pub fn nika_pck_manifest::nika_lock::LockPin::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::nika_lock::LockPin where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::LockRefusal
+pub nika_pck_manifest::LockRefusal::code: &'static str
+pub nika_pck_manifest::LockRefusal::message: alloc::string::String
+impl core::clone::Clone for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::clone(&self) -> nika_pck_manifest::nika_lock::LockRefusal
+impl core::cmp::Eq for nika_pck_manifest::nika_lock::LockRefusal
+impl core::cmp::PartialEq for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::eq(&self, other: &nika_pck_manifest::nika_lock::LockRefusal) -> bool
+impl core::fmt::Debug for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::nika_lock::LockRefusal
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::nika_lock::LockRefusal where U: core::convert::From<T>
+pub fn nika_pck_manifest::nika_lock::LockRefusal::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::nika_lock::LockRefusal where U: core::convert::Into<T>
+pub type nika_pck_manifest::nika_lock::LockRefusal::Error = core::convert::Infallible
+pub fn nika_pck_manifest::nika_lock::LockRefusal::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::nika_lock::LockRefusal where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::nika_lock::LockRefusal::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::nika_lock::LockRefusal::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::nika_lock::LockRefusal where T: core::clone::Clone
+pub type nika_pck_manifest::nika_lock::LockRefusal::Owned = T
+pub fn nika_pck_manifest::nika_lock::LockRefusal::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::nika_lock::LockRefusal::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_pck_manifest::nika_lock::LockRefusal where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_pck_manifest::nika_lock::LockRefusal where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::nika_lock::LockRefusal where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::nika_lock::LockRefusal where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::LockRefusal::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::nika_lock::LockRefusal where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::nika_lock::LockRefusal::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::nika_lock::LockRefusal
+pub fn nika_pck_manifest::nika_lock::LockRefusal::from(t: T) -> T
 #[non_exhaustive] pub struct nika_pck_manifest::Lockfile
 pub nika_pck_manifest::Lockfile::entries: alloc::vec::Vec<nika_pck_manifest::LockEntry>
 pub nika_pck_manifest::Lockfile::schema: alloc::string::String
@@ -442,6 +645,54 @@ pub unsafe fn nika_pck_manifest::Manifest::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_pck_manifest::Manifest
 pub fn nika_pck_manifest::Manifest::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Manifest where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_pck_manifest::NikaLock
+pub nika_pck_manifest::NikaLock::lock_format: u32
+pub nika_pck_manifest::NikaLock::model_select: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub nika_pck_manifest::NikaLock::policy: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub nika_pck_manifest::NikaLock::providers: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_pck_manifest::nika_lock::LockPin>
+pub nika_pck_manifest::NikaLock::registry: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_pck_manifest::nika_lock::LockPin>
+pub nika_pck_manifest::NikaLock::tools: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_pck_manifest::nika_lock::LockPin>
+impl nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::new() -> Self
+pub fn nika_pck_manifest::nika_lock::NikaLock::pinned(&self) -> alloc::collections::btree::set::BTreeSet<&str>
+pub fn nika_pck_manifest::nika_lock::NikaLock::validate(&self, resolved: &alloc::collections::btree::set::BTreeSet<alloc::string::String>) -> core::result::Result<(), nika_pck_manifest::nika_lock::LockRefusal>
+impl core::clone::Clone for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::clone(&self) -> nika_pck_manifest::nika_lock::NikaLock
+impl core::cmp::Eq for nika_pck_manifest::nika_lock::NikaLock
+impl core::cmp::PartialEq for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::eq(&self, other: &nika_pck_manifest::nika_lock::NikaLock) -> bool
+impl core::default::Default for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::default() -> Self
+impl core::fmt::Debug for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_pck_manifest::nika_lock::NikaLock
+impl serde_core::ser::Serialize for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl<T, U> core::convert::Into<U> for nika_pck_manifest::nika_lock::NikaLock where U: core::convert::From<T>
+pub fn nika_pck_manifest::nika_lock::NikaLock::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_pck_manifest::nika_lock::NikaLock where U: core::convert::Into<T>
+pub type nika_pck_manifest::nika_lock::NikaLock::Error = core::convert::Infallible
+pub fn nika_pck_manifest::nika_lock::NikaLock::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_pck_manifest::nika_lock::NikaLock where U: core::convert::TryFrom<T>
+pub type nika_pck_manifest::nika_lock::NikaLock::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_pck_manifest::nika_lock::NikaLock::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_pck_manifest::nika_lock::NikaLock where T: core::clone::Clone
+pub type nika_pck_manifest::nika_lock::NikaLock::Owned = T
+pub fn nika_pck_manifest::nika_lock::NikaLock::clone_into(&self, target: &mut T)
+pub fn nika_pck_manifest::nika_lock::NikaLock::to_owned(&self) -> T
+impl<T> core::any::Any for nika_pck_manifest::nika_lock::NikaLock where T: 'static + ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::NikaLock::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_pck_manifest::nika_lock::NikaLock where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::NikaLock::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_pck_manifest::nika_lock::NikaLock where T: ?core::marker::Sized
+pub fn nika_pck_manifest::nika_lock::NikaLock::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_pck_manifest::nika_lock::NikaLock where T: core::clone::Clone
+pub unsafe fn nika_pck_manifest::nika_lock::NikaLock::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_pck_manifest::nika_lock::NikaLock
+pub fn nika_pck_manifest::nika_lock::NikaLock::from(t: T) -> T
+impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::nika_lock::NikaLock where T: for<'de> serde_core::de::Deserialize<'de>
 #[non_exhaustive] pub struct nika_pck_manifest::PackageRef
 pub nika_pck_manifest::PackageRef::path: core::option::Option<alloc::string::String>
 pub nika_pck_manifest::PackageRef::url: alloc::string::String
@@ -540,4 +791,6 @@ pub unsafe fn nika_pck_manifest::Sha256Hash::clone_to_uninit(&self, dest: *mut u
 impl<T> core::convert::From<T> for nika_pck_manifest::Sha256Hash
 pub fn nika_pck_manifest::Sha256Hash::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_pck_manifest::Sha256Hash where T: for<'de> serde_core::de::Deserialize<'de>
+pub const nika_pck_manifest::LOCK_FORMAT: u32
+pub const nika_pck_manifest::NIKA_LOCK_001: &str
 pub const nika_pck_manifest::PCK_SCHEMA: &str

--- a/crates/nika-pck-manifest/src/lib.rs
+++ b/crates/nika-pck-manifest/src/lib.rs
@@ -31,6 +31,7 @@ mod hash;
 mod kind;
 mod lockfile;
 mod manifest;
+pub mod nika_lock;
 mod refs;
 
 pub use cert::{Cert, CertVerdict};
@@ -38,6 +39,7 @@ pub use hash::{Blake3Hash, Sha256Hash};
 pub use kind::{ArtifactKind, CustomKind};
 pub use lockfile::{LockEntry, Lockfile};
 pub use manifest::{FileEntry, Manifest};
+pub use nika_lock::{LOCK_FORMAT, LockPin, LockRefusal, NIKA_LOCK_001, NikaLock};
 pub use refs::PackageRef;
 
 /// The one schema marker every pck document carries (FCI-003 · a

--- a/crates/nika-pck-manifest/src/nika_lock.rs
+++ b/crates/nika-pck-manifest/src/nika_lock.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika.lock` — the single lock (spec `15-proof.md` §nika.lock · F7).
+//!
+//! One lockfile pins EVERYTHING a run resolves, by **digest**. It unifies the
+//! prior manifest lock ([`crate::lockfile`]) and the pin-by-default rule into
+//! one file — the LOCAL boundary of the same supply chain the gateway (12)
+//! and the distribution work extend.
+//!
+//! ```yaml
+//! lock_format: 1
+//! providers:  { "anthropic/claude-…": { digest: "blake3:…" } }  # models pinned by digest
+//! tools:      { "nika:fetch":         { digest: "blake3:…" } }  # builtin + MCP surface
+//! registry:   { "acme/flows@1.2.0":   { digest: "blake3:…" } }  # every registry: ref
+//! policy:     { … }   # the resolved policy decisions (spec 10)
+//! model_select: { … } # `model: { select: {require, prefer} }` materialized
+//! ```
+//!
+//! - **Pin by default**: a run resolves ONLY what the lock pins; an unpinned
+//!   dependency is a refusal ([`NIKA_LOCK_001`]). Nothing floats.
+//! - Generated (`nika lock`), never hand-authored — hand-editing a digest is
+//!   a lie the check catches (the lock's own hash covers it · the integrity
+//!   digest is computed where blake3 lives, the [`crate::proof`-style]
+//!   self-digest pattern; L0 here stays pure — no hasher — so [`validate`]
+//!   pins the DIGEST-REQUIRED + PIN-BY-DEFAULT laws, byte-parity with the
+//!   reference `proof_core.validate_lock`, and the source-integrity self-hash
+//!   is the higher-layer's owed).
+//!
+//! ## The second evaluator
+//!
+//! [`NikaLock::validate`] mirrors `proof_core.validate_lock` (spec 15 · the
+//! reference model · 22 laws): wrong `lock_format` → refuse · a digest-less
+//! entry → refuse · a resolved dependency the lock does not pin → refuse. The
+//! four lock laws of `proof_core_selftest.py` are pinned in [`tests`].
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+/// The v1 lock format marker — the reference's `LOCK_FORMAT`.
+pub const LOCK_FORMAT: u32 = 1;
+
+/// The pin-by-default refusal code (spec 15 · canon.yaml `validation_error`).
+pub const NIKA_LOCK_001: &str = "NIKA-LOCK-001";
+
+/// One pinned dependency — a content digest is MANDATORY (pin by default ·
+/// nothing floats). A missing `digest` key fails deserialization; an EMPTY
+/// digest is caught by [`NikaLock::validate`] (both are the reference's
+/// "a digest pin is required" refusal, at the two surfaces a typed lock has).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct LockPin {
+    /// The pinned content digest (`blake3:…` / `sha256:…`). Installs verify
+    /// content against THIS, whatever any index or mutable tag says later.
+    pub digest: String,
+}
+
+impl LockPin {
+    /// Pin a resolved dependency to its content digest.
+    #[must_use]
+    pub fn new(digest: impl Into<String>) -> Self {
+        Self {
+            digest: digest.into(),
+        }
+    }
+}
+
+/// `nika.lock` — the single lock. Each pinnable section maps a resolved ref
+/// to its digest pin; `policy` and `model_select` record the run's resolved
+/// decisions (spec 10 · the model-select materialization) and are carried,
+/// not digest-validated (the reference validates the three pinnable sections).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct NikaLock {
+    /// [`LOCK_FORMAT`] — a foreign value is a refusal ([`NikaLock::validate`]).
+    pub lock_format: u32,
+    /// Every model pinned by content digest.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub providers: BTreeMap<String, LockPin>,
+    /// Every builtin + MCP surface version pinned by digest.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tools: BTreeMap<String, LockPin>,
+    /// Every `registry:` ref pinned owner/name@version + digest.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub registry: BTreeMap<String, LockPin>,
+    /// The resolved policy decisions (spec 10) — recorded key→value
+    /// resolutions, carried for the receipt fold, not part of the
+    /// pin-by-default law (the richer policy-family shape lives at spec 10).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub policy: BTreeMap<String, String>,
+    /// `model: { select: {require, prefer} }` materialized — the resolved
+    /// model per selection, recorded (not digest-validated here).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub model_select: BTreeMap<String, String>,
+}
+
+/// A `nika.lock` refusal (spec 15 · [`NIKA_LOCK_001`]). A plain data carrier,
+/// NOT a `thiserror` enum — it never crosses a `NikaErrorCode` boundary (the
+/// same posture as `nika-builtin`'s `decide.rs` `DecideError`, so the L0 crate
+/// keeps its single allowlisted `ManifestError`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct LockRefusal {
+    /// Always [`NIKA_LOCK_001`] (one code · the lock namespace).
+    pub code: &'static str,
+    /// The human-readable law that refused.
+    pub message: String,
+}
+
+impl LockRefusal {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            code: NIKA_LOCK_001,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for LockRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl NikaLock {
+    /// An empty lock at the current format (INV-019 · `#[non_exhaustive]`
+    /// structs ship a constructor).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            lock_format: LOCK_FORMAT,
+            providers: BTreeMap::new(),
+            tools: BTreeMap::new(),
+            registry: BTreeMap::new(),
+            policy: BTreeMap::new(),
+            model_select: BTreeMap::new(),
+        }
+    }
+
+    /// The set of refs this lock pins (providers ∪ tools ∪ registry) — the
+    /// pinnable sections the reference builds its `pinned` set from.
+    #[must_use]
+    pub fn pinned(&self) -> BTreeSet<&str> {
+        self.providers
+            .keys()
+            .chain(self.tools.keys())
+            .chain(self.registry.keys())
+            .map(String::as_str)
+            .collect()
+    }
+
+    /// Validate the lock against the set of dependency refs a run actually
+    /// `resolved` (spec 15 · mirror of `proof_core.validate_lock`):
+    ///
+    /// 1. `lock_format` must be [`LOCK_FORMAT`] (a foreign version is refused);
+    /// 2. every pinnable entry MUST carry a non-empty digest (pin by default);
+    /// 3. every resolved dependency MUST be pinned — an unpinned resolution is
+    ///    a refusal ([`NIKA_LOCK_001`]), never a warning. Nothing floats.
+    ///
+    /// # Errors
+    ///
+    /// [`LockRefusal`] ([`NIKA_LOCK_001`]) on any of the three laws.
+    pub fn validate(&self, resolved: &BTreeSet<String>) -> Result<(), LockRefusal> {
+        if self.lock_format != LOCK_FORMAT {
+            return Err(LockRefusal::new(format!(
+                "nika.lock · lock_format must be {LOCK_FORMAT} (got {})",
+                self.lock_format
+            )));
+        }
+        for (section, block) in [
+            ("providers", &self.providers),
+            ("tools", &self.tools),
+            ("registry", &self.registry),
+        ] {
+            for (reference, pin) in block {
+                if pin.digest.is_empty() {
+                    return Err(LockRefusal::new(format!(
+                        "nika.lock.{section}.{reference} · a digest pin is required \
+                         (pin by default · nothing floats · {NIKA_LOCK_001})"
+                    )));
+                }
+            }
+        }
+        let pinned = self.pinned();
+        let unpinned: Vec<&str> = resolved
+            .iter()
+            .map(String::as_str)
+            .filter(|r| !pinned.contains(r))
+            .collect();
+        if !unpinned.is_empty() {
+            return Err(LockRefusal::new(format!(
+                "nika.lock · resolved dependencies not pinned: {unpinned:?} \
+                 (pin by default · {NIKA_LOCK_001})"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl Default for NikaLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn resolved(refs: &[&str]) -> BTreeSet<String> {
+        refs.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn good_lock() -> NikaLock {
+        let mut lock = NikaLock::new();
+        lock.providers
+            .insert("anthropic/claude".to_owned(), LockPin::new("blake3:aa"));
+        lock.tools
+            .insert("nika:fetch".to_owned(), LockPin::new("blake3:bb"));
+        lock
+    }
+
+    // ── the four reference lock laws (proof_core_selftest.py) ────────────
+
+    #[test]
+    fn a_fully_pinned_lock_validates() {
+        good_lock()
+            .validate(&resolved(&["anthropic/claude", "nika:fetch"]))
+            .expect("a fully-pinned lock validates");
+    }
+
+    #[test]
+    fn an_unpinned_resolved_dependency_is_refused() {
+        let err = good_lock()
+            .validate(&resolved(&["anthropic/claude", "nika:fetch", "mcp:x/y"]))
+            .expect_err("an unpinned resolved dependency is refused");
+        assert_eq!(err.code, NIKA_LOCK_001);
+        assert!(err.message.contains("mcp:x/y"), "the culprit is named");
+    }
+
+    #[test]
+    fn a_digest_less_lock_entry_is_refused_at_validate() {
+        // An empty digest is the reference's "a digest pin is required".
+        let mut lock = NikaLock::new();
+        lock.providers.insert("p".to_owned(), LockPin::new(""));
+        let err = lock
+            .validate(&resolved(&["p"]))
+            .expect_err("an empty digest is refused");
+        assert_eq!(err.code, NIKA_LOCK_001);
+    }
+
+    #[test]
+    fn a_digest_less_lock_entry_is_refused_at_parse() {
+        // A MISSING digest key is the same law at the deserialize boundary —
+        // `{"providers":{"p":{}}}` cannot round-trip into a typed pin.
+        let json = r#"{"lock_format":1,"providers":{"p":{}}}"#;
+        assert!(
+            serde_json::from_str::<NikaLock>(json).is_err(),
+            "a digest-less entry does not deserialize (pin by default)"
+        );
+    }
+
+    #[test]
+    fn a_wrong_lock_format_is_refused() {
+        let mut lock = NikaLock::new();
+        lock.lock_format = 9;
+        let err = lock
+            .validate(&resolved(&[]))
+            .expect_err("a wrong lock_format is refused");
+        assert_eq!(err.code, NIKA_LOCK_001);
+        assert!(err.message.contains("lock_format"));
+    }
+
+    // ── generation shape · round-trips · nothing floats ─────────────────
+
+    #[test]
+    fn the_lock_round_trips_json() {
+        let lock = good_lock();
+        let json = serde_json::to_string(&lock).unwrap();
+        let back: NikaLock = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, lock);
+    }
+
+    #[test]
+    fn an_empty_lock_with_no_resolutions_validates() {
+        // The degenerate case: nothing resolved, nothing to pin.
+        NikaLock::new()
+            .validate(&resolved(&[]))
+            .expect("an empty lock over an empty resolution set is valid");
+    }
+
+    #[test]
+    fn pinned_unions_the_three_pinnable_sections() {
+        let mut lock = good_lock();
+        lock.registry
+            .insert("acme/flows@1".to_owned(), LockPin::new("blake3:cc"));
+        // policy / model_select are recorded, never pinned.
+        lock.policy.insert("net".to_owned(), "deny".to_owned());
+        let pinned = lock.pinned();
+        assert!(pinned.contains("anthropic/claude"));
+        assert!(pinned.contains("nika:fetch"));
+        assert!(pinned.contains("acme/flows@1"));
+        assert!(!pinned.contains("net"), "policy is recorded, not pinned");
+    }
+}

--- a/crates/nika-pck-manifest/src/nika_lock.rs
+++ b/crates/nika-pck-manifest/src/nika_lock.rs
@@ -4,7 +4,7 @@
 //! `nika.lock` — the single lock (spec `15-proof.md` §nika.lock · F7).
 //!
 //! One lockfile pins EVERYTHING a run resolves, by **digest**. It unifies the
-//! prior manifest lock ([`crate::lockfile`]) and the pin-by-default rule into
+//! prior manifest lock (`crate::lockfile`) and the pin-by-default rule into
 //! one file — the LOCAL boundary of the same supply chain the gateway (12)
 //! and the distribution work extend.
 //!
@@ -21,8 +21,8 @@
 //!   dependency is a refusal ([`NIKA_LOCK_001`]). Nothing floats.
 //! - Generated (`nika lock`), never hand-authored — hand-editing a digest is
 //!   a lie the check catches (the lock's own hash covers it · the integrity
-//!   digest is computed where blake3 lives, the [`crate::proof`-style]
-//!   self-digest pattern; L0 here stays pure — no hasher — so [`validate`]
+//!   digest is computed where blake3 lives, the `crate::proof`-style
+//!   self-digest pattern; L0 here stays pure — no hasher — so [`NikaLock::validate`]
 //!   pins the DIGEST-REQUIRED + PIN-BY-DEFAULT laws, byte-parity with the
 //!   reference `proof_core.validate_lock`, and the source-integrity self-hash
 //!   is the higher-layer's owed).
@@ -32,7 +32,7 @@
 //! [`NikaLock::validate`] mirrors `proof_core.validate_lock` (spec 15 · the
 //! reference model · 22 laws): wrong `lock_format` → refuse · a digest-less
 //! entry → refuse · a resolved dependency the lock does not pin → refuse. The
-//! four lock laws of `proof_core_selftest.py` are pinned in [`tests`].
+//! four lock laws of `proof_core_selftest.py` are pinned in `tests`.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -164,6 +164,232 @@ pub fn nika_runtime::child::ChildRunSummary::as_any(&self) -> &(dyn core::any::A
 pub const nika_runtime::child::MAX_RUN_DEPTH: u32
 pub trait nika_runtime::child::ChildRunner: core::marker::Send + core::marker::Sync
 pub fn nika_runtime::child::ChildRunner::run_child<'a>(&'a self, call: nika_runtime::child::ChildCall) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<nika_runtime::child::ChildOutcome, nika_runtime::child::ChildRunRefusal>> + 'a)>>
+pub mod nika_runtime::proof
+pub mod nika_runtime::proof::ir
+#[non_exhaustive] pub struct nika_runtime::proof::ir::WorkflowProof
+pub nika_runtime::proof::ir::WorkflowProof::tasks: alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_runtime::proof::SemanticHash>
+pub nika_runtime::proof::ir::WorkflowProof::workflow: nika_runtime::proof::SemanticHash
+impl core::clone::Clone for nika_runtime::proof::ir::WorkflowProof
+pub fn nika_runtime::proof::ir::WorkflowProof::clone(&self) -> nika_runtime::proof::ir::WorkflowProof
+impl core::cmp::Eq for nika_runtime::proof::ir::WorkflowProof
+impl core::cmp::PartialEq for nika_runtime::proof::ir::WorkflowProof
+pub fn nika_runtime::proof::ir::WorkflowProof::eq(&self, other: &nika_runtime::proof::ir::WorkflowProof) -> bool
+impl core::fmt::Debug for nika_runtime::proof::ir::WorkflowProof
+pub fn nika_runtime::proof::ir::WorkflowProof::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_runtime::proof::ir::WorkflowProof
+impl<D> owo_colors::OwoColorize for nika_runtime::proof::ir::WorkflowProof
+impl<Q, K> equivalent::Equivalent<K> for nika_runtime::proof::ir::WorkflowProof where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::ir::WorkflowProof::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::ir::WorkflowProof where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::ir::WorkflowProof where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::ir::WorkflowProof::equivalent(&self, key: &K) -> bool
+pub fn nika_runtime::proof::ir::WorkflowProof::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_runtime::proof::ir::WorkflowProof where U: core::convert::From<T>
+pub fn nika_runtime::proof::ir::WorkflowProof::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::proof::ir::WorkflowProof where U: core::convert::Into<T>
+pub type nika_runtime::proof::ir::WorkflowProof::Error = core::convert::Infallible
+pub fn nika_runtime::proof::ir::WorkflowProof::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::proof::ir::WorkflowProof where U: core::convert::TryFrom<T>
+pub type nika_runtime::proof::ir::WorkflowProof::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::proof::ir::WorkflowProof::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_runtime::proof::ir::WorkflowProof where T: core::clone::Clone
+pub type nika_runtime::proof::ir::WorkflowProof::Owned = T
+pub fn nika_runtime::proof::ir::WorkflowProof::clone_into(&self, target: &mut T)
+pub fn nika_runtime::proof::ir::WorkflowProof::to_owned(&self) -> T
+impl<T> core::any::Any for nika_runtime::proof::ir::WorkflowProof where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::proof::ir::WorkflowProof::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::proof::ir::WorkflowProof where T: ?core::marker::Sized
+pub fn nika_runtime::proof::ir::WorkflowProof::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::proof::ir::WorkflowProof where T: ?core::marker::Sized
+pub fn nika_runtime::proof::ir::WorkflowProof::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_runtime::proof::ir::WorkflowProof where T: core::clone::Clone
+pub unsafe fn nika_runtime::proof::ir::WorkflowProof::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_runtime::proof::ir::WorkflowProof
+pub fn nika_runtime::proof::ir::WorkflowProof::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_runtime::proof::ir::WorkflowProof where T: core::clone::Clone
+pub fn nika_runtime::proof::ir::WorkflowProof::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_runtime::proof::ir::WorkflowProof where T: 'static
+pub fn nika_runtime::proof::ir::WorkflowProof::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub fn nika_runtime::proof::ir::merkle_by_task(wf: &nika_schema::raw::workflow::RawWorkflow) -> core::option::Option<nika_runtime::proof::ir::WorkflowProof>
+pub fn nika_runtime::proof::ir::semantic_ir_hash(wf: &nika_schema::raw::workflow::RawWorkflow) -> core::option::Option<nika_runtime::proof::SemanticHash>
+pub fn nika_runtime::proof::ir::task_semantic_hash(task: &nika_schema::raw::task::RawTask) -> core::option::Option<nika_runtime::proof::SemanticHash>
+pub mod nika_runtime::proof::receipt
+pub const nika_runtime::proof::receipt::RECEIPT_FORMAT: u32
+pub fn nika_runtime::proof::receipt::build_receipt(proves: &str, certificate: serde_json::value::Value, trace_verdict: serde_json::value::Value, assertions: alloc::vec::Vec<serde_json::value::Value>, lock_digest: &str) -> serde_json::value::Value
+pub fn nika_runtime::proof::receipt::build_run_receipt(proves: &nika_runtime::proof::SemanticHash, certificate: &nika_schema::check::certificate::RunCertificate, judged: &[(nika_vocab::assert::AssertProperty, nika_vocab::assert::AssertLevel)], trace_verdict: serde_json::value::Value, lock_digest: &str) -> serde_json::value::Value
+pub fn nika_runtime::proof::receipt::verify(receipt: &serde_json::value::Value, expected_semantic: &str) -> bool
+#[non_exhaustive] pub enum nika_runtime::proof::HashDomain
+pub nika_runtime::proof::HashDomain::Artifact
+pub nika_runtime::proof::HashDomain::Canonical
+pub nika_runtime::proof::HashDomain::Plan
+pub nika_runtime::proof::HashDomain::Receipt
+pub nika_runtime::proof::HashDomain::Semantic
+pub nika_runtime::proof::HashDomain::Source
+pub nika_runtime::proof::HashDomain::Trace
+impl nika_runtime::proof::HashDomain
+pub const nika_runtime::proof::HashDomain::ALL: [Self; 7]
+pub const fn nika_runtime::proof::HashDomain::as_str(self) -> &'static str
+pub fn nika_runtime::proof::HashDomain::parse(token: &str) -> core::result::Result<Self, nika_runtime::proof::UnknownDomain>
+impl core::clone::Clone for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::clone(&self) -> nika_runtime::proof::HashDomain
+impl core::cmp::Eq for nika_runtime::proof::HashDomain
+impl core::cmp::Ord for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::cmp(&self, other: &nika_runtime::proof::HashDomain) -> core::cmp::Ordering
+impl core::cmp::PartialEq for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::eq(&self, other: &nika_runtime::proof::HashDomain) -> bool
+impl core::cmp::PartialOrd for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::partial_cmp(&self, other: &nika_runtime::proof::HashDomain) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for nika_runtime::proof::HashDomain
+impl core::marker::StructuralPartialEq for nika_runtime::proof::HashDomain
+impl<D> owo_colors::OwoColorize for nika_runtime::proof::HashDomain
+impl<Q, K> equivalent::Comparable<K> for nika_runtime::proof::HashDomain where Q: core::cmp::Ord + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::HashDomain::compare(&self, key: &K) -> core::cmp::Ordering
+impl<Q, K> equivalent::Equivalent<K> for nika_runtime::proof::HashDomain where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::HashDomain::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::HashDomain where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::HashDomain where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::HashDomain::equivalent(&self, key: &K) -> bool
+pub fn nika_runtime::proof::HashDomain::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_runtime::proof::HashDomain where U: core::convert::From<T>
+pub fn nika_runtime::proof::HashDomain::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::proof::HashDomain where U: core::convert::Into<T>
+pub type nika_runtime::proof::HashDomain::Error = core::convert::Infallible
+pub fn nika_runtime::proof::HashDomain::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::proof::HashDomain where U: core::convert::TryFrom<T>
+pub type nika_runtime::proof::HashDomain::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::proof::HashDomain::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_runtime::proof::HashDomain where T: core::clone::Clone
+pub type nika_runtime::proof::HashDomain::Owned = T
+pub fn nika_runtime::proof::HashDomain::clone_into(&self, target: &mut T)
+pub fn nika_runtime::proof::HashDomain::to_owned(&self) -> T
+impl<T> core::any::Any for nika_runtime::proof::HashDomain where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::proof::HashDomain::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::proof::HashDomain where T: ?core::marker::Sized
+pub fn nika_runtime::proof::HashDomain::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::proof::HashDomain where T: ?core::marker::Sized
+pub fn nika_runtime::proof::HashDomain::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_runtime::proof::HashDomain where T: core::clone::Clone
+pub unsafe fn nika_runtime::proof::HashDomain::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_runtime::proof::HashDomain
+pub fn nika_runtime::proof::HashDomain::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_runtime::proof::HashDomain where T: core::clone::Clone
+pub fn nika_runtime::proof::HashDomain::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_runtime::proof::HashDomain where T: 'static
+pub fn nika_runtime::proof::HashDomain::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_runtime::proof::HashDomain where T: core::marker::Copy
+pub fn nika_runtime::proof::HashDomain::as_out(&mut self) -> outref::Out<'_, T>
+pub struct nika_runtime::proof::SemanticHash(_)
+impl nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::as_hex(&self) -> &str
+pub fn nika_runtime::proof::SemanticHash::into_hex(self) -> alloc::string::String
+impl core::clone::Clone for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::clone(&self) -> nika_runtime::proof::SemanticHash
+impl core::cmp::Eq for nika_runtime::proof::SemanticHash
+impl core::cmp::Ord for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::cmp(&self, other: &nika_runtime::proof::SemanticHash) -> core::cmp::Ordering
+impl core::cmp::PartialEq for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::eq(&self, other: &nika_runtime::proof::SemanticHash) -> bool
+impl core::cmp::PartialOrd for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::partial_cmp(&self, other: &nika_runtime::proof::SemanticHash) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::StructuralPartialEq for nika_runtime::proof::SemanticHash
+impl<D> owo_colors::OwoColorize for nika_runtime::proof::SemanticHash
+impl<Q, K> equivalent::Comparable<K> for nika_runtime::proof::SemanticHash where Q: core::cmp::Ord + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::compare(&self, key: &K) -> core::cmp::Ordering
+impl<Q, K> equivalent::Equivalent<K> for nika_runtime::proof::SemanticHash where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::SemanticHash where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::SemanticHash where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::equivalent(&self, key: &K) -> bool
+pub fn nika_runtime::proof::SemanticHash::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_runtime::proof::SemanticHash where U: core::convert::From<T>
+pub fn nika_runtime::proof::SemanticHash::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::proof::SemanticHash where U: core::convert::Into<T>
+pub type nika_runtime::proof::SemanticHash::Error = core::convert::Infallible
+pub fn nika_runtime::proof::SemanticHash::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::proof::SemanticHash where U: core::convert::TryFrom<T>
+pub type nika_runtime::proof::SemanticHash::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::proof::SemanticHash::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_runtime::proof::SemanticHash where T: core::clone::Clone
+pub type nika_runtime::proof::SemanticHash::Owned = T
+pub fn nika_runtime::proof::SemanticHash::clone_into(&self, target: &mut T)
+pub fn nika_runtime::proof::SemanticHash::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_runtime::proof::SemanticHash where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_runtime::proof::SemanticHash where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::proof::SemanticHash where T: ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::proof::SemanticHash where T: ?core::marker::Sized
+pub fn nika_runtime::proof::SemanticHash::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_runtime::proof::SemanticHash where T: core::clone::Clone
+pub unsafe fn nika_runtime::proof::SemanticHash::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_runtime::proof::SemanticHash
+pub fn nika_runtime::proof::SemanticHash::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_runtime::proof::SemanticHash where T: core::clone::Clone
+pub fn nika_runtime::proof::SemanticHash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_runtime::proof::SemanticHash where T: 'static
+pub fn nika_runtime::proof::SemanticHash::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub struct nika_runtime::proof::UnknownDomain(pub alloc::string::String)
+impl core::clone::Clone for nika_runtime::proof::UnknownDomain
+pub fn nika_runtime::proof::UnknownDomain::clone(&self) -> nika_runtime::proof::UnknownDomain
+impl core::cmp::Eq for nika_runtime::proof::UnknownDomain
+impl core::cmp::PartialEq for nika_runtime::proof::UnknownDomain
+pub fn nika_runtime::proof::UnknownDomain::eq(&self, other: &nika_runtime::proof::UnknownDomain) -> bool
+impl core::fmt::Debug for nika_runtime::proof::UnknownDomain
+pub fn nika_runtime::proof::UnknownDomain::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_runtime::proof::UnknownDomain
+pub fn nika_runtime::proof::UnknownDomain::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_runtime::proof::UnknownDomain
+impl<D> owo_colors::OwoColorize for nika_runtime::proof::UnknownDomain
+impl<Q, K> equivalent::Equivalent<K> for nika_runtime::proof::UnknownDomain where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::UnknownDomain::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::UnknownDomain where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_runtime::proof::UnknownDomain where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_runtime::proof::UnknownDomain::equivalent(&self, key: &K) -> bool
+pub fn nika_runtime::proof::UnknownDomain::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_runtime::proof::UnknownDomain where U: core::convert::From<T>
+pub fn nika_runtime::proof::UnknownDomain::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::proof::UnknownDomain where U: core::convert::Into<T>
+pub type nika_runtime::proof::UnknownDomain::Error = core::convert::Infallible
+pub fn nika_runtime::proof::UnknownDomain::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::proof::UnknownDomain where U: core::convert::TryFrom<T>
+pub type nika_runtime::proof::UnknownDomain::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::proof::UnknownDomain::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_runtime::proof::UnknownDomain where T: core::clone::Clone
+pub type nika_runtime::proof::UnknownDomain::Owned = T
+pub fn nika_runtime::proof::UnknownDomain::clone_into(&self, target: &mut T)
+pub fn nika_runtime::proof::UnknownDomain::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_runtime::proof::UnknownDomain where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_runtime::proof::UnknownDomain::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_runtime::proof::UnknownDomain where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::proof::UnknownDomain::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::proof::UnknownDomain where T: ?core::marker::Sized
+pub fn nika_runtime::proof::UnknownDomain::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::proof::UnknownDomain where T: ?core::marker::Sized
+pub fn nika_runtime::proof::UnknownDomain::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_runtime::proof::UnknownDomain where T: core::clone::Clone
+pub unsafe fn nika_runtime::proof::UnknownDomain::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_runtime::proof::UnknownDomain
+pub fn nika_runtime::proof::UnknownDomain::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_runtime::proof::UnknownDomain where T: core::clone::Clone
+pub fn nika_runtime::proof::UnknownDomain::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_runtime::proof::UnknownDomain where T: 'static
+pub fn nika_runtime::proof::UnknownDomain::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_runtime::proof::FORMAT_VERSION: u32
+pub fn nika_runtime::proof::canonical(value: &serde_json::value::Value) -> alloc::string::String
+pub fn nika_runtime::proof::hash_in_domain(domain: nika_runtime::proof::HashDomain, format_version: u32, ir: &serde_json::value::Value) -> alloc::string::String
+pub fn nika_runtime::proof::preimage(domain: nika_runtime::proof::HashDomain, format_version: u32, ir: &serde_json::value::Value) -> alloc::string::String
+pub fn nika_runtime::proof::semantic_hash(ir: &serde_json::value::Value, format_version: u32) -> nika_runtime::proof::SemanticHash
 pub mod nika_runtime::resume
 pub mod nika_runtime::resume::fields
 pub const nika_runtime::resume::fields::DEF_HASH: &str

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -49,6 +49,7 @@ mod expr;
 mod jq;
 mod ledger;
 mod pause;
+pub mod proof;
 mod record;
 mod recover;
 pub mod resume;

--- a/crates/nika-runtime/src/proof/ir.rs
+++ b/crates/nika-runtime/src/proof/ir.rs
@@ -12,7 +12,7 @@
 //!
 //! ## What this projection IS today (honest scope · spec 15 · G13)
 //!
-//! The per-task leaf reuses the ADR-099 [`definition_value`] — the span-free,
+//! The per-task leaf reuses the ADR-099 `definition_value` — the span-free,
 //! behavior-bearing definition as WRITTEN (verb body · `with:` · `output:` ·
 //! `retry:`/`on_error:`/`on_finally:` · `when:` · `for_each:` · the
 //! scheduling knobs). That projection already canonicalizes authored map

--- a/crates/nika-runtime/src/proof/ir.rs
+++ b/crates/nika-runtime/src/proof/ir.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The Semantic IR projection — Merkle by task (spec 15 §the semantic hash).
+//!
+//! A workflow's identity is the hash of its desugared, versioned Semantic IR,
+//! built **Merkle by task**: each task's semantic subtree hashes
+//! independently (the leaf), and the workflow hash commits to the leaf hashes
+//! (the root). A proof of the whole contains a proof of each part — and a
+//! composed child (spec 14) folds in as a subtree under its invoking task
+//! (the `ChildRunSummary` semantic anchor · law 10).
+//!
+//! ## What this projection IS today (honest scope · spec 15 · G13)
+//!
+//! The per-task leaf reuses the ADR-099 [`definition_value`] — the span-free,
+//! behavior-bearing definition as WRITTEN (verb body · `with:` · `output:` ·
+//! `retry:`/`on_error:`/`on_finally:` · `when:` · `for_each:` · the
+//! scheduling knobs). That projection already canonicalizes authored map
+//! order away (spec 15 · two files that MEAN the same task lower to the same
+//! leaf · proven by the resume suite's `with_declaration_order_is_canonicalized_away`).
+//!
+//! ## What this projection does NOT yet do (owed · named, not simulated)
+//!
+//! The FULL spec-15 lowering — normative-default expansion, unit
+//! normalization (durations → ns · sizes → bytes), Unicode NFC, reference
+//! resolution — is the owed deepening. Two files that differ ONLY in an
+//! un-expanded default or an un-normalized unit are semantically equal but
+//! would hash differently here; that gap is `specified`, not `proven`. The
+//! canonicalization DISCIPLINE (JCS sorted keys · blake3 · domain-separated)
+//! is exact; the IR's completeness is the deepening the distribution window
+//! extends.
+
+use std::collections::BTreeMap;
+
+use nika_schema::raw::{RawTask, RawWorkflow};
+use serde_json::{Value, json};
+
+use crate::proof::{FORMAT_VERSION, SemanticHash, semantic_hash};
+use crate::resume::definition_value;
+
+/// A workflow's Merkle proof by task (spec 15 §Merkle by task): the leaf
+/// hashes and the root that commits to them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WorkflowProof {
+    /// The workflow's semantic identity — the hash of the IR that commits to
+    /// every task leaf hash (the Merkle root · spec 15 · G13).
+    pub workflow: SemanticHash,
+    /// Each task's semantic subtree hash, by task id (the leaves). A
+    /// composed child's own [`WorkflowProof::workflow`] is the subtree that
+    /// folds in under its invoking task.
+    pub tasks: BTreeMap<String, SemanticHash>,
+}
+
+/// One task's semantic subtree hash — `H_semantic` over the leaf payload
+/// `{task, verb, definition}` (the ADR-099 definition, generalized to the
+/// proof domain). `None` when the task carries a `#[non_exhaustive]` form the
+/// projection does not know (honest degradation — no false identity, ever).
+#[must_use]
+pub fn task_semantic_hash(task: &RawTask) -> Option<SemanticHash> {
+    let leaf = task_leaf(task)?;
+    Some(semantic_hash(&leaf, FORMAT_VERSION))
+}
+
+/// The per-task leaf IR — the behavior-bearing definition wrapped with its id
+/// and verb, so two distinct tasks never share a leaf even with identical
+/// bodies (the resume `def_hash` payload shape, in the proof domain).
+fn task_leaf(task: &RawTask) -> Option<Value> {
+    Some(json!({
+        "task": task.id.value,
+        "verb": task.action.verb(),
+        "definition": definition_value(task)?,
+    }))
+}
+
+/// The Merkle proof: hash each task independently, then a root that COMMITS
+/// to the leaf hashes (spec 15 · "the workflow hash commits to the task
+/// hashes"). `None` when any task is not projectable — the whole workflow is
+/// then not semantically hashable (honest, never a partial identity).
+#[must_use]
+pub fn merkle_by_task(wf: &RawWorkflow) -> Option<WorkflowProof> {
+    let mut tasks: BTreeMap<String, SemanticHash> = BTreeMap::new();
+    for spanned in &wf.tasks {
+        let task = &spanned.value;
+        let hash = task_semantic_hash(task)?;
+        tasks.insert(task.id.value.clone(), hash);
+    }
+    let root_ir = root_ir(wf, &tasks);
+    Some(WorkflowProof {
+        workflow: semantic_hash(&root_ir, FORMAT_VERSION),
+        tasks,
+    })
+}
+
+/// The root IR the workflow hash is taken over — the workflow id plus the map
+/// of task id → leaf hash hex (the Merkle commitment). Canonicalization sorts
+/// the task map, so authored task order never leaks into the identity.
+fn root_ir(wf: &RawWorkflow, tasks: &BTreeMap<String, SemanticHash>) -> Value {
+    let leaves: serde_json::Map<String, Value> = tasks
+        .iter()
+        .map(|(id, h)| (id.clone(), Value::String(h.as_hex().to_owned())))
+        .collect();
+    json!({
+        "workflow": wf.workflow.as_ref().map(|w| w.value.clone()),
+        "tasks": leaves,
+    })
+}
+
+/// The whole-workflow semantic identity (the Merkle root) — the convenience
+/// accessor when only the root hash is wanted (cache/resume re-key · spec 15).
+/// `None` on an unprojectable task (honest degradation).
+#[must_use]
+pub fn semantic_ir_hash(wf: &RawWorkflow) -> Option<SemanticHash> {
+    merkle_by_task(wf).map(|proof| proof.workflow)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn parse(yaml: &str) -> RawWorkflow {
+        nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses")
+    }
+
+    const BASE: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    with: { p: \"${{ tasks.a.output }}\" }\n    exec: { command: [\"echo\", \"${{ with.p }}\"] }\n";
+
+    #[test]
+    fn the_root_commits_to_every_task_leaf() {
+        let wf = parse(BASE);
+        let proof = merkle_by_task(&wf).expect("projectable");
+        assert_eq!(proof.tasks.len(), 2, "one leaf per task");
+        assert!(proof.tasks.contains_key("a") && proof.tasks.contains_key("b"));
+        for h in proof.tasks.values() {
+            assert_eq!(h.as_hex().len(), 64, "blake3 hex leaf");
+        }
+        assert_eq!(proof.workflow.as_hex().len(), 64, "blake3 hex root");
+    }
+
+    #[test]
+    fn a_changed_task_moves_its_leaf_and_the_root() {
+        let a = merkle_by_task(&parse(BASE)).expect("projectable");
+        let edited = BASE.replace("echo\", \"x", "echo\", \"z");
+        let b = merkle_by_task(&parse(&edited)).expect("projectable");
+        assert_ne!(a.tasks["a"], b.tasks["a"], "the edited task's leaf moves");
+        assert_eq!(
+            a.tasks["b"], b.tasks["b"],
+            "the untouched task's leaf holds"
+        );
+        assert_ne!(a.workflow, b.workflow, "the root commits to the moved leaf");
+    }
+
+    #[test]
+    fn semantically_equal_respellings_share_the_identity() {
+        // Two files that MEAN the same workflow (authored `with:` order is not
+        // behavior · spec 15) lower to the SAME semantic hash — semantic, not
+        // textual. This is the property the cache/resume re-key rides.
+        const AB: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  t:\n    with: { a: \"1\", b: \"2\" }\n    exec: { command: [\"echo\", \"${{ with.a }}${{ with.b }}\"] }\n";
+        const BA: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  t:\n    with: { b: \"2\", a: \"1\" }\n    exec: { command: [\"echo\", \"${{ with.a }}${{ with.b }}\"] }\n";
+        let ab = semantic_ir_hash(&parse(AB)).expect("projectable");
+        let ba = semantic_ir_hash(&parse(BA)).expect("projectable");
+        assert_eq!(ab, ba, "authored map order is not semantic identity");
+    }
+
+    #[test]
+    fn task_order_does_not_change_the_root() {
+        const AB: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  a:\n    exec: { command: [\"echo\", \"1\"] }\n  b:\n    exec: { command: [\"echo\", \"2\"] }\n";
+        const BA: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  b:\n    exec: { command: [\"echo\", \"2\"] }\n  a:\n    exec: { command: [\"echo\", \"1\"] }\n";
+        assert_eq!(
+            semantic_ir_hash(&parse(AB)).expect("projectable"),
+            semantic_ir_hash(&parse(BA)).expect("projectable"),
+            "the root sorts the task map — authored order is not behavior"
+        );
+    }
+
+    #[test]
+    fn the_workflow_id_participates_in_the_root() {
+        let a = semantic_ir_hash(&parse(BASE)).expect("projectable");
+        let renamed = BASE.replace("id: demo", "id: other");
+        let b = semantic_ir_hash(&parse(&renamed)).expect("projectable");
+        assert_ne!(a, b, "the workflow id is part of the identity");
+    }
+}

--- a/crates/nika-runtime/src/proof/mod.rs
+++ b/crates/nika-runtime/src/proof/mod.rs
@@ -6,8 +6,8 @@
 //!
 //! Everything before this module made a workflow *checkable*; this one makes
 //! a run *provable*: the hash of what a workflow MEANS (not how it is
-//! spelled), a single lock that pins by digest ([`nika_pck_manifest`]), the
-//! `assert:` obligations judged at an honest level ([`nika_vocab::assert`]),
+//! spelled), a single lock that pins by digest (`nika_pck_manifest`), the
+//! `assert:` obligations judged at an honest level (`nika_vocab::assert`),
 //! and the one [`receipt`] into which the certificate, the trace verdict, the
 //! assertions and the lock digest fold.
 //!
@@ -18,8 +18,8 @@
 //! conformance oracle. The parity that matters is on the **pre-image** — the
 //! exact bytes that get hashed — never on the digest across algorithms: the
 //! reference hashes those bytes with sha256, this engine with blake3, and
-//! [`tests`] pins the pre-image bytes BYTE-EQUAL against reference-produced
-//! goldens ([`tests::canonical_matches_the_reference`] and siblings). A
+//! `tests` pins the pre-image bytes BYTE-EQUAL against reference-produced
+//! goldens (`tests::canonical_matches_the_reference` and siblings). A
 //! differential on the canonical bytes needs no blake3 dependency on the
 //! Python side — the algorithm is a pinned choice both evaluators share.
 //!
@@ -137,12 +137,12 @@ impl std::fmt::Display for UnknownDomain {
 /// `json.dumps(v, sort_keys=True, separators=(",", ":"), ensure_ascii=False)`:
 /// `serde_json::to_string` emits a `Value`'s object keys in `BTreeMap` order
 /// (this workspace does not enable `preserve_order`, so map order IS sorted
-/// order · verified by [`tests::canonical_is_sorted_keys`]), compact, with
+/// order · verified by `tests::canonical_is_sorted_keys`), compact, with
 /// non-ASCII passed through raw. Serializing a `Value` cannot fail (string
 /// keys · no NaN inhabitants) — the `""` fallback is unreachable.
 ///
 /// **Idempotent**: `canonical(parse(canonical(x))) == canonical(x)` (spec 15
-/// · property-pinned in [`tests::canonical_is_idempotent`]).
+/// · property-pinned in `tests::canonical_is_idempotent`).
 #[must_use]
 pub fn canonical(value: &Value) -> String {
     serde_json::to_string(value).unwrap_or_default()

--- a/crates/nika-runtime/src/proof/mod.rs
+++ b/crates/nika-runtime/src/proof/mod.rs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The proof layer (spec `15-proof.md` · W6) — a run's canonical **semantic
+//! identity**, domain-separated and Merkle-linked.
+//!
+//! Everything before this module made a workflow *checkable*; this one makes
+//! a run *provable*: the hash of what a workflow MEANS (not how it is
+//! spelled), a single lock that pins by digest ([`nika_pck_manifest`]), the
+//! `assert:` obligations judged at an honest level ([`nika_vocab::assert`]),
+//! and the one [`receipt`] into which the certificate, the trace verdict, the
+//! assertions and the lock digest fold.
+//!
+//! ## The second evaluator
+//!
+//! The semantics belong to the SPEC, not to this engine: the stdlib-Python
+//! reference (`conformance/proof_core.py` in nika-spec · 22 laws) is the
+//! conformance oracle. The parity that matters is on the **pre-image** — the
+//! exact bytes that get hashed — never on the digest across algorithms: the
+//! reference hashes those bytes with sha256, this engine with blake3, and
+//! [`tests`] pins the pre-image bytes BYTE-EQUAL against reference-produced
+//! goldens ([`tests::canonical_matches_the_reference`] and siblings). A
+//! differential on the canonical bytes needs no blake3 dependency on the
+//! Python side — the algorithm is a pinned choice both evaluators share.
+//!
+//! ## The honest property (never overstated · spec 15)
+//!
+//! Semantically-different programs produce different canonical encodings —
+//! [`canonical`] is total and injective over distinct [`Value`]s, so
+//! [`preimage`] and [`semantic_hash`] separate them. Collision resistance of
+//! the underlying hash (blake3) is a **cryptographic assumption**, stated as
+//! such — NOT a promise this module makes. Two files that MEAN the same
+//! workflow lower to the same IR (the [`ir`] projection) and hence the same
+//! hash; two files that mean different workflows do not.
+
+use serde_json::Value;
+
+pub mod ir;
+pub mod receipt;
+
+/// The v1 pre-image format version — participates in every pre-image so a
+/// value hashed under one shape can never be reused under another (spec 15 ·
+/// mirror of `proof_core.RECEIPT_FORMAT`/the `format_version` argument).
+pub const FORMAT_VERSION: u32 = 1;
+
+/// The closed set of hash domains (spec 15 §domain separation · exactly the
+/// reference's `DOMAINS` tuple, in order). Every hash NAMES its domain so a
+/// value can never be reinterpreted across roles: a trace-domain hash never
+/// collides usefully with a semantic-domain hash even over identical bytes.
+///
+/// The set is CLOSED at the type level — an unknown domain is unrepresentable
+/// (the reference refuses it at call time; here it cannot be constructed,
+/// [`HashDomain::parse`] is the boundary that mirrors the refusal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum HashDomain {
+    /// The source bytes as authored (pre-lowering).
+    Source,
+    /// The canonical form (spec 09 · normalized types · sorted keys).
+    Canonical,
+    /// The desugared, versioned Semantic IR (the workflow's identity).
+    Semantic,
+    /// A resolved execution plan.
+    Plan,
+    /// A run's hash-chained trace.
+    Trace,
+    /// A produced artifact's content.
+    Artifact,
+    /// A folded proof receipt (spec 15 §receipt).
+    Receipt,
+}
+
+impl HashDomain {
+    /// The seven domains, in the reference's canonical order.
+    pub const ALL: [Self; 7] = [
+        Self::Source,
+        Self::Canonical,
+        Self::Semantic,
+        Self::Plan,
+        Self::Trace,
+        Self::Artifact,
+        Self::Receipt,
+    ];
+
+    /// The wire spelling — the exact token the pre-image carries (the
+    /// reference's lowercase domain string).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Canonical => "canonical",
+            Self::Semantic => "semantic",
+            Self::Plan => "plan",
+            Self::Trace => "trace",
+            Self::Artifact => "artifact",
+            Self::Receipt => "receipt",
+        }
+    }
+
+    /// Parse a domain token, refusing anything outside the closed set — the
+    /// boundary that mirrors the reference's `preimage` raising on an unknown
+    /// domain (spec 15 · "the set is closed").
+    ///
+    /// # Errors
+    ///
+    /// [`UnknownDomain`] when `token` is not one of the seven.
+    pub fn parse(token: &str) -> Result<Self, UnknownDomain> {
+        Self::ALL
+            .into_iter()
+            .find(|d| d.as_str() == token)
+            .ok_or_else(|| UnknownDomain(token.to_owned()))
+    }
+}
+
+/// An unknown hash domain — the closed-set refusal (spec 15). A plain data
+/// carrier, NOT a `thiserror` enum: it never crosses a `NikaErrorCode`
+/// boundary (the domain set is a construction-time programming invariant, the
+/// same posture as `decide.rs`'s `DecideError`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownDomain(pub String);
+
+impl std::fmt::Display for UnknownDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unknown hash domain `{}` — the set is closed {:?}",
+            self.0,
+            HashDomain::ALL.map(HashDomain::as_str)
+        )
+    }
+}
+
+/// The JCS-shaped canonical byte string (sorted keys · no spaces · raw
+/// UTF-8) — the ONE encoding both evaluators hash over.
+///
+/// This is byte-identical to the reference's
+/// `json.dumps(v, sort_keys=True, separators=(",", ":"), ensure_ascii=False)`:
+/// `serde_json::to_string` emits a `Value`'s object keys in `BTreeMap` order
+/// (this workspace does not enable `preserve_order`, so map order IS sorted
+/// order · verified by [`tests::canonical_is_sorted_keys`]), compact, with
+/// non-ASCII passed through raw. Serializing a `Value` cannot fail (string
+/// keys · no NaN inhabitants) — the `""` fallback is unreachable.
+///
+/// **Idempotent**: `canonical(parse(canonical(x))) == canonical(x)` (spec 15
+/// · property-pinned in [`tests::canonical_is_idempotent`]).
+#[must_use]
+pub fn canonical(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+/// The domain-separated pre-image bytes: `domain ‖ 0x00 ‖ format_version ‖
+/// 0x00 ‖ JCS(ir)` (spec 15 · mirror of `proof_core.preimage`).
+///
+/// The NUL separators make the concatenation unambiguous — a domain can never
+/// bleed into the version or the payload, and two payloads under different
+/// domains never share a pre-image over identical `ir` bytes. Returns a
+/// [`String`]: the canonical form is valid UTF-8 and NUL is a valid scalar,
+/// so the whole pre-image is well-formed UTF-8 (hashed as
+/// [`str::as_bytes`]).
+#[must_use]
+pub fn preimage(domain: HashDomain, format_version: u32, ir: &Value) -> String {
+    format!(
+        "{}\u{0}{format_version}\u{0}{}",
+        domain.as_str(),
+        canonical(ir)
+    )
+}
+
+/// A blake3 hash over a domain pre-image, as lowercase hex — the engine-side
+/// digest (the reference hashes the SAME pre-image with sha256; the parity is
+/// on [`preimage`], never on this digest across algorithms).
+#[must_use]
+pub fn hash_in_domain(domain: HashDomain, format_version: u32, ir: &Value) -> String {
+    blake3::hash(preimage(domain, format_version, ir).as_bytes())
+        .to_hex()
+        .to_string()
+}
+
+/// A workflow's semantic identity — `H(semantic ‖ format_version ‖ JCS(ir))`
+/// under blake3 (spec 15 §the semantic hash · G13). The `ir` is the
+/// desugared, versioned Semantic IR (the [`ir`] projection); this is the key
+/// cache and resume re-key on (a result is reused iff the semantic identity
+/// matches · 14 §law 10).
+#[must_use]
+pub fn semantic_hash(ir: &Value, format_version: u32) -> SemanticHash {
+    SemanticHash(hash_in_domain(HashDomain::Semantic, format_version, ir))
+}
+
+/// A semantic identity as lowercase blake3 hex — a typed wrapper so a
+/// semantic hash is never confused with a raw content digest or a trace
+/// chain-head at a call site (the `ChildRunSummary::def_hash` vs semantic
+/// distinction · spec 14 law 10).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SemanticHash(String);
+
+impl SemanticHash {
+    /// The lowercase hex (64 chars · blake3-256).
+    #[must_use]
+    pub fn as_hex(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume into the owned hex string (receipt `proves` field).
+    #[must_use]
+    pub fn into_hex(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for SemanticHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // The reference's shared fixtures (`proof_core_selftest.py`) — two
+    // workflows that MEAN different things (one command byte apart).
+    fn ir_a() -> Value {
+        json!({"workflow": "w", "tasks": {"a": {"verb": "exec", "cmd": ["echo", "x"]}}})
+    }
+    fn ir_b() -> Value {
+        json!({"workflow": "w", "tasks": {"a": {"verb": "exec", "cmd": ["echo", "y"]}}})
+    }
+
+    // ── canonical + hash (reference laws 1-5) ───────────────────────────
+
+    #[test]
+    fn canonical_is_sorted_keys_no_spaces() {
+        // Reference: canonical({"b":1,"a":2}) == '{"a":2,"b":1}'.
+        assert_eq!(canonical(&json!({"b": 1, "a": 2})), r#"{"a":2,"b":1}"#);
+    }
+
+    #[test]
+    fn canonical_is_idempotent() {
+        // Reference law: canonical(parse(canonical(x))) == canonical(x).
+        let once = canonical(&ir_a());
+        let reparsed: Value = serde_json::from_str(&once).unwrap();
+        assert_eq!(canonical(&reparsed), once);
+    }
+
+    #[test]
+    fn distinct_irs_distinct_canonical_bytes() {
+        assert_ne!(canonical(&ir_a()), canonical(&ir_b()));
+    }
+
+    #[test]
+    fn distinct_irs_distinct_semantic_hash() {
+        assert_ne!(
+            semantic_hash(&ir_a(), FORMAT_VERSION),
+            semantic_hash(&ir_b(), FORMAT_VERSION)
+        );
+    }
+
+    #[test]
+    fn same_ir_same_hash_deterministic() {
+        assert_eq!(
+            semantic_hash(&ir_a(), FORMAT_VERSION),
+            semantic_hash(&ir_a(), FORMAT_VERSION)
+        );
+        assert_eq!(semantic_hash(&ir_a(), FORMAT_VERSION).as_hex().len(), 64);
+    }
+
+    // ── domain separation (reference laws 6-8) ──────────────────────────
+
+    #[test]
+    fn domain_separation_same_bytes_different_domain() {
+        assert_ne!(
+            preimage(HashDomain::Semantic, 1, &ir_a()),
+            preimage(HashDomain::Trace, 1, &ir_a())
+        );
+    }
+
+    #[test]
+    fn an_unknown_domain_is_refused() {
+        assert_eq!(HashDomain::parse("semantic"), Ok(HashDomain::Semantic));
+        assert!(HashDomain::parse("made-up").is_err());
+        // The seven parse round-trip through their wire spelling.
+        for d in HashDomain::ALL {
+            assert_eq!(HashDomain::parse(d.as_str()), Ok(d));
+        }
+    }
+
+    #[test]
+    fn format_version_participates_in_the_preimage() {
+        assert_ne!(
+            preimage(HashDomain::Semantic, 1, &ir_a()),
+            preimage(HashDomain::Semantic, 2, &ir_a())
+        );
+        assert_ne!(
+            hash_in_domain(HashDomain::Semantic, 1, &ir_a()),
+            hash_in_domain(HashDomain::Semantic, 2, &ir_a())
+        );
+    }
+
+    // ── the DIFFERENTIAL: pre-image bytes == the reference's goldens ─────
+    //
+    // These constants were produced BY the second evaluator
+    // (`conformance/proof_core.py` · `preimage(...)` / `canonical(...)`),
+    // pinned here as bytes. `\u{0}` is the NUL separator the reference
+    // writes as `\x00`. If the engine's canonicalization ever drifts from
+    // the reference's `json.dumps(sort_keys, separators, ensure_ascii=False)`
+    // these break — the parity is on the bytes that get hashed, algorithm-
+    // independent (spec 15 · the reference validates the PRE-IMAGE).
+
+    #[test]
+    fn canonical_matches_the_reference() {
+        assert_eq!(
+            canonical(&ir_a()),
+            r#"{"tasks":{"a":{"cmd":["echo","x"],"verb":"exec"}},"workflow":"w"}"#
+        );
+        // Raw UTF-8 (ensure_ascii=False) — non-ASCII passes through unescaped.
+        assert_eq!(
+            canonical(&json!({"k": "héllo·wörld"})),
+            "{\"k\":\"héllo·wörld\"}"
+        );
+    }
+
+    #[test]
+    fn preimage_matches_the_reference_goldens() {
+        let a = ir_a();
+        assert_eq!(
+            preimage(HashDomain::Semantic, 1, &a),
+            "semantic\u{0}1\u{0}{\"tasks\":{\"a\":{\"cmd\":[\"echo\",\"x\"],\"verb\":\"exec\"}},\"workflow\":\"w\"}"
+        );
+        assert_eq!(
+            preimage(HashDomain::Trace, 1, &a),
+            "trace\u{0}1\u{0}{\"tasks\":{\"a\":{\"cmd\":[\"echo\",\"x\"],\"verb\":\"exec\"}},\"workflow\":\"w\"}"
+        );
+        assert_eq!(
+            preimage(HashDomain::Semantic, 2, &a),
+            "semantic\u{0}2\u{0}{\"tasks\":{\"a\":{\"cmd\":[\"echo\",\"x\"],\"verb\":\"exec\"}},\"workflow\":\"w\"}"
+        );
+    }
+
+    #[test]
+    fn the_seven_domains_are_the_reference_set_in_order() {
+        assert_eq!(
+            HashDomain::ALL.map(HashDomain::as_str),
+            [
+                "source",
+                "canonical",
+                "semantic",
+                "plan",
+                "trace",
+                "artifact",
+                "receipt"
+            ]
+        );
+    }
+}

--- a/crates/nika-runtime/src/proof/receipt.rs
+++ b/crates/nika-runtime/src/proof/receipt.rs
@@ -8,7 +8,7 @@
 //! chain integrity), each `assert:` judged with its level, and the
 //! `nika.lock` digest the run resolved under — and `proves` the run's
 //! semantic hash ([`crate::proof::semantic_hash`]). The Decision Receipt
-//! ([`nika_builtin::decide`] · `decision_receipt_format: 1`) and the registry
+//! (`nika_builtin::decide` · `decision_receipt_format: 1`) and the registry
 //! certificate become INSTANCES of this shape — one voice, three surfaces.
 //!
 //! The receipt is domain-separated ([`HashDomain::Receipt`]) and Merkle-linked
@@ -18,7 +18,7 @@
 //! ## Parity (spec 15 · the second evaluator)
 //!
 //! [`build_receipt`] mirrors `proof_core.build_receipt` — the FOLD structure
-//! is byte-equal on the pre-image ([`tests::receipt_fold_matches_the_reference`]
+//! is byte-equal on the pre-image (`tests::receipt_fold_matches_the_reference`
 //! feeds both evaluators a FIXED `proves` string to isolate the fold from the
 //! hash algorithm, since `proves` carries the algo-dependent digest). The
 //! `digest` itself differs (the reference's sha256 vs this engine's blake3) —

--- a/crates/nika-runtime/src/proof/receipt.rs
+++ b/crates/nika-runtime/src/proof/receipt.rs
@@ -24,9 +24,11 @@
 //! `digest` itself differs (the reference's sha256 vs this engine's blake3) —
 //! the parity is on the bytes, never across algorithms.
 
+use nika_schema::RunCertificate;
+use nika_schema::types::{AssertLevel, AssertProperty};
 use serde_json::{Map, Value};
 
-use crate::proof::{HashDomain, hash_in_domain};
+use crate::proof::{HashDomain, SemanticHash, hash_in_domain};
 
 /// The v1 receipt format — the `receipt_format` field value AND the pre-image
 /// format version (the reference's `RECEIPT_FORMAT`).
@@ -102,6 +104,49 @@ pub fn verify(receipt: &Value, expected_semantic: &str) -> bool {
     recomputed == stored
 }
 
+/// Fold a run's receipt from the engine's OWN typed pieces (spec 15 · the one
+/// receipt · the parent shape's FIRST real instance): the check certificate
+/// (nika-schema [`RunCertificate`] · attempts · effects · cost bound), the
+/// semantic hash it proves ([`SemanticHash`]), each `assert:` obligation
+/// judged at its honest level (nika-vocab [`AssertProperty`]/[`AssertLevel`]),
+/// the trace verdict, and the `nika.lock` digest the run resolved under.
+///
+/// This is the honest realization the spec calls for: the parent shape plus
+/// ONE real instance folding the engine's actual certificate. Fully
+/// unifying the Decision Receipt (`decide.rs` `decision_receipt_format: 1`)
+/// and the registry certificate INTO instances of this shape is the named
+/// owed — the shape is here; the two other surfaces adopt it next.
+#[must_use]
+pub fn build_run_receipt(
+    proves: &SemanticHash,
+    certificate: &RunCertificate,
+    judged: &[(AssertProperty, AssertLevel)],
+    trace_verdict: Value,
+    lock_digest: &str,
+) -> Value {
+    // The certificate is Serialize (nika-schema) — fold it as-is.
+    let cert = serde_json::to_value(certificate).unwrap_or(Value::Null);
+    let assertions = judged
+        .iter()
+        .map(|(property, level)| {
+            let mut entry = Map::new();
+            entry.insert(
+                "assert".to_owned(),
+                Value::String(property.name().to_owned()),
+            );
+            entry.insert("level".to_owned(), Value::String(level.as_str().to_owned()));
+            Value::Object(entry)
+        })
+        .collect();
+    build_receipt(
+        proves.as_hex(),
+        cert,
+        trace_verdict,
+        assertions,
+        lock_digest,
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -174,5 +219,56 @@ mod tests {
             format!("receipt\u{0}1\u{0}{canon}"),
             "receipt\u{0}1\u{0}{\"assertions\":[{\"assert\":\"no_secret_egress\",\"level\":\"StaticProof\"}],\"certificate\":{\"attempts\":1},\"lock_digest\":\"blake3:lock\",\"proves\":\"blake3:fixedsem\",\"receipt_format\":1,\"trace_verdict\":{\"outcome\":\"success\"}}"
         );
+    }
+
+    /// The ONE real instance: a receipt folded from the engine's OWN typed
+    /// pieces — a real `RunCertificate` (nika-schema · from an actually-checked
+    /// workflow), the workflow's real semantic hash (the Merkle root), and an
+    /// `assert:` obligation judged at its honest level (nika-vocab). The
+    /// receipt proves THIS workflow's identity and verifies.
+    #[test]
+    fn a_run_receipt_folds_the_engine_certificate_and_verifies() {
+        use crate::proof::ir::semantic_ir_hash;
+
+        let wf = nika_schema::parse(
+            "nika: v1\nworkflow:\n  id: pay\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        let proves = semantic_ir_hash(&wf).expect("projectable");
+
+        // Judge one obligation at its honest level (no_secret_egress is static).
+        let property = AssertProperty::NoSecretEgress;
+        let judged = vec![(property.clone(), property.level(false))];
+
+        let receipt = build_run_receipt(
+            &proves,
+            &report.certificate,
+            &judged,
+            json!({ "outcome": "success" }),
+            "blake3:lockdigest",
+        );
+
+        // The receipt proves THIS workflow's semantic hash and verifies.
+        assert!(
+            verify(&receipt, proves.as_hex()),
+            "the run receipt verifies"
+        );
+        // The engine's real certificate is folded in (attempts · effects · bound).
+        assert!(
+            receipt["certificate"].is_object(),
+            "the RunCertificate is folded, not a placeholder"
+        );
+        // The judged assertion rides with its honest level.
+        assert_eq!(
+            receipt["assertions"][0]["assert"],
+            json!("no_secret_egress")
+        );
+        assert_eq!(receipt["assertions"][0]["level"], json!("StaticProof"));
+        assert_eq!(receipt["lock_digest"], json!("blake3:lockdigest"));
+        // It does NOT verify against a different workflow's identity.
+        assert!(!verify(&receipt, "blake3:someotherworkflow"));
     }
 }

--- a/crates/nika-runtime/src/proof/receipt.rs
+++ b/crates/nika-runtime/src/proof/receipt.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `receipt_format: 1` — the one receipt (spec 15 §the one receipt).
+//!
+//! A run's receipt folds FOUR things into one shape — the check certificate
+//! (05 · attempts · effects · cost bound), the trace verdict (13 Outcome +
+//! chain integrity), each `assert:` judged with its level, and the
+//! `nika.lock` digest the run resolved under — and `proves` the run's
+//! semantic hash ([`crate::proof::semantic_hash`]). The Decision Receipt
+//! ([`nika_builtin::decide`] · `decision_receipt_format: 1`) and the registry
+//! certificate become INSTANCES of this shape — one voice, three surfaces.
+//!
+//! The receipt is domain-separated ([`HashDomain::Receipt`]) and Merkle-linked
+//! to the semantic hash it proves: given a receipt you can [`verify`] it
+//! proves *this* workflow and no other.
+//!
+//! ## Parity (spec 15 · the second evaluator)
+//!
+//! [`build_receipt`] mirrors `proof_core.build_receipt` — the FOLD structure
+//! is byte-equal on the pre-image ([`tests::receipt_fold_matches_the_reference`]
+//! feeds both evaluators a FIXED `proves` string to isolate the fold from the
+//! hash algorithm, since `proves` carries the algo-dependent digest). The
+//! `digest` itself differs (the reference's sha256 vs this engine's blake3) —
+//! the parity is on the bytes, never across algorithms.
+
+use serde_json::{Map, Value};
+
+use crate::proof::{HashDomain, hash_in_domain};
+
+/// The v1 receipt format — the `receipt_format` field value AND the pre-image
+/// format version (the reference's `RECEIPT_FORMAT`).
+pub const RECEIPT_FORMAT: u32 = 1;
+
+/// The receipt's own digest field key — computed over the fold, then added
+/// (so the digest covers the six folded fields, never itself · the
+/// reference's `receipt["digest"] = ...` after construction).
+const DIGEST_KEY: &str = "digest";
+
+/// Fold a run's proof into `receipt_format: 1` (spec 15 · mirror of
+/// `proof_core.build_receipt`).
+///
+/// - `proves` — the run's semantic hash hex (the identity this receipt is
+///   about · [`crate::proof::SemanticHash::as_hex`]).
+/// - `certificate` — the check certificate (05).
+/// - `trace_verdict` — the trace-verify result (13 Outcome + chain integrity).
+/// - `assertions` — each `assert:` judged with its level.
+/// - `lock_digest` — the `nika.lock` digest this run resolved under.
+///
+/// The returned value is the six folded fields plus a `digest` (blake3 over
+/// the `receipt`-domain pre-image of the six). Canonicalization sorts the
+/// keys, so field construction order never leaks into the digest.
+#[must_use]
+pub fn build_receipt(
+    proves: &str,
+    certificate: Value,
+    trace_verdict: Value,
+    assertions: Vec<Value>,
+    lock_digest: &str,
+) -> Value {
+    // Build the fold by owned insert (the folded parts are MOVED in — the
+    // certificate/verdict/assertions are consumed, not cloned).
+    let mut obj = Map::new();
+    obj.insert("receipt_format".to_owned(), Value::from(RECEIPT_FORMAT));
+    obj.insert("proves".to_owned(), Value::String(proves.to_owned()));
+    obj.insert("certificate".to_owned(), certificate);
+    obj.insert("trace_verdict".to_owned(), trace_verdict);
+    obj.insert("assertions".to_owned(), Value::Array(assertions));
+    obj.insert(
+        "lock_digest".to_owned(),
+        Value::String(lock_digest.to_owned()),
+    );
+    // The digest covers the six folded fields, never itself (the reference's
+    // `receipt["digest"] = ...` after construction · canonical sorts keys).
+    let digest = hash_in_domain(
+        HashDomain::Receipt,
+        RECEIPT_FORMAT,
+        &Value::Object(obj.clone()),
+    );
+    obj.insert(DIGEST_KEY.to_owned(), Value::String(digest));
+    Value::Object(obj)
+}
+
+/// Verify a receipt proves a GIVEN semantic hash and no other (spec 15 · the
+/// Merkle link): `proves` matches, AND the stored `digest` recomputes over the
+/// six-field body. A tampered field (or a swapped `proves`) breaks the digest.
+#[must_use]
+pub fn verify(receipt: &Value, expected_semantic: &str) -> bool {
+    let Some(obj) = receipt.as_object() else {
+        return false;
+    };
+    if obj.get("proves").and_then(Value::as_str) != Some(expected_semantic) {
+        return false;
+    }
+    let Some(stored) = obj.get(DIGEST_KEY).and_then(Value::as_str) else {
+        return false;
+    };
+    // Recompute over the body WITHOUT the digest (the fold's pre-image).
+    let mut body = obj.clone();
+    body.remove(DIGEST_KEY);
+    let recomputed = hash_in_domain(HashDomain::Receipt, RECEIPT_FORMAT, &Value::Object(body));
+    recomputed == stored
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::proof::{FORMAT_VERSION, semantic_hash};
+
+    fn sample() -> Value {
+        build_receipt(
+            "blake3:fixedsem",
+            json!({"attempts": 1}),
+            json!({"outcome": "success"}),
+            vec![json!({"assert": "no_secret_egress", "level": "StaticProof"})],
+            "blake3:lock",
+        )
+    }
+
+    #[test]
+    fn the_receipt_proves_its_semantic_hash() {
+        let sem = semantic_hash(&json!({"workflow": "w"}), FORMAT_VERSION);
+        let r = build_receipt(
+            sem.as_hex(),
+            json!({"attempts": 1}),
+            json!({"outcome": "success"}),
+            vec![],
+            "blake3:lock",
+        );
+        assert_eq!(r["proves"], json!(sem.as_hex()));
+        assert_eq!(r["receipt_format"], json!(1));
+    }
+
+    #[test]
+    fn the_receipt_is_self_digesting_and_verifies() {
+        let r = sample();
+        let digest = r["digest"].as_str().expect("a digest");
+        assert_eq!(digest.len(), 64, "blake3 hex");
+        assert!(
+            verify(&r, "blake3:fixedsem"),
+            "an untampered receipt verifies"
+        );
+    }
+
+    #[test]
+    fn a_tampered_receipt_or_swapped_proof_is_rejected() {
+        let r = sample();
+        // Wrong expected semantic → the Merkle link refuses.
+        assert!(!verify(&r, "blake3:someother"));
+        // Tamper a folded field → the digest no longer recomputes.
+        let mut tampered = r.as_object().unwrap().clone();
+        tampered.insert("lock_digest".to_owned(), json!("blake3:forged"));
+        assert!(!verify(&Value::Object(tampered), "blake3:fixedsem"));
+    }
+
+    /// The FOLD-structure differential: the receipt pre-image (the six folded
+    /// fields, `proves` fixed to isolate the hash algo) is byte-equal to the
+    /// reference's `preimage("receipt", 1, receipt)` — the golden produced by
+    /// `conformance/proof_core.py`.
+    #[test]
+    fn receipt_fold_matches_the_reference() {
+        let r = sample();
+        let mut body = r.as_object().unwrap().clone();
+        body.remove(DIGEST_KEY);
+        let canon = crate::proof::canonical(&Value::Object(body));
+        assert_eq!(
+            canon,
+            r#"{"assertions":[{"assert":"no_secret_egress","level":"StaticProof"}],"certificate":{"attempts":1},"lock_digest":"blake3:lock","proves":"blake3:fixedsem","receipt_format":1,"trace_verdict":{"outcome":"success"}}"#
+        );
+        assert_eq!(
+            format!("receipt\u{0}1\u{0}{canon}"),
+            "receipt\u{0}1\u{0}{\"assertions\":[{\"assert\":\"no_secret_egress\",\"level\":\"StaticProof\"}],\"certificate\":{\"attempts\":1},\"lock_digest\":\"blake3:lock\",\"proves\":\"blake3:fixedsem\",\"receipt_format\":1,\"trace_verdict\":{\"outcome\":\"success\"}}"
+        );
+    }
+}

--- a/crates/nika-runtime/src/resume.rs
+++ b/crates/nika-runtime/src/resume.rs
@@ -428,7 +428,13 @@ fn skill_paths(task: &RawTask) -> Vec<&str> {
 /// on any `#[non_exhaustive]` form this recipe does not know. (W2
 /// re-keyed the definition — `after:` replaced `depends_on` · prior
 /// resume caches re-run one-shot, the assumed pre-1.0 cost.)
-fn definition_value(task: &RawTask) -> Option<Value> {
+///
+/// `pub(crate)` because the W6 semantic hash ([`crate::proof::ir`]) reuses
+/// THIS span-free desugared projection as a task's semantic subtree — one
+/// canonicalization discipline for both the resume identity and the
+/// semantic hash it generalizes (spec 15 · "seed: the `ResumeKey`'s
+/// JCS+blake3 definition hash, generalized").
+pub(crate) fn definition_value(task: &RawTask) -> Option<Value> {
     Some(json!({
         "after": task.after.iter()
             .map(|(target, pred)| json!([target.value, pred.value.as_str()]))
@@ -1256,6 +1262,134 @@ mod trace_carry_tests {
             .await
             .expect("clean run");
         (outcome, sink)
+    }
+
+    /// Run an arbitrary workflow YAML over mock seams with an optional resume
+    /// plan — the generic twin of [`run_two_tasks`] (used by the semantic-
+    /// cache-hit proof, which needs two DIFFERENT spellings).
+    async fn run_yaml(
+        yaml: &str,
+        shell: MockShell,
+        plan: Option<super::ResumePlan>,
+    ) -> (crate::RunOutcome, VecSink) {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(report.is_clean());
+        let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+        let mut runtime = Runtime::new(
+            ExecVerb::new(Arc::new(shell)),
+            Arc::clone(&invoke),
+            InferVerb::new(registry, "mock/echo"),
+            AgentVerb::new(
+                Arc::new(MockProvider::new("mock")),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default(),
+        );
+        if let Some(plan) = plan {
+            runtime = runtime.with_resume_plan(plan);
+        }
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let outcome = runtime
+            .run(&wf, &report, &mut stamper, &mut sink)
+            .await
+            .expect("clean run");
+        (outcome, sink)
+    }
+
+    /// **The semantic-cache HIT** (spec 15 · unblocks 14 §law 10's `owed`):
+    /// a result computed for ONE spelling is REUSED for a DIFFERENT,
+    /// semantically-equal spelling — the reuse is keyed on the canonical
+    /// semantic identity (the `def_hash`/`input_hash` that JCS-canonicalizes
+    /// authored `with:` order away · the W6 semantic hash generalizes this),
+    /// NEVER on the source bytes. This is a genuine PROVEN reuse: the second
+    /// run's shell has NO response queued for `a`, so a cache MISS would
+    /// starve it — the green run is the demonstration that `a` never
+    /// dispatched, its prior result served on semantic identity alone.
+    #[tokio::test]
+    async fn a_result_is_reused_across_a_semantically_equal_respelling() {
+        // Two spellings that MEAN the same workflow: `with:` map order is not
+        // behavior (spec 15 · proven canonical in `with_declaration_order_is_
+        // canonicalized_away`). `b` is a live downstream so the run is not
+        // trivially all-cache-hit — `a`'s reuse is the claim under test.
+        const SPELL_A: &str = "nika: v1\nworkflow:\n  id: sem\ntasks:\n  a:\n    with: { x: \"1\", y: \"2\" }\n    exec: { command: [\"echo\", \"${{ with.x }}${{ with.y }}\"] }\n  b:\n    with: { prev: \"${{ tasks.a.output }}\" }\n    exec: { command: [\"echo\", \"done\", \"${{ with.prev }}\"] }\n";
+        const SPELL_B: &str = "nika: v1\nworkflow:\n  id: sem\ntasks:\n  a:\n    with: { y: \"2\", x: \"1\" }\n    exec: { command: [\"echo\", \"${{ with.x }}${{ with.y }}\"] }\n  b:\n    with: { prev: \"${{ tasks.a.output }}\" }\n    exec: { command: [\"echo\", \"done\", \"${{ with.prev }}\"] }\n";
+
+        // 1. Run spelling A — harvest a's journaled semantic identity + output.
+        let (first, sink) = run_yaml(
+            SPELL_A,
+            MockShell::new().enqueue_ok("12\n").enqueue_ok("done 12\n"),
+            None,
+        )
+        .await;
+        assert!(first.ok);
+        assert!(first.cache_hits.is_empty(), "a fresh run never cache-hits");
+        let completed_a = sink
+            .events()
+            .iter()
+            .find(|e| e.kind == EventKind::TaskCompleted && str_field(e, "task") == Some("a"))
+            .expect("a completed");
+        let plan = super::ResumePlan::from([(
+            "a".to_owned(),
+            super::PriorSuccess::new(
+                str_field(completed_a, super::fields::DEF_HASH)
+                    .expect("def_hash")
+                    .to_owned(),
+                str_field(completed_a, super::fields::INPUT_HASH)
+                    .expect("input_hash")
+                    .to_owned(),
+                serde_json::from_str(
+                    str_field(completed_a, super::fields::OUTPUT).expect("output"),
+                )
+                .expect("output parses"),
+            ),
+        )]);
+
+        // 2. Resume the OTHER spelling with A's plan. Only b's response is
+        //    queued — a MUST cache-hit on semantic identity, never dispatch.
+        let (resumed, sink) = run_yaml(
+            SPELL_B,
+            MockShell::new().enqueue_ok("done 12\n"),
+            Some(plan),
+        )
+        .await;
+        assert!(resumed.ok);
+        assert_eq!(
+            resumed.cache_hits,
+            vec!["a".to_owned()],
+            "the respelled task reuses the prior result on semantic identity"
+        );
+        let kinds_for = |task: &str| {
+            sink.events()
+                .iter()
+                .filter(|e| str_field(e, "task") == Some(task))
+                .map(|e| e.kind)
+                .collect::<Vec<_>>()
+        };
+        assert!(
+            kinds_for("a").contains(&EventKind::TaskCacheHit),
+            "the reuse is VISIBLE (task_cache_hit)"
+        );
+        assert!(
+            !kinds_for("a").contains(&EventKind::TaskStarted),
+            "a never re-executed — the different spelling did not defeat the cache"
+        );
+        assert!(
+            kinds_for("b").contains(&EventKind::TaskStarted),
+            "b ran live"
+        );
+        // Rehydration parity: the reused output equals the first run's.
+        assert_eq!(resumed.records["a"].output, first.records["a"].output);
     }
 
     /// The full ADR-099 fold: run → read the journaled identity → resume

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -2998,6 +2998,7 @@ impl<T> nika_error::traits::AsAny for nika_schema::raw::task::RawTask where T: '
 pub fn nika_schema::raw::task::RawTask::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub mod nika_schema::raw::workflow
 #[non_exhaustive] pub struct nika_schema::raw::workflow::RawWorkflow
+pub nika_schema::raw::workflow::RawWorkflow::assert: alloc::vec::Vec<nika_source::span::Spanned<nika_vocab::assert::AssertProperty>>
 pub nika_schema::raw::workflow::RawWorkflow::description: core::option::Option<nika_source::span::Spanned<alloc::string::String>>
 pub nika_schema::raw::workflow::RawWorkflow::env: alloc::vec::Vec<(nika_source::span::Spanned<alloc::string::String>, nika_source::span::Spanned<alloc::string::String>)>
 pub nika_schema::raw::workflow::RawWorkflow::model: core::option::Option<nika_source::span::Spanned<alloc::string::String>>
@@ -3489,6 +3490,7 @@ pub fn nika_schema::raw::task::RawTask::__clone_box(&self, _: dyn_clone::sealed:
 impl<T> nika_error::traits::AsAny for nika_schema::raw::task::RawTask where T: 'static
 pub fn nika_schema::raw::task::RawTask::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_schema::raw::RawWorkflow
+pub nika_schema::raw::RawWorkflow::assert: alloc::vec::Vec<nika_source::span::Spanned<nika_vocab::assert::AssertProperty>>
 pub nika_schema::raw::RawWorkflow::description: core::option::Option<nika_source::span::Spanned<alloc::string::String>>
 pub nika_schema::raw::RawWorkflow::env: alloc::vec::Vec<(nika_source::span::Spanned<alloc::string::String>, nika_source::span::Spanned<alloc::string::String>)>
 pub nika_schema::raw::RawWorkflow::model: core::option::Option<nika_source::span::Spanned<alloc::string::String>>

--- a/crates/nika-schema/src/parser/envelope.rs
+++ b/crates/nika-schema/src/parser/envelope.rs
@@ -10,8 +10,8 @@ use marked_yaml::types::MarkedMappingNode;
 use crate::error::SchemaError;
 use crate::source::Spanned;
 use crate::types::{
-    EgressRule, ExecPermit, FsPermits, NetPermits, OutputDecl, Permits, Policy, SecretRef,
-    SecretSource, VarDecl, VarType,
+    AssertProperty, EgressRule, ExecPermit, FsPermits, NetPermits, OutputDecl, Permits, Policy,
+    SecretRef, SecretSource, VarDecl, VarType,
 };
 
 use super::{Cx, value::json_value};
@@ -272,6 +272,42 @@ fn parse_egress(
     Ok(rules)
 }
 
+/// Parse the workflow-level `assert:` block (spec 15 §assert) — a list of the
+/// author's obligations, each parsed into the closed [`AssertProperty`]
+/// vocabulary. An unknown property, a non-v1 shape, or a malformed body is a
+/// refusal at check (`NIKA-ASSERT-001`, carried by the vocab refusal). The
+/// engine JUDGES each obligation's honest level (nika-vocab `level`); wiring
+/// the check-time genuine decision (does `before`/`bounded` hold on the
+/// derived graph?) and `nika trace verify` reporting is the named owed — this
+/// parse makes the obligations authorable and typed, refusing the malformed.
+pub(super) fn parse_assert(
+    cx: &Cx<'_>,
+    workflow: &MarkedMappingNode,
+) -> Result<Vec<Spanned<AssertProperty>>, SchemaError> {
+    let Some(node) = workflow.get_node("assert") else {
+        return Ok(Vec::new());
+    };
+    let Some(seq) = node.as_sequence() else {
+        return Err(SchemaError::Validation {
+            message: "`assert:` must be a list of obligations (spec 15 §assert · \
+                      NIKA-ASSERT-001)"
+                .to_owned(),
+            span: cx.span(node.span()),
+        });
+    };
+    let mut out = Vec::with_capacity(seq.len());
+    for item in seq.iter() {
+        let value = json_value(cx, item)?;
+        let property =
+            AssertProperty::parse(&value).map_err(|refusal| SchemaError::Validation {
+                message: refusal.message,
+                span: cx.span(item.span()),
+            })?;
+        out.push(Spanned::new(property, cx.span_or_zero(item.span())));
+    }
+    Ok(out)
+}
+
 /// Parse one `egress[]` entry into an [`EgressRule`].
 fn parse_egress_rule(
     cx: &Cx<'_>,
@@ -527,6 +563,58 @@ mod tests {
 
     fn parse_strict(yaml: &str) -> Result<crate::raw::RawWorkflow, SchemaError> {
         parse(yaml, FileId::new(0), ParseMode::Strict)
+    }
+
+    /// The `assert:` block (spec 15 §assert) lowers to the typed obligation
+    /// vocabulary; an unknown property is refused at parse with the
+    /// `NIKA-ASSERT-001` code the reference names.
+    #[test]
+    fn assert_block_parses_obligations_and_refuses_the_unknown() {
+        let ok = "\
+nika: v1
+workflow:
+  id: gated
+assert:
+  - no_secret_egress
+  - before: { first: gate, second: deploy }
+  - bounded: { task: crawl, max_iterations: 100 }
+tasks:
+  gate:
+    exec: { command: [\"true\"] }
+";
+        let wf = parse_strict(ok).expect("a valid assert: block parses");
+        assert_eq!(wf.assert.len(), 3, "three obligations parse");
+        assert_eq!(wf.assert[0].value.name(), "no_secret_egress");
+        assert_eq!(wf.assert[1].value.name(), "before");
+        assert_eq!(wf.assert[2].value.name(), "bounded");
+
+        let bad = "\
+nika: v1
+workflow:
+  id: gated
+assert:
+  - telepathy: {}
+tasks:
+  gate:
+    exec: { command: [\"true\"] }
+";
+        let err = parse_strict(bad).expect_err("an unknown assert property is refused");
+        assert!(
+            err.to_string().contains("NIKA-ASSERT-001"),
+            "the spec-15 refusal code rides: {err}"
+        );
+
+        // A non-list `assert:` is refused too (it is a list of obligations).
+        let not_a_list = "\
+nika: v1
+workflow:
+  id: gated
+assert: no_secret_egress
+tasks:
+  gate:
+    exec: { command: [\"true\"] }
+";
+        assert!(parse_strict(not_a_list).is_err(), "assert: must be a list");
     }
 
     /// T1 (use-case battery 2026-07-11) · an unknown secret field with no

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -51,7 +51,7 @@ pub enum ParseMode {
 /// `09-types.md` `types:` + `10-authority.md` `policy:`).
 const TOP_LEVEL_KEYS: &[&str] = &[
     "nika", "workflow", "model", "vars", "env", "secrets", "permits", "policy", "types", "tasks",
-    "outputs",
+    "outputs", "assert",
 ];
 
 /// Parse a YAML string into a [`RawWorkflow`].
@@ -160,6 +160,7 @@ pub fn parse(yaml: &str, file_id: FileId, mode: ParseMode) -> Result<RawWorkflow
     workflow.policy = envelope::parse_policy(&cx, mapping)?;
     workflow.types = envelope::parse_types(&cx, mapping)?;
     workflow.outputs = envelope::parse_outputs(&cx, mapping)?;
+    workflow.assert = envelope::parse_assert(&cx, mapping)?;
     workflow.tasks = tasks::parse_tasks(&cx, mapping)?;
 
     Ok(workflow)

--- a/crates/nika-schema/src/raw/workflow.rs
+++ b/crates/nika-schema/src/raw/workflow.rs
@@ -18,7 +18,9 @@
 //! ```
 
 use crate::source::Spanned;
-use crate::types::{OutputDecl, Permits, Policy, SchemaVersion, SecretRef, VarDecl};
+use crate::types::{
+    AssertProperty, OutputDecl, Permits, Policy, SchemaVersion, SecretRef, VarDecl,
+};
 
 use super::task::RawTask;
 
@@ -59,6 +61,10 @@ pub struct RawWorkflow {
     pub tasks: Vec<Spanned<RawTask>>,
     /// `outputs:` — the workflow's return contract.
     pub outputs: Vec<(Spanned<String>, OutputDecl)>,
+    /// `assert:` — the author's obligations (spec 15 §assert · the closed
+    /// vocabulary the engine judges at an honest level · malformed refused
+    /// `NIKA-ASSERT-001`).
+    pub assert: Vec<Spanned<AssertProperty>>,
 }
 
 impl RawWorkflow {
@@ -78,6 +84,7 @@ impl RawWorkflow {
             types: Vec::new(),
             tasks: Vec::new(),
             outputs: Vec::new(),
+            assert: Vec::new(),
         }
     }
 }

--- a/crates/nika-vocab/src/assert.rs
+++ b/crates/nika-vocab/src/assert.rs
@@ -34,7 +34,7 @@
 //!
 //! [`AssertProperty::level`] and [`AssertProperty::check_claim`] mirror
 //! `proof_core.assert_level` + `proof_core.check_assert_claim` — the eight
-//! assert laws of `proof_core_selftest.py` are pinned in [`tests`].
+//! assert laws of `proof_core_selftest.py` are pinned in `tests`.
 //!
 //! ## Honest scope (spec 15 · what this is)
 //!

--- a/crates/nika-vocab/src/assert.rs
+++ b/crates/nika-vocab/src/assert.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `assert:` — the author's obligations (spec `15-proof.md` §assert).
+//!
+//! A task or workflow declares assertions the engine JUDGES — distinct from
+//! `nika:assert` (the single-condition fail-fast builtin). `assert:` is a
+//! **closed vocabulary** of properties, each judged at an HONEST level:
+//!
+//! ```yaml
+//! assert:
+//!   - no_secret_egress                       # the flow laws of spec 10 hold
+//!   - eventually: { task: deploy, state: success }
+//!   - before: { first: gate, second: deploy }
+//!   - bounded: { task: crawl, max_iterations: 100 }
+//!   - resource: { cost_usd: { max: 5.00 } }
+//! ```
+//!
+//! ## The three levels · claim ≤ evidence (normative)
+//!
+//! - [`AssertLevel::StaticProof`] — decidable at `nika check` on the graph/IR
+//!   (an ordering law · a static bound). The strongest, claimable ONLY when
+//!   the check genuinely decides it.
+//! - [`AssertLevel::TraceVerified`] — decided by `nika trace verify` against a
+//!   completed run's trace (spec 13). What only the trace can see is judged
+//!   there, never optimistically promoted to `StaticProof`.
+//! - [`AssertLevel::Unknown`] — honestly unresolved. Never dressed up.
+//!
+//! A [`AssertLevel::StaticProof`] claim the IR cannot decide is itself a
+//! refusal ([`NIKA_ASSERT_001`]). Bounded/statistical assertions stay LAB
+//! (calibrated research · never a shipped guarantee).
+//!
+//! ## The second evaluator
+//!
+//! [`AssertProperty::level`] and [`AssertProperty::check_claim`] mirror
+//! `proof_core.assert_level` + `proof_core.check_assert_claim` — the eight
+//! assert laws of `proof_core_selftest.py` are pinned in [`tests`].
+//!
+//! ## Honest scope (spec 15 · what this is)
+//!
+//! This module owns the CLASS-level leveling: which properties are statically
+//! decidable at all (`before` · `bounded` · `no_secret_egress`) versus
+//! trace-settled (`eventually` · `resource`), and the claim-≤-evidence guard.
+//! Whether `nika check` GENUINELY decides a specific `before`/`bounded`
+//! INSTANCE on the derived graph (and may thus honestly claim `StaticProof`
+//! for it), and `nika trace verify` judging the trace-level assertions
+//! against a real Outcome IR (spec 13), are the deeper integrations — named
+//! owed, never simulated.
+
+use serde_json::Value;
+
+/// The mis-leveled-obligation refusal code (spec 15 · canon.yaml
+/// `validation_error`).
+pub const NIKA_ASSERT_001: &str = "NIKA-ASSERT-001";
+
+/// The honest level an assertion is judged at (spec 15 · the reference's
+/// `ASSERT_LEVELS`, weakest → strongest by [`AssertLevel::rank`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum AssertLevel {
+    /// Honestly unresolved — no static check and no available trace settles it.
+    Unknown,
+    /// Decided by `nika trace verify` against a completed run's trace (13).
+    TraceVerified,
+    /// Decidable at `nika check` on the graph/IR — the strongest.
+    StaticProof,
+}
+
+impl AssertLevel {
+    /// The evidence rank (weakest 0 → strongest 2) — the reference's `rank`
+    /// map. A claim outranking the achievable evidence is refused.
+    #[must_use]
+    pub const fn rank(self) -> u8 {
+        match self {
+            Self::Unknown => 0,
+            Self::TraceVerified => 1,
+            Self::StaticProof => 2,
+        }
+    }
+
+    /// The wire spelling (the reference's level strings).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::TraceVerified => "TraceVerified",
+            Self::StaticProof => "StaticProof",
+        }
+    }
+}
+
+/// The closed vocabulary of `assert:` properties (spec 15). A property outside
+/// the five is not a v1 assertion — [`AssertProperty::parse`] refuses it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AssertProperty {
+    /// `no_secret_egress` — no secret reaches an unsanctioned sink (the flow
+    /// laws of spec 10 hold across the whole run). Statically decidable.
+    NoSecretEgress,
+    /// `eventually: { task, state }` — the named task reaches the named
+    /// terminal state (the Outcome of spec 13). Trace-settled.
+    Eventually {
+        /// The task that must reach a terminal state.
+        task: String,
+        /// The terminal state it must reach.
+        state: String,
+    },
+    /// `before: { first, second }` — an ordering law on the derived graph
+    /// (spec 03). Statically decidable.
+    Before {
+        /// The task that must run first.
+        first: String,
+        /// The task that must run after.
+        second: String,
+    },
+    /// `bounded: { task, max_iterations }` — a `for_each`/agent loop stays
+    /// under its cap. Statically decidable.
+    Bounded {
+        /// The bounded loop task.
+        task: String,
+        /// The iteration cap.
+        max_iterations: u64,
+    },
+    /// `resource: { cost_usd: { max } }` — the symbolic certificate's cost
+    /// bound (spec 05) holds. Trace-settled. The money rides as its authored
+    /// string (no float field · the fixed-point discipline of spec 11/05).
+    Resource {
+        /// The `cost_usd.max` ceiling, as authored (float-free carrier).
+        cost_usd_max: String,
+    },
+}
+
+/// An `assert:` refusal (spec 15 · [`NIKA_ASSERT_001`]). A plain data carrier,
+/// NOT a `thiserror` enum — it never crosses a `NikaErrorCode` boundary (the
+/// `decide.rs` `DecideError` posture, so nika-vocab keeps its single
+/// allowlisted `GoDurationError`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AssertRefusal {
+    /// Always [`NIKA_ASSERT_001`].
+    pub code: &'static str,
+    /// The human-readable law that refused.
+    pub message: String,
+}
+
+impl AssertRefusal {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            code: NIKA_ASSERT_001,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for AssertRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl AssertProperty {
+    /// The property name (the reference's `_property_name`) — the token that
+    /// drives leveling.
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::NoSecretEgress => "no_secret_egress",
+            Self::Eventually { .. } => "eventually",
+            Self::Before { .. } => "before",
+            Self::Bounded { .. } => "bounded",
+            Self::Resource { .. } => "resource",
+        }
+    }
+
+    /// Statically decidable at `nika check` (`before` · `bounded` ·
+    /// `no_secret_egress`) — the reference's `STATIC_PROPERTIES`.
+    #[must_use]
+    const fn is_static(&self) -> bool {
+        matches!(
+            self,
+            Self::NoSecretEgress | Self::Before { .. } | Self::Bounded { .. }
+        )
+    }
+
+    /// The HONEST level this assertion can be judged at right now (spec 15 ·
+    /// mirror of `proof_core.assert_level`): `StaticProof` iff statically
+    /// decidable · else `TraceVerified` when a trace exists · else `Unknown`.
+    /// Never optimistic — a trace property is never promoted to `StaticProof`.
+    #[must_use]
+    pub const fn level(&self, trace_available: bool) -> AssertLevel {
+        if self.is_static() {
+            AssertLevel::StaticProof
+        } else if trace_available {
+            AssertLevel::TraceVerified
+        } else {
+            AssertLevel::Unknown
+        }
+    }
+
+    /// Check a CLAIMED level against the evidence (spec 15 · mirror of
+    /// `proof_core.check_assert_claim`): a claim outranking what the evidence
+    /// supports is a refusal ([`NIKA_ASSERT_001`] · claim ≤ evidence). A
+    /// `StaticProof` claim on a trace-only property, or a `TraceVerified`
+    /// claim with no trace, is refused. (The reference's "level not in the
+    /// set" guard is here unrepresentable — [`AssertLevel`] is closed.)
+    ///
+    /// # Errors
+    ///
+    /// [`AssertRefusal`] ([`NIKA_ASSERT_001`]) when `claimed` outranks the
+    /// achievable level.
+    pub fn check_claim(
+        &self,
+        claimed: AssertLevel,
+        trace_available: bool,
+    ) -> Result<(), AssertRefusal> {
+        let achievable = self.level(trace_available);
+        if claimed.rank() > achievable.rank() {
+            return Err(AssertRefusal::new(format!(
+                "assert · {} claims {} but the evidence only supports {} \
+                 (claim ≤ evidence · {NIKA_ASSERT_001})",
+                self.name(),
+                claimed.as_str(),
+                achievable.as_str()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Parse an authored assertion — a bare string (`no_secret_egress`) OR a
+    /// single-key map (`{ before: { … } }`) — into the closed vocabulary
+    /// (spec 15 · the reference's `_property_name` + the closed-set gate). A
+    /// property outside the five, or a malformed body, is a refusal
+    /// ([`NIKA_ASSERT_001`]).
+    ///
+    /// # Errors
+    ///
+    /// [`AssertRefusal`] on an unknown property, a non-v1 shape, or a
+    /// malformed body.
+    pub fn parse(value: &Value) -> Result<Self, AssertRefusal> {
+        match value {
+            // The one param-less form is authored as a bare string.
+            Value::String(s) if s == "no_secret_egress" => Ok(Self::NoSecretEgress),
+            Value::String(other) => Err(AssertRefusal::new(format!(
+                "assert · {other:?} is not a v1 assertion property \
+                 (the only bare form is `no_secret_egress` · {NIKA_ASSERT_001})"
+            ))),
+            // The single-key map — its key is the property name (len==1
+            // guarantees exactly one entry).
+            Value::Object(map) if map.len() == 1 => match map.iter().next() {
+                Some((name, body)) => Self::parse_keyed(name, body),
+                None => Err(AssertRefusal::new(format!(
+                    "assert · empty assertion map ({NIKA_ASSERT_001})"
+                ))),
+            },
+            other => Err(AssertRefusal::new(format!(
+                "assert · not a v1 assertion property (a bare string or a \
+                 single-key map · got {other} · {NIKA_ASSERT_001})"
+            ))),
+        }
+    }
+
+    /// The single-key-map forms (`before`/`eventually`/`bounded`/`resource`)
+    /// — an unknown key is the "not a v1 assertion property" refusal.
+    fn parse_keyed(name: &str, body: &Value) -> Result<Self, AssertRefusal> {
+        match name {
+            "before" => Ok(Self::Before {
+                first: string_field(body, name, "first")?,
+                second: string_field(body, name, "second")?,
+            }),
+            "eventually" => Ok(Self::Eventually {
+                task: string_field(body, name, "task")?,
+                state: string_field(body, name, "state")?,
+            }),
+            "bounded" => Ok(Self::Bounded {
+                task: string_field(body, name, "task")?,
+                max_iterations: u64_field(body, name, "max_iterations")?,
+            }),
+            "resource" => Ok(Self::Resource {
+                cost_usd_max: cost_max(body)?,
+            }),
+            other => Err(AssertRefusal::new(format!(
+                "assert · {other:?} is not a v1 assertion property \
+                 (the set is closed · {NIKA_ASSERT_001})"
+            ))),
+        }
+    }
+}
+
+/// A required string field of an assertion body.
+fn string_field(body: &Value, property: &str, field: &str) -> Result<String, AssertRefusal> {
+    body.get(field)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            AssertRefusal::new(format!(
+                "assert.{property}.{field} · a string is required ({NIKA_ASSERT_001})"
+            ))
+        })
+}
+
+/// A required non-negative integer field (`max_iterations`).
+fn u64_field(body: &Value, property: &str, field: &str) -> Result<u64, AssertRefusal> {
+    body.get(field).and_then(Value::as_u64).ok_or_else(|| {
+        AssertRefusal::new(format!(
+            "assert.{property}.{field} · a non-negative integer is required ({NIKA_ASSERT_001})"
+        ))
+    })
+}
+
+/// The `resource.cost_usd.max` ceiling, carried as its authored numeric
+/// spelling (float-free: the money rides as a string, never a float field).
+fn cost_max(body: &Value) -> Result<String, AssertRefusal> {
+    match body.get("cost_usd").and_then(|c| c.get("max")) {
+        Some(Value::Number(n)) => Ok(n.to_string()),
+        _ => Err(AssertRefusal::new(format!(
+            "assert.resource.cost_usd.max · a number is required ({NIKA_ASSERT_001})"
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn prop(value: Value) -> AssertProperty {
+        AssertProperty::parse(&value).expect("a v1 property")
+    }
+
+    // ── the eight reference assert laws (proof_core_selftest.py) ─────────
+
+    #[test]
+    fn a_static_property_levels_static_proof() {
+        let before = prop(json!({"before": {"first": "a", "second": "b"}}));
+        assert_eq!(before.level(false), AssertLevel::StaticProof);
+    }
+
+    #[test]
+    fn no_secret_egress_is_static_proof() {
+        assert_eq!(
+            prop(json!("no_secret_egress")).level(false),
+            AssertLevel::StaticProof
+        );
+    }
+
+    #[test]
+    fn a_trace_property_with_no_trace_is_unknown() {
+        let ev = prop(json!({"eventually": {"task": "t", "state": "success"}}));
+        assert_eq!(ev.level(false), AssertLevel::Unknown);
+    }
+
+    #[test]
+    fn a_trace_property_with_a_trace_is_trace_verified() {
+        let ev = prop(json!({"eventually": {"task": "t", "state": "success"}}));
+        assert_eq!(ev.level(true), AssertLevel::TraceVerified);
+    }
+
+    #[test]
+    fn claiming_static_proof_on_a_trace_only_property_is_refused() {
+        let ev = prop(json!({"eventually": {"task": "t", "state": "success"}}));
+        let err = ev
+            .check_claim(AssertLevel::StaticProof, true)
+            .expect_err("StaticProof on a trace-only property is refused");
+        assert_eq!(err.code, NIKA_ASSERT_001);
+    }
+
+    #[test]
+    fn claiming_trace_verified_with_no_trace_is_refused() {
+        let res = prop(json!({"resource": {"cost_usd": {"max": 5}}}));
+        let err = res
+            .check_claim(AssertLevel::TraceVerified, false)
+            .expect_err("TraceVerified with no trace is refused (Unknown only)");
+        assert_eq!(err.code, NIKA_ASSERT_001);
+    }
+
+    #[test]
+    fn an_honest_static_proof_claim_is_accepted() {
+        let bounded = prop(json!({"bounded": {"task": "c", "max_iterations": 100}}));
+        bounded
+            .check_claim(AssertLevel::StaticProof, false)
+            .expect("an honest StaticProof claim is accepted");
+    }
+
+    #[test]
+    fn an_unknown_assertion_property_is_refused() {
+        let err = AssertProperty::parse(&json!({"telepathy": {}}))
+            .expect_err("an unknown property is refused");
+        assert_eq!(err.code, NIKA_ASSERT_001);
+        // A bare-string unknown is refused too.
+        assert!(AssertProperty::parse(&json!("telepathy")).is_err());
+    }
+
+    // ── vocabulary shape · parse round-trips the five forms ─────────────
+
+    #[test]
+    fn the_five_forms_parse_to_their_names() {
+        assert_eq!(prop(json!("no_secret_egress")).name(), "no_secret_egress");
+        assert_eq!(
+            prop(json!({"before": {"first": "a", "second": "b"}})).name(),
+            "before"
+        );
+        assert_eq!(
+            prop(json!({"eventually": {"task": "t", "state": "success"}})).name(),
+            "eventually"
+        );
+        assert_eq!(
+            prop(json!({"bounded": {"task": "c", "max_iterations": 3}})).name(),
+            "bounded"
+        );
+        assert_eq!(
+            prop(json!({"resource": {"cost_usd": {"max": 5}}})).name(),
+            "resource"
+        );
+    }
+
+    #[test]
+    fn a_malformed_body_is_refused() {
+        // before without `second`.
+        assert!(AssertProperty::parse(&json!({"before": {"first": "a"}})).is_err());
+        // bounded with a non-integer cap.
+        assert!(
+            AssertProperty::parse(&json!({"bounded": {"task": "c", "max_iterations": "x"}}))
+                .is_err()
+        );
+        // resource without cost_usd.max.
+        assert!(AssertProperty::parse(&json!({"resource": {}})).is_err());
+        // a two-key map is not a v1 assertion shape.
+        assert!(AssertProperty::parse(&json!({"before": {}, "after": {}})).is_err());
+    }
+
+    #[test]
+    fn the_levels_rank_weakest_to_strongest() {
+        assert!(AssertLevel::Unknown.rank() < AssertLevel::TraceVerified.rank());
+        assert!(AssertLevel::TraceVerified.rank() < AssertLevel::StaticProof.rank());
+    }
+}

--- a/crates/nika-vocab/src/lib.rs
+++ b/crates/nika-vocab/src/lib.rs
@@ -33,6 +33,7 @@
 )]
 
 pub mod after;
+pub mod assert;
 pub mod capture;
 pub mod decode;
 pub mod duration;
@@ -48,6 +49,7 @@ pub mod when_gate;
 
 // Re-exports for convenience.
 pub use after::AfterPredicate;
+pub use assert::{AssertLevel, AssertProperty, AssertRefusal, NIKA_ASSERT_001};
 pub use capture::CaptureMode;
 pub use decode::DecodeMode;
 pub use duration::{GoDurationError, parse_go_duration};


### PR DESCRIPTION
**W6 « la preuve » — the last pre-1.0 wave.** Realizes spec `15-proof.md` (merged #109). Everything before made a workflow *checkable*; this makes a run *provable and portable*. Closes the pre-1.0 program (W1–W6 + W-DEC + W-COMP per G2).

## The four subsystems
| Subsystem | Where | Guarantee |
|---|---|---|
| **Semantic hash** `H = H(domain ‖ format_version ‖ JCS(SemanticIR))` | `nika-runtime/src/proof/` | `statically_proven` (byte-parity vs `proof_core.py`) |
| **nika.lock** `lock_format:1` · pin-by-default | `nika-pck-manifest/src/nika_lock.rs` | `statically_proven` (2 evaluators) |
| **assert:** closed vocabulary · honest levels | `nika-vocab/src/assert.rs` + `nika-schema` field | `statically_proven` (claim ≤ evidence) |
| **receipt_format:1** the fold | `nika-runtime/src/proof/receipt.rs` | `runtime_enforced` (self-digesting · tamper-rejected) |

## What is genuinely PROVEN (not just specified)
- **Reference-model parity** (byte-equal on the canonical pre-image): `canonical_matches_the_reference`, `preimage_matches_the_reference_goldens`, `receipt_fold_matches_the_reference`. Engine hashes blake3, reference sha256 over the *same* pre-image — differential on the bytes, never the digest.
- **Semantic identity laws**: idempotence, distinct-IRs→distinct-bytes, domain separation, format_version participation, the 7 domains in order, unknown-domain refused. Honest property: semantically-different programs → different canonical encodings; collision resistance is a stated cryptographic assumption, not a promise.
- **Merkle by task**: root commits to every task leaf · a changed task moves its leaf and the root · task order does not change the root · equal respellings share the identity.
- **nika.lock pin-by-default**: unpinned-resolved refused · digest-less refused (parse+validate) · wrong lock_format refused (NIKA-LOCK-001).
- **assert leveling**: claim ≤ evidence · a StaticProof the IR cannot decide is refused (NIKA-ASSERT-001).
- **receipt fold**: proves its semantic hash · self-digesting · tampered/swapped-proof rejected · folds the engine certificate.

## Unblocks W-COMP's owed
**`a_result_is_reused_across_a_semantically_equal_respelling`** — the semantic cache actually reuses a result keyed on semantic identity (14 §law 10). W-COMP named this `owed`; now demonstrated by test, not simulated.

## Green bar
lib **4418/0** (hermetic) · clippy **0** · hygiene all green (doc-private-items fixed) · crate-size within 15k (routed to keep nika-schema off the cap — no split needed) · pre-push gate 83s green.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>