### PR TITLE
feat(nika-kernel-core): SandboxSpec network tri-state — deny / allow / allowlist (C11 part 1)

### DIFF
--- a/crates/nika-kernel-core/public-api.txt
+++ b/crates/nika-kernel-core/public-api.txt
@@ -1893,6 +1893,45 @@ pub trait nika_kernel_core::io::ocr::OcrEngineDyn: core::marker::Send + core::ma
 pub fn nika_kernel_core::io::ocr::OcrEngineDyn::read(&self, frame: &nika_kernel_core::io::screen::Frame) -> impl core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<nika_kernel_core::io::ocr::TextRegion>, nika_kernel_core::io::ocr::OcrError>> + core::marker::Send
 pub fn nika_kernel_core::io::ocr::OcrEngineDyn::read_region(&self, frame: &nika_kernel_core::io::screen::Frame, region: nika_kernel_core::io::screen::Rect) -> impl core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<nika_kernel_core::io::ocr::TextRegion>, nika_kernel_core::io::ocr::OcrError>> + core::marker::Send
 pub mod nika_kernel_core::io::process
+#[non_exhaustive] pub enum nika_kernel_core::io::process::NetPolicy
+pub nika_kernel_core::io::process::NetPolicy::Allow
+pub nika_kernel_core::io::process::NetPolicy::Allowlist(nika_kernel_core::io::process::EgressAllowlist)
+pub nika_kernel_core::io::process::NetPolicy::Deny
+impl core::clone::Clone for nika_kernel_core::io::process::NetPolicy
+pub fn nika_kernel_core::io::process::NetPolicy::clone(&self) -> nika_kernel_core::io::process::NetPolicy
+impl core::cmp::Eq for nika_kernel_core::io::process::NetPolicy
+impl core::cmp::PartialEq for nika_kernel_core::io::process::NetPolicy
+pub fn nika_kernel_core::io::process::NetPolicy::eq(&self, other: &nika_kernel_core::io::process::NetPolicy) -> bool
+impl core::default::Default for nika_kernel_core::io::process::NetPolicy
+pub fn nika_kernel_core::io::process::NetPolicy::default() -> nika_kernel_core::io::process::NetPolicy
+impl core::fmt::Debug for nika_kernel_core::io::process::NetPolicy
+pub fn nika_kernel_core::io::process::NetPolicy::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_kernel_core::io::process::NetPolicy
+impl<D> owo_colors::OwoColorize for nika_kernel_core::io::process::NetPolicy
+impl<T, U> core::convert::Into<U> for nika_kernel_core::io::process::NetPolicy where U: core::convert::From<T>
+pub fn nika_kernel_core::io::process::NetPolicy::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_core::io::process::NetPolicy where U: core::convert::Into<T>
+pub type nika_kernel_core::io::process::NetPolicy::Error = core::convert::Infallible
+pub fn nika_kernel_core::io::process::NetPolicy::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_core::io::process::NetPolicy where U: core::convert::TryFrom<T>
+pub type nika_kernel_core::io::process::NetPolicy::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_core::io::process::NetPolicy::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_kernel_core::io::process::NetPolicy where T: core::clone::Clone
+pub type nika_kernel_core::io::process::NetPolicy::Owned = T
+pub fn nika_kernel_core::io::process::NetPolicy::clone_into(&self, target: &mut T)
+pub fn nika_kernel_core::io::process::NetPolicy::to_owned(&self) -> T
+impl<T> core::any::Any for nika_kernel_core::io::process::NetPolicy where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_core::io::process::NetPolicy::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_core::io::process::NetPolicy where T: ?core::marker::Sized
+pub fn nika_kernel_core::io::process::NetPolicy::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_core::io::process::NetPolicy where T: ?core::marker::Sized
+pub fn nika_kernel_core::io::process::NetPolicy::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_kernel_core::io::process::NetPolicy where T: core::clone::Clone
+pub unsafe fn nika_kernel_core::io::process::NetPolicy::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_kernel_core::io::process::NetPolicy
+pub fn nika_kernel_core::io::process::NetPolicy::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_core::io::process::NetPolicy where T: 'static
+pub fn nika_kernel_core::io::process::NetPolicy::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub enum nika_kernel_core::io::process::ShellError
 pub nika_kernel_core::io::process::ShellError::Blocked
 pub nika_kernel_core::io::process::ShellError::Blocked::reason: alloc::string::String
@@ -1935,10 +1974,50 @@ impl<T> core::convert::From<T> for nika_kernel_core::io::process::ShellError
 pub fn nika_kernel_core::io::process::ShellError::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_kernel_core::io::process::ShellError where T: 'static
 pub fn nika_kernel_core::io::process::ShellError::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_kernel_core::io::process::EgressAllowlist
+pub nika_kernel_core::io::process::EgressAllowlist::hosts: alloc::vec::Vec<alloc::string::String>
+pub nika_kernel_core::io::process::EgressAllowlist::proxy_port: core::option::Option<u16>
+impl nika_kernel_core::io::process::EgressAllowlist
+pub fn nika_kernel_core::io::process::EgressAllowlist::new(hosts: alloc::vec::Vec<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_kernel_core::io::process::EgressAllowlist
+pub fn nika_kernel_core::io::process::EgressAllowlist::clone(&self) -> nika_kernel_core::io::process::EgressAllowlist
+impl core::cmp::Eq for nika_kernel_core::io::process::EgressAllowlist
+impl core::cmp::PartialEq for nika_kernel_core::io::process::EgressAllowlist
+pub fn nika_kernel_core::io::process::EgressAllowlist::eq(&self, other: &nika_kernel_core::io::process::EgressAllowlist) -> bool
+impl core::default::Default for nika_kernel_core::io::process::EgressAllowlist
+pub fn nika_kernel_core::io::process::EgressAllowlist::default() -> nika_kernel_core::io::process::EgressAllowlist
+impl core::fmt::Debug for nika_kernel_core::io::process::EgressAllowlist
+pub fn nika_kernel_core::io::process::EgressAllowlist::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_kernel_core::io::process::EgressAllowlist
+impl<D> owo_colors::OwoColorize for nika_kernel_core::io::process::EgressAllowlist
+impl<T, U> core::convert::Into<U> for nika_kernel_core::io::process::EgressAllowlist where U: core::convert::From<T>
+pub fn nika_kernel_core::io::process::EgressAllowlist::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_core::io::process::EgressAllowlist where U: core::convert::Into<T>
+pub type nika_kernel_core::io::process::EgressAllowlist::Error = core::convert::Infallible
+pub fn nika_kernel_core::io::process::EgressAllowlist::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_core::io::process::EgressAllowlist where U: core::convert::TryFrom<T>
+pub type nika_kernel_core::io::process::EgressAllowlist::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_core::io::process::EgressAllowlist::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_kernel_core::io::process::EgressAllowlist where T: core::clone::Clone
+pub type nika_kernel_core::io::process::EgressAllowlist::Owned = T
+pub fn nika_kernel_core::io::process::EgressAllowlist::clone_into(&self, target: &mut T)
+pub fn nika_kernel_core::io::process::EgressAllowlist::to_owned(&self) -> T
+impl<T> core::any::Any for nika_kernel_core::io::process::EgressAllowlist where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_core::io::process::EgressAllowlist::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_core::io::process::EgressAllowlist where T: ?core::marker::Sized
+pub fn nika_kernel_core::io::process::EgressAllowlist::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_core::io::process::EgressAllowlist where T: ?core::marker::Sized
+pub fn nika_kernel_core::io::process::EgressAllowlist::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_kernel_core::io::process::EgressAllowlist where T: core::clone::Clone
+pub unsafe fn nika_kernel_core::io::process::EgressAllowlist::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_kernel_core::io::process::EgressAllowlist
+pub fn nika_kernel_core::io::process::EgressAllowlist::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_core::io::process::EgressAllowlist where T: 'static
+pub fn nika_kernel_core::io::process::EgressAllowlist::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_kernel_core::io::process::SandboxSpec
-pub nika_kernel_core::io::process::SandboxSpec::allow_network: bool
 pub nika_kernel_core::io::process::SandboxSpec::fs_read: alloc::vec::Vec<alloc::string::String>
 pub nika_kernel_core::io::process::SandboxSpec::fs_write: alloc::vec::Vec<alloc::string::String>
+pub nika_kernel_core::io::process::SandboxSpec::net: nika_kernel_core::io::process::NetPolicy
 impl nika_kernel_core::io::process::SandboxSpec
 pub fn nika_kernel_core::io::process::SandboxSpec::new() -> Self
 impl core::clone::Clone for nika_kernel_core::io::process::SandboxSpec

--- a/crates/nika-kernel-core/src/io/process.rs
+++ b/crates/nika-kernel-core/src/io/process.rs
@@ -18,10 +18,10 @@ use std::time::Duration;
 /// derived from `permits.fs` / `permits.net`). A `CommandSandbox` (the L1
 /// `nika-sandbox-{seatbelt,landlock}` crates) translates this into a
 /// platform sandbox (Seatbelt profile · Landlock ruleset) that confines the
-/// child to the declared filesystem reach and denies network unless granted.
+/// child to the declared filesystem reach and the declared network arm.
 ///
 /// Empty spec = maximally confined (no reads/writes beyond the always-allowed
-/// system paths · no network) — `permits: {}` pure compute. Absent (the
+/// system paths · network denied) — `permits: {}` pure compute. Absent (the
 /// `ShellCommand.sandbox` field is `None`) = today's behavior, unconfined
 /// (the blocklist floor is the only gate).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -33,10 +33,9 @@ pub struct SandboxSpec {
     /// Writable path prefixes (the ONLY paths the child may write · beyond
     /// the always-allowed scratch like `$TMPDIR`).
     pub fs_write: Vec<String>,
-    /// Whether outbound network is allowed at all. `false` = deny egress (the
-    /// default under a declared boundary). Host-granular filtering is a
-    /// follow-on (it needs a local proxy · a Seatbelt host rule is TLS-blind).
-    pub allow_network: bool,
+    /// The network arm (the tri-state below). [`NetPolicy::Deny`] is the
+    /// default under a declared boundary — fail-closed.
+    pub net: NetPolicy,
 }
 
 impl SandboxSpec {
@@ -44,6 +43,66 @@ impl SandboxSpec {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// The network arm of the confinement boundary — the tri-state derived from
+/// `permits.net` (ADR-095 Layer 6 · the Anthropic sandbox-runtime model:
+/// host-granular egress needs a loopback proxy, a Seatbelt host rule is
+/// TLS-blind).
+///
+/// Derivation (`nika-runtime`'s `permits:` → [`SandboxSpec`] pass):
+///
+/// - a declared `net.http` host list maps to [`NetPolicy::Allowlist`] —
+///   egress confined to exactly that set, enforced by the per-run loopback
+///   egress proxy (the child gets proxy env vars · the OS fence admits
+///   loopback only). Until the proxy lands, this arm confines EXACTLY as
+///   [`NetPolicy::Allow`] (the pre-tri-state `allow_network = true`
+///   behavior — zero regression, never a silent partial).
+/// - an absent `net:` block or an empty `net.http` maps to
+///   [`NetPolicy::Deny`] — the default, fail-closed.
+/// - the bare `*` host entry (`net: { http: ["*"] }`) maps to
+///   [`NetPolicy::Allow`] — unrestricted egress, reachable ONLY from that
+///   explicit in-file declaration, never by default.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NetPolicy {
+    /// No outbound network (the default under a declared boundary ·
+    /// fail-closed).
+    #[default]
+    Deny,
+    /// Unrestricted outbound network — the explicit escape hatch, reached
+    /// only by declaring the bare `*` host in `permits.net.http`.
+    Allow,
+    /// Egress confined to the declared `permits.net.http` host set, via the
+    /// loopback egress proxy (see the enum doc for the transitional mapping).
+    Allowlist(EgressAllowlist),
+}
+
+/// The declared `permits.net.http` host set carried by
+/// [`NetPolicy::Allowlist`]. Matched with the ONE host matcher
+/// (`nika_types::net::host_glob_matches`) so the sandbox decision can never
+/// drift from the static check or the http effect's boundary.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EgressAllowlist {
+    /// Allowed hosts (exact names or leading-`*.` subdomain globs — the same
+    /// language the author writes in `permits.net.http`).
+    pub hosts: Vec<String>,
+    /// The loopback port the per-run egress proxy listens on — filled by the
+    /// runner when it starts the proxy (the Seatbelt fence scopes outbound to
+    /// exactly this port). `None` at derivation time.
+    pub proxy_port: Option<u16>,
+}
+
+impl EgressAllowlist {
+    /// The derivation-time allowlist — the declared hosts, no proxy yet.
+    #[must_use]
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self {
+            hosts,
+            proxy_port: None,
+        }
     }
 }
 

--- a/crates/nika-runtime/src/dispatch/sandbox.rs
+++ b/crates/nika-runtime/src/dispatch/sandbox.rs
@@ -15,14 +15,17 @@
 //!   absolute subpaths only (`grant_subpath` fail-closes on a relative
 //!   grant), so the derivation absolutizes HERE — a task-level `cwd:`
 //!   does not re-anchor the boundary, exactly like the builtin gate.
-//! - **Network is binary at the OS grain**: `permits.net.http` non-empty
-//!   lifts the deny; host-granular egress filtering is the documented
-//!   proxy follow-on (a Seatbelt host rule is TLS-blind), never a silent
-//!   partial today.
+//! - **Network is a tri-state** ([`NetPolicy`] · the Anthropic
+//!   sandbox-runtime model): `net.http` non-empty maps to `Allowlist`
+//!   (exactly the declared set, via the loopback egress proxy); the bare
+//!   `*` entry maps to `Allow` (the explicit escape hatch, in-file only);
+//!   an absent `net:` block or empty `net.http` maps to `Deny` (the
+//!   default, fail-closed). Until the proxy lands the allowlist arm
+//!   confines exactly as the pre-tri-state grant did — zero regression.
 
 use std::path::{Component, Path};
 
-use nika_kernel::process::SandboxSpec;
+use nika_kernel::process::{EgressAllowlist, NetPolicy, SandboxSpec};
 use nika_schema::types::Permits;
 
 /// Derive the OS-confinement spec from the declared boundary, anchored at
@@ -36,8 +39,25 @@ pub(super) fn spec_of(permits: &Permits, root: &Path) -> SandboxSpec {
     let mut spec = SandboxSpec::new();
     spec.fs_read = read.iter().map(|g| absolutize(root, g)).collect();
     spec.fs_write = write.iter().map(|g| absolutize(root, g)).collect();
-    spec.allow_network = permits.net.as_ref().is_some_and(|n| !n.http.is_empty());
+    spec.net = net_policy_of(permits);
     spec
+}
+
+/// The network arm (see the module doc): declared host list → `Allowlist`
+/// (that exact set) · a bare `*` entry anywhere in the list → `Allow` (the
+/// explicit escape hatch — it subsumes every other entry) · absent/empty →
+/// `Deny` (fail-closed).
+fn net_policy_of(permits: &Permits) -> NetPolicy {
+    let Some(net) = permits.net.as_ref() else {
+        return NetPolicy::Deny;
+    };
+    if net.http.iter().any(|g| g == "*") {
+        return NetPolicy::Allow;
+    }
+    if net.http.is_empty() {
+        return NetPolicy::Deny;
+    }
+    NetPolicy::Allowlist(EgressAllowlist::new(net.http.clone()))
 }
 
 /// Absolutize one declared glob against the run root: a relative glob
@@ -99,21 +119,68 @@ mod tests {
         );
         assert_eq!(spec.fs_read, vec!["/repo/data/**".to_owned()]);
         assert_eq!(spec.fs_write, vec!["/repo/out/**".to_owned()]);
-        assert!(
-            !spec.allow_network,
+        assert_eq!(
+            spec.net,
+            NetPolicy::Deny,
             "an empty net.http keeps the network deny"
         );
     }
 
     #[test]
-    fn absolute_globs_pass_through_and_network_lifts_on_a_host() {
+    fn absolute_globs_pass_through_and_a_host_list_maps_to_allowlist() {
         let spec = spec_of(
             &permits(&["/data/in/**"], &["/data/out/**"], &["api.example.com"]),
             Path::new("/repo"),
         );
         assert_eq!(spec.fs_read, vec!["/data/in/**".to_owned()]);
         assert_eq!(spec.fs_write, vec!["/data/out/**".to_owned()]);
-        assert!(spec.allow_network);
+        assert_eq!(
+            spec.net,
+            NetPolicy::Allowlist(EgressAllowlist::new(vec!["api.example.com".to_owned()])),
+            "a declared net.http set maps to the allowlist arm, verbatim"
+        );
+    }
+
+    /// The tri-state derivation matrix: absent `net:` → Deny · empty
+    /// `net.http` → Deny · declared hosts → Allowlist(exactly that set) ·
+    /// the bare `*` entry → Allow (the explicit escape hatch — alone or
+    /// mixed into a list, where it subsumes the rest).
+    #[test]
+    fn the_tri_state_derivation_matrix() {
+        // absent net: → Deny (the default, fail-closed)
+        let mut p = Permits::new();
+        assert_eq!(net_policy_of(&p), NetPolicy::Deny);
+        // declared-but-empty net.http → Deny
+        p.net = Some(NetPermits::new(vec![]));
+        assert_eq!(net_policy_of(&p), NetPolicy::Deny);
+        // declared hosts → Allowlist, the set verbatim
+        p.net = Some(NetPermits::new(vec![
+            "api.example.com".to_owned(),
+            "*.github.com".to_owned(),
+        ]));
+        assert_eq!(
+            net_policy_of(&p),
+            NetPolicy::Allowlist(EgressAllowlist::new(vec![
+                "api.example.com".to_owned(),
+                "*.github.com".to_owned(),
+            ]))
+        );
+        // the bare `*` escape hatch → Allow (never by default — the author
+        // must type it), alone or subsuming a mixed list
+        p.net = Some(NetPermits::new(vec!["*".to_owned()]));
+        assert_eq!(net_policy_of(&p), NetPolicy::Allow);
+        p.net = Some(NetPermits::new(vec![
+            "api.example.com".to_owned(),
+            "*".to_owned(),
+        ]));
+        assert_eq!(
+            net_policy_of(&p),
+            NetPolicy::Allow,
+            "a bare `*` anywhere in the list subsumes the rest"
+        );
+        // a leading-`*.` glob is NOT the hatch — it stays an allowlist entry
+        p.net = Some(NetPermits::new(vec!["*.example.com".to_owned()]));
+        assert!(matches!(net_policy_of(&p), NetPolicy::Allowlist(_)));
     }
 
     #[test]
@@ -126,6 +193,6 @@ mod tests {
     fn no_fs_block_means_no_extra_grants() {
         let spec = spec_of(&Permits::new(), Path::new("/repo"));
         assert!(spec.fs_read.is_empty() && spec.fs_write.is_empty());
-        assert!(!spec.allow_network, "no net block = the deny holds");
+        assert_eq!(spec.net, NetPolicy::Deny, "no net block = the deny holds");
     }
 }

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -74,9 +74,10 @@ impl EventSink for NotifyOnFastSettle {
 /// the sink has seen fast's `task_completed` — join-granularity frames
 /// ADR-095 Layer 6 — a declared boundary attaches the OS-confinement
 /// spec to every exec child (grants absolutized at the config root ·
-/// network denied unless `net.http` lifts it).
+/// network denied unless `net.http` names an allowlist).
 #[tokio::test]
 async fn declared_boundary_attaches_the_sandbox_spec_to_exec() {
+    use nika_kernel::process::NetPolicy;
     use nika_kernel_mock::{
         MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
     };
@@ -121,7 +122,7 @@ async fn declared_boundary_attaches_the_sandbox_spec_to_exec() {
         .expect("a declared boundary attaches the spec");
     assert_eq!(spec.fs_read, vec!["/repo/data/**".to_owned()]);
     assert_eq!(spec.fs_write, vec!["/repo/out/**".to_owned()]);
-    assert!(!spec.allow_network, "no net.http = the deny holds");
+    assert_eq!(spec.net, NetPolicy::Deny, "no net.http = the deny holds");
 }
 
 /// No `permits:` block = today's unconfined floor (the blocklist only —

--- a/crates/nika-sandbox-landlock/src/lib.rs
+++ b/crates/nika-sandbox-landlock/src/lib.rs
@@ -16,8 +16,15 @@
 //!
 //! ## What the jail enforces (deny-default)
 //!
-//! - **Network** — denied entirely (`--unshare-net`) unless `spec.allow_network`
-//!   (host-granular filtering needs a proxy · follow-on, matching the sibling).
+//! - **Network** — the [`NetPolicy`] tri-state: `Deny` keeps the network
+//!   namespace unshared (`--unshare-all`); `Allow` re-shares it
+//!   (`--share-net`). `Allowlist` — host-granular egress — confines EXACTLY
+//!   as `Allow` until the per-run loopback egress proxy lands (the
+//!   pre-tri-state behavior, zero regression · matching the macOS sibling).
+//!   The proxy then serves the declared host set over the shared namespace +
+//!   the env contract; scoping the namespace itself to loopback needs the
+//!   socat/unix-socket bridge of the sandbox-runtime model (named follow-on,
+//!   honestly — bwrap cannot express a loopback-only fence alone).
 //! - **Writes** — allowed ONLY under the declared `fs_write` prefixes plus
 //!   scratch (`--bind`). Everything else is read-only or absent.
 //! - **Reads** — the system paths every binary + the dynamic linker need are
@@ -39,7 +46,7 @@
 use std::path::Path;
 
 use nika_kernel::command_sandbox::{CommandSandbox, CommandSandboxError};
-use nika_kernel::process::{SandboxSpec, ShellCommand};
+use nika_kernel::process::{NetPolicy, SandboxSpec, ShellCommand};
 
 /// The bubblewrap launcher. A fixed absolute path (not `$PATH`) so a hijacked
 /// `PATH` cannot point the sandbox at an impostor launcher.
@@ -160,9 +167,16 @@ fn build_jail_args(spec: &SandboxSpec) -> Result<Vec<String>, CommandSandboxErro
         a.push(prefix);
     }
 
-    // Network: `--unshare-all` already dropped the net namespace. To ALLOW it,
-    // re-share the network namespace and bind the resolver config read-only.
-    if spec.allow_network {
+    // Network: `--unshare-all` already dropped the net namespace. The ALLOW
+    // arms re-share it and bind the resolver config read-only — Allow (the
+    // explicit escape hatch) and Allowlist, which rides the same shared
+    // namespace until the egress proxy lands (the pre-tri-state behavior ·
+    // module doc); the proxy then serves the declared hosts over it and a
+    // loopback-only namespace fence needs the socat/unix-socket bridge
+    // (named follow-on). Every other arm — Deny and, by the
+    // #[non_exhaustive] law, any future variant — fails CLOSED: the
+    // namespace stays unshared, no network physically.
+    if matches!(spec.net, NetPolicy::Allow | NetPolicy::Allowlist(_)) {
         a.push("--share-net".to_owned());
         if Path::new("/etc/resolv.conf").exists() {
             a.push("--ro-bind".to_owned());
@@ -170,7 +184,6 @@ fn build_jail_args(spec: &SandboxSpec) -> Result<Vec<String>, CommandSandboxErro
             a.push("/etc/resolv.conf".to_owned());
         }
     }
-    // else: the net namespace stays unshared — no network, physically.
 
     Ok(a)
 }
@@ -369,11 +382,27 @@ mod tests {
         );
 
         let mut net = SandboxSpec::new();
-        net.allow_network = true;
+        net.net = NetPolicy::Allow;
         let with_net = build_jail_args(&net).unwrap();
         assert!(
             with_net.iter().any(|a| a == "--share-net"),
             "network re-shared on request"
+        );
+    }
+
+    /// The allowlist arm rides the shared namespace until the egress proxy
+    /// lands (the pre-tri-state behavior · module doc) — then the proxy
+    /// serves the declared hosts over it.
+    #[test]
+    fn allowlist_rides_the_shared_namespace_pre_proxy() {
+        let mut spec = SandboxSpec::new();
+        spec.net = NetPolicy::Allowlist(nika_kernel::process::EgressAllowlist::new(vec![
+            "api.example.com".to_owned(),
+        ]));
+        let args = build_jail_args(&spec).unwrap();
+        assert!(
+            args.iter().any(|a| a == "--share-net"),
+            "allowlist confines as allow pre-proxy"
         );
     }
 

--- a/crates/nika-sandbox-seatbelt/src/lib.rs
+++ b/crates/nika-sandbox-seatbelt/src/lib.rs
@@ -13,8 +13,14 @@
 //!
 //! ## What the profile enforces (deny-default)
 //!
-//! - **Network** — denied entirely unless `spec.allow_network` (Seatbelt host
-//!   filtering is TLS-blind · host-granular needs a proxy · follow-on).
+//! - **Network** — the [`NetPolicy`] tri-state: `Deny` keeps network out of
+//!   the profile entirely (`(deny default)` holds); `Allow` emits
+//!   `(allow network*)`. `Allowlist` — host-granular egress — confines
+//!   EXACTLY as `Allow` until the per-run loopback egress proxy lands (the
+//!   pre-tri-state `allow_network = true` behavior, zero regression): the
+//!   proxy then fences this arm to loopback-only + injects its env contract
+//!   (the Anthropic sandbox-runtime model · a Seatbelt host rule is
+//!   TLS-blind, so the allowlist is the proxy's job, not the profile's).
 //! - **Writes** — allowed ONLY under the declared `fs_write` prefixes plus
 //!   scratch. Everything else (home, the repo, `/etc`) is read-only-or-denied.
 //! - **Reads** — the system paths every binary + the dynamic linker need are
@@ -36,7 +42,7 @@
 use std::path::Path;
 
 use nika_kernel::command_sandbox::{CommandSandbox, CommandSandboxError};
-use nika_kernel::process::{SandboxSpec, ShellCommand};
+use nika_kernel::process::{NetPolicy, SandboxSpec, ShellCommand};
 
 /// The OS-shipped Seatbelt launcher. A fixed absolute path (not `$PATH`) so a
 /// hijacked `PATH` cannot point the sandbox at an impostor launcher.
@@ -114,10 +120,18 @@ fn build_profile(spec: &SandboxSpec) -> Result<String, CommandSandboxError> {
         );
     }
 
-    if spec.allow_network {
+    // The open arms: Allow (the explicit escape hatch) and Allowlist — the
+    // allowlist confines EXACTLY as Allow until the loopback egress proxy
+    // lands (see the module doc — the pre-tri-state `allow_network = true`
+    // behavior, never a silent partial). The proxy then fences this arm to
+    // loopback-only and serves the declared host set; a Seatbelt host rule
+    // is TLS-blind, so the allowlist itself is the proxy's job, never the
+    // profile's. Every other arm — Deny and, by the #[non_exhaustive] law,
+    // any future variant — fails CLOSED: network stays denied by
+    // `(deny default)`, the load-bearing line.
+    if matches!(spec.net, NetPolicy::Allow | NetPolicy::Allowlist(_)) {
         p.push_str("(allow network*)\n");
     }
-    // else: network stays denied by `(deny default)` — the load-bearing line.
 
     Ok(p)
 }
@@ -383,8 +397,24 @@ mod tests {
         );
 
         let mut allow = SandboxSpec::new();
-        allow.allow_network = true;
+        allow.net = NetPolicy::Allow;
         assert!(build_profile(&allow).unwrap().contains("(allow network*)"));
+    }
+
+    #[test]
+    fn allowlist_confines_as_allow_until_the_egress_proxy_lands() {
+        // The transitional mapping (module doc): host-granular egress needs
+        // the loopback proxy — until it lands, the allowlist arm keeps the
+        // pre-tri-state `allow_network = true` behavior, zero regression.
+        let mut spec = SandboxSpec::new();
+        spec.net = NetPolicy::Allowlist(nika_kernel::process::EgressAllowlist::new(vec![
+            "api.example.com".to_owned(),
+        ]));
+        let p = build_profile(&spec).unwrap();
+        assert!(
+            p.contains("(allow network*)"),
+            "allowlist confines as allow pre-proxy"
+        );
     }
 
     #[test]

--- a/crates/nika-types/src/net.rs
+++ b/crates/nika-types/src/net.rs
@@ -22,9 +22,13 @@
 use alloc::format;
 use alloc::string::String;
 
-/// Host glob match — exact, or a LEADING `*.` subdomain wildcard
-/// (`*.github.com` matches `api.github.com` AND the bare `github.com`).
-/// Distinct from the tool-id trailing-`*` glob (`nika:*`).
+/// Host glob match — exact, a LEADING `*.` subdomain wildcard
+/// (`*.github.com` matches `api.github.com` AND the bare `github.com`), or
+/// the BARE `*` — the explicit allow-all escape hatch. Distinct from the
+/// tool-id trailing-`*` glob (`nika:*`): an embedded `*` (`foo*.com`) still
+/// matches nothing; only the whole-entry `*` opens the boundary, and only
+/// because the author typed it in-file (never a default — the sandbox
+/// network arm maps it to `allow`, the explicit egress escape hatch).
 ///
 /// CASE-INSENSITIVE (RFC 4343 · DNS hostnames are case-insensitive). The
 /// connect host arrives WHATWG-lowercased, so an author-written permit entry
@@ -35,6 +39,9 @@ use alloc::string::String;
 pub fn host_glob_matches(glob: &str, host: &str) -> bool {
     let glob = glob.to_ascii_lowercase();
     let host = host.to_ascii_lowercase();
+    if glob == "*" {
+        return true;
+    }
     if let Some(suffix) = glob.strip_prefix("*.") {
         return host == suffix || host.ends_with(&format!(".{suffix}"));
     }
@@ -305,6 +312,21 @@ mod tests {
         // case-folding does not loosen the boundary — a different host stays out
         assert!(!host_glob_matches("EXAMPLE.COM", "evil.com"));
         assert!(!host_glob_matches("*.GITHUB.COM", "github.com.evil.com"));
+    }
+
+    #[test]
+    fn bare_star_is_the_explicit_allow_all_hatch() {
+        // The escape hatch: `net: { http: ["*"] }` opens the boundary to every
+        // host — the author's explicit in-file act (maps the sandbox network
+        // arm to `allow`), never a default.
+        assert!(host_glob_matches("*", "example.com"));
+        assert!(host_glob_matches("*", "anything.at.all"));
+        assert!(host_glob_matches("*", ""));
+        // ONLY the bare entry: an embedded `*` is not a wildcard here (the
+        // host language has exact + leading-`*.` forms only), so a typo like
+        // `foo*.com` keeps matching nothing (fail-closed).
+        assert!(!host_glob_matches("foo*.com", "foo1.com"));
+        assert!(!host_glob_matches("*.com", "example.com."));
     }
 
     #[test]

--- a/crates/nika-verb-exec/src/lib.rs
+++ b/crates/nika-verb-exec/src/lib.rs
@@ -467,7 +467,7 @@ mod tests {
         let v = verb(mock.clone());
         let mut spec = nika_kernel::process::SandboxSpec::new();
         spec.fs_read = vec!["/repo/data/**".to_owned()];
-        spec.allow_network = false;
+        spec.net = nika_kernel::process::NetPolicy::Deny;
         let mut input = ExecInput::argv(["echo", "x"]);
         input.sandbox = Some(spec.clone());
         v.run(input).await.expect("runs");

--- a/docs/crate-specs/nika-sandbox-landlock.md
+++ b/docs/crate-specs/nika-sandbox-landlock.md
@@ -31,9 +31,11 @@ ride the outer launcher so the confined child inherits them.
 
 ## 3. What the jail enforces (deny-default)
 
-- **Network** — `--unshare-all` drops the net namespace; `--share-net` re-adds it
-  ONLY when `spec.allow_network` (host-granular filtering needs a proxy · the
-  same honest follow-on the sibling declares).
+- **Network** — the `spec.net` tri-state: `--unshare-all` drops the net
+  namespace (`deny`); `--share-net` re-adds it (`allow`, and `allowlist` until
+  the loopback egress proxy lands — the proxy then serves the declared hosts
+  over the shared namespace; a loopback-only fence needs the socat/unix-socket
+  bridge, the named follow-on).
 - **Writes** — read-write `--bind` only under the validated `fs_write` literal
   prefixes; everything else is read-only or absent.
 - **Reads** — the system trees (linker, libs, shell) are `--ro-bind`; declared

--- a/docs/crate-specs/nika-sandbox-seatbelt.md
+++ b/docs/crate-specs/nika-sandbox-seatbelt.md
@@ -31,8 +31,10 @@ the confined child inherits them.
 
 ## 3. The SBPL profile (the security heart · deny-default)
 
-- **Network** denied unless `spec.allow_network` (Seatbelt host filtering is
-  TLS-blind · host-granular needs a proxy · follow-on).
+- **Network** — the `spec.net` tri-state: `deny` keeps network out of the
+  profile; `allow` emits `(allow network*)`; `allowlist` confines as `allow`
+  until the loopback egress proxy lands (Seatbelt host filtering is TLS-blind,
+  so host-granular egress is the proxy's job, never the profile's).
 - **Writes** allowed ONLY under declared `fs_write` prefixes + scratch.
 - **Reads** allow the system paths every binary + the dynamic linker need;
   declared `fs_read` prefixes added; sensitive home paths (`~/.ssh`) denied.


### PR DESCRIPTION
## Summary

First half of the sandbox-network granularity mission (C11) — the **SandboxSpec network arm becomes a tri-state**, derived from the workflow's `permits:` with zero behavior regression. The loopback egress proxy that enforces the allowlist arm lands in the stacked follow-up PR.

This mirrors the [Anthropic sandbox-runtime (srt)](https://github.com/anthropic-experimental/sandbox-runtime) posture the engine already cites in ADR-095 Layer 6: host-granular egress cannot be a Seatbelt rule (TLS-blind), so the network arm names the *intent* and a per-run loopback proxy does the enforcement.

## Tri-state semantics (derivation: `permits:` → `SandboxSpec.net`)

| `permits:` declaration | `NetPolicy` | Profile behavior |
|---|---|---|
| `net:` absent · `net.http: []` | `Deny` (default, fail-closed) | unchanged from today (seatbelt: `(deny default)`; bwrap: `--unshare-all`) |
| `net.http: [hosts…]` | `Allowlist(hosts)` | **transitional**: confines exactly as today's `allow_network = true` (see below); the follow-up PR fences it to loopback-only + injects the proxy env contract |
| `net.http: ["*"]` (bare `*` anywhere in the list) | `Allow` | unrestricted — as today's grant |

The **escape hatch** (`Allow`) is reachable *only* from an explicit in-file declaration — the bare `*` host entry — never by default. This is the same posture `ExecPermit::Any` already takes for `exec: true`. The ONE host matcher (`nika_types::net::host_glob_matches`, shared by `nika-schema` check, `nika-http`'s wire boundary, `nika-cap`, and now the sandbox arm) learns the bare-`*` allow-all form so check ≡ run ≡ jail cannot drift on the hatch; an embedded `*` (`foo*.com`) still matches nothing (fail-closed on typos).

## Zero regression, by construction

Today `permits.net.http` non-empty grants the exec child *full* network (`allow_network = true`, shipped in #642). If the allowlist arm went loopback-only in this PR while its proxy only lands in the next, those workflows would regress on main in between. So in this PR the profile writers map:

- `Deny` / `Allow` → exactly the old `false` / `true` branches;
- `Allowlist` → the old `true` branch, **loudly documented** in both sandbox crates and their crate-specs as the transitional mapping (never a silent partial).

The follow-up PR (egress proxy) then tightens `Allowlist` to the srt model: loopback-only fence + proxy env + journaled decisions.

## Changes

- `nika-kernel-core`: `NetPolicy { Deny, Allow, Allowlist(EgressAllowlist) }` replaces `SandboxSpec::allow_network`; `EgressAllowlist { hosts, proxy_port }` carries the declared set + the seam the runner fills when it starts the per-run proxy. Public-api baseline regenerated with cargo-public-api 0.51.0 (`--omit auto-trait-impls`; only the new items + the field swap — the one platform-skew line kept at its ubuntu form).
- `nika-types`: bare-`*` hatch in `host_glob_matches` + tests.
- `nika-runtime`: `net_policy_of` derivation + the tri-state matrix test; the exec attachment test asserts `Deny`.
- `nika-sandbox-seatbelt` / `nika-sandbox-landlock`: profile/jail writers map the arms as above (fail-closed wildcard per the `#[non_exhaustive]` law), module docs + crate-specs updated.
- `nika-verb-exec`: passthrough test updated to the new field.

## Tests

- tri-state derivation matrix: absent→`Deny`, empty→`Deny`, declared→`Allowlist(verbatim)`, bare-`*`→`Allow` (alone and mixed, where it subsumes), `*.x` is *not* the hatch.
- matcher: `*` matches everything incl. the empty host; embedded-`*` stays match-nothing; case-insensitivity preserved.
- profile writers: deny/allow/allowlist arms emit exactly the pre-tri-state SBPL/bwrap forms.
- `cargo test --workspace --lib` green (54 suites), clippy `-D warnings` clean, fmt clean, hygiene 0 RED.

## Follow-up (stacked)

The egress proxy PR adds: the loopback CONNECT+SOCKS5 mux proxy in `nika-exec-runner` (one port, protocol-sniffed — srt's mux model), the env contract injection (`HTTP(S)_PROXY`/`ALL_PROXY`/`NO_PROXY`…), the journaled allow/refuse decisions, and the seatbelt loopback-port fence (`(allow network-outbound (remote ip "localhost:PORT"))` — srt's exact seatbelt line).

Co-authored-by: Nika <nika@supernovae.studio>
