### PR TITLE
feat(nika-cli): signed run seals — run_sealed event + run-key custody

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +185,17 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "arraydeque"
@@ -533,6 +555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +777,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2568,6 +2608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +2959,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -3136,6 +3186,27 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid-simd",
+]
+
+[[package]]
+name = "keyring"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -3738,6 +3809,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "expectrl",
+ "keyring",
+ "minisign",
  "nika-builtin",
  "nika-catalog",
  "nika-clock",
@@ -5787,7 +5860,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5954,6 +6027,48 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7473,6 +7588,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8089,6 +8217,17 @@ dependencies = [
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -40,6 +40,9 @@ nika-fs          = { path = "../nika-fs", version = "0.105.0" }            # Tok
 nika-clock       = { path = "../nika-clock", version = "0.105.0" }         # SystemClock — backoff + timeout + the date builtin
 nika-http        = { path = "../nika-http", version = "0.105.0" }          # ReqwestHttp — the registry + fetch effect
 nika-exec-runner = { path = "../nika-exec-runner", version = "0.105.0" }   # TokioShell — the exec verb's subprocess runner
+keyring        = { version = "4" }   # the run-key custody (S2 · OS keychain first: macOS keychain · Windows credman · secret-service)
+minisign       = { version = "0.7", default-features = false }   # the seal signature primitive (the registry v0.2 voice, shared)
+sha2           = { workspace = true }   # the seal fingerprint (key_id) · shared with the registry chain
 nika-sandbox-seatbelt = { path = "../nika-sandbox-seatbelt", version = "0.105.0" }  # the macOS exec jail (ADR-095 L6)
 nika-sandbox-landlock = { path = "../nika-sandbox-landlock", version = "0.105.0" }  # the Linux exec jail (ADR-095 L6 · bwrap)
 nika-catalog     = { path = "../nika-catalog", version = "0.105.0", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
@@ -70,7 +73,6 @@ path = "src/main.rs"
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
 nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.105.0" }
-sha2 = { workspace = true }       # composition e2e · the INDEPENDENT chain re-walk (tests/composition_e2e.rs)
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 expectrl = { workspace = true }   # PTY e2e · the wizard conversation is TTY-gated — unreachable

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -14,6 +14,10 @@ pub use nika_cli::registry::RegistryError
 pub use nika_cli::registry::Resolved
 pub use nika_cli::registry::is_registry_ref
 pub fn nika_cli::registry::resolve_blocking(arg: &str) -> core::result::Result<nika_registry_client::Resolved, nika_registry_client::RegistryError>
+pub mod nika_cli::seal
+pub fn nika_cli::seal::key_init(force: bool) -> core::result::Result<alloc::string::String, alloc::string::String>
+pub fn nika_cli::seal::key_rotate() -> core::result::Result<alloc::string::String, alloc::string::String>
+pub fn nika_cli::seal::key_trust() -> core::option::Option<(alloc::string::String, alloc::string::String)>
 pub mod nika_cli::verbs
 pub mod nika_cli::verbs::catalog
 pub fn nika_cli::verbs::catalog::run(json: bool, theme: nika_display::theme::Theme) -> nika_cli::verbs::VerbOutput
@@ -173,6 +177,61 @@ pub type nika_cli::verbs::init::CanvasTheme::Output = T
 pub fn nika_cli::verbs::init::run(dir: &str, force: bool, yes: bool, recipe: core::option::Option<&str>, example: core::option::Option<&str>, canvas: core::option::Option<nika_cli::verbs::init::CanvasTheme>, wires: &[nika_cli::verbs::wire::WireTarget], theme: nika_display::theme::Theme) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::inspect
 pub fn nika_cli::verbs::inspect::run(path: &str, theme: nika_display::theme::Theme) -> nika_cli::verbs::VerbOutput
+pub mod nika_cli::verbs::key
+pub enum nika_cli::verbs::key::KeyAction
+pub nika_cli::verbs::key::KeyAction::Init
+pub nika_cli::verbs::key::KeyAction::Init::force: bool
+pub nika_cli::verbs::key::KeyAction::Rotate
+pub nika_cli::verbs::key::KeyAction::Trust
+impl clap_builder::derive::FromArgMatches for nika_cli::verbs::key::KeyAction
+pub fn nika_cli::verbs::key::KeyAction::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::key::KeyAction::from_arg_matches_mut(__clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::key::KeyAction::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+pub fn nika_cli::verbs::key::KeyAction::update_from_arg_matches_mut<'b>(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+impl clap_builder::derive::Subcommand for nika_cli::verbs::key::KeyAction
+pub fn nika_cli::verbs::key::KeyAction::augment_subcommands<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::key::KeyAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::key::KeyAction::has_subcommand(__clap_name: &str) -> bool
+impl core::clone::Clone for nika_cli::verbs::key::KeyAction
+pub fn nika_cli::verbs::key::KeyAction::clone(&self) -> nika_cli::verbs::key::KeyAction
+impl core::marker::Copy for nika_cli::verbs::key::KeyAction
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::key::KeyAction
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::key::KeyAction where U: core::convert::From<T>
+pub fn nika_cli::verbs::key::KeyAction::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::key::KeyAction where U: core::convert::Into<T>
+pub type nika_cli::verbs::key::KeyAction::Error = core::convert::Infallible
+pub fn nika_cli::verbs::key::KeyAction::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::key::KeyAction where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::key::KeyAction::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::key::KeyAction::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::key::KeyAction where T: core::clone::Clone
+pub type nika_cli::verbs::key::KeyAction::Owned = T
+pub fn nika_cli::verbs::key::KeyAction::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::key::KeyAction::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::key::KeyAction where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::key::KeyAction::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::key::KeyAction where T: ?core::marker::Sized
+pub fn nika_cli::verbs::key::KeyAction::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::key::KeyAction where T: ?core::marker::Sized
+pub fn nika_cli::verbs::key::KeyAction::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::key::KeyAction where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::key::KeyAction::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::key::KeyAction
+pub fn nika_cli::verbs::key::KeyAction::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::key::KeyAction where T: core::clone::Clone
+pub fn nika_cli::verbs::key::KeyAction::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::key::KeyAction where T: 'static
+pub fn nika_cli::verbs::key::KeyAction::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_cli::verbs::key::KeyAction where T: core::marker::Copy
+pub fn nika_cli::verbs::key::KeyAction::as_out(&mut self) -> outref::Out<'_, T>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::key::KeyAction where T: ?core::marker::Sized
+pub fn nika_cli::verbs::key::KeyAction::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::key::KeyAction::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::key::KeyAction
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::key::KeyAction
+impl<T> typenum::type_operators::Same for nika_cli::verbs::key::KeyAction
+pub type nika_cli::verbs::key::KeyAction::Output = T
+pub fn nika_cli::verbs::key::run(action: nika_cli::verbs::key::KeyAction) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::model
 pub mod nika_cli::verbs::model::pull
 pub fn nika_cli::verbs::model::pull::run(arg: &str, yes: bool) -> nika_cli::verbs::VerbOutput

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -483,6 +483,9 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::run::SystemStamper
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::run::SystemStamper
 impl<T> typenum::type_operators::Same for nika_cli::verbs::run::SystemStamper
 pub type nika_cli::verbs::run::SystemStamper::Output = T
+impl<T> zvariant::optional::NoneValue for nika_cli::verbs::run::SystemStamper where T: core::default::Default
+pub type nika_cli::verbs::run::SystemStamper::NoneType = T
+pub fn nika_cli::verbs::run::SystemStamper::null_value() -> T
 pub fn nika_cli::verbs::run::capabilities_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_cli::verbs::run::RuntimeCapabilities
 pub fn nika_cli::verbs::run::example(slug: &str, model_override: core::option::Option<&str>, vars: &[alloc::string::String], (quiet, no_progress): (bool, bool), max_cost_usd: core::option::Option<f64>, theme: nika_display::theme::Theme) -> u8
 pub fn nika_cli::verbs::run::fs_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_builtin::permits::FsBoundary

--- a/crates/nika-cli/src/lib.rs
+++ b/crates/nika-cli/src/lib.rs
@@ -27,6 +27,7 @@
 pub use nika_display as display;
 pub use nika_display::demo;
 pub mod registry;
+pub mod seal;
 pub(crate) mod text;
 pub mod verbs;
 pub mod wires;

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -209,6 +209,14 @@ enum Command {
         #[arg(long)]
         forecast: bool,
     },
+    /// The run-signing key lifecycle (S2 · verifiable runs): mint the
+    /// ed25519 key the journal seals with, print the TOFU fingerprint to
+    /// enroll elsewhere, rotate with the old public half kept verifiable.
+    #[command(display_order = 70)]
+    Key {
+        #[command(subcommand)]
+        action: verbs::key::KeyAction,
+    },
     /// Diagnose this machine (binary · config · provider keys · local models).
     /// Diagnose-only — prints the exact fix command, never mutates anything.
     #[command(display_order = 42)]
@@ -775,6 +783,7 @@ fn main() -> std::process::ExitCode {
             json,
             forecast,
         } => emit(&explain_dispatch(&code, json, forecast, plain_theme)),
+        Command::Key { action } => emit(&verbs::key::run(action)),
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json, plain_theme)),
         Command::Init(args) => emit(&init_verb(&args, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target, &dir)),

--- a/crates/nika-cli/src/seal.rs
+++ b/crates/nika-cli/src/seal.rs
@@ -102,7 +102,7 @@ pub(crate) fn fingerprint(pubkey_box: &str) -> String {
 
 /// The signing half of the run-key, when one exists on this machine
 /// (keychain first · the 0600 fallback file second).
-pub(crate) fn load_secret_key() -> Option<(minisign::SecretKey, String)> {
+pub(crate) fn load_signing_key() -> Option<(minisign::SecretKey, String)> {
     // An explicit key file wins (CI injects keys this way · hermetic tests
     // too — the OS keychain is never the only door).
     if let (Ok(kf), Ok(pf)) = (
@@ -148,7 +148,7 @@ fn load_from_files(key: &Path, pub_: &Path) -> Option<(minisign::SecretKey, Stri
 /// generation/storage fails (keychain unavailable AND the 0600 fallback
 /// unwritable).
 pub fn key_init(force: bool) -> Result<String, String> {
-    if load_secret_key().is_some() && !force {
+    if load_signing_key().is_some() && !force {
         return Err(
             "a run-signing key already exists — `nika key trust` prints it, `--force` rotates it"
                 .to_owned(),
@@ -159,7 +159,7 @@ pub fn key_init(force: bool) -> Result<String, String> {
     let sk_box = pair
         .sk
         .to_box(None)
-        .map_err(|e| format!("cannot box the secret key: {e}"))?
+        .map_err(|e| format!("cannot box the signing key: {e}"))?
         .to_string();
     let pk_box = pair
         .pk
@@ -168,14 +168,14 @@ pub fn key_init(force: bool) -> Result<String, String> {
         .to_string()
         .trim()
         .to_owned();
-    store_secret_box(&sk_box, &pk_box)?;
+    store_key_boxes(&sk_box, &pk_box)?;
     Ok(fingerprint(&pk_box))
 }
 
 /// `nika key trust` — the public key + fingerprint to enroll elsewhere.
 #[must_use]
 pub fn key_trust() -> Option<(String, String)> {
-    let (_, pk_box) = load_secret_key()?;
+    let (_, pk_box) = load_signing_key()?;
     Some((pk_box.clone(), fingerprint(&pk_box)))
 }
 
@@ -188,7 +188,7 @@ pub fn key_trust() -> Option<(String, String)> {
 /// A refusal string when no key exists to rotate, or when the ledger or
 /// the new key cannot be written.
 pub fn key_rotate() -> Result<String, String> {
-    let (_, old_pk) = load_secret_key()
+    let (_, old_pk) = load_signing_key()
         .ok_or_else(|| "no run-signing key to rotate — `nika key init` first".to_owned())?;
     if let Some(path) = retired_path() {
         if let Some(parent) = path.parent() {
@@ -207,7 +207,7 @@ pub fn key_rotate() -> Result<String, String> {
 
 /// Store both boxes — the env override first (init writes where load
 /// reads), then the keychain, then the 0600 files as fallback.
-fn store_secret_box(sk_box: &str, pk_box: &str) -> Result<(), String> {
+fn store_key_boxes(sk_box: &str, pk_box: &str) -> Result<(), String> {
     if let (Ok(kf), Ok(pf)) = (
         key_file_env("NIKA_RUN_KEY_FILE"),
         key_file_env("NIKA_RUN_PUB_FILE"),

--- a/crates/nika-cli/src/seal.rs
+++ b/crates/nika-cli/src/seal.rs
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The run seal (the verifiable-run wave · S2) — ONE ed25519 signature,
+//! emitted as the journal's last line, binding the whole chain to the
+//! run-key that minted it. The sha256 chain was already tamper-evident;
+//! the seal makes it attributable: forging a signed journal now requires
+//! the key, not just write access to the file.
+//!
+//! ## The envelope (`seal_format: 1`)
+//!
+//! A journal event like any other — `kind: run_sealed`, chained — whose
+//! fields carry:
+//!
+//! - `covers` — `{ head, events, workflow }`: the chain head BEFORE the
+//!   seal line (so the seal commits to every prior line) and the
+//!   workflow's semantic hash (the proof layer's Merkle commitment), so
+//!   journal ↔ workflow bind into one certificate;
+//! - `key_id` — the first 16 hex of the public key's sha256 (the TOFU
+//!   fingerprint `nika key trust` prints);
+//! - `alg` — `"ed25519"` (the envelope is algorithm-versioned from day
+//!   one: a PQ migration lands as `seal_format: 2`, never a flag day);
+//! - `sig` — the detached minisign over `proof::preimage(HashDomain::
+//!   Trace, 1, covers)` — the proof layer's ONE canonicalization voice,
+//!   so a second evaluator re-derives the exact bytes.
+//!
+//! ## Custody
+//!
+//! OS keychain first (entry `nika/run-signing-key`, the minisign secret
+//! box as text); `~/.nika/keys/run-signing.key` (0600) as the no-backend
+//! fallback (CI without a session keyring). `nika key init|trust|rotate`
+//! manages the lifecycle; an absent key keeps the journal unsigned and
+//! says so — sealing is additive, never a gate.
+
+use std::fmt::Write as _;
+use std::io::{Cursor, Write as IoWrite};
+use std::path::{Path, PathBuf};
+
+use nika_event::{Event, EventKind};
+use nika_types::id::EventId;
+use nika_types::timestamp::Timestamp;
+
+/// The keychain entries the run-key lives under (the public half rides
+/// beside it — `SecretKey` cannot re-derive it).
+const KEYRING_SERVICE: &str = "nika";
+const KEYRING_USER: &str = "run-signing-key";
+const KEYRING_USER_PUB: &str = "run-signing-key.pub";
+
+/// The local custody fallback (no session keyring on this host).
+// Env reads are CONFIG paths (HOME only — no secret value crosses here ·
+// the scoped `env_flag`/`link_host` precedent).
+#[allow(clippy::disallowed_methods)]
+fn fallback_key_path() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|home| {
+            PathBuf::from(home)
+                .join(".nika")
+                .join("keys")
+                .join("run-signing.key")
+        })
+}
+
+/// The retired-pubkeys ledger (rotation keeps old journals verifiable).
+// Same scoped exemption — a config path, never a secret read.
+#[allow(clippy::disallowed_methods)]
+fn retired_path() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|home| {
+            PathBuf::from(home)
+                .join(".nika")
+                .join("keys")
+                .join("retired.pub")
+        })
+}
+
+/// The custody password (v1): `NIKA_RUN_KEY_PASSWORD`, empty allowed —
+/// the minisign box is encrypted with it end to end; the OS keychain is
+/// the primary protection, this is the file-fallback's own lock.
+// The custody password is operator config (a box password, not a
+// workflow secret) — the scoped exemption holds.
+#[allow(clippy::disallowed_methods)]
+fn key_password() -> String {
+    std::env::var("NIKA_RUN_KEY_PASSWORD").unwrap_or_default()
+}
+
+/// The CI/test key-file override (config path · scoped exemption).
+#[allow(clippy::disallowed_methods)]
+fn key_file_env(name: &str) -> Result<String, std::env::VarError> {
+    std::env::var(name)
+}
+
+/// The public fingerprint of a public-key box string — the first 16 hex
+/// of its sha256 (what `nika key trust` prints and the seal's `key_id`
+/// records).
+#[must_use]
+pub(crate) fn fingerprint(pubkey_box: &str) -> String {
+    let digest = sha256_hex(pubkey_box.as_bytes());
+    digest[..16].to_owned()
+}
+
+/// The signing half of the run-key, when one exists on this machine
+/// (keychain first · the 0600 fallback file second).
+pub(crate) fn load_secret_key() -> Option<(minisign::SecretKey, String)> {
+    // An explicit key file wins (CI injects keys this way · hermetic tests
+    // too — the OS keychain is never the only door).
+    if let (Ok(kf), Ok(pf)) = (
+        key_file_env("NIKA_RUN_KEY_FILE"),
+        key_file_env("NIKA_RUN_PUB_FILE"),
+    ) && let Some(pair) = load_from_files(Path::new(&kf), Path::new(&pf))
+    {
+        return Some(pair);
+    }
+    // The keychain holds the minisign secret box as text (custody IS the
+    // keychain's own encryption).
+    if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)
+        && let Ok(text) = entry.get_password()
+        && let Ok(boxed) = minisign::SecretKeyBox::from_string(&text)
+        && let Ok(sk) = boxed.into_secret_key(Some(key_password()))
+        && let Ok(pub_entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER_PUB)
+        && let Ok(pk_box) = pub_entry.get_password()
+    {
+        return Some((sk, pk_box.trim().to_owned()));
+    }
+    // Fallback: the 0600 files (unencrypted in v1 — the encrypted upgrade
+    // lands with the password/keychain-hydration pass).
+    let path = fallback_key_path()?;
+    load_from_files(&path, &path.with_extension("pub"))
+}
+
+/// Load a (secret box, public box) pair from two files — `None` on any
+/// miss (absent file · unparseable box).
+fn load_from_files(key: &Path, pub_: &Path) -> Option<(minisign::SecretKey, String)> {
+    let text = std::fs::read_to_string(key).ok()?;
+    let boxed = minisign::SecretKeyBox::from_string(&text).ok()?;
+    let sk = boxed.into_secret_key(Some(key_password())).ok()?;
+    let pk_box = std::fs::read_to_string(pub_).ok()?;
+    Some((sk, pk_box.trim().to_owned()))
+}
+
+/// `nika key init` — generate + store a run-key (idempotent: refuses to
+/// clobber an existing one without `--force`).
+///
+/// # Errors
+///
+/// A refusal string when a key already exists without `--force`, or when
+/// generation/storage fails (keychain unavailable AND the 0600 fallback
+/// unwritable).
+pub fn key_init(force: bool) -> Result<String, String> {
+    if load_secret_key().is_some() && !force {
+        return Err(
+            "a run-signing key already exists — `nika key trust` prints it, `--force` rotates it"
+                .to_owned(),
+        );
+    }
+    let pair = minisign::KeyPair::generate_encrypted_keypair(Some(key_password()))
+        .map_err(|e| format!("key generation failed: {e}"))?;
+    let sk_box = pair
+        .sk
+        .to_box(None)
+        .map_err(|e| format!("cannot box the secret key: {e}"))?
+        .to_string();
+    let pk_box = pair
+        .pk
+        .to_box()
+        .map_err(|e| format!("cannot box the public key: {e}"))?
+        .to_string()
+        .trim()
+        .to_owned();
+    store_secret_box(&sk_box, &pk_box)?;
+    Ok(fingerprint(&pk_box))
+}
+
+/// `nika key trust` — the public key + fingerprint to enroll elsewhere.
+#[must_use]
+pub fn key_trust() -> Option<(String, String)> {
+    let (_, pk_box) = load_secret_key()?;
+    Some((pk_box.clone(), fingerprint(&pk_box)))
+}
+
+/// `nika key rotate` — retire the current pubkey to the ledger, then
+/// generate a fresh key (old journals stay verifiable against the
+/// ledger).
+///
+/// # Errors
+///
+/// A refusal string when no key exists to rotate, or when the ledger or
+/// the new key cannot be written.
+pub fn key_rotate() -> Result<String, String> {
+    let (_, old_pk) = load_secret_key()
+        .ok_or_else(|| "no run-signing key to rotate — `nika key init` first".to_owned())?;
+    if let Some(path) = retired_path() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| format!("cannot open {}: {e}", path.display()))?;
+        writeln!(file, "{old_pk}").map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+    }
+    key_init(true)
+}
+
+/// Store both boxes — the env override first (init writes where load
+/// reads), then the keychain, then the 0600 files as fallback.
+fn store_secret_box(sk_box: &str, pk_box: &str) -> Result<(), String> {
+    if let (Ok(kf), Ok(pf)) = (
+        key_file_env("NIKA_RUN_KEY_FILE"),
+        key_file_env("NIKA_RUN_PUB_FILE"),
+    ) {
+        if let Some(parent) = Path::new(&kf).parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+        }
+        write_0600(Path::new(&kf), sk_box)?;
+        return write_0600(Path::new(&pf), pk_box);
+    }
+    if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER)
+        && entry.set_password(sk_box).is_ok()
+        && let Ok(pub_entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER_PUB)
+        && pub_entry.set_password(pk_box).is_ok()
+    {
+        return Ok(());
+    }
+    let path = fallback_key_path().ok_or("no HOME for the key fallback".to_owned())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+    }
+    write_0600(&path, sk_box)?;
+    write_0600(&path.with_extension("pub"), pk_box)
+}
+
+fn write_0600(path: &Path, text: &str) -> Result<(), String> {
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| format!("cannot open {}: {e}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    file.write_all(text.as_bytes())
+        .map_err(|e| format!("cannot write {}: {e}", path.display()))
+}
+
+/// The seal event for one finished run — the terminal line of a signed
+/// journal. `covers` binds head + event count + the workflow's semantic
+/// hash; the signature rides the proof layer's ONE canonicalization.
+pub(crate) fn seal_event(
+    run_id: EventId,
+    at: Timestamp,
+    head: &str,
+    events: usize,
+    workflow_hash: &str,
+    engine: &str,
+    sk: &minisign::SecretKey,
+    pk_box: &str,
+) -> Option<Event> {
+    let covers = serde_json::json!({
+        "head": head,
+        "events": events,
+        "workflow": workflow_hash,
+        "engine": engine,
+    });
+    let preimage =
+        nika_runtime::proof::preimage(nika_runtime::proof::HashDomain::Trace, 1, &covers);
+    let sig_box = minisign::sign(None, sk, Cursor::new(preimage.as_bytes()), None, None).ok()?;
+    let fields = vec![
+        nika_types::resource::KeyValue::new("seal_format", nika_types::resource::Value::Int(1)),
+        nika_types::resource::KeyValue::new(
+            "covers",
+            nika_types::resource::Value::String(covers.to_string()),
+        ),
+        nika_types::resource::KeyValue::new(
+            "key_id",
+            nika_types::resource::Value::String(fingerprint(pk_box)),
+        ),
+        nika_types::resource::KeyValue::new(
+            "alg",
+            nika_types::resource::Value::String("ed25519".to_owned()),
+        ),
+        nika_types::resource::KeyValue::new(
+            "sig",
+            nika_types::resource::Value::String(sig_box.into_string()),
+        ),
+    ];
+    Some(Event::new(run_id, at, EventKind::RunSealed).with_fields(fields))
+}
+
+/// sha256 → lowercase hex (the registry client's idiom, mirrored).
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::Digest as _;
+    let digest = sha2::Sha256::digest(bytes);
+    digest.iter().fold(String::with_capacity(64), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use nika_event::EventKind;
+    use nika_types::id::EventId;
+    use nika_types::timestamp::Timestamp;
+
+    use super::*;
+
+    fn keypair() -> (String, minisign::SecretKey) {
+        let pair =
+            minisign::KeyPair::generate_encrypted_keypair(Some(String::new())).expect("keypair");
+        (pair.pk.to_box().expect("pk box").to_string(), pair.sk)
+    }
+
+    #[test]
+    fn the_fingerprint_is_16_hex_of_the_pubkey_sha256() {
+        let (pk, _) = keypair();
+        let fp = fingerprint(&pk);
+        assert_eq!(fp.len(), 16);
+        assert!(fp.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_eq!(fingerprint(&pk), fp, "deterministic");
+    }
+
+    #[test]
+    fn the_seal_event_carries_the_envelope_and_verifies() {
+        let (pk, sk) = keypair();
+        let ev = seal_event(
+            EventId::generate(),
+            Timestamp::from_unix_ms(1_700_000_000_000),
+            "ab12cd",
+            142,
+            "wf-hash-7c2a",
+            "0.105.0",
+            &sk,
+            &pk,
+        )
+        .expect("the seal mints");
+        assert!(matches!(ev.kind, EventKind::RunSealed));
+        let get = |key: &str| {
+            ev.fields
+                .iter()
+                .find(|f| f.key == key)
+                .and_then(|f| match &f.value {
+                    nika_types::resource::Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+        };
+        assert_eq!(get("alg").as_deref(), Some("ed25519"));
+        assert_eq!(get("key_id").as_deref(), Some(fingerprint(&pk).as_str()));
+        let covers = get("covers").expect("covers present");
+        assert!(covers.contains("ab12cd") && covers.contains("wf-hash-7c2a"));
+
+        // The signature verifies against the pubkey box over the SAME
+        // preimage (the proof layer's canonicalization).
+        let covers_json = serde_json::json!({
+            "head": "ab12cd", "events": 142, "workflow": "wf-hash-7c2a", "engine": "0.105.0",
+        });
+        let preimage =
+            nika_runtime::proof::preimage(nika_runtime::proof::HashDomain::Trace, 1, &covers_json);
+        let sig_box = minisign::SignatureBox::from_string(&get("sig").expect("sig present"))
+            .expect("sig parses");
+        let pk_box = minisign::PublicKeyBox::from_string(&pk).expect("pk box parses");
+        let pk_key = pk_box.into_public_key().expect("pk decodes");
+        minisign::verify(
+            &pk_key,
+            &sig_box,
+            std::io::Cursor::new(preimage.as_bytes()),
+            true,
+            false,
+            false,
+        )
+        .expect("the seal verifies");
+    }
+
+    #[test]
+    fn the_file_fallback_round_trips_secret_and_public_boxes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (pk, sk) = keypair();
+        let key_path = dir.path().join("run-signing.key");
+        let pub_path = dir.path().join("run-signing.pub");
+        std::fs::write(&key_path, sk.to_box(None).expect("sk box").to_string()).expect("write key");
+        std::fs::write(&pub_path, &pk).expect("write pub");
+
+        let (loaded_key, loaded_pub) =
+            load_from_files(&key_path, &pub_path).expect("the pair loads");
+        assert_eq!(loaded_pub, pk.trim(), "the public box round-trips");
+        // The loaded secret signs the same bytes to the same verifiable
+        // signature shape (ed25519 is deterministic).
+        let sig = minisign::sign(None, &loaded_key, std::io::Cursor::new(b"x"), None, None)
+            .expect("signs");
+        let pk_box = minisign::PublicKeyBox::from_string(&pk).expect("pk box");
+        let pk_key = pk_box.into_public_key().expect("pk decodes");
+        minisign::verify(
+            &pk_key,
+            &sig,
+            std::io::Cursor::new(b"x"),
+            true,
+            false,
+            false,
+        )
+        .expect("round-trip signature verifies");
+    }
+}

--- a/crates/nika-cli/src/verbs/key.rs
+++ b/crates/nika-cli/src/verbs/key.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika key …` — the run-signing key lifecycle (S2 · the verifiable-run
+//! seal's custody): mint the ed25519 key the journal seals with, print
+//! the TOFU fingerprint to enroll elsewhere, rotate with the retired
+//! public half kept verifiable. The crypto + custody live in
+//! `nika_cli::seal` — this verb is the operator-facing surface only.
+
+use clap::Subcommand;
+
+use super::VerbOutput;
+
+#[derive(Clone, Copy, Subcommand)]
+pub enum KeyAction {
+    /// Mint the run-signing key (idempotent — refuses to clobber without `--force`).
+    Init {
+        /// Overwrite an existing key (a rotation without the retired-pub ledger entry).
+        #[arg(long)]
+        force: bool,
+    },
+    /// Print the public key + TOFU fingerprint to enroll on other machines.
+    Trust,
+    /// Retire the current public key to the ledger and mint a fresh one
+    /// (old journals stay verifiable against the retired pubs).
+    Rotate,
+}
+
+/// Dispatch one key action — the verb body behind `nika key <action>`.
+#[must_use]
+pub fn run(action: KeyAction) -> VerbOutput {
+    match action {
+        KeyAction::Init { force } => match crate::seal::key_init(force) {
+            Ok(fp) => VerbOutput {
+                text: format!(
+                    "run-signing key minted · fingerprint {fp}\n  every run on this machine now seals its journal (verify: nika trace verify <file>)"
+                ),
+                code: super::exit::OK,
+            },
+            Err(msg) => VerbOutput {
+                text: format!("nika key init: {msg}"),
+                code: super::exit::FILE,
+            },
+        },
+        KeyAction::Trust => match crate::seal::key_trust() {
+            Some((pk, fp)) => VerbOutput {
+                text: format!("run-signing public key · fingerprint {fp}\n{pk}"),
+                code: super::exit::OK,
+            },
+            None => VerbOutput {
+                text: "no run-signing key on this machine — `nika key init` mints one".to_owned(),
+                code: super::exit::OK,
+            },
+        },
+        KeyAction::Rotate => match crate::seal::key_rotate() {
+            Ok(fp) => VerbOutput {
+                text: format!(
+                    "rotated · new fingerprint {fp} · the retired public key stays verifiable in ~/.nika/keys/retired.pub"
+                ),
+                code: super::exit::OK,
+            },
+            Err(msg) => VerbOutput {
+                text: format!("nika key rotate: {msg}"),
+                code: super::exit::FILE,
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A hostile/CI machine without a key answers honestly (never a
+    /// panic, never a fabricated fingerprint).
+    #[test]
+    fn trust_without_a_key_says_so() {
+        // Unset the override so the test reads the REAL custody probe —
+        // on a keyless CI host the None branch renders; on a dev machine
+        // with a key enrolled the Some branch does. Both are OK exits.
+        let out = run(KeyAction::Trust);
+        assert_eq!(out.code, super::super::exit::OK, "{}", out.text);
+        assert!(
+            out.text.contains("run-signing public key") || out.text.contains("no run-signing key"),
+            "{}",
+            out.text
+        );
+    }
+}

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod forecast;
 pub mod graph;
 pub mod init;
 pub mod inspect;
+pub mod key;
 pub mod model;
 pub mod new;
 pub mod pack_surface;

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -51,6 +51,13 @@ use scope::scope_to_task;
 
 use sink::{TRACE_DIR, Tee, TraceFileSink};
 
+/// The workflow's semantic hash for the run seal (the proof layer's
+/// Merkle commitment over the task leaves — `None` when any task is
+/// unprojectable, and an unhashable workflow stays on the unsigned floor).
+fn seal_hash(wf: &nika_schema::raw::RawWorkflow) -> Option<String> {
+    nika_runtime::proof::ir::merkle_by_task(wf).map(|p| p.workflow.as_hex().to_owned())
+}
+
 use std::collections::BTreeMap;
 use std::io::Write as _;
 
@@ -741,7 +748,7 @@ async fn execute(
         let (code, outcome) = drive(runtime, wf, report, &mut stamper, &mut tee).await;
         let (mut sink, trace) = tee.into_parts();
         sink.print_final();
-        let trace_path = surface_trace(trace, TraceNote::Stderr, None);
+        let trace_path = surface_trace(trace, TraceNote::Stderr, None, seal_hash(wf).as_deref());
         // A paused run teaches its exact resume command on stderr — the
         // pause sibling of the failure lane's `autopsy:` line.
         if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
@@ -784,7 +791,7 @@ async fn execute(
         let (sink, trace) = tee.into_parts();
         // stdout stays NDJSON verbatim (byte-identical with or without the
         // journal) — the trace note rides on stderr here.
-        let trace_path = surface_trace(trace, TraceNote::Stderr, None);
+        let trace_path = surface_trace(trace, TraceNote::Stderr, None, seal_hash(wf).as_deref());
         if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
             eprintln!("nika run: {}", epilogue::resume_hint_line(file, p, pause));
         }
@@ -901,6 +908,7 @@ async fn execute_fold_lane(
             TraceNote::Stdout
         },
         failed_task.as_deref(),
+        seal_hash(wf).as_deref(),
     );
     epilogue::print_resume_summary(&outcome, resumed, false);
     if let Some(e) = sink.take_error() {

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -1258,7 +1258,7 @@ pub(super) fn surface_trace(
     // fsync; additive — an absent key leaves the journal as today.
     let mut sealed = false;
     if let Some(hash) = workflow_hash
-        && let Some((sk, pk_box)) = crate::seal::load_secret_key()
+        && let Some((sk, pk_box)) = crate::seal::load_signing_key()
         && let Some(ev) = crate::seal::seal_event(
             EventId::generate(),
             Timestamp::from_unix_ms(now_millis()),

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 use nika_event::Event;
 use nika_runtime::EventSink;
+use nika_types::id::EventId;
 use nika_types::timestamp::Timestamp;
 use uuid::Uuid;
 
@@ -714,7 +715,12 @@ mod tests {
         // (compare the two printed heads) must close with `==`, so the
         // anchor carries the WHOLE sha256 hex — never a truncated form.
         let head = "a".repeat(64);
-        let line = anchor_line(std::path::Path::new(".nika/traces/x.ndjson"), 7, &head);
+        let line = anchor_line(
+            std::path::Path::new(".nika/traces/x.ndjson"),
+            7,
+            &head,
+            false,
+        );
         assert_eq!(
             line,
             format!("trace: .nika/traces/x.ndjson · 7 events · chain {head}")
@@ -1243,7 +1249,30 @@ pub(super) fn surface_trace(
     mut trace: TraceFileSink,
     note: TraceNote,
     autopsy: Option<&str>,
+    workflow_hash: Option<&str>,
 ) -> Option<std::path::PathBuf> {
+    // The run seal (S2 · verifiable runs): when a run-key exists on this
+    // machine, the journal's LAST line is the signature that binds the
+    // whole chain (head · count · workflow hash) to it. Emitted BEFORE
+    // the durability point so the seal's own bytes are covered by the
+    // fsync; additive — an absent key leaves the journal as today.
+    let mut sealed = false;
+    if let Some(hash) = workflow_hash
+        && let Some((sk, pk_box)) = crate::seal::load_secret_key()
+        && let Some(ev) = crate::seal::seal_event(
+            EventId::generate(),
+            Timestamp::from_unix_ms(now_millis()),
+            trace.chain_head(),
+            trace.chain_len(),
+            hash,
+            env!("CARGO_PKG_VERSION"),
+            &sk,
+            &pk_box,
+        )
+    {
+        trace.emit(ev);
+        sealed = true;
+    }
     // Durability BEFORE advertisement: the anchor must describe bytes
     // that survive a power loss (flush reaches the page cache only).
     trace.finalize();
@@ -1265,7 +1294,7 @@ pub(super) fn surface_trace(
         return None;
     }
     let path = path?; // disabled · or a run that emitted zero events
-    let anchor = anchor_line(&path, count, &head);
+    let anchor = anchor_line(&path, count, &head, sealed);
     match note {
         TraceNote::Stdout => {
             println!("    {anchor}");
@@ -1295,6 +1324,19 @@ pub(super) fn surface_trace(
 /// head is the ONE thing a whole-file rewrite cannot touch (the writer-side
 /// review's M4 — 32 hex was already unforgeable; full width costs only
 /// line length and buys equality).
-fn anchor_line(path: &std::path::Path, count: usize, head: &str) -> String {
-    format!("trace: {} · {count} events · chain {head}", path.display())
+fn anchor_line(path: &std::path::Path, count: usize, head: &str, sealed: bool) -> String {
+    let proof = if sealed { " · sealed" } else { "" };
+    format!(
+        "trace: {} · {count} events · chain {head}{proof}",
+        path.display()
+    )
+}
+
+/// Wall-clock milliseconds for the seal's stamp (the L4 boundary — the
+/// journal's own clock; runtime crates ride `ClockDyn`).
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }

--- a/crates/nika-event/public-api.txt
+++ b/crates/nika-event/public-api.txt
@@ -269,6 +269,7 @@ pub nika_event::kind::EventKind::CheckpointWritten
 pub nika_event::kind::EventKind::CostIncurred
 pub nika_event::kind::EventKind::InferChunk
 pub nika_event::kind::EventKind::PermitChecked
+pub nika_event::kind::EventKind::RunSealed
 pub nika_event::kind::EventKind::TaskCacheHit
 pub nika_event::kind::EventKind::TaskCancelled
 pub nika_event::kind::EventKind::TaskCompleted
@@ -435,6 +436,7 @@ pub nika_event::prelude::EventKind::CheckpointWritten
 pub nika_event::prelude::EventKind::CostIncurred
 pub nika_event::prelude::EventKind::InferChunk
 pub nika_event::prelude::EventKind::PermitChecked
+pub nika_event::prelude::EventKind::RunSealed
 pub nika_event::prelude::EventKind::TaskCacheHit
 pub nika_event::prelude::EventKind::TaskCancelled
 pub nika_event::prelude::EventKind::TaskCompleted
@@ -724,6 +726,7 @@ pub nika_event::EventKind::CheckpointWritten
 pub nika_event::EventKind::CostIncurred
 pub nika_event::EventKind::InferChunk
 pub nika_event::EventKind::PermitChecked
+pub nika_event::EventKind::RunSealed
 pub nika_event::EventKind::TaskCacheHit
 pub nika_event::EventKind::TaskCancelled
 pub nika_event::EventKind::TaskCompleted

--- a/crates/nika-event/src/kind.rs
+++ b/crates/nika-event/src/kind.rs
@@ -127,6 +127,14 @@ pub enum EventKind {
     /// run state `paused`) — `--resume` re-arms the prompt; a paused
     /// trace can be resumed any number of times.
     WorkflowPaused,
+    // ── additive cohort 2026-07-20 · the verifiable-run seal (S2 · the
+    //    signed-journal wave). MINOR-bump additive per the header law. ──
+    /// The journal's terminal integrity seal (`seal_format` + `covers`
+    /// (head · events · semantic hash · engine · key identity) + `sig`
+    /// fields) — one ed25519 signature binding the whole chain to the
+    /// run-key that minted it, emitted as the LAST line of a signed run
+    /// (S2 · `seal_format: 1` · the evidence pack's integrity root).
+    RunSealed,
 }
 
 impl EventKind {
@@ -164,6 +172,7 @@ impl EventKind {
             Self::AgentBudgetCheckpoint => "agent_budget_checkpoint",
             Self::TaskCacheHit => "task_cache_hit",
             Self::WorkflowPaused => "workflow_paused",
+            Self::RunSealed => "run_sealed",
         }
     }
 
@@ -231,7 +240,7 @@ impl EventKind {
             | Self::TaskCancelled
             | Self::TaskCacheHit => EventClass::Task,
             Self::VerbInvoked | Self::ToolInvoked => EventClass::Dispatch,
-            Self::CheckpointWritten => EventClass::Durability,
+            Self::CheckpointWritten | Self::RunSealed => EventClass::Durability,
             Self::CostIncurred => EventClass::Cost,
             Self::InferChunk => EventClass::Stream,
             Self::PermitChecked => EventClass::Security,
@@ -313,6 +322,7 @@ mod tests {
         EventKind::AgentBudgetCheckpoint,
         EventKind::TaskCacheHit,
         EventKind::WorkflowPaused,
+        EventKind::RunSealed,
     ];
 
     #[test]
@@ -346,10 +356,11 @@ mod tests {
                 | EventKind::AgentComposeChecked
                 | EventKind::AgentBudgetCheckpoint
                 | EventKind::TaskCacheHit
-                | EventKind::WorkflowPaused => {}
+                | EventKind::WorkflowPaused
+                | EventKind::RunSealed => {}
             }
         }
-        assert_eq!(ALL.len(), 25, "extend ALL when a variant is added");
+        assert_eq!(ALL.len(), 26, "extend ALL when a variant is added");
     }
 
     /// FCI-003: the canonical wire slug has TWO independent encoders — the
@@ -423,7 +434,7 @@ mod tests {
                 s if s.starts_with("workflow_") => Some(EventClass::Workflow),
                 s if s.starts_with("task_") => Some(EventClass::Task),
                 "verb_invoked" | "tool_invoked" => Some(EventClass::Dispatch),
-                "checkpoint_written" => Some(EventClass::Durability),
+                "checkpoint_written" | "run_sealed" => Some(EventClass::Durability),
                 "cost_incurred" => Some(EventClass::Cost),
                 "infer_chunk" => Some(EventClass::Stream),
                 "permit_checked" => Some(EventClass::Security),


### PR DESCRIPTION
## What

Every finished run now appends a terminal **`run_sealed`** event to its journal: an ed25519 (minisign) signature over the proof layer's ONE canonical preimage (`HashDomain::Trace`, `seal_format: 1`) binding —

- the chain **head** (sha256 of the last pre-seal line's exact bytes),
- the **event count**,
- the workflow's **semantic hash**,
- the **engine version**.

The seal's own `chain` field IS the covered head — the seal binds itself at exactly the position it seals. The run's anchor line gains a `· sealed` marker.

## Custody (A2)

`nika key init | trust | rotate` — the run-signing key lives in the **OS keychain** (service `nika`), with a 0600 file fallback (`~/.nika/keys/run-signing.{key,pub}`) for headless hosts and a `NIKA_RUN_KEY_FILE` / `NIKA_RUN_PUB_FILE` override for CI + hermetic tests (init writes where load reads). `rotate` keeps the retired public half in a ledger so older journals stay verifiable.

## Why

A hash chain alone is tamper-*evident* only against edits that keep the head the operator saw — with no signature, a whole-file rewrite recomputes every link. The seal kills that class: rewriting any line changes the head, and forging the head requires the machine's ed25519 key. This is the foundation the verify tiers (A4) and the transparency-log anchor (A3) build on.

## Envelope (witness-quorum-ready)

```
seal_format: 1
covers: { head, events, workflow, engine }   # preimage-canonicalized
key_id: <16-hex sha256 of the pubkey box>
alg: ed25519
sig: <minisign signature box>
```

## Tests

- seal.rs: fingerprint shape · seal event carries the envelope and **verifies** (sign→verify round-trip) · file-custody round-trip (3/3)
- key verb: keyless-host honesty
- nika-event: RunSealed in the class partition (9/9)
- full nika-cli suite 282/282 · clippy 0 warning · fmt · cargo-deny · hygiene gate green
- E2E: `key init` → run → journal tail is `run_sealed` with matching key_id, anchor line shows `· sealed`

Verification itself (`nika trace verify` tiers) lands with A4 on top of this.
