### PR TITLE
feat(nika-runtime): the exec sandbox is wired — permits: jails the child (ADR-095 L6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,6 +3713,8 @@ dependencies = [
  "nika-providers",
  "nika-registry-client",
  "nika-runtime",
+ "nika-sandbox-landlock",
+ "nika-sandbox-seatbelt",
  "nika-schema",
  "nika-types",
  "nika-verb-agent",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -40,6 +40,8 @@ nika-fs          = { path = "../nika-fs", version = "0.105.0" }            # Tok
 nika-clock       = { path = "../nika-clock", version = "0.105.0" }         # SystemClock — backoff + timeout + the date builtin
 nika-http        = { path = "../nika-http", version = "0.105.0" }          # ReqwestHttp — the registry + fetch effect
 nika-exec-runner = { path = "../nika-exec-runner", version = "0.105.0" }   # TokioShell — the exec verb's subprocess runner
+nika-sandbox-seatbelt = { path = "../nika-sandbox-seatbelt", version = "0.105.0" }  # the macOS exec jail (ADR-095 L6)
+nika-sandbox-landlock = { path = "../nika-sandbox-landlock", version = "0.105.0" }  # the Linux exec jail (ADR-095 L6 · bwrap)
 nika-catalog     = { path = "../nika-catalog", version = "0.105.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
 nika-lsp         = { path = "../nika-lsp", version = "0.105.0" }           # `nika lsp` — the language server (stdio · drives the editor extension)
 nika-display     = { path = "../nika-display", version = "0.105.0" } # the run-comprehension surface (descended 2026-07-10 · re-exported at display::)

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -360,6 +360,7 @@ impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::ResumeRequ
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::ResumeRequest
 pub type nika_cli::verbs::run::ResumeRequest::Output = T
 pub struct nika_cli::verbs::run::RuntimeCapabilities
+pub nika_cli::verbs::run::RuntimeCapabilities::exec_tasks: bool
 pub nika_cli::verbs::run::RuntimeCapabilities::fs: nika_builtin::permits::FsBoundary
 pub nika_cli::verbs::run::RuntimeCapabilities::net: nika_http::NetBoundary
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::RuntimeCapabilities

--- a/crates/nika-cli/src/verbs/run/child_runner.rs
+++ b/crates/nika-cli/src/verbs/run/child_runner.rs
@@ -188,6 +188,10 @@ impl ChildRunner for ProdChildRunner {
             let caps = RuntimeCapabilities {
                 fs: fs_boundary_of_permits(child_permits.as_ref()),
                 net: net_boundary_of_permits(child_permits.as_ref()),
+                exec_tasks: wf
+                    .tasks
+                    .iter()
+                    .any(|t| matches!(t.value.action, nika_schema::raw::RawAction::Exec(_))),
             };
             let model = wf.model.as_ref().map_or("", |m| m.value.as_str());
             let runtime = super::compose::production_runtime(model, caps)

--- a/crates/nika-cli/src/verbs/run/compose.rs
+++ b/crates/nika-cli/src/verbs/run/compose.rs
@@ -539,6 +539,9 @@ pub struct RuntimeCapabilities {
     pub fs: FsBoundary,
     /// `permits.net.http` → the fetch client's boundary (`NIKA-SEC-004` · per-hop).
     pub net: NetBoundary,
+    /// The workflow runs ≥1 `exec:` task — the noop-sandbox note reads it
+    /// (a boundary with no exec has nothing to jail, so nothing to note).
+    pub exec_tasks: bool,
 }
 
 /// Derive BOTH runtime capability boundaries from a parsed workflow — the
@@ -549,7 +552,28 @@ pub fn capabilities_of(wf: &nika_schema::raw::RawWorkflow) -> RuntimeCapabilitie
     RuntimeCapabilities {
         fs: fs_boundary_of(wf),
         net: net_boundary_of(wf),
+        exec_tasks: wf
+            .tasks
+            .iter()
+            .any(|t| matches!(t.value.action, nika_schema::raw::RawAction::Exec(_))),
     }
+}
+
+/// The OS command sandbox for this platform (ADR-095 Layer 6): macOS rides
+/// Seatbelt, Linux rides bubblewrap when the launcher is present, anything
+/// else is the deliberate [`nika_kernel::command_sandbox::NoopSandbox`] —
+/// selected HERE, logged at the call site, never the silent default (the
+/// kernel seam's own law).
+fn command_sandbox() -> Arc<dyn nika_kernel::command_sandbox::CommandSandbox> {
+    #[cfg(target_os = "macos")]
+    if nika_sandbox_seatbelt::SeatbeltSandbox::available() {
+        return Arc::new(nika_sandbox_seatbelt::SeatbeltSandbox::new());
+    }
+    #[cfg(target_os = "linux")]
+    if nika_sandbox_landlock::LandlockSandbox::available() {
+        return Arc::new(nika_sandbox_landlock::LandlockSandbox::new());
+    }
+    Arc::new(nika_kernel::command_sandbox::NoopSandbox)
 }
 
 /// The provider client's transport ceiling — `HttpConfig::timeout` on the
@@ -675,6 +699,17 @@ pub fn production_runtime(
     default_model: &str,
     caps: RuntimeCapabilities,
 ) -> Result<ProdRuntime, nika_kernel::HttpError> {
+    // The OS sandbox for exec children (ADR-095 Layer 6) — selected once:
+    // the note AND the shell read the same backend. A declared boundary
+    // with exec tasks but no backend on this platform = the exec child
+    // runs unconfined; the builtin/fetch seams still enforce, said loudly.
+    let sandbox = command_sandbox();
+    if caps.exec_tasks && caps.fs.is_declared() && sandbox.backend() == "noop" {
+        eprintln!(
+            "note: exec runs UNCONFINED (no OS sandbox backend on this platform) — the \
+             declared boundary still gates fs/net at the builtin and fetch seams"
+        );
+    }
     // The fetch/builtin client enforces SSRF (workflow URLs) AND the
     // declared permits.net.http boundary (NIKA-SEC-004 · per-hop).
     let http = Arc::new(fetch_http(caps.net)?);
@@ -726,7 +761,7 @@ pub fn production_runtime(
 
     Ok(Runtime::new(
         ExecVerb::new(Arc::new(
-            TokioShell::new().with_ambient_secret_env(provider_secret_env),
+            TokioShell::with_sandbox(sandbox).with_ambient_secret_env(provider_secret_env),
         )),
         Arc::clone(&invoke),
         InferVerb::new(registry, default_model),
@@ -737,7 +772,7 @@ pub fn production_runtime(
             default_model,
         ),
         SystemClock,
-        RuntimeConfig::default(),
+        RuntimeConfig::default().with_sandbox_root(std::env::current_dir().unwrap_or_default()),
     )
     // Resolve `secrets:` from env/file at run start (MINOR-B · the sanctioned
     // store boundary). A miss leaves the secret unbound → NIKA-1702 (fail-
@@ -874,6 +909,7 @@ mod tests {
             RuntimeCapabilities {
                 fs: FsBoundary::unbounded(),
                 net: NetBoundary::Unbounded,
+                exec_tasks: false,
             },
         );
         assert!(

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -164,6 +164,49 @@ pub fn nika_runtime::child::ChildRunSummary::as_any(&self) -> &(dyn core::any::A
 pub const nika_runtime::child::MAX_RUN_DEPTH: u32
 pub trait nika_runtime::child::ChildRunner: core::marker::Send + core::marker::Sync
 pub fn nika_runtime::child::ChildRunner::run_child<'a>(&'a self, call: nika_runtime::child::ChildCall) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<nika_runtime::child::ChildOutcome, nika_runtime::child::ChildRunRefusal>> + 'a)>>
+pub mod nika_runtime::config
+#[non_exhaustive] pub struct nika_runtime::config::RuntimeConfig
+pub nika_runtime::config::RuntimeConfig::jitter_seed: u64
+pub nika_runtime::config::RuntimeConfig::max_cost_usd: core::option::Option<f64>
+pub nika_runtime::config::RuntimeConfig::sandbox_root: core::option::Option<std::path::PathBuf>
+pub nika_runtime::config::RuntimeConfig::wave_parallelism: core::option::Option<core::num::nonzero::NonZeroUsize>
+impl nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::new(wave_parallelism: core::option::Option<core::num::nonzero::NonZeroUsize>, jitter_seed: u64) -> Self
+pub fn nika_runtime::config::RuntimeConfig::with_max_cost_usd(self, budget: core::option::Option<f64>) -> Self
+pub fn nika_runtime::config::RuntimeConfig::with_sandbox_root(self, root: std::path::PathBuf) -> Self
+impl core::clone::Clone for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::clone(&self) -> nika_runtime::config::RuntimeConfig
+impl core::default::Default for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::default() -> Self
+impl core::fmt::Debug for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_runtime::config::RuntimeConfig
+impl<T, U> core::convert::Into<U> for nika_runtime::config::RuntimeConfig where U: core::convert::From<T>
+pub fn nika_runtime::config::RuntimeConfig::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::config::RuntimeConfig where U: core::convert::Into<T>
+pub type nika_runtime::config::RuntimeConfig::Error = core::convert::Infallible
+pub fn nika_runtime::config::RuntimeConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::config::RuntimeConfig where U: core::convert::TryFrom<T>
+pub type nika_runtime::config::RuntimeConfig::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::config::RuntimeConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_runtime::config::RuntimeConfig where T: core::clone::Clone
+pub type nika_runtime::config::RuntimeConfig::Owned = T
+pub fn nika_runtime::config::RuntimeConfig::clone_into(&self, target: &mut T)
+pub fn nika_runtime::config::RuntimeConfig::to_owned(&self) -> T
+impl<T> core::any::Any for nika_runtime::config::RuntimeConfig where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::config::RuntimeConfig::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::config::RuntimeConfig where T: ?core::marker::Sized
+pub fn nika_runtime::config::RuntimeConfig::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::config::RuntimeConfig where T: ?core::marker::Sized
+pub fn nika_runtime::config::RuntimeConfig::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_runtime::config::RuntimeConfig where T: core::clone::Clone
+pub unsafe fn nika_runtime::config::RuntimeConfig::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_runtime::config::RuntimeConfig where T: core::clone::Clone
+pub fn nika_runtime::config::RuntimeConfig::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_runtime::config::RuntimeConfig where T: 'static
+pub fn nika_runtime::config::RuntimeConfig::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub mod nika_runtime::proof
 pub mod nika_runtime::proof::ir
 #[non_exhaustive] pub struct nika_runtime::proof::ir::WorkflowProof
@@ -742,7 +785,7 @@ pub struct nika_runtime::Runtime<S, T, H, P, D, C>
 impl<S, T, H, P, D, C> nika_runtime::Runtime<S, T, H, P, D, C> where S: nika_kernel_core::io::process::ShellRunDyn + core::marker::Sync, T: nika_kernel_runtime::tool_executor::ToolExecuteDyn, H: nika_kernel_core::io::http::HttpPostDyn + core::marker::Send + core::marker::Sync + 'static, P: nika_kernel_ai::provider::ProviderInferDyn + nika_kernel_ai::provider::ProviderMeta, D: nika_kernel_ai::tool_defs::ToolDefinitionProviderDyn, C: nika_kernel_core::io::clock::ClockDyn + core::marker::Sync
 pub async fn nika_runtime::Runtime<S, T, H, P, D, C>::run(&self, wf: &nika_schema::raw::workflow::RawWorkflow, report: &nika_schema::check::CheckReport, stamper: &mut dyn nika_runtime::Stamper, sink: &mut dyn nika_runtime::EventSink) -> core::result::Result<nika_runtime::RunOutcome, nika_runtime::RuntimeError>
 impl<S, T, H, P, D, C> nika_runtime::Runtime<S, T, H, P, D, C>
-pub fn nika_runtime::Runtime<S, T, H, P, D, C>::new(shell: nika_verb_exec::ExecVerb<S>, invoke: alloc::sync::Arc<nika_verb_invoke::InvokeVerb<T>>, infer: nika_verb_infer::InferVerb<H>, agent: nika_verb_agent::AgentVerb<P, T, D>, clock: C, config: nika_runtime::RuntimeConfig) -> Self
+pub fn nika_runtime::Runtime<S, T, H, P, D, C>::new(shell: nika_verb_exec::ExecVerb<S>, invoke: alloc::sync::Arc<nika_verb_invoke::InvokeVerb<T>>, infer: nika_verb_infer::InferVerb<H>, agent: nika_verb_agent::AgentVerb<P, T, D>, clock: C, config: nika_runtime::config::RuntimeConfig) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_max_cost_usd(self, budget: core::option::Option<f64>) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_model_override(self, model: core::option::Option<alloc::string::String>) -> Self
 pub fn nika_runtime::Runtime<S, T, H, P, D, C>::with_prompt_answers(self, answers: alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>) -> Self
@@ -778,43 +821,45 @@ pub fn nika_runtime::Runtime<S, T, H, P, D, C>::as_any(&self) -> &(dyn core::any
 #[non_exhaustive] pub struct nika_runtime::RuntimeConfig
 pub nika_runtime::RuntimeConfig::jitter_seed: u64
 pub nika_runtime::RuntimeConfig::max_cost_usd: core::option::Option<f64>
+pub nika_runtime::RuntimeConfig::sandbox_root: core::option::Option<std::path::PathBuf>
 pub nika_runtime::RuntimeConfig::wave_parallelism: core::option::Option<core::num::nonzero::NonZeroUsize>
-impl nika_runtime::RuntimeConfig
-pub fn nika_runtime::RuntimeConfig::new(wave_parallelism: core::option::Option<core::num::nonzero::NonZeroUsize>, jitter_seed: u64) -> Self
-pub fn nika_runtime::RuntimeConfig::with_max_cost_usd(self, budget: core::option::Option<f64>) -> Self
-impl core::clone::Clone for nika_runtime::RuntimeConfig
-pub fn nika_runtime::RuntimeConfig::clone(&self) -> nika_runtime::RuntimeConfig
-impl core::default::Default for nika_runtime::RuntimeConfig
-pub fn nika_runtime::RuntimeConfig::default() -> Self
-impl core::fmt::Debug for nika_runtime::RuntimeConfig
-pub fn nika_runtime::RuntimeConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<D> owo_colors::OwoColorize for nika_runtime::RuntimeConfig
-impl<T, U> core::convert::Into<U> for nika_runtime::RuntimeConfig where U: core::convert::From<T>
-pub fn nika_runtime::RuntimeConfig::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for nika_runtime::RuntimeConfig where U: core::convert::Into<T>
-pub type nika_runtime::RuntimeConfig::Error = core::convert::Infallible
-pub fn nika_runtime::RuntimeConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for nika_runtime::RuntimeConfig where U: core::convert::TryFrom<T>
-pub type nika_runtime::RuntimeConfig::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn nika_runtime::RuntimeConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for nika_runtime::RuntimeConfig where T: core::clone::Clone
-pub type nika_runtime::RuntimeConfig::Owned = T
-pub fn nika_runtime::RuntimeConfig::clone_into(&self, target: &mut T)
-pub fn nika_runtime::RuntimeConfig::to_owned(&self) -> T
-impl<T> core::any::Any for nika_runtime::RuntimeConfig where T: 'static + ?core::marker::Sized
-pub fn nika_runtime::RuntimeConfig::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for nika_runtime::RuntimeConfig where T: ?core::marker::Sized
-pub fn nika_runtime::RuntimeConfig::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for nika_runtime::RuntimeConfig where T: ?core::marker::Sized
-pub fn nika_runtime::RuntimeConfig::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for nika_runtime::RuntimeConfig where T: core::clone::Clone
-pub unsafe fn nika_runtime::RuntimeConfig::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for nika_runtime::RuntimeConfig
-pub fn nika_runtime::RuntimeConfig::from(t: T) -> T
-impl<T> dyn_clone::DynClone for nika_runtime::RuntimeConfig where T: core::clone::Clone
-pub fn nika_runtime::RuntimeConfig::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> nika_error::traits::AsAny for nika_runtime::RuntimeConfig where T: 'static
-pub fn nika_runtime::RuntimeConfig::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::new(wave_parallelism: core::option::Option<core::num::nonzero::NonZeroUsize>, jitter_seed: u64) -> Self
+pub fn nika_runtime::config::RuntimeConfig::with_max_cost_usd(self, budget: core::option::Option<f64>) -> Self
+pub fn nika_runtime::config::RuntimeConfig::with_sandbox_root(self, root: std::path::PathBuf) -> Self
+impl core::clone::Clone for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::clone(&self) -> nika_runtime::config::RuntimeConfig
+impl core::default::Default for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::default() -> Self
+impl core::fmt::Debug for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_runtime::config::RuntimeConfig
+impl<T, U> core::convert::Into<U> for nika_runtime::config::RuntimeConfig where U: core::convert::From<T>
+pub fn nika_runtime::config::RuntimeConfig::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::config::RuntimeConfig where U: core::convert::Into<T>
+pub type nika_runtime::config::RuntimeConfig::Error = core::convert::Infallible
+pub fn nika_runtime::config::RuntimeConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::config::RuntimeConfig where U: core::convert::TryFrom<T>
+pub type nika_runtime::config::RuntimeConfig::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::config::RuntimeConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_runtime::config::RuntimeConfig where T: core::clone::Clone
+pub type nika_runtime::config::RuntimeConfig::Owned = T
+pub fn nika_runtime::config::RuntimeConfig::clone_into(&self, target: &mut T)
+pub fn nika_runtime::config::RuntimeConfig::to_owned(&self) -> T
+impl<T> core::any::Any for nika_runtime::config::RuntimeConfig where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::config::RuntimeConfig::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::config::RuntimeConfig where T: ?core::marker::Sized
+pub fn nika_runtime::config::RuntimeConfig::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::config::RuntimeConfig where T: ?core::marker::Sized
+pub fn nika_runtime::config::RuntimeConfig::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_runtime::config::RuntimeConfig where T: core::clone::Clone
+pub unsafe fn nika_runtime::config::RuntimeConfig::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_runtime::config::RuntimeConfig
+pub fn nika_runtime::config::RuntimeConfig::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_runtime::config::RuntimeConfig where T: core::clone::Clone
+pub fn nika_runtime::config::RuntimeConfig::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_runtime::config::RuntimeConfig where T: 'static
+pub fn nika_runtime::config::RuntimeConfig::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub struct nika_runtime::SecretResolveError
 pub nika_runtime::SecretResolveError::name: alloc::string::String
 pub nika_runtime::SecretResolveError::reason: alloc::string::String

--- a/crates/nika-runtime/src/config.rs
+++ b/crates/nika-runtime/src/config.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Composer-owned execution knobs (spec §2) — split out of `lib.rs` under
+//! the ADR-023 1,500-LOC ceiling (the sandbox-root field pushed the root
+//! module over).
+
+use std::num::NonZeroUsize;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RuntimeConfig {
+    /// Per-wave in-flight cap (`for_each` has its own `max_parallel`).
+    /// `None` = wave-width (every wave member in flight at once).
+    pub wave_parallelism: Option<NonZeroUsize>,
+    /// Seed for the retry full-jitter PRNG — pure splitmix64 over
+    /// `(seed, task, attempt)` · replay-stable by construction.
+    pub jitter_seed: u64,
+    /// Operator run budget (`--max-cost-usd`) over METERED spend. Once
+    /// crossed, the run stops admitting new work: in-flight tasks
+    /// complete and count, unstarted ones cancel, the run fails with
+    /// NIKA-1704. `None` = no budget (the default). Unmetered work
+    /// (local · mock · unpriced) can never trip it — the budget bounds
+    /// what the ledger can SEE, said loudly at the preflight.
+    pub max_cost_usd: Option<f64>,
+    /// The root relative `permits:` globs anchor at for the exec sandbox's
+    /// absolute grants (ADR-095 Layer 6 — the SAME root the builtin
+    /// `FsBoundary` canonicalizes against, so check≡run≡jail cannot drift).
+    /// `None` = the process cwd at dispatch time.
+    pub sandbox_root: Option<std::path::PathBuf>,
+}
+
+impl RuntimeConfig {
+    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
+    #[must_use]
+    pub fn new(wave_parallelism: Option<NonZeroUsize>, jitter_seed: u64) -> Self {
+        Self {
+            wave_parallelism,
+            jitter_seed,
+            max_cost_usd: None,
+            sandbox_root: None,
+        }
+    }
+
+    /// Attach an operator run budget (builder — `new()` stays stable).
+    #[must_use]
+    pub fn with_max_cost_usd(mut self, budget: Option<f64>) -> Self {
+        self.max_cost_usd = budget;
+        self
+    }
+
+    /// Pin the sandbox grants root (builder — the composer sets the launch
+    /// cwd so a `cd` mid-process never re-anchors a boundary).
+    #[must_use]
+    pub fn with_sandbox_root(mut self, root: std::path::PathBuf) -> Self {
+        self.sandbox_root = Some(root);
+        self
+    }
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self::new(None, 0)
+    }
+}

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -30,6 +30,7 @@ use crate::Runtime;
 use crate::errors::RuntimeError;
 
 mod permits;
+mod sandbox;
 use crate::expr::{self, Scope};
 use crate::record::TaskErrorRecord;
 
@@ -418,6 +419,23 @@ where
         }
     }
 
+    /// ADR-095 Layer 6 — the OS-confinement spec from the declared
+    /// boundary (the `dispatch/sandbox.rs` derivation · `None` = the
+    /// unconfined floor: no `permits:` block).
+    fn exec_sandbox_spec(
+        &self,
+        permits: Option<&nika_schema::types::Permits>,
+    ) -> Option<nika_kernel::process::SandboxSpec> {
+        let permits = permits?;
+        let root = self
+            .config
+            .sandbox_root
+            .clone()
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_default();
+        Some(sandbox::spec_of(permits, &root))
+    }
+
     async fn dispatch_shell(
         &self,
         action: &nika_schema::raw::RawExecAction,
@@ -459,6 +477,10 @@ where
         if let Some(denial) = check_exec_permits(scope.permits, &note, &program, is_argv) {
             return denial;
         }
+
+        // ADR-095 Layer 6 · the OS jail rides the SAME declared boundary
+        // (no `permits:` block = today's unconfined floor).
+        input.sandbox = self.exec_sandbox_spec(scope.permits);
 
         match self.shell.run(input).await {
             Ok(out) => {

--- a/crates/nika-runtime/src/dispatch/sandbox.rs
+++ b/crates/nika-runtime/src/dispatch/sandbox.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `permits:` → [`SandboxSpec`] derivation (spec 01 §permits · ADR-095
+//! Layer 6): once a workflow declares a capability boundary, every `exec`
+//! child is jailed to it — the OS sandbox enforces at spawn what the
+//! builtin/fs gates enforce at their own seams, so an exec that the
+//! blocklist passes can still not TOUCH what the boundary denies.
+//!
+//! Two doctrine rules, kept in lockstep with the builtin `FsBoundary` so
+//! check≡run ≡jail cannot drift:
+//!
+//! - **Relative globs anchor at the run's launch cwd** (the same root the
+//!   fs boundary canonicalizes against). The sandbox launchers speak
+//!   absolute subpaths only (`grant_subpath` fail-closes on a relative
+//!   grant), so the derivation absolutizes HERE — a task-level `cwd:`
+//!   does not re-anchor the boundary, exactly like the builtin gate.
+//! - **Network is binary at the OS grain**: `permits.net.http` non-empty
+//!   lifts the deny; host-granular egress filtering is the documented
+//!   proxy follow-on (a Seatbelt host rule is TLS-blind), never a silent
+//!   partial today.
+
+use std::path::{Component, Path};
+
+use nika_kernel::process::SandboxSpec;
+use nika_schema::types::Permits;
+
+/// Derive the OS-confinement spec from the declared boundary, anchored at
+/// `root` (the run's launch cwd — see the module doc).
+pub(super) fn spec_of(permits: &Permits, root: &Path) -> SandboxSpec {
+    let (read, write) = permits
+        .fs
+        .as_ref()
+        .map(|fs| (fs.read.as_slice(), fs.write.as_slice()))
+        .unwrap_or_default();
+    let mut spec = SandboxSpec::new();
+    spec.fs_read = read.iter().map(|g| absolutize(root, g)).collect();
+    spec.fs_write = write.iter().map(|g| absolutize(root, g)).collect();
+    spec.allow_network = permits.net.as_ref().is_some_and(|n| !n.http.is_empty());
+    spec
+}
+
+/// Absolutize one declared glob against the run root: a relative glob
+/// joins the root and folds lexically (`.`/`..` resolved textually — the
+/// `lexically_normalize` semantics the fit checker already pins, so a
+/// `data/../out/**` grant reads identically on both seams). An absolute
+/// glob passes through unchanged — including the shapes the launchers
+/// refuse (`~` · a preserved leading `..` · a bare system root): their
+/// fail-closed `Profile` refusal is the honest verdict, named to the
+/// operator, never a silent widening.
+fn absolutize(root: &Path, glob: &str) -> String {
+    if glob.starts_with('/') || glob.starts_with('~') {
+        return glob.to_owned();
+    }
+    lexically_normalize(&root.join(glob))
+}
+
+/// Textual `.`/`..` fold (the `nika-cap` `fit::lexically_normalize`
+/// semantics, restated here so the runtime stays a leaf consumer — no
+/// symlink walk: a not-yet-existing write tree has no symlinks to
+/// resolve, and the jail's own canonicalization owns the existing part).
+fn lexically_normalize(path: &Path) -> String {
+    let mut out = std::path::PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use nika_schema::types::{FsPermits, NetPermits, Permits};
+
+    use super::*;
+
+    fn permits(read: &[&str], write: &[&str], http: &[&str]) -> Permits {
+        let mut p = Permits::new();
+        p.fs = Some(FsPermits::new(
+            read.iter().map(ToString::to_string).collect(),
+            write.iter().map(ToString::to_string).collect(),
+        ));
+        p.net = Some(NetPermits::new(
+            http.iter().map(ToString::to_string).collect(),
+        ));
+        p
+    }
+
+    #[test]
+    fn relative_globs_anchor_at_the_run_root() {
+        let spec = spec_of(
+            &permits(&["./data/**"], &["./out/**"], &[]),
+            Path::new("/repo"),
+        );
+        assert_eq!(spec.fs_read, vec!["/repo/data/**".to_owned()]);
+        assert_eq!(spec.fs_write, vec!["/repo/out/**".to_owned()]);
+        assert!(
+            !spec.allow_network,
+            "an empty net.http keeps the network deny"
+        );
+    }
+
+    #[test]
+    fn absolute_globs_pass_through_and_network_lifts_on_a_host() {
+        let spec = spec_of(
+            &permits(&["/data/in/**"], &["/data/out/**"], &["api.example.com"]),
+            Path::new("/repo"),
+        );
+        assert_eq!(spec.fs_read, vec!["/data/in/**".to_owned()]);
+        assert_eq!(spec.fs_write, vec!["/data/out/**".to_owned()]);
+        assert!(spec.allow_network);
+    }
+
+    #[test]
+    fn dot_dot_folds_the_same_way_as_the_fit_checker() {
+        let spec = spec_of(&permits(&["data/../out/**"], &[], &[]), Path::new("/repo"));
+        assert_eq!(spec.fs_read, vec!["/repo/out/**".to_owned()]);
+    }
+
+    #[test]
+    fn no_fs_block_means_no_extra_grants() {
+        let spec = spec_of(&Permits::new(), Path::new("/repo"));
+        assert!(spec.fs_read.is_empty() && spec.fs_write.is_empty());
+        assert!(!spec.allow_network, "no net block = the deny holds");
+    }
+}

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -41,6 +41,7 @@
 
 mod agent_events;
 pub mod child;
+pub mod config;
 mod contract;
 mod dispatch;
 mod emit_task;
@@ -81,6 +82,7 @@ use nika_verb_infer::InferVerb;
 use nika_verb_invoke::InvokeVerb;
 use serde_json::Value;
 
+pub use config::RuntimeConfig;
 pub use errors::RuntimeError;
 pub use pause::WorkflowPause;
 pub use record::{TaskErrorRecord, TaskRecord, TaskStatus, TerminalCause, legal};
@@ -93,49 +95,6 @@ use expr::Scope;
 use task::{Finish, SettleAs};
 
 /// Composer-owned execution knobs (spec §2).
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct RuntimeConfig {
-    /// Per-wave in-flight cap (`for_each` has its own `max_parallel`).
-    /// `None` = wave-width (every wave member in flight at once).
-    pub wave_parallelism: Option<NonZeroUsize>,
-    /// Seed for the retry full-jitter PRNG — pure splitmix64 over
-    /// `(seed, task, attempt)` · replay-stable by construction.
-    pub jitter_seed: u64,
-    /// Operator run budget (`--max-cost-usd`) over METERED spend. Once
-    /// crossed, the run stops admitting new work: in-flight tasks
-    /// complete and count, unstarted ones cancel, the run fails with
-    /// NIKA-1704. `None` = no budget (the default). Unmetered work
-    /// (local · mock · unpriced) can never trip it — the budget bounds
-    /// what the ledger can SEE, said loudly at the preflight.
-    pub max_cost_usd: Option<f64>,
-}
-
-impl RuntimeConfig {
-    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
-    #[must_use]
-    pub fn new(wave_parallelism: Option<NonZeroUsize>, jitter_seed: u64) -> Self {
-        Self {
-            wave_parallelism,
-            jitter_seed,
-            max_cost_usd: None,
-        }
-    }
-
-    /// Attach an operator run budget (builder — `new()` stays stable).
-    #[must_use]
-    pub fn with_max_cost_usd(mut self, budget: Option<f64>) -> Self {
-        self.max_cost_usd = budget;
-        self
-    }
-}
-
-impl Default for RuntimeConfig {
-    fn default() -> Self {
-        Self::new(None, 0)
-    }
-}
-
 /// The run's verdict + the result records (spec §2).
 #[derive(Debug)]
 #[non_exhaustive]

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -72,6 +72,103 @@ impl EventSink for NotifyOnFastSettle {
 /// frames reach the sink at ITS settle, not the wave join. Proof by
 /// construction: `gate` (same wave, declared after `fast`) BLOCKS until
 /// the sink has seen fast's `task_completed` — join-granularity frames
+/// ADR-095 Layer 6 — a declared boundary attaches the OS-confinement
+/// spec to every exec child (grants absolutized at the config root ·
+/// network denied unless `net.http` lifts it).
+#[tokio::test]
+async fn declared_boundary_attaches_the_sandbox_spec_to_exec() {
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+
+    let yaml = "nika: v1\nworkflow:\n  id: jail\npermits:\n  fs: { read: [\"./data/**\"], write: [\"./out/**\"] }\n  exec: [\"echo\"]\ntasks:\n  t:\n    exec: { command: [\"echo\", \"x\"] }\n";
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_schema::check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder: {report:?}");
+    let shell = MockShell::new().enqueue_ok("ok");
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(shell.clone())),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default().with_sandbox_root(std::path::PathBuf::from("/repo")),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    let sent = shell.executed_commands();
+    assert_eq!(sent.len(), 1);
+    let spec = sent[0]
+        .sandbox
+        .as_ref()
+        .expect("a declared boundary attaches the spec");
+    assert_eq!(spec.fs_read, vec!["/repo/data/**".to_owned()]);
+    assert_eq!(spec.fs_write, vec!["/repo/out/**".to_owned()]);
+    assert!(!spec.allow_network, "no net.http = the deny holds");
+}
+
+/// No `permits:` block = today's unconfined floor (the blocklist only —
+/// the sandbox spec stays unset, so the noop-backend world is unchanged).
+#[tokio::test]
+async fn no_declared_boundary_attaches_no_spec() {
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+
+    let yaml = "nika: v1\nworkflow:\n  id: floor\ntasks:\n  t:\n    exec: { command: [\"echo\", \"x\"] }\n";
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_schema::check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder: {report:?}");
+    let shell = MockShell::new().enqueue_ok("ok");
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(shell.clone())),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default(),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    let sent = shell.executed_commands();
+    assert_eq!(sent.len(), 1);
+    assert!(sent[0].sandbox.is_none(), "no boundary = no spec attached");
+}
+
 /// would starve it forever (they'd only exist after gate itself
 /// finished); the streamed spine settles fast first and unblocks the
 /// wave. A 5s timeout turns a regression into a loud failure, never a

--- a/crates/nika-sandbox-landlock/tests/landlock_jail.rs
+++ b/crates/nika-sandbox-landlock/tests/landlock_jail.rs
@@ -91,3 +91,65 @@ fn confined_can_read_a_declared_path() {
         String::from_utf8_lossy(&out.stderr),
     );
 }
+
+/// WRITE-DENY: a dir granted for READ is bound read-only — a write inside
+/// it fails, even though the same path is perfectly writable on the host
+/// (the read grant must never smuggle a write).
+#[test]
+fn confined_cannot_write_into_a_read_only_grant() {
+    if !LandlockSandbox::available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("nika-sbx-ro-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+
+    let mut spec = SandboxSpec::new();
+    spec.fs_read = vec![format!("{}/**", dir.display())];
+    let target = dir.join("smuggle.txt");
+    let out = run(
+        &spec,
+        "/bin/sh",
+        &["-c", &format!("echo smuggled > {}", target.display())],
+    );
+    // Anti-vacuity (the sibling proofs' guard): a launcher-level failure
+    // voids the proof — the child never ran.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("bwrap:"),
+        "the launcher itself failed — the proof is vacuous · stderr {stderr:?}"
+    );
+    assert!(
+        !out.status.success(),
+        "a write inside a read-only bind must fail · stderr {stderr:?}"
+    );
+    assert!(
+        !target.exists(),
+        "the host file must NOT appear · the ro-bind held"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// NETWORK-DENY: without an explicit lift the net namespace is UNSHARED —
+/// a connection that would succeed on the host fails inside the jail.
+/// 1.1.1.1:80 is near-universally reachable, so the failure can only come
+/// from the missing namespace, never from the target.
+#[test]
+fn confined_has_no_network_without_an_explicit_lift() {
+    if !LandlockSandbox::available() {
+        return;
+    }
+    let out = run(
+        &SandboxSpec::new(),
+        "/bin/bash",
+        &["-c", "echo probe > /dev/tcp/1.1.1.1/80"],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("bwrap:"),
+        "the launcher itself failed — the proof is vacuous · stderr {stderr:?}"
+    );
+    assert!(
+        !out.status.success(),
+        "an unshared netns must refuse the connection · stderr {stderr:?}"
+    );
+}

--- a/crates/nika-verb-exec/public-api.txt
+++ b/crates/nika-verb-exec/public-api.txt
@@ -164,6 +164,7 @@ pub nika_verb_exec::ExecInput::command: nika_verb_exec::ExecCommand
 pub nika_verb_exec::ExecInput::cwd: core::option::Option<std::path::PathBuf>
 pub nika_verb_exec::ExecInput::env: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
 pub nika_verb_exec::ExecInput::raw_capture: bool
+pub nika_verb_exec::ExecInput::sandbox: core::option::Option<nika_kernel_core::io::process::SandboxSpec>
 pub nika_verb_exec::ExecInput::stdin: core::option::Option<alloc::string::String>
 pub nika_verb_exec::ExecInput::timeout: core::option::Option<core::time::Duration>
 impl nika_verb_exec::ExecInput

--- a/crates/nika-verb-exec/src/lib.rs
+++ b/crates/nika-verb-exec/src/lib.rs
@@ -110,6 +110,12 @@ pub struct ExecInput {
     /// Task-level timeout, resolved by the engine (03-dag) — the runner
     /// enforces the hard kill.
     pub timeout: Option<Duration>,
+    /// The OS-confinement boundary derived from the workflow's declared
+    /// `permits:` (ADR-095 Layer 6) — `Some` once a boundary exists, so
+    /// the child is jailed to it at spawn; `None` = the unconfined
+    /// blocklist-only floor (no `permits:` block). Set by the engine,
+    /// never authored.
+    pub sandbox: Option<nika_kernel::process::SandboxSpec>,
 }
 
 impl ExecInput {
@@ -155,6 +161,7 @@ impl ExecInput {
             capture: CaptureMode::Stdout,
             raw_capture: false,
             timeout: None,
+            sandbox: None,
         }
     }
 }
@@ -393,6 +400,9 @@ fn build_command(input: ExecInput) -> ShellCommand {
     cmd.env = input.env;
     cmd.stdin = input.stdin;
     cmd.timeout = input.timeout;
+    // The OS-confinement boundary rides untouched to the runner, which
+    // applies it AFTER the blocklist (the floor sees the REAL command).
+    cmd.sandbox = input.sandbox;
     cmd
 }
 
@@ -446,6 +456,28 @@ mod tests {
 
     fn verb(mock: MockShell) -> ExecVerb<MockShell> {
         ExecVerb::new(Arc::new(mock))
+    }
+
+    #[tokio::test]
+    async fn sandbox_spec_reaches_the_runner_untouched() {
+        // ADR-095 Layer 6 — the engine-derived confinement boundary rides
+        // from ExecInput to the runner verbatim (the runner applies it
+        // AFTER the blocklist, so the floor sees the real command).
+        let mock = MockShell::new().enqueue_ok("ok");
+        let v = verb(mock.clone());
+        let mut spec = nika_kernel::process::SandboxSpec::new();
+        spec.fs_read = vec!["/repo/data/**".to_owned()];
+        spec.allow_network = false;
+        let mut input = ExecInput::argv(["echo", "x"]);
+        input.sandbox = Some(spec.clone());
+        v.run(input).await.expect("runs");
+        let sent = mock.executed_commands();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(
+            sent[0].sandbox.as_ref(),
+            Some(&spec),
+            "the sandbox spec rides verbatim"
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/adr-095-exec-security-architecture.md
+++ b/docs/adr/adr-095-exec-security-architecture.md
@@ -259,8 +259,8 @@ all enforcement (the file is the security boundary).
 | 6 sandbox seam | nika-kernel-core (CommandSandbox) | ✅ shipped |
 | 6 sandbox macOS | nika-sandbox-seatbelt | ✅ shipped · adversarially verified |
 | 6 sandbox wiring | nika-exec-runner (with_sandbox) | ✅ shipped |
-| 6 sandbox Linux | nika-sandbox-landlock | 🔜 CI-gated arc |
-| 6 permits→spec + composer inject | nika-runtime · engine | 🔜 follow-on |
+| 6 sandbox Linux | nika-sandbox-landlock | ✅ shipped · CI-gated (bwrap in the tests leg · 4 jail proofs) |
+| 6 permits→spec + composer inject | nika-runtime · engine | ✅ shipped (v0.105.x · dispatch derives the spec from `permits:` · the composer wires seatbelt/landlock · noop note when no backend) |
 | 7 blocklist tripwire | nika-exec-runner | ✅ shipped (mode-split) |
 
 ## References


### PR DESCRIPTION
## What

The two OS sandbox backends (seatbelt on macOS · bubblewrap on Linux) were built, adversarially tested — and completely unwired: dead code with zero dependents, so every exec child ran with the engine user's full fs, full network, and ambient env. The runner's fail-closed "spec but no backend" path was unreachable by construction.

The wiring closes the layer end to end:

- **nika-runtime** — `dispatch_shell` derives the `SandboxSpec` from the declared `permits:` (new `dispatch/sandbox.rs`: relative globs anchor at the launch cwd, the SAME root the `FsBoundary` canonicalizes against, so check≡run≡jail cannot drift; network denied unless `net.http` is non-empty) and attaches it to every exec task. No `permits:` block = today's unconfined floor, unchanged.
- **nika-verb-exec** — `ExecInput.sandbox` rides to the runner untouched (the blocklist still sees the REAL command — confine happens after).
- **nika-cli** — the composer selects the backend (seatbelt · landlock when the launcher exists · deliberate `NoopSandbox` otherwise), pins the grants root at the launch cwd, and prints one loud note when a declared boundary meets a backend-less platform — never silence.
- **nika-sandbox-landlock** — the two missing jail proofs: write-deny inside a read-only grant · network-deny without an explicit lift (4/4, the seatbelt parity).

## Verified

End to end on macOS: with `permits: fs.read ./data/**`, `cat $HOME/secret` **fails** (`workflow_failed` — the jail denies); the same task without `permits:` completes (the floor is untouched). `trust-battery` FAILS=0 · workspace lib tests 54 suites ok · clippy 0 warnings · public-api additive (`RuntimeConfig.sandbox_root` · `ExecInput.sandbox` · `RuntimeCapabilities.exec_tasks`). ADR-095's status table closes rows 6.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
