### PR TITLE
docs(nika-onboard): the authoring floor speaks the four authorities — W7

### DIFF
--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -142,11 +142,11 @@ Envelope: `nika: v1` (always · frozen forever). Extensions: `.nika.yaml` (canon
 - `agent:` multi-turn loop (`prompt`, `tools`, `max_turns`, `max_tokens_total`)
 
 ## Authoring Discipline
-- Interpolation uses `${{ vars.x }}` · `${{ tasks.id.output }}` · `${{ env.KEY }}` · `${{ with.alias }}`.
+- Interpolation uses `${{ inputs.x }}` · `${{ const.x }}` · `${{ config.KEY }}` · `${{ tasks.id.output }}` · `${{ with.alias }}`.
 - Bindings use `with: { alias: ${{ tasks.id.output }} }` then `${{ with.alias }}`.
 - Models use the combined form `provider/name` (for example `mock/echo`, `ollama/qwen3.5:4b`, `mistral/mistral-small`).
 - Edges are declared, never restated: a `with:` binding reading `${{ tasks.id.output }}` IS the data edge · `after: { task_id: success }` is the control edge (predicates: `success` · `failure` · `skipped` · `terminal`). `depends_on` is dead — `nika check --fix` migrates it.
-- Secrets are declared in a top-level `secrets:` block (e.g. `source: env`, `key: MY_KEY`) and referenced as `${{ secrets.name }}` — never inline literal keys; `${{ env.* }}` is for non-sensitive configuration.
+- Secrets are declared in a top-level `secrets:` block (e.g. `source: env`, `key: MY_KEY`) and referenced as `${{ secrets.name }}` — never inline literal keys; non-sensitive configuration declares `config:` and reads `${{ config.KEY }}`.
 - After every edit, run `nika check <file>` — `--fix` heals the mechanical
   renames, the diagnostics teach the rest.
 - Unknown code? Run `nika explain NIKA-XXXX`.

--- a/scripts/media/fixtures/meeting-actions.nika.yaml
+++ b/scripts/media/fixtures/meeting-actions.nika.yaml
@@ -9,14 +9,14 @@ workflow:
 
 model: mock/echo            # offline demo path · swap for any provider
 
-vars:
+const:
   transcript_path: "scripts/media/fixtures/sample-transcript.txt"
 
 tasks:
   transcript:
     invoke:
       tool: "nika:read"
-      args: { path: "${{ vars.transcript_path }}" }
+      args: { path: "${{ const.transcript_path }}" }
 
   extract:
     with:
@@ -54,5 +54,4 @@ tasks:
 outputs:
   actions:
     value: ${{ tasks.extract.output.actions }}
-    type: array
     description: "Typed action items, tracker-ready"


### PR DESCRIPTION
W7 wave (code half). briefs.rs taught ${{ vars.x }} + ${{ env.* }} — both dead post-#669; now ${{ inputs.x }} · ${{ const.x }} · ${{ config.KEY }} and config: for non-sensitive configuration. The predicate teaching was already R5-clean. The scripts/media fixture (the one non-pack vars: workflow) migrated per the E-split classes: vars:→const:, class-aware refs, bare `type: array` dropped (no 'any array' TypeExpr post-#673, the pack's own answer). Verified: nika-onboard 60/60 lib tests · the fixture passes the built engine's `nika check` with a fully green audit (3 tasks, 3 waves). The pack half of W7 (#607 merge) follows separately per the choreography.