### PR TITLE
feat(permits): the env permit dimension (F-O4 · NEP-0005)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,6 +4340,7 @@ dependencies = [
  "futures-core",
  "insta",
  "miette",
+ "nika-cap",
  "nika-error",
  "serde",
  "serde_json",

--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-38614d2dddac6829a523c5e1e937a89a4807ae24
+aa964686404debcfaadc2588cd243ca37dc060bf

--- a/crates/nika-cap/public-api.txt
+++ b/crates/nika-cap/public-api.txt
@@ -1,4 +1,9 @@
 pub mod nika_cap
+pub mod nika_cap::env
+pub const nika_cap::env::DANGEROUS_ENV_VARS: &[&str]
+pub const nika_cap::env::RUNNER_FLOOR_ENV_VARS: &[&str]
+pub fn nika_cap::env::compose_child_env(lookup: impl core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>, passthrough: &[alloc::string::String], authored: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub fn nika_cap::env::is_dangerous_env_name(name: &str) -> bool
 pub enum nika_cap::BuiltinEffect
 pub nika_cap::BuiltinEffect::Fs
 pub nika_cap::BuiltinEffect::Fs::path_arg: &'static str
@@ -488,14 +493,17 @@ impl<T> core::convert::From<T> for nika_cap::NetPermits
 pub fn nika_cap::NetPermits::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_cap::NetPermits where T: for<'de> serde_core::de::Deserialize<'de>
 #[non_exhaustive] pub struct nika_cap::Permits
+pub nika_cap::Permits::env: core::option::Option<alloc::vec::Vec<alloc::string::String>>
 pub nika_cap::Permits::exec: core::option::Option<nika_cap::ExecPermit>
 pub nika_cap::Permits::fs: core::option::Option<nika_cap::FsPermits>
 pub nika_cap::Permits::net: core::option::Option<nika_cap::NetPermits>
 pub nika_cap::Permits::tools: core::option::Option<alloc::vec::Vec<alloc::string::String>>
 impl nika_cap::Permits
+pub fn nika_cap::Permits::allows_env_key(&self, name: &str) -> bool
 pub fn nika_cap::Permits::allows_exec(&self) -> bool
 pub fn nika_cap::Permits::allows_program(&self, program: &str) -> bool
 pub fn nika_cap::Permits::allows_tool(&self, tool: &str) -> bool
+pub fn nika_cap::Permits::env_passthrough(&self) -> &[alloc::string::String]
 pub fn nika_cap::Permits::new() -> Self
 impl nika_cap::Permits
 pub fn nika_cap::Permits::allows_host(&self, host: &str) -> bool
@@ -854,15 +862,19 @@ pub unsafe fn nika_cap::TrifectaViolation::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_cap::TrifectaViolation
 pub fn nika_cap::TrifectaViolation::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for nika_cap::TrifectaViolation where T: for<'de> serde_core::de::Deserialize<'de>
+pub const nika_cap::DANGEROUS_ENV_VARS: &[&str]
 pub const nika_cap::HUMAN_GATE_TOOL: &str
 pub const nika_cap::POLICY_KEYS: &[&str]
 pub const nika_cap::PURE_INTERNAL_TOOLS: &[&str]
+pub const nika_cap::RUNNER_FLOOR_ENV_VARS: &[&str]
 pub fn nika_cap::builtin_effect(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> core::option::Option<nika_cap::BuiltinEffect>
 pub fn nika_cap::builtin_egresses(tool: &str) -> bool
 pub fn nika_cap::builtin_shape_findings(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_cap::chart_vl_sibling(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> core::option::Option<alloc::string::String>
+pub fn nika_cap::compose_child_env(lookup: impl core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>, passthrough: &[alloc::string::String], authored: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
 pub fn nika_cap::glob_matches(glob: &str, value: &str) -> bool
 pub fn nika_cap::invoke_tool_is_ingress(tool_id: &str, mcp_content_trusted: bool) -> bool
+pub fn nika_cap::is_dangerous_env_name(name: &str) -> bool
 pub fn nika_cap::is_pure_internal(tool: &str) -> bool
 pub fn nika_cap::lexically_normalize(path: &str) -> alloc::string::String
 pub fn nika_cap::policy_child_keys(family: &str) -> core::option::Option<&'static [&'static str]>

--- a/crates/nika-cap/src/algebra.rs
+++ b/crates/nika-cap/src/algebra.rs
@@ -83,6 +83,12 @@ impl Permits {
                 (None, Some(y)) => Some(y.to_vec()),
                 (Some(x), Some(y)) => Some(list_union(x, y)),
             },
+            env: match (self.env.as_deref(), other.env.as_deref()) {
+                (None, None) => None,
+                (Some(x), None) => Some(x.to_vec()),
+                (None, Some(y)) => Some(y.to_vec()),
+                (Some(x), Some(y)) => Some(list_union(x, y)),
+            },
         }
     }
 
@@ -114,6 +120,12 @@ impl Permits {
                 (Some(x), Some(y)) => Some(list_intersect(x, y)),
                 _ => None,
             },
+            // `env:` names are exact literals (NEP-0005 · no globs), so the
+            // conservative string-equal meet IS the true set intersection.
+            env: match (self.env.as_deref(), other.env.as_deref()) {
+                (Some(x), Some(y)) => Some(list_intersect(x, y)),
+                _ => None,
+            },
         }
     }
 }
@@ -139,6 +151,33 @@ mod tests {
     fn intersect_is_the_meet_for_tools() {
         let i = tools(&["nika:read", "nika:write"]).intersect(&tools(&["nika:read"]));
         assert!(i.allows_tool("nika:read") && !i.allows_tool("nika:write"));
+    }
+
+    fn env(list: &[&str]) -> Permits {
+        Permits {
+            env: Some(list.iter().map(|s| (*s).to_owned()).collect()),
+            ..Permits::new()
+        }
+    }
+
+    #[test]
+    fn env_meet_is_the_exact_name_intersection() {
+        // NEP-0005 law 5 · child ∩ parent on exact names — and since env
+        // bounds are literals (no globs), the conservative meet IS the
+        // true set intersection here.
+        let i = env(&["CI_COMMIT_SHA", "CI_JOB_ID"]).intersect(&env(&["CI_COMMIT_SHA"]));
+        assert!(i.allows_env_key("CI_COMMIT_SHA"));
+        assert!(!i.allows_env_key("CI_JOB_ID"));
+        // an absent side means zero: no child inherits a passthrough its
+        // parent could not grant.
+        let z = env(&["CI_COMMIT_SHA"]).intersect(&Permits::new());
+        assert!(!z.allows_env_key("CI_COMMIT_SHA"));
+    }
+
+    #[test]
+    fn env_union_is_the_join() {
+        let u = env(&["A_ONE"]).union(&env(&["B_TWO"]));
+        assert!(u.allows_env_key("A_ONE") && u.allows_env_key("B_TWO"));
     }
 
     #[test]

--- a/crates/nika-cap/src/env.rs
+++ b/crates/nika-cap/src/env.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The environment plane of the capability boundary (NEP-0005 · spec 01
+//! §permits env) — the two canonical name floors and the ONE composition
+//! law every child-process spawn family runs.
+//!
+//! A child process environment is COMPOSED, never inherited:
+//! [`RUNNER_FLOOR_ENV_VARS`] ∪ the declared `permits.env:` passthrough ∪
+//! the task's authored `env:` map, minus [`DANGEROUS_ENV_VARS`]. The
+//! composition is [`compose_child_env`] — pure (the ambient read is
+//! injected), so the law is testable without touching the real
+//! environment and both spawn families (the exec runner · the MCP stdio
+//! client) run the SAME function. The static twin (`nika-check` ·
+//! `NIKA-AUTH-009` dead grants) reads the same lists — engine ≡ check ≡
+//! reference by construction.
+
+use std::collections::BTreeMap;
+
+/// Environment variables ALWAYS stripped from a spawned child's environment —
+/// the injection vectors that grant code execution or library injection with no
+/// dangerous flag in the command itself (the "env-var injection" class). The
+/// strip is independent of any pre-validation and wins even over an explicit
+/// `env` set (the floor wins — a workflow does not pass these).
+///
+/// The ONE canonical list (ADR-095 Layer 3): every subprocess-spawn site runs
+/// the clean-slate posture (NEP-0005 · spec 01 §permits env) — the child
+/// environment is COMPOSED via [`compose_child_env`], the spawn starts from
+/// `env_clear`, applies exactly that map, and strips THIS list last, so a
+/// floor name smuggled into the map still dies. A `permits.env:` entry naming
+/// one of these is an inert dead grant, flagged at check (`NIKA-AUTH-009`).
+pub const DANGEROUS_ENV_VARS: &[&str] = &[
+    // Dynamic-linker library injection (run attacker code in any dynamically
+    // linked child) — Linux + macOS (incl. the macOS fallback paths · P2).
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "GCONV_PATH", // glibc iconv module load → code execution (P2)
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_FALLBACK_FRAMEWORK_PATH",
+    // Shell startup-file sourcing on non-interactive `sh`/bash.
+    "BASH_ENV",
+    "ENV",
+    // Tool-specific command hooks (RCE with no flags).
+    "GIT_SSH_COMMAND",
+    "GIT_SSH",
+    "GIT_EXTERNAL_DIFF",
+    "GIT_PAGER",
+    "GIT_PROXY_COMMAND", // config-driven git RCE (P2)
+    "GIT_CONFIG_GLOBAL", // point git at an attacker config (core.pager/fsmonitor)
+    "GIT_CONFIG_SYSTEM",
+    "GIT_TEMPLATE_DIR", // attacker hooks copied into a new repo
+    "LESSOPEN",         // pager-input-preprocess command injection (P2)
+    "HOSTALIASES",      // attacker file read during hostname resolution (P2)
+    "TERMINFO",         // load a crafted terminfo entry (P2)
+    "TERMINFO_DIRS",    // terminfo search-path override (P2)
+    "TERMCAP",          // crafted termcap string executed by some pagers (P2)
+    // Interpreter pre-exec hooks.
+    "PYTHONSTARTUP",
+    "PYTHONPATH", // inject a module into any python that imports (P2)
+    "PERL5OPT",
+    "PERL5LIB",
+    "RUBYOPT",
+    "NODE_OPTIONS",
+    // Field-splitting injection for shell-mode commands.
+    "IFS",
+];
+
+/// The runner env floor — the ONLY names a child process may inherit from
+/// the engine's environment without a declared `permits.env:` grant
+/// (NEP-0005 · spec 01 §permits env · the list is normative there as the
+/// implicit MAXIMUM: an engine passes at most these, and may pass fewer).
+///
+/// A loader path, a home for tool caches, scratch, locale and timezone —
+/// what a child needs to RUN, and nothing that names a credential. The
+/// composition order is floor ∪ declared passthrough ∪ the task's authored
+/// `env:` map, and [`DANGEROUS_ENV_VARS`] strips last (floor ∩ dangerous
+/// is empty by construction — asserted in tests). ONE canonical list, two
+/// consumers (the exec runner's spawn site and the MCP stdio scrub), so
+/// the two spawn families cannot drift.
+pub const RUNNER_FLOOR_ENV_VARS: &[&str] = &[
+    "PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "TZ", "USER", "LOGNAME",
+];
+
+/// Whether `name` is on the dangerous-name floor — the check-side twin's
+/// predicate (`NIKA-AUTH-009` · a granting `permits.env:` entry is an
+/// inert dead grant) and the composition's final strip, one source.
+#[must_use]
+pub fn is_dangerous_env_name(name: &str) -> bool {
+    DANGEROUS_ENV_VARS.contains(&name)
+}
+
+/// Compose a child process environment (NEP-0005 · spec 01 §permits env) —
+/// the ONE law every spawn family runs (the exec runner · the MCP stdio
+/// client): [`RUNNER_FLOOR_ENV_VARS`] ∪ the declared `permits.env:`
+/// passthrough (both resolved through `lookup`, the spawn site's ambient
+/// reader) ∪ the AUTHORED task map (wins on a same-name collision), minus
+/// [`DANGEROUS_ENV_VARS`] (stripped last — no grant overrides that floor).
+///
+/// Pure: the ambient read is injected, so the law is testable without
+/// touching the real environment. A looked-up name that is absent passes
+/// nothing (no error · no empty-string synthesis · NEP-0005 definitions).
+pub fn compose_child_env(
+    lookup: impl Fn(&str) -> Option<String>,
+    passthrough: &[String],
+    authored: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    for name in RUNNER_FLOOR_ENV_VARS {
+        if let Some(value) = lookup(name) {
+            env.insert((*name).to_owned(), value);
+        }
+    }
+    for name in passthrough {
+        if let Some(value) = lookup(name) {
+            env.insert(name.clone(), value);
+        }
+    }
+    for (name, value) in authored {
+        env.insert(name.clone(), value.clone());
+    }
+    for name in DANGEROUS_ENV_VARS {
+        env.remove(*name);
+    }
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fake ambient environment for the pure composition law.
+    fn ambient(name: &str) -> Option<String> {
+        match name {
+            "PATH" => Some("/usr/bin:/bin".to_owned()),
+            "HOME" => Some("/home/op".to_owned()),
+            "AWS_SECRET_ACCESS_KEY" => Some("hunter2".to_owned()),
+            "CI_COMMIT_SHA" => Some("abc123".to_owned()),
+            "LD_PRELOAD" => Some("/tmp/evil.so".to_owned()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn compose_floor_passes_ambient_credential_does_not() {
+        // NEP-0005 law 1 · undeclared = the floor and nothing else.
+        let env = compose_child_env(ambient, &[], &BTreeMap::new());
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin:/bin"));
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/home/op"));
+        assert!(
+            !env.contains_key("AWS_SECRET_ACCESS_KEY"),
+            "an ambient credential must never cross undeclared"
+        );
+    }
+
+    #[test]
+    fn compose_declared_passthrough_passes_absent_name_passes_nothing() {
+        // NEP-0005 law 2 · presence grants REACH, ambient supplies the value
+        // or nothing (no error · no empty-string synthesis).
+        let names = vec!["CI_COMMIT_SHA".to_owned(), "NOT_SET_ANYWHERE".to_owned()];
+        let env = compose_child_env(ambient, &names, &BTreeMap::new());
+        assert_eq!(env.get("CI_COMMIT_SHA").map(String::as_str), Some("abc123"));
+        assert!(!env.contains_key("NOT_SET_ANYWHERE"));
+    }
+
+    #[test]
+    fn compose_authored_wins_over_passthrough_and_floor() {
+        // NEP-0005 law 6 · the authored map applies AFTER the passthrough.
+        let names = vec!["CI_COMMIT_SHA".to_owned()];
+        let mut authored = BTreeMap::new();
+        authored.insert("CI_COMMIT_SHA".to_owned(), "authored".to_owned());
+        authored.insert("PATH".to_owned(), "/decl".to_owned());
+        let env = compose_child_env(ambient, &names, &authored);
+        assert_eq!(
+            env.get("CI_COMMIT_SHA").map(String::as_str),
+            Some("authored")
+        );
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/decl"));
+    }
+
+    #[test]
+    fn compose_dangerous_floor_wins_over_every_grant() {
+        // NEP-0005 law 3 · a dangerous name is never passable: not via the
+        // passthrough (an inert dead grant) and not via the authored map.
+        let names = vec!["LD_PRELOAD".to_owned()];
+        let mut authored = BTreeMap::new();
+        authored.insert("BASH_ENV".to_owned(), "/tmp/hook".to_owned());
+        let env = compose_child_env(ambient, &names, &authored);
+        assert!(!env.contains_key("LD_PRELOAD"));
+        assert!(!env.contains_key("BASH_ENV"));
+        assert!(is_dangerous_env_name("LD_PRELOAD"));
+        assert!(!is_dangerous_env_name("CI_COMMIT_SHA"));
+    }
+
+    #[test]
+    fn floor_and_dangerous_lists_are_disjoint() {
+        // The structural invariant the composition order relies on: a floor
+        // name stripped by the dangerous pass would be a silent self-break.
+        for name in RUNNER_FLOOR_ENV_VARS {
+            assert!(
+                !DANGEROUS_ENV_VARS.contains(name),
+                "{name} is on both the runner floor and the dangerous floor"
+            );
+        }
+    }
+}

--- a/crates/nika-cap/src/lib.rs
+++ b/crates/nika-cap/src/lib.rs
@@ -23,6 +23,7 @@
 
 mod algebra;
 mod effect;
+pub mod env;
 mod fit;
 mod integrity;
 mod permits;
@@ -42,6 +43,9 @@ mod trifecta;
 pub use effect::{
     BuiltinEffect, PURE_INTERNAL_TOOLS, builtin_effect, builtin_egresses, chart_vl_sibling,
     is_pure_internal,
+};
+pub use env::{
+    DANGEROUS_ENV_VARS, RUNNER_FLOOR_ENV_VARS, compose_child_env, is_dangerous_env_name,
 };
 pub use fit::lexically_normalize;
 // F-O1 PR-1 · the runtime integrity label (the Integ axis of RS-06's

--- a/crates/nika-cap/src/permits.rs
+++ b/crates/nika-cap/src/permits.rs
@@ -33,6 +33,12 @@ pub struct Permits {
     /// `tools:` — the `nika:`/`mcp:` tool surface (id globs).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<String>>,
+    /// `env:` — engine environment names passed through to child processes
+    /// (exact POSIX names · no globs · NEP-0005). Omitted or empty = no
+    /// passthrough: a child sees the runner env floor plus the task's
+    /// authored `env:` map, nothing else.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<Vec<String>>,
 }
 
 impl Permits {
@@ -74,6 +80,26 @@ impl Permits {
             None => false,
             Some(globs) => globs.iter().any(|g| glob_matches(g, tool)),
         }
+    }
+
+    /// Whether the engine variable `name` is declared for child passthrough.
+    ///
+    /// Exact-name match (NEP-0005 · no globs). The dangerous-name floor
+    /// still strips a granted dangerous name at the spawn site — such an
+    /// entry is an inert dead grant, flagged at check (`NIKA-AUTH-009`).
+    #[must_use]
+    pub fn allows_env_key(&self, name: &str) -> bool {
+        match &self.env {
+            None => false,
+            Some(names) => names.iter().any(|n| n == name),
+        }
+    }
+
+    /// The declared `env:` passthrough names (empty when the category is
+    /// omitted) — the spawn sites' input to the composed child environment.
+    #[must_use]
+    pub fn env_passthrough(&self) -> &[String] {
+        self.env.as_deref().unwrap_or_default()
     }
 }
 

--- a/crates/nika-cap/src/trifecta.rs
+++ b/crates/nika-cap/src/trifecta.rs
@@ -283,6 +283,7 @@ mod tests {
             )),
             exec: None,
             tools: Some(tools.iter().map(ToString::to_string).collect()),
+            env: None,
         }
     }
 

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -608,6 +608,7 @@ pub fn nika_check::GateFindingKind::as_out(&mut self) -> outref::Out<'_, T>
 #[non_exhaustive] pub enum nika_check::PermitTaintKind
 pub nika_check::PermitTaintKind::ArgEscapes
 pub nika_check::PermitTaintKind::BoundInterpolated
+pub nika_check::PermitTaintKind::EnvDeadGrant
 impl core::clone::Clone for nika_check::PermitTaintKind
 pub fn nika_check::PermitTaintKind::clone(&self) -> nika_check::PermitTaintKind
 impl core::cmp::Eq for nika_check::PermitTaintKind

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -378,14 +378,16 @@ impl CheckReport {
                 SpecCode::new("SEC", 4, SpecCategory::SecurityError)
             }
         }));
-        // The permit-parameterization taint (NEP-0004): the finding's own
-        // kind maps to its ONE wire code (law 1 → AUTH-007 · law 2 →
-        // AUTH-008 · both check-time security refusals).
+        // The permits-block taint findings: the finding's own kind maps to
+        // its ONE wire code (NEP-0004 law 1 → AUTH-007 · law 2 → AUTH-008 ·
+        // NEP-0005 law 3 env dead grant → AUTH-009 · all check-time
+        // security refusals).
         codes.extend(self.permit_taints.iter().map(|t| match t.kind {
             PermitTaintKind::BoundInterpolated => {
                 SpecCode::new("AUTH", 7, SpecCategory::SecurityError)
             }
             PermitTaintKind::ArgEscapes => SpecCode::new("AUTH", 8, SpecCategory::SecurityError),
+            PermitTaintKind::EnvDeadGrant => SpecCode::new("AUTH", 9, SpecCategory::SecurityError),
         }));
         // Hard policy: violations (spec 10) → NIKA-POLICY-001.
         let policy_code = SpecCode::new("POLICY", 1, SpecCategory::SecurityError);

--- a/crates/nika-check/src/permit_taint.rs
+++ b/crates/nika-check/src/permit_taint.rs
@@ -50,6 +50,9 @@ use super::permits_fit::url_host;
 pub(crate) const BOUND_CODE: &str = "NIKA-AUTH-007";
 /// The wire code of an untrusted-argument escape (law 2).
 pub(crate) const REGATE_CODE: &str = "NIKA-AUTH-008";
+/// The wire code of a dangerous-floor dead grant in `permits.env:`
+/// (NEP-0005 law 3 · LAW-AUTH-0326).
+pub(crate) const ENV_DEAD_GRANT_CODE: &str = "NIKA-AUTH-009";
 
 /// The fs-read tool set whose `path` arg the static re-gate judges
 /// (the reference oracle's table — the engine≡oracle differential law
@@ -78,6 +81,10 @@ pub enum PermitTaintKind {
     /// Law 2 · an untrusted value's canonical resolved form escapes the
     /// step's permit (`NIKA-AUTH-008`).
     ArgEscapes,
+    /// NEP-0005 law 3 · a `permits.env:` entry names a dangerous-floor
+    /// variable — an inert dead grant, the engine strips the name
+    /// unconditionally (`NIKA-AUTH-009` · LAW-AUTH-0326).
+    EnvDeadGrant,
 }
 
 /// One permit-taint finding (law 1 or law 2) — the check-time twin of
@@ -106,6 +113,7 @@ impl PermitTaint {
         match self.kind {
             PermitTaintKind::BoundInterpolated => BOUND_CODE,
             PermitTaintKind::ArgEscapes => REGATE_CODE,
+            PermitTaintKind::EnvDeadGrant => ENV_DEAD_GRANT_CODE,
         }
     }
 }
@@ -121,8 +129,38 @@ pub(crate) fn scan_permit_taint(wf: &RawWorkflow) -> Vec<PermitTaint> {
     let permits = &permits.value;
     let mut out = Vec::new();
     scan_bound_literality(permits, &mut out);
+    scan_env_dead_grants(permits, &mut out);
     scan_regate(wf, permits, &mut out);
     out
+}
+
+/// NEP-0005 law 3 (LAW-AUTH-0326) · a `permits.env:` entry naming a
+/// dangerous-floor variable is an inert dead grant — the spawn sites
+/// strip the name unconditionally (`nika_cap::env::compose_child_env` ·
+/// the same list THIS reads, so the check and the composition cannot
+/// drift), so the grant can never take effect. Interpolated entries are
+/// law 1's ground (`NIKA-AUTH-007` · the bound walk above), never
+/// judged here.
+fn scan_env_dead_grants(permits: &Permits, out: &mut Vec<PermitTaint>) {
+    let Some(env) = permits.env.as_ref() else {
+        return;
+    };
+    for (i, name) in env.iter().enumerate() {
+        if name.contains("${{") || !nika_cap::env::is_dangerous_env_name(name) {
+            continue;
+        }
+        out.push(PermitTaint {
+            task: "permits".to_owned(),
+            kind: PermitTaintKind::EnvDeadGrant,
+            detail: format!(
+                "permit entry `env[{i}]` names the dangerous-floor variable `{name}` ·                  the engine strips this name unconditionally, the grant can never take                  effect: an inert dead grant (NEP-0005 law 3)"
+            ),
+            fix: Some(
+                "remove the entry · pass authored data through the task env: map, or a                  non-dangerous engine variable by its exact name"
+                    .to_owned(),
+            ),
+        });
+    }
 }
 
 /// Law 1 · every bound string inside the block MUST be a literal — an
@@ -170,6 +208,14 @@ fn scan_bound_literality(permits: &nika_schema::types::Permits, out: &mut Vec<Pe
     if let Some(tools) = permits.tools.as_ref() {
         for (i, tool) in tools.iter().enumerate() {
             check(format!("tools[{i}]"), tool);
+        }
+    }
+    // NEP-0005 · env names are bounds too (LAW-AUTH-0325 covers every
+    // category · the parser lets the island through so THIS refusal
+    // carries the teaching detail).
+    if let Some(env) = permits.env.as_ref() {
+        for (i, name) in env.iter().enumerate() {
+            check(format!("env[{i}]"), name);
         }
     }
 }
@@ -541,12 +587,13 @@ permits:
   net: { http: ["${{ inputs.b }}"] }
   exec: ["${{ inputs.c }}"]
   tools: ["${{ inputs.d }}"]
+  env: ["${{ inputs.e }}"]
 tasks:
   t:
     exec: { command: ["true"] }
 "#;
         let paths: Vec<String> = taints_of(y).iter().map(|t| t.detail.clone()).collect();
-        for needle in ["fs.read[0]", "net.http[0]", "exec[0]", "tools[0]"] {
+        for needle in ["fs.read[0]", "net.http[0]", "exec[0]", "tools[0]", "env[0]"] {
             assert!(
                 paths.iter().any(|d| d.contains(needle)),
                 "{needle} flagged: {paths:?}"
@@ -554,6 +601,58 @@ tasks:
         }
         // the literal write glob is NOT flagged.
         assert!(!paths.iter().any(|d| d.contains("fs.write[0]")));
+    }
+
+    // ── NEP-0005 law 3 · the env dead grant (NIKA-AUTH-009) — the
+    //    conformance fixtures core/authority/014-017, mirrored ──
+
+    #[test]
+    fn fixture_015_env_dangerous_dead_grant_is_refused() {
+        let y = r#"nika: v1
+workflow:
+  id: t-env-dangerous-dead-grant
+permits:
+  exec: true
+  env: ["LD_PRELOAD"]
+tasks:
+  build:
+    exec: { shell: "echo ok" }
+"#;
+        let taints = taints_of(y);
+        assert_eq!(taints.len(), 1, "{taints:?}");
+        assert_eq!(taints[0].kind, PermitTaintKind::EnvDeadGrant);
+        assert_eq!(taints[0].wire_code(), "NIKA-AUTH-009");
+        assert!(taints[0].detail.contains("env[0]"), "{}", taints[0].detail);
+        assert!(taints[0].detail.contains("LD_PRELOAD"));
+    }
+
+    #[test]
+    fn fixtures_016_017_declared_and_zero_env_pass_clean() {
+        for y in [
+            r#"nika: v1
+workflow:
+  id: t-env-passthrough-declared
+permits:
+  exec: true
+  env: ["CI_COMMIT_SHA"]
+tasks:
+  stamp:
+    exec: { shell: "echo ok" }
+"#,
+            r#"nika: v1
+workflow:
+  id: t-env-declared-zero
+permits:
+  exec: true
+  env: []
+tasks:
+  hermetic:
+    exec: { shell: "echo ok" }
+"#,
+        ] {
+            let taints = taints_of(y);
+            assert!(taints.is_empty(), "{taints:?}");
+        }
     }
 
     // ── Law 2 · the static re-gate (NIKA-AUTH-008) — the conformance

--- a/crates/nika-check/src/permits_infer.rs
+++ b/crates/nika-check/src/permits_infer.rs
@@ -72,6 +72,11 @@ struct Collector {
 
 /// Infer the tightest `permits:` for a workflow.
 #[must_use]
+// `env:` is NEVER inferred (NEP-0005 law 7 · LAW-AUTH-0326): a
+// subprocess's environment reads are opaque to static analysis, so the
+// inferred block carries no `env` category — the author declares intent,
+// and the undeclared-read failure mode is the child tool's own
+// missing-variable error (the repair is one `env: [NAME]` line).
 pub(super) fn infer(wf: &RawWorkflow) -> InferredPermits {
     let mut c = Collector::default();
     for task in &wf.tasks {

--- a/crates/nika-exec-runner/public-api.txt
+++ b/crates/nika-exec-runner/public-api.txt
@@ -39,7 +39,6 @@ pub fn nika_exec_runner::EgressDecision::as_any(&self) -> &(dyn core::any::Any +
 pub struct nika_exec_runner::TokioShell
 impl nika_exec_runner::TokioShell
 pub fn nika_exec_runner::TokioShell::new() -> Self
-pub fn nika_exec_runner::TokioShell::with_ambient_secret_env(self, names: impl core::convert::Into<alloc::sync::Arc<[alloc::string::String]>>) -> Self
 pub fn nika_exec_runner::TokioShell::with_egress_observer(self, observer: nika_exec_runner::EgressObserver) -> Self
 pub fn nika_exec_runner::TokioShell::with_sandbox(sandbox: alloc::sync::Arc<dyn nika_kernel_core::io::command_sandbox::CommandSandbox>) -> Self
 impl core::clone::Clone for nika_exec_runner::TokioShell

--- a/crates/nika-exec-runner/src/lib.rs
+++ b/crates/nika-exec-runner/src/lib.rs
@@ -73,7 +73,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use nika_kernel::command_sandbox::{CommandSandbox, CommandSandboxError};
-use nika_kernel::process::{DANGEROUS_ENV_VARS, ShellCancelDyn, ShellRunDyn};
+use nika_kernel::process::{DANGEROUS_ENV_VARS, ShellCancelDyn, ShellRunDyn, compose_child_env};
 use nika_kernel::{ShellCommand, ShellError, ShellResult};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
@@ -119,14 +119,6 @@ pub struct TokioShell {
     /// The OS-confinement backend (injected by the wiring layer · `None` =
     /// no sandbox available, today's behavior). Applied AFTER the blocklist.
     sandbox: Option<Arc<dyn CommandSandbox>>,
-    /// Env-var NAMES the child must NOT inherit from the ENGINE's ambient
-    /// environment — the provider API keys `config_from_env` loaded for the
-    /// engine's OWN inference calls (ADR-095 Layer 3 · ambient-secret scrub).
-    /// Injected by the composition root from the provider catalog. A workflow
-    /// that genuinely needs a key in its child still sets it EXPLICITLY in
-    /// `env:` (explicit intent wins over the ambient scrub · see `run`). Empty
-    /// = today's behavior (inherit all). `Arc<[…]>` for a cheap `Clone`.
-    ambient_secret_env: Arc<[String]>,
     /// The per-run loopback egress proxy (the `NetPolicy::Allowlist` arm's
     /// enforcement half) — `Arc`-shared so every clone of this shell serves
     /// the SAME boundary on the SAME port; started lazily, stopped when the
@@ -151,7 +143,6 @@ impl Default for TokioShell {
         Self {
             registry: Registry::default(),
             sandbox: None,
-            ambient_secret_env: Arc::default(),
             egress_proxy: Arc::new(Mutex::new(None)),
             egress_observer: egress::stderr_journal(),
         }
@@ -185,21 +176,6 @@ impl TokioShell {
     #[must_use]
     pub fn with_egress_observer(mut self, observer: EgressObserver) -> Self {
         self.egress_observer = observer;
-        self
-    }
-
-    /// Scrub the ENGINE's ambient provider API keys from every child's
-    /// environment (ADR-095 Layer 3 · least-privilege by default). `names` are
-    /// the provider env-var names the engine reads for its OWN inference calls
-    /// (from the provider catalog · injected by the composition root); an exec
-    /// child has no legitimate need for them via ambient inheritance, and
-    /// leaving them in lets an untrusted command exfiltrate them (`printenv`,
-    /// `cat /proc/self/environ`). A workflow that DOES need a key in its child
-    /// sets it explicitly in `env:` — that wins (only the ambient copy is
-    /// stripped · see `run`). Chainable with [`Self::with_sandbox`].
-    #[must_use]
-    pub fn with_ambient_secret_env(mut self, names: impl Into<Arc<[String]>>) -> Self {
-        self.ambient_secret_env = names.into();
         self
     }
 
@@ -244,17 +220,6 @@ impl ShellRunDyn for TokioShell {
 
         let start = Instant::now();
         let mut cmd = build_command(&command);
-        // Ambient-secret scrub (ADR-095 Layer 3): the engine loaded provider
-        // API keys from ITS env for its own inference calls; strip them from
-        // the child UNLESS the workflow set the name EXPLICITLY in `env:`
-        // (explicit intent wins · only the ambient copy is removed). Runs after
-        // build_command applied the explicit `env:` map, so an explicit set is
-        // preserved; env_remove of an absent key is a harmless no-op.
-        for name in self.ambient_secret_env.iter() {
-            if !command.env.contains_key(name) {
-                cmd.env_remove(name);
-            }
-        }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         cmd.stdin(if command.stdin.is_some() {
@@ -472,10 +437,12 @@ impl ShellCancelDyn for TokioShell {
 // `nika_kernel::process::DANGEROUS_ENV_VARS` (imported above): the injection
 // vectors that grant code execution or library injection with no dangerous
 // flag in the command itself (the "env-var injection" class). The strip here
-// is independent of `pre_validated` and runs AFTER the explicit `env` map
-// (the floor wins — a workflow does not pass these). The stronger
-// clean-slate posture (drop ALL inherited env + a curated `PATH`) belongs to
-// the sandbox layer (the MCP stdio client already runs it).
+// is independent of `pre_validated` and runs AFTER the composed `env` map
+// (the floor wins — a workflow does not pass these). Since NEP-0005 the
+// child environment is CLEAN-SLATE: `env_clear` first, then exactly the
+// composed map (`ShellCommand::env` — the runner floor ∪ the declared
+// `permits.env:` passthrough ∪ the task's authored entries, composed
+// upstream by the dispatch), then the dangerous strip. Nothing is inherited.
 
 /// Build the `tokio::process::Command` (program/args or `sh -c`, env, cwd).
 fn build_command(command: &ShellCommand) -> Command {
@@ -493,17 +460,26 @@ fn build_command(command: &ShellCommand) -> Command {
         c.args(&command.args);
         c
     };
-    for (k, v) in &command.env {
+    // NEP-0005 clean slate: nothing is inherited. The child environment is
+    // COMPOSED — the runner floor ∪ the declared `permits.env:` passthrough
+    // (both resolved from the operator's ambient values HERE: reading the
+    // ambient env to re-admit a curated subset to the child is the spawn
+    // site's duty, the MCP stdio client's import-site precedent) ∪ the
+    // authored `env` map, minus the dangerous floor (inside the compose).
+    cmd.env_clear();
+    #[allow(clippy::disallowed_methods)] // the spawn-site ambient read (see above)
+    let composed = compose_child_env(
+        |name| std::env::var(name).ok(),
+        &command.env_passthrough,
+        &command.env,
+    );
+    for (k, v) in &composed {
         cmd.env(k, v);
     }
-    // After env so a removal wins over a set of the same key.
-    for k in &command.env_remove {
-        cmd.env_remove(k);
-    }
-    // SECURITY (always-on · independent of `pre_validated`): strip the
-    // dangerous-env injection vectors LAST so the floor wins even over an
-    // explicit set — these grant code/library injection with no dangerous
-    // flag in the command (see [`DANGEROUS_ENV_VARS`]).
+    // SECURITY belt (always-on · independent of `pre_validated`): the compose
+    // already stripped the dangerous floor — strip it again LAST at the spawn
+    // boundary so a future compose regression cannot re-open the injection
+    // class (see [`DANGEROUS_ENV_VARS`]).
     for var in DANGEROUS_ENV_VARS {
         cmd.env_remove(var);
     }
@@ -714,43 +690,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ambient_secret_env_scrubbed_unless_set_explicitly() {
-        // ADR-095 Layer 3. PATH is reliably present in the test process env
-        // AND unneeded to run an ABSOLUTE-path program — so it stands in for an
-        // ambient provider secret without the (forbidden) unsafe env::set_var.
-        let scrub = TokioShell::new().with_ambient_secret_env(vec!["PATH".to_owned()]);
-
-        // Scrubbed + not set explicitly → the child's PATH is gone (printenv
-        // prints nothing · exits non-zero, which `run` surfaces as data).
-        let out = scrub
-            .run(ShellCommand::new("/usr/bin/printenv").arg("PATH"))
+    async fn child_env_is_composed_never_inherited() {
+        // NEP-0005 law 1 · the clean slate. CARGO_PKG_NAME is reliably
+        // present in a `cargo test` process env and is NOT on the runner
+        // floor — it stands in for an ambient credential without the
+        // (forbidden) unsafe env::set_var.
+        let shell = TokioShell::new();
+        let out = shell
+            .run(ShellCommand::new("/usr/bin/printenv").arg("CARGO_PKG_NAME"))
             .await
             .expect("printenv runs");
         assert!(
             out.stdout.trim().is_empty(),
-            "ambient PATH must be scrubbed from the child, got {:?}",
+            "an ambient non-floor variable must never reach the child, got {:?}",
             out.stdout
         );
 
-        // Explicit `env:` wins over the scrub — the child sees the declared value.
-        let mut explicit = ShellCommand::new("/usr/bin/printenv").arg("PATH");
-        explicit.env.insert("PATH".to_owned(), "/decl".to_owned());
-        let out2 = scrub.run(explicit).await.expect("printenv runs");
-        assert_eq!(
-            out2.stdout.trim(),
-            "/decl",
-            "an explicit env entry must win over the ambient scrub"
-        );
-
-        // Default (no scrub set) inherits the ambient PATH as before.
-        let out3 = TokioShell::new()
+        // The runner floor still crosses (PATH is floor · law 1's "at most").
+        let floor = shell
             .run(ShellCommand::new("/usr/bin/printenv").arg("PATH"))
             .await
             .expect("printenv runs");
         assert!(
-            !out3.stdout.trim().is_empty(),
-            "default TokioShell must still inherit the ambient PATH"
+            !floor.stdout.trim().is_empty(),
+            "the runner floor must compose PATH into the child"
         );
+
+        // The declared passthrough passes exactly the named variable (law 2).
+        let mut declared = ShellCommand::new("/usr/bin/printenv").arg("CARGO_PKG_NAME");
+        declared.env_passthrough = vec!["CARGO_PKG_NAME".to_owned()];
+        let out2 = shell.run(declared).await.expect("printenv runs");
+        assert_eq!(
+            out2.stdout.trim(),
+            env!("CARGO_PKG_NAME"),
+            "a declared name must pass the ambient value through"
+        );
+
+        // The authored map wins over the passthrough on the same name (law 6).
+        let mut authored = ShellCommand::new("/usr/bin/printenv").arg("CARGO_PKG_NAME");
+        authored.env_passthrough = vec!["CARGO_PKG_NAME".to_owned()];
+        authored
+            .env
+            .insert("CARGO_PKG_NAME".to_owned(), "authored".to_owned());
+        let out3 = shell.run(authored).await.expect("printenv runs");
+        assert_eq!(out3.stdout.trim(), "authored");
+    }
+
+    #[tokio::test]
+    async fn program_resolution_rides_the_composed_floor_path() {
+        // The flip must not brick relative-program spawns: the floor PATH is
+        // in the composed map and `Command` resolves against the CHILD env.
+        let out = TokioShell::new()
+            .run(ShellCommand::new("echo").arg("resolved"))
+            .await
+            .expect("echo resolves via the composed floor PATH");
+        assert_eq!(out.stdout.trim(), "resolved");
     }
 
     #[tokio::test]

--- a/crates/nika-exec-runner/tests/exec_contract.rs
+++ b/crates/nika-exec-runner/tests/exec_contract.rs
@@ -123,8 +123,8 @@ async fn env_var_is_set() {
 #[tokio::test]
 async fn dangerous_env_vars_are_stripped_from_the_child() {
     // The dangerous-env floor strips library-injection / startup-sourcing /
-    // tool-hook vectors even when EXPLICITLY set — so it strips an ambient
-    // inherited one too (`env_remove` removes regardless of source). Argv
+    // tool-hook vectors even when EXPLICITLY set — and nothing ambient ever
+    // crosses at all (NEP-0005 · the composed clean slate). Argv
     // mode (`printenv` is not a dangerous program); `printenv VAR` exits
     // non-zero with empty stdout when VAR is absent → proof of the strip.
     for var in ["LD_PRELOAD", "BASH_ENV", "GIT_SSH_COMMAND", "NODE_OPTIONS"] {

--- a/crates/nika-kernel-core/Cargo.toml
+++ b/crates/nika-kernel-core/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 nika-error    = { path = "../nika-error", version = "0.105.0" }
+nika-cap      = { path = "../nika-cap", version = "0.105.0" }     # the env plane of the capability boundary (NEP-0005 · DANGEROUS/RUNNER floors + compose_child_env · re-exported at the historical process path)
 trait-variant = { workspace = true }
 thiserror     = { workspace = true }
 miette        = { workspace = true }

--- a/crates/nika-kernel-core/public-api.txt
+++ b/crates/nika-kernel-core/public-api.txt
@@ -1893,6 +1893,9 @@ pub trait nika_kernel_core::io::ocr::OcrEngineDyn: core::marker::Send + core::ma
 pub fn nika_kernel_core::io::ocr::OcrEngineDyn::read(&self, frame: &nika_kernel_core::io::screen::Frame) -> impl core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<nika_kernel_core::io::ocr::TextRegion>, nika_kernel_core::io::ocr::OcrError>> + core::marker::Send
 pub fn nika_kernel_core::io::ocr::OcrEngineDyn::read_region(&self, frame: &nika_kernel_core::io::screen::Frame, region: nika_kernel_core::io::screen::Rect) -> impl core::future::future::Future<Output = core::result::Result<alloc::vec::Vec<nika_kernel_core::io::ocr::TextRegion>, nika_kernel_core::io::ocr::OcrError>> + core::marker::Send
 pub mod nika_kernel_core::io::process
+pub use nika_kernel_core::io::process::DANGEROUS_ENV_VARS
+pub use nika_kernel_core::io::process::RUNNER_FLOOR_ENV_VARS
+pub use nika_kernel_core::io::process::compose_child_env
 #[non_exhaustive] pub enum nika_kernel_core::io::process::NetPolicy
 pub nika_kernel_core::io::process::NetPolicy::Allow
 pub nika_kernel_core::io::process::NetPolicy::Allowlist(nika_kernel_core::io::process::EgressAllowlist)
@@ -2059,7 +2062,7 @@ pub fn nika_kernel_core::io::process::SandboxSpec::as_any(&self) -> &(dyn core::
 pub nika_kernel_core::io::process::ShellCommand::args: alloc::vec::Vec<alloc::string::String>
 pub nika_kernel_core::io::process::ShellCommand::cwd: core::option::Option<std::path::PathBuf>
 pub nika_kernel_core::io::process::ShellCommand::env: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
-pub nika_kernel_core::io::process::ShellCommand::env_remove: alloc::vec::Vec<alloc::string::String>
+pub nika_kernel_core::io::process::ShellCommand::env_passthrough: alloc::vec::Vec<alloc::string::String>
 pub nika_kernel_core::io::process::ShellCommand::pre_validated: bool
 pub nika_kernel_core::io::process::ShellCommand::program: alloc::string::String
 pub nika_kernel_core::io::process::ShellCommand::sandbox: core::option::Option<nika_kernel_core::io::process::SandboxSpec>
@@ -2140,7 +2143,6 @@ impl<T> core::convert::From<T> for nika_kernel_core::io::process::ShellResult
 pub fn nika_kernel_core::io::process::ShellResult::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_kernel_core::io::process::ShellResult where T: 'static
 pub fn nika_kernel_core::io::process::ShellResult::as_any(&self) -> &(dyn core::any::Any + 'static)
-pub const nika_kernel_core::io::process::DANGEROUS_ENV_VARS: &[&str]
 pub trait nika_kernel_core::io::process::ShellCancel: core::marker::Send + core::marker::Sync
 pub async fn nika_kernel_core::io::process::ShellCancel::cancel(&self, id: &str) -> core::result::Result<(), nika_kernel_core::io::process::ShellError>
 impl<TraitVariantBlanketType: nika_kernel_core::io::process::ShellCancelDyn> nika_kernel_core::io::process::ShellCancel for TraitVariantBlanketType

--- a/crates/nika-kernel-core/src/io/process.rs
+++ b/crates/nika-kernel-core/src/io/process.rs
@@ -106,60 +106,13 @@ impl EgressAllowlist {
     }
 }
 
-/// Environment variables ALWAYS stripped from a spawned child's environment —
-/// the injection vectors that grant code execution or library injection with no
-/// dangerous flag in the command itself (the "env-var injection" class). An
-/// ambient `LD_PRELOAD` inherited from the engine's own environment is not
-/// something a policy vouched for, so the strip is independent of any
-/// pre-validation and wins even over an explicit `env` set (the floor wins — a
-/// workflow does not pass these).
-///
-/// The ONE canonical list (ADR-095 Layer 3): every subprocess-spawn site
-/// scrubs against it — the `exec` verb's runner (`nika-exec-runner`, which
-/// strips it after applying the declared `env` map) and the MCP stdio client
-/// (`nika-mcp`, which goes further: `env_clear` + a curated passthrough, so
-/// these names are structurally absent). The stronger clean-slate posture
-/// (drop ALL inherited env + a curated `PATH`) belongs to the sandbox layer,
-/// which knows the confined process's declared needs.
-pub const DANGEROUS_ENV_VARS: &[&str] = &[
-    // Dynamic-linker library injection (run attacker code in any dynamically
-    // linked child) — Linux + macOS (incl. the macOS fallback paths · P2).
-    "LD_PRELOAD",
-    "LD_LIBRARY_PATH",
-    "LD_AUDIT",
-    "GCONV_PATH", // glibc iconv module load → code execution (P2)
-    "DYLD_INSERT_LIBRARIES",
-    "DYLD_LIBRARY_PATH",
-    "DYLD_FRAMEWORK_PATH",
-    "DYLD_FALLBACK_LIBRARY_PATH",
-    "DYLD_FALLBACK_FRAMEWORK_PATH",
-    // Shell startup-file sourcing on non-interactive `sh`/bash.
-    "BASH_ENV",
-    "ENV",
-    // Tool-specific command hooks (RCE with no flags).
-    "GIT_SSH_COMMAND",
-    "GIT_SSH",
-    "GIT_EXTERNAL_DIFF",
-    "GIT_PAGER",
-    "GIT_PROXY_COMMAND", // config-driven git RCE (P2)
-    "GIT_CONFIG_GLOBAL", // point git at an attacker config (core.pager/fsmonitor)
-    "GIT_CONFIG_SYSTEM",
-    "GIT_TEMPLATE_DIR", // attacker hooks copied into a new repo
-    "LESSOPEN",         // pager-input-preprocess command injection (P2)
-    "HOSTALIASES",      // attacker file read during hostname resolution (P2)
-    "TERMINFO",         // load a crafted terminfo entry (P2)
-    "TERMINFO_DIRS",    // terminfo search-path override (P2)
-    "TERMCAP",          // crafted termcap string executed by some pagers (P2)
-    // Interpreter pre-exec hooks.
-    "PYTHONSTARTUP",
-    "PYTHONPATH", // inject a module into any python that imports (P2)
-    "PERL5OPT",
-    "PERL5LIB",
-    "RUBYOPT",
-    "NODE_OPTIONS",
-    // Field-splitting injection for shell-mode commands.
-    "IFS",
-];
+// The environment plane of the capability boundary lives in `nika-cap::env`
+// (NEP-0005 · the permits vocabulary crate): the dangerous-name floor, the
+// runner env floor, and the ONE composition law every spawn family runs.
+// Re-exported here at the historical kernel path so every consumer import
+// (`nika_kernel::process::DANGEROUS_ENV_VARS` · the spawn sites) resolves
+// unchanged.
+pub use nika_cap::env::{DANGEROUS_ENV_VARS, RUNNER_FLOOR_ENV_VARS, compose_child_env};
 
 /// A shell command to execute.
 #[derive(Debug, Clone)]
@@ -169,10 +122,18 @@ pub struct ShellCommand {
     pub program: String,
     /// Command arguments.
     pub args: Vec<String>,
-    /// Environment variables to set.
+    /// The AUTHORED environment entries (the task's `env:` map · values the
+    /// file carries). The spawn site composes the child environment via
+    /// [`compose_child_env`] — a CLEARED slate + the runner floor + the
+    /// declared [`Self::env_passthrough`] + this map (which wins on a
+    /// same-name collision), minus [`DANGEROUS_ENV_VARS`]. Nothing is ever
+    /// inherited (NEP-0005).
     pub env: BTreeMap<String, String>,
-    /// Environment variable names to remove from inherited env.
-    pub env_remove: Vec<String>,
+    /// The declared `permits.env:` passthrough NAMES (NEP-0005) — resolved
+    /// from the ENGINE's ambient environment at the spawn site, beneath the
+    /// authored [`Self::env`] map and above the runner floor. Empty = floor
+    /// + authored map only.
+    pub env_passthrough: Vec<String>,
     /// Working directory.
     pub cwd: Option<PathBuf>,
     /// Execution timeout.
@@ -201,7 +162,7 @@ impl ShellCommand {
             program: program.into(),
             args: Vec::new(),
             env: BTreeMap::new(),
-            env_remove: Vec::new(),
+            env_passthrough: Vec::new(),
             cwd: None,
             timeout: None,
             stdin: None,

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -1141,7 +1141,11 @@ fn infer_block_offers_the_verb_fields() {
 fn permits_and_fs_route_by_parent() {
     let text = "nika: v1\nworkflow:\n  id: w\npermits:\n  ";
     let got = labels(&completion(text, text.len()));
-    assert_eq!(got, vec!["fs:", "net:", "exec:", "tools:"], "{got:?}");
+    assert_eq!(
+        got,
+        vec!["fs:", "net:", "exec:", "tools:", "env:"],
+        "{got:?}"
+    );
 
     let text2 = "nika: v1\nworkflow:\n  id: w\npermits:\n  fs:\n    ";
     let got2 = labels(&completion(text2, text2.len()));

--- a/crates/nika-lsp/src/analysis/vocab.rs
+++ b/crates/nika-lsp/src/analysis/vocab.rs
@@ -93,7 +93,7 @@ pub const TOP_LEVEL_KEYS: &[Entry] = &[
     Entry {
         name: "permits",
         doc: "The declared capability boundary. Once present, every \
-              category is default-deny (exec, tools, fs, net).",
+              category is default-deny (exec, tools, fs, net, env).",
     },
     Entry {
         name: "tasks",

--- a/crates/nika-mcp/src/sandbox.rs
+++ b/crates/nika-mcp/src/sandbox.rs
@@ -59,19 +59,21 @@ pub fn platform_sandbox() -> Arc<dyn CommandSandbox> {
     Arc::new(nika_kernel::command_sandbox::NoopSandbox)
 }
 
-/// The env-var names a spawned MCP server may inherit — a CURATED
-/// passthrough; everything else the engine holds is dropped (`env_clear` at
-/// the spawn site). A server needs its loader path, a home for tool caches,
-/// scratch, and locale/timezone — nothing else. Provider API keys and every
-/// other ambient value stay with the engine.
-pub(crate) const PASSTHROUGH_ENV_VARS: &[&str] = &[
-    "PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "TZ", "USER", "LOGNAME",
-];
+/// The env-var names a spawned MCP server may inherit — the ONE canonical
+/// runner env floor (NEP-0005 · `nika_kernel::process::RUNNER_FLOOR_ENV_VARS`
+/// · the same list the exec spawn site composes from, so the two spawn
+/// families cannot drift). A server needs its loader path, a home for tool
+/// caches, scratch, and locale/timezone — nothing else. Provider API keys and
+/// every other ambient value stay with the engine; a workflow-declared
+/// `permits.env:` passthrough joins here when run-time MCP spawning lands
+/// (the seam is `compose_child_env` · today's spawns are the pin/approve
+/// verbs, outside any workflow — floor-only is the correct composition).
+pub(crate) const PASSTHROUGH_ENV_VARS: &[&str] = nika_kernel::process::RUNNER_FLOOR_ENV_VARS;
 
-/// The spawn-env decision, pure: ONLY the curated passthrough names inherit,
-/// and the exec path's [`DANGEROUS_ENV_VARS`] floor wins even over those — a
-/// name on both lists never reaches the child (the same « the floor wins »
-/// posture as the exec runner's after-`env` strip).
+/// The spawn-env decision, pure: ONLY the floor names inherit, and the
+/// [`DANGEROUS_ENV_VARS`] floor wins even over those — a name on both lists
+/// never reaches the child (the same « the floor wins » posture as the exec
+/// runner's composed strip · disjointness is asserted kernel-side).
 pub(crate) fn env_passthrough(name: &str) -> bool {
     PASSTHROUGH_ENV_VARS.contains(&name) && !DANGEROUS_ENV_VARS.contains(&name)
 }

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -7,7 +7,7 @@
 #   sealed outcome_class enum) · the 15 ledger sections (canon/EXCEPTIONS.md ·
 #   SSOT-1 §18) stay AUTHORED and are carried verbatim — editing those is legal.
 # regenerate: python3 scripts/ssot-compiler.py --emit-canon
-# body-sha256: 6929dadb6724ab8384fe619973faa84017cc5798fcd0557961b58cb969432d59
+# body-sha256: e8a4f414e53b6efc1cf93247f814bf134bd7ae5f82723913a24ae2aa029e4688
 #   (digest of every byte below the end-of-header line · detached self-hash per PAA-006)
 # ---- end generated header (SSOT-1 §21-23 · the canon flip · C0)
 # nika canonical registry · the single source of truth for Nika canonical facts
@@ -65,7 +65,7 @@ counts:
   templates: 10
   error_namespaces: 25
   error_categories: 12
-  error_codes: 88
+  error_codes: 91
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -296,7 +296,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 90
+  count: 91
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }
@@ -400,8 +400,9 @@ error_codes:
 # Order is semantic · envelope frames · verbs act · dag composes · variables
 # thread state · errors handle failure.
     - { code: NIKA-AUTH-006, category: security_error, transient: "false", failure: "no permits: block declared and the body has effects — absent = zero authority (F-O8 · NEP-0003)" }
-    - { code: NIKA-AUTH-007, category: security_error, transient: "false", failure: "an interpolation reaches a permit bound (host · glob · program) — a bound MUST be a literal, the boundary would be self-serve (F-O1 · NEP-0004)" }
+    - { code: NIKA-AUTH-007, category: security_error, transient: "false", failure: "an interpolation reaches a permit bound (host · glob · program · env name) — a bound MUST be a literal, the boundary would be self-serve (F-O1 · NEP-0004 · env per NEP-0005)" }
     - { code: NIKA-AUTH-008, category: security_error, transient: "false", failure: "an untrusted value reaches a permitted verb's argument and its canonical resolved form escapes the step's permit — re-gate refused (F-O1 · NEP-0004)" }
+    - { code: NIKA-AUTH-009, category: security_error, transient: "false", failure: "a permits env: entry names a dangerous-floor variable · the engine strips the name unconditionally, the grant can never take effect: an inert dead grant (F-O4 · NEP-0005)" }
     - { code: NIKA-VALUES-001, category: validation_error, transient: "false", failure: "vars: is a dead envelope field (R3a · the E-split)" }
     - { code: NIKA-VALUES-002, category: validation_error, transient: "false", failure: "env: is a dead envelope field (R3a · the E-split)" }
     - { code: NIKA-VALUES-003, category: validation_error, transient: "false", failure: "a value-namespace read outside the four-authority family (R3a · LAW-SURFACE-0201)" }

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -279,6 +279,21 @@
             "type": "string"
           },
           "description": "Allowed nika:/mcp: tool ids · globs ok."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+              },
+              {
+                "pattern": "\\$\\{\\{"
+              }
+            ]
+          },
+          "description": "Engine env names passed through to child processes · exact POSIX names, no globs · composed with the runner env floor, never inherited (spec/01-envelope.md §permits · NEP-0005). An interpolated entry passes the shape gate and is refused as a non-literal bound (NIKA-AUTH-007)."
         }
       }
     },
@@ -531,6 +546,39 @@
           "additionalProperties": {
             "type": "string",
             "format": "jq"
+          }
+        },
+        "declassify": {
+          "type": "array",
+          "description": "The ONLY door through the permit-parameterization taint (spec/10-authority.md §the permit-parameterization taint · NEP-0004 · LAW-AUTH-0325) · each entry raises ONE binding from untrusted to trusted, check-visible and receipt-recorded. Lifts the taint law only — the value is still matched against the declared boundary (never a permit bypass).",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "from",
+              "to",
+              "because"
+            ],
+            "properties": {
+              "from": {
+                "type": "string",
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+$",
+                "description": "The ONE binding this entry raises (e.g. inputs.p · config.region · tasks.fetch.output) · a dotted value-binding path."
+              },
+              "to": {
+                "type": "string",
+                "enum": [
+                  "trusted"
+                ],
+                "description": "The target integrity label · v1 knows exactly one raise: untrusted -> trusted."
+              },
+              "because": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The non-empty justification · recorded in the run receipt with the taint path and the value digest."
+              }
+            }
           }
         },
         "infer": {

--- a/crates/nika-pack/pack/spec/01-envelope.md
+++ b/crates/nika-pack/pack/spec/01-envelope.md
@@ -407,9 +407,11 @@ report for taints originating from THIS secret and nothing else — it
 never authorizes a send, and a `nika:fetch` clearance never authorizes
 the boundary. Absent the rule, the report stands (default-deny).
 
-The general untrusted→decision integrity lattice (full taint of attacker-controlled
-inputs into security decisions) is a documented follow-up; the static guards
-above cover the main injection / laundering vectors with the existing analysis.
+The general untrusted→decision integrity lattice lands surface by surface:
+the permit-parameterization taint (untrusted values under a present
+`permits:` block) is normative in [10](./10-authority.md) §the
+permit-parameterization taint (NEP-0004); the remaining decision surfaces
+stay a documented follow-up covered by the static guards above.
 
 ### `permits` · *optional · the declared capability boundary*
 
@@ -419,6 +421,7 @@ permits:                          # the workflow's entire blast radius, declared
   net:  { http: ["api.example.com", "*.github.com"] }  # host allowlist — the SSRF boundary, in-file
   exec: false                     # may this workflow run shells? false | true | ["git", "cargo"] (program allowlist)
   tools: ["nika:read", "nika:write", "mcp:browser/*"]  # the builtin/MCP surface it may invoke
+  env:  ["CI_COMMIT_SHA"]         # engine env names passed through to child processes · exact names · composed, never inherited
 ```
 
 `permits:` makes the **file itself the security boundary**: an auditable
@@ -437,7 +440,11 @@ absence is a wall, the zero wall: a parent's grants never flow down to a
 child implicitly (`NIKA-COMP-002`).
 
 **Semantics (normative) · once `permits:` is present, every category is
-DEFAULT-DENY unless listed** ·
+DEFAULT-DENY unless listed, and every bound in the block is a LITERAL —
+interpolation never reaches this block (an interpolated host/glob/program
+is a hard refusal, `NIKA-AUTH-007` · untrusted values under the block are
+re-gated on their canonical resolved form, [10](./10-authority.md) §the
+permit-parameterization taint)** ·
 
 | Category | When listed | When the `permits:` block is present but this category is omitted |
 |---|---|---|
@@ -445,6 +452,7 @@ DEFAULT-DENY unless listed** ·
 | `net.http` | only the listed hosts (globs ok) · tightens the engine SSRF floor — the one loosening is the exact-loopback declassification below | **no** outbound network |
 | `exec` | `false` = no shells · `true` = any (still blocklist-gated) · array = only those program names (argv `command[0]`) | treated as `false` · **no** `exec:` |
 | `tools` | only the matching `nika:` / `mcp:` ids (globs ok) | **no** `invoke:` of any tool |
+| `env` | only the named engine variables pass through to child processes (exact names · the runner env floor rides beneath) | **no** passthrough · a child sees the runner env floor plus the task `env:` map only |
 
 **A program allowlist verifies the argv form only** (normative) · when
 `exec:` is an array of program names, a task whose `command:` is a shell
@@ -471,9 +479,36 @@ to any un-permitted floor host still refuses (`NIKA-SEC-005`). An
 engine MUST NOT auto-write a loopback grant (e.g. from permits
 inference) — the explicit act stays the author's.
 
+**The environment category** (normative · NEP-0005 · LAW-AUTH-0326) · a
+child process environment (the `exec` subprocess · a stdio `mcp:*` tool
+server) is **composed, never inherited**: the runner env floor ∪ the
+declared `env:` passthrough (resolved from the engine's environment at
+spawn) ∪ the task's explicit `env:` map (authored values · applied after
+the passthrough, so an authored entry wins on the same name), minus the
+dangerous-name floor. The **runner env floor** is the fixed list `PATH`,
+`HOME`, `TMPDIR`, `LANG`, `LC_ALL`, `TZ`, `USER`, `LOGNAME` · a normative
+MAXIMUM: an engine MUST NOT pass any undeclared name beyond it and MAY
+pass fewer. An `env:` entry is an exact POSIX name
+(`[A-Za-z_][A-Za-z0-9_]*` · no globs) and a permit BOUND: an interpolated
+entry is `NIKA-AUTH-007` (a bound MUST be a literal · [10](./10-authority.md)).
+The **dangerous-name floor** (dynamic-linker injection · shell startup
+sourcing · tool command hooks · interpreter pre-exec hooks · `IFS` · the
+engine's canonical `DANGEROUS_ENV_VARS` list) is never passable: an
+`env:` entry naming one is an inert dead grant, flagged at check
+(`NIKA-AUTH-009` · the SSRF dead-grant teaching applied to the env
+plane), and a task-map entry naming one is stripped last. A declared name
+absent from the engine environment passes nothing (no error · no
+empty-string synthesis). Under composition ([14](./14-composition.md))
+the effective category is the exact-name intersection child ∩ parent.
+`env:` is **not inferable**: permit inference MUST NOT invent the list (a
+subprocess's environment reads are opaque) · the undeclared-read failure
+mode is the child tool's own missing-variable error, and the repair is
+one declared line (`env: [NAME]`).
+
 So `permits: {}` is a workflow provably limited to pure compute (`infer:` +
-CEL + `nika:jq`): zero fs, zero net, zero shell, zero tools. That property
-is checkable BEFORE the run.
+CEL + `nika:jq`): zero fs, zero net, zero shell, zero tools, zero env
+passthrough (its children see the runner env floor plus their task `env:`
+maps, nothing else). That property is checkable BEFORE the run.
 
 **The engine MUST enforce `permits:` on BOTH surfaces** ·
 1. **Statically** (`nika check`) · a `nika:write ./etc/x` outside `fs.write`,
@@ -705,6 +740,7 @@ A v0.1-compliant engine MUST ·
 6. Validate each typed `outputs` value against its declared `type:` at run end · a value that does not match its declared type fails the run (`NIKA-VAR-009` · `validation_error`): the callable contract is enforced on BOTH halves (typed in via `inputs`, typed out via `outputs`) · symmetric with rule 5
 7. Mask resolved `secrets` values in all logs · traces · journal events
 8. Enforce a declared `permits:` block on both surfaces: refuse statically-detectable escapes at check time, and fail any runtime effect outside the boundary with `NIKA-SEC-004` · once `permits:` is present every category is default-deny unless listed
+9. Compose every child process environment (§permits env · NEP-0005): the runner env floor ∪ the declared `env:` passthrough ∪ the task `env:` map, minus the dangerous-name floor · never inherit the engine environment
 
 ---
 

--- a/crates/nika-pack/pack/spec/02-verbs.md
+++ b/crates/nika-pack/pack/spec/02-verbs.md
@@ -139,7 +139,7 @@ test:
 | `command` | one of | array | **argv** — `["prog", "arg", …]` → direct `execve`, **NO shell** · each element substituted independently — an interpolated `${{ }}` value can never break out of its argument (see Security). Exactly one of `command` \| `shell`. |
 | `shell` | one of | string | **The explicit shell door** — one line run via `/bin/sh -c` · pipes · redirects · globs. The blocklist applies HERE; interpolating untrusted values here is the author's own risk, visibly. Exactly one of `command` \| `shell`. *(D1 · #75: semantics never fork on a YAML type — the field name carries the meaning. The old string `command:` is rejected at parse.)* |
 | `cwd` | no | string | Working directory · default = engine's cwd |
-| `env` | no | object | OS environment variables for **this subprocess** · key→value map |
+| `env` | no | object | OS environment variables for **this subprocess** · key→value map · applied over the COMPOSED environment ([01 §permits](./01-envelope.md#permits--optional--the-declared-capability-boundary) env · never inherited) |
 | `stdin` | no | string | Stdin data · may use `${{ ... }}` |
 | `capture` | no | enum | `stdout` (default) · `stderr` · `combined` · `structured` (= `{ stdout, stderr, exit_code }`) — the **source** |
 | `decode` | no | enum | `text` (default) · `json` · `jsonl` · `bytes` — how the captured **string** becomes a value ([09 §decode](./09-types.md#decode--how-exec-bytes-become-a-value-normative)) · illegal with `capture: structured` (`NIKA-PARSE-025` — that capture already IS an object) · a non-parsing stream settles the task `failure` inside `on_error:` scope |
@@ -149,7 +149,12 @@ test:
 > `NIKA-VALUES-002`). The envelope `config:` is *workflow config* read via
 > `${{ config.* }}`; `exec.env` is the *OS environment of this subprocess*. They
 > are NOT auto-connected. To pass a workflow value into the process, do it
-> explicitly: `env: { API_BASE: "${{ config.API_BASE }}" }`.
+> explicitly: `env: { API_BASE: "${{ config.API_BASE }}" }`. The subprocess
+> environment itself is COMPOSED, never inherited (NEP-0005 ·
+> [01 §permits](./01-envelope.md#permits--optional--the-declared-capability-boundary)):
+> the runner env floor ∪ the `permits.env:` passthrough ∪ this map, minus
+> the dangerous-name floor · an ambient engine variable reaches the child
+> only through a declared `permits.env:` name.
 
 > `timeout` and `retry` are **task-level** fields (see [03-dag.md](./03-dag.md)): they apply uniformly to every verb, so they are not repeated inside `exec:`.
 

--- a/crates/nika-pack/pack/spec/10-authority.md
+++ b/crates/nika-pack/pack/spec/10-authority.md
@@ -142,6 +142,61 @@ decoration: it is the **minimal witness** that lets an author decide
 sanction-or-fix without re-deriving the flow by eye. The secret's
 *value* never appears in any diagnostic.
 
+## The permit-parameterization taint (normative)
+
+The fit above proves `Required ⊆ Declared` on **categories**; it says
+nothing about the resolved VALUES flowing under a present block. Every
+value carries an integrity label — **Integ ∈ {trusted, untrusted}** —
+orthogonal to Conf (the secrets axis): literals, `const.*`, and
+`secrets.*` are trusted; `inputs.*` (caller-supplied at launch),
+`config.*` (deployment-supplied, outside the file), fetch/tool results,
+and anything derived from them are untrusted, with monotone propagation
+(one untrusted operand taints the whole interpolation). Two rules bind
+untrusted values under a `permits:` block (NEP-0004 · LAW-AUTH-0325):
+
+| Code | Class | Witness (in the diagnostic) |
+|---|---|---|
+| `NIKA-AUTH-007` | an interpolation reaches a **permit bound** (a host, glob, program, or env-name literal inside `permits:` · NEP-0005 counts `env:` entries among the bounds) | the bound's own path (`net.http[0]`) — a bound MUST be a literal: the boundary would be self-serve, there is nothing left to canonicalize against |
+| `NIKA-AUTH-008` | an untrusted value reaches a permitted verb's **argument** and its canonical resolved form escapes the step's permit | the **taint path**, source-first (`inputs.p → args.path`) + the resolved value, its canonical form, and the bound it escaped |
+
+Both are `security_error`, check-time, blocking. The **re-gate** never
+matches raw strings: the engine canonicalizes the RESOLVED value first,
+per plane — fs paths are lexically normalized (`.`/`..` resolved,
+separators collapsed) before the glob match, net hosts are lowercased
+(IDNA→punycode, trailing dot and default port stripped), and for exec
+argv the program is argv[0] while re-entry-class tokens (`--exec`, `-c`,
+`eval`…) are never covered unless the permit lists them explicitly.
+`datasets/../datasets/q3.csv` is INSIDE `datasets/**`;
+`../../etc/passwd` is not — a prefix matcher cannot tell them apart,
+the canonical form can.
+
+An untrusted value not resolvable at check (no default) **defers**: the
+file stays valid, the run-time re-gate is mandatory (an escape fails the
+task `NIKA-SEC-004` — the defense-in-depth twin of NEP-0003 law 3), and
+the check report SHOULD list the deferred re-gates informationally so CI
+sees the attack surface before launch.
+
+The only door is the authored one — a task-level `declassify:` entry:
+
+```yaml
+tasks:
+  load:
+    invoke:
+      tool: nika:read
+      args: { path: "${{ inputs.p }}" }
+    declassify:
+      - from: inputs.p            # one binding
+        to: trusted
+        because: "vendor inventory path, deployment-controlled, reviewed at release time"
+```
+
+`declassify:` MUST name `from:` (one binding), `to: trusted`, and a
+non-empty `because:`; the receipt records it (taint path · because ·
+value digest). It lifts the TAINT law only — the value is then matched
+like a literal and must still sit inside the declared boundary.
+Declassify is never a permit bypass, and there is no implicit
+declassification in v1.
+
 ## The certificate names its effects (normative)
 
 `nika check --json` already emits a resource certificate
@@ -172,7 +227,8 @@ projection: the judge is the check ladder, never the JSON.
 | `NIKA-POLICY-001` | `security_error` | a hard `policy:` rule is violated (the diagnostic names rule + task + witness) |
 
 `NIKA-SEC-006` / `NIKA-SEC-007` join the existing `NIKA-SEC` namespace
-([05](./05-errors.md)).
+([05](./05-errors.md)); `NIKA-AUTH-007` / `NIKA-AUTH-008` join the
+`NIKA-AUTH` namespace opened by NEP-0003's `NIKA-AUTH-006`.
 
 ## One obvious way (normative for linters)
 

--- a/crates/nika-runtime/src/compose.rs
+++ b/crates/nika-runtime/src/compose.rs
@@ -740,15 +740,6 @@ pub fn production_runtime(
     // (SSRF enforced · workflow-controlled URLs).
     let provider_http = Arc::new(provider_http()?);
     let config = config_from_env();
-    // The provider API-key env-var names the engine reads for its OWN inference
-    // calls — scrubbed from every exec child's ambient environment so an
-    // untrusted command cannot exfiltrate them (ADR-095 Layer 3). A workflow
-    // that needs a key in its child still sets it explicitly in `env:`.
-    let provider_secret_env: Vec<String> = nika_catalog::all_providers()
-        .iter()
-        .filter(|p| !p.env_var.is_empty())
-        .map(|p| p.env_var.to_string())
-        .collect();
 
     // The builtin tool plane (invoke + the agent's tools) over real
     // effects · shared by InvokeVerb and the agent's tool-defs seam. The
@@ -782,9 +773,11 @@ pub fn production_runtime(
     let agent_provider = Arc::new(RegistryProvider::new(Arc::clone(&registry), default_model));
 
     Ok(Runtime::new(
-        ExecVerb::new(Arc::new(
-            TokioShell::with_sandbox(sandbox).with_ambient_secret_env(provider_secret_env),
-        )),
+        // The exec child environment is COMPOSED at the spawn site (NEP-0005 ·
+        // the runner floor ∪ the declared `permits.env:` passthrough carried
+        // on each command ∪ the authored map) — the old ambient-secret
+        // denylist scrub is gone because nothing ambient crosses at all.
+        ExecVerb::new(Arc::new(TokioShell::with_sandbox(sandbox))),
         Arc::clone(&invoke),
         InferVerb::new(registry, default_model),
         AgentVerb::new(

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -546,7 +546,7 @@ where
         // cwd · env · stdin flow to the subprocess (spec 02 §exec). All
         // three may carry `${{ }}` and are rendered against the scope; the
         // parser captured them but the dispatch dropped them before this
-        // (the subprocess ran in the engine cwd with the inherited env).
+        // (the subprocess ran in the engine cwd with a floor-only env).
         if let Err(err) = render_exec_io(&mut input, action, scope) {
             return Dispatched::template_err(&note, &err);
         }
@@ -588,6 +588,14 @@ where
         // (F-O8: no `permits:` block = the zero-authority spec · the exec
         // is already refused above, this is the double lock).
         input.sandbox = Some(self.exec_sandbox_spec(scope.permits));
+        // NEP-0005 · the declared `permits.env:` passthrough rides the
+        // command to the spawn site, which composes the child environment
+        // (the runner floor ∪ these names ∪ the authored `env:` map) from
+        // a cleared slate — nothing ambient crosses undeclared.
+        input.env_passthrough = scope
+            .permits
+            .map(|p| p.env_passthrough().to_vec())
+            .unwrap_or_default();
 
         match self.shell.run(input).await {
             Ok(out) => settle_exec_out(&note, out, decode, contract),
@@ -1236,7 +1244,7 @@ mod tests {
         render_exec_io(&mut input, &action, &scope).expect("renders");
         assert!(input.cwd.is_none(), "no cwd → inherited");
         assert!(input.stdin.is_none(), "no stdin");
-        assert!(input.env.is_empty(), "no env → inherited only");
+        assert!(input.env.is_empty(), "no env → the composed floor only");
     }
 
     #[test]

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -18,10 +18,9 @@ use nika_kernel::http::HttpPostDyn;
 use nika_kernel::process::ShellRunDyn;
 use nika_kernel::tool_executor::ToolExecuteDyn;
 use nika_schema::raw::{RawAction, RawCommand};
-use nika_schema::types::CaptureMode as SpecCaptureMode;
 use nika_types::cost::UnpricedReason;
 use nika_verb_agent::{AgentInput, AgentValue};
-use nika_verb_exec::{CaptureMode, ExecCommand, ExecInput, ExecValue};
+use nika_verb_exec::{CaptureMode, ExecCommand, ExecValue};
 use nika_verb_infer::{InferInput, InferValue};
 use nika_verb_invoke::InvokeInput;
 use serde_json::Value;
@@ -29,11 +28,13 @@ use serde_json::Value;
 use crate::Runtime;
 use crate::errors::RuntimeError;
 
+mod exec_io;
 mod permits;
 mod regate;
 mod sandbox;
 use crate::expr::{self, Scope};
 use crate::record::TaskErrorRecord;
+use exec_io::{build_exec_input, capture_mode, render_exec_io};
 
 /// One dispatch's outcome — the display note + value-or-error.
 /// (Agent decisions do NOT ride here: the buffer lives in the CALLER,
@@ -948,109 +949,6 @@ pub(crate) fn system_with_skills(system: Option<String>, docs: &[nika_schema::Sk
     out
 }
 
-/// Build the [`ExecInput`] from the authored command form — each form
-/// maps to its OWN variant: the argv form is rendered PER ELEMENT and
-/// passed as a vector (NO join, NO shell), so an interpolated value can
-/// never break out of its argv token; the shell form keeps `/bin/sh -c`
-/// for genuine pipelines. Returns `(input, program, is_argv)` — a
-/// refusal comes back boxed (clippy: the error path stays thin).
-fn build_exec_input(
-    action: &nika_schema::raw::RawExecAction,
-    scope: &Scope<'_>,
-) -> Result<(ExecInput, String, bool), Box<Dispatched>> {
-    match &action.command {
-        RawCommand::Shell(text) => match expr::render(&text.value, scope) {
-            Ok(line) => {
-                let program = shell_leading_program(&line);
-                Ok((ExecInput::shell(line), program, false))
-            }
-            Err(err) => Err(Box::new(Dispatched::template_err("exec · ?", &err))),
-        },
-        RawCommand::Argv(parts) => {
-            let rendered: Result<Vec<_>, _> = parts
-                .iter()
-                .map(|p| expr::render(&p.value, scope))
-                .collect();
-            match rendered {
-                Ok(argv) => {
-                    let program = argv.first().cloned().unwrap_or_else(|| "?".to_owned());
-                    Ok((ExecInput::argv(argv), program, true))
-                }
-                Err(err) => Err(Box::new(Dispatched::template_err("exec · ?", &err))),
-            }
-        }
-        // #[non_exhaustive] · refuse loudly · never guess a shape.
-        other => Err(Box::new(Dispatched::unwired(
-            "exec · ?",
-            format!("command form not wired in the runtime yet: {other:?}"),
-        ))),
-    }
-}
-
-/// Render the exec subprocess I/O (`cwd` · `env` · `stdin`) onto `input`.
-///
-/// Each field may carry `${{ }}` and is resolved against the scope. `env`
-/// keys AND values are both rendered (a value commonly forwards an envelope
-/// var · `env: { API_BASE: "${{ env.API_BASE }}" }` per spec 02 §exec).
-fn render_exec_io(
-    input: &mut ExecInput,
-    action: &nika_schema::raw::RawExecAction,
-    scope: &Scope<'_>,
-) -> Result<(), RuntimeError> {
-    input.cwd = render_opt(action.cwd.as_ref(), scope)?.map(std::path::PathBuf::from);
-    input.stdin = render_opt(action.stdin.as_ref(), scope)?;
-    for (key, value) in &action.env {
-        let k = expr::render(&key.value, scope)?;
-        let v = expr::render(&value.value, scope)?;
-        input.env.insert(k, v);
-    }
-    Ok(())
-}
-
-/// The leading program token of a shell command line (for the display note +
-/// identity), skipping leading `NAME=value` env assignments — `FOO=bar git`
-/// → `git`, matching the static `permits_fit::leading_program` so the note
-/// names the real program (not the assignment).
-fn shell_leading_program(line: &str) -> String {
-    line.split_whitespace()
-        .find(|token| !is_env_assignment(token))
-        .unwrap_or("?")
-        .to_owned()
-}
-
-/// Whether a shell token is a `NAME=value` environment assignment (a valid
-/// env name before the `=`), not the program — `FOO=bar` runs `git`, not `FOO`.
-fn is_env_assignment(token: &str) -> bool {
-    match token.split_once('=') {
-        Some((name, _)) => {
-            !name.is_empty()
-                && name
-                    .chars()
-                    .next()
-                    .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-        }
-        None => false,
-    }
-}
-
-/// Map the authored `capture:` (spec 02 §exec · schema enum) to the verb's
-/// own `CaptureMode`. Two parallel closed enums (the schema layer vs the
-/// verb layer) bridged here. `None` (omitted) is the spec default
-/// (`stdout`); a future `#[non_exhaustive]` schema variant also falls to
-/// `stdout` (the safe spec default) — the named arms below are the wired
-/// set, so when a new mode lands in BOTH enums it must be added here to
-/// stop riding the default.
-fn capture_mode(spec: Option<SpecCaptureMode>) -> CaptureMode {
-    match spec {
-        Some(SpecCaptureMode::Stderr) => CaptureMode::Stderr,
-        Some(SpecCaptureMode::Combined) => CaptureMode::Combined,
-        Some(SpecCaptureMode::Structured) => CaptureMode::Structured,
-        // `stdout`, omitted, OR an unknown future variant → the default.
-        None | Some(SpecCaptureMode::Stdout | _) => CaptureMode::Stdout,
-    }
-}
-
 /// OBS-E · the silent-empty-answer footgun for reasoning models.
 ///
 /// A thinking model (gemini-2.5-flash · openai o-series · anthropic
@@ -1124,18 +1022,7 @@ fn value_is_blank(value: &Value) -> bool {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use nika_schema::raw::{RawCommand, RawExecAction};
-    use nika_schema::{Span, Spanned};
-    use nika_verb_exec::ExecInput;
     use serde_json::Value;
-
-    use super::{Scope, render_exec_io};
-
-    fn spanned(s: &str) -> Spanned<String> {
-        Spanned::new(s.to_owned(), Span::default())
-    }
 
     #[test]
     fn invoke_meters_a_top_level_cost_usd_from_structured_output() {
@@ -1168,96 +1055,6 @@ mod tests {
             None,
             "non-finite refused"
         );
-    }
-
-    #[test]
-    fn exec_cwd_env_stdin_render_onto_the_input() {
-        // The Findings #3/#4 regression: the parser captured cwd/env/stdin
-        // but dispatch dropped them. All three resolve `${{ }}` and land on
-        // the ExecInput the verb spawns from.
-        let records = BTreeMap::new();
-        let vars = BTreeMap::from([
-            ("dir".to_owned(), Value::String("./engine".to_owned())),
-            ("base".to_owned(), Value::String("https://x".to_owned())),
-            ("payload".to_owned(), Value::String("hello".to_owned())),
-        ]);
-        let scope = Scope::workflow(&records, &vars);
-
-        let mut action = RawExecAction::with_command(RawCommand::Shell(spanned("printenv")));
-        action.cwd = Some(spanned("${{ inputs.dir }}"));
-        action.env = vec![
-            (spanned("API_BASE"), spanned("${{ inputs.base }}")),
-            (spanned("STATIC"), spanned("lit")),
-        ];
-        action.stdin = Some(spanned("${{ inputs.payload }}"));
-
-        let mut input = ExecInput::shell("printenv");
-        render_exec_io(&mut input, &action, &scope).expect("renders");
-
-        assert_eq!(input.cwd.as_deref(), Some(std::path::Path::new("./engine")));
-        assert_eq!(input.stdin.as_deref(), Some("hello"));
-        assert_eq!(
-            input.env.get("API_BASE").map(String::as_str),
-            Some("https://x")
-        );
-        assert_eq!(input.env.get("STATIC").map(String::as_str), Some("lit"));
-    }
-
-    #[test]
-    fn exec_env_can_forward_envelope_env_config() {
-        // The spec has two env layers: envelope `env:` config and
-        // `exec.env` subprocess variables. The latter commonly forwards the
-        // former (`QRCODE_AI_API_BASE: ${{ config.QRCODE_AI_API_BASE }}`); this
-        // must render after a green `nika check`.
-        let records = BTreeMap::new();
-        let inputs = BTreeMap::new();
-        let config = BTreeMap::from([(
-            "QRCODE_AI_API_BASE".to_owned(),
-            Value::String("https://odin.qrcode-ai.com".to_owned()),
-        )]);
-        let consts = BTreeMap::new();
-        let secrets = BTreeMap::new();
-        let scope =
-            Scope::workflow_with_value_authorities(&records, &inputs, &config, &consts, &secrets);
-
-        let mut action = RawExecAction::with_command(RawCommand::Shell(spanned("printenv")));
-        action.env = vec![(
-            spanned("QRCODE_AI_API_BASE"),
-            spanned("${{ config.QRCODE_AI_API_BASE }}"),
-        )];
-
-        let mut input = ExecInput::shell("printenv");
-        render_exec_io(&mut input, &action, &scope).expect("renders");
-        assert_eq!(
-            input.env.get("QRCODE_AI_API_BASE").map(String::as_str),
-            Some("https://odin.qrcode-ai.com")
-        );
-    }
-
-    #[test]
-    fn absent_exec_io_leaves_the_input_at_its_defaults() {
-        let records = BTreeMap::new();
-        let vars = BTreeMap::new();
-        let scope = Scope::workflow(&records, &vars);
-        let action = RawExecAction::with_command(RawCommand::Shell(spanned("true")));
-        let mut input = ExecInput::shell("true");
-        render_exec_io(&mut input, &action, &scope).expect("renders");
-        assert!(input.cwd.is_none(), "no cwd → inherited");
-        assert!(input.stdin.is_none(), "no stdin");
-        assert!(input.env.is_empty(), "no env → the composed floor only");
-    }
-
-    #[test]
-    fn a_bad_template_in_exec_io_is_a_loud_error() {
-        // An unresolvable reference in cwd/env/stdin must surface, not be
-        // swallowed (the loud doctrine · same class as a bad command).
-        let records = BTreeMap::new();
-        let vars = BTreeMap::new();
-        let scope = Scope::workflow(&records, &vars);
-        let mut action = RawExecAction::with_command(RawCommand::Shell(spanned("true")));
-        action.cwd = Some(spanned("${{ vars.nope }}"));
-        let mut input = ExecInput::shell("true");
-        assert!(render_exec_io(&mut input, &action, &scope).is_err());
     }
 
     // ── OBS-E · the reasoning-model blank-answer footgun ────────────────

--- a/crates/nika-runtime/src/dispatch/exec_io.rs
+++ b/crates/nika-runtime/src/dispatch/exec_io.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The exec verb's INPUT surface — authored command form → [`ExecInput`]
+//! (argv rendered per element · shell kept whole), the subprocess I/O
+//! rendering (`cwd` · `env` · `stdin` · spec 02 §exec), the shell
+//! leading-program identity, and the `capture:` enum bridge. Split from
+//! `dispatch.rs` at the 1500-LOC wall (the `dispatch/{permits,regate,
+//! sandbox}` precedent) — the exec DISPATCH (gates · re-gate · spawn)
+//! stays in the parent; this module owns the pure input shaping.
+
+use nika_schema::raw::RawCommand;
+use nika_schema::types::CaptureMode as SpecCaptureMode;
+use nika_verb_exec::{CaptureMode, ExecInput};
+
+use super::{Dispatched, render_opt};
+use crate::errors::RuntimeError;
+use crate::expr::{self, Scope};
+
+/// Build the [`ExecInput`] from the authored command form — each form
+/// maps to its OWN variant: the argv form is rendered PER ELEMENT and
+/// passed as a vector (NO join, NO shell), so an interpolated value can
+/// never break out of its argv token; the shell form keeps `/bin/sh -c`
+/// for genuine pipelines. Returns `(input, program, is_argv)` — a
+/// refusal comes back boxed (clippy: the error path stays thin).
+pub(super) fn build_exec_input(
+    action: &nika_schema::raw::RawExecAction,
+    scope: &Scope<'_>,
+) -> Result<(ExecInput, String, bool), Box<Dispatched>> {
+    match &action.command {
+        RawCommand::Shell(text) => match expr::render(&text.value, scope) {
+            Ok(line) => {
+                let program = shell_leading_program(&line);
+                Ok((ExecInput::shell(line), program, false))
+            }
+            Err(err) => Err(Box::new(Dispatched::template_err("exec · ?", &err))),
+        },
+        RawCommand::Argv(parts) => {
+            let rendered: Result<Vec<_>, _> = parts
+                .iter()
+                .map(|p| expr::render(&p.value, scope))
+                .collect();
+            match rendered {
+                Ok(argv) => {
+                    let program = argv.first().cloned().unwrap_or_else(|| "?".to_owned());
+                    Ok((ExecInput::argv(argv), program, true))
+                }
+                Err(err) => Err(Box::new(Dispatched::template_err("exec · ?", &err))),
+            }
+        }
+        // #[non_exhaustive] · refuse loudly · never guess a shape.
+        other => Err(Box::new(Dispatched::unwired(
+            "exec · ?",
+            format!("command form not wired in the runtime yet: {other:?}"),
+        ))),
+    }
+}
+
+/// Render the exec subprocess I/O (`cwd` · `env` · `stdin`) onto `input`.
+///
+/// Each field may carry `${{ }}` and is resolved against the scope. `env`
+/// keys AND values are both rendered (a value commonly forwards an envelope
+/// var · `env: { API_BASE: "${{ env.API_BASE }}" }` per spec 02 §exec).
+pub(super) fn render_exec_io(
+    input: &mut ExecInput,
+    action: &nika_schema::raw::RawExecAction,
+    scope: &Scope<'_>,
+) -> Result<(), RuntimeError> {
+    input.cwd = render_opt(action.cwd.as_ref(), scope)?.map(std::path::PathBuf::from);
+    input.stdin = render_opt(action.stdin.as_ref(), scope)?;
+    for (key, value) in &action.env {
+        let k = expr::render(&key.value, scope)?;
+        let v = expr::render(&value.value, scope)?;
+        input.env.insert(k, v);
+    }
+    Ok(())
+}
+
+/// The leading program token of a shell command line (for the display note +
+/// identity), skipping leading `NAME=value` env assignments — `FOO=bar git`
+/// → `git`, matching the static `permits_fit::leading_program` so the note
+/// names the real program (not the assignment).
+fn shell_leading_program(line: &str) -> String {
+    line.split_whitespace()
+        .find(|token| !is_env_assignment(token))
+        .unwrap_or("?")
+        .to_owned()
+}
+
+/// Whether a shell token is a `NAME=value` environment assignment (a valid
+/// env name before the `=`), not the program — `FOO=bar` runs `git`, not `FOO`.
+fn is_env_assignment(token: &str) -> bool {
+    match token.split_once('=') {
+        Some((name, _)) => {
+            !name.is_empty()
+                && name
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        None => false,
+    }
+}
+
+/// Map the authored `capture:` (spec 02 §exec · schema enum) to the verb's
+/// own `CaptureMode`. Two parallel closed enums (the schema layer vs the
+/// verb layer) bridged here. `None` (omitted) is the spec default
+/// (`stdout`); a future `#[non_exhaustive]` schema variant also falls to
+/// `stdout` (the safe spec default) — the named arms below are the wired
+/// set, so when a new mode lands in BOTH enums it must be added here to
+/// stop riding the default.
+pub(super) fn capture_mode(spec: Option<SpecCaptureMode>) -> CaptureMode {
+    match spec {
+        Some(SpecCaptureMode::Stderr) => CaptureMode::Stderr,
+        Some(SpecCaptureMode::Combined) => CaptureMode::Combined,
+        Some(SpecCaptureMode::Structured) => CaptureMode::Structured,
+        // `stdout`, omitted, OR an unknown future variant → the default.
+        None | Some(SpecCaptureMode::Stdout | _) => CaptureMode::Stdout,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nika_schema::raw::{RawCommand, RawExecAction};
+    use nika_schema::{Span, Spanned};
+    use nika_verb_exec::ExecInput;
+    use serde_json::Value;
+
+    use super::render_exec_io;
+    use crate::expr::Scope;
+
+    fn spanned(s: &str) -> Spanned<String> {
+        Spanned::new(s.to_owned(), Span::default())
+    }
+
+    #[test]
+    fn exec_cwd_env_stdin_render_onto_the_input() {
+        // The Findings #3/#4 regression: the parser captured cwd/env/stdin
+        // but dispatch dropped them. All three resolve `${{ }}` and land on
+        // the ExecInput the verb spawns from.
+        let records = BTreeMap::new();
+        let vars = BTreeMap::from([
+            ("dir".to_owned(), Value::String("./engine".to_owned())),
+            ("base".to_owned(), Value::String("https://x".to_owned())),
+            ("payload".to_owned(), Value::String("hello".to_owned())),
+        ]);
+        let scope = Scope::workflow(&records, &vars);
+
+        let mut action = RawExecAction::with_command(RawCommand::Shell(spanned("printenv")));
+        action.cwd = Some(spanned("${{ inputs.dir }}"));
+        action.env = vec![
+            (spanned("API_BASE"), spanned("${{ inputs.base }}")),
+            (spanned("STATIC"), spanned("lit")),
+        ];
+        action.stdin = Some(spanned("${{ inputs.payload }}"));
+
+        let mut input = ExecInput::shell("printenv");
+        render_exec_io(&mut input, &action, &scope).expect("renders");
+
+        assert_eq!(input.cwd.as_deref(), Some(std::path::Path::new("./engine")));
+        assert_eq!(input.stdin.as_deref(), Some("hello"));
+        assert_eq!(
+            input.env.get("API_BASE").map(String::as_str),
+            Some("https://x")
+        );
+        assert_eq!(input.env.get("STATIC").map(String::as_str), Some("lit"));
+    }
+
+    #[test]
+    fn exec_env_can_forward_envelope_env_config() {
+        // The spec has two env layers: envelope `env:` config and
+        // `exec.env` subprocess variables. The latter commonly forwards the
+        // former (`QRCODE_AI_API_BASE: ${{ config.QRCODE_AI_API_BASE }}`); this
+        // must render after a green `nika check`.
+        let records = BTreeMap::new();
+        let inputs = BTreeMap::new();
+        let config = BTreeMap::from([(
+            "QRCODE_AI_API_BASE".to_owned(),
+            Value::String("https://odin.qrcode-ai.com".to_owned()),
+        )]);
+        let consts = BTreeMap::new();
+        let secrets = BTreeMap::new();
+        let scope =
+            Scope::workflow_with_value_authorities(&records, &inputs, &config, &consts, &secrets);
+
+        let mut action = RawExecAction::with_command(RawCommand::Shell(spanned("printenv")));
+        action.env = vec![(
+            spanned("QRCODE_AI_API_BASE"),
+            spanned("${{ config.QRCODE_AI_API_BASE }}"),
+        )];
+
+        let mut input = ExecInput::shell("printenv");
+        render_exec_io(&mut input, &action, &scope).expect("renders");
+        assert_eq!(
+            input.env.get("QRCODE_AI_API_BASE").map(String::as_str),
+            Some("https://odin.qrcode-ai.com")
+        );
+    }
+
+    #[test]
+    fn absent_exec_io_leaves_the_input_at_its_defaults() {
+        let records = BTreeMap::new();
+        let vars = BTreeMap::new();
+        let scope = Scope::workflow(&records, &vars);
+        let action = RawExecAction::with_command(RawCommand::Shell(spanned("true")));
+        let mut input = ExecInput::shell("true");
+        render_exec_io(&mut input, &action, &scope).expect("renders");
+        assert!(input.cwd.is_none(), "no cwd → inherited");
+        assert!(input.stdin.is_none(), "no stdin");
+        assert!(input.env.is_empty(), "no env → the composed floor only");
+    }
+
+    #[test]
+    fn a_bad_template_in_exec_io_is_a_loud_error() {
+        // An unresolvable reference in cwd/env/stdin must surface, not be
+        // swallowed (the loud doctrine · same class as a bad command).
+        let records = BTreeMap::new();
+        let vars = BTreeMap::new();
+        let scope = Scope::workflow(&records, &vars);
+        let mut action = RawExecAction::with_command(RawCommand::Shell(spanned("true")));
+        action.cwd = Some(spanned("${{ vars.nope }}"));
+        let mut input = ExecInput::shell("true");
+        assert!(render_exec_io(&mut input, &action, &scope).is_err());
+    }
+}

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -128,6 +128,66 @@ async fn declared_boundary_attaches_the_sandbox_spec_to_exec() {
     assert_eq!(spec.fs_read, vec!["/repo/data/**".to_owned()]);
     assert_eq!(spec.fs_write, vec!["/repo/out/**".to_owned()]);
     assert_eq!(spec.net, NetPolicy::Deny, "no net.http = the deny holds");
+    assert!(
+        sent[0].env_passthrough.is_empty(),
+        "no env: category = zero declared passthrough (NEP-0005 law 1)"
+    );
+}
+
+/// NEP-0005 — the declared `permits.env:` passthrough rides every exec
+/// command to the spawn site (which composes floor ∪ these names ∪ the
+/// authored map from a cleared slate), and the authored task `env:` map
+/// stays exactly the authored entries.
+#[tokio::test]
+async fn declared_env_passthrough_rides_the_exec_command() {
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+
+    let yaml = "nika: v1\nworkflow:\n  id: envpass\npermits:\n  exec: [\"echo\"]\n  env: [\"CI_COMMIT_SHA\", \"CI_JOB_ID\"]\ntasks:\n  t:\n    exec:\n      command: [\"echo\", \"x\"]\n      env:\n        AUTHORED: \"lit\"\n";
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_check::check(&wf);
+    assert!(report.is_clean(), "fixture passes the ladder: {report:?}");
+    let shell = MockShell::new().enqueue_ok("ok");
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(MockToolExecutor::new())));
+    let runtime = Runtime::new(
+        ExecVerb::new(Arc::new(shell.clone())),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(MockProvider::new("mock")),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        RuntimeConfig::default().with_sandbox_root(std::path::PathBuf::from("/repo")),
+    );
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    let sent = shell.executed_commands();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(
+        sent[0].env_passthrough,
+        vec!["CI_COMMIT_SHA".to_owned(), "CI_JOB_ID".to_owned()],
+        "the declared names ride the command to the spawn site"
+    );
+    assert_eq!(
+        sent[0].env.get("AUTHORED").map(String::as_str),
+        Some("lit"),
+        "the authored task env: map stays the authored entries"
+    );
 }
 
 /// No `permits:` block = ZERO AUTHORITY (F-O8): the check flags the

--- a/crates/nika-sandbox-landlock/src/lib.rs
+++ b/crates/nika-sandbox-landlock/src/lib.rs
@@ -225,7 +225,7 @@ fn wrap(command: ShellCommand, jail: Vec<String>) -> ShellCommand {
     wrapped.shell = false;
     wrapped.cwd = command.cwd;
     wrapped.env = command.env;
-    wrapped.env_remove = command.env_remove;
+    wrapped.env_passthrough = command.env_passthrough;
     wrapped.stdin = command.stdin;
     wrapped.timeout = command.timeout;
     wrapped.pre_validated = true; // the original already passed the floor; the launcher is benign

--- a/crates/nika-sandbox-seatbelt/src/lib.rs
+++ b/crates/nika-sandbox-seatbelt/src/lib.rs
@@ -186,7 +186,7 @@ fn wrap(command: ShellCommand, profile: &str) -> ShellCommand {
     wrapped.shell = false;
     wrapped.cwd = command.cwd;
     wrapped.env = command.env;
-    wrapped.env_remove = command.env_remove;
+    wrapped.env_passthrough = command.env_passthrough;
     wrapped.stdin = command.stdin;
     wrapped.timeout = command.timeout;
     wrapped.pre_validated = true; // the original already passed the floor; the launcher is benign

--- a/crates/nika-schema/src/parser/envelope.rs
+++ b/crates/nika-schema/src/parser/envelope.rs
@@ -868,7 +868,41 @@ pub(super) fn parse_permits(
         permits.tools = Some(string_list_values(cx, mapping, "tools")?);
     }
 
+    if mapping.get_node("env").is_some() {
+        let entries = super::tasks::parse_string_list(cx, mapping, "env")?;
+        let mut names = Vec::with_capacity(entries.len());
+        for entry in entries {
+            if !is_env_permit_entry(&entry.value) {
+                return Err(SchemaError::Validation {
+                    message: format!(
+                        "`permits.env` entry `{}` is not an environment variable name \
+                         (POSIX shape `[A-Za-z_][A-Za-z0-9_]*` · exact names, no globs · \
+                         NEP-0005)",
+                        entry.value
+                    ),
+                    span: Some(entry.span),
+                });
+            }
+            names.push(entry.value);
+        }
+        permits.env = Some(names);
+    }
+
     Ok(Some(Spanned::new(permits, cx.span_or_zero(node.span()))))
+}
+
+/// A `permits.env` entry shape (NEP-0005 law 4): an exact POSIX name, or a
+/// string carrying a `${{ }}` island — the island passes the parse so the
+/// CHECK refuses it as a non-literal bound (`NIKA-AUTH-007`) with the
+/// teaching detail; any other string is a parse-level refusal (the spec
+/// schema's `anyOf` shape gate, mirrored).
+fn is_env_permit_entry(s: &str) -> bool {
+    if s.contains("${{") {
+        return true;
+    }
+    let mut chars = s.chars();
+    matches!(chars.next(), Some(c) if c == '_' || c.is_ascii_alphabetic())
+        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
 }
 
 /// `permits.exec` — the closed tri-state · `false` | `true` | `[programs…]`.
@@ -1114,6 +1148,43 @@ permits:
         assert!(!p.allows_program("rm"));
         assert!(p.allows_tool("mcp:browser/navigate"));
         assert!(!p.allows_tool("mcp:postgres/query"));
+    }
+
+    #[test]
+    fn env_permit_parses_exact_names() {
+        let yaml = format!("{BASE}permits:\n  env: [\"CI_COMMIT_SHA\", \"_UNDERSCORE1\"]\n");
+        let wf = parse_mode(&yaml, ParseMode::Strict);
+        let p = &wf.permits.expect("present").value;
+        assert_eq!(
+            p.env.as_deref(),
+            Some(&["CI_COMMIT_SHA".to_owned(), "_UNDERSCORE1".to_owned()][..])
+        );
+        assert!(p.allows_env_key("CI_COMMIT_SHA"));
+        assert!(!p.allows_env_key("HOME"), "the floor is not a grant");
+        assert_eq!(p.env_passthrough().len(), 2);
+    }
+
+    #[test]
+    fn env_permit_refuses_a_non_name_string() {
+        // NEP-0005 law 4 · a non-name, non-island string is a parse-level
+        // refusal (the spec schema's anyOf shape gate, mirrored).
+        for bad in ["AWS_*", "1LEADING", "WITH-DASH", "with space"] {
+            let yaml = format!("{BASE}permits:\n  env: [\"{bad}\"]\n");
+            let err =
+                parse(&yaml, FileId::new(0), ParseMode::Strict).expect_err("non-name refused");
+            let msg = err.to_string();
+            assert!(msg.contains("permits.env"), "{bad}: {msg}");
+        }
+    }
+
+    #[test]
+    fn env_permit_island_passes_the_parse_for_the_check_refusal() {
+        // The island is NOT a parse error: the CHECK refuses it as a
+        // non-literal bound (NIKA-AUTH-007) with the teaching detail.
+        let yaml = format!("{BASE}permits:\n  env: [\"${{{{ inputs.k }}}}\"]\n");
+        let wf = parse_mode(&yaml, ParseMode::Strict);
+        let p = &wf.permits.expect("present").value;
+        assert_eq!(p.env.as_ref().map(Vec::len), Some(1));
     }
 
     #[test]

--- a/crates/nika-verb-exec/public-api.txt
+++ b/crates/nika-verb-exec/public-api.txt
@@ -163,6 +163,7 @@ pub nika_verb_exec::ExecInput::capture: nika_verb_exec::CaptureMode
 pub nika_verb_exec::ExecInput::command: nika_verb_exec::ExecCommand
 pub nika_verb_exec::ExecInput::cwd: core::option::Option<std::path::PathBuf>
 pub nika_verb_exec::ExecInput::env: alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
+pub nika_verb_exec::ExecInput::env_passthrough: alloc::vec::Vec<alloc::string::String>
 pub nika_verb_exec::ExecInput::raw_capture: bool
 pub nika_verb_exec::ExecInput::sandbox: core::option::Option<nika_kernel_core::io::process::SandboxSpec>
 pub nika_verb_exec::ExecInput::stdin: core::option::Option<alloc::string::String>

--- a/crates/nika-verb-exec/src/lib.rs
+++ b/crates/nika-verb-exec/src/lib.rs
@@ -95,8 +95,14 @@ pub struct ExecInput {
     pub command: ExecCommand,
     /// Working directory (default: engine cwd).
     pub cwd: Option<PathBuf>,
-    /// OS environment for THIS subprocess (NOT the envelope `env:`).
+    /// OS environment for THIS subprocess (NOT the envelope `env:`) — the
+    /// AUTHORED entries; the runner composes the child environment from the
+    /// runner floor + [`Self::env_passthrough`] + this map (NEP-0005).
     pub env: BTreeMap<String, String>,
+    /// The declared `permits.env:` passthrough names (NEP-0005) — resolved
+    /// from the engine's ambient environment at the spawn site. Set by the
+    /// engine from the step's permit, never authored.
+    pub env_passthrough: Vec<String>,
     /// Stdin data.
     pub stdin: Option<String>,
     /// Output capture mode (default `Stdout`).
@@ -157,6 +163,7 @@ impl ExecInput {
             command,
             cwd: None,
             env: BTreeMap::new(),
+            env_passthrough: Vec::new(),
             stdin: None,
             capture: CaptureMode::Stdout,
             raw_capture: false,
@@ -398,6 +405,7 @@ fn build_command(input: ExecInput) -> ShellCommand {
     };
     cmd.cwd = input.cwd;
     cmd.env = input.env;
+    cmd.env_passthrough = input.env_passthrough;
     cmd.stdin = input.stdin;
     cmd.timeout = input.timeout;
     // The OS-confinement boundary rides untouched to the runner, which

--- a/crates/nika-vocab/src/keys.rs
+++ b/crates/nika-vocab/src/keys.rs
@@ -33,7 +33,7 @@ pub const EGRESS_KEYS: &[&str] = &["to", "host", "host_from_self"];
 pub const TYPED_OUTPUT_KEYS: &[&str] = &["value", "type", "description"];
 
 /// Keys of the `permits:` block (spec 01 §permits · closed).
-pub const PERMITS_KEYS: &[&str] = &["fs", "net", "exec", "tools"];
+pub const PERMITS_KEYS: &[&str] = &["fs", "net", "exec", "tools", "env"];
 
 /// Keys of `permits.fs` (closed).
 pub const PERMITS_FS_KEYS: &[&str] = &["read", "write"];


### PR DESCRIPTION
## The law (F-O4 · ratified 2026-07-22 · blocking-v1 · spec merged as [NEP-0005](https://github.com/supernovae-st/nika-spec/pull/179))

A child process environment is **composed, never inherited**: the runner env floor (8 names · one canonical kernel list) ∪ the declared `permits.env:` passthrough (exact POSIX names) ∪ the task's authored `env:` map, minus the dangerous-name floor. An allowlisted program can no longer read `AWS_SECRET_ACCESS_KEY` without a declared grant — HF kill-chain stage 3 closes at the spawn.

## What ships (8 commits)

- **nika-cap** · the env plane (`env.rs`): `DANGEROUS_ENV_VARS` moves in from the kernel (one list · re-exported at the historical path), `RUNNER_FLOOR_ENV_VARS` (the 8 names the MCP spawn proved), `compose_child_env` (pure · lookup injected · floor ∩ dangerous asserted empty) · `Permits.env` + `allows_env_key` + union/intersect arms (exact-name meet = true set intersection)
- **nika-kernel-core** · `ShellCommand.env` = the authored entries · new `env_passthrough` (declared names) · `env_remove` dies with the inheritance it subtracted from · sandbox wrappers carry the field
- **nika-exec-runner** · `env_clear` + the composed map at every spawn · the ambient-secret denylist scrub (`with_ambient_secret_env`) dies — the allowlist IS the scrub · the MCP passthrough list becomes THE kernel floor (two spawn families, one law) · real-spawn contract tests: non-floor ambient never crosses, floor PATH resolves relative programs, a declared name passes, authored wins
- **nika-schema** · `permits.env:` in the ONE closed vocabulary (LSP completion free) · non-name strings refused at parse · islands pass to the check
- **runtime** · the dispatch threads the step permit's names onto every exec command next to the sandbox spec · MockShell end-to-end pin
- **nika-check** · `NIKA-AUTH-009` (dangerous dead grant) + the env family joins the AUTH-007 bound walk · env never inferred (law 7) · mirrors oracle fixtures 014-017
- **refactor** · `dispatch/exec_io.rs` split (the 1500-LOC wall fired at 1502 · parent back to 1299)
- **chore** · SPEC_PIN → `aa96468` + pack vendored (canon 91 codes)

## Proof

- `cargo test --workspace --lib` · 55 crates green · `cargo test --workspace` with `NIKA_SPEC_DIR` at the new pin · **5432 passed · 0 failed** (engine ≡ reference oracle on the new fixtures)
- `cargo clippy --workspace --all-targets -- -D warnings` clean · pre-push gate rc=0 (8/8 CI ratchets)
- Census: zero corpus workflow reads ambient env in a command — the flag-day breaks ≈ 0 files

## Declared residuals

- Taint of authored step-env VALUES = F-O1's declared residual (unchanged)
- Run-time MCP stdio spawning is not wired yet (BuiltinDispatcher → NotFound): when it lands it composes through the same `compose_child_env` seam with the workflow's declared names · today's pin/approve spawns are floor-only (outside any workflow · correct)
- `runtime/permits/005-006` behavioral contracts stay reserved-tier data (the executable proof here = exec_contract real spawns + the threading pin)
- env → OS-profile projection (Seatbelt/bwrap) = lane F-O2's ground

🤖 Generated with [Claude Code](https://claude.com/claude-code)