### PR TITLE
fix(nika-runtime,nika-cli): the required-input admission preflight — refuse before the DAG

### DIFF
--- a/crates/nika-cli/src/verbs/run/inputs.rs
+++ b/crates/nika-cli/src/verbs/run/inputs.rs
@@ -7,7 +7,7 @@
 //! type-coercion fix pushed the file past the 1500-LOC ratchet): the
 //! run-time input surface is one coherent unit — the raw pairs in, the
 //! validated `BTreeMap<String, Value>` out, the declared `inputs:` block
-//! the sole authority on both keys and types.
+//! the sole authority on keys, types — and (#603) required-satisfaction.
 
 use std::collections::BTreeMap;
 
@@ -65,18 +65,26 @@ pub(super) fn parse_var_overrides(
     Ok(overrides)
 }
 
-/// [`parse_var_overrides`] mapped to the ENV-class refusal the caller
+/// [`parse_var_overrides`] + the admission preflight (#603 — the runtime's
+/// ONE constructor), both mapped to the ENV-class refusal the caller
 /// returns — the message rides stderr + the machine error envelope.
 pub(super) fn validated_var_overrides(
     vars: &[String],
     wf: &RawWorkflow,
     output_json: bool,
 ) -> Result<BTreeMap<String, Value>, u8> {
-    parse_var_overrides(vars, wf).map_err(|message| {
+    let overrides = parse_var_overrides(vars, wf).map_err(|message| {
         eprintln!("nika run: {message}");
         epilogue::emit_error_envelope(&message, output_json);
         exit::ENV
-    })
+    })?;
+    if let Some(err) = nika_runtime::required_inputs_refusal(wf, &overrides) {
+        let message = err.to_string();
+        eprintln!("nika run: {message}");
+        epilogue::emit_error_envelope(&message, output_json);
+        return Err(exit::ENV);
+    }
+    Ok(overrides)
 }
 
 #[cfg(test)]

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -64,7 +64,7 @@ use std::io::Write as _;
 use serde_json::Value;
 
 use nika_runtime::resume::ResumePlan;
-use nika_runtime::{EventSink, RunOutcome, Runtime, Stamper};
+use nika_runtime::{EventSink, RunOutcome, Runtime, RuntimeError, Stamper};
 use nika_schema::check::CheckReport;
 use nika_schema::raw::RawWorkflow;
 
@@ -974,9 +974,8 @@ fn shared_fold(
 
 /// Run the workflow through a sink + map the outcome to an exit code.
 ///
-/// A `RuntimeError` on a CLEAN report is a SYSTEM contract breach (the
-/// checker proved it clean · the runtime should never reject it) — exit
-/// 3 with the wire code, never a panic (the zero-unwrap policy).
+/// A `RuntimeError` out of `run` is exit 3, never a panic: NIKA-1708 (the
+/// admission refusal · an OPERATOR miss) prints its text — any other class is a SYSTEM breach and says so.
 async fn drive<S, T, H, P, D, C>(
     runtime: &Runtime<S, T, H, P, D, C>,
     wf: &RawWorkflow,
@@ -1009,13 +1008,18 @@ where
         Err(err) => {
             use nika_error::traits::NikaErrorCode as _;
             let mut stderr = std::io::stderr().lock();
-            let _ = writeln!(
-                stderr,
-                "nika run: system: the checked workflow was rejected at run \
-                 time ({} · {err}) — this is an engine contract breach, \
-                 please report it",
-                err.nika_code()
-            );
+            if let RuntimeError::MissingRequiredInputs { .. } = err {
+                // The admission refusal (#603): an OPERATOR miss, its text names the fix.
+                let _ = writeln!(stderr, "nika run: {err}");
+            } else {
+                let _ = writeln!(
+                    stderr,
+                    "nika run: system: the checked workflow was rejected at run \
+                     time ({} · {err}) — this is an engine contract breach, \
+                     please report it",
+                    err.nika_code()
+                );
+            }
             (
                 exit::ENV,
                 RunOutcome::new(false, BTreeMap::new(), BTreeMap::new()),
@@ -1202,12 +1206,13 @@ mod tests {
 
     #[test]
     fn var_flag_satisfies_a_required_var() {
-        // Without the flag the first `${{ vars.topic }}` reference fails
-        // the task (NIKA-VAR-001) → workflow failed.
+        // Without the flag the run refuses at ADMISSION (issue #603 ·
+        // NIKA-1708 · exit 3) — before the DAG spends a task; the mid-DAG
+        // NIKA-VAR-001 at the first `${{ inputs.topic }}` read was the bug.
         assert_eq!(
             run_with_vars("var-missing.nika.yaml", &[]),
-            exit::WORKFLOW,
-            "an unbound required var still fails the run"
+            exit::ENV,
+            "an unsatisfied required input refuses at admission (#603)"
         );
         // With `--var topic=rust` the SAME workflow runs green.
         assert_eq!(

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -263,3 +263,100 @@ fn examples_run_unknown_slug_is_a_finding() {
         "points at the set: {stderr}"
     );
 }
+
+/// The #603 admission repro (the 2026-07-21 four-authority translation):
+/// `needle` is `required: true` with no `default:` — without `--var` the
+/// run must refuse at ADMISSION, before wave 1 spends a task.
+fn required_input_wf(out_path: &std::path::Path) -> String {
+    r#"nika: v1
+workflow:
+  id: req-input-admission
+inputs:
+  needle: { type: string, required: true }
+permits:
+  fs: { write: ["OUT"] }
+  tools: ["nika:write"]
+tasks:
+  first:
+    invoke: { tool: "nika:write", args: { path: "OUT", content: "spends before the crash" } }
+  use:
+    after:
+      first: succeeded
+    invoke: { tool: "nika:write", args: { path: "OUT", content: "${{ inputs.needle }}" } }
+"#
+    .replace("OUT", &out_path.display().to_string())
+}
+
+#[test]
+fn a_missing_required_input_is_refused_before_any_task_event() {
+    let out_file = std::env::temp_dir()
+        .join("nika-run-verb")
+        .join("req-input-missing-out.txt");
+    let _ = std::fs::remove_file(&out_file);
+    let wf = fixture("req-input-missing.nika.yaml", &required_input_wf(&out_file));
+    let out = bin()
+        .arg("run")
+        .arg(&wf)
+        .arg("--json")
+        .args(["--color", "never"])
+        .output()
+        .expect("binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "the admission refusal is the ENV class · stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(
+        stdout.trim().is_empty(),
+        "refused BEFORE any event — not even the prologue on the journal stream: {stdout}"
+    );
+    let stderr = String::from_utf8(out.stderr).expect("utf8");
+    assert!(stderr.contains("NIKA-1708"), "the launch class: {stderr}");
+    assert!(stderr.contains("`needle`"), "the input is named: {stderr}");
+    assert!(
+        stderr.contains("--var needle=<value>"),
+        "the satisfaction is taught: {stderr}"
+    );
+    assert!(
+        !out_file.exists(),
+        "wave 1 never spent — `first` never wrote the file"
+    );
+}
+
+#[test]
+fn a_var_override_satisfies_the_required_input() {
+    // The control: `--var needle=…` IS the input's value (F4) — the SAME
+    // workflow completes.
+    let out_file = std::env::temp_dir()
+        .join("nika-run-verb")
+        .join("req-input-satisfied-out.txt");
+    let _ = std::fs::remove_file(&out_file);
+    let wf = fixture(
+        "req-input-satisfied.nika.yaml",
+        &required_input_wf(&out_file),
+    );
+    let out = bin()
+        .arg("run")
+        .arg(&wf)
+        .arg("--json")
+        .args(["--color", "never"])
+        .arg("--var")
+        .arg("needle=ok")
+        .output()
+        .expect("binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "the override satisfies admission · stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(stdout.contains("workflow_completed"), "the run completes");
+    let written = std::fs::read_to_string(&out_file).expect("the use task wrote");
+    assert!(
+        written.contains("ok"),
+        "the override reached the read: {written}"
+    );
+}

--- a/crates/nika-error/public-api.txt
+++ b/crates/nika-error/public-api.txt
@@ -469,6 +469,8 @@ pub const nika_error::codes::NIKA_1706: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_1706: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_1707: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_1707: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1708: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1708: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_234: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_234: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_430: nika_error::codes::NikaCode
@@ -853,6 +855,7 @@ pub const nika_error::prelude::codes::NIKA_1704: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_1705: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_1706: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_1707: nika_error::codes::NikaCode
+pub const nika_error::prelude::codes::NIKA_1708: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_234: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_430: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_431: nika_error::codes::NikaCode

--- a/crates/nika-error/src/codes.rs
+++ b/crates/nika-error/src/codes.rs
@@ -343,6 +343,9 @@ fn run_code_help(num: u16) -> &'static str {
         1707 => {
             "The CheckReport does not match the workflow bytes — the run-start boundary re-derivation (permits-fit · trifecta) found something a clean report was credited with not having. Re-run `nika check` on THIS file; a clean report over different bytes is not clean."
         }
+        1708 => {
+            "A `required: true` input has neither a declared `default:` nor a `--var` override — the run refuses at admission, before any task spends. Supply each named input with `nika run <file> --var <name>=<value>` (or declare a `default:`)."
+        }
         _ => "Runtime error. Re-run `nika check`, then `nika explain` the exact code.",
     }
 }

--- a/crates/nika-error/src/codes/registry.rs
+++ b/crates/nika-error/src/codes/registry.rs
@@ -804,6 +804,17 @@ pub const NIKA_1707: NikaCode = NikaCode {
     severity: Severity::Error,
     slug: "runtime-report-mismatch",
 };
+/// NIKA-1708: A `required: true` input reached `run` with neither a
+/// declared `default:` nor an operator `--var` override — the admission
+/// preflight refuses the launch BEFORE the prologue (issue #603 · zero
+/// events, zero spend; the mid-DAG NIKA-VAR-001 at the first read was
+/// the bug).
+pub const NIKA_1708: NikaCode = NikaCode {
+    num: 1708,
+    category: Category::Runtime,
+    severity: Severity::Error,
+    slug: "runtime-missing-required-input",
+};
 
 /// All registered codes within nika-error's own ranges + the M2
 /// computer-use L1 ranges (Screen/Ocr/A11y · ADR-081 · the impls live
@@ -831,4 +842,5 @@ pub const ALL: &[NikaCode] = &[
     NIKA_1401, NIKA_1402, NIKA_1403, NIKA_1404, NIKA_1405, NIKA_1406, NIKA_1501, NIKA_1502,
     NIKA_1503, NIKA_1504, NIKA_1505, NIKA_1601, NIKA_1602, NIKA_1603, NIKA_1604, NIKA_1605,
     NIKA_1700, NIKA_1701, NIKA_1702, NIKA_1703, NIKA_1704, NIKA_1705, NIKA_1706, NIKA_1707,
+    NIKA_1708,
 ];

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -525,6 +525,9 @@ pub nika_runtime::RuntimeError::ContractViolation::message: alloc::string::Strin
 pub nika_runtime::RuntimeError::Decode
 pub nika_runtime::RuntimeError::Decode::message: alloc::string::String
 pub nika_runtime::RuntimeError::DirtyReport
+pub nika_runtime::RuntimeError::MissingRequiredInputs
+pub nika_runtime::RuntimeError::MissingRequiredInputs::declared: alloc::vec::Vec<alloc::string::String>
+pub nika_runtime::RuntimeError::MissingRequiredInputs::missing: alloc::vec::Vec<alloc::string::String>
 pub nika_runtime::RuntimeError::OutputBinding
 pub nika_runtime::RuntimeError::OutputBinding::code: &'static str
 pub nika_runtime::RuntimeError::OutputBinding::message: alloc::string::String
@@ -1088,4 +1091,5 @@ pub fn nika_runtime::WorkflowSecretResolver::resolve(&self, name: &str, referenc
 impl nika_runtime::WorkflowSecretResolver for nika_runtime::NoSecrets
 pub fn nika_runtime::NoSecrets::resolve(&self, name: &str, _reference: &nika_vocab::secret::SecretRef) -> core::result::Result<alloc::string::String, nika_runtime::SecretResolveError>
 pub const fn nika_runtime::legal(class: nika_runtime::TaskStatus, cause: nika_runtime::TerminalCause) -> bool
+pub fn nika_runtime::required_inputs_refusal(wf: &nika_schema::raw::workflow::RawWorkflow, overrides: &alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>) -> core::option::Option<nika_runtime::RuntimeError>
 pub fn nika_runtime::source_is_runtime_resolvable(source: nika_vocab::secret::SecretSource) -> bool

--- a/crates/nika-runtime/src/admit.rs
+++ b/crates/nika-runtime/src/admit.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The run-ADMISSION preflight (issue #603) — the missing-required-input
+//! refusal.
+//!
+//! A `required: true` input with no declared `default:` has exactly one
+//! other value source: the operator's `--var` override (F4). When neither
+//! exists, `envelope_values` builds the `inputs` map WITHOUT the key and
+//! the run used to learn about it mid-DAG — wave 1 already spent (infer
+//! tasks burned tokens · exec tasks mutated) and the first
+//! `${{ inputs.x }}` read died NIKA-VAR-001. The preflight moves the
+//! refusal to ADMISSION: it fires before the prologue, so a refused run
+//! emits zero events and spends zero tasks.
+//!
+//! ONE constructor, TWO surfaces (the trust-gate posture): the runtime
+//! gate inside `Runtime::run` is the fail-closed word for every embedder;
+//! the CLI's input gauntlet (the `--var` validation seam) surfaces the
+//! SAME constructor natively — same predicate, same text, no drift.
+//!
+//! What satisfies a `required: true` input (either is enough):
+//! - a declared `default:` (the author's value) ·
+//! - a `--var <name>=<value>` override (the operator's value).
+//!
+//! A NON-required input is never refused here: declared optional means an
+//! unbound read stays the read-time NIKA-VAR-001 (unchanged). `config:`,
+//! `const:`, `secrets:` are untouched — the preflight reads `inputs:`
+//! only.
+
+use std::collections::BTreeMap;
+
+use nika_schema::check::CheckReport;
+use nika_schema::raw::RawWorkflow;
+use nika_schema::types::VarDecl;
+use serde_json::Value;
+
+use crate::errors::RuntimeError;
+
+/// The run's launch gates, in order: the report trust check
+/// (audit-before-run) · the required-input preflight below — both
+/// refuse BEFORE the prologue, so a refused run emits zero events and
+/// spends zero tasks.
+pub(crate) fn gates(
+    wf: &RawWorkflow,
+    report: &CheckReport,
+    overrides: &BTreeMap<String, Value>,
+) -> Result<(), RuntimeError> {
+    crate::trust::check_report(wf, report)?;
+    if let Some(err) = required_inputs_refusal(wf, overrides) {
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// The missing-required-input refusal — `Some` run-abort error when a
+/// `required: true` input has neither a declared `default:` nor an
+/// operator override, `None` when every required input is satisfied.
+/// The ONE constructor both admission surfaces (the runtime's launch
+/// gate · the CLI's input gauntlet) speak.
+#[must_use]
+pub fn required_inputs_refusal(
+    wf: &RawWorkflow,
+    overrides: &BTreeMap<String, Value>,
+) -> Option<RuntimeError> {
+    let missing: Vec<String> = wf
+        .inputs
+        .iter()
+        .filter(|(key, decl)| {
+            matches!(
+                decl,
+                VarDecl::Typed {
+                    required: true,
+                    default: None,
+                    ..
+                }
+            ) && !overrides.contains_key(&key.value)
+        })
+        .map(|(key, _)| key.value.clone())
+        .collect();
+    if missing.is_empty() {
+        return None;
+    }
+    let declared = wf.inputs.iter().map(|(key, _)| key.value.clone()).collect();
+    Some(RuntimeError::MissingRequiredInputs { missing, declared })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use std::sync::Arc;
+
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_verb_agent::AgentVerb;
+    use nika_verb_exec::ExecVerb;
+    use nika_verb_infer::InferVerb;
+    use nika_verb_invoke::InvokeVerb;
+    use serde_json::json;
+
+    use super::*;
+    use crate::{DeterministicStamper, RunOutcome, Runtime, RuntimeConfig, VecSink};
+
+    type MockRuntime = Runtime<
+        MockShell,
+        MockToolExecutor,
+        nika_providers::NoHttp,
+        MockProvider,
+        MockToolDefinitionProvider,
+        MockClock,
+    >;
+
+    fn runtime_with(shell: MockShell) -> MockRuntime {
+        let executor = MockToolExecutor::new();
+        let provider = MockProvider::new("mock");
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(executor)));
+        Runtime::new(
+            ExecVerb::new(Arc::new(shell)),
+            Arc::clone(&invoke),
+            InferVerb::new(
+                Arc::new(nika_providers::ProviderRegistry::without_http(
+                    nika_providers::ProvidersConfig::new(),
+                )),
+                "mock/echo",
+            ),
+            AgentVerb::new(
+                Arc::new(provider),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default(),
+        )
+    }
+
+    fn parse(yaml: &str) -> RawWorkflow {
+        nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses")
+    }
+
+    /// One `exec` task inside its declared boundary (clean report) · the
+    /// `inputs:` block varies per case. NOTHING reads the input — the
+    /// preflight judges the DECLARATION ⊕ the overrides, never the reads.
+    fn fixture(inputs: &str) -> String {
+        format!(
+            "nika: v1\nworkflow:\n  id: admit\n{inputs}permits: {{ exec: [\"true\"] }}\ntasks:\n  t:\n    exec: {{ command: [\"true\"] }}\n"
+        )
+    }
+
+    async fn run(runtime: &MockRuntime, wf: &RawWorkflow) -> RunOutcome {
+        let report = nika_schema::check(wf);
+        assert!(report.is_clean(), "the fixture checks clean");
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        runtime
+            .run(wf, &report, &mut stamper, &mut sink)
+            .await
+            .expect("run settles")
+    }
+
+    /// A refused run ABORTS at the preflight — the error, for inspection.
+    /// The refusal precedes the prologue (fail-closed): the sink MUST
+    /// stay empty (the trust-gate pin, mirrored once here).
+    async fn run_refused(runtime: &MockRuntime, wf: &RawWorkflow) -> RuntimeError {
+        let report = nika_schema::check(wf);
+        assert!(report.is_clean(), "the fixture checks clean");
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let err = runtime
+            .run(wf, &report, &mut stamper, &mut sink)
+            .await
+            .expect_err("an unsatisfied required input never reaches dispatch");
+        assert!(
+            sink.events().is_empty(),
+            "refused BEFORE any event — not even the prologue: {:?}",
+            sink.events()
+        );
+        err
+    }
+
+    #[test]
+    fn required_without_default_or_override_is_the_missing_set() {
+        let wf = parse(&fixture(
+            "inputs:\n  needle: { type: string, required: true }\n  region: { type: string, required: true }\n  limit: { type: integer, default: 3 }\n  note: { type: string }\n",
+        ));
+        let err = required_inputs_refusal(&wf, &BTreeMap::new()).expect("two unsatisfied");
+        let RuntimeError::MissingRequiredInputs { missing, declared } = &err else {
+            panic!("expected MissingRequiredInputs, got {err:?}");
+        };
+        // Declaration order — the author's own reading order.
+        assert_eq!(missing, &["needle", "region"]);
+        assert_eq!(declared, &["needle", "region", "limit", "note"]);
+    }
+
+    #[test]
+    fn satisfied_cases_pass_the_predicate() {
+        let no_override = BTreeMap::new();
+        // A declared `default:` satisfies (required or not).
+        let wf = parse(&fixture(
+            "inputs:\n  needle: { type: string, required: true, default: \"x\" }\n",
+        ));
+        assert!(required_inputs_refusal(&wf, &no_override).is_none());
+        // A `--var` override satisfies a default-less required input.
+        let wf = parse(&fixture(
+            "inputs:\n  needle: { type: string, required: true }\n",
+        ));
+        let overrides = BTreeMap::from([("needle".to_owned(), json!("ok"))]);
+        assert!(required_inputs_refusal(&wf, &overrides).is_none());
+        // A NON-required input without a default is unaffected (an unbound
+        // OPTIONAL read stays the read-time NIKA-VAR-001).
+        let wf = parse(&fixture("inputs:\n  note: { type: string }\n"));
+        assert!(required_inputs_refusal(&wf, &no_override).is_none());
+        // No `inputs:` block at all — nothing to refuse.
+        let wf = parse(&fixture(""));
+        assert!(required_inputs_refusal(&wf, &no_override).is_none());
+    }
+
+    /// (a) The #603 mechanism, refused: a default-less `required: true`
+    /// input with no override ABORTS the run at admission — before one
+    /// event, one task, one effect (the mock shell is the spend probe).
+    #[tokio::test]
+    async fn a_missing_required_input_is_refused_before_any_event() {
+        let wf = parse(&fixture(
+            "inputs:\n  needle: { type: string, required: true }\n",
+        ));
+        let shell = MockShell::new(); // EMPTY — any execution is a bug
+        let probe = shell.clone();
+        let runtime = runtime_with(shell);
+        let err = run_refused(&runtime, &wf).await;
+        assert_eq!(err.spec_code(), "NIKA-1708");
+        let msg = err.to_string();
+        assert!(msg.contains("`needle`"), "the input is named: {msg}");
+        assert!(msg.contains("--var needle=<value>"), "the fix rides: {msg}");
+        assert!(
+            probe.executed_commands().is_empty(),
+            "not one task spent: {:?}",
+            probe.executed_commands()
+        );
+    }
+
+    /// (b) The positive control: a `--var` override on the required input
+    /// passes admission and the run completes (F4 — the override IS the
+    /// input's value).
+    #[tokio::test]
+    async fn a_var_override_satisfies_the_admission_gate() {
+        let wf = parse(&fixture(
+            "inputs:\n  needle: { type: string, required: true }\n",
+        ));
+        let shell = MockShell::new().enqueue_ok("ok");
+        let probe = shell.clone();
+        let runtime = runtime_with(shell)
+            .with_var_overrides(BTreeMap::from([("needle".to_owned(), json!("ok"))]));
+        let outcome = run(&runtime, &wf).await;
+        assert!(outcome.ok, "the satisfied gate is inert — no false refusal");
+        assert_eq!(probe.executed_commands().len(), 1, "the exec ran");
+    }
+
+    /// (c) The author-side satisfaction: a declared `default:` passes
+    /// admission with NO override.
+    #[tokio::test]
+    async fn a_declared_default_satisfies_the_admission_gate() {
+        let wf = parse(&fixture(
+            "inputs:\n  needle: { type: string, required: true, default: \"x\" }\n",
+        ));
+        let shell = MockShell::new().enqueue_ok("ok");
+        let probe = shell.clone();
+        let runtime = runtime_with(shell);
+        let outcome = run(&runtime, &wf).await;
+        assert!(outcome.ok, "a defaulted required input never refuses");
+        assert_eq!(probe.executed_commands().len(), 1, "the exec ran");
+    }
+}

--- a/crates/nika-runtime/src/errors.rs
+++ b/crates/nika-runtime/src/errors.rs
@@ -4,7 +4,8 @@
 //! `nika-runtime` errors — the NIKA-1700 range (`Category::Runtime`).
 //!
 //! These are RUN-ABORT classes only (contract breaches between the
-//! checker and the runtime · template/gate static failures). A verb
+//! checker and the runtime · template/gate static failures · launch
+//! refusals like the admission preflight's NIKA-1708). A verb
 //! failing inside a task is NOT a runtime error — it becomes a
 //! `TaskFailed` event carrying the verb's own `nika_code()` and the run
 //! continues per the cascade semantics (spec §3).
@@ -12,7 +13,7 @@
 use nika_error::traits::NikaErrorCode;
 use nika_kernel::prelude::codes;
 
-/// Run-abort errors · `NIKA-1700..1703` (spec §4).
+/// Run-abort errors · the `NIKA-170x` range (spec §4).
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 #[non_exhaustive]
 pub enum RuntimeError {
@@ -48,6 +49,23 @@ pub enum RuntimeError {
         index: usize,
         /// The workflow's task count.
         task_count: usize,
+    },
+
+    /// NIKA-1708 · a `required: true` input reached `run` with neither a
+    /// declared `default:` nor a `--var` override — the ADMISSION
+    /// preflight (issue #603) refuses the launch BEFORE the prologue
+    /// (zero events · zero spend); the mid-DAG NIKA-VAR-001 at the first
+    /// `${{ inputs.x }}` read was the bug. The launch-refusal family
+    /// with [`Self::DirtyReport`]/[`Self::ReportMismatch`]: it aborts
+    /// before the task pipeline, so the engine-internal code IS the
+    /// wire form (never a `tasks.X.error` record).
+    #[error("NIKA-1708 · {}", missing_required_message(.missing, .declared))]
+    #[diagnostic(code(nika::runtime::missing_required_input))]
+    MissingRequiredInputs {
+        /// Each unsatisfied `required: true` input (declaration order).
+        missing: Vec<String>,
+        /// The full declared `inputs:` set (the satisfaction vocabulary).
+        declared: Vec<String>,
     },
 
     /// A `${{ }}` reference did not resolve (unknown task id / var key ·
@@ -159,6 +177,31 @@ fn var_cli_hint(reference: &str) -> &'static str {
     }
 }
 
+/// The teaching text of [`RuntimeError::MissingRequiredInputs`] — names
+/// EACH unsatisfied input, the `--var` satisfaction (the operator fix,
+/// no workflow edit), the `default:` alternative, and the declared set
+/// (the same vocabulary the CLI's unknown-`--var`-key refusal lists).
+fn missing_required_message(missing: &[String], declared: &[String]) -> String {
+    let names = missing
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(" · ");
+    let fix = match missing.first() {
+        Some(first) => format!("`--var {first}=<value>` satisfies it"),
+        None => "`--var <name>=<value>` satisfies it".to_owned(),
+    };
+    let vocabulary = if declared.is_empty() {
+        String::new()
+    } else {
+        format!(" · the workflow declares: {}", declared.join(" · "))
+    };
+    format!(
+        "missing required inputs: {names} — a `required: true` input with no `default:` \
+         must be supplied at launch ({fix}){vocabulary}"
+    )
+}
+
 impl RuntimeError {
     /// The WIRE code a consumer filters on (`on_codes:` · the user-
     /// visible code). Defaults to the engine-internal `nika_code()` for
@@ -182,10 +225,11 @@ impl RuntimeError {
             // An out-of-subset expression reaching the runtime is NIKA-VAR-005
             // (validation_error · the checker is the primary site).
             Self::WhenUnsupported { .. } => "NIKA-VAR-005".to_owned(),
-            // DirtyReport · ReportMismatch · WaveOutOfBounds are engine
-            // invariant breaches that abort the run before the task pipeline
-            // (never a workflow-visible record) · their engine-internal code
-            // is the only wire form.
+            // DirtyReport · ReportMismatch · WaveOutOfBounds ·
+            // MissingRequiredInputs are launch refusals / invariant
+            // breaches that abort the run before the task pipeline
+            // (never a workflow-visible record) · their engine-internal
+            // code is the only wire form.
             other => other.nika_code().to_string(),
         }
     }
@@ -244,6 +288,7 @@ impl NikaErrorCode for RuntimeError {
             Self::DirtyReport => codes::NIKA_1700,
             Self::ReportMismatch { .. } => codes::NIKA_1707,
             Self::WaveOutOfBounds { .. } => codes::NIKA_1701,
+            Self::MissingRequiredInputs { .. } => codes::NIKA_1708,
             Self::UnresolvedTemplate { .. } => codes::NIKA_1702,
             // CelEval + OutputBinding are spec-plane evaluation classes ·
             // at the engine-internal layer they share the "expression
@@ -269,7 +314,7 @@ impl NikaErrorCode for RuntimeError {
 mod tests {
     use super::*;
 
-    fn all() -> [RuntimeError; 7] {
+    fn all() -> [RuntimeError; 8] {
         [
             RuntimeError::DirtyReport,
             RuntimeError::ReportMismatch {
@@ -278,6 +323,10 @@ mod tests {
             RuntimeError::WaveOutOfBounds {
                 index: 9,
                 task_count: 3,
+            },
+            RuntimeError::MissingRequiredInputs {
+                missing: vec!["needle".into()],
+                declared: vec!["needle".into(), "limit".into()],
             },
             RuntimeError::UnresolvedTemplate {
                 reference: "tasks.ghost.output".into(),
@@ -299,7 +348,7 @@ mod tests {
         let mut nums: Vec<u16> = all().iter().map(|e| e.nika_code().num).collect();
         nums.sort_unstable();
         nums.dedup();
-        assert_eq!(nums.len(), 7, "duplicate code in the 1700 range");
+        assert_eq!(nums.len(), 8, "duplicate code in the 1700 range");
         assert!(nums.iter().all(|n| (1700..1800).contains(n)));
     }
 
@@ -320,6 +369,37 @@ mod tests {
         assert!(msg.contains("re-check the file"), "{msg}");
         assert!(msg.contains("task `leak`"), "the finding is named: {msg}");
         assert!(!err.is_transient(), "a forged report never retries");
+    }
+
+    #[test]
+    fn missing_required_inputs_is_the_launch_refusal_class() {
+        // Issue #603: the admission preflight's refusal TEACHES — every
+        // unsatisfied input named, the `--var` satisfaction (the operator
+        // fix, no workflow edit), the declared vocabulary. The wire form
+        // is the engine-internal code (a launch refusal, never a
+        // `tasks.X.error` record — the 1700/1707 posture).
+        let err = RuntimeError::MissingRequiredInputs {
+            missing: vec!["needle".into(), "region".into()],
+            declared: vec!["needle".into(), "region".into(), "limit".into()],
+        };
+        assert_eq!(err.spec_code(), "NIKA-1708");
+        assert_eq!(err.nika_code(), codes::NIKA_1708);
+        let msg = err.to_string();
+        assert!(msg.starts_with("NIKA-1708 · "), "{msg}");
+        assert!(
+            msg.contains("`needle`") && msg.contains("`region`"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("--var needle=<value>"),
+            "the fix is named: {msg}"
+        );
+        assert!(msg.contains("default:"), "the author alternative: {msg}");
+        assert!(
+            msg.contains("the workflow declares: needle · region · limit"),
+            "the declared set rides: {msg}"
+        );
+        assert!(!err.is_transient(), "an unsatisfied input never retries");
     }
 
     #[test]

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -43,6 +43,7 @@
 
 #![forbid(unsafe_code)]
 
+mod admit;
 mod agent_events;
 pub mod child;
 pub mod config;
@@ -88,6 +89,7 @@ use nika_verb_infer::InferVerb;
 use nika_verb_invoke::InvokeVerb;
 use serde_json::Value;
 
+pub use admit::required_inputs_refusal;
 pub use config::RuntimeConfig;
 pub use errors::RuntimeError;
 pub use pause::WorkflowPause;
@@ -590,7 +592,11 @@ where
     /// boundary lanes do not match the workflow bytes (re-derived at run
     /// start under a declared `permits:` block — a clean report over
     /// different bytes is not clean) ·
-    /// [`RuntimeError::WaveOutOfBounds`] (NIKA-1701) · schedule breach.
+    /// [`RuntimeError::WaveOutOfBounds`] (NIKA-1701) · schedule breach ·
+    /// [`RuntimeError::MissingRequiredInputs`] (NIKA-1708) · the admission
+    /// preflight (issue #603): a `required: true` input with neither a
+    /// declared `default:` nor a `--var` override refuses BEFORE the
+    /// prologue — zero events, zero spend.
     /// Expression failures (NIKA-1702/1703) fail the TASK (cascade) ·
     /// they never abort the run.
     pub async fn run(
@@ -600,7 +606,9 @@ where
         stamper: &mut dyn Stamper,
         sink: &mut dyn EventSink,
     ) -> Result<RunOutcome, RuntimeError> {
-        trust::check_report(wf, report)?;
+        // The launch gates (audit-before-run · the #603 preflight) —
+        // a refusal here precedes the prologue: zero events, zero spend.
+        admit::gates(wf, report, &self.var_overrides)?;
         let EnvelopeValues {
             inputs,
             config,

--- a/crates/nika-runtime/tests/var_overrides.rs
+++ b/crates/nika-runtime/tests/var_overrides.rs
@@ -3,8 +3,10 @@
 
 //! F4 — operator `--var` overrides through the REAL parse → check → run
 //! chain: an override wins over a declared `default:`, and a
-//! `required: true` var without one becomes runnable (before: the run
-//! could only die NIKA-VAR-001 at first reference).
+//! `required: true` var without one becomes runnable. Post-#603 an
+//! UNSATISFIED required input refuses at ADMISSION (NIKA-1708 · before
+//! the prologue); only an unbound OPTIONAL read still dies NIKA-VAR-001
+//! at reference — the surviving read-time class, pinned here too.
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
@@ -40,9 +42,12 @@ outputs:
   lang_out: ${{ inputs.lang }}
 "#;
 
-async fn run_with(overrides: BTreeMap<String, Value>) -> RunOutcome {
+async fn try_run(
+    yaml: &str,
+    overrides: BTreeMap<String, Value>,
+) -> (Result<RunOutcome, nika_runtime::RuntimeError>, VecSink) {
     let wf = nika_schema::parse(
-        WORKFLOW,
+        yaml,
         nika_schema::FileId::new(0),
         nika_schema::ParseMode::Strict,
     )
@@ -68,10 +73,12 @@ async fn run_with(overrides: BTreeMap<String, Value>) -> RunOutcome {
     .with_var_overrides(overrides);
     let mut stamper = DeterministicStamper::new();
     let mut sink = VecSink::new();
-    runtime
-        .run(&wf, &report, &mut stamper, &mut sink)
-        .await
-        .expect("clean run")
+    let result = runtime.run(&wf, &report, &mut stamper, &mut sink).await;
+    (result, sink)
+}
+
+async fn run_with(overrides: BTreeMap<String, Value>) -> RunOutcome {
+    try_run(WORKFLOW, overrides).await.0.expect("clean run")
 }
 
 #[tokio::test]
@@ -90,11 +97,50 @@ async fn override_satisfies_a_required_var_and_beats_the_default() {
 }
 
 #[tokio::test]
-async fn missing_required_var_still_fails_var001_at_reference() {
-    // No override → the pre-F4 behavior is intact: the task's
-    // `${{ inputs.topic }}` fails NIKA-VAR-001 (with the --var hint).
-    let outcome = run_with(BTreeMap::new()).await;
-    assert!(!outcome.ok, "unbound required var fails the task");
+async fn missing_required_var_is_refused_at_admission_nika_1708() {
+    // No override on a `required: true` input → the admission preflight
+    // (#603) refuses BEFORE the DAG: NIKA-1708, not one event — the
+    // mid-DAG NIKA-VAR-001 death this suite used to pin was the bug.
+    let (result, sink) = try_run(WORKFLOW, BTreeMap::new()).await;
+    let err = result.expect_err("an unsatisfied required input never reaches dispatch");
+    assert_eq!(err.spec_code(), "NIKA-1708");
+    let msg = err.to_string();
+    assert!(msg.contains("`topic`"), "the input is named: {msg}");
+    assert!(
+        msg.contains("--var topic=<value>"),
+        "the satisfaction is taught: {msg}"
+    );
+    assert!(
+        sink.events().is_empty(),
+        "refused before the prologue — zero events"
+    );
+}
+
+/// The OPTIONAL sibling of the required fixture: `note` declares no
+/// `default:` and is not `required:` — declared optional.
+const OPTIONAL_WORKFLOW: &str = r#"
+nika: v1
+workflow:
+  id: var-optional
+inputs:
+  note: { type: string }
+tasks:
+  say:
+    exec: { command: ["echo", "${{ inputs.note }}"] }
+"#;
+
+#[tokio::test]
+async fn unbound_optional_var_still_fails_var001_at_reference() {
+    // A NON-required input with no default and no override is NOT an
+    // admission refusal (declared optional) — the run still launches and
+    // the unbound READ dies at reference, the surviving read-time class.
+    let (result, sink) = try_run(OPTIONAL_WORKFLOW, BTreeMap::new()).await;
+    let outcome = result.expect("an optional miss never refuses admission");
+    assert!(
+        !sink.events().is_empty(),
+        "the OPTIONAL miss still RUNS — only the required case refuses admission"
+    );
+    assert!(!outcome.ok, "the unbound optional read fails the task");
     let record = &outcome.records["say"];
     let error = record.error.as_ref().expect("task carries its error");
     assert_eq!(error.code, "NIKA-VAR-001");

--- a/docs/crate-specs/nika-runtime.md
+++ b/docs/crate-specs/nika-runtime.md
@@ -264,11 +264,13 @@ unresolvable output is omitted · the verdict unchanged).
 | NIKA-1702 | unresolved `${{ }}` reference (silent-literal guard) |
 | NIKA-1703 | expression outside the v0 subset (when/render forms) |
 | NIKA-1707 | report's boundary lanes ≠ workflow bytes (run-start re-derivation of the pure permits-fit + trifecta subset · the fail-closed backstop for library embedders — a clean report over different bytes is not clean) |
+| NIKA-1708 | a `required: true` input reached `run` with neither `default:` nor `--var` (the admission preflight · issue #603 — refuses BEFORE the prologue, zero events zero spend; the CLI gauntlet speaks the same constructor) |
 
-NIKA-1700/1701/1707 abort the RUN. NIKA-1702/1703 inside a task pipeline
-fail THE TASK (cascade · the detail carries the code) — only a
+NIKA-1700/1701/1707/1708 abort the RUN. NIKA-1702/1703 inside a task pipeline
+fail THE TASK (cascade · the detail carries the code) — a
 **system** surface (a corrupt schedule · a report that does not match
-the bytes) aborts the run. Verb failures
+the bytes) or a LAUNCH refusal (the unsatisfied `required: true` input)
+aborts the run. Verb failures
 are `TaskFailed` events carrying the verb's own `nika_code()` wire
 form; the timeout class surfaces the SPEC code `NIKA-TIMEOUT-001`.
 


### PR DESCRIPTION
## The bug (#603)

A workflow whose `inputs:` entry is `required: true` with no `default:` and no `--var` override was **not refused at admission**: the run launched the DAG, spent real tasks, then died at the first `${{ inputs.x }}` read (loud NIKA-VAR-001 unresolved — and its fix line suggested declaring a `default:`, the wrong repair for a deliberately required input). The mechanism: `envelope_values` (nika-runtime) builds the inputs map from declared defaults ⊕ overrides, so a default-less required input is silently absent until read time.

## The fix — refuse at ADMISSION

`Runtime::run` now refuses **before the prologue** — zero events, zero spend — when a `required: true` input has neither a declared `default:` nor a `--var` override.

### WHERE (decision + evidence)

The refusal lives in the **runtime's run admission**: `Runtime::run` opens with `admit::gates` — the named launch-gate pair (the report trust check, then the preflight) — the same fail-closed slot the audit-before-run family uses, with the same pin (trust.rs: *"refused BEFORE any event — not even the prologue"*). An embedder bypassing the CLI gets it too.

The CLI **surfaces** it natively rather than duplicating the rule: the run verb's input gauntlet `validated_var_overrides` (where the unknown-`--var`-key refusal already lives) calls the **same one constructor**, `nika_runtime::required_inputs_refusal`, so the two surfaces cannot drift. This mirrors the house's established dual posture (trust.rs: *"The trust clause is NOT a second check for the CLI, which re-checks right before run; it is the fail-closed word for every other driver"*).

`drive`'s `RuntimeError` arm also special-cases the variant: every other class is framed *"engine contract breach — please report it"*, which would be a lie for an operator miss. That path is reachable outside the gauntlet via `nika test`'s mock drive (no `--var` seam).

### CODE (decision + evidence)

New engine-internal **NIKA-1708** (`Category::Runtime` · `runtime-missing-required-input`), registered the house way (`nika-error` registry const + `ALL` + the `run_code_help` arm). Wire form = the engine-internal code.

- **NIKA-VAR-001 is the wrong class**: it is the read-time unresolved-reference code whose wire presence is `tasks.X.error.code` (spec 05 §142). The admission refusal aborts *before* the task pipeline — no task record exists. That is the launch-refusal family (NIKA-1700/1701/1707), whose *"engine-internal code is the only wire form"* (errors.rs).
- **No existing code fits, so one was minted**: the spec canon (`nika-pack/pack/canon.yaml` `error_codes`) carries no launch/admission row at all, and 1700–1707 were already allocated (1704 = budget). **Pending spec-canon mint**: if the spec wants a launch-refusal row (an admission class), that mint happens in the spec repo — the engine-internal 1708 stands regardless (the NIKA-1705-pre-NIKA-EXEC posture).

### The refusal (verbatim)

```
nika run: NIKA-1708 · missing required inputs: `needle` — a `required: true` input with no `default:` must be supplied at launch (`--var needle=<value>` satisfies it) · the workflow declares: needle
```

Exit code 3 (the ENV class — one voice with the `--var` gauntlet refusals).

### Before / after — the #603 repro (four-authority dialect)

```yaml
nika: v1
workflow:
  id: req-input-admission
inputs:
  needle: { type: string, required: true }
permits:
  fs: { write: ["/tmp/req-var-repro-out.txt"] }
  tools: ["nika:write"]
tasks:
  first:
    invoke: { tool: "nika:write", args: { path: "/tmp/req-var-repro-out.txt", content: "spends before the crash" } }
  use:
    after:
      first: succeeded
    invoke: { tool: "nika:write", args: { path: "/tmp/req-var-repro-out.txt", content: "${{ inputs.needle }}" } }
```

- **BEFORE**: `✔ first` executes (the file is written — real spend), then `✖ use` dies `NIKA-VAR-001 · unresolved template reference 'inputs.needle'` mid-DAG, exit 1 (the issue's observed behavior, re-verified 2026-07-21).
- **AFTER (no `--var`)**: the refusal above, before the first task event — the `--json` journal stream is **empty** (not even the prologue), the file is **never written**, exit 3.
- **AFTER (control, `--var needle=ok`)**: completes 2/2, the file carries `ok`, exit 0.

`default:` still satisfies · non-required inputs unaffected (an unbound *optional* read stays the read-time NIKA-VAR-001) · `config:`/`const:`/`secrets:` untouched.

### LOC deltas

- **nika-cli** prod LOC: 14986 → **14998 / 15000** (wall measured first; the preflight folded into `validated_var_overrides`, not a new fn — the 100-line fn ratchet also held: `run_verdict` stays 99, no allowlisting).
- **nika-runtime** prod LOC: 10741 → ~10840 (new `admit.rs` module — the preflight + the named `gates` pair, extracted when `run` crossed the 100-line ratchet — + the error variant).
- **nika-error**: +15 (registry const + `ALL` + the help arm).
- public-api.txt: **append-only** (+3 nika-error, +4 nika-runtime — regenerated with cargo-public-api 0.51.0; local macOS render, will adopt the CI artifact if the job disagrees).

### Tests

- **Unit** (nika-runtime `admit.rs`): the predicate — the missing set in declaration order · satisfied cases (default satisfies · override satisfies · non-required unaffected · no `inputs:` block) — plus the run-level pin: refused **before any event** with the mock shell proving **zero spend**, and the two satisfaction controls (override runs · default runs).
- **Unit** (nika-runtime `errors.rs`): the teaching message (each missing input named · the `--var` fix · the declared set) · wire = NIKA-1708 · registry-resolvable · never transient · the 8-variant uniqueness sweep.
- **Integration** (nika-cli `tests/run_verb.rs`, binary plane): the #603 repro — no `--var` → exit 3, empty journal stream, refusal text on stderr, the out file never written · `--var needle=ok` → exit 0, `workflow_completed`, the file carries the override.
- **Updated pin**: the pre-existing `var_flag_satisfies_a_required_var` asserted the OLD behavior (mid-DAG death, exit 1) — its first half now asserts the admission refusal (exit 3); the F4 half is untouched.

### Gates

- `cargo test --workspace --lib` — green
- `cargo test -p nika-error -p nika-runtime -p nika-cli --tests` — green (with `NIKA_SPEC_DIR` set for the conformance tier; the pre-existing local `wizard_pty` PTY flake excepted per house note)
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo fmt --check` — clean
- `bash scripts/hygiene/check-all.sh` — 0 RED (36 green · 4 pre-existing yellow)
- `bash scripts/ci/check-crate-size.sh` — OK (all crates ≤ 15000 prod LOC)

Closes #603
