### PR TITLE
test(runtime): boundary differential — check and runtime agree on exec permits

### DIFF
--- a/crates/nika-lsp/src/analysis/semantic_document.rs
+++ b/crates/nika-lsp/src/analysis/semantic_document.rs
@@ -140,12 +140,21 @@ mod tests {
     fn the_surface_names_its_own_version() {
         // healthy: both versions present, and they are not the same key
         let ok = as_value(&semantic_document(DIAMOND));
-        assert_eq!(ok["semantic_document_format"], 1, "the surface's own version");
+        assert_eq!(
+            ok["semantic_document_format"], 1,
+            "the surface's own version"
+        );
         assert_eq!(ok["graph"]["graph_format"], 2, "the nested graph's version");
         // absent-graph cases still name the surface version (findings · parse)
         let findings = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: succeeded }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n";
-        assert_eq!(as_value(&semantic_document(findings))["semantic_document_format"], 1);
-        assert_eq!(as_value(&semantic_document("nika: v1\ntasks: ["))["semantic_document_format"], 1);
+        assert_eq!(
+            as_value(&semantic_document(findings))["semantic_document_format"],
+            1
+        );
+        assert_eq!(
+            as_value(&semantic_document("nika: v1\ntasks: ["))["semantic_document_format"],
+            1
+        );
     }
 
     /// Spans map every task id to its declaring token's range.

--- a/crates/nika-runtime/tests/boundary_differential.rs
+++ b/crates/nika-runtime/tests/boundary_differential.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic, clippy::unreachable)]
+
+//! Boundary differential — the `permits.exec` boundary decided the same way by
+//! BOTH enforcement paths, over the whole generated permit lattice.
+//!
+//! The proposition (spec 01 §permits · NIKA-SEC-004): an effect outside the
+//! declared boundary is refused. Two independent implementations decide it —
+//! the static checker (`nika-cap`/`permits_fit`, consumed by `nika check`) and
+//! the runtime exec sink (`nika-runtime`, `check_exec_permits`). They share no
+//! code, so a common bug would have to be born twice. This battery pins BOTH to
+//! the SAME reference semantics, `Permits::allows_program`, so they agree:
+//!
+//! * **static side** — a LITERAL `command[0]` is statically checkable, so
+//!   `check()` decides; `check`-accepts <=> `allows_program`.
+//! * **runtime side** — an INTERPOLATED `command[0]` is opaque to the static
+//!   ladder (the report is clean), so the runtime sink is the last gate;
+//!   `runtime`-allows <=> `allows_program`.
+//!
+//! Composed: `check`-accepts <=> `allows_program` <=> `runtime`-allows. Any
+//! divergence on either leg is a soundness (static laxer than runtime) or
+//! completeness (static stricter) bug in the boundary.
+
+use std::sync::Arc;
+
+use nika_kernel_mock::{
+    MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+};
+use nika_providers::{ProviderRegistry, ProvidersConfig};
+use nika_runtime::{DeterministicStamper, RunOutcome, Runtime, RuntimeConfig, VecSink};
+use nika_schema::types::{ExecPermit, Permits};
+use nika_schema::{FileId, ParseMode, check, parse};
+use nika_verb_agent::AgentVerb;
+use nika_verb_exec::ExecVerb;
+use nika_verb_infer::InferVerb;
+use nika_verb_invoke::InvokeVerb;
+use proptest::prelude::*;
+
+// -- generators --------------------------------------------------------------
+// Programs share a small alphabet so `Programs` lists produce a real allow/deny
+// mix against the attempted program (`allows_program` is EXACT match, not glob).
+
+fn prog() -> impl Strategy<Value = String> {
+    prop_oneof!["git", "rm", "ls", "a", "b"].prop_map(String::from)
+}
+
+fn prog_list() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(prog(), 0..4)
+}
+
+fn arb_exec() -> impl Strategy<Value = Option<ExecPermit>> {
+    prop_oneof![
+        Just(None),
+        Just(Some(ExecPermit::No)),
+        Just(Some(ExecPermit::Any)),
+        prog_list().prop_map(|l| Some(ExecPermit::Programs(l))),
+    ]
+}
+
+/// exec-category ENABLED only (Any or Programs). The static ladder is clean
+/// for these (the category is permitted; only the interpolated program is
+/// opaque), so `runtime.run` proceeds and the exec sink is the real decider.
+/// None/No are category-denied and refuse statically (covered by the static leg).
+fn arb_exec_enabled() -> impl Strategy<Value = Option<ExecPermit>> {
+    prop_oneof![
+        Just(Some(ExecPermit::Any)),
+        prog_list().prop_map(|l| Some(ExecPermit::Programs(l))),
+    ]
+}
+
+/// The reference boundary both paths are pinned to.
+fn permits_of(exec: Option<&ExecPermit>) -> Permits {
+    let mut p = Permits::new();
+    p.exec = exec.cloned();
+    p
+}
+
+/// The `permits:` block for a generated `exec:` category (serde-exact form:
+/// `false | true | [programs]`). `None` renders `{}` — the empty, pure-compute
+/// boundary that default-denies exec. The wildcard is unreachable: `arb_exec`
+/// only yields the four variants below.
+fn permits_block(exec: Option<&ExecPermit>) -> String {
+    match exec {
+        None => "permits: {}".to_string(),
+        Some(ExecPermit::No) => "permits:\n  exec: false".to_string(),
+        Some(ExecPermit::Any) => "permits:\n  exec: true".to_string(),
+        Some(ExecPermit::Programs(list)) => {
+            let items = list
+                .iter()
+                .map(|p| format!("\"{p}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("permits:\n  exec: [{items}]")
+        }
+        _ => unreachable!("arb_exec only yields None/No/Any/Programs"),
+    }
+}
+
+// -- runtime driver (no cleanliness assert -- the differential needs dirty runs
+//    to be possible; the interpolated form keeps the STATIC report clean) -----
+
+async fn drive(yaml: &str, shell: MockShell) -> RunOutcome {
+    let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    let report = check(&wf);
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(shell)),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("run completes")
+}
+
+proptest! {
+    // -- static leg ----------------------------------------------------------
+    // A LITERAL program is statically checkable; `check()` must accept exactly
+    // when the reference boundary allows the program. `capability_escapes` with
+    // `floor == false` is the NIKA-SEC-004 (declared-boundary) verdict; the
+    // SSRF floor (SEC-005, `floor == true`) is a different law and filtered out.
+    #[test]
+    fn static_check_matches_allows_program(exec in arb_exec(), program in prog()) {
+        let yaml = format!(
+"nika: v1
+workflow:
+  id: diff
+{permits}
+tasks:
+  t:
+    exec:
+      command: [\"{program}\", \"--version\"]
+",
+            permits = permits_block(exec.as_ref()),
+        );
+        let wf = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let report = check(&wf);
+        let static_accepts = !report
+            .capability_escapes
+            .iter()
+            .any(|e| !e.floor && e.task == "t");
+        prop_assert_eq!(static_accepts, permits_of(exec.as_ref()).allows_program(&program));
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 96, ..ProptestConfig::default() })]
+
+    // -- runtime leg ---------------------------------------------------------
+    // An INTERPOLATED program is opaque to the static ladder (the report stays
+    // clean), so the runtime exec sink is the last gate. It must allow exactly
+    // when the reference boundary allows the resolved program. A denied program
+    // fails the task with NIKA-SEC-004 before any spawn (the enqueued ok is
+    // simply unused); an allowed program consumes it and succeeds.
+    #[test]
+    fn runtime_gate_matches_allows_program(exec in arb_exec_enabled(), program in prog()) {
+        let yaml = format!(
+"nika: v1
+workflow:
+  id: diff
+{permits}
+vars:
+  prog: \"{program}\"
+tasks:
+  t:
+    exec:
+      command: [\"${{{{ vars.prog }}}}\", \"--version\"]
+",
+            permits = permits_block(exec.as_ref()),
+        );
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let outcome = rt.block_on(drive(&yaml, MockShell::new().enqueue_ok("ok\n")));
+        let runtime_allows = outcome.records["t"]
+            .error
+            .as_ref()
+            .is_none_or(|e| e.code != "NIKA-SEC-004");
+        prop_assert_eq!(runtime_allows, permits_of(exec.as_ref()).allows_program(&program));
+    }
+}


### PR DESCRIPTION
The paper-critical check↔runtime boundary differential (exec axis), as a property test.

**What it proves.** Both enforcement paths of the `permits.exec` boundary — the static checker (`nika-cap`/`permits_fit`, consumed by `nika check`) and the runtime exec sink (`nika-runtime`, `check_exec_permits`), which share no code — are pinned to one reference semantics, `Permits::allows_program`. A boundary bug would have to be born twice to pass.

- **static leg** — a LITERAL `command[0]` is statically checkable, so `check()` decides; asserts `check-accepts ⟺ allows_program` over the full generated permit lattice.
- **runtime leg** — an INTERPOLATED `command[0]` is opaque to the static ladder (the report stays clean, so `runtime.run` proceeds and the exec sink is the last gate); asserts `runtime-allows ⟺ allows_program` over the enabled-category lattice (None/No are category-denied and covered by the static leg — `runtime.run` returns `DirtyReport` on a non-clean report, so the runtime leg only exercises the exec-enabled cases).

Composed: `check-accepts ⟺ allows_program ⟺ runtime-allows`.

Self-contained: mock shell/clock/provider, no external deps. Local: `cargo test -p nika-runtime --test boundary_differential` → 2 passed; clippy `-D warnings` clean; fmt clean.

Also includes a one-commit rustfmt reconcile of `semantic_document.rs` (a drift #598 landed on main without passing fmt) so the whole-workspace fmt gate is green.

Next axes (separate PRs): fs differential (nika-builtin), net differential (nika-http), then fuzz targets 3-4 + mutants-in-CI.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>