### PR TITLE
docs(crate-spec): the gate-3 verb tree drops the phantom pack

### DIFF
--- a/docs/crate-specs/nika-cli.md
+++ b/docs/crate-specs/nika-cli.md
@@ -255,7 +255,7 @@ surface auto-escalates permits, ever.
 |---|---|
 | 1 SPEC | ✅ this file (2026-06-11 · ahead of build) |
 | 2 TDD | ✅ RED→GREEN · render frames + verbs + the e2e pipeline |
-| 3 IMPL | ✅ compiles · the full first-15-min verb tree (check · run · trace · inspect · explain · spec · examples · new · doctor · pack · completions · lsp · mcp) |
+| 3 IMPL | ✅ compiles · the full first-15-min verb tree (check · run · trace · inspect · explain · spec · examples · new · doctor · completions · lsp · mcp) |
 | 4 CLIPPY | ✅ 0 warnings (`--all-targets -D warnings`) |
 | 5 MUTATION | ✅ 91.0% killed (264/290 viable) · residual are equivalent (the sparkline `.min()` clamp + unreachable `unwrap_or`) or low-value (infallible-writer `into_error`, best-effort stderr, a few composition-root paths) |
 | 6 PROPERTY | ✅ `tests/fold_property.rs` — the fold's monoid invariants (cost conservation · one-row-per-task · permutation-invariance · sequential≡interleaved-wave) |


### PR DESCRIPTION
One-word truth fix flagged during #625: the gate-3 IMPL row claims « the full first-15-min verb tree » and lists `pack` — no `Pack` variant exists in the clap Command enum (`verbs::pack_surface::{schema,spec}` are the Spec/Catalog dump helpers, not a verb). The tree now lists exactly the shipped set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)