### PR TITLE
ci(release): every release opens its thread — the announcements door

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
             --notes-file "$RUNNER_TEMP/release-notes.md" \
             --generate-notes \
             --verify-tag \
+            --discussion-category "Announcements" \
             artifacts/nika-*.tar.gz artifacts/SHA256SUMS
       - name: Attest build provenance (SLSA · verifiable via `gh attestation verify`)
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
## What

`gh release create` gains `--discussion-category "Announcements"`: every tag auto-opens a discussion thread, so release feedback lands where the release lives. Composes with the What/Install/Verify/Provenance front page (0.106+).

One flag · actionlint ✓ · nothing runs until a tag is pushed.