### PR TITLE
test(schema): fuzz the permit checker and the infer-permits surface

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [parse_workflow, cel_expression]
+        target: [parse_workflow, cel_expression, cap_check, infer_permits]
     steps:
       - uses: actions/checkout@v4
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,4 +29,18 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "cap_check"
+path = "fuzz_targets/cap_check.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "infer_permits"
+path = "fuzz_targets/infer_permits.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]

--- a/fuzz/corpus/cap_check/seed.nika.yaml
+++ b/fuzz/corpus/cap_check/seed.nika.yaml
@@ -1,0 +1,8 @@
+nika: v1
+workflow:
+  id: seed
+permits: {}
+tasks:
+  t:
+    exec:
+      command: ["true"]

--- a/fuzz/corpus/infer_permits/seed.nika.yaml
+++ b/fuzz/corpus/infer_permits/seed.nika.yaml
@@ -1,0 +1,8 @@
+nika: v1
+workflow:
+  id: seed
+permits: {}
+tasks:
+  t:
+    exec:
+      command: ["true"]

--- a/fuzz/fuzz_targets/cap_check.rs
+++ b/fuzz/fuzz_targets/cap_check.rs
@@ -1,0 +1,24 @@
+//! Fuzz target 3 · the capability CHECKER.
+//!
+//! Invariant under fuzz · for any input that PARSES, `nika_schema::check`
+//! NEVER panics, aborts, or hangs — it returns a `CheckReport` (findings or
+//! clean). The checker is the component whose soundness the whole
+//! capability-boundary argument rests on, so its robustness on arbitrary
+//! workflows is a first-class fuzz invariant (the parser itself is covered by
+//! `parse_workflow`). Both strict and lenient parses are checked.
+//!
+//! Corpus · `fuzz/corpus/cap_check/` (seeded from conformance permits fixtures).
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use nika_schema::{check, parse, FileId, ParseMode};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(src) = std::str::from_utf8(data) {
+        for mode in [ParseMode::Strict, ParseMode::Lenient] {
+            if let Ok(wf) = parse(src, FileId::new(0), mode) {
+                let _ = check(&wf);
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/infer_permits.rs
+++ b/fuzz/fuzz_targets/infer_permits.rs
@@ -1,0 +1,23 @@
+//! Fuzz target 4 · the `--infer-permits` synthesis surface.
+//!
+//! Invariant under fuzz · for any input that PARSES, `nika_schema::infer_permits`
+//! (the mechanism behind `nika check --infer-permits`, which derives the
+//! tightest boundary a workflow needs) NEVER panics, aborts, or hangs. This is
+//! the second surface the thesis leans on — the audit flagged it uncovered
+//! alongside the checker. Both strict and lenient parses feed the inference.
+//!
+//! Corpus · `fuzz/corpus/infer_permits/` (seeded from conformance permits fixtures).
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use nika_schema::{infer_permits, parse, FileId, ParseMode};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(src) = std::str::from_utf8(data) {
+        for mode in [ParseMode::Strict, ParseMode::Lenient] {
+            if let Ok(wf) = parse(src, FileId::new(0), mode) {
+                let _ = infer_permits(&wf);
+            }
+        }
+    }
+});


### PR DESCRIPTION
Two new libFuzzer targets close the audit gap that only the YAML parser and CEL were fuzzed, while the security thesis rests on the **checker**.

- **cap_check** — every parsing input → `nika_schema::check` (the capability checker), assert no panic/abort/hang (strict + lenient).
- **infer_permits** — every parsing input → `nika_schema::infer_permits` (the `--infer-permits` synthesis surface, flagged uncovered by the audit).

Wired into the fuzz-nightly matrix with seeded corpora. Verified locally: `cargo +nightly check` on the fuzz crate is clean. Prereq for a serious OSS-Fuzz dossier (4 targets + corpus).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>