### PR TITLE
ci: SHA-pin every workflow action (Scorecard Pinned-Dependencies)

### DIFF
--- a/.github/workflows/catalog-verify.yml
+++ b/.github/workflows/catalog-verify.yml
@@ -33,13 +33,15 @@ jobs:
     name: probe registries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: . -> target
           shared-key: catalog-verify
@@ -57,7 +59,7 @@ jobs:
           exit "$exit_code"
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: catalog-verify-report
           path: report.json
@@ -76,7 +78,7 @@ jobs:
 
       - name: File GitHub issue on scheduled drift
         if: github.event_name == 'schedule' && steps.verify.outputs.exit_code != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/changelog-cliff.yml
+++ b/.github/workflows/changelog-cliff.yml
@@ -15,13 +15,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v0.8') || startsWith(github.ref, 'refs/tags/v0.9') || startsWith(github.ref, 'refs/tags/v0.10') || startsWith(github.ref, 'refs/tags/v0.11')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: main
 
       - name: Generate latest changelog section
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --latest --strip all

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,13 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
@@ -46,7 +47,7 @@ jobs:
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload lcov artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lcov
           path: lcov.info
@@ -54,7 +55,7 @@ jobs:
 
       - name: Upload to Codecov (best-effort · tokenless)
         continue-on-error: true
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       CHECK: ${{ matrix.check }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run ratchet
         run: ./scripts/ci/check-"$CHECK".sh
 
@@ -49,7 +49,7 @@ jobs:
     env:
       JOB: ${{ matrix.job }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # No system libs installed here ON PURPOSE: the default workspace build is
       # pure-Rust. The only crate that links C system deps is `nika-screen`
       # (xcap → Wayland/X11/PipeWire/DRM/EGL), and that backend now lives behind
@@ -57,16 +57,16 @@ jobs:
       # IS the headless-build proof (a missing system lib here = a regression).
       # The `--features xcap` path is exercised by the cargo-hack job, which
       # installs the desktop libs.
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
         with:
           toolchain: "1.91"
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: diamond
       - name: Install cargo-nextest (tests leg)
         if: matrix.job == 'tests'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2
         with:
           tool: cargo-nextest
       # The conformance suites (nika-schema tests/) read the PUBLIC spec
@@ -95,22 +95,26 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # The floating EmbarkStudios/cargo-deny-action@v2 broke 2026-07-13:
       # its musl container trips over our rust-toolchain.toml pin
       # (`override toolchain '1.91-…-musl' is not installed`) and its
       # arg plumbing regressed (`unrecognized subcommand 'warn'`).
       # Install the binary and run it directly — the SAME invocation the
       # local pre-push hook has proven for months (one lane, no wrapper).
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-deny
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # cargo-deny
+        with:
+          tool: cargo-deny
       - run: cargo deny --all-features check
 
   hack:
     name: cargo-hack (feature matrix)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Linux desktop deps
         run: |
           sudo apt-get update
@@ -118,13 +122,15 @@ jobs:
             libwayland-dev libxkbcommon-dev libdbus-1-dev libudev-dev \
             libx11-dev libxi-dev libxtst-dev libpipewire-0.3-dev \
             libegl1-mesa-dev libgl1-mesa-dev libgbm-dev pkg-config
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
         with:
           toolchain: "1.91"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: diamond
-      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # cargo-hack
+        with:
+          tool: cargo-hack
       - name: check feature powerset (no dev deps)
         # `metal` (nika-infer-local) pulls candle-core/metal → the Apple-GPU
         # `metal` crate, which only builds on macOS/iOS. Exclude it from the
@@ -150,11 +156,12 @@ jobs:
     # Non-blocking (continue-on-error) until workspace-wide miri stabilises.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # nightly
         with:
+          toolchain: nightly
           components: miri
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: diamond-miri
       - name: miri test — nika-error
@@ -178,8 +185,10 @@ jobs:
     name: cargo-machete (unused deps)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-machete
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # cargo-machete
+        with:
+          tool: cargo-machete
       - name: check for unused dependencies
         run: cargo machete
 
@@ -191,16 +200,16 @@ jobs:
     # Non-blocking on push to main (only rejects PRs).
     continue-on-error: ${{ github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
         with:
           toolchain: "1.91"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: diamond-semver
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
           package: nika-error,nika-catalog,nika-kernel
           baseline-rev: origin/main
@@ -209,5 +218,5 @@ jobs:
     name: typos (spell check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@master
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: crate-ci/typos@3bc303c295c081add5df4a4d52a1e117f2fb2dce # master

--- a/.github/workflows/ecosystem-coherence.yml
+++ b/.github/workflows/ecosystem-coherence.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Self-test the bot (offline decision table — grace · lockstep · pre-release · dark surfaces)
         run: python3 scripts/ci/test-ecosystem-coherence.py
       - name: Run the coherence bot

--- a/.github/workflows/forward-compat.yml
+++ b/.github/workflows/forward-compat.yml
@@ -16,15 +16,15 @@ jobs:
   public-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: nightly
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-public-api
         run: cargo install cargo-public-api --locked
@@ -48,12 +48,14 @@ jobs:
   semver-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
           # nika-fx and nika-onboard are publish=true (nika-bm25 class) but
           # have no crates.io release yet — the action hard-errors on the

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         target: [parse_workflow, cel_expression, cap_check, infer_permits]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install nightly toolchain
         # rust-toolchain.toml pins stable for the workspace and that
@@ -41,7 +41,7 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fuzz-artifacts-${{ matrix.target }}
           path: fuzz/artifacts/

--- a/.github/workflows/hygiene-nightly.yml
+++ b/.github/workflows/hygiene-nightly.yml
@@ -13,7 +13,7 @@ jobs:
   drift-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: main   # explicit — always check main even if default branch differs (renamed from nika-diamond 2026-05-06)
@@ -25,7 +25,7 @@ jobs:
       # drift-issue spam (2026-06; vector 15 was the last holdout, the
       # standing YELLOW in the #240 drift table).
       - name: Install supply-chain tools (cargo-deny + cargo-machete + cargo-audit)
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2
         with:
           tool: cargo-deny,cargo-machete,cargo-audit
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -29,12 +29,14 @@ jobs:
       matrix:
         crate: [nika-cap]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
       - name: Flake eval
         run: nix flake check --no-build --print-build-logs
       - name: Build the package

--- a/.github/workflows/pack-resync.yml
+++ b/.github/workflows/pack-resync.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: The pack follows the spec
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -36,8 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
       - name: install nightly rustdoc (required by cargo-public-api)
         # cargo-public-api shells out to `cargo +nightly rustdoc` for JSON
         # output — with only stable installed every run died in ~1m40s on
@@ -45,7 +47,7 @@ jobs:
         # leaving the API-freeze gate silently blind (observed on every run
         # through 2026-07-01). Same pattern as fuzz-nightly.yml.
         run: rustup toolchain install nightly --profile minimal
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: install cargo-public-api
         # Pinned to the version the committed public-api.txt baselines were
         # generated with (scripts/hygiene/check-public-api-coverage.sh uses
@@ -91,7 +93,7 @@ jobs:
           exit $fail
       - name: upload canonical renderings (drift repair source)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: public-api-actual
           path: /tmp/public-api-actual/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, name: linux-x64 }
           - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, name: linux-arm64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify tag matches Cargo workspace version
         env:
           REF_NAME: ${{ github.event.inputs.tag || github.ref_name }}
@@ -64,7 +64,7 @@ jobs:
       - name: Add the Rust target
         run: rustup target add ${{ matrix.target }}
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -189,7 +189,7 @@ jobs:
           # tamper/drop exit 2 · OTLP export). A release whose flight
           # recorder lies never uploads. scripts/test/trust-battery.sh.
           bash scripts/test/trust-battery.sh "$smoke/nika"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nika-${{ matrix.name }}
           path: |
@@ -204,7 +204,7 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
@@ -257,14 +257,14 @@ jobs:
             echo "ok=false" >> "$GITHUB_OUTPUT"
             echo "::notice::TAP_DEPLOY_KEY unset — skipping the formula bump. The release + checksums are published; run scripts/release/update-formula.sh against the tap manually."
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: steps.guard.outputs.ok == 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         if: steps.guard.outputs.ok == 'true'
         with:
           path: artifacts
           merge-multiple: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: steps.guard.outputs.ok == 'true'
         with:
           # The tap repo is homebrew-tap — the canonical brew mapping for
@@ -312,8 +312,8 @@ jobs:
       contents: read # checkout the Dockerfile
       packages: write # push to ghcr.io — scoped to THIS job only
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
@@ -328,15 +328,15 @@ jobs:
           mkdir -p dist/linux/amd64 dist/linux/arm64
           tar -xzf "artifacts/nika-linux-x64-${VERSION}.tar.gz" -C dist/linux/amd64 nika
           tar -xzf "artifacts/nika-linux-arm64-${VERSION}.tar.gz" -C dist/linux/arm64 nika
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Build + push (linux/amd64 · linux/arm64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -22,9 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks
       - name: check every covered lib crate

--- a/.github/workflows/spec-pin-heal.yml
+++ b/.github/workflows/spec-pin-heal.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: The pin follows the spec
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
All workflow actions move from mutable tags to 40-char commit SHAs with a `# vN` comment, so Dependabot (wired in #609) keeps bumping them. Closes the Scorecard **Pinned-Dependencies** gap (A4).

The two **ref-as-selector** actions are handled without losing their selector (a naked SHA-pin would silently break them):
- `dtolnay/rust-toolchain` — the ref WAS the toolchain channel → every step that lacked an explicit `toolchain:` gains one (the nightly/miri step → `toolchain: nightly`, the bare `@stable` steps → `toolchain: stable`); the `@master` steps already pinning `toolchain: "1.91"` and the `@stable`-with-`nightly`-override keep theirs.
- `taiki-e/install-action` — the ref WAS the tool → gains `with.tool: cargo-deny/hack/machete`.

12 dtolnay steps map 1:1 to 12 `toolchain:` lines; all workflows parse (python YAML); no mutable ref remains. CI validates the selectors end-to-end (a wrong toolchain pin fails miri, a wrong tool pin fails cargo-deny/hack/machete).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>