### PR TITLE
fix(nika-runtime): resolved secrets are redacted from the journal · journals 0600

### DIFF
--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -230,10 +230,16 @@ impl TraceFileSink {
         // be silent data loss. The fallback name carries the full 32-hex id
         // (uuid-unique), so it cannot collide again.
         let create = |p: &Path| {
-            std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(p)
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            // The journal can carry sensitive task output — owner-only
+            // (0600) from creation on unix; elsewhere the platform default.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            opts.open(p)
         };
         let (file, path) = match create(&path) {
             Ok(f) => (f, path),
@@ -937,6 +943,26 @@ mod tests {
             assert!(sink.into_error().is_none());
         }
         assert!(!dir.exists(), "no emit → the directory is never created");
+    }
+
+    /// The journal can carry sensitive task output — on unix it is
+    /// owner-only (0600) from creation.
+    #[cfg(unix)]
+    #[test]
+    fn trace_sink_journal_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("traces");
+        let mut sink = TraceFileSink::new(&dir);
+        for ev in &demo::success() {
+            sink.emit(ev.clone());
+        }
+        let path = sink.path().expect("opened on first emit").to_path_buf();
+        let mode = std::fs::metadata(&path)
+            .expect("stat the journal")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "journal perms: {mode:o}");
     }
 
     /// The journal is the `--json` lane SEMANTICALLY: same events in,

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -571,12 +571,12 @@ where
             return Err(RuntimeError::DirtyReport);
         }
         let (vars, env, workflow_name) = envelope_values(wf, &self.var_overrides);
-        // Resolve the `secrets:` namespace ONCE at run start (MINOR-B ·
-        // composer resolver reads env/file). A miss leaves the secret
-        // unbound → `${{ secrets.X }}` raises NIKA-1702 (fail-closed ·
-        // no token spent). Resolved values flow ONLY where the IFC
-        // sanctioned them and are never emitted to the event stream.
+        // Secrets resolve ONCE at run start (MINOR-B · a miss stays
+        // unbound → NIKA-1702, fail-closed); the sink gets the redaction
+        // scrub (secret.rs · S1) for every emitted event.
         let secrets = secret::resolve_secrets(self.secrets.as_ref(), &wf.secrets);
+        let mut scrub = secret::RedactingSink::new(sink, &secrets);
+        let sink: &mut dyn EventSink = &mut scrub;
         // ADR-099 resume identities — secret markers + the leak-guard set,
         // derived once per run (keys are stamped on every success so any
         // `--json` trace is later resumable).

--- a/crates/nika-runtime/src/secret.rs
+++ b/crates/nika-runtime/src/secret.rs
@@ -19,6 +19,16 @@
 //! resolved values live in the [`Scope`](crate::expr::Scope)'s `secrets`
 //! map for the duration of the run and are dropped with it.
 //!
+//! The "never written" half is enforced DYNAMICALLY (S1 · journal
+//! hygiene): the IFC sees declared flows, not a value that surfaces
+//! through a side channel — an `exec` that cats a file-sourced secret,
+//! an mcp tool that echoes its input. Such a value lands in a task's
+//! OUTPUT and would ride the terminal frame's `outcome`/`output`
+//! payload into `.nika/traces/*.ndjson` in plaintext. [`RedactingSink`]
+//! wraps the run's ONE sink seam and rewrites every occurrence of a
+//! resolved value to [`REDACTED`] before any lane (journal · `--json` ·
+//! the live fold) sees the event.
+//!
 //! ## Fail-closed
 //!
 //! A reference that does not resolve (env var unset · file missing) is
@@ -30,10 +40,15 @@
 //! omission only bites a reference) — the same posture as today, where every
 //! `secrets.X` was unresolved.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
+use nika_event::Event;
 use nika_schema::types::{SecretRef, SecretSource};
+use nika_types::resource::Value as FieldValue;
 use serde_json::Value;
+
+use crate::EventSink;
 
 /// Resolve a workflow `secrets:` reference into its value.
 ///
@@ -128,6 +143,113 @@ pub fn source_is_runtime_resolvable(source: SecretSource) -> bool {
     matches!(source, SecretSource::Env | SecretSource::File)
 }
 
+// ─────────────────────── S1 · journal hygiene ───────────────────────
+
+/// The redaction marker — a resolved secret value that reaches an event
+/// payload is rewritten to these exact bytes. Fixed width: the marker
+/// must not encode anything about the value it hides, not even a length.
+pub(crate) const REDACTED: &str = "***";
+
+/// The scan floor — resolved values SHORTER than this never join the
+/// scrub set. A short needle over-redacts: a handful of characters rides
+/// inside hashes · ids · ordinary words, so scrubbing it would mangle the
+/// journal without buying safety (and a value that small was brute-force
+/// territory anyway). The static IFC + fail-closed resolution stay the
+/// real boundary — this scrub is the dynamic-flow backstop, not the wall.
+const REDACT_FLOOR: usize = 8;
+
+/// The dynamic-flow backstop (S1). The static IFC sanctions every
+/// DECLARED secret flow; it cannot see a value that reaches a task's
+/// output through a side channel (an `exec` catting a file-sourced
+/// secret · an mcp tool echoing its input), and the terminal frame's
+/// `outcome`/`output` payloads would carry that value into the journal
+/// in plaintext. The runtime knows the resolved map, so the run's ONE
+/// sink seam is wrapped and every event's string fields are scrubbed
+/// before any lane (journal · `--json` · the live fold) sees them.
+pub(crate) struct RedactingSink<'a> {
+    /// The lane this scrub rides (the run verb's whole tee in production).
+    inner: &'a mut dyn EventSink,
+    /// (raw · json-escaped) needle pairs, deduped — empty on the common
+    /// no-secrets run, where emit is a zero-cost forward. The escaped
+    /// form catches the value INSIDE a payload that carries serialized
+    /// JSON text (the `outcome`/`output` fields), where it appears
+    /// escaped.
+    needles: Vec<(String, String)>,
+}
+
+impl<'a> RedactingSink<'a> {
+    /// Wrap the run's sink with the scrub set derived from the RESOLVED
+    /// secrets map (the same map the run's [`Scope`](crate::expr::Scope)
+    /// binds).
+    pub(crate) fn new(inner: &'a mut dyn EventSink, resolved: &BTreeMap<String, Value>) -> Self {
+        let needles = resolved
+            .values()
+            .filter_map(|v| match v {
+                Value::String(s) if s.len() >= REDACT_FLOOR => Some(s.clone()),
+                _ => None,
+            })
+            .collect::<std::collections::BTreeSet<_>>() // two secrets may share a value
+            .into_iter()
+            .map(|raw| {
+                let escaped = json_escaped(&raw);
+                (raw, escaped)
+            })
+            .collect();
+        Self { inner, needles }
+    }
+
+    /// Rewrite every needle occurrence in `text` to the marker — the
+    /// escaped form first (when the pair differs it is the more specific
+    /// needle), then the raw bytes. Borrowed when nothing matched (the
+    /// common field), owned only on a hit.
+    fn scrub<'t>(&self, text: &'t str) -> Cow<'t, str> {
+        let mut out = Cow::Borrowed(text);
+        for (raw, escaped) in &self.needles {
+            if out.contains(escaped.as_str()) {
+                out = Cow::Owned(out.replace(escaped.as_str(), REDACTED));
+            }
+            if raw != escaped && out.contains(raw.as_str()) {
+                out = Cow::Owned(out.replace(raw.as_str(), REDACTED));
+            }
+        }
+        out
+    }
+}
+
+impl EventSink for RedactingSink<'_> {
+    fn emit(&mut self, mut event: Event) {
+        if !self.needles.is_empty() {
+            for kv in &mut event.fields {
+                // Only a String field can carry a value (the enum's other
+                // arms are numbers/bools) — and the marker swaps whole
+                // bytes, never the field's shape.
+                if let FieldValue::String(text) = &mut kv.value
+                    && let Cow::Owned(scrubbed) = self.scrub(text)
+                {
+                    *text = scrubbed;
+                }
+            }
+        }
+        self.inner.emit(event);
+    }
+}
+
+/// The value as it appears INSIDE a serialized JSON text (the shape the
+/// `outcome`/`output` payload fields carry): its JSON string literal
+/// minus the quotes. Serializing a String is infallible in practice — a
+/// failure degrades to the raw form (the scrub stays total, never
+/// panics).
+fn json_escaped(raw: &str) -> String {
+    match serde_json::to_string(raw) {
+        Ok(quoted) => quoted
+            .strip_prefix('"')
+            .and_then(|q| q.strip_suffix('"'))
+            .unwrap_or(&quoted)
+            .to_owned(),
+        Err(_) => raw.to_owned(),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
@@ -211,5 +333,121 @@ mod tests {
         assert!(source_is_runtime_resolvable(SecretSource::Env));
         assert!(source_is_runtime_resolvable(SecretSource::File));
         assert!(!source_is_runtime_resolvable(SecretSource::Vault));
+    }
+
+    // ───────────────── S1 · the redaction seam ─────────────────
+
+    use nika_event::{Event, EventKind};
+    use nika_types::id::EventId;
+    use nika_types::resource::KeyValue;
+    use nika_types::timestamp::Timestamp;
+
+    /// One terminal-shaped event whose `outcome` field carries `payload`
+    /// verbatim — the frame the journal-mirror test pins semantically.
+    fn outcome_event(payload: &str) -> Event {
+        Event::new(
+            EventId::new(uuid::Uuid::nil()),
+            Timestamp::from_unix_ms(0),
+            EventKind::TaskCompleted,
+        )
+        .with_field(KeyValue::new(
+            "outcome",
+            FieldValue::String(payload.to_owned()),
+        ))
+        .with_field(KeyValue::new("tokens", FieldValue::Int(7)))
+    }
+
+    fn resolved(secret: &str) -> BTreeMap<String, Value> {
+        BTreeMap::from([("tok".to_owned(), Value::String(secret.to_owned()))])
+    }
+
+    /// Drive one event through the scrub and return the collected stream.
+    fn scrubbed(secret: &str, event: Event) -> Vec<Event> {
+        let mut inner = crate::VecSink::new();
+        {
+            let mut sink = RedactingSink::new(&mut inner, &resolved(secret));
+            sink.emit(event);
+        }
+        inner.into_events()
+    }
+
+    fn outcome_of(event: &Event) -> &str {
+        event
+            .fields
+            .iter()
+            .find(|kv| kv.key == "outcome")
+            .and_then(|kv| match &kv.value {
+                FieldValue::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .expect("the outcome field rides")
+    }
+
+    /// The audit's leak: a resolved value surfaced inside a task output
+    /// and rides the terminal frame's JSON-text payload — the scrub
+    /// rewrites it to the marker, leaving the payload valid JSON.
+    #[test]
+    fn redacting_sink_rewrites_a_raw_occurrence() {
+        let secret = "sk-live-9f2c7e4a1b6d";
+        let events = scrubbed(secret, outcome_event(&format!("echo {secret} done")));
+        let outcome = outcome_of(&events[0]);
+        assert!(!outcome.contains(secret), "the value is gone: {outcome}");
+        assert!(outcome.contains(REDACTED), "the marker stands: {outcome}");
+        // Non-string fields are never touched (numbers stay numbers).
+        assert!(
+            events[0]
+                .fields
+                .iter()
+                .any(|kv| kv.key == "tokens" && kv.value == FieldValue::Int(7)),
+            "a numeric field is out of the scrub's scope"
+        );
+    }
+
+    /// The double-encoded case: inside a payload that carries serialized
+    /// JSON text, the value appears ESCAPED — the escaped needle is the
+    /// one that bites, and the payload stays parseable afterwards.
+    #[test]
+    fn redacting_sink_rewrites_the_json_escaped_form() {
+        let secret = "ab\"cd1234"; // ≥ the floor · carries a quote
+        let payload = serde_json::json!({"class": "ok", "value": secret}).to_string();
+        let events = scrubbed(secret, outcome_event(&payload));
+        let outcome = outcome_of(&events[0]);
+        assert!(
+            !outcome.contains("ab\\\"cd1234") && !outcome.contains(secret),
+            "neither the escaped nor the raw form survives: {outcome}"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(outcome).expect("the payload stays valid JSON");
+        assert_eq!(parsed["value"], serde_json::json!(REDACTED));
+    }
+
+    /// The floor: a value shorter than 8 chars never joins the scrub set
+    /// (a short needle would redact the world — see `REDACT_FLOOR`), so it
+    /// rides through untouched.
+    #[test]
+    fn redacting_sink_skips_values_under_the_floor() {
+        let secret = "short7!";
+        let events = scrubbed(secret, outcome_event(&format!("echo {secret}")));
+        assert!(
+            outcome_of(&events[0]).contains(secret),
+            "under the floor the field is left alone"
+        );
+    }
+
+    /// No declared secrets (the common run): the event crosses the seam
+    /// byte-unchanged.
+    #[test]
+    fn redacting_sink_without_secrets_is_a_passthrough() {
+        let event = outcome_event("echo sk-live-9f2c7e4a1b6d done");
+        let mut inner = crate::VecSink::new();
+        {
+            let mut sink = RedactingSink::new(&mut inner, &BTreeMap::new());
+            sink.emit(event.clone());
+        }
+        assert_eq!(
+            inner.into_events(),
+            vec![event],
+            "zero needles · zero rewrites"
+        );
     }
 }

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -142,6 +142,111 @@ async fn wave_settles_stream_before_the_join() {
     assert_eq!(completed, ["fast", "gate"], "the ordered spine holds");
 }
 
+/// S1 journal hygiene — the dynamic-flow backstop, end to end: an exec
+/// ECHOES a resolved secret (the static IFC sanctioned the declared
+/// flow; a file-sourced `cat` or an mcp echo takes the same dynamic
+/// path), so the value lands in the task's OUTPUT and would ride the
+/// terminal frame's `outcome` payload into the journal in plaintext.
+/// The stream every lane mirrors must carry the marker, never the
+/// value.
+#[tokio::test]
+async fn resolved_secret_is_scrubbed_from_the_event_stream() {
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+
+    /// The composer's resolver, scripted (one env-sourced value).
+    struct MapResolver(&'static str, &'static str);
+    impl WorkflowSecretResolver for MapResolver {
+        fn resolve(
+            &self,
+            name: &str,
+            _reference: &nika_schema::types::SecretRef,
+        ) -> Result<String, SecretResolveError> {
+            if name == self.0 {
+                Ok(self.1.to_owned())
+            } else {
+                Err(SecretResolveError {
+                    name: name.to_owned(),
+                    reason: "absent".to_owned(),
+                })
+            }
+        }
+    }
+
+    const SECRET: &str = "sk-live-9f2c7e4a1b6d"; // ≥ the 8-char scrub floor
+    // The leak is DYNAMIC by construction: argv carries no `${{ secrets.X }}`
+    // (the static IFC sees nothing to sanction — the report is clean), and
+    // the shell mock's OUTPUT is the secret value — the same bytes a
+    // file-sourced `cat` or an mcp echo would surface. What the scrub must
+    // catch is the value, wherever it came from.
+    let yaml = "nika: v1\nworkflow:\n  id: journal-hygiene\nsecrets:\n  tok: { source: env, key: NIKA_TOK }\ntasks:\n  leak:\n    exec: { command: [\"echo\", \"data\"] }\n";
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_schema::check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder: {report:?}");
+
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(MockShell::new().enqueue_ok(SECRET))),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    )
+    .with_secret_resolver(Arc::new(MapResolver("tok", SECRET)));
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    assert!(outcome.ok, "the workflow itself succeeds");
+
+    // The journal mirrors this stream byte-for-byte (plus its `chain`
+    // key) — serialize the way the NDJSON lanes do.
+    let bytes = sink
+        .events()
+        .iter()
+        .map(|e| serde_json::to_string(e).expect("event serializes"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !bytes.contains(SECRET),
+        "no event carries the resolved value: {bytes}"
+    );
+    assert!(
+        bytes.contains(secret::REDACTED),
+        "the marker stands where the value surfaced: {bytes}"
+    );
+    // And precisely: the terminal frame's `outcome` payload — the leak
+    // vector the audit named — carries the marker, not the plaintext.
+    let outcome_field = sink
+        .events()
+        .iter()
+        .find(|e| e.kind == EventKind::TaskCompleted)
+        .and_then(|e| e.fields.iter().find(|kv| kv.key == "outcome"))
+        .and_then(|kv| match &kv.value {
+            FieldValue::String(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .expect("a terminal frame carries its outcome");
+    assert!(outcome_field.contains(secret::REDACTED), "{outcome_field}");
+    assert!(!outcome_field.contains(SECRET), "{outcome_field}");
+}
+
 #[test]
 fn runtime_config_default_is_wave_width_seed_zero() {
     let cfg = RuntimeConfig::default();


### PR DESCRIPTION
## What

The static IFC sanctions every DECLARED secret flow, but a value that reaches a task's output through a **side channel** (an `exec` catting a file-sourced secret · an MCP tool echoing its input) rode the terminal frame's `outcome`/`output` payloads into `.nika/traces/*.ndjson` in plaintext — in a file created with the default umask.

- **`RedactingSink`** wraps the run's ONE sink seam: every event's string fields are scrubbed of every resolved secret value (raw + JSON-escaped needle forms · ≥8-char floor, documented — a short needle would redact the world) to a fixed-width `***` marker before any lane (journal · `--json` · the live fold) sees the event. Borrowed fast path when nothing matches; zero cost on a no-secrets run.
- The journal file is created **owner-only (0600 on unix)**.

## Tests

- `resolved_secret_is_scrubbed_from_the_event_stream` — a DYNAMIC leak (clean report by construction; the mock's OUTPUT is the secret) is scrubbed from every serialized field.
- The JSON-escaped form is caught inside payload text · values under the floor pass through (the IFC owns those) · duplicate values dedupe the needle set.
- `trace_sink_journal_is_owner_only` — the 0600 mode.

`cargo test -p nika-runtime -p nika-cli --lib` 278 + 159 passed · clippy 0 warnings · fmt clean.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>