### PR TITLE
feat(runtime,dap,cli): the run lifecycle is attested (F-P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   shims; the clean cut). Static judgment without the CLI, for the
   embedder/SDK surface.
 
+- **The run's lifecycle is attested (F-P2 · NEP-0011 draft)** — the
+  `workflow_started` prologue becomes a boot manifest (`spec_pin` ·
+  `stamper_kind` · the resolved `clock` · `seed` under a determinism
+  demand); the run seal's `covers` extends additively with the folded
+  `receipt_digest`, the consumed budgets and the exercised effects
+  (the classic four-field seal stays byte-identical); a journal that
+  never reached a lifecycle-terminal frame verifies **INCOMPLETE** —
+  the verifier's finding, never the dying run's silence; and a check
+  report stamped with a different semantic hash than the booting
+  workflow refuses before the first event (the judged-vs-booted
+  binding · exit 2 · semantic grain).
+
 ### Changed
 
 - **`run:` declared-pair refusals ride their dedicated mints** — the

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -1025,6 +1025,7 @@ pub nika_check::CheckReport::trifecta_findings: alloc::vec::Vec<nika_cap::trifec
 pub nika_check::CheckReport::unknown_args: alloc::vec::Vec<nika_check::UnknownArg>
 pub nika_check::CheckReport::unknown_tools: alloc::vec::Vec<nika_check::UnknownTool>
 pub nika_check::CheckReport::waves: alloc::vec::Vec<alloc::vec::Vec<usize>>
+pub nika_check::CheckReport::workflow_semantic: core::option::Option<alloc::string::String>
 impl nika_check::CheckReport
 pub fn nika_check::CheckReport::extra_conformance_codes(&self) -> alloc::vec::Vec<nika_schema::error::spec_code::SpecCode>
 pub fn nika_check::CheckReport::is_clean(&self) -> bool

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -339,6 +339,16 @@ pub struct CheckReport {
     /// honest skip: no claim, never wrong. Additive: `report_version`
     /// stays 1.
     pub analysis: Option<DagAnalysis>,
+    /// The semantic hash (the proof layer's Merkle root) of the workflow
+    /// this report JUDGED — the judged-vs-booted binding (F-P2). The
+    /// stamp is applied by the producer that owns the hash machinery:
+    /// `check()` stays pure over nika-schema types (the semantic hash
+    /// lives in nika-runtime, which depends on THIS crate — computing it
+    /// here would close a dependency cycle), so the CLI's load seam
+    /// stamps it. `None` = unstamped: the runtime's trust gate then
+    /// rides the boundary-lane clause alone (today's posture). Additive:
+    /// `report_version` stays 1.
+    pub workflow_semantic: Option<String>,
 }
 
 impl CheckReport {
@@ -568,6 +578,7 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
         waves: topo_waves,
         analysis: dag_read.analysis,
         findings: Vec::new(),
+        workflow_semantic: None,
     };
     // The class-erased list folds the FINISHED report (one truth, read
     // back) — every consumer (CLI --json · MCP nika_check) gets it free.

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -168,10 +168,22 @@ pub(crate) fn load_checked_with_source(
         .map_err(|e| VerbOutput::file(format!("PARSE ✗  [{}] {e}", e.spec_code())))?;
     // The composed lane (spec 14): child targets resolve against the
     // file the operator named; the fs edge is the skills reader's twin.
-    let report = nika_check::check_composed(&wf, path, &mut |p| {
+    let mut report = nika_check::check_composed(&wf, path, &mut |p| {
         std::fs::read_to_string(p).map_err(|e| e.to_string())
     });
+    stamp_judged_semantic(&wf, &mut report);
     Ok((yaml, wf, report))
+}
+
+/// Stamp the judged-vs-booted binding (F-P2): the report records the
+/// semantic hash of the workflow it JUDGED, so the runtime's trust gate
+/// refuses a report that describes OTHER bytes — a file edited after
+/// the check (same structure) handed its now-stale report refuses
+/// NIKA-1707 at boot. An unprojectable workflow stamps `None` (the
+/// gate's boundary-lane clause rides alone, today's posture).
+pub(crate) fn stamp_judged_semantic(wf: &RawWorkflow, report: &mut CheckReport) {
+    report.workflow_semantic =
+        nika_runtime::proof::ir::semantic_ir_hash(wf).map(|h| h.as_hex().to_owned());
 }
 
 /// The `skills:` fs edge (#473) — the ONE reader check · run · test share.

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -37,7 +37,9 @@ use sink::{TraceNote, surface_trace};
 mod budget;
 mod epilogue;
 mod heartbeat;
+mod teardown;
 pub(crate) use nika_event::source_id::{lf_normal_form, sha256_hex};
+use teardown::teardown_facts;
 
 use nika_dap::journal::{JsonSink, Tee, TraceFileSink};
 use nika_dap::resume::ResumeRequest;
@@ -699,7 +701,10 @@ fn apply_task_scope(
     };
     match scope_to_task(wf, target) {
         Ok(sub) => {
-            let sub_report = nika_check::check(&sub);
+            let mut sub_report = nika_check::check(&sub);
+            // F-P2 · the scoped report is judged over the CONE — stamp
+            // the cone's semantic hash so the trust gate binds it.
+            crate::verbs::stamp_judged_semantic(&sub, &mut sub_report);
             Ok((sub, sub_report))
         }
         Err(msg) => {
@@ -763,7 +768,13 @@ async fn execute(
         let (code, outcome) = drive(runtime, wf, report, stamper.as_mut(), &mut tee).await;
         let (mut sink, trace) = tee.into_parts();
         sink.print_final();
-        let trace_path = surface_trace(trace, TraceNote::Stderr, None, seal_hash(wf).as_deref());
+        let trace_path = surface_trace(
+            trace,
+            TraceNote::Stderr,
+            None,
+            seal_hash(wf).as_deref(),
+            Some(&teardown_facts(wf, report, &outcome)),
+        );
         // A paused run teaches its exact resume command on stderr — the
         // pause sibling of the failure lane's `autopsy:` line.
         if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
@@ -801,24 +812,15 @@ async fn execute(
             failure: first_failure(&outcome),
         }
     } else if json {
-        let mut tee = Tee::new(JsonSink::new(std::io::stdout().lock()), trace);
-        let (code, outcome) = drive(runtime, wf, report, stamper.as_mut(), &mut tee).await;
-        let (sink, trace) = tee.into_parts();
-        // stdout stays NDJSON verbatim (byte-identical with or without the
-        // journal) — the trace note rides on stderr here.
-        let trace_path = surface_trace(trace, TraceNote::Stderr, None, seal_hash(wf).as_deref());
-        if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
-            eprintln!("nika run: {}", epilogue::resume_hint_line(file, p, pause));
-        }
-        if let Some(e) = sink.into_error() {
-            eprintln!("nika run: stream write failed: {e}");
-            return RunVerdict::bare(exit::ENV);
-        }
-        epilogue::print_resume_summary(&outcome, resumed, true);
-        RunVerdict {
-            code,
-            failure: first_failure(&outcome),
-        }
+        execute_json_lane(
+            runtime,
+            (file, wf),
+            report,
+            stamper.as_mut(),
+            resumed,
+            trace,
+        )
+        .await
     } else {
         execute_fold_lane(
             runtime,
@@ -832,6 +834,42 @@ async fn execute(
             model_override,
         )
         .await
+    }
+}
+
+/// The NDJSON machine lane (`--json`) — extracted whole (the fold-lane
+/// precedent · the fn-length wall): stdout stays NDJSON verbatim
+/// (byte-identical with or without the journal), the trace note rides
+/// stderr.
+async fn execute_json_lane(
+    runtime: &ProdRuntime,
+    (file, wf): (&str, &RawWorkflow),
+    report: &CheckReport,
+    stamper: &mut dyn Stamper,
+    resumed: bool,
+    trace: TraceFileSink,
+) -> RunVerdict {
+    let mut tee = Tee::new(JsonSink::new(std::io::stdout().lock()), trace);
+    let (code, outcome) = drive(runtime, wf, report, stamper, &mut tee).await;
+    let (sink, trace) = tee.into_parts();
+    let trace_path = surface_trace(
+        trace,
+        TraceNote::Stderr,
+        None,
+        seal_hash(wf).as_deref(),
+        Some(&teardown_facts(wf, report, &outcome)),
+    );
+    if let (Some(p), Some(pause)) = (&trace_path, &outcome.paused) {
+        eprintln!("nika run: {}", epilogue::resume_hint_line(file, p, pause));
+    }
+    if let Some(e) = sink.into_error() {
+        eprintln!("nika run: stream write failed: {e}");
+        return RunVerdict::bare(exit::ENV);
+    }
+    epilogue::print_resume_summary(&outcome, resumed, true);
+    RunVerdict {
+        code,
+        failure: first_failure(&outcome),
     }
 }
 
@@ -924,6 +962,7 @@ async fn execute_fold_lane(
         },
         failed_task.as_deref(),
         seal_hash(wf).as_deref(),
+        Some(&teardown_facts(wf, report, &outcome)),
     );
     epilogue::print_resume_summary(&outcome, resumed, false);
     if let Some(e) = sink.take_error() {
@@ -1006,6 +1045,15 @@ where
             let mut stderr = std::io::stderr().lock();
             if let RuntimeError::MissingRequiredInputs { .. } = err {
                 let _ = writeln!(stderr, "nika run: {err}");
+            } else if let RuntimeError::ReportMismatch { .. } = err {
+                // Audit-before-run (spec §4): the report does not describe
+                // THESE bytes — the file-findings class (the F-P2
+                // judged-vs-booted binding), never a system breach.
+                let _ = writeln!(stderr, "nika run: {err}");
+                return (
+                    exit::FILE,
+                    RunOutcome::new(false, BTreeMap::new(), BTreeMap::new()),
+                );
             } else {
                 let _ = writeln!(
                     stderr,

--- a/crates/nika-cli/src/verbs/run/sink.rs
+++ b/crates/nika-cli/src/verbs/run/sink.rs
@@ -664,11 +664,14 @@ pub(super) enum TraceNote {
 /// contract: journaling is a rider, a broken rider is a note, not a
 /// failure). An fs error goes to stderr with the path when one was opened;
 /// a written journal prints its `trace:` pointer per [`TraceNote`].
+/// `teardown` folds the run's F-P2 teardown facts into the seal's
+/// `covers` (the receipt digest · budgets ρ · effects ε).
 pub(super) fn surface_trace(
     mut trace: TraceFileSink,
     note: TraceNote,
     autopsy: Option<&str>,
     workflow_hash: Option<&str>,
+    teardown: Option<&nika_dap::seal::SealTeardown>,
 ) -> Option<std::path::PathBuf> {
     // The run seal (S2 · verifiable runs): when a run-key exists on this
     // machine, the journal's LAST line is the signature that binds the
@@ -676,7 +679,7 @@ pub(super) fn surface_trace(
     // the durability point so the seal's own bytes are covered by the
     // fsync; additive — an absent key leaves the journal as today. The
     // sealing itself lives in `nika_dap::journal` (the journal's home).
-    let sealed = nika_dap::journal::seal_journal(&mut trace, workflow_hash);
+    let sealed = nika_dap::journal::seal_journal_with(&mut trace, workflow_hash, teardown);
     // Durability BEFORE advertisement: the anchor must describe bytes
     // that survive a power loss (flush reaches the page cache only).
     trace.finalize();

--- a/crates/nika-cli/src/verbs/run/teardown.rs
+++ b/crates/nika-cli/src/verbs/run/teardown.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The run's teardown facts (F-P2 · LOT-1) — the seal's extended
+//! `covers` inputs, folded from what the run honestly knows (split out
+//! of `run/mod.rs` at the 1500-line wall).
+
+use nika_check::CheckReport;
+use nika_runtime::RunOutcome;
+use nika_schema::raw::RawWorkflow;
+
+/// The run's teardown facts for the seal's extended `covers` (F-P2 ·
+/// LOT-1): the receipt inputs (proves · the check certificate · each
+/// `assert:` judged at its honest level · the outcome word), the budgets
+/// ρ consumed against the certificate's ceiling, and the effects ε
+/// exercised against the declared bound. The seal folds only what the
+/// run honestly knows — an unprojectable workflow keeps the receipt
+/// digest out (absent is honest); the seal attests WHAT HAPPENED, it
+/// never promises the future.
+pub(super) fn teardown_facts(
+    wf: &RawWorkflow,
+    report: &CheckReport,
+    outcome: &RunOutcome,
+) -> nika_dap::seal::SealTeardown {
+    let mut teardown = nika_dap::seal::SealTeardown::new();
+    teardown.proves = nika_runtime::proof::ir::semantic_ir_hash(wf).map(|h| h.as_hex().to_owned());
+    teardown.certificate = serde_json::to_value(&report.certificate).ok();
+    // The judged-assertions fold mirrors the evidence pack's receipt
+    // (`level(true)` — the journal IS the trace).
+    teardown.assertions = wf
+        .assert
+        .iter()
+        .map(|sp| {
+            let property = sp.value.clone();
+            let level = property.level(true);
+            serde_json::json!({
+                "assert": property.name(),
+                "level": level.as_str(),
+            })
+        })
+        .collect();
+    teardown.outcome = Some(
+        if outcome.paused.is_some() {
+            "paused"
+        } else if outcome.ok {
+            "completed"
+        } else {
+            "failed"
+        }
+        .to_owned(),
+    );
+    // Budgets ρ — consumed vs the certificate's ceiling: `spent_usd`
+    // rides ONLY when metered (the no-fake-zero law the terminal frame
+    // already keeps); the ceiling is the certificate's parametric bound,
+    // absent when any spender is unpriceable.
+    let mut budgets = serde_json::Map::new();
+    if let Some(spent) = outcome.total_cost_usd {
+        budgets.insert("spent_usd".to_owned(), serde_json::json!(spent));
+    }
+    budgets.insert("priced_calls".to_owned(), outcome.priced_calls.into());
+    budgets.insert("unpriced_calls".to_owned(), outcome.unpriced_calls.into());
+    budgets.insert("budget_exceeded".to_owned(), outcome.budget_exceeded.into());
+    if let Some(ceiling) = &report.certificate.usd_micros
+        && let Ok(value) = serde_json::to_value(ceiling)
+    {
+        budgets.insert("ceiling".to_owned(), value);
+    }
+    teardown.budgets = Some(serde_json::Value::Object(budgets));
+    // Effects ε — exercised vs declared: `exercised` counts the effect
+    // tasks' settled ATTEMPTS (exec · invoke — the task-attempt grain:
+    // a fan-out's elements fold into their task's attempts, a traverse
+    // fetch's pages stay the bound's grain), `declared` is the
+    // certificate's static effect-call bound, `escapes` the checker's
+    // static escape count. Facts next to the ceiling — never a judgment.
+    let exercised: u64 = wf
+        .tasks
+        .iter()
+        .filter(|task| {
+            matches!(
+                task.value.action,
+                nika_schema::raw::RawAction::Exec(_) | nika_schema::raw::RawAction::Invoke(_)
+            )
+        })
+        .map(|task| {
+            outcome
+                .records
+                .get(task.value.id.value.as_str())
+                .and_then(|record| record.attempts)
+                .unwrap_or(0)
+        })
+        .map(u64::from)
+        .sum();
+    let mut effects = serde_json::Map::new();
+    effects.insert("exercised".to_owned(), exercised.into());
+    if let Ok(declared) = serde_json::to_value(&report.certificate.effect_calls) {
+        effects.insert("declared".to_owned(), declared);
+    }
+    effects.insert(
+        "escapes".to_owned(),
+        u64::try_from(report.certificate.effects.escapes)
+            .unwrap_or(u64::MAX)
+            .into(),
+    );
+    teardown.effects = Some(serde_json::Value::Object(effects));
+    teardown
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use std::collections::BTreeMap;
+
+    use nika_runtime::{TaskRecord, TaskStatus, TerminalCause};
+
+    use super::*;
+
+    fn parsed(yaml: &str) -> RawWorkflow {
+        nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses")
+    }
+
+    /// ρ · the no-fake-zero law: an unmetered run carries NO `spent_usd`
+    /// key (absent is honest — a `0.0` nobody metered is not), while the
+    /// call counters and the outcome word always ride.
+    #[test]
+    fn budgets_omit_spent_when_nothing_was_metered() {
+        let wf = parsed(
+            "nika: v1\nworkflow:\n  id: t\npermits: { exec: [\"echo\"] }\ntasks:\n  a:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        let report = nika_check::check(&wf);
+        let outcome = RunOutcome::new(true, BTreeMap::new(), BTreeMap::new());
+        let td = teardown_facts(&wf, &report, &outcome);
+        let budgets = td.budgets.expect("the budgets fold rides");
+        assert!(
+            budgets.get("spent_usd").is_none(),
+            "no-fake-zero: {budgets}"
+        );
+        assert_eq!(budgets["priced_calls"], 0);
+        assert_eq!(budgets["budget_exceeded"], false);
+        assert_eq!(td.outcome.as_deref(), Some("completed"));
+    }
+
+    /// ε · the attempt grain counts EFFECT tasks only (exec · invoke):
+    /// an infer task's attempts never inflate `exercised` — and a
+    /// metered spend DOES surface as `spent_usd`.
+    #[test]
+    fn effects_count_effect_task_attempts_only() {
+        let wf = parsed(
+            "nika: v1\nworkflow:\n  id: grain\nmodel: mock/echo\npermits: { exec: [\"echo\"] }\ntasks:\n  e:\n    exec: { command: [\"echo\", \"hi\"] }\n  i:\n    infer: { prompt: \"x\" }\n",
+        );
+        let report = nika_check::check(&wf);
+        let mut records = BTreeMap::new();
+        let mut exec_rec = TaskRecord::unran(TaskStatus::Success, TerminalCause::Normal);
+        exec_rec.attempts = Some(3);
+        records.insert("e".to_owned(), exec_rec);
+        let mut infer_rec = TaskRecord::unran(TaskStatus::Success, TerminalCause::Normal);
+        infer_rec.attempts = Some(5);
+        records.insert("i".to_owned(), infer_rec);
+        let mut outcome = RunOutcome::new(true, records, BTreeMap::new());
+        outcome.total_cost_usd = Some(0.5);
+        outcome.priced_calls = 1;
+        let td = teardown_facts(&wf, &report, &outcome);
+        let effects = td.effects.expect("the effects fold rides");
+        assert_eq!(
+            effects["exercised"], 3,
+            "the infer attempts stay out of ε: {effects}"
+        );
+        let budgets = td.budgets.expect("the budgets fold rides");
+        assert_eq!(budgets["spent_usd"], 0.5, "metered spend surfaces");
+    }
+}

--- a/crates/nika-cli/src/verbs/trace_verify.rs
+++ b/crates/nika-cli/src/verbs/trace_verify.rs
@@ -10,6 +10,11 @@
 //! - **OK** — the chain is intact (tamper-evident, not tamper-proof:
 //!   with no external trust root, an attacker can rewrite the whole
 //!   chain; compare the head against the one the run printed).
+//! - **INCOMPLETE** (F-P2) — the chain is intact but the run never
+//!   reached a lifecycle-terminal frame (kill -9 · crash between
+//!   writes): the finding rides the verifier — the dying run writes
+//!   nothing. The exit stays OK (the journal is honestly what it is);
+//!   the ladder below still climbs over the complete prefix.
 //! - **SEALED** — the terminal `run_sealed` event's ed25519 signature
 //!   verifies against a custody-resolved key (`--key` ·
 //!   `~/.nika/keys/run-signing.pub` · the `retired.pub` ledger),
@@ -73,12 +78,33 @@ pub fn verify_with(trace: &str, opts: &VerifyOptions) -> VerbOutput {
         Err(e) => return VerbOutput::env(format!("cannot read {trace}: {e}")),
     };
     match walk(&raw) {
-        Verdict::Intact { events, head, .. } => {
-            tiered(trace, &raw, events, &head, None, opts, &candidates)
-        }
-        Verdict::TornTail { events, head, .. } => {
-            tiered(trace, &raw, events, &head, Some(()), opts, &candidates)
-        }
+        Verdict::Intact { events, head, .. } => tiered(
+            trace,
+            &raw,
+            events,
+            &head,
+            ChainHeadline::Intact,
+            opts,
+            &candidates,
+        ),
+        Verdict::Incomplete { events, head, .. } => tiered(
+            trace,
+            &raw,
+            events,
+            &head,
+            ChainHeadline::Incomplete,
+            opts,
+            &candidates,
+        ),
+        Verdict::TornTail { events, head, .. } => tiered(
+            trace,
+            &raw,
+            events,
+            &head,
+            ChainHeadline::Torn,
+            opts,
+            &candidates,
+        ),
         Verdict::Broken {
             line,
             recorded,
@@ -139,10 +165,26 @@ pub fn verify_many_with(traces: &[std::path::PathBuf], opts: &VerifyOptions) -> 
     }
 }
 
+/// The chain-intact headline the verify surface prints (the lifecycle
+/// truth the walk attested, F-P2). `Intact`'s OK line stays byte-
+/// identical to the pre-tier surface; `Torn` and `Incomplete` name the
+/// crash signature the journal carries.
+#[derive(Clone, Copy)]
+enum ChainHeadline {
+    /// Chain intact AND the run reached a lifecycle-terminal frame.
+    Intact,
+    /// Chain intact — the final line is torn (a crash mid-write).
+    Torn,
+    /// Chain intact — the run never reached a terminal frame (kill -9 ·
+    /// crash between writes): a finding, never a silence.
+    Incomplete,
+}
+
 /// The ladder above an intact chain: the OK line stays byte-identical
 /// to the pre-tier surface; the tiers then speak for themselves.
-/// `torn` marks the torn-tail OK variant (a crash mid-write — the
-/// ladder still climbs over the COMPLETE prefix). The EVALUATION lives
+/// `headline` carries the walk's lifecycle truth (the torn-tail OK
+/// variant · the F-P2 INCOMPLETE class — the ladder still climbs over
+/// the COMPLETE prefix). The EVALUATION lives
 /// in the forensics crate (`nika_dap::anchor::tier::evaluate` — the
 /// 15k descent); this verb keeps the OK line, the reproduce shim call
 /// (the fs seam), and the `VerbOutput` envelope + exit code.
@@ -151,18 +193,25 @@ fn tiered(
     raw: &str,
     events: usize,
     head: &str,
-    torn: Option<()>,
+    headline: ChainHeadline,
     opts: &VerifyOptions,
     candidates: &[(String, String)],
 ) -> VerbOutput {
-    let mut out = if torn.is_some() {
-        format!(
+    let mut out = match headline {
+        ChainHeadline::Torn => format!(
             "OK — {events} events · chain intact · head {head}\n  the final line is TORN (a crash mid-write, not tampering) — the chain\n  covers every complete line"
-        )
-    } else {
-        format!(
+        ),
+        ChainHeadline::Intact => format!(
             "OK — {events} events · chain intact · head {head}\n  internally consistent (tamper-evident, not tamper-proof) — compare the head\n  against the one the run printed to close the loop"
-        )
+        ),
+        // F-P2 · the killed run: the chain attests every complete line —
+        // the lifecycle end is absent, said out loud. A FINDING (the
+        // exit stays OK: the journal is honestly what it is), never the
+        // `unknown` silence a truncated fold used to answer. The
+        // attestation rides the VERIFIER — the dying run writes nothing.
+        ChainHeadline::Incomplete => format!(
+            "INCOMPLETE — {events} events · chain intact · head {head}\n  the journal never reached a terminal frame (no workflow_completed · workflow_failed ·\n  workflow_paused · workflow_cancelled · run_sealed) — the run was killed or crashed:\n  the chain attests every complete line; the lifecycle end is unattested, a finding\n  the verifier carries (the dying run can attest nothing)"
+        ),
     };
     // The replay comparison is the CLI's fs seam — the ladder only
     // hears what the outcome MEANS.
@@ -305,7 +354,7 @@ mod tests {
     fn verify_many_reports_per_file_and_exits_worst_of() {
         let intact = stage(
             "intact.ndjson",
-            &chained(&["workflow_started", "task_completed"]),
+            &chained(&["workflow_started", "workflow_completed"]),
         );
         // Tamper a MIDDLE line — the next line's recorded chain breaks.
         // (An edited FINAL line is exactly what only the externally
@@ -426,6 +475,81 @@ mod tests {
         assert!(
             out.text.contains("REPLAYED — not attempted"),
             "{}",
+            out.text
+        );
+        let _ = std::fs::remove_file(trace);
+        let _ = std::fs::remove_file(key);
+    }
+
+    /// (F-P2) A journal that never reached a terminal frame verifies
+    /// INCOMPLETE — the finding is the VERIFIER's (the dying run writes
+    /// nothing) and the exit stays OK: the journal is honestly what it
+    /// is, the tier ladder still speaks.
+    #[test]
+    fn a_terminal_less_journal_verifies_incomplete() {
+        let trace = stage(
+            "incomplete.ndjson",
+            &chained(&["workflow_started", "task_completed"]),
+        );
+        let out = verify_with(&trace.to_string_lossy(), &VerifyOptions::default());
+        assert_eq!(out.code, super::super::exit::OK, "{}", out.text);
+        assert!(out.text.contains("INCOMPLETE — 2 events"), "{}", out.text);
+        assert!(
+            out.text.contains("never reached a terminal frame"),
+            "{}",
+            out.text
+        );
+        let _ = std::fs::remove_file(trace);
+    }
+
+    /// (F-P2) The EXTENDED seal (teardown covers) attains SEALED through
+    /// the real verify tier — the verifier signs off on the extended
+    /// covers object exactly as on the classic four.
+    #[test]
+    fn an_extended_seal_attains_sealed_through_the_tier() {
+        let (pk_box, sk) = keypair();
+        let kinds = ["workflow_started", "workflow_completed"];
+        let mut chain = sha256_hex(CHAIN_GENESIS);
+        let mut journal = String::new();
+        for kind in kinds {
+            let mut v = serde_json::json!({
+                "id": {"uuid": "01912345-0000-7000-8000-000000000002"},
+                "timestamp": 1000, "kind": kind, "run": null,
+                "correlation": null, "fields": []
+            });
+            v["chain"] = serde_json::Value::String(chain.clone());
+            let line = serde_json::to_string(&v).expect("test json");
+            chain = sha256_hex(line.as_bytes());
+            journal.push_str(&line);
+            journal.push('\n');
+        }
+        let mut teardown = crate::seal::SealTeardown::new();
+        teardown.outcome = Some("completed".to_owned());
+        teardown.budgets = Some(serde_json::json!({ "priced_calls": 0 }));
+        let seal = crate::seal::seal_event_with(
+            nika_types::id::EventId::generate(),
+            nika_types::timestamp::Timestamp::from_unix_ms(1_700_000_000_000),
+            &chain,
+            kinds.len(),
+            "wf-hash-test",
+            "0.105.0-test",
+            Some(&teardown),
+            &sk,
+            &pk_box,
+        )
+        .expect("the extended seal mints");
+        let mut v = serde_json::to_value(&seal).expect("seal json");
+        v["chain"] = serde_json::Value::String(chain);
+        journal.push_str(&serde_json::to_string(&v).expect("seal line"));
+        journal.push('\n');
+        let trace = stage("sealed-extended.ndjson", &journal);
+        let key = stage_key("sealed-extended.pub", &pk_box);
+        let out = verify_with(&trace.to_string_lossy(), &opts_with_key(key.clone()));
+        assert_eq!(out.code, super::super::exit::OK, "{}", out.text);
+        assert!(
+            out.text
+                .contains("SEALED — the run_sealed signature verifies"),
+            "the extended covers verify: {}",
             out.text
         );
         let _ = std::fs::remove_file(trace);

--- a/crates/nika-dap/public-api.txt
+++ b/crates/nika-dap/public-api.txt
@@ -1062,6 +1062,9 @@ pub nika_dap::chain::Verdict::Broken::computed: alloc::string::String
 pub nika_dap::chain::Verdict::Broken::line: usize
 pub nika_dap::chain::Verdict::Broken::recorded: alloc::string::String
 pub nika_dap::chain::Verdict::Empty
+#[non_exhaustive] pub nika_dap::chain::Verdict::Incomplete
+pub nika_dap::chain::Verdict::Incomplete::events: usize
+pub nika_dap::chain::Verdict::Incomplete::head: alloc::string::String
 #[non_exhaustive] pub nika_dap::chain::Verdict::Intact
 pub nika_dap::chain::Verdict::Intact::events: usize
 pub nika_dap::chain::Verdict::Intact::head: alloc::string::String
@@ -1495,6 +1498,7 @@ impl<T> tracing::instrument::WithSubscriber for nika_dap::journal::TraceFileSink
 impl<T> typenum::type_operators::Same for nika_dap::journal::TraceFileSink
 pub type nika_dap::journal::TraceFileSink::Output = T
 pub fn nika_dap::journal::seal_journal(trace: &mut nika_dap::journal::TraceFileSink, workflow_hash: core::option::Option<&str>) -> bool
+pub fn nika_dap::journal::seal_journal_with(trace: &mut nika_dap::journal::TraceFileSink, workflow_hash: core::option::Option<&str>, teardown: core::option::Option<&nika_dap::seal::SealTeardown>) -> bool
 pub mod nika_dap::otel
 pub struct nika_dap::otel::ExportOutcome
 pub nika_dap::otel::ExportOutcome::broken_at: core::option::Option<usize>
@@ -2099,6 +2103,58 @@ pub fn nika_dap::retention::collect(dir: &std::path::Path, cfg: &nika_dap::reten
 pub fn nika_dap::retention::newest_per_workflow(traces: &[nika_dap::store::TraceMeta]) -> alloc::collections::btree::set::BTreeSet<usize>
 pub fn nika_dap::retention::plan(traces: &[nika_dap::store::TraceMeta], cfg: &nika_dap::retention::RetentionConfig, now: std::time::SystemTime) -> alloc::vec::Vec<(usize, nika_dap::retention::Reason)>
 pub mod nika_dap::seal
+#[non_exhaustive] pub struct nika_dap::seal::SealTeardown
+pub nika_dap::seal::SealTeardown::assertions: alloc::vec::Vec<serde_json::value::Value>
+pub nika_dap::seal::SealTeardown::budgets: core::option::Option<serde_json::value::Value>
+pub nika_dap::seal::SealTeardown::certificate: core::option::Option<serde_json::value::Value>
+pub nika_dap::seal::SealTeardown::effects: core::option::Option<serde_json::value::Value>
+pub nika_dap::seal::SealTeardown::outcome: core::option::Option<alloc::string::String>
+pub nika_dap::seal::SealTeardown::proves: core::option::Option<alloc::string::String>
+impl nika_dap::seal::SealTeardown
+pub fn nika_dap::seal::SealTeardown::new() -> Self
+impl core::clone::Clone for nika_dap::seal::SealTeardown
+pub fn nika_dap::seal::SealTeardown::clone(&self) -> nika_dap::seal::SealTeardown
+impl core::default::Default for nika_dap::seal::SealTeardown
+pub fn nika_dap::seal::SealTeardown::default() -> nika_dap::seal::SealTeardown
+impl core::fmt::Debug for nika_dap::seal::SealTeardown
+pub fn nika_dap::seal::SealTeardown::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_dap::seal::SealTeardown
+impl<T, U> core::convert::Into<U> for nika_dap::seal::SealTeardown where U: core::convert::From<T>
+pub fn nika_dap::seal::SealTeardown::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_dap::seal::SealTeardown where U: core::convert::Into<T>
+pub type nika_dap::seal::SealTeardown::Error = core::convert::Infallible
+pub fn nika_dap::seal::SealTeardown::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_dap::seal::SealTeardown where U: core::convert::TryFrom<T>
+pub type nika_dap::seal::SealTeardown::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_dap::seal::SealTeardown::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_dap::seal::SealTeardown where T: core::clone::Clone
+pub type nika_dap::seal::SealTeardown::Owned = T
+pub fn nika_dap::seal::SealTeardown::clone_into(&self, target: &mut T)
+pub fn nika_dap::seal::SealTeardown::to_owned(&self) -> T
+impl<T> core::any::Any for nika_dap::seal::SealTeardown where T: 'static + ?core::marker::Sized
+pub fn nika_dap::seal::SealTeardown::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_dap::seal::SealTeardown where T: ?core::marker::Sized
+pub fn nika_dap::seal::SealTeardown::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_dap::seal::SealTeardown where T: ?core::marker::Sized
+pub fn nika_dap::seal::SealTeardown::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_dap::seal::SealTeardown where T: core::clone::Clone
+pub unsafe fn nika_dap::seal::SealTeardown::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_dap::seal::SealTeardown
+pub fn nika_dap::seal::SealTeardown::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_dap::seal::SealTeardown where T: core::clone::Clone
+pub fn nika_dap::seal::SealTeardown::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_dap::seal::SealTeardown where T: 'static
+pub fn nika_dap::seal::SealTeardown::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_dap::seal::SealTeardown where T: ?core::marker::Sized
+pub fn nika_dap::seal::SealTeardown::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_dap::seal::SealTeardown::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_dap::seal::SealTeardown
+impl<T> tracing::instrument::WithSubscriber for nika_dap::seal::SealTeardown
+impl<T> typenum::type_operators::Same for nika_dap::seal::SealTeardown
+pub type nika_dap::seal::SealTeardown::Output = T
+impl<T> zvariant::optional::NoneValue for nika_dap::seal::SealTeardown where T: core::default::Default
+pub type nika_dap::seal::SealTeardown::NoneType = T
+pub fn nika_dap::seal::SealTeardown::null_value() -> T
 pub fn nika_dap::seal::candidate_pubkeys(key_file: core::option::Option<&std::path::Path>) -> core::result::Result<alloc::vec::Vec<(alloc::string::String, alloc::string::String)>, alloc::string::String>
 pub fn nika_dap::seal::fingerprint(pubkey_box: &str) -> alloc::string::String
 pub fn nika_dap::seal::key_init(force: bool) -> core::result::Result<alloc::string::String, alloc::string::String>
@@ -2107,6 +2163,7 @@ pub fn nika_dap::seal::key_trust() -> core::option::Option<(alloc::string::Strin
 pub fn nika_dap::seal::load_public_box() -> core::option::Option<alloc::string::String>
 pub fn nika_dap::seal::load_signing_key() -> core::option::Option<(minisign::secret_key::SecretKey, alloc::string::String)>
 pub fn nika_dap::seal::seal_event(run_id: nika_types::id::EventId, at: nika_types::timestamp::Timestamp, head: &str, events: usize, workflow_hash: &str, engine: &str, sk: &minisign::secret_key::SecretKey, pk_box: &str) -> core::option::Option<nika_event::event::Event>
+pub fn nika_dap::seal::seal_event_with(run_id: nika_types::id::EventId, at: nika_types::timestamp::Timestamp, head: &str, events: usize, workflow_hash: &str, engine: &str, teardown: core::option::Option<&nika_dap::seal::SealTeardown>, sk: &minisign::secret_key::SecretKey, pk_box: &str) -> core::option::Option<nika_event::event::Event>
 pub mod nika_dap::sign
 pub enum nika_dap::sign::WorkflowSig
 pub nika_dap::sign::WorkflowSig::Invalid(alloc::string::String)

--- a/crates/nika-dap/src/anchor/mod.rs
+++ b/crates/nika-dap/src/anchor/mod.rs
@@ -553,17 +553,21 @@ pub enum HeadRefusal {
     Unknown,
 }
 
-/// The head one may anchor: the walk's `Intact` verdict ONLY. A broken
+/// The head one may anchor: the walk's CHAIN-INTACT verdicts. A broken
 /// chain is refused (notarizing a forgery), a torn tail is refused
 /// (the anchor would notarize a head that excludes live bytes), and
-/// the pre-chain / garbage classes have no head to offer.
+/// the pre-chain / garbage classes have no head to offer. An
+/// `Incomplete` journal (the run died mid-flight · F-P2) anchors like
+/// `Intact`: its head covers every complete line — exactly the state an
+/// auditor notarizes after a kill.
 ///
 /// # Errors
 ///
 /// The [`HeadRefusal`] class the walk's verdict maps to.
 pub fn head_of(raw: &str) -> Result<(String, [u8; 32], usize), HeadRefusal> {
     let (head, events) = match crate::chain::walk(raw) {
-        crate::chain::Verdict::Intact { events, head, .. } => (head, events),
+        crate::chain::Verdict::Intact { events, head, .. }
+        | crate::chain::Verdict::Incomplete { events, head, .. } => (head, events),
         crate::chain::Verdict::Broken { line, .. } => return Err(HeadRefusal::Broken { line }),
         crate::chain::Verdict::TornTail { events, .. } => {
             return Err(HeadRefusal::TornTail { events });

--- a/crates/nika-dap/src/chain.rs
+++ b/crates/nika-dap/src/chain.rs
@@ -21,9 +21,23 @@ pub const CHAIN_GENESIS: &[u8] = b"nika-trace-v1";
 /// The walk's verdict over one raw journal text.
 #[non_exhaustive]
 pub enum Verdict {
-    /// Every line chained — `head` is the last line's sha256.
+    /// Every line chained, and the last one CLOSES the run's lifecycle
+    /// — `head` is the last line's sha256.
     #[non_exhaustive]
     Intact {
+        /// Verified event-line count.
+        events: usize,
+        /// sha256 hex of the last verified line's exact bytes.
+        head: String,
+    },
+    /// Every line chained, but the last complete line never CLOSES the
+    /// run's lifecycle (no terminal frame, no seal): the run was killed
+    /// or crashed between writes. The chain attests every complete line
+    /// exactly as `Intact` does — the LIFECYCLE end is absent, said out
+    /// loud (a killed run is a finding, never a silence; the attestation
+    /// rides the verifier, never the dying run).
+    #[non_exhaustive]
+    Incomplete {
         /// Verified event-line count.
         events: usize,
         /// sha256 hex of the last verified line's exact bytes.
@@ -64,6 +78,20 @@ pub enum Verdict {
     },
 }
 
+/// The kinds that CLOSE a run's lifecycle: the four terminal frames
+/// (spec 13 · `EventKind::is_terminal`) plus the seal that rides after
+/// one. A journal whose last complete line carries any of these reached
+/// an attested end; anything else means the run died mid-flight (kill ·
+/// crash · power) — the walk names that [`Verdict::Incomplete`], never
+/// `Intact` (F-P2 · LOT-1).
+const LIFECYCLE_TERMINAL: &[&str] = &[
+    "workflow_completed",
+    "workflow_failed",
+    "workflow_cancelled",
+    "workflow_paused",
+    "run_sealed",
+];
+
 /// The pure walk — recompute the chain over exact line bytes. Line
 /// numbers are FILE lines (blanks skipped, never renumbered — the
 /// recover path counts the same way), each line parses exactly once,
@@ -81,6 +109,7 @@ pub fn walk(raw: &str) -> Verdict {
     }
     let mut expected = sha256_hex(CHAIN_GENESIS);
     let mut verified = 0usize;
+    let mut last_closes = false;
     for (pos, &(lineno, line)) in numbered.iter().enumerate() {
         let is_last = pos + 1 == numbered.len();
         let parsed: Option<serde_json::Value> = serde_json::from_str(line).ok();
@@ -118,10 +147,21 @@ pub fn walk(raw: &str) -> Verdict {
         }
         expected = sha256_hex(line.as_bytes());
         verified += 1;
+        last_closes = value
+            .get("kind")
+            .and_then(|k| k.as_str())
+            .is_some_and(|k| LIFECYCLE_TERMINAL.contains(&k));
     }
-    Verdict::Intact {
-        events: verified,
-        head: expected,
+    if last_closes {
+        Verdict::Intact {
+            events: verified,
+            head: expected,
+        }
+    } else {
+        Verdict::Incomplete {
+            events: verified,
+            head: expected,
+        }
     }
 }
 
@@ -225,7 +265,7 @@ mod tests {
 
     #[test]
     fn broken_line_numbers_are_file_lines_even_with_blanks() {
-        let raw = chained(&[ev("workflow_started"), ev("task_completed")]);
+        let raw = chained(&[ev("workflow_started"), ev("workflow_completed")]);
         // Insert a blank line between the two — the second event now
         // sits on FILE line 3 and its chain still verifies; tamper it
         // and the report must say line 3, not post-filter line 2.
@@ -240,6 +280,42 @@ mod tests {
         // see it.)
         let tampered = spaced.replace("workflow_started", "workflow_startex");
         assert!(matches!(walk(&tampered), Verdict::Broken { line: 3, .. }));
+    }
+
+    /// F-P2 · a chain-intact journal whose last complete line never
+    /// closes the lifecycle is `Incomplete` (the run died mid-flight),
+    /// never `Intact`; the four terminal frames and the seal all close
+    /// it. The chain facts (events · head) carry identically on both.
+    #[test]
+    fn a_journal_without_a_terminal_frame_is_incomplete_not_intact() {
+        let killed = chained(&[ev("workflow_started"), ev("task_started")]);
+        let Verdict::Incomplete { events, head } = walk(&killed) else {
+            panic!("a killed run's journal is Incomplete, never Intact");
+        };
+        assert_eq!(events, 2);
+        let last = killed.lines().last().expect("last line");
+        assert_eq!(
+            head,
+            sha256_hex(last.as_bytes()),
+            "the head still binds every line"
+        );
+
+        for terminal in [
+            "workflow_completed",
+            "workflow_failed",
+            "workflow_cancelled",
+            "workflow_paused",
+            "run_sealed",
+        ] {
+            let raw = chained(&[ev("workflow_started"), ev(terminal)]);
+            assert!(
+                matches!(walk(&raw), Verdict::Intact { events: 2, .. }),
+                "{terminal} closes the lifecycle"
+            );
+        }
+        // A mid-flight kind anywhere but last never flips the class.
+        let finished = chained(&[ev("task_started"), ev("workflow_completed")]);
+        assert!(matches!(walk(&finished), Verdict::Intact { .. }));
     }
 
     #[test]

--- a/crates/nika-dap/src/evidence.rs
+++ b/crates/nika-dap/src/evidence.rs
@@ -54,8 +54,10 @@ const EVIDENCE_FORMAT: u32 = 1;
 /// The receipt's lock-digest placeholder: the journal does not record
 /// the `nika.lock` the run resolved under, so the receipt SAYS so —
 /// hashing whatever lock file sits nearby TODAY would be a claim
-/// without provenance (it may differ from run time).
-const LOCK_UNRECORDED: &str = "unrecorded — the journal does not carry the run's nika.lock digest";
+/// without provenance (it may differ from run time). Shared with the
+/// teardown seal (F-P2): the run's receipt fold says the same words.
+pub(crate) const LOCK_UNRECORDED: &str =
+    "unrecorded — the journal does not carry the run's nika.lock digest";
 
 /// The one pointer every workflow-derived null shares.
 const WORKFLOW_HINT: &str =
@@ -299,6 +301,14 @@ fn chain_facts(raw: &str, label: &str) -> Result<ChainFacts, PackError> {
             status: "intact",
             head: Some(head),
             note: None,
+        }),
+        Verdict::Incomplete { head, .. } => Ok(ChainFacts {
+            status: "incomplete",
+            head: Some(head),
+            note: Some(
+                "the run never reached a terminal frame (killed or crashed between writes) — the chain covers every complete line"
+                    .to_owned(),
+            ),
         }),
         Verdict::TornTail { head, .. } => Ok(ChainFacts {
             status: "torn_tail",

--- a/crates/nika-dap/src/journal.rs
+++ b/crates/nika-dap/src/journal.rs
@@ -377,17 +377,32 @@ impl<A: EventSink, B: EventSink> EventSink for Tee<A, B> {
 /// `surface_trace` seal block 2026-07-22 — the journal seals itself in
 /// the journal's home; `CARGO_PKG_VERSION` is the one workspace version
 /// on both sides of the old seam, so the sealed bytes are unchanged.)
+/// The teardown-less path: the classic four `covers` fields
+/// ([`seal_journal_with`] folds the F-P2 teardown in).
 pub fn seal_journal(trace: &mut TraceFileSink, workflow_hash: Option<&str>) -> bool {
+    seal_journal_with(trace, workflow_hash, None)
+}
+
+/// [`seal_journal`] with the run's teardown facts (F-P2 · LOT-1): the
+/// seal's `covers` attests the receipt digest, the budgets ρ and the
+/// effects ε the run settled with — the run's END is as attested as its
+/// boot. `None` keeps the classic covers (byte-unchanged).
+pub fn seal_journal_with(
+    trace: &mut TraceFileSink,
+    workflow_hash: Option<&str>,
+    teardown: Option<&crate::seal::SealTeardown>,
+) -> bool {
     let mut sealed = false;
     if let Some(hash) = workflow_hash
         && let Some((sk, pk_box)) = crate::seal::load_signing_key()
-        && let Some(ev) = crate::seal::seal_event(
+        && let Some(ev) = crate::seal::seal_event_with(
             EventId::generate(),
             Timestamp::from_unix_ms(now_millis()),
             trace.chain_head(),
             trace.chain_len(),
             hash,
             env!("CARGO_PKG_VERSION"),
+            teardown,
             &sk,
             &pk_box,
         )

--- a/crates/nika-dap/src/otel.rs
+++ b/crates/nika-dap/src/otel.rs
@@ -97,7 +97,11 @@ pub fn project(
         resource_attrs.push(kv_str("nika.platform", platform));
     }
     match chain {
-        Some(Verdict::Intact { head, .. } | Verdict::TornTail { head, .. }) => {
+        Some(
+            Verdict::Intact { head, .. }
+            | Verdict::Incomplete { head, .. }
+            | Verdict::TornTail { head, .. },
+        ) => {
             resource_attrs.push(kv_str("nika.trace.chain_head", head));
         }
         Some(Verdict::Broken { .. }) => {

--- a/crates/nika-dap/src/seal.rs
+++ b/crates/nika-dap/src/seal.rs
@@ -19,7 +19,12 @@
 //! - `covers` — `{ head, events, workflow }`: the chain head BEFORE the
 //!   seal line (so the seal commits to every prior line) and the
 //!   workflow's semantic hash (the proof layer's Merkle commitment), so
-//!   journal ↔ workflow bind into one certificate;
+//!   journal ↔ workflow bind into one certificate. F-P2 folds the run's
+//!   TEARDOWN in additively ([`SealTeardown`]): `receipt_digest` (the
+//!   receipt the run folded at teardown), `budgets` (ρ consumed vs the
+//!   certificate's ceiling), `effects` (ε exercised vs declared) — the
+//!   format stays `1` (the verify tier reads `covers` tolerantly:
+//!   unknown keys are ignored, the signature covers the whole object);
 //! - `key_id` — the first 16 hex of the public key's sha256 (the TOFU
 //!   fingerprint `nika key trust` prints);
 //! - `alg` — `"ed25519"` (the envelope is algorithm-versioned from day
@@ -321,7 +326,10 @@ fn write_0600(path: &Path, text: &str) -> Result<(), String> {
 /// The seal event for one finished run — the terminal line of a signed
 /// journal. `covers` binds head + event count + the workflow's semantic
 /// hash; the signature rides the proof layer's ONE canonicalization.
+/// The teardown-less path: `covers` carries the classic four fields,
+/// byte-unchanged ([`seal_event_with`] folds the F-P2 teardown in).
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn seal_event(
     run_id: EventId,
     at: Timestamp,
@@ -332,12 +340,81 @@ pub fn seal_event(
     sk: &minisign::SecretKey,
     pk_box: &str,
 ) -> Option<Event> {
-    let covers = serde_json::json!({
+    seal_event_with(
+        run_id,
+        at,
+        head,
+        events,
+        workflow_hash,
+        engine,
+        None,
+        sk,
+        pk_box,
+    )
+}
+
+/// The run's teardown facts (F-P2 · LOT-1) — what the seal's `covers`
+/// attests BEYOND the chain: the receipt the run folded at teardown
+/// (its digest rides; the body stays the evidence pack's surface), the
+/// budgets ρ consumed against the certificate's ceiling, and the
+/// effects ε exercised against the declared bound. Every field is
+/// ADDITIVE — `seal_format` stays 1: the verify tier reads `covers`
+/// tolerantly (unknown keys are ignored, verified by the tier tests),
+/// and the signature's canonicalization covers the whole object either
+/// way. A `None`/empty fact keeps its key OUT of the covers (absent is
+/// honest — never a fabricated zero).
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct SealTeardown {
+    /// The run's semantic hash hex (the receipt's `proves` — the same
+    /// Merkle root the boot manifest's `semantic_hash` carries).
+    pub proves: Option<String>,
+    /// The check certificate as JSON (the receipt's `certificate`).
+    pub certificate: Option<serde_json::Value>,
+    /// The judged assertions as receipt entries (`{assert, level}`).
+    pub assertions: Vec<serde_json::Value>,
+    /// The terminal outcome word (`completed` · `failed` · `paused`).
+    pub outcome: Option<String>,
+    /// The budgets ρ fold (consumed vs ceiling), pre-shaped by the caller.
+    pub budgets: Option<serde_json::Value>,
+    /// The effects ε fold (exercised vs declared), pre-shaped by the caller.
+    pub effects: Option<serde_json::Value>,
+}
+
+impl SealTeardown {
+    /// An empty teardown (INV-019): the seal carries its classic four
+    /// `covers` fields and nothing more.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// The seal event with the run's teardown facts folded into `covers`
+/// (F-P2): the receipt's digest (folded HERE — the chain head and count
+/// it binds are this seal's own), the budgets ρ, and the effects ε.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn seal_event_with(
+    run_id: EventId,
+    at: Timestamp,
+    head: &str,
+    events: usize,
+    workflow_hash: &str,
+    engine: &str,
+    teardown: Option<&SealTeardown>,
+    sk: &minisign::SecretKey,
+    pk_box: &str,
+) -> Option<Event> {
+    let mut covers = serde_json::json!({
         "head": head,
         "events": events,
         "workflow": workflow_hash,
         "engine": engine,
     });
+    if let Some(teardown) = teardown {
+        extend_covers(&mut covers, head, events, teardown);
+    }
     let preimage =
         nika_runtime::proof::preimage(nika_runtime::proof::HashDomain::Trace, 1, &covers);
     let sig_box = minisign::sign(None, sk, Cursor::new(preimage.as_bytes()), None, None).ok()?;
@@ -361,6 +438,50 @@ pub fn seal_event(
         ),
     ];
     Some(Event::new(run_id, at, EventKind::RunSealed).with_fields(fields))
+}
+
+/// Fold the teardown facts into the seal's `covers` (F-P2 · ADDITIVE).
+fn extend_covers(
+    covers: &mut serde_json::Value,
+    head: &str,
+    events: usize,
+    teardown: &SealTeardown,
+) {
+    // The receipt digest: the receipt is folded AT TEARDOWN with the
+    // chain facts only this seal knows (the pre-seal head and count —
+    // the seal cannot cover its own bytes). The receipt body stays the
+    // evidence pack's surface; the digest binds it here. The verdict's
+    // `sealed` is written `true`: it becomes true when this line lands
+    // — the seal attests WHAT HAPPENED, it never promises the future.
+    if let (Some(proves), Some(certificate), Some(outcome)) = (
+        teardown.proves.as_deref(),
+        teardown.certificate.clone(),
+        teardown.outcome.as_deref(),
+    ) {
+        let trace_verdict = serde_json::json!({
+            "outcome": outcome,
+            "chain": "intact",
+            "events": events,
+            "head": head,
+            "sealed": true,
+        });
+        let receipt = nika_runtime::proof::receipt::build_receipt(
+            proves,
+            certificate,
+            trace_verdict,
+            teardown.assertions.clone(),
+            crate::evidence::LOCK_UNRECORDED,
+        );
+        if let Some(digest) = receipt.get("digest").and_then(serde_json::Value::as_str) {
+            covers["receipt_digest"] = serde_json::Value::String(digest.to_owned());
+        }
+    }
+    if let Some(budgets) = &teardown.budgets {
+        covers["budgets"] = budgets.clone();
+    }
+    if let Some(effects) = &teardown.effects {
+        covers["effects"] = effects.clone();
+    }
 }
 
 /// Strict standard-alphabet base64 → bytes (`None` on any
@@ -513,6 +634,16 @@ mod tests {
         let covers = get("covers").expect("covers present");
         assert!(covers.contains("ab12cd") && covers.contains("wf-hash-7c2a"));
 
+        // (e) the teardown-less regression guard: `covers` is EXACTLY
+        // the classic four keys (the pre-F-P2 wire, byte-unchanged).
+        let parsed: serde_json::Value = serde_json::from_str(&covers).expect("covers parses");
+        let keys: Vec<&String> = parsed.as_object().expect("an object").keys().collect();
+        assert_eq!(
+            keys,
+            ["engine", "events", "head", "workflow"],
+            "the classic covers is the classic four, nothing more"
+        );
+
         // The signature verifies against the pubkey box over the SAME
         // preimage (the proof layer's canonicalization).
         let covers_json = serde_json::json!({
@@ -533,6 +664,103 @@ mod tests {
             false,
         )
         .expect("the seal verifies");
+    }
+
+    /// F-P2 (b) · the extended seal: the teardown facts ride `covers`
+    /// additively — the receipt digest RECOMPUTES from the same inputs,
+    /// and the signature verifies over the extended object (the proof
+    /// layer's ONE canonicalization covers whatever `covers` carries).
+    #[test]
+    fn the_teardown_seal_carries_the_run_end_attestation_and_verifies() {
+        let (pk, sk) = keypair();
+        let mut teardown = SealTeardown::new();
+        teardown.proves = Some("wf-semantic-7c2a".to_owned());
+        teardown.certificate = Some(serde_json::json!({
+            "task_attempts": { "constant": 2, "terms": [] }
+        }));
+        teardown.assertions = vec![serde_json::json!({
+            "assert": "no_secret_egress", "level": "TraceVerified"
+        })];
+        teardown.outcome = Some("completed".to_owned());
+        teardown.budgets = Some(serde_json::json!({
+            "spent_usd": 0.012, "priced_calls": 3, "unpriced_calls": 0, "budget_exceeded": false
+        }));
+        teardown.effects = Some(serde_json::json!({ "exercised": 2, "escapes": 0 }));
+        let ev = seal_event_with(
+            EventId::generate(),
+            Timestamp::from_unix_ms(1_700_000_000_000),
+            "ab12cd",
+            142,
+            "wf-semantic-7c2a",
+            "0.105.0",
+            Some(&teardown),
+            &sk,
+            &pk,
+        )
+        .expect("the seal mints");
+        let get = |key: &str| {
+            ev.fields
+                .iter()
+                .find(|f| f.key == key)
+                .and_then(|f| match &f.value {
+                    nika_types::resource::Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+        };
+        let covers: serde_json::Value =
+            serde_json::from_str(&get("covers").expect("covers present")).expect("covers parses");
+
+        // The classic four ride unchanged; the teardown keys join them.
+        assert_eq!(covers["head"], serde_json::json!("ab12cd"));
+        assert_eq!(covers["events"], serde_json::json!(142));
+        assert_eq!(covers["workflow"], serde_json::json!("wf-semantic-7c2a"));
+        assert_eq!(covers["engine"], serde_json::json!("0.105.0"));
+        assert_eq!(covers["budgets"]["priced_calls"], serde_json::json!(3));
+        assert_eq!(covers["effects"]["exercised"], serde_json::json!(2));
+
+        // The receipt digest recomputes from the same inputs (the
+        // seal's own pre-seal chain facts + the run's certificate).
+        let verdict = serde_json::json!({
+            "outcome": "completed", "chain": "intact",
+            "events": 142, "head": "ab12cd", "sealed": true,
+        });
+        let receipt = nika_runtime::proof::receipt::build_receipt(
+            "wf-semantic-7c2a",
+            serde_json::json!({ "task_attempts": { "constant": 2, "terms": [] } }),
+            verdict,
+            vec![serde_json::json!({
+                "assert": "no_secret_egress", "level": "TraceVerified"
+            })],
+            crate::evidence::LOCK_UNRECORDED,
+        );
+        assert_eq!(
+            covers["receipt_digest"]
+                .as_str()
+                .expect("the receipt digest rides"),
+            receipt["digest"].as_str().expect("the recomputed digest"),
+            "the seal's receipt digest IS the folded receipt's own digest"
+        );
+        assert!(
+            nika_runtime::proof::receipt::verify(&receipt, "wf-semantic-7c2a"),
+            "the folded receipt verifies its self-digest"
+        );
+
+        // The signature verifies over the EXTENDED covers.
+        let preimage =
+            nika_runtime::proof::preimage(nika_runtime::proof::HashDomain::Trace, 1, &covers);
+        let sig_box = minisign::SignatureBox::from_string(&get("sig").expect("sig present"))
+            .expect("sig parses");
+        let pk_box = minisign::PublicKeyBox::from_string(&pk).expect("pk box parses");
+        let pk_key = pk_box.into_public_key().expect("pk decodes");
+        minisign::verify(
+            &pk_key,
+            &sig_box,
+            std::io::Cursor::new(preimage.as_bytes()),
+            true,
+            false,
+            false,
+        )
+        .expect("the extended seal verifies");
     }
 
     /// (a) The pair probe hands back the public box + a 16-hex

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -492,6 +492,9 @@ fn emit_prologue(
     opening.push(("engine_version", s(env!("CARGO_PKG_VERSION"))));
     let platform = format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH);
     opening.push(("platform", s(&platform)));
+    // F-P2 · the boot attestation (spec pin · the declaration-resolved
+    // entropy seam · the seed under a determinism demand).
+    opening.extend(boot_attestation_fields(wf));
     emit(stamper, sink, EventKind::WorkflowStarted, &opening);
     for task in &wf.tasks {
         emit(
@@ -501,6 +504,74 @@ fn emit_prologue(
             &[("task", s(&task.value.id.value))],
         );
     }
+}
+
+/// The spec commit this engine's conformance is proven at (F-P2 · the
+/// boot manifest's `spec_pin`) — the workspace-root `SPEC_PIN` file,
+/// baked in at compile time (the `engine_version`/`platform` idiom:
+/// a compile-time constant, no clock, no I/O — determinism intact).
+/// `None` only if the file ever loses its hash line (a comment-only
+/// `SPEC_PIN` pins nothing — absent is honest).
+fn spec_pin() -> Option<&'static str> {
+    const RAW: &str = include_str!("../../../SPEC_PIN");
+    RAW.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .next_back()
+}
+
+/// The F-P2 boot attestation fields (LOT-1 · the run's life opens with
+/// an attested BOOT frame). Additive to the opening vec — older readers
+/// ignore unknown fields, newer readers find them absent on older
+/// journals and say "unrecorded", never a guess:
+///
+/// - `spec_pin` — the spec commit the engine was proven at (above);
+/// - `stamper_kind` — the event-identity seam the `run:` declaration
+///   resolves to (F-P3 · `RunSeams`): `deterministic` under
+///   `entropy: none | seeded(N)`, `system` otherwise. The composer's
+///   stamper pick rides the SAME resolution (`RunSeams::stamper` is the
+///   one pick site), so the manifest names the seam the journal's own
+///   identities came from;
+/// - `clock` — the resolved clock the run rides (F-P3 ·
+///   [`nika_schema::types::RunDecl::clock_or_default`]): `virtual` when
+///   declared or forced by a determinism demand, `system` otherwise —
+///   the run-level time-source claim, so the journal names the clock
+///   its durations were measured against;
+/// - `seed` — only under a determinism demand: the value that keys the
+///   retry jitter stream (`seeded(N)` → `N` · `none` → the zero
+///   stream). An ambient run carries no seed claim (absent is honest).
+///
+/// `time_source`/`time_scale` stay the F-N10 RECEIPT enums (out of the
+/// run block by design); the run-level time axis is claimed above as
+/// `clock`. The `nika.lock` digest has no recording surface today (the
+/// `LOCK_UNRECORDED` posture) — the manifest claims only what exists.
+fn boot_attestation_fields(wf: &RawWorkflow) -> Vec<(&'static str, FieldValue)> {
+    let mut fields = Vec::new();
+    if let Some(pin) = spec_pin() {
+        fields.push(("spec_pin", s(pin)));
+    }
+    let decl = wf
+        .run
+        .as_ref()
+        .map_or_else(nika_schema::types::RunDecl::default, |decl| decl.value);
+    let entropy = decl.entropy_or_default();
+    fields.push((
+        "stamper_kind",
+        s(if entropy.is_deterministic() {
+            "deterministic"
+        } else {
+            "system"
+        }),
+    ));
+    fields.push(("clock", s(decl.clock_or_default().name())));
+    if entropy.is_deterministic() {
+        // The u64→wire idiom (settle.rs `delay_ms`): saturate at i64::MAX.
+        fields.push((
+            "seed",
+            i(i64::try_from(entropy.jitter_seed()).unwrap_or(i64::MAX)),
+        ));
+    }
+    fields
 }
 
 /// The envelope's value view (the four-authority family · C2): `inputs`

--- a/crates/nika-runtime/src/tests.rs
+++ b/crates/nika-runtime/src/tests.rs
@@ -1293,3 +1293,53 @@ mod tools_permits_tests {
         assert_eq!(probe.captured_requests().len(), 1, "one provider turn");
     }
 }
+
+// ─── the F-P2 boot manifest (attestation inputs follow the declaration) ─────
+
+/// The boot manifest claims only what exists, per the `run:`
+/// declaration: absent → the system stamper + the system clock, no seed
+/// claim · `entropy: none` → deterministic + virtual + the zero seed ·
+/// `seeded(42)` → seed 42 · a lone `clock: virtual` is a test
+/// configuration (system stamper · virtual clock · no seed). `spec_pin`
+/// always rides (the workspace `SPEC_PIN` carries a hash line).
+#[test]
+fn the_boot_manifest_follows_the_run_declaration() {
+    const HEAD: &str = "nika: v1\nworkflow:\n  id: w\npermits: { exec: [\"x\"] }\ntasks:\n  t:\n    exec: { command: [\"x\"] }\n";
+    let dump = |yaml: &str| {
+        let wf = nika_schema::parse(
+            yaml,
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("fixture parses");
+        format!("{:?}", super::boot_attestation_fields(&wf))
+    };
+    let ambient = dump(HEAD);
+    assert!(ambient.contains("spec_pin"), "{ambient}");
+    assert!(
+        ambient.contains("stamper_kind") && ambient.contains("system"),
+        "{ambient}"
+    );
+    assert!(ambient.contains("clock"), "{ambient}");
+    assert!(
+        !ambient.contains("seed"),
+        "no seed claim on ambient: {ambient}"
+    );
+    let strict = dump(&format!("{HEAD}run: {{ entropy: none }}\n"));
+    assert!(strict.contains("deterministic"), "{strict}");
+    assert!(
+        strict.contains("virtual"),
+        "the forced virtual clock: {strict}"
+    );
+    assert!(
+        strict.contains("seed"),
+        "the zero stream is a claim: {strict}"
+    );
+    let seeded = dump(&format!("{HEAD}run: {{ entropy: {{ seeded: 42 }} }}\n"));
+    assert!(seeded.contains("42"), "{seeded}");
+    let lone_clock = dump(&format!("{HEAD}run: {{ clock: virtual }}\n"));
+    assert!(
+        lone_clock.contains("virtual") && !lone_clock.contains("seed"),
+        "a lone virtual clock claims no determinism: {lone_clock}"
+    );
+}

--- a/crates/nika-runtime/src/trust.rs
+++ b/crates/nika-runtime/src/trust.rs
@@ -1,11 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The run-start report gate — audit-before-run, TWO clauses.
+//! The run-start report gate — audit-before-run, THREE clauses.
 //!
 //! 1. **Dirty** (spec §3 · NIKA-1700) — a dirty [`CheckReport`] never
 //!    executes.
-//! 2. **Trust** (NIKA-1707) — the audit's « honor system » backstop.
+//! 2. **Binding** (F-P2 · NIKA-1707) — the judged-vs-booted semantic
+//!    binding: a report STAMPED with the semantic hash of the workflow
+//!    it judged (the CLI's load seam stamps it) must match the workflow
+//!    the run is booting. A file edited after the check — same
+//!    structure, a prompt string changed — re-keys the semantic hash,
+//!    so its stale report refuses at boot; a COSMETIC edit (whitespace
+//!    · a comment) re-keys nothing and never refuses (the semantic
+//!    grain, exactly like resume). An UNSTAMPED report skips the clause
+//!    (today's posture — the stamp is opt-in at the producer).
+//! 3. **Trust** (NIKA-1707) — the audit's « honor system » backstop.
 //!    Nothing BINDS a clean report to the workflow bytes: a library
 //!    embedder can hand `run` a hand-built clean one (a skipped check
 //!    and a forged report are indistinguishable). Under a declared
@@ -17,16 +26,18 @@
 //!    floor has its own live enforcement in the effect path) and the
 //!    clause costs nothing — it never runs.
 //!
-//! The trust clause is NOT a second check for the CLI, which re-checks
-//! right before run; it is the fail-closed word for every other driver.
+//! The trust clauses are NOT a second check for the CLI, which re-checks
+//! right before run; they are the fail-closed word for every other driver.
 
 use nika_check::CheckReport;
 use nika_schema::raw::RawWorkflow;
 
 use crate::errors::RuntimeError;
 
-/// The audit-before-run gate, both clauses, in order: a dirty report is
-/// [`RuntimeError::DirtyReport`] (NIKA-1700) · a clean report whose
+/// The audit-before-run gate, the three clauses, in order: a dirty report is
+/// [`RuntimeError::DirtyReport`] (NIKA-1700) · a stamped report whose
+/// judged semantic hash is not the workflow's boot hash is
+/// [`RuntimeError::ReportMismatch`] (NIKA-1707 · F-P2) · a clean report whose
 /// boundary lanes the workflow's own re-derivation contradicts is
 /// [`RuntimeError::ReportMismatch`] (NIKA-1707) — `Ok` only when the
 /// report may vouch for THESE bytes.
@@ -36,6 +47,20 @@ pub(crate) fn check_report(wf: &RawWorkflow, report: &CheckReport) -> Result<(),
     const MAX_NAMED: usize = 8;
     if !report.is_clean() {
         return Err(RuntimeError::DirtyReport);
+    }
+    // The judged-vs-booted binding (F-P2): the report names the semantic
+    // hash of the workflow it judged — the run refuses when the workflow
+    // it is BOOTING hashes differently (edited after the check, even
+    // structure-preserving). An unprojectable workflow carries no boot
+    // hash: the clause stays silent (no claim, never a guess).
+    if let Some(judged) = report.workflow_semantic.as_deref()
+        && let Some(booted) = crate::proof::ir::semantic_ir_hash(wf)
+        && judged != booted.as_hex()
+    {
+        return Err(RuntimeError::ReportMismatch {
+            detail: "the report was judged over different workflow bytes (semantic hash mismatch — the file changed after the check)"
+                .to_owned(),
+        });
     }
     if wf.permits.is_none() {
         return Ok(());
@@ -324,5 +349,62 @@ mod tests {
             probe.captured_calls().is_empty(),
             "the refused tool NEVER executed"
         );
+    }
+
+    /// (F-P2 · the judged-vs-booted binding) A report STAMPED with a
+    /// different semantic hash refuses at boot — before one event: the
+    /// file changed after the check, even structure-preserving.
+    #[tokio::test]
+    async fn a_stamped_report_over_different_bytes_refuses_at_boot() {
+        let wf = parse(
+            "nika: v1\nworkflow:\n  id: stale\npermits: { exec: [\"echo\"] }\ntasks:\n  t:\n    exec: { command: [\"echo\", \"hi\"] }\n",
+        );
+        let mut report = nika_check::check(&wf);
+        assert!(report.is_clean(), "the fixture fits its boundary");
+        report.workflow_semantic = Some("0".repeat(64));
+        let runtime = runtime_with(
+            MockShell::new(),
+            MockToolExecutor::new(),
+            MockProvider::new("mock"),
+        );
+        let err = run_refused(&runtime, &wf, &report).await;
+        let crate::RuntimeError::ReportMismatch { detail } = &err else {
+            panic!("expected ReportMismatch, got {err:?}");
+        };
+        assert_eq!(err.spec_code(), "NIKA-1707");
+        assert!(
+            detail.contains("semantic hash mismatch"),
+            "the refusal names the binding: {detail}"
+        );
+    }
+
+    /// The binding's positive control + the semantic grain: a report
+    /// stamped with the workflow's OWN hash runs (no false refusal),
+    /// and a cosmetic twin (a comment) re-keys nothing — the SAME stamp
+    /// still vouches, exactly the resume grain. The unstamped-skip half
+    /// is the (b′) test above: `check()` produces `workflow_semantic:
+    /// None` and that report passes the gate untouched.
+    #[tokio::test]
+    async fn a_stamped_matching_report_passes_and_the_grain_is_semantic() {
+        let yaml = "nika: v1\nworkflow:\n  id: honest\npermits: { exec: [\"echo\"] }\ntasks:\n  t:\n    exec: { command: [\"echo\", \"hi\"] }\n";
+        let wf = parse(yaml);
+        let mut report = nika_check::check(&wf);
+        let stamp = crate::proof::ir::semantic_ir_hash(&wf)
+            .expect("the fixture projects")
+            .as_hex()
+            .to_owned();
+        report.workflow_semantic = Some(stamp.clone());
+        let shell = MockShell::new().enqueue_ok("ok");
+        let runtime = runtime_with(shell, MockToolExecutor::new(), MockProvider::new("mock"));
+        let outcome = run(&runtime, &wf, &report).await;
+        assert!(outcome.ok, "the stamped match vouches — no false refusal");
+        // The cosmetic twin: a comment changes the bytes, never the
+        // semantic hash — the SAME stamp would still match.
+        let twin = parse(&format!("# a cosmetic comment\n{yaml}"));
+        let twin_stamp = crate::proof::ir::semantic_ir_hash(&twin)
+            .expect("the twin projects")
+            .as_hex()
+            .to_owned();
+        assert_eq!(stamp, twin_stamp, "the grain is semantic, never bytes");
     }
 }

--- a/crates/nika-runtime/tests/run_declaration.rs
+++ b/crates/nika-runtime/tests/run_declaration.rs
@@ -172,20 +172,35 @@ tasks:
     assert_eq!(stream42.len(), stream43.len(), "same events, same order");
     assert_ne!(stream42, stream43, "different seeds diverge");
 
-    // The divergence is EXACTLY the jittered retry delay — every other
-    // event line is byte-equal (stamps are seq-keyed, durations are
-    // virtual; nothing else reads the seed).
+    // The divergence is EXACTLY two lines — the boot manifest NAMING its
+    // seed (F-P2: the journal self-describes its determinism contract)
+    // and the jittered retry delay the seed keys. Every other event line
+    // is byte-equal (stamps are seq-keyed, durations are virtual;
+    // nothing else reads the seed).
     let differing: Vec<usize> = (0..stream42.len())
         .filter(|&i| stream42[i] != stream43[i])
         .collect();
-    assert_eq!(differing.len(), 1, "one field diverges: {differing:?}");
-    let line = &stream42[differing[0]];
+    assert_eq!(
+        differing.len(),
+        2,
+        "the manifest's seed claim + the jittered delay: {differing:?}"
+    );
+    let manifest = &stream42[differing[0]];
+    assert!(
+        manifest.contains(&format!(
+            "\"kind\":\"{}\"",
+            EventKind::WorkflowStarted.as_str()
+        )),
+        "the first divergence is the boot manifest's seed claim: {manifest}"
+    );
+    assert!(manifest.contains("\"seed\""), "{manifest}");
+    let line = &stream42[differing[1]];
     assert!(
         line.contains(&format!(
             "\"kind\":\"{}\"",
             EventKind::TaskRetrying.as_str()
         )),
-        "the divergence IS the journaled retry delay: {line}"
+        "the second divergence IS the journaled retry delay: {line}"
     );
     assert!(line.contains("\"delay_ms\""), "{line}");
 }


### PR DESCRIPTION
The lot-1 F-P2 lane — the run has an attested beginning and an attested end (NEP-0011 draft · nika-spec #200). Base implementation by the cut annex session's coder agent, adversarially audited (ADOPT_WITH_FIXES), finished and hardened.

**BOOT** — the `workflow_started` prologue becomes a boot manifest: `spec_pin` (compile-time, honest-absent) · `stamper_kind` (the F-P3 resolution the composer rides) · the resolved `clock` (the run-level time axis that exists TODAY) · `seed` under a determinism demand. `lock_digest` + the F-N10 receipt enums stay explicitly deferred (claims only what exists — operator ratification points below).

**TEARDOWN** — the seal's `covers` extends additively: folded `receipt_digest` (recomputable from the seal's own chain facts) · budgets ρ (no-fake-zero) · effects ε (effect-task attempt grain). The classic four-field covers is byte-pinned by a regression test; tolerant readers untouched.

**INCOMPLETE** — classified in the chain walk itself (`Verdict::Incomplete` · non_exhaustive-additive) so evidence packs, otel projection, `head_of` and `trace verify` all speak it; terminal set = the four terminal kinds + `run_sealed`. Exit stays the tier ladder's (op choice to tighten).

**Jugé ≠ booté = refus** — trust clause 2: a report stamped `workflow_semantic` ≠ the booting workflow's semantic hash refuses BEFORE the prologue (zero events · NIKA-1707 · CLI exit 2). Semantic grain proven by a cosmetic-twin test; unstamped reports skip (opt-in stamp at the CLI load seam).

Structure: `teardown_facts` split to `run/teardown.rs` and the `--json` lane extracted to `execute_json_lane` (the fold-lane precedent) — both at the fn-length wall. Tests: 8 new (trust binding ×2 · boot manifest fields · INCOMPLETE at the verify surface · extended seal through the real tier ladder · teardown folds ×2 · the WIP's chain/seal pair) — 1220 lib tests green on the rebased tree, clippy `-D warnings` clean, the full pre-push gate green at push.

Operator ratification points: (1) `lock_digest` omission (no recording surface · LOCK_UNRECORDED posture) · (2) INCOMPLETE exit = 0 today · (3) shipped recos: seal-only binding + semantic `covers.workflow`.

Remaining TEST_DEBT (CI-side · non-blocking): run_verb e2e for the exit-2 map · evidence/otel incomplete units · storyboard regen if CI asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)