### PR TITLE
chore(estate): the manifest follows the tree (4160 files · the pin hash)

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "impl-owned test evidence — fixtures, corpora, batteries: proves behavior; neither shipped code nor derived output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4159
+  classified_files: 4160
   file_rows: 10
   pattern_rows: 22
   by_class:
-    authored: 1276
+    authored: 1277
     authored-pin: 1
     generated: 111
     pinned-copy: 75
@@ -63,7 +63,7 @@ files:
   note: "ROADMAP.md:98 carries the same refresh-status.sh AUTO-GENERATED status block — a tool-maintained block inside an authored file"
 - path: "SPEC_PIN"
   class: authored-pin
-  sha256: d8c126a5eab8e61f30b9910b58c64d8cfa621f171b00aee1ab780ee5f924de3a
+  sha256: 366edd52e514e7c6965b944e1704cd765fe134d7ecfa178902428bc64daeafa8
   evidence: "its own header: 'Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.'"
 - path: "crates/nika-catalog/data/model-pricing.toml"
   class: generated
@@ -104,7 +104,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 75
-  aggregate_sha256: ddb30df6508748671acdda03cf3cd52517560aff66fee749d16445411b7977cc
+  aggregate_sha256: 3d4ad4035453296369991208af8bdaa71c6020ccd91dc0c1418bf8d1453703f1
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -146,8 +146,8 @@ patterns:
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 109
-  aggregate_sha256: 96be99a69edcb0a640a71b76f6296df984dc76bfdbb78484e6adf3a5782b0afe
+  match_count: 110
+  aggregate_sha256: a610cb8077ff8cab3121675ec4b24ed34f57c2747dc81b14ad71ae3bdad6043d
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored


### PR DESCRIPTION
Estate drift heal — the observation manifest re-follows the tree after the #744-#746 cascade (estate.yaml · 6 pin-hash rows). The estate check judges on this PR; the drift advisory on sister PRs clears once this lands (the chore-regen follows the cascade · the never-blocks law).