### PR TITLE
fix(pack): the canon counts and the manifest hashes tell the truth

### DIFF
--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -65,7 +65,7 @@ counts:
   templates: 10
   error_namespaces: 25
   error_categories: 12
-  error_codes: 98
+  error_codes: 100
   pillars: 5
   # ---- extended v0.2 · 2026-05-27 · lifecycle + diamond + steal + severity
   lifecycle_product: 4
@@ -296,7 +296,7 @@ error_categories:
 # check binds the prose table to it (same row set · same fields).
 # transient · false | engine-assessed
 error_codes:
-  count: 98
+  count: 100
   reference: spec/05-errors.md
   items:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -36,7 +36,7 @@ templates:
   - file: templates/agent-loop.nika.yaml
     sha256_16: fba1d9e2c3c6c05d
   - file: templates/api-upload-and-create.nika.yaml
-    sha256_16: a159c013142a0288
+    sha256_16: 6a66f28263c1cb0d
   - file: templates/chain.nika.yaml
     sha256_16: db5460bf09b58462
   - file: templates/docker-report.nika.yaml
@@ -44,7 +44,7 @@ templates:
   - file: templates/etl-state.nika.yaml
     sha256_16: e8d2b3c79e7057f1
   - file: templates/fanout.nika.yaml
-    sha256_16: 8bc7121f826240f2
+    sha256_16: 1b480f5fe640f8e2
   - file: templates/gate-and-act.nika.yaml
     sha256_16: edfd4419aafaa80a
   - file: templates/human-gated-ship.nika.yaml


### PR DESCRIPTION
Main went red twice stacked after the R3-F1 pushes:

1. the vendored canon carries **100** error rows (INFER-003 + AGENT-005 joined engine-side) but both count lines still said **98** — `error_codes_registry_parses_typed_and_complete` red;
2. two template entries in the pack manifest held pre-sweep lean hashes (`api-upload-and-create` · `fanout` — the files themselves are current with the spec) — `every_manifest_entry_resolves_and_hashes_clean` red behind it.

The counts read 100 and the two `sha256_16` entries name the files' actual lean digests (verified against the spec's own manifest values). `cargo test -p nika-pack --test pack_integrity`: 6/6 green.

Named, not fixed here: the canon's `body-sha256` header line is stale by the same R3-F1 rows — its source of truth is the spec repo's `ssot-compiler`, and the two R3-F1 codes belong to a spec-side registration + re-vendor (the vendoring lane owns it).