### PR TITLE
feat(nika-cli): nika sign + run --require-signature — workflow author-binding (S3)

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -491,8 +491,48 @@ pub fn nika_cli::verbs::run::example(slug: &str, model_override: core::option::O
 pub fn nika_cli::verbs::run::fs_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_builtin::permits::FsBoundary
 pub fn nika_cli::verbs::run::net_boundary_of(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_http::NetBoundary
 pub fn nika_cli::verbs::run::production_runtime(default_model: &str, caps: nika_cli::verbs::run::RuntimeCapabilities) -> core::result::Result<nika_cli::verbs::run::ProdRuntime, nika_kernel_core::io::http::HttpError>
-pub fn nika_cli::verbs::run::run(file: &str, json: bool, output: core::option::Option<&str>, theme: nika_display::theme::Theme, mode: nika_cli::verbs::run::RenderMode, dry_run: bool, model_override: core::option::Option<&str>, vars: &[alloc::string::String], resume: core::option::Option<&nika_cli::verbs::run::ResumeRequest>, no_trace_file: bool, task_filter: core::option::Option<&str>, no_outputs: bool, max_cost_usd: core::option::Option<f64>, no_gc: bool) -> u8
+pub fn nika_cli::verbs::run::run(file: &str, json: bool, output: core::option::Option<&str>, theme: nika_display::theme::Theme, mode: nika_cli::verbs::run::RenderMode, dry_run: bool, model_override: core::option::Option<&str>, vars: &[alloc::string::String], resume: core::option::Option<&nika_cli::verbs::run::ResumeRequest>, no_trace_file: bool, task_filter: core::option::Option<&str>, no_outputs: bool, max_cost_usd: core::option::Option<f64>, no_gc: bool, require_signature: bool) -> u8
 pub type nika_cli::verbs::run::ProdRuntime = nika_runtime::Runtime<nika_exec_runner::TokioShell, nika_builtin::BuiltinDispatcher<nika_fs::TokioFs, nika_http::ReqwestHttp, nika_clock::SystemClock, nika_cli::verbs::run::compose::StderrEmitter, nika_builtin::NonInteractive, nika_builtin::NoWorkflow>, nika_http::ReqwestHttp, nika_cli::verbs::run::compose::RegistryProvider<nika_http::ReqwestHttp>, nika_builtin::BuiltinDispatcher<nika_fs::TokioFs, nika_http::ReqwestHttp, nika_clock::SystemClock, nika_cli::verbs::run::compose::StderrEmitter, nika_builtin::NonInteractive, nika_builtin::NoWorkflow>, nika_clock::SystemClock>
+pub mod nika_cli::verbs::sign
+pub struct nika_cli::verbs::sign::SignArgs
+pub nika_cli::verbs::sign::SignArgs::check: bool
+pub nika_cli::verbs::sign::SignArgs::file: alloc::string::String
+impl clap_builder::derive::Args for nika_cli::verbs::sign::SignArgs
+pub fn nika_cli::verbs::sign::SignArgs::augment_args<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::sign::SignArgs::augment_args_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::sign::SignArgs::group_id() -> core::option::Option<clap_builder::util::id::Id>
+impl clap_builder::derive::FromArgMatches for nika_cli::verbs::sign::SignArgs
+pub fn nika_cli::verbs::sign::SignArgs::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::sign::SignArgs::from_arg_matches_mut(__clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::sign::SignArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+pub fn nika_cli::verbs::sign::SignArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::sign::SignArgs
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::From<T>
+pub fn nika_cli::verbs::sign::SignArgs::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::Into<T>
+pub type nika_cli::verbs::sign::SignArgs::Error = core::convert::Infallible
+pub fn nika_cli::verbs::sign::SignArgs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::sign::SignArgs::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::sign::SignArgs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::sign::SignArgs where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::sign::SignArgs::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::sign::SignArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::sign::SignArgs::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::sign::SignArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::sign::SignArgs::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::sign::SignArgs
+pub fn nika_cli::verbs::sign::SignArgs::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::sign::SignArgs where T: 'static
+pub fn nika_cli::verbs::sign::SignArgs::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::sign::SignArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::sign::SignArgs::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::sign::SignArgs::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::sign::SignArgs
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::sign::SignArgs
+impl<T> typenum::type_operators::Same for nika_cli::verbs::sign::SignArgs
+pub type nika_cli::verbs::sign::SignArgs::Output = T
+pub fn nika_cli::verbs::sign::run(args: &nika_cli::verbs::sign::SignArgs) -> nika_cli::verbs::VerbOutput
 pub mod nika_cli::verbs::test
 pub fn nika_cli::verbs::test::run(file: &str, update: bool, theme: nika_display::theme::Theme) -> u8
 pub mod nika_cli::verbs::tools

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -217,6 +217,9 @@ enum Command {
         #[command(subcommand)]
         action: verbs::key::KeyAction,
     },
+    /// Sign a workflow file (S3 · author-binding): mint `<file>.minisig` · `--check` verifies.
+    #[command(display_order = 71)]
+    Sign(verbs::sign::SignArgs),
     /// Diagnose this machine (binary · config · provider keys · local models).
     /// Diagnose-only — prints the exact fix command, never mutates anything.
     #[command(display_order = 42)]
@@ -581,6 +584,10 @@ struct RunArgs {
     /// so on stderr).
     #[arg(long)]
     no_gc: bool,
+    /// Refuse to run an unsigned or invalidly-signed workflow (exit 2 ·
+    /// checked BEFORE any task executes). OPT-IN — default is unsigned-tolerant.
+    #[arg(long)]
+    require_signature: bool,
 }
 
 /// `--max-cost-usd` must be a real, non-negative dollar amount — `NaN`
@@ -784,6 +791,7 @@ fn main() -> std::process::ExitCode {
             forecast,
         } => emit(&explain_dispatch(&code, json, forecast, plain_theme)),
         Command::Key { action } => emit(&verbs::key::run(action)),
+        Command::Sign(args) => emit(&verbs::sign::run(&args)),
         Command::Doctor { ping, json } => emit(&verbs::doctor::run(ping, json, plain_theme)),
         Command::Init(args) => emit(&init_verb(&args, plain_theme)),
         Command::Wire { target, dir } => emit(&verbs::wire::run(target, &dir)),
@@ -1054,6 +1062,7 @@ fn run_verb(
         args.no_outputs,
         args.max_cost_usd,
         args.no_gc,
+        args.require_signature,
     )
 }
 

--- a/crates/nika-cli/src/seal.rs
+++ b/crates/nika-cli/src/seal.rs
@@ -299,11 +299,100 @@ pub(crate) fn seal_event(
 /// sha256 → lowercase hex (the registry client's idiom, mirrored).
 fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::Digest as _;
-    let digest = sha2::Sha256::digest(bytes);
-    digest.iter().fold(String::with_capacity(64), |mut out, b| {
-        let _ = write!(out, "{b:02x}");
-        out
+    hex_lower(&sha2::Sha256::digest(bytes))
+}
+
+pub(crate) fn sidecar_path(workflow: &Path) -> PathBuf {
+    let mut name = workflow.as_os_str().to_os_string();
+    name.push(".minisig");
+    PathBuf::from(name)
+}
+
+/// The enrolled pub (env · keychain · 0600 file) then retired-ledger lines.
+fn enrolled_pubboxes() -> Vec<String> {
+    let current = if let Ok(pf) = key_file_env("NIKA_RUN_PUB_FILE") {
+        std::fs::read_to_string(pf).ok() // seam-bypass-ok: CLI custody read (L4 surface)
+    } else if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER_PUB) {
+        entry.get_password().ok()
+    } else {
+        fallback_key_path().and_then(|p| std::fs::read_to_string(p.with_extension("pub")).ok()) // seam-bypass-ok: same custody read
+    };
+    let mut out: Vec<String> = current.into_iter().map(|pk| pk.trim().to_owned()).collect();
+    let retired = retired_path().and_then(|p| std::fs::read_to_string(p).ok()); // seam-bypass-ok: same custody read
+    if let Some(text) = retired {
+        let lines = text.lines().map(str::trim);
+        out.extend(lines.filter(|l| !l.is_empty()).map(str::to_owned));
+    }
+    out
+}
+/// The workflow-signature verdict (each surface maps its own exit codes).
+pub(crate) enum WorkflowSig {
+    Valid(String),   // verified — the enrolled key's 16-hex TOFU fingerprint
+    Invalid(String), // the sidecar exists but does not verify / unknown key
+    MissingSidecar,  // no `<file>.minisig` beside the workflow
+    NoEnrolledKey,   // nothing enrolled on this machine to verify against
+}
+/// The injected-key `nika sign` (hermetic tests drive it directly): ONE
+/// detached minisign over the EXACT file bytes → `<file>.minisig`.
+pub(crate) fn sign_workflow_with(
+    path: &Path,
+    sk: &minisign::SecretKey,
+    pk_box: &str,
+) -> Result<String, String> {
+    let data = std::fs::read(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?; // seam-bypass-ok: CLI reads the named workflow file
+    let comment = format!("nika-fp:{}", fingerprint(pk_box));
+    let sig = minisign::sign(None, sk, Cursor::new(&data), Some(&comment), None)
+        .map_err(|e| format!("cannot sign {}: {e}", path.display()))?;
+    let write = std::fs::write(sidecar_path(path), sig.into_string()); // seam-bypass-ok: CLI writes the sidecar beside the named file
+    write.map_err(|e| format!("cannot write {}: {e}", sidecar_path(path).display()))?;
+    Ok(fingerprint(pk_box))
+}
+/// `sign --check` / the `--require-signature` gate ([`verify_sidecar`]).
+pub(crate) fn check_workflow(path: &Path) -> WorkflowSig {
+    let text = std::fs::read_to_string(sidecar_path(path)); // seam-bypass-ok: CLI reads the sidecar beside the named file
+    let Ok(text) = text else {
+        return WorkflowSig::MissingSidecar;
+    };
+    let data = std::fs::read(path); // seam-bypass-ok: CLI reads the named workflow file
+    let Ok(data) = data else {
+        return WorkflowSig::Invalid(format!("cannot read {}", path.display()));
+    };
+    verify_sidecar(&data, &text, &enrolled_pubboxes())
+}
+/// The pure half of `sign --check`: 16-hex key-id match, then minisign-verify.
+fn verify_sidecar(data: &[u8], sig_text: &str, candidates: &[String]) -> WorkflowSig {
+    let Ok(sig) = minisign::SignatureBox::from_string(sig_text) else {
+        return WorkflowSig::Invalid("unparseable sidecar".to_owned());
+    };
+    if candidates.is_empty() {
+        return WorkflowSig::NoEnrolledKey;
+    }
+    let pubs = candidates.iter().filter_map(|pk_box| {
+        let pk = minisign::PublicKeyBox::from_string(pk_box).ok()?;
+        pk.into_public_key().ok().map(|pk| (pk_box, pk))
+    });
+    let mut known_key = false;
+    for (pk_box, pk) in pubs {
+        if pk.keynum() != sig.keynum() {
+            continue;
+        }
+        known_key = true;
+        if minisign::verify(&pk, &sig, Cursor::new(data), true, false, false).is_ok() {
+            return WorkflowSig::Valid(fingerprint(pk_box));
+        }
+    }
+    WorkflowSig::Invalid(if known_key {
+        "bad signature — the enrolled key does not verify these bytes".to_owned()
+    } else {
+        format!("unknown key {} — not enrolled", hex_lower(sig.keynum()))
     })
+}
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
 }
 
 #[cfg(test)]
@@ -408,5 +497,96 @@ mod tests {
             false,
         )
         .expect("round-trip signature verifies");
+    }
+
+    /// `sign → check` round-trip: a workflow signed with an injected key
+    /// verifies against that key's enrolled pub, naming its TOFU
+    /// fingerprint — and the workflow file itself is untouched.
+    #[test]
+    fn workflow_sign_then_check_round_trips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (pk, sk) = keypair();
+        let wf = dir.path().join("flow.nika.yaml");
+        let bytes = b"nika: v1\nworkflow:\n  id: signed\n";
+        std::fs::write(&wf, bytes).expect("fixture");
+
+        let fp = sign_workflow_with(&wf, &sk, pk.trim()).expect("signs");
+        assert_eq!(fp, fingerprint(pk.trim()));
+        assert_eq!(
+            std::fs::read(&wf).expect("workflow still readable"),
+            bytes,
+            "the workflow file never changes (canonical bytes stay hashable)"
+        );
+        let sidecar = sidecar_path(&wf);
+        assert!(sidecar.ends_with("flow.nika.yaml.minisig"));
+        let text = std::fs::read_to_string(&sidecar).expect("sidecar written");
+        assert!(
+            text.contains("trusted comment: nika-fp:"),
+            "authenticated provenance rides the trusted comment: {text}"
+        );
+        let WorkflowSig::Valid(got) = verify_sidecar(bytes, &text, &[pk.trim().to_owned()]) else {
+            unreachable!("a fresh signature must verify")
+        };
+        assert_eq!(got, fp);
+    }
+
+    /// One flipped byte in the workflow turns the verdict into the
+    /// bad-signature class (the key is known — the bytes are not his).
+    #[test]
+    fn tampered_workflow_is_rejected_as_bad_signature() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (pk, sk) = keypair();
+        let wf = dir.path().join("flow.nika.yaml");
+        std::fs::write(&wf, b"nika: v1\nworkflow:\n  id: honest\n").expect("fixture");
+        sign_workflow_with(&wf, &sk, pk.trim()).expect("signs");
+        let text = std::fs::read_to_string(sidecar_path(&wf)).expect("sidecar");
+
+        let forged = b"nika: v1\nworkflow:\n  id: FORGED\n";
+        let WorkflowSig::Invalid(why) = verify_sidecar(forged, &text, &[pk.trim().to_owned()])
+        else {
+            unreachable!("a tampered workflow must not verify")
+        };
+        assert!(why.contains("bad signature"), "{why}");
+    }
+
+    /// A sidecar minted by a key this machine does not enroll names the
+    /// unknown-key class (never a silent pass, never a confusing 'bad').
+    #[test]
+    fn unknown_signing_key_is_named() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (pk_a, sk_a) = keypair();
+        let (pk_b, _) = keypair();
+        let wf = dir.path().join("flow.nika.yaml");
+        std::fs::write(&wf, b"nika: v1\n").expect("fixture");
+        sign_workflow_with(&wf, &sk_a, pk_a.trim()).expect("signs");
+        let text = std::fs::read_to_string(sidecar_path(&wf)).expect("sidecar");
+
+        match verify_sidecar(b"nika: v1\n", &text, &[pk_b.trim().to_owned()]) {
+            WorkflowSig::Invalid(why) => assert!(why.contains("unknown key"), "{why}"),
+            _ => unreachable!("a key that never signed must not verify"),
+        }
+    }
+
+    /// Honest empty states: no enrolled key is ENV-class, a missing
+    /// sidecar is its own class, a garbage sidecar is invalid — never a
+    /// panic, never a forged pass.
+    #[test]
+    fn verify_empty_states_are_honest() {
+        assert!(matches!(
+            verify_sidecar(b"x", "garbage", &[]),
+            WorkflowSig::Invalid(_)
+        ));
+        let (_, sk) = keypair();
+        let sig = minisign::sign(None, &sk, std::io::Cursor::new(b"x"), None, None)
+            .expect("signs")
+            .into_string();
+        assert!(matches!(
+            verify_sidecar(b"x", &sig, &[]),
+            WorkflowSig::NoEnrolledKey
+        ));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wf = dir.path().join("flow.nika.yaml");
+        std::fs::write(&wf, b"nika: v1\n").expect("fixture");
+        assert!(matches!(check_workflow(&wf), WorkflowSig::MissingSidecar));
     }
 }

--- a/crates/nika-cli/src/verbs/key.rs
+++ b/crates/nika-cli/src/verbs/key.rs
@@ -31,38 +31,22 @@ pub enum KeyAction {
 pub fn run(action: KeyAction) -> VerbOutput {
     match action {
         KeyAction::Init { force } => match crate::seal::key_init(force) {
-            Ok(fp) => VerbOutput {
-                text: format!(
-                    "run-signing key minted · fingerprint {fp}\n  every run on this machine now seals its journal (verify: nika trace verify <file>)"
-                ),
-                code: super::exit::OK,
-            },
-            Err(msg) => VerbOutput {
-                text: format!("nika key init: {msg}"),
-                code: super::exit::FILE,
-            },
+            Ok(fp) => VerbOutput::ok(format!(
+                "run-signing key minted · fingerprint {fp}\n  every run on this machine now seals its journal (verify: nika trace verify <file>)"
+            )),
+            Err(msg) => VerbOutput::file(format!("nika key init: {msg}")),
         },
         KeyAction::Trust => match crate::seal::key_trust() {
-            Some((pk, fp)) => VerbOutput {
-                text: format!("run-signing public key · fingerprint {fp}\n{pk}"),
-                code: super::exit::OK,
-            },
-            None => VerbOutput {
-                text: "no run-signing key on this machine — `nika key init` mints one".to_owned(),
-                code: super::exit::OK,
-            },
+            Some((pk, fp)) => {
+                VerbOutput::ok(format!("run-signing public key · fingerprint {fp}\n{pk}"))
+            }
+            None => VerbOutput::ok("no run-signing key — `nika key init` mints one".to_owned()),
         },
         KeyAction::Rotate => match crate::seal::key_rotate() {
-            Ok(fp) => VerbOutput {
-                text: format!(
-                    "rotated · new fingerprint {fp} · the retired public key stays verifiable in ~/.nika/keys/retired.pub"
-                ),
-                code: super::exit::OK,
-            },
-            Err(msg) => VerbOutput {
-                text: format!("nika key rotate: {msg}"),
-                code: super::exit::FILE,
-            },
+            Ok(fp) => VerbOutput::ok(format!(
+                "rotated · new fingerprint {fp} · the retired public key stays verifiable in ~/.nika/keys/retired.pub"
+            )),
+            Err(msg) => VerbOutput::file(format!("nika key rotate: {msg}")),
         },
     }
 }

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -28,6 +28,7 @@ pub mod new;
 pub mod pack_surface;
 pub mod probe;
 pub mod run;
+pub mod sign;
 pub mod test;
 pub mod tools;
 pub mod trace;
@@ -70,21 +71,21 @@ pub struct VerbOutput {
 }
 
 impl VerbOutput {
-    fn ok(text: String) -> Self {
+    pub(crate) fn ok(text: String) -> Self {
         Self {
             text,
             code: exit::OK,
         }
     }
 
-    fn file(text: String) -> Self {
+    pub(crate) fn file(text: String) -> Self {
         Self {
             text,
             code: exit::FILE,
         }
     }
 
-    fn env(text: String) -> Self {
+    pub(crate) fn env(text: String) -> Self {
         Self {
             text,
             code: exit::ENV,

--- a/crates/nika-cli/src/verbs/run/example.rs
+++ b/crates/nika-cli/src/verbs/run/example.rs
@@ -82,6 +82,7 @@ pub fn example(
         // An example runs a TEMP-staged file, not a workspace run — the
         // workspace's trace store is not this invocation's to collect.
         true,
+        false, // examples are engine-staged content — unsigned-tolerant
     );
     // The example's own envelope model — what we suggest overriding when a
     // run fails offline. A parse miss leaves it empty (the infer tip then

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -157,8 +157,7 @@ fn first_failure(outcome: &RunOutcome) -> Option<nika_runtime::TaskErrorRecord> 
         .and_then(|r| r.error.clone())
 }
 
-// Fourteen independent CLI parameters ARE the clap surface — the same idiom
-// as TraceArgs' bools, not a state machine to encode in a struct.
+// Fifteen independent CLI parameters ARE the clap surface (the TraceArgs idiom).
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 #[must_use]
 pub fn run(
@@ -176,6 +175,7 @@ pub fn run(
     no_outputs: bool,
     max_cost_usd: Option<f64>,
     no_gc: bool,
+    require_signature: bool,
 ) -> u8 {
     run_verdict(
         file,
@@ -192,6 +192,7 @@ pub fn run(
         no_outputs,
         max_cost_usd,
         no_gc,
+        require_signature,
     )
     .code
 }
@@ -213,9 +214,8 @@ fn run_verdict(
     no_outputs: bool,
     max_cost_usd: Option<f64>,
     no_gc: bool,
+    require_signature: bool,
 ) -> RunVerdict {
-    // `--output` validated up front so an unknown format fails before any
-    // work (machine-result mode · see `output_mode`).
     let output_json = match output_mode(output) {
         Ok(flag) => flag,
         Err(code) => return RunVerdict::bare(code),
@@ -233,6 +233,9 @@ fn run_verdict(
         }
     };
 
+    if require_signature && let Err(code) = require_signature_gate(file, output_json) {
+        return RunVerdict::bare(code);
+    }
     // ── `--task` scope + clean/skills gates + `--var` overrides ─────
     let (wf, report, skills) =
         match scoped_clean_gate(wf, report, task_filter, file, json, theme, output_json) {
@@ -391,6 +394,22 @@ fn load_resume_plan(
             .map_err(|message| refuse(format!("--resume: {message}")))?;
     }
     Ok(plan)
+}
+
+/// The `--require-signature` trust gate: verify against an enrolled key
+/// before anything executes (exit 2 FILE · already printed + enveloped).
+fn require_signature_gate(file: &str, output_json: bool) -> Result<(), u8> {
+    use crate::seal::WorkflowSig;
+    let reason = match crate::seal::check_workflow(std::path::Path::new(file)) {
+        WorkflowSig::Valid(_) => return Ok(()),
+        WorkflowSig::MissingSidecar => "missing sidecar — `nika sign <file>` mints one".to_owned(),
+        WorkflowSig::NoEnrolledKey => "unknown key — nothing enrolled on this machine".to_owned(),
+        WorkflowSig::Invalid(why) => why,
+    };
+    let message = format!("--require-signature: {reason}");
+    eprintln!("nika run: {message}");
+    epilogue::emit_error_envelope(&message, output_json);
+    Err(exit::FILE)
 }
 
 /// House-voice a pre-run refusal (the empty-state audit · design §3):
@@ -1110,6 +1129,7 @@ mod tests {
             false,
             None,
             true,
+            false, // unsigned-tolerant (the signature gate has its own test)
         );
         assert_eq!(
             code,
@@ -1144,6 +1164,7 @@ mod tests {
             false,
             None,
             true,
+            false, // unsigned-tolerant (the signature gate has its own test)
         );
         assert_eq!(
             overridden,
@@ -1175,6 +1196,7 @@ mod tests {
             false,
             None,
             true,
+            false, // unsigned-tolerant (the signature gate has its own test)
         )
     }
 
@@ -1309,5 +1331,66 @@ mod tests {
             exit::WORKFLOW,
             "no skills map → NIKA-AGENT-003 task failure"
         );
+    }
+
+    /// `--require-signature` refuses an unsigned workflow BEFORE any task
+    /// executes: exit 2, and the exec task's sentinel is never created.
+    /// The counterfactual (the file itself is runnable) rides a dry-run —
+    /// plan only, zero effects.
+    #[test]
+    fn require_signature_refuses_unsigned_before_execution() {
+        let sentinel =
+            std::env::temp_dir().join(format!("nika-sig-gate-sentinel-{}", std::process::id()));
+        let _ = std::fs::remove_file(&sentinel);
+        let yaml = format!(
+            "nika: v1\nworkflow:\n  id: sig-gate\nmodel: mock/echo\ntasks:\n  touch:\n    exec: {{ command: [\"touch\", \"{}\"] }}\n",
+            sentinel.display()
+        );
+        let wf = stage("sig-gate.nika.yaml", &yaml);
+        let gated = run(
+            &wf.to_string_lossy(),
+            false,
+            None,
+            plain_theme(),
+            RenderMode::Plain,
+            false,
+            None,
+            &[],
+            None,
+            true, // tests never write .nika/traces (cwd hygiene)
+            None,
+            false,
+            None,
+            true,
+            true, // --require-signature
+        );
+        assert_eq!(
+            gated,
+            exit::FILE,
+            "unsigned + --require-signature must refuse (exit 2)"
+        );
+        assert!(
+            !sentinel.exists(),
+            "the gate fired BEFORE execution — the exec task never ran"
+        );
+        // The counterfactual: the SAME file without the flag plans green.
+        let planned = run(
+            &wf.to_string_lossy(),
+            false,
+            None,
+            plain_theme(),
+            RenderMode::Plain,
+            true, // --dry-run: plan only, zero effects
+            None,
+            &[],
+            None,
+            true,
+            None,
+            false,
+            None,
+            true,
+            false, // unsigned-tolerant default
+        );
+        assert_eq!(planned, exit::OK, "the workflow itself is runnable");
     }
 }

--- a/crates/nika-cli/src/verbs/sign.rs
+++ b/crates/nika-cli/src/verbs/sign.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika sign <workflow.nika.yaml>` — author-binding: ONE detached
+//! minisign over the EXACT bytes → `<file>.minisig` (the workflow itself
+//! never changes; v1 signs raw bytes · canonical-YAML is a later wave).
+
+use super::VerbOutput;
+use clap::Args;
+
+#[derive(Args)]
+pub struct SignArgs {
+    /// Workflow file (`*.nika.yaml`) to sign — or to verify with `--check`.
+    pub file: String,
+    /// Verify the `<file>.minisig` sidecar instead of minting it
+    /// (exits: 0 valid · 2 FILE invalid/forged · 3 ENV missing/none).
+    #[arg(long)]
+    pub check: bool,
+}
+
+#[must_use]
+pub fn run(args: &SignArgs) -> VerbOutput {
+    use crate::seal::WorkflowSig as Ws;
+    if args.check {
+        return match crate::seal::check_workflow(std::path::Path::new(&args.file)) {
+            Ws::Valid(fp) => VerbOutput::ok(format!("valid signature · key {fp}")),
+            Ws::Invalid(why) => VerbOutput::file(format!("INVALID signature · {why}")),
+            Ws::MissingSidecar => VerbOutput::env("no sidecar — `nika sign` mints one".to_owned()),
+            Ws::NoEnrolledKey => VerbOutput::env("no enrolled key — `nika key init`".to_owned()),
+        };
+    }
+    let Some((sk, pk_box)) = crate::seal::load_signing_key() else {
+        return VerbOutput::env("no run-signing key — `nika key init` mints one".to_owned());
+    };
+    match crate::seal::sign_workflow_with(std::path::Path::new(&args.file), &sk, &pk_box) {
+        Ok(fp) => VerbOutput::ok(format!("signed {} · key {fp}", args.file)),
+        Err(msg) => VerbOutput::env(format!("nika sign: {msg}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(file: &std::path::Path, check: bool) -> SignArgs {
+        SignArgs {
+            file: file.to_string_lossy().into_owned(),
+            check,
+        }
+    }
+
+    /// `sign --check` without a sidecar is the ENV class (3) — the
+    /// deterministic branch (no custody read happens before it).
+    #[test]
+    fn check_without_a_sidecar_is_env() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wf = dir.path().join("flow.nika.yaml");
+        std::fs::write(&wf, "nika: v1\n").expect("fixture");
+        let out = run(&args(&wf, true));
+        assert_eq!(out.code, super::super::exit::ENV, "{}", out.text);
+        assert!(out.text.contains("no sidecar"), "{}", out.text);
+    }
+
+    /// A garbage sidecar is the FILE class (2) — invalid, never valid,
+    /// regardless of the machine's custody.
+    #[test]
+    fn check_a_garbage_sidecar_is_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wf = dir.path().join("flow.nika.yaml");
+        std::fs::write(&wf, "nika: v1\n").expect("fixture");
+        std::fs::write(dir.path().join("flow.nika.yaml.minisig"), "garbage\n").expect("sidecar");
+        let out = run(&args(&wf, true));
+        assert_eq!(out.code, super::super::exit::FILE, "{}", out.text);
+        assert!(out.text.contains("INVALID signature"), "{}", out.text);
+    }
+
+    /// The sign half answers honestly about custody: on a keyless
+    /// machine it is the ENV class naming `nika key init`; on a machine
+    /// with an enrolled key it mints the sidecar and says so (the
+    /// tolerant two-branch idiom the `key` verb's test already runs).
+    #[test]
+    fn sign_either_mints_the_sidecar_or_names_the_fix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wf = dir.path().join("flow.nika.yaml");
+        std::fs::write(&wf, "nika: v1\n").expect("fixture");
+        let out = run(&args(&wf, false));
+        if out.code == super::super::exit::OK {
+            assert!(dir.path().join("flow.nika.yaml.minisig").exists());
+        } else {
+            assert_eq!(out.code, super::super::exit::ENV, "{}", out.text);
+            assert!(out.text.contains("key"), "{}", out.text);
+        }
+    }
+}

--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -98,6 +98,12 @@ builtins. Copy, fill, check.
 - `nika trace show|replay <run>` — the flight recorder (every run records).
 - `nika trace verify <run>` — the journal is hash-chained: verify it after a
   run that matters, cite the trace instead of trusting a memory of the run.
+- `nika key init|trust|rotate` — the run-signing key: it seals journals and
+  signs workflows (print the fingerprint with `nika key trust` to enroll it).
+- `nika sign <file>` — author-bind a workflow (detached `<file>.minisig`
+  sidecar · the workflow itself never changes) · `nika sign --check <file>`
+  verifies · `nika run --require-signature <file>` refuses an unsigned or
+  invalidly-signed workflow BEFORE anything executes (exit 2).
 - `nika dap` — step a recorded run under a debugger UI, forward AND back.
 
 ## Servers (stdio · for editors and agent clients)


### PR DESCRIPTION
## `nika sign` + `nika run --require-signature` — author-binding for workflow files (A7)

### Threat model

A swapped `.nika.yaml` in a repo is a supply-chain vector: `nika run` audits and then executes whatever the file says — shell commands, tool calls, model spend. Git tells you a file changed; it does not tell you the change came from an author you trust. This PR lands the author-binding half of the verifiable-run wave on top of the S2 journal seal (#655): a workflow can now carry a detached signature that the engine verifies BEFORE anything executes.

### What lands

- **`nika sign <workflow.nika.yaml>`** — ONE detached minisign (ed25519) over the **exact file bytes**, written to a `<file>.minisig` sidecar next to the workflow. The workflow file itself **never changes** — canonical bytes stay hashable (goldens, semantic hashes, and the S2 journal seal keep their meaning). v1 deliberately signs raw bytes via `minisign::sign`; a canonical-YAML transform (comment/formatting-insensitive signatures) is a later wave — documented in the module docs, not built here. The sidecar's trusted comment carries `nika-fp:<fingerprint>` (authenticated provenance naming the signing key).
- **`nika sign --check <file>`** — verifies a sidecar against the enrolled keys. Candidate order: `~/.nika/keys/run-signing.pub` (or `NIKA_RUN_PUB_FILE` / the OS keychain), then every line of `~/.nika/keys/retired.pub` (rotation keeps old sidecars verifiable). The sidecar's 16-hex minisign key id picks the candidate, then `minisign::verify` over the exact bytes.
- **`nika run --require-signature <file>`** — the opt-in enforcement boundary: refuses to run an unsigned or invalidly-signed workflow, checked **before any task executes** (right after the audit, before scoping/vars/composition). Every refusal is exit 2 FILE with the reason: `missing sidecar` / `bad signature` / `unknown key`.

### Trust model

Local-key TOFU, v1: the signing key is the machine's run-signing key from #655 (`nika key init|trust|rotate` — OS keychain first, 0600-file fallback, env override for CI). You trust a workflow because its sidecar verifies against a public key you enrolled; enrollment is an explicit operator act (`nika key trust` prints the fingerprint to move between machines). Registry-distributed author keys (sign at publish, verify at `registry:` pull) are the natural next wave and slot into the same `WorkflowSig` verdict — the enrolled-candidate seam is already an ordered list.

### Exit codes

| Surface | 0 | 2 (FILE) | 3 (ENV) |
|---|---|---|---|
| `nika sign` | sidecar minted | — | unreadable file · no key · unwritable sidecar |
| `nika sign --check` | valid | invalid / forged / unknown key | missing sidecar · no enrolled key |
| `nika run --require-signature` | runs | unsigned / bad signature / unknown key (before any task executes) | — |

The default stays unsigned-tolerant everywhere — `--require-signature` is an opt-in boundary (the flag help says so).

### Tests (all hermetic — Rust 2024 forbids `env::set_var` in-process, so keys are injected directly)

- sign → check round-trip (`minisign::KeyPair` crafted in-test; asserts the workflow bytes are untouched and the sidecar's trusted comment carries `nika-fp:`)
- tampered workflow → `bad signature` (key known, bytes forged)
- unknown signing key → `unknown key` (never a silent pass, never a confusing "bad")
- missing sidecar → ENV 3 at the verb · unparseable sidecar → FILE 2 · zero enrolled keys → `NoEnrolledKey`
- run gate: an unsigned workflow whose `exec` would touch a sentinel file is refused exit 2 — and the sentinel does **not** exist after (the counterfactual — same file without the flag — plans green under `--dry-run`)

### House-gate notes

- `nika-cli` sat at **14,851/15,000** prod LOC (vector 24). The wave fits in ~150 lines by letting the now-`pub(crate)` `VerbOutput::{ok,file,env}` constructors absorb the `key` verb's struct literals (−16) and keeping the new docs lean — landed at 14,997.
- `public-api.txt`: the `verbs::sign` block + the `run()` param appended/spliced — modeled on the `verbs::key` entries (CI ubuntu style; no full local regen).
- Based on `origin/main` post-#655/#656 (the merged seal renamed `load_secret_key` → `load_signing_key`; the call site is folded in).
- The scaffolded `AGENTS.md` (`nika-onboard`) now teaches `key`/`sign`/`--require-signature` — the bin test `the_scaffolded_agents_md_teaches_the_live_clap_tree` pins parity with the live clap tree (it only runs on the bin target, so `--lib`-only local runs can't see it; CI's nextest caught the first pass).
