### PR TITLE
fix(nika-cli): shed 16 prod LOC — the #673×#674 merge crossed the 15k wall

### DIFF
--- a/crates/nika-cli/src/examples_args.rs
+++ b/crates/nika-cli/src/examples_args.rs
@@ -39,8 +39,7 @@ pub(crate) enum ExamplesAction {
         /// `--model mock/echo` to preview offline (zero key · zero network).
         #[arg(long, value_name = "PROVIDER/NAME")]
         model: Option<String>,
-        /// Set a workflow `vars:` input (repeatable) — several examples
-        /// declare required vars and say so in their header.
+        /// Set a workflow `inputs:` value (repeatable) — required examples name theirs in the header.
         #[arg(long, value_name = "KEY=VALUE")]
         var: Vec<String>,
         /// Verdict line only (suppress the storyboard).

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -7,8 +7,7 @@
 //! over production seams). Exit codes per the locked contract (spec §4):
 //! `0` ok · `1` workflow failed · `2` file findings · `3` environment.
 
-// A terminal binary's whole job is printing — the same exemption as the
-// nika-catalog-verify binary and the nika-schema check example.
+// A terminal binary's whole job is printing (the nika-catalog-verify precedent).
 #![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
 
 use std::io::{IsTerminal, Write};
@@ -394,10 +393,9 @@ struct RunArgs {
     /// mock/echo` previews any workflow offline (zero key · zero network).
     #[arg(long, value_name = "PROVIDER/NAME")]
     model: Option<String>,
-    /// Set a workflow `vars:` value (repeatable). Overrides a declared
-    /// `default:` and satisfies a `required: true` var. The value is
-    /// parsed as JSON when it parses (numbers · booleans · arrays),
-    /// else taken as a string. Unknown keys are refused.
+    /// Set a workflow `inputs:` value (repeatable). Overrides a declared
+    /// `default:` and satisfies a `required: true` input. JSON when it
+    /// parses (numbers · booleans · arrays), else a string. Unknown keys refused.
     #[arg(long = "var", value_name = "KEY=VALUE")]
     var: Vec<String>,
     /// Resume from a prior run's NDJSON trace (`nika run … --json >

--- a/crates/nika-cli/src/verbs/run/epilogue.rs
+++ b/crates/nika-cli/src/verbs/run/epilogue.rs
@@ -20,6 +20,7 @@ use nika_runtime::{RunOutcome, WorkflowPause};
 
 use super::resume;
 use crate::Theme;
+use crate::verbs::exit;
 
 /// The `--resume` post-run summary (`resumed · N skipped · M ran live`) —
 /// printed ONLY when a resume was requested (a fresh run's surfaces stay
@@ -135,6 +136,14 @@ pub(super) fn emit_error_envelope(message: &str, output_json: bool) {
     if output_json {
         println!("{}", error_envelope_line(message));
     }
+}
+
+/// The ENV-class refusal surface — the message rides stderr + the machine
+/// error envelope (one voice for every pre-run refusal).
+pub(super) fn env_refusal(message: &str, output_json: bool) -> u8 {
+    eprintln!("nika run: {message}");
+    emit_error_envelope(message, output_json);
+    exit::ENV
 }
 
 /// ONE `{"paused":{…}}` line — the machine pause contract (ADR-099 rider

--- a/crates/nika-cli/src/verbs/run/inputs.rs
+++ b/crates/nika-cli/src/verbs/run/inputs.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The `--var KEY=VALUE` input seam — parse, key-validate, type-honor.
-//!
-//! Extracted from `run/mod.rs` (2026-07-11 · the input gauntlet's
-//! type-coercion fix pushed the file past the 1500-LOC ratchet): the
-//! run-time input surface is one coherent unit — the raw pairs in, the
-//! validated `BTreeMap<String, Value>` out, the declared `inputs:` block
-//! the sole authority on keys, types — and (#603) required-satisfaction.
+//! The `--var KEY=VALUE` input seam — parse, key-validate, type-honor
+//! (extracted from `run/mod.rs` 2026-07-11 · the 1500-LOC ratchet): one
+//! unit — the raw pairs in, the validated `BTreeMap<String, Value>` out,
+//! the declared `inputs:` the sole authority (keys · types · #603 required).
 
 use std::collections::BTreeMap;
 
@@ -16,18 +13,15 @@ use nika_schema::types::VarDecl;
 use serde_json::Value;
 
 use super::epilogue;
-use crate::verbs::exit;
 
 /// Parse the repeatable `--var KEY=VALUE` overrides and validate every
 /// key against the workflow's declared `inputs:` — an unknown key is
 /// refused with the declared set (a typo'd override silently doing
 /// nothing would be the worst outcome). A TYPED input's declared `type:`
-/// DRIVES the value parse (spec 01 §inputs · « the engine validate
-/// inputs » · R3b: the full `TypeExpr`, the one fit): `--var
-/// count=notanumber` on an `integer` input is refused up front, and a
-/// `string` input takes the raw text verbatim (`--var name=5` is the
-/// string `"5"`). An UNTYPED constant keeps the JSON-or-string guess:
-/// `--var limit=5` the number `5`, `--var topic=news` the string.
+/// DRIVES the value parse (spec 01 §inputs · R3b: the full `TypeExpr`,
+/// the one fit): `--var count=notanumber` on an `integer` refuses up
+/// front · a `string` takes the raw text (`--var name=5` is `"5"`).
+/// An UNTYPED constant keeps the JSON-or-string guess (`limit=5` → `5`).
 pub(super) fn parse_var_overrides(
     pairs: &[String],
     wf: &RawWorkflow,
@@ -52,15 +46,13 @@ pub(super) fn parse_var_overrides(
             });
         };
         let value = match decl {
-            // The declared TypeExpr drives the parse (spec-mandated input
-            // validation · the one type core, never a second fit) — a
-            // mismatch is refused with the declared form + the value.
+            // The declared TypeExpr drives the parse (the one type core,
+            // never a second fit) — a mismatch names the form + the value.
             VarDecl::Typed { r#type, .. } => {
                 nika_schema::types::coerce_declared(&r#type.value, &type_names, &named, raw)
                     .map_err(|why| format!("--var {key}: {why}"))?
             }
-            // Untyped constant: the JSON-or-string guess — no declared
-            // type to honor.
+            // Untyped constant: the JSON-or-string guess (no declared type).
             VarDecl::Untyped(_) => {
                 serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()))
             }
@@ -70,24 +62,17 @@ pub(super) fn parse_var_overrides(
     Ok(overrides)
 }
 
-/// [`parse_var_overrides`] + the admission preflight (#603 — the runtime's
-/// ONE constructor), both mapped to the ENV-class refusal the caller
-/// returns — the message rides stderr + the machine error envelope.
+/// [`parse_var_overrides`] + the admission preflight (#603 · the runtime's
+/// ONE constructor) — both ENV-class refusals (stderr + the envelope).
 pub(super) fn validated_var_overrides(
     vars: &[String],
     wf: &RawWorkflow,
     output_json: bool,
 ) -> Result<BTreeMap<String, Value>, u8> {
-    let overrides = parse_var_overrides(vars, wf).map_err(|message| {
-        eprintln!("nika run: {message}");
-        epilogue::emit_error_envelope(&message, output_json);
-        exit::ENV
-    })?;
+    let overrides = parse_var_overrides(vars, wf)
+        .map_err(|message| epilogue::env_refusal(&message, output_json))?;
     if let Some(err) = nika_runtime::required_inputs_refusal(wf, &overrides) {
-        let message = err.to_string();
-        eprintln!("nika run: {message}");
-        epilogue::emit_error_envelope(&message, output_json);
-        return Err(exit::ENV);
+        return Err(epilogue::env_refusal(&err.to_string(), output_json));
     }
     Ok(overrides)
 }

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -599,11 +599,10 @@ fn composed_runtime(
                 None => rt,
             })
         }
-        Err(e) => {
-            eprintln!("nika run: environment: {e}");
-            epilogue::emit_error_envelope(&e.to_string(), output_json);
-            Err(exit::ENV)
-        }
+        Err(e) => Err(epilogue::env_refusal(
+            &format!("environment: {e}"),
+            output_json,
+        )),
     }
 }
 
@@ -615,11 +614,6 @@ fn composed_runtime(
 /// the caller owns stdout for its own verdict/diff surface. `skills` =
 /// the composer-resolved SKILL.md texts (#473 · the caller gates their
 /// findings first, same as `run`).
-///
-/// # Errors
-///
-/// A composition/executor failure (environment class) as a human-readable
-/// message — the caller maps it to `exit::ENV`.
 pub(crate) fn capture_mock_outputs(
     wf: &RawWorkflow,
     report: &CheckReport,
@@ -1009,7 +1003,6 @@ where
             use nika_error::traits::NikaErrorCode as _;
             let mut stderr = std::io::stderr().lock();
             if let RuntimeError::MissingRequiredInputs { .. } = err {
-                // The admission refusal (#603): an OPERATOR miss, its text names the fix.
                 let _ = writeln!(stderr, "nika run: {err}");
             } else {
                 let _ = writeln!(


### PR DESCRIPTION
## Why main went RED

A merge interaction: #674 (the required-input admission preflight) landed nika-cli at **14,998** prod LOC and #673 (the R3b TypeExpr widen) added **+5** on a nearby base — each PR's CI was green on its own base, but the squash combination is **15,003**, and the crate-size ratchet (`scripts/ci/check-crate-size.sh` · max 15,000 prod LOC, all non-`cfg(test)` lines counted incl. comments/blanks) fails on the merge commit.

## The fix — shed 16 lines, zero behavior change

**nika-cli prod LOC: 15,003 → 14,987** (13 under the wall · verified with the ratchet's own counter).

Three honest moves, nothing gamed (no code moved into `cfg(test)`, no `#[cfg]` tricks, no load-bearing docs stripped):

- **De-duplication (the merge's own)** — the ENV-class refusal surface (`eprintln!` + the machine error envelope + `exit::ENV`) appeared **three times** after the two PRs crossed in `inputs.rs`/`mod.rs`: twice in `validated_var_overrides` (the `--var` parse refusal + the #603 admission refusal) and once in `composed_runtime`'s env arm. One `epilogue::env_refusal` helper now speaks for all three (−9 at the call sites, +8 for the helper incl. its import).
- **Doc compressions in the run verb's recent additions** — the inputs.rs module header and `parse_var_overrides`/`validated_var_overrides` docs restated at full width; the `drive` arm's comment repeated the `drive` doc verbatim; the pub(crate) `capture_mock_outputs` carried a `# Errors` section whose contract (a `String` the one caller maps to `exit::ENV`) the signature and the call site already state. Tightened, no facts lost.
- **Stale-help corrections (C2 follow-ups, user-visible)** — the `--var` help on `nika run` and `nika examples run` still named the dead `vars:` field; both now say `inputs:` (verified in the rendered `--help`). These were wrong on main regardless of the wall.

## Verification

- `bash scripts/ci/check-crate-size.sh` — **OK** (15,003 → 14,987, measured before/after with the ratchet's counter)
- `cargo test -p nika-cli --lib` — 306 passed, 0 failed
- `cargo test -p nika-cli --test run_verb --test bin_smoke` — 10 + 38 passed (the #603 repro tests exercise the de-duplicated refusal path; unchanged behavior)
- `cargo clippy -p nika-cli --all-targets -- -D warnings` — clean · `cargo fmt --check` — clean
- `cargo public-api -p nika-cli` — no API change: the helper is `pub(super)`, all other edits are doc/help text; public-api.txt untouched (local macOS render skews `std`/`core` — the committed CI/ubuntu form is the lock)
