### PR TITLE
chore(deps): the github-actions bumps move together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
       interval: weekly
       day: saturday
     open-pull-requests-limit: 5
+    # One grouped PR per wave · never per-action: the codeql-action
+    # init/analyze pair MUST move together (a split bump leaves the pair
+    # at different versions inside one workflow run and CodeQL fails ·
+    # proven on nika-spec 2026-07-19, first ungrouped wave).
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Ratchet of a law proven on nika-spec this morning: its first ungrouped dependabot wave split the `codeql-action` init/analyze pair across two PRs — each alone puts the pair at different versions inside one workflow run and CodeQL fails (both PR runs red · fixed spec-side in nika-spec#135). This repo's `github-actions` ecosystem (armed by #609) has the same exposure next Saturday; the cargo ecosystem already groups. One `groups:` block · one weekly PR · the pair can never split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)