### PR TITLE
docs(crate-specs): nika-cli exit-4 paused · fold graph/schema residues (#622 follow-up)

### DIFF
--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -31,7 +31,7 @@ chrome ≤30%, zero decorative noise). And the human always keeps the hand.
 | `nika explain NIKA-XXXX` | teach one error code (cause · fix-form · doc link) | 0 · 2 unknown code |
 | `nika completions <shell>` | shell completions (clap-generated) | 0 |
 | `nika new --from <template\|intent>` | instantiate one of the 6 skeletons (plain words BM25-route to the closest) · `--from '?'` = first-class discovery listing (exit 0 · the `embedded set:` line is the editor wire contract) · bare `nika new` on a terminal = the guided flow, at most three questions (template → file → model · the model question only fires for skeletons carrying a top-level `model:` · the default file name walks past collisions · Enter-only path lands on the offline mock) · bare in a pipe fails fast naming `--from` | 0 · 2 unknown/bare-in-pipe · 3 env |
-| `nika spec` / `nika examples list\|show\|run` / `nika schema` | the embedded self-contained surface | 0 |
+| `nika spec` (`--schema` folds the old `nika schema`) / `nika examples list\|show\|run` | the embedded self-contained surface | 0 |
 | `nika lsp` | the in-binary language server (stdio) | — |
 | `nika mcp` | the in-binary MCP server | — |
 
@@ -149,8 +149,10 @@ colour alone (a11y).
 ```
 0    success (run completed · check clean · verb done)
 1    workflow failed        — a task reached failed; engine itself healthy
-2    validation findings    — check/inspect/graph found errors in the FILE
+2    validation findings    — check/inspect found errors in the FILE
 3    environment error      — config · missing provider key · doctor findings
+4    run paused             — durable nika:prompt gate (ADR-099); resume with
+                             --resume <trace> --answer <task>=<value>
 101  engine panic           — never deliberate; the trace is the crash report
 ```
 
@@ -168,8 +170,9 @@ the trace path (the flight recorder IS the crash report, owned by the user)
 
 ## 6. The graph projector (one projector · N renderers)
 
-`nika graph --json` is the canonical projection; mermaid/dot/ASCII/webview
-all derive from it. Versioned envelope (`graph_format: 2` · typed edges):
+`nika inspect <file> --format json` is the canonical projection (`nika graph`
+folded into `inspect --format`); mermaid/dot/ASCII/webview all derive from
+it. Versioned envelope (`graph_format: 2` · typed edges):
 
 ```json
 {
@@ -252,7 +255,7 @@ surface auto-escalates permits, ever.
 |---|---|
 | 1 SPEC | ✅ this file (2026-06-11 · ahead of build) |
 | 2 TDD | ✅ RED→GREEN · render frames + verbs + the e2e pipeline |
-| 3 IMPL | ✅ compiles · the full first-15-min verb tree (check · run · trace · inspect · graph · explain · spec · schema · examples · new · doctor · pack · completions · lsp · mcp) |
+| 3 IMPL | ✅ compiles · the full first-15-min verb tree (check · run · trace · inspect · explain · spec · examples · new · doctor · pack · completions · lsp · mcp) |
 | 4 CLIPPY | ✅ 0 warnings (`--all-targets -D warnings`) |
 | 5 MUTATION | ✅ 91.0% killed (264/290 viable) · residual are equivalent (the sparkline `.min()` clamp + unreachable `unwrap_or`) or low-value (infallible-writer `into_error`, best-effort stderr, a few composition-root paths) |
 | 6 PROPERTY | ✅ `tests/fold_property.rs` — the fold's monoid invariants (cost conservation · one-row-per-task · permutation-invariance · sequential≡interleaved-wave) |


### PR DESCRIPTION
Follow-up to #622. That PR fixed the §2 `nika run` exit-code cell and the
`inspect --format` cell, but deliberately left the matching residues in §4,
§6, and the gate-3 verb tree out of its surgical scope. This PR closes them —
doc-only, `docs/crate-specs/nika-cli.md` only.

## What changed

### §4 · exit-code contract
- **Added the missing `4 · run paused` row** — a durable `nika:prompt` gate
  (ADR-099), resume with `--resume <trace> --answer <task>=<value>`. Now
  consistent with the §2 run-cell #622 already fixed and with the exit module
  (`crates/nika-cli/src/verbs/mod.rs`: `OK=0 · WORKFLOW=1 · FILE=2 · ENV=3 ·
  PAUSED=4`).
- Dropped the folded `graph` from the "check/inspect found errors" line.

### §6 · the graph projector + gate-3 IMPL line
- `nika graph --json` → **`nika inspect <file> --format json`** as the
  canonical projection (with a `nika graph` folded-into note), preserving the
  section's content about the projection envelope itself (`graph_format: 2`).
- Dropped the standalone `graph` verb from the gate-3 "verb tree" list.

### Sweep · `nika schema` residue
- `nika schema` folds into **`nika spec --schema`** (code: `Spec { schema }`,
  "the old `schema` verb, one roof") — dropped the standalone-verb residues in
  the §2 surface row and the gate-3 verb tree.
- No `nika tools` residue exists in this file (the `catalog --tools` fold has
  no teaching-surface leftover here).

## The `101` verdict
**Kept, not stale.** `101` is the Rust engine-panic exit convention ("engine
panic — never deliberate; the trace is the crash report"). It is not a Nika
exit-contract code (those are `0/1/2/3/4`) — it is what any panicking Rust
process returns — so it stays documented with its meaning, alongside the new
`4 · paused` row.

## Verification
- Re-grepped the file: no `nika graph` / `nika schema` / `nika tools`
  standalone-verb invocations remain; the surviving `nika graph` mentions are
  explicit fold-notes.
- Cross-checked every claim against `crates/nika-cli/src/main.rs` (clap
  `Command` enum) and `crates/nika-cli/src/verbs/mod.rs` (exit module).
- Markdown integrity confirmed (table columns intact; §4 code-block dashes
  aligned).

Doc-only. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
