### PR TITLE
feat(lsp): semantic_document_format:1 — the oracle surface names its own version (W7)

### DIFF
--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-a57195347264eaf522599ecd49cec8e16ebbbcd1
+24c3dfdeee7de5181107c02bdda7bc211d167bb8

--- a/crates/nika-lsp/public-api.txt
+++ b/crates/nika-lsp/public-api.txt
@@ -102,6 +102,7 @@ pub mod nika_lsp::analysis::semantic_document
 pub struct nika_lsp::analysis::semantic_document::SemanticDocument
 pub nika_lsp::analysis::semantic_document::SemanticDocument::graph: core::option::Option<nika_graph::GraphDoc>
 pub nika_lsp::analysis::semantic_document::SemanticDocument::reason: core::option::Option<&'static str>
+pub nika_lsp::analysis::semantic_document::SemanticDocument::semantic_document_format: u32
 pub nika_lsp::analysis::semantic_document::SemanticDocument::spans: alloc::collections::btree::map::BTreeMap<alloc::string::String, lsp_types::Range>
 impl core::fmt::Debug for nika_lsp::analysis::semantic_document::SemanticDocument
 pub fn nika_lsp::analysis::semantic_document::SemanticDocument::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -126,6 +127,7 @@ impl<T> core::convert::From<T> for nika_lsp::analysis::semantic_document::Semant
 pub fn nika_lsp::analysis::semantic_document::SemanticDocument::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_lsp::analysis::semantic_document::SemanticDocument where T: 'static
 pub fn nika_lsp::analysis::semantic_document::SemanticDocument::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_lsp::analysis::semantic_document::SEMANTIC_DOCUMENT_FORMAT: u32
 pub fn nika_lsp::analysis::semantic_document::semantic_document(text: &str) -> nika_lsp::analysis::semantic_document::SemanticDocument
 pub mod nika_lsp::analysis::symbols
 pub fn nika_lsp::analysis::symbols::document_symbols(text: &str) -> alloc::vec::Vec<lsp_types::document_symbols::DocumentSymbol>

--- a/crates/nika-lsp/src/analysis/semantic_document.rs
+++ b/crates/nika-lsp/src/analysis/semantic_document.rs
@@ -15,8 +15,10 @@
 //!   has findings (no valid DAG order → nothing to project; the
 //!   diagnostics lane already tells that story).
 //! - `spans` — task id → LSP `Range` of the declaring `id` token.
-//! - the payload names its OWN version via `graph.graph_format`
-//!   (in-payload versioning — additive, spec-first evolution).
+//! - the surface names its OWN version via `semantic_document_format`
+//!   (spec 16 · distinct from the nested `graph.graph_format`, which
+//!   versions the graph; a surface that grows additive fields needs a
+//!   version of its own — in-payload, additive, spec-first evolution).
 //!
 //! Security: structure only. No env values, no secret material — the
 //! projector never carried them.
@@ -30,11 +32,21 @@ use serde::Serialize;
 
 use super::position::LineIndex;
 
+/// The oracle surface's own version (spec 16 · `semantic_document_format`).
+/// Distinct from the nested `graph.graph_format` (which versions the
+/// graph): a surface that grows additive fields — holes · actions ·
+/// capabilities — is versioned here, so a consumer reasons about the
+/// surface without unwrapping the graph.
+pub const SEMANTIC_DOCUMENT_FORMAT: u32 = 1;
+
 /// The `nika/semanticDocument` result — a TYPED contract, not a JSON
 /// bag: renaming a field breaks compilation (and the law tests), never
 /// the wire silently.
 #[derive(Debug, Serialize)]
 pub struct SemanticDocument {
+    /// The surface's own version (spec 16 · [`SEMANTIC_DOCUMENT_FORMAT`]) —
+    /// serialized first, distinct from the nested `graph.graph_format`.
+    pub semantic_document_format: u32,
     /// The canonical projection, verbatim — absent while the document
     /// cannot be projected (see [`Self::reason`]).
     pub graph: Option<GraphDoc>,
@@ -58,6 +70,7 @@ pub fn semantic_document(text: &str) -> SemanticDocument {
     let index = LineIndex::new(text);
     let Ok(wf) = parse(text, FileId::new(0), ParseMode::Lenient) else {
         return SemanticDocument {
+            semantic_document_format: SEMANTIC_DOCUMENT_FORMAT,
             graph: None,
             reason: Some("parse"),
             spans: BTreeMap::new(),
@@ -78,12 +91,14 @@ pub fn semantic_document(text: &str) -> SemanticDocument {
         .collect();
     if report.is_clean() {
         SemanticDocument {
+            semantic_document_format: SEMANTIC_DOCUMENT_FORMAT,
             graph: Some(nika_graph::project(&wf, &report)),
             reason: None,
             spans,
         }
     } else {
         SemanticDocument {
+            semantic_document_format: SEMANTIC_DOCUMENT_FORMAT,
             graph: None,
             reason: Some("findings"),
             spans,
@@ -117,6 +132,20 @@ mod tests {
             Some(4),
             "wave-ordered nodes"
         );
+    }
+
+    /// The surface names its OWN version (spec 16 · `semantic_document_format`),
+    /// present in every case and DISTINCT from the nested `graph.graph_format`.
+    #[test]
+    fn the_surface_names_its_own_version() {
+        // healthy: both versions present, and they are not the same key
+        let ok = as_value(&semantic_document(DIAMOND));
+        assert_eq!(ok["semantic_document_format"], 1, "the surface's own version");
+        assert_eq!(ok["graph"]["graph_format"], 2, "the nested graph's version");
+        // absent-graph cases still name the surface version (findings · parse)
+        let findings = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: succeeded }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n";
+        assert_eq!(as_value(&semantic_document(findings))["semantic_document_format"], 1);
+        assert_eq!(as_value(&semantic_document("nika: v1\ntasks: ["))["semantic_document_format"], 1);
     }
 
     /// Spans map every task id to its declaring token's range.

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -167,6 +167,7 @@ outputs:                              # what the workflow returns · symmetric t
 | [13 outcomes](./13-outcomes.md) | The Outcome IR · TerminalClass × Cause × Payload · the normative transition table (one source: canon) · `trace_format: 2` |
 | [14 composition](./14-composition.md) | Workflow calling workflow · `invoke: workflow:` (tagged union) · the CallableContract · the ten composition laws · the trace forest |
 | [15 proof](./15-proof.md) | The proof layer · the semantic hash (H = H(domain ‖ version ‖ JCS(IR))) · `nika.lock` (pin by default) · `assert:` (StaticProof · TraceVerified · Unknown) · the one receipt |
+| [16 projections](./16-projections.md) | The oracle surface · one canonical projection (graph_format:2) served byte-identical across CLI · LSP · MCP · the LSP semantic document (`semantic_document_format: 1`) wraps it with spans + one-word `reason` · the additive arc (holes · actions · capabilities over the frozen IR) |
 
 **Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/): **<!-- canon:providers -->16<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->28<!-- /canon --> builtins** (6 core · 5 file · 8 data · 2 network · 2 introspection · 4 media).
 

--- a/crates/nika-pack/pack/spec/16-projections.md
+++ b/crates/nika-pack/pack/spec/16-projections.md
@@ -1,0 +1,162 @@
+# 16 · Projections
+
+> The first fifteen chapters define what a workflow *is* and what a run
+> *proves*. This chapter defines what a tool *sees*: the **oracle
+> surface** — the single, versioned, read-only projection of a workflow
+> that the CLI, the language server, and the MCP tool all serve **byte
+> for byte the same**. One truth, many lenses.
+>
+> This is the first chapter of the post-1.0, additive arc. Everything it
+> adds is a **projection over the frozen `nika: v1` IR** — never a change
+> to the language. A projection is a *view*; the thing viewed does not
+> move.
+
+---
+
+## The one projection (normative)
+
+There is **one canonical projection** of a workflow — the graph of
+[03](./03-dag.md) (`graph_format: 2`) — and every surface serves *that same
+projection*. `nika inspect --format json` (CLI), `nika/semanticDocument`
+(LSP), and the `nika_inspect` MCP tool all carry the **byte-identical**
+canonical projection; the surfaces differ only in what presentation they
+wrap around it.
+
+A **semantic document** is the LSP-side surface: the canonical projection
+*verbatim*, plus the source spans a client needs to link graph nodes back
+to text, plus — when the graph cannot be built — the one-word reason why.
+It is a **superset** of the bare projection (the CLI and MCP serve the
+projection without editor spans), and it is the **growth point** of the
+oracle: holes, actions, and capabilities land here (§the additive arc),
+which is why it carries its own version.
+
+```
+semantic_document = (
+  semantic_document_format   # the surface's OWN version (this chapter)
+  graph?                     # the canonical projection (03 · graph_format: 2) · absent when unbuildable
+  reason?                    # WHY graph is absent · one word · closed vocabulary · omitted when graph is present
+  spans                      # task id → the range of its declaring `id` token
+)
+```
+
+- **`semantic_document_format: 1`** — the surface names its **own**
+  version, independent of the nested `graph.graph_format`. Until now the
+  document versioned itself *implicitly* through `graph.graph_format: 2`;
+  a projection that will grow additive fields (holes · actions ·
+  capabilities · §the additive arc) needs a version of its own so a
+  consumer can reason about the *surface* without unwrapping the graph.
+- **`graph`** is the canonical projection of [03](./03-dag.md) *verbatim*
+  (`graph_format: 2` · the derived edges · the reference identity). The
+  semantic document never re-derives it — it carries it.
+- **`spans`** map each task id to the LSP range of its declaring `id`
+  token, so a canvas or a lens links a node back to source without
+  re-scanning YAML.
+
+## `reason` · *why the graph is absent (normative · closed)*
+
+When the graph cannot be projected, `graph` is null and `reason` names
+why in **one word**, from a closed vocabulary — never a sentence, never a
+duplicate of a diagnostic (the details live in the diagnostics lane, [05](./05-errors.md)):
+
+| `reason` | Meaning |
+|---|---|
+| `parse` | the source did not parse — there is no tree to project |
+| `findings` | the source parsed but a check finding blocks a sound graph |
+
+The set is **closed**: a new reason is an additive change that bumps
+`semantic_document_format`. `reason` is omitted entirely when `graph` is
+present (a healthy document carries no reason key) — presence is the
+signal, not a sentinel value.
+
+## The triangle law (normative)
+
+The **canonical projection** has **exactly one producer** and is served,
+byte-identical, by three surfaces:
+
+```
+nika inspect --format json     ┐  the canonical projection (graph_format: 2)
+nika/semanticDocument (LSP)     ├─ byte-identical · one projection, three lenses
+nika_inspect (MCP)              ┘  (the LSP additionally wraps editor spans)
+```
+
+- The three MUST serve the **same canonical-projection bytes** for the
+  same input — a lens that drifts is a bug, tested by parity, not by
+  convention. The LSP's semantic document carries that same projection
+  *verbatim* and adds spans (a presentation superset, not a re-derivation);
+  the CLI and MCP serve the projection without editor spans.
+- Each surface is a **typed contract**, not a JSON bag: renaming a field
+  breaks the producer's compilation (and the law tests) before it can
+  break a consumer silently.
+
+## Read discipline (normative)
+
+- **A projection always answers.** The request is a *read*, never a
+  judgment. A malformed document still returns a semantic document — with
+  a `reason` and whatever spans it could recover — never an error. Judgment
+  lives in `nika check` (05), never in the projection.
+- **Structure only.** The projection carries names, shapes, spans, and
+  derived structure — **never** an env value, a secret, or resolved
+  material ([10](./10-authority.md) flow laws hold here too). A projection
+  that leaked a secret would be a sink; it is not one, by construction.
+- **A projection is a view over the frozen IR.** It never mutates, never
+  re-orders, never re-interprets the workflow. Given the same source it is
+  deterministic — the same bytes, every time.
+
+## The additive arc (normative · forward-compat)
+
+This surface is the plug-board for the post-1.0 oracle work. Every future
+field is **additive under the version key**, and every future field is a
+**projection or an edit-proposal over the frozen v1 IR** — never a new
+piece of the language:
+
+- **Additive-field discipline.** A new optional field (holes · actions ·
+  capabilities) bumps `semantic_document_format` and is `skip`-omitted when
+  empty. A consumer that ignores an additive field still reads the whole
+  older surface correctly — the same forward-compat the `graph_format: 2`
+  envelope already keeps (03). A consumer MUST ignore fields it does not
+  know, never fail on them.
+- **Capabilities are negotiated, not assumed.** A client announces which
+  extensions it understands under `experimental.nika.*`; the server offers
+  an extension only when the client asked. An un-negotiated field is never
+  sent.
+- **Projection, never grammar.** No field on this surface adds syntax a
+  workflow author writes. Holes describe *where a workflow is incomplete*;
+  actions describe *an edit a tool could apply*; both are computed **from**
+  the v1 IR and validated **against** it. The language stays frozen (the
+  1.0 contract) while the oracle around it grows.
+
+## What v1 deliberately does not do (yet)
+
+The following are **named** here so the surface reserves room for them,
+and **specified in their own later windows** — not shipped by this chapter:
+
+- **`holes`** — typed descriptions of where a workflow is incomplete (a
+  missing `prompt:`, an unfilled output), each anchored to a span,
+  including spans for **absent** fields. (`nika/holes` · `nika/fillHole`.)
+- **`actions`** — `SemanticAction`s: edit proposals a tool can apply,
+  each carrying its own verification (apply-in-memory → re-check → delta)
+  so an action is never offered that `nika check` would then reject.
+- **`witness`** on a finding — the computed DAG/taint path that justifies
+  it, promoted from thrown-away intermediate to payload.
+- **`pathToRunnable`** and the planner over actions — a route from an
+  incomplete document to a checkable one, searched by BFS/Dijkstra (an
+  admissible A* only once its heuristic law is written).
+
+Each stays out of the shipped surface until its window proves it. Naming
+them is a reservation, never a promise they exist.
+
+## One obvious way (normative for linters)
+
+- A tool that shows structure reads the semantic document — it does not
+  re-parse the YAML itself (one producer, one truth).
+- The version a surface reasons about is `semantic_document_format` — the
+  nested `graph.graph_format` versions the graph, not the document.
+- An unknown field on the surface is ignored, never rejected (additive
+  forward-compat).
+
+## Related
+
+- [03 · DAG](./03-dag.md) — the `graph_format: 2` projection this carries
+- [05 · Errors](./05-errors.md) — the diagnostics lane (judgment lives there, not here)
+- [10 · Authority](./10-authority.md) — the flow laws the projection also obeys (structure only)
+- [15 · Proof](./15-proof.md) — the semantic identity the projected graph commits to


### PR DESCRIPTION
Spec 16 (projections) realized engine-side — the first W7 engine window.

The **semantic document** (the LSP surface that carries the canonical projection verbatim and adds spans) now names its **own** version, distinct from the nested `graph.graph_format`:

- `pub const SEMANTIC_DOCUMENT_FORMAT: u32 = 1`, serialized first on `SemanticDocument`, present in every case (healthy · findings · parse).
- It's the **growth point**: holes/actions/capabilities land here additively under this key, while `graph.graph_format:2` keeps versioning the graph. A consumer reasons about the surface without unwrapping the graph.
- Test `the_surface_names_its_own_version` pins: `format:1` present in all three cases and **distinct** from `graph_format:2`.

Scope note (honest): this window ships only the version key on the surface — the byte-identical triangle stays the canonical *graph* projection (per the chapter-16 correction: CLI/MCP serve the graph, the LSP wraps spans). Holes · actions · witness · planner are reserved in spec 16 and land in their own later W7 windows.

`SPEC_PIN → 24c3dfd` (chapter 16 + the triangle-precision correction). nika-lsp 202/0 · pre-push gate green.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>