### PR TITLE
test(nika-cli): the wizard PTY colour env is hermetic — the macOS flake dies

### DIFF
--- a/crates/nika-cli/tests/wizard_pty.rs
+++ b/crates/nika-cli/tests/wizard_pty.rs
@@ -53,9 +53,19 @@ fn fresh_dir(tag: &str) -> tempfile::TempDir {
 
 /// Spawn `nika <args>` on a PTY in `dir`. `plain` = `NO_COLOR` (keeps the
 /// transcript byte-assertable); one test drops it to prove colour lives.
+///
+/// The colour env is HERMETIC (nika#675): the ambient developer shell can
+/// leak `NO_COLOR` / `CLICOLOR*` / `TERM` into the PTY child and silently
+/// flip the wizard's `--color auto` resolution — the two halves must pin
+/// the four knobs the resolver reads (`main.rs`), never inherit them.
 fn spawn_pty(dir: &std::path::Path, args: &[&str], plain: bool) -> LoggedSession {
     let mut cmd = Command::new(bin());
     cmd.args(args).current_dir(dir);
+    cmd.env_remove("NO_COLOR")
+        .env_remove("CLICOLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("FORCE_COLOR");
+    cmd.env("TERM", "xterm-256color");
     if plain {
         cmd.env("NO_COLOR", "1");
     }


### PR DESCRIPTION
Root cause of #675: spawn_pty inherited the ambient env — a shell exporting NO_COLOR=1 / TERM=dumb flips the wizard's --color auto, so the colour test failed locally (10/11) while CI stayed green. The fail-fast-across-binaries interaction made whole suites vanish behind it (#674's local/CI discrepancy). Fix: the PTY child scrubs NO_COLOR/CLICOLOR/CLICOLOR_FORCE/FORCE_COLOR and pins TERM=xterm-256color; plain=true sets NO_COLOR=1 explicitly. Verified on the poisoned machine: wizard_pty 11/11. Closes #675.