### PR TITLE
feat(exec-runner,check): the egress proxy is the exact projection of net.http (F-P5)

### DIFF
--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -609,6 +609,7 @@ pub fn nika_check::GateFindingKind::as_out(&mut self) -> outref::Out<'_, T>
 pub nika_check::PermitTaintKind::ArgEscapes
 pub nika_check::PermitTaintKind::BoundInterpolated
 pub nika_check::PermitTaintKind::EnvDeadGrant
+pub nika_check::PermitTaintKind::NetWildcard
 impl core::clone::Clone for nika_check::PermitTaintKind
 pub fn nika_check::PermitTaintKind::clone(&self) -> nika_check::PermitTaintKind
 impl core::cmp::Eq for nika_check::PermitTaintKind

--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -494,4 +494,47 @@ mod tests {
         assert!(row.get("task").is_none(), "absent, not null: {row}");
         assert!(row.get("code").is_some());
     }
+
+    /// F-P5 (c) · the `*.` wildcard in `permits.net.http` is a hard
+    /// refusal at check — the finding lands in findings[] with its wire
+    /// code (NIKA-AUTH-010) so the run gate blocks on it.
+    #[test]
+    fn a_wildcard_net_http_entry_is_an_error_finding() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"*.github.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  t:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.github.com/x\" } }\n",
+        );
+        assert!(!r.is_clean(), "the wildcard is a run-blocker");
+        let hit = r
+            .findings
+            .iter()
+            .find(|f| f.kind == "permit_taint")
+            .expect("the wildcard finding");
+        assert_eq!(hit.code.as_deref(), Some("NIKA-AUTH-010"));
+        assert_eq!(hit.severity, super::FindingSeverity::Error);
+        assert!(hit.message.contains("net.http[0]"), "{}", hit.message);
+    }
+
+    /// F-P5 (d) · the dead-grant twin of NIKA-AUTH-009 (env): a
+    /// floor-blocked `permits.net.http` entry is an inert grant — flagged
+    /// at the ENTRY with the floor code (check≡run down to the code: the
+    /// run refuses the same target with NIKA-SEC-005).
+    #[test]
+    fn a_floor_blocked_net_http_entry_is_a_dead_grant_finding() {
+        let r = report(
+            "nika: v1\nworkflow:\n  id: w\npermits:\n  net: { http: [\"169.254.169.254\", \"api.x.com\"] }\n  tools: [\"nika:fetch\"]\ntasks:\n  t:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://api.x.com/x\" } }\n",
+        );
+        assert!(!r.is_clean());
+        let hit = r
+            .findings
+            .iter()
+            .find(|f| f.kind == "capability_escape" && f.task.as_deref() == Some("permits"))
+            .expect("the dead-grant entry finding");
+        assert_eq!(hit.code.as_deref(), Some("NIKA-SEC-005"));
+        assert!(hit.message.contains("169.254.169.254"), "{}", hit.message);
+        assert!(
+            hit.message.contains("can never take effect"),
+            "the dead-grant teaching: {}",
+            hit.message
+        );
+    }
 }

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -389,14 +389,15 @@ impl CheckReport {
         }));
         // The permits-block taint findings: the finding's own kind maps to
         // its ONE wire code (NEP-0004 law 1 → AUTH-007 · law 2 → AUTH-008 ·
-        // NEP-0005 law 3 env dead grant → AUTH-009 · all check-time
-        // security refusals).
+        // NEP-0005 law 3 env dead grant → AUTH-009 · F-P5 net wildcard →
+        // AUTH-010 · all check-time security refusals).
         codes.extend(self.permit_taints.iter().map(|t| match t.kind {
             PermitTaintKind::BoundInterpolated => {
                 SpecCode::new("AUTH", 7, SpecCategory::SecurityError)
             }
             PermitTaintKind::ArgEscapes => SpecCode::new("AUTH", 8, SpecCategory::SecurityError),
             PermitTaintKind::EnvDeadGrant => SpecCode::new("AUTH", 9, SpecCategory::SecurityError),
+            PermitTaintKind::NetWildcard => SpecCode::new("AUTH", 10, SpecCategory::SecurityError),
         }));
         // The data-as-code sink (NEP-0006) → NIKA-SEC-008.
         let sink_code = SpecCode::new("SEC", 8, SpecCategory::SecurityError);

--- a/crates/nika-check/src/permit_taint.rs
+++ b/crates/nika-check/src/permit_taint.rs
@@ -33,6 +33,12 @@
 //!   binding to trusted HERE (the static twin never re-gates it); the
 //!   value is still matched like a literal everywhere else (never a
 //!   permit bypass) and the run receipt records the event.
+//! - **F-P5 ([`PermitTaintKind::NetWildcard`] · `NIKA-AUTH-010`)** — a
+//!   `permits.net.http:` entry carrying the `*.` subdomain wildcard is a
+//!   hard refusal: the grant delegates the boundary to the zone operator
+//!   (every host under the suffix, present and future — the srt A2
+//!   lesson). The BARE `*` stays legal: the explicit allow-all hatch
+//!   (`NetPolicy::Allow` — visible, never stealth).
 //!
 //! Everything is judged against the WORKFLOW's `permits:` block (v1 has
 //! no task-level narrowing — the step permit IS the declared block), and
@@ -53,6 +59,9 @@ pub(crate) const REGATE_CODE: &str = "NIKA-AUTH-008";
 /// The wire code of a dangerous-floor dead grant in `permits.env:`
 /// (NEP-0005 law 3 · LAW-AUTH-0326).
 pub(crate) const ENV_DEAD_GRANT_CODE: &str = "NIKA-AUTH-009";
+/// The wire code of a `*.` subdomain wildcard in `permits.net.http:`
+/// (F-P5 · the wildcard delegates the boundary to the zone operator).
+pub(crate) const NET_WILDCARD_CODE: &str = "NIKA-AUTH-010";
 
 /// The fs-read tool set whose `path` arg the static re-gate judges
 /// (the reference oracle's table — the engine≡oracle differential law
@@ -85,6 +94,12 @@ pub enum PermitTaintKind {
     /// variable — an inert dead grant, the engine strips the name
     /// unconditionally (`NIKA-AUTH-009` · LAW-AUTH-0326).
     EnvDeadGrant,
+    /// F-P5 · a `permits.net.http:` entry carries the `*.` subdomain
+    /// wildcard — the grant delegates the boundary to the zone operator,
+    /// admitting every host under the suffix, present and future
+    /// (`NIKA-AUTH-010`). The BARE `*` stays legal (the explicit
+    /// allow-all hatch).
+    NetWildcard,
 }
 
 /// One permit-taint finding (law 1 or law 2) — the check-time twin of
@@ -114,6 +129,7 @@ impl PermitTaint {
             PermitTaintKind::BoundInterpolated => BOUND_CODE,
             PermitTaintKind::ArgEscapes => REGATE_CODE,
             PermitTaintKind::EnvDeadGrant => ENV_DEAD_GRANT_CODE,
+            PermitTaintKind::NetWildcard => NET_WILDCARD_CODE,
         }
     }
 }
@@ -130,6 +146,7 @@ pub(crate) fn scan_permit_taint(wf: &RawWorkflow) -> Vec<PermitTaint> {
     let mut out = Vec::new();
     scan_bound_literality(permits, &mut out);
     scan_env_dead_grants(permits, &mut out);
+    scan_net_wildcards(permits, &mut out);
     scan_regate(wf, permits, &mut out);
     out
 }
@@ -157,6 +174,43 @@ fn scan_env_dead_grants(permits: &Permits, out: &mut Vec<PermitTaint>) {
             ),
             fix: Some(
                 "remove the entry · pass authored data through the task env: map, or a                  non-dangerous engine variable by its exact name"
+                    .to_owned(),
+            ),
+        });
+    }
+}
+
+/// F-P5 · a `permits.net.http:` entry carrying the `*.` substring is
+/// REFUSED (the srt A2 lesson: the wildcard delegates the permit to the
+/// zone operator — `*.github.io` is every user of the shared zone,
+/// present and future; the matcher cannot see what the zone will serve
+/// tomorrow). The rule is the verbatim substring: the leading form
+/// (`*.github.com`) AND a would-be glob like `foo*.com` (which matches
+/// nothing by matcher law yet LOOKS like one — the author meant a glob)
+/// are both refused. The BARE `*` stays legal: the author's explicit
+/// allow-all hatch (the sandbox projection maps it to `NetPolicy::Allow`
+/// — visible, never stealth). Interpolated entries are law 1's ground
+/// (`NIKA-AUTH-007` · the bound walk above), never judged here.
+fn scan_net_wildcards(permits: &Permits, out: &mut Vec<PermitTaint>) {
+    let Some(net) = permits.net.as_ref() else {
+        return;
+    };
+    for (i, entry) in net.http.iter().enumerate() {
+        if entry.contains("${{") || !entry.contains("*.") {
+            continue;
+        }
+        out.push(PermitTaint {
+            task: "permits".to_owned(),
+            kind: PermitTaintKind::NetWildcard,
+            detail: format!(
+                "permit entry `net.http[{i}]` carries the `*.` subdomain wildcard \
+                 (`{entry}`) · the grant delegates the boundary to the zone \
+                 operator: every host under the suffix, present and future, is \
+                 admitted (F-P5)"
+            ),
+            fix: Some(
+                "name the exact hosts · or, when allow-all is genuinely intended, \
+                 the bare `*` (the explicit hatch · maps to NetPolicy::Allow)"
                     .to_owned(),
             ),
         });
@@ -655,6 +709,99 @@ tasks:
         }
     }
 
+    // ── F-P5 · the net wildcard refusal (NIKA-AUTH-010) ──
+
+    #[test]
+    fn a_subdomain_wildcard_in_net_http_is_a_hard_refusal() {
+        // The matcher ADMITS the task's host through the wildcard (no
+        // escape) — the refusal is entry-level: the grant itself is the
+        // hole, whatever the body does.
+        let y = r#"nika: v1
+workflow:
+  id: t-wildcard
+permits:
+  net: { http: ["*.github.com"] }
+  tools: ["nika:fetch"]
+tasks:
+  t:
+    invoke: { tool: "nika:fetch", args: { url: "https://api.github.com/x" } }
+"#;
+        let taints = taints_of(y);
+        assert_eq!(taints.len(), 1, "{taints:?}");
+        assert_eq!(taints[0].kind, PermitTaintKind::NetWildcard);
+        assert_eq!(taints[0].wire_code(), "NIKA-AUTH-010");
+        assert_eq!(taints[0].task, "permits");
+        assert!(
+            taints[0].detail.contains("net.http[0]"),
+            "{}",
+            taints[0].detail
+        );
+        assert!(taints[0].detail.contains("*.github.com"));
+        // …and every wildcard entry is named, exact neighbours aside.
+        // `foo*.com` carries the `*.` substring (a would-be glob that
+        // matches nothing yet LOOKS like one) — refused with the rest.
+        let mixed = y.replace(
+            "\"*.github.com\"",
+            "\"api.example.com\", \"*.github.io\", \"foo*.com\"",
+        );
+        let taints = taints_of(&mixed);
+        assert_eq!(taints.len(), 2, "{taints:?}");
+        assert!(
+            taints
+                .iter()
+                .all(|t| t.kind == PermitTaintKind::NetWildcard)
+        );
+        assert!(
+            taints[0].detail.contains("net.http[1]"),
+            "{}",
+            taints[0].detail
+        );
+        assert!(
+            taints[1].detail.contains("net.http[2]"),
+            "{}",
+            taints[1].detail
+        );
+    }
+
+    #[test]
+    fn the_bare_star_and_exact_hosts_stay_legal() {
+        // The bare `*` is the explicit allow-all hatch (NetPolicy::Allow —
+        // the author typed it, visible, never stealth): NOT this law's
+        // ground (it carries no `*.` substring). Exact hosts neither.
+        for entries in ["\"*\"", "\"api.github.com\", \"github.com\""] {
+            let y = format!(
+                "nika: v1\nworkflow:\n  id: w\npermits:\n  net: {{ http: [{entries}] }}\n  \
+                 tools: [\"nika:fetch\"]\ntasks:\n  t:\n    \
+                 invoke: {{ tool: \"nika:fetch\", args: {{ url: \"https://api.github.com/x\" }} }}\n"
+            );
+            assert!(
+                taints_of(&y).is_empty(),
+                "{entries} must stay legal: {:?}",
+                taints_of(&y)
+            );
+        }
+    }
+
+    #[test]
+    fn an_interpolated_wildcard_bound_is_law1s_ground_only() {
+        // `${{ inputs.h }}` containing `*.` never double-fires: law 1
+        // (BoundInterpolated) owns the interpolated bound.
+        let y = r#"nika: v1
+workflow:
+  id: w
+permits:
+  net: { http: ["${{ inputs.h }}"] }
+inputs:
+  h: { type: string, default: "*.github.com" }
+tasks:
+  t:
+    exec: { command: ["true"] }
+"#;
+        let taints = taints_of(y);
+        assert_eq!(taints.len(), 1, "{taints:?}");
+        assert_eq!(taints[0].kind, PermitTaintKind::BoundInterpolated);
+    }
+
     // ── Law 2 · the static re-gate (NIKA-AUTH-008) — the conformance
     //    fixtures core/authority/007..013, mirrored one test each ──
 
@@ -964,7 +1111,7 @@ tasks:
             .into_iter()
             .map(|row| row.code.to_string())
             .collect();
-        for code in [BOUND_CODE, REGATE_CODE] {
+        for code in [BOUND_CODE, REGATE_CODE, NET_WILDCARD_CODE] {
             assert!(
                 registered.contains(code),
                 "`{code}` is not in the canon registry (spec/05-errors.md SSOT)"

--- a/crates/nika-check/src/permits_fit.rs
+++ b/crates/nika-check/src/permits_fit.rs
@@ -919,17 +919,19 @@ tasks:
 
     #[test]
     fn fetch_to_listed_host_is_clean() {
+        // F-P5: the listed form is the EXACT host — the `*.` wildcard is
+        // refused at check (NIKA-AUTH-010 · the permit_taint lane).
         let y = r#"nika: v1
 workflow:
   id: w
 permits:
-  net: { http: ["*.anthropic.com"] }
+  net: { http: ["api.anthropic.com"] }
   tools: ["nika:fetch"]
 tasks:
   t:
     invoke: { tool: "nika:fetch", args: { url: "https://api.anthropic.com/v1/x" } }
 "#;
-        assert!(escapes(y).is_empty(), "glob host match is clean");
+        assert!(escapes(y).is_empty(), "exact host match is clean");
     }
 
     #[test]
@@ -1306,7 +1308,10 @@ tasks:
     #[test]
     fn glob_entries_and_public_hosts_stay_silent() {
         // A glob may match public names — glob-vs-floor inclusion is DNS
-        // knowledge the static pass does not have. Never flagged.
+        // knowledge the static pass does not have. Never flagged HERE:
+        // the FLOOR scan stays silent on globs (F-P5's wildcard refusal
+        // is the permit_taint lane's · NIKA-AUTH-010 · a separate finding,
+        // never a floor classification).
         let y = r#"nika: v1
 workflow:
   id: w

--- a/crates/nika-exec-runner/public-api.txt
+++ b/crates/nika-exec-runner/public-api.txt
@@ -1,4 +1,44 @@
 pub mod nika_exec_runner
+#[non_exhaustive] pub enum nika_exec_runner::EgressEvent
+pub nika_exec_runner::EgressEvent::Closed
+pub nika_exec_runner::EgressEvent::Closed::bytes_down: u64
+pub nika_exec_runner::EgressEvent::Closed::bytes_up: u64
+pub nika_exec_runner::EgressEvent::Closed::host: alloc::string::String
+pub nika_exec_runner::EgressEvent::Closed::port: u16
+pub nika_exec_runner::EgressEvent::Decision(nika_exec_runner::EgressDecision)
+impl core::clone::Clone for nika_exec_runner::EgressEvent
+pub fn nika_exec_runner::EgressEvent::clone(&self) -> nika_exec_runner::EgressEvent
+impl core::cmp::Eq for nika_exec_runner::EgressEvent
+impl core::cmp::PartialEq for nika_exec_runner::EgressEvent
+pub fn nika_exec_runner::EgressEvent::eq(&self, other: &nika_exec_runner::EgressEvent) -> bool
+impl core::fmt::Debug for nika_exec_runner::EgressEvent
+pub fn nika_exec_runner::EgressEvent::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_exec_runner::EgressEvent
+impl<D> owo_colors::OwoColorize for nika_exec_runner::EgressEvent
+impl<T, U> core::convert::Into<U> for nika_exec_runner::EgressEvent where U: core::convert::From<T>
+pub fn nika_exec_runner::EgressEvent::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_exec_runner::EgressEvent where U: core::convert::Into<T>
+pub type nika_exec_runner::EgressEvent::Error = core::convert::Infallible
+pub fn nika_exec_runner::EgressEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_exec_runner::EgressEvent where U: core::convert::TryFrom<T>
+pub type nika_exec_runner::EgressEvent::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_exec_runner::EgressEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_exec_runner::EgressEvent where T: core::clone::Clone
+pub type nika_exec_runner::EgressEvent::Owned = T
+pub fn nika_exec_runner::EgressEvent::clone_into(&self, target: &mut T)
+pub fn nika_exec_runner::EgressEvent::to_owned(&self) -> T
+impl<T> core::any::Any for nika_exec_runner::EgressEvent where T: 'static + ?core::marker::Sized
+pub fn nika_exec_runner::EgressEvent::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_exec_runner::EgressEvent where T: ?core::marker::Sized
+pub fn nika_exec_runner::EgressEvent::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_exec_runner::EgressEvent where T: ?core::marker::Sized
+pub fn nika_exec_runner::EgressEvent::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_exec_runner::EgressEvent where T: core::clone::Clone
+pub unsafe fn nika_exec_runner::EgressEvent::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_exec_runner::EgressEvent
+pub fn nika_exec_runner::EgressEvent::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_exec_runner::EgressEvent where T: 'static
+pub fn nika_exec_runner::EgressEvent::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_exec_runner::EgressDecision
 pub nika_exec_runner::EgressDecision::allowed: bool
 pub nika_exec_runner::EgressDecision::host: alloc::string::String
@@ -81,4 +121,4 @@ impl<TraitVariantBlanketType> nika_kernel_core::io::process::ShellCancel for nik
 pub async fn nika_exec_runner::TokioShell::cancel(&self, id: &str) -> core::result::Result<(), nika_kernel_core::io::process::ShellError>
 impl<TraitVariantBlanketType> nika_kernel_core::io::process::ShellRun for nika_exec_runner::TokioShell where TraitVariantBlanketType: nika_kernel_core::io::process::ShellRunDyn
 pub async fn nika_exec_runner::TokioShell::run(&self, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellResult, nika_kernel_core::io::process::ShellError>
-pub type nika_exec_runner::EgressObserver = alloc::sync::Arc<(dyn core::ops::function::Fn(&nika_exec_runner::EgressDecision) + core::marker::Send + core::marker::Sync)>
+pub type nika_exec_runner::EgressObserver = alloc::sync::Arc<(dyn core::ops::function::Fn(&nika_exec_runner::EgressEvent) + core::marker::Send + core::marker::Sync)>

--- a/crates/nika-exec-runner/src/egress.rs
+++ b/crates/nika-exec-runner/src/egress.rs
@@ -23,7 +23,9 @@
 //! upstream; anything else is refused (CONNECT → `403`, SOCKS5 →
 //! `0x02` "not allowed by ruleset"). Every decision is journalised through
 //! the injected [`EgressObserver`] — a refused host is a security event, an
-//! allowed one a debug line (the composer surfaces both on stderr, the
+//! allowed one a debug line, and a relayed tunnel reports its byte counters
+//! at close (F-P5 metering: host + port + octets, NEVER the content — the
+//! TLS-blind posture) — (the composer surfaces all three on stderr, the
 //! FCI-009 honest seam: the run journal's `EventSink` is a `&mut` threaded
 //! through the settle pass, unreachable from an out-of-band proxy thread —
 //! the `StderrEmitter` precedent in `nika-cli`).
@@ -88,30 +90,67 @@ pub struct EgressDecision {
     pub allowed: bool,
 }
 
-/// The decision sink — the composer wires the stderr journal, tests wire a
+/// One journalised egress event (F-P5) — the observer's unit: a verdict
+/// on a target, or the closure of a relayed tunnel with its byte
+/// counters. The TLS-blind posture swears host + port + OCTETS, never
+/// the content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EgressEvent {
+    /// An allow/refuse verdict on a CONNECT/SOCKS target.
+    Decision(EgressDecision),
+    /// A relayed tunnel closed — the metering (F-P5): the bytes the
+    /// proxy moved in each direction, nothing about their content.
+    Closed {
+        /// The upstream host, exactly as the client named it.
+        host: String,
+        /// The upstream port.
+        port: u16,
+        /// Bytes relayed client → upstream (the request direction).
+        bytes_up: u64,
+        /// Bytes relayed upstream → client (the response direction).
+        bytes_down: u64,
+    },
+}
+
+/// The event sink — the composer wires the stderr journal, tests wire a
 /// collecting probe. `Fn` (never `FnMut`): the proxy calls it from
 /// connection threads.
-pub type EgressObserver = Arc<dyn Fn(&EgressDecision) + Send + Sync>;
+pub type EgressObserver = Arc<dyn Fn(&EgressEvent) + Send + Sync>;
+
+/// The one journal line for an event (pure — the [`stderr_journal`]
+/// wrapper's `eprintln` is the only impurity, so tests pin the EXACT
+/// shapes: the REFUSED row is the greppable security event, `allowed`
+/// the debug line, `closed` the metering row).
+fn journal_line(event: &EgressEvent) -> String {
+    match event {
+        EgressEvent::Decision(d) if d.allowed => {
+            format!("nika:egress allowed {}:{}", d.host, d.port)
+        }
+        EgressEvent::Decision(d) => format!(
+            "nika:egress REFUSED {}:{} (not in permits.net.http)",
+            d.host, d.port
+        ),
+        EgressEvent::Closed {
+            host,
+            port,
+            bytes_up,
+            bytes_down,
+        } => format!("nika:egress closed {host}:{port} up={bytes_up} down={bytes_down}"),
+    }
+}
 
 /// The default journal when no observer is injected — a namespaced stderr
-/// line per decision (see the module doc for the FCI-009 seam rationale).
-/// REFUSED is the security event (greppable), `allowed` the debug line.
+/// line per event (see the module doc for the FCI-009 seam rationale).
+/// REFUSED is the security event (greppable), `allowed` the debug line,
+/// `closed` the metering row (F-P5 · octets, never content).
 /// stderr, NOT `tracing::warn!`: no workspace tracing subscriber exists
 /// (the `StderrEmitter` precedent in `nika-cli`), so a tracing call would
 /// journal into the void — and a security journal that can silently vanish
 /// is worse than an unformatted one.
 #[allow(clippy::disallowed_macros, clippy::print_stderr)]
 pub(crate) fn stderr_journal() -> EgressObserver {
-    Arc::new(|d: &EgressDecision| {
-        if d.allowed {
-            eprintln!("nika:egress allowed {}:{}", d.host, d.port);
-        } else {
-            eprintln!(
-                "nika:egress REFUSED {}:{} (not in permits.net.http)",
-                d.host, d.port
-            );
-        }
-    })
+    Arc::new(|e: &EgressEvent| eprintln!("{}", journal_line(e)))
 }
 
 /// The per-run loopback proxy. Owns the accept thread; `Drop` stops the
@@ -239,11 +278,11 @@ const DANGEROUS_EGRESS_PORTS: &[u16] = &[
 fn decide(host: &str, port: u16, allowlist: &[String], observer: &EgressObserver) -> bool {
     let allowed = !DANGEROUS_EGRESS_PORTS.contains(&port)
         && nika_types::net::host_in_allowlist(allowlist, host);
-    observer(&EgressDecision {
+    observer(&EgressEvent::Decision(EgressDecision {
         host: host.to_owned(),
         port,
         allowed,
-    });
+    }));
     allowed
 }
 
@@ -287,7 +326,10 @@ fn dial_upstream(host: &str, port: u16, allowlist: &[String]) -> std::io::Result
 /// each direction's EOF propagated as a write-shutdown to the other side
 /// (half-close fidelity — a server's `close_notify` reaches the client).
 /// The handshake deadlines are cleared first: the tunnel outlives them.
-fn relay(client: TcpStream, upstream: TcpStream) {
+/// F-P5 metering: both directions' byte counts are captured and journalled
+/// as ONE `Closed` event when the tunnel ends — the TLS-blind posture
+/// swears host + port + octets, never the content.
+fn relay(client: TcpStream, upstream: TcpStream, host: &str, port: u16, observer: &EgressObserver) {
     let _ = client.set_read_timeout(None);
     let _ = client.set_write_timeout(None);
     let _ = upstream.set_read_timeout(None);
@@ -299,14 +341,27 @@ fn relay(client: TcpStream, upstream: TcpStream) {
     let west = std::thread::Builder::new()
         .name("nika-egress-relay".to_owned())
         .spawn(move || {
-            let _ = std::io::copy(&mut client_r, &mut upstream_w);
+            let up = std::io::copy(&mut client_r, &mut upstream_w);
             let _ = upstream_w.shutdown(Shutdown::Write);
+            up
         });
-    let _ = std::io::copy(&mut upstream_r, &mut client_w);
+    let down = std::io::copy(&mut upstream_r, &mut client_w);
     let _ = client_w.shutdown(Shutdown::Write);
-    if let Ok(west) = west {
-        let _ = west.join();
-    }
+    // A copy error (or a failed relay-thread spawn) reports the bytes
+    // moved before the failure — 0 when the direction never ran. The
+    // counters are what the proxy RELAYED, errors included.
+    let bytes_up = west
+        .ok()
+        .and_then(|w| w.join().ok())
+        .and_then(Result::ok)
+        .unwrap_or(0);
+    let bytes_down = down.unwrap_or(0);
+    observer(&EgressEvent::Closed {
+        host: host.to_owned(),
+        port,
+        bytes_up,
+        bytes_down,
+    });
 }
 
 /// The HTTP `CONNECT` handler (HTTPS tunneling). Reads the header block
@@ -346,7 +401,7 @@ fn serve_connect(mut client: TcpStream, allowlist: &[String], observer: &EgressO
     {
         return;
     }
-    relay(client, upstream);
+    relay(client, upstream, &host, port, observer);
 }
 
 /// Read up to the end of the CONNECT header block (`\r\n\r\n`), capped at
@@ -433,7 +488,7 @@ fn serve_socks5(mut client: TcpStream, allowlist: &[String], observer: &EgressOb
     if client.write_all(&socks_reply(0x00)).is_err() {
         return;
     }
-    relay(client, upstream);
+    relay(client, upstream, &host, port, observer);
 }
 
 /// Read exactly `n` bytes (handshake-sized — the read deadline bounds it).
@@ -599,25 +654,69 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// A collecting observer — every decision the proxy journalised, in order.
+    /// A collecting observer — every event the proxy journalised, in order.
     #[derive(Clone, Default)]
     struct Probe {
-        decisions: Arc<Mutex<Vec<EgressDecision>>>,
+        events: Arc<Mutex<Vec<EgressEvent>>>,
     }
 
     impl Probe {
         fn observer(&self) -> EgressObserver {
-            let decisions = Arc::clone(&self.decisions);
-            Arc::new(move |d| {
-                if let Ok(mut v) = decisions.lock() {
-                    v.push(d.clone());
+            let events = Arc::clone(&self.events);
+            Arc::new(move |e| {
+                if let Ok(mut v) = events.lock() {
+                    v.push(e.clone());
                 }
             })
         }
 
-        fn taken(&self) -> Vec<EgressDecision> {
-            self.decisions.lock().map(|v| v.clone()).unwrap_or_default()
+        /// The Decision rail (the allow/refuse verdicts), in order.
+        fn decisions(&self) -> Vec<EgressDecision> {
+            self.events
+                .lock()
+                .map(|v| {
+                    v.iter()
+                        .filter_map(|e| match e {
+                            EgressEvent::Decision(d) => Some(d.clone()),
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
         }
+
+        /// The metering rail — `(host, port, bytes_up, bytes_down)` per
+        /// relayed tunnel, in order.
+        fn closed(&self) -> Vec<(String, u16, u64, u64)> {
+            self.events
+                .lock()
+                .map(|v| {
+                    v.iter()
+                        .filter_map(|e| match e {
+                            EgressEvent::Closed {
+                                host,
+                                port,
+                                bytes_up,
+                                bytes_down,
+                            } => Some((host.clone(), *port, *bytes_up, *bytes_down)),
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+    }
+
+    /// Poll `cond` until it holds (10 ms steps · 2 s ceiling) — the Closed
+    /// event rides the relay thread, so a metering assertion waits for it.
+    fn wait_for(cond: impl Fn() -> bool) {
+        for _ in 0..200 {
+            if cond() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("condition not met within 2s");
     }
 
     /// A throwaway upstream: accepts one connection, echoes what it reads.
@@ -673,7 +772,7 @@ mod tests {
         let n = c.read(&mut buf).unwrap();
         assert_eq!(&buf[..n], b"PING", "the tunnel echoes both ways");
         echo.join().unwrap();
-        let decisions = probe.taken();
+        let decisions = probe.decisions();
         assert_eq!(
             decisions,
             vec![EgressDecision {
@@ -682,6 +781,62 @@ mod tests {
                 allowed: true,
             }],
             "the allowed decision is journalised"
+        );
+    }
+
+    #[test]
+    fn a_relayed_tunnel_reports_its_byte_counters_at_close() {
+        // F-P5 (e) · the TLS-blind metering: ONE Closed event per relayed
+        // connection, swearing host + port + octets — never the content.
+        let (upstream_port, echo) = echo_upstream();
+        let (proxy, probe) = start(&["127.0.0.1"]);
+        let mut c = dial(proxy.port());
+        write!(c, "CONNECT 127.0.0.1:{upstream_port} HTTP/1.1\r\n\r\n").unwrap();
+        let mut buf = [0u8; 64];
+        let n = c.read(&mut buf).unwrap();
+        assert!(String::from_utf8_lossy(&buf[..n]).contains("200"));
+        c.write_all(b"PING").unwrap(); // 4 octets up · 4 echoed down
+        let n = c.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"PING");
+        echo.join().unwrap();
+        drop(c); // closing the client ends the tunnel → the Closed event
+        wait_for(|| !probe.closed().is_empty());
+        assert_eq!(
+            probe.closed(),
+            vec![("127.0.0.1".to_owned(), upstream_port, 4, 4)],
+            "the metering swears octets, never content"
+        );
+    }
+
+    #[test]
+    fn the_journal_lines_are_the_greppable_contract() {
+        // F-P5 (b) · REFUSED is the security event, verbatim — the
+        // composer greps this line; `allowed` and `closed` are the debug
+        // and metering rows.
+        let refused = journal_line(&EgressEvent::Decision(EgressDecision {
+            host: "evil.com".to_owned(),
+            port: 443,
+            allowed: false,
+        }));
+        assert_eq!(
+            refused,
+            "nika:egress REFUSED evil.com:443 (not in permits.net.http)"
+        );
+        let allowed = journal_line(&EgressEvent::Decision(EgressDecision {
+            host: "api.github.com".to_owned(),
+            port: 443,
+            allowed: true,
+        }));
+        assert_eq!(allowed, "nika:egress allowed api.github.com:443");
+        let closed = journal_line(&EgressEvent::Closed {
+            host: "api.github.com".to_owned(),
+            port: 443,
+            bytes_up: 128,
+            bytes_down: 4096,
+        });
+        assert_eq!(
+            closed,
+            "nika:egress closed api.github.com:443 up=128 down=4096"
         );
     }
 
@@ -737,7 +892,7 @@ mod tests {
         let n = c.read(&mut buf).unwrap();
         let text = String::from_utf8_lossy(&buf[..n]);
         assert!(text.starts_with("HTTP/1.1 403"), "refused: {text}");
-        let decisions = probe.taken();
+        let decisions = probe.decisions();
         assert_eq!(decisions.len(), 1);
         assert!(!decisions[0].allowed, "the refusal is the security event");
         assert_eq!(decisions[0].host, "127.0.0.1");
@@ -766,7 +921,7 @@ mod tests {
         assert_eq!(&buf, b"PONG");
         echo.join().unwrap();
         assert_eq!(
-            probe.taken(),
+            probe.decisions(),
             vec![EgressDecision {
                 host: "127.0.0.1".to_owned(),
                 port: upstream_port,
@@ -792,7 +947,7 @@ mod tests {
         c.read_exact(&mut granted).unwrap();
         assert_eq!(granted[1], 0x02, "not allowed by ruleset: {granted:?}");
         assert_eq!(
-            probe.taken(),
+            probe.decisions(),
             vec![EgressDecision {
                 host: "evil.com".to_owned(),
                 port: 443,
@@ -1031,7 +1186,7 @@ mod tests {
         let mut buf = [0u8; 64];
         let n = c.read(&mut buf).unwrap();
         assert!(String::from_utf8_lossy(&buf[..n]).starts_with("HTTP/1.1 403"));
-        let decisions = probe.taken();
+        let decisions = probe.decisions();
         assert_eq!(decisions.len(), 1);
         assert!(!decisions[0].allowed, "the refused host is journalised");
         assert_eq!(decisions[0].host, "evil.com");

--- a/crates/nika-exec-runner/src/egress.rs
+++ b/crates/nika-exec-runner/src/egress.rs
@@ -28,13 +28,28 @@
 //! through the settle pass, unreachable from an out-of-band proxy thread —
 //! the `StderrEmitter` precedent in `nika-cli`).
 //!
-//! Honest limits (mirrored from srt's own): the matcher gates the HOST, not
-//! the resolved address — a DNS name that resolves to a private/metadata IP
-//! is the documented DNS-rebinding class srt also declines to close (the
-//! `nika-http` effect's `GuardedResolver` owns that half for `nika:fetch`;
-//! exec egress has no static URL to vet). Plain-HTTP forward-proxy requests
-//! (`GET http://…`) are NOT served — CONNECT and SOCKS5 only; anything else
-//! gets an honest `405` and a closed socket (fail-closed).
+//! The floor under the allowlist (the 2026-07-23 red-team stopgaps, now
+//! law): (1) DNS-rebinding is REFUSED AT THE DIAL — every resolved address
+//! passes [`nika_types::net::ip_is_blocked`] (the same oracle the
+//! `nika-http` `GuardedResolver` runs) INSIDE the dial loop, before
+//! `connect_timeout` on that address, so an allowlisted name that resolves
+//! to a loopback/private/link-local/metadata range dies with
+//! `PermissionDenied`, with zero window between resolve and connect. The
+//! one carve-out is the author's EXACT loopback literal declared in the
+//! allowlist (#395) — never another range. (2) The egress PORT floor
+//! (`DANGEROUS_EGRESS_PORTS`): a `net.http` permit is an HTTP-egress grant
+//! — it never admits the classic non-HTTP service ports (ssh · smtp ·
+//! docker · kube · the databases), and no permit overrides the floor.
+//!
+//! The proxy runs WITHOUT a session token (srt's posture, stated honestly):
+//! a co-located local process CAN connect to it — and gains nothing. An
+//! unconfined process could dial the declared hosts directly anyway; a
+//! process confined by ANOTHER run is stopped by its own fence before it
+//! reaches this proxy. The boundary (the allowlist) holds for every
+//! client: one run's authority never leaks to hosts it did not declare.
+//! Plain-HTTP forward-proxy requests (`GET http://…`) are NOT served —
+//! CONNECT and SOCKS5 only; anything else gets an honest `405` and a
+//! closed socket (fail-closed).
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 

--- a/crates/nika-exec-runner/src/lib.rs
+++ b/crates/nika-exec-runner/src/lib.rs
@@ -44,7 +44,9 @@
 //! injects the srt-mirrored env contract (`HTTP(S)_PROXY` / `ALL_PROXY` /
 //! `NO_PROXY` … on the muxed CONNECT+SOCKS5 port), and lets the OS fence
 //! admit loopback only. Every target is evaluated against the ONE host
-//! matcher and every decision journalised (see the `egress` module doc).
+//! matcher and every event journalised — the allow/refuse verdict, then
+//! the relayed tunnel's byte counters at close (the F-P5 metering · see
+//! the `egress` module doc).
 //!
 //! # Process safety (kernel CANCEL SAFETY contract)
 //!
@@ -65,7 +67,7 @@
 mod blocklist;
 mod egress;
 
-pub use egress::{EgressDecision, EgressObserver};
+pub use egress::{EgressDecision, EgressEvent, EgressObserver};
 
 use std::collections::BTreeMap;
 use std::process::Stdio;
@@ -124,8 +126,9 @@ pub struct TokioShell {
     /// the SAME boundary on the SAME port; started lazily, stopped when the
     /// last clone drops (no orphan listener outlives the run).
     egress_proxy: Arc<Mutex<Option<egress::EgressProxy>>>,
-    /// The egress-decision journal sink (every proxy verdict — a refused
-    /// host is a security event). Default: the namespaced stderr line (see
+    /// The egress-event journal sink (every proxy verdict — a refused
+    /// host is a security event — plus each relayed tunnel's byte
+    /// counters at close, F-P5). Default: the namespaced stderr line (see
     /// the `egress` module doc for the FCI-009 seam rationale).
     egress_observer: EgressObserver,
 }
@@ -169,10 +172,11 @@ impl TokioShell {
         }
     }
 
-    /// Replace the egress-decision journal sink (the allowlist arm's
-    /// allow/refuse verdicts). The default is the namespaced stderr line —
-    /// the honest out-of-band channel (FCI-009 · see the `egress` module
-    /// doc); tests and embedders wire a collecting probe here. Chainable.
+    /// Replace the egress-event journal sink (the allowlist arm's
+    /// allow/refuse verdicts + the relayed tunnels' byte counters). The
+    /// default is the namespaced stderr line — the honest out-of-band
+    /// channel (FCI-009 · see the `egress` module doc); tests and
+    /// embedders wire a collecting probe here. Chainable.
     #[must_use]
     pub fn with_egress_observer(mut self, observer: EgressObserver) -> Self {
         self.egress_observer = observer;

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -404,6 +404,7 @@ error_codes:
     - { code: NIKA-AUTH-007, category: security_error, transient: "false", failure: "an interpolation reaches a permit bound (host · glob · program · env name) — a bound MUST be a literal, the boundary would be self-serve (F-O1 · NEP-0004 · env per NEP-0005)" }
     - { code: NIKA-AUTH-008, category: security_error, transient: "false", failure: "an untrusted value reaches a permitted verb's argument and its canonical resolved form escapes the step's permit — re-gate refused (F-O1 · NEP-0004)" }
     - { code: NIKA-AUTH-009, category: security_error, transient: "false", failure: "a permits env: entry names a dangerous-floor variable · the engine strips the name unconditionally, the grant can never take effect: an inert dead grant (F-O4 · NEP-0005)" }
+    - { code: NIKA-AUTH-010, category: security_error, transient: "false", failure: "a permits net.http: entry carries the *. subdomain wildcard · the grant delegates the boundary to the zone operator (every host under the suffix, present and future) — refused: name exact hosts, or the bare * when allow-all is genuinely intended (F-P5)" }
     - { code: NIKA-VALUES-001, category: validation_error, transient: "false", failure: "vars: is a dead envelope field (R3a · the E-split)" }
     - { code: NIKA-VALUES-002, category: validation_error, transient: "false", failure: "env: is a dead envelope field (R3a · the E-split)" }
     - { code: NIKA-VALUES-003, category: validation_error, transient: "false", failure: "a value-namespace read outside the four-authority family (R3a · LAW-SURFACE-0201)" }

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -7,7 +7,7 @@
 #   sealed outcome_class enum) · the 15 ledger sections (canon/EXCEPTIONS.md ·
 #   SSOT-1 §18) stay AUTHORED and are carried verbatim — editing those is legal.
 # regenerate: python3 scripts/ssot-compiler.py --emit-canon
-# body-sha256: a18d927d1903207bfae4ed23a21a662742702bcfa90f43efd7d259f69f9606dd
+# body-sha256: 23c8cfb839646e346049762d27b60b5d66ed5b8e3c009370253508124c9cc5f8
 #   (digest of every byte below the end-of-header line · detached self-hash per PAA-006)
 # ---- end generated header (SSOT-1 §21-23 · the canon flip · C0)
 # nika canonical registry · the single source of truth for Nika canonical facts
@@ -65,7 +65,7 @@ counts:
   templates: 10
   error_namespaces: 25
   error_categories: 12
-  error_codes: 92
+  error_codes: 93
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -296,7 +296,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 92
+  count: 93
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }
@@ -404,7 +404,7 @@ error_codes:
     - { code: NIKA-AUTH-007, category: security_error, transient: "false", failure: "an interpolation reaches a permit bound (host · glob · program · env name) — a bound MUST be a literal, the boundary would be self-serve (F-O1 · NEP-0004 · env per NEP-0005)" }
     - { code: NIKA-AUTH-008, category: security_error, transient: "false", failure: "an untrusted value reaches a permitted verb's argument and its canonical resolved form escapes the step's permit — re-gate refused (F-O1 · NEP-0004)" }
     - { code: NIKA-AUTH-009, category: security_error, transient: "false", failure: "a permits env: entry names a dangerous-floor variable · the engine strips the name unconditionally, the grant can never take effect: an inert dead grant (F-O4 · NEP-0005)" }
-    - { code: NIKA-AUTH-010, category: security_error, transient: "false", failure: "a permits net.http: entry carries the *. subdomain wildcard · the grant delegates the boundary to the zone operator (every host under the suffix, present and future) — refused: name exact hosts, or the bare * when allow-all is genuinely intended (F-P5)" }
+    - { code: NIKA-AUTH-010, category: security_error, transient: "false", failure: "a permits net.http: entry carries the *. subdomain wildcard · the grant delegates the boundary to the zone operator (every host under the suffix, present and future) — refused: name exact hosts, or the bare * when allow-all is genuinely intended (F-P5 · NEP-0008)" }
     - { code: NIKA-VALUES-001, category: validation_error, transient: "false", failure: "vars: is a dead envelope field (R3a · the E-split)" }
     - { code: NIKA-VALUES-002, category: validation_error, transient: "false", failure: "env: is a dead envelope field (R3a · the E-split)" }
     - { code: NIKA-VALUES-003, category: validation_error, transient: "false", failure: "a value-namespace read outside the four-authority family (R3a · LAW-SURFACE-0201)" }

--- a/crates/nika-schema/src/parser/envelope.rs
+++ b/crates/nika-schema/src/parser/envelope.rs
@@ -1131,7 +1131,7 @@ tasks:
             "{BASE}\
 permits:
   fs:   {{ read: [\"./data/**\"], write: [\"./out/**\"] }}
-  net:  {{ http: [\"api.example.com\", \"*.github.com\"] }}
+  net:  {{ http: [\"api.example.com\", \"api.github.com\"] }}
   exec: [\"git\", \"cargo\"]
   tools: [\"nika:read\", \"mcp:browser/*\"]
 "
@@ -1142,7 +1142,7 @@ permits:
         assert_eq!(p.fs.as_ref().expect("fs").write, vec!["./out/**"]);
         assert_eq!(
             p.net.as_ref().expect("net").http,
-            vec!["api.example.com", "*.github.com"]
+            vec!["api.example.com", "api.github.com"]
         );
         assert!(p.allows_program("git") && p.allows_program("cargo"));
         assert!(!p.allows_program("rm"));


### PR DESCRIPTION
## F-P5 ENGINE · le proxy egress est la projection exacte de `net.http` — rien de plus, rien de moins

Le stopgap #703 a fermé le code (DNS rebinding refusé au dial · floor ports) · cette lane grave la LOI : doc-truth, lint wildcard, dead-grant twin, metering, fixtures.

### La loi en 4 points

1. **Doc-truth** · le module doc de `egress.rs` disait encore « the documented DNS-rebinding class srt also declines to close » — faux depuis #703. Réécrit : le rebinding est REFUSÉ au dial (check par adresse dans la boucle de dial via `ip_is_blocked`, le même oracle que le `GuardedResolver` de nika-http), le floor ports est nommé (`DANGEROUS_EGRESS_PORTS` · denylist · **no permit overrides it**), et la posture no-auth du proxy loopback est énoncée honnêtement (un processus co-localisé peut se connecter — et ne gagne rien : non confiné il dialerait les hôtes déclarés directement, confiné par un AUTRE run sa propre fence l'arrête avant · la boundary tient pour tout client).
2. **Wildcard `*.` = refus sec au check** · toute entrée `net.http` portant la sous-chaîne `*.` est un finding ERROR `PermitTaintKind::NetWildcard`, wire code **NIKA-AUTH-010** (enregistré dans le canon vendored · la leçon srt A2 : le wildcard délègue le permit à l'opérateur de zone — `*.github.io` = tous les utilisateurs de la zone mutualisée, présents et futurs). Le bare `*` reste LÉGAL — l'échappatoire explicite (`NetPolicy::Allow` · visible, jamais furtif) — et un bound interpolé reste le terrain de law 1 (NIKA-AUTH-007). Casse mesurée : 0 fixture trackée (vérifié contre le checkout spec · les deux YAMLs de test inline incidentels flippent vers des hôtes exacts · les tests du matcher gardent le wildcard — le matcher est inchangé, le refus est la couche check).
3. **Dead-grant twin net** · une entrée `net.http` floor-blocked (littéral IP privée/métadata type `169.254.169.254`) est un grant inerte — le twin net de NIKA-AUTH-009 env. Il EXISTAIT déjà dans `permits_fit` (floor-class · check≡run `NIKA-SEC-005` · introduit par la batterie #395) · il est maintenant épinglé au niveau unified-findings (task `permits` · code `NIKA-SEC-005` · « can never take effect »). Aucun nouveau code nécessaire — le code wire du run est honnête.
4. **Metering octets** · `relay()` jetait les deux compteurs `io::copy` · il journalise désormais UN `EgressEvent::Closed { host, port, bytes_up, bytes_down }` par tunnel via le même observer (ADDITIF · `#[non_exhaustive]` · la seule ligne d'API publique touchée — la signature Fn de l'observer — est régénérée dans `public-api.txt` · zéro consommateur downstream dans le workspace). Le TLS-blind jure host+port+octets, JAMAIS le contenu · le journal stderr garde son contrat greppable, épinglé verbatim par un formatter pur (`nika:egress REFUSED host:port` reste l'event sécurité).

### Fixtures (engine-side · inline · la matrice a–f)

- **(a)** green allowlisté passe par le proxy — `connect_allowed_relays_bytes_and_journals` + le wiring `TokioShell` end-to-end (env contract + port fence) · ré-épinglé
- **(b)** hôte non déclaré → `403` + `nika:egress REFUSED` journalisé — `connect_refused_is_403_and_journalised_as_a_security_event` + le contrat des lignes épinglé verbatim (`the_journal_lines_are_the_greppable_contract`)
- **(c)** wildcard au check = finding ERROR — `a_subdomain_wildcard_in_net_http_is_a_hard_refusal` (permit_taint) + `a_wildcard_net_http_entry_is_an_error_finding` (findings[])
- **(d)** dead-grant floor-blocked = finding — les tests `permits_fit` existants + `a_floor_blocked_net_http_entry_is_a_dead_grant_finding` (findings[])
- **(e)** metering — `a_relayed_tunnel_reports_its_byte_counters_at_close` (4 octets up · 4 echoed down · compteurs exacts à la clôture)
- **(f)** two-boundaries = le refus « one run, one allowlist » — `a_conflicting_boundary_in_one_run_is_refused_fail_closed` + `boundary_reuse_and_conflict_detection` (existants · vérifiés)

La fixture conformance est gérée dans la PR spec sœur (0 fixture trackée n'usait le wildcard). Les tests EPERM seatbelt (`allowlist_fences_loopback_to_the_proxy_port`) prouvent déjà la fence au syscall — inchangés.

### Vérifs

- `cargo test --workspace --lib` · 55 suites vertes
- `cargo clippy --workspace --all-targets -- -D warnings` · propre
- `cargo test -p nika-exec-runner -p nika-check` (intégration incluse) · vert
- ratchets fn-length · loc-limits · unwrap · expect · OK · `egress.rs` = 1246 LOC (< 1500)
- la suite `conformance_core` (NIKA_SPEC_DIR) montre 12 échecs PRÉ-EXISTANTS sur origin/main @ c814a22fc (checkout spec 86be877 en avance · NEP-0002 v2.0) — identiques avec et sans cette lane · 0 fixture n'use le wildcard

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
