### PR TITLE
docs(count-truth): the 42-crate ghost is dead — ADR-037's 50-90 horizon, projected counts everywhere

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,9 +25,9 @@ If any doc contradicts another, **POST_AUDIT_REVISIONS wins**.
 
 ## 🎯 What we're doing
 
-Nika Diamond = 42 crates architecture (cap 100). Building on fresh
-orphan branch. Each crate passes 12 gates before admission to workspace.
-Count finalized by POST_AUDIT_REVISIONS 2026-04-14 — includes pck + natives.
+Nika Diamond = layered crate architecture (L0→L5 · the count is
+projected, never a gate — ADR-037 horizon 50-90 · cap 100 · ruled
+D-2026-07-21-N1). Building on fresh orphan branch. Each crate passes 12 gates before admission to workspace.
 
 Timeline honnête : 11-12 mois total. No deadline pressure — quality > speed.
 Current: Phase 2 M2 (L1 computer-use effect crates) in progress — the M2
@@ -133,7 +133,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | HEAD             | `f6755b019` (`f6755b01914925b01a5776178939f73e5a68d5d9`)             |
 | workspace        | v0.105.0                                  |
 | crates (workspace)| 55                                              |
-| crates (admitted)| 53 / 42                                   |
+| crates (admitted)| 53                                             |
 | crates (WIP)     | 2 — nika-chart nika-fx                                  |
 | L0               | 17                                              |
 | L0.5             | 6                                              |
@@ -151,7 +151,7 @@ dylint + nika-lints — custom architectural lints (Phase 4+)
 | HEAD             | `25db7137d` (`25db7137dddbe6fdb7782663d1a07096cafb3bad`)             |
 | workspace        | v0.105.0                                  |
 | crates (workspace)| 42                                              |
-| crates (admitted)| 42 / 42                                   |
+| crates (admitted)| 42                                              |
 | crates (WIP)     | 0 —                                   |
 | L0               | 11                                              |
 | L0.5             | 6                                              |
@@ -188,7 +188,7 @@ Narrative context (manually maintained):
   slice is now CLOSED · nika-cli (operator surface) + nika-builtin (s16 · the
   23 stdlib tools) + nika-infer-local (candle · ADR-091) + nika-extract (the 9
   fetch extract modes) are ALL admitted (2026-06-21) — **the wip array is empty**
-  (39/42 · all existing crates admitted).
+  (39 admitted at the time · all existing crates admitted).
 - **Last stabilization — 2026-06-16** (origin/main `0b558f7f8`) · the static-check
   layer hardened to runtime-parity. **DEEP_GAPS conformance ledger EMPTIED** ·
   jq compile-check (jaq) + schema meta-check (jsonschema), both in L0 calling the
@@ -198,11 +198,10 @@ Narrative context (manually maintained):
   stream-binding lint. CF-1 for_each positional-null verified spec-correct (not a
   bug · test + spec clarification). Full battery green · 2687 lib + e2e + 503-wf
   corpus check (0 panic / 0 internal-code leak) + hygiene 0-RED.
-- **Next** · the wip array is EMPTY (40/42 · every workspace crate admitted) ·
-  the remaining 2 toward the 42-target are the L0-completion crates
-  (nika-pck-manifest · nika-binding) · then design-partner `1.0.0-rc.N` → the **1.0.0**
+- **Next** · design-partner `1.0.0-rc.N` → the **1.0.0**
   launch (amended D-2026-06-20-N1). Latest tagged release is 0.91.0; `main`
   carries the next dev version so contributor binaries cannot masquerade as the
-  Homebrew asset. 42-crate target reached additively across the 1.x minors.
+  Homebrew asset. The crate count follows the ADR-037 horizon (50-90 · cap 100 ·
+  projected, never a gate · ruled D-2026-07-21-N1).
 
 🦋 Nika — workflow engine for AI, AGPL, SuperNovae Studio.

--- a/.claude/commands/diamond-health.md
+++ b/.claude/commands/diamond-health.md
@@ -39,7 +39,7 @@ find crates -name '*.rs' -not -path '*/target/*' | xargs wc -l 2>/dev/null | sor
 ```
 💎 DIAMOND HEALTH — <date>
 
-Crates admitted:  N / 42 target (cap 100 · reached additively across the 1.x minors)
+Crates admitted:  N (ADR-037 horizon 50-90 · cap 100 · projected, never a gate)
 Workspace LOC:    N (caps: ≤15k prod LOC/crate · ≤1500 LOC/file — no workspace-total target)
 Files >1500:      N (target 0)
 Unwraps src/:     N (target 0)

--- a/.claude/rules/nika-invariants.md
+++ b/.claude/rules/nika-invariants.md
@@ -2,7 +2,7 @@
 
 ## Crate structure
 
-- Total target : **42-crate diamond architecture** (cap 100 · reached additively across the 1.x minors · amended D-2026-06-20-N1 · was "v0.90") + **11 Connectome crates** (1 L2 orchestrator `nika-connectome` + **10 L1 satellite crates** · autodesc split per ADR-042) — separate count, the **2.0** Connectome era. Satellites · `hnsw, bm25, rrf, rerank, fsrs, rdfs-reasoner, temporal, graph-algos, autodesc-minimal, autodesc-full`. Phase-M climb · cognition in the 2.0 era · specs at `docs/crate-specs/nika-<sat>.md`. See ADR-004 + ADR-042 + `BLUEPRINT_2036.md`.
+- Crate count : **not the invariant** (ruled D-2026-07-21-N1). ADR-037 (accepted 2026-04-17) revised the stale 40-42 target to **50-90 · cap 100 unchanged** — a planning horizon, never a gate. The count invariants are **collapse-vs-publish** (below), the **layer contract** (`docs/architecture/crate-layer-registry.md`), and the **15k prod-LOC wall**; the live count is PROJECTED (`scripts/crate-metrics.sh` · hygiene vector 2), never hand-typed. + **11 Connectome crates** (1 L2 orchestrator `nika-connectome` + **10 L1 satellite crates** · autodesc split per ADR-042) — separate count, the **2.0** Connectome era. Satellites · `hnsw, bm25, rrf, rerank, fsrs, rdfs-reasoner, temporal, graph-algos, autodesc-minimal, autodesc-full`. Phase-M climb · cognition in the 2.0 era · specs at `docs/crate-specs/nika-<sat>.md`. See ADR-004 + ADR-042 + `BLUEPRINT_2036.md`.
 
 ## Collapse-vs-publish principle (decision RULE locked · cluster collapses = QUEUED proposals)
 
@@ -64,7 +64,7 @@
   (D-2026-05-22-N17)
 - `nika-infer-local` — native in-process backend (candle sidecar · ADR-091)
 
-## Added in POST_AUDIT 2026-04-14 expansion (8 new crates · toward the 42-crate target)
+## Added in POST_AUDIT 2026-04-14 expansion (8 new crates · per the ADR-037 count horizon)
 
 **Builtin bundles × 3** (native API adapters):
 - `nika-builtin-github` — octocrab wrapper (~800 LOC)
@@ -78,7 +78,7 @@
 - `nika-pck` — L2, orchestrator (~3k LOC)
 - `nika-git` — L1, gix wrapper for pck (~1.5k LOC)
 
-Total architecture target confirmed: **42 crates** (including these 8 · amended D-2026-06-20-N1 · was "v0.90").
+Count note (D-2026-07-21-N1): these 8 landed under the ADR-037 horizon (**50-90 · cap 100**) — the count is projected, never a gate.
 
 ## Kernel hooks Phase 0 (mandatory)
 
@@ -131,8 +131,8 @@ And 17+ more from rust-analyzer adapted invariants in RUST_ENFORCEMENT.md §6.
 Real semver toward a **1.0** public launch (amended D-2026-06-20-N1 · was
 "forever-v0.x — no v1.0 target"). The engine is at **0.91.0** (latest release · main on
 0.92.0-dev · release-candidate grade); the **1.0.0** launch ships when the 7 shadow zones are green, and
-the remaining crates land additively across the 1.x minors toward the 42-crate
-architecture target. The `nika: v1` LANGUAGE envelope is frozen forever
+the remaining crates land additively across the 1.x minors under the ADR-037
+count horizon (50-90 · cap 100 · projected, never a gate · ruled D-2026-07-21-N1). The `nika: v1` LANGUAGE envelope is frozen forever
 (orthogonal to the engine version).
 
 No hard per-phase deadlines — quality > speed. The pace is self-paced, not a

--- a/.claude/tracking/legacy-features-checklist.md
+++ b/.claude/tracking/legacy-features-checklist.md
@@ -5,7 +5,7 @@
 >
 > Last updated: 2026-04-14. Produced by 4-agent legacy audit.
 
-## Migrated (admitted crates, 5/42)
+## Migrated (admitted crates, 5 at the time)
 
 | Legacy source | Diamond crate | Status |
 |---|---|---|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing to Nika
 
 Welcome. Nika is a Rust workflow engine for AI, built as a **diamond
-rewrite toward a 1.0 launch** (amended D-2026-06-20-N1): 42 crates,
-each passing a 12-gate admission checklist before joining the workspace.
+rewrite toward a 1.0 launch** (amended D-2026-06-20-N1): layered crates
+(the count is projected, never a gate — ADR-037 horizon 50-90 · cap 100 ·
+ruled D-2026-07-21-N1), each passing a 12-gate admission checklist before joining the workspace.
 This document explains how to contribute.
 
 See also: [`README.md`](README.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md),
@@ -10,7 +11,7 @@ See also: [`README.md`](README.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md),
 [`DIAMOND.md`](DIAMOND.md) (strategy overview),
 [`ROADMAP.md`](ROADMAP.md) (real-semver plan toward 1.0),
 [`docs/architecture/BLUEPRINT_2036.md`](docs/architecture/BLUEPRINT_2036.md)
-(10-year horizon canon · v1.3 · 42-crate target · 11/10 amplifiers).
+(10-year horizon canon · v1.3 · ADR-037 count horizon 50-90 · cap 100 · 11/10 amplifiers).
 
 ---
 
@@ -33,7 +34,7 @@ If you are unsure whether something is in scope, open an issue first.
 
 ## Philosophy
 
-- **Real semver toward 1.0** (amended D-2026-06-20-N1). The engine is at 0.91.0 (latest release · main on 0.92.0-dev · release-candidate grade); the first public launch ships as 1.0.0, then 1.x minors add the remaining crates additively toward the 42-crate target. Each version is diamond-grade for its declared scope.
+- **Real semver toward 1.0** (amended D-2026-06-20-N1). The engine is at 0.91.0 (latest release · main on 0.92.0-dev · release-candidate grade); the first public launch ships as 1.0.0, then 1.x minors add the remaining crates additively toward the ADR-037 count horizon (50-90 · cap 100 · projected, never a gate · ruled D-2026-07-21-N1). Each version is diamond-grade for its declared scope.
 - **Quality over speed.** No deadline pressure. A PR lands when it is ready.
 - **Perfect diamond.** Zero band-aid, zero residue, zero ghost reference. Every leftover gets fixed or flagged — never ignored.
 - **Craft, not extraction.** Legacy code at `main` (v0.79.3) is a read-only reference. Diamond rewrites each crate from scratch, guided by the legacy.

--- a/DIAMOND.md
+++ b/DIAMOND.md
@@ -17,7 +17,8 @@ the real-semver plan toward a 1.0 launch (amended D-2026-06-20-N1 · was
 "forever-v0.x") — the CHANGELOG top names the latest tagged release, `main` on the next
 dev version → 1.0.0 → 1.x adds the remaining crates → 2.0 the Connectome era — see [`ROADMAP.md`](ROADMAP.md). For the
 **10-year architectural horizon
-(2026 → 2036)** with refined 42-crate target, 4-verb stress test
+(2026 → 2036)** with the ADR-037 count horizon (50-90 · cap 100 ·
+projected, never a gate · ruled D-2026-07-21-N1), 4-verb stress test
 through 2036, 7-ADR queue (050-056) and per-crate detail, see
 [`docs/architecture/BLUEPRINT_2036.md`](docs/architecture/BLUEPRINT_2036.md)
 (proposal-grade · annual decennial review 2027-04+ · version lives in
@@ -76,9 +77,10 @@ servers via `rmcp`.
 
 ## Crate architecture
 
-42-crate architecture target (reached additively across the 1.x minors ·
-amended D-2026-06-20-N1), expanding to ~75 in later minors, hard cap
-100 ever. Strict downward-only layering (L0 → L5):
+Crate count: ADR-037 horizon **50-90** (reached additively across the 1.x
+minors), hard cap 100 ever — the count is projected
+(`scripts/crate-metrics.sh`), never a gate (ruled D-2026-07-21-N1).
+Strict downward-only layering (L0 → L5):
 
 ```
 L5   nika                         binary, <500 LOC composition root
@@ -159,7 +161,7 @@ Version ladder (no per-tag dates · quality > speed):
 - **release-candidate grade reached at 0.91.0**: usable vertical slice (4 verbs, 16 providers per canon.yaml, effects, static-check, MCP/LSP, CLI), headless workspace build — the CHANGELOG top names the current release.
 - **1.0.0-rc.N** — design-partner hardening, 7 shadow zones green.
 - **1.0.0** — **first public launch**: language + installable binary, validated.
-- **1.x minors** — add the remaining crates additively toward the 42-crate architecture target (pck, native API adapters, WASM plugins, full observability, full LSP, keys subsystem).
+- **1.x minors** — add the remaining crates additively under the ADR-037 count horizon (50-90 · cap 100 · projected, never a gate) (pck, native API adapters, WASM plugins, full observability, full LSP, keys subsystem).
 - **2.0** — **the Connectome era**: memory + cognition (1 L2 orchestrator + 10 L1 satellites, agent-v2). The next epoch.
 
 Full breakdown: [`ROADMAP.md`](ROADMAP.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,7 +101,7 @@ See `docs/architecture/ai-velocity.md` for the full argument.
 | HEAD             | `f6755b019` (`f6755b01914925b01a5776178939f73e5a68d5d9`)             |
 | workspace        | v0.105.0                                  |
 | crates (workspace)| 55                                              |
-| crates (admitted)| 53 / 42                                   |
+| crates (admitted)| 53                                             |
 | crates (WIP)     | 2 — nika-chart nika-fx                                  |
 | L0               | 17                                              |
 | L0.5             | 6                                              |
@@ -227,8 +227,9 @@ Real semver toward a 1.0 launch, then `MAJOR.MINOR.PATCH`:
 > **Superseded `v0.8X.Y` layer-tag scheme (kept for history).** Before
 > D-2026-06-20-N1 the tags climbed per layer-phase (`v0.81`=L0 complete …
 > `v0.90`=L3 complete … `v0.92`=L5 binary, "forever-v0.x"). That scheme is
-> retired · the engine re-versions `0.80.0 → 0.90.0` and the 42-crate target
-> moves to post-1.0 minors. Original table preserved in git history.
+> retired · the engine re-versions `0.80.0 → 0.90.0` and the crate count
+> moves to post-1.0 minors (ADR-037 horizon 50-90 · cap 100 · projected,
+> never a gate · ruled D-2026-07-21-N1). Original table preserved in git history.
 
 ## Schema envelope — forever v1 (Q-R5 · per nika-spec)
 
@@ -884,7 +885,7 @@ the historical `v0.8X.Y` layer-phase scheme is retired).
 - [`DIAMOND.md`](DIAMOND.md) — strategy overview · 7 shadow zones
 - [`docs/architecture/BLUEPRINT_2036.md`](docs/architecture/BLUEPRINT_2036.md)
   — **10-year horizon canon (v1.3) · LAYER 1 DECENNIAL anchor** ·
-  42-crate target · 4-verb 2036 stress-test · 11/10 amplifiers ·
+  ADR-037 count horizon (50-90 · cap 100) · 4-verb 2036 stress-test · 11/10 amplifiers ·
   ADR queue 050-056 + 060/062/064/066/070/071/072/073
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — 12-gate admission · contributor process
 - [`SECURITY.md`](SECURITY.md) — vulnerability disclosure · 11-row defense layers + NIKA-390 queued

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -19,7 +19,9 @@ quarter we sit down and narrate the journey. The commits are public.
 The mutation scores are public. The architecture diagram is a living
 anatomy.
 
-We are crafting 40 to 42 crates over however long it takes. No deadline.
+We are crafting the crates the doctrine asks for (ADR-037 horizon 50-90 ·
+cap 100 · the count is projected, never a gate · ruled D-2026-07-21-N1)
+over however long it takes. No deadline.
 No hack week. Each crate passes 12 gates before it enters the body. If it
 fails mutation testing, it doesn't ship. If it leaks an `.unwrap()` into
 production, it doesn't ship. If it can't explain itself in under 1,500

--- a/docs/architecture/BLUEPRINT_2036.md
+++ b/docs/architecture/BLUEPRINT_2036.md
@@ -19,6 +19,15 @@ sources:
 
 # Nika Diamond · Blueprint final v0.x · 10-year horizon (2026 → 2036)
 
+> **v1.8 amendment (D-2026-07-21-N1)** · the « 42-crate target » throughout
+> this doc is SUPERSEDED. ADR-037 (accepted 2026-04-17) had already revised
+> the count target 40-42 → **50-90 (cap 100 unchanged)**; the operator ruled
+> 2026-07-21 that **the count is not the invariant** — collapse-vs-publish
+> (§1.5), the layer contract (`crate-layer-registry.md`), and the 15k-LOC
+> wall are. The live count is projected (`scripts/crate-metrics.sh`), never
+> hand-typed. Prior prose preserved below as audit trail per
+> `cross-source-validation.md` §2.7.
+
 > **v1.7 stack-pin note (2026-06-11)** · the dependency pins of this doc's
 > date are SUPERSEDED where the Connectome stack ratification + shipped
 > crates differ: `oxigraph@0.5.8` (not 0.5.6) · embeddings via **candle**

--- a/docs/architecture/VISION_2040_intelligence-layer.md
+++ b/docs/architecture/VISION_2040_intelligence-layer.md
@@ -45,12 +45,13 @@ not a fork of the atelier.
    │  L0.5 kernel · sealed traits                          (the contract) │
    │  L0 primitives · types · error · schema              (the floor)     │
    └───────────────────────────────────────────────────────────────────┘
-                          the Diamond engine (BLUEPRINT_2036 · 42 crates)
+                          the Diamond engine (BLUEPRINT_2036 · the ladder)
 ```
 
 The Diamond crate-ladder (L0→L5) is the **engine**. The intelligence layer is
 the **experience** — it's how a human or an agent *meets* the engine. Today the
-engine is ~18/42 crates; the intelligence layer is mostly design + seams.
+engine is 55 crates (projected — the count is never hand-typed · ADR-037
+horizon 50-90 · cap 100); the intelligence layer is mostly design + seams.
 
 ---
 
@@ -296,7 +297,7 @@ promise.
 ## §9 · Related (canonical sources)
 
 - `ROADMAP.md` — what ships when (the phases, the tag scheme)
-- `docs/architecture/BLUEPRINT_2036.md` — the 42-crate ladder + 7 future ADRs + SOTA-2030
+- `docs/architecture/BLUEPRINT_2036.md` — the crate ladder (ADR-037 horizon 50-90 · cap 100) + 7 future ADRs + SOTA-2030
 - `docs/architecture/forward-compat-invariants.md` — the 8 patterns / 10 rules (Gate 12)
 - `docs/adr/adr-085-spec-schema-oneof-bridge-to-schemars-codegen.md` — the LSP + schema-codegen seam
 - `docs/adr/adr-090-structural-doctrine-enforcement.md` — the SSOT-projection discipline (this doc's through-line)

--- a/docs/architecture/ai-velocity.md
+++ b/docs/architecture/ai-velocity.md
@@ -85,8 +85,8 @@ product was complete AT EACH RELEASE for what it claimed to do. We follow
 the same arc: ship 1.0 complete for what it claims, then grow it.
 
 **1.0.0** ships when the 7 shadow zones are green — the first public launch.
-The remaining crates toward the 42-crate architecture land additively across
-the **1.x minors**. The Connectome and agent-v2 are the **2.0** era. Each
+The remaining crates (ADR-037 horizon 50-90 · cap 100 · projected, never a
+gate · ruled D-2026-07-21-N1) land additively across the **1.x minors**. The Connectome and agent-v2 are the **2.0** era. Each
 release is a complete chrysalis stage, not an intermediate build.
 
 ## Cost
@@ -95,7 +95,8 @@ release is a complete chrysalis stage, not an intermediate build.
 docs. ~30 min for canary + parity + review swarm. ~10 min for atomic commit
 and MEMORY update.
 
-Call it 4 hours per crate, 42 crates, 168 hours of craft work. Against an
+Call it 4 hours per crate; at the ADR-037 horizon (50-90 · cap 100 ·
+projected, never a gate) that's 200-360 hours of craft work. Against an
 11-12 month self-paced schedule, that's 15 hours of craft per week — well
 under the 70/20/10 rhythm (craft / docs / social) we committed to.
 

--- a/docs/architecture/crate-layer-registry.md
+++ b/docs/architecture/crate-layer-registry.md
@@ -14,7 +14,7 @@ into nika-binding, nika-event scoped sub-enums, nika-kernel prelude hub).
 
 ## Why this document exists
 
-42 crates without a layer contract converge on a kitchen-sink dependency
+A crate workspace without a layer contract converges on a kitchen-sink dependency
 graph: everything imports everything, every crate pulls in tokio, every
 change ripples through the workspace. Diamond discipline defines six
 layers (L0 → L5, with an L0.5 for trait-only crates) and makes upward

--- a/docs/architecture/l0-l05-architecture-decisions.md
+++ b/docs/architecture/l0-l05-architecture-decisions.md
@@ -13,7 +13,7 @@
 With **6 crates admitted** (types, error, catalog, catalog-verify, kernel, kernel-mock)
 + **1 WIP** (nika-schema parser) and 33-35 remaining, this document locks the L0 + L0.5
 layer architecture. All decisions account for v0.100 forward-compatibility and are
-designed to avoid breaking changes as the workspace scales to 42 crates.
+designed to avoid breaking changes as the workspace scales (ADR-037 count horizon 50-90 · cap 100).
 
 ---
 

--- a/docs/crate-specs/nika-cap.md
+++ b/docs/crate-specs/nika-cap.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **PLANNED** — Gate 1 (this document) authored 2026-07-03, prior to TDD. Target tag `v0.93.0` per `ROADMAP.md` (40/42). |
+| Status | **PLANNED** — Gate 1 (this document) authored 2026-07-03, prior to TDD. Target tag `v0.93.0` per `ROADMAP.md`. |
 | Layer | L0 — pure, zero I/O, zero async |
 | Design | A pure vocabulary + set-algebra crate: the declared capability boundary (`permits:`, spec `01-envelope.md` §permits) as data + the "fits" predicate over it. No AST types, no workflow coupling. |
 | LOC budget | ≤600 src (target ~480), ≤800 hard cap — sized against the closest L0 sibling, `nika-event` (~462 LOC), not against `nika-schema` (a monolith by different design constraints, see §2) |

--- a/docs/crate-specs/nika-pck-manifest.md
+++ b/docs/crate-specs/nika-pck-manifest.md
@@ -15,7 +15,7 @@
 The pck suite (registry L1 · git L1 · orchestrator L2 · CLI verbs L4) is
 post-1.0, but its **data contract** is L0 and admission-ready NOW: pure
 types every future pck crate deserializes against. Landing the types first
-(a) completes the 42-crate architecture target, (b) freezes the wire shapes
+(a) lands under the ADR-037 count horizon (50-90 · cap 100 · projected, never a gate), (b) freezes the wire shapes
 under `#[non_exhaustive]` + INV#19 before any I/O code exists (additive
 forever), (c) encodes the D4 taxonomy the operator just ratified as the ONE
 closed-but-extensible enum every registry surface shares.

--- a/docs/crate-specs/nika-tmpl.md
+++ b/docs/crate-specs/nika-tmpl.md
@@ -109,7 +109,7 @@ Design notes:
   where they are. This crate is *below* the body language.
 - **No taint / label rules** — those are checker-internal (`flow.rs`); the runtime
   does no taint. Sharing them requires the (deferred) expression-frontend unification
-  — a separate ADR (the real `nika-binding` engine · see the 42/42 master plan §3.5).
+  — a separate ADR (the real `nika-binding` engine · see the master plan §3.5).
 - **No transforms / resolver** — that is the `nika-binding` engine, later.
 
 ## 6 · Coherence

--- a/scripts/refresh-status.sh
+++ b/scripts/refresh-status.sh
@@ -98,7 +98,7 @@ cat <<EOF
 | HEAD             | \`$HEAD_SHA_SHORT\` (\`$HEAD_SHA_FULL\`)             |
 | workspace        | v$WORKSPACE_VERSION                                  |
 | crates (workspace)| $WORKSPACE_MEMBERS                                              |
-| crates (admitted)| $ADMITTED_COUNT / 42                                   |
+| crates (admitted)| $ADMITTED_COUNT                                             |
 | crates (WIP)     | $WIP_COUNT — $WIP_CRATES                                  |
 | L0               | $L0_COUNT                                              |
 | L0.5             | $L05_COUNT                                              |


### PR DESCRIPTION
## Why

The "42-crate target" made agents hallucinate a cap that doesn't exist. **ADR-037 (accepted 2026-04-17) had already revised the count target 40-42 → 50-90 (cap 100 unchanged)** — but 17 live spots kept preaching 42, including `scripts/refresh-status.sh` itself: the canonical status block every doc quotes was rendering the nonsense `crates (admitted)| 53 / 42` (53 admitted out of "42" — self-evidently broken). Operator ruling (D-2026-07-21-N1): **the count is not the invariant** — collapse-vs-publish (Blueprint §1.5), the layer contract, and the 15k-LOC wall are; the live count is projected (`scripts/crate-metrics.sh`), never hand-typed.

## What (17 files, docs-only + the one generator)

- **`scripts/refresh-status.sh`** — the admitted row drops the `/ 42` suffix (the hallucination's source).
- **`.claude/rules/nika-invariants.md`** — the "Total target: 42-crate" line becomes "Crate count: not the invariant" + the ADR-037 horizon; 3 downstream spots aligned.
- **`.claude/CLAUDE.md` / `ROADMAP.md`** — canonical blocks byte-matched to the fixed generator (hygiene vector 23 green); stale `39/42`, `40/42` prose dropped.
- **CONTRIBUTING / DIAMOND / MANIFESTO / ROADMAP / crate-layer-registry / ai-velocity / l0-l05 / VISION_2040 / nika-{cap,pck-manifest,tmpl} specs / diamond-health command** — every live 42-target claim → ADR-037 horizon (50-90 · cap 100 · projected, never a gate).
- **`BLUEPRINT_2036.md`** — v1.8 amendment note in front-matter (house doctrine: amend by note, prose preserved as audit trail per `cross-source-validation.md` §2.7). CHANGELOG + ADRs untouched — they are history.

## Verification

- `bash scripts/hygiene/check-status-claims-sync.sh` → **OK** (both whitelisted docs byte-match the fixed generator).
- Zero code touched; the two remaining `42` grep hits are HTTP status codes (`5xx/408/429`) in the pack stdlib docs — not the count.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
