### PR TITLE
fix(agents): the taught flow bindings quote their islands

### DIFF
--- a/.agents/plugins/nika/agents/nika-migrator.md
+++ b/.agents/plugins/nika/agents/nika-migrator.md
@@ -28,7 +28,7 @@ parity is the proof.
    loops → `for_each:` · conditionals → `when:` · parameters →
    `vars:` + `${{ env.KEY }}` · credentials → `${{ secrets.X }}`
    declared with an `egress:` sink. Every task that reads another's
-   output binds it — `with: { alias: ${{ tasks.A.output }} }` (the
+   output binds it — `with: { alias: "${{ tasks.A.output }}" }` (the
    binding IS the edge) — and reads `${{ with.alias }}`; pure ordering
    without data is `after: { A: succeeded }`.
 4. **Guard the irreversible.** Any step the source author would have

--- a/.agents/plugins/nika/rules/nika-workflow-language.mdc
+++ b/.agents/plugins/nika/rules/nika-workflow-language.mdc
@@ -16,7 +16,7 @@ Envelope: `nika: v1` (always · frozen forever). Extensions: `.nika.yaml` (canon
 
 ## Authoring Discipline
 - Interpolation uses `${{ vars.x }}` · `${{ tasks.id.output }}` · `${{ env.KEY }}` · `${{ with.alias }}`.
-- Bindings use `with: { alias: ${{ tasks.id.output }} }` then `${{ with.alias }}`.
+- Bindings use `with: { alias: "${{ tasks.id.output }}" }` then `${{ with.alias }}`.
 - Models use the combined form `provider/name` (for example `mock/echo`, `ollama/qwen3.5:4b`, `mistral/mistral-small`).
 - Edges are the two doors: a `with:` binding IS the data edge (never restate it) · `after: { task_id: succeeded|failed|skipped|terminal }` is pure control. `depends_on` is dead (NIKA-PARSE-024 · `nika check --fix` migrates).
 - Secrets are declared in a top-level `secrets:` block (e.g. `source: env`, `key: MY_KEY`) and referenced as `${{ secrets.name }}` — never inline literal keys; `${{ env.* }}` is for non-sensitive configuration.

--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -120,7 +120,7 @@ Every surviving `exec:` gets a row in the workflow's header comment:
   this as `[envelope-output]`; fix the binding, never re-baseline
   around it.
 - A task that reads another task's output binds it in `with:` —
-  `with: { alias: ${{ tasks.<id>.output }} }` — and the body reads
+  `with: { alias: "${{ tasks.<id>.output }}" }` — and the body reads
   `${{ with.alias }}` (the binding IS the edge; `tasks.*` anywhere
   else is NIKA-VAR-021). Pure ordering is `after: { <id>: succeeded }`.
 - Models are `provider/name` (`ollama/llama3.2:3b` local-first ·

--- a/.agents/plugins/nika/skills/nika-migration/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-migration/SKILL.md
@@ -37,7 +37,7 @@ sub-second pure-shell pipelines with zero AI and zero HTTP (a
 | `if <condition>` | a `when:` gate |
 | `$1`, `$ENV_VAR` parameters | `vars:` + `--var key=value` · `${{ env.KEY }}` |
 | `API_KEY=…` literals | `${{ secrets.X }}` + `secrets:` block with its `egress:` sink |
-| step B reads step A's output | `with: { a: ${{ tasks.A.output }} }` on B — the binding IS the edge — then `${{ with.a }}` in the body |
+| step B reads step A's output | `with: { a: "${{ tasks.A.output }}" }` on B — the binding IS the edge — then `${{ with.a }}` in the body |
 | step B only waits for step A (no data) | `after: { A: succeeded }` (`terminal` for cleanup/notify paths) |
 | the irreversible step (deploy, send, publish) | a confirm gate before it (`nika:prompt`) — human answers at run time |
 | what no builtin/MCP covers (git, build tools) | `exec:` + a row in the exec ledger |


### PR DESCRIPTION
The YAML flow-binding trap: the four `.agents` teaching surfaces taught `with: { alias: ${{ tasks.id.output }} }` unquoted — in a YAML flow mapping the island's braces open a nested mapping and `nika check` refuses `NIKA-PARSE-001`. Proven both ways against the 0.105 engine (unquoted = parse error · quoted = audited).

Twin of nika-spec #201 (spec/03-dag.md · 4 sites). The vendored pack picks the spec fix up at the next resync; the nika-agents mirror follows the release heal. adr-092's mention is a historical analysis illustration, left as the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)