### PR TITLE
docs(release): the release matrices speak the voice, no em-dash authored

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,15 +1,15 @@
 # Releasing Nika
 
 The release train is one tag push; everything after is CI. This file is the
-ceremony — what a releaser does, what the machine does, and what a user can
+ceremony: what a releaser does, what the machine does, and what a user can
 prove afterwards. The lineage law applies throughout: a published release is
-a historical record — **never rewrite a live release body retroactively**
+a historical record: **never rewrite a live release body retroactively**
 without an explicit operator decision.
 
 ## The ceremony (human side)
 
 1. **Fill the changelog.** The `[Unreleased]` section becomes the version
-   section — generate it, don't hand-type it:
+   section: generate it, don't hand-type it:
 
    ```sh
    git-cliff --config cliff.toml v<PREV>..HEAD --tag v<NEXT> --strip all
@@ -17,10 +17,10 @@ without an explicit operator decision.
 
    Splice the output under `## [Unreleased]` as `## [<NEXT>]`, newest first.
    Hand-curated narrative (a BREAKING window, an era note) may replace the
-   generated body — the section, not the release page, is where curation
+   generated body: the section, not the release page, is where curation
    lives. `CHANGELOG.md` is the single source the release body renders from.
 
-2. **Bump the workspace version** in `Cargo.toml` to `<NEXT>` — the release
+2. **Bump the workspace version** in `Cargo.toml` to `<NEXT>`: the release
    workflow refuses a tag that disagrees with the manifest (first gate).
 
 3. **Tag and push.**
@@ -43,9 +43,9 @@ without an explicit operator decision.
 | `ghcr.io/supernovae-st/nika:{<ver>,latest}` | multi-arch image, bit-identical to the tarballs |
 | Homebrew formula bump | `supernovae-st/homebrew-tap` (deploy-key scoped) |
 
-The release body is rendered by `scripts/release/render-notes.sh` — the
+The release body is rendered by `scripts/release/render-notes.sh`: the
 curated **What / Install / Verify / Provenance** front page from the
-changelog section — with GitHub's generated PR list appended below it.
+changelog section: with GitHub's generated PR list appended below it.
 
 ## What a user can prove
 
@@ -63,7 +63,7 @@ failing is a stop-the-line event.
 
 ## The record
 
-Every release is also a claim on the machine-verified timeline —
+Every release is also a claim on the machine-verified timeline ·
 [nika.sh/timeline](https://nika.sh/timeline) renders the spec's
 `timeline/timeline.yaml`, and CI re-proves the provable claims (GitHub ·
 crates.io) on every push and weekly. A release that isn't in the record

--- a/scripts/release/render-notes.sh
+++ b/scripts/release/render-notes.sh
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
-# render-notes.sh — the curated release body: What · Install · Verify · Provenance.
+# render-notes.sh: the curated release body: What · Install · Verify · Provenance.
 #
 # The generated PR list (`gh release create --generate-notes`) is a good index
 # and a bad front page: a reader landing on a release should see what shipped,
 # how to install it, and how to PROVE the artifact they hold is the artifact
-# CI built — before the merge log. This script renders that front page; the
+# CI built: before the merge log. This script renders that front page; the
 # workflow passes it via `--notes-file` and keeps `--generate-notes`, so the
 # full PR list still rides at the bottom (gh prepends provided notes to the
-# generated ones — the index survives, the story leads).
+# generated ones: the index survives, the story leads).
 #
-# The What section reads CHANGELOG.md — the same section git-cliff maintains —
+# The What section reads CHANGELOG.md: the same section git-cliff maintains ·
 # so the release body and the changelog can never tell two stories. An empty
 # or missing section degrades to the compare link, never to silence.
 #
 # Usage: render-notes.sh vX.Y.Z            (from the repo root)
-# Stdout is the markdown body. No network, no mutation — pure projection.
+# Stdout is the markdown body. No network, no mutation: pure projection.
 set -euo pipefail
 
 tag="${1:?usage: render-notes.sh vX.Y.Z}"
 version="${tag#v}"
 repo="${GITHUB_REPOSITORY:-supernovae-st/nika}"
 
-# ── What — the CHANGELOG section between this version's header and the next `## [`
+# ── What: the CHANGELOG section between this version's header and the next `## [`
 what="$(awk -v ver="$version" '
   index($0, "## [" ver "]") == 1 { grab = 1; next }
   grab && /^## \[/ { exit }
@@ -30,7 +30,7 @@ what="$(awk -v ver="$version" '
 # strip leading blank lines; trailing ones are harmless in markdown
 what="$(printf '%s\n' "$what" | sed -e '/[^[:space:]]/,$!d')"
 if [ -z "${what//[[:space:]]/}" ]; then
-  what="Curated notes pending for this tag — the full diff: https://github.com/${repo}/compare/$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || echo "v0.90.0")..${tag}"
+  what="Curated notes pending for this tag: the full diff: https://github.com/${repo}/compare/$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || echo "v0.90.0")..${tag}"
 fi
 
 cat <<EOF
@@ -48,16 +48,16 @@ docker run --rm ghcr.io/${repo}:${version} --version
 
 Tarballs below: macOS arm64 / x64 · Linux x64 / arm64, plus \`SHA256SUMS\`.
 
-## Verify — three independent proofs
+## Verify: three independent proofs
 
 \`\`\`sh
-# 1 · checksum — the bytes you hold are the bytes CI hashed
+# 1 · checksum: the bytes you hold are the bytes CI hashed
 sha256sum -c SHA256SUMS --ignore-missing     # macOS: shasum -a 256 -c
 
-# 2 · attestation — GitHub-signed build provenance for this exact artifact
+# 2 · attestation: GitHub-signed build provenance for this exact artifact
 gh attestation verify nika-<platform>-${version}.tar.gz --repo ${repo}
 
-# 3 · SLSA provenance — the intoto asset, verifiable offline
+# 3 · SLSA provenance: the intoto asset, verifiable offline
 slsa-verifier verify-artifact nika-<platform>-${version}.tar.gz \\
   --provenance-path multiple.intoto.jsonl \\
   --source-uri github.com/${repo} --source-tag ${tag}


### PR DESCRIPTION
render-notes.sh (12) and RELEASING.md (8) shed their authored em-dashes: every 0.106+ release is born from these templates, so the purge lands before the next tag. The What section stays a verbatim CHANGELOG citation (quoted commit subjects keep their punctuation: the voice law never rewrites a citation). shellcheck ✓ typos ✓ rendered preview: 0 authored em-dash.