### PR TITLE
feat(nika-schema): trifecta v2.0 — the realized-flow judge (NEP-0002)

### DIFF
--- a/crates/nika-cap/public-api.txt
+++ b/crates/nika-cap/public-api.txt
@@ -696,13 +696,51 @@ pub unsafe fn nika_cap::Require::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_cap::Require
 pub fn nika_cap::Require::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_cap::Require where T: for<'de> serde_core::de::Deserialize<'de>
+#[non_exhaustive] pub struct nika_cap::TaintWitness
+pub nika_cap::TaintWitness::source: core::option::Option<alloc::string::String>
+pub nika_cap::TaintWitness::tainted: bool
+impl nika_cap::TaintWitness
+pub fn nika_cap::TaintWitness::clean() -> Self
+pub fn nika_cap::TaintWitness::new(tainted: bool, source: core::option::Option<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_cap::TaintWitness
+pub fn nika_cap::TaintWitness::clone(&self) -> nika_cap::TaintWitness
+impl core::cmp::Eq for nika_cap::TaintWitness
+impl core::cmp::PartialEq for nika_cap::TaintWitness
+pub fn nika_cap::TaintWitness::eq(&self, other: &nika_cap::TaintWitness) -> bool
+impl core::fmt::Debug for nika_cap::TaintWitness
+pub fn nika_cap::TaintWitness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_cap::TaintWitness
+impl<T, U> core::convert::Into<U> for nika_cap::TaintWitness where U: core::convert::From<T>
+pub fn nika_cap::TaintWitness::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cap::TaintWitness where U: core::convert::Into<T>
+pub type nika_cap::TaintWitness::Error = core::convert::Infallible
+pub fn nika_cap::TaintWitness::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cap::TaintWitness where U: core::convert::TryFrom<T>
+pub type nika_cap::TaintWitness::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cap::TaintWitness::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cap::TaintWitness where T: core::clone::Clone
+pub type nika_cap::TaintWitness::Owned = T
+pub fn nika_cap::TaintWitness::clone_into(&self, target: &mut T)
+pub fn nika_cap::TaintWitness::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cap::TaintWitness where T: 'static + ?core::marker::Sized
+pub fn nika_cap::TaintWitness::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cap::TaintWitness where T: ?core::marker::Sized
+pub fn nika_cap::TaintWitness::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cap::TaintWitness where T: ?core::marker::Sized
+pub fn nika_cap::TaintWitness::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cap::TaintWitness where T: core::clone::Clone
+pub unsafe fn nika_cap::TaintWitness::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cap::TaintWitness
+pub fn nika_cap::TaintWitness::from(t: T) -> T
 #[non_exhaustive] pub struct nika_cap::TrifectaSubject
 pub nika_cap::TrifectaSubject::egress_capable: bool
 pub nika_cap::TrifectaSubject::human_gate: bool
 pub nika_cap::TrifectaSubject::id: alloc::string::String
+pub nika_cap::TrifectaSubject::ingress_source: bool
 pub nika_cap::TrifectaSubject::parents: alloc::vec::Vec<usize>
 impl nika_cap::TrifectaSubject
 pub fn nika_cap::TrifectaSubject::new(id: alloc::string::String, egress_capable: bool, human_gate: bool) -> Self
+pub fn nika_cap::TrifectaSubject::with_ingress_source(self, ingress_source: bool) -> Self
 impl core::clone::Clone for nika_cap::TrifectaSubject
 pub fn nika_cap::TrifectaSubject::clone(&self) -> nika_cap::TrifectaSubject
 impl core::cmp::Eq for nika_cap::TrifectaSubject
@@ -735,6 +773,7 @@ impl<T> core::convert::From<T> for nika_cap::TrifectaSubject
 pub fn nika_cap::TrifectaSubject::from(t: T) -> T
 #[non_exhaustive] pub struct nika_cap::TrifectaViolation
 pub nika_cap::TrifectaViolation::detail: alloc::string::String
+pub nika_cap::TrifectaViolation::source: core::option::Option<alloc::string::String>
 pub nika_cap::TrifectaViolation::task: alloc::string::String
 impl core::clone::Clone for nika_cap::TrifectaViolation
 pub fn nika_cap::TrifectaViolation::clone(&self) -> nika_cap::TrifectaViolation
@@ -774,8 +813,10 @@ impl<T> serde_core::de::DeserializeOwned for nika_cap::TrifectaViolation where T
 pub const nika_cap::HUMAN_GATE_TOOL: &str
 pub const nika_cap::POLICY_KEYS: &[&str]
 pub fn nika_cap::builtin_effect(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> core::option::Option<nika_cap::BuiltinEffect>
+pub fn nika_cap::builtin_egresses(tool: &str) -> bool
 pub fn nika_cap::builtin_shape_findings(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_cap::chart_vl_sibling(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> core::option::Option<alloc::string::String>
+pub fn nika_cap::glob_matches(glob: &str, value: &str) -> bool
 pub fn nika_cap::policy_child_keys(family: &str) -> core::option::Option<&'static [&'static str]>
 pub fn nika_cap::policy_violations(policy: &nika_cap::Policy, tasks: &[nika_cap::PolicySubject]) -> alloc::vec::Vec<nika_cap::PolicyViolation>
-pub fn nika_cap::trifecta_violations(permits: &nika_cap::Permits, uses_fetch: bool, subjects: &[nika_cap::TrifectaSubject], topo_order: &[usize]) -> alloc::vec::Vec<nika_cap::TrifectaViolation>
+pub fn nika_cap::trifecta_violations(permits: &nika_cap::Permits, subjects: &[nika_cap::TrifectaSubject], witnesses: &[nika_cap::TaintWitness], topo_order: &[usize]) -> alloc::vec::Vec<nika_cap::TrifectaViolation>

--- a/crates/nika-cap/src/effect.rs
+++ b/crates/nika-cap/src/effect.rs
@@ -125,6 +125,24 @@ pub fn builtin_effect(tool: &str, args: Option<&serde_json::Value>) -> Option<Bu
     }
 }
 
+/// Can this builtin realize an EXTERNAL effect — net or fs-write (NEP-0002
+/// v2.0's egress classification, beside the ONE effect table so the two
+/// cannot drift)? `nika:notify` counts without a literal channel arg: an
+/// agent picks the webhook channel at runtime, which no static reading of
+/// a WHITELIST can see (conservative — the arg-reading call sites use
+/// [`builtin_effect`] directly).
+#[must_use]
+pub fn builtin_egresses(tool: &str) -> bool {
+    if tool == "nika:notify" {
+        return true;
+    }
+    match builtin_effect(tool, None) {
+        Some(BuiltinEffect::Net { .. }) => true,
+        Some(BuiltinEffect::Fs { writes, .. }) => writes,
+        None => false,
+    }
+}
+
 /// `nika:chart` with `compile_to: vega_lite` writes a SECOND gated file —
 /// the `.vl.json` sibling next to the svg. One derivation, shared by the
 /// escape scan and the boundary inference, matching the runtime byte for
@@ -238,6 +256,15 @@ mod tests {
                 ),
                 "{tool}"
             );
+        }
+        // builtin_egresses: net + fs-write + the notify-conservative arm,
+        // never a read-only or pure-compute builtin (NEP-0002 v2.0's
+        // agent-whitelist classification, from the ONE table).
+        for tool in ["nika:fetch", "nika:write", "nika:edit", "nika:notify"] {
+            assert!(crate::effect::builtin_egresses(tool), "{tool}");
+        }
+        for tool in ["nika:read", "nika:grep", "nika:jq", "nika:glob", "nika:log"] {
+            assert!(!crate::effect::builtin_egresses(tool), "{tool}");
         }
         // read-only file builtins carry NO coarse class beyond tools
         // (reads are not gateable in v1 — spec 10).

--- a/crates/nika-cap/src/lib.rs
+++ b/crates/nika-cap/src/lib.rs
@@ -36,8 +36,8 @@ mod trifecta;
 // The fine-grained builtin effect table (boundary checking · inference) —
 // extracted from nika-schema's permits_fit under the same 15k pressure as
 // shape.rs; the coarse policy table (EffectClass) lives beside it.
-pub use effect::{BuiltinEffect, builtin_effect, chart_vl_sibling};
-pub use permits::{ExecPermit, FsPermits, NetPermits, Permits};
+pub use effect::{BuiltinEffect, builtin_effect, builtin_egresses, chart_vl_sibling};
+pub use permits::{ExecPermit, FsPermits, NetPermits, Permits, glob_matches};
 // W4 « the authority » (spec 10) — the policy: vocabulary (closed at the
 // type level) + the pure judge + the certificate's authority projection.
 pub use policy::{
@@ -49,4 +49,4 @@ pub use shape::builtin_shape_findings;
 // NEP-0002 · the lethal-trifecta judge (`NIKA-SEC-009`) — the pure
 // leg-conjunction + path-dominance logic; the projection lives in
 // `nika-schema::check::trifecta` (the PolicySubject / policy_violations split).
-pub use trifecta::{TrifectaSubject, TrifectaViolation, trifecta_violations};
+pub use trifecta::{TaintWitness, TrifectaSubject, TrifectaViolation, trifecta_violations};

--- a/crates/nika-cap/src/permits.rs
+++ b/crates/nika-cap/src/permits.rs
@@ -165,9 +165,11 @@ impl<'de> Deserialize<'de> for ExecPermit {
 
 /// Gitignore-style glob match for tool ids / hosts — v0.1 surface:
 /// exact match, or a single trailing `*` matching any (possibly empty)
-/// tail. Mirrors the agent `tools:` whitelist semantics.
+/// tail. Mirrors the agent `tools:` whitelist semantics. Public since
+/// v0.105.x (NEP-0002 v2.0's whitelist classification needs the ONE
+/// matcher — a second spelling of the same rule would drift).
 #[must_use]
-pub(crate) fn glob_matches(glob: &str, value: &str) -> bool {
+pub fn glob_matches(glob: &str, value: &str) -> bool {
     match glob.strip_suffix('*') {
         Some(prefix) => value.starts_with(prefix),
         None => glob == value,

--- a/crates/nika-cap/src/trifecta.rs
+++ b/crates/nika-cap/src/trifecta.rs
@@ -6,35 +6,38 @@
 //! The lethal trifecta (Willison) + the Agents Rule of Two (Meta) are the
 //! two dominant agent-safety heuristics; NEP-0002 makes them DECIDABLE from
 //! the declared capability boundary. Three legs, read off `permits:` and the
-//! task graph (NEP-0002 §Specification — v1 deliberately coarse):
+//! task graph (NEP-0002 §Specification · v2.0):
 //!
 //! - **① private-data** — `permits.fs.read` is non-empty.
-//! - **② untrusted ingress** — a `nika:fetch` builtin is invoked, OR
-//!   `permits.tools` grants an ingress-capable tool: `nika:fetch` (a glob
-//!   like `nika:*` covers it) or any `mcp:*` server (server-provided
-//!   content is untrusted by construction). First-party LOCAL builtins
-//!   (`nika:read` · `nika:write` · …) are NOT ingress — a private read is
-//!   ①'s domain, a write ③'s (v1.1: the coarse any-grant reading flagged
-//!   the spec's own permits-fit fixture deep/014; per-tool trust marks
-//!   remain the documented v2 refinement).
+//! - **② untrusted ingress** — the boundary grants an ingress-capable tool
+//!   (`nika:fetch` covered by a glob · any `mcp:*` server) AND the task
+//!   graph REALIZES one: a fetch invoked · an `mcp:*` invoked · an
+//!   `agent:` whose whitelist admits ingress. Untrusted content propagates
+//!   through `with:` bindings, `for_each` items, `tasks.*.output` reads and
+//!   `on_error.recover` reads — and `infer:`/`agent:` outputs carry it when
+//!   their prompt sees it (the integrity direction; the ADR-092 verbatim-
+//!   echo carve-out is confidentiality-only and does not apply). First-party
+//!   LOCAL builtins are NOT ingress (①/③'s domains).
 //! - **③ external egress** — `permits.net.http` is non-empty, OR a declared
 //!   `fs.write` glob escapes the workspace (absolute · `~` · a preserved
 //!   leading `..` after lexical normalization — the [`crate::fit`] semantics),
 //!   OR `permits.exec` is enabled.
 //!
-//! When ①∧②∧③ hold, every egress-capable task MUST be dominated by a
-//! blocking human gate — an `invoke:` of [`crate::HUMAN_GATE_TOOL`] carrying
-//! NO `default:` arg (a default lets the run proceed unattended; the Rule of
-//! Two escape is the HUMAN decision, not a scripted fallback). **Dominance**,
-//! not mere ancestry: a gate a sibling branch bypasses mitigates nothing
-//! (« dominates every egress-capable task on that path »). One violation per
-//! ungated egress task, message opening with the NEP's verbatim
+//! When ①∧②∧③ hold, every egress-capable task **the untrusted content
+//! actually reaches** (a realized flow — v2.0, witness-named `source →
+//! sink`) MUST be dominated by a blocking human gate — an `invoke:` of
+//! [`crate::HUMAN_GATE_TOOL`] carrying NO `default:` arg (a default lets
+//! the run proceed unattended; the Rule of Two escape is the HUMAN
+//! decision, not a scripted fallback). **Dominance**, not mere ancestry: a
+//! gate a sibling branch bypasses mitigates nothing. One violation per
+//! ungated tainted egress task, message opening with the NEP's verbatim
 //! « lethal trifecta complete · human gate required ».
 //!
 //! The judge is pure L0 (the [`crate::policy_violations`] precedent): it
-//! reads projected [`TrifectaSubject`] rows + the declared boundary, never
-//! an AST. `nika_schema::check` owns the projection and the DAG-validity
-//! gating (an unanalyzable graph yields NO claim — skipped, never wrong).
+//! reads projected [`TrifectaSubject`] rows, [`TaintWitness`] flow facts
+//! and the declared boundary, never an AST. `nika_schema::check` owns the
+//! projection, the content-taint pass, and the DAG-validity gating (an
+//! unanalyzable graph yields NO claim — skipped, never wrong).
 
 use std::collections::BTreeSet;
 
@@ -53,14 +56,21 @@ pub struct TrifectaSubject {
     /// Whether the task can realize a boundary-permitted external effect:
     /// an `exec:` task · an `invoke:` with a net or fs-write builtin effect
     /// · an `mcp:` tool call (effects are server-side — the `tools:` grant
-    /// is the boundary, fail-closed) · an `agent:` loop with a non-empty
-    /// tools whitelist. `infer:` is NOT egress — provider egress rides the
-    /// engine's media plane, not `permits.net.http` (the effect.rs table's
-    /// own doctrine).
+    /// is the boundary, fail-closed) · an `agent:` loop whose whitelist
+    /// admits an egress-effecting tool. `infer:` is NOT egress — provider
+    /// egress rides the engine's media plane, not `permits.net.http` (the
+    /// effect.rs table's own doctrine).
     pub egress_capable: bool,
     /// Whether the task is a BLOCKING human gate (an `invoke:` of
     /// [`crate::HUMAN_GATE_TOOL`] with no `default:` arg).
     pub human_gate: bool,
+    /// Whether the task is a REALIZED untrusted-content source (v2.0): an
+    /// invoked `nika:fetch` · an invoked `mcp:*` whose catalog mark is not
+    /// `trusted` (absent/unknown = untrusted, fail-closed) · an `agent:`
+    /// whose whitelist admits an ingress-capable tool (a browsing agent's
+    /// final message is attacker-influenced even with a clean prompt).
+    /// v1's granted-but-never-invoked arming is gone: ② needs one of these.
+    pub ingress_source: bool,
     /// Direct predecessors (indices into the same subject slice).
     pub parents: Vec<usize>,
 }
@@ -75,8 +85,44 @@ impl TrifectaSubject {
             id,
             egress_capable,
             human_gate,
+            ingress_source: false,
             parents: Vec::new(),
         }
+    }
+
+    /// Mark the subject an untrusted-content source (v2.0 builder — the
+    /// projection sets it, the judge's ② reads it).
+    #[must_use]
+    pub fn with_ingress_source(mut self, ingress_source: bool) -> Self {
+        self.ingress_source = ingress_source;
+        self
+    }
+}
+
+/// The realized-flow fact for one subject (v2.0): whether untrusted
+/// content from an ingress source REACHES it (the projection computes it
+/// over the data graph; the judge stays pure L0).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TaintWitness {
+    /// Untrusted content reaches this subject's effect surface.
+    pub tainted: bool,
+    /// The ingress task the content originates from (the flow witness a
+    /// violation names), when tainted.
+    pub source: Option<String>,
+}
+
+impl TaintWitness {
+    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
+    #[must_use]
+    pub fn new(tainted: bool, source: Option<String>) -> Self {
+        Self { tainted, source }
+    }
+
+    /// A clean subject (no realized flow).
+    #[must_use]
+    pub fn clean() -> Self {
+        Self::new(false, None)
     }
 }
 
@@ -87,6 +133,10 @@ impl TrifectaSubject {
 pub struct TrifectaViolation {
     /// The egress-capable task no blocking human gate dominates.
     pub task: String,
+    /// The ingress task whose untrusted content reaches `task` (the
+    /// realized-flow witness · `None` only for a v1-shaped caller).
+    #[serde(default)]
+    pub source: Option<String>,
     /// Human detail — opens with « lethal trifecta complete · human gate
     /// required » (NEP-0002 verbatim), then names the fix.
     pub detail: String,
@@ -118,11 +168,13 @@ fn grants_untrusted_ingress(tools: &[String]) -> bool {
     })
 }
 
-/// The three legs off the DECLARED boundary (NEP-0002 §Specification).
-fn legs(permits: &Permits, uses_fetch: bool) -> (bool, bool, bool) {
+/// The three legs off the DECLARED boundary (NEP-0002 §Specification ·
+/// v2.0: ② needs the grant AND one realized source — a granted-but-never
+/// invoked ingress no longer arms the trifecta).
+fn legs(permits: &Permits, subjects: &[TrifectaSubject]) -> (bool, bool, bool) {
     let private_read = permits.fs.as_ref().is_some_and(|fs| !fs.read.is_empty());
-    let untrusted_ingress = uses_fetch
-        || permits
+    let untrusted_ingress = subjects.iter().any(|s| s.ingress_source)
+        && permits
             .tools
             .as_ref()
             .is_some_and(|t| grants_untrusted_ingress(t));
@@ -138,19 +190,21 @@ fn legs(permits: &Permits, uses_fetch: bool) -> (bool, bool, bool) {
 /// The virtual-root marker in dominator sets (never a subject index).
 const ROOT: usize = usize::MAX;
 
-/// Judge the trifecta. `topo_order` is any topological order of the SAME
-/// derived graph the subjects' `parents` index into, covering every subject
-/// exactly once (the caller owns DAG validity — an unanalyzable graph yields
-/// no order and NO claim, the IFC/policy gating precedent). Deterministic:
-/// violations follow task declaration order.
+/// Judge the trifecta (v2.0). `witnesses[i]` is the realized-flow fact for
+/// `subjects[i]` (the projection computes it — the judge stays pure L0);
+/// `topo_order` is any topological order of the SAME derived graph the
+/// subjects' `parents` index into, covering every subject exactly once (the
+/// caller owns DAG validity — an unanalyzable graph yields no order and NO
+/// claim, the IFC/policy gating precedent). Deterministic: violations
+/// follow task declaration order.
 #[must_use]
 pub fn trifecta_violations(
     permits: &Permits,
-    uses_fetch: bool,
     subjects: &[TrifectaSubject],
+    witnesses: &[TaintWitness],
     topo_order: &[usize],
 ) -> Vec<TrifectaViolation> {
-    let (one, two, three) = legs(permits, uses_fetch);
+    let (one, two, three) = legs(permits, subjects);
     if !(one && two && three) {
         return Vec::new();
     }
@@ -184,21 +238,31 @@ pub fn trifecta_violations(
         if !s.egress_capable {
             continue;
         }
+        // v2.0 — the REALIZED trifecta: untrusted content must actually
+        // reach this egress task (a flow witness), not merely be granted
+        // somewhere in the workflow.
+        let witness = witnesses.get(i);
+        if !witness.is_some_and(|w| w.tainted) {
+            continue;
+        }
         let gated = dom[i]
             .iter()
             .any(|&g| subjects.get(g).is_some_and(|t| t.human_gate));
         if !gated {
+            let source = witness.and_then(|w| w.source.clone());
             out.push(TrifectaViolation {
                 task: s.id.clone(),
                 detail: format!(
-                    "lethal trifecta complete · human gate required — task `{}` reaches \
-                     egress while private read + untrusted ingress + external egress are all \
-                     permitted, and no blocking `invoke: {}` dominates every path to it · fix: \
-                     gate the egress path behind a human prompt task (NEP-0002 · the Rule of \
-                     Two as a check)",
+                    "lethal trifecta complete · human gate required — untrusted content from \
+                     `{}` reaches egress task `{}` while private read + untrusted ingress + \
+                     external egress are all permitted, and no blocking `invoke: {}` dominates \
+                     every path to it · fix: gate the egress path behind a human prompt task \
+                     (NEP-0002 · the Rule of Two as a check)",
+                    source.as_deref().unwrap_or("<ingress>"),
                     s.id,
                     crate::HUMAN_GATE_TOOL
                 ),
+                source,
             });
         }
     }
@@ -248,56 +312,86 @@ mod tests {
         order
     }
 
+    fn ingress_subjects() -> Vec<TrifectaSubject> {
+        vec![TrifectaSubject::new("fetch".to_owned(), true, false).with_ingress_source(true)]
+    }
+
+    /// A fetch → leak pair: both egress-capable, fetch the realized
+    /// ingress source, leak tainted by it — the canonical v2.0 trifecta.
+    fn realized_pair() -> (Vec<TrifectaSubject>, Vec<TaintWitness>) {
+        let fetch =
+            TrifectaSubject::new("fetch_page".to_owned(), true, false).with_ingress_source(true);
+        let mut leak = TrifectaSubject::new("leak".to_owned(), true, false);
+        leak.parents.push(0);
+        let subjects = vec![fetch, leak];
+        let witnesses = vec![
+            TaintWitness::clean(),
+            TaintWitness::new(true, Some("fetch_page".to_owned())),
+        ];
+        (subjects, witnesses)
+    }
+
     #[test]
     fn legs_read_off_the_declared_boundary() {
-        let (a, b, c) = legs(&full_boundary(), false);
+        let (a, b, c) = legs(&full_boundary(), &ingress_subjects());
         assert!((a, b, c) == (true, true, true), "all three legs declared");
         // ① falls with an empty read set.
         let mut p = full_boundary();
         p.fs = Some(FsPermits::new(Vec::new(), vec!["./out/**".to_owned()]));
-        assert!(!legs(&p, false).0, "① falls with an empty read set");
-        // ② falls with no fetch and no tools.
+        assert!(
+            !legs(&p, &ingress_subjects()).0,
+            "① falls with an empty read set"
+        );
+        // ② falls with no ingress-capable grant…
         p = full_boundary();
         p.tools = Some(Vec::new());
-        assert!(!legs(&p, false).1, "② falls with no fetch and no tools");
-        // …but a fetch task alone re-arms it (the NEP's first ② form).
-        assert!(legs(&p, true).1, "a fetch task re-arms ②");
+        assert!(
+            !legs(&p, &ingress_subjects()).1,
+            "② falls with no tools grant"
+        );
+        // …and with no REALIZED source either (v2.0's conjunction).
+        assert!(
+            !legs(
+                &full_boundary(),
+                &[TrifectaSubject::new("x".to_owned(), true, false)]
+            )
+            .1,
+            "② falls with no realized source"
+        );
         // ③ falls with no net, no escaping write, no exec.
-        p = boundary(&["./private/**"], &["./out/**"], &[], &["nika:fetch"]);
-        assert!(!legs(&p, false).2, "③ falls with no egress channel");
+        let mut p = boundary(&["./private/**"], &["./out/**"], &[], &["nika:fetch"]);
+        assert!(
+            !legs(&p, &ingress_subjects()).2,
+            "③ falls with no egress channel"
+        );
         // …and ANY of the three variants re-arms it.
         p.exec = Some(ExecPermit::Any);
-        assert!(legs(&p, false).2, "exec enabled is egress");
+        assert!(legs(&p, &ingress_subjects()).2, "exec enabled is egress");
     }
 
     #[test]
     fn first_party_local_tools_are_not_ingress() {
         // The spec's own permits-fit fixture (conformance deep/014) —
         // private read + workspace write + an exec allowlist + LOCAL
-        // builtins only: two legs, never three (the v1.1 refinement).
-        let p = Permits {
-            fs: Some(FsPermits::new(
-                vec!["./data/**".to_owned()],
-                vec!["./out/**".to_owned()],
-            )),
-            net: None,
-            exec: Some(ExecPermit::Programs(vec!["git".to_owned()])),
-            tools: Some(vec!["nika:read".to_owned(), "nika:write".to_owned()]),
-        };
-        let (one, two, three) = legs(&p, false);
+        // builtins only: two legs, never three (the v1.1 grant refinement,
+        // kept verbatim in v2.0).
+        let mut p = Permits::new();
+        p.fs = Some(FsPermits::new(
+            vec!["./data/**".to_owned()],
+            vec!["./out/**".to_owned()],
+        ));
+        p.exec = Some(ExecPermit::Programs(vec!["git".to_owned()]));
+        p.tools = Some(vec!["nika:read".to_owned(), "nika:write".to_owned()]);
+        let subjects = vec![TrifectaSubject::new("log_head".to_owned(), true, false)];
+        let (one, two, three) = legs(&p, &subjects);
         assert!(
             one && !two && three,
             "local builtins drop ② — the fixture stays VALID: {one} {two} {three}"
         );
+        let witnesses = vec![TaintWitness::new(true, Some("x".to_owned()))];
         assert!(
-            trifecta_violations(
-                &p,
-                false,
-                &[TrifectaSubject::new("log_head".to_owned(), true, false)],
-                &[0]
-            )
-            .is_empty(),
-            "② dropped → no finding even with an ungated egress task"
+            trifecta_violations(&p, &subjects, &witnesses, &[0]).is_empty(),
+            "② dropped → no finding even with a tainted ungated egress task"
         );
     }
 
@@ -305,10 +399,13 @@ mod tests {
     fn ingress_grants_are_fetch_globs_and_mcp() {
         // `nika:*` covers fetch → ② holds.
         let p = boundary(&["./private/**"], &["./out/**"], &[], &["nika:*"]);
-        assert!(legs(&p, false).1, "a nika:* grant covers nika:fetch");
+        assert!(
+            legs(&p, &ingress_subjects()).1,
+            "a nika:* grant covers nika:fetch"
+        );
         // Any mcp:* server is untrusted content by construction.
         let p = boundary(&["./private/**"], &["./out/**"], &[], &["mcp:browser/*"]);
-        assert!(legs(&p, false).1, "an mcp grant is ingress");
+        assert!(legs(&p, &ingress_subjects()).1, "an mcp grant is ingress");
         // A negation-only list ADMITS nothing → ② falls.
         let p = boundary(
             &["./private/**"],
@@ -316,7 +413,7 @@ mod tests {
             &[],
             &["!mcp:x", "!nika:fetch"],
         );
-        assert!(!legs(&p, false).1, "negations admit nothing");
+        assert!(!legs(&p, &ingress_subjects()).1, "negations admit nothing");
         // A first-party grant outside fetch/mcp is not ingress.
         let p = boundary(
             &["./private/**"],
@@ -325,7 +422,7 @@ mod tests {
             &["nika:connectome/*"],
         );
         assert!(
-            !legs(&p, false).1,
+            !legs(&p, &ingress_subjects()).1,
             "connectome is first-party memory, not ingress"
         );
     }
@@ -341,39 +438,59 @@ mod tests {
     }
 
     #[test]
-    fn trifecta_complete_refuses_every_ungated_egress() {
-        let subjects = vec![
-            TrifectaSubject::new("fetch_page".to_owned(), true, false),
-            TrifectaSubject::new("leak".to_owned(), true, false),
-        ];
-        let v = trifecta_violations(&full_boundary(), true, &subjects, &topo(&subjects));
-        assert_eq!(v.len(), 2, "one finding per ungated egress task: {v:?}");
+    fn trifecta_complete_refuses_every_tainted_ungated_egress() {
+        let (subjects, witnesses) = realized_pair();
+        let v = trifecta_violations(&full_boundary(), &subjects, &witnesses, &topo(&subjects));
+        assert_eq!(v.len(), 1, "one finding per tainted ungated egress: {v:?}");
+        assert_eq!(v[0].task, "leak");
+        assert_eq!(v[0].source.as_deref(), Some("fetch_page"));
         assert!(
             v[0].detail
                 .starts_with("lethal trifecta complete · human gate required"),
             "NEP-0002 message verbatim first: {}",
             v[0].detail
         );
+        assert!(
+            v[0].detail
+                .contains("`fetch_page` reaches egress task `leak`"),
+            "the flow witness is named: {}",
+            v[0].detail
+        );
+    }
+
+    #[test]
+    fn an_untainted_egress_is_clean_even_ungated() {
+        // v2.0 precision: egress capability WITHOUT a realized flow is not
+        // a trifecta (the deploy-exec on a parallel branch, far from the
+        // fetch — clean; v1.1 fired here).
+        let (subjects, _) = realized_pair();
+        let witnesses = vec![TaintWitness::clean(), TaintWitness::clean()];
+        assert!(
+            trifecta_violations(&full_boundary(), &subjects, &witnesses, &topo(&subjects))
+                .is_empty(),
+            "no realized flow → no finding"
+        );
     }
 
     #[test]
     fn two_of_three_legs_is_clean() {
-        let subjects = vec![TrifectaSubject::new("act".to_owned(), true, false)];
+        let (subjects, witnesses) = realized_pair();
         // Drop ①.
         let p = boundary(&[], &["./out/**"], &["api.example.com"], &["nika:fetch"]);
-        assert!(trifecta_violations(&p, true, &subjects, &[0]).is_empty());
-        // Drop ② (no fetch, no tools).
+        assert!(trifecta_violations(&p, &subjects, &witnesses, &topo(&subjects)).is_empty());
+        // Drop ② (no fetch grant).
         let p = boundary(&["./private/**"], &["./out/**"], &["api.example.com"], &[]);
-        assert!(trifecta_violations(&p, false, &subjects, &[0]).is_empty());
+        assert!(trifecta_violations(&p, &subjects, &witnesses, &topo(&subjects)).is_empty());
         // Drop ③ (no net · workspace-confined writes · no exec).
         let p = boundary(&["./private/**"], &["./out/**"], &[], &["nika:fetch"]);
-        assert!(trifecta_violations(&p, true, &subjects, &[0]).is_empty());
+        assert!(trifecta_violations(&p, &subjects, &witnesses, &topo(&subjects)).is_empty());
     }
 
     #[test]
     fn a_dominating_gate_disarms_the_trifecta() {
         // ask (gate) → fetch_page → leak : every path to egress crosses ask.
-        let mut fetch = TrifectaSubject::new("fetch_page".to_owned(), true, false);
+        let mut fetch =
+            TrifectaSubject::new("fetch_page".to_owned(), true, false).with_ingress_source(true);
         fetch.parents.push(0);
         let mut leak = TrifectaSubject::new("leak".to_owned(), true, false);
         leak.parents.push(1);
@@ -382,7 +499,12 @@ mod tests {
             fetch,
             leak,
         ];
-        let v = trifecta_violations(&full_boundary(), true, &subjects, &topo(&subjects));
+        let witnesses = vec![
+            TaintWitness::clean(),
+            TaintWitness::clean(),
+            TaintWitness::new(true, Some("fetch_page".to_owned())),
+        ];
+        let v = trifecta_violations(&full_boundary(), &subjects, &witnesses, &topo(&subjects));
         assert!(v.is_empty(), "the gate dominates every egress path: {v:?}");
     }
 
@@ -395,9 +517,14 @@ mod tests {
         let subjects = vec![
             TrifectaSubject::new("ask".to_owned(), false, true),
             left,
-            TrifectaSubject::new("leak".to_owned(), true, false),
+            TrifectaSubject::new("leak".to_owned(), true, false).with_ingress_source(true),
         ];
-        let v = trifecta_violations(&full_boundary(), true, &subjects, &topo(&subjects));
+        let witnesses = vec![
+            TaintWitness::clean(),
+            TaintWitness::clean(),
+            TaintWitness::new(true, Some("fetch_page".to_owned())),
+        ];
+        let v = trifecta_violations(&full_boundary(), &subjects, &witnesses, &topo(&subjects));
         assert_eq!(v.len(), 1, "{v:?}");
         assert_eq!(v[0].task, "leak");
         assert!(
@@ -409,10 +536,11 @@ mod tests {
     #[test]
     fn no_egress_task_means_no_surface() {
         // Wide-open boundary, but every task is pure compute: the trifecta
-        // has no egress task to fire on (vacuously gated).
+        // has no egress task to fire on (vacuously gated — even tainted).
         let subjects = vec![TrifectaSubject::new("think".to_owned(), false, false)];
+        let witnesses = vec![TaintWitness::new(true, Some("x".to_owned()))];
         assert!(
-            trifecta_violations(&full_boundary(), true, &subjects, &[0]).is_empty(),
+            trifecta_violations(&full_boundary(), &subjects, &witnesses, &[0]).is_empty(),
             "no egress-capable task · no finding"
         );
     }

--- a/crates/nika-lsp/src/analysis/diagnostics.rs
+++ b/crates/nika-lsp/src/analysis/diagnostics.rs
@@ -400,8 +400,9 @@ mod tests {
     fn a_trifecta_finding_projects_with_its_code_and_span() {
         // NEP-0002 one-voice proof: a lethal-trifecta finding born in the
         // check ladder (`NIKA-SEC-009`) rides the SAME from_report
-        // projection — anchored on the ungated egress task's id.
-        let yaml = "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/x\" }\n";
+        // projection — anchored on the ungated tainted egress task's id
+        // (the SINK · v2.0).
+        let yaml = "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/x\" }\n  leak:\n    with: { d: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/${{ with.d }}\" }\n";
         let diags = diags_of(yaml);
         let tri = diags
             .iter()
@@ -415,8 +416,8 @@ mod tests {
             "the NEP-0002 message survives the projection: {}",
             tri.message
         );
-        // anchored on the task id `fetch_page`, not the origin
-        let id_byte = yaml.find("\n  fetch_page:").map(|p| p + 3).expect("id");
+        // anchored on the task id `leak` (the sink), not the origin
+        let id_byte = yaml.find("\n  leak:").map(|p| p + 3).expect("id");
         let expected = index_of(yaml).position(id_byte);
         assert_eq!(tri.range.start, expected, "anchored on the task id");
         assert!(tri.range.start.line > 0, "a real span, never 0:0");

--- a/crates/nika-schema/src/check/content_flow.rs
+++ b/crates/nika-schema/src/check/content_flow.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The content-taint pass (NEP-0002 v2.0 · the INTEGRITY half of the flow
+//! lattice — [`super::flow`] tracks secret CONFIDENTIALITY): does untrusted
+//! content actually REACH a task's effect surface, and from which ingress?
+//! Sources: invoked `nika:fetch` · `mcp:*` (fail-closed) · `agent:` with an
+//! ingress whitelist. Propagation mirrors [`super::flow`] with three
+//! inversions: `infer:`/`agent:` outputs ARE tainted when their prompt sees
+//! it · an `exec:` is tainted when a tainted WRITER ran earlier under a
+//! declared `fs.read` (the file channel argv cannot see) · recover reads
+//! propagate. One sweep = the least fixpoint (the DAG is acyclic).
+
+use std::collections::BTreeMap;
+
+use nika_cap::TaintWitness;
+
+use super::flow::{action_effect_fields, collect_json_strings, refs_in_str};
+use crate::expression::NamespaceRef;
+use crate::raw::{RawAction, RawWorkflow};
+use crate::types::OnErrorAction;
+
+/// Compute the per-task content-taint witness. `mcp_trusted(server_id)`
+/// answers the catalog's `content_trust` mark (`true` = trusted content).
+pub(super) fn analyze_content_flow(
+    wf: &RawWorkflow,
+    waves: &[Vec<usize>],
+    mcp_trusted: &dyn Fn(&str) -> bool,
+) -> Vec<TaintWitness> {
+    let n = wf.tasks.len();
+    let id_of: BTreeMap<&str, usize> = wf
+        .tasks
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (t.value.id.value.as_str(), i))
+        .collect();
+    let fs_read_declared = wf
+        .permits
+        .as_ref()
+        .and_then(|p| p.value.fs.as_ref())
+        .is_some_and(|fs| !fs.read.is_empty());
+
+    // output[i] / effect[i] = the untrusted origin reaching each (None = clean).
+    let mut output: Vec<Option<String>> = vec![None; n];
+    let mut effect: Vec<Option<String>> = vec![None; n];
+    let mut any_writer_so_far: Option<String> = None;
+
+    for wave in waves {
+        for &i in wave {
+            let task = &wf.tasks[i].value;
+
+            let mut with_src: BTreeMap<&str, String> = BTreeMap::new();
+            for (key, value) in &task.with {
+                for r in collect_json_strings(&value.value)
+                    .into_iter()
+                    .flat_map(refs_in_str)
+                {
+                    if let Some(src) = source_of(&r, &with_src, None, &output, &id_of) {
+                        with_src.insert(key.value.as_str(), src);
+                        break;
+                    }
+                }
+            }
+            let item_src: Option<String> = task.for_each.as_ref().and_then(|f| match &f.value {
+                crate::raw::ForEachValue::Expression(src) => refs_in_str(src)
+                    .into_iter()
+                    .find_map(|r| source_of(&r, &with_src, None, &output, &id_of)),
+                crate::raw::ForEachValue::List(_) => None,
+            });
+
+            let mut effect_src: Option<String> = action_effect_fields(&task.action)
+                .into_iter()
+                .flat_map(refs_in_str)
+                .find_map(|r| source_of(&r, &with_src, item_src.as_ref(), &output, &id_of));
+            if effect_src.is_none() && matches!(task.action, RawAction::Exec(_)) && fs_read_declared
+            {
+                effect_src.clone_from(&any_writer_so_far);
+            }
+
+            // Output taint: born-source wins; else effect flows out (inversion).
+            let mut out_src = if classify(&task.action, mcp_trusted).0 {
+                Some(task.id.value.clone())
+            } else {
+                effect_src.clone()
+            };
+            if out_src.is_none()
+                && let Some(on_error) = &task.on_error
+                && let OnErrorAction::Recover(value) = &on_error.value.action
+            {
+                out_src = collect_json_strings(&value.value)
+                    .into_iter()
+                    .flat_map(refs_in_str)
+                    .find_map(|r| source_of(&r, &with_src, item_src.as_ref(), &output, &id_of));
+            }
+
+            if out_src.is_some()
+                && any_writer_so_far.is_none()
+                && classify(&task.action, mcp_trusted).1
+            {
+                any_writer_so_far.clone_from(&out_src);
+            }
+            effect[i] = effect_src;
+            output[i] = out_src;
+        }
+    }
+
+    (0..n)
+        .map(|i| TaintWitness::new(effect[i].is_some(), effect[i].clone()))
+        .collect()
+}
+
+fn source_of(
+    r: &NamespaceRef,
+    with_src: &BTreeMap<&str, String>,
+    item_src: Option<&String>,
+    output: &[Option<String>],
+    id_of: &BTreeMap<&str, usize>,
+) -> Option<String> {
+    match r {
+        NamespaceRef::Tasks { id, .. } => id_of
+            .get(id.as_str())
+            .and_then(|&u| output.get(u).cloned().flatten()),
+        NamespaceRef::With(key) => with_src.get(key.as_str()).cloned(),
+        NamespaceRef::Item => item_src.cloned(),
+        _ => None,
+    }
+}
+
+/// The invoke-side classifications, ONE effect-table walk: `(born_ingress,
+/// writes_fs)` — the module doc's source table, and the writer clause.
+pub(super) fn classify(action: &RawAction, mcp_trusted: &dyn Fn(&str) -> bool) -> (bool, bool) {
+    match action {
+        RawAction::Exec(_) => (false, true),
+        RawAction::Agent(a) => (
+            a.tools.iter().any(|t| {
+                let g = t.value.as_str();
+                !g.starts_with('!')
+                    && (g.starts_with("mcp:") || nika_cap::glob_matches(g, "nika:fetch"))
+            }),
+            false,
+        ),
+        RawAction::Invoke(inv) => {
+            let Some(tool) = inv.tool() else {
+                return (false, false); // a child call — spec 14 owns its boundary
+            };
+            let id = tool.value.as_str();
+            if id == "nika:fetch" {
+                return (true, false);
+            }
+            if let Some(server) = id.strip_prefix("mcp:") {
+                // Server content untrusted UNLESS the catalog marks it
+                // (absent/unknown = untrusted) · server writes are opaque.
+                return (
+                    !mcp_trusted(server.split('/').next().unwrap_or(server)),
+                    true,
+                );
+            }
+            let args = inv.args.as_ref().map(|a| &a.value);
+            let writes = match nika_cap::builtin_effect(id, args) {
+                Some(nika_cap::BuiltinEffect::Fs { writes, .. }) => writes,
+                _ => false,
+            };
+            (false, writes)
+        }
+        _ => (false, false),
+    }
+}

--- a/crates/nika-schema/src/check/findings.rs
+++ b/crates/nika-schema/src/check/findings.rs
@@ -330,8 +330,10 @@ mod tests {
                 "COMPOSITION",
             ),
             (
-                // trifecta: all three legs declared + ungated egress (NEP-0002)
-                "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/x\" }\n",
+                // trifecta: all three legs declared + an ungated egress the
+                // untrusted content REACHES (NEP-0002 v2.0 · the second
+                // fetch's url rides the first's untrusted output)
+                "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/x\" }\n  b:\n    with: { d: \"${{ tasks.a.output }}\" }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/${{ with.d }}\" }\n",
                 "trifecta",
                 "TRIFECTA",
             ),
@@ -414,9 +416,10 @@ mod tests {
         assert_eq!(policy.gate, "POLICY");
 
         // trifecta → NIKA-SEC-009 (NEP-0002) — the code rides with the
-        // witness task, one voice with the conformance-code surface.
+        // witness task (the SINK the content reaches · v2.0), one voice
+        // with the conformance-code surface.
         let r = report(
-            "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/x\" }\n",
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/x\" }\n  b:\n    with: { d: \"${{ tasks.a.output }}\" }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/${{ with.d }}\" }\n",
         );
         let tri = r
             .findings
@@ -428,7 +431,7 @@ mod tests {
             tri.docs_url.as_deref(),
             Some("https://nika.sh/errors/NIKA-SEC-009")
         );
-        assert_eq!(tri.task.as_deref(), Some("a"));
+        assert_eq!(tri.task.as_deref(), Some("b"), "the sink is the witness");
     }
 
     /// The wire shape: absent optionals are ABSENT (never null) — the

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -30,6 +30,7 @@
 mod analysis;
 mod certificate;
 mod composition;
+mod content_flow;
 mod cost;
 mod declass;
 mod effective;
@@ -428,12 +429,9 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
     } else {
         Vec::new()
     };
-    // The trifecta lane shares the gating (NEP-0002 · valid DAG + declared
-    // boundary or no claim); the flat topological order drives the
-    // judge's dominance pass.
-    let topo_flat: Vec<usize> = topo_waves.iter().flatten().copied().collect();
+    // The trifecta lane shares the gating (NEP-0002 · valid DAG or no claim).
     let trifecta_findings = if conformance.is_empty() {
-        trifecta::scan_trifecta(wf, &edges, &topo_flat)
+        trifecta::scan_trifecta(wf, &edges, &topo_waves)
     } else {
         Vec::new()
     };

--- a/crates/nika-schema/src/check/trifecta.rs
+++ b/crates/nika-schema/src/check/trifecta.rs
@@ -3,47 +3,38 @@
 
 //! The lethal-trifecta lane (NEP-0002 · `NIKA-SEC-009`) — needle-thin BY
 //! DESIGN (the [`super::policy`] precedent): this module only PROJECTS the
-//! workflow (declared boundary · per-task egress capability · gate-ness ·
-//! direct parents from the ONE edge derivation); the pure judge lives in
-//! `nika-cap` ([`nika_cap::trifecta_violations`]).
+//! workflow; the pure judge lives in `nika-cap`, the realized-flow facts
+//! come from [`super::content_flow`].
 //!
-//! Projection choices (documented, not silent):
-//! - **egress-capable** = an `exec:` task · an `invoke:` whose builtin
-//!   carries a net or fs-write effect ([`nika_cap::builtin_effect`] — the
-//!   ONE effect table, so this lane and the escape checker cannot drift) ·
-//!   an `mcp:` tool call (server-side effects — the `tools:` grant is the
-//!   boundary, fail-closed) · an `agent:` loop with a non-empty tools
-//!   whitelist. `infer:` is not egress (provider egress rides the media
-//!   plane). A child-workflow call is NOT judged here — spec 14's
-//!   `NIKA-COMP-002` owns the child's boundary containment.
+//! - **egress-capable** = `exec:` · `invoke:` with a net/fs-write effect
+//!   (the ONE effect table) · `mcp:` (fail-closed) · `agent:` whose
+//!   whitelist admits an egress-effecting tool. `infer:` is not egress; a
+//!   child-workflow call is spec 14's (`NIKA-COMP-002`), never here.
 //! - **blocking human gate** = an `invoke:` of `nika:prompt` with NO
-//!   `default:` arg (a default lets the run proceed unattended — the NEP's
-//!   Rule-of-Two escape is the HUMAN decision). This is intentionally
-//!   stricter than `policy: require.human_gate_before`, which accepts a
-//!   `default: false` fail-closed prompt; the trifecta wants consent, not
-//!   just a pause shape (NEP-0002 §Specification · v2 refinement candidate).
-//! - The lane is gated on a valid DAG (the caller passes the derived
-//!   edges plus a topological order) and on a DECLARED `permits:` block —
-//!   without one the legs are not decidable as declared, so there is no
-//!   claim (skipped, never wrong).
+//!   `default:` arg (the NEP's escape is the HUMAN decision). Gated on a
+//!   valid DAG + a DECLARED `permits:` block (skipped, never wrong).
 
 use nika_cap::TrifectaSubject;
 
 use crate::analyzer::Edge;
 use crate::raw::{RawAction, RawWorkflow};
+use crate::source::Spanned;
 
 /// Judge the trifecta over the derived graph. Empty unless the workflow
 /// declares `permits:` AND the trifecta legs all hold AND an egress-capable
-/// task escapes gate dominance.
+/// task the untrusted content reaches escapes gate dominance.
 pub(super) fn scan_trifecta(
     wf: &RawWorkflow,
     edges: &[Edge],
-    topo_order: &[usize],
+    topo_waves: &[Vec<usize>],
 ) -> Vec<nika_cap::TrifectaViolation> {
     let Some(permits) = wf.permits.as_ref() else {
         return Vec::new();
     };
-    let mut uses_fetch = false;
+    // The realized-flow facts (v2.0). The MCP trust closure is the
+    // catalog mark's seam — until it lands, every server is untrusted.
+    let mcp_trusted = |_: &str| false;
+    let witnesses = super::content_flow::analyze_content_flow(wf, topo_waves, &mcp_trusted);
     let mut subjects: Vec<TrifectaSubject> = wf
         .tasks
         .iter()
@@ -51,9 +42,10 @@ pub(super) fn scan_trifecta(
             let task = &t.value;
             TrifectaSubject::new(
                 task.id.value.clone(),
-                egress_capable(&task.action, &mut uses_fetch),
+                egress_capable(&task.action),
                 human_gate(&task.action),
             )
+            .with_ingress_source(super::content_flow::classify(&task.action, &mcp_trusted).0)
         })
         .collect();
     for e in edges {
@@ -61,14 +53,15 @@ pub(super) fn scan_trifecta(
             s.parents.push(e.from);
         }
     }
-    nika_cap::trifecta_violations(&permits.value, uses_fetch, &subjects, topo_order)
+    let topo_flat: Vec<usize> = topo_waves.iter().flatten().copied().collect();
+    nika_cap::trifecta_violations(&permits.value, &subjects, &witnesses, &topo_flat)
 }
 
 /// The task's egress capability (see the module doc for the table).
-fn egress_capable(action: &RawAction, uses_fetch: &mut bool) -> bool {
+fn egress_capable(action: &RawAction) -> bool {
     match action {
         RawAction::Exec(_) => true,
-        RawAction::Agent(a) => !a.tools.is_empty(),
+        RawAction::Agent(a) => agent_egress(&a.tools),
         RawAction::Infer(_) => false,
         RawAction::Invoke(inv) => {
             let Some(tool) = inv.tool() else {
@@ -77,9 +70,6 @@ fn egress_capable(action: &RawAction, uses_fetch: &mut bool) -> bool {
                 return false;
             };
             let id = tool.value.as_str();
-            if id == "nika:fetch" {
-                *uses_fetch = true;
-            }
             if id.starts_with("mcp:") {
                 // Server-side effects — the `tools:` grant is the boundary.
                 return true;
@@ -92,6 +82,21 @@ fn egress_capable(action: &RawAction, uses_fetch: &mut bool) -> bool {
             }
         }
     }
+}
+
+/// An agent's whitelist admits an egress-effecting tool (v2.0's aim) — any
+/// glob covering a net/fs-write builtin (the ONE effect table) or `mcp:*`
+/// (fail-closed). A pure-compute whitelist (`["nika:jq"]`) is NOT egress.
+fn agent_egress(tools: &[Spanned<String>]) -> bool {
+    tools.iter().any(|t| {
+        let g = t.value.as_str();
+        !g.starts_with('!')
+            && (g.starts_with("mcp:")
+                || nika_catalog::all_builtins()
+                    .iter()
+                    .map(|b| format!("nika:{}", b.name))
+                    .any(|id| nika_cap::glob_matches(g, &id) && nika_cap::builtin_egresses(&id)))
+    })
 }
 
 /// A BLOCKING `invoke: nika:prompt` (no `default:` arg) is the NEP's gate.
@@ -126,22 +131,31 @@ mod tests {
     const TRIFECTA: &str = "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    after: { fetch_page: succeeded }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n";
 
     /// ①∧②∧③ declared, no gate → the diagnostic, once per ungated egress
-    /// task, message opening with the NEP's verbatim string.
+    /// task THE CONTENT REACHES (v2.0: `leak` is the realized sink;
+    /// `fetch_page` is the SOURCE — its own args are operator content, so
+    /// it is not itself tainted), message opening with the NEP's verbatim.
     #[test]
     fn trifecta_complete_refuse() {
         let r = report(TRIFECTA);
         assert_eq!(
             r.trifecta_findings.len(),
-            2,
-            "fetch_page (net) + leak (fs write) are both ungated egress: {:?}",
+            1,
+            "only the realized sink is flagged (v2.0 precision): {:?}",
             r.trifecta_findings
         );
+        let v = &r.trifecta_findings[0];
+        assert_eq!(v.task, "leak");
+        assert_eq!(v.source.as_deref(), Some("fetch_page"));
         assert!(
-            r.trifecta_findings[0]
-                .detail
+            v.detail
                 .starts_with("lethal trifecta complete · human gate required"),
             "{}",
-            r.trifecta_findings[0].detail
+            v.detail
+        );
+        assert!(
+            v.detail.contains("`fetch_page` reaches egress task `leak`"),
+            "the flow witness is named: {}",
+            v.detail
         );
         assert!(!r.is_clean(), "the lane gates the check");
         let f = r
@@ -163,7 +177,7 @@ mod tests {
             .collect();
         assert_eq!(
             codes.iter().filter(|c| *c == "NIKA-SEC-009").count(),
-            2,
+            1,
             "one SEC-009 per finding: {codes:?}"
         );
     }
@@ -226,10 +240,11 @@ mod tests {
         let r = report(&bypass);
         assert_eq!(
             r.trifecta_findings.len(),
-            2,
+            1,
             "a bypassable gate mitigates nothing: {:?}",
             r.trifecta_findings
         );
+        assert_eq!(r.trifecta_findings[0].task, "leak");
     }
 
     /// A `default:`-carrying prompt is NOT a gate (the run proceeds
@@ -244,10 +259,11 @@ mod tests {
         let r = report(&defaulted);
         assert_eq!(
             r.trifecta_findings.len(),
-            2,
+            1,
             "default: true answers without a human: {:?}",
             r.trifecta_findings
         );
+        assert_eq!(r.trifecta_findings[0].task, "leak");
     }
 
     /// No `permits:` block → the legs are not decidable as declared → the
@@ -276,5 +292,137 @@ mod tests {
         );
         assert!(!r.conformance.is_empty());
         assert!(r.trifecta_findings.is_empty(), "{:?}", r.trifecta_findings);
+    }
+
+    // ── v2.0 pins (the realized-flow judgment) ─────────────────────────
+
+    /// The v2.0 behavior-change pin: an ingress-capable GRANT that is
+    /// never invoked arms nothing (v1.1 fired here).
+    #[test]
+    fn granted_not_invoked_pass() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\"]\ntasks:\n  save:\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/report.txt\", content: \"pure operator content\" }\n",
+        );
+        assert!(
+            r.trifecta_findings.is_empty(),
+            "granted-but-never-invoked fetch → no realized source → clean: {:?}",
+            r.trifecta_findings
+        );
+    }
+
+    /// The integrity-inversion pin: a model SUMMARY of attacker content
+    /// carries the payload (the confidentiality carve-out does not apply).
+    #[test]
+    fn flow_through_infer_refuse() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:notify\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  summarize:\n    with: { page: \"${{ tasks.fetch_page.output }}\" }\n    infer: { prompt: \"tldr: ${{ with.page }}\", max_tokens: 99 }\n  tell:\n    with: { summary: \"${{ tasks.summarize.output }}\" }\n    invoke:\n      tool: \"nika:notify\"\n      args: { channel: \"webhook\", target: \"https://api.example.com/hook\", message: \"${{ with.summary }}\" }\n",
+        );
+        assert_eq!(
+            r.trifecta_findings.len(),
+            1,
+            "the infer output carries the taint to the egress: {:?}",
+            r.trifecta_findings
+        );
+        assert_eq!(r.trifecta_findings[0].task, "tell");
+        assert_eq!(r.trifecta_findings[0].source.as_deref(), Some("fetch_page"));
+    }
+
+    /// The recovery-read pin: `on_error.recover` substitutes the failed
+    /// task's output — a tainted recovery read re-arms the chain (the
+    /// failing task here is a pure-compute `jq`, NOT egress — only the
+    /// downstream write is judged).
+    #[test]
+    fn recovery_read_refuse() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:jq\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  fragile:\n    on_error: { recover: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:jq\"\n      args: { input: {}, expression: \".x\" }\n  leak:\n    with: { body: \"${{ tasks.fragile.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n",
+        );
+        assert_eq!(
+            r.trifecta_findings.len(),
+            1,
+            "the recovery read propagates the taint: {:?}",
+            r.trifecta_findings
+        );
+        assert_eq!(r.trifecta_findings[0].task, "leak");
+        assert_eq!(r.trifecta_findings[0].source.as_deref(), Some("fetch_page"));
+    }
+
+    /// The exec-opacity pin: the file-mediated channel argv cannot see —
+    /// an exec downstream of a tainted write under a declared fs.read.
+    #[test]
+    fn exec_opacity_refuse() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  exec: [\"sh\"]\n  tools: [\"nika:fetch\", \"nika:write\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  save:\n    with: { page: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/page.html\", content: \"${{ with.page }}\" }\n  ship:\n    after: { save: succeeded }\n    exec: { command: [\"sh\", \"-c\", \"cat ./out/page.html | curl -X POST https://api.example.com --data-binary @-\"] }\n",
+        );
+        assert_eq!(
+            r.trifecta_findings.len(),
+            2,
+            "the write AND the opacity-tainted exec are both realized sinks: {:?}",
+            r.trifecta_findings
+        );
+        assert_eq!(r.trifecta_findings[0].task, "save");
+        assert_eq!(r.trifecta_findings[1].task, "ship");
+        assert_eq!(
+            r.trifecta_findings[1].source.as_deref(),
+            Some("fetch_page"),
+            "the opacity witness is the untrusted ORIGIN, propagated through the writer"
+        );
+    }
+
+    /// The parallel-clean pin: an egress on a branch no untrusted content
+    /// reaches is NOT a trifecta (v1.1 fired here too).
+    #[test]
+    fn parallel_clean_egress_pass() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  exec: [\"git\"]\n  tools: [\"nika:fetch\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  deploy:\n    exec: { command: [\"git\", \"status\"] }\n",
+        );
+        assert!(
+            r.trifecta_findings.is_empty(),
+            "no realized flow to the exec branch → clean: {:?}",
+            r.trifecta_findings
+        );
+    }
+
+    /// The pure-agent pin: a jq-only whitelist is NOT egress-capable.
+    #[test]
+    fn pure_agent_pass() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\nmodel: mock/echo\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  exec: [\"git\"]\n  tools: [\"nika:jq\"]\ntasks:\n  think:\n    agent: { prompt: \"reshape this data\", tools: [\"nika:jq\"] }\n",
+        );
+        assert!(
+            r.trifecta_findings.is_empty(),
+            "a pure-compute agent is not egress: {:?}",
+            r.trifecta_findings
+        );
+    }
+
+    /// The agent-as-source pin: a browsing agent's final message is
+    /// attacker-influenced even with a statically clean prompt.
+    #[test]
+    fn ingress_agent_refuse() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\nmodel: mock/echo\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:write\", \"mcp:browser/*\"]\ntasks:\n  browse:\n    agent: { prompt: \"summarize the news\", tools: [\"mcp:browser/*\"] }\n  leak:\n    with: { brief: \"${{ tasks.browse.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/brief.txt\", content: \"${{ with.brief }}\" }\n",
+        );
+        assert_eq!(
+            r.trifecta_findings.len(),
+            1,
+            "the agent's output is a content source: {:?}",
+            r.trifecta_findings
+        );
+        assert_eq!(r.trifecta_findings[0].task, "leak");
+        assert_eq!(r.trifecta_findings[0].source.as_deref(), Some("browse"));
+    }
+
+    /// The gate-once pin: one blocking prompt dominating BOTH tainted
+    /// sinks disarms the whole run (consent once per run, not per task).
+    #[test]
+    fn gate_once_dominates_two_sinks_pass() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"ship it?\" }\n  fetch_page:\n    after: { ask: succeeded }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n  leak2:\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak2.txt\", content: \"${{ with.body }}\" }\n",
+        );
+        assert!(
+            r.trifecta_findings.is_empty(),
+            "one dominating gate disarms every sink it dominates: {:?}",
+            r.trifecta_findings
+        );
     }
 }


### PR DESCRIPTION
## What

Trifecta v2.0 (NEP-0002, amended on nika-spec#150): the judge graduates from capability-set analysis to **realized-flow** analysis — the integrity half of the IFC lattice, mirroring ADR-092's secrets engine (the confidentiality half). v1.1 asked "could this workflow complete the trifecta?"; v2.0 asks "does untrusted content actually REACH an egress?" — the check PACT argues for: the dangerous moment is when untrusted content determines an authority-bearing action, not when a capability is merely declared.

- **`check/content_flow.rs`** (new) — the content-taint pass. Sources: an invoked `nika:fetch` · an invoked `mcp:*` (fail-closed; the catalog `content_trust` mark is the documented follow-on) · an `agent:` whose whitelist admits ingress (a browsing agent's final message is attacker-influenced even with a clean prompt). Propagation: `with:` slots · `for_each` items · `tasks.*.output` reads · `on_error.recover` reads. **The inversion**: `infer:`/`agent:` outputs carry the taint when their prompt sees it — a summary of an attacker's page carries the payload (the ADR-092 verbatim-echo carve-out is confidentiality-only). **The exec opacity clause** (`fs.read` non-empty ∧ a tainted WRITER ran earlier) keeps the file-mediated finding argv cannot see, WITHOUT re-tainting parallel read-only branches.
- **nika-cap** — the judge consumes per-subject `ingress_source` + per-task `TaintWitness` (tainted · source); ② needs a realized source; findings name the flow witness (`source → sink`). `glob_matches` goes public (the ONE matcher — the whitelist classification shares it); `builtin_egresses` joins the effect table (the agent refinement's predicate).
- **The agent refinement** — egress-capable iff the whitelist admits an egress-effecting tool (the ONE effect table + `nika:notify` conservative) — a jq-only agent is not egress.
- **v2.0 findings ⊆ v1.1** — zero migration: every v2.0 finding is a realized flow v1.1 already flagged; the deep suite at the SPEC_PIN stays 37/37.

## Tests

15 trifecta tests incl. the eight v2.0 pins (granted-not-invoked · flow-through-infer · recovery-read · exec-opacity · parallel-clean · pure-agent · ingress-agent · gate-once) · findings/LSP fixtures now carry a realized flow (the sink is the witness) · E2E on the real binary: ungated realized flow → exit 2 naming `fetch_page → leak` · gated → 0 · granted-not-invoked → 0. Workspace lib tests green · clippy 0 warnings · crate-size 15k holds (the lane was dieted to fit).

Spec: NEP-0002 v2.0 on supernovae-st/nika-spec#150 (registry + canon + 05-errors cascade in the same wave).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
