### PR TITLE
feat: nika-sandbox-landlock, the Linux command-sandbox twin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nika-sandbox-landlock"
+version = "0.103.0"
+dependencies = [
+ "nika-kernel",
+]
+
+[[package]]
 name = "nika-sandbox-seatbelt"
 version = "0.103.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members  = ["crates/nika-types", "crates/nika-error", "crates/nika-catalog", "crates/nika-catalog-codegen", "crates/nika-catalog-verify", "crates/nika-chart", "crates/nika-kernel", "crates/nika-kernel-ai", "crates/nika-kernel-core", "crates/nika-kernel-runtime", "crates/nika-kernel-plugin", "crates/nika-kernel-mock", "crates/nika-schema", "crates/nika-source", "crates/nika-vocab", "crates/nika-lints", "crates/nika-graph", "crates/nika-bm25", "crates/nika-screen", "crates/nika-event", "crates/nika-extract", "crates/nika-exec-runner", "crates/nika-sandbox-seatbelt", "crates/nika-blob", "crates/nika-clock", "crates/nika-fs", "crates/nika-fx", "crates/nika-http", "crates/nika-ocr", "crates/nika-a11y", "crates/nika-input", "crates/nika-browser", "crates/nika-pack", "crates/nika-providers", "crates/nika-infer-local", "crates/nika-verb-infer", "crates/nika-verb-exec", "crates/nika-verb-invoke", "crates/nika-verb-agent", "crates/nika-builtin", "crates/nika-cel", "crates/nika-registry-client", "crates/nika-runtime", "crates/nika-cli", "crates/nika-lsp", "crates/nika-mcp", "crates/nika-dap", "crates/nika-display", "crates/nika-onboard", "crates/nika-models", "crates/nika-cap", "crates/nika-pck-manifest", "crates/nika-tmpl", "crates/nika-migrate"]
+members  = ["crates/nika-types", "crates/nika-error", "crates/nika-catalog", "crates/nika-catalog-codegen", "crates/nika-catalog-verify", "crates/nika-chart", "crates/nika-kernel", "crates/nika-kernel-ai", "crates/nika-kernel-core", "crates/nika-kernel-runtime", "crates/nika-kernel-plugin", "crates/nika-kernel-mock", "crates/nika-schema", "crates/nika-source", "crates/nika-vocab", "crates/nika-lints", "crates/nika-graph", "crates/nika-bm25", "crates/nika-screen", "crates/nika-event", "crates/nika-extract", "crates/nika-exec-runner", "crates/nika-sandbox-seatbelt", "crates/nika-sandbox-landlock", "crates/nika-blob", "crates/nika-clock", "crates/nika-fs", "crates/nika-fx", "crates/nika-http", "crates/nika-ocr", "crates/nika-a11y", "crates/nika-input", "crates/nika-browser", "crates/nika-pack", "crates/nika-providers", "crates/nika-infer-local", "crates/nika-verb-infer", "crates/nika-verb-exec", "crates/nika-verb-invoke", "crates/nika-verb-agent", "crates/nika-builtin", "crates/nika-cel", "crates/nika-registry-client", "crates/nika-runtime", "crates/nika-cli", "crates/nika-lsp", "crates/nika-mcp", "crates/nika-dap", "crates/nika-display", "crates/nika-onboard", "crates/nika-models", "crates/nika-cap", "crates/nika-pck-manifest", "crates/nika-tmpl", "crates/nika-migrate"]
 # Excluded so cargo does not try to descend into untracked main-leftover
 # manifests under crates/ (the orphan working tree carries them but they
 # are not part of the diamond workspace).
@@ -87,6 +87,10 @@ layers.nika-exec-runner = "L1"
 # per-platform sandbox pair named by plugin::sandbox) · wraps a command in
 # sandbox-exec with an SBPL profile from permits · no unsafe, no FFI.
 layers.nika-sandbox-seatbelt = "L1"
+# nika-sandbox-landlock · Linux CommandSandbox impl (ADR-095 Layer 6 · the
+# Linux half of the per-platform sandbox pair) · wraps a command in bwrap with a
+# namespace jail from permits · no unsafe, no FFI · Landlock LSM hardening owed.
+layers.nika-sandbox-landlock = "L1"
 # nika-http · Phase-B slice step 5 (announce ladder · D-2026-06-10-N6 cascade) ·
 # implements kernel io::http {HttpGet,HttpPost} via reqwest · SSRF defense
 # (static + DNS-resolve + per-hop redirect re-check) · response size cap.

--- a/crates/nika-sandbox-landlock/Cargo.toml
+++ b/crates/nika-sandbox-landlock/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name          = "nika-sandbox-landlock"
+description   = "Linux command-sandbox L1 effect crate — implements the nika-kernel CommandSandbox trait by wrapping a command in the bwrap (bubblewrap) launcher with a namespace jail generated from the workflow's permits boundary (deny-default · network-deny · write-confine · sensitive-read-deny). The Linux half of the per-platform sandbox pair (sibling: nika-sandbox-seatbelt). Landlock LSM hardening is the named follow-on."
+version.workspace      = true
+edition.workspace      = true
+license.workspace      = true
+authors.workspace      = true
+rust-version.workspace = true
+repository.workspace   = true
+homepage.workspace     = true
+publish                = false  # Internal L1 effect crate (not a standalone crates.io satellite).
+
+# Reserved-architecture realization: plugin::sandbox's doc names this crate as
+# the Linux sandbox impl. Implements the CommandSandbox seam (exec-child
+# confinement · the wrapper model · same as the macOS sibling).
+[package.metadata.adr]
+adr = ["ADR-003", "ADR-095"]
+
+[dependencies]
+# The trait + ShellCommand + SandboxSpec. NO heavy deps: this crate only builds
+# the bwrap launcher argv and wraps the command (the wrapper model · no unsafe ·
+# no FFI · the runner spawns the result).
+nika-kernel = { path = "../nika-kernel", version = "0.103.0" }
+
+[package.metadata.lore]
+daemon        = "sentinelle"
+archetype     = "kodama-sentinelle"
+spirit_role   = "trace le cercle de craie autour du process Linux · rien ne sort qui n'ait été nommé"
+voice_pattern = "silent"
+layer         = "L1"
+err_prefix    = "none"
+
+[lints]
+workspace = true

--- a/crates/nika-sandbox-landlock/public-api.txt
+++ b/crates/nika-sandbox-landlock/public-api.txt
@@ -1,0 +1,40 @@
+pub mod nika_sandbox_landlock
+pub struct nika_sandbox_landlock::LandlockSandbox
+impl nika_sandbox_landlock::LandlockSandbox
+pub fn nika_sandbox_landlock::LandlockSandbox::available() -> bool
+pub fn nika_sandbox_landlock::LandlockSandbox::new() -> Self
+impl core::clone::Clone for nika_sandbox_landlock::LandlockSandbox
+pub fn nika_sandbox_landlock::LandlockSandbox::clone(&self) -> nika_sandbox_landlock::LandlockSandbox
+impl core::default::Default for nika_sandbox_landlock::LandlockSandbox
+pub fn nika_sandbox_landlock::LandlockSandbox::default() -> nika_sandbox_landlock::LandlockSandbox
+impl core::fmt::Debug for nika_sandbox_landlock::LandlockSandbox
+pub fn nika_sandbox_landlock::LandlockSandbox::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_sandbox_landlock::LandlockSandbox
+impl nika_kernel_core::io::command_sandbox::CommandSandbox for nika_sandbox_landlock::LandlockSandbox
+pub fn nika_sandbox_landlock::LandlockSandbox::backend(&self) -> &'static str
+pub fn nika_sandbox_landlock::LandlockSandbox::confine(&self, spec: &nika_kernel_core::io::process::SandboxSpec, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellCommand, nika_kernel_core::io::command_sandbox::CommandSandboxError>
+impl<D> owo_colors::OwoColorize for nika_sandbox_landlock::LandlockSandbox
+impl<T, U> core::convert::Into<U> for nika_sandbox_landlock::LandlockSandbox where U: core::convert::From<T>
+pub fn nika_sandbox_landlock::LandlockSandbox::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_sandbox_landlock::LandlockSandbox where U: core::convert::Into<T>
+pub type nika_sandbox_landlock::LandlockSandbox::Error = core::convert::Infallible
+pub fn nika_sandbox_landlock::LandlockSandbox::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_sandbox_landlock::LandlockSandbox where U: core::convert::TryFrom<T>
+pub type nika_sandbox_landlock::LandlockSandbox::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_sandbox_landlock::LandlockSandbox::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_sandbox_landlock::LandlockSandbox where T: core::clone::Clone
+pub type nika_sandbox_landlock::LandlockSandbox::Owned = T
+pub fn nika_sandbox_landlock::LandlockSandbox::clone_into(&self, target: &mut T)
+pub fn nika_sandbox_landlock::LandlockSandbox::to_owned(&self) -> T
+impl<T> core::any::Any for nika_sandbox_landlock::LandlockSandbox where T: 'static + ?core::marker::Sized
+pub fn nika_sandbox_landlock::LandlockSandbox::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_sandbox_landlock::LandlockSandbox where T: ?core::marker::Sized
+pub fn nika_sandbox_landlock::LandlockSandbox::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_sandbox_landlock::LandlockSandbox where T: ?core::marker::Sized
+pub fn nika_sandbox_landlock::LandlockSandbox::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_sandbox_landlock::LandlockSandbox where T: core::clone::Clone
+pub unsafe fn nika_sandbox_landlock::LandlockSandbox::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_sandbox_landlock::LandlockSandbox
+pub fn nika_sandbox_landlock::LandlockSandbox::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_sandbox_landlock::LandlockSandbox where T: 'static
+pub fn nika_sandbox_landlock::LandlockSandbox::as_any(&self) -> &(dyn core::any::Any + 'static)

--- a/crates/nika-sandbox-landlock/src/lib.rs
+++ b/crates/nika-sandbox-landlock/src/lib.rs
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika-sandbox-landlock` — the Linux command sandbox (the `CommandSandbox`
+//! seam · spec 01 §permits · ADR-095 Layer 6).
+//!
+//! Confines the `exec` verb's CHILD process by wrapping it in the `bwrap`
+//! (bubblewrap) launcher with a mount + namespace jail generated from the
+//! workflow's [`SandboxSpec`] (derived from `permits.fs` / `permits.net`). The
+//! wrapper model (the same one Claude Code / Codex / Cursor use, and the exact
+//! model the macOS sibling `nika-sandbox-seatbelt` uses) needs NO `unsafe` and
+//! NO FFI — this crate only builds the launcher argv; the runner spawns the
+//! result. (Landlock LSM hardening — the unprivileged in-kernel path-filter —
+//! is the named follow-on; bwrap's namespaces are the shipping floor and share
+//! this crate's spec-to-grant logic.)
+//!
+//! ## What the jail enforces (deny-default)
+//!
+//! - **Network** — denied entirely (`--unshare-net`) unless `spec.allow_network`
+//!   (host-granular filtering needs a proxy · follow-on, matching the sibling).
+//! - **Writes** — allowed ONLY under the declared `fs_write` prefixes plus
+//!   scratch (`--bind`). Everything else is read-only or absent.
+//! - **Reads** — the system paths every binary + the dynamic linker need are
+//!   bound read-only (`--ro-bind`, else nothing runs); the declared `fs_read`
+//!   prefixes are added read-only; SENSITIVE user paths (`~/.ssh`, `~/.aws`,
+//!   arbitrary `$HOME` files) are bound NOWHERE, so they are absent from the
+//!   jail's mount namespace (deny-default · the strongest form of read-deny).
+//!
+//! ## Coarseness (honest limits · identical to the sibling)
+//!
+//! `permits.fs` globs are gitignore-style; a bwrap `--bind` is a literal path.
+//! This crate binds the glob's literal prefix — a COARSENING (the jail admits
+//! at least the declared reach). The precise glob check is `permits_fit`'s
+//! static job; the sandbox is the OS FLOOR (no network · no out-of-bounds
+//! writes · no sensitive reads), path-prefix granularity, not per-file.
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+use std::path::Path;
+
+use nika_kernel::command_sandbox::{CommandSandbox, CommandSandboxError};
+use nika_kernel::process::{SandboxSpec, ShellCommand};
+
+/// The bubblewrap launcher. A fixed absolute path (not `$PATH`) so a hijacked
+/// `PATH` cannot point the sandbox at an impostor launcher.
+const LAUNCHER: &str = "/usr/bin/bwrap";
+
+/// System trees every dynamically-linked binary needs bound read-only to even
+/// start (the linker, shared libs, the shell). Absent trees are silently
+/// skipped at wrap time (a minimal container may lack `/sbin`), so binding a
+/// non-existent path is never an error.
+const SYSTEM_RO_BINDS: &[&str] = &[
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/etc/alternatives",
+    "/etc/ld.so.cache",
+];
+
+/// The Linux command sandbox (`bwrap` + a generated namespace jail).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LandlockSandbox;
+
+impl LandlockSandbox {
+    /// Construct the Linux sandbox.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Whether the bwrap launcher is present (Linux + the binary exists).
+    /// On any non-Linux target this is `false` (fail-closed).
+    #[must_use]
+    pub fn available() -> bool {
+        available_given(cfg!(target_os = "linux"), Path::new(LAUNCHER).exists())
+    }
+}
+
+impl CommandSandbox for LandlockSandbox {
+    fn confine(
+        &self,
+        spec: &SandboxSpec,
+        command: ShellCommand,
+    ) -> Result<ShellCommand, CommandSandboxError> {
+        if !Self::available() {
+            return Err(CommandSandboxError::Unavailable {
+                reason: format!("{LAUNCHER} not available on this host"),
+            });
+        }
+        let jail = build_jail_args(spec)?;
+        Ok(wrap(command, jail))
+    }
+
+    fn backend(&self) -> &'static str {
+        "landlock"
+    }
+}
+
+/// The availability DECISION, pure — Linux AND the launcher binary both
+/// present, never either alone (fail-closed). Split from
+/// [`LandlockSandbox::available`] so the truth table is testable on EVERY
+/// platform (the same Gate-5 discipline as the macOS sibling).
+fn available_given(is_linux: bool, launcher_exists: bool) -> bool {
+    is_linux && launcher_exists
+}
+
+/// Build the bwrap jail argv (deny-default · see module doc) from the spec.
+///
+/// The base is a fully unshared namespace with a fresh `/proc` + `/tmp`, the
+/// system trees bound read-only, network denied. Declared reads add `--ro-bind`,
+/// declared writes add `--bind`; `$HOME` is never bound, so sensitive home files
+/// are simply absent from the jail.
+fn build_jail_args(spec: &SandboxSpec) -> Result<Vec<String>, CommandSandboxError> {
+    // Fresh namespaces · deny-default. `--unshare-all` drops net/ipc/pid/uts/
+    // cgroup/user; `--die-with-parent` ties the child's lifetime to the runner;
+    // a minimal virtual filesystem gets a fresh proc + dev + a private tmp.
+    let mut a: Vec<String> = [
+        "--unshare-all",
+        "--die-with-parent",
+        "--new-session",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--tmpfs",
+        "/tmp",
+    ]
+    .iter()
+    .map(|s| (*s).to_owned())
+    .collect();
+
+    // System trees read-only (skip any that do not exist on this host).
+    for tree in SYSTEM_RO_BINDS {
+        if Path::new(tree).exists() {
+            a.push("--ro-bind".to_owned());
+            a.push((*tree).to_owned());
+            a.push((*tree).to_owned());
+        }
+    }
+
+    // Declared reads · read-only binds under the validated literal prefix.
+    for glob in &spec.fs_read {
+        let Some(prefix) = grant_subpath(glob)? else {
+            continue; // a glob with no literal prefix is un-expressible as a bind
+        };
+        a.push("--ro-bind-try".to_owned());
+        a.push(prefix.clone());
+        a.push(prefix);
+    }
+
+    // Declared writes · read-write binds under the validated literal prefix.
+    for glob in &spec.fs_write {
+        let Some(prefix) = grant_subpath(glob)? else {
+            continue;
+        };
+        a.push("--bind-try".to_owned());
+        a.push(prefix.clone());
+        a.push(prefix);
+    }
+
+    // Network: `--unshare-all` already dropped the net namespace. To ALLOW it,
+    // re-share the network namespace and bind the resolver config read-only.
+    if spec.allow_network {
+        a.push("--share-net".to_owned());
+        if Path::new("/etc/resolv.conf").exists() {
+            a.push("--ro-bind".to_owned());
+            a.push("/etc/resolv.conf".to_owned());
+            a.push("/etc/resolv.conf".to_owned());
+        }
+    }
+    // else: the net namespace stays unshared — no network, physically.
+
+    Ok(a)
+}
+
+/// Wrap a command in `bwrap <jail args> -- <inner argv>`.
+///
+/// The inner invocation is reconstructed faithfully: the shell form becomes
+/// `/bin/sh -c <line>` (jailed), the argv form runs the program directly.
+/// `cwd` / `env` / `stdin` / `timeout` ride on the OUTER command so they apply
+/// to the launcher and are inherited by the confined child. `pre_validated` is
+/// set (the blocklist floor already ran on the ORIGINAL command; the wrapped
+/// launcher argv must not be re-scanned).
+fn wrap(command: ShellCommand, jail: Vec<String>) -> ShellCommand {
+    let inner: Vec<String> = if command.shell {
+        let line = if command.args.is_empty() {
+            command.program.clone()
+        } else {
+            format!("{} {}", command.program, command.args.join(" "))
+        };
+        vec!["/bin/sh".to_owned(), "-c".to_owned(), line]
+    } else {
+        let mut v = Vec::with_capacity(1 + command.args.len());
+        v.push(command.program.clone());
+        v.extend(command.args.iter().cloned());
+        v
+    };
+
+    let mut wrapped = ShellCommand::new(LAUNCHER);
+    let mut args = Vec::with_capacity(jail.len() + 1 + inner.len());
+    args.extend(jail);
+    args.push("--".to_owned());
+    args.extend(inner);
+    wrapped.args = args;
+    wrapped.shell = false;
+    wrapped.cwd = command.cwd;
+    wrapped.env = command.env;
+    wrapped.env_remove = command.env_remove;
+    wrapped.stdin = command.stdin;
+    wrapped.timeout = command.timeout;
+    wrapped.pre_validated = true; // the original already passed the floor; the launcher is benign
+    wrapped.sandbox = None; // already confined
+    wrapped
+}
+
+/// The grant subpath for a glob: its literal prefix, VALIDATED so the floor
+/// holds even against a hostile or wrong permit (the sandbox's whole job). The
+/// transform that turns a declared glob into a real OS grant must never be able
+/// to express a whole-filesystem or system-root grant. (Identical soundness
+/// contract to the macOS sibling's `grant_subpath` — the two backends validate
+/// permits the same way.)
+///
+/// - `Ok(None)` — the glob has no literal prefix (`**/x` · `*`) — skipped.
+/// - `Ok(Some(p))` — a safe absolute path.
+/// - `Err(Profile)` — the prefix would over-grant or is non-canonical: root
+///   `/`, a non-absolute / `~` / `$`-bearing path, a `..` traversal, or a bare
+///   system-root directory (`/etc`, `/usr`, `/home`, … — a filename glob that
+///   trims to one of these would bind the whole tree). Fail-closed: the caller
+///   maps this to a refusal to spawn.
+fn grant_subpath(glob: &str) -> Result<Option<String>, CommandSandboxError> {
+    let prefix = literal_prefix(glob);
+    if prefix.is_empty() {
+        return Ok(None);
+    }
+    let refuse = |why: &str| {
+        Err(CommandSandboxError::Profile {
+            reason: format!("permits path {glob:?} cannot be confined: {why}"),
+        })
+    };
+    if !prefix.starts_with('/') {
+        // rejects relative (`./out`, `data/`), `~/…`, and `$VAR/…` — bwrap has
+        // no shell expansion, so these would not match the canonical path.
+        return refuse("a sandbox path must be absolute (canonicalize it first)");
+    }
+    if prefix.contains('\0') {
+        return refuse("a NUL byte cannot be expressed in a bwrap bind argument");
+    }
+    if prefix.split('/').any(|seg| seg == "..") {
+        return refuse("a `..` traversal cannot be expressed as a stable bind");
+    }
+    let normalized = prefix.trim_end_matches('/');
+    if normalized.is_empty() {
+        return refuse("a path of `/` would bind the whole filesystem");
+    }
+    if SYSTEM_ROOTS.contains(&normalized) {
+        return refuse("a bare system-root directory would over-bind its whole tree");
+    }
+    Ok(Some(prefix))
+}
+
+/// The literal directory prefix of a gitignore-style glob — everything before
+/// the first glob metacharacter, trimmed back to the last path separator so a
+/// directory boundary is kept. `./output/**` -> `./output`; `/data/lo*` ->
+/// `/data`; `/data/x.txt` -> `/data/x.txt`; `**/y` -> empty (no literal prefix).
+/// (Byte-identical to the sibling's `literal_prefix`.)
+fn literal_prefix(glob: &str) -> String {
+    let cut = glob.find(['*', '?', '[']).unwrap_or(glob.len());
+    let head = &glob[..cut];
+    match head.rfind('/') {
+        Some(slash) if cut < glob.len() => head[..slash].to_owned(),
+        _ => head.to_owned(),
+    }
+}
+
+/// Bare system-root directories a permit must NOT bind (binding the whole tree
+/// would defeat the jail). A filename glob that trims to one of these
+/// (`/etc/passwd*` -> `/etc`) is refused; the author must declare a more
+/// specific subpath (`/etc/myapp/**`). The Linux root set (the macOS sibling
+/// carries the Darwin equivalents).
+const SYSTEM_ROOTS: &[&str] = &[
+    "/etc", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/var", "/opt", "/root", "/home", "/dev",
+    "/proc", "/sys", "/run", "/tmp", "/boot", "/srv", "/mnt", "/media",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The availability truth table — all four rows, platform-free.
+    /// Kills Gate 5's three survivors: `-> true` (row 4 fails), `-> false`
+    /// (row 1 fails), `&& → ||` (rows 2+3 fail).
+    #[test]
+    fn available_given_is_the_and_of_both_facts() {
+        assert!(available_given(true, true));
+        assert!(
+            !available_given(true, false),
+            "Linux without bwrap is UNAVAILABLE"
+        );
+        assert!(
+            !available_given(false, true),
+            "a launcher path on non-Linux is UNAVAILABLE"
+        );
+        assert!(!available_given(false, false));
+    }
+
+    /// A glob with no literal prefix yields no bind (not an error).
+    #[test]
+    fn no_literal_prefix_is_skipped() {
+        assert_eq!(grant_subpath("**/x").unwrap(), None);
+        assert_eq!(grant_subpath("*").unwrap(), None);
+    }
+
+    /// A declared absolute subpath becomes a bind target.
+    #[test]
+    fn absolute_prefix_is_granted() {
+        assert_eq!(
+            grant_subpath("/data/project/**").unwrap(),
+            Some("/data/project".to_owned())
+        );
+        assert_eq!(
+            grant_subpath("/data/x.txt").unwrap(),
+            Some("/data/x.txt".to_owned())
+        );
+    }
+
+    /// The soundness refusals — a permit can never bind the whole tree.
+    #[test]
+    fn over_grant_is_refused() {
+        for hostile in [
+            "/",
+            "//",
+            "/etc",
+            "/usr",
+            "/home",
+            "/etc/passwd*",
+            "relative/x",
+            "~/s",
+            "$HOME/x",
+            "/a/../..",
+        ] {
+            assert!(
+                grant_subpath(hostile).is_err(),
+                "{hostile:?} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn literal_prefix_trims_to_directory_boundary() {
+        assert_eq!(literal_prefix("./output/**"), "./output");
+        assert_eq!(literal_prefix("/data/lo*"), "/data");
+        assert_eq!(literal_prefix("/data/x.txt"), "/data/x.txt");
+        assert_eq!(literal_prefix("**/y"), "");
+    }
+
+    /// The jail denies network by default and re-shares only on request.
+    #[test]
+    fn network_is_deny_default() {
+        let base = build_jail_args(&SandboxSpec::new()).unwrap();
+        assert!(
+            base.iter().any(|a| a == "--unshare-all"),
+            "base unshares everything"
+        );
+        assert!(
+            !base.iter().any(|a| a == "--share-net"),
+            "no network by default"
+        );
+
+        let mut net = SandboxSpec::new();
+        net.allow_network = true;
+        let with_net = build_jail_args(&net).unwrap();
+        assert!(
+            with_net.iter().any(|a| a == "--share-net"),
+            "network re-shared on request"
+        );
+    }
+
+    /// A declared write becomes a read-write bind; a declared read a ro-bind.
+    #[test]
+    fn declared_paths_become_binds() {
+        let mut spec = SandboxSpec::new();
+        spec.fs_read = vec!["/data/in/**".to_owned()];
+        spec.fs_write = vec!["/data/out/**".to_owned()];
+        let args = build_jail_args(&spec).unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("--ro-bind-try /data/in /data/in"),
+            "read is a ro-bind: {joined}"
+        );
+        assert!(
+            joined.contains("--bind-try /data/out /data/out"),
+            "write is a rw-bind: {joined}"
+        );
+    }
+
+    /// The wrap transform: argv form runs the program directly under bwrap.
+    #[test]
+    fn wrap_argv_runs_program_under_launcher() {
+        let mut cmd = ShellCommand::new("/bin/echo");
+        cmd.args = vec!["hi".to_owned()];
+        let jail = build_jail_args(&SandboxSpec::new()).unwrap();
+        let w = wrap(cmd, jail);
+        assert_eq!(w.program, LAUNCHER);
+        assert!(w.pre_validated, "the launcher argv must not be re-scanned");
+        assert!(w.sandbox.is_none(), "already confined");
+        // the inner program appears after the `--` separator
+        let sep = w
+            .args
+            .iter()
+            .position(|a| a == "--")
+            .expect("a -- separator");
+        assert_eq!(w.args[sep + 1], "/bin/echo");
+        assert_eq!(w.args[sep + 2], "hi");
+    }
+
+    /// The shell form becomes `/bin/sh -c <line>` under the jail.
+    #[test]
+    fn wrap_shell_form_becomes_sh_c() {
+        let mut cmd = ShellCommand::new("echo hi > f");
+        cmd.shell = true;
+        let w = wrap(cmd, build_jail_args(&SandboxSpec::new()).unwrap());
+        let sep = w.args.iter().position(|a| a == "--").unwrap();
+        assert_eq!(w.args[sep + 1], "/bin/sh");
+        assert_eq!(w.args[sep + 2], "-c");
+        assert_eq!(w.args[sep + 3], "echo hi > f");
+    }
+
+    #[test]
+    fn backend_name_is_stable() {
+        assert_eq!(LandlockSandbox::new().backend(), "landlock");
+    }
+
+    /// A path with an unescapable NUL is refused (the injection boundary).
+    #[test]
+    fn nul_in_path_is_refused() {
+        assert!(grant_subpath("/data/\0evil").is_err());
+    }
+}

--- a/crates/nika-sandbox-landlock/tests/landlock_jail.rs
+++ b/crates/nika-sandbox-landlock/tests/landlock_jail.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+// This test SPAWNS bwrap directly (std::process::Command) to PROVE the
+// generated jail confines — the one legitimate place outside the runner that
+// spawns, because verifying the jail requires actually entering it.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+// The ADVERSARIAL jail proof — actually runs bwrap and verifies the generated
+// namespace jail CONFINES the child (not just that the argv builds).
+// Linux-only (bwrap); the macOS counterpart lives in nika-sandbox-seatbelt.
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use nika_kernel::command_sandbox::CommandSandbox;
+use nika_kernel::process::{SandboxSpec, ShellCommand};
+use nika_sandbox_landlock::LandlockSandbox;
+
+/// Confine `program args…` under `spec` and actually run it via bwrap.
+fn run(spec: &SandboxSpec, program: &str, args: &[&str]) -> std::process::Output {
+    let mut cmd = ShellCommand::new(program);
+    cmd.args = args.iter().map(|s| (*s).to_string()).collect();
+    let w = LandlockSandbox::new().confine(spec, cmd).expect("confine");
+    assert_eq!(w.program, "/usr/bin/bwrap");
+    Command::new(&w.program)
+        .args(&w.args)
+        .output()
+        .expect("spawn bwrap")
+}
+
+fn home() -> PathBuf {
+    PathBuf::from(std::env::var("HOME").expect("HOME set"))
+}
+
+/// THE HEADLINE: a confined command cannot read a SENSITIVE file in the home
+/// dir (the `~/.ssh/id_rsa` class) — `$HOME` is bound nowhere in the jail, so
+/// the file is absent and the read fails (deny-default by absence).
+#[test]
+fn confined_cannot_read_a_sensitive_home_file() {
+    if !LandlockSandbox::available() {
+        return; // no bwrap on this runner — skip, not fail (matches the sibling)
+    }
+    let secret = home().join(format!(".nika-sbx-secret-{}", std::process::id()));
+    std::fs::write(&secret, "TOPSECRET-KEY-MATERIAL").expect("write secret");
+
+    // Empty spec = maximally confined (no declared reads, no network).
+    let out = run(&SandboxSpec::new(), "/bin/cat", &[secret.to_str().unwrap()]);
+    let _ = std::fs::remove_file(&secret);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("TOPSECRET"),
+        "the jail must NOT expose a sensitive home file · stdout was {stdout:?}"
+    );
+    assert!(!out.status.success(), "reading an unbound file must fail");
+}
+
+/// A confined command can read a DECLARED path (the jail admits the granted reach).
+#[test]
+fn confined_can_read_a_declared_path() {
+    if !LandlockSandbox::available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("nika-sbx-in-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let file = dir.join("in.txt");
+    std::fs::write(&file, "DECLARED-READABLE").expect("write");
+
+    let mut spec = SandboxSpec::new();
+    spec.fs_read = vec![format!("{}/**", dir.display())];
+    let out = run(&spec, "/bin/cat", &[file.to_str().unwrap()]);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("DECLARED-READABLE"),
+        "a declared read path must be inside the jail"
+    );
+}

--- a/docs/crate-specs/nika-sandbox-landlock.md
+++ b/docs/crate-specs/nika-sandbox-landlock.md
@@ -1,0 +1,59 @@
+# Crate spec — `nika-sandbox-landlock`
+
+| | |
+|---|---|
+| Status | **Linux backend SHIPPED (bwrap wrapper) · adversarial jail proof CI-gated (runs when bwrap present, skips otherwise · matches the sibling's macOS-runner pattern) · Landlock LSM hardening + mutation ≥90% + review swarm pending** (ADR-095 Layer 6) |
+| Layer | L1 — effect crate · the Linux impl of the L0.5 `nika_kernel::command_sandbox::CommandSandbox` seam |
+| Design | wraps a command in the `bwrap` (bubblewrap) launcher with a mount + namespace jail generated from `SandboxSpec` (derived from `permits.fs/net`) · the wrapper model · NO unsafe · NO FFI · NO heavy deps |
+| LOC budget | well under the caps · an argv builder + the shared spec-to-grant validation |
+| License | `AGPL-3.0-or-later` · Edition 2024 · Publish `false` |
+| NIKA codes | none — speaks the kernel `CommandSandboxError` (`Unavailable` · `Profile`) |
+
+---
+
+## 1. Purpose
+
+Confine the `exec` verb's CHILD process to the workflow's declared filesystem +
+network boundary (`permits.fs/net`) on Linux. The Linux half of the per-platform
+sandbox pair the kernel's reserved `plugin::sandbox` doc names
+(`nika-sandbox-seatbelt` is the macOS sibling). Distinct from that reserved
+capability `Sandbox` (WASM / MCP · `enter()` self-restriction · later 1.x): this
+implements the additive `CommandSandbox` "transform-the-command" seam.
+
+## 2. The wrapper model (no `unsafe`)
+
+`confine(spec, command)` returns `bwrap <jail args> -- <inner command>` — the
+runner spawns it. No in-process `pre_exec` closure (which would need `unsafe`,
+banned workspace-wide). The same model coding-agent CLIs use, and byte-for-byte
+the model the macOS sibling uses. The inner command is reconstructed faithfully
+(argv verbatim · shell form → `/bin/sh -c <line>`); `cwd`/`env`/`stdin`/`timeout`
+ride the outer launcher so the confined child inherits them.
+
+## 3. What the jail enforces (deny-default)
+
+- **Network** — `--unshare-all` drops the net namespace; `--share-net` re-adds it
+  ONLY when `spec.allow_network` (host-granular filtering needs a proxy · the
+  same honest follow-on the sibling declares).
+- **Writes** — read-write `--bind` only under the validated `fs_write` literal
+  prefixes; everything else is read-only or absent.
+- **Reads** — the system trees (linker, libs, shell) are `--ro-bind`; declared
+  `fs_read` prefixes add read-only reach; `$HOME` is bound NOWHERE, so sensitive
+  files (`~/.ssh`, `~/.aws`) are absent from the jail — deny-default by absence.
+
+## 4. Soundness (shared with the sibling)
+
+`grant_subpath` / `literal_prefix` are the same validation the macOS backend
+uses: a permit glob's literal prefix, refused if it is `/`, non-absolute,
+`~`/`$`-bearing, a `..` traversal, contains a NUL, or a bare system-root
+directory (which would bind a whole tree). Fail-closed: a rejected permit maps to
+a refusal to spawn, never a wider grant.
+
+## 5. Honest limits (future work)
+
+Path-prefix granularity, not per-file (the precise glob check is `permits_fit`'s
+static job; the sandbox is the OS floor). Host-granular network needs a proxy.
+The named hardening is **Landlock LSM** (unprivileged in-kernel path filtering,
+kernel ≥ 5.13) applied via a helper alongside the bwrap namespaces — a follow-on
+that reuses this crate's spec-to-grant logic. The adversarial jail proof runs in
+CI when bwrap is present and skips (never fails) otherwise, exactly like the
+sibling's macOS-runner-gated proof.


### PR DESCRIPTION
The Linux half of the per-platform sandbox pair the kernel reserved (sibling: `nika-sandbox-seatbelt`). Realizes the reserved `nika-sandbox-landlock` slot named in `nika-kernel-core/io/command_sandbox.rs`.

**Design** — the same `CommandSandbox` transform-the-command seam as the macOS sibling, wrapper model, no unsafe/FFI. `confine(spec, cmd)` returns `bwrap <jail> -- <inner>`:
- `--unshare-all` → **network denied by default** (`--share-net` only when `permits.net` is declared).
- system trees `--ro-bind`; declared reads `--ro-bind`, declared writes `--bind` under the **validated literal prefix**.
- `$HOME` bound nowhere → sensitive files (`~/.ssh`) are **absent from the jail** (deny-default by absence).

**Soundness** — `grant_subpath`/`literal_prefix` are shared byte-for-byte with the sibling: a permit glob that trims to `/`, a bare system root, `..`, non-absolute, or a NUL is refused (fail-closed).

**Proof** — 11 pure unit tests (argv builder · availability truth table · refusals · wrap forms) run everywhere; the adversarial jail test (`tests/landlock_jail.rs`, `cfg(target_os = "linux")`) actually spawns bwrap and proves a confined command cannot read a sensitive home file — it runs when bwrap is present on the runner and **skips (never fails) otherwise**, exactly like the sibling macOS-runner-gated proof.

**Follow-on** — Landlock LSM in-kernel path-filtering (kernel ≥ 5.13) as hardening over the bwrap namespaces (reuses this crate spec-to-grant logic); installing `bubblewrap` on the linux CI matrix to force-run the jail proof. Ships crate-spec + workspace member + L1 layer entry. Not yet wired into the runner selection (symmetric to the sibling, which is also unwired — that is a shared future step).

Verified locally: `cargo test --lib` 11/11, `clippy -D warnings` clean, `cargo +nightly fmt --check` clean.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>