### PR TITLE
feat(schema,check): the run-decl refusals ride their dedicated mints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   shims; the clean cut). Static judgment without the CLI, for the
   embedder/SDK surface.
 
+### Changed
+
+- **`run:` declared-pair refusals ride their dedicated mints** — the
+  parse-level entropy × clock contradictions stamp `NIKA-PARSE-026`
+  (ambient × virtual) and `NIKA-PARSE-027` (none | seeded × system), and
+  the check-side `entropy: none` × structural-source judgment stamps
+  `NIKA-PARSE-028` — was the registered generic `NIKA-PARSE-019`; the
+  NEP-0010 mints landed with the 87f764a spec pack resync.
+
 ## [0.105.0](https://github.com/supernovae-st/nika/compare/v0.104.0..v0.105.0) - 2026-07-20
 
 ### ✨ Features

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -430,12 +430,11 @@ impl CheckReport {
             }
         }));
         // F-P3 · the run: declaration contradicted by the body — the
-        // registered generic structural validation (the dedicated mint is
-        // the spec-side follow-up).
+        // dedicated NIKA-PARSE-028 mint (NEP-0010 · the 87f764a pack).
         codes.extend(
             self.run_decl_findings
                 .iter()
-                .map(|_| SpecCode::new("PARSE", 19, SpecCategory::ValidationError)),
+                .map(|_| SpecCode::new("PARSE", 28, SpecCategory::ValidationError)),
         );
         // Composition lane (spec 14): COMP-002 is the security law
         // (child boundary ⊄ parent); 001/003/004 are validation.
@@ -1029,11 +1028,11 @@ tasks:
     }
 
     #[test]
-    fn extra_conformance_codes_maps_run_decl_to_parse_019() {
+    fn extra_conformance_codes_maps_run_decl_to_parse_028() {
         // F-P3 · `entropy: none` contradicted by a live retry jitter →
         // the run_decl lane refuses (is_clean fails), the class-erased
-        // findings carry the row, and the code map yields the registered
-        // generic (the dedicated mint is the spec-side follow-up).
+        // findings carry the row, and the code map yields the dedicated
+        // NIKA-PARSE-028 mint (NEP-0010 · the 87f764a pack).
         let r = check_yaml(
             "\
 nika: v1
@@ -1055,13 +1054,13 @@ tasks:
             .find(|f| f.kind == "run_decl")
             .expect("the row lands in findings[]");
         assert_eq!(hit.gate, "RUN");
-        assert_eq!(hit.code.as_deref(), Some("NIKA-PARSE-019"));
+        assert_eq!(hit.code.as_deref(), Some("NIKA-PARSE-028"));
         assert_eq!(hit.task.as_deref(), Some("flaky"));
         let codes = r.extra_conformance_codes();
         let rendered: Vec<String> = codes.iter().map(ToString::to_string).collect();
         assert!(
-            rendered.iter().any(|c| c == "NIKA-PARSE-019"),
-            "run_decl → NIKA-PARSE-019: {rendered:?}",
+            rendered.iter().any(|c| c == "NIKA-PARSE-028"),
+            "run_decl → NIKA-PARSE-028: {rendered:?}",
         );
     }
 

--- a/crates/nika-check/src/run_decl.rs
+++ b/crates/nika-check/src/run_decl.rs
@@ -29,16 +29,16 @@
 //! positive), and the replay-divergence half of the contract (a seeded
 //! run that still diverges) is the fixture's, not a static judgment.
 //!
-//! The wire code rides NIKA-PARSE-019 (the registered generic structural
-//! validation — the dedicated NIKA-PARSE-027 mint for this class is the
-//! spec-side follow-up, mirrored from the engine's choice).
+//! The wire code is the dedicated `NIKA-PARSE-028` mint (NEP-0010 ·
+//! registered by the 87f764a pack resync — this lane's generic
+//! NIKA-PARSE-019 era ended when the spec-side follow-up landed).
 
 use nika_schema::raw::{RawAction, RawWorkflow};
 use nika_schema::types::RunEntropy;
 
-/// The wire code of a run-declaration contradiction (the registered
-/// generic — the dedicated mint is the spec-side follow-up).
-pub(crate) const RUN_DECL_CODE: &str = "NIKA-PARSE-019";
+/// The wire code of a body-level run-declaration contradiction — the
+/// dedicated `entropy: none` × structural-source mint (NEP-0010).
+pub(crate) const RUN_DECL_CODE: &str = "NIKA-PARSE-028";
 
 /// One `run:` declaration the workflow body contradicts (F-P3).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -140,7 +140,7 @@ mod tests {
         );
         let f = findings_of(&y);
         assert_eq!(f.len(), 1, "{f:?}");
-        assert_eq!(f[0].wire_code(), "NIKA-PARSE-019");
+        assert_eq!(f[0].wire_code(), "NIKA-PARSE-028");
         assert_eq!(f[0].task, "flaky");
         assert_eq!(f[0].source, "retry jitter");
         assert!(
@@ -227,18 +227,20 @@ mod tests {
     }
 
     /// The emitted⊆registered ratchet, run-declaration tier (the
-    /// `composition.rs` / `permit_taint.rs` pattern): the wire code this
-    /// lane stamps must exist in the vendored canon registry (the dedicated
-    /// mint lands spec-side; the generic is registered today).
+    /// `composition.rs` / `permit_taint.rs` pattern): every F-P3 mint the
+    /// engine stamps — the check-side 028 here, the parse-side 026/027 in
+    /// nika-schema's envelope — must exist in the vendored canon registry.
     #[test]
-    fn the_run_decl_code_is_registered_in_the_canon() {
+    fn the_run_decl_codes_are_registered_in_the_canon() {
         let registered: std::collections::BTreeSet<String> = nika_pack::error_codes()
             .into_iter()
             .map(|row| row.code.to_string())
             .collect();
-        assert!(
-            registered.contains(RUN_DECL_CODE),
-            "`{RUN_DECL_CODE}` is not in the canon registry (spec/05-errors.md SSOT)"
-        );
+        for code in ["NIKA-PARSE-026", "NIKA-PARSE-027", RUN_DECL_CODE] {
+            assert!(
+                registered.contains(code),
+                "`{code}` is not in the canon registry (spec/05-errors.md SSOT)"
+            );
+        }
     }
 }

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -218,6 +218,30 @@ fn cli_fix_hint(code: &str) -> Option<&'static str> {
              above the declared floor; a MISSING required key is not an \
              error (the evaluation defers — abstention is a safety property)",
         ),
+        _ => run_decl_fix_hint(code),
+    }
+}
+
+/// The `run:` declaration hints (F-P3 · NEP-0010 · the dedicated
+/// mints) — split out of [`cli_fix_hint`] at the fn-length wall.
+fn run_decl_fix_hint(code: &str) -> Option<&'static str> {
+    match code {
+        "NIKA-PARSE-026" => Some(
+            "`entropy: ambient` declares live entropy while `clock: virtual` \
+             demands a simulated clock — drop `clock: virtual`, or name the \
+             stream (`entropy: none` or `{ seeded: <u64> }`)",
+        ),
+        "NIKA-PARSE-027" => Some(
+            "`entropy: none | seeded` forces byte-identical journals; a wall \
+             clock would leak real durations into them — drop `clock: system` \
+             (the virtual clock is implied) or declare `clock: virtual`",
+        ),
+        "NIKA-PARSE-028" => Some(
+            "`entropy: none` is a strict no-entropy promise but the body \
+             consumes a structural source (a live retry jitter · `nika:uuid`) \
+             — set `jitter: false`, drop the uuid call, or name the stream \
+             with `entropy: { seeded: <u64> }`",
+        ),
         _ => None,
     }
 }

--- a/crates/nika-schema/public-api.txt
+++ b/crates/nika-schema/public-api.txt
@@ -219,6 +219,9 @@ pub nika_schema::error::SchemaError::ReservedBindingName
 pub nika_schema::error::SchemaError::ReservedBindingName::name: alloc::string::String
 pub nika_schema::error::SchemaError::ReservedBindingName::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::error::SchemaError::ReservedBindingName::task: alloc::string::String
+pub nika_schema::error::SchemaError::RunContradiction
+pub nika_schema::error::SchemaError::RunContradiction::class: nika_vocab::run::RunContradiction
+pub nika_schema::error::SchemaError::RunContradiction::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::error::SchemaError::TemplateSyntax
 pub nika_schema::error::SchemaError::TemplateSyntax::reason: alloc::string::String
 pub nika_schema::error::SchemaError::TemplateSyntax::span: core::option::Option<nika_source::span::Span>
@@ -1881,6 +1884,9 @@ pub nika_schema::SchemaError::ReservedBindingName
 pub nika_schema::SchemaError::ReservedBindingName::name: alloc::string::String
 pub nika_schema::SchemaError::ReservedBindingName::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::SchemaError::ReservedBindingName::task: alloc::string::String
+pub nika_schema::SchemaError::RunContradiction
+pub nika_schema::SchemaError::RunContradiction::class: nika_vocab::run::RunContradiction
+pub nika_schema::SchemaError::RunContradiction::span: core::option::Option<nika_source::span::Span>
 pub nika_schema::SchemaError::TemplateSyntax
 pub nika_schema::SchemaError::TemplateSyntax::reason: alloc::string::String
 pub nika_schema::SchemaError::TemplateSyntax::span: core::option::Option<nika_source::span::Span>

--- a/crates/nika-schema/src/error.rs
+++ b/crates/nika-schema/src/error.rs
@@ -361,6 +361,18 @@ pub enum SchemaError {
         span: Option<Span>,
     },
 
+    /// The `run:` block declares a contradicting entropy × clock pair
+    /// (F-P3 · the parse-level law) — the wire code follows the class
+    /// (`NIKA-PARSE-026` ambient × virtual · `NIKA-PARSE-027`
+    /// determinism × system · NEP-0010).
+    #[error("`run:` contradicts itself — {class}")]
+    RunContradiction {
+        /// Which declared pair contradicts (the vocab-level class).
+        class: crate::types::RunContradiction,
+        /// Source span.
+        span: Option<Span>,
+    },
+
     /// A builtin `invoke:` violates its statically-checkable arg
     /// contract (`stdlib/builtins-v0.1.md` · deep fixtures 009-012).
     #[error("task `{task}` · `{tool}` {reason}")]
@@ -716,6 +728,7 @@ impl SchemaError {
             | Self::DuplicateKey { span, .. }
             | Self::MissingField { span, .. }
             | Self::Validation { span, .. }
+            | Self::RunContradiction { span, .. }
             | Self::BadBuiltinArgs { span, .. }
             | Self::RecoverAwaitDeadlock { span, .. }
             | Self::WhenNotBoolean { span, .. }
@@ -824,6 +837,7 @@ schema_code!(SCHEMA_323, 323, "decode-with-structured-capture");
 schema_code!(SCHEMA_324, 324, "dead-value-form");
 schema_code!(SCHEMA_325, 325, "foreign-value-namespace");
 schema_code!(SCHEMA_326, 326, "default-not-conforming");
+schema_code!(SCHEMA_327, 327, "run-contradiction");
 
 impl NikaErrorCode for SchemaError {
     fn nika_code(&self) -> NikaCode {
@@ -855,6 +869,7 @@ impl NikaErrorCode for SchemaError {
             Self::DuplicateKey { .. } => SCHEMA_297,
             Self::MissingField { .. } => SCHEMA_298,
             Self::Validation { .. } => SCHEMA_299,
+            Self::RunContradiction { .. } => SCHEMA_327,
             Self::WhenNotBoolean { .. } => SCHEMA_300,
             Self::RecoverAwaitDeadlock { .. } => SCHEMA_308,
             Self::BadBuiltinArgs { .. } => SCHEMA_309,

--- a/crates/nika-schema/src/error/spec_code.rs
+++ b/crates/nika-schema/src/error/spec_code.rs
@@ -174,6 +174,18 @@ const fn builtin_spec_code(tool: &str) -> SpecCode {
     }
 }
 
+/// The `run:` declared-pair mints (F-P3 · NEP-0010) — the wire code
+/// follows the vocab class; a future contradiction class rides the
+/// registered generic until its dedicated mint lands.
+const fn run_contradiction_code(class: crate::types::RunContradiction) -> SpecCode {
+    use crate::types::RunContradiction as Class;
+    match class {
+        Class::AmbientTimesVirtual => parse(26, SpecCategory::ValidationError),
+        Class::DeterminismTimesSystem => parse(27, SpecCategory::ValidationError),
+        _ => parse(19, SpecCategory::ValidationError),
+    }
+}
+
 impl SchemaError {
     /// Map to the spec-facing code (spec `05-errors.md`).
     ///
@@ -184,6 +196,15 @@ impl SchemaError {
     /// with the R3b `TypeExpr` widen (the rich forms are admitted ·
     /// out-of-grammar refuses NIKA-TYPE-001 · the surviving shape
     /// refusals ride NIKA-PARSE-019).
+    ///
+    /// NIKA-VAR-005 (spec 05 registry) = « static expression violation —
+    /// outside cel-subset/0.1 · chained relation · unknown function ·
+    /// non-boolean `when:` root · jq compile error »: the class spans the
+    /// non-boolean `when:` shape gate (the retired NIKA-PARSE-WHEN-001
+    /// folded here), `${{ }}` inside an output binding (04 §binding rules
+    /// · deep fixtures 003/007/008), and a CLOSED `${{ }}` island whose
+    /// CEL is outside the subset (`ExpressionViolation` — distinct from
+    /// the unclosed-opener VAR-008).
     #[must_use]
     pub fn spec_code(&self) -> SpecCode {
         use SpecCategory::{ParseError, ValidationError, VariableError};
@@ -210,6 +231,7 @@ impl SchemaError {
             Self::DuplicateKey { .. } => parse(17, ValidationError),
             Self::MissingField { .. } => parse(18, ValidationError),
             Self::Validation { .. } => parse(19, ValidationError),
+            Self::RunContradiction { class, .. } => run_contradiction_code(*class),
             // W1 « the map » migration teachings (dead forms · 0.104)
             Self::W1WorkflowScalar { .. } => parse(20, ValidationError),
             Self::W1TopLevelDescription { .. } => parse(21, ValidationError),
@@ -217,16 +239,6 @@ impl SchemaError {
             Self::W1TaskIdField { .. } => parse(23, ValidationError),
             // W2 « the flow » migration teaching (dead form · 0.104)
             Self::W2DependsOnField { .. } => parse(24, ValidationError),
-            // Spec 05 registry · NIKA-VAR-005 = « static expression
-            // violation — outside cel-subset/0.1 · chained relation ·
-            // unknown function · non-boolean when: root · jq compile
-            // error ». The class spans the non-boolean `when:` shape gate
-            // (the retired NIKA-PARSE-WHEN-001 folded here), `${{ }}` inside
-            // an output binding (04 §binding rules · deep fixtures 003/007/008),
-            // AND a CLOSED `${{ }}` island whose CEL is outside the subset
-            // (chained relation · unknown function · arithmetic · stray token
-            // — `ExpressionViolation`, distinct from the unclosed-opener
-            // VAR-008 below).
             Self::WhenNotBoolean { .. }
             | Self::JqBindingContainsTemplate { .. }
             | Self::ExpressionViolation { .. } => var(5, ValidationError),

--- a/crates/nika-schema/src/parser/envelope.rs
+++ b/crates/nika-schema/src/parser/envelope.rs
@@ -981,12 +981,13 @@ pub(super) fn parse_policy(
 /// a single-key map for the one parameterized value (`{ seeded: <u64> }`).
 ///
 /// The ONE semantic judgment the parser makes here is the declared
-/// CONTRADICTION ([`RunDecl::contradiction`]): a determinism demand
-/// sharing the block with a declared non-deterministic source
-/// (`entropy: ambient` × `clock: virtual` · `entropy: none | seeded` ×
-/// `clock: system`). Everything else — which seams the declaration
-/// pilots, the body-level entropy-source judgment — belongs to the
-/// composer and the checker, never to a shape pass.
+/// CONTRADICTION ([`RunDecl::contradiction_class`]): a determinism demand
+/// sharing the block with a declared non-deterministic source, each
+/// class riding its dedicated mint (`NIKA-PARSE-026` ambient × virtual ·
+/// `NIKA-PARSE-027` none|seeded × system · NEP-0010). Everything else —
+/// which seams the declaration pilots, the body-level entropy-source
+/// judgment — belongs to the composer and the checker, never to a
+/// shape pass.
 pub(super) fn parse_run(
     cx: &Cx<'_>,
     workflow: &MarkedMappingNode,
@@ -1028,9 +1029,9 @@ pub(super) fn parse_run(
     };
 
     let decl = RunDecl::new(entropy, clock);
-    if let Some(why) = decl.contradiction() {
-        return Err(SchemaError::Validation {
-            message: format!("`run:` contradicts itself — {why}"),
+    if let Some(class) = decl.contradiction_class() {
+        return Err(SchemaError::RunContradiction {
+            class,
             span: cx.span(node.span()),
         });
     }
@@ -1391,6 +1392,11 @@ workflow:
         // F-P3 (a) — the determinism demand × the ambient declaration.
         let yaml = format!("{BASE}run: {{ entropy: ambient, clock: virtual }}\n");
         let err = parse_strict(&yaml).expect_err("contradiction refused");
+        assert_eq!(
+            err.spec_code().to_string(),
+            "NIKA-PARSE-026",
+            "the dedicated mint (NEP-0010)"
+        );
         let msg = err.to_string();
         assert!(msg.contains("contradicts itself"), "{msg}");
         assert!(msg.contains("ambient") && msg.contains("virtual"), "{msg}");
@@ -1403,6 +1409,11 @@ workflow:
         for entropy in ["none", "{ seeded: 42 }"] {
             let yaml = format!("{BASE}run: {{ entropy: {entropy}, clock: system }}\n");
             let err = parse_strict(&yaml).expect_err("contradiction refused");
+            assert_eq!(
+                err.spec_code().to_string(),
+                "NIKA-PARSE-027",
+                "{entropy}: the dedicated mint (NEP-0010)"
+            );
             assert!(
                 err.to_string().contains("contradicts itself"),
                 "{entropy}: {err}"

--- a/crates/nika-vocab/public-api.txt
+++ b/crates/nika-vocab/public-api.txt
@@ -737,6 +737,48 @@ impl<T> core::clone::CloneToUninit for nika_vocab::run::RunClock where T: core::
 pub unsafe fn nika_vocab::run::RunClock::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_vocab::run::RunClock
 pub fn nika_vocab::run::RunClock::from(t: T) -> T
+#[non_exhaustive] pub enum nika_vocab::run::RunContradiction
+pub nika_vocab::run::RunContradiction::AmbientTimesVirtual
+pub nika_vocab::run::RunContradiction::DeterminismTimesSystem
+impl nika_vocab::run::RunContradiction
+pub const fn nika_vocab::run::RunContradiction::why(self) -> &'static str
+impl core::clone::Clone for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::clone(&self) -> nika_vocab::run::RunContradiction
+impl core::cmp::Eq for nika_vocab::run::RunContradiction
+impl core::cmp::PartialEq for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::eq(&self, other: &nika_vocab::run::RunContradiction) -> bool
+impl core::fmt::Debug for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for nika_vocab::run::RunContradiction
+impl core::marker::StructuralPartialEq for nika_vocab::run::RunContradiction
+impl<T, U> core::convert::Into<U> for nika_vocab::run::RunContradiction where U: core::convert::From<T>
+pub fn nika_vocab::run::RunContradiction::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_vocab::run::RunContradiction where U: core::convert::Into<T>
+pub type nika_vocab::run::RunContradiction::Error = core::convert::Infallible
+pub fn nika_vocab::run::RunContradiction::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_vocab::run::RunContradiction where U: core::convert::TryFrom<T>
+pub type nika_vocab::run::RunContradiction::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_vocab::run::RunContradiction::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_vocab::run::RunContradiction where T: core::clone::Clone
+pub type nika_vocab::run::RunContradiction::Owned = T
+pub fn nika_vocab::run::RunContradiction::clone_into(&self, target: &mut T)
+pub fn nika_vocab::run::RunContradiction::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_vocab::run::RunContradiction where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_vocab::run::RunContradiction where T: 'static + ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_vocab::run::RunContradiction where T: ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_vocab::run::RunContradiction where T: ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_vocab::run::RunContradiction where T: core::clone::Clone
+pub unsafe fn nika_vocab::run::RunContradiction::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::from(t: T) -> T
 #[non_exhaustive] pub enum nika_vocab::run::RunEntropy
 pub nika_vocab::run::RunEntropy::Ambient
 pub nika_vocab::run::RunEntropy::None
@@ -784,6 +826,7 @@ pub nika_vocab::run::RunDecl::entropy: core::option::Option<nika_vocab::run::Run
 impl nika_vocab::run::RunDecl
 pub const fn nika_vocab::run::RunDecl::clock_or_default(&self) -> nika_vocab::run::RunClock
 pub const fn nika_vocab::run::RunDecl::contradiction(&self) -> core::option::Option<&'static str>
+pub const fn nika_vocab::run::RunDecl::contradiction_class(&self) -> core::option::Option<nika_vocab::run::RunContradiction>
 pub const fn nika_vocab::run::RunDecl::entropy_or_default(&self) -> nika_vocab::run::RunEntropy
 pub const fn nika_vocab::run::RunDecl::new(entropy: core::option::Option<nika_vocab::run::RunEntropy>, clock: core::option::Option<nika_vocab::run::RunClock>) -> Self
 impl core::clone::Clone for nika_vocab::run::RunDecl
@@ -1665,6 +1708,48 @@ impl<T> core::clone::CloneToUninit for nika_vocab::run::RunClock where T: core::
 pub unsafe fn nika_vocab::run::RunClock::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_vocab::run::RunClock
 pub fn nika_vocab::run::RunClock::from(t: T) -> T
+#[non_exhaustive] pub enum nika_vocab::RunContradiction
+pub nika_vocab::RunContradiction::AmbientTimesVirtual
+pub nika_vocab::RunContradiction::DeterminismTimesSystem
+impl nika_vocab::run::RunContradiction
+pub const fn nika_vocab::run::RunContradiction::why(self) -> &'static str
+impl core::clone::Clone for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::clone(&self) -> nika_vocab::run::RunContradiction
+impl core::cmp::Eq for nika_vocab::run::RunContradiction
+impl core::cmp::PartialEq for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::eq(&self, other: &nika_vocab::run::RunContradiction) -> bool
+impl core::fmt::Debug for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for nika_vocab::run::RunContradiction
+impl core::marker::StructuralPartialEq for nika_vocab::run::RunContradiction
+impl<T, U> core::convert::Into<U> for nika_vocab::run::RunContradiction where U: core::convert::From<T>
+pub fn nika_vocab::run::RunContradiction::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_vocab::run::RunContradiction where U: core::convert::Into<T>
+pub type nika_vocab::run::RunContradiction::Error = core::convert::Infallible
+pub fn nika_vocab::run::RunContradiction::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_vocab::run::RunContradiction where U: core::convert::TryFrom<T>
+pub type nika_vocab::run::RunContradiction::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_vocab::run::RunContradiction::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_vocab::run::RunContradiction where T: core::clone::Clone
+pub type nika_vocab::run::RunContradiction::Owned = T
+pub fn nika_vocab::run::RunContradiction::clone_into(&self, target: &mut T)
+pub fn nika_vocab::run::RunContradiction::to_owned(&self) -> T
+impl<T> alloc::string::ToString for nika_vocab::run::RunContradiction where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_vocab::run::RunContradiction where T: 'static + ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_vocab::run::RunContradiction where T: ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_vocab::run::RunContradiction where T: ?core::marker::Sized
+pub fn nika_vocab::run::RunContradiction::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_vocab::run::RunContradiction where T: core::clone::Clone
+pub unsafe fn nika_vocab::run::RunContradiction::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_vocab::run::RunContradiction
+pub fn nika_vocab::run::RunContradiction::from(t: T) -> T
 #[non_exhaustive] pub enum nika_vocab::RunEntropy
 pub nika_vocab::RunEntropy::Ambient
 pub nika_vocab::RunEntropy::None
@@ -2039,6 +2124,7 @@ pub nika_vocab::RunDecl::entropy: core::option::Option<nika_vocab::run::RunEntro
 impl nika_vocab::run::RunDecl
 pub const fn nika_vocab::run::RunDecl::clock_or_default(&self) -> nika_vocab::run::RunClock
 pub const fn nika_vocab::run::RunDecl::contradiction(&self) -> core::option::Option<&'static str>
+pub const fn nika_vocab::run::RunDecl::contradiction_class(&self) -> core::option::Option<nika_vocab::run::RunContradiction>
 pub const fn nika_vocab::run::RunDecl::entropy_or_default(&self) -> nika_vocab::run::RunEntropy
 pub const fn nika_vocab::run::RunDecl::new(entropy: core::option::Option<nika_vocab::run::RunEntropy>, clock: core::option::Option<nika_vocab::run::RunClock>) -> Self
 impl core::clone::Clone for nika_vocab::run::RunDecl

--- a/crates/nika-vocab/src/lib.rs
+++ b/crates/nika-vocab/src/lib.rs
@@ -65,7 +65,7 @@ pub use output_decl::OutputDecl;
 pub use nika_cap::{EffectClass, Objective, Policy, PolicyViolation};
 pub use permits::{ExecPermit, FsPermits, NetPermits, Permits};
 pub use retry::{BackoffStrategy, RetryConfig, is_valid_error_code};
-pub use run::{RunClock, RunDecl, RunEntropy};
+pub use run::{RunClock, RunContradiction, RunDecl, RunEntropy};
 pub use schema_version::SchemaVersion;
 pub use secret::{EgressRule, SecretRef, SecretSource};
 pub use type_expr::{coerce_declared, default_not_conforming_teaching, type_expr_display};

--- a/crates/nika-vocab/src/run.rs
+++ b/crates/nika-vocab/src/run.rs
@@ -177,18 +177,67 @@ impl RunDecl {
     /// Defaults never contradict — only two EXPLICIT values can.
     #[must_use]
     pub const fn contradiction(&self) -> Option<&'static str> {
+        match self.contradiction_class() {
+            Some(class) => Some(class.why()),
+            None => None,
+        }
+    }
+
+    /// The typed twin of [`Self::contradiction`] — WHICH declared pair
+    /// contradicts. The wire code follows the class (the NEP-0010 mints:
+    /// `NIKA-PARSE-026` ambient × virtual · `NIKA-PARSE-027`
+    /// determinism × system).
+    #[must_use]
+    pub const fn contradiction_class(&self) -> Option<RunContradiction> {
         match (self.entropy, self.clock) {
-            (Some(RunEntropy::Ambient), Some(RunClock::Virtual)) => Some(
-                "`entropy: ambient` declares live entropy but `clock: virtual` demands a \
-                 simulated clock — the run cannot be both ambient and simulated",
-            ),
-            (Some(e), Some(RunClock::System)) if e.is_deterministic() => Some(
-                "`entropy: none | seeded` forces the deterministic seams (byte-identical \
-                 journals) but `clock: system` lets task durations ride the wall clock — \
-                 drop `clock: system` (the virtual clock is implied) or declare `clock: virtual`",
-            ),
+            (Some(RunEntropy::Ambient), Some(RunClock::Virtual)) => {
+                Some(RunContradiction::AmbientTimesVirtual)
+            }
+            (Some(e), Some(RunClock::System)) if e.is_deterministic() => {
+                Some(RunContradiction::DeterminismTimesSystem)
+            }
             _ => None,
         }
+    }
+}
+
+/// A declared `run:` pair contradiction (F-P3 · NEP-0010) — the two
+/// EXPLICIT pairs the parse-level law refuses, each carrying its
+/// dedicated wire mint (spec `05-errors.md` registry).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum RunContradiction {
+    /// `entropy: ambient` × `clock: virtual` — live entropy cannot ride
+    /// a simulated clock (`NIKA-PARSE-026`).
+    AmbientTimesVirtual,
+    /// `entropy: none | seeded` × `clock: system` — byte-identical
+    /// journals cannot ride the wall clock (`NIKA-PARSE-027`).
+    DeterminismTimesSystem,
+}
+
+impl RunContradiction {
+    /// The witness sentence (the declared pair × why it cannot hold) —
+    /// the ONE prose source every refusal renders.
+    #[must_use]
+    pub const fn why(self) -> &'static str {
+        match self {
+            Self::AmbientTimesVirtual => {
+                "`entropy: ambient` declares live entropy but `clock: virtual` demands a \
+                 simulated clock — the run cannot be both ambient and simulated"
+            }
+            Self::DeterminismTimesSystem => {
+                "`entropy: none | seeded` forces the deterministic seams (byte-identical \
+                 journals) but `clock: system` lets task durations ride the wall clock — \
+                 drop `clock: system` (the virtual clock is implied) or declare `clock: virtual`"
+            }
+        }
+    }
+}
+
+impl core::fmt::Display for RunContradiction {
+    /// Renders [`Self::why`] — the refusal's human sentence.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.why())
     }
 }
 
@@ -211,6 +260,27 @@ mod tests {
         assert_eq!(decl.clock_or_default(), RunClock::System);
         assert_eq!(decl.entropy_or_default().jitter_seed(), 0);
         assert!(decl.contradiction().is_none());
+    }
+
+    #[test]
+    fn the_contradiction_class_names_the_pair() {
+        let av = RunDecl::new(Some(RunEntropy::Ambient), Some(RunClock::Virtual));
+        assert_eq!(
+            av.contradiction_class(),
+            Some(RunContradiction::AmbientTimesVirtual)
+        );
+        for e in [RunEntropy::None, RunEntropy::Seeded(7)] {
+            let ds = RunDecl::new(Some(e), Some(RunClock::System));
+            assert_eq!(
+                ds.contradiction_class(),
+                Some(RunContradiction::DeterminismTimesSystem)
+            );
+        }
+        // One prose source: contradiction() renders the class's why().
+        assert_eq!(
+            av.contradiction(),
+            av.contradiction_class().map(RunContradiction::why)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the F-P3 convergence: the three run-decl refusal sites migrate from the registered generic `NIKA-PARSE-019` to the dedicated NEP-0010 mints registered by the 87f764a pack resync (#712).

- **Parse side** — the `run:` declared-pair contradiction carries a typed class: `RunContradiction` in nika-vocab (additive · one prose source · `Display` renders the witness sentence), `SchemaError::RunContradiction` mapped to `NIKA-PARSE-026` (ambient × virtual) / `NIKA-PARSE-027` (none | seeded × system). A future contradiction class rides the generic until its mint lands (the non-exhaustive wildcard).
- **Check side** — `RUN_DECL_CODE` → `NIKA-PARSE-028` (entropy: none × structural source), including the `extra_conformance_codes` map the plan had not seen.
- The emitted⊆registered ratchet test now pins the trio · `nika explain` teaches the three pages (split at the fn-length wall, as was `spec_code()` itself — the VAR-005 teaching moved to the fn doc) · internal one-voice `SCHEMA_327` · CHANGELOG entry.
- `NIKA-PARSE-019` STAYS the generic structural code for the meta-schema/shape classes (schema_lint · Validation) — untouched.

Proof: 1096 lib tests green (vocab 79 · schema 211 · check 535 · cli 271) · clippy `-D warnings` clean on the four crates · the full pre-push gate (tests · clippy · hygiene · ratchets) green at push.

Spec anchors: NEP-0010 (#197) · the declared-pair scoping (#198) · pack #712 · pin #713 · the schema-description doc-truth follow-up (nika-spec #199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)