### PR TITLE
fix(check): nika-sec-005 is core-visible — law 5 at every tier

### DIFF
--- a/crates/nika-check/tests/common/mod.rs
+++ b/crates/nika-check/tests/common/mod.rs
@@ -171,9 +171,17 @@ pub(crate) fn check_core_codes(yaml: &str, mode: ParseMode, dir: &Path) -> Vec<S
                     // NEP-0006 · the data-as-code sink (NIKA-SEC-008) is a
                     // Core-visible law: the reference oracle judges it on
                     // every tier, so the core verdict must too — the REST
-                    // of the SEC namespace (004/005 escapes · 009 trifecta)
+                    // of the SEC namespace (004 escape · 009 trifecta)
                     // stays the deep tier's ground.
                     || (c.namespace == "SEC" && c.num == 8)
+                    // NEP-0008 law 5 · the floor-parity dead grant
+                    // (NIKA-SEC-005) is Core-visible for the same reason:
+                    // the reference oracle judges the net boundary on
+                    // every tier (deep_static.py net_egress_boundary_errors),
+                    // and the law lives in the authority suite's home tier
+                    // (core/authority/026) — a fetch-side SEC-005 emitted
+                    // at run stays the deep/runtime ground as before.
+                    || (c.namespace == "SEC" && c.num == 5)
             })
             .collect()
         }


### PR DESCRIPTION
## What

The core-tier conformance filter in `nika-check`'s test harness now admits `NIKA-SEC-005` beside `NIKA-SEC-008`: NEP-0008 law 5 (the floor-parity dead grant) is judged at every tier.

## Why

The reference oracle judges the net-egress boundary on every tier (`deep_static.py` · `net_egress_boundary_errors`), and spec `a149e4f` lands the law's home fixture in the CORE authority suite (`core/authority/026-net-dead-grant-floor-blocked`). The engine already emits SEC-005 in `check()` since #706 — only the core-tier harness hid it, which is #707's red leg (`core_conformance_suite`).

## Proof (local · both pins)

- `conformance_core` **green at 1553eb9** (the current pin · fixture 026 absent · the change is inert — this PR's CI stays green)
- `conformance_core` **green at a149e4f** (#707's pin · the 026 verdict lands)
- `conformance_deep` **green at a149e4f** (the deep ground is untouched)

Unblocks #707 (spec-pin heal · refresh after this merges).
