### PR TITLE
chore(ci): scorecard + dependabot + codeql — the exposure layer lands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot · weekly freshness for the two ecosystems that feed the build.
+# Security-update toggles are repo settings (operator switch); this file
+# drives version updates + the Scorecard Dependency-Update-Tool check.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+    open-pull-requests-limit: 5
+    groups:
+      rust-minor-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+# CodeQL · static analysis (SAST) on the Rust workspace. Zero `run:` steps ·
+# every step a SHA-pinned `uses:` (same pin family as scorecard.yml) ·
+# build-mode none keeps the job independent from the cargo build graph.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 2 * * 6'
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: rust
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:rust"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+# OpenSSF Scorecard · supply-chain posture, measured weekly and on every
+# main push. Results publish to the OpenSSF API (badge + scorecard.dev
+# viewer) and to GitHub code scanning. Template: ossf/scorecard's own
+# scorecard-analysis.yml (upstream pins kept verbatim — their tested combo).
+#
+# Security note: read-all default · the job elevates only security-events
+# (SARIF upload) + id-token (OIDC · publish_results) · zero `run:` steps —
+# every step is a SHA-pinned `uses:` · no user-controlled strings anywhere ·
+# main-branch + schedule + dispatch only.
+
+name: Scorecard supply-chain analysis
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # code-scanning SARIF upload
+      id-token: write # OIDC · required by publish_results
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Three additive files, zero touch to existing CI.

- **scorecard.yml** — byte-for-byte the exemplar shipped on nika-spec (#125): upstream-tested SHA pins, `read-all` default, OIDC `publish_results`, zero `run:` steps. Lights the scorecard.dev badge pipeline.
- **dependabot.yml** — weekly `cargo` + `github-actions` version updates, minor/patch grouped to keep PR noise low (security-update toggles remain repo settings · operator switch).
- **codeql.yml** — rust SAST, `build-mode: none` (independent of the cargo build graph), zero `run:` steps, same SHA-pin family as the exemplar.

Together they light the Scorecard checks the 2026-07-18 audit found dark: SAST · Dependency-Update-Tool · the badge/exposure layer. Companion of the certifications matrix shipped spec-side (`governance/certifications.md`).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>