### PR TITLE
feat(runtime+cli): the permit witness · trace verify finding · the check-run equivalence oracle (F-O6)

### DIFF
--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-ffc9389f442ebac18b8a266ef85c203dc2c401cb
+bcb3fbb7b5dc52f05dc22796125d9d56ec6c007b

--- a/crates/nika-check/tests/e_diff_soundness.rs
+++ b/crates/nika-check/tests/e_diff_soundness.rs
@@ -25,8 +25,9 @@
 //!   inference never over-grants by a removable entry.
 //!
 //! Composed: check ⇔ reference boundary ⇔ inference. The runtime legs
-//! for fs/net (driving the real builtin sinks under a mock transport)
-//! are the named follow-on.
+//! for fs/net LANDED with the F-O6 lane · `nika-cli/tests/
+//! check_run_equivalence.rs` drives the real builtin sinks at the real
+//! binary (deny + floor sides · the allow-side dial stays undialed).
 
 use std::fmt::Write as _;
 

--- a/crates/nika-cli/src/verbs/trace_verify.rs
+++ b/crates/nika-cli/src/verbs/trace_verify.rs
@@ -193,6 +193,10 @@ fn tiered(
         use std::fmt::Write as _;
         let _ = write!(out, "\n{line}");
     }
+    if let Some(finding) = witness_finding(raw) {
+        use std::fmt::Write as _;
+        let _ = write!(out, "\n{finding}");
+    }
     let code = match report.exit {
         tier::TierExit::Ok => super::exit::OK,
         tier::TierExit::File => super::exit::FILE,
@@ -201,6 +205,48 @@ fn tiered(
         _ => super::exit::ENV,
     };
     VerbOutput { text: out, code }
+}
+
+/// NEP-0007 law 3 (spec 17 §the permit witness) — the REQUIRED-witness
+/// rule: a chain-intact journal whose run exercised effects (an
+/// `exec ·` / `invoke ·` / `agent ·` task started) and carries ZERO
+/// `permit_checked` frames is a FINDING · the witness is absent (the
+/// journal predates NEP-0007 or the engine is not conformant) · never
+/// FORGED (the chain still binds every line) · never a crash (an
+/// unreadable line is the walk's business, not this rule's).
+fn witness_finding(raw: &str) -> Option<&'static str> {
+    let mut effects = false;
+    for line in raw.lines().filter(|l| !l.trim().is_empty()) {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        match v.get("kind").and_then(serde_json::Value::as_str) {
+            Some("permit_checked") => return None,
+            Some("task_started") => {
+                let note = v
+                    .get("fields")
+                    .and_then(serde_json::Value::as_array)
+                    .and_then(|fields| {
+                        fields.iter().find(|f| {
+                            f.get("key").and_then(serde_json::Value::as_str) == Some("note")
+                        })
+                    })
+                    .and_then(|f| f.get("value"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                if ["exec ·", "invoke ·", "agent ·"]
+                    .iter()
+                    .any(|p| note.starts_with(p))
+                {
+                    effects = true;
+                }
+            }
+            _ => {}
+        }
+    }
+    effects.then_some(
+        "FINDING — the run exercised effects and carries zero permit_checked frames: the\n  permit witness is absent (NEP-0007 · the journal predates the witness or the\n  engine is not conformant) — the chain still binds every line",
+    )
 }
 
 // The walk + its verdict live in the forensics crate (one genesis tag ·
@@ -574,5 +620,103 @@ mod tests {
             out.text
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A chained journal with explicit `fields` payloads — the witness
+    /// rule reads `task_started.note` and the `permit_checked` kind.
+    fn chained_with(frames: &[(&str, &[(&str, &str)])]) -> String {
+        let mut chain = sha256_hex(CHAIN_GENESIS);
+        let mut out = String::new();
+        for (kind, fields) in frames {
+            let fields: Vec<serde_json::Value> = fields
+                .iter()
+                .map(|(k, v)| serde_json::json!({"key": k, "value": v}))
+                .collect();
+            let mut v = serde_json::json!({
+                "id": {"uuid": "01912345-0000-7000-8000-000000000001"},
+                "timestamp": 1000, "kind": kind, "run": null,
+                "correlation": null, "fields": fields
+            });
+            v["chain"] = serde_json::Value::String(chain.clone());
+            let line = serde_json::to_string(&v).expect("test json");
+            chain = sha256_hex(line.as_bytes());
+            out.push_str(&line);
+            out.push('\n');
+        }
+        out
+    }
+
+    /// NEP-0007 law 3 — an effectful run (an `exec ·` task started) with
+    /// zero `permit_checked` frames: FINDING in the text, exit stays OK
+    /// (never FORGED · the chain holds · never a crash).
+    #[test]
+    fn absent_witness_on_effectful_run_is_a_finding_never_a_failure() {
+        let raw = chained_with(&[
+            ("workflow_started", &[]),
+            (
+                "task_started",
+                &[("task", "stamp"), ("note", "exec · echo")],
+            ),
+            ("task_completed", &[("task", "stamp")]),
+            ("workflow_completed", &[]),
+        ]);
+        let path = stage("witness-absent", &raw);
+        let out = verify(&path.to_string_lossy());
+        assert_eq!(
+            out.code,
+            super::super::exit::OK,
+            "a finding never fails: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("FINDING"),
+            "the finding line rides: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("permit_checked"),
+            "it names the absent frame: {}",
+            out.text
+        );
+    }
+
+    /// One `permit_checked` frame silences the rule — and a run with NO
+    /// effectful task (pure infer) never triggers it.
+    #[test]
+    fn witness_present_or_pure_infer_run_stays_clean() {
+        let witnessed = chained_with(&[
+            (
+                "task_started",
+                &[("task", "stamp"), ("note", "exec · echo")],
+            ),
+            (
+                "permit_checked",
+                &[("plane", "exec"), ("decision", "allow")],
+            ),
+            ("task_completed", &[("task", "stamp")]),
+        ]);
+        let path = stage("witness-present", &witnessed);
+        let out = verify(&path.to_string_lossy());
+        assert_eq!(out.code, super::super::exit::OK);
+        assert!(
+            !out.text.contains("FINDING"),
+            "witnessed run is clean: {}",
+            out.text
+        );
+
+        let infer_only = chained_with(&[
+            (
+                "task_started",
+                &[("task", "think"), ("note", "infer · mock/echo")],
+            ),
+            ("task_completed", &[("task", "think")]),
+        ]);
+        let path = stage("witness-infer-only", &infer_only);
+        let out = verify(&path.to_string_lossy());
+        assert!(
+            !out.text.contains("FINDING"),
+            "no effects = no required witness: {}",
+            out.text
+        );
     }
 }

--- a/crates/nika-cli/tests/check_run_equivalence.rs
+++ b/crates/nika-cli/tests/check_run_equivalence.rs
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// Same carve-out as gate_matrix_conformance: this suite's WHOLE JOB is
+// the real binary, and NIKA_SPEC_DIR is harness plumbing. println is
+// the suite's DELIVERABLE — the DERIVED coverage lines (families × legs
+// counted at execution) that the doc law forbids hand-writing.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    clippy::print_stdout
+)]
+
+//! The check ⇔ run equivalence oracle (spec 17 · NEP-0007 · invariant 4:
+//! judged = executed = attested) — the conformance corpus replayed
+//! through BOTH evaluators AT THE REAL BINARY, under the mapping law:
+//!
+//! * **static-red ⇒ never executes** — every `core/authority` fixture
+//!   the oracle judges invalid is fed to `nika run`: the run refuses
+//!   BEFORE the prologue (zero task frames · the judged verdict is the
+//!   executed verdict) and the refusal voices the fixture's code.
+//! * **static-clean + DEFER ⇒ the run twin decides** — every
+//!   `runtime/permits` fixture must be check-CLEAN, and its real run's
+//!   per-task terminals must match `expected-run.json` (the same
+//!   comparison law as `gate_matrix_conformance`).
+//! * **executed ⇒ attested** — a run that dispatched an effect carries
+//!   `permit_checked` frames in its own event stream (NEP-0007 · the
+//!   witness), tying the third leg at the shipped surface.
+//! * **`e_diff` runtime legs (fs · net)** — the named follow-on from
+//!   `nika-check/tests/e_diff_soundness.rs`, landed: a small exhaustive
+//!   lattice drives the REAL builtin sinks (`nika:read` under a tempdir
+//!   root · `nika:fetch` on its deny/floor sides — the allow-side
+//!   network dial is the declared residual: no test dials out).
+//!
+//! Coverage is DERIVED: the suite prints what it replayed — families ×
+//! legs counted at execution, never hand-written.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn spec_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("NIKA_SPEC_DIR") {
+        return PathBuf::from(dir);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .parent()
+        .expect("engine parent")
+        .join("spec")
+}
+
+/// One observed run at the real binary: per-task terminal status,
+/// per-task failure code, the raw event kinds, and the process verdict.
+struct Observed {
+    statuses: std::collections::BTreeMap<String, String>,
+    codes: std::collections::BTreeMap<String, String>,
+    outputs: std::collections::BTreeMap<String, String>,
+    kinds: Vec<String>,
+    effectful: bool,
+    ok: bool,
+    text: String,
+}
+
+fn run_observed(workflow: &Path, envs: &[(String, String)], vars: &[(String, String)]) -> Observed {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_nika-cli"));
+    cmd.arg("run").arg(workflow).arg("--json");
+    for (k, v) in vars {
+        cmd.arg("--var").arg(format!("{k}={v}"));
+    }
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("binary runs");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let mut statuses = std::collections::BTreeMap::new();
+    let mut codes = std::collections::BTreeMap::new();
+    let mut outputs = std::collections::BTreeMap::new();
+    let mut kinds = Vec::new();
+    let mut effectful = false;
+    for line in stdout.lines() {
+        let line = line.trim();
+        if !line.starts_with('{') {
+            continue;
+        }
+        let Ok(ev) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if let Some(kind) = ev["kind"].as_str() {
+            kinds.push(kind.to_owned());
+            // The effect predicate (same as the verify rule): a started
+            // task whose note names a dispatch-boundary verb.
+            if kind == "task_started"
+                && let Some(fields) = ev["fields"].as_array()
+                && let Some(note) = fields
+                    .iter()
+                    .find(|f| f["key"] == "note")
+                    .and_then(|f| f["value"].as_str())
+                && ["exec ·", "invoke ·", "agent ·"]
+                    .iter()
+                    .any(|p| note.starts_with(p))
+            {
+                effectful = true;
+            }
+        }
+        let status = match ev["kind"].as_str() {
+            Some("task_completed") => "success",
+            Some("task_failed") => "failure",
+            Some("task_skipped") => "skipped",
+            Some("task_cancelled") => "cancelled",
+            _ => continue,
+        };
+        let Some(fields) = ev["fields"].as_array() else {
+            continue;
+        };
+        let field = |key: &str| {
+            fields
+                .iter()
+                .find(|f| f["key"] == key)
+                .and_then(|f| f["value"].as_str())
+                .map(str::to_owned)
+        };
+        if let Some(task) = field("task") {
+            // A terminal's wire code rides the `outcome` JSON (spec 13 ·
+            // `payload.error.code`) — a bare `code` field is the recover
+            // frame's shape, kept as the fallback.
+            let code = field("outcome")
+                .and_then(|o| serde_json::from_str::<serde_json::Value>(&o).ok())
+                .and_then(|o| o["payload"]["error"]["code"].as_str().map(str::to_owned))
+                .or_else(|| field("code"));
+            if let Some(code) = code {
+                codes.insert(task.clone(), code);
+            }
+            if let Some(output) = field("output") {
+                outputs.insert(task.clone(), output);
+            }
+            statuses.insert(task, status.to_owned());
+        }
+    }
+    Observed {
+        statuses,
+        codes,
+        outputs,
+        kinds,
+        effectful,
+        ok: out.status.success(),
+        text: format!("{stdout}\n{stderr}"),
+    }
+}
+
+fn fixture_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(root)
+        .expect("readable fixture root")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir())
+        .collect();
+    dirs.sort();
+    dirs
+}
+
+/// Mapping-law row 1 — static-red ⇒ never executes. Every invalid
+/// `core/authority` fixture runs at the real binary: the refusal lands
+/// BEFORE the prologue (zero task frames) and voices the judged code.
+#[test]
+fn statically_refused_fixtures_never_execute() {
+    let root = spec_dir().join("conformance/tests/core/authority");
+    assert!(
+        root.is_dir(),
+        "authority tier missing: {} — set NIKA_SPEC_DIR",
+        root.display()
+    );
+    let mut red = 0usize;
+    let mut clean = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for dir in fixture_dirs(&root) {
+        let name = dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let input = dir.join("input.yaml");
+        if !input.is_file() {
+            continue;
+        }
+        let expected: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.join("expected.json")).expect("expected.json"),
+        )
+        .expect("expected parses");
+        if expected["valid"].as_bool() == Some(true) {
+            clean += 1;
+            continue; // clean core fixtures may declare real effects — never run here
+        }
+        red += 1;
+        let observed = run_observed(&input, &[], &[]);
+        if observed.ok {
+            failures.push(format!("{name}: judged red but the run SUCCEEDED"));
+        }
+        if observed.kinds.iter().any(|k| k.starts_with("task_")) {
+            failures.push(format!(
+                "{name}: judged red but tasks ran — the refusal must land pre-prologue ({:?})",
+                observed.kinds
+            ));
+        }
+        for err in expected["errors"].as_array().into_iter().flatten() {
+            let code = err["code"].as_str().unwrap_or_default();
+            if !code.is_empty() && !observed.text.contains(code) {
+                failures.push(format!("{name}: the refusal never voices {code}"));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "the judged verdict must BE the executed verdict:\n{}",
+        failures.join("\n")
+    );
+    assert!(
+        red >= 10,
+        "the authority corpus carries red fixtures (saw {red})"
+    );
+    println!(
+        "equivalence leg 1 (static-red never executes): {red} red replayed · {clean} clean checked-only"
+    );
+}
+
+/// One fixture's `expected-run.json` against one observed run: the
+/// workflow verdict, per-task terminal status, wire code, and output.
+/// Output assertions are SUBSTRING contracts: the frame carries the
+/// JSON-encoded value and a provider voice may frame a canary (mock
+/// prefixes) — the fixture asserts the substance.
+fn compare_run_contract(
+    name: &str,
+    observed: &Observed,
+    expected: &serde_json::Value,
+    failures: &mut Vec<String>,
+) {
+    let want_ok = expected["workflow_state"] == "success";
+    if observed.ok != want_ok {
+        failures.push(format!(
+            "{name}: workflow verdict — expected {} · binary rc says {}\n{}",
+            expected["workflow_state"], observed.ok, observed.text
+        ));
+    }
+    for (task, spec) in expected["tasks"].as_object().expect("tasks map") {
+        let want = spec["status"].as_str().expect("status");
+        match observed.statuses.get(task) {
+            Some(got) if got == want => {}
+            got => failures.push(format!(
+                "{name}: task `{task}` — expected {want} · observed {got:?}"
+            )),
+        }
+        if let Some(code) = spec["error_code"].as_str() {
+            match observed.codes.get(task) {
+                Some(got) if got == code => {}
+                got => failures.push(format!(
+                    "{name}: task `{task}` — expected code {code} · observed {got:?}"
+                )),
+            }
+        }
+        if let Some(output) = spec["output"].as_str() {
+            match observed.outputs.get(task) {
+                Some(got) if got.contains(output) => {}
+                got => failures.push(format!(
+                    "{name}: task `{task}` — expected output containing {output:?} · observed {got:?}"
+                )),
+            }
+        }
+    }
+}
+
+/// Mapping-law rows 2+3 — check-clean + DEFER ⇒ the run twin decides,
+/// and an executed effect is attested. Every `runtime/permits` fixture
+/// must be check-CLEAN; its real run's terminals must match
+/// `expected-run.json`; a run that dispatched an effect must carry
+/// `permit_checked` frames (NEP-0007 · the witness).
+#[test]
+fn deferred_fixtures_match_their_run_contract_and_are_witnessed() {
+    let root = spec_dir().join("conformance/tests/runtime/permits");
+    assert!(
+        root.is_dir(),
+        "runtime permits tier missing: {} — set NIKA_SPEC_DIR",
+        root.display()
+    );
+    let mut total = 0usize;
+    let mut witnessed = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for dir in fixture_dirs(&root) {
+        let name = dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let input = dir.join("input.nika.yaml");
+        if !input.is_file() {
+            continue;
+        }
+        total += 1;
+
+        // check-CLEAN is the DEFER law — the static judge saw nothing
+        // refusable, the run twin owns the verdict.
+        let check = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+            .arg("check")
+            .arg(&input)
+            .output()
+            .expect("binary checks");
+        if !check.status.success() {
+            failures.push(format!(
+                "{name}: a runtime fixture must be check-CLEAN (DEFER): {}",
+                String::from_utf8_lossy(&check.stdout)
+            ));
+            continue;
+        }
+
+        let run_spec: serde_json::Value = if dir.join("run.json").is_file() {
+            serde_json::from_str(&std::fs::read_to_string(dir.join("run.json")).expect("run.json"))
+                .expect("run spec parses")
+        } else {
+            serde_json::json!({})
+        };
+        let kv = |key: &str| -> Vec<(String, String)> {
+            run_spec[key]
+                .as_object()
+                .map(|m| {
+                    m.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_owned()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let observed = run_observed(&input, &kv("env"), &kv("inputs"));
+
+        let expected: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.join("expected-run.json")).expect("expected-run.json"),
+        )
+        .expect("expected parses");
+        compare_run_contract(&name, &observed, &expected, &mut failures);
+        // executed ⇒ attested: an effectful dispatch carries its witness
+        // (pure-compute infer runs owe none — NEP-0007 scopes the
+        // witness to the dispatch boundary).
+        if observed.effectful {
+            if observed.kinds.iter().any(|k| k == "permit_checked") {
+                witnessed += 1;
+            } else {
+                failures.push(format!(
+                    "{name}: effects ran with ZERO permit_checked frames — the witness is REQUIRED (NEP-0007)"
+                ));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "the run twin must honor the contract:\n{}",
+        failures.join("\n")
+    );
+    assert!(total >= 7, "the permits runtime corpus (saw {total})");
+    println!(
+        "equivalence legs 2+3 (defer contract + witness): {total} fixtures · {witnessed} witnessed"
+    );
+}
+
+/// The `e_diff` runtime FS leg — the named follow-on from
+/// `e_diff_soundness.rs`, landed at the real binary: a small exhaustive
+/// lattice of `permits.fs` shapes × read paths drives the REAL
+/// `nika:read` sink under a tempdir root. Each row names its law; the
+/// binary's verdict must match it.
+#[test]
+fn e_diff_runtime_fs_leg() {
+    let root = std::env::temp_dir().join(format!("nika-ediff-fs-{}", std::process::id()));
+    let data = root.join("data");
+    std::fs::create_dir_all(&data).expect("tempdir");
+    std::fs::write(data.join("in.txt"), "payload").expect("seed file");
+    std::fs::write(root.join("outside.txt"), "secret").expect("seed outside");
+
+    // (name · permits block · path · expect_success · the law)
+    let rows: &[(&str, &str, &str, bool)] = &[
+        (
+            "absent-block-refused",
+            "",
+            "data/in.txt",
+            false, // F-O8 · no permits block = zero authority
+        ),
+        (
+            "declared-empty-refused",
+            "permits: {}\n",
+            "data/in.txt",
+            false, // NEP-0003 · empty declared = pure compute
+        ),
+        (
+            "covering-glob-allows",
+            "permits:\n  fs: { read: [\"data/**\"] }\n  tools: [\"nika:read\"]\n",
+            "data/in.txt",
+            true, // inside the declared boundary
+        ),
+        (
+            "non-covering-glob-refused",
+            "permits:\n  fs: { read: [\"data/**\"] }\n  tools: [\"nika:read\"]\n",
+            "outside.txt",
+            false, // outside the declared boundary
+        ),
+        (
+            "traversal-escape-refused",
+            "permits:\n  fs: { read: [\"data/**\"] }\n  tools: [\"nika:read\"]\n",
+            "data/../outside.txt",
+            false, // canonicalize-then-confine · the resolved path decides
+        ),
+    ];
+    let mut failures: Vec<String> = Vec::new();
+    for (name, permits, path, want_ok) in rows {
+        let yaml = format!(
+            "nika: v1\nworkflow:\n  id: ediff-fs\n{permits}tasks:\n  grab:\n    invoke:\n      tool: \"nika:read\"\n      args: {{ path: \"{path}\" }}\n"
+        );
+        let wf = root.join(format!("{name}.nika.yaml"));
+        std::fs::write(&wf, yaml).expect("write workflow");
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_nika-cli"));
+        cmd.arg("run").arg(&wf).arg("--json").current_dir(&root);
+        let out = cmd.output().expect("binary runs");
+        let ok = out.status.success();
+        if ok != *want_ok {
+            failures.push(format!(
+                "fs leg `{name}`: expected success={want_ok} · observed {ok}\n{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            ));
+        }
+    }
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(
+        failures.is_empty(),
+        "the REAL fs sink must decide as the boundary law says:\n{}",
+        failures.join("\n")
+    );
+    println!(
+        "e_diff runtime fs leg: {} rows driven at the real binary",
+        rows.len()
+    );
+}
+
+/// The `e_diff` runtime NET leg — deny and floor sides only (the
+/// allow-side network dial is the DECLARED residual: no test dials
+/// out). A host outside `permits.net.http` refuses at the boundary; a
+/// loopback host UNDER a permit still refuses (the SSRF floor stays on
+/// top of the declared boundary — floors never widen).
+#[test]
+fn e_diff_runtime_net_leg() {
+    let root = std::env::temp_dir().join(format!("nika-ediff-net-{}", std::process::id()));
+    std::fs::create_dir_all(&root).expect("tempdir");
+    // (name · permits block · url · the law)
+    let rows: &[(&str, &str, &str)] = &[
+        (
+            "absent-block-refused",
+            "",
+            "https://example.com/data.csv", // F-O8 · zero authority
+        ),
+        (
+            "host-not-covered-refused",
+            "permits:\n  net: { http: [\"api.example.com\"] }\n  tools: [\"nika:fetch\"]\n",
+            "https://evil.example.net/data.csv", // outside the boundary
+        ),
+        (
+            "loopback-under-permit-floor-refused",
+            "permits:\n  net: { http: [\"127.0.0.1\"] }\n  tools: [\"nika:fetch\"]\n",
+            "http://127.0.0.1:9/data.csv", // the SSRF floor stays on top
+        ),
+    ];
+    let mut failures: Vec<String> = Vec::new();
+    let mut observed_codes: Vec<String> = Vec::new();
+    for (name, permits, url) in rows {
+        let yaml = format!(
+            "nika: v1\nworkflow:\n  id: ediff-net\n{permits}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"{url}\" }}\n"
+        );
+        let wf = root.join(format!("{name}.nika.yaml"));
+        std::fs::write(&wf, yaml).expect("write workflow");
+        let observed = run_observed(&wf, &[], &[]);
+        if observed.ok {
+            failures.push(format!(
+                "net leg `{name}`: the refusal law did not hold — the fetch SUCCEEDED\n{}",
+                observed.text
+            ));
+        }
+        observed_codes.push(format!(
+            "{name} → {}",
+            observed
+                .codes
+                .get("grab")
+                .cloned()
+                .unwrap_or_else(|| "(pre-prologue)".into())
+        ));
+    }
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(
+        failures.is_empty(),
+        "the REAL net sink must refuse as the boundary law says:\n{}",
+        failures.join("\n")
+    );
+    println!(
+        "e_diff runtime net leg: {} deny/floor rows · codes: {}",
+        rows.len(),
+        observed_codes.join(" · ")
+    );
+}

--- a/crates/nika-cli/tests/trace_witness_conformance.rs
+++ b/crates/nika-cli/tests/trace_witness_conformance.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// Same carve-out as gate_matrix_conformance: this suite's WHOLE JOB is
+// the shipped verify surface, and NIKA_SPEC_DIR is harness plumbing.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+//! The spec `runtime/trace` contract fixtures replayed through the REAL
+//! `nika trace verify` (spec 17 · NEP-0007): each fixture's
+//! `expected-verify.json` names the verdict — `clean` (OK · no finding
+//! line) · `finding` (OK · the REQUIRED-witness FINDING rides) ·
+//! `forged` (FILE · the chain walk breaks). The expectation is READ
+//! from the fixture, never hand-written here — the golden swap that
+//! flips 001 from `finding` to `clean` flips this suite with it.
+//!
+//! The spec dir resolves from `$NIKA_SPEC_DIR` or the sibling checkout
+//! (`<engine>/../spec`) — the suite HARD-FAILS when missing (the
+//! conformance gate must never silently skip).
+
+use std::path::PathBuf;
+
+fn spec_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("NIKA_SPEC_DIR") {
+        return PathBuf::from(dir);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../spec")
+}
+
+#[test]
+fn runtime_trace_fixtures_hold_their_verify_verdict() {
+    let root = spec_dir().join("conformance/tests/runtime/trace");
+    assert!(
+        root.is_dir(),
+        "conformance dir missing: {} — set NIKA_SPEC_DIR",
+        root.display()
+    );
+    let mut seen = 0_usize;
+    let mut entries: Vec<_> = std::fs::read_dir(&root)
+        .expect("readable fixture dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    entries.sort();
+    for dir in entries {
+        let expected_path = dir.join("expected-verify.json");
+        let trace = dir.join("trace.ndjson");
+        if !expected_path.is_file() || !trace.is_file() {
+            continue;
+        }
+        seen += 1;
+        let expected: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&expected_path).expect("expected json"))
+                .expect("valid expected-verify.json");
+        let verdict = expected["verdict"].as_str().expect("a verdict string");
+        let out = nika_cli::verbs::trace_verify::verify(&trace.to_string_lossy());
+        let name = dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        match verdict {
+            "clean" => {
+                assert_eq!(out.code, 0, "{name}: clean verdict exits OK: {}", out.text);
+                assert!(
+                    !out.text.contains("FINDING"),
+                    "{name}: clean carries no finding line: {}",
+                    out.text
+                );
+            }
+            "finding" => {
+                assert_eq!(out.code, 0, "{name}: a finding never fails: {}", out.text);
+                assert!(
+                    out.text.contains("FINDING"),
+                    "{name}: the REQUIRED-witness finding rides: {}",
+                    out.text
+                );
+            }
+            "forged" => {
+                assert_eq!(
+                    out.code, 2,
+                    "{name}: forged is the FILE class: {}",
+                    out.text
+                );
+            }
+            other => panic!("{name}: unknown fixture verdict {other}"),
+        }
+    }
+    assert!(
+        seen >= 3,
+        "the spec runtime/trace corpus has >= 3 fixtures (saw {seen})"
+    );
+}

--- a/crates/nika-pack/pack/spec/00-overview.md
+++ b/crates/nika-pack/pack/spec/00-overview.md
@@ -168,6 +168,7 @@ outputs:                              # what the workflow returns · symmetric t
 | [14 composition](./14-composition.md) | Workflow calling workflow · `invoke: workflow:` (tagged union) · the CallableContract · the ten composition laws · the trace forest |
 | [15 proof](./15-proof.md) | The proof layer · the semantic hash (H = H(domain ‖ version ‖ JCS(IR))) · `nika.lock` (pin by default) · `assert:` (StaticProof · TraceVerified · Unknown) · the one receipt |
 | [16 projections](./16-projections.md) | The oracle surface · one canonical projection (graph_format:2) served byte-identical across CLI · LSP · MCP · the LSP semantic document (`semantic_document_format: 1`) wraps it with spans + one-word `reason` · the additive arc (holes · actions · capabilities over the frozen IR) |
+| [17 trace](./17-trace.md) | The run journal · NDJSON frames chained by sha256 (`trace_format: 2` · the prologue manifest · the closed kind vocabulary) · the REQUIRED permit-decision witness (NEP-0007 · granted and refused alike) · the differential check ⇔ run equivalence law · graved from an observed run |
 
 **Stdlib** (versioned independently · not a spec section) · [stdlib/](../stdlib/): **<!-- canon:providers -->17<!-- /canon --> providers · <!-- canon:extract_modes -->9<!-- /canon --> extract modes · <!-- canon:builtins -->28<!-- /canon --> builtins** (6 core · 5 file · 8 data · 2 network · 2 introspection · 4 media).
 

--- a/crates/nika-pack/pack/spec/17-trace.md
+++ b/crates/nika-pack/pack/spec/17-trace.md
@@ -1,0 +1,156 @@
+# 17 · Trace
+
+> Every run leaves a journal · one NDJSON file, one event per line, each
+> line chained to the last by hash. The trace is the run's flight
+> recorder (`nika trace show|replay|verify`), the resume substrate, and
+> the stream the receipt folds FROM ([15](./15-proof.md)). This chapter
+> makes the dialect NORMATIVE: `trace_format: 2`, the frame grammar, the
+> chain law, the kind vocabulary, and the permit-decision witness
+> (NEP-0007) · the trace stops being an engine-private dialect. What is
+> written here is the OBSERVED wire, grave-not-invented: the conformance
+> golden is a real run's journal, byte-verifiable.
+
+---
+
+## The journal (normative)
+
+One run → at most one journal file · `<trace-dir>/<ISO-compact>-<short
+-id>.ndjson` (production: `.nika/traces/`). Three laws shape it:
+
+- **Lazy open** · file creation waits for the FIRST emitted frame (a run
+  refused before its prologue · audit refusal · composition failure ·
+  leaves no file).
+- **Infallible rider** · journal I/O failure never changes the run's
+  verdict or its primary output; the error surfaces AFTER the run as a
+  note. The journal tees BESIDE the chosen primary lane, byte-identical
+  with or without it.
+- **Append-only** · frames are written in emission order and never
+  rewritten; the chain (below) makes any rewrite evident.
+
+## The frame (normative)
+
+One event per line · one JSON object · the member set:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `chain` | string | sha256 hex of the PREVIOUS line's exact bytes (the chain law below) |
+| `id` | object | `{ "uuid": "<UUIDv7>" }` · unique per frame · time-ordered |
+| `timestamp` | integer | unix epoch **nanoseconds** |
+| `kind` | string | the closed-per-minor kind vocabulary (below) |
+| `fields` | array | ordered `{ "key": string, "value": any }` pairs · the frame's payload |
+| `run` | string \| null | the run correlation id when one is set |
+| `correlation` | string \| null | causal correlation across runs when one is set |
+
+Field VALUES are JSON values (string · number · object-as-string when a
+payload is itself serialized · the observed `permits_json` and `outcome`
+carry serialized JSON as a string, so the frame grammar stays flat).
+Sensitive payloads are hashed by the emitter, never carried raw.
+**Additive law** · a reader MUST ignore an unknown member and an unknown
+`fields` key (report « unrecorded », never guess); an unknown `kind` is
+tolerated by verifiers (the walk continues · the chain still binds it).
+
+## The chain (normative)
+
+The first line's `chain` is the sha256 of the GENESIS tag; every later
+line's `chain` is the sha256 hex of the previous line's EXACT bytes.
+After the run, the last line's hash is the journal's HEAD · printed at
+run end and carried by the seal. Verification recomputes the walk:
+any byte edit, insertion, deletion, or reorder breaks every subsequent
+link (`nika trace verify` · FORGED). The chain proves INTEGRITY of the
+sequence; it does not prove authorship (the seal and anchor rails of
+[15](./15-proof.md) carry authenticity).
+
+## `trace_format: 2` (normative · the version)
+
+The dialect version rides the FIRST frame (the prologue's
+`trace_format` field). It versions the JOURNAL WIRE · orthogonal to
+`nika: v1` (the language), `receipt_format: 1` (the folded receipt) and
+`graph_format: 2` (the projection). Version 2 is THIS chapter. A wire
+change that breaks a version-2 reader MUST bump it; additive fields and
+additive kinds MUST NOT.
+
+## The prologue (normative · `workflow_started`)
+
+The first frame is `workflow_started`, and it is the run's MANIFEST.
+Version-2 fields (the observed set):
+
+| Field | Meaning |
+|---|---|
+| `workflow` | the workflow id |
+| `permits` | the boundary posture, human-readable (`declared boundary · default-deny` \| the zero-authority note) |
+| `permits_json` | the DECLARED `permits:` block, serialized verbatim · the boundary the run was judged under |
+| `workflow_sha256` / `workflow_sha256_lf` | the source bytes' digest (raw · LF-normalized) |
+| `semantic_hash` | the semantic identity ([15](./15-proof.md) · H(domain ‖ version ‖ JCS(IR))) |
+| `sandbox` | the OS-confinement backend the run selected (`seatbelt` · `landlock` · `noop`, loudly) |
+| `trace_format` | this dialect's version · `2` |
+| `engine_version` | the emitting engine |
+| `platform` | `os/arch` |
+
+An engine MAY add fields (additive law); it MUST NOT drop these.
+
+## The kind vocabulary (normative · closed per minor)
+
+Version 2 names exactly these kinds · additive per minor, never
+re-meant:
+
+`workflow_started` · `workflow_completed` · `workflow_failed` ·
+`workflow_cancelled` · `workflow_paused` · `task_scheduled` ·
+`task_started` · `task_completed` · `task_failed` · `task_skipped` ·
+`task_retrying` · `task_recovered` · `task_cancelled` ·
+`task_cache_hit` · `verb_invoked` · `tool_invoked` ·
+`checkpoint_written` · `cost_incurred` · `infer_chunk` ·
+`permit_checked` · `declassify` · `run_sealed` ·
+`agent_tools_selected` · `agent_nudge` · `agent_stalled` ·
+`agent_compose_checked` · `agent_budget_checkpoint`
+
+Per-task terminal frames carry the task's witness fields (the observed
+`task_completed`: `task` · `note` · `duration_ms` · `def_hash` ·
+`input_hash` · `output` · `outcome` · the outcome record serialized).
+
+## The permit witness (normative · REQUIRED · NEP-0007)
+
+Every permit decision taken at the dispatch boundary is a
+`permit_checked` frame · granted AND refused alike: the exec program
+gate, the tool grant, the taint re-gate ([10](./10-authority.md) ·
+NEP-0004), the environment composition (NEP-0005 · the passed names),
+and the data-as-code sink (NEP-0006). The per-operation fs/net
+enforcement decisions live inside the builtin sinks (their refusals
+surface as typed task failures; their allow-side witness is the
+declared v1 residual · NEP-0007 law 2). The frame's fields name the `gate` (the
+bound consulted), the `decision` (`allow` \| `deny`), the `why` (the
+law applied), and the `task`. This is a CONFORMANCE requirement on the
+ENGINE, not a wire bump: the frame grammar is unchanged (one more kind
+in the stream), so `trace_format` stays 2. A journal from an OLDER
+conformant engine simply lacks the frames: `nika trace verify` reports
+a run that exercised effects with zero permit-decision frames as a
+FINDING (the witness is absent · the journal is old or the engine is
+not NEP-0007-conformant) · never FORGED (the chain still holds), never
+a crash.
+
+The witness is what makes invariant 4 · judged = executed = attested ·
+CHECKABLE: the static judge's verdicts, the runtime's decisions, and
+the journal's frames speak the same boundary, and the conformance
+differential replays the same inputs through checker and engine and
+FAILS on any verdict divergence.
+
+## The fold law (pointer)
+
+Every proof consumer reads THIS stream: the receipt folds from it
+([15](./15-proof.md)), `--resume` replans from it, `nika trace
+show|replay` renders it, the verify walk re-hashes it. One stream, no
+side-channel.
+
+## Conformance
+
+A v1-conformant engine MUST ·
+
+1. Write one chained NDJSON journal per run that emits at least one frame (lazy open · append-only · infallible rider)
+2. Open with the version-2 prologue (the manifest fields above · `trace_format: 2`)
+3. Chain every line to the previous line's exact bytes (genesis-tagged · the head reported at run end)
+4. Emit a terminal workflow frame (`workflow_completed` \| `workflow_failed` \| `workflow_cancelled` \| `workflow_paused`) and a terminal task frame per settled task
+5. Emit a `permit_checked` frame for every permit decision, granted and refused alike (NEP-0007 · the witness)
+6. Tolerate unknown members, fields, and kinds when READING a journal (the additive law · report « unrecorded », never guess)
+
+---
+
+🦋 *Related · [15 · Proof](./15-proof.md) · [10 · Authority](./10-authority.md) · [07 · Conformance](./07-conformance.md)*

--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -342,6 +342,12 @@ fn settle_exec_out(
     Dispatched::ok(note.to_owned(), value, None)
 }
 
+/// `temperature:` lowering — f64 grammar to the provider's f32 seat.
+#[allow(clippy::cast_possible_truncation)] // 0-2 range · checker-validated
+fn temp_f32(t: Option<&nika_schema::Spanned<f64>>) -> Option<f32> {
+    t.map(|t| t.value as f32)
+}
+
 /// The per-attempt task context the dispatch threads to its arms — the
 /// task-level knobs that are not the action itself (bundled at the
 /// 8-argument clippy wall · an additive knob lands HERE, never as a new
@@ -355,6 +361,10 @@ pub(crate) struct DispatchCtx<'a> {
     /// NEP-0006 · the task's declared `inert:` door (the data-as-code
     /// sink's run twin honors it).
     pub inert: Option<&'a str>,
+    /// NEP-0007 · the attempt's permit-decision collector (spec 17 §the
+    /// permit witness) — every dispatch-boundary decision records here,
+    /// the settle spine emits one `permit_checked` frame per entry.
+    pub witness: &'a crate::witness::PermitWitness,
 }
 
 impl<'a> DispatchCtx<'a> {
@@ -366,11 +376,13 @@ impl<'a> DispatchCtx<'a> {
         task: &'a nika_schema::raw::RawTask,
         deadline: Option<std::time::Duration>,
         child_budget: Option<f64>,
+        witness: &'a crate::witness::PermitWitness,
     ) -> Self {
         Self {
             deadline,
             child_budget,
             inert: task.inert.as_ref().map(|s| s.value.as_str()),
+            witness,
         }
     }
 }
@@ -414,23 +426,19 @@ where
     ) -> Dispatched {
         match action {
             RawAction::Invoke(inner) => {
-                self.dispatch_invoke(
-                    inner,
-                    scope,
-                    taint,
-                    (ctx.deadline, ctx.child_budget),
-                    contract,
-                    ctx.inert,
-                )
-                .await
+                self.dispatch_invoke(inner, scope, taint, &ctx, contract)
+                    .await
             }
-            RawAction::Exec(inner) => self.dispatch_shell(inner, scope, taint, contract).await,
+            RawAction::Exec(inner) => {
+                self.dispatch_shell(inner, scope, taint, &ctx, contract)
+                    .await
+            }
             RawAction::Infer(inner) => {
                 self.dispatch_infer(inner, scope, ctx.deadline, contract)
                     .await
             }
             RawAction::Agent(inner) => {
-                self.dispatch_agent(inner, scope, agent_buffer, contract)
+                self.dispatch_agent(inner, scope, agent_buffer, &ctx, contract)
                     .await
             }
             // #[non_exhaustive] · a future verb must land HERE loudly ·
@@ -447,28 +455,24 @@ where
         action: &nika_schema::raw::RawInvokeAction,
         scope: &Scope<'_>,
         taint: &crate::integrity::ValueTaint<'_>,
-        (deadline, child_budget): (Option<std::time::Duration>, Option<f64>),
+        ctx: &DispatchCtx<'_>,
         contract: Option<&crate::contract::TaskContract<'_>>,
-        inert: Option<&str>,
     ) -> Dispatched {
+        let (deadline, child_budget, inert) = (ctx.deadline, ctx.child_budget, ctx.inert);
+        let witness = ctx.witness;
         let tool = match &action.target {
             nika_schema::raw::RawInvokeTarget::Tool(t) => t.value.clone(),
             nika_schema::raw::RawInvokeTarget::Workflow(w) => {
+                let args = action.args.as_ref();
                 return self
-                    .dispatch_workflow_call(
-                        w,
-                        action.args.as_ref(),
-                        scope,
-                        (deadline, child_budget),
-                        contract,
-                    )
+                    .dispatch_workflow_call(w, args, scope, (deadline, child_budget), contract)
                     .await;
             }
         };
         let note = format!("invoke · {tool}");
         // NIKA-SEC-004 BEFORE any arg rendering — the tool id is static,
         // so an out-of-boundary invoke is refused without touching the scope.
-        if let Some(denial) = permits::check_tool_permits(scope.permits, &note, &tool) {
+        if let Some(denial) = permits::check_tool_permits(scope.permits, &note, &tool, witness) {
             return denial;
         }
         let args = match &action.args {
@@ -482,7 +486,7 @@ where
         // fetch URL is classified against the one closed list, honoring
         // the task's declared inert: door — the dynamic case the static
         // classifier deferred (dispatch/permits.rs · check_fetch_sink).
-        if let Some(denial) = permits::check_fetch_sink(inert, &note, &tool, &args) {
+        if let Some(denial) = permits::check_fetch_sink(inert, &note, &tool, &args, witness) {
             return denial;
         }
         // F-O1 PR-2 · the mcp border re-gate (NEP-0004 law 2): the grant
@@ -501,6 +505,7 @@ where
                 &args,
                 taint,
                 scope.records,
+                witness,
             )
         {
             return denial;
@@ -568,6 +573,7 @@ where
         action: &nika_schema::raw::RawExecAction,
         scope: &Scope<'_>,
         taint: &crate::integrity::ValueTaint<'_>,
+        ctx: &DispatchCtx<'_>,
         contract: Option<&crate::contract::TaskContract<'_>>,
     ) -> Dispatched {
         let (mut input, program, is_argv) = match build_exec_input(action, scope) {
@@ -602,7 +608,9 @@ where
             return Dispatched::template_err(&note, &err);
         }
 
-        if let Some(denial) = permits::check_exec_permits(scope.permits, &note, &program, is_argv) {
+        if let Some(denial) =
+            permits::check_exec_permits(scope.permits, &note, &program, is_argv, ctx.witness)
+        {
             return denial;
         }
 
@@ -616,8 +624,15 @@ where
         if let Some(boundary) = scope.permits {
             if let (RawCommand::Argv(elements), ExecCommand::Argv(argv)) =
                 (&action.command, &input.command)
-                && let Some(denial) =
-                    regate::regate_exec_argv(boundary, &note, elements, argv, taint, scope.records)
+                && let Some(denial) = regate::regate_exec_argv(
+                    boundary,
+                    &note,
+                    elements,
+                    argv,
+                    taint,
+                    scope.records,
+                    ctx.witness,
+                )
             {
                 return denial;
             }
@@ -629,6 +644,7 @@ where
                     &cwd.to_string_lossy(),
                     taint,
                     scope.records,
+                    ctx.witness,
                 )
             {
                 return denial;
@@ -643,10 +659,7 @@ where
         // command to the spawn site, which composes the child environment
         // (the runner floor ∪ these names ∪ the authored `env:` map) from
         // a cleared slate — nothing ambient crosses undeclared.
-        input.env_passthrough = scope
-            .permits
-            .map(|p| p.env_passthrough().to_vec())
-            .unwrap_or_default();
+        input.env_passthrough = permits::env_passthrough_witnessed(scope.permits, ctx.witness);
 
         match self.shell.run(input).await {
             Ok(out) => settle_exec_out(&note, out, decode, contract),
@@ -674,10 +687,7 @@ where
             Err(err) => return Dispatched::template_err("infer · ?", &err),
         };
         input.model = action.model.as_ref().map(|m| m.value.clone());
-        #[allow(clippy::cast_possible_truncation)] // 0-2 range · checker-validated
-        {
-            input.temperature = action.temperature.as_ref().map(|t| t.value as f32);
-        }
+        input.temperature = temp_f32(action.temperature.as_ref());
         input.max_tokens = action.max_tokens.as_ref().map(|t| t.value);
         // `returns:` compiles `lower(returns)` as the structured-output
         // contract — EXACTLY the `schema:` lane (spec 09 §returns · one
@@ -741,12 +751,15 @@ where
         action: &nika_schema::raw::RawAgentAction,
         scope: &Scope<'_>,
         agent_buffer: &crate::agent_events::BufferingObserver,
+        ctx: &DispatchCtx<'_>,
         contract: Option<&crate::contract::TaskContract<'_>>,
     ) -> Dispatched {
         // NIKA-SEC-004: the declared `tools:` universe must FIT
         // `permits.tools` — refused before any render or provider call,
         // one refusal for the whole task.
-        if let Some(denial) = permits::check_agent_tools_permits(scope.permits, &action.tools) {
+        if let Some(denial) =
+            permits::check_agent_tools_permits(scope.permits, &action.tools, ctx.witness)
+        {
             return denial;
         }
         let prompt = match expr::render(&action.prompt.value, scope) {
@@ -771,10 +784,7 @@ where
         input.tools = action.tools.iter().map(|t| t.value.clone()).collect();
         input.max_turns = action.max_turns.as_ref().map(|t| t.value);
         input.max_tokens_total = action.max_tokens_total.as_ref().map(|t| t.value);
-        #[allow(clippy::cast_possible_truncation)] // 0-2 range · checker-validated
-        {
-            input.temperature = action.temperature.as_ref().map(|t| t.value as f32);
-        }
+        input.temperature = temp_f32(action.temperature.as_ref());
         // `returns:` — same as infer: `lower(returns)` rides the
         // structured-output lane over the loop's FINAL message (spec 09
         // §returns · violations stay NIKA-INFER-002 · one voice).

--- a/crates/nika-runtime/src/dispatch/permits.rs
+++ b/crates/nika-runtime/src/dispatch/permits.rs
@@ -7,6 +7,8 @@
 //! `permits_fit` scan so check≡run cannot drift.
 
 use super::Dispatched;
+use crate::witness::PermitWitness;
+use nika_schema::types::Permits;
 
 /// The tools capability boundary (spec 01 §permits · NIKA-SEC-004): once a
 /// workflow declares `permits`, every tool the body names — an `invoke:`
@@ -23,6 +25,7 @@ pub(super) fn check_tool_permits(
     permits: Option<&nika_schema::types::Permits>,
     note: &str,
     tool: &str,
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
     let Some(permits) = permits else {
         // F-O8 · absent = zero authority: every tool effect refused —
@@ -30,8 +33,20 @@ pub(super) fn check_tool_permits(
         // check-time exemption · check≡run: pure compute RUNS under the
         // legal zero, effects refuse).
         if nika_cap::is_pure_internal(tool) {
+            witness.record(
+                "tool",
+                tool,
+                "allow",
+                "pure-internal exemption (NEP-0003 law 1)",
+            );
             return None;
         }
+        witness.record(
+            "tool",
+            tool,
+            "deny",
+            "absent permits: = zero authority (NEP-0003)",
+        );
         return Some(Dispatched::security_err(
             note,
             format!(
@@ -42,8 +57,10 @@ pub(super) fn check_tool_permits(
         ));
     };
     if permits.allows_tool(tool) {
+        witness.record("tool", tool, "allow", "permits.tools covers the id");
         return None;
     }
+    witness.record("tool", tool, "deny", "not in the permits.tools allowlist");
     Some(Dispatched::security_err(
         note,
         format!("tool {tool:?} is not in the `permits.tools` allowlist"),
@@ -62,13 +79,37 @@ pub(super) fn check_fetch_sink(
     note: &str,
     tool: &str,
     args: &serde_json::Value,
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
-    if tool != "nika:fetch" || inert.is_some() {
+    if tool != "nika:fetch" {
+        return None;
+    }
+    if let Some(because) = inert {
+        witness.record(
+            "sink",
+            tool,
+            "allow",
+            format!("inert door declared · {because}"),
+        );
         return None;
     }
     let url = args.get("url")?.as_str()?;
     let path = url::Url::parse(url).ok().map(|u| u.path().to_owned())?;
-    let (class, ext) = nika_cap::code_bearing_path_class(&path)?;
+    let Some((class, ext)) = nika_cap::code_bearing_path_class(&path) else {
+        witness.record(
+            "sink",
+            path,
+            "allow",
+            "no code-bearing class on the URL path",
+        );
+        return None;
+    };
+    witness.record(
+        "sink",
+        format!("{class} · {ext}"),
+        "deny",
+        "code-bearing fetch with no inert door (NEP-0006 law 1)",
+    );
     Some(Dispatched::security_err(
         note,
         format!(
@@ -86,9 +127,10 @@ pub(super) fn check_fetch_sink(
 pub(super) fn check_agent_tools_permits(
     permits: Option<&nika_schema::types::Permits>,
     tools: &[nika_schema::Spanned<String>],
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
     for tool in tools {
-        if let Some(denial) = check_tool_permits(permits, "agent · ?", &tool.value) {
+        if let Some(denial) = check_tool_permits(permits, "agent · ?", &tool.value, witness) {
             return Some(denial);
         }
     }
@@ -112,10 +154,17 @@ pub(super) fn check_exec_permits(
     note: &str,
     program: &str,
     is_argv: bool,
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
     use nika_schema::types::ExecPermit;
     let Some(permits) = permits else {
         // F-O8 · absent = zero authority: refuse before spawn (zero process).
+        witness.record(
+            "exec",
+            program,
+            "deny",
+            "absent permits: = zero authority (NEP-0003)",
+        );
         return Some(Dispatched::security_err(
             note,
             "no `permits:` block declared · zero authority (F-O8) — \
@@ -125,17 +174,39 @@ pub(super) fn check_exec_permits(
     };
     match &permits.exec {
         // Omitted or `false` → this workflow runs zero processes.
-        None | Some(ExecPermit::No) => Some(Dispatched::security_err(
-            note,
-            "exec is not permitted by the workflow `permits` boundary",
-        )),
+        None | Some(ExecPermit::No) => {
+            witness.record(
+                "exec",
+                program,
+                "deny",
+                "exec is not permitted by the boundary",
+            );
+            Some(Dispatched::security_err(
+                note,
+                "exec is not permitted by the workflow `permits` boundary",
+            ))
+        }
         // `true` → any process (still blocklist-gated at the floor).
-        Some(ExecPermit::Any) => None,
+        Some(ExecPermit::Any) => {
+            witness.record(
+                "exec",
+                program,
+                "allow",
+                "exec: true (blocklist floor stays on top)",
+            );
+            None
+        }
         // A program allowlist → ARRAY form only (argv[0] must be listed); the
         // SHELL form cannot be verified (a pipeline can launch any program), so
         // it is refused — use the array form.
         Some(ExecPermit::Programs(allowed)) => {
             if !is_argv {
+                witness.record(
+                    "exec",
+                    program,
+                    "deny",
+                    "shell form under a program allowlist is unverifiable",
+                );
                 return Some(Dispatched::security_err(
                     note,
                     "a shell-string command cannot be verified against a \
@@ -144,17 +215,42 @@ pub(super) fn check_exec_permits(
                 ));
             }
             if !allowed.iter().any(|p| p == program) {
+                witness.record("exec", program, "deny", "not in the permits.exec allowlist");
                 return Some(Dispatched::security_err(
                     note,
                     format!("program {program:?} is not in the `permits.exec` allowlist"),
                 ));
             }
+            witness.record("exec", program, "allow", "permits.exec lists the program");
             None
         }
         // #[non_exhaustive] · a future permit form fails CLOSED.
-        Some(_) => Some(Dispatched::security_err(
-            note,
-            "exec permit form not understood by this engine version",
-        )),
+        Some(_) => {
+            witness.record("exec", program, "deny", "unknown permit form fails closed");
+            Some(Dispatched::security_err(
+                note,
+                "exec permit form not understood by this engine version",
+            ))
+        }
     }
+}
+
+/// NEP-0005 · the declared `permits.env:` passthrough for the spawn
+/// site, witnessed (NEP-0007): the passed names ARE the exercised
+/// authority — one `env` frame per spawn, allow-side by construction
+/// (an undeclared name never reaches the composition).
+pub(super) fn env_passthrough_witnessed(
+    permits: Option<&Permits>,
+    witness: &PermitWitness,
+) -> Vec<String> {
+    let names = permits
+        .map(|p| p.env_passthrough().to_vec())
+        .unwrap_or_default();
+    witness.record(
+        "env",
+        names.join(","),
+        "allow",
+        "composed floor ∪ declared passthrough (NEP-0005)",
+    );
+    names
 }

--- a/crates/nika-runtime/src/dispatch/regate.rs
+++ b/crates/nika-runtime/src/dispatch/regate.rs
@@ -63,6 +63,7 @@ use serde_json::Value;
 use super::Dispatched;
 use crate::integrity::ValueTaint;
 use crate::record::TaskRecord;
+use crate::witness::PermitWitness;
 
 /// The exec argv re-gate — every `argv[1..]` element whose RAW template
 /// reads untrusted content is matched on its RENDERED value against the
@@ -75,6 +76,7 @@ pub(super) fn regate_exec_argv(
     argv: &[String],
     taint: &ValueTaint<'_>,
     records: &BTreeMap<String, TaskRecord>,
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
     debug_assert_eq!(
         elements.len(),
@@ -95,8 +97,20 @@ pub(super) fn regate_exec_argv(
             rendered,
             Plane::Exec,
         ) {
+            witness.record(
+                "regate",
+                &sink,
+                "deny",
+                format!("tainted by {source} · escaped"),
+            );
             return Some(denial);
         }
+        witness.record(
+            "regate",
+            &sink,
+            "allow",
+            format!("tainted by {source} · covered"),
+        );
     }
     None
 }
@@ -111,13 +125,26 @@ pub(super) fn regate_exec_cwd(
     rendered: &str,
     taint: &ValueTaint<'_>,
     records: &BTreeMap<String, TaskRecord>,
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
     let Integrity::Untrusted { source } = taint.label(template, records) else {
         return None;
     };
     if permits.allows_path(rendered, false) {
+        witness.record(
+            "regate",
+            "exec.cwd",
+            "allow",
+            format!("tainted by {source} · covered"),
+        );
         return None;
     }
+    witness.record(
+        "regate",
+        "exec.cwd",
+        "deny",
+        format!("tainted by {source} · escaped"),
+    );
     Some(path_refusal(
         note,
         &source,
@@ -131,6 +158,7 @@ pub(super) fn regate_exec_cwd(
 /// with the RENDERED one (same keys, same array lengths — `render_json`
 /// preserves shape; only string leaves can change type). Every tainted
 /// string leaf re-gates on its rendered value.
+#[allow(clippy::too_many_arguments)] // REASON: the border's own state (permit · note · tool · two JSON views · oracle · records · witness) — each a distinct read.
 pub(super) fn regate_mcp_args(
     permits: &Permits,
     note: &str,
@@ -139,8 +167,9 @@ pub(super) fn regate_mcp_args(
     rendered_args: &Value,
     taint: &ValueTaint<'_>,
     records: &BTreeMap<String, TaskRecord>,
+    witness: &PermitWitness,
 ) -> Option<Dispatched> {
-    regate_json(
+    let denial = regate_json(
         permits,
         note,
         tool,
@@ -149,7 +178,15 @@ pub(super) fn regate_mcp_args(
         "",
         taint,
         records,
-    )
+    );
+    // The mcp border's decision, one frame per call: per-leaf verdicts
+    // stay internal to the walk (the denial names the leaf) — the
+    // witness records the BORDER outcome (NEP-0007 · bounded volume).
+    match &denial {
+        Some(_) => witness.record("regate", tool, "deny", "a tainted arg leaf escaped"),
+        None => witness.record("regate", tool, "allow", "rendered args within the boundary"),
+    }
+    denial
 }
 
 /// The recursive half of [`regate_mcp_args`] — `path` is the JSON
@@ -408,7 +445,15 @@ mod tests {
             "-xf".to_owned(),
             "--checkpoint-action=exec=sh id".to_owned(),
         ];
-        let denial = regate_exec_argv(&permits, "exec · tar", &elements, &argv, &taint, &records);
+        let denial = regate_exec_argv(
+            &permits,
+            "exec · tar",
+            &elements,
+            &argv,
+            &taint,
+            &records,
+            &PermitWitness::new(),
+        );
         let denial = denial.expect("the option token is refused");
         let err = denial.result.err().expect("a refusal");
         assert_eq!(err.record.code, "NIKA-SEC-004");
@@ -433,7 +478,16 @@ mod tests {
         ];
         let argv = vec!["tar".to_owned(), "--file=report.csv".to_owned()];
         assert!(
-            regate_exec_argv(&permits, "exec · tar", &authored, &argv, &taint, &records).is_none(),
+            regate_exec_argv(
+                &permits,
+                "exec · tar",
+                &authored,
+                &argv,
+                &taint,
+                &records,
+                &PermitWitness::new()
+            )
+            .is_none(),
             "an authored option with a plain-data value runs"
         );
     }
@@ -463,6 +517,7 @@ mod tests {
             &escaping,
             &taint,
             &records,
+            &PermitWitness::new(),
         )
         .expect("the traversal is refused");
         let err = denial.result.err().expect("a refusal");
@@ -481,8 +536,16 @@ mod tests {
             "datasets/2026/report.csv".to_owned(),
         ];
         assert!(
-            regate_exec_argv(&permits, "exec · tar", &elements, &inside, &taint, &records)
-                .is_none(),
+            regate_exec_argv(
+                &permits,
+                "exec · tar",
+                &elements,
+                &inside,
+                &taint,
+                &records,
+                &PermitWitness::new()
+            )
+            .is_none(),
             "a value covered by the permit is not a blind deny"
         );
         // A back-spelled in-boundary path (`datasets/../datasets/q3.csv`)
@@ -493,8 +556,16 @@ mod tests {
             "datasets/../datasets/q3.csv".to_owned(),
         ];
         assert!(
-            regate_exec_argv(&permits, "exec · tar", &elements, &folded, &taint, &records)
-                .is_none(),
+            regate_exec_argv(
+                &permits,
+                "exec · tar",
+                &elements,
+                &folded,
+                &taint,
+                &records,
+                &PermitWitness::new()
+            )
+            .is_none(),
             "the canonical form, never a raw prefix"
         );
     }
@@ -512,8 +583,16 @@ mod tests {
             ),
         ];
         let evil = vec!["curl".to_owned(), "https://evil.example/x".to_owned()];
-        let denial = regate_exec_argv(&permits, "exec · curl", &elements, &evil, &taint, &records)
-            .expect("the escaped host is refused");
+        let denial = regate_exec_argv(
+            &permits,
+            "exec · curl",
+            &elements,
+            &evil,
+            &taint,
+            &records,
+            &PermitWitness::new(),
+        )
+        .expect("the escaped host is refused");
         let err = denial.result.err().expect("a refusal");
         assert!(
             err.record
@@ -524,7 +603,16 @@ mod tests {
         );
         let ok = vec!["curl".to_owned(), "https://api.example.com/v1".to_owned()];
         assert!(
-            regate_exec_argv(&permits, "exec · curl", &elements, &ok, &taint, &records).is_none(),
+            regate_exec_argv(
+                &permits,
+                "exec · curl",
+                &elements,
+                &ok,
+                &taint,
+                &records,
+                &PermitWitness::new()
+            )
+            .is_none(),
             "an in-permit host runs"
         );
     }
@@ -540,7 +628,8 @@ mod tests {
                 "${{ tasks.dl.output }}",
                 "src/lib",
                 &taint,
-                &records
+                &records,
+                &PermitWitness::new()
             )
             .is_none()
         );
@@ -551,6 +640,7 @@ mod tests {
             "src/../../etc",
             &taint,
             &records,
+            &PermitWitness::new(),
         )
         .expect("the escaping cwd is refused");
         assert_eq!(
@@ -584,6 +674,7 @@ mod tests {
             &escaping,
             &taint,
             &records,
+            &PermitWitness::new(),
         )
         .expect("the escaping leaf is refused");
         let err = denial.result.err().expect("a refusal");
@@ -606,7 +697,8 @@ mod tests {
                 &raw,
                 &covered,
                 &taint,
-                &records
+                &records,
+                &PermitWitness::new()
             )
             .is_none(),
             "fs.write alone covers an mcp leaf (direction unknowable)"
@@ -623,7 +715,8 @@ mod tests {
                 &raw_island,
                 &structured,
                 &taint,
-                &records
+                &records,
+                &PermitWitness::new()
             )
             .is_none(),
             "the structured-payload channel is the declared v1 residual"
@@ -643,7 +736,16 @@ mod tests {
         ];
         let argv = vec!["echo".to_owned(), "hello world".to_owned()];
         assert!(
-            regate_exec_argv(&permits, "exec · echo", &elements, &argv, &taint, &records).is_none(),
+            regate_exec_argv(
+                &permits,
+                "exec · echo",
+                &elements,
+                &argv,
+                &taint,
+                &records,
+                &PermitWitness::new()
+            )
+            .is_none(),
             "a tainted plain word carries no path/host/option shape"
         );
     }

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -70,6 +70,7 @@ mod settle;
 mod stamp;
 mod task;
 mod trust;
+pub(crate) mod witness;
 mod workflow_call;
 
 use std::collections::BTreeMap;

--- a/crates/nika-runtime/src/pause.rs
+++ b/crates/nika-runtime/src/pause.rs
@@ -175,6 +175,7 @@ mod tests {
         Finish {
             id: id.to_owned(),
             settle: SettleAs::Ran(RanTask {
+                decisions: Vec::new(),
                 note: "invoke · nika:prompt".to_owned(),
                 retries: Vec::new(),
                 agent_events: Vec::new(),

--- a/crates/nika-runtime/src/recover.rs
+++ b/crates/nika-runtime/src/recover.rs
@@ -102,6 +102,9 @@ struct Parked {
     agent_events: Vec<crate::agent_events::StampedAgentEvent>,
     duration_ms: u64,
     resume: Option<crate::resume::ResumeStamp>,
+    /// The dispatch boundary's permit decisions recorded before the park
+    /// (NEP-0007) — they ride to resolution like the declassify events.
+    decisions: Vec<crate::witness::PermitDecision>,
     /// The `declassify:` receipt evidence computed when the task ran —
     /// the door opened BEFORE the park; the events ride to resolution.
     declassified: Vec<crate::task::DeclassifyEvidence>,
@@ -192,6 +195,26 @@ pub(crate) fn settle_or_park(
     drain_ready(scope, parked, prior, live, ok, cache_hits, stamper, sink);
 }
 
+/// Reassemble a `Finish` around a settle — the shared tail of every
+/// park path (declined · not-parkable · resolved).
+fn finish_with(
+    id: String,
+    settle: SettleAs,
+    named: BTreeMap<String, Value>,
+    resume: Option<crate::resume::ResumeStamp>,
+    integrity: nika_cap::Integrity,
+    declassified: Vec<crate::task::DeclassifyEvidence>,
+) -> Finish {
+    Finish {
+        id,
+        settle,
+        named,
+        resume,
+        integrity,
+        declassified,
+    }
+}
+
 /// Park a pending-recovery finish — `None` when parked (nothing settles
 /// yet). `Some(finish)` settles normally: either the finish untouched
 /// (not a pending recovery), or its immediate failure when an awaited
@@ -213,20 +236,15 @@ fn try_park(
     let ran = match settled_as {
         SettleAs::Ran(ran) => ran,
         other => {
-            return Some(Finish {
-                id,
-                settle: other,
-                named,
-                resume,
-                integrity,
-                declassified,
-            });
+            let done = finish_with(id, other, named, resume, integrity, declassified);
+            return Some(done);
         }
     };
     let RanTask {
         note,
         retries,
         agent_events,
+        decisions,
         duration_ms,
         result,
     } = ran;
@@ -237,17 +255,13 @@ fn try_park(
                 note,
                 retries,
                 agent_events,
+                decisions,
                 duration_ms,
                 result: other,
             };
-            return Some(Finish {
-                id,
-                settle: SettleAs::Ran(ran),
-                named,
-                resume,
-                integrity,
-                declassified,
-            });
+            let settle = SettleAs::Ran(ran);
+            let done = finish_with(id, settle, named, resume, integrity, declassified);
+            return Some(done);
         }
     };
     let declared = |t: &String| scope.wf.tasks.iter().any(|s| s.value.id.value == *t);
@@ -263,6 +277,7 @@ fn try_park(
                 agent_events,
                 duration_ms,
                 resume,
+                decisions,
                 declassified,
                 pending,
             },
@@ -281,6 +296,7 @@ fn try_park(
         note,
         retries,
         agent_events,
+        decisions,
         duration_ms,
         result: RunResult::Failed {
             error: render_error,
@@ -288,14 +304,15 @@ fn try_park(
             cost_unpriced: failed.cost_unpriced,
         },
     };
-    Some(Finish {
+    let settle = SettleAs::Ran(ran);
+    Some(finish_with(
         id,
-        settle: SettleAs::Ran(ran),
+        settle,
         named,
         resume,
         integrity,
         declassified,
-    })
+    ))
 }
 
 /// Resolve + settle every park the spine's terminal truth covers, to a
@@ -423,6 +440,7 @@ fn resolve_parked(
         note,
         retries,
         agent_events,
+        decisions,
         duration_ms,
         resume,
         declassified,
@@ -482,6 +500,7 @@ fn resolve_parked(
         note,
         retries,
         agent_events,
+        decisions,
         duration_ms,
         result,
     });
@@ -503,14 +522,7 @@ fn resolve_parked(
         .map_or_else(nika_cap::Integrity::trusted, |task| {
             crate::integrity::task_integrity(&task.value, view)
         });
-    Finish {
-        id,
-        settle: settled_as,
-        named,
-        resume,
-        integrity,
-        declassified,
-    }
+    finish_with(id, settled_as, named, resume, integrity, declassified)
 }
 
 /// The declared recover template of `wf.tasks[index]`, when it is one.

--- a/crates/nika-runtime/src/recover/tests.rs
+++ b/crates/nika-runtime/src/recover/tests.rs
@@ -365,6 +365,7 @@ fn undeclared_awaited_root_fails_fast_at_the_park_site() {
     let finish = task::Finish {
         id: "risky".to_owned(),
         settle: task::SettleAs::Ran(task::RanTask {
+            decisions: Vec::new(),
             note: "exec · sh".to_owned(),
             retries: Vec::new(),
             agent_events: Vec::new(),

--- a/crates/nika-runtime/src/retry.rs
+++ b/crates/nika-runtime/src/retry.rs
@@ -21,7 +21,13 @@
 //! requirement) — the determinism contract of the event stream
 //! extends to the retry delays for free.
 
+use nika_schema::raw::RawTask;
+use nika_schema::types::OnError;
 use nika_schema::types::{BackoffStrategy, RetryConfig};
+
+use crate::expr::Scope;
+use crate::record::TaskErrorRecord;
+use crate::task::FailedOutcome;
 
 /// The backoff delay before retry number `attempt` (1-based · `1` =
 /// the delay before the FIRST retry), in milliseconds.
@@ -100,6 +106,100 @@ pub(crate) fn rand_unit(seed: u64, task_id: &str, attempt: u32) -> f64 {
     #[allow(clippy::cast_precision_loss)] // by construction ≤ 2^53 − 1
     let unit = (mixed >> 11) as f64 * (1.0 / 9_007_199_254_740_992.0);
     unit
+}
+
+/// The jitter stream selector — fan-out iterations get DISTINCT
+/// streams (anti-thundering-herd applies WITHIN a fan-out too ·
+/// Brooker 2015: same-task iterations retrying the same upstream
+/// must not synchronize) while staying replay-stable (the index
+/// is part of the deterministic coordinates). Collision-free: task
+/// ids are `snake_case` (checker law · CEL-safe) so `[` can never
+/// appear in a real id — iteration `t[0]` can't collide with a task
+/// NAMED `t[0]`.
+pub(crate) fn jitter_key(task: &RawTask, scope: &Scope<'_>) -> String {
+    match scope.index {
+        Some(i) => format!("{}[{i}]", task.id.value),
+        None => task.id.value.clone(),
+    }
+}
+
+/// `retry:` eligibility (spec 05 · transient-only unless `on_codes`).
+fn retry_eligible(task: &RawTask, error: &TaskErrorRecord) -> bool {
+    let Some(retry) = task.retry.as_ref() else {
+        return false;
+    };
+    if retry.value.on_codes.is_empty() {
+        error.transient
+    } else {
+        retry.value.on_codes.iter().any(|c| c == &error.code)
+    }
+}
+
+/// `on_error.on_codes` filter (spec 05 · empty = applies to all).
+/// `pub(crate)`: the ADR-099 pause rider consults it too (an authored
+/// route for PROMPT-001 wins over the pause).
+pub(crate) fn on_error_applies(on_error: &OnError, error: &TaskErrorRecord) -> bool {
+    on_error.on_codes.is_empty() || on_error.on_codes.iter().any(|c| c.value == error.code)
+}
+
+impl<S, T, H, P, D, C> crate::Runtime<S, T, H, P, D, C>
+where
+    S: nika_kernel::process::ShellRunDyn + Sync,
+    T: nika_kernel::tool_executor::ToolExecuteDyn,
+    H: nika_kernel::http::HttpPostDyn + Send + Sync + 'static,
+    P: nika_kernel::ai::provider::ProviderInferDyn + nika_kernel::ai::provider::ProviderMeta,
+    D: nika_kernel::ai::tool_defs::ToolDefinitionProviderDyn,
+    C: nika_kernel::clock::ClockDyn + Sync,
+{
+    /// The attempt loop — `retry:` (transient-only · `on_codes` filter ·
+    /// full-jitter backoff via the clock seam) racing the task's ONE
+    /// `timeout:` budget (spec 03 · "including any retries and their
+    /// backoff sleeps") · then `on_error:` (spec 05).
+    /// One failed attempt's debit + retry decision (spec 05) — split out
+    /// of `attempt_loop` for the 100-line fn ratchet · the error rides
+    /// the `FailedOutcome` when the policy admits no more.
+    // REASON: the retry decision reads the task + the dispatch + the
+    // ledger + the spend fold + the attempt counters — the loop's own seam.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn failed_attempt_delay(
+        &self,
+        task: &RawTask,
+        failed: crate::dispatch::FailedDispatch,
+        ledger: &crate::ledger::RunLedger,
+        failed_cost: &mut Option<f64>,
+        failed_unpriced: &mut Option<nika_types::cost::UnpricedReason>,
+        attempt: u32,
+        max_attempts: u32,
+        jitter_key: &str,
+    ) -> Result<u64, FailedOutcome> {
+        // Debits PER ATTEMPT — a retry storm is never invisible.
+        let error = failed.debit_and_fold(ledger, failed_cost, failed_unpriced);
+        // Retry iff attempts remain AND the policy admits (spec 05).
+        let Some(delay) = self.retry_delay(task, &error, attempt, max_attempts, jitter_key) else {
+            return Err(FailedOutcome::new(error, *failed_cost, *failed_unpriced));
+        };
+        Ok(delay)
+    }
+
+    /// The retry decision — `Some(delay_ms)` when attempts remain AND
+    /// the policy admits the error (spec 05 · the config is present by
+    /// construction past the gate) · `None` = the failure is final.
+    fn retry_delay(
+        &self,
+        task: &RawTask,
+        error: &TaskErrorRecord,
+        attempt: u32,
+        max_attempts: u32,
+        jitter_key: &str,
+    ) -> Option<u64> {
+        let eligible = attempt < max_attempts && retry_eligible(task, error);
+        let cfg = task.retry.as_ref().filter(|_| eligible).map(|r| &r.value)?;
+        Some(delay_ms(
+            cfg,
+            attempt,
+            rand_unit(self.config.jitter_seed, jitter_key, attempt),
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/crates/nika-runtime/src/settle.rs
+++ b/crates/nika-runtime/src/settle.rs
@@ -260,8 +260,8 @@ fn emit_retry_history(
 }
 
 /// The Ran preamble (NEP-0004 law 5 · the declassify door BEFORE the
-/// attempt history · retries · the agent loop's decisions ADR-096) —
-/// split for the 100-line fn ratchet.
+/// attempt history · then the NEP-0007 permit witness · retries · the
+/// agent loop's decisions ADR-096) — split for the 100-line fn ratchet.
 fn emit_ran_preamble(
     id: &str,
     declassified: &[task::DeclassifyEvidence],
@@ -270,8 +270,35 @@ fn emit_ran_preamble(
     sink: &mut dyn EventSink,
 ) {
     emit_declassified(id, declassified, stamper, sink);
+    emit_permit_checked(id, &run.decisions, stamper, sink);
     emit_retry_history(id, &run.retries, stamper, sink);
     agent_events::emit_agent_events(id, &run.agent_events, stamper, sink);
+}
+
+/// Emit one `permit_checked` frame per dispatch-boundary decision
+/// (NEP-0007 law 2 · spec 17 §the permit witness): granted and refused
+/// alike, between `task_started` and the terminal frame — the hash
+/// chain binds the exercised authority to the task that exercised it.
+fn emit_permit_checked(
+    id: &str,
+    decisions: &[crate::witness::PermitDecision],
+    stamper: &mut dyn Stamper,
+    sink: &mut dyn EventSink,
+) {
+    for d in decisions {
+        emit(
+            stamper,
+            sink,
+            EventKind::PermitChecked,
+            &[
+                ("task", s(id)),
+                ("plane", s(d.plane)),
+                ("gate", s(&d.gate)),
+                ("decision", s(d.decision)),
+                ("why", s(&d.why)),
+            ],
+        );
+    }
 }
 
 pub(crate) fn settle_ran(

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -22,15 +22,18 @@ use nika_kernel::http::HttpPostDyn;
 use nika_kernel::process::ShellRunDyn;
 use nika_kernel::tool_executor::ToolExecuteDyn;
 use nika_schema::raw::{ForEachValue, RawAction, RawTask};
-use nika_schema::types::{OnError, OnErrorAction, Permits, WhenGate};
+use nika_schema::types::{OnErrorAction, Permits, WhenGate};
 use serde_json::Value;
 
 use crate::Runtime;
+use crate::dispatch::DispatchCtx;
 use crate::dispatch::DispatchOk;
 use crate::errors::RuntimeError;
 use crate::expr::{self, Scope};
 use crate::record::{TaskErrorRecord, TaskRecord, TaskStatus};
-use crate::retry::{delay_ms, rand_unit};
+use crate::retry::jitter_key;
+pub(crate) use crate::retry::on_error_applies;
+use crate::witness::PermitWitness;
 
 mod fan_out;
 
@@ -168,6 +171,9 @@ pub(crate) struct RanTask {
     /// attempt a timeout cut short (the buffer lives OUTSIDE the
     /// cancellable region — review F1).
     pub agent_events: Vec<crate::agent_events::StampedAgentEvent>,
+    /// The dispatch boundary's permit decisions across attempts (NEP-0007
+    /// law 2 · spec 17) — one `permit_checked` frame each at settle.
+    pub decisions: Vec<crate::witness::PermitDecision>,
     /// Clock-measured wall time across attempts + cleanup (0 under a
     /// mock clock · real under the production clock — the event-stream
     /// determinism contract is "deterministic seams in · deterministic
@@ -215,7 +221,7 @@ type ValueBags<'a> = (
 );
 
 impl FailedOutcome {
-    fn new(
+    pub(crate) fn new(
         record: TaskErrorRecord,
         cost_usd: Option<f64>,
         cost_unpriced: Option<nika_types::cost::UnpricedReason>,
@@ -584,7 +590,10 @@ where
             permits,
         };
         let started = self.clock.now();
-        let mut ran = self.attempt_loop(task, &scope, types, ledger).await;
+        let witness = PermitWitness::new();
+        let mut ran = self
+            .attempt_loop(task, &scope, types, ledger, &witness)
+            .await;
         // `on_finally:` — the task STARTED (spec 03 · success AND
         // failure · before the failure propagates in the DAG).
         self.run_finally(task, &scope, &ran, integrity).await;
@@ -677,6 +686,7 @@ where
             note: format!("for_each · {total} items"),
             retries,
             agent_events,
+            decisions: acc.decisions,
             duration_ms: 0,
             result,
         };
@@ -743,6 +753,7 @@ where
                     note: format!("for_each[{}]", locals.index),
                     retries: Vec::new(),
                     agent_events: Vec::new(),
+                    decisions: Vec::new(),
                     duration_ms: 0,
                     result: RunResult::Failed {
                         error: runtime_error_record(&err),
@@ -763,7 +774,10 @@ where
             index: Some(locals.index),
             permits,
         };
-        let mut ran = self.attempt_loop(task, &scope, types, ledger).await;
+        let witness = PermitWitness::new();
+        let mut ran = self
+            .attempt_loop(task, &scope, types, ledger, &witness)
+            .await;
         // Stamp the lane: without it a 2-iteration fan-out and a retried
         // single lane produce indistinguishable flat streams (review F3).
         #[allow(clippy::cast_possible_truncation)] // fan-out ≪ u32::MAX
@@ -773,42 +787,13 @@ where
         ran
     }
 
-    /// The attempt loop — `retry:` (transient-only · `on_codes` filter ·
-    /// full-jitter backoff via the clock seam) racing the task's ONE
-    /// `timeout:` budget (spec 03 · "including any retries and their
-    /// backoff sleeps") · then `on_error:` (spec 05).
-    /// One failed attempt's debit + retry decision (spec 05) — split out
-    /// of `attempt_loop` for the 100-line fn ratchet · the error rides
-    /// the `FailedOutcome` when the policy admits no more.
-    // REASON: the retry decision reads the task + the dispatch + the
-    // ledger + the spend fold + the attempt counters — the loop's own seam.
-    #[allow(clippy::too_many_arguments)]
-    fn failed_attempt_delay(
-        &self,
-        task: &RawTask,
-        failed: crate::dispatch::FailedDispatch,
-        ledger: &crate::ledger::RunLedger,
-        failed_cost: &mut Option<f64>,
-        failed_unpriced: &mut Option<nika_types::cost::UnpricedReason>,
-        attempt: u32,
-        max_attempts: u32,
-        jitter_key: &str,
-    ) -> Result<u64, FailedOutcome> {
-        // Debits PER ATTEMPT — a retry storm is never invisible.
-        let error = failed.debit_and_fold(ledger, failed_cost, failed_unpriced);
-        // Retry iff attempts remain AND the policy admits (spec 05).
-        let Some(delay) = self.retry_delay(task, &error, attempt, max_attempts, jitter_key) else {
-            return Err(FailedOutcome::new(error, *failed_cost, *failed_unpriced));
-        };
-        Ok(delay)
-    }
-
     async fn attempt_loop(
         &self,
         task: &RawTask,
         scope: &Scope<'_>,
         types: &BTreeMap<String, nika_types::types::NikaType>,
         ledger: &crate::ledger::RunLedger,
+        witness: &PermitWitness,
     ) -> RanTask {
         let started = self.clock.now();
         let max_attempts = task
@@ -818,8 +803,7 @@ where
         let jitter_key = jitter_key(task, scope);
         let mut note = String::new();
         let mut retries: Vec<RetryStamp> = Vec::new();
-        // OUTSIDE the timeout-cancellable region: a timed-out attempt's
-        // decisions survive the drop of the attempt future (review F1).
+        // Outside the timeout-cancellable region — survives the attempt's drop (review F1).
         let agent_buffer = crate::agent_events::BufferingObserver::new();
         let mut attempt_marks: Vec<usize> = Vec::new();
         let outcome = {
@@ -827,13 +811,10 @@ where
             let budget = task.timeout.as_ref().map(|t| t.value);
             // The `returns:` contract, resolved ONCE (spec 09 · W3) — `None` = gradual.
             let contract = crate::contract::TaskContract::of(task, types);
-            // F-O1 PR-2 · the re-gate's per-template oracle — computed ONCE
-            // (a static walk over the task's own templates + the wave-frozen
-            // records; iteration-agnostic), consumed per dispatch attempt.
+            // F-O1 PR-2 · the re-gate's per-template oracle — computed ONCE, used per attempt.
             let value_taint = crate::integrity::ValueTaint::of_task(task, scope.records);
             // law 6 · the child budget reads the ledger AT CALL TIME (per attempt).
-            let ctx =
-                || crate::dispatch::DispatchCtx::of_task(task, budget, ledger.remaining_usd());
+            let ctx = || DispatchCtx::of_task(task, budget, ledger.remaining_usd(), witness);
             let attempts = async {
                 let mut attempt = 1_u32;
                 // Spend of FAILED attempts — folded onto the terminal frame.
@@ -899,29 +880,10 @@ where
                 agent_buffer.into_events(),
                 &attempt_marks,
             ),
+            decisions: witness.take(),
             duration_ms,
             result,
         }
-    }
-
-    /// The retry decision — `Some(delay_ms)` when attempts remain AND
-    /// the policy admits the error (spec 05 · the config is present by
-    /// construction past the gate) · `None` = the failure is final.
-    fn retry_delay(
-        &self,
-        task: &RawTask,
-        error: &TaskErrorRecord,
-        attempt: u32,
-        max_attempts: u32,
-        jitter_key: &str,
-    ) -> Option<u64> {
-        let eligible = attempt < max_attempts && retry_eligible(task, error);
-        let cfg = task.retry.as_ref().filter(|_| eligible).map(|r| &r.value)?;
-        Some(delay_ms(
-            cfg,
-            attempt,
-            rand_unit(self.config.jitter_seed, jitter_key, attempt),
-        ))
     }
 
     /// Race the attempt future against the task's ONE `timeout:` budget
@@ -978,21 +940,6 @@ where
             .now()
             .checked_duration_since(started)
             .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-    }
-}
-
-/// The jitter stream selector — fan-out iterations get DISTINCT
-/// streams (anti-thundering-herd applies WITHIN a fan-out too ·
-/// Brooker 2015: same-task iterations retrying the same upstream
-/// must not synchronize) while staying replay-stable (the index
-/// is part of the deterministic coordinates). Collision-free: task
-/// ids are `snake_case` (checker law · CEL-safe) so `[` can never
-/// appear in a real id — iteration `t[0]` can't collide with a task
-/// NAMED `t[0]`.
-fn jitter_key(task: &RawTask, scope: &Scope<'_>) -> String {
-    match scope.index {
-        Some(i) => format!("{}[{i}]", task.id.value),
-        None => task.id.value.clone(),
     }
 }
 
@@ -1417,25 +1364,6 @@ fn apply_on_error(task: &RawTask, scope: &Scope<'_>, failed: FailedOutcome) -> R
             cost_unpriced,
         },
     }
-}
-
-/// `retry:` eligibility (spec 05 · transient-only unless `on_codes`).
-fn retry_eligible(task: &RawTask, error: &TaskErrorRecord) -> bool {
-    let Some(retry) = task.retry.as_ref() else {
-        return false;
-    };
-    if retry.value.on_codes.is_empty() {
-        error.transient
-    } else {
-        retry.value.on_codes.iter().any(|c| c == &error.code)
-    }
-}
-
-/// `on_error.on_codes` filter (spec 05 · empty = applies to all).
-/// `pub(crate)`: the ADR-099 pause rider consults it too (an authored
-/// route for PROMPT-001 wins over the pause).
-pub(crate) fn on_error_applies(on_error: &OnError, error: &TaskErrorRecord) -> bool {
-    on_error.on_codes.is_empty() || on_error.on_codes.iter().any(|c| c.value == error.code)
 }
 
 /// Render the task's `with:` map (spec 03 · per-iteration in fan-out ·

--- a/crates/nika-runtime/src/task/fan_out.rs
+++ b/crates/nika-runtime/src/task/fan_out.rs
@@ -64,6 +64,8 @@ pub(super) struct FanOutAccum {
     pub(super) retries: Vec<RetryStamp>,
     /// The agent decisions across all iterations, in order.
     pub(super) agent_events: Vec<crate::agent_events::StampedAgentEvent>,
+    /// NEP-0007 · the per-lane permit decisions, folded in lane order.
+    pub(super) decisions: Vec<crate::witness::PermitDecision>,
     /// The FIRST iteration error (the one the task reports on failure).
     pub(super) first_error: Option<TaskErrorRecord>,
     /// Per-iteration token spend SUMMED onto the parent (a 50-infer fan-out
@@ -89,6 +91,7 @@ where
         outputs: Vec::with_capacity(total),
         retries: Vec::new(),
         agent_events: Vec::new(),
+        decisions: Vec::new(),
         first_error: None,
         tokens_sum: None,
         cost_sum: None,
@@ -98,6 +101,7 @@ where
     while let Some(iter_ran) = stream.next().await {
         acc.retries.extend(iter_ran.retries);
         acc.agent_events.extend(iter_ran.agent_events);
+        acc.decisions.extend(iter_ran.decisions);
         match iter_ran.result {
             // OBS-E `warning` is per-call · a fan-out element's diagnostic
             // is not aggregated up (only `value` + `tokens` fold).

--- a/crates/nika-runtime/src/task/finally.rs
+++ b/crates/nika-runtime/src/task/finally.rs
@@ -150,6 +150,11 @@ where
         // `with:`/`for_each` — the records + inputs lookups still label
         // a tainted cleanup argv/arg · F-O1 PR-2).
         let value_taint = crate::integrity::ValueTaint::bare();
+        // NEP-0007 · the cleanup lane records its decisions too, into a
+        // lane-local witness the settle of the PARENT does not carry
+        // (the finally frames are best-effort · the residual is named
+        // in the witness module doc).
+        let finally_witness = crate::witness::PermitWitness::new();
         let attempt = std::pin::pin!(self.dispatch(
             &mini.action,
             scope,
@@ -165,6 +170,7 @@ where
                 // a finally mini-task carries no inert: door (NEP-0006)
                 // — a code-bearing cleanup fetch refuses like any other.
                 inert: None,
+                witness: &finally_witness,
             },
             None,
         ));

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -215,6 +215,105 @@ async fn code_bearing_fetch_refuses_at_run_and_the_inert_door_opens() {
     }
 }
 
+/// NEP-0007 — the permit witness end to end: every dispatch-boundary
+/// decision becomes ONE `permit_checked` frame between `task_started`
+/// and the terminal — the exec program gate and the env composition on
+/// the allow side; the SAME channel carries the deny when the RUNTIME
+/// gate refuses a check-deferred program (granted and refused alike ·
+/// spec 17 §the permit witness).
+#[tokio::test]
+async fn permit_witness_frames_ride_the_journal() {
+    use nika_kernel::tool_executor::ToolResult;
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::{ProviderRegistry, ProvidersConfig};
+
+    // (allowed, yaml): the allow case is a static echo under its permit;
+    // the deny case derives the program from a task output — the static
+    // judge DEFERS (dynamic command), the runtime gate refuses `curl`.
+    let allow_yaml = "nika: v1\nworkflow:\n  id: witness\npermits:\n  exec: [\"echo\"]\ntasks:\n  stamp:\n    exec: { command: [\"echo\", \"ok\"] }\n";
+    let deny_yaml = "nika: v1\nworkflow:\n  id: witness\npermits:\n  exec: [\"echo\"]\n  tools: [\"nika:jq\"]\ntasks:\n  name:\n    invoke:\n      tool: \"nika:jq\"\n      args: { input: \"curl ok\", expression: \".\" }\n  stamp:\n    with: { c: \"${{ tasks.name.output }}\" }\n    exec: { command: [\"${{ with.c }}\", \"ok\"] }\n";
+    for (allowed, yaml) in [(true, allow_yaml), (false, deny_yaml)] {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        let report = nika_check::check(&wf);
+        assert!(report.is_clean(), "both shapes defer to run: {report:?}");
+        let executor = MockToolExecutor::new().enqueue_ok(ToolResult::success("tc1", "curl ok"));
+        let invoke = Arc::new(InvokeVerb::new(Arc::new(executor)));
+        let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+        let runtime = Runtime::new(
+            ExecVerb::new(Arc::new(MockShell::new().enqueue_ok("ok"))),
+            Arc::clone(&invoke),
+            InferVerb::new(registry, "mock/echo"),
+            AgentVerb::new(
+                Arc::new(MockProvider::new("mock")),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "mock/echo",
+            ),
+            MockClock::new(),
+            RuntimeConfig::default().with_sandbox_root(std::path::PathBuf::from("/repo")),
+        );
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let outcome = runtime.run(&wf, &report, &mut stamper, &mut sink).await;
+        let outcome = outcome.expect("the run completes either way");
+        assert_eq!(outcome.ok, allowed, "the gate decides the run");
+
+        let events = sink.events();
+        let field = |e: &nika_event::Event, key: &str| -> String {
+            e.fields
+                .iter()
+                .find(|f| f.key == key)
+                .map(|f| match &f.value {
+                    FieldValue::String(s) => s.clone(),
+                    other => format!("{other:?}"),
+                })
+                .unwrap_or_default()
+        };
+        let witness: Vec<(String, String)> = events
+            .iter()
+            .filter(|e| e.kind == EventKind::PermitChecked)
+            .map(|e| (field(e, "plane"), field(e, "decision")))
+            .collect();
+        if allowed {
+            assert!(
+                witness.contains(&("exec".to_owned(), "allow".to_owned())),
+                "the exec program gate witnesses its allow: {witness:?}"
+            );
+            assert!(
+                witness.iter().any(|(p, d)| p == "env" && d == "allow"),
+                "the env composition witnesses the passed names: {witness:?}"
+            );
+        } else {
+            assert!(
+                witness.contains(&("exec".to_owned(), "deny".to_owned())),
+                "the refused gate rides the SAME channel: {witness:?}"
+            );
+        }
+        // Position law (spec 17): the frames land between task_started
+        // and the terminal.
+        let kinds: Vec<EventKind> = events.iter().map(|e| e.kind).collect();
+        let started = kinds
+            .iter()
+            .position(|k| *k == EventKind::TaskStarted)
+            .expect("a task_started frame");
+        let first_witness = kinds
+            .iter()
+            .position(|k| *k == EventKind::PermitChecked)
+            .expect("at least one permit_checked frame");
+        assert!(
+            started < first_witness,
+            "witness frames follow task_started"
+        );
+    }
+}
+
 /// NEP-0005 — the declared `permits.env:` passthrough rides every exec
 /// command to the spawn site (which composes floor ∪ these names ∪ the
 /// authored map from a cleared slate), and the authored task `env:` map
@@ -625,6 +724,7 @@ fn declared_output_types_fit_lenient_floats_strict_cross_type() {
 #[test]
 fn recovered_success_emits_task_recovered_before_completed() {
     let ran = task::RanTask {
+        decisions: Vec::new(),
         note: "exec · sh".to_owned(),
         retries: Vec::new(),
         agent_events: Vec::new(),
@@ -683,6 +783,7 @@ fn recovered_success_emits_task_recovered_before_completed() {
 #[test]
 fn obs_e_warning_rides_task_completed() {
     let ran = task::RanTask {
+        decisions: Vec::new(),
         note: "infer · gemini/flash".to_owned(),
         retries: Vec::new(),
         agent_events: Vec::new(),
@@ -743,6 +844,7 @@ fn obs_e_warning_rides_task_completed() {
 #[test]
 fn no_warning_field_on_a_clean_success() {
     let ran = task::RanTask {
+        decisions: Vec::new(),
         note: "exec · true".to_owned(),
         retries: Vec::new(),
         agent_events: Vec::new(),
@@ -796,6 +898,7 @@ fn no_warning_field_on_a_clean_success() {
 #[test]
 fn cost_unpriced_reason_rides_task_completed() {
     let ran = task::RanTask {
+        decisions: Vec::new(),
         note: "infer · ollama/llama3.2".to_owned(),
         retries: Vec::new(),
         agent_events: Vec::new(),

--- a/crates/nika-runtime/src/witness.rs
+++ b/crates/nika-runtime/src/witness.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The permit-decision witness (NEP-0007 law 2 · spec 17 §the permit
+//! witness) — every decision taken at the DISPATCH boundary is recorded
+//! here during the attempt and emitted as one `permit_checked` frame per
+//! decision at settle, between `task_started` and the terminal frame
+//! (the hash chain binds the decisions to the task that took them).
+//!
+//! Granted decisions are witnessed, not only refusals: an auditor
+//! reconstructs WHAT authority was exercised. The v1 planes are the
+//! dispatch-visible gates (exec program · tool grant · the NEP-0004
+//! re-gate · the NEP-0005 env composition · the NEP-0006 sink); the
+//! per-operation fs/net enforcement decisions live INSIDE the builtin
+//! sinks and their allow-side witness is the DECLARED v1 residual
+//! (NEP-0007 law 2 · a dispatch-side pre-witness could lie against
+//! canonicalize-then-confine).
+//!
+//! The collector is the [`crate::agent_events::BufferingObserver`] twin:
+//! cheap lock + push during the attempt, drained once by the attempt
+//! that created it — telemetry never panics a run.
+
+use std::sync::Mutex;
+
+/// One permit decision (the frame's payload · spec 17).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PermitDecision {
+    /// The plane · `exec` · `tool` · `regate` · `env` · `sink`.
+    pub plane: &'static str,
+    /// The bound consulted (the program · the tool id · the escaped
+    /// bound · the passed names · the artifact class).
+    pub gate: String,
+    /// `allow` | `deny`.
+    pub decision: &'static str,
+    /// The law applied (the teaching one-liner).
+    pub why: String,
+}
+
+/// Collects one attempt's permit decisions (lock + push · drained by
+/// the attempt that created it).
+#[derive(Debug, Default)]
+pub(crate) struct PermitWitness {
+    decisions: Mutex<Vec<PermitDecision>>,
+}
+
+impl PermitWitness {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one decision (poisoning recovers — the witness must never
+    /// panic a run; a poisoned lock keeps the earlier decisions).
+    pub(crate) fn record(
+        &self,
+        plane: &'static str,
+        gate: impl Into<String>,
+        decision: &'static str,
+        why: impl Into<String>,
+    ) {
+        let entry = PermitDecision {
+            plane,
+            gate: gate.into(),
+            decision,
+            why: why.into(),
+        };
+        match self.decisions.lock() {
+            Ok(mut d) => d.push(entry),
+            Err(poisoned) => poisoned.into_inner().push(entry),
+        }
+    }
+
+    /// Take the buffered decisions (once · at attempt end).
+    pub(crate) fn take(&self) -> Vec<PermitDecision> {
+        match self.decisions.lock() {
+            Ok(mut d) => std::mem::take(&mut *d),
+            Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_take_roundtrip_and_take_drains() {
+        let w = PermitWitness::new();
+        w.record("tool", "nika:fetch", "allow", "permits.tools covers it");
+        w.record("exec", "rm", "deny", "not in the program allowlist");
+        let taken = w.take();
+        assert_eq!(taken.len(), 2);
+        assert_eq!(taken[0].plane, "tool");
+        assert_eq!(taken[0].decision, "allow");
+        assert_eq!(taken[1].decision, "deny");
+        assert!(w.take().is_empty(), "take drains");
+    }
+}

--- a/crates/nika-runtime/tests/floor.rs
+++ b/crates/nika-runtime/tests/floor.rs
@@ -692,8 +692,10 @@ async fn stress_deep_chain_threads_bindings_in_order() {
 
     assert!(outcome.ok);
     assert_eq!(outcome.records.len(), DEPTH, "every link recorded");
-    // Event arithmetic · 1 started + N scheduled + N×(started+completed) + 1 terminal.
-    assert_eq!(events.len(), 1 + DEPTH + 2 * DEPTH + 1);
+    // Event arithmetic · 1 started + N scheduled + N×(started + the
+    // NEP-0007 witness pair [exec gate + env composition] + completed)
+    // + 1 terminal.
+    assert_eq!(events.len(), 1 + DEPTH + 4 * DEPTH + 1);
     // Strict chain order · TaskStarted frames appear exactly t0..t23.
     let started: Vec<String> = storyboard(&events)
         .into_iter()

--- a/crates/nika-runtime/tests/snapshots/floor__floor_happy_path_storyboard.snap
+++ b/crates/nika-runtime/tests/snapshots/floor__floor_happy_path_storyboard.snap
@@ -10,14 +10,18 @@ expression: lines
 - "TaskScheduled · write_out · "
 - "TaskScheduled · notify · "
 - "TaskStarted · gather · invoke · nika:read"
+- "PermitChecked · gather · "
 - "TaskCompleted · gather · invoke · nika:read"
 - TaskStarted · probe · exec · wc
+- "PermitChecked · probe · "
+- "PermitChecked · probe · "
 - TaskCompleted · probe · exec · wc
 - TaskStarted · extract · infer · mock/echo
 - TaskCompleted · extract · infer · mock/echo
 - TaskStarted · think · infer · mock/echo
 - TaskCompleted · think · infer · mock/echo
 - "TaskStarted · write_out · invoke · nika:write"
+- "PermitChecked · write_out · "
 - "TaskCompleted · write_out · invoke · nika:write"
 - "TaskSkipped · notify · when: closed (post-gate)"
 - "WorkflowCompleted ·  · "


### PR DESCRIPTION
**Lane F-O6 · « jugé = exécuté = attesté » (invariant 4) · the engine leg.** Spec counterparts merged: nika-spec#184 (chapter 17-trace · NEP-0007 · LAW-AUTH-0328 · trace contracts) + nika-spec#187 (fixtures engine-proven · the witnessed golden).

## The witness (NEP-0007 law 2)
- `EventKind::PermitChecked` — reserved-never-emitted since ADR-092 — is WIRED. A per-attempt collector (`witness.rs`) rides `DispatchCtx` into every dispatch-boundary gate and records **granted AND refused alike**: exec program gate · tool grant · agent tools · the data-as-code sink run twin (NEP-0006) · the taint re-gate argv/cwd/mcp (NEP-0004) · the env composition (NEP-0005 · the passed names ARE the authority).
- Frames drain through `RanTask.decisions` and emit between `task_started` and the terminal (fields `task/plane/gate/decision/why`) — threaded through fan-out, finally, recover parks/resumes. `trace_format` stays 2 (one more kind · additive).

## trace verify (NEP-0007 law 3)
- An effectful chain-intact journal with ZERO `permit_checked` frames → **FINDING** line at exit OK · never FORGED · never a crash.

## The equivalence oracle (invariant 4, checkable)
`check_run_equivalence.rs` replays the conformance corpus through BOTH evaluators **at the real binary**:
- **static-red never executes** — every invalid `core/authority` fixture: refusal PRE-PROLOGUE (zero task frames) voicing the judged code
- **defer contract** — every `runtime/permits` fixture: check-CLEAN, then real-run terminals (status · code · output substance) vs `expected-run.json`
- **executed ⇒ attested** — effectful runs carry their witness frames
- **e_diff runtime legs fs/net LANDED** (the named follow-on from `e_diff_soundness.rs`) — real builtin sinks at the real binary (fs lattice under tempdir · net deny+floor sides · allow-side dial = declared residual)
- `trace_witness_conformance.rs` replays the spec `runtime/trace` contracts (clean/finding/forged) — expectations READ from fixtures

Coverage is **DERIVED** (each leg prints families × legs at execution). The suite caught and drove the spec-side fixes in #187 (both shell probe forms refused by the exec floor · the honest printenv pair).

## Pin
`SPEC_PIN` → `bcb3fbb7b5dc52f05dc22796125d9d56ec6c007b` · pack re-vendored (`17-trace.md` new · `00-overview` row 17).

## Proof
Battery **4794 lib tests** green · clippy 0 (workspace, all targets) · fn ≤100 · files ≤1500 · pre-push gate 8/8 ratchets · equivalence suites 4/4 + trace conformance 1/1 at the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)