### PR TITLE
fix(ci): least-privilege tokens + patched deps — scorecard palier 1

### DIFF
--- a/.github/workflows/changelog-cliff.yml
+++ b/.github/workflows/changelog-cliff.yml
@@ -6,14 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read # least privilege at the top — the job elevates (Scorecard Token-Permissions)
 
 jobs:
   changelog:
     # Only diamond-era tags (v0.80+) — excludes legacy v0.79.x
     if: startsWith(github.ref, 'refs/tags/v0.8') || startsWith(github.ref, 'refs/tags/v0.9') || startsWith(github.ref, 'refs/tags/v0.10') || startsWith(github.ref, 'refs/tags/v0.11')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the changelog commit
+      pull-requests: write # open the changelog PR
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/pack-resync.yml
+++ b/.github/workflows/pack-resync.yml
@@ -14,12 +14,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read # least privilege at the top — the job elevates (Scorecard Token-Permissions)
 
 jobs:
   heal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the heal branch
+      pull-requests: write # open the heal PR
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
         required: true
 
 permissions:
-  contents: write # create the release + upload assets
+  contents: read # least privilege at the top — release job elevates (Scorecard Token-Permissions)
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/spec-pin-heal.yml
+++ b/.github/workflows/spec-pin-heal.yml
@@ -14,12 +14,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read # least privilege at the top — the job elevates (Scorecard Token-Permissions)
 
 jobs:
   heal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the heal branch
+      pull-requests: write # open the heal PR
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arraydeque"
@@ -3382,9 +3382,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Run:  docker run --rm -v "$PWD:/work" -w /work ghcr.io/supernovae-st/nika check flow.nika.yaml
 # MCP:  docker run -i --rm ghcr.io/supernovae-st/nika mcp
 
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 ARG TARGETARCH
 LABEL org.opencontainers.image.source="https://github.com/supernovae-st/nika" \
       org.opencontainers.image.description="Nika — the workflow language for AI. One YAML file: check it, run it, trace it." \


### PR DESCRIPTION
## What

Scorecard palier 1 (agent-doable slice of the 10/10 gate plan):

- **Token-Permissions 0→10 path** · top-level `permissions:` drops to `contents: read` on the four write-holding workflows (`changelog-cliff` · `pack-resync` · `spec-pin-heal` · `release`) — each job now elevates exactly what it uses (job-level `contents: write` + `pull-requests: write` where the job commits/opens a PR · the `release` job already carried its own block).
- **Vulnerabilities 5→7 path** · the two available patches land: `anyhow` 1.0.104 (RUSTSEC-2026-0190 · unsound `downcast_mut`) and `memmap2` 0.9.11 (RUSTSEC-2026-0186 · unchecked pointer offset). The remaining three advisories (`paste` unmaintained · `quick-xml` 0.30/0.39 pair) are transitive-only with no patched parent chain (candle/gemm · xcap/wayland/zbus a11y-screenshot stack) and were already documented in `deny.toml` ignores with reasons.
- **Pinned-Dependencies 9→10 path** · runtime `Dockerfile` base pinned by digest (`ubuntu:24.04@sha256:4fbb8e6a…`).

## Why

Operator gate (2026-07-20): the official v1 does not ship until the repo scores 10/10 on OpenSSF Scorecard. This PR is the mechanical palier — plan: `strategy/2026-07-20-scorecard-10-of-10-plan.md` (private monorepo).

## Verification

- YAML of the four workflows parses clean (python yaml.safe_load).
- `Cargo.lock`-only dependency change (no code) — CI judges the build.
- Local slow rail skipped per operator authorization; the GitHub CI is the judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)