### PR TITLE
fix(nika-models): pulled weights are sha256-verified against the Hub's declaration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,6 +4039,7 @@ dependencies = [
  "nika-kernel",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
 ]
 

--- a/crates/nika-models/Cargo.toml
+++ b/crates/nika-models/Cargo.toml
@@ -17,6 +17,7 @@ nika-http   = { path = "../nika-http", version = "0.105.0" }   # ReqwestHttp —
 tokio       = { workspace = true }                            # the blocking pull seam's current-thread runtime (the registry #452 idiom)
 serde       = { workspace = true }                            # the Hub tree rows
 serde_json  = { workspace = true }                            # tree-listing parse
+sha2        = { workspace = true }                            # the pull integrity gate — Hub-declared sha256, hard refuse on mismatch (the registry client's exact dep)
 
 # ── the sovereign local-inference launch surface (ADR-091/093) — OFF by default ─
 # `serve` boots the candle backend behind the tiny_http sidecar server.

--- a/crates/nika-models/public-api.txt
+++ b/crates/nika-models/public-api.txt
@@ -60,5 +60,7 @@ pub fn nika_models::ModelsProbe::and<P, B, E>(self, other: P) -> tower_http::fol
 pub fn nika_models::ModelsProbe::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
 impl<T> tracing::instrument::Instrument for nika_models::ModelsProbe
 impl<T> tracing::instrument::WithSubscriber for nika_models::ModelsProbe
+impl<T> typenum::type_operators::Same for nika_models::ModelsProbe
+pub type nika_models::ModelsProbe::Output = T
 pub const nika_models::SERVE_FAMILY: &str
 pub fn nika_models::models_probe() -> nika_models::ModelsProbe

--- a/crates/nika-models/src/digest.rs
+++ b/crates/nika-models/src/digest.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The pull integrity gate — multi-gigabyte GGUF weights verify against
+//! the Hub-declared sha256 BEFORE they land in the models dir (a
+//! size-confirm gate says the COUNT is right; only a digest says the
+//! BYTES are).
+//!
+//! The digest of record, in order of authority:
+//! 1. `x-linked-etag` on the download response — the Hub puts the LFS
+//!    sha256 on the resolve redirect; a transport that surfaces the hop
+//!    hands it straight over;
+//! 2. the tree listing's `lfs.oid` — THE production lane: `nika-http`
+//!    follows the redirect and answers the FINAL hop's headers, where
+//!    the CDN's own `etag` is the Xet/md5 hash, never the file's
+//!    sha256 (verified live 2026-07-20);
+//! 3. a bare `etag`, only when it is exactly a 64-hex sha256.
+//!
+//! Anything else declares nothing: the pull then SUCCEEDS unverified —
+//! skip-with-loud-note, never fail (a small non-LFS `tokenizer.json`
+//! carries no sha256 at all). A DECLARED digest that mismatches is the
+//! opposite arm: HARD-REFUSE with both digests named, and nothing left
+//! behind — no artifact, no `.part` (a re-pull must not resume onto
+//! tampered bytes). Hashing happens ONCE at completion, over the whole
+//! `.part` from disk: an incremental hash would miss the bytes an
+//! earlier interrupted process wrote, so a resumed pull and a fresh
+//! pull share this one gate.
+
+use std::collections::BTreeMap;
+use std::io::Read as _;
+use std::path::Path;
+
+use crate::pull::{Refusal, refuse};
+use crate::store;
+
+/// What the integrity gate did with a completed transfer — the pull
+/// seam's loud note and the store record both read this verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Integrity {
+    /// The Hub declared a sha256 and the completed bytes matched it;
+    /// the digest records beside the file (`nika model list` shows it).
+    Verified(String),
+    /// The Hub declared no sha256 for this file — the pull succeeded
+    /// size-checked only; the caller surfaces the loud note.
+    NotDeclared,
+}
+
+/// The completed bytes failed the Hub-declared sha256 — typed at the
+/// gate so expected and actual cannot blur into prose (the registry
+/// client's `HashMismatch` arm, in this crate's plain-refusal voice).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DigestMismatch {
+    /// The file whose bytes lied.
+    pub file: String,
+    /// The Hub-declared sha256 (64-hex).
+    pub expected: String,
+    /// What the downloaded bytes actually hash to.
+    pub actual: String,
+}
+
+impl DigestMismatch {
+    /// The hard refusal: both digests named, the cleanup stated.
+    pub(crate) fn refusal(&self) -> Refusal {
+        refuse(format!(
+            "model pull: {} failed the integrity check — the bytes do not match the Hub's \
+             declared sha256\n  expected: {}\n  actual:   {}\n  nothing was installed (the \
+             partial file was deleted — a re-pull starts clean)\n  fix: re-run the pull; if \
+             it fails again the mirror or the network is tampering — fetch the file from \
+             huggingface.co directly\n",
+            self.file, self.expected, self.actual
+        ))
+    }
+}
+
+/// The Hub-declared sha256 for one download (the module doc names the
+/// order of authority). `lfs_oid` is the tree listing's pointer; the
+/// headers are the download response's.
+pub(crate) fn declared_sha256(
+    headers: &BTreeMap<String, String>,
+    lfs_oid: Option<&str>,
+) -> Option<String> {
+    header_sha256(headers, "x-linked-etag")
+        .or_else(|| {
+            lfs_oid
+                .filter(|oid| store::is_sha256_hex(oid))
+                .map(str::to_ascii_lowercase)
+        })
+        .or_else(|| header_sha256(headers, "etag"))
+}
+
+/// A response header carrying a sha256? Values arrive quoted (the Hub
+/// spells `x-linked-etag: "abcd…"`); a weak-validator `W/` prefix drops
+/// too. Anything not exactly 64 hex (a CDN's Xet/md5 etag) is not a
+/// sha256 and declares nothing.
+fn header_sha256(headers: &BTreeMap<String, String>, name: &str) -> Option<String> {
+    let raw = headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))?
+        .1;
+    let trimmed = raw.trim();
+    let unquoted = trimmed
+        .strip_prefix("W/")
+        .unwrap_or(trimmed)
+        .trim_matches('"');
+    store::is_sha256_hex(unquoted).then(|| unquoted.to_ascii_lowercase())
+}
+
+/// The completion gate, run ONCE per finished transfer (the module doc
+/// names the arms): verify → land → record. The `.part` renames into
+/// place ONLY after the check — a mismatch never produces a named
+/// artifact.
+pub(crate) fn finish_write(
+    declared: Option<String>,
+    part: &Path,
+    dest: &Path,
+    file: &str,
+) -> Result<Integrity, Refusal> {
+    let integrity = match declared {
+        Some(expected) => {
+            let actual = sha256_file(part)?;
+            if actual != expected {
+                let _ = std::fs::remove_file(part);
+                let _ = std::fs::remove_file(dest);
+                return Err(DigestMismatch {
+                    file: file.to_owned(),
+                    expected,
+                    actual,
+                }
+                .refusal());
+            }
+            Integrity::Verified(expected)
+        }
+        None => Integrity::NotDeclared,
+    };
+    std::fs::rename(part, dest).map_err(|e| {
+        refuse(format!(
+            "model pull: cannot move {} into place ({e})\n  fix: check the models dir\n",
+            part.display()
+        ))
+    })?;
+    if let Integrity::Verified(digest) = &integrity {
+        record_digest(dest, digest)?;
+    }
+    Ok(integrity)
+}
+
+/// `<file>.sha256` beside the verified GGUF — the store metadata
+/// `nika model list` reads (the registry's digest-record precedent, one
+/// plain hex line). A record that will not write refuses honestly: the
+/// verified file IS in place and the message says so.
+fn record_digest(dest: &Path, digest: &str) -> Result<(), Refusal> {
+    std::fs::write(store::digest_sidecar(dest), format!("{digest}\n")).map_err(|e| {
+        refuse(format!(
+            "model pull: {} is verified and in place, but its digest record would not write \
+             ({e})\n  fix: check the models dir\n",
+            dest.display()
+        ))
+    })
+}
+
+/// sha256 the completed file in one streaming pass (1 MiB chunks — the
+/// GGUF is gigabytes, never load it whole). Hex-lowercase, the Hub's
+/// spelling.
+fn sha256_file(path: &Path) -> Result<String, Refusal> {
+    use sha2::Digest as _;
+    let unreadable = |e: std::io::Error| {
+        refuse(format!(
+            "model pull: cannot re-read {} for the integrity check ({e})\n  fix: check the \
+             models dir\n",
+            path.display()
+        ))
+    };
+    let mut file = std::fs::File::open(path).map_err(&unreadable)?;
+    let mut hasher = sha2::Sha256::new();
+    // 1 MiB chunks, heap-held (the GGUF is gigabytes — never load it
+    // whole, never blow the stack either).
+    let mut buf = vec![0u8; 1024 * 1024].into_boxed_slice();
+    loop {
+        let read = file.read(&mut buf).map_err(&unreadable)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+/// sha256 of a byte slice, hex-lowercase — the test-facing spelling of
+/// the same primitive (the pull integration tests declare their
+/// expected etags through it, never a hand-computed constant).
+#[cfg(test)]
+pub(crate) fn sha256_of(bytes: &[u8]) -> String {
+    use sha2::Digest as _;
+    hex_lower(&sha2::Sha256::digest(bytes))
+}
+
+/// Lowercase-hex encode (no hex crate — two lines, zero deps; the
+/// registry client's exact idiom).
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut out, b| {
+            let _ = write!(out, "{b:02x}");
+            out
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    // The pull/store tests' exact fixture idiom.
+    #[allow(clippy::disallowed_methods)]
+    fn temp_root(name: &str) -> PathBuf {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(
+            || {
+                std::env::current_dir()
+                    .expect("current dir")
+                    .join("target")
+                    .join("tmp")
+            },
+            PathBuf::from,
+        );
+        let dir = base.join(format!("nika-digest-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp root");
+        dir
+    }
+
+    fn headers(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    /// A real Hub sha256 shape (the `SmolLM2` `Q4_K_M` x-linked-etag).
+    const GOOD: &str = "2e8040ceae7815abe0dcb3540b9995eaa1fa0d2ca9e797d0a635ae4433c68c2d";
+
+    /// The order of authority: `x-linked-etag`, then the tree's
+    /// `lfs.oid`, then a bare sha256-shaped `etag`; anything weaker
+    /// declares nothing. Quoted / weak-validator / uppercase forms
+    /// normalize; a 32-hex md5 etag is NOT a sha256.
+    #[test]
+    fn declared_sha256_walks_the_order_of_authority() {
+        // The redirect-hop header wins when a transport surfaces it.
+        let quoted = format!("\"{GOOD}\"");
+        let h = headers(&[("x-linked-etag", quoted.as_str())]);
+        assert_eq!(declared_sha256(&h, None).as_deref(), Some(GOOD));
+
+        // The tree pointer is the production lane: the CDN's own etag
+        // (here a 64-hex Xet hash) must NOT shadow it.
+        let xet = format!("\"{}\"", "f".repeat(64));
+        let cdn = headers(&[("etag", xet.as_str())]);
+        assert_eq!(declared_sha256(&cdn, Some(GOOD)).as_deref(), Some(GOOD));
+
+        // No tree pointer: a 64-hex etag is the fallback…
+        let f64 = "f".repeat(64);
+        assert_eq!(declared_sha256(&cdn, None).as_deref(), Some(f64.as_str()));
+
+        // …but a 32-hex md5 etag is not a sha256 — nothing declared.
+        let md5 = headers(&[("etag", "\"9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d\"")]);
+        assert_eq!(declared_sha256(&md5, None), None);
+
+        // Weak-validator + uppercase normalize to the lowercase digest.
+        let weak = format!("W/\"{}\"", GOOD.to_uppercase());
+        let odd = headers(&[("x-linked-etag", weak.as_str())]);
+        assert_eq!(declared_sha256(&odd, None).as_deref(), Some(GOOD));
+
+        // A garbage tree pointer declares nothing on its own.
+        assert_eq!(declared_sha256(&BTreeMap::new(), Some("not-hex")), None);
+    }
+
+    /// A declared match lands the file + its digest record; the verdict
+    /// carries the verified digest.
+    #[test]
+    fn finish_write_verifies_lands_and_records() {
+        let root = temp_root("gate-happy");
+        let part = root.join("w.gguf.part");
+        let dest = root.join("w.gguf");
+        std::fs::write(&part, b"weights").expect("part");
+        let digest = sha256_file(&part).expect("hash");
+        let verdict =
+            finish_write(Some(digest.clone()), &part, &dest, "w.gguf").expect("gate passes");
+        assert_eq!(verdict, Integrity::Verified(digest.clone()));
+        assert_eq!(std::fs::read(&dest).expect("dest"), b"weights");
+        assert!(!part.exists(), "the .part renamed into place");
+        assert_eq!(
+            std::fs::read_to_string(store::digest_sidecar(&dest)).expect("record"),
+            format!("{digest}\n"),
+            "the verified digest records beside the GGUF"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A mismatch HARD-refuses naming both digests — and leaves
+    /// NOTHING: no artifact, no .part, no record.
+    #[test]
+    fn finish_write_hard_refuses_a_mismatch_and_leaves_nothing() {
+        let root = temp_root("gate-mismatch");
+        let part = root.join("w.gguf.part");
+        let dest = root.join("w.gguf");
+        std::fs::write(&part, b"tampered").expect("part");
+        let expected = "ab".repeat(32);
+        let refusal = finish_write(Some(expected.clone()), &part, &dest, "w.gguf")
+            .expect_err("a mismatch refuses");
+        assert!(refusal.contains(&expected), "expected named: {refusal}");
+        let actual = {
+            use sha2::Digest as _;
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(b"tampered");
+            hex_lower(&hasher.finalize())
+        };
+        assert!(refusal.contains(&actual), "actual named: {refusal}");
+        assert!(!dest.exists(), "no artifact lands");
+        assert!(
+            !part.exists(),
+            "the .part dies — a re-pull must not resume onto tampered bytes"
+        );
+        assert!(!store::digest_sidecar(&dest).exists(), "no digest record");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// No declaration: the file lands unverified (the caller's loud
+    /// note is the surface) and nothing records.
+    #[test]
+    fn finish_write_without_a_declaration_lands_unverified() {
+        let root = temp_root("gate-undeclared");
+        let part = root.join("w.gguf.part");
+        let dest = root.join("w.gguf");
+        std::fs::write(&part, b"small").expect("part");
+        let verdict = finish_write(None, &part, &dest, "w.gguf").expect("lands");
+        assert_eq!(verdict, Integrity::NotDeclared);
+        assert_eq!(std::fs::read(&dest).expect("dest"), b"small");
+        assert!(!store::digest_sidecar(&dest).exists(), "nothing to record");
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/crates/nika-models/src/lib.rs
+++ b/crates/nika-models/src/lib.rs
@@ -21,6 +21,7 @@
 // Test fixtures expect/unwrap freely — the nika-http/nika-cli idiom.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod digest;
 pub mod gguf;
 pub mod pull;
 pub mod serve;

--- a/crates/nika-models/src/pull.rs
+++ b/crates/nika-models/src/pull.rs
@@ -44,6 +44,7 @@ use std::path::{Path, PathBuf};
 
 use nika_kernel::http::{HttpGetDyn, HttpPostDyn, HttpRequest, HttpStreamResponse};
 
+use crate::digest;
 use crate::store::{self, ModelRef};
 
 /// The Hugging Face Hub origin (metadata + `resolve/` downloads; the
@@ -68,6 +69,19 @@ pub(crate) struct TreeEntry {
     /// Size in bytes (the confirm gate reads it BEFORE any download).
     #[serde(default)]
     pub size: u64,
+    /// The LFS pointer row, when the tree listing carries one — the
+    /// digest gate's declaration of record for LFS-backed files (every
+    /// GGUF); absent for small plain files.
+    #[serde(default)]
+    pub lfs: Option<LfsPointer>,
+}
+
+/// The Hub's LFS pointer (`lfs` on a tree row) — the file's sha256 in
+/// `oid` for LFS-backed content.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub(crate) struct LfsPointer {
+    /// The LFS object id — the file's sha256 (64-hex).
+    pub oid: String,
 }
 
 /// The confirm-gate verdict over a size (pure — the prompt I/O lives in
@@ -385,6 +399,9 @@ impl<H: HttpGetDyn + HttpPostDyn> Puller<H> {
             .send_streaming(request)
             .await
             .map_err(|e| transport_refusal(&mref.repo_id(), &e))?;
+        // The digest gate reads the response headers BEFORE the body
+        // drains (the `x-linked-etag` rides the redirect hop).
+        let resp_headers = response.headers.clone();
         let (out, start) = begin_write(
             response.status,
             &part,
@@ -402,12 +419,24 @@ impl<H: HttpGetDyn + HttpPostDyn> Puller<H> {
                 store::human_size(entry.size)
             )));
         }
-        std::fs::rename(&part, &dest).map_err(|e| {
-            refuse(format!(
-                "model pull: cannot move {} into place ({e})\n  fix: check the models dir\n",
-                part.display()
-            ))
-        })?;
+        // The integrity gate: the byte count says HOW MUCH landed; only
+        // the Hub-declared sha256 says WHAT landed. A declared digest
+        // that mismatches hard-refuses with nothing left behind.
+        let declared = digest::declared_sha256(
+            &resp_headers,
+            entry.lfs.as_ref().map(|lfs| lfs.oid.as_str()),
+        );
+        match digest::finish_write(declared, &part, &dest, file)? {
+            digest::Integrity::Verified(digest) => {
+                eprintln!("  {file} · sha256 verified · {digest}");
+            }
+            digest::Integrity::NotDeclared => {
+                eprintln!(
+                    "  {file} pulled WITHOUT integrity verification — the Hub declared no \
+                     sha256 for this file (size-checked only)"
+                );
+            }
+        }
         Ok((dest, start))
     }
 
@@ -772,7 +801,7 @@ pub(crate) type Refusal = String;
 
 /// The semantic marker: every `refuse(...)` site is a refusal, never a
 /// receipt (the identity keeps the sites greppable).
-fn refuse(text: String) -> Refusal {
+pub(crate) fn refuse(text: String) -> Refusal {
     text
 }
 
@@ -922,6 +951,7 @@ mod tests {
             kind: kind.to_owned(),
             path: path.to_owned(),
             size,
+            lfs: None,
         }
     }
 
@@ -964,6 +994,7 @@ mod tests {
         status: u16,
         content_length: Option<u64>,
         chunks: Vec<Bytes>,
+        headers: BTreeMap<String, String>,
     }
 
     /// The house-seam double: `get` answers from one queue,
@@ -998,6 +1029,31 @@ mod tests {
                     status,
                     content_length,
                     chunks: chunks.iter().map(|c| Bytes::copy_from_slice(c)).collect(),
+                    headers: BTreeMap::new(),
+                });
+            self
+        }
+
+        /// A streamed answer carrying response headers (the digest
+        /// gate's `x-linked-etag` hop).
+        fn stream_ok_with_headers(
+            self,
+            status: u16,
+            headers: &[(&str, &str)],
+            chunks: &[&[u8]],
+        ) -> Self {
+            let headers = headers
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+                .collect();
+            self.streams
+                .lock()
+                .expect("streams")
+                .push_back(CannedStream {
+                    status,
+                    content_length: None,
+                    chunks: chunks.iter().map(|c| Bytes::copy_from_slice(c)).collect(),
+                    headers,
                 });
             self
         }
@@ -1047,7 +1103,7 @@ mod tests {
                 canned.chunks.into_iter().map(Ok).collect();
             Ok(HttpStreamResponse::new(
                 canned.status,
-                BTreeMap::new(),
+                canned.headers,
                 String::new(),
                 canned.content_length,
                 Box::pin(ChunkStream(chunks)),
@@ -1224,6 +1280,72 @@ mod tests {
             "{}",
             sent[0].url
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // -- the integrity gate, end to end --------------------------------
+
+    #[tokio::test]
+    async fn download_verifies_against_the_linked_etag_and_records() {
+        let digest = digest::sha256_of(b"hello wor");
+        let etag = format!("\"{digest}\"");
+        let http = StreamHttp::default().stream_ok_with_headers(
+            200,
+            &[("x-linked-etag", &etag)],
+            &[b"hello ", b"wor"],
+        );
+        let root = temp_root("dl-verified");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let (dest, _) = puller
+            .download(&mref("u/m"), &entry("file", "w.gguf", 9))
+            .await
+            .expect("verified download completes");
+        assert_eq!(std::fs::read(&dest).expect("dest"), b"hello wor");
+        // The verified digest records beside the GGUF (what `list` shows).
+        let recorded = store::read_digest(&dest).expect("a digest sidecar exists");
+        assert_eq!(recorded, digest);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_hard_refuses_a_digest_mismatch_and_leaves_nothing() {
+        let etag = format!("\"{}\"", "0".repeat(64));
+        let http = StreamHttp::default().stream_ok_with_headers(
+            200,
+            &[("x-linked-etag", &etag)],
+            &[b"hello wor"],
+        );
+        let root = temp_root("dl-mismatch");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let refusal = puller
+            .download(&mref("u/m"), &entry("file", "w.gguf", 9))
+            .await
+            .expect_err("a mismatched digest hard-refuses");
+        assert!(refusal.contains("integrity check"), "{refusal}");
+        assert!(refusal.contains("expected"), "{refusal}");
+        let dir = root.join("u").join("m");
+        assert!(
+            !dir.join("w.gguf").exists() && !dir.join("w.gguf.part").exists(),
+            "nothing was installed — no artifact, no .part to resume onto"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn download_uses_the_tree_lfs_oid_when_headers_declare_nothing() {
+        let bytes = b"weights";
+        let mut e = entry("file", "w.gguf", bytes.len() as u64);
+        e.lfs = Some(LfsPointer {
+            oid: digest::sha256_of(bytes),
+        });
+        let http = StreamHttp::default().stream_ok(200, None, &[&bytes[..]]);
+        let root = temp_root("dl-lfs-oid");
+        let puller = Puller::new(http, root.clone(), None, false);
+        let (dest, _) = puller
+            .download(&mref("u/m"), &e)
+            .await
+            .expect("the tree's lfs.oid verifies the bytes");
+        assert!(store::read_digest(&dest).is_some());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/nika-models/src/store.rs
+++ b/crates/nika-models/src/store.rs
@@ -192,6 +192,31 @@ fn files(dir: &Path) -> Vec<(String, PathBuf, u64)> {
     out
 }
 
+/// A sha256 in the Hub's spelling: exactly 64 lowercase-or-uppercase
+/// hex characters, nothing else (a CDN Xet/md5 `etag` is 32 and
+/// declares nothing — the digest gate reads this before trusting any
+/// header).
+pub(crate) fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// `<file>.sha256` — the digest sidecar beside a verified GGUF (the
+/// store metadata `nika model list` reads).
+pub(crate) fn digest_sidecar(file: &Path) -> PathBuf {
+    let mut name = file.as_os_str().to_owned();
+    name.push(".sha256");
+    PathBuf::from(name)
+}
+
+/// Read the verified digest recorded beside an installed GGUF, when one
+/// exists (a pre-verification install has none — `None`, never an
+/// error).
+pub(crate) fn read_digest(file: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(digest_sidecar(file)).ok()?;
+    let digest = text.trim();
+    is_sha256_hex(digest).then(|| digest.to_owned())
+}
+
 /// The quant tag read from a GGUF file name (`model-Q4_K_M.gguf` →
 /// `Q4_K_M`) — the LAST `-`/`.`-separated segment that reads as a quant
 /// (quants sit at the tail by Hub convention). Uppercased.
@@ -416,9 +441,14 @@ pub(crate) fn list_at(root: &Path) -> String {
             any_servable = true;
         }
         let note = family.map_or(String::new(), |arch| format!("  ·  {arch} — runner-only"));
+        // A pulled GGUF that verified against the Hub's sha256 shows
+        // the proof (first 12 hex — the sidecar carries the whole).
+        let verified = read_digest(&m.path)
+            .map(|d| format!("  ·  sha256 ✓ {}", &d[..12]))
+            .unwrap_or_default();
         let _ = writeln!(
             text,
-            "  {:<id_width$}  ·  {:>9}  ·  {}{note}",
+            "  {:<id_width$}  ·  {:>9}  ·  {}{note}{verified}",
             m.serve_id(),
             human_size(m.size),
             m.file_name,


### PR DESCRIPTION
## What

A size-confirm gate says the COUNT is right; only a digest says the BYTES are. Multi-GB GGUF pulls landed with **zero integrity evidence** — the biggest unauthenticated-bytes-into-production gap in the engine (the sovereign local-inference lane).

The pull now verifies: the Hub's declaration of record — `x-linked-etag` on the resolve redirect · the tree listing's `lfs.oid` · a bare 64-hex `etag`, in that order of authority — is checked against the completed `.part` in one streaming pass.

- **Mismatch** → hard-refuse with both digests named, nothing left behind (no artifact, no `.part` to resume onto tampered bytes).
- **Nothing declared** (a small non-LFS `tokenizer.json`) → succeeds size-checked with the loud note — skip, never fail.
- **Verified** → the digest records beside the GGUF (`<file>.sha256`); `nika model list` shows `sha256 ✓ <first-12>`.

## Tests

`declared_sha256` walks the order of authority (quoted/weak validators · a 32-hex CDN etag declares nothing) · `finish_write` verifies+lands+records · mismatch leaves nothing · no-declaration lands unverified · end to end through the mock stream (linked-etag verify+record · mismatch hard-refuse · tree `lfs.oid` fallback). 53 passed · clippy 0 warnings · fmt clean.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>