### PR TITLE
feat(nika-exec-runner): the loopback egress proxy — sandbox allowlist arm enforced (C11 part 2, srt model)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3927,6 +3927,7 @@ name = "nika-exec-runner"
 version = "0.105.0"
 dependencies = [
  "nika-kernel",
+ "nika-types",
  "nix 0.30.1",
  "proptest",
  "tokio",

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -17,6 +17,10 @@ adr = ["ADR-003", "ADR-016"]
 
 [dependencies]
 nika-kernel = { path = "../nika-kernel", version = "0.105.0" }
+# The ONE host matcher (host_in_allowlist) the egress proxy decides with —
+# shared with nika-http's wire boundary and the static check, so check ≡
+# run ≡ jail cannot drift on the glob (L0 leaf, no I/O pulled in).
+nika-types = { path = "../nika-types", version = "0.105.0" }
 unicode-normalization = { workspace = true }  # NFKC confusable-bypass defense
 # tokio::process spawns the child; io-util drains pipes; sync::Notify backs the
 # cancel-by-pid registry; time::timeout enforces the deadline.

--- a/crates/nika-exec-runner/public-api.txt
+++ b/crates/nika-exec-runner/public-api.txt
@@ -1,13 +1,51 @@
 pub mod nika_exec_runner
+#[non_exhaustive] pub struct nika_exec_runner::EgressDecision
+pub nika_exec_runner::EgressDecision::allowed: bool
+pub nika_exec_runner::EgressDecision::host: alloc::string::String
+pub nika_exec_runner::EgressDecision::port: u16
+impl core::clone::Clone for nika_exec_runner::EgressDecision
+pub fn nika_exec_runner::EgressDecision::clone(&self) -> nika_exec_runner::EgressDecision
+impl core::cmp::Eq for nika_exec_runner::EgressDecision
+impl core::cmp::PartialEq for nika_exec_runner::EgressDecision
+pub fn nika_exec_runner::EgressDecision::eq(&self, other: &nika_exec_runner::EgressDecision) -> bool
+impl core::fmt::Debug for nika_exec_runner::EgressDecision
+pub fn nika_exec_runner::EgressDecision::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_exec_runner::EgressDecision
+impl<D> owo_colors::OwoColorize for nika_exec_runner::EgressDecision
+impl<T, U> core::convert::Into<U> for nika_exec_runner::EgressDecision where U: core::convert::From<T>
+pub fn nika_exec_runner::EgressDecision::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_exec_runner::EgressDecision where U: core::convert::Into<T>
+pub type nika_exec_runner::EgressDecision::Error = core::convert::Infallible
+pub fn nika_exec_runner::EgressDecision::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_exec_runner::EgressDecision where U: core::convert::TryFrom<T>
+pub type nika_exec_runner::EgressDecision::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_exec_runner::EgressDecision::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_exec_runner::EgressDecision where T: core::clone::Clone
+pub type nika_exec_runner::EgressDecision::Owned = T
+pub fn nika_exec_runner::EgressDecision::clone_into(&self, target: &mut T)
+pub fn nika_exec_runner::EgressDecision::to_owned(&self) -> T
+impl<T> core::any::Any for nika_exec_runner::EgressDecision where T: 'static + ?core::marker::Sized
+pub fn nika_exec_runner::EgressDecision::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_exec_runner::EgressDecision where T: ?core::marker::Sized
+pub fn nika_exec_runner::EgressDecision::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_exec_runner::EgressDecision where T: ?core::marker::Sized
+pub fn nika_exec_runner::EgressDecision::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_exec_runner::EgressDecision where T: core::clone::Clone
+pub unsafe fn nika_exec_runner::EgressDecision::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_exec_runner::EgressDecision
+pub fn nika_exec_runner::EgressDecision::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_exec_runner::EgressDecision where T: 'static
+pub fn nika_exec_runner::EgressDecision::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub struct nika_exec_runner::TokioShell
 impl nika_exec_runner::TokioShell
 pub fn nika_exec_runner::TokioShell::new() -> Self
 pub fn nika_exec_runner::TokioShell::with_ambient_secret_env(self, names: impl core::convert::Into<alloc::sync::Arc<[alloc::string::String]>>) -> Self
+pub fn nika_exec_runner::TokioShell::with_egress_observer(self, observer: nika_exec_runner::EgressObserver) -> Self
 pub fn nika_exec_runner::TokioShell::with_sandbox(sandbox: alloc::sync::Arc<dyn nika_kernel_core::io::command_sandbox::CommandSandbox>) -> Self
 impl core::clone::Clone for nika_exec_runner::TokioShell
 pub fn nika_exec_runner::TokioShell::clone(&self) -> nika_exec_runner::TokioShell
 impl core::default::Default for nika_exec_runner::TokioShell
-pub fn nika_exec_runner::TokioShell::default() -> nika_exec_runner::TokioShell
+pub fn nika_exec_runner::TokioShell::default() -> Self
 impl core::fmt::Debug for nika_exec_runner::TokioShell
 pub fn nika_exec_runner::TokioShell::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl nika_kernel_core::io::process::ShellCancelDyn for nika_exec_runner::TokioShell
@@ -44,3 +82,4 @@ impl<TraitVariantBlanketType> nika_kernel_core::io::process::ShellCancel for nik
 pub async fn nika_exec_runner::TokioShell::cancel(&self, id: &str) -> core::result::Result<(), nika_kernel_core::io::process::ShellError>
 impl<TraitVariantBlanketType> nika_kernel_core::io::process::ShellRun for nika_exec_runner::TokioShell where TraitVariantBlanketType: nika_kernel_core::io::process::ShellRunDyn
 pub async fn nika_exec_runner::TokioShell::run(&self, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellResult, nika_kernel_core::io::process::ShellError>
+pub type nika_exec_runner::EgressObserver = alloc::sync::Arc<(dyn core::ops::function::Fn(&nika_exec_runner::EgressDecision) + core::marker::Send + core::marker::Sync)>

--- a/crates/nika-exec-runner/src/egress.rs
+++ b/crates/nika-exec-runner/src/egress.rs
@@ -1,0 +1,1002 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The loopback egress proxy — the Anthropic sandbox-runtime (srt) model in
+//! Nika (ADR-095 Layer 6 · the `allowlist` network arm's enforcement half).
+//!
+//! Started per-run (lazily, on the first exec whose
+//! [`SandboxSpec`](nika_kernel::process::SandboxSpec) carries
+//! [`NetPolicy::Allowlist`](nika_kernel::process::NetPolicy::Allowlist)) by
+//! [`crate::TokioShell`]; binds `127.0.0.1` on an
+//! ephemeral port; serves BOTH HTTP `CONNECT` and SOCKS5 on the ONE muxed
+//! port — protocol-sniffed on the first byte (`0x05` = SOCKS5, anything else
+//! = CONNECT), the same mux srt ships ("the mux serves both on one port",
+//! `sandbox-runtime` `macos-sandbox-utils.ts`). Non-loopback peers are
+//! refused outright: the proxy exists ONLY for the sandboxed child on this
+//! host.
+//!
+//! Every CONNECT/SOCKS target is evaluated against the declared
+//! `permits.net.http` set with the ONE host matcher —
+//! [`nika_types::net::host_in_allowlist`], the same predicate `nika-http`
+//! enforces at the wire boundary and `nika-schema`/`nika-cap` at check time,
+//! so check ≡ run ≡ jail cannot drift on the glob. Only a match is dialed
+//! upstream; anything else is refused (CONNECT → `403`, SOCKS5 →
+//! `0x02` "not allowed by ruleset"). Every decision is journalised through
+//! the injected [`EgressObserver`] — a refused host is a security event, an
+//! allowed one a debug line (the composer surfaces both on stderr, the
+//! FCI-009 honest seam: the run journal's `EventSink` is a `&mut` threaded
+//! through the settle pass, unreachable from an out-of-band proxy thread —
+//! the `StderrEmitter` precedent in `nika-cli`).
+//!
+//! Honest limits (mirrored from srt's own): the matcher gates the HOST, not
+//! the resolved address — a DNS name that resolves to a private/metadata IP
+//! is the documented DNS-rebinding class srt also declines to close (the
+//! `nika-http` effect's `GuardedResolver` owns that half for `nika:fetch`;
+//! exec egress has no static URL to vet). Plain-HTTP forward-proxy requests
+//! (`GET http://…`) are NOT served — CONNECT and SOCKS5 only; anything else
+//! gets an honest `405` and a closed socket (fail-closed).
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, Shutdown, TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use nika_kernel::process::EgressAllowlist;
+
+/// Handshake-phase I/O deadline (greeting, CONNECT line, SOCKS request). A
+/// stalled handshake cannot hold a connection thread forever; the tunnel
+/// itself runs unbounded (the run's own lifetime bounds it — the proxy dies
+/// with the runner).
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Per-address upstream dial deadline (each resolved address is tried in
+/// turn, mirroring the blocking resolver semantics of srt's Node proxies).
+const UPSTREAM_DIAL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The byte ceiling on the CONNECT header block (request line + headers) —
+/// a forward proxy needs the first line only, the rest is drained-and-ignored.
+const CONNECT_HEADER_CAP: usize = 8192;
+
+/// One allow/refuse verdict on a CONNECT/SOCKS target — the journal unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EgressDecision {
+    /// The requested target host, exactly as the client sent it.
+    pub host: String,
+    /// The requested target port.
+    pub port: u16,
+    /// Whether the declared allowlist admitted the target.
+    pub allowed: bool,
+}
+
+/// The decision sink — the composer wires the stderr journal, tests wire a
+/// collecting probe. `Fn` (never `FnMut`): the proxy calls it from
+/// connection threads.
+pub type EgressObserver = Arc<dyn Fn(&EgressDecision) + Send + Sync>;
+
+/// The default journal when no observer is injected — a namespaced stderr
+/// line per decision (see the module doc for the FCI-009 seam rationale).
+/// REFUSED is the security event (greppable), `allowed` the debug line.
+/// stderr, NOT `tracing::warn!`: no workspace tracing subscriber exists
+/// (the `StderrEmitter` precedent in `nika-cli`), so a tracing call would
+/// journal into the void — and a security journal that can silently vanish
+/// is worse than an unformatted one.
+#[allow(clippy::disallowed_macros, clippy::print_stderr)]
+pub(crate) fn stderr_journal() -> EgressObserver {
+    Arc::new(|d: &EgressDecision| {
+        if d.allowed {
+            eprintln!("nika:egress allowed {}:{}", d.host, d.port);
+        } else {
+            eprintln!(
+                "nika:egress REFUSED {}:{} (not in permits.net.http)",
+                d.host, d.port
+            );
+        }
+    })
+}
+
+/// The per-run loopback proxy. Owns the accept thread; `Drop` stops the
+/// listener (no orphan listener outlives the runner — see `Drop`).
+pub(crate) struct EgressProxy {
+    port: u16,
+    allowlist: Arc<[String]>,
+    shutdown: Arc<AtomicBool>,
+    accept: Option<JoinHandle<()>>,
+}
+
+impl EgressProxy {
+    /// Bind `127.0.0.1:0` (an ephemeral, OS-assigned port) and start serving.
+    ///
+    /// # Errors
+    /// The loopback bind or the accept-thread spawn failed — fail-closed:
+    /// the caller (the runner) refuses the command rather than run an
+    /// allowlisted child without its proxy.
+    pub(crate) fn start(allowlist: Vec<String>, observer: EgressObserver) -> std::io::Result<Self> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+        let port = listener.local_addr()?.port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let allowlist: Arc<[String]> = allowlist.into();
+        let accept = {
+            let shutdown = Arc::clone(&shutdown);
+            let allowlist = Arc::clone(&allowlist);
+            std::thread::Builder::new()
+                .name("nika-egress".to_owned())
+                .spawn(move || accept_loop(listener, allowlist, observer, shutdown))?
+        };
+        Ok(Self {
+            port,
+            allowlist,
+            shutdown,
+            accept: Some(accept),
+        })
+    }
+
+    /// The ephemeral loopback port the child env points at.
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// The declared host set this proxy serves (one boundary per run — the
+    /// runner refuses a second, conflicting set rather than widen silently).
+    pub(crate) fn allowlist(&self) -> &[String] {
+        &self.allowlist
+    }
+}
+
+impl Drop for EgressProxy {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        // Wake the blocking accept() so the loop observes the flag NOW (the
+        // wake connection arrives, sees the flag, and is closed unserved).
+        let _ = TcpStream::connect((Ipv4Addr::LOCALHOST, self.port));
+        if let Some(accept) = self.accept.take() {
+            let _ = accept.join();
+        }
+        // The listener dies with the accept thread — the port is closed, no
+        // orphan listener outlives the run (the orphan test pins this).
+    }
+}
+
+/// The accept loop: loopback peers only, one thread per connection.
+/// By-value by design: this fn IS the accept thread's body — the listener,
+/// the shared allowlist and the observer move onto the thread with it.
+#[allow(clippy::needless_pass_by_value)]
+fn accept_loop(
+    listener: TcpListener,
+    allowlist: Arc<[String]>,
+    observer: EgressObserver,
+    shutdown: Arc<AtomicBool>,
+) {
+    for conn in listener.incoming() {
+        if shutdown.load(Ordering::Acquire) {
+            break;
+        }
+        let Ok(stream) = conn else {
+            break; // the listener errored (closed from under us) — stop.
+        };
+        let Ok(peer) = stream.peer_addr() else {
+            continue;
+        };
+        if !peer.ip().is_loopback() {
+            continue; // this proxy exists ONLY for the sandboxed child on this host.
+        }
+        let (allowlist, observer) = (Arc::clone(&allowlist), Arc::clone(&observer));
+        let _ = std::thread::Builder::new()
+            .name("nika-egress-conn".to_owned())
+            .spawn(move || serve(stream, &allowlist, &observer));
+    }
+}
+
+/// Serve one connection: sniff the protocol, parse the target, decide,
+/// tunnel. Every path closes the socket on exit — no half-served protocol.
+fn serve(client: TcpStream, allowlist: &[String], observer: &EgressObserver) {
+    let _ = client.set_read_timeout(Some(HANDSHAKE_TIMEOUT));
+    let _ = client.set_write_timeout(Some(HANDSHAKE_TIMEOUT));
+    let mut first = [0u8; 1];
+    let Ok(n) = client.peek(&mut first) else {
+        return;
+    };
+    if n == 0 {
+        return; // peer hung up before speaking (e.g. the Drop wake connection).
+    }
+    if first[0] == 0x05 {
+        serve_socks5(client, allowlist, observer);
+    } else {
+        serve_connect(client, allowlist, observer);
+    }
+}
+
+/// The shared verdict: the ONE matcher over the declared set, journalised.
+/// Refused targets never leave this fn with an open upstream.
+fn decide(host: &str, port: u16, allowlist: &[String], observer: &EgressObserver) -> bool {
+    let allowed = nika_types::net::host_in_allowlist(allowlist, host);
+    observer(&EgressDecision {
+        host: host.to_owned(),
+        port,
+        allowed,
+    });
+    allowed
+}
+
+/// Dial the approved target — each resolved address in turn, per-address
+/// deadline (the blocking-resolver semantics of srt's Node proxies).
+fn dial_upstream(host: &str, port: u16) -> std::io::Result<TcpStream> {
+    use std::net::ToSocketAddrs;
+    let mut last = std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "no address resolved");
+    for addr in (host, port).to_socket_addrs()? {
+        match TcpStream::connect_timeout(&addr, UPSTREAM_DIAL_TIMEOUT) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last = e,
+        }
+    }
+    Err(last)
+}
+
+/// Full-duplex tunnel after the upgrade: both directions copy until EOF,
+/// each direction's EOF propagated as a write-shutdown to the other side
+/// (half-close fidelity — a server's `close_notify` reaches the client).
+/// The handshake deadlines are cleared first: the tunnel outlives them.
+fn relay(client: TcpStream, upstream: TcpStream) {
+    let _ = client.set_read_timeout(None);
+    let _ = client.set_write_timeout(None);
+    let _ = upstream.set_read_timeout(None);
+    let _ = upstream.set_write_timeout(None);
+    let (Ok(mut client_w), Ok(mut upstream_w)) = (client.try_clone(), upstream.try_clone()) else {
+        return;
+    };
+    let (mut client_r, mut upstream_r) = (client, upstream);
+    let west = std::thread::Builder::new()
+        .name("nika-egress-relay".to_owned())
+        .spawn(move || {
+            let _ = std::io::copy(&mut client_r, &mut upstream_w);
+            let _ = upstream_w.shutdown(Shutdown::Write);
+        });
+    let _ = std::io::copy(&mut upstream_r, &mut client_w);
+    let _ = client_w.shutdown(Shutdown::Write);
+    if let Ok(west) = west {
+        let _ = west.join();
+    }
+}
+
+/// The HTTP `CONNECT` handler (HTTPS tunneling). Reads the header block
+/// (capped), parses the authority-form target, decides, then either tunnels
+/// (`200 Connection Established`) or refuses (`403`). A non-CONNECT request
+/// gets an honest `405` — forward-proxy GETs are out of scope by design.
+fn serve_connect(mut client: TcpStream, allowlist: &[String], observer: &EgressObserver) {
+    let Some(head) = read_header_block(&mut client) else {
+        return;
+    };
+    let Some(line) = head.lines().next() else {
+        return;
+    };
+    let mut parts = line.split_whitespace();
+    let (method, authority) = (parts.next().unwrap_or(""), parts.next().unwrap_or(""));
+    if !method.eq_ignore_ascii_case("CONNECT") {
+        let _ = client.write_all(
+            b"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        );
+        return;
+    }
+    let Some((host, port)) = parse_authority(authority) else {
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+        return;
+    };
+    if !decide(&host, port, allowlist, observer) {
+        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+        return;
+    }
+    let Ok(upstream) = dial_upstream(&host, port) else {
+        let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+        return;
+    };
+    if client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .is_err()
+    {
+        return;
+    }
+    relay(client, upstream);
+}
+
+/// Read up to the end of the CONNECT header block (`\r\n\r\n`), capped at
+/// [`CONNECT_HEADER_CAP`] bytes — a header flood is refused by silence
+/// (close), never buffered unboundedly. Non-UTF8/control garbage fails the
+/// line parse downstream.
+fn read_header_block(client: &mut TcpStream) -> Option<String> {
+    let mut buf = Vec::with_capacity(512);
+    let mut chunk = [0u8; 512];
+    loop {
+        if buf.len() >= CONNECT_HEADER_CAP {
+            return None;
+        }
+        let n = client.read(&mut chunk).ok()?;
+        if n == 0 {
+            return None; // EOF before the block completed.
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            return Some(String::from_utf8_lossy(&buf).into_owned());
+        }
+    }
+}
+
+/// Parse the authority-form target `host:port` — bracketed v6 (`[::1]:443`)
+/// included. The host token must be free of whitespace/control chars: it is
+/// journalised verbatim to a terminal (the terminal-escape injection
+/// boundary) and fed to the matcher (a control char can never be a host).
+fn parse_authority(authority: &str) -> Option<(String, u16)> {
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let (v6, port) = rest.split_once("]:")?;
+        (v6, port)
+    } else {
+        authority.rsplit_once(':')?
+    };
+    if host.is_empty() || host.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return None;
+    }
+    let port: u16 = port.parse().ok()?;
+    Some((host.to_owned(), port))
+}
+
+/// The SOCKS5 handler (raw TCP — SSH, databases, everything that is not
+/// HTTP): greeting → no-auth method → CONNECT request → decide → tunnel.
+/// Only the CONNECT command is served; BIND/UDP-ASSOCIATE are refused
+/// (`0x07` command not supported).
+fn serve_socks5(mut client: TcpStream, allowlist: &[String], observer: &EgressObserver) {
+    // Greeting: VER=5, NMETHODS, methods… — answer no-auth (0x00) when
+    // offered, 0xFF ("no acceptable methods") otherwise.
+    let Some(greeting) = read_exact_buf(&mut client, 2) else {
+        return;
+    };
+    let nmethods = usize::from(greeting[1]);
+    let Some(methods) = read_exact_buf(&mut client, nmethods) else {
+        return;
+    };
+    if greeting[0] != 0x05 || nmethods == 0 || !methods.contains(&0x00) {
+        let _ = client.write_all(&[0x05, 0xFF]);
+        return;
+    }
+    if client.write_all(&[0x05, 0x00]).is_err() {
+        return;
+    }
+    // Request: VER CMD RSV ATYP ADDR PORT — CONNECT (0x01) only.
+    let Some(head) = read_exact_buf(&mut client, 4) else {
+        return;
+    };
+    if head[0] != 0x05 || head[1] != 0x01 {
+        let _ = client.write_all(&socks_reply(0x07));
+        return;
+    }
+    let Some((host, port)) = read_socks_address(&mut client, head[3]) else {
+        let _ = client.write_all(&socks_reply(0x08));
+        return;
+    };
+    if !decide(&host, port, allowlist, observer) {
+        let _ = client.write_all(&socks_reply(0x02)); // not allowed by ruleset
+        return;
+    }
+    let Ok(upstream) = dial_upstream(&host, port) else {
+        let _ = client.write_all(&socks_reply(0x05)); // connection refused
+        return;
+    };
+    if client.write_all(&socks_reply(0x00)).is_err() {
+        return;
+    }
+    relay(client, upstream);
+}
+
+/// Read exactly `n` bytes (handshake-sized — the read deadline bounds it).
+fn read_exact_buf(client: &mut TcpStream, n: usize) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; n];
+    client.read_exact(&mut buf).ok()?;
+    Some(buf)
+}
+
+/// Parse the SOCKS5 address body per ATYP: v4 (0x01), domain (0x03 — the
+/// form that keeps DNS on the proxy side, `socks5h`), v6 (0x04). Domain
+/// tokens pass through [`parse_authority`]'s host validation indirectly —
+/// a control/whitespace char can never be a host (or a journal line).
+fn read_socks_address(client: &mut TcpStream, atyp: u8) -> Option<(String, u16)> {
+    let host = match atyp {
+        0x01 => {
+            let b = read_exact_buf(client, 4)?;
+            Ipv4Addr::new(b[0], b[1], b[2], b[3]).to_string()
+        }
+        0x03 => {
+            let len = read_exact_buf(client, 1)?[0] as usize;
+            let b = read_exact_buf(client, len)?;
+            let h = String::from_utf8(b).ok()?;
+            if h.is_empty() || h.chars().any(|c| c.is_control() || c.is_whitespace()) {
+                return None;
+            }
+            h
+        }
+        0x04 => {
+            let b = read_exact_buf(client, 16)?;
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(&b);
+            std::net::Ipv6Addr::from(octets).to_string()
+        }
+        _ => return None,
+    };
+    let p = read_exact_buf(client, 2)?;
+    Some((host, u16::from_be_bytes([p[0], p[1]])))
+}
+
+/// A SOCKS5 reply with a nil bind address (`0.0.0.0:0`) — clients ignore
+/// the bind field on CONNECT replies.
+fn socks_reply(rep: u8) -> [u8; 10] {
+    [0x05, rep, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+}
+
+/// The env contract injected into an allowlisted child — mirrors srt's
+/// `generateProxyEnvVars` on the ONE muxed port: `HTTP(S)_PROXY` (both
+/// cases) for the CONNECT speakers, `ALL_PROXY` + `GRPC_PROXY` as the http
+/// URL (srt's own choice — gRPC C-core speaks CONNECT only, and Python
+/// httpx crashes on a socks URL it cannot import), `FTP_PROXY` on the
+/// `socks5h` form (transparent TCP), `RSYNC_PROXY` as bare host:port, and
+/// `NO_PROXY` for the loopback + RFC1918 direct set (srt's verbatim list).
+/// Every name is SET (both cases), so an ambient inherited value can never
+/// outrank the boundary — the confined child's only egress is the proxy.
+pub(crate) fn proxy_env(port: u16) -> [(&'static str, String); 13] {
+    let http = format!("http://127.0.0.1:{port}");
+    let socks = format!("socks5h://127.0.0.1:{port}");
+    let no_proxy = "localhost,127.0.0.1,::1,169.254.0.0/16,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16";
+    [
+        ("HTTP_PROXY", http.clone()),
+        ("http_proxy", http.clone()),
+        ("HTTPS_PROXY", http.clone()),
+        ("https_proxy", http.clone()),
+        ("ALL_PROXY", http.clone()),
+        ("all_proxy", http.clone()),
+        ("GRPC_PROXY", http.clone()),
+        ("grpc_proxy", http),
+        ("FTP_PROXY", socks.clone()),
+        ("ftp_proxy", socks),
+        ("RSYNC_PROXY", format!("127.0.0.1:{port}")),
+        ("NO_PROXY", no_proxy.to_owned()),
+        ("no_proxy", no_proxy.to_owned()),
+    ]
+}
+
+/// The guard the runner applies before reusing the running proxy: a second,
+/// DIFFERENT `permits.net.http` set in the same run is refused (fail-closed)
+/// rather than silently widened — the per-run proxy serves one boundary.
+pub(crate) fn conflicting_boundary(proxy: &EgressProxy, spec: &EgressAllowlist) -> bool {
+    proxy.allowlist() != spec.hosts.as_slice()
+}
+
+/// The runner-side wiring of the allowlist arm (kept here so `lib.rs` stays
+/// a lean process-lifecycle surface — this module owns the whole egress
+/// concern, proxy AND confinement hand-off).
+impl crate::TokioShell {
+    /// Apply the injected OS sandbox to a command that requests one. No spec =
+    /// unchanged (today's behavior); spec + backend = confined; spec but NO
+    /// backend = fail-closed (refuse rather than run an asked-for-confined
+    /// command unconfined).
+    ///
+    /// The `NetPolicy::Allowlist` arm first secures its per-run loopback
+    /// egress proxy (started lazily on first use): the child gets the proxy
+    /// env contract (srt-mirrored — every name SET, both cases, so ambient
+    /// values never outrank the boundary) and the spec handed to the backend
+    /// learns the proxy's port (the seatbelt fence scopes outbound loopback
+    /// to exactly it).
+    pub(super) fn apply_sandbox(
+        &self,
+        mut command: nika_kernel::ShellCommand,
+    ) -> Result<nika_kernel::ShellCommand, nika_kernel::ShellError> {
+        use nika_kernel::{ShellError, process::NetPolicy};
+        let Some(mut spec) = command.sandbox.take() else {
+            return Ok(command);
+        };
+        let Some(backend) = &self.sandbox else {
+            return Err(ShellError::Blocked {
+                reason: "command requires an OS sandbox but no backend is wired \
+                         (refusing to run unconfined)"
+                    .to_string(),
+            });
+        };
+        if let NetPolicy::Allowlist(allowlist) = &mut spec.net {
+            let port = self.ensure_egress_proxy(allowlist)?;
+            for (name, value) in proxy_env(port) {
+                command.env.insert(name.to_owned(), value);
+            }
+            allowlist.proxy_port = Some(port);
+        }
+        backend
+            .confine(&spec, command)
+            .map_err(|e| crate::map_sandbox_error(&e))
+    }
+
+    /// Secure the per-run loopback egress proxy for the allowlist arm:
+    /// started on first use, REUSED for the identical boundary, and a second
+    /// DIFFERENT `permits.net.http` set in the same run is refused
+    /// (fail-closed) rather than silently widened — one run, one boundary.
+    fn ensure_egress_proxy(
+        &self,
+        allowlist: &EgressAllowlist,
+    ) -> Result<u16, nika_kernel::ShellError> {
+        use nika_kernel::ShellError;
+        let mut cell = self.egress_proxy.lock().map_err(|_| ShellError::Other {
+            reason: "the egress proxy lock is poisoned".to_string(),
+        })?;
+        if let Some(proxy) = cell.as_ref() {
+            if conflicting_boundary(proxy, allowlist) {
+                return Err(ShellError::Blocked {
+                    reason: "a second, different permits.net.http set reached the \
+                             per-run egress proxy — refusing to widen the boundary \
+                             (one run, one allowlist)"
+                        .to_string(),
+                });
+            }
+            return Ok(proxy.port());
+        }
+        let proxy = EgressProxy::start(allowlist.hosts.clone(), Arc::clone(&self.egress_observer))
+            .map_err(|e| ShellError::Blocked {
+                reason: format!(
+                    "could not start the loopback egress proxy for the allowlist arm: {e}"
+                ),
+            })?;
+        let port = proxy.port();
+        *cell = Some(proxy);
+        Ok(port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A collecting observer — every decision the proxy journalised, in order.
+    #[derive(Clone, Default)]
+    struct Probe {
+        decisions: Arc<Mutex<Vec<EgressDecision>>>,
+    }
+
+    impl Probe {
+        fn observer(&self) -> EgressObserver {
+            let decisions = Arc::clone(&self.decisions);
+            Arc::new(move |d| {
+                if let Ok(mut v) = decisions.lock() {
+                    v.push(d.clone());
+                }
+            })
+        }
+
+        fn taken(&self) -> Vec<EgressDecision> {
+            self.decisions.lock().map(|v| v.clone()).unwrap_or_default()
+        }
+    }
+
+    /// A throwaway upstream: accepts one connection, echoes what it reads.
+    fn echo_upstream() -> (u16, JoinHandle<()>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind upstream");
+        let port = listener.local_addr().expect("addr").port();
+        let handle = std::thread::Builder::new()
+            .name("nika-egress-test-echo".to_owned())
+            .spawn(move || {
+                if let Ok((mut s, _)) = listener.accept() {
+                    let mut buf = [0u8; 64];
+                    if let Ok(n) = s.read(&mut buf) {
+                        let _ = s.write_all(&buf[..n]);
+                    }
+                }
+            })
+            .expect("echo thread");
+        (port, handle)
+    }
+
+    fn start(hosts: &[&str]) -> (EgressProxy, Probe) {
+        let probe = Probe::default();
+        let proxy = EgressProxy::start(
+            hosts.iter().map(|h| (*h).to_owned()).collect(),
+            probe.observer(),
+        )
+        .expect("proxy starts on loopback");
+        (proxy, probe)
+    }
+
+    fn dial(port: u16) -> TcpStream {
+        TcpStream::connect((Ipv4Addr::LOCALHOST, port)).expect("proxy accepts loopback")
+    }
+
+    #[test]
+    fn connect_allowed_relays_bytes_and_journals() {
+        let (upstream_port, echo) = echo_upstream();
+        let (proxy, probe) = start(&["127.0.0.1"]);
+        let mut c = dial(proxy.port());
+        write!(
+            c,
+            "CONNECT 127.0.0.1:{upstream_port} HTTP/1.1\r\nHost: x\r\n\r\n"
+        )
+        .unwrap();
+        let mut head = Vec::new();
+        let mut buf = [0u8; 128];
+        // read the 200 line, then the echoed payload through the tunnel
+        let n = c.read(&mut buf).unwrap();
+        head.extend_from_slice(&buf[..n]);
+        let text = String::from_utf8_lossy(&head);
+        assert!(text.contains("200 Connection Established"), "got: {text}");
+        c.write_all(b"PING").unwrap();
+        let n = c.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"PING", "the tunnel echoes both ways");
+        echo.join().unwrap();
+        let decisions = probe.taken();
+        assert_eq!(
+            decisions,
+            vec![EgressDecision {
+                host: "127.0.0.1".to_owned(),
+                port: upstream_port,
+                allowed: true,
+            }],
+            "the allowed decision is journalised"
+        );
+    }
+
+    #[test]
+    fn connect_refused_is_403_and_journalised_as_a_security_event() {
+        let (upstream_port, _echo) = echo_upstream();
+        let (proxy, probe) = start(&["example.com"]); // 127.0.0.1 NOT declared
+        let mut c = dial(proxy.port());
+        write!(c, "CONNECT 127.0.0.1:{upstream_port} HTTP/1.1\r\n\r\n").unwrap();
+        let mut buf = [0u8; 128];
+        let n = c.read(&mut buf).unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]);
+        assert!(text.starts_with("HTTP/1.1 403"), "refused: {text}");
+        let decisions = probe.taken();
+        assert_eq!(decisions.len(), 1);
+        assert!(!decisions[0].allowed, "the refusal is the security event");
+        assert_eq!(decisions[0].host, "127.0.0.1");
+    }
+
+    #[test]
+    fn socks5_allowed_relays_and_journals() {
+        let (upstream_port, echo) = echo_upstream();
+        let (proxy, probe) = start(&["127.0.0.1"]);
+        let mut c = dial(proxy.port());
+        // greeting: VER=5, 1 method, no-auth
+        c.write_all(&[0x05, 0x01, 0x00]).unwrap();
+        let mut reply = [0u8; 2];
+        c.read_exact(&mut reply).unwrap();
+        assert_eq!(reply, [0x05, 0x00], "no-auth accepted");
+        // CONNECT 127.0.0.1:port (ATYP v4)
+        let mut req = vec![0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1];
+        req.extend_from_slice(&upstream_port.to_be_bytes());
+        c.write_all(&req).unwrap();
+        let mut granted = [0u8; 10];
+        c.read_exact(&mut granted).unwrap();
+        assert_eq!(granted[1], 0x00, "succeeded: {granted:?}");
+        c.write_all(b"PONG").unwrap();
+        let mut buf = [0u8; 4];
+        c.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"PONG");
+        echo.join().unwrap();
+        assert_eq!(
+            probe.taken(),
+            vec![EgressDecision {
+                host: "127.0.0.1".to_owned(),
+                port: upstream_port,
+                allowed: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn socks5_refused_domain_is_ruleset_denied_and_journalised() {
+        let (proxy, probe) = start(&["example.com"]);
+        let mut c = dial(proxy.port());
+        c.write_all(&[0x05, 0x01, 0x00]).unwrap();
+        let mut reply = [0u8; 2];
+        c.read_exact(&mut reply).unwrap();
+        // CONNECT evil.com:443 (ATYP domain)
+        let host = b"evil.com";
+        let mut req = vec![0x05, 0x01, 0x00, 0x03, u8::try_from(host.len()).unwrap()];
+        req.extend_from_slice(host);
+        req.extend_from_slice(&443u16.to_be_bytes());
+        c.write_all(&req).unwrap();
+        let mut granted = [0u8; 10];
+        c.read_exact(&mut granted).unwrap();
+        assert_eq!(granted[1], 0x02, "not allowed by ruleset: {granted:?}");
+        assert_eq!(
+            probe.taken(),
+            vec![EgressDecision {
+                host: "evil.com".to_owned(),
+                port: 443,
+                allowed: false,
+            }]
+        );
+    }
+
+    /// The wire verdict IS the ONE matcher's verdict: for a battery of
+    /// (allowlist, host) rows, the proxy's decision over a real connection
+    /// equals `host_in_allowlist` — the same predicate `nika-http` and the
+    /// static check enforce (no second glob dialect, check ≡ run ≡ jail).
+    #[test]
+    fn the_wire_decision_is_the_shared_matchers_decision() {
+        let hosts = ["api.example.com", "*.github.com"];
+        let cases: &[(&str, bool)] = &[
+            ("api.example.com", true),
+            ("API.example.com", true), // case-insensitive (RFC 4343)
+            ("github.com", true),      // *.x admits the bare apex
+            ("raw.github.com", true),
+            ("github.com.evil.com", false),
+            ("example.com", false),
+            ("127.0.0.1", false),
+        ];
+        let owned: Vec<String> = hosts.iter().map(|h| (*h).to_owned()).collect();
+        for (host, _) in cases {
+            assert_eq!(
+                nika_types::net::host_in_allowlist(&owned, host),
+                decide(host, 443, &owned, &Probe::default().observer()),
+                "wire ≡ matcher for {host}"
+            );
+        }
+        // …and the bare-* hatch opens every row (the explicit escape hatch).
+        let star = vec!["*".to_owned()];
+        assert!(decide(
+            "anything.test",
+            443,
+            &star,
+            &Probe::default().observer()
+        ));
+    }
+
+    #[test]
+    fn a_non_connect_request_gets_an_honest_405() {
+        let (proxy, _probe) = start(&["example.com"]);
+        let mut c = dial(proxy.port());
+        write!(
+            c,
+            "GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        )
+        .unwrap();
+        let mut buf = [0u8; 128];
+        let n = c.read(&mut buf).unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]);
+        assert!(text.starts_with("HTTP/1.1 405"), "got: {text}");
+    }
+
+    #[test]
+    fn authority_parsing_is_strict() {
+        assert_eq!(
+            parse_authority("api.example.com:443"),
+            Some(("api.example.com".to_owned(), 443))
+        );
+        assert_eq!(
+            parse_authority("[::1]:8443"),
+            Some(("::1".to_owned(), 8443))
+        );
+        // a control char or space can never ride into a journal line
+        assert!(parse_authority("evil.com:443\n(allow").is_none());
+        assert!(parse_authority("evil host:443").is_none());
+        assert!(parse_authority(":443").is_none());
+        assert!(parse_authority("host:notaport").is_none());
+        assert!(parse_authority("host:99999").is_none());
+    }
+
+    /// The no-orphan assertion, robust under the plain-`cargo test` shared
+    /// process: a freed ephemeral port can be RE-BOUND by a parallel test's
+    /// own proxy, so a bare `connect` failing is not the only green outcome.
+    /// What must NEVER answer is OUR proxy: probe `127.0.0.2` (loopback, no
+    /// DNS, in NO other test's allowlist) — our zombie would 502 it
+    /// (allowlisted, undialable), a dead port refuses, a foreign proxy 403s.
+    fn assert_no_orphan_on(port: u16, probe_hosts: &[&str]) {
+        for host in probe_hosts {
+            let Ok(mut c) = TcpStream::connect((Ipv4Addr::LOCALHOST, port)) else {
+                continue; // dead, as required
+            };
+            let _ = c.set_read_timeout(Some(Duration::from_secs(2)));
+            let _ = write!(c, "CONNECT {host}:9 HTTP/1.1\r\n\r\n");
+            let mut buf = [0u8; 64];
+            let n = c.read(&mut buf).unwrap_or(0);
+            let text = String::from_utf8_lossy(&buf[..n]);
+            assert!(
+                !text.contains("502"),
+                "an orphan egress listener outlived its run on :{port}: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_dies_with_its_owner_no_orphan_listener() {
+        let (proxy, _probe) = start(&["127.0.0.2"]);
+        let port = proxy.port();
+        dial(port); // alive: the listener answers
+        drop(proxy);
+        assert_no_orphan_on(port, &["127.0.0.2"]);
+    }
+
+    #[test]
+    fn boundary_reuse_and_conflict_detection() {
+        let (proxy, _probe) = start(&["a.test", "b.test"]);
+        let same = EgressAllowlist::new(vec!["a.test".to_owned(), "b.test".to_owned()]);
+        let other = EgressAllowlist::new(vec!["c.test".to_owned()]);
+        assert!(!conflicting_boundary(&proxy, &same));
+        assert!(conflicting_boundary(&proxy, &other));
+    }
+
+    #[test]
+    fn proxy_env_mirrors_the_srt_contract_on_one_muxed_port() {
+        let env = proxy_env(60080);
+        let get = |k: &str| env.iter().find(|(n, _)| *n == k).map(|(_, v)| v.as_str());
+        assert_eq!(get("HTTP_PROXY"), Some("http://127.0.0.1:60080"));
+        assert_eq!(get("https_proxy"), Some("http://127.0.0.1:60080"));
+        assert_eq!(get("ALL_PROXY"), Some("http://127.0.0.1:60080"));
+        assert_eq!(get("grpc_proxy"), Some("http://127.0.0.1:60080"));
+        assert_eq!(get("FTP_PROXY"), Some("socks5h://127.0.0.1:60080"));
+        assert_eq!(get("RSYNC_PROXY"), Some("127.0.0.1:60080"));
+        let no_proxy = get("NO_PROXY").expect("NO_PROXY set");
+        for want in [
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            "10.0.0.0/8",
+            "192.168.0.0/16",
+        ] {
+            assert!(no_proxy.contains(want), "NO_PROXY missing {want}");
+        }
+        assert_eq!(get("no_proxy"), get("NO_PROXY"), "both cases, one value");
+    }
+
+    // ── the runner wiring (apply_sandbox · the allowlist arm end-to-end) ──
+
+    use nika_kernel::command_sandbox::{CommandSandbox, CommandSandboxError};
+    use nika_kernel::process::{NetPolicy, SandboxSpec};
+    use nika_kernel::{ShellCommand, ShellError};
+
+    /// A backend that records the spec + env it confined (pass-through).
+    #[derive(Debug, Default)]
+    struct CaptureSandbox {
+        seen: Mutex<Vec<(SandboxSpec, std::collections::BTreeMap<String, String>)>>,
+    }
+
+    impl CommandSandbox for CaptureSandbox {
+        fn confine(
+            &self,
+            spec: &SandboxSpec,
+            command: ShellCommand,
+        ) -> Result<ShellCommand, CommandSandboxError> {
+            if let Ok(mut v) = self.lock() {
+                v.push((spec.clone(), command.env.clone()));
+            }
+            Ok(command)
+        }
+        fn backend(&self) -> &'static str {
+            "capture"
+        }
+    }
+
+    impl CaptureSandbox {
+        #[allow(clippy::type_complexity)]
+        fn lock(
+            &self,
+        ) -> std::sync::LockResult<
+            std::sync::MutexGuard<
+                '_,
+                Vec<(SandboxSpec, std::collections::BTreeMap<String, String>)>,
+            >,
+        > {
+            self.seen.lock()
+        }
+    }
+
+    fn allowlisted(hosts: &[&str]) -> SandboxSpec {
+        let mut spec = SandboxSpec::new();
+        spec.net = NetPolicy::Allowlist(EgressAllowlist::new(
+            hosts.iter().map(|h| (*h).to_owned()).collect(),
+        ));
+        spec
+    }
+
+    fn confined(shell: &crate::TokioShell, spec: SandboxSpec) -> ShellCommand {
+        let mut cmd = ShellCommand::new("echo");
+        cmd.args = vec!["x".to_owned()];
+        cmd.sandbox = Some(spec);
+        shell.apply_sandbox(cmd).expect("confined")
+    }
+
+    #[test]
+    fn allowlist_arm_injects_the_env_and_the_proxy_port() {
+        let backend = Arc::new(CaptureSandbox::default());
+        let probe = Probe::default();
+        let shell =
+            crate::TokioShell::with_sandbox(backend.clone()).with_egress_observer(probe.observer());
+        let out = confined(&shell, allowlisted(&["api.example.com", "127.0.0.2"]));
+
+        // the srt env contract points at the running proxy, both cases set
+        let url = out.env.get("HTTP_PROXY").expect("HTTP_PROXY injected");
+        let port: u16 = url
+            .strip_prefix("http://127.0.0.1:")
+            .expect("loopback url")
+            .parse()
+            .expect("a port");
+        assert_eq!(out.env.get("https_proxy"), Some(url));
+        assert_eq!(
+            out.env.get("ALL_PROXY").map(String::as_str),
+            Some(url.as_str())
+        );
+        assert!(out.env.contains_key("NO_PROXY"));
+
+        // the spec the backend confined carries the proxy's port (the
+        // seatbelt fence scopes loopback to exactly it)
+        let seen = backend.lock().unwrap();
+        let (spec, _) = &seen[0];
+        match &spec.net {
+            NetPolicy::Allowlist(a) => assert_eq!(a.proxy_port, Some(port)),
+            other => panic!("expected allowlist, got {other:?}"),
+        }
+        drop(seen);
+
+        // a second command with the SAME boundary reuses the SAME proxy
+        let out2 = confined(&shell, allowlisted(&["api.example.com", "127.0.0.2"]));
+        assert_eq!(out2.env.get("HTTP_PROXY"), Some(url));
+
+        // and the proxy refuses a non-declared host WITH the journal line
+        let mut c = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).unwrap();
+        write!(c, "CONNECT evil.com:443 HTTP/1.1\r\n\r\n").unwrap();
+        let mut buf = [0u8; 64];
+        let n = c.read(&mut buf).unwrap();
+        assert!(String::from_utf8_lossy(&buf[..n]).starts_with("HTTP/1.1 403"));
+        let decisions = probe.taken();
+        assert_eq!(decisions.len(), 1);
+        assert!(!decisions[0].allowed, "the refused host is journalised");
+        assert_eq!(decisions[0].host, "evil.com");
+
+        // the proxy dies with the shell — no orphan listener
+        drop(shell);
+        assert_no_orphan_on(port, &["127.0.0.2"]);
+    }
+
+    #[test]
+    fn deny_and_allow_arms_start_no_proxy_and_inject_no_env() {
+        for arm in [NetPolicy::Deny, NetPolicy::Allow] {
+            let backend = Arc::new(CaptureSandbox::default());
+            let shell = crate::TokioShell::with_sandbox(backend);
+            let mut spec = SandboxSpec::new();
+            spec.net = arm.clone();
+            let out = confined(&shell, spec);
+            assert!(
+                !out.env.contains_key("HTTP_PROXY") && !out.env.contains_key("http_proxy"),
+                "arm {arm:?} injects no proxy env"
+            );
+            assert!(
+                shell.egress_proxy.lock().unwrap().is_none(),
+                "arm {arm:?} starts no proxy"
+            );
+        }
+    }
+
+    #[test]
+    fn a_conflicting_boundary_in_one_run_is_refused_fail_closed() {
+        let backend = Arc::new(CaptureSandbox::default());
+        let shell = crate::TokioShell::with_sandbox(backend);
+        let _ = confined(&shell, allowlisted(&["a.test"]));
+        let mut cmd = ShellCommand::new("echo");
+        cmd.sandbox = Some(allowlisted(&["b.test"]));
+        let err = shell.apply_sandbox(cmd).unwrap_err();
+        assert!(
+            matches!(err, ShellError::Blocked { .. }),
+            "a second boundary must not widen the per-run proxy: {err}"
+        );
+    }
+
+    #[test]
+    fn allowlist_without_a_backend_is_refused_before_the_proxy_starts() {
+        let shell = crate::TokioShell::new(); // no backend wired
+        let mut cmd = ShellCommand::new("echo");
+        cmd.sandbox = Some(allowlisted(&["a.test"]));
+        assert!(matches!(
+            shell.apply_sandbox(cmd),
+            Err(ShellError::Blocked { .. })
+        ));
+        assert!(
+            shell.egress_proxy.lock().unwrap().is_none(),
+            "a refused command starts no proxy"
+        );
+    }
+}

--- a/crates/nika-exec-runner/src/lib.rs
+++ b/crates/nika-exec-runner/src/lib.rs
@@ -35,6 +35,17 @@
 //! is a TRIPWIRE, not a boundary — `permits.exec` + the sandbox are the real
 //! gates (a glob/symlink in `$PATH` resolution is theirs to contain).
 //!
+//! # Egress proxy (the sandbox `allowlist` arm · ADR-095 Layer 6)
+//!
+//! The `egress` module is the per-run loopback proxy that gives the
+//! sandbox's network tri-state its host granularity (the Anthropic
+//! sandbox-runtime model): when a confined command carries
+//! `NetPolicy::Allowlist`, the runner starts (or reuses) the ONE proxy,
+//! injects the srt-mirrored env contract (`HTTP(S)_PROXY` / `ALL_PROXY` /
+//! `NO_PROXY` … on the muxed CONNECT+SOCKS5 port), and lets the OS fence
+//! admit loopback only. Every target is evaluated against the ONE host
+//! matcher and every decision journalised (see the `egress` module doc).
+//!
 //! # Process safety (kernel CANCEL SAFETY contract)
 //!
 //! - **`kill_on_drop(true)`** (INV-011) — dropping the `run()` future SIGKILLs
@@ -52,6 +63,9 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod blocklist;
+mod egress;
+
+pub use egress::{EgressDecision, EgressObserver};
 
 use std::collections::BTreeMap;
 use std::process::Stdio;
@@ -97,7 +111,9 @@ type Registry = Arc<Mutex<BTreeMap<u32, Arc<Notify>>>>;
 /// the safe-by-default floor; `kill_on_drop` + the registry give cancellation.
 /// An optional injected [`CommandSandbox`] (the `nika-sandbox-{seatbelt,
 /// landlock}` backends) confines a command that carries a `SandboxSpec`.
-#[derive(Clone, Default)]
+/// Clones of one `TokioShell` share ONE loopback egress proxy (started lazily
+/// on the first allowlisted exec, dying with the last clone — per-run).
+#[derive(Clone)]
 pub struct TokioShell {
     registry: Registry,
     /// The OS-confinement backend (injected by the wiring layer · `None` =
@@ -111,6 +127,15 @@ pub struct TokioShell {
     /// `env:` (explicit intent wins over the ambient scrub · see `run`). Empty
     /// = today's behavior (inherit all). `Arc<[…]>` for a cheap `Clone`.
     ambient_secret_env: Arc<[String]>,
+    /// The per-run loopback egress proxy (the `NetPolicy::Allowlist` arm's
+    /// enforcement half) — `Arc`-shared so every clone of this shell serves
+    /// the SAME boundary on the SAME port; started lazily, stopped when the
+    /// last clone drops (no orphan listener outlives the run).
+    egress_proxy: Arc<Mutex<Option<egress::EgressProxy>>>,
+    /// The egress-decision journal sink (every proxy verdict — a refused
+    /// host is a security event). Default: the namespaced stderr line (see
+    /// the `egress` module doc for the FCI-009 seam rationale).
+    egress_observer: EgressObserver,
 }
 
 impl std::fmt::Debug for TokioShell {
@@ -118,6 +143,18 @@ impl std::fmt::Debug for TokioShell {
         f.debug_struct("TokioShell")
             .field("sandbox", &self.sandbox.as_ref().map(|s| s.backend()))
             .finish_non_exhaustive()
+    }
+}
+
+impl Default for TokioShell {
+    fn default() -> Self {
+        Self {
+            registry: Registry::default(),
+            sandbox: None,
+            ambient_secret_env: Arc::default(),
+            egress_proxy: Arc::new(Mutex::new(None)),
+            egress_observer: egress::stderr_journal(),
+        }
     }
 }
 
@@ -139,6 +176,16 @@ impl TokioShell {
             sandbox: Some(sandbox),
             ..Self::default()
         }
+    }
+
+    /// Replace the egress-decision journal sink (the allowlist arm's
+    /// allow/refuse verdicts). The default is the namespaced stderr line —
+    /// the honest out-of-band channel (FCI-009 · see the `egress` module
+    /// doc); tests and embedders wire a collecting probe here. Chainable.
+    #[must_use]
+    pub fn with_egress_observer(mut self, observer: EgressObserver) -> Self {
+        self.egress_observer = observer;
+        self
     }
 
     /// Scrub the ENGINE's ambient provider API keys from every child's
@@ -169,26 +216,6 @@ impl TokioShell {
     fn deregister(&self, pid: u32) {
         if let Ok(mut reg) = self.registry.lock() {
             reg.remove(&pid);
-        }
-    }
-
-    /// Apply the injected OS sandbox to a command that requests one. No spec =
-    /// unchanged (today's behavior); spec + backend = confined; spec but NO
-    /// backend = fail-closed (refuse rather than run an asked-for-confined
-    /// command unconfined).
-    fn apply_sandbox(&self, command: ShellCommand) -> Result<ShellCommand, ShellError> {
-        let Some(spec) = command.sandbox.clone() else {
-            return Ok(command);
-        };
-        match &self.sandbox {
-            Some(backend) => backend
-                .confine(&spec, command)
-                .map_err(|e| map_sandbox_error(&e)),
-            None => Err(ShellError::Blocked {
-                reason: "command requires an OS sandbox but no backend is wired \
-                         (refusing to run unconfined)"
-                    .to_string(),
-            }),
         }
     }
 }

--- a/crates/nika-sandbox-landlock/src/lib.rs
+++ b/crates/nika-sandbox-landlock/src/lib.rs
@@ -17,14 +17,20 @@
 //! ## What the jail enforces (deny-default)
 //!
 //! - **Network** — the [`NetPolicy`] tri-state: `Deny` keeps the network
-//!   namespace unshared (`--unshare-all`); `Allow` re-shares it
-//!   (`--share-net`). `Allowlist` — host-granular egress — confines EXACTLY
-//!   as `Allow` until the per-run loopback egress proxy lands (the
-//!   pre-tri-state behavior, zero regression · matching the macOS sibling).
-//!   The proxy then serves the declared host set over the shared namespace +
-//!   the env contract; scoping the namespace itself to loopback needs the
-//!   socat/unix-socket bridge of the sandbox-runtime model (named follow-on,
-//!   honestly — bwrap cannot express a loopback-only fence alone).
+//!   namespace unshared (`--unshare-all` — loopback included, the stricter
+//!   reading of the loopback-only floor: bwrap cannot bring `lo` up alone);
+//!   `Allow` re-shares it (`--share-net`, the explicit escape hatch);
+//!   `Allowlist` re-shares it too and the child gets the egress proxy's env
+//!   contract (the Anthropic sandbox-runtime model — the proxy in
+//!   `nika-exec-runner` serves exactly the declared `permits.net.http` set).
+//!   HONEST LIMIT, stated loudly: bwrap cannot express a loopback-only
+//!   fence, so on Linux the allowlist arm's OS floor is the env contract —
+//!   an env-honoring client (curl · wget · node · python) is confined to
+//!   the allowlist, while a client that strips its proxy env reaches
+//!   anything (unlike macOS, where the Seatbelt port fence closes that).
+//!   srt's own answer — `--unshare-net` + a socat bridge over a
+//!   bind-mounted unix socket pair — is the named follow-on that brings
+//!   Linux to the same strength.
 //! - **Writes** — allowed ONLY under the declared `fs_write` prefixes plus
 //!   scratch (`--bind`). Everything else is read-only or absent.
 //! - **Reads** — the system paths every binary + the dynamic linker need are
@@ -169,13 +175,12 @@ fn build_jail_args(spec: &SandboxSpec) -> Result<Vec<String>, CommandSandboxErro
 
     // Network: `--unshare-all` already dropped the net namespace. The ALLOW
     // arms re-share it and bind the resolver config read-only — Allow (the
-    // explicit escape hatch) and Allowlist, which rides the same shared
-    // namespace until the egress proxy lands (the pre-tri-state behavior ·
-    // module doc); the proxy then serves the declared hosts over it and a
-    // loopback-only namespace fence needs the socat/unix-socket bridge
-    // (named follow-on). Every other arm — Deny and, by the
-    // #[non_exhaustive] law, any future variant — fails CLOSED: the
-    // namespace stays unshared, no network physically.
+    // explicit escape hatch) and Allowlist, which shares the namespace so
+    // the loopback egress proxy is reachable and serves the declared hosts
+    // via the env contract (the srt model · bwrap cannot fence loopback-only
+    // — the socat bridge is the named follow-on · module doc). Every other
+    // arm — Deny and, by the #[non_exhaustive] law, any future variant —
+    // fails CLOSED: the namespace stays unshared, no network physically.
     if matches!(spec.net, NetPolicy::Allow | NetPolicy::Allowlist(_)) {
         a.push("--share-net".to_owned());
         if Path::new("/etc/resolv.conf").exists() {
@@ -390,11 +395,12 @@ mod tests {
         );
     }
 
-    /// The allowlist arm rides the shared namespace until the egress proxy
-    /// lands (the pre-tri-state behavior · module doc) — then the proxy
-    /// serves the declared hosts over it.
+    /// The allowlist arm rides the shared namespace + the proxy's env
+    /// contract (the srt model — bwrap cannot fence loopback-only, so the
+    /// env contract IS the Linux floor; the socat bridge is the named
+    /// follow-on · module doc).
     #[test]
-    fn allowlist_rides_the_shared_namespace_pre_proxy() {
+    fn allowlist_rides_the_shared_namespace_and_the_env_contract() {
         let mut spec = SandboxSpec::new();
         spec.net = NetPolicy::Allowlist(nika_kernel::process::EgressAllowlist::new(vec![
             "api.example.com".to_owned(),
@@ -402,7 +408,7 @@ mod tests {
         let args = build_jail_args(&spec).unwrap();
         assert!(
             args.iter().any(|a| a == "--share-net"),
-            "allowlist confines as allow pre-proxy"
+            "the allowlist arm shares the namespace so the loopback proxy is reachable"
         );
     }
 

--- a/crates/nika-sandbox-seatbelt/src/lib.rs
+++ b/crates/nika-sandbox-seatbelt/src/lib.rs
@@ -13,14 +13,16 @@
 //!
 //! ## What the profile enforces (deny-default)
 //!
-//! - **Network** — the [`NetPolicy`] tri-state: `Deny` keeps network out of
-//!   the profile entirely (`(deny default)` holds); `Allow` emits
-//!   `(allow network*)`. `Allowlist` — host-granular egress — confines
-//!   EXACTLY as `Allow` until the per-run loopback egress proxy lands (the
-//!   pre-tri-state `allow_network = true` behavior, zero regression): the
-//!   proxy then fences this arm to loopback-only + injects its env contract
-//!   (the Anthropic sandbox-runtime model · a Seatbelt host rule is
-//!   TLS-blind, so the allowlist is the proxy's job, not the profile's).
+//! - **Network** — the [`NetPolicy`] tri-state (the Anthropic sandbox-runtime
+//!   seatbelt model, verified live against `sandbox-exec`): `Deny` admits
+//!   loopback outbound ONLY (`(allow network-outbound (remote ip
+//!   "localhost:*"))` — no syscall goes beyond loopback); `Allow` emits
+//!   `(allow network*)` (the explicit escape hatch); `Allowlist` admits
+//!   outbound loopback scoped to the per-run egress proxy's PORT
+//!   (`(remote ip "localhost:PORT")`) — the proxy (in `nika-exec-runner`)
+//!   serves exactly the declared `permits.net.http` set and the child gets
+//!   its env contract, because a Seatbelt host rule is TLS-blind: the
+//!   profile fences the CHANNEL, the proxy fences the HOSTS.
 //! - **Writes** — allowed ONLY under the declared `fs_write` prefixes plus
 //!   scratch. Everything else (home, the repo, `/etc`) is read-only-or-denied.
 //! - **Reads** — the system paths every binary + the dynamic linker need are
@@ -120,17 +122,32 @@ fn build_profile(spec: &SandboxSpec) -> Result<String, CommandSandboxError> {
         );
     }
 
-    // The open arms: Allow (the explicit escape hatch) and Allowlist — the
-    // allowlist confines EXACTLY as Allow until the loopback egress proxy
-    // lands (see the module doc — the pre-tri-state `allow_network = true`
-    // behavior, never a silent partial). The proxy then fences this arm to
-    // loopback-only and serves the declared host set; a Seatbelt host rule
-    // is TLS-blind, so the allowlist itself is the proxy's job, never the
-    // profile's. Every other arm — Deny and, by the #[non_exhaustive] law,
-    // any future variant — fails CLOSED: network stays denied by
-    // `(deny default)`, the load-bearing line.
-    if matches!(spec.net, NetPolicy::Allow | NetPolicy::Allowlist(_)) {
-        p.push_str("(allow network*)\n");
+    // The network arms (the Anthropic sandbox-runtime seatbelt model —
+    // verified live against sandbox-exec on macOS):
+    //
+    // - Allow (the explicit escape hatch): unrestricted — `(allow network*)`.
+    // - Allowlist: outbound loopback ONLY, scoped to the egress proxy's port
+    //   when the runner has started it (`proxy_port` — always filled by the
+    //   runner; `None` only for a spec that never passed one). The allowlist
+    //   itself is the proxy's job: a Seatbelt host rule is TLS-blind, so the
+    //   profile fences the CHANNEL and the proxy fences the HOSTS.
+    // - Deny (and, by the #[non_exhaustive] law, any future arm): loopback
+    //   outbound only — no network syscall goes BEYOND loopback (the
+    //   sandbox-runtime posture: local services stay reachable, egress is
+    //   refused). Fail-closed, one rule, no exceptions.
+    match &spec.net {
+        NetPolicy::Allow => p.push_str("(allow network*)\n"),
+        NetPolicy::Allowlist(allowlist) => {
+            let scope = match allowlist.proxy_port {
+                Some(port) => port.to_string(),
+                None => "*".to_owned(),
+            };
+            let _ = writeln!(
+                p,
+                "(allow network-outbound (remote ip \"localhost:{scope}\"))"
+            );
+        }
+        _ => p.push_str("(allow network-outbound (remote ip \"localhost:*\"))\n"),
     }
 
     Ok(p)
@@ -393,7 +410,11 @@ mod tests {
         assert!(denied.contains("(deny default)"));
         assert!(
             !denied.contains("(allow network*)"),
-            "network denied by default"
+            "no unrestricted network by default"
+        );
+        assert!(
+            denied.contains("(allow network-outbound (remote ip \"localhost:*\"))"),
+            "the deny arm admits loopback outbound only (the srt posture)"
         );
 
         let mut allow = SandboxSpec::new();
@@ -402,19 +423,30 @@ mod tests {
     }
 
     #[test]
-    fn allowlist_confines_as_allow_until_the_egress_proxy_lands() {
-        // The transitional mapping (module doc): host-granular egress needs
-        // the loopback proxy — until it lands, the allowlist arm keeps the
-        // pre-tri-state `allow_network = true` behavior, zero regression.
+    fn allowlist_fences_outbound_loopback_to_the_proxy_port() {
+        // The srt seatbelt line: the channel is fenced to the proxy's port;
+        // the proxy (not the profile) fences the hosts — a Seatbelt host
+        // rule is TLS-blind.
+        let mut spec = SandboxSpec::new();
+        let mut allowlist =
+            nika_kernel::process::EgressAllowlist::new(vec!["api.example.com".to_owned()]);
+        allowlist.proxy_port = Some(60080);
+        spec.net = NetPolicy::Allowlist(allowlist);
+        let p = build_profile(&spec).unwrap();
+        assert!(
+            p.contains("(allow network-outbound (remote ip \"localhost:60080\"))"),
+            "port-scoped fence: {p}"
+        );
+        assert!(!p.contains("(allow network*)"), "never unrestricted");
+
+        // A spec that never passed the runner (no proxy yet) degrades to
+        // loopback-any — fail-closed, the allowlist simply cannot be served.
         let mut spec = SandboxSpec::new();
         spec.net = NetPolicy::Allowlist(nika_kernel::process::EgressAllowlist::new(vec![
             "api.example.com".to_owned(),
         ]));
         let p = build_profile(&spec).unwrap();
-        assert!(
-            p.contains("(allow network*)"),
-            "allowlist confines as allow pre-proxy"
-        );
+        assert!(p.contains("(allow network-outbound (remote ip \"localhost:*\"))"));
     }
 
     #[test]

--- a/crates/nika-sandbox-seatbelt/tests/seatbelt_jail.rs
+++ b/crates/nika-sandbox-seatbelt/tests/seatbelt_jail.rs
@@ -148,3 +148,72 @@ fn ordinary_command_still_runs_under_the_sandbox() {
     );
     assert!(String::from_utf8_lossy(&out.stdout).contains("SCRATCH-OK"));
 }
+
+/// THE EGRESS FENCE (the sandbox-runtime seatbelt model, live): under the
+/// `allowlist` arm with the proxy port filled, a confined child CAN reach
+/// loopback on exactly the proxy's port and is EPERM-refused on every other
+/// port — the channel is fenced, so the loopback proxy (which lives OUTSIDE
+/// the jail) is the child's only way out. And under `deny`, loopback is
+/// reachable but nothing beyond it (the mission's carve-out).
+#[test]
+fn allowlist_fences_loopback_to_the_proxy_port() {
+    use std::net::{Ipv4Addr, TcpListener};
+
+    if !SeatbeltSandbox::available() {
+        return;
+    }
+    // The "proxy" listener and an "other service" listener, both loopback.
+    let proxy = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind proxy");
+    let proxy_port = proxy.local_addr().expect("addr").port();
+    let other = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind other");
+    let other_port = other.local_addr().expect("addr").port();
+    // drain both so a successful connect never hangs nc
+    for l in [proxy, other] {
+        std::thread::spawn(move || {
+            while let Ok((s, _)) = l.accept() {
+                drop(s);
+            }
+        });
+    }
+
+    let mut spec = SandboxSpec::new();
+    let mut allowlist = nika_kernel::process::EgressAllowlist::new(vec!["api.example.com".into()]);
+    allowlist.proxy_port = Some(proxy_port);
+    spec.net = nika_kernel::process::NetPolicy::Allowlist(allowlist);
+
+    // 1. loopback on the PROXY port: reachable from inside the jail.
+    let out = run(
+        &spec,
+        "/usr/bin/nc",
+        &["-w", "2", "127.0.0.1", &proxy_port.to_string()],
+    );
+    assert!(
+        out.status.success(),
+        "the proxy port must be reachable under allowlist: {out:?}"
+    );
+
+    // 2. loopback on any OTHER port: EPERM (the fence) — not a TCP-level
+    //    "Connection refused" (a listener is present), the sandbox verdict.
+    let out = run(
+        &spec,
+        "/usr/bin/nc",
+        &["-w", "2", "127.0.0.1", &other_port.to_string()],
+    );
+    assert!(!out.status.success(), "another port must be fenced");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("Operation not permitted"),
+        "the refusal is the seatbelt EPERM, not a refused TCP: {out:?}"
+    );
+
+    // 3. the DENY arm: loopback outbound is allowed (the carve-out) — the
+    //    same connect succeeds where pre-tri-state deny admitted nothing.
+    let out = run(
+        &SandboxSpec::new(),
+        "/usr/bin/nc",
+        &["-w", "2", "127.0.0.1", &other_port.to_string()],
+    );
+    assert!(
+        out.status.success(),
+        "deny admits loopback outbound (the srt posture): {out:?}"
+    );
+}

--- a/docs/crate-specs/nika-exec-runner.md
+++ b/docs/crate-specs/nika-exec-runner.md
@@ -6,7 +6,7 @@
 | Layer | L1 — effect crate · the only production site spawning PLAIN subprocesses (`tokio::process`) — one deliberate second site: `nika-mcp`’s stdio MCP client (a persistent pipe session the one-shot shell seam cannot express) |
 | Design | `TokioShell` impl of the L0.5 `nika_kernel::process` traits (`ShellRun` + `ShellCancel`) via the `*Dyn` (`Send`) companions · SECURITY-SENSITIVE (command blocklist + injection defense) |
 | LOC budget | well under the ≤1500/file + ≤15k/crate caps (enforced live by vectors 12+24) · live count · `scripts/crate-metrics.sh nika-exec-runner` |
-| LOC (live) | ~1412 LOC src (live · `scripts/crate-metrics.sh nika-exec-runner`) |
+| LOC (live) | ~2598 LOC src (live · `scripts/crate-metrics.sh nika-exec-runner`) |
 | Function cap | ≤100 lines each |
 | Crate version | tracks workspace |
 | License | `AGPL-3.0-or-later` |
@@ -29,6 +29,15 @@ capability gating.
 The only production site spawning PLAIN subprocesses (the second, deliberate site is `nika-mcp`’s stdio MCP client) — tests inject a mock.
 Effect-crate discipline (Invariant #27).
 
+It also hosts the **loopback egress proxy** (`src/egress.rs`) — the
+`sandbox.net = allowlist` arm's enforcement half (ADR-095 Layer 6 · the
+Anthropic sandbox-runtime model): a per-run `127.0.0.1:0` mux serving HTTP
+CONNECT + SOCKS5 (protocol-sniffed), evaluating every target against the
+ONE host matcher (`nika_types::net::host_in_allowlist`), injecting the
+srt-mirrored env contract into the confined child, and journalising every
+allow/refuse decision (the `EgressObserver` seam — default: the namespaced
+stderr line).
+
 ## 2. Public API
 
 ```rust
@@ -36,7 +45,10 @@ pub struct TokioShell { /* Arc<Mutex<registry>> for cancel-by-pid */ }
 
 impl TokioShell {
     pub fn new() -> Self;   // Clone (Arc-shared registry) · Default
+    pub fn with_egress_observer(self, o: EgressObserver) -> Self;  // the journal seam
 }
+pub struct EgressDecision { pub host, pub port, pub allowed }  // one proxy verdict
+pub type EgressObserver = Arc<dyn Fn(&EgressDecision) + Send + Sync>;
 impl ShellRunDyn    for TokioShell { run }
 impl ShellCancelDyn for TokioShell { cancel }
 ```

--- a/docs/crate-specs/nika-sandbox-landlock.md
+++ b/docs/crate-specs/nika-sandbox-landlock.md
@@ -32,10 +32,15 @@ ride the outer launcher so the confined child inherits them.
 ## 3. What the jail enforces (deny-default)
 
 - **Network** — the `spec.net` tri-state: `--unshare-all` drops the net
-  namespace (`deny`); `--share-net` re-adds it (`allow`, and `allowlist` until
-  the loopback egress proxy lands — the proxy then serves the declared hosts
-  over the shared namespace; a loopback-only fence needs the socat/unix-socket
-  bridge, the named follow-on).
+  namespace (`deny` — loopback included, the stricter reading: bwrap cannot
+  bring `lo` up alone); `--share-net` re-adds it (`allow`, and `allowlist`).
+  Under `allowlist` the child gets the loopback egress proxy's env contract
+  (the sandbox-runtime model — the proxy serves exactly the declared
+  `permits.net.http` set). HONEST LIMIT: bwrap cannot fence loopback-only,
+  so on Linux the allowlist arm's OS floor IS the env contract (an
+  env-stripping client is not fenced — unlike macOS's Seatbelt port fence);
+  srt's `--unshare-net` + socat-bridge-over-unix-socket is the named
+  follow-on that closes it.
 - **Writes** — read-write `--bind` only under the validated `fs_write` literal
   prefixes; everything else is read-only or absent.
 - **Reads** — the system trees (linker, libs, shell) are `--ro-bind`; declared

--- a/docs/crate-specs/nika-sandbox-seatbelt.md
+++ b/docs/crate-specs/nika-sandbox-seatbelt.md
@@ -31,10 +31,15 @@ the confined child inherits them.
 
 ## 3. The SBPL profile (the security heart · deny-default)
 
-- **Network** — the `spec.net` tri-state: `deny` keeps network out of the
-  profile; `allow` emits `(allow network*)`; `allowlist` confines as `allow`
-  until the loopback egress proxy lands (Seatbelt host filtering is TLS-blind,
-  so host-granular egress is the proxy's job, never the profile's).
+- **Network** — the `spec.net` tri-state (the Anthropic sandbox-runtime
+  seatbelt model, verified live against `sandbox-exec`): `deny` admits
+  loopback outbound only (`(remote ip "localhost:*")`); `allow` emits
+  `(allow network*)` (the explicit escape hatch); `allowlist` admits
+  loopback scoped to the per-run egress proxy's port
+  (`(remote ip "localhost:PORT")`) — the proxy (`nika-exec-runner`'s
+  CONNECT+SOCKS5 mux) serves exactly the declared `permits.net.http` set and
+  the child gets its env contract, because a Seatbelt host rule is
+  TLS-blind: the profile fences the CHANNEL, the proxy fences the HOSTS.
 - **Writes** allowed ONLY under declared `fs_write` prefixes + scratch.
 - **Reads** allow the system paths every binary + the dynamic linker need;
   declared `fs_read` prefixes added; sensitive home paths (`~/.ssh`) denied.


### PR DESCRIPTION
## Summary

Second half of the sandbox-network granularity mission (C11), stacked on **#658** (the tri-state — this branch contains it until #658 lands; `--base main` per protocol, so the diff shows both commits). Here the `allowlist` arm gets its enforcement: a **Rust loopback egress proxy** giving sandboxed exec network granularity — deny / allow / allowlist-from-`permits.net.http` — with every connection journalised.

This is the [Anthropic sandbox-runtime (srt)](https://github.com/anthropic-experimental/sandbox-runtime) model implemented in Nika (zero new dependencies — `std::net` + threads; cargo-deny stays green).

## What mirrors srt (each cited)

| srt | this PR |
|---|---|
| HTTP proxy + SOCKS5 proxy on the host; **mux serves both on one port** (their `macos-sandbox-utils.ts`: *"the mux serves both on one port"*) | `crates/nika-exec-runner/src/egress.rs`: one `127.0.0.1:0` listener, protocol sniffed on the first byte (`0x05` = SOCKS5, else CONNECT) |
| Seatbelt: *"allows communication only to a specific localhost port"* — `(allow network-outbound (remote ip "localhost:PORT"))` | `nika-sandbox-seatbelt`: `allowlist` arm emits exactly that line with the proxy's ephemeral port; `deny` admits loopback-outbound only (`localhost:*` — no syscall beyond loopback); `allow` = `network*` |
| `generateProxyEnvVars` (`sandbox-utils.ts`): `HTTP(S)_PROXY` (both cases) + `ALL_PROXY`/`GRPC_PROXY` as the http URL (gRPC speaks CONNECT; httpx crashes on socks URLs) + `FTP_PROXY` socks5h + `RSYNC_PROXY` + `NO_PROXY` = `localhost,127.0.0.1,::1,169.254.0.0/16,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` | same contract injected into the confined child (`egress::proxy_env`), every name SET in both cases so an ambient inherited value never outranks the boundary |
| *"Connection blocked by network allowlist"* + violation log | every decision journalised via the `EgressObserver` seam — refused host = security event, allowed = debug line |
| Linux: *"Currently uses environment variables … may be ignored by programs that don't respect these variables"* (their `--unshare-net` + socat bridge closes it) | **honest limit, documented in crate + crate-spec**: bwrap cannot fence loopback-only, so the Linux `allowlist` arm is `--share-net` + env contract; srt's socat/unix-socket bridge is the named follow-on. macOS gets the full port fence |

Deliberate deviations (documented): no per-session proxy auth token (srt itself: acceptable on a single-user machine; the seatbelt port fence + loopback-only bind are our channel fence); no `GIT_SSH_COMMAND` (it's on the runner's `DANGEROUS_ENV_VARS` strip list — overriding user ssh config is out of scope); plain-HTTP forward-proxy GETs get an honest `405` (CONNECT + SOCKS5 only); no DNS-rebinding IP re-check (srt declines this too — the `nika-http` effect's `GuardedResolver` owns that class for `nika:fetch`).

## Tri-state semantics (final, with #658)

| `permits:` declaration | arm | enforcement |
|---|---|---|
| `net:` absent · `net.http: []` | `Deny` (default, fail-closed) | seatbelt: loopback-outbound only · bwrap: net namespace unshared · **no proxy, no env** |
| `net.http: [hosts…]` | `Allowlist(hosts)` | per-run proxy started; child gets env contract; seatbelt fences loopback to the proxy port; proxy dials only hosts matching the ONE matcher (`nika_types::net::host_in_allowlist` — the same predicate `nika-http` + `nika check` enforce, check ≡ run ≡ jail) |
| `net.http: ["*"]` | `Allow` (explicit escape hatch only) | as today — unrestricted, no proxy |

## The threat closed

A hijacked exec task curling an attacker host is refused **even with the full user env**: the seatbelt fence admits loopback only on the proxy's port, the proxy refuses non-declared hosts (CONNECT → 403 · SOCKS5 → `0x02`), ambient proxy vars are overridden wholesale, and the refusal is journalised as a security event. **Verified live on this macOS host**: sandboxed `curl -x proxy --proxytunnel http://allowlisted/` succeeded through the fence (`ALLOWED-BY-PROXY` body via the tunnel); the direct bypass to the same loopback upstream failed in 0 ms (`curl: (7) Failed to connect` — the seatbelt EPERM).

## Journal decision (documented)

No new `EventKind`: the run journal's `EventSink` is a `&mut` threaded through the settle pass — an out-of-band proxy thread cannot reach it (FCI-009, the exact gap `nika-cli`'s `StderrEmitter` already documents). The `EgressObserver` seam receives every `EgressDecision { host, port, allowed }`; the default observer emits the namespaced stderr line (`nika:egress REFUSED host:port (not in permits.net.http)` / `nika:egress allowed host:port`), and tests/embedders inject a collecting probe via `TokioShell::with_egress_observer`. Not `tracing::warn!`: no workspace tracing subscriber exists, so a tracing call would journal into the void.

## Tests (all `cargo test --workspace --lib` · 59 in exec-runner alone)

- **matcher sharing**: battery of (allowlist, host) rows — the wire verdict IS `host_in_allowlist`'s verdict (no second glob dialect), incl. the bare-`*` hatch.
- **proxy allow/refuse over a real loopback TCP pair** (a local echo listener as upstream — no external network): CONNECT 200+tunnel echo, CONNECT 403+journal, SOCKS5 v4 allowed+echo, SOCKS5 domain refused (`0x02`)+journal, non-CONNECT → 405, strict authority parsing (control/whitespace chars rejected — the journal-line terminal-injection boundary).
- **deny arm**: no proxy started, no env injected (and `allow` likewise); `allowlist` injects the full srt env + `proxy_port` reaches the confined spec.
- **allowlist refuses a non-declared host WITH the journal line** (end-to-end at the runner level, collecting observer).
- **proxy dies with the run** — no orphan listener (race-hardened: a parallel test re-binding the freed ephemeral port cannot false-fail the assertion).
- **one run, one boundary**: a second, different `net.http` set is refused fail-closed; an allowlist spec with no sandbox backend is refused *before* the proxy starts.
- **tri-state derivation matrix** (in #658): absent→deny, declared→allowlist, `*`→allow.
- **darwin live fence** (`tests/seatbelt_jail.rs`, CI-ran — house rule forbids local `--test`; the same assertions were verified manually via shell here): allowlist child reaches loopback:proxy-port, EPERM on any other port, deny admits loopback-outbound.

Gates: `cargo test --workspace --lib` green (54 suites) · clippy `-D warnings` 0 · fmt clean · hygiene 0 RED · public-api baseline regenerated with cargo-public-api 0.51.0 (additive only; `TokioShell::default` renders `-> Self` from the manual impl — derive moved to a hand impl for the new fields).

Co-authored-by: Nika <nika@supernovae.studio>
