### PR TITLE
fix(release): the immutable-sha checkout learns its one tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,14 +274,24 @@ jobs:
           # rendered from CHANGELOG.md; --generate-notes keeps the full PR
           # list appended below it (gh prepends provided notes to generated).
           bash scripts/release/render-notes.sh "$REF_NAME" > "$RUNNER_TEMP/release-notes.md"
-          gh release create "$REF_NAME" \
-            --repo "$REPO" \
-            --title "$REF_NAME" \
-            --notes-file "$RUNNER_TEMP/release-notes.md" \
-            --generate-notes \
-            --verify-tag \
-            --discussion-category "Announcements" \
-            artifacts/nika-*.tar.gz artifacts/SHA256SUMS
+          # idempotent on a workflow_dispatch rebuild (a documented path in
+          # this file): an existing release keeps its body + discussion —
+          # the LINEAGE LAW (never rewrite a live release retroactively) —
+          # and only the assets refresh (--clobber)
+          if gh release view "$REF_NAME" --repo "$REPO" > /dev/null 2>&1; then
+            echo "::notice::release ${REF_NAME} already exists — refreshing assets only"
+            gh release upload "$REF_NAME" --repo "$REPO" --clobber \
+              artifacts/nika-*.tar.gz artifacts/SHA256SUMS
+          else
+            gh release create "$REF_NAME" \
+              --repo "$REPO" \
+              --title "$REF_NAME" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              --generate-notes \
+              --verify-tag \
+              --discussion-category "Announcements" \
+              artifacts/nika-*.tar.gz artifacts/SHA256SUMS
+          fi
       - name: Attest build provenance (SLSA · verifiable via `gh attestation verify`)
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
@@ -423,6 +433,15 @@ jobs:
           echo "b5bf1f0eaf17c63ee588ff7a5954dc8f6ce2c26989051c66f24dfe9ece3e46db  $RUNNER_TEMP/binaryen.tar.gz" | sha256sum -c
           tar -xzf "$RUNNER_TEMP/binaryen.tar.gz" -C "$RUNNER_TEMP"
           echo "$RUNNER_TEMP/binaryen-version_131/bin" >> "$GITHUB_PATH"
+      - name: Fetch the release tag (first-exercise find №4 — the version assert caught it)
+        # the sha checkout above is the supply-chain fix (immutable ref) but
+        # it carries ZERO tags — npm-pack.sh's honesty gate then reads the
+        # tree as untagged and packs a -dev prerelease, and the version
+        # assert below refuses it (proven on v0.106.1's first run: packed
+        # 0.106.1-dev.g… ≠ released 0.106.1). One tag, fetched explicitly.
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+        run: git fetch origin tag "$TAG" --no-tags
       - name: Pack (tests · wasm-release build · bindgen · wasm-opt · projected manifest)
         env:
           NIKA_SPEC_DIR: ${{ github.workspace }}/nika-spec

--- a/estate.yaml
+++ b/estate.yaml
@@ -178,7 +178,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 19
-  aggregate_sha256: 922e0e7f768d7062fa19d80bbe192378190a2850f2f2c597afb79ae2302ee480
+  aggregate_sha256: c020584186ef8b08bb607c302581b0355339678161e24458f8e429801d1d67aa
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
First-exercise find №4 on the npm leg's maiden run, caught by its own version
assert exactly where the assert was moved to fire (before any upload): the
immutable-sha checkout (the supply-chain fix) carries zero tags, so the
honesty gate packed a `-dev` prerelease and the assert refused
`0.106.1-dev.g… ≠ 0.106.1`. The job now fetches the release's own tag
explicitly. Same commit: `gh release create` turns idempotent on a
workflow_dispatch rebuild (existing release keeps its body + discussion per
the lineage law; assets refresh with --clobber), so re-dispatching v0.106.1
to rerun the npm leg is safe.

After the squash: `gh workflow run release.yml --ref main -f tag=v0.106.1` —
the rebuild runs main's workflow over the tag's tree; every other leg is
idempotent by design (formula no-ops, docker re-points the same tag, uploads
clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
