### PR TITLE
docs(cite): the citation cross-references the spec — additive only

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,23 +1,34 @@
-# GitHub reads this file for « Cite this repository »; Zenodo reads it at
-# archive time. The research Nika itself builds on is credited in CITATIONS.md.
-# Version/date are stamped by releases (see CHANGELOG.md), not hand-written here.
 cff-version: 1.2.0
-message: "If you use Nika in your work, please cite this repository."
+message: >-
+  If you reference Nika (the engine or the language) in academic or
+  technical work, please cite it.
+title: "Nika: the workflow language for AI — reference engine"
 type: software
-title: "Nika"
-abstract: "Intent-as-code workflow engine for AI: reviewable YAML DAGs, statically checked (schema, permits, cost floor) before execution, tamper-evident traces after. Single Rust binary."
 authors:
   - name: "SuperNovae Studio"
-    city: "Paris"
-    country: "FR"
-    website: "https://nika.sh"
+    website: "https://supernovae.studio"
+  - family-names: "Melen"
+    given-names: "Thibaut"
 repository-code: "https://github.com/supernovae-st/nika"
 url: "https://nika.sh"
 license: AGPL-3.0-or-later
 keywords:
-  - workflow-engine
-  - ai-agents
-  - llm-orchestration
-  - static-analysis
-  - mcp
-  - rust
+  - AI workflows
+  - workflow engine
+  - static analysis
+  - capability security
+  - Rust
+abstract: >-
+  The reference implementation of the Nika workflow language: a single
+  Rust binary that statically audits a declarative YAML workflow before
+  any token is spent (plan, cost ceiling, secret flows, capability
+  boundary), then executes it locally across multiple LLM providers with
+  a hash-chained trace. The language specification is a separate
+  Apache-2.0 repository (supernovae-st/nika-spec).
+references:
+  - type: software
+    title: "Nika language specification"
+    repository-code: "https://github.com/supernovae-st/nika-spec"
+    license: Apache-2.0
+    authors:
+      - name: "SuperNovae Studio"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,33 +1,29 @@
+# GitHub reads this file for « Cite this repository »; Zenodo reads it at
+# archive time. The research Nika itself builds on is credited in CITATIONS.md.
+# Version/date are stamped by releases (see CHANGELOG.md), not hand-written here.
 cff-version: 1.2.0
-message: >-
-  If you reference Nika (the engine or the language) in academic or
-  technical work, please cite it.
-title: "Nika: the workflow language for AI — reference engine"
+message: "If you use Nika in your work, please cite this repository."
 type: software
+title: "Nika"
+abstract: "Intent-as-code workflow engine for AI: reviewable YAML DAGs, statically checked (schema, permits, cost floor) before execution, tamper-evident traces after. Single Rust binary."
 authors:
   - name: "SuperNovae Studio"
-    website: "https://supernovae.studio"
-  - family-names: "Melen"
-    given-names: "Thibaut"
+    city: "Paris"
+    country: "FR"
+    website: "https://nika.sh"
 repository-code: "https://github.com/supernovae-st/nika"
 url: "https://nika.sh"
 license: AGPL-3.0-or-later
 keywords:
-  - AI workflows
-  - workflow engine
-  - static analysis
-  - capability security
-  - Rust
-abstract: >-
-  The reference implementation of the Nika workflow language: a single
-  Rust binary that statically audits a declarative YAML workflow before
-  any token is spent (plan, cost ceiling, secret flows, capability
-  boundary), then executes it locally across multiple LLM providers with
-  a hash-chained trace. The language specification is a separate
-  Apache-2.0 repository (supernovae-st/nika-spec).
+  - workflow-engine
+  - ai-agents
+  - llm-orchestration
+  - static-analysis
+  - mcp
+  - rust
 references:
   - type: software
-    title: "Nika language specification"
+    title: "Nika language specification (nika-spec)"
     repository-code: "https://github.com/supernovae-st/nika-spec"
     license: Apache-2.0
     authors:


### PR DESCRIPTION
Reforged after a near-clobber: the first push overwrote the existing CITATION.cff (deliberate design — Zenodo archive-time, release-stamped versions, CITATIONS.md separation — likely the paper lane's work; my premise « the engine had none » was false). Now strictly ADDITIVE: the file stays byte-identical except the `references:` block cross-linking the Apache-2.0 spec repo (the twin of nika-spec#140's back-reference). cffconvert-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)