### PR TITLE
fix(cap,runtime): the final review's two catches (decode-then-trim + finally attestation)

### DIFF
--- a/crates/nika-cap/src/sink.rs
+++ b/crates/nika-cap/src/sink.rs
@@ -46,18 +46,17 @@ const CODE_BEARING_CLASSES: &[ClassRow] = &[
 /// for the unbounded inert world.
 #[must_use]
 pub fn code_bearing_path_class(path: &str) -> Option<(&'static str, &'static str)> {
-    // O7-C · a trailing slash or dot is a display artifact, not a class
-    // change (`/setup.sh/` and `/setup.sh.` are the same fetch of the
-    // same artifact — the edge case blade, 2026-07-23).
-    let path = path.trim_end_matches(['/', '.']);
+    // O7-A + O7-C · the order IS the law (the final review 2026-07-23):
+    // trailing slashes are a path-structure artifact (trimmed first),
+    // then the segment decodes exactly once (RFC 3986 §2.3 · the origin
+    // decodes once too), then the trailing dot is trimmed AFTER decode —
+    // `legacy%2epkl%2e` and the literal `legacy.pkl.` are the SAME
+    // artifact and take the SAME verdict (the composition the first two
+    // passes got wrong).
+    let path = path.trim_end_matches('/');
     let segment = path.rsplit('/').next().unwrap_or(path);
-    // O7-A · the encoded-extension bypass (red-team 2026-07-23): the
-    // verdict reads the DECODED final segment exactly once — the same
-    // single decode URI normalizers apply (RFC 3986 §2.3), so
-    // `legacy%2epkl` classifies like `legacy.pkl` and double-encoded
-    // `%252e` stays inert (the origin decodes once too).
     let segment = percent_decode_once(segment);
-    let segment = segment.as_str();
+    let segment = segment.trim_end_matches('.');
     let dot = segment.rfind('.')?;
     let ext = &segment[dot..];
     for (class, exts) in CODE_BEARING_CLASSES {
@@ -143,6 +142,21 @@ mod tests {
         assert_eq!(
             code_bearing_path_class("/dl/setup.sh."),
             Some(("script/interpreter", ".sh"))
+        );
+    }
+
+    #[test]
+    fn decode_then_trim_is_one_verdict_for_encoded_and_literal() {
+        // The final review's catch: the composition must give the SAME
+        // verdict to the encoded form and the literal form of the same
+        // artifact.
+        assert_eq!(
+            code_bearing_path_class("/models/legacy%2epkl%2e"),
+            Some(("serialized-executable", ".pkl"))
+        );
+        assert_eq!(
+            code_bearing_path_class("/models/legacy.pkl."),
+            Some(("serialized-executable", ".pkl"))
         );
     }
 

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -595,8 +595,13 @@ where
             .attempt_loop(task, &scope, types, ledger, &witness)
             .await;
         // `on_finally:` — the task STARTED (spec 03 · success AND
-        // failure · before the failure propagates in the DAG).
-        self.run_finally(task, &scope, &ran, integrity).await;
+        // failure · before the failure propagates in the DAG). The
+        // cleanup lane's decisions ride a dedicated witness (the
+        // parent's is already drained by attempt_loop) merged right after.
+        let finally_witness = PermitWitness::new();
+        self.run_finally(task, &scope, &ran, integrity, &finally_witness)
+            .await;
+        ran.decisions.extend(finally_witness.take());
         ran.duration_ms = self.since_ms(started);
         SettleAs::Ran(ran)
     }
@@ -694,8 +699,10 @@ where
         // `item`/`index` are NOT in scope there).
         let finally_scope =
             Self::fan_out_finally_scope(records, (inputs, config, consts, secrets), permits);
-        self.run_finally(task, &finally_scope, &ran, integrity)
+        let finally_witness = PermitWitness::new();
+        self.run_finally(task, &finally_scope, &ran, integrity, &finally_witness)
             .await;
+        ran.decisions.extend(finally_witness.take());
         ran.duration_ms = self.since_ms(started);
         SettleAs::Ran(ran)
     }

--- a/crates/nika-runtime/src/task/finally.rs
+++ b/crates/nika-runtime/src/task/finally.rs
@@ -94,6 +94,7 @@ where
         scope: &Scope<'_>,
         ran: &RanTask,
         integrity: &nika_cap::Integrity,
+        witness: &crate::witness::PermitWitness,
     ) {
         if task.on_finally.is_empty() {
             return;
@@ -124,14 +125,21 @@ where
             index: None,
             permits: scope.permits, // on_finally exec stays within the boundary
         };
-        for mini in &task.on_finally {
-            self.run_one_cleanup(&mini.value, &cleanup_scope).await;
+        for (index, mini) in task.on_finally.iter().enumerate() {
+            self.run_one_cleanup(&mini.value, &cleanup_scope, witness, index)
+                .await;
         }
     }
 
     /// One cleanup mini-task · own `when:` + `timeout:` · outcome
     /// swallowed (best-effort semantics · spec 03).
-    async fn run_one_cleanup(&self, mini: &RawFinallyTask, scope: &Scope<'_>) {
+    async fn run_one_cleanup(
+        &self,
+        mini: &RawFinallyTask,
+        scope: &Scope<'_>,
+        witness: &crate::witness::PermitWitness,
+        index: usize,
+    ) {
         if let Some(gate) = mini.when.as_ref() {
             match eval_gate(&gate.value, scope) {
                 Ok(true) => {}
@@ -150,11 +158,17 @@ where
         // `with:`/`for_each` — the records + inputs lookups still label
         // a tainted cleanup argv/arg · F-O1 PR-2).
         let value_taint = crate::integrity::ValueTaint::bare();
-        // NEP-0007 · the cleanup lane records its decisions too, into a
-        // lane-local witness the settle of the PARENT does not carry
-        // (the finally frames are best-effort · the residual is named
-        // in the witness module doc).
-        let finally_witness = crate::witness::PermitWitness::new();
+        // NEP-0007 law 2 (the final review's catch · 2026-07-23): the
+        // cleanup lane's decisions are recorded into the PARENT's
+        // witness — they settle with it as `permit_checked` frames (the
+        // lane-local witness that never drained is retired · the
+        // attestation blind spot is closed).
+        witness.record(
+            "on_finally",
+            format!("cleanup #{index}"),
+            "attempt",
+            "cleanup mini-task starts (spec 03 · best-effort lane)",
+        );
         let attempt = std::pin::pin!(self.dispatch(
             &mini.action,
             scope,
@@ -170,7 +184,7 @@ where
                 // a finally mini-task carries no inert: door (NEP-0006)
                 // — a code-bearing cleanup fetch refuses like any other.
                 inert: None,
-                witness: &finally_witness,
+                witness,
             },
             None,
         ));

--- a/crates/nika-runtime/tests/on_finally.rs
+++ b/crates/nika-runtime/tests/on_finally.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! The `on_finally:` battery (spec 03 · always-run cleanup) — extracted
+//! from `spec_v2.rs` (the 1500-LOC ratchet) — every test runs the REAL
+//! parse → check → run chain over mock seams (the floor discipline).
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use nika_check::CheckReport;
+use nika_check::check;
+use nika_event::{Event, EventKind};
+use nika_kernel_mock::{
+    MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+};
+use nika_providers::{ProviderRegistry, ProvidersConfig};
+use nika_runtime::{DeterministicStamper, RunOutcome, Runtime, RuntimeConfig, TaskStatus, VecSink};
+use nika_schema::raw::RawWorkflow;
+use nika_schema::{FileId, ParseMode, parse};
+use nika_types::resource::Value as FieldValue;
+use nika_verb_agent::AgentVerb;
+use nika_verb_exec::ExecVerb;
+use nika_verb_infer::InferVerb;
+use nika_verb_invoke::InvokeVerb;
+
+// ─── harness (same seams as spec_v2.rs) ──────────────────────────────────
+
+fn parse_and_check(yaml: &str) -> (RawWorkflow, CheckReport) {
+    let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
+    let report = check(&wf);
+    (wf, report)
+}
+
+fn runtime_with_tools<T: nika_kernel::tool_executor::ToolExecuteDyn>(
+    shell: MockShell,
+    tools: T,
+    provider: MockProvider,
+    config: RuntimeConfig,
+) -> Runtime<
+    MockShell,
+    T,
+    nika_providers::NoHttp,
+    MockProvider,
+    MockToolDefinitionProvider,
+    MockClock,
+> {
+    let registry = Arc::new(ProviderRegistry::without_http(ProvidersConfig::default()));
+    let invoke = Arc::new(InvokeVerb::new(Arc::new(tools)));
+    Runtime::new(
+        ExecVerb::new(Arc::new(shell)),
+        Arc::clone(&invoke),
+        InferVerb::new(registry, "mock/echo"),
+        AgentVerb::new(
+            Arc::new(provider),
+            invoke,
+            Arc::new(MockToolDefinitionProvider::new()),
+            "mock/echo",
+        ),
+        MockClock::new(),
+        config,
+    )
+}
+
+async fn run_to_events(
+    yaml: &str,
+    shell: MockShell,
+    tools: MockToolExecutor,
+    provider: MockProvider,
+    config: RuntimeConfig,
+) -> (RunOutcome, Vec<Event>) {
+    let (wf, report) = parse_and_check(yaml);
+    assert!(report.is_clean(), "fixture passes the ladder");
+    let runtime = runtime_with_tools(shell, tools, provider, config);
+    let mut stamper = DeterministicStamper::new();
+    let mut sink = VecSink::new();
+    let outcome = runtime
+        .run(&wf, &report, &mut stamper, &mut sink)
+        .await
+        .expect("clean run");
+    (outcome, sink.into_events())
+}
+
+fn str_field<'a>(event: &'a Event, key: &str) -> Option<&'a str> {
+    match event.fields.iter().find(|f| f.key == key).map(|f| &f.value) {
+        Some(FieldValue::String(s)) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+// ─── the battery ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn on_finally_runs_on_success_and_failure_and_routes_on_status() {
+    let yaml = r#"
+nika: v1
+workflow:
+  id: cleanup
+permits: { exec: true }
+tasks:
+  works:
+    exec: { command: ["make", "thing"] }
+    on_finally:
+      - exec: { command: ["rm", "-f", "scratch-a"] }
+  breaks:
+    exec: { command: ["make", "other"] }
+    on_finally:
+      - when: ${{ tasks.breaks.status == 'failure' }}
+        exec: { command: ["alert", "on-call"] }
+      - exec: { command: ["rm", "-f", "scratch-b"] }
+  never_ran:
+    after: { breaks: success }
+    exec: { command: ["downstream"] }
+    on_finally:
+      - exec: { command: ["must", "not", "run"] }
+"#;
+    // Queue: works · works-cleanup · breaks(FAIL) · breaks-cleanup-1
+    // (alert · gate OPEN on failure) · breaks-cleanup-2 — and NOTHING
+    // for never_ran (cancelled tasks run no cleanup · an extra dequeue
+    // would panic the mock).
+    let shell = MockShell::new()
+        .enqueue_ok("made\n")
+        .enqueue_ok("cleaned-a\n")
+        .enqueue_fail(2, "make exploded")
+        .enqueue_ok("alerted\n")
+        .enqueue_ok("cleaned-b\n");
+    let (outcome, _events) = run_to_events(
+        yaml,
+        shell,
+        MockToolExecutor::new(),
+        MockProvider::new("mock"),
+        RuntimeConfig::new(NonZeroUsize::new(1), 0), // FIFO queue alignment
+    )
+    .await;
+
+    assert!(!outcome.ok);
+    assert_eq!(outcome.records["works"].status, TaskStatus::Success);
+    assert_eq!(outcome.records["breaks"].status, TaskStatus::Failure);
+    // The cancelled task ran NO cleanup — proven by the mock queue
+    // being exactly drained (a 6th dequeue panics).
+    assert_eq!(outcome.records["never_ran"].status, TaskStatus::Cancelled);
+}
+
+/// NEP-0007 law 2 · the cleanup lane ATTESTS too (the final review's
+/// catch): a workflow whose only effect is an `on_finally:` exec must
+/// carry `permit_checked` frames for it (the lane-local witness that
+/// never drained is retired — decisions merge into the parent's stream).
+#[tokio::test]
+async fn on_finally_decisions_are_attested_as_permit_checked() {
+    let yaml = r#"
+nika: v1
+workflow:
+  id: attest-finally
+model: mock/echo
+permits: { exec: ["echo"] }
+tasks:
+  main:
+    infer: { prompt: "hi" }
+    on_finally:
+      - exec: { command: ["echo", "cleanup"] }
+"#;
+    let (_outcome, events) = run_to_events(
+        yaml,
+        MockShell::new().enqueue_ok("done\n"),
+        MockToolExecutor::new(),
+        MockProvider::new("mock"),
+        RuntimeConfig::default(),
+    )
+    .await;
+    // The lane marker rides the parent's stream (plane on_finally)…
+    let lane = events
+        .iter()
+        .find(|e| {
+            e.kind == nika_event::EventKind::PermitChecked
+                && str_field(e, "plane") == Some("on_finally")
+        })
+        .expect("the on_finally lane marker is attested");
+    assert_eq!(str_field(lane, "decision"), Some("attempt"));
+    // …and the cleanup's exec decision itself (allow under the grant).
+    let exec_frame = events
+        .iter()
+        .find(|e| {
+            e.kind == nika_event::EventKind::PermitChecked && str_field(e, "plane") == Some("exec")
+        })
+        .expect("the cleanup exec decision is attested");
+    assert_eq!(str_field(exec_frame, "decision"), Some("allow"));
+    assert_eq!(str_field(exec_frame, "gate"), Some("echo"));
+}
+
+/// A cleanup error is swallowed — the parent's status reflects ONLY
+/// the main verb (spec 03 · best-effort semantics).
+#[tokio::test]
+async fn on_finally_errors_are_swallowed() {
+    let yaml = r#"
+nika: v1
+workflow:
+  id: cleanup-err
+permits: { exec: true }
+tasks:
+  main:
+    exec: { command: ["work"] }
+    on_finally:
+      - exec: { command: ["broken", "cleanup"] }
+"#;
+    let shell = MockShell::new()
+        .enqueue_ok("worked\n")
+        .enqueue_fail(13, "cleanup died");
+    let (outcome, events) = run_to_events(
+        yaml,
+        shell,
+        MockToolExecutor::new(),
+        MockProvider::new("mock"),
+        RuntimeConfig::default(),
+    )
+    .await;
+    assert!(outcome.ok, "the cleanup failure never propagates");
+    assert_eq!(outcome.records["main"].status, TaskStatus::Success);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| e.kind == EventKind::TaskFailed)
+            .count(),
+        0
+    );
+}

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -5,7 +5,8 @@
 //! The v2 spec-parity battery — bounded intra-wave concurrency with
 //! ordered settlement (determinism THEOREMS made tests) + the full
 //! task pipeline of spec 03/05: gates · records · retry · timeout ·
-//! `on_error:` · `for_each:` · `on_finally:`.
+//! `on_error:` · `for_each:`.
+//! `on_finally:` lives in `on_finally.rs` (the 1500-LOC ratchet).
 //!
 //! Every test runs the REAL parse → check → run chain over mock seams
 //! (the floor discipline) — no hand-built reports, no played layers.
@@ -1082,97 +1083,7 @@ tasks:
     );
 }
 
-// ─── 9 · on_finally (spec 03 · always-run cleanup) ──────────────────────
-
-#[tokio::test]
-async fn on_finally_runs_on_success_and_failure_and_routes_on_status() {
-    let yaml = r#"
-nika: v1
-workflow:
-  id: cleanup
-permits: { exec: true }
-tasks:
-  works:
-    exec: { command: ["make", "thing"] }
-    on_finally:
-      - exec: { command: ["rm", "-f", "scratch-a"] }
-  breaks:
-    exec: { command: ["make", "other"] }
-    on_finally:
-      - when: ${{ tasks.breaks.status == 'failure' }}
-        exec: { command: ["alert", "on-call"] }
-      - exec: { command: ["rm", "-f", "scratch-b"] }
-  never_ran:
-    after: { breaks: success }
-    exec: { command: ["downstream"] }
-    on_finally:
-      - exec: { command: ["must", "not", "run"] }
-"#;
-    // Queue: works · works-cleanup · breaks(FAIL) · breaks-cleanup-1
-    // (alert · gate OPEN on failure) · breaks-cleanup-2 — and NOTHING
-    // for never_ran (cancelled tasks run no cleanup · an extra dequeue
-    // would panic the mock).
-    let shell = MockShell::new()
-        .enqueue_ok("made\n")
-        .enqueue_ok("cleaned-a\n")
-        .enqueue_fail(2, "make exploded")
-        .enqueue_ok("alerted\n")
-        .enqueue_ok("cleaned-b\n");
-    let (outcome, _events) = run_to_events(
-        yaml,
-        shell,
-        MockToolExecutor::new(),
-        MockProvider::new("mock"),
-        RuntimeConfig::new(NonZeroUsize::new(1), 0), // FIFO queue alignment
-    )
-    .await;
-
-    assert!(!outcome.ok);
-    assert_eq!(outcome.records["works"].status, TaskStatus::Success);
-    assert_eq!(outcome.records["breaks"].status, TaskStatus::Failure);
-    // The cancelled task ran NO cleanup — proven by the mock queue
-    // being exactly drained (a 6th dequeue panics).
-    assert_eq!(outcome.records["never_ran"].status, TaskStatus::Cancelled);
-}
-
-/// A cleanup error is swallowed — the parent's status reflects ONLY
-/// the main verb (spec 03 · best-effort semantics).
-#[tokio::test]
-async fn on_finally_errors_are_swallowed() {
-    let yaml = r#"
-nika: v1
-workflow:
-  id: cleanup-err
-permits: { exec: true }
-tasks:
-  main:
-    exec: { command: ["work"] }
-    on_finally:
-      - exec: { command: ["broken", "cleanup"] }
-"#;
-    let shell = MockShell::new()
-        .enqueue_ok("worked\n")
-        .enqueue_fail(13, "cleanup died");
-    let (outcome, events) = run_to_events(
-        yaml,
-        shell,
-        MockToolExecutor::new(),
-        MockProvider::new("mock"),
-        RuntimeConfig::default(),
-    )
-    .await;
-    assert!(outcome.ok, "the cleanup failure never propagates");
-    assert_eq!(outcome.records["main"].status, TaskStatus::Success);
-    assert_eq!(
-        events
-            .iter()
-            .filter(|e| e.kind == EventKind::TaskFailed)
-            .count(),
-        0
-    );
-}
-
-// ─── 10 · records in gates (spec 04 · status routing) ───────────────────
+// ─── 9 · records in gates (spec 04 · status routing) ───────────────────
 
 #[tokio::test]
 async fn status_gates_route_on_skipped_upstream() {
@@ -1205,7 +1116,7 @@ tasks:
     assert_eq!(output_str(&outcome, "report"), "reported");
 }
 
-// ─── 11 · spec-plane wire codes pin to the embedded canon ───────────────
+// ─── 10 · spec-plane wire codes pin to the embedded canon ───────────────
 
 /// Every spec-plane code the runtime EMITS into `TaskErrorRecord` must
 /// resolve in the embedded spec table (`nika_pack::error_codes()` —
@@ -1288,7 +1199,7 @@ tasks:
     assert_eq!(var_code, "NIKA-VAR-006");
 }
 
-// ─── 12 · the for_each when-gate scope hazard (pinned) ──────────────────
+// ─── 11 · the for_each when-gate scope hazard (pinned) ──────────────────
 
 /// Spec-drift pin: the checker ACCEPTS `item` inside a `for_each`
 /// task's `when:` (statically clean — probed 2026-06-13) but the
@@ -1344,7 +1255,7 @@ tasks:
     );
 }
 
-// ─── 13 · structured tool output survives the seam (BUG#3) ──────────────
+// ─── 12 · structured tool output survives the seam (BUG#3) ──────────────
 
 /// A builtin that returns a typed value (here an array, as `nika:glob`
 /// does) must reach `tasks.X.output` AS the array — so a downstream


### PR DESCRIPTION
The final socratic/cyber review found two real holes · both fixed here.

**1 · composition O7-A × O7-C (sink.rs)** · the trailing-dot trim ran BEFORE the percent-decode, so `legacy%2epkl%2e` passed inert while the literal `legacy.pkl.` was refused. Decode now precedes the trim · encoded ≡ literal, same verdict.

**2 · NEP-0007 law 2 (task/finally.rs)** · the `on_finally:` lane enforced but never attested · its lane-local witness was never drained, so a workflow whose only effect is a cleanup exec rendered a journal with zero `permit_checked` frames that `trace verify` scored CLEAN. The lane's decisions now merge into the parent's witness stream (plane `on_finally`).

Tests · the attestation battery moves to `tests/on_finally.rs` (the 1500-LOC ratchet · spec_v2.rs 1533 → 1398) · 3/3 on_finally + 24/24 spec_v2 + 243/243 lib · clippy clean · pre-push gate green.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>