### PR TITLE
fix(audit): wave A — the general adversarial audit's law+security findings

### DIFF
--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -2609,6 +2609,7 @@ pub fn nika_check::check_composed(wf: &nika_schema::raw::workflow::RawWorkflow, 
 pub fn nika_check::infer_permits(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_check::InferredPermits
 pub fn nika_check::lowered_returns(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>
 pub fn nika_check::named_types(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::types::NikaType>
+pub fn nika_check::policy_wire_code(rule: &str) -> &'static str
 pub fn nika_check::returns_type(task: &nika_schema::raw::task::RawTask, wf: &nika_schema::raw::workflow::RawWorkflow) -> core::option::Option<nika_types::types::NikaType>
 pub fn nika_check::static_read_paths(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub fn nika_check::task_permits(task: &nika_schema::raw::task::RawTask) -> alloc::vec::Vec<alloc::string::String>

--- a/crates/nika-check/src/analysis.rs
+++ b/crates/nika-check/src/analysis.rs
@@ -20,12 +20,18 @@
 //! - **blast radius** — AND-join makes failure analysis exact: a failed
 //!   task blocks EVERY transitive dependent;
 //! - **write-write conflicts** (F-P15 · NEP-0014 law 1) — two tasks that
-//!   CAN run concurrently (incomparable) and both write the same literal
-//!   `nika:write` path: last-writer-wins is a race the file never
-//!   declares. The LAW (a `NIKA-SEC-012` finding · deterministic) —
-//!   promoted from its advisory-hint era 2026-07-29: parallelism is safe
-//!   exactly where the effects are provably disjoint, and a hint is not
-//!   a boundary.
+//!   CAN run concurrently (incomparable) and both target the same literal
+//!   `nika:write`/`nika:edit` path, compared under LEXICAL normalization
+//!   (`./out/x.md` ≡ `out//x.md` ≡ `out/d/../x.md` ≡ `out/x.md` — pure
+//!   text, no filesystem claim; see [`normalize_lexical`]):
+//!   last-writer-wins is a race the file never declares. The LAW (a
+//!   `NIKA-SEC-012` finding · deterministic) — promoted from its
+//!   advisory-hint era 2026-07-29: parallelism is safe exactly where the
+//!   effects are provably disjoint, and a hint is not a boundary. Above
+//!   [`ANALYSIS_TASK_CAP`] the closure-based pair scan is skipped and
+//!   the skip is STATED ([`DagRead::stated_miss`] — the report carries
+//!   it as a hint, never a silent no-claim); the closure-free
+//!   `for_each` same-path flavor still judges.
 //!
 //! Width can EXCEED the largest wave — witness `p→a1→x2 · p→x1 ·
 //! isolated x0`: waves peak at 2, width is 3 (`{x0, x1, x2}`). The
@@ -44,9 +50,10 @@ use nika_schema::source::Spanned;
 const WRITE_CONFLICT_CODE: &str = "NIKA-SEC-012";
 
 /// One write-write conflict (F-P15 · NEP-0014 law 1): two tasks
-/// incomparable in the DAG closure whose literal `nika:write` paths
-/// collide, or a `for_each` fan writing one constant path — the
-/// last-writer-wins race, refused at check.
+/// incomparable in the DAG closure whose literal `nika:write` /
+/// `nika:edit` paths collide under lexical normalization, or a
+/// `for_each` fan writing one constant path — the last-writer-wins
+/// race, refused at check.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[non_exhaustive]
 pub struct WriteConflict {
@@ -56,9 +63,12 @@ pub struct WriteConflict {
     /// The second writer — `None` for the `for_each` flavor (the task
     /// races its own iterations).
     pub other: Option<String>,
-    /// The literal `nika:write` path both writes target.
+    /// The colliding path in its LEXICAL normal form (the pair flavor —
+    /// both literals reduce to it) · the literal as spelled (the
+    /// `for_each` flavor — nothing is compared).
     pub path: String,
-    /// The witness sentence (the race, named).
+    /// The witness sentence (the race, named — both spellings when the
+    /// literals differ textually).
     pub detail: String,
     /// The one repair.
     pub fix: String,
@@ -107,27 +117,37 @@ pub(super) struct DagRead {
     pub analysis: Option<DagAnalysis>,
     /// Write-write conflicts (F-P15 · the law, never advisory).
     pub conflicts: Vec<WriteConflict>,
+    /// The STATED MISS when the closure-based read was skipped for width
+    /// (H6 · the verdict-coverage law: a law that did not judge says so,
+    /// in the report's own surface — the builder folds it as a hint).
+    /// `None` when the read ran, and on the conformance skip — that one
+    /// is already stated by the CONFORM rows themselves.
+    pub stated_miss: Option<String>,
 }
 
 impl DagRead {
-    /// The skipped read (conformance failed — claim nothing).
+    /// The skipped read (conformance failed — claim nothing; the
+    /// CONFORM rows state why, so no extra miss rides).
     pub(super) fn skipped() -> Self {
         Self {
             analysis: None,
             conflicts: Vec::new(),
+            stated_miss: None,
         }
     }
 }
 
-/// Above this task count the exact read is SKIPPED (honest, never
-/// wrong — same posture as the conformance gate). The materialized
-/// closure is O(n²) and the matching phases O(E√V): at the parser's
-/// 10k-task cap that is ~400 MB + minutes of CPU from a few-KB YAML —
-/// a `DoS` surface on a checker that markets static safety (house
-/// precedent: the marked-yaml depth caps · the 64 MiB ceilings). At
-/// 2 000 tasks the worst case stays ~60 MB · milliseconds typical —
-/// far above any real workflow. The cap also bounds the augmenting
-/// DFS recursion (≤ n frames · see [`hk_dfs`]).
+/// Above this task count the exact read is SKIPPED — and the skip is a
+/// STATED MISS ([`DagRead::stated_miss`]), never silent; the
+/// closure-free `for_each` same-path flavor of the write-write law
+/// still runs (H6). The materialized closure is O(n²) and the matching
+/// phases O(E√V): at the parser's 10k-task cap that is ~400 MB +
+/// minutes of CPU from a few-KB YAML — a `DoS` surface on a checker
+/// that markets static safety (house precedent: the marked-yaml depth
+/// caps · the 64 MiB ceilings). At 2 000 tasks the worst case stays
+/// ~60 MB · milliseconds typical — far above any real workflow. The cap
+/// also bounds the augmenting DFS recursion (≤ n frames · see
+/// [`hk_dfs`]).
 const ANALYSIS_TASK_CAP: usize = 2_000;
 
 /// Run the engineering read over a conformant workflow.
@@ -142,10 +162,24 @@ pub(super) fn read_dag(wf: &RawWorkflow, topo_waves: &[Vec<usize>]) -> DagRead {
                 blast_radius: Vec::new(),
             }),
             conflicts: Vec::new(),
+            stated_miss: None,
         };
     }
     if n > ANALYSIS_TASK_CAP {
-        return DagRead::skipped();
+        // H6 · the verdict-coverage law at the cap: the skip is STATED
+        // (never a silent no-claim), and the closure-free flavor of the
+        // write-write law still judges — a fan racing its own iterations
+        // needs no closure.
+        return DagRead {
+            analysis: None,
+            conflicts: scan_for_each_fans(wf),
+            stated_miss: Some(format!(
+                "{n} tasks is over the {ANALYSIS_TASK_CAP}-task analysis cap (the O(n²) closure \
+                 stays a DoS floor): width · pinch points · blast radius made NO claim, and the \
+                 write-write law judged only the `for_each` same-path flavor — the pair scan did \
+                 not run"
+            )),
+        };
     }
 
     let down = downstream_adjacency(&wf.tasks);
@@ -193,6 +227,7 @@ pub(super) fn read_dag(wf: &RawWorkflow, topo_waves: &[Vec<usize>]) -> DagRead {
             blast_radius: blast,
         }),
         conflicts: scan_parallel_writers(wf, &desc),
+        stated_miss: None,
     }
 }
 
@@ -401,13 +436,20 @@ fn koenig_witness(
     (0..n).filter(|&i| z_left[i] && !z_right[i]).collect()
 }
 
-/// The literal `nika:write` target of a task, when statically known —
-/// island-bearing paths are dynamic and make no static claim.
+/// The literal `nika:write`/`nika:edit` target of a task, when
+/// statically known — island-bearing paths are dynamic and make no
+/// static claim. (H4 · the canon text names BOTH writer builtins: they
+/// take `path:` identically and return it as their output, and the
+/// edit's read-modify-write loses updates to a concurrent writer
+/// exactly like the write's rename does.)
 fn literal_write_path(task: &RawTask) -> Option<&str> {
     let RawAction::Invoke(invoke) = &task.action else {
         return None;
     };
-    if invoke.tool().map(|t| t.value.as_str()) != Some("nika:write") {
+    if !matches!(
+        invoke.tool().map(|t| t.value.as_str()),
+        Some("nika:write" | "nika:edit")
+    ) {
         return None;
     }
     invoke
@@ -419,25 +461,111 @@ fn literal_write_path(task: &RawTask) -> Option<&str> {
         .filter(|p| !p.contains("${{"))
 }
 
+/// The LEXICAL normal form two write paths are compared under (H5 ·
+/// F-P15) — component-wise, pure text, no filesystem access:
+///
+/// - duplicate separators collapse (`out//x.md` ≡ `out/x.md`) and a
+///   trailing separator drops;
+/// - `.` components drop (`./out/x.md` ≡ `out/x.md`);
+/// - `..` pops the last kept component (`out/d/../x.md` ≡ `out/x.md`) —
+///   except a `..` with nothing to pop, which is KEPT verbatim (a
+///   relative path's escape stays its own: `../x.md` ≡ only `../x.md`),
+///   as is one past an absolute root (`/..` ≡ `/`).
+///
+/// The claim is LEXICAL, not filesystem: two spellings sharing a normal
+/// form name one file UNLESS a `..` crossed a symlinked directory (the
+/// kernel resolves `..` against the link target's parent, not the
+/// spelled one) or the filesystem folds case. The error direction is
+/// the safe one — a symlink false positive merely orders two writers
+/// that might have differed; the spelling false negative this fixes
+/// raced two writers on one file.
+fn normalize_lexical(path: &str) -> String {
+    let absolute = path.starts_with('/');
+    let mut kept: Vec<&str> = Vec::new();
+    for component in path.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => match kept.last() {
+                Some(&last) if last != ".." => {
+                    kept.pop();
+                }
+                // Absolute: the root absorbs the `..`. Relative: the
+                // escape is the path's own — kept.
+                _ if absolute => {}
+                _ => kept.push(".."),
+            },
+            c => kept.push(c),
+        }
+    }
+    let joined = kept.join("/");
+    match (absolute, joined.is_empty()) {
+        (true, true) => "/".to_owned(),
+        (true, false) => format!("/{joined}"),
+        // The empty and all-dot spellings share one normal form.
+        (false, true) => ".".to_owned(),
+        (false, false) => joined,
+    }
+}
+
 /// Write-write races, statically (F-P15 · NEP-0014 law 1): two tasks
 /// that CAN run concurrently (incomparable in the closure) and both
-/// write the same literal path — plus the fan-out flavor (`for_each`
-/// over a constant path: every iteration overwrites the same file). The
-/// LAW: each conflict is a finding (an ordering edge — `after:` /
-/// `with:` — discharges it; parallelism is safe exactly where the
-/// writes are provably disjoint).
+/// target the same literal path under lexical normalization — plus the
+/// fan-out flavor ([`scan_for_each_fans`]). The LAW: each conflict is a
+/// finding (an ordering edge — `after:` / `with:` — discharges it;
+/// parallelism is safe exactly where the writes are provably disjoint).
 fn scan_parallel_writers(wf: &RawWorkflow, desc: &[Vec<u64>]) -> Vec<WriteConflict> {
-    let writers: Vec<(usize, &str)> = wf
+    let mut conflicts = scan_for_each_fans(wf);
+    // (task index · the literal as spelled · its lexical normal form).
+    let writers: Vec<(usize, &str, String)> = wf
         .tasks
         .iter()
         .enumerate()
-        .filter_map(|(i, t)| literal_write_path(&t.value).map(|p| (i, p)))
+        .filter_map(|(i, t)| literal_write_path(&t.value).map(|p| (i, p, normalize_lexical(p))))
         .collect();
 
     let comparable = |a: usize, b: usize| -> bool {
         desc[a][b / 64] & (1u64 << (b % 64)) != 0 || desc[b][a / 64] & (1u64 << (a % 64)) != 0
     };
 
+    for (a, (ai, ap, an)) in writers.iter().enumerate() {
+        for (bi, bp, bn) in writers.iter().skip(a + 1) {
+            if an != bn || comparable(*ai, *bi) {
+                continue;
+            }
+            let (first, second) = (&wf.tasks[*ai].value.id.value, &wf.tasks[*bi].value.id.value);
+            // Both literals are named when the spellings differ — the
+            // collision is exactly that they reduce to one file.
+            let detail = if ap == bp {
+                format!(
+                    "`{first}` and `{second}` can run CONCURRENTLY and both write \
+                     `{ap}` — last-writer-wins is a race the file never declares"
+                )
+            } else {
+                format!(
+                    "`{first}` and `{second}` can run CONCURRENTLY and write the SAME file \
+                     spelled `{ap}` and `{bp}` — last-writer-wins is a race the file never \
+                     declares"
+                )
+            };
+            conflicts.push(WriteConflict {
+                task: first.clone(),
+                other: Some(second.clone()),
+                path: an.clone(),
+                detail,
+                fix: "order them with `after:` (one writer after the other) · or \
+                      merge the writes into one task"
+                    .to_owned(),
+            });
+        }
+    }
+    conflicts
+}
+
+/// The `for_each` flavor, closure-free: a fan writing one constant path
+/// races its OWN iterations — no DAG read is needed, so this judgment
+/// runs even when the closure-based pair scan is capped out (H6 · every
+/// iteration overwrites the same file, the last silently wins).
+fn scan_for_each_fans(wf: &RawWorkflow) -> Vec<WriteConflict> {
     let mut conflicts = Vec::new();
     for t in &wf.tasks {
         if t.value.for_each.is_some()
@@ -454,26 +582,6 @@ fn scan_parallel_writers(wf: &RawWorkflow, desc: &[Vec<u64>]) -> Vec<WriteConfli
                 ),
                 fix: "derive the path from `${{ item }}` so each iteration writes \
                       its own file · or drop `for_each`"
-                    .to_owned(),
-            });
-        }
-    }
-    for (a, &(ai, ap)) in writers.iter().enumerate() {
-        for &(bi, bp) in writers.iter().skip(a + 1) {
-            if ap != bp || comparable(ai, bi) {
-                continue;
-            }
-            let (first, second) = (&wf.tasks[ai].value.id.value, &wf.tasks[bi].value.id.value);
-            conflicts.push(WriteConflict {
-                task: first.clone(),
-                other: Some(second.clone()),
-                path: ap.to_owned(),
-                detail: format!(
-                    "`{first}` and `{second}` can run CONCURRENTLY and both write \
-                     `{ap}` — last-writer-wins is a race the file never declares"
-                ),
-                fix: "order them with `after:` (one writer after the other) · or \
-                      merge the writes into one task"
                     .to_owned(),
             });
         }
@@ -691,6 +799,140 @@ mod tests {
     }
 
     #[test]
+    fn parallel_editors_same_literal_path_is_a_finding() {
+        // H4 · the canon text names BOTH writer builtins: `nika:edit`
+        // takes `path:` identically, and its read-modify-write loses
+        // updates to a concurrent edit exactly like `nika:write`.
+        let yaml = format!(
+            "{HEADER}  left:\n    invoke:\n      tool: nika:edit\n      args:\n        path: out/report.md\n        find: a\n        replace: b\n  right:\n    invoke:\n      tool: nika:edit\n      args:\n        path: out/report.md\n        find: c\n        replace: d\n"
+        );
+        let conflicts = read(&yaml).conflicts;
+        assert_eq!(conflicts.len(), 1);
+        let c = &conflicts[0];
+        assert_eq!(c.task, "left");
+        assert_eq!(c.other.as_deref(), Some("right"));
+        assert_eq!(c.path, "out/report.md");
+        assert_eq!(c.wire_code(), "NIKA-SEC-012");
+    }
+
+    #[test]
+    fn a_write_and_an_edit_on_one_path_race() {
+        // H4 · the mixed pair: the write's atomic rename and the edit's
+        // read-modify-write have no order — one of them loses.
+        let yaml = format!(
+            "{HEADER}  left:\n    invoke:\n      tool: nika:write\n      args:\n        path: out/report.md\n        content: \"a\"\n  right:\n    invoke:\n      tool: nika:edit\n      args:\n        path: out/report.md\n        find: a\n        replace: b\n"
+        );
+        let conflicts = read(&yaml).conflicts;
+        assert_eq!(conflicts.len(), 1, "write+edit on one path refuses");
+        assert_eq!(conflicts[0].wire_code(), "NIKA-SEC-012");
+    }
+
+    #[test]
+    fn path_spellings_collide_after_lexical_normalization() {
+        // H5 · the raw-string compare let `./out/x.md` vs `out/x.md` vs
+        // `out//x.md` vs `out/d/../x.md` evade the law — every spelling
+        // names the same file and must refuse against the plain form.
+        for (a, b) in [
+            ("./out/x.md", "out/x.md"),
+            ("out//x.md", "out/x.md"),
+            ("out/d/../x.md", "out/x.md"),
+        ] {
+            let yaml = format!(
+                "{HEADER}  left:\n    invoke:\n      tool: nika:write\n      args:\n        path: {a}\n        content: \"a\"\n  right:\n    invoke:\n      tool: nika:write\n      args:\n        path: {b}\n        content: \"b\"\n"
+            );
+            let conflicts = read(&yaml).conflicts;
+            assert_eq!(
+                conflicts.len(),
+                1,
+                "`{a}` and `{b}` name one file — the race must refuse"
+            );
+            let c = &conflicts[0];
+            assert_eq!(c.path, "out/x.md", "the normal form rides: {a} vs {b}");
+            assert!(
+                c.detail.contains(a) && c.detail.contains(b),
+                "both spellings named: {}",
+                c.detail
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_lexical_is_component_wise_and_pure() {
+        // H5 · the normal form's edges: dot components drop, duplicate
+        // separators collapse, `..` pops lexically — and an escape past
+        // the root is KEPT (lexically, nothing proves what it pops).
+        assert_eq!(normalize_lexical("./out/x.md"), "out/x.md");
+        assert_eq!(normalize_lexical("out//x.md"), "out/x.md");
+        assert_eq!(normalize_lexical("out/./x.md"), "out/x.md");
+        assert_eq!(normalize_lexical("out/d/../x.md"), "out/x.md");
+        assert_eq!(normalize_lexical("out/x.md"), "out/x.md");
+        assert_eq!(normalize_lexical("../x.md"), "../x.md");
+        assert_eq!(normalize_lexical("a/../../x.md"), "../x.md");
+        assert_eq!(normalize_lexical("/a//b/../c"), "/a/c");
+        assert_eq!(normalize_lexical(""), ".");
+        // Distinct files stay distinct (no merge-happy normalization).
+        assert_ne!(normalize_lexical("out/x.md"), normalize_lexical("out/y.md"));
+    }
+
+    #[test]
+    fn over_the_cap_the_miss_is_stated_and_the_fan_flavor_still_judges() {
+        // H6 · the cap used to judge NOTHING silently. Now the skip is
+        // a STATED MISS the report carries, and the closure-free
+        // `for_each` same-path flavor — which needs no closure — still
+        // refuses above the cap.
+        let mut yaml = String::from(HEADER);
+        yaml.push_str("  fan:\n    for_each: [1, 2]\n    invoke:\n      tool: nika:write\n      args:\n        path: out/same.md\n        content: \"x\"\n");
+        for i in 0..ANALYSIS_TASK_CAP {
+            yaml.push_str(&infer_task(&format!("t{i}"), &[]));
+        }
+        let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
+        assert_eq!(parsed.tasks.len(), ANALYSIS_TASK_CAP + 1);
+        let analyzed = crate::analyzer::analyze(&parsed).expect("conformant");
+        let read = read_dag(&parsed, &analyzed.topo_waves);
+        assert!(
+            read.analysis.is_none(),
+            "over the cap the exact read claims nothing"
+        );
+        let miss = read
+            .stated_miss
+            .as_deref()
+            .expect("the skip is STATED, never silent");
+        assert!(
+            miss.contains("the pair scan did not run"),
+            "the miss names what did not judge: {miss}"
+        );
+        assert_eq!(read.conflicts.len(), 1, "the fan flavor needs no closure");
+        assert_eq!(read.conflicts[0].task, "fan");
+        assert_eq!(read.conflicts[0].other, None);
+    }
+
+    #[test]
+    fn the_stated_miss_rides_the_report_hints() {
+        // H6 · through `check()`: the miss lands as an `analysis` hint
+        // (JSON `hints[]` + the console HINTS section carry it), and the
+        // fan flavor's refusal lands as the law's finding.
+        let mut yaml = String::from(HEADER);
+        yaml.push_str("  fan:\n    for_each: [1, 2]\n    invoke:\n      tool: nika:write\n      args:\n        path: out/same.md\n        content: \"x\"\n");
+        for i in 0..ANALYSIS_TASK_CAP {
+            yaml.push_str(&infer_task(&format!("t{i}"), &[]));
+        }
+        let parsed = parse(&yaml, FileId::new(0), ParseMode::Strict).expect("parse");
+        let report = crate::check(&parsed);
+        let hint = report
+            .hints
+            .iter()
+            .find(|h| h.kind == "analysis")
+            .expect("the stated miss rides hints[]");
+        assert!(
+            hint.advice.contains("the pair scan did not run"),
+            "the hint names the miss: {}",
+            hint.advice
+        );
+        assert_eq!(report.write_conflicts.len(), 1);
+        assert_eq!(report.write_conflicts[0].task, "fan");
+    }
+
+    #[test]
     fn empty_workflow_reads_as_width_zero() {
         let parsed = parse(
             "nika: v1\nworkflow:\n  id: t\n\nmodel: mock/echo\n\ntasks: []\n",
@@ -738,7 +980,9 @@ mod tests {
     fn oversized_workflows_skip_the_exact_read_honestly() {
         // One task above the cap: the read is skipped (None · no claim)
         // instead of materializing an O(n²) closure — never slow, never
-        // wrong, same posture as the conformance gate.
+        // wrong. H6: the skip is no longer silent either — the read
+        // carries its STATED MISS (no fan in this fixture, so the
+        // closure-free flavor finds nothing).
         let mut yaml = String::from(HEADER);
         yaml.push_str(&infer_task("t0", &[]));
         for i in 1..=ANALYSIS_TASK_CAP {
@@ -753,6 +997,10 @@ mod tests {
             "above the cap the read claims nothing"
         );
         assert!(read.conflicts.is_empty());
+        assert!(
+            read.stated_miss.is_some(),
+            "above the cap the skip is STATED, never silent"
+        );
     }
 
     #[test]

--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -279,20 +279,14 @@ fn fold_permit_taints(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
 }
 
 /// The hard-`policy:` class (spec 10 · NIKA-POLICY-001) — the detail
-/// already names rule + task + witness. F-P4: the `approval.*` rules
-/// (NEP-0013) speak the approval-capability code NIKA-SEC-010, not the
-/// policy-lane code. F-P23: the `endorsement.*` rules (NEP-0017) speak
-/// NIKA-SEC-013.
+/// already names rule + task + witness. The wire code is the ONE
+/// mapping every surface reads ([`crate::policy_wire_code`]): F-P4's
+/// `approval.*` rules (NEP-0013) speak NIKA-SEC-010, F-P23's
+/// `endorsement.*` rules (NEP-0017) speak NIKA-SEC-013.
 fn fold_policy_findings(report: &CheckReport, out: &mut Vec<UnifiedFinding>) {
     for p in &report.policy_findings {
         let mut f = UnifiedFinding::new("policy", "POLICY", p.detail.clone());
-        let code = if p.rule.starts_with("approval.") {
-            "NIKA-SEC-010"
-        } else if p.rule.starts_with("endorsement.") {
-            "NIKA-SEC-013"
-        } else {
-            "NIKA-POLICY-001"
-        };
+        let code = crate::policy_wire_code(p.rule);
         f.code = Some(code.to_owned());
         f.docs_url = Some(format!("{}/{code}", super::ERROR_DOCS_BASE));
         f.task.clone_from(&p.task);

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -37,6 +37,11 @@
 //! - **concurrent same-path writers** — RETIRED by F-P15 (NEP-0014 law
 //!   1): the write-write race is the `NIKA-SEC-012` FINDING now (the
 //!   DAG analysis pass owns it · a hint is not a boundary).
+//! - **over-cap DAG read** (`analysis`) — H6: past the analysis task
+//!   cap the width/pinch/blast read and the pair scan of the
+//!   write-write law are skipped (the O(n²) `DoS` floor) — the skip is
+//!   STATED here, never silent; the closure-free `for_each` same-path
+//!   flavor still judged.
 //! - **exec with a native path** (`native-first`) — emitted by the
 //!   `check/native_first.rs` pass (the `native-first/001..005` ruleset:
 //!   http/file/data/media/helper commands a builtin or MCP tool
@@ -79,7 +84,8 @@ pub struct Hint {
     /// `redundant-gate` · `retry-effects` ·
     /// `secrets-store` · `native-first` · `exec-json-capture` ·
     /// `unwrapped-ref` · `envelope-output` · `policy-soft` · `run-clock`
-    /// (additive · agents route on it; the module doc describes each).
+    /// · `analysis` (additive · agents route on it; the module doc
+    /// describes each).
     /// `parallel-writers` is RETIRED (F-P15 · promoted to the
     /// NIKA-SEC-012 finding — an error owns its repair, never a hint).
     pub kind: &'static str,

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -157,6 +157,7 @@ pub use hints::Hint;
 pub use permit_taint::{PermitTaint, PermitTaintKind};
 pub use permits_fit::CapabilityEscape;
 pub use permits_infer::InferredPermits;
+pub use policy::policy_wire_code;
 pub use reach::{GateFinding, GateFindingKind, STATUS_VOCAB};
 pub use requirements::{ModelRequirement, Requirements, SecretRequirement};
 pub use run_decl::RunDeclFinding;
@@ -636,6 +637,17 @@ pub fn check(wf: &RawWorkflow) -> CheckReport {
     };
     let mut hints = hints::scan_hints(wf);
     hints.extend(native_first::scan(wf));
+    // H6 · the width-capped DAG read STATES its miss (the
+    // verdict-coverage law: a law that did not judge says so, in the
+    // report's own surface — the JSON `hints[]` and the console HINTS
+    // section both carry it).
+    if let Some(miss) = dag_read.stated_miss {
+        hints.push(Hint {
+            kind: "analysis",
+            task: "-".to_owned(),
+            advice: miss,
+        });
+    }
     // policy reads graph ancestors — valid order or no claim (IFC gating)
     let policy_findings = if conformance.is_empty() {
         policy::scan_policy(wf, &edges)

--- a/crates/nika-check/src/policy.rs
+++ b/crates/nika-check/src/policy.rs
@@ -15,6 +15,25 @@ use crate::analyzer::Edge;
 use nika_schema::expression::scan_templates;
 use nika_schema::raw::{RawAction, RawWorkflow};
 
+/// The wire code a policy finding stamps (spec 10 · F-P4 · F-P23) —
+/// ONE match, every surface: the `--json` `findings[]` fold
+/// (`check/findings.rs`), the console POLICY rung
+/// (`nika-display/check_render.rs`), and the LSP projection all read
+/// THIS. The `approval.*` rules (NEP-0013) speak the
+/// approval-capability code NIKA-SEC-010, the `endorsement.*` rules
+/// (NEP-0017) speak NIKA-SEC-013, every other rule the policy-lane
+/// NIKA-POLICY-001.
+#[must_use]
+pub fn policy_wire_code(rule: &str) -> &'static str {
+    if rule.starts_with("approval.") {
+        "NIKA-SEC-010"
+    } else if rule.starts_with("endorsement.") {
+        "NIKA-SEC-013"
+    } else {
+        "NIKA-POLICY-001"
+    }
+}
+
 /// Judge the hard `policy:` families (require · forbid · allow · limits
 /// · endorsement) over the derived edges. The caller gates on a valid
 /// DAG — the order rules read ancestors, so an unanalyzable workflow
@@ -93,12 +112,34 @@ fn provider_pin(action: &RawAction, root_model: Option<&str>) -> ProviderPin {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
+    use super::policy_wire_code;
     use crate::check;
     use nika_schema::parser::{ParseMode, parse};
     use nika_schema::source::FileId;
 
     fn report(yaml: &str) -> crate::CheckReport {
         check(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses"))
+    }
+
+    /// 2a · the ONE mapping every surface reads: `approval.*` speaks
+    /// NIKA-SEC-010 (NEP-0013), `endorsement.*` NIKA-SEC-013 (NEP-0017),
+    /// every other rule the policy-lane NIKA-POLICY-001 (spec 10).
+    #[test]
+    fn the_wire_code_mapping_is_prefix_exact() {
+        assert_eq!(
+            policy_wire_code("approval.heterogeneous_batch"),
+            "NIKA-SEC-010"
+        );
+        assert_eq!(policy_wire_code("endorsement.solo_count"), "NIKA-SEC-013");
+        assert_eq!(
+            policy_wire_code("endorsement.undeclared_mode"),
+            "NIKA-SEC-013"
+        );
+        assert_eq!(
+            policy_wire_code("require.human_gate_before"),
+            "NIKA-POLICY-001"
+        );
+        assert_eq!(policy_wire_code("limits.max_tasks"), "NIKA-POLICY-001");
     }
 
     /// Mirror of core/policy/001+002: the gate rule reads REAL ancestry

--- a/crates/nika-cli/tests/run_verb.rs
+++ b/crates/nika-cli/tests/run_verb.rs
@@ -363,3 +363,75 @@ fn a_var_override_satisfies_the_required_input() {
         "the override reached the read: {written}"
     );
 }
+
+/// M1 · the offline agent rehearsal, end to end at the binary: an agent
+/// granted `["nika:wait", "nika:done"]` watches its FIRST tool error
+/// once (the mock's synthesized args fail the real `nika:wait`
+/// contract), then the mock prefers the granted `nika:done` — the loop
+/// completes in two turns instead of stalling byte-identically
+/// (NIKA-467, the pre-fix verdict on this exact shape).
+#[test]
+fn a_wait_done_agent_errors_once_then_completes_via_done() {
+    const WAIT_DONE: &str = r#"
+nika: v1
+workflow:
+  id: run-agent-mock-done
+model: mock/echo
+permits:
+  tools: ["nika:wait", "nika:done"]
+tasks:
+  loop:
+    agent:
+      prompt: "wait once, then finish"
+      tools: ["nika:wait", "nika:done"]
+      max_turns: 5
+"#;
+    let wf = fixture("agent-wait-done.nika.yaml", WAIT_DONE);
+    let out = bin()
+        .arg("run")
+        .arg(&wf)
+        .arg("--json")
+        .args(["--color", "never"])
+        .output()
+        .expect("binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "the rehearsal completes · stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(
+        !stdout.contains("agent_stalled") && !stdout.contains("NIKA-467"),
+        "no byte-identical stall"
+    );
+    // The wait errored EXACTLY once (turn 1) — then the mock preferred
+    // the granted done (turn 2 is loop-owned: no dispatch frame rides).
+    let wait_frames: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.contains("\"kind\":\"tool_invoked\"") && l.contains("nika:wait"))
+        .collect();
+    assert_eq!(
+        wait_frames.len(),
+        1,
+        "one wait call, errored, never repeated: {stdout}"
+    );
+    let frame: serde_json::Value = serde_json::from_str(wait_frames[0]).expect("one JSON event");
+    assert!(
+        frame["fields"]
+            .as_array()
+            .expect("fields")
+            .iter()
+            .any(|f| f["key"] == "error" && f["value"] == true),
+        "the wait's synthesized args error deterministically: {}",
+        wait_frames[0]
+    );
+    let completed = stdout
+        .lines()
+        .find(|l| l.contains("\"kind\":\"task_completed\""))
+        .expect("the loop completed");
+    assert!(
+        completed.contains("agent · 2 turns"),
+        "done on turn two, deterministically: {completed}"
+    );
+}

--- a/crates/nika-cli/tests/verdict_coverage_oracle.rs
+++ b/crates/nika-cli/tests/verdict_coverage_oracle.rs
@@ -735,14 +735,18 @@ fn the_oracle_is_observed_both_firing_and_staying_silent() {
     // never opens (the retired const-url twin's story is the doc above).
     let fetch_literal = "tasks:\n  upload:\n    invoke:\n      tool: \"nika:fetch\"\n      args: { url: \"https://api.example.com/upload\" }\n";
 
-    // (arm · permits block · body · must the predicate FIRE?)
-    let arms: &[(&str, &str, &str, bool)] = &[
+    // (arm · permits block · body · must the predicate FIRE? · expected
+    // check verdict — ASSERTED, no longer narrated: the comments used to
+    // carry "check refuses it now" with nothing pinning it, and a check
+    // that quietly flipped green would have hollowed the arm's story)
+    let arms: &[(&str, &str, &str, bool, bool)] = &[
         // the honest declaration — green at check, silent at run
         (
             "honest",
             "permits:\n  fs: { read: [\"data/**\"] }\n  tools: [\"nika:read\"]\n",
             read_task,
             false,
+            true,
         ),
         // F8 · the body still reads, the fs grant is deleted
         (
@@ -750,6 +754,7 @@ fn the_oracle_is_observed_both_firing_and_staying_silent() {
             "permits:\n  tools: [\"nika:read\"]\n",
             read_task,
             false, // check refuses it now — the F8 repair
+            false,
         ),
         // the tool id itself is outside the declared set
         (
@@ -757,15 +762,16 @@ fn the_oracle_is_observed_both_firing_and_staying_silent() {
             "permits:\n  fs: { read: [\"data/**\"] }\n  tools: [\"nika:jq\"]\n",
             read_task,
             false, // check refuses it now
+            false,
         ),
         // the same dispatch with a LITERAL url — check decides it, so
         // the inversion never opens. The paired baseline.
-        ("fetch-literal-url", "", fetch_literal, false),
+        ("fetch-literal-url", "", fetch_literal, false, false),
     ];
 
     let mut verdicts: Vec<String> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
-    for (name, permits, body, must_fire) in arms {
+    for (name, permits, body, must_fire, expect_check_ok) in arms {
         let wf = root.join(format!("{name}.nika.yaml"));
         std::fs::write(
             &wf,
@@ -776,6 +782,25 @@ fn the_oracle_is_observed_both_firing_and_staying_silent() {
         let probe = probe(&wf, &[], &[]);
         let observed = probe.observed.expect("a verdict");
         let denied = !observed.authority_denials.is_empty();
+
+        // The arm's check verdict is an ASSERTION, not a narration:
+        // green arms must be green; refused arms must name their law
+        // (the leg-1 idiom — a refusal without a NIKA- finding is a
+        // crash, not a verdict).
+        if probe.check_ok != *expect_check_ok {
+            failures.push(format!(
+                "control arm `{name}`: check verdict — expected {} · got {}:\n{}",
+                if *expect_check_ok { "green" } else { "red" },
+                if probe.check_ok { "green" } else { "red" },
+                probe.check_text
+            ));
+        }
+        if !*expect_check_ok && !probe.check_text.contains("NIKA-") {
+            failures.push(format!(
+                "control arm `{name}`: a refusal must NAME its law (a NIKA- finding):\n{}",
+                probe.check_text
+            ));
+        }
 
         // The law, on every arm: green at check AND denied on authority
         // at run is the inversion, and nothing makes that pair lawful.

--- a/crates/nika-dap/src/quarantine.rs
+++ b/crates/nika-dap/src/quarantine.rs
@@ -22,6 +22,20 @@
 //! `run_sealed` line's `covers` via the F-P2 teardown (which proves
 //! THAT the end happened; F-P14 says WHAT the end must do).
 //!
+//! Two Success settle classes are NOT debt — only paths THIS run
+//! actually wrote are:
+//!
+//! - **recovered** (`cause == Recovered`) — the task FAILED, its
+//!   `on_error: recover:` chain settled it, and the record's `output`
+//!   is the AUTHOR-SUPPLIED fallback value, not a path a verb wrote.
+//!   Moving it would rename an arbitrary author-named file past the
+//!   permits boundary (the write permits gated the failed verb's
+//!   `path:`, never the recover arm's value).
+//! - **cache-hit** (the id rides [`RunOutcome::cache_hits`]) — a
+//!   resumed run's hit REHYDRATES a prior run's honest output; nothing
+//!   was written here, so there is nothing to quarantine (the prior
+//!   run's own teardown already judged that debt).
+//!
 //! Boundaries (the ledger text): the saga/compensation palier is
 //! declared P2 — no `finally:` schema block in v1, no new `EventKind`,
 //! no runtime change (the runtime stays fs-free by design; this is the
@@ -36,7 +50,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use nika_runtime::{RunOutcome, TaskStatus};
+use nika_runtime::{RunOutcome, TaskStatus, TerminalCause};
 use nika_schema::raw::{RawAction, RawInvokeTarget, RawWorkflow};
 
 /// The write-capable builtins whose settled outputs ARE the
@@ -80,9 +94,17 @@ pub fn attend(
 /// Dedupe first-wins (two tasks writing the same path move it once);
 /// non-string outputs are skipped (v1 scope — the writers return
 /// strings by contract, anything else is not a path we can name).
+///
+/// Two Success classes are excluded — only a path THIS run's verb
+/// actually wrote is debt: a `Recovered` record's output is the
+/// author's `recover:` fallback (the failed verb wrote nothing; moving
+/// the author-named value would be an arbitrary file move past the
+/// permits boundary), and a cache-hit record rehydrates a PRIOR run's
+/// output (nothing written here — the prior teardown judged its debt).
 fn written_paths(wf: &RawWorkflow, outcome: &RunOutcome) -> Vec<String> {
     let mut seen = BTreeSet::new();
     let mut paths = Vec::new();
+    let cache_hits: BTreeSet<&str> = outcome.cache_hits.iter().map(String::as_str).collect();
     for task in &wf.tasks {
         let RawAction::Invoke(invoke) = &task.value.action else {
             continue;
@@ -93,11 +115,18 @@ fn written_paths(wf: &RawWorkflow, outcome: &RunOutcome) -> Vec<String> {
         if !WRITER_TOOLS.contains(&tool.value.as_str()) {
             continue;
         }
-        let Some(record) = outcome.records.get(task.value.id.value.as_str()) else {
+        let id = task.value.id.value.as_str();
+        let Some(record) = outcome.records.get(id) else {
             continue;
         };
         if record.status != TaskStatus::Success {
             continue; // cancelled/upstream/failed records carry Null (spec 04)
+        }
+        if record.cause == TerminalCause::Recovered {
+            continue; // the recover arm's fallback — this run wrote no path
+        }
+        if cache_hits.contains(id) {
+            continue; // a rehydrated prior output — not this run's debt
         }
         let candidates: &[serde_json::Value] = match &record.output {
             single @ serde_json::Value::String(_) => std::slice::from_ref(single),
@@ -330,6 +359,55 @@ tasks:
             // `f` · `j` · `x` · `z` never settled — no record at all.
         ]);
         assert_eq!(written_paths(&wf, &outcome), ["one.txt"]);
+    }
+
+    /// H7 — a RECOVERED writer is not debt: the task failed, its
+    /// `on_error: recover:` arm settled it, and the record's `output` is
+    /// the AUTHOR-SUPPLIED fallback value — a path no verb of this run
+    /// wrote. Moving it would rename an arbitrary author-named file past
+    /// the permits boundary, so the enumeration names NOTHING and the
+    /// fold never happens.
+    #[test]
+    fn a_recovered_writers_output_is_not_debt() {
+        let wf = parsed(WF);
+        let mut recovered = TaskRecord::unran(TaskStatus::Success, TerminalCause::Recovered);
+        recovered.output = serde_json::json!("author-named.txt");
+        recovered.recovered_from = Some(nika_runtime::TaskErrorRecord {
+            code: "NIKA-BUILTIN-WRITE-001".to_owned(),
+            message: "the write failed".to_owned(),
+            transient: false,
+        });
+        let outcome = outcome_with(&[("a", recovered)]);
+        assert!(
+            written_paths(&wf, &outcome).is_empty(),
+            "the recover arm's value is no path this run wrote"
+        );
+        assert!(
+            attend(&wf, &outcome, None).is_none(),
+            "no debt, no quarantine fold"
+        );
+    }
+
+    /// H8 — a CACHE-HIT writer is not debt: a resumed run's hit
+    /// rehydrates a PRIOR run's honest output (status Success · cause
+    /// Normal — the hit is visible only on `outcome.cache_hits`).
+    /// Nothing was written here, so the enumeration names NOTHING.
+    #[test]
+    fn a_cache_hit_writers_output_is_not_debt() {
+        let wf = parsed(WF);
+        let mut outcome = outcome_with(&[(
+            "a",
+            settled(TaskStatus::Success, serde_json::json!("one.txt")),
+        )]);
+        outcome.cache_hits.push("a".to_owned());
+        assert!(
+            written_paths(&wf, &outcome).is_empty(),
+            "the rehydrated output is the prior run's, not this run's debt"
+        );
+        assert!(
+            attend(&wf, &outcome, None).is_none(),
+            "no debt, no quarantine fold"
+        );
     }
 
     /// The lane gate: a COMPLETED run attests nothing even when writers

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -239,7 +239,10 @@ fn narrowed_rungs(out: &mut String, report: &CheckReport, t: Theme) {
 
 /// POLICY rung (spec 10 · W4) · silent when the file binds no law — the
 /// rows are the ladder's own findings, code first (one voice with
-/// `--json` findings[] and the LSP projection).
+/// `--json` findings[] and the LSP projection: the code is
+/// [`nika_check::policy_wire_code`], the same mapping the findings fold
+/// reads — `approval.*` speaks NIKA-SEC-010, `endorsement.*`
+/// NIKA-SEC-013).
 fn policy_rung(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
     if wf.policy.is_some() {
         // DAG-gated at the source (`lib.rs`: the order rules read
@@ -255,7 +258,7 @@ fn policy_rung(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Them
             report
                 .policy_findings
                 .iter()
-                .map(|p| format!("[NIKA-POLICY-001] {}", p.detail))
+                .map(|p| format!("[{}] {}", nika_check::policy_wire_code(p.rule), p.detail))
                 .collect(),
         );
     }
@@ -1372,6 +1375,66 @@ fn loopback_declassification_lines(out: &mut String, wf: &RawWorkflow, t: Theme)
                 ),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod policy_rung_tests {
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    use super::*;
+
+    fn console(yaml: &str) -> String {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let report = nika_check::check(&wf);
+        render(
+            &report,
+            &wf,
+            yaml,
+            "w.nika.yaml",
+            Theme::new(false, false, false),
+            &[],
+            &nika_schema::ResolvedSkills::default(),
+            &[],
+        )
+    }
+
+    /// 2a · the console speaks the findings[] voice: an `endorsement.*`
+    /// finding prints NIKA-SEC-013 on the POLICY rung — the rung used to
+    /// stamp NIKA-POLICY-001 on EVERY policy row while the wire spoke
+    /// SEC-013 (measured live broken).
+    #[test]
+    fn a_solo_count_row_prints_sec_013_on_console() {
+        let out = console(
+            "nika: v1\nworkflow:\n  id: t\npolicy:\n  endorsement: solo\npermits:\n  exec: [\"echo\"]\n  tools: [\"nika:prompt\"]\ntasks:\n  first:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"one?\", default: false }\n  second:\n    after: { first: success }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"two?\", default: false }\n  act:\n    after: { second: success }\n    exec: { command: [\"echo\", \"shipped\"] }\n",
+        );
+        let row = out
+            .lines()
+            .find(|l| l.contains("POLICY") && l.contains("solo_count"))
+            .expect("the POLICY finding row");
+        assert!(
+            row.contains("[NIKA-SEC-013]"),
+            "the console speaks the wire code: {row}"
+        );
+        assert!(
+            !out.contains("[NIKA-POLICY-001]"),
+            "no stale policy-lane code on an endorsement row:\n{out}"
+        );
+    }
+
+    /// The mapping is prefix-exact, not a blanket rename: a plain
+    /// policy-lane rule keeps NIKA-POLICY-001 on the console too.
+    #[test]
+    fn a_limits_row_keeps_policy_001_on_console() {
+        let out = console(
+            "nika: v1\nworkflow:\n  id: t\npolicy:\n  limits: { max_tasks: 1 }\ntasks:\n  a:\n    infer: { prompt: \"x\" }\n  b:\n    infer: { prompt: \"y\" }\n",
+        );
+        let row = out
+            .lines()
+            .find(|l| l.contains("POLICY") && l.contains('['))
+            .expect("the POLICY finding row");
+        assert!(row.contains("[NIKA-POLICY-001]"), "the lane code: {row}");
     }
 }
 

--- a/crates/nika-proof/src/receipt.rs
+++ b/crates/nika-proof/src/receipt.rs
@@ -514,14 +514,29 @@ fn bound_text(bound: Option<&Value>) -> String {
     text
 }
 
-/// The stable scalar render (strings verbatim · numbers/bools plain ·
-/// null named).
+/// The stable scalar render (strings ESCAPED · numbers/bools plain ·
+/// null named). A receipt is an untrusted artifact (F-P16 · NEP-0012
+/// law 2): a string cloned raw into the explain output would reach the
+/// TTY with its control bytes live (the OSC52 / terminal-escape
+/// class), so the string arm routes through the escape. The READING
+/// posture is unaffected — `verify` owns the proof and never reads
+/// this render.
 fn scalar_text(value: &Value) -> String {
     match value {
-        Value::String(s) => s.clone(),
+        Value::String(s) => escape_tty(s),
         Value::Null => "null".to_owned(),
         other => other.to_string(),
     }
+}
+
+/// Strip every control character (C0 · C1 · DEL — ESC dies, so the
+/// OSC52 clipboard class dies) from an artifact-originated string
+/// before it reaches a terminal. The local twin of
+/// `nika_dap::escape_tty`, duplicated deliberately: that one-voice
+/// helper lives at L4, and this L0 crate cannot depend on an interface
+/// crate — the semantics are identical and both are pinned by test.
+fn escape_tty(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
 }
 
 #[cfg(test)]
@@ -602,4 +617,28 @@ mod tests {
     // engine's OWN certificate + the workflow's semantic IR hash) lives
     // with the `ir` projection — nika-runtime's `proof::ir` tests, since
     // the projection stayed with the runtime's resume family.
+
+    /// F-P16 · NEP-0012 law 2: a receipt is an UNTRUSTED artifact — its
+    /// strings reach the explain TTY escaped (ESC dies, so the OSC52
+    /// clipboard class dies), never live.
+    #[test]
+    fn explain_escapes_control_chars_in_artifact_strings() {
+        let mut r = sample();
+        r["trace_verdict"]["outcome"] = json!("success\u{1b}]52;;evil\u{7}\nforged-line");
+        let out = explain_receipt(&r);
+        assert!(
+            !out.contains('\u{1b}'),
+            "no live ESC reaches the TTY: {out:?}"
+        );
+        assert!(!out.contains('\u{7}'), "no live BEL either: {out:?}");
+        // The escape STRIPS (it does not mangle): the visible text
+        // survives on one line, control bytes gone.
+        assert!(
+            out.contains("success]52;;evilforged-line"),
+            "the text survives, stripped: {out:?}"
+        );
+        // And the escape helper's own edges (the nika_dap twin's pin).
+        assert_eq!(escape_tty("plain-key_1234"), "plain-key_1234");
+        assert_eq!(escape_tty("\u{7f}\u{9b}"), "");
+    }
 }

--- a/crates/nika-providers/src/wire/mock.rs
+++ b/crates/nika-providers/src/wire/mock.rs
@@ -13,6 +13,17 @@
 //! returns a SYNTHESIZED schema-conformant instance (`mock_schema` · F3),
 //! so every structured workflow dry-runs offline instead of dying
 //! NIKA-INFER-002 after burning its retry budget.
+//!
+//! The tool-call contract (M1 · the offline agent rehearsal): tools
+//! granted ⇒ the mock invokes the FIRST granted tool, schema-shaped args
+//! — UNTIL the conversation shows that call cannot progress (its last
+//! call to the same tool ERRORED, or the call it is about to make
+//! repeats a prior one BYTE-IDENTICALLY), at which point a granted
+//! `nika:done` is preferred (schema-shaped result, like any tool). A
+//! first-granted `nika:done` still fires on turn one (agent/002); no
+//! `nika:done` granted ⇒ the first tool stands and the loop exhausts
+//! honestly (agent/001). The witnesses are read off the request's own
+//! messages — the mock stays stateless, so determinism is untouched.
 
 use std::collections::VecDeque;
 use std::pin::Pin;
@@ -21,7 +32,7 @@ use std::task::{Context, Poll};
 use futures_core::Stream;
 use nika_kernel::ai::provider::{
     ContentBlock, InferEvent, InferEventStream, InferRequest, InferResponse, ProviderError,
-    ResponseFormat, Role, StopReason, TokenUsage,
+    ResponseFormat, Role, StopReason, TokenUsage, ToolChoice, ToolDef,
 };
 
 use super::mock_schema;
@@ -36,13 +47,18 @@ use crate::registry::ResolvedProvider;
 /// against the tool's own schema — an agent loop drives offline to its
 /// `done` (002) or its exhaustion (001). No tools offered (or tool use
 /// disabled) ⇒ the plain echo, unchanged.
+///
+/// M1's amendment: a first tool that is not `nika:done` stalls the loop
+/// byte-identically once its synthesized args error or succeed without
+/// changing the next call (NIKA-467 — the contract broke
+/// templates/agent-loop and the research/review examples at rehearsal).
+/// So after the FIRST errored or byte-identical repeated call to the
+/// same tool, a granted `nika:done` is preferred ([`done_preference`]).
 pub(crate) fn infer<H>(rp: &ResolvedProvider<H>, request: &InferRequest) -> InferResponse {
     let called = match &request.tool_choice {
-        nika_kernel::ai::provider::ToolChoice::None => None,
-        nika_kernel::ai::provider::ToolChoice::Specific(name) => {
-            request.tools.iter().find(|t| &t.name == name)
-        }
-        _ => request.tools.first(),
+        ToolChoice::None => None,
+        ToolChoice::Specific(name) => request.tools.iter().find(|t| &t.name == name),
+        _ => done_preference(request, request.tools.first()),
     };
     if let Some(tool) = called {
         let input = mock_schema::synthesize(&tool.parameters);
@@ -124,6 +140,71 @@ pub(crate) fn infer_stream<H>(
         finish_reason_raw: full.finish_reason_raw.clone(),
     }));
     Box::pin(ReadyStream(events))
+}
+
+/// M1 — the offline-rehearsal loop escape. When the default pick (the
+/// FIRST granted tool) is not `nika:done` and the conversation shows the
+/// call cannot progress, prefer a granted `nika:done` — with its args
+/// synthesized against the offered schema like any tool, so the loop's
+/// `schema:` contract still validates. No `nika:done` granted ⇒ the
+/// first tool stands (agent/001 still exhausts); a first-granted
+/// `nika:done` is already the pick and fires on turn one (agent/002).
+fn done_preference<'a>(
+    request: &'a InferRequest,
+    first: Option<&'a ToolDef>,
+) -> Option<&'a ToolDef> {
+    let tool = first?;
+    if tool.name == "nika:done" || !stalled_on(request, tool) {
+        return first;
+    }
+    request
+        .tools
+        .iter()
+        .find(|t| t.name == "nika:done")
+        .or(first)
+}
+
+/// Has the conversation already seen `tool` called in a way the next
+/// call cannot progress past? Two witnesses, both read off the request's
+/// own messages (the agent loop rides results as user-role `ToolResult`
+/// blocks keyed by the call id):
+///
+/// - the tool's last call ERRORED (`is_error: true` — the loop's
+///   model-feedback seam for every non-security tool failure); or
+/// - the call the mock is about to make repeats a prior call
+///   BYTE-IDENTICALLY (the synthesized args are deterministic — same
+///   tool, same bytes, same observation: the NIKA-467 stall signature).
+fn stalled_on(request: &InferRequest, tool: &ToolDef) -> bool {
+    let input = mock_schema::synthesize(&tool.parameters);
+    request.messages.iter().any(|message| {
+        message.content.iter().any(|block| {
+            let ContentBlock::ToolUse {
+                id,
+                name,
+                input: prior,
+            } = block
+            else {
+                return false;
+            };
+            name == &tool.name && (prior == &input || result_errored(request, id))
+        })
+    })
+}
+
+/// The `ToolResult` riding a prior call carries `is_error: true`.
+fn result_errored(request: &InferRequest, tool_use_id: &str) -> bool {
+    request.messages.iter().any(|message| {
+        message.content.iter().any(|block| {
+            matches!(
+                block,
+                ContentBlock::ToolResult {
+                    tool_use_id: id,
+                    is_error: true,
+                    ..
+                } if id == tool_use_id
+            )
+        })
+    })
 }
 
 fn last_user_text(request: &InferRequest) -> String {
@@ -236,16 +317,12 @@ mod tests {
         let rp = resolved();
         let mut request = req("loop forever");
         request.tools = vec![
-            nika_kernel::ai::provider::ToolDef::new(
+            ToolDef::new(
                 "nika:wait",
                 "wait",
                 serde_json::json!({ "type": "object", "required": ["ms"], "properties": { "ms": { "type": "integer" } } }),
             ),
-            nika_kernel::ai::provider::ToolDef::new(
-                "nika:done",
-                "done",
-                serde_json::json!({ "type": "object" }),
-            ),
+            ToolDef::new("nika:done", "done", serde_json::json!({ "type": "object" })),
         ];
         let a = infer(&rp, &request);
         let ContentBlock::ToolUse { id, name, input } = &a.content[0] else {
@@ -263,7 +340,7 @@ mod tests {
 
         // Tool use explicitly disabled ⇒ the plain echo, unchanged.
         let mut off = req("loop forever");
-        off.tool_choice = nika_kernel::ai::provider::ToolChoice::None;
+        off.tool_choice = ToolChoice::None;
         off.tools = request.tools.clone();
         let plain = infer(&rp, &off);
         let ContentBlock::Text { text } = &plain.content[0] else {
@@ -273,14 +350,148 @@ mod tests {
 
         // A specific choice names its tool, first or not.
         let mut specific = req("finish");
-        specific.tool_choice =
-            nika_kernel::ai::provider::ToolChoice::Specific("nika:done".to_owned());
+        specific.tool_choice = ToolChoice::Specific("nika:done".to_owned());
         specific.tools = request.tools;
         let done = infer(&rp, &specific);
         let ContentBlock::ToolUse { name, .. } = &done.content[0] else {
             panic!("expected a tool call");
         };
         assert_eq!(name, "nika:done");
+    }
+
+    // ─── M1 · the done-preference ────────────────────────────────────
+
+    fn wait_def() -> ToolDef {
+        ToolDef::new(
+            "nika:wait",
+            "wait",
+            serde_json::json!({ "type": "object", "required": ["ms"], "properties": { "ms": { "type": "integer" } } }),
+        )
+    }
+
+    fn done_def() -> ToolDef {
+        ToolDef::new(
+            "nika:done",
+            "done",
+            serde_json::json!({ "type": "object", "required": ["result"], "properties": { "result": { "type": "string" } } }),
+        )
+    }
+
+    /// A turn-2 conversation exactly as the agent loop builds it: the
+    /// mock's turn-1 call (its own id + args) rides as an assistant
+    /// message, the tool's result as a user `ToolResult` block.
+    fn after_call(name: &str, input: serde_json::Value, is_error: bool) -> Vec<Message> {
+        vec![
+            Message::text(Role::User, "work the loop"),
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "mock-call-1".to_owned(),
+                    name: name.to_owned(),
+                    input,
+                }],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "mock-call-1".to_owned(),
+                    content: if is_error {
+                        "NIKA-BUILTIN-WAIT-001 · unparseable duration".to_owned()
+                    } else {
+                        "null".to_owned()
+                    },
+                    is_error,
+                }],
+            ),
+        ]
+    }
+
+    fn tool_request(tools: Vec<ToolDef>, history: Vec<Message>) -> InferRequest {
+        let mut request = InferRequest::new("echo", history);
+        request.tools = tools;
+        request
+    }
+
+    fn called_name(response: &InferResponse) -> &str {
+        let ContentBlock::ToolUse { name, .. } = &response.content[0] else {
+            panic!("expected a tool call, got {:?}", response.content[0]);
+        };
+        name
+    }
+
+    /// M1 · the wait+done rehearsal: the wait's synthesized args ERROR
+    /// deterministically against the real builtin — after that first
+    /// errored call the mock prefers the granted `nika:done` (with a
+    /// schema-shaped result) instead of stalling byte-identically.
+    #[test]
+    fn an_errored_call_prefers_a_granted_done() {
+        let rp = resolved();
+        let wait = wait_def();
+        let history = after_call("nika:wait", mock_schema::synthesize(&wait.parameters), true);
+        let request = tool_request(vec![wait, done_def()], history);
+        let a = infer(&rp, &request);
+        let ContentBlock::ToolUse { name, input, .. } = &a.content[0] else {
+            panic!("expected a tool call, got {:?}", a.content[0]);
+        };
+        assert_eq!(name, "nika:done");
+        assert_eq!(input["result"], "mock", "the schema-shaped result rides");
+        assert!(matches!(a.stop_reason, StopReason::ToolUse));
+        // Deterministic: the same conversation always makes the same pick.
+        let b = infer(&rp, &request);
+        assert_eq!(
+            serde_json::to_value(&a.content[0]).expect("serializes"),
+            serde_json::to_value(&b.content[0]).expect("serializes"),
+            "the preference is byte-stable"
+        );
+    }
+
+    /// M1 · the stall twin: even a SUCCESSFUL call cannot be repeated —
+    /// the mock's next call would be byte-identical (deterministic
+    /// synthesis), which is exactly the NIKA-467 signature, so the
+    /// granted `nika:done` wins on turn two.
+    #[test]
+    fn a_byte_identical_repeat_prefers_done_even_after_a_success() {
+        let rp = resolved();
+        let wait = wait_def();
+        let history = after_call(
+            "nika:wait",
+            mock_schema::synthesize(&wait.parameters),
+            false,
+        );
+        let request = tool_request(vec![wait, done_def()], history);
+        assert_eq!(called_name(&infer(&rp, &request)), "nika:done");
+    }
+
+    /// agent/001's shape: NO `nika:done` granted — the stall witness
+    /// changes nothing, the first tool stands, and the loop exhausts
+    /// honestly (the fixture pins the exhaustion at the runtime).
+    #[test]
+    fn no_done_offered_keeps_calling_the_first_tool() {
+        let rp = resolved();
+        let wait = wait_def();
+        let history = after_call("nika:wait", mock_schema::synthesize(&wait.parameters), true);
+        let request = tool_request(vec![wait], history);
+        assert_eq!(called_name(&infer(&rp, &request)), "nika:wait");
+    }
+
+    /// agent/002's shape: `nika:done` IS the first granted tool — turn
+    /// one, no witness needed, the preference never even runs.
+    #[test]
+    fn done_first_fires_on_turn_one() {
+        let rp = resolved();
+        let request = tool_request(vec![done_def()], vec![Message::text(Role::User, "finish")]);
+        assert_eq!(called_name(&infer(&rp, &request)), "nika:done");
+    }
+
+    /// The preference is not a hair trigger: a prior call to the same
+    /// tool with DIFFERENT args that succeeded is no stall witness — the
+    /// mock's own call would be new bytes, so the first tool stands.
+    #[test]
+    fn a_successful_different_call_is_no_stall_witness() {
+        let rp = resolved();
+        let history = after_call("nika:wait", serde_json::json!({ "ms": 42 }), false);
+        let request = tool_request(vec![wait_def(), done_def()], history);
+        assert_eq!(called_name(&infer(&rp, &request)), "nika:wait");
     }
 
     #[tokio::test]

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 58
-  aggregate_sha256: fa5d0701f2ba8711e7514a1bddb053e8e30a4e430864c0beae64c149c4d45954
+  aggregate_sha256: 4f27bc72499d11d9a6b80d834000ec6fad4f47e952bfb2ca4b162286580a7200
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --all-features --omit auto-trait-impls > crates/<crate>/public-api.txt (cargo-public-api 0.51.0 pinned · regenerate from the public-api-actual CI artifact)"
@@ -152,12 +152,12 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 660
-  aggregate_sha256: 0bce1c2530cad815b445c644ee31e2561c47091e2a89c13ce3b50af6e49925f8
+  aggregate_sha256: 7fb575eebf8312c76613b7c4dd75243b8804b07ad79813b16fa59d413dea4002
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 115
-  aggregate_sha256: 20d32eb60c997074cd6c9b14a7e1b0b0ef76b5747f2a53967a1320e23c769aba
+  aggregate_sha256: b5bc1cbba01507be3e03667d15580d145d98d8ae48e078177888790dc8280b39
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 129
-  aggregate_sha256: df94b2e1dcf6c38d97bf12bcaef5eb454e2cea33ae6a27b03b17d8be0d653815
+  aggregate_sha256: 618f9af65476d4fe1183d31eaf451ce7e4cbd767735dc0588ab8f09e47e40451
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored


### PR DESCRIPTION
The 3-agent adversarial audit of everything shipped this cycle (lot 3 · F-P8 · the repairs) — wave A, the law+security findings, each with its own behavioral test:

- **quarantine trusts only real debt** (H7/H8):  fallbacks and cache-hit rehydrations are no longer moved — an author-named file could be moved past the permits boundary, and a prior run's honest output is not this run's debt.
- **F-P15 covers edit, spellings, and the cap** (H4/H5/H6):  judged beside  (the canon's own sentence) · lexical path normalization kills the spelling dodge · above the analysis cap a stated miss rides the hints and the for_each flavor still judges.
- **console one-voice** (2a): the POLICY rung maps rule prefixes to SEC-010/SEC-013/POLICY-001 via  — console ≡ JSON ≡ LSP.
- **receipt explain escapes artifact strings** (F-P16): the OSC52/control class stripped at the explain boundary (NEP-0012 law 2); verify untouched.
- **mock done-preference** (M1): at the stall witness (an errored call or a byte-identical repeat) the mock prefers a granted  — offline rehearsals complete again (agent-loop · deep-research-brief verified green), agent/001 still exhausts, agent/002 still fires turn 1.
- **oracle arms assert their check verdicts** (R1): refused arms must name a NIKA- code.

Verified: workspace --lib 58 targets green · oracle + quarantine E2E green at the pin · clippy -D warnings · fmt · pack_integrity 6/6 · doc clean. Wave B (nika-store hardening: the seal-line O(1) fold · walk bounds · journal bounds · escape-at-birth · 0600) follows separately.