### PR TITLE
feat(permits): the data-as-code sink (F-O7 · NEP-0006)

### DIFF
--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-aa964686404debcfaadc2588cd243ca37dc060bf
+ffc9389f442ebac18b8a266ef85c203dc2c401cb

--- a/crates/nika-cap/public-api.txt
+++ b/crates/nika-cap/public-api.txt
@@ -4,6 +4,8 @@ pub const nika_cap::env::DANGEROUS_ENV_VARS: &[&str]
 pub const nika_cap::env::RUNNER_FLOOR_ENV_VARS: &[&str]
 pub fn nika_cap::env::compose_child_env(lookup: impl core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>, passthrough: &[alloc::string::String], authored: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
 pub fn nika_cap::env::is_dangerous_env_name(name: &str) -> bool
+pub mod nika_cap::sink
+pub fn nika_cap::sink::code_bearing_path_class(path: &str) -> core::option::Option<(&'static str, &'static str)>
 pub enum nika_cap::BuiltinEffect
 pub nika_cap::BuiltinEffect::Fs
 pub nika_cap::BuiltinEffect::Fs::path_arg: &'static str
@@ -871,6 +873,7 @@ pub fn nika_cap::builtin_effect(tool: &str, args: core::option::Option<&serde_js
 pub fn nika_cap::builtin_egresses(tool: &str) -> bool
 pub fn nika_cap::builtin_shape_findings(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_cap::chart_vl_sibling(tool: &str, args: core::option::Option<&serde_json::value::Value>) -> core::option::Option<alloc::string::String>
+pub fn nika_cap::code_bearing_path_class(path: &str) -> core::option::Option<(&'static str, &'static str)>
 pub fn nika_cap::compose_child_env(lookup: impl core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>, passthrough: &[alloc::string::String], authored: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
 pub fn nika_cap::glob_matches(glob: &str, value: &str) -> bool
 pub fn nika_cap::invoke_tool_is_ingress(tool_id: &str, mcp_content_trusted: bool) -> bool

--- a/crates/nika-cap/src/lib.rs
+++ b/crates/nika-cap/src/lib.rs
@@ -29,6 +29,7 @@ mod integrity;
 mod permits;
 mod policy;
 mod shape;
+pub mod sink;
 mod trifecta;
 
 // Public surface = the 4 capability types + their inherent methods (allows_* ·
@@ -48,6 +49,7 @@ pub use env::{
     DANGEROUS_ENV_VARS, RUNNER_FLOOR_ENV_VARS, compose_child_env, is_dangerous_env_name,
 };
 pub use fit::lexically_normalize;
+pub use sink::code_bearing_path_class;
 // F-O1 PR-1 · the runtime integrity label (the Integ axis of RS-06's
 // trifecta Value) + the shared untrusted-ingress source predicates
 // (check≡run by construction).

--- a/crates/nika-cap/src/sink.rs
+++ b/crates/nika-cap/src/sink.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The data-as-code sink (NEP-0006 · LAW-AUTH-0327 · spec 10 §the
+//! data-as-code sink) — the CLOSED v1 code-bearing classes and the ONE
+//! classification predicate the check twin, the run twin, and the
+//! reference oracle all read (the engine ≡ reference differential per
+//! LAW-AUTH-0319 keeps the mirrored lists honest · one fixture per class).
+//!
+//! Classification reads a URL PATH only (the query carries no verdict ·
+//! NEP-0006 law 4), case-insensitively on the path's final extension.
+//! Byte-sniffing is the declared v1 residual.
+
+/// One code-bearing class: its teaching name + its extensions.
+type ClassRow = (&'static str, &'static [&'static str]);
+
+/// The three CLOSED v1 classes (NEP-0006 · only a NEP amends them). Each
+/// class is justified by a named RCE mechanism: the serialized-executable
+/// family deserializes by running code (the HF loader-RCE vector), a
+/// script exists to be run, a binary/module is code by definition. The
+/// deliberate exclusions (`.safetensors` · `.npy`/`.npz` · archives ·
+/// templates) and their reasons live in the NEP.
+const CODE_BEARING_CLASSES: &[ClassRow] = &[
+    (
+        "serialized-executable",
+        &[
+            ".pkl", ".pickle", ".dill", ".joblib", ".pt", ".pth", ".ckpt",
+        ],
+    ),
+    (
+        "script/interpreter",
+        &[
+            ".py", ".sh", ".bash", ".zsh", ".ps1", ".bat", ".cmd", ".rb", ".pl", ".php", ".js",
+            ".mjs", ".ipynb",
+        ],
+    ),
+    (
+        "executable binary/module",
+        &[".exe", ".dll", ".so", ".dylib", ".wasm", ".jar"],
+    ),
+];
+
+/// Classify a URL PATH (not a full URL — the caller extracts the path
+/// with the WHATWG parser it already holds): `Some((class, extension))`
+/// when the path's final extension names a code-bearing class, `None`
+/// for the unbounded inert world.
+#[must_use]
+pub fn code_bearing_path_class(path: &str) -> Option<(&'static str, &'static str)> {
+    let segment = path.rsplit('/').next().unwrap_or(path);
+    let dot = segment.rfind('.')?;
+    let ext = &segment[dot..];
+    for (class, exts) in CODE_BEARING_CLASSES {
+        if let Some(hit) = exts
+            .iter()
+            .find(|candidate| candidate.eq_ignore_ascii_case(ext))
+        {
+            return Some((class, hit));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_hit_per_class_and_case_insensitive() {
+        // One probe per class keeps this mirror honest with the oracle's
+        // (the conformance fixtures 018-022 are the cross-repo half).
+        assert_eq!(
+            code_bearing_path_class("/models/legacy.pkl"),
+            Some(("serialized-executable", ".pkl"))
+        );
+        assert_eq!(
+            code_bearing_path_class("/setup.sh"),
+            Some(("script/interpreter", ".sh"))
+        );
+        assert_eq!(
+            code_bearing_path_class("/lib/native.DYLIB"),
+            Some(("executable binary/module", ".dylib"))
+        );
+    }
+
+    #[test]
+    fn the_inert_world_stays_none() {
+        for p in [
+            "/q3/rows.csv",
+            "/feed.json",
+            "/report.pdf",
+            "/weights.safetensors",
+            "/data.npz",
+            "/bundle.tar.gz",
+            "/no-extension",
+            "/",
+            "",
+        ] {
+            assert_eq!(code_bearing_path_class(p), None, "{p}");
+        }
+    }
+
+    #[test]
+    fn the_final_extension_decides_never_a_middle_one() {
+        // `.py.txt` is a text file whose NAME mentions py — inert. The
+        // final extension is the classification surface (NEP-0006).
+        assert_eq!(code_bearing_path_class("/notes/script.py.txt"), None);
+        assert_eq!(
+            code_bearing_path_class("/notes/archive.txt.py"),
+            Some(("script/interpreter", ".py"))
+        );
+    }
+}

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -1018,6 +1018,7 @@ pub nika_check::CheckReport::schema_findings: alloc::vec::Vec<nika_check::Schema
 pub nika_check::CheckReport::schema_lints: alloc::vec::Vec<nika_check::SchemaLintFinding>
 pub nika_check::CheckReport::secret_egresses: alloc::vec::Vec<nika_check::SecretEgress>
 pub nika_check::CheckReport::secret_leaks: alloc::vec::Vec<nika_check::SecretLeak>
+pub nika_check::CheckReport::sink_findings: alloc::vec::Vec<nika_check::SinkFinding>
 pub nika_check::CheckReport::trifecta_findings: alloc::vec::Vec<nika_cap::trifecta::TrifectaViolation>
 pub nika_check::CheckReport::unknown_args: alloc::vec::Vec<nika_check::UnknownArg>
 pub nika_check::CheckReport::unknown_tools: alloc::vec::Vec<nika_check::UnknownTool>
@@ -1938,6 +1939,58 @@ impl<T> dyn_clone::DynClone for nika_check::SecretRequirement where T: core::clo
 pub fn nika_check::SecretRequirement::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
 impl<T> nika_error::traits::AsAny for nika_check::SecretRequirement where T: 'static
 pub fn nika_check::SecretRequirement::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_check::SinkFinding
+pub nika_check::SinkFinding::class: &'static str
+pub nika_check::SinkFinding::detail: alloc::string::String
+pub nika_check::SinkFinding::ext: &'static str
+pub nika_check::SinkFinding::fix: alloc::string::String
+pub nika_check::SinkFinding::task: alloc::string::String
+pub nika_check::SinkFinding::url: alloc::string::String
+impl nika_check::SinkFinding
+pub fn nika_check::SinkFinding::wire_code(&self) -> &'static str
+impl core::clone::Clone for nika_check::SinkFinding
+pub fn nika_check::SinkFinding::clone(&self) -> nika_check::SinkFinding
+impl core::cmp::Eq for nika_check::SinkFinding
+impl core::cmp::PartialEq for nika_check::SinkFinding
+pub fn nika_check::SinkFinding::eq(&self, other: &nika_check::SinkFinding) -> bool
+impl core::fmt::Debug for nika_check::SinkFinding
+pub fn nika_check::SinkFinding::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_check::SinkFinding
+impl serde_core::ser::Serialize for nika_check::SinkFinding
+pub fn nika_check::SinkFinding::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<D> owo_colors::OwoColorize for nika_check::SinkFinding
+impl<Q, K> equivalent::Equivalent<K> for nika_check::SinkFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::SinkFinding::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_check::SinkFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_check::SinkFinding where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_check::SinkFinding::equivalent(&self, key: &K) -> bool
+pub fn nika_check::SinkFinding::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_check::SinkFinding where U: core::convert::From<T>
+pub fn nika_check::SinkFinding::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_check::SinkFinding where U: core::convert::Into<T>
+pub type nika_check::SinkFinding::Error = core::convert::Infallible
+pub fn nika_check::SinkFinding::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_check::SinkFinding where U: core::convert::TryFrom<T>
+pub type nika_check::SinkFinding::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_check::SinkFinding::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_check::SinkFinding where T: core::clone::Clone
+pub type nika_check::SinkFinding::Owned = T
+pub fn nika_check::SinkFinding::clone_into(&self, target: &mut T)
+pub fn nika_check::SinkFinding::to_owned(&self) -> T
+impl<T> core::any::Any for nika_check::SinkFinding where T: 'static + ?core::marker::Sized
+pub fn nika_check::SinkFinding::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_check::SinkFinding where T: ?core::marker::Sized
+pub fn nika_check::SinkFinding::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_check::SinkFinding where T: ?core::marker::Sized
+pub fn nika_check::SinkFinding::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_check::SinkFinding where T: core::clone::Clone
+pub unsafe fn nika_check::SinkFinding::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_check::SinkFinding
+pub fn nika_check::SinkFinding::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_check::SinkFinding where T: core::clone::Clone
+pub fn nika_check::SinkFinding::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_check::SinkFinding where T: 'static
+pub fn nika_check::SinkFinding::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_check::TaintTrace
 pub nika_check::TaintTrace::secret: alloc::string::String
 impl nika_check::TaintTrace

--- a/crates/nika-check/src/data_sink.rs
+++ b/crates/nika-check/src/data_sink.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The data-as-code sink (NEP-0006 · LAW-AUTH-0327) — the STATIC twin of
+//! the runtime sink refusal. A `nika:fetch` whose RESOLVED URL path names
+//! a code-bearing class (the CLOSED three-class list in
+//! [`nika_cap::code_bearing_path_class`] · one predicate for the check
+//! twin, the run twin, and the reference oracle) is refused
+//! (`NIKA-SEC-008`) unless the task declares the honest door
+//! (`inert: "<because>"` · the parser enforces the non-empty because).
+//!
+//! Resolution at check covers the literal URL and every island over
+//! `const.*` or an `inputs.*`/`config.*` entry carrying a declared string
+//! default (the NEP-0004 resolution rules extended to the trusted const
+//! root — the SINK law classifies the artifact; trust is not the question
+//! here). Anything else DEFERS to the run twin (`NIKA-SEC-004` on the
+//! resolved URL · NEP-0006 law 3) — never a static refusal.
+
+use nika_schema::Spanned;
+use nika_schema::expression::{NamespaceRef, expr_refs, scan_templates};
+use nika_schema::raw::{RawAction, RawWorkflow};
+use nika_schema::types::VarDecl;
+
+/// The wire code of a code-bearing fetch refusal (NEP-0006 law 1).
+pub(crate) const SINK_CODE: &str = "NIKA-SEC-008";
+
+/// One data-as-code sink finding — the check-time half of NEP-0006.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
+pub struct SinkFinding {
+    /// The offending task.
+    pub task: String,
+    /// The resolved URL whose path named a code-bearing class.
+    pub url: String,
+    /// The class name (teaching · the closed NEP-0006 list).
+    pub class: &'static str,
+    /// The matched extension.
+    pub ext: &'static str,
+    /// The witness sentence (class · extension · the sink it hides).
+    pub detail: String,
+    /// The two repairs (model as exec · or declare the inert door).
+    pub fix: String,
+}
+
+impl SinkFinding {
+    /// The canonical spec code this finding stamps.
+    #[must_use]
+    pub fn wire_code(&self) -> &'static str {
+        SINK_CODE
+    }
+}
+
+/// Scan a workflow for code-bearing fetches (NEP-0006 law 1) — the door
+/// (law 2) silences a task, the unresolvable defers (law 3).
+#[must_use]
+pub(crate) fn scan_data_sink(wf: &RawWorkflow) -> Vec<SinkFinding> {
+    let mut out = Vec::new();
+    for task in &wf.tasks {
+        let task = &task.value;
+        if task.inert.is_some() {
+            continue; // the declared door · law 2 (non-empty by the parser)
+        }
+        let RawAction::Invoke(a) = &task.action else {
+            continue;
+        };
+        let Some(tool) = a.tool() else {
+            continue;
+        };
+        if tool.value.as_str() != "nika:fetch" {
+            continue;
+        }
+        let Some(template) = url_arg(a.args.as_ref()) else {
+            continue;
+        };
+        let Some(resolved) = resolve_static(template, wf) else {
+            continue; // dynamic · the run twin owns it (law 3)
+        };
+        let Some(path) = url_path(&resolved) else {
+            continue; // not a parseable URL · the fetch arg checks own it
+        };
+        let Some((class, ext)) = nika_cap::code_bearing_path_class(&path) else {
+            continue; // the unbounded inert world
+        };
+        out.push(SinkFinding {
+            task: task.id.value.clone(),
+            url: resolved.clone(),
+            class,
+            ext,
+            detail: format!(
+                "fetches a code-bearing artifact ({class} class · `{ext}`) · {resolved} is a \
+                 program, not data: the read hides an execution sink (NEP-0006 law 1)"
+            ),
+            fix: "model the acquisition as the exec it feeds (exec: + a program permit) · or \
+                  declare the read inert on the task (inert: \"<because>\")"
+                .to_owned(),
+        });
+    }
+    out
+}
+
+/// The `url` argument's raw string — literal or template alike (unlike
+/// the taint lane's `string_arg`, which wants templates only).
+fn url_arg(args: Option<&Spanned<serde_json::Value>>) -> Option<&str> {
+    args?.value.get("url")?.as_str()
+}
+
+/// Resolve a fetch URL at check: the literal as-is · every island over
+/// `const.*` (the author-fixed string) or `inputs.*`/`config.*` with a
+/// declared STRING default. `None` = at least one island stays dynamic.
+fn resolve_static(template: &str, wf: &RawWorkflow) -> Option<String> {
+    let islands = scan_templates(template).ok()?;
+    if islands.is_empty() {
+        return Some(template.to_owned());
+    }
+    let mut resolved = String::with_capacity(template.len());
+    let mut cursor = 0_usize;
+    for island in &islands {
+        let refs = expr_refs(&island.expr);
+        let [reference] = refs.as_slice() else {
+            return None; // a computed island is not statically decidable
+        };
+        let value = match reference {
+            NamespaceRef::Const(name) => const_string(wf, name)?,
+            NamespaceRef::Inputs(name) => declared_string_default(&wf.inputs, name)?,
+            NamespaceRef::Config(name) => declared_string_default(&wf.config, name)?,
+            _ => return None, // secrets · tasks.* · with.* — dynamic here
+        };
+        resolved.push_str(&template[cursor..island.start]);
+        resolved.push_str(value);
+        cursor = island.end;
+    }
+    resolved.push_str(&template[cursor..]);
+    Some(resolved)
+}
+
+/// A `const.<name>` string value — the bare literal, or the typed
+/// constant whose `value:` rides `default` (nika-vocab `VarDecl`).
+fn const_string<'a>(wf: &'a RawWorkflow, name: &str) -> Option<&'a str> {
+    let (_, decl) = wf.consts.iter().find(|(n, _)| n.value == name)?;
+    match decl {
+        VarDecl::Untyped(serde_json::Value::String(s))
+        | VarDecl::Typed {
+            default: Some(serde_json::Value::String(s)),
+            ..
+        } => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// A declared STRING default of an `inputs:`/`config:` entry.
+fn declared_string_default<'a>(
+    declarations: &'a [(Spanned<String>, VarDecl)],
+    name: &str,
+) -> Option<&'a str> {
+    let (_, decl) = declarations.iter().find(|(n, _)| n.value == name)?;
+    match decl {
+        VarDecl::Typed {
+            default: Some(serde_json::Value::String(s)),
+            ..
+        } => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// The URL's PATH (the classification surface · query and fragment carry
+/// no verdict) — the same WHATWG parser every other URL judgment reads.
+fn url_path(url: &str) -> Option<String> {
+    url::Url::parse(url).ok().map(|u| u.path().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nika_schema::{FileId, ParseMode, parse};
+
+    fn findings_of(yaml: &str) -> Vec<SinkFinding> {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+        scan_data_sink(&wf)
+    }
+
+    const BASE: &str = "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"data.example.com\"] }\n  tools: [\"nika:fetch\"]\n";
+
+    // ── the conformance fixtures 018-022, mirrored one test each ──
+
+    #[test]
+    fn fixture_018_serialized_class_is_refused() {
+        let y = format!(
+            "{BASE}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/models/legacy.pkl\" }}\n"
+        );
+        let f = findings_of(&y);
+        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f[0].wire_code(), "NIKA-SEC-008");
+        assert_eq!(f[0].class, "serialized-executable");
+        assert_eq!(f[0].ext, ".pkl");
+        assert_eq!(f[0].task, "grab");
+    }
+
+    #[test]
+    fn fixture_019_script_class_is_refused() {
+        let y = format!(
+            "{BASE}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/setup.sh\" }}\n"
+        );
+        let f = findings_of(&y);
+        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f[0].class, "script/interpreter");
+    }
+
+    #[test]
+    fn fixture_020_inert_data_passes() {
+        let y = format!(
+            "{BASE}tasks:\n  rows:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/q3/rows.csv\" }}\n  feed:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/feed.json\" }}\n"
+        );
+        assert!(findings_of(&y).is_empty());
+    }
+
+    #[test]
+    fn fixture_021_the_declared_door_silences() {
+        let y = format!(
+            "{BASE}tasks:\n  archive:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/models/legacy.pkl\" }}\n    inert: \"archived for provenance · never loaded by any child of this workflow\"\n"
+        );
+        assert!(findings_of(&y).is_empty());
+    }
+
+    #[test]
+    fn dynamic_url_defers_and_resolvable_ones_classify() {
+        // no default → the run twin owns it (law 3)
+        let dynamic = format!(
+            "{BASE}inputs:\n  artifact: {{ type: string }}\ntasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"${{{{ inputs.artifact }}}}\" }}\n"
+        );
+        assert!(findings_of(&dynamic).is_empty());
+        // a declared string default resolves · classify
+        let defaulted = format!(
+            "{BASE}inputs:\n  artifact: {{ type: string, default: \"https://data.example.com/a.pkl\" }}\ntasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"${{{{ inputs.artifact }}}}\" }}\n"
+        );
+        assert_eq!(findings_of(&defaulted).len(), 1);
+        // the trusted const root resolves too (the oracle parity)
+        let via_const = format!(
+            "{BASE}const:\n  artifact: \"https://data.example.com/a.pkl\"\ntasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"${{{{ const.artifact }}}}\" }}\n"
+        );
+        assert_eq!(findings_of(&via_const).len(), 1);
+    }
+
+    #[test]
+    fn the_query_carries_no_verdict() {
+        let y = format!(
+            "{BASE}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/render?file=x.py\" }}\n"
+        );
+        assert!(findings_of(&y).is_empty(), "NEP-0006 law 4 · path only");
+    }
+}

--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -154,6 +154,7 @@ pub(super) fn collect(report: &CheckReport) -> Vec<UnifiedFinding> {
         out.push(f);
     }
     fold_permit_taints(report, &mut out);
+    fold_sink_findings(report, &mut out);
     for p in &report.policy_findings {
         // spec 10 — the detail already names rule + task + witness.
         let mut f = UnifiedFinding::new("policy", "POLICY", p.detail.clone());
@@ -219,6 +220,23 @@ fn fold_permit_taints(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
         f.code = Some(code.to_owned());
         f.docs_url = Some(format!("{}/{code}", super::ERROR_DOCS_BASE));
         f.task = Some(t.task.clone());
+        out.push(f);
+    }
+}
+
+/// The data-as-code sink class (NEP-0006 · NIKA-SEC-008) — the detail
+/// names the class + extension, the fix carries both repairs.
+fn fold_sink_findings(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
+    for s in &report.sink_findings {
+        let mut f = UnifiedFinding::new(
+            "data_sink",
+            "PERMITS",
+            format!("{} (task `{}`) — fix: {}", s.detail, s.task, s.fix),
+        );
+        let code = s.wire_code();
+        f.code = Some(code.to_owned());
+        f.docs_url = Some(format!("{}/{code}", super::ERROR_DOCS_BASE));
+        f.task = Some(s.task.clone());
         out.push(f);
     }
 }

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -54,6 +54,7 @@ mod certificate;
 mod composition;
 mod content_flow;
 mod cost;
+mod data_sink;
 mod declass;
 mod effective;
 mod findings;
@@ -79,6 +80,7 @@ pub use analysis::{DagAnalysis, TaskBlast};
 pub use certificate::{Bound, CertTerm, RunCertificate};
 pub use composition::CompositionFinding;
 pub use cost::{CostCeiling, TaskCost, UnboundedReason};
+pub use data_sink::SinkFinding;
 pub use effective::{EffectivePermits, PermitsSource};
 pub use findings::UnifiedFinding;
 pub use flow::{FlowFacts, TaintTrace, action_effect_fields};
@@ -254,6 +256,12 @@ pub struct CheckReport {
     /// defer to the runtime `NIKA-SEC-004` (law 4). Additive:
     /// `report_version` stays 1.
     pub permit_taints: Vec<PermitTaint>,
+    /// Every data-as-code sink finding (NEP-0006 · `NIKA-SEC-008`): a
+    /// `nika:fetch` whose resolved URL path names a code-bearing class
+    /// with no `inert:` door declared. The unresolvable defers to the
+    /// run twin (`NIKA-SEC-004` · law 3). Additive: `report_version`
+    /// stays 1.
+    pub sink_findings: Vec<SinkFinding>,
     /// Every hard `policy:` rule violation (spec 10 · `NIKA-POLICY-001` —
     /// judged on the derived graph, so empty when `conformance` has
     /// entries). Additive: `report_version` stays 1.
@@ -338,6 +346,7 @@ impl CheckReport {
             && self.secret_egresses.is_empty()
             && self.capability_escapes.is_empty()
             && self.permit_taints.is_empty()
+            && self.sink_findings.is_empty()
             && self.policy_findings.is_empty()
             && self.trifecta_findings.is_empty()
             && self.schema_findings.is_empty()
@@ -389,6 +398,9 @@ impl CheckReport {
             PermitTaintKind::ArgEscapes => SpecCode::new("AUTH", 8, SpecCategory::SecurityError),
             PermitTaintKind::EnvDeadGrant => SpecCode::new("AUTH", 9, SpecCategory::SecurityError),
         }));
+        // The data-as-code sink (NEP-0006) → NIKA-SEC-008.
+        let sink_code = SpecCode::new("SEC", 8, SpecCategory::SecurityError);
+        codes.extend(self.sink_findings.iter().map(|_| sink_code));
         // Hard policy: violations (spec 10) → NIKA-POLICY-001.
         let policy_code = SpecCode::new("POLICY", 1, SpecCategory::SecurityError);
         codes.extend(self.policy_findings.iter().map(|_| policy_code));
@@ -519,6 +531,7 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         secret_egresses: secrets::scan_egresses(&flow),
         capability_escapes,
         permit_taints: permit_taint::scan_permit_taint(wf),
+        sink_findings: data_sink::scan_data_sink(wf),
         policy_findings,
         trifecta_findings,
         schema_findings: schema_typing::scan_types(wf),

--- a/crates/nika-check/tests/common/mod.rs
+++ b/crates/nika-check/tests/common/mod.rs
@@ -166,7 +166,15 @@ pub(crate) fn check_core_codes(yaml: &str, mode: ParseMode, dir: &Path) -> Vec<S
             })
             .extra_conformance_codes()
             .into_iter()
-            .filter(|c| matches!(c.namespace, "POLICY" | "AUTH" | "COMP"))
+            .filter(|c| {
+                matches!(c.namespace, "POLICY" | "AUTH" | "COMP")
+                    // NEP-0006 · the data-as-code sink (NIKA-SEC-008) is a
+                    // Core-visible law: the reference oracle judges it on
+                    // every tier, so the core verdict must too — the REST
+                    // of the SEC namespace (004/005 escapes · 009 trifecta)
+                    // stays the deep tier's ground.
+                    || (c.namespace == "SEC" && c.num == 8)
+            })
             .collect()
         }
         // A parse error (fixture 009's closed-set refusal) surfaces

--- a/crates/nika-cli/src/verbs/check/render.rs
+++ b/crates/nika-cli/src/verbs/check/render.rs
@@ -696,7 +696,10 @@ pub(super) fn permits(out: &mut String, report: &CheckReport, wf: &RawWorkflow, 
         );
         return;
     }
-    if report.capability_escapes.is_empty() && report.permit_taints.is_empty() {
+    if report.capability_escapes.is_empty()
+        && report.permit_taints.is_empty()
+        && report.sink_findings.is_empty()
+    {
         let _ = writeln!(
             out,
             " {} {}  {}",
@@ -735,6 +738,20 @@ pub(super) fn permits(out: &mut String, report: &CheckReport, wf: &RawWorkflow, 
             e.category,
             e.task,
             e.detail,
+        );
+    }
+    for sink in &report.sink_findings {
+        // NEP-0006 · the finding's own code (the same one findings[] and
+        // extra_conformance_codes read).
+        let code = sink.wire_code();
+        let _ = writeln!(
+            out,
+            " {} {}  [{code}] task `{}` · {} · fix: {}",
+            mark(t, false),
+            t.paint(Role::Strong, "PERMITS"),
+            sink.task,
+            sink.detail,
+            sink.fix,
         );
     }
     for taint in &report.permit_taints {

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -431,7 +431,7 @@ fn task_field_offers_exactly_the_fields_and_verbs() {
     assert_eq!(
         labels(&items),
         vec![
-            // the 12 task fields (vocab order · W2: after/with are the
+            // the 13 task fields (vocab order · W2: after/with are the
             // two doors · id and depends_on are dead forms · NEP-0004
             // law 7 added declassify)
             "after",
@@ -446,6 +446,7 @@ fn task_field_offers_exactly_the_fields_and_verbs() {
             "output",
             "on_finally",
             "declassify",
+            "inert",
             // then the 4 verbs
             "infer",
             "exec",
@@ -454,15 +455,15 @@ fn task_field_offers_exactly_the_fields_and_verbs() {
         ],
         "task fields then the 4 verbs"
     );
-    // the first 12 are PROPERTY (fields), the last 4 are KEYWORD (verbs).
+    // the first 13 are PROPERTY (fields), the last 4 are KEYWORD (verbs).
     let ks = kinds(&items);
-    assert_eq!(ks.len(), 16, "16 items, all kinded");
+    assert_eq!(ks.len(), 17, "17 items, all kinded");
     assert!(
-        ks[..12].iter().all(|k| *k == CompletionItemKind::PROPERTY),
+        ks[..13].iter().all(|k| *k == CompletionItemKind::PROPERTY),
         "fields are PROPERTY-kinded"
     );
     assert!(
-        ks[12..].iter().all(|k| *k == CompletionItemKind::KEYWORD),
+        ks[13..].iter().all(|k| *k == CompletionItemKind::KEYWORD),
         "verbs are KEYWORD-kinded"
     );
     // the verb items carry their doc as detail (the detail field).

--- a/crates/nika-lsp/src/analysis/vocab.rs
+++ b/crates/nika-lsp/src/analysis/vocab.rs
@@ -165,6 +165,13 @@ pub const TASK_FIELD_KEYS: &[Entry] = &[
               the re-gate): `{from, to: trusted, because}` entries — \
               check-visible and receipt-recorded, never a permit bypass.",
     },
+    Entry {
+        name: "inert",
+        doc: "Declare this task's fetch a code-bearing artifact it will \
+              never load or run (NEP-0006 · the data-as-code door): one \
+              non-empty justification string — lifts the sink law only, \
+              never the host boundary or the SSRF floor.",
+    },
 ];
 
 /// The JSON-Schema keyset inside a `schema:` block (02-verbs: the typed

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -7,7 +7,7 @@
 #   sealed outcome_class enum) · the 15 ledger sections (canon/EXCEPTIONS.md ·
 #   SSOT-1 §18) stay AUTHORED and are carried verbatim — editing those is legal.
 # regenerate: python3 scripts/ssot-compiler.py --emit-canon
-# body-sha256: e8a4f414e53b6efc1cf93247f814bf134bd7ae5f82723913a24ae2aa029e4688
+# body-sha256: a18d927d1903207bfae4ed23a21a662742702bcfa90f43efd7d259f69f9606dd
 #   (digest of every byte below the end-of-header line · detached self-hash per PAA-006)
 # ---- end generated header (SSOT-1 §21-23 · the canon flip · C0)
 # nika canonical registry · the single source of truth for Nika canonical facts
@@ -65,7 +65,7 @@ counts:
   templates: 10
   error_namespaces: 25
   error_categories: 12
-  error_codes: 91
+  error_codes: 92
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -296,7 +296,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 91
+  count: 92
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }
@@ -386,6 +386,7 @@ error_codes:
     - { code: NIKA-SEC-005, category: security_error, transient: "false", failure: "SSRF block — a nika:fetch/nika:notify URL resolves to a loopback/private/link-local/metadata target (always-on engine floor · independent of permits:)" }
     - { code: NIKA-SEC-006, category: security_error, transient: "false", failure: "secret flow — a secrets.<name> value reaches an unsanctioned sink (exec argument · invoke payload · infer/agent prompt) · the diagnostic carries the taint path + the egress clause that would sanction it (spec 10 · flow rules in 01 §egress)" }
     - { code: NIKA-SEC-007, category: security_error, transient: "false", failure: "secret egress — a tainted value reaches the workflow boundary (outputs:) · the diagnostic carries the taint path (spec 10 · the to: outputs sanction in 01 §egress)" }
+    - { code: NIKA-SEC-008, category: security_error, transient: "false", failure: "data-as-code sink · a nika:fetch resolved URL path names a code-bearing class (serialized-executable · script/interpreter · executable binary/module · the closed NEP-0006 list) and the task declares no inert: door · the read hides an execution sink (F-O7 · NEP-0006)" }
     - { code: NIKA-SEC-009, category: security_error, transient: "false", failure: "lethal trifecta complete — the declared boundary grants private read (fs.read non-empty) + untrusted ingress (a nika:fetch builtin invoked · an mcp:* tool invoked · an agent: whose whitelist admits ingress) + external egress (net.http non-empty · an escaping fs.write glob · exec enabled), the untrusted content REACHES an egress-capable task's effect surface (a realized flow), and no blocking invoke: nika:prompt (no default:) dominates it (NEP-0002 v2.0 · the Rule of Two as a static check)" }
     - { code: NIKA-TIMEOUT-001, category: timeout_error, transient: "false", failure: "task (or for_each iteration) exceeded timeout:" }
     - { code: NIKA-CANCEL-001, category: cancelled, transient: "false", failure: "task cancelled (workflow failure gate · user cancellation)" }

--- a/crates/nika-pack/pack/schemas/workflow.schema.json
+++ b/crates/nika-pack/pack/schemas/workflow.schema.json
@@ -548,6 +548,11 @@
             "format": "jq"
           }
         },
+        "inert": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The honest door of the data-as-code sink (spec/10-authority.md \u00a7the data-as-code sink \u00b7 NEP-0006 \u00b7 LAW-AUTH-0327) \u00b7 declares this task's fetch a code-bearing artifact it will never load or run \u00b7 the non-empty string IS the justification \u00b7 lifts the sink law only, never the net boundary or the SSRF floor."
+        },
         "declassify": {
           "type": "array",
           "description": "The ONLY door through the permit-parameterization taint (spec/10-authority.md §the permit-parameterization taint · NEP-0004 · LAW-AUTH-0325) · each entry raises ONE binding from untrusted to trusted, check-visible and receipt-recorded. Lifts the taint law only — the value is still matched against the declared boundary (never a permit bypass).",

--- a/crates/nika-pack/pack/spec/10-authority.md
+++ b/crates/nika-pack/pack/spec/10-authority.md
@@ -197,6 +197,29 @@ like a literal and must still sit inside the declared boundary.
 Declassify is never a permit bypass, and there is no implicit
 declassification in v1.
 
+## The data-as-code sink (normative · NEP-0006 · LAW-AUTH-0327)
+
+The contract distinguishes an INERT read from a CODE-BEARING read.
+Some artifact classes execute at load: the serialized-executable
+family (the deserializer runs code · `.pkl` `.pickle` `.dill`
+`.joblib` `.pt` `.pth` `.ckpt`), scripts and notebooks (`.py` `.sh`
+`.bash` `.zsh` `.ps1` `.bat` `.cmd` `.rb` `.pl` `.php` `.js` `.mjs`
+`.ipynb`), and executable binaries/modules (`.exe` `.dll` `.so`
+`.dylib` `.wasm` `.jar`). The three classes are CLOSED and normative
+(only a NEP amends them · the deliberate exclusions and their reasons
+live in NEP-0006). A `nika:fetch` whose RESOLVED URL path names one ·
+matched case-insensitively on the path's final extension, the query
+carries no verdict · is refused at check (`NIKA-SEC-008` ·
+security_error · the diagnostic names the class and both repairs) when
+the URL is literal or resolvable through the taint rules above; the
+unresolvable DEFERS to the run-time twin (`NIKA-SEC-004` · the same
+class refused on the resolved URL · defense in depth). The honest door
+is the task-level `inert: "<because>"` declaration (non-empty ·
+greppable): it lifts THIS law only · never the `net.http` boundary,
+never the SSRF floor, never the taint re-gate. The repair in the other
+direction is to model the acquisition as the `exec` it feeds, under a
+program permit review can see.
+
 ## The certificate names its effects (normative)
 
 `nika check --json` already emits a resource certificate

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -298,6 +298,14 @@ invoke: { tool: "nika:fetch", args: { url: "https://example.com/article", mode: 
 `PUT` · `PATCH`) and OWN their `content-type` (a user-supplied
 `content-type` header alongside them is a refused conflict).
 
+**The data-as-code sink (normative pointer · NEP-0006)** · a fetch whose
+resolved URL path names a code-bearing class (serialized-executable ·
+script/interpreter · executable binary/module · the closed list in
+`10-authority.md` §the data-as-code sink) is refused at check
+(`NIKA-SEC-008`) and at run (`NIKA-SEC-004`) unless the task declares the
+read inert (`inert: "<because>"` · the honest door · it never lifts the
+host boundary or the SSRF floor).
+
 **`traverse` semantics (normative)** · same-origin BFS from `url` ·
 fragment-stripped dedup · per-page output is the fixed page digest
 `{url, status, title, description, headings ≤16, links ≤30, images ≤24,

--- a/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-02-realized-flow-to-exec/expected.json
+++ b/crates/nika-runtime/fixtures/adversarial/f1-direct-injection/f1-02-realized-flow-to-exec/expected.json
@@ -2,7 +2,7 @@
   "family": "F1",
   "slug": "f1-02-realized-flow-to-exec",
   "title": "The untrusted page flows directly into an exec command line",
-  "rationale": "fs.read (private data) + realized fetch (untrusted ingress) + exec enabled (egress) with no dominating human gate — the lethal trifecta is complete and the realized-flow judge must refuse statically",
+  "rationale": "fs.read (private data) + realized fetch (untrusted ingress) + exec enabled (egress) with no dominating human gate — the lethal trifecta is complete and the realized-flow judge must refuse statically · since NEP-0006 the data-as-code sink ALSO refuses this fixture even earlier (install.sh is the script class · NIKA-SEC-008 · the sidecar keys on the trifecta finding, its theme) — two independent static walls",
   "verdict": "static-deny",
   "containment": "trifecta-static",
   "static": {

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -342,6 +342,21 @@ fn settle_exec_out(
     Dispatched::ok(note.to_owned(), value, None)
 }
 
+/// The per-attempt task context the dispatch threads to its arms — the
+/// task-level knobs that are not the action itself (bundled at the
+/// 8-argument clippy wall · an additive knob lands HERE, never as a new
+/// parameter).
+pub(crate) struct DispatchCtx<'a> {
+    /// The task's ONE `timeout:` (03-dag) — enforced at dispatch too.
+    pub deadline: Option<std::time::Duration>,
+    /// Law 6 · the ledger's remaining budget AT CALL TIME (a child
+    /// workflow's ceiling).
+    pub child_budget: Option<f64>,
+    /// NEP-0006 · the task's declared `inert:` door (the data-as-code
+    /// sink's run twin honors it).
+    pub inert: Option<&'a str>,
+}
+
 impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C>
 where
     S: ShellRunDyn + Sync,
@@ -376,17 +391,26 @@ where
         scope: &Scope<'_>,
         taint: &crate::integrity::ValueTaint<'_>,
         agent_buffer: &crate::agent_events::BufferingObserver,
-        deadline: Option<std::time::Duration>,
+        ctx: DispatchCtx<'_>,
         contract: Option<&crate::contract::TaskContract<'_>>,
-        child_budget: Option<f64>,
     ) -> Dispatched {
         match action {
             RawAction::Invoke(inner) => {
-                self.dispatch_invoke(inner, scope, taint, (deadline, child_budget), contract)
-                    .await
+                self.dispatch_invoke(
+                    inner,
+                    scope,
+                    taint,
+                    (ctx.deadline, ctx.child_budget),
+                    contract,
+                    ctx.inert,
+                )
+                .await
             }
             RawAction::Exec(inner) => self.dispatch_shell(inner, scope, taint, contract).await,
-            RawAction::Infer(inner) => self.dispatch_infer(inner, scope, deadline, contract).await,
+            RawAction::Infer(inner) => {
+                self.dispatch_infer(inner, scope, ctx.deadline, contract)
+                    .await
+            }
             RawAction::Agent(inner) => {
                 self.dispatch_agent(inner, scope, agent_buffer, contract)
                     .await
@@ -407,6 +431,7 @@ where
         taint: &crate::integrity::ValueTaint<'_>,
         (deadline, child_budget): (Option<std::time::Duration>, Option<f64>),
         contract: Option<&crate::contract::TaskContract<'_>>,
+        inert: Option<&str>,
     ) -> Dispatched {
         let tool = match &action.target {
             nika_schema::raw::RawInvokeTarget::Tool(t) => t.value.clone(),
@@ -435,6 +460,13 @@ where
                 Err(err) => return Dispatched::template_err(&note, &err),
             },
         };
+        // NEP-0006 law 3 · the data-as-code sink's run twin: the RESOLVED
+        // fetch URL is classified against the one closed list, honoring
+        // the task's declared inert: door — the dynamic case the static
+        // classifier deferred (dispatch/permits.rs · check_fetch_sink).
+        if let Some(denial) = permits::check_fetch_sink(inert, &note, &tool, &args) {
+            return denial;
+        }
         // F-O1 PR-2 · the mcp border re-gate (NEP-0004 law 2): the grant
         // of the tool IS the boundary, and a tainted path/host in its args
         // slipped through — the resolved value is canonicalized then

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -357,6 +357,24 @@ pub(crate) struct DispatchCtx<'a> {
     pub inert: Option<&'a str>,
 }
 
+impl<'a> DispatchCtx<'a> {
+    /// The per-attempt context of a task (invariant #19 · the type owns
+    /// its constructor): the ONE `timeout:`, the ledger's remaining
+    /// budget AT CALL TIME (law 6 · computed by the caller each
+    /// attempt), and the NEP-0006 `inert:` door.
+    pub(crate) fn of_task(
+        task: &'a nika_schema::raw::RawTask,
+        deadline: Option<std::time::Duration>,
+        child_budget: Option<f64>,
+    ) -> Self {
+        Self {
+            deadline,
+            child_budget,
+            inert: task.inert.as_ref().map(|s| s.value.as_str()),
+        }
+    }
+}
+
 impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C>
 where
     S: ShellRunDyn + Sync,

--- a/crates/nika-runtime/src/dispatch/permits.rs
+++ b/crates/nika-runtime/src/dispatch/permits.rs
@@ -50,6 +50,36 @@ pub(super) fn check_tool_permits(
     ))
 }
 
+/// The data-as-code sink's RUN twin (NEP-0006 law 3 · LAW-AUTH-0327 ·
+/// the dynamic case the static classifier defers): the RESOLVED
+/// `nika:fetch` URL path is classified against the ONE closed list
+/// (`nika_cap::code_bearing_path_class` · the same predicate the check
+/// twin and the reference oracle read), honoring the task's declared
+/// `inert:` door. Refusal = `NIKA-SEC-004` (one runtime refusal voice ·
+/// the detail names the class and both repairs).
+pub(super) fn check_fetch_sink(
+    inert: Option<&str>,
+    note: &str,
+    tool: &str,
+    args: &serde_json::Value,
+) -> Option<Dispatched> {
+    if tool != "nika:fetch" || inert.is_some() {
+        return None;
+    }
+    let url = args.get("url")?.as_str()?;
+    let path = url::Url::parse(url).ok().map(|u| u.path().to_owned())?;
+    let (class, ext) = nika_cap::code_bearing_path_class(&path)?;
+    Some(Dispatched::security_err(
+        note,
+        format!(
+            "fetch of a code-bearing artifact refused ({class} class · `{ext}`) · {url} is a \
+             program, not data: the read hides an execution sink (NEP-0006) · model the \
+             acquisition as the exec it feeds (exec: + a program permit) · or declare the read \
+             inert on the task (inert: \"<because>\")"
+        ),
+    ))
+}
+
 /// The agent half of the tools boundary: every entry of the declared
 /// `tools:` universe must fit `permits.tools` — one refusal for the
 /// whole task (the run-time half of the static `permits_fit` scan).

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -831,6 +831,9 @@ where
             // (a static walk over the task's own templates + the wave-frozen
             // records; iteration-agnostic), consumed per dispatch attempt.
             let value_taint = crate::integrity::ValueTaint::of_task(task, scope.records);
+            // law 6 · the child budget reads the ledger AT CALL TIME (per attempt).
+            let ctx =
+                || crate::dispatch::DispatchCtx::of_task(task, budget, ledger.remaining_usd());
             let attempts = async {
                 let mut attempt = 1_u32;
                 // Spend of FAILED attempts — folded onto the terminal frame.
@@ -843,12 +846,7 @@ where
                             scope,
                             &value_taint,
                             &agent_buffer,
-                            crate::dispatch::DispatchCtx {
-                                deadline: budget,
-                                // law 6 · remaining AT CALL TIME
-                                child_budget: ledger.remaining_usd(),
-                                inert: task.inert.as_ref().map(|s| s.value.as_str()),
-                            },
+                            ctx(),
                             contract.as_ref(),
                         )
                         .await;

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -843,9 +843,13 @@ where
                             scope,
                             &value_taint,
                             &agent_buffer,
-                            budget,
+                            crate::dispatch::DispatchCtx {
+                                deadline: budget,
+                                // law 6 · remaining AT CALL TIME
+                                child_budget: ledger.remaining_usd(),
+                                inert: task.inert.as_ref().map(|s| s.value.as_str()),
+                            },
                             contract.as_ref(),
-                            ledger.remaining_usd(), // law 6 · remaining AT CALL TIME
                         )
                         .await;
                     note.clone_from(&dispatched.note);

--- a/crates/nika-runtime/src/task/finally.rs
+++ b/crates/nika-runtime/src/task/finally.rs
@@ -155,11 +155,17 @@ where
             scope,
             &value_taint,
             &cleanup_buffer,
-            Some(limit),
-            None,
-            // best-effort lane: no ledger here — a finally child inherits
-            // no cost bound (the lane has no budget admission by design);
-            // the select timer below still bounds it in TIME.
+            crate::dispatch::DispatchCtx {
+                deadline: Some(limit),
+                // best-effort lane: no ledger here — a finally child
+                // inherits no cost bound (the lane has no budget
+                // admission by design); the select timer below still
+                // bounds it in TIME.
+                child_budget: None,
+                // a finally mini-task carries no inert: door (NEP-0006)
+                // — a code-bearing cleanup fetch refuses like any other.
+                inert: None,
+            },
             None,
         ));
         let timer = std::pin::pin!(self.clock.sleep(limit));

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -134,6 +134,87 @@ async fn declared_boundary_attaches_the_sandbox_spec_to_exec() {
     );
 }
 
+/// NEP-0006 law 3 — the data-as-code sink's RUN twin: a fetch URL the
+/// static classifier deferred (a `tasks.*` derivation) resolves at run to
+/// a code-bearing artifact and is refused BEFORE the tool executor ever
+/// sees the call; the task's declared `inert:` door lets it through.
+#[tokio::test]
+async fn code_bearing_fetch_refuses_at_run_and_the_inert_door_opens() {
+    use nika_kernel::tool_executor::ToolResult;
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+
+    let base = "nika: v1\nworkflow:\n  id: sinkrun\npermits:\n  net: { http: [\"data.example.com\"] }\n  tools: [\"nika:jq\", \"nika:fetch\"]\ntasks:\n  name:\n    invoke:\n      tool: \"nika:jq\"\n      args: { input: \"https://data.example.com/models/legacy.pkl\", expression: \".\" }\n  grab:\n    with: { u: \"${{ tasks.name.output }}\" }\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"${{ with.u }}\" }\n";
+    for (inert, expect_calls) in [(false, 1_usize), (true, 2_usize)] {
+        let yaml = if inert {
+            base.replace(
+                "      args: { url: \"${{ with.u }}\" }\n",
+                "      args: { url: \"${{ with.u }}\" }\n    inert: \"archived for provenance · never loaded\"\n",
+            )
+        } else {
+            base.to_owned()
+        };
+        let wf = nika_schema::parse(
+            &yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_check::check(&wf);
+        assert!(
+            report.is_clean(),
+            "the dynamic URL defers at check (law 3): {report:?}"
+        );
+        let executor = MockToolExecutor::new()
+            .enqueue_ok(ToolResult::success(
+                "tc1",
+                "https://data.example.com/models/legacy.pkl",
+            ))
+            .enqueue_ok(ToolResult::success("tc2", "bytes"));
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(executor.clone())));
+        let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+        let runtime = Runtime::new(
+            ExecVerb::new(Arc::new(MockShell::new())),
+            Arc::clone(&invoke),
+            InferVerb::new(registry, "mock/echo"),
+            AgentVerb::new(
+                Arc::new(MockProvider::new("mock")),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default().with_sandbox_root(std::path::PathBuf::from("/repo")),
+        );
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let outcome = runtime.run(&wf, &report, &mut stamper, &mut sink).await;
+        let calls = executor.captured_calls();
+        assert_eq!(
+            calls.len(),
+            expect_calls,
+            "inert={inert} · the refusal fires BEFORE the executor (calls: {:?})",
+            calls.iter().map(|c| c.name.clone()).collect::<Vec<_>>()
+        );
+        let outcome = outcome.expect("the run completes either way");
+        if inert {
+            assert!(outcome.ok, "the declared door lets the fetch through");
+        } else {
+            assert!(!outcome.ok, "the code-bearing fetch fails the run");
+            let record = outcome.records.get("grab").expect("grab settled");
+            let error = record.error.as_ref().expect("a typed refusal");
+            assert_eq!(error.code, "NIKA-SEC-004");
+            assert!(
+                error.message.contains("code-bearing"),
+                "the refusal teaches the sink: {}",
+                error.message
+            );
+        }
+    }
+}
+
 /// NEP-0005 — the declared `permits.env:` passthrough rides every exec
 /// command to the spawn site (which composes floor ∪ these names ∪ the
 /// authored map from a cleared slate), and the authored task `env:` map

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -924,6 +924,7 @@ pub nika_schema::raw::task::RawTask::declassify: alloc::vec::Vec<nika_schema::ra
 pub nika_schema::raw::task::RawTask::fail_fast: core::option::Option<nika_source::span::Spanned<bool>>
 pub nika_schema::raw::task::RawTask::for_each: core::option::Option<nika_source::span::Spanned<nika_schema::raw::task::ForEachValue>>
 pub nika_schema::raw::task::RawTask::id: nika_source::span::Spanned<alloc::string::String>
+pub nika_schema::raw::task::RawTask::inert: core::option::Option<nika_source::span::Spanned<alloc::string::String>>
 pub nika_schema::raw::task::RawTask::max_parallel: core::option::Option<nika_source::span::Spanned<u32>>
 pub nika_schema::raw::task::RawTask::on_error: core::option::Option<nika_source::span::Spanned<nika_vocab::on_error::OnError>>
 pub nika_schema::raw::task::RawTask::on_finally: alloc::vec::Vec<nika_source::span::Spanned<nika_schema::raw::task::RawFinallyTask>>
@@ -1430,6 +1431,7 @@ pub nika_schema::raw::RawTask::declassify: alloc::vec::Vec<nika_schema::raw::tas
 pub nika_schema::raw::RawTask::fail_fast: core::option::Option<nika_source::span::Spanned<bool>>
 pub nika_schema::raw::RawTask::for_each: core::option::Option<nika_source::span::Spanned<nika_schema::raw::task::ForEachValue>>
 pub nika_schema::raw::RawTask::id: nika_source::span::Spanned<alloc::string::String>
+pub nika_schema::raw::RawTask::inert: core::option::Option<nika_source::span::Spanned<alloc::string::String>>
 pub nika_schema::raw::RawTask::max_parallel: core::option::Option<nika_source::span::Spanned<u32>>
 pub nika_schema::raw::RawTask::on_error: core::option::Option<nika_source::span::Spanned<nika_vocab::on_error::OnError>>
 pub nika_schema::raw::RawTask::on_finally: alloc::vec::Vec<nika_source::span::Spanned<nika_schema::raw::task::RawFinallyTask>>

--- a/crates/nika-schema/src/parser/inert.rs
+++ b/crates/nika-schema/src/parser/inert.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `inert:` task-level key parser (NEP-0006 · the honest door of the
+//! data-as-code sink) — split beside `declassify.rs` under the ADR-023
+//! 1,500-LOC ceiling on `tasks.rs`.
+
+use marked_yaml::types::MarkedMappingNode;
+
+use crate::error::SchemaError;
+use crate::source::Spanned;
+
+use super::Cx;
+
+/// `inert:` — the task-level declaration that this task's fetch reads a
+/// code-bearing artifact it will never load or run (NEP-0006 law 2 · the
+/// only door through the sink law). Shape-only here: ONE non-empty string
+/// scalar — the string IS the justification (the because is the
+/// substance, an empty door is a refusal, never a silent toggle). WHICH
+/// fetches the door blesses is the check's judgment, not the parser's.
+pub(super) fn parse_inert(
+    cx: &Cx<'_>,
+    mapping: &MarkedMappingNode,
+    task_label: &str,
+) -> Result<Option<Spanned<String>>, SchemaError> {
+    let Some(node) = mapping.get_node("inert") else {
+        return Ok(None);
+    };
+    let Some(scalar) = node.as_scalar() else {
+        return Err(SchemaError::Validation {
+            message: format!(
+                "`inert` on {task_label} must be one non-empty string (the justification · \
+                 NEP-0006)"
+            ),
+            span: cx.span(node.span()),
+        });
+    };
+    let value = scalar.as_str().to_owned();
+    if value.is_empty() {
+        return Err(SchemaError::Validation {
+            message: format!(
+                "`inert` on {task_label} is empty — the because IS the substance of the door \
+                 (NEP-0006 · declare why this read never feeds an interpreter)"
+            ),
+            span: cx.span(scalar.span()),
+        });
+    }
+    Ok(Some(Spanned::new(value, cx.span_or_zero(scalar.span()))))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{FileId, ParseMode, parse};
+
+    const BASE: &str = "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"data.example.com\"] }\n  tools: [\"nika:fetch\"]\n";
+
+    #[test]
+    fn inert_parses_a_non_empty_string() {
+        let yaml = format!(
+            "{BASE}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/a.csv\" }}\n    inert: \"archived for provenance\"\n"
+        );
+        let wf = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let task = &wf.tasks[0].value;
+        assert_eq!(
+            task.inert.as_ref().map(|s| s.value.as_str()),
+            Some("archived for provenance")
+        );
+    }
+
+    #[test]
+    fn inert_empty_or_non_scalar_is_refused() {
+        for bad in ["inert: \"\"", "inert: [x]"] {
+            let yaml = format!(
+                "{BASE}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/a.csv\" }}\n    {bad}\n"
+            );
+            let err = parse(&yaml, FileId::new(0), ParseMode::Strict).expect_err("refused");
+            assert!(err.to_string().contains("inert"), "{bad}: {err}");
+        }
+    }
+}

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -21,6 +21,7 @@
 pub(crate) mod declassify;
 pub(crate) mod envelope;
 pub(crate) mod envelope_values;
+mod inert;
 pub(crate) mod tasks;
 mod value;
 pub(crate) mod verbs;

--- a/crates/nika-schema/src/parser/tasks.rs
+++ b/crates/nika-schema/src/parser/tasks.rs
@@ -48,6 +48,7 @@ const TASK_KEYS: &[&str] = &[
     "returns",
     "on_finally",
     "declassify",
+    "inert",
 ];
 
 pub(crate) use nika_vocab::keys::{FINALLY_KEYS, ON_ERROR_KEYS, RETRY_KEYS};
@@ -184,6 +185,7 @@ fn parse_task(
     task.returns = parse_returns(cx, mapping)?;
     task.on_finally = parse_on_finally(cx, mapping, &task_label)?;
     task.declassify = super::declassify::parse_declassify(cx, mapping, &task_label)?;
+    task.inert = super::inert::parse_inert(cx, mapping, &task_label)?;
 
     Ok(task)
 }

--- a/crates/nika-schema/src/raw/task.rs
+++ b/crates/nika-schema/src/raw/task.rs
@@ -84,6 +84,9 @@ pub struct RawTask {
     /// `declassify:` — the task-level taint-lift declarations (NEP-0004
     /// law 5 · the only door through the re-gate · receipt-recorded).
     pub declassify: Vec<DeclassifyEntry>,
+    /// `inert:` — the declared data-as-code door (NEP-0006 law 2 · one
+    /// non-empty justification · lifts the sink law only).
+    pub inert: Option<Spanned<String>>,
     /// The verb (exactly one · parser-enforced).
     pub action: RawAction,
 }
@@ -107,6 +110,7 @@ impl RawTask {
             returns: None,
             on_finally: Vec::new(),
             declassify: Vec::new(),
+            inert: None,
             action,
         }
     }


### PR DESCRIPTION
## The law (F-O7 · ratified 2026-07-22 · blocking-v1 · HF kill-chain vector n°1 · spec merged as [NEP-0006](https://github.com/supernovae-st/nika-spec/pull/180))

A `nika:fetch` whose RESOLVED URL path names a **code-bearing class** (three closed classes · serialized-executable whose deserializer runs code · script/interpreter · executable binary/module) is refused at check (`NIKA-SEC-008`) unless the task declares the honest door (`inert: "<because>"`). The unresolvable defers to the run twin (`NIKA-SEC-004` on the resolved URL · at the exact mcp-re-gate dispatch seam · before the tool executor ever sees the call).

## What ships (7 commits)

- **nika-cap** · `sink.rs`: the closed three-class extension map + `code_bearing_path_class` — ONE predicate for the check twin, the run twin, and the reference oracle (path-only · final extension · case-insensitive · per-class tests)
- **nika-schema** · the `inert:` task key in its own parser module (the declassify split precedent · tasks.rs stays at 1499): one non-empty string, an empty door is a parse refusal · LSP learns the 13th task field
- **nika-check** · `data_sink.rs`: literal + const/default-resolvable URLs classify at check · dynamic defers (law 3) · own finding family (report field · unified fold · CLI PERMITS block) · mirrors fixtures 018-022
- **runtime** · the run twin at the dispatch seam honoring the door · `DispatchCtx` bundles the task knobs (the 8-arg wall · then the type owns its constructor at the 1500-file wall · the ratchets bit twice and the shape got better twice) · the run-twin test proves both directions with zero executor calls on refusal
- **test harness** · the engine↔oracle differential CAUGHT a real divergence (the core tier filtered SEC-008 out · « engine accepted » vs the oracle's refusal) — the core verdict now admits exactly the sink code, the rest of SEC stays deep-tier
- **f1-02 adversarial** · the rationale names the second static wall honestly (install.sh = the script class · the sidecar keys on the trifecta, its theme)
- **chore** · SPEC_PIN → `ffc9389` + pack vendored (canon 92 codes)

## Proof

- `cargo test --workspace` at the new pin · **5444 passed · 0 failed** (core conformance 121/121 · the oracle and the engine agree on 018-022) · clippy `-D warnings` clean · pre-push gate rc=0 (8/8 ratchets)
- Census: zero corpus workflow fetches a code-bearing URL · the one deliberate story is f1-02 becoming living proof

## Declared residuals

- Agent-loop fetches (the loop holds the executor directly · no task door exists for a model call): the host boundary + SSRF floor + whitelist still bind · the sink classification for agent tool-calls lands with the agent-hardening lane (F-O3's ground)
- Byte-sniffing/magic bytes (run 2.0) · archives (the inner artifact at its consumer · F-O2 jail) · templates (extension signal too weak v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)