### PR TITLE
fix(cap,schema): close the 4 edge cases the red team found

### DIFF
--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-ffc9389f442ebac18b8a266ef85c203dc2c401cb
+1553eb95f10d829ef40a881df1f39420d050fe3c

--- a/crates/nika-cap/src/env.rs
+++ b/crates/nika-cap/src/env.rs
@@ -52,19 +52,28 @@ pub const DANGEROUS_ENV_VARS: &[&str] = &[
     "GIT_PROXY_COMMAND", // config-driven git RCE (P2)
     "GIT_CONFIG_GLOBAL", // point git at an attacker config (core.pager/fsmonitor)
     "GIT_CONFIG_SYSTEM",
-    "GIT_TEMPLATE_DIR", // attacker hooks copied into a new repo
-    "LESSOPEN",         // pager-input-preprocess command injection (P2)
-    "HOSTALIASES",      // attacker file read during hostname resolution (P2)
-    "TERMINFO",         // load a crafted terminfo entry (P2)
-    "TERMINFO_DIRS",    // terminfo search-path override (P2)
-    "TERMCAP",          // crafted termcap string executed by some pagers (P2)
+    "GIT_CONFIG_PARAMETERS", // inline config (core.pager) with no file at all (O4-A)
+    "GIT_CONFIG_COUNT",      // the enumerated form of the same inline class (O4-A)
+    "GIT_TEMPLATE_DIR",      // attacker hooks copied into a new repo
+    "LESSOPEN",              // pager-input-preprocess command injection (P2)
+    "HOSTALIASES",           // attacker file read during hostname resolution (P2)
+    "TERMINFO",              // load a crafted terminfo entry (P2)
+    "TERMINFO_DIRS",         // terminfo search-path override (P2)
+    "TERMCAP",               // crafted termcap string executed by some pagers (P2)
     // Interpreter pre-exec hooks.
     "PYTHONSTARTUP",
     "PYTHONPATH", // inject a module into any python that imports (P2)
     "PERL5OPT",
     "PERL5LIB",
     "RUBYOPT",
+    "RUBYLIB", // ruby search-path override (O4-A)
     "NODE_OPTIONS",
+    "NODE_PATH",            // node module search-path override (O4-A)
+    "JAVA_TOOL_OPTIONS",    // JVM -agentlib/-agentpath hook (O4-A)
+    "_JAVA_OPTIONS",        // the same class, honored even when the other is set (O4-A)
+    "DOTNET_STARTUP_HOOKS", // .NET startup hook assembly (O4-A)
+    "OPENSSL_CONF",         // OpenSSL config → module load (O4-A)
+    "OPENSSL_MODULES",      // OpenSSL provider search path (O4-A)
     // Field-splitting injection for shell-mode commands.
     "IFS",
 ];
@@ -193,6 +202,25 @@ mod tests {
         assert!(!env.contains_key("BASH_ENV"));
         assert!(is_dangerous_env_name("LD_PRELOAD"));
         assert!(!is_dangerous_env_name("CI_COMMIT_SHA"));
+    }
+
+    #[test]
+    fn the_o4_a_inline_config_class_is_dangerous() {
+        // O4-A · the same-RCE-with-no-file class (red team 2026-07-23):
+        // inline git config + the interpreter pre-exec hooks join the floor.
+        for name in [
+            "GIT_CONFIG_PARAMETERS",
+            "GIT_CONFIG_COUNT",
+            "JAVA_TOOL_OPTIONS",
+            "_JAVA_OPTIONS",
+            "DOTNET_STARTUP_HOOKS",
+            "RUBYLIB",
+            "NODE_PATH",
+            "OPENSSL_CONF",
+            "OPENSSL_MODULES",
+        ] {
+            assert!(is_dangerous_env_name(name), "{name} must be on the floor");
+        }
     }
 
     #[test]

--- a/crates/nika-cap/src/sink.rs
+++ b/crates/nika-cap/src/sink.rs
@@ -47,6 +47,13 @@ const CODE_BEARING_CLASSES: &[ClassRow] = &[
 #[must_use]
 pub fn code_bearing_path_class(path: &str) -> Option<(&'static str, &'static str)> {
     let segment = path.rsplit('/').next().unwrap_or(path);
+    // O7-A · the encoded-extension bypass (red-team 2026-07-23): the
+    // verdict reads the DECODED final segment exactly once — the same
+    // single decode URI normalizers apply (RFC 3986 §2.3), so
+    // `legacy%2epkl` classifies like `legacy.pkl` and double-encoded
+    // `%252e` stays inert (the origin decodes once too).
+    let segment = percent_decode_once(segment);
+    let segment = segment.as_str();
     let dot = segment.rfind('.')?;
     let ext = &segment[dot..];
     for (class, exts) in CODE_BEARING_CLASSES {
@@ -57,7 +64,47 @@ pub fn code_bearing_path_class(path: &str) -> Option<(&'static str, &'static str
             return Some((class, hit));
         }
     }
+    // O7-B · the versioned native form (red-team 2026-07-23): `lib.so.1.2`
+    // IS the on-disk shape dlopen loads — strip trailing `.N` groups and
+    // re-match the native class only (a versioned script name like
+    // `model.pt.2` is not a convention and stays out).
+    let base = segment.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.');
+    if base.len() != segment.len() {
+        let dot = base.rfind('.')?;
+        let ext = &base[dot..];
+        if let Some((class, exts)) = CODE_BEARING_CLASSES
+            .iter()
+            .find(|(class, _)| *class == "executable binary/module")
+            && let Some(hit) = exts
+                .iter()
+                .find(|candidate| candidate.eq_ignore_ascii_case(ext))
+        {
+            return Some((class, hit));
+        }
+    }
     None
+}
+
+/// Decode the `%XX` octets of a path segment ONCE (best-effort · an
+/// invalid triplet is left as-is, matching URI normalizer posture).
+fn percent_decode_once(segment: &str) -> String {
+    let bytes = segment.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push(u8::try_from((hi << 4) | lo).unwrap_or_default());
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 #[cfg(test)]
@@ -97,6 +144,42 @@ mod tests {
         ] {
             assert_eq!(code_bearing_path_class(p), None, "{p}");
         }
+    }
+
+    #[test]
+    fn the_encoded_extension_decodes_once() {
+        // O7-A · the bypass the red team found: an encoded extension is
+        // the same verdict as the decoded one (one decode, like the
+        // origin's resolver).
+        assert_eq!(
+            code_bearing_path_class("/models/legacy%2epkl"),
+            Some(("serialized-executable", ".pkl"))
+        );
+        assert_eq!(
+            code_bearing_path_class("/dl/setup%2esh"),
+            Some(("script/interpreter", ".sh"))
+        );
+        // A double-encoded octet stays inert (the origin decodes once too).
+        assert_eq!(code_bearing_path_class("/models/legacy%252epkl"), None);
+        // A malformed triplet is left as-is (no crash · no verdict).
+        assert_eq!(code_bearing_path_class("/models/legacy%2pkl"), None);
+    }
+
+    #[test]
+    fn the_versioned_native_matches_its_class_only() {
+        // O7-B · the on-disk dlopen form.
+        assert_eq!(
+            code_bearing_path_class("/lib/libevil.so.1.2.3"),
+            Some(("executable binary/module", ".so"))
+        );
+        assert_eq!(
+            code_bearing_path_class("/lib/native.dylib.4"),
+            Some(("executable binary/module", ".dylib"))
+        );
+        // The strip never rescues a NON-native class (a versioned script
+        // name is not a convention).
+        assert_eq!(code_bearing_path_class("/models/model.pt.2"), None);
+        assert_eq!(code_bearing_path_class("/dl/setup.sh.2"), None);
     }
 
     #[test]

--- a/crates/nika-schema/src/parser/inert.rs
+++ b/crates/nika-schema/src/parser/inert.rs
@@ -36,7 +36,7 @@ pub(super) fn parse_inert(
         });
     };
     let value = scalar.as_str().to_owned();
-    if value.is_empty() {
+    if value.trim().is_empty() {
         return Err(SchemaError::Validation {
             message: format!(
                 "`inert` on {task_label} is empty — the because IS the substance of the door \
@@ -65,6 +65,17 @@ mod tests {
             task.inert.as_ref().map(|s| s.value.as_str()),
             Some("archived for provenance")
         );
+    }
+
+    #[test]
+    fn inert_whitespace_only_is_refused_too() {
+        // O7-E · the door needs a real because, not spaces (red team
+        // 2026-07-23 · `inert: " "` used to pass the non-empty check).
+        let yaml = format!(
+            "{BASE}tasks:\n  grab:\n    invoke:\n      tool: \"nika:fetch\"\n      args: {{ url: \"https://data.example.com/a.csv\" }}\n    inert: \"   \"\n"
+        );
+        let err = parse(&yaml, FileId::new(0), ParseMode::Strict).expect_err("refused");
+        assert!(err.to_string().contains("inert"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
The adversarial sweep found 4 edge cases after the F-O7/F-O4 merges: the encoded-extension sink bypass (%2epkl ≡ .pkl after the origin's single decode) · the versioned native form (lib.so.1.2.3 = dlopen's on-disk shape) · a whitespace-only inert door · the incomplete DANGEROUS env list (inline git config + interpreter pre-exec hooks). One decode, one strip, one trim, nine names · tests green · clippy clean · conformance 023/024 at the spec (#191).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>