### PR TITLE
ci: SLSA build-provenance attestations on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,10 @@ jobs:
     name: github release
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the release + upload assets
+      id-token: write # SLSA provenance · OIDC identity for Sigstore
+      attestations: write # publish the build-provenance attestation
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
@@ -235,6 +239,10 @@ jobs:
             --generate-notes \
             --verify-tag \
             artifacts/nika-*.tar.gz artifacts/SHA256SUMS
+      - name: Attest build provenance (SLSA · verifiable via `gh attestation verify`)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: 'artifacts/nika-*.tar.gz'
 
   bump-formula:
     name: bump homebrew tap


### PR DESCRIPTION
The custody-chain centerpiece for the /trust page: each release tarball gets a signed **SLSA build-provenance attestation** (Sigstore + Rekor under the hood), verifiable by anyone:

```
gh attestation verify nika-<target>.tar.gz --repo supernovae-st/nika
```

next to the `SHA256SUMS` already shipped.

- The `release` job gains job-level `permissions` (`id-token: write` + `attestations: write`, keeping `contents: write`).
- One additive `actions/attest-build-provenance` step, SHA-pinned (like #626), placed **after** the release is created — so a failed attestation can never lose the release (graceful degradation).

`release.yml` runs on a tag push, not on this PR, so the change is validated by `python -c yaml.safe_load` + the standard attest-build-provenance pattern, and exercised on the next release. B9-B11 (cargo-auditable, SBOM, cosign) follow as build-touching steps in a later release-pipeline PR.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>