### PR TITLE
fix(nika-runtime): permits.tools enforced at run — the last check-only axis closes

### DIFF
--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -28,6 +28,8 @@ use serde_json::Value;
 
 use crate::Runtime;
 use crate::errors::RuntimeError;
+
+mod permits;
 use crate::expr::{self, Scope};
 use crate::record::TaskErrorRecord;
 
@@ -366,6 +368,11 @@ where
             }
         };
         let note = format!("invoke · {tool}");
+        // NIKA-SEC-004 BEFORE any arg rendering — the tool id is static,
+        // so an out-of-boundary invoke is refused without touching the scope.
+        if let Some(denial) = permits::check_tool_permits(scope.permits, &note, &tool) {
+            return denial;
+        }
         let args = match &action.args {
             None => Value::Object(serde_json::Map::new()),
             Some(a) => match expr::render_json(&a.value, scope) {
@@ -596,6 +603,12 @@ where
         agent_buffer: &crate::agent_events::BufferingObserver,
         contract: Option<&crate::contract::TaskContract<'_>>,
     ) -> Dispatched {
+        // NIKA-SEC-004: the declared `tools:` universe must FIT
+        // `permits.tools` — refused before any render or provider call,
+        // one refusal for the whole task.
+        if let Some(denial) = permits::check_agent_tools_permits(scope.permits, &action.tools) {
+            return denial;
+        }
         let prompt = match expr::render(&action.prompt.value, scope) {
             Ok(p) => p,
             Err(err) => return Dispatched::template_err("agent · ?", &err),

--- a/crates/nika-runtime/src/dispatch/permits.rs
+++ b/crates/nika-runtime/src/dispatch/permits.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The tools capability gates (spec 01 §permits · NIKA-SEC-004) — split
+//! out of `dispatch.rs` under the ADR-023 1,500-LOC ceiling: same
+//! predicates, same posture, one predicate shared with the static
+//! `permits_fit` scan so check≡run cannot drift.
+
+use super::Dispatched;
+
+/// The tools capability boundary (spec 01 §permits · NIKA-SEC-004): once a
+/// workflow declares `permits`, every tool the body names — an `invoke:`
+/// target or an `agent:` universe entry — must fit `permits.tools`. The
+/// verdict is [`nika_schema::types::Permits::allows_tool`] itself — the
+/// ONE predicate the
+/// static `permits_fit` scan and the e-diff parity battery already pin —
+/// so an omitted `tools:` under a declared block is DEFAULT-DENY and
+/// check≡run cannot drift. `None` permits = nothing to enforce (today's
+/// behavior · the exec gate's posture). A `workflow:` call never reaches
+/// here — spec 14's containment law (NIKA-COMP-002) owns it.
+pub(super) fn check_tool_permits(
+    permits: Option<&nika_schema::types::Permits>,
+    note: &str,
+    tool: &str,
+) -> Option<Dispatched> {
+    let permits = permits?;
+    if permits.allows_tool(tool) {
+        return None;
+    }
+    Some(Dispatched::security_err(
+        note,
+        format!("tool {tool:?} is not in the `permits.tools` allowlist"),
+    ))
+}
+
+/// The agent half of the tools boundary: every entry of the declared
+/// `tools:` universe must fit `permits.tools` — one refusal for the
+/// whole task (the run-time half of the static `permits_fit` scan).
+pub(super) fn check_agent_tools_permits(
+    permits: Option<&nika_schema::types::Permits>,
+    tools: &[nika_schema::Spanned<String>],
+) -> Option<Dispatched> {
+    for tool in tools {
+        if let Some(denial) = check_tool_permits(permits, "agent · ?", &tool.value) {
+            return Some(denial);
+        }
+    }
+    None
+}

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -1043,3 +1043,217 @@ mod skill_compose_tests {
         assert!(error.message.contains("frontmatter"), "{}", error.message);
     }
 }
+
+/// `permits.tools` RUNTIME enforcement (spec 01 §permits · NIKA-SEC-004) —
+/// the last check-only axis closes. The static `permits_fit` scan refuses
+/// an out-of-boundary tool at `nika check`; these fixtures prove the RUN
+/// refuses it too when the report can no longer vouch for the body — an
+/// embedder that skipped `check`, or a clean report forged for a different
+/// (permit-free) workflow. The honest path (check THEN run the same file)
+/// is covered by the granted fixtures, which ride their REAL clean report.
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tools_permits_tests {
+    use std::sync::Arc;
+
+    use nika_kernel::tool_executor::ToolResult;
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_verb_agent::AgentVerb;
+    use nika_verb_exec::ExecVerb;
+    use nika_verb_infer::InferVerb;
+    use nika_verb_invoke::InvokeVerb;
+
+    use crate::{DeterministicStamper, RunOutcome, Runtime, RuntimeConfig, TaskStatus, VecSink};
+
+    type MockRuntime = Runtime<
+        MockShell,
+        MockToolExecutor,
+        nika_providers::NoHttp,
+        MockProvider,
+        MockToolDefinitionProvider,
+        MockClock,
+    >;
+
+    fn runtime_with(executor: MockToolExecutor, provider: MockProvider) -> MockRuntime {
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(executor)));
+        Runtime::new(
+            ExecVerb::new(Arc::new(MockShell::new())),
+            Arc::clone(&invoke),
+            InferVerb::new(
+                Arc::new(nika_providers::ProviderRegistry::without_http(
+                    nika_providers::ProvidersConfig::new(),
+                )),
+                "mock/echo",
+            ),
+            AgentVerb::new(
+                Arc::new(provider),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default(),
+        )
+    }
+
+    fn parse(yaml: &str) -> nika_schema::raw::RawWorkflow {
+        nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses")
+    }
+
+    /// The embedder-bypass shape: `check` refuses the REAL workflow (its
+    /// body escapes the declared boundary), so the run is fed the CLEAN
+    /// report of its permit-free twin — same tasks, same waves. A skipped
+    /// check and a forged report are indistinguishable to the runtime; it
+    /// must enforce the boundary the WORKFLOW declares, never the one a
+    /// report vouches for. Every fixture writes `permits:` as ONE line so
+    /// the twin is a line-strip away.
+    fn forged_clean_report(
+        yaml: &str,
+    ) -> (nika_schema::raw::RawWorkflow, nika_schema::CheckReport) {
+        let wf = parse(yaml);
+        assert!(
+            !nika_schema::check(&wf).is_clean(),
+            "the honest check refuses the real workflow (the static half)"
+        );
+        let twin_yaml = yaml
+            .lines()
+            .filter(|line| !line.starts_with("permits:"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let report = nika_schema::check(&parse(&twin_yaml));
+        assert!(
+            report.is_clean(),
+            "the permit-free twin checks clean (same tasks → same waves)"
+        );
+        (wf, report)
+    }
+
+    async fn run(
+        runtime: &MockRuntime,
+        wf: &nika_schema::raw::RawWorkflow,
+        report: &nika_schema::CheckReport,
+    ) -> RunOutcome {
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        runtime
+            .run(wf, report, &mut stamper, &mut sink)
+            .await
+            .expect("run settles")
+    }
+
+    /// A tool OUTSIDE `permits.tools` is refused at the dispatch with the
+    /// SAME code the static checker emits — even under a forged clean
+    /// report — and the executor is NEVER reached.
+    #[tokio::test]
+    async fn invoke_outside_tools_boundary_is_refused_under_a_forged_report() {
+        let (wf, report) = forged_clean_report(
+            "nika: v1\nworkflow:\n  id: tools-deny\npermits: { tools: [\"nika:read\"] }\ntasks:\n  danger:\n    invoke: { tool: \"nika:write\", args: { path: \"x\", content: \"y\" } }\n",
+        );
+        let executor = MockToolExecutor::new(); // EMPTY — any call is a bug
+        let probe = executor.clone();
+        let runtime = runtime_with(executor, MockProvider::new("mock"));
+        let outcome = run(&runtime, &wf, &report).await;
+        assert!(!outcome.ok, "a refused tool fails the run");
+        let rec = &outcome.records["danger"];
+        assert_eq!(rec.status, TaskStatus::Failure);
+        let err = rec.error.as_ref().expect("the refusal is recorded");
+        assert_eq!(
+            err.code, "NIKA-SEC-004",
+            "one voice with the static checker"
+        );
+        assert!(!err.transient, "a security boundary never retries");
+        assert!(
+            err.message.contains("nika:write"),
+            "the refusal names the tool: {}",
+            err.message
+        );
+        assert!(
+            probe.captured_calls().is_empty(),
+            "the refused tool NEVER executed"
+        );
+    }
+
+    /// A declared block that omits `tools:` grants NO tool (default-deny —
+    /// the exact `Permits::allows_tool` verdict the static scan pins: an
+    /// omitted category is not an allow-all).
+    #[tokio::test]
+    async fn declared_block_with_omitted_tools_denies_every_tool() {
+        let (wf, report) = forged_clean_report(
+            "nika: v1\nworkflow:\n  id: tools-omitted\npermits: { exec: true }\ntasks:\n  t:\n    invoke: { tool: \"nika:read\", args: { path: \"x\" } }\n",
+        );
+        let executor = MockToolExecutor::new();
+        let probe = executor.clone();
+        let runtime = runtime_with(executor, MockProvider::new("mock"));
+        let outcome = run(&runtime, &wf, &report).await;
+        assert!(!outcome.ok, "an omitted category is default-deny");
+        let err = outcome.records["t"].error.as_ref().expect("recorded");
+        assert_eq!(err.code, "NIKA-SEC-004");
+        assert!(probe.captured_calls().is_empty());
+    }
+
+    /// The honest path: a granted tool passes check AND run — the gate is
+    /// inert on a body that fits its declared boundary.
+    #[tokio::test]
+    async fn invoke_inside_tools_boundary_runs_on_the_real_report() {
+        let wf = parse(
+            "nika: v1\nworkflow:\n  id: tools-allow\npermits: { tools: [\"nika:read\"], fs: { read: [\"x\"] } }\ntasks:\n  ok:\n    invoke: { tool: \"nika:read\", args: { path: \"x\" } }\n",
+        );
+        let report = nika_schema::check(&wf);
+        assert!(report.is_clean(), "the fixture fits its boundary");
+        let executor = MockToolExecutor::new().enqueue_ok(ToolResult::success("t1", "file-bytes"));
+        let probe = executor.clone();
+        let runtime = runtime_with(executor, MockProvider::new("mock"));
+        let outcome = run(&runtime, &wf, &report).await;
+        assert!(outcome.ok, "a granted tool runs to success");
+        assert_eq!(outcome.records["ok"].status, TaskStatus::Success);
+        assert_eq!(probe.captured_calls().len(), 1, "exactly one tool call");
+    }
+
+    /// The agent verb's declared `tools:` universe is gated the same way —
+    /// refused BEFORE any provider call (the in-loop whitelist governs the
+    /// model's picks only within a boundary-fitting universe).
+    #[tokio::test]
+    async fn agent_universe_outside_tools_boundary_is_refused() {
+        let (wf, report) = forged_clean_report(
+            "nika: v1\nworkflow:\n  id: agent-tools-deny\nmodel: mock/echo\npermits: { tools: [\"nika:read\"] }\ntasks:\n  go:\n    agent:\n      prompt: \"go\"\n      tools: [\"nika:read\", \"nika:write\"]\n",
+        );
+        let provider = MockProvider::new("mock").enqueue_text("never reached");
+        let probe = provider.clone();
+        let runtime = runtime_with(MockToolExecutor::new(), provider);
+        let outcome = run(&runtime, &wf, &report).await;
+        assert!(!outcome.ok);
+        let rec = &outcome.records["go"];
+        assert_eq!(rec.status, TaskStatus::Failure);
+        let err = rec.error.as_ref().expect("the refusal is recorded");
+        assert_eq!(err.code, "NIKA-SEC-004");
+        assert!(
+            probe.captured_requests().is_empty(),
+            "no token is spent on an out-of-boundary universe"
+        );
+    }
+
+    /// A universe INSIDE the boundary runs untouched — the gate defers to
+    /// the loop's whitelist for the model's picks (behavior unchanged).
+    #[tokio::test]
+    async fn agent_universe_inside_tools_boundary_runs() {
+        let wf = parse(
+            "nika: v1\nworkflow:\n  id: agent-tools-allow\nmodel: mock/echo\npermits: { tools: [\"nika:read\"] }\ntasks:\n  go:\n    agent:\n      prompt: \"go\"\n      tools: [\"nika:read\"]\n",
+        );
+        let report = nika_schema::check(&wf);
+        assert!(report.is_clean(), "the fixture fits its boundary");
+        let provider = MockProvider::new("mock").enqueue_text("done");
+        let probe = provider.clone();
+        let runtime = runtime_with(MockToolExecutor::new(), provider);
+        let outcome = run(&runtime, &wf, &report).await;
+        assert!(outcome.ok, "a granted universe runs to success");
+        assert_eq!(outcome.records["go"].status, TaskStatus::Success);
+        assert_eq!(probe.captured_requests().len(), 1, "one provider turn");
+    }
+}


### PR DESCRIPTION
## What

The static `permits_fit` scan refused an `invoke`/`agent` tool outside `permits.tools` at check time, but the runtime dispatch never consulted the grant: an embedder driving `nika-runtime` directly (or a hand-built clean `CheckReport`) bypassed the boundary on the tools axis — the one axis with zero runtime backstop.

- `dispatch_invoke` refuses the tool id **before any arg rendering** (the id is static — no scope touched), NIKA-SEC-004.
- `dispatch_agent` refuses a whitelist entry **before any provider call** — one refusal for the whole task.
- The verdict is `Permits::allows_tool` itself — the ONE predicate the static scan and the e-diff parity battery already pin, so check≡run cannot drift. Omitted `tools:` under a declared block is default-deny; no `permits:` block keeps today's blocklist-only posture (the exec gate's doctrine). `workflow:` calls never reach here — spec 14's containment law owns them.
- The gates live in a new `dispatch/permits.rs` (the ADR-023 1,500-LOC ceiling — dispatch.rs sat at 1,504).

## Tests

- `invoke_outside_tools_boundary_is_refused_under_a_forged_report` — the embedder hole itself.
- `declared_block_with_omitted_tools_denies_every_tool`.
- `invoke_inside_tools_boundary_runs_on_the_real_report`.

`cargo test -p nika-runtime --lib` 159 passed · clippy 0 warnings · cargo doc private-items clean · fn-length ratchet OK.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>