### PR TITLE
feat(ci): slsa provenance asset + security insights — scorecard palier 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,8 @@ jobs:
       attestations: write # publish the build-provenance attestation
     outputs:
       version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      hashes: ${{ steps.meta.outputs.hashes }}
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -219,7 +221,11 @@ jobs:
         run: |
           set -euo pipefail
           echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          echo "tag=${REF_NAME}" >> "$GITHUB_OUTPUT"
           (cd artifacts && cat ./*.tar.gz.sha256 | sort > SHA256SUMS)
+          # Subjects for the SLSA generator job below — sha256 of every
+          # shipped tarball, base64 one-line, per the generator contract.
+          echo "hashes=$(cd artifacts && sha256sum nika-*.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
           {
             echo "## Checksums"
             echo '```'
@@ -243,6 +249,27 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: 'artifacts/nika-*.tar.gz'
+
+  provenance:
+    # The scorecard-visible provenance: this reusable workflow builds and
+    # UPLOADS `multiple.intoto.jsonl` as a release asset. The native
+    # attest-build-provenance step above stays (gh attestation verify) but
+    # scorecard's Signed-Releases probe only reads release ASSET NAMES
+    # (ossf/scorecard#4080) — the .intoto.jsonl asset is what scores.
+    # Tag pin is the generator's own hard requirement (its internal
+    # verifier refuses SHA refs) — the one documented exception to the
+    # SHA-pin law; scorecard's Pinned-Dependencies knows this exception.
+    name: slsa provenance (intoto asset)
+    needs: release
+    permissions:
+      actions: read # read the workflow run for provenance
+      id-token: write # sign the provenance (Sigstore OIDC)
+      contents: write # upload the .intoto.jsonl asset to the release
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.release.outputs.hashes }}
+      upload-assets: true
+      upload-tag-name: ${{ needs.release.outputs.tag }}
 
   bump-formula:
     name: bump homebrew tap

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,0 +1,104 @@
+# OpenSSF Security Insights v2 — machine-readable security metadata.
+# Spec: https://github.com/ossf/security-insights-spec (v2.0.0)
+# Consumed by LFX Insights and planned for Scorecard v6 OSPS verdicts.
+header:
+  schema-version: 2.0.0
+  last-updated: '2026-07-20'
+  last-reviewed: '2026-07-20'
+  url: https://github.com/supernovae-st/nika/blob/main/security-insights.yml
+  comment: >-
+    Security posture of the Nika reference engine. The spec repo
+    (supernovae-st/nika-spec) carries the language standard surfaces
+    (conformance suite · governance · certifications matrix).
+
+project:
+  name: nika
+  homepage: https://nika.sh
+  roadmap: https://nika.sh/changelog
+  administrators:
+    - name: Thibaut Melen
+      affiliation: SuperNovae Studio
+      email: security@supernovae.studio
+      primary: true
+  repositories:
+    - name: nika
+      url: https://github.com/supernovae-st/nika
+      comment: Reference engine (Rust · AGPL-3.0-or-later).
+    - name: nika-spec
+      url: https://github.com/supernovae-st/nika-spec
+      comment: Language specification + public conformance suite (Apache-2.0).
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: Security team
+      email: security@supernovae.studio
+      primary: true
+    security-policy: https://github.com/supernovae-st/nika/blob/main/SECURITY.md
+    comment: >-
+      Private disclosure via email or GitHub private vulnerability
+      reporting. No public issues for vulnerabilities.
+
+repository:
+  url: https://github.com/supernovae-st/nika
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: Thibaut Melen
+      affiliation: SuperNovae Studio
+      email: security@supernovae.studio
+      primary: true
+  license:
+    url: https://github.com/supernovae-st/nika/blob/main/LICENSE
+    expression: AGPL-3.0-or-later
+  security:
+    assessments:
+      self:
+        comment: >-
+          Continuous: OpenSSF Scorecard on every main push · CodeQL ·
+          cargo-deny (advisories + licenses) · cargo-fuzz (4 targets,
+          nightly) · cargo-mutants floor on the checker · miri UB
+          detection on L0 · boundary differentials (check vs runtime).
+    champions:
+      - name: Thibaut Melen
+        email: security@supernovae.studio
+        primary: true
+    tools:
+      - name: CodeQL
+        type: sca
+        rulesets:
+          - default
+        integration:
+          ad-hoc: false
+          ci: true
+          before-release: true
+      - name: cargo-deny
+        type: sca
+        rulesets:
+          - advisories
+          - licenses
+        integration:
+          ad-hoc: false
+          ci: true
+          before-release: true
+      - name: cargo-fuzz
+        type: fuzzer
+        rulesets:
+          - cap_check
+          - cel_expression
+          - infer_permits
+          - parse_workflow
+        integration:
+          ad-hoc: false
+          ci: true
+          before-release: false
+      - name: OpenSSF Scorecard
+        type: sca
+        rulesets:
+          - default
+        integration:
+          ad-hoc: false
+          ci: true
+          before-release: false


### PR DESCRIPTION
## What

- **Provenance job on the release train** · `slsa-framework/slsa-github-generator` (generic, **v2.1.0** — tag pin is the generator's own hard requirement; the one documented exception to the SHA-pin law) takes the sha256 set of every shipped tarball (`base64-subjects`) and uploads **`multiple.intoto.jsonl`** as a release asset on the tag.
- **`security-insights.yml`** (OpenSSF Security Insights v2.0.0) at the repo root: administrators, vulnerability reporting contract, the four security tools (CodeQL · cargo-deny · cargo-fuzz · Scorecard).

## Why

Scorecard's Signed-Releases probe reads release **asset names** only — `*.intoto.jsonl` = provenance = 10, and native GitHub attestations are invisible to it ([ossf/scorecard#4080](https://github.com/ossf/scorecard/issues/4080), open). Our #628 attestation step stays for `gh attestation verify`; this adds the asset the probe scores. Effect: +2 per release, 10/10 after five consecutive trains. Security Insights is the machine surface LFX Insights reads today and Scorecard v6 plans to consume for OSPS verdicts.

Plan: `strategy/2026-07-20-scorecard-10-of-10-plan.md` §5ter (private monorepo) — gate « 10/10 before official v1 ».

## Verification

- `yaml.safe_load` clean on both files; jobs: build → release → provenance → bump-formula/docker.
- The provenance job exercises on the NEXT tag (workflow_dispatch re-run of an existing tag also works — `upload-tag-name` pins the target release).
- Local slow rail skipped per operator authorization; CI judges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)