### PR TITLE
feat(nika-cli): declared-vs-used drift hints in check — NIKA-DRIFT-001

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,6 +3739,7 @@ dependencies = [
  "clap_complete",
  "expectrl",
  "nika-builtin",
+ "nika-cap",
  "nika-catalog",
  "nika-clock",
  "nika-dap",
@@ -3775,6 +3776,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml_edit",
+ "url",
  "uuid",
 ]
 

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -17,6 +17,8 @@ nika-schema = { path = "../nika-schema", version = "0.105.0" } # parse + the ADR
 nika-graph = { path = "../nika-graph", version = "0.105.0" }   # the canonical projection (inspect --format json renders it)
 nika-error  = { path = "../nika-error", version = "0.105.0" }  # the code registry (`nika explain`)
 nika-pack   = { path = "../nika-pack", version = "0.105.0" }   # the embedded language pack (`nika spec|schema|examples|new`)
+nika-cap    = { path = "../nika-cap", version = "0.105.0" }    # the permits matchers (the check drift family's ONE oracle)
+url         = { workspace = true }                             # WHATWG host extraction (drift's net-entry read — the checker's own normalization)
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde       = { workspace = true }                             # graph projection envelope (§6)

--- a/crates/nika-cli/src/verbs/check/drift.rs
+++ b/crates/nika-cli/src/verbs/check/drift.rs
@@ -1,0 +1,923 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Declared-vs-used drift — the `NIKA-DRIFT-001` advisory family.
+//!
+//! A workflow's envelope DECLARES its contract (`vars:` · `env:` ·
+//! `secrets:` · `permits:`); the body USES it. When the two drift apart
+//! the file lies about itself: a declared input nothing reads is smell
+//! (the author pruned the body but not the contract). This pass names
+//! the dead declaration and suggests the removal. Advisory — a dead
+//! declaration breaks nothing (`is_clean` ignores hints; a green exit
+//! stays green).
+//!
+//! ## Why the pass lives at the CLI edge
+//!
+//! The natural home was `nika_schema::check`, but that crate sits AT
+//! the 15,000-LOC cap (vector 24 · zero headroom), so the family
+//! renders from the check verb like the `[inputs]` hint families
+//! already do. The wire is identical: the terminal HINT block prints
+//! `[NIKA-DRIFT-001 · drift]` rows (the PERMITS bracket pattern) and
+//! `--json` appends `{kind, task, advice, code}` rows to `hints[]`.
+//!
+//! ## The boundary vs the HARD diagnostics (one voice, no double report)
+//!
+//! The reverse direction — USED but UNDECLARED — is already a hard
+//! failure everywhere the check surface can see it:
+//!
+//! - `${{ vars./env./secrets./with.X }}` with no `X` declared →
+//!   `NIKA-VAR-001` (the analyzer's template scan, EVERY island surface);
+//! - `tasks.X` with no task `X` → `NIKA-DAG-002`;
+//! - an effect outside the declared `permits:` → `NIKA-SEC-004`
+//!   (fires on the CATEGORY regardless of arg dynamism);
+//! - a literal URL the always-on SSRF floor refuses → `NIKA-SEC-005`.
+//!
+//! Nothing is left for a used-but-undeclared hint, so the family mints
+//! exactly ONE wire code — `NIKA-DRIFT-001`, declared-but-unused — and
+//! no `NIKA-DRIFT-002` (an unemittable code would be dead weight). The
+//! no-duplication law is STRUCTURAL: the hard codes name REFERENCES,
+//! this pass names DECLARATIONS — the two never fire on the same yaml
+//! site. The honest adjacency is the typo pair: `vars.topik` declared +
+//! `${{ vars.topic }}` used fires VAR-001 on the reference AND DRIFT-001
+//! on the declaration — both true; the hint clears when the typo is
+//! fixed.
+//!
+//! ## What counts as a use
+//!
+//! The SAME surface set the analyzer scans — the drift voice can never
+//! contradict the conformance voice. Permits usage is judged only where
+//! PROVABLE: per-entry flags need a COMPLETE static used set; a dynamic
+//! consumer poisons the set to `None` (no claim, never wrong — a
+//! shell-form exec hides its programs · a dynamic URL/path hides the
+//! host/path set · an `agent:` whitelist dispatches dynamically, glob
+//! ⊆ glob being undecidable). A templated tool name needs no
+//! suppression case: the parser refuses it (the closed `nika:`/`mcp:`
+//! grammar).
+
+use std::collections::BTreeSet;
+
+use nika_cap::BuiltinEffect;
+use nika_schema::expression::{NamespaceRef, expr_refs, scan_templates};
+use nika_schema::raw::{
+    ForEachValue, RawAction, RawCommand, RawInvokeAction, RawWorkflow, VisionInput,
+};
+use nika_schema::types::{ExecPermit, FsPermits, OnErrorAction, Permits, WhenGate};
+
+/// The family's wire code — registered in the canon (`nika explain` teaches it).
+pub(super) const DRIFT_CODE: &str = "NIKA-DRIFT-001";
+
+/// The declared-but-unused advices for a workflow, sorted. Every row is
+/// the same class (`drift` · [`DRIFT_CODE`] · workflow-level), so both
+/// projections shape the constant fields around the advice texts.
+#[must_use]
+pub(super) fn scan(wf: &RawWorkflow) -> Vec<String> {
+    let mut out = Vec::new();
+    push_unused_declarations(wf, &UsedNames::collect(wf), &mut out);
+    push_unused_permits(wf, &mut out);
+    out.sort();
+    out
+}
+
+/// Every `vars./env./secrets.` name the body references (module-doc parity set).
+#[derive(Default)]
+struct UsedNames {
+    vars: BTreeSet<String>,
+    env: BTreeSet<String>,
+    secrets: BTreeSet<String>,
+}
+
+impl UsedNames {
+    fn collect(wf: &RawWorkflow) -> Self {
+        let mut used = Self::default();
+        for task in &wf.tasks {
+            let t = &task.value;
+            used.eat_gate(t.when.as_ref());
+            if let Some(for_each) = &t.for_each {
+                match &for_each.value {
+                    ForEachValue::Expression(expr) => used.eat(expr),
+                    ForEachValue::List(list) => used.eat_json(list),
+                    _ => {} // a future for_each form joins deliberately (#[non_exhaustive])
+                }
+            }
+            for (_, v) in &t.with {
+                used.eat_json(&v.value);
+            }
+            used.eat_action(&t.action);
+            if let Some(on_error) = &t.on_error
+                && let OnErrorAction::Recover(value) = &on_error.value.action
+            {
+                used.eat_json(&value.value);
+            }
+            for cleanup in &t.on_finally {
+                used.eat_gate(cleanup.value.when.as_ref());
+                used.eat_action(&cleanup.value.action);
+            }
+        }
+        for (_, decl) in &wf.outputs {
+            used.eat(&decl.value().value);
+        }
+        if let Some(model) = &wf.model {
+            used.eat(&model.value); // the one templated envelope field
+        }
+        used
+    }
+
+    fn eat_gate(&mut self, gate: Option<&nika_schema::source::Spanned<WhenGate>>) {
+        if let Some(when) = gate
+            && let WhenGate::Expr(expr) = &when.value
+        {
+            self.eat(expr);
+        }
+    }
+
+    /// Every namespace ref of one `${{ }}`-bearing text (a broken island yields nothing).
+    fn eat(&mut self, text: &str) {
+        let Ok(islands) = scan_templates(text) else {
+            return;
+        };
+        for island in &islands {
+            for r in expr_refs(&island.expr) {
+                match r {
+                    NamespaceRef::Vars(name) => {
+                        self.vars.insert(name);
+                    }
+                    NamespaceRef::Env(name) => {
+                        self.env.insert(name);
+                    }
+                    NamespaceRef::Secrets(name) => {
+                        self.secrets.insert(name);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn eat_json(&mut self, value: &serde_json::Value) {
+        match value {
+            serde_json::Value::String(s) => self.eat(s),
+            serde_json::Value::Array(items) => items.iter().for_each(|i| self.eat_json(i)),
+            serde_json::Value::Object(map) => map.values().for_each(|v| self.eat_json(v)),
+            _ => {}
+        }
+    }
+
+    /// The verb-body surfaces, mirroring the analyzer's action scan. The
+    /// wildcards are the forward-compat law (render.rs's `verb_of`
+    /// precedent): a future verb with templated fields must extend this
+    /// walker deliberately — a silent under-read would flag USED names.
+    fn eat_action(&mut self, action: &RawAction) {
+        match action {
+            RawAction::Infer(a) => {
+                self.eat(&a.prompt.value);
+                for s in [&a.system, &a.model].into_iter().flatten() {
+                    self.eat(&s.value);
+                }
+                for vision in &a.vision {
+                    match &vision.value {
+                        VisionInput::File { path } => self.eat(&path.value),
+                        VisionInput::Url { url } => self.eat(&url.value),
+                        _ => {}
+                    }
+                }
+            }
+            RawAction::Exec(a) => {
+                match &a.command {
+                    RawCommand::Shell(c) => self.eat(&c.value),
+                    RawCommand::Argv(parts) => parts.iter().for_each(|p| self.eat(&p.value)),
+                    _ => {}
+                }
+                for s in [&a.cwd, &a.stdin].into_iter().flatten() {
+                    self.eat(&s.value);
+                }
+                for (_, v) in &a.env {
+                    self.eat(&v.value);
+                }
+            }
+            RawAction::Invoke(a) => {
+                if let Some(tool) = a.tool() {
+                    self.eat(&tool.value);
+                }
+                if let Some(args) = &a.args {
+                    self.eat_json(&args.value);
+                }
+            }
+            RawAction::Agent(a) => {
+                self.eat(&a.prompt.value);
+                for s in [&a.system, &a.model].into_iter().flatten() {
+                    self.eat(&s.value);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Declared `vars:`/`env:`/`secrets:` names nothing references.
+fn push_unused_declarations(wf: &RawWorkflow, used: &UsedNames, out: &mut Vec<String>) {
+    let declared: [(&str, Vec<&str>, &BTreeSet<String>, &str); 3] = [
+        (
+            "vars",
+            wf.vars.iter().map(|(n, _)| n.value.as_str()).collect(),
+            &used.vars,
+            "a dead input drifts from the body it describes",
+        ),
+        (
+            "env",
+            wf.env.iter().map(|(n, _)| n.value.as_str()).collect(),
+            &used.env,
+            "a dead config entry drifts from the body it describes",
+        ),
+        (
+            "secrets",
+            wf.secrets.iter().map(|(n, _)| n.value.as_str()).collect(),
+            &used.secrets,
+            "an unread store entry is attack surface without a purpose",
+        ),
+    ];
+    for (ns, names, seen, why) in &declared {
+        for name in names {
+            if !seen.contains(*name) {
+                out.push(format!(
+                    "`{ns}.{name}` is declared but never referenced — remove the \
+                     declaration (or reference it); {why}"
+                ));
+            }
+        }
+    }
+}
+
+/// The body's statically-known effect usage. A set is `None` when a
+/// dynamic consumer makes it INCOMPLETE: the category stays silent (no
+/// claim, never wrong).
+#[derive(Default)]
+struct BodyUsage {
+    /// An exec task exists (main verb or `on_finally`).
+    has_exec: bool,
+    /// An `agent:` whitelist exists (dynamic dispatch — suppresses tools/net/fs).
+    has_agent_whitelist: bool,
+    /// Static `argv[0]`s of argv-form execs.
+    programs: Option<BTreeSet<String>>,
+    /// Static invoke tool names — complete by construction (the parser
+    /// refuses templated tool references), hence no `Option`.
+    tools: BTreeSet<String>,
+    /// Literal hosts from net-effect invokes.
+    hosts: Option<BTreeSet<String>>,
+    /// Literal fs read paths.
+    reads: Option<BTreeSet<String>>,
+    /// Literal fs write paths (incl. `nika:chart`'s `vega_lite` sibling).
+    writes: Option<BTreeSet<String>>,
+}
+
+impl BodyUsage {
+    fn collect(wf: &RawWorkflow) -> Self {
+        let mut u = Self {
+            programs: Some(BTreeSet::new()),
+            hosts: Some(BTreeSet::new()),
+            reads: Some(BTreeSet::new()),
+            writes: Some(BTreeSet::new()),
+            ..Self::default()
+        };
+        for task in &wf.tasks {
+            u.eat_action(&task.value.action);
+            for cleanup in &task.value.on_finally {
+                u.eat_action(&cleanup.value.action);
+            }
+        }
+        u
+    }
+
+    fn eat_action(&mut self, action: &RawAction) {
+        match action {
+            RawAction::Exec(a) => {
+                self.has_exec = true;
+                offer(
+                    &mut self.programs,
+                    static_program(&a.command).map(str::to_owned),
+                );
+            }
+            RawAction::Invoke(a) => {
+                if let Some(tool) = a.tool() {
+                    self.tools.insert(tool.value.clone());
+                }
+                match builtin_effect_of(a) {
+                    Some(BuiltinEffect::Net { url_arg }) => {
+                        offer(
+                            &mut self.hosts,
+                            literal_arg(a, url_arg).as_deref().and_then(url_host),
+                        );
+                    }
+                    Some(BuiltinEffect::Fs {
+                        path_arg,
+                        reads,
+                        writes,
+                        ..
+                    }) => {
+                        let path = literal_arg(a, path_arg);
+                        if reads {
+                            offer(&mut self.reads, path.clone());
+                        }
+                        if writes {
+                            offer(&mut self.writes, path.clone());
+                        }
+                        // chart's `compile_to: vega_lite` writes a second
+                        // literal file beside `out:` — `None` there is NOT
+                        // a dynamic path (no poisoning).
+                        if let Some(sibling) = chart_vl_sibling_of(a)
+                            && let Some(set) = &mut self.writes
+                        {
+                            set.insert(sibling);
+                        }
+                    }
+                    None => {}
+                }
+            }
+            RawAction::Agent(a) => {
+                if !a.tools.is_empty() {
+                    self.has_agent_whitelist = true;
+                }
+            }
+            // Infer is effect-free; a future verb joins deliberately (the
+            // forward-compat wildcard, same law as the name walker).
+            _ => {}
+        }
+    }
+}
+
+/// Declared `permits:` entries no task effect can use — per category,
+/// per entry where the used set is fully static.
+fn push_unused_permits(wf: &RawWorkflow, out: &mut Vec<String>) {
+    let Some(permits) = wf.permits.as_ref().map(|p| &p.value) else {
+        return;
+    };
+    let usage = BodyUsage::collect(wf);
+    push_exec_drift(permits, &usage, out);
+    push_tools_drift(permits, &usage, out);
+    push_net_drift(permits, &usage, out);
+    push_fs_drift(permits, &usage, out);
+}
+
+/// `exec:` — `true` is used by ANY exec task; a program allowlist is
+/// judged per entry. `exec: false` is a posture, not a grant — never drift.
+fn push_exec_drift(permits: &Permits, usage: &BodyUsage, out: &mut Vec<String>) {
+    match permits.exec.as_ref() {
+        Some(ExecPermit::Any) => {
+            if !usage.has_exec {
+                out.push(
+                    "`permits.exec: true` grants shell reach no task uses — remove it \
+                     (no `exec:` task exists)"
+                        .to_owned(),
+                );
+            }
+        }
+        Some(ExecPermit::Programs(list)) => {
+            // `None` = a shell-form/dynamic exec hides its programs —
+            // per-entry is undecidable then. (No exec task at all keeps
+            // the set complete-and-empty: every entry is provably dead.)
+            let Some(used) = &usage.programs else {
+                return;
+            };
+            for program in list {
+                if !used.contains(program) {
+                    out.push(format!(
+                        "`permits.exec` entry `{program}` admits a program no task runs \
+                         — remove the entry"
+                    ));
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// `tools:` — per entry, through the ONE glob matcher (`nika_cap`).
+/// Silent when an agent whitelist dispatches dynamically.
+fn push_tools_drift(permits: &Permits, usage: &BodyUsage, out: &mut Vec<String>) {
+    let Some(globs) = permits.tools.as_ref() else {
+        return;
+    };
+    if usage.has_agent_whitelist {
+        return;
+    }
+    for glob in globs {
+        if !usage.tools.iter().any(|t| nika_cap::glob_matches(glob, t)) {
+            out.push(format!(
+                "`permits.tools` entry `{glob}` admits no tool the body invokes \
+                 — remove the entry"
+            ));
+        }
+    }
+}
+
+/// `net.http:` — per entry through the ONE host matcher (the boundary's
+/// own). Floor-dead entries are skipped: the `NIKA-SEC-005` escape
+/// already names them (one voice, never twice).
+fn push_net_drift(permits: &Permits, usage: &BodyUsage, out: &mut Vec<String>) {
+    let Some(net) = permits.net.as_ref() else {
+        return;
+    };
+    if usage.has_agent_whitelist {
+        return;
+    }
+    let Some(hosts) = &usage.hosts else {
+        return; // a dynamic URL hides the host set — no claim
+    };
+    for entry in &net.http {
+        let floor_dead = !entry.contains('*')
+            && nika_types::net::host_is_blocked(entry)
+            && !nika_types::net::is_exact_loopback_literal(entry);
+        if floor_dead {
+            continue;
+        }
+        if !hosts
+            .iter()
+            .any(|h| nika_types::net::host_glob_matches(entry, h))
+        {
+            out.push(format!(
+                "`permits.net.http` entry `{entry}` matches no host the body reaches \
+                 — remove the entry"
+            ));
+        }
+    }
+}
+
+/// `fs.read`/`fs.write` — per entry per direction (`Permits::allows_path` over a single-entry boundary).
+fn push_fs_drift(permits: &Permits, usage: &BodyUsage, out: &mut Vec<String>) {
+    let Some(fs) = permits.fs.as_ref() else {
+        return;
+    };
+    if usage.has_agent_whitelist {
+        return;
+    }
+    let (Some(reads), Some(writes)) = (&usage.reads, &usage.writes) else {
+        return; // a dynamic path hides the path sets — no claim
+    };
+    for entry in &fs.read {
+        if !reads.iter().any(|p| single_entry_admits(entry, p, false)) {
+            out.push(format!(
+                "`permits.fs.read` entry `{entry}` matches no path the body reads \
+                 — remove the entry"
+            ));
+        }
+    }
+    for entry in &fs.write {
+        if !writes.iter().any(|p| single_entry_admits(entry, p, true)) {
+            out.push(format!(
+                "`permits.fs.write` entry `{entry}` matches no path the body writes \
+                 — remove the entry"
+            ));
+        }
+    }
+}
+
+/// Does ONE declared fs entry admit this literal path? (`Permits::allows_path` on a synthetic boundary.)
+fn single_entry_admits(entry: &str, path: &str, write: bool) -> bool {
+    let mut boundary = Permits::new();
+    boundary.fs = Some(if write {
+        FsPermits::new(Vec::new(), vec![entry.to_owned()])
+    } else {
+        FsPermits::new(vec![entry.to_owned()], Vec::new())
+    });
+    boundary.allows_path(path, write)
+}
+
+/// Feed one literal into a used set · `None` (dynamic) poisons it.
+fn offer(set: &mut Option<BTreeSet<String>>, value: Option<String>) {
+    match value {
+        Some(v) => {
+            if let Some(s) = set {
+                s.insert(v);
+            }
+        }
+        None => *set = None,
+    }
+}
+
+/// The invoke's builtin effect classification — the `nika_cap` oracle.
+fn builtin_effect_of(a: &RawInvokeAction) -> Option<BuiltinEffect> {
+    let tool = a.tool()?;
+    nika_cap::builtin_effect(&tool.value, a.args.as_ref().map(|s| &s.value))
+}
+
+/// The invoke's `compile_to: vega_lite` sibling file (the checker fit
+/// pass's own law) — `None` for other tools/targets, never a dynamic read.
+fn chart_vl_sibling_of(a: &RawInvokeAction) -> Option<String> {
+    let tool = a.tool()?;
+    nika_cap::chart_vl_sibling(&tool.value, a.args.as_ref().map(|s| &s.value))
+}
+
+/// An arg as a STATIC string — `None` when absent, non-string, or
+/// `${{ }}`-built (dynamic → the runtime's concern, never a guess).
+fn literal_arg(a: &RawInvokeAction, key: &str) -> Option<String> {
+    let s = a.args.as_ref()?.value.get(key)?.as_str()?;
+    if s.contains("${{") {
+        return None;
+    }
+    Some(s.to_owned())
+}
+
+/// The statically-known program of an ARRAY-form command (`argv[0]`
+/// when literal) · `None` for the shell-string form.
+fn static_program(command: &RawCommand) -> Option<&str> {
+    match command {
+        RawCommand::Argv(_) => command.argv_program().filter(|p| !p.contains("${{")),
+        _ => None,
+    }
+}
+
+/// The host of a literal URL, via the `url` crate — the SAME WHATWG
+/// normalization the checker's `url_host` enforces with (a hand-rolled
+/// parser is a boundary bypass); duplicated only because the checker's
+/// copy sits behind the capped crate's private module (module doc).
+fn url_host(raw: &str) -> Option<String> {
+    match url::Url::parse(raw).ok()?.host()? {
+        url::Host::Domain(d) => Some(d.trim_end_matches('.').to_owned()),
+        url::Host::Ipv4(a) => Some(a.to_string()),
+        url::Host::Ipv6(a) => Some(a.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nika_schema::{FileId, ParseMode, parse};
+
+    fn drifted(yaml: &str) -> Vec<String> {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+        scan(&wf)
+    }
+
+    // ─── namespace declarations (vars · env · secrets) ───────────────
+
+    #[test]
+    fn unused_var_env_and_secret_are_hinted() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  topic: \"x\"\nenv:\n  REGION: eu\nsecrets:\n  k: { source: env, key: K }\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        assert_eq!(advice.len(), 3, "{advice:?}");
+        assert!(
+            advice.iter().any(|a| a.contains("`vars.topic`")),
+            "{advice:?}"
+        );
+        assert!(
+            advice.iter().any(|a| a.contains("`env.REGION`")),
+            "{advice:?}"
+        );
+        assert!(
+            advice.iter().any(|a| a.contains("`secrets.k`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn used_everything_stays_silent() {
+        // every declaration referenced — across DIFFERENT surfaces so
+        // each walker arm is pinned: prompt · exec env · with · outputs ·
+        // the envelope model: · on_error.recover · when:.
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\nmodel: \"${{ vars.backend }}\"\nvars:\n  topic: \"x\"\n  backend: mock/echo\n  recovered: \"fallback\"\n  gate: \"yes\"\nenv:\n  REGION: eu\nsecrets:\n  k: { source: env, key: K }\ntasks:\n  a:\n    when: ${{ vars.gate == \"yes\" }}\n    with: { token: \"${{ secrets.k }}\" }\n    on_error: { recover: \"${{ vars.recovered }}\" }\n    exec:\n      command: [\"echo\", \"${{ vars.topic }}\"]\n      env: { R: \"${{ env.REGION }}\" }\noutputs:\n  out: \"${{ vars.topic }}\"\n",
+        );
+        assert!(advice.is_empty(), "{advice:?}");
+    }
+
+    #[test]
+    fn references_in_for_each_and_on_finally_and_vision_count_as_uses() {
+        // the less-obvious surfaces: for_each expression · on_finally
+        // cleanup command · infer vision endpoint — each pins its walker
+        // arm (a blind arm would flag a USED name).
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  items: { type: array, required: true }\n  cleanup_msg: \"done\"\n  image: \"./in.png\"\ntasks:\n  a:\n    for_each: \"${{ vars.items }}\"\n    on_finally:\n      - exec: { command: [\"echo\", \"${{ vars.cleanup_msg }}\"] }\n    infer:\n      prompt: \"describe\"\n      max_tokens: 10\n      vision: [{ source: file, path: \"${{ vars.image }}\" }]\noutputs:\n  r: ${{ tasks.a.output }}\n",
+        );
+        assert!(advice.is_empty(), "{advice:?}");
+    }
+
+    #[test]
+    fn hints_are_sorted_and_deterministic() {
+        let first = drifted(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  zeta: \"x\"\n  alpha: \"y\"\nsecrets:\n  k2: { source: env, key: K2 }\n  k1: { source: env, key: K1 }\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        let second = drifted(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  zeta: \"x\"\n  alpha: \"y\"\nsecrets:\n  k2: { source: env, key: K2 }\n  k1: { source: env, key: K1 }\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        assert_eq!(first, second, "same input → same order");
+        let mut sorted = first.clone();
+        sorted.sort();
+        assert_eq!(first, sorted, "emitted sorted: {first:?}");
+    }
+
+    // ─── the boundary vs the hard diagnostics ────────────────────────
+
+    #[test]
+    fn used_but_undeclared_never_produces_a_drift_hint() {
+        // `${{ vars.ghost }}` with NOTHING declared: the conformance
+        // ladder owns it (NIKA-VAR-001) — the drift pass stays silent
+        // (the two codes must never fire on the same reference).
+        let wf = parse(
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"echo\", \"${{ vars.ghost }}\"] }\n",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(
+            report.conformance.iter().any(|c| c.code == "NIKA-VAR-001"),
+            "the hard diagnostic fires: {:?}",
+            report.conformance
+        );
+        assert!(
+            scan(&wf).is_empty(),
+            "no drift hint duplicates it: {:?}",
+            scan(&wf)
+        );
+    }
+
+    #[test]
+    fn the_typo_pair_names_two_different_sites() {
+        // `topik` DECLARED · `topic` USED — the hard code names the
+        // reference (VAR-001), the drift hint names the declaration
+        // (topik): both true, never the same site, and the hint clears
+        // when the typo is fixed.
+        let wf = parse(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  topik: \"x\"\ntasks:\n  a:\n    exec: { command: [\"echo\", \"${{ vars.topic }}\"] }\n",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(
+            report
+                .conformance
+                .iter()
+                .any(|c| c.code == "NIKA-VAR-001" && c.message.contains("vars.topic")),
+            "{:?}",
+            report.conformance
+        );
+        let drift = scan(&wf);
+        assert_eq!(drift.len(), 1, "{drift:?}");
+        assert!(drift[0].contains("`vars.topik`"), "{drift:?}");
+    }
+
+    // ─── permits: exec ───────────────────────────────────────────────
+
+    #[test]
+    fn exec_true_without_any_exec_task_is_hinted() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: true }\ntasks:\n  a:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n",
+        );
+        assert!(
+            advice.iter().any(|a| a.contains("`permits.exec: true`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn exec_true_with_an_exec_task_is_silent() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: true }\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("permits.exec")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn exec_false_is_a_posture_never_a_drift() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: false }\ntasks:\n  a:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("permits.exec")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn exec_program_list_is_judged_per_entry() {
+        // `cargo` is used · `make` is not — ONLY `make` is flagged.
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: [\"cargo\", \"make\"] }\ntasks:\n  a:\n    exec: { command: [\"cargo\", \"build\"] }\n",
+        );
+        assert!(
+            advice
+                .iter()
+                .any(|a| a.contains("`permits.exec` entry `make`")),
+            "{advice:?}"
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("entry `cargo`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn exec_program_list_with_no_exec_task_flags_every_entry() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: [\"cargo\", \"make\"] }\ntasks:\n  a:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n",
+        );
+        let exec_hints: Vec<&String> = advice
+            .iter()
+            .filter(|a| a.contains("`permits.exec` entry"))
+            .collect();
+        assert_eq!(exec_hints.len(), 2, "{advice:?}");
+    }
+
+    #[test]
+    fn shell_form_exec_suppresses_per_entry_program_flags() {
+        // a shell command's program set is opaque — no per-entry claim
+        // (the form under an allowlist is the hard lane's business).
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: [\"cargo\", \"make\"] }\ntasks:\n  a:\n    exec: { shell: \"cargo build && make test\" }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("`permits.exec` entry")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn exec_in_on_finally_counts_as_a_use() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { exec: [\"cargo\"] }\ntasks:\n  a:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n    on_finally:\n      - exec: { command: [\"cargo\", \"clean\"] }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("permits.exec")),
+            "{advice:?}"
+        );
+    }
+
+    // ─── permits: tools ──────────────────────────────────────────────
+
+    #[test]
+    fn tools_entry_nothing_invokes_is_hinted() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { tools: [\"nika:read\", \"mcp:github/*\"] }\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
+        );
+        assert!(
+            advice
+                .iter()
+                .any(|a| a.contains("`permits.tools` entry `mcp:github/*`")),
+            "{advice:?}"
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("entry `nika:read`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn agent_whitelist_suppresses_tools_entry_flags() {
+        // the agent dispatches dynamically; a tools entry may exist to
+        // cover its whitelist globs — glob ⊆ glob is undecidable.
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits: { tools: [\"mcp:github/*\"] }\ntasks:\n  a:\n    agent: { prompt: \"triage\", tools: [\"mcp:github/*\"], max_tokens_total: 1000, model: \"mock/echo\" }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("`permits.tools` entry")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn templated_tool_names_are_parse_refused_so_no_suppression_case_exists() {
+        // The static tool set is complete BY CONSTRUCTION: the closed
+        // `nika:`/`mcp:` grammar refuses a templated reference at parse
+        // time. This pins WHY the tools/net/fs passes carry no
+        // template-suppression arm — if the grammar ever loosens, this
+        // test turns red and the suppression must be (re)added.
+        let result = parse(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  t: \"nika:read\"\ntasks:\n  a:\n    invoke: { tool: \"${{ vars.t }}\" }\n",
+            FileId::new(0),
+            ParseMode::Strict,
+        );
+        assert!(
+            result.is_err(),
+            "templated tool reference must stay refused"
+        );
+    }
+
+    // ─── permits: net ────────────────────────────────────────────────
+
+    #[test]
+    fn net_entry_matching_no_literal_host_is_hinted() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"api.example.com\", \"other.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/x\" } }\n",
+        );
+        assert!(
+            advice
+                .iter()
+                .any(|a| a.contains("`permits.net.http` entry `other.example.com`")),
+            "{advice:?}"
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("entry `api.example.com`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn net_entries_all_unused_when_no_net_effect_exists() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:read\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
+        );
+        assert!(
+            advice
+                .iter()
+                .any(|a| a.contains("`permits.net.http` entry `api.example.com`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn dynamic_url_suppresses_net_entry_flags() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  u: \"https://api.example.com/x\"\npermits:\n  net: { http: [\"other.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:fetch\", args: { url: \"${{ vars.u }}\" } }\n",
+        );
+        assert!(
+            !advice
+                .iter()
+                .any(|a| a.contains("`permits.net.http` entry")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn floor_dead_net_entry_is_not_drift_hinted() {
+        // `10.0.0.8` can never take effect — the NIKA-SEC-005 escape
+        // already names it (the hard lane); the drift hint must NOT
+        // double-report the same entry.
+        let wf = parse(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"10.0.0.8\", \"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/x\" } }\n",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_schema::check(&wf);
+        assert!(
+            report
+                .capability_escapes
+                .iter()
+                .any(|e| e.detail.contains("10.0.0.8")),
+            "the floor-dead escape fires: {:?}",
+            report.capability_escapes
+        );
+        assert!(
+            !scan(&wf).iter().any(|a| a.contains("10.0.0.8")),
+            "no second report for the same entry: {:?}",
+            scan(&wf)
+        );
+    }
+
+    // ─── permits: fs ─────────────────────────────────────────────────
+
+    #[test]
+    fn fs_entries_are_judged_per_direction() {
+        // read `./in/**` is used · write `./out/**` is not — ONLY the
+        // write entry is flagged (a read use never covers a write grant).
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./in/**\"], write: [\"./out/**\"] }\n  tools: [\"nika:read\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"./in/data.txt\" } }\n",
+        );
+        assert!(
+            advice
+                .iter()
+                .any(|a| a.contains("`permits.fs.write` entry `./out/**`")),
+            "{advice:?}"
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("`permits.fs.read`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn fs_write_use_via_chart_sibling_counts() {
+        // `compile_to: vega_lite` writes `out` AND its `.vl.json`
+        // sibling — both literal writes (the fit pass's own law).
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { write: [\"./chart.svg\", \"./chart.vl.json\"] }\n  tools: [\"nika:chart\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:chart\", args: { spec: { mark: \"line\" }, out: \"./chart.svg\", compile_to: \"vega_lite\" } }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("`permits.fs.write`")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn dynamic_path_suppresses_fs_entry_flags() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  p: \"./in/data.txt\"\npermits:\n  fs: { read: [\"./other/**\"] }\n  tools: [\"nika:read\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"${{ vars.p }}\" } }\n",
+        );
+        assert!(
+            !advice.iter().any(|a| a.contains("`permits.fs.read` entry")),
+            "{advice:?}"
+        );
+    }
+
+    #[test]
+    fn no_permits_block_means_no_permits_drift() {
+        let advice = drifted(
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        assert!(advice.is_empty(), "{advice:?}");
+    }
+}

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -20,6 +20,7 @@ use nika_schema::raw::RawWorkflow;
 use crate::display::theme::{Role, Theme};
 use crate::verbs::{VerbOutput, load_checked, load_checked_with_source};
 
+mod drift;
 mod models_rung;
 use models_rung::{ModelFinding, pricing_section, unresolvable_models};
 
@@ -61,6 +62,9 @@ pub fn run(
         }
         None => (wf, report),
     };
+    // The declared-vs-used drift family (NIKA-DRIFT-001 · drift.rs) —
+    // advisory in both projections, never an exit-code input.
+    let drift_hints = drift::scan(&wf);
     let native_hints = report
         .hints
         .iter()
@@ -80,13 +84,23 @@ pub fn run(
             &report,
             &model_findings,
             &skills,
+            &drift_hints,
             clean,
             strict_clean,
             native_strict,
         );
     }
 
-    let mut text = render(&report, &wf, &source, path, theme, &model_findings, &skills);
+    let mut text = render(
+        &report,
+        &wf,
+        &source,
+        path,
+        theme,
+        &model_findings,
+        &skills,
+        &drift_hints,
+    );
     if native_strict && report.is_clean() && native_hints > 0 {
         let hint_word = if native_hints == 1 { "hint" } else { "hints" };
         let _ = writeln!(
@@ -148,11 +162,13 @@ fn parse_fatal_json(out: &VerbOutput) -> VerbOutput {
 /// The `--json` verdict: the full report + the machine keys (`clean` ·
 /// `models_resolve` · `model_findings[]` · `skills_resolve` ·
 /// `skill_findings[]` · `pricing` · the strict flag) — never coloured,
-/// the contract bytes are the contract.
+/// the contract bytes are the contract. The drift rows (NIKA-DRIFT-001)
+/// append to `hints[]` in the report's row shape plus their `code`.
 fn json_verdict(
     report: &CheckReport,
     model_findings: &[ModelFinding],
     skills: &nika_schema::ResolvedSkills,
+    drift_hints: &[String],
     clean: bool,
     strict_clean: bool,
     native_strict: bool,
@@ -162,6 +178,14 @@ fn json_verdict(
         Err(e) => return VerbOutput::env(format!("cannot serialize report: {e}")),
     };
     if let Some(obj) = payload.as_object_mut() {
+        if let Some(hints) = obj
+            .get_mut("hints")
+            .and_then(serde_json::Value::as_array_mut)
+        {
+            for advice in drift_hints {
+                hints.push(serde_json::json!({"kind": "drift", "task": "-", "advice": advice, "code": drift::DRIFT_CODE}));
+            }
+        }
         obj.insert("clean".to_owned(), serde_json::Value::Bool(clean));
         obj.insert(
             "models_resolve".to_owned(),
@@ -781,6 +805,88 @@ mod tests {
         assert!(
             text.contains("(skipped — no valid DAG order while conformance fails)"),
             "{text}"
+        );
+    }
+
+    /// NIKA-DRIFT-001: a declared-but-unused envelope entry is an
+    /// advisory HINT — rendered code-first (the bracket voice), counted
+    /// in the audited card line, and the exit stays GREEN (dead
+    /// declarations are smell, not failure).
+    #[test]
+    fn unused_declaration_is_hinted_and_the_exit_stays_green() {
+        let out = checked_output(
+            "drift-unused.nika.yaml",
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  ghost: \"x\"\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+            false,
+        );
+        assert_eq!(out.code, 0, "a drift hint never fails: {}", out.text);
+        assert!(
+            out.text.contains("[NIKA-DRIFT-001 · drift]"),
+            "code-first bracket voice: {}",
+            out.text
+        );
+        assert!(out.text.contains("`vars.ghost`"), "{}", out.text);
+        assert!(
+            out.text.contains("audited") && out.text.contains("hint"),
+            "the card line still renders: {}",
+            out.text
+        );
+    }
+
+    /// The machine projection law: `--json` carries the drift hint with
+    /// its code, `clean` stays true, and the exit stays 0.
+    #[test]
+    fn drift_hint_rides_the_json_projection() {
+        // Per-PROCESS dir (the check-expect mktemp collision class, #376).
+        let dir = std::env::temp_dir().join(format!("nika-cli-killtests-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let path = dir.join("drift-json.nika.yaml");
+        std::fs::write(
+            &path,
+            "nika: v1\nworkflow:\n  id: w\nvars:\n  ghost: \"x\"\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        )
+        .expect("fixture body");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            true,
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        assert_eq!(out.code, 0, "{}", out.text);
+        let payload: serde_json::Value = serde_json::from_str(&out.text).expect("json");
+        assert_eq!(payload["clean"], true, "{payload:#}");
+        let hints = payload["hints"].as_array().expect("hints array");
+        let drift = hints
+            .iter()
+            .find(|h| h["kind"] == "drift")
+            .expect("the drift hint rides the machine surface");
+        assert_eq!(drift["code"], "NIKA-DRIFT-001", "{drift:#}");
+        assert!(
+            drift["advice"]
+                .as_str()
+                .expect("advice")
+                .contains("`vars.ghost`"),
+            "{drift:#}"
+        );
+    }
+
+    /// The no-duplication law: an UNDECLARED reference is the hard
+    /// lane's (`NIKA-VAR-001`) — the drift code must not also fire for
+    /// it (the two codes never name the same site).
+    #[test]
+    fn unresolved_reference_never_also_drifts() {
+        let out = checked_output(
+            "drift-no-dup.nika.yaml",
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"echo\", \"${{ vars.ghost }}\"] }\n",
+            false,
+        );
+        assert_eq!(out.code, 2, "the hard lane fails: {}", out.text);
+        assert!(out.text.contains("NIKA-VAR-001"), "{}", out.text);
+        assert!(
+            !out.text.contains("NIKA-DRIFT-001"),
+            "no drift duplication: {}",
+            out.text
         );
     }
 }

--- a/crates/nika-cli/src/verbs/check/render.rs
+++ b/crates/nika-cli/src/verbs/check/render.rs
@@ -66,6 +66,7 @@ pub(super) fn render(
     t: Theme,
     model_findings: &[ModelFinding],
     skills: &nika_schema::ResolvedSkills,
+    drift_hints: &[String],
 ) -> String {
     let mut out = String::new();
     let name = path.rsplit('/').next().unwrap_or(path);
@@ -158,7 +159,7 @@ pub(super) fn render(
     permits(&mut out, report, wf, t);
     policy_rung(&mut out, report, wf, t);
     trifecta_rung(&mut out, report, wf, t);
-    hints_and_verdict(&mut out, report, wf, t);
+    hints_and_verdict(&mut out, report, wf, t, drift_hints);
     // The MAP beside the verdict — the same themed wire art `graph
     // --format ascii` speaks, so the audit READS as the DAG it judged
     // (operator ask 2026-07-12: « quand on fait check, voir la dag »).
@@ -301,8 +302,14 @@ fn arg_rows(report: &CheckReport) -> Vec<String> {
 }
 
 /// Advisory hints + the one-line verdict (the report's last words).
-fn hints_and_verdict(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
-    let mut hint_count = report.hints.len();
+fn hints_and_verdict(
+    out: &mut String,
+    report: &CheckReport,
+    wf: &RawWorkflow,
+    t: Theme,
+    drift_hints: &[String],
+) {
+    let mut hint_count = report.hints.len() + drift_hints.len();
     for h in &report.hints {
         let _ = writeln!(
             out,
@@ -311,6 +318,19 @@ fn hints_and_verdict(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t
             t.paint(Role::Strong, "HINT"),
             h.kind,
             h.advice
+        );
+    }
+    // NIKA-DRIFT-001 rows — the declared-vs-unused family, computed at
+    // this edge (super::drift); the code-first bracket voice matches the
+    // PERMITS rows (`[NIKA-SEC-005 · net]`).
+    for advice in drift_hints {
+        let _ = writeln!(
+            out,
+            " {} {}     [{} · drift] {}",
+            t.paint(Role::Accent, "↳"),
+            t.paint(Role::Strong, "HINT"),
+            super::drift::DRIFT_CODE,
+            advice
         );
     }
     // The stranger's first trap (V-arc F1): statically-resolvable

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -51,9 +51,9 @@ counts:
   providers: 16
   extract_modes: 9
   templates: 10
-  error_namespaces: 21
+  error_namespaces: 22
   error_categories: 12
-  error_codes: 82
+  error_codes: 83
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -224,7 +224,7 @@ templates:
 # matching "fetch is a builtin, not a verb" D-N18 · prior count 15 → 14).
 # spec/05-errors.md is the prose home (matches at 15 · NIKA-TYPE joined at W3 · cascade complete 2026-07-14).
 error_namespaces:
-  count: 21
+  count: 22
   reference: spec/05-errors.md
   items:
     - NIKA-AGENT
@@ -240,6 +240,7 @@ error_namespaces:
     - NIKA-LOCK
     - NIKA-MCP
     - NIKA-DECIDE
+    - NIKA-DRIFT
     - NIKA-PARSE
     - NIKA-POLICY
     - NIKA-PORT
@@ -275,7 +276,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 82
+  count: 83
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }
@@ -367,6 +368,7 @@ error_codes:
     - { code: NIKA-LOCK-001, category: validation_error, transient: "false", failure: "a dependency resolved that nika.lock does not pin, or a hand-edited lock digest does not match (pin-by-default · the lock's own hash catches the edit · spec 15)" }
     - { code: NIKA-BUILTIN-001, category: validation_error, transient: "false", failure: "builtin invoke violates its statically-checkable arg contract (e.g. nika:fetch without url: · nika:jq arg shape)" }
     - { code: NIKA-BUILTIN-DONE-001, category: validation_error, transient: "false", failure: "nika:done invoked outside an agent: loop" }
+    - { code: NIKA-DRIFT-001, category: validation_error, transient: "false", failure: "declared-but-unused — a vars:/env:/secrets: name or a permits: entry (exec program · tool glob · net host · fs path) that nothing in the body references (advisory check hint · never fails the audit — the reverse direction, used-but-undeclared, is the hard NIKA-VAR-001/NIKA-DAG-002/NIKA-SEC-004 surface)" }
 
 # ---------------------------------------------------------------- pillars
 # 5 immutable pillars forever (spec/00-overview · the language backbone).


### PR DESCRIPTION
# Declared-vs-used drift hint in `nika check` — NIKA-DRIFT-001

When a workflow **declares more than it uses**, `check` now says so. A new advisory hint family flags envelope declarations nothing in the body references — informational only: dead declarations are smell, not failure, so **a green exit stays green** (`is_clean` ignores hints; `--json`'s `clean` stays `true`).

## What drifts it catches

**Namespace declarations** — a `vars:` / `env:` / `secrets:` name no `${{ }}` island references. The used set is computed over **the same surface set the analyzer scans** (verb fields · `with:` · `when:` · `for_each:` · `on_error.recover` · `on_finally` · `outputs:` · envelope `model:`), so the drift voice can never contradict the conformance voice.

**Permits entries** — judged per category, per entry, through the ONE `nika_cap` / `nika_types` matchers (never a re-rolled glob):

- `permits.exec: true` with no `exec:` task anywhere · program-allowlist entries no static `argv[0]` runs (a shell-form or dynamic argv **poisons** the program set — per-entry claims go silent, never wrong);
- `permits.tools` entries no `invoke` names (an `agent:` whitelist suppresses the category: runtime dispatch is dynamic and glob ⊆ glob is undecidable — `nika_cap::effect`'s own law; templated tool names need no case at all — the parser refuses them);
- `permits.net.http` entries matching no literal fetch/notify host (a dynamic URL poisons the host set; **floor-dead entries are skipped** — the `NIKA-SEC-005` escape already names them, one voice);
- `permits.fs.read` / `permits.fs.write` entries matching no literal path, **per direction** (a read use never covers a write grant; `nika:chart`'s `vega_lite` sibling counts as a second literal write).

Hints aggregate per file in the HINT block, **sorted and deterministic**, printed code-first (`[NIKA-DRIFT-001 · drift]` — the PERMITS-row bracket pattern), counted in the audited card line, and ride the `--json` projection as `{kind, task, advice, code}` rows appended to `hints[]` (the machine-projection law).

## The boundary vs existing hard diagnostics

The reverse direction — **used-but-undeclared** — is deliberately **not** a hint. It is already a hard failure everywhere the check surface can see it:

- `${{ vars./env./secrets./with.X }}` with no `X` declared → `NIKA-VAR-001` (the analyzer's template scan, on every island surface);
- `tasks.X` with no task `X` → `NIKA-DAG-002`;
- an effect outside the declared `permits:` → `NIKA-SEC-004` (fires on the category regardless of arg dynamism);
- a literal URL the always-on SSRF floor refuses → `NIKA-SEC-005`.

Nothing is left for a used-but-undeclared hint, so the family mints **exactly one wire code — NIKA-DRIFT-001** — and no `NIKA-DRIFT-002` (an unemittable code would be dead weight). The no-duplication law is **structural**: the hard codes name *references*, drift names *declarations* — the two never fire on the same yaml site. The honest adjacency is the typo pair (`vars.topik` declared + `${{ vars.topic }}` used): VAR-001 fires on the reference, DRIFT-001 on the declaration — both true, and the hint clears when the typo is fixed. (Documented in `verbs/check/drift.rs`'s module doc.)

`NIKA-DRIFT-001` is registered the house way in the vendored canon (`crates/nika-pack/pack/canon.yaml` · `error_codes` 82→83 · `error_namespaces` 21→22), so `nika explain NIKA-DRIFT-001` teaches it today. **Follow-up:** the same row should land in the nika-spec repo's `canon.yaml` + `spec/05-errors.md` (the SSOT this pack is vendored from), or the next `sync-pack.sh` will drop it.

## Placement note (house-gate surprise)

The analysis is pure AST + matchers, so the natural home was `nika_schema::check` beside the other hint families — but **nika-schema sits AT the 15,000-LOC production cap** (hygiene vector 24, measured at exactly 15000 on `main`: zero headroom). The pass therefore renders from the check verb (`crates/nika-cli/src/verbs/check/drift.rs`), the same edge where the `[inputs]` hint families already live. A side effect of the move: cross-crate matches on `#[non_exhaustive]` raw AST types need explicit wildcards (each carries the forward-compat comment — a future verb with templated fields must extend the walker deliberately).

## Tests

Module tests (24 · `verbs/check/drift.rs`):

- unused var/env/secret hinted · used-everything silent (every walker arm pinned: prompt · exec env · `with` · `outputs` · envelope `model:` · `on_error.recover` · `when:` · `for_each` · `on_finally` · vision endpoint);
- sorted, deterministic emission;
- permits per category: `exec: true` with/without exec tasks · `exec: false` never flagged · program list per-entry · no-exec flags every entry · shell-form suppresses · `on_finally` counts · tools entry unused/used · agent-whitelist suppression · templated-tool parse refusal (pins why no suppression case exists) · net entry unused/used/no-net-effect/dynamic-URL/floor-dead-not-double-reported · fs per-direction · chart sibling · dynamic path suppression · no-permits-block;
- the boundary: used-but-undeclared produces **zero** drift hints (VAR-001 owns it) · the typo pair names two different sites.

Verb tests (3 · `verbs/check/mod.rs`):

- unused var hinted **and exit stays 0** (code-first row + the audited card line counts it);
- `--json` carries the hint with `"code": "NIKA-DRIFT-001"` and `clean: true`;
- an unresolved reference exits 2 with `NIKA-VAR-001` and **never** a `NIKA-DRIFT-001` alongside.

## Gates

`cargo test --workspace --lib` (0 failures) · `cargo clippy --workspace --all-targets -- -D warnings` (clean) · `cargo fmt --check` (clean) · `bash scripts/hygiene/check-all.sh` (**36 green · 4 yellow · 0 red**, incl. vector 24 crate-size after the placement move) · `cargo doc --no-deps -p nika-cli -D warnings` (clean) · `nika explain NIKA-DRIFT-001` answers from the canon. No public-API surface change (nika-cli is internal; nika-schema untouched).
