### PR TITLE
fix(store,dap,event): the memory substrate carries its own bounds (audit wave B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4091,6 +4091,7 @@ dependencies = [
 name = "nika-cli"
 version = "0.106.1"
 dependencies = [
+ "blake3",
  "clap",
  "clap_complete",
  "expectrl",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -67,6 +67,7 @@ path = "src/main.rs"
 [dev-dependencies]
 # Test-only seams: the mocks the e2e pipeline + the run-verb tests inject.
 minisign       = { workspace = true }                              # the tier tests' keypair fixtures + the memory-fold teardown test (custody lives in nika-dap)
+blake3         = { workspace = true }                              # the memory e2e's independent set-digest recompute (H13 fold shape)
 nika-store       = { path = "../nika-store", version = "0.106.0" }  # F-P8 signed memory — the teardown fold test + the e2e's seeded store
 nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.106.0" }
 nika-cap         = { path = "../nika-cap", version = "0.106.0" }           # the teardown memory-fold test's Integrity label (F-P8)

--- a/crates/nika-cli/src/verbs/run/teardown.rs
+++ b/crates/nika-cli/src/verbs/run/teardown.rs
@@ -264,10 +264,11 @@ mod tests {
         assert!(td.quarantine.is_none(), "absent is honest");
     }
 
-    /// F-P8 · the signed-memory fold: a tempdir store with ONE admitted
-    /// entry and ONE tampered entry folds to `{store, admitted: [digest],
-    /// rejected: 1}` and rides the teardown VERBATIM (the seal's
-    /// `extend_covers` places it under `covers["memory"]`).
+    /// F-P8 · the signed-memory fold: a tempdir store with ONE tampered
+    /// entry folds to `{store, set_digest, admitted_count: 0, rejected: 1}`
+    /// (the O(1) shape — the set's digest IS its name) and rides the
+    /// teardown VERBATIM (the seal's `extend_covers` places it under
+    /// `covers["memory"]`).
     #[test]
     fn the_memory_fold_counts_the_admitted_set_and_the_rejected() {
         let pair = minisign::KeyPair::generate_encrypted_keypair(Some(String::new()))
@@ -297,9 +298,17 @@ mod tests {
         assert_eq!(fold["v"], serde_json::json!(1), "the fold is versioned");
         assert_eq!(fold["stores"][0]["store"], serde_json::json!("default"));
         assert_eq!(
-            fold["stores"][0]["admitted"],
-            serde_json::json!([]),
+            fold["stores"][0]["admitted_count"],
+            serde_json::json!(0),
             "the tampered entry never rides the admitted set"
+        );
+        assert_eq!(
+            fold["stores"][0]["set_digest"]
+                .as_str()
+                .expect("the set digest rides")
+                .len(),
+            64,
+            "ONE constant-size digest names the (empty) set"
         );
         assert_eq!(fold["stores"][0]["rejected"], serde_json::json!(1));
 

--- a/crates/nika-cli/tests/memory_store_e2e.rs
+++ b/crates/nika-cli/tests/memory_store_e2e.rs
@@ -10,7 +10,7 @@
 //! from the CLI crate's vantage (the API the L2 orchestrator will drive)
 //! plus the seal integration:
 //!
-//! - **(a) the positive** — a signed write is admitted and its digest
+//! - **(a) the positive** — a signed write is admitted and its set digest
 //!   lands in the fold (`remember_signed` · `recall_verified` ·
 //!   `seal_fold` through the public API, hermetic keypair).
 //! - **(b) the out-of-engine edit** — one byte flipped in the entry
@@ -19,13 +19,16 @@
 //! - **(c) the unsigned entry** — an envelope whose `sig` was never
 //!   minted is REJECTED (`unsigned`) — the SMSR 0 %-admission floor.
 //! - **(d) the seal** — a run whose CWD holds `.nika/memory/` seals its
-//!   journal with `covers["memory"]` pinning the admitted digests beside
-//!   the rejection count, and the law's third leg rides the SAME journal:
+//!   journal with `covers["memory"]` pinning the admitted set's ONE
+//!   digest + the counts, and the law's third leg rides the SAME journal:
 //!   one `memory_entry_rejected` event per rejection, landed BEFORE the
 //!   `run_sealed` line so the chain covers it. v1 has no production
 //!   memory writer, so the store is SEEDED before the run (signed with
 //!   the same hermetic key the env files carry) — the teardown's
 //!   `memory_attend` is exercised for real, end to end.
+//! - **(e) the planted root** — a FILE at `.nika/memory` is never
+//!   collapsed to "no memory" (H16): the seal names the unreadable root
+//!   as an error entry in the covers.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -76,8 +79,23 @@ fn entry(store: &str, content: &str) -> UnsignedEntry {
     )
 }
 
-/// (a) The positive: a signed write is admitted and its digest lands in
-/// the fold.
+/// The e2e-side re-construction of the fold's set digest (H13): sort +
+/// dedup, blake3 over the concatenated 64-hex words. Written twice on
+/// purpose — a divergence from the substrate's construction (the sort ·
+/// the dedup · the framing) fails this cross-check.
+fn set_digest(digests: &[String]) -> String {
+    let mut sorted = digests.to_vec();
+    sorted.sort();
+    sorted.dedup();
+    let mut hasher = blake3::Hasher::new();
+    for digest in &sorted {
+        hasher.update(digest.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+/// (a) The positive: a signed write is admitted and its set digest lands
+/// in the fold.
 #[test]
 fn a_signed_write_is_admitted_and_its_digest_lands_in_the_fold() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -94,10 +112,11 @@ fn a_signed_write_is_admitted_and_its_digest_lands_in_the_fold() {
     let fold = seal_fold(&root, &pair.pk).expect("a memory root folds");
     assert_eq!(fold["stores"][0]["store"], serde_json::json!("default"));
     assert_eq!(
-        fold["stores"][0]["admitted"],
-        serde_json::json!([written.digest()]),
-        "the receipt names the verified SET"
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(set_digest(&[written.digest()])),
+        "the receipt names the verified SET — ONE constant-size digest (O(1))"
     );
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(1));
     assert_eq!(fold["stores"][0]["rejected"], serde_json::json!(0));
 }
 
@@ -210,8 +229,8 @@ fn sealed_covers(journal: &Path) -> serde_json::Value {
 }
 
 /// (d) The seal: a run whose CWD holds `.nika/memory/` seals its journal
-/// with `covers["memory"]` — the admitted digests beside the rejection
-/// count. The store is SEEDED (v1 has no production writer): one honest
+/// with `covers["memory"]` — the admitted set's ONE digest beside the
+/// counts. The store is SEEDED (v1 has no production writer): one honest
 /// entry + one tampered entry, signed/edited with the same hermetic key
 /// the env files carry, so the teardown's custody probe stays off the
 /// OS keychain.
@@ -250,9 +269,14 @@ fn the_seal_covers_carry_the_memory_fold() {
     assert_eq!(memory["v"], serde_json::json!(1), "the fold is versioned");
     assert_eq!(memory["stores"][0]["store"], serde_json::json!("default"));
     assert_eq!(
-        memory["stores"][0]["admitted"],
-        serde_json::json!([honest.digest()]),
-        "the seal pins the admitted digest (the tampered entry never rides)"
+        memory["stores"][0]["set_digest"],
+        serde_json::json!(set_digest(&[honest.digest()])),
+        "the seal pins the set's ONE digest (the tampered entry never rides)"
+    );
+    assert_eq!(
+        memory["stores"][0]["admitted_count"],
+        serde_json::json!(1),
+        "…the set's size beside it"
     );
     assert_eq!(
         memory["stores"][0]["rejected"],
@@ -318,5 +342,36 @@ fn a_run_without_a_memory_store_seals_no_memory_key() {
     assert!(
         covers.get("memory").is_none(),
         "the key stays OUT — a store-less run attests nothing: {covers}"
+    );
+}
+
+/// (e) H16 · the planted root: a FILE at `.nika/memory` is NOT collapsed
+/// to "no memory" (a plant must never pass as honest absence) — the seal
+/// names the unreadable root as an error entry in the covers.
+#[test]
+fn a_planted_file_at_the_memory_root_is_named_never_absent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (_pair, envs) = signing_key(tmp.path());
+    std::fs::write(tmp.path().join("w.nika.yaml"), WF).expect("workflow");
+    // The plant: a regular file where the memory root must be a dir.
+    std::fs::create_dir_all(tmp.path().join(".nika")).expect("the .nika dir");
+    std::fs::write(tmp.path().join(MEMORY_ROOT), "not a directory").expect("the plant lands");
+
+    let run = nika_run(tmp.path(), &envs);
+    assert_eq!(
+        run.status.code(),
+        Some(0),
+        "the run completes · stderr: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let covers = sealed_covers(&journal(tmp.path()));
+    let entry = &covers["memory"]["stores"][0];
+    assert!(
+        entry["store"].is_null(),
+        "no store name to name — the error denies it: {entry}"
+    );
+    assert!(
+        entry["error"].as_str().is_some(),
+        "the unreadable root rides as an error entry, never as absence: {entry}"
     );
 }

--- a/crates/nika-dap/public-api.txt
+++ b/crates/nika-dap/public-api.txt
@@ -1915,9 +1915,11 @@ impl<T> tracing::instrument::Instrument for nika_dap::memory::RejectedEntry
 impl<T> tracing::instrument::WithSubscriber for nika_dap::memory::RejectedEntry
 impl<T> typenum::type_operators::Same for nika_dap::memory::RejectedEntry
 pub type nika_dap::memory::RejectedEntry::Output = T
+pub const nika_dap::memory::MAX_JOURNALED_REJECTIONS: usize
 pub fn nika_dap::memory::attend(cwd: core::option::Option<&std::path::Path>) -> nika_dap::memory::MemoryAttend
 pub fn nika_dap::memory::journal_rejected(trace: &mut nika_dap::journal::TraceFileSink, rejected: &[nika_dap::memory::RejectedEntry])
 pub fn nika_dap::memory::rejected_event(entry: &nika_dap::memory::RejectedEntry) -> nika_event::event::Event
+pub fn nika_dap::memory::rejections_summary_event(total: usize) -> nika_event::event::Event
 pub mod nika_dap::otel
 pub struct nika_dap::otel::ExportOutcome
 pub nika_dap::otel::ExportOutcome::broken_at: core::option::Option<usize>

--- a/crates/nika-dap/src/memory.rs
+++ b/crates/nika-dap/src/memory.rs
@@ -6,14 +6,18 @@
 //! `.nika/memory/` store, [`attend`] verifies every entry against the
 //! run-signing pair's PUBLIC half and returns the [`MemoryAttend`] — the
 //! fold the seal pins in `covers["memory"]`
-//! (`{v: 1, stores: [{store, admitted: [digest…], rejected: n} | {store,
-//! error}]}` — the admitted SET named by digest beside the rejection
-//! count, a failed walk NAMED in place, never collapsed) PLUS the
-//! per-entry rejections, named (unsigned · bad signature · relabel =
-//! rejected, never filtered). The rejections are the law's third leg:
-//! [`journal_rejected`] writes one `memory_entry_rejected` event per
-//! rejection INTO the journal BEFORE the seal lands, so the chain the
-//! seal signs covers the evidence it attests the count of.
+//! (`{v: 1, stores: [{store, set_digest, admitted_count, rejected} |
+//! {store, error}]}` — the admitted SET named by ONE constant-size digest
+//! beside the rejection count, a failed walk NAMED in place, never
+//! collapsed) PLUS the per-entry rejections, named (unsigned · bad
+//! signature · relabel = rejected, never filtered). The rejections are
+//! the law's third leg: [`journal_rejected`] writes
+//! `memory_entry_rejected` events INTO the journal BEFORE the seal lands,
+//! so the chain the seal signs covers the evidence it attests the count
+//! of — BOUNDED ([`MAX_JOURNALED_REJECTIONS`]): the first K rejections
+//! ride individually named, a flood gets ONE `memory_rejections_summary`
+//! event carrying the true total (NEP-0012 law 1 — 10^4 planted
+//! rejections can never spam the journal or its teardown).
 //!
 //! The honest postures (the quarantine sibling's): no store ⇒ a
 //! fold-less, rejection-less attendance and the `memory` key stays OUT of
@@ -36,7 +40,8 @@ use nika_types::resource::{KeyValue, Value};
 use nika_types::timestamp::Timestamp;
 
 /// One rejected memory entry, named for the journal (the fold counts;
-/// the journal NAMES — one `memory_entry_rejected` event each).
+/// the journal NAMES — one `memory_entry_rejected` event each, up to
+/// [`MAX_JOURNALED_REJECTIONS`] before the summary takes over).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct RejectedEntry {
@@ -72,23 +77,33 @@ impl RejectedEntry {
 pub struct MemoryAttend {
     /// The `covers["memory"]` fold (`None` = the key stays OUT).
     pub fold: Option<serde_json::Value>,
-    /// The named rejections — journaled one `memory_entry_rejected`
-    /// event each BEFORE the seal (the chain then covers them).
+    /// The named rejections — journaled BEFORE the seal, BOUNDED: the
+    /// first [`MAX_JOURNALED_REJECTIONS`] ride one
+    /// `memory_entry_rejected` event each, a flood beyond gets ONE
+    /// `memory_rejections_summary` with the true total (the chain then
+    /// covers them all).
     pub rejected: Vec<RejectedEntry>,
 }
 
 /// The memory attendance for one run, empty when there is honestly
-/// nothing to attest (no `.nika/memory/` dir · no store below it · no
-/// usable run-key on this machine). `cwd` is the run's directory:
-/// `Some(dir)` for tests, `None` for the process's own CWD (a `nika
-/// run` never chdirs — the same posture the quarantine paths keep).
+/// nothing to attest (no `.nika/memory/` · no store below it · no usable
+/// run-key on this machine). `cwd` is the run's directory: `Some(dir)`
+/// for tests, `None` for the process's own CWD (a `nika run` never
+/// chdirs — the same posture the quarantine paths keep).
+///
+/// The short-circuit is EXISTENCE-only: a root that exists but is not a
+/// dir (a planted FILE at `.nika/memory`) is NOT collapsed to "no
+/// memory" — the fold names the unreadable root as an error entry
+/// (H16: a plant must never pass as honest absence). The custody probe
+/// still runs only for an existing root (a store-less run never touches
+/// the keychain).
 #[must_use]
 pub fn attend(cwd: Option<&Path>) -> MemoryAttend {
     let root = cwd.map_or_else(
         || std::path::PathBuf::from(nika_store::MEMORY_ROOT),
         |dir| dir.join(nika_store::MEMORY_ROOT),
     );
-    if !root.is_dir() {
+    if !root.exists() {
         return MemoryAttend::default(); // absent is honest — no store, no custody probe
     }
     let attended = crate::seal::load_public_box()
@@ -111,11 +126,25 @@ pub fn attend(cwd: Option<&Path>) -> MemoryAttend {
     }
 }
 
+/// The most rejections one teardown journals INDIVIDUALLY (H14 ·
+/// NEP-0012 law 1): past it, ONE `memory_rejections_summary` event
+/// carries the true total ([`rejections_summary_event`]) — the same
+/// number the fold's `rejected: n` pins in the seal's covers, said once.
+/// 10^4 planted rejections then cost K+1 chained lines, never an
+/// unbounded journal and its teardown cost.
+pub const MAX_JOURNALED_REJECTIONS: usize = 32;
+
 /// The `memory_entry_rejected` journal event for one named rejection —
 /// `store` + `entry` + `reason` fields (the kind's documented shape).
 /// Stamped from the journal's own epilogue clock with a fresh `UUIDv7` —
 /// the seal's own stamping precedent (the runtime's stamper belongs to
 /// the run; this is the journal's teardown).
+///
+/// The store name and the entry's file name are fs-born (a store dir
+/// name is attacker-plantable): they are ESCAPED AT BIRTH
+/// ([`crate::escape_tty`] — control bytes stripped) so a planted OSC
+/// sequence never reaches a terminal through the journal. The reason is
+/// a closed-set wire word — nothing to escape.
 #[must_use]
 pub fn rejected_event(entry: &RejectedEntry) -> Event {
     let name = entry
@@ -129,22 +158,52 @@ pub fn rejected_event(entry: &RejectedEntry) -> Event {
         EventKind::MemoryEntryRejected,
     )
     .with_fields(vec![
-        KeyValue::new("store", Value::String(entry.store.clone())),
-        KeyValue::new("entry", Value::String(name)),
+        KeyValue::new("store", Value::String(crate::escape_tty(&entry.store))),
+        KeyValue::new("entry", Value::String(crate::escape_tty(&name))),
         KeyValue::new("reason", Value::String(entry.reason.clone())),
     ])
 }
 
-/// Journal one `memory_entry_rejected` event per named rejection — the
-/// teardown lanes call this BEFORE [`crate::journal::seal_journal_with`],
-/// so the events sit INSIDE the chain the seal signs (the seal's
-/// `covers["memory"]` attests their count; the chain covers their names).
-/// The sink contract is infallible: a broken journal buffers its own
-/// error, the run's verdict never depends on the evidence.
+/// The ONE `memory_rejections_summary` event for a rejection flood
+/// ([`MAX_JOURNALED_REJECTIONS`]): the TRUE `total` (the same number the
+/// fold's `rejected: n` pins — said once) beside the `journaled` count
+/// of individually-named events. No fs-born strings ride it — nothing
+/// to escape.
+#[must_use]
+pub fn rejections_summary_event(total: usize) -> Event {
+    let as_int = |n: usize| i64::try_from(n).unwrap_or(i64::MAX);
+    Event::new(
+        EventId::generate(),
+        Timestamp::from_unix_ms(crate::journal::now_millis()),
+        EventKind::MemoryRejectionsSummary,
+    )
+    .with_fields(vec![
+        KeyValue::new("total", Value::Int(as_int(total))),
+        KeyValue::new(
+            "journaled",
+            Value::Int(as_int(total.min(MAX_JOURNALED_REJECTIONS))),
+        ),
+    ])
+}
+
+/// Journal the named rejections, BOUNDED (H14): the first
+/// [`MAX_JOURNALED_REJECTIONS`] ride one `memory_entry_rejected` event
+/// each, a flood beyond the cap gets ONE `memory_rejections_summary`
+/// naming the true total — the fold's `rejected: n` already pins the
+/// same number in the seal's covers, so nothing is lost and the journal
+/// never balloons. The teardown lanes call this BEFORE
+/// [`crate::journal::seal_journal_with`], so the events sit INSIDE the
+/// chain the seal signs (the seal's `covers["memory"]` attests their
+/// count; the chain covers their names). The sink contract is
+/// infallible: a broken journal buffers its own error, the run's
+/// verdict never depends on the evidence.
 pub fn journal_rejected(trace: &mut crate::journal::TraceFileSink, rejected: &[RejectedEntry]) {
     use nika_runtime::EventSink as _;
-    for entry in rejected {
+    for entry in rejected.iter().take(MAX_JOURNALED_REJECTIONS) {
         trace.emit(rejected_event(entry));
+    }
+    if rejected.len() > MAX_JOURNALED_REJECTIONS {
+        trace.emit(rejections_summary_event(rejected.len()));
     }
 }
 
@@ -230,5 +289,118 @@ mod tests {
             assert!(line.contains(reason), "{line}");
             assert!(line.contains("\"chain\""), "chained like every line");
         }
+    }
+
+    /// H14 · the journal bound: more than K rejections produce exactly
+    /// K individually-named events plus ONE `memory_rejections_summary`
+    /// carrying the TRUE total — the fold's `rejected: n` says the same
+    /// number in the seal's covers, the journal says it once here.
+    #[test]
+    fn a_rejection_flood_is_bounded_to_k_named_events_plus_one_summary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut trace = crate::journal::TraceFileSink::new(tmp.path().join("traces"));
+        let flood = MAX_JOURNALED_REJECTIONS + 8;
+        let rejected: Vec<RejectedEntry> = (0..flood)
+            .map(|i| RejectedEntry {
+                store: "default".to_owned(),
+                path: PathBuf::from(format!(".nika/memory/default/1800000000000-{i:016x}.json")),
+                reason: "overflow".to_owned(),
+            })
+            .collect();
+        journal_rejected(&mut trace, &rejected);
+        let path = trace.path().expect("the journal opened").to_path_buf();
+        assert!(trace.into_error().is_none());
+        let text = std::fs::read_to_string(path).expect("journal reads");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(
+            lines.len(),
+            MAX_JOURNALED_REJECTIONS + 1,
+            "K named events + ONE summary, never the flood: {}",
+            lines.len()
+        );
+        let summary = lines.last().expect("the summary rides last");
+        assert!(
+            summary.contains("\"kind\":\"memory_rejections_summary\""),
+            "{summary}"
+        );
+        assert!(
+            summary.contains(&format!("\"value\":{flood}")),
+            "the TRUE total is named: {summary}"
+        );
+        assert!(
+            summary.contains(&format!("\"value\":{MAX_JOURNALED_REJECTIONS}")),
+            "the journaled count beside it: {summary}"
+        );
+        assert!(
+            lines[..MAX_JOURNALED_REJECTIONS]
+                .iter()
+                .all(|l| l.contains("\"memory_entry_rejected\"")),
+            "the K before it are individually named"
+        );
+    }
+
+    /// The summary event's own shape: `total` + `journaled`, no fs-born
+    /// strings (nothing to escape), stamped from the epilogue clock.
+    #[test]
+    fn the_summary_event_names_the_total_and_the_journaled_count() {
+        let ev = rejections_summary_event(10_004);
+        assert!(matches!(ev.kind, EventKind::MemoryRejectionsSummary));
+        let get = |key: &str| {
+            ev.fields
+                .iter()
+                .find(|f| f.key == key)
+                .and_then(|f| match &f.value {
+                    Value::Int(n) => Some(*n),
+                    _ => None,
+                })
+        };
+        assert_eq!(get("total"), Some(10_004));
+        assert_eq!(
+            get("journaled"),
+            Some(i64::try_from(MAX_JOURNALED_REJECTIONS).expect("small"))
+        );
+    }
+
+    /// H15 · escape at birth: a store name carrying an OSC escape
+    /// sequence (attacker-plantable dir name) and an entry file name with
+    /// control bytes surface in the journal ESCAPED — no live control
+    /// byte ever reaches a terminal through the event's fields.
+    #[test]
+    fn the_rejected_event_escapes_fs_born_strings() {
+        let entry = RejectedEntry {
+            store: "ev\u{1b}]52;;pwn\u{7}il".to_owned(),
+            path: PathBuf::from(".nika/memory/evil/1700000000000-ab12\u{1b}cd34ef56ab12.json"),
+            reason: "bad_signature".to_owned(),
+        };
+        let ev = rejected_event(&entry);
+        for f in &ev.fields {
+            if let Value::String(s) = &f.value {
+                assert!(
+                    !s.chars().any(char::is_control),
+                    "field {} carries a live control byte: {s:?}",
+                    f.key
+                );
+            }
+        }
+        let get = |key: &str| {
+            ev.fields
+                .iter()
+                .find(|f| f.key == key)
+                .and_then(|f| match &f.value {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+        };
+        assert_eq!(get("store").as_deref(), Some("ev]52;;pwnil"));
+        assert_eq!(
+            get("entry").as_deref(),
+            Some("1700000000000-ab12cd34ef56ab12.json"),
+            "stripped, still readable"
+        );
+        assert_eq!(
+            get("reason").as_deref(),
+            Some("bad_signature"),
+            "the wire word is a closed set — nothing to escape"
+        );
     }
 }

--- a/crates/nika-dap/src/seal.rs
+++ b/crates/nika-dap/src/seal.rs
@@ -358,7 +358,7 @@ pub fn seal_event(
 /// (its digest rides; the body stays the evidence pack's surface), the
 /// budgets ρ consumed against the certificate's ceiling, the
 /// effects ε exercised against the declared bound, the signed-memory
-/// fold (F-P8 · the admitted digests + the rejection count), and the
+/// fold (F-P8 · the admitted set's digest + the rejection count), and the
 /// failed run's quarantine fold (F-P14 · la dette du run). Every field is
 /// ADDITIVE — `seal_format` stays 1: the verify tier reads `covers`
 /// tolerantly (unknown keys are ignored, verified by the tier tests),
@@ -382,11 +382,15 @@ pub struct SealTeardown {
     /// The effects ε fold (exercised vs declared), pre-shaped by the caller.
     pub effects: Option<serde_json::Value>,
     /// The memory fold (F-P8 · SMSR signed memory): `{"v": 1, "stores":
-    /// [{store, admitted: [digest…], rejected: n} | {store, error}]}` —
-    /// the admitted set NAMED by digest, the rejections counted (unsigned
-    /// · bad signature · relabel = rejected, never filtered) and named
-    /// one `memory_entry_rejected` journal event each BEFORE this seal
-    /// (the chain covers them), a failed store walk NAMED in place.
+    /// [{store, set_digest, admitted_count, rejected} | {store,
+    /// error}]}` — the admitted set NAMED by ONE constant-size digest
+    /// (blake3 over the sorted digests — the set's digest IS its name,
+    /// so the seal line never crosses the chain walk's 1 MiB line bound,
+    /// H13), the rejections counted (unsigned · bad signature · relabel
+    /// = rejected, never filtered) and named — the first
+    /// `MAX_JOURNALED_REJECTIONS` as `memory_entry_rejected` journal
+    /// events, a flood as ONE `memory_rejections_summary` — BEFORE this
+    /// seal (the chain covers them), a failed store walk NAMED in place.
     /// Pre-shaped by the caller from `nika_store::seal_fold`. Rides ONLY
     /// when the run's CWD holds a `.nika/memory/` store — `None` keeps
     /// the key OUT (absent is honest).
@@ -509,8 +513,9 @@ fn extend_covers(
         covers["effects"] = effects.clone();
     }
     // F-P8 · the signed-memory fold rides verbatim: the seal pins the
-    // verified SET (the admitted digests) and the rejection count beside
-    // it; `None` keeps the key OUT (absent is honest).
+    // verified SET (its ONE set digest + the admitted count) and the
+    // rejection count beside it; `None` keeps the key OUT (absent is
+    // honest).
     if let Some(memory) = &teardown.memory {
         covers["memory"] = memory.clone();
     }
@@ -940,7 +945,7 @@ mod tests {
     }
 
     /// F-P8 (SMSR signed memory) · the memory fold rides `covers`
-    /// additively — the admitted digests + the rejection count — and the
+    /// additively — the admitted set's ONE digest + the counts — and the
     /// signature verifies over the extended object; a `None` keeps the
     /// key OUT (no `.nika/memory/` in the run's CWD ⇒ nothing to attest).
     #[test]
@@ -952,9 +957,8 @@ mod tests {
             "stores": [
                 {
                     "store": "default",
-                    "admitted": [
-                        "b2f1a0c94e6d41f8a0d3c5b7e9f1a2c4b6d8e0f2a4c6b8d0e2f4a6c8b0d2e4f6",
-                    ],
+                    "set_digest": "b2f1a0c94e6d41f8a0d3c5b7e9f1a2c4b6d8e0f2a4c6b8d0e2f4a6c8b0d2e4f6",
+                    "admitted_count": 1,
                     "rejected": 1,
                 },
             ],
@@ -974,19 +978,24 @@ mod tests {
         let covers: serde_json::Value = mint_and_covers(&teardown, &sk, &pk);
 
         // The classic four ride unchanged; the memory fold joins them
-        // VERBATIM (the admitted digests AND the rejection count).
+        // VERBATIM (the set digest AND the counts).
         assert_eq!(covers["head"], serde_json::json!("ab12cd"));
         assert_eq!(
             covers["memory"]["stores"][0]["store"],
             serde_json::json!("default")
         );
         assert_eq!(
-            covers["memory"]["stores"][0]["admitted"][0]
+            covers["memory"]["stores"][0]["set_digest"]
                 .as_str()
-                .expect("the digest rides")
+                .expect("the set digest rides")
                 .len(),
             64,
-            "the admitted set is NAMED by full digest"
+            "the admitted set is NAMED by ONE constant-size digest (H13)"
+        );
+        assert_eq!(
+            covers["memory"]["stores"][0]["admitted_count"],
+            serde_json::json!(1),
+            "the set's size rides beside its name"
         );
         assert_eq!(
             covers["memory"]["stores"][0]["rejected"],

--- a/crates/nika-event/public-api.txt
+++ b/crates/nika-event/public-api.txt
@@ -283,6 +283,7 @@ pub nika_event::kind::EventKind::CostIncurred
 pub nika_event::kind::EventKind::Declassify
 pub nika_event::kind::EventKind::InferChunk
 pub nika_event::kind::EventKind::MemoryEntryRejected
+pub nika_event::kind::EventKind::MemoryRejectionsSummary
 pub nika_event::kind::EventKind::PermitChecked
 pub nika_event::kind::EventKind::RunSealed
 pub nika_event::kind::EventKind::TaskCacheHit
@@ -459,6 +460,7 @@ pub nika_event::prelude::EventKind::CostIncurred
 pub nika_event::prelude::EventKind::Declassify
 pub nika_event::prelude::EventKind::InferChunk
 pub nika_event::prelude::EventKind::MemoryEntryRejected
+pub nika_event::prelude::EventKind::MemoryRejectionsSummary
 pub nika_event::prelude::EventKind::PermitChecked
 pub nika_event::prelude::EventKind::RunSealed
 pub nika_event::prelude::EventKind::TaskCacheHit
@@ -767,6 +769,7 @@ pub nika_event::EventKind::CostIncurred
 pub nika_event::EventKind::Declassify
 pub nika_event::EventKind::InferChunk
 pub nika_event::EventKind::MemoryEntryRejected
+pub nika_event::EventKind::MemoryRejectionsSummary
 pub nika_event::EventKind::PermitChecked
 pub nika_event::EventKind::RunSealed
 pub nika_event::EventKind::TaskCacheHit

--- a/crates/nika-event/src/kind.rs
+++ b/crates/nika-event/src/kind.rs
@@ -173,6 +173,14 @@ pub enum EventKind {
     /// the names). Diagnostic, like the agent-telemetry cohort: the recall
     /// verdict itself rides the recall API.
     MemoryEntryRejected,
+    /// The ONE summary of a rejection flood (`total` + `journaled` fields —
+    /// additive cohort 2026-07-30 · H14 · NEP-0012 law 1): a store stuffed
+    /// with rejections journals at most K individually-named
+    /// `memory_entry_rejected` events, then this summary carrying the TRUE
+    /// total once (the fold's `rejected: n` pins the same number in the
+    /// seal's covers). Same diagnostic posture as its named sibling: the
+    /// fold attests the count, the journal names the evidence, bounded.
+    MemoryRejectionsSummary,
 }
 
 impl EventKind {
@@ -214,6 +222,7 @@ impl EventKind {
             Self::Declassify => "declassify",
             Self::ApprovalDecided => "approval_decided",
             Self::MemoryEntryRejected => "memory_entry_rejected",
+            Self::MemoryRejectionsSummary => "memory_rejections_summary",
         }
     }
 
@@ -287,7 +296,8 @@ impl EventKind {
             Self::PermitChecked
             | Self::Declassify
             | Self::ApprovalDecided
-            | Self::MemoryEntryRejected => EventClass::Security,
+            | Self::MemoryEntryRejected
+            | Self::MemoryRejectionsSummary => EventClass::Security,
             Self::AgentToolsSelected
             | Self::AgentNudge
             | Self::AgentStalled
@@ -370,6 +380,7 @@ mod tests {
         EventKind::Declassify,
         EventKind::ApprovalDecided,
         EventKind::MemoryEntryRejected,
+        EventKind::MemoryRejectionsSummary,
     ];
 
     #[test]
@@ -407,10 +418,11 @@ mod tests {
                 | EventKind::RunSealed
                 | EventKind::Declassify
                 | EventKind::ApprovalDecided
-                | EventKind::MemoryEntryRejected => {}
+                | EventKind::MemoryEntryRejected
+                | EventKind::MemoryRejectionsSummary => {}
             }
         }
-        assert_eq!(ALL.len(), 29, "extend ALL when a variant is added");
+        assert_eq!(ALL.len(), 30, "extend ALL when a variant is added");
     }
 
     /// FCI-003: the canonical wire slug has TWO independent encoders — the
@@ -487,9 +499,11 @@ mod tests {
                 "checkpoint_written" | "run_sealed" => Some(EventClass::Durability),
                 "cost_incurred" => Some(EventClass::Cost),
                 "infer_chunk" => Some(EventClass::Stream),
-                "permit_checked" | "declassify" | "approval_decided" | "memory_entry_rejected" => {
-                    Some(EventClass::Security)
-                }
+                "permit_checked"
+                | "declassify"
+                | "approval_decided"
+                | "memory_entry_rejected"
+                | "memory_rejections_summary" => Some(EventClass::Security),
                 s if s.starts_with("agent_") => Some(EventClass::Agent),
                 _ => None,
             };
@@ -526,6 +540,18 @@ mod tests {
         assert!(!k.is_failure(), "{k:?} must not be a lifecycle failure");
         assert_eq!(k.class(), EventClass::Security);
         assert_eq!(k.as_str(), "memory_entry_rejected");
+    }
+
+    #[test]
+    fn memory_rejections_summary_is_diagnostic_security_evidence() {
+        // H14: the flood summary rides the same posture as its named
+        // sibling — the fold attests the count, the journal names the
+        // evidence ONCE, and neither is a lifecycle state.
+        let k = EventKind::MemoryRejectionsSummary;
+        assert!(!k.is_terminal(), "{k:?} must not be terminal");
+        assert!(!k.is_failure(), "{k:?} must not be a lifecycle failure");
+        assert_eq!(k.class(), EventClass::Security);
+        assert_eq!(k.as_str(), "memory_rejections_summary");
     }
 
     #[test]

--- a/crates/nika-store/public-api.txt
+++ b/crates/nika-store/public-api.txt
@@ -42,6 +42,8 @@ pub nika_store::RejectReason::BadSignature
 pub nika_store::RejectReason::KeyMismatch
 pub nika_store::RejectReason::Malformed
 pub nika_store::RejectReason::NameMismatch
+pub nika_store::RejectReason::Overflow
+pub nika_store::RejectReason::Oversized
 pub nika_store::RejectReason::StoreMismatch
 pub nika_store::RejectReason::Unsigned
 pub nika_store::RejectReason::UnsupportedVersion
@@ -87,6 +89,8 @@ pub fn nika_store::RejectReason::as_any(&self) -> &(dyn core::any::Any + 'static
 impl<T> typenum::type_operators::Same for nika_store::RejectReason
 pub type nika_store::RejectReason::Output = T
 #[non_exhaustive] pub enum nika_store::StoreError
+pub nika_store::StoreError::Conflict
+pub nika_store::StoreError::Conflict::reason: alloc::string::String
 pub nika_store::StoreError::DirLayout
 pub nika_store::StoreError::DirLayout::reason: alloc::string::String
 pub nika_store::StoreError::Io

--- a/crates/nika-store/src/dir.rs
+++ b/crates/nika-store/src/dir.rs
@@ -17,6 +17,23 @@ use crate::errors::StoreError;
 /// The memory root relative to a run's CWD (`.nika/memory/<store>/` below it).
 pub const MEMORY_ROOT: &str = ".nika/memory";
 
+/// The per-entry size bound (NEP-0012 law 1 for the memory lane — a
+/// stuffed store must never turn a run's teardown into seconds of verify
+/// and a memory blow): an entry file larger than this is rejected
+/// [`RejectReason::Oversized`] WITHOUT a full read — a multi-GB planted
+/// `.json` never lands in memory.
+pub(crate) const MAX_ENTRY_BYTES: usize = 1024 * 1024; // 1 MiB
+
+/// The per-store entry-count bound: a store holding more `.json` entry
+/// files walks the FIRST [`MAX_WALK_ENTRIES`] (path-sorted) normally and
+/// names every file beyond the cap [`RejectReason::Overflow`] — UNREAD and
+/// unexamined, counted and journaled like every rejection, never silently
+/// dropped. 10^4 planted junk files then cost the teardown a bounded read
+/// set plus one dirent name each. Generous for v1's honest traffic (a run
+/// writes tens of entries); amend the number when the L2 orchestrator's
+/// real shape lands.
+pub(crate) const MAX_WALK_ENTRIES: usize = 1024;
+
 /// The store dir under a memory root. The store name MUST be one path
 /// segment: empty · a `/` or `\` separator · `..` is a
 /// [`StoreError::DirLayout`] — a store name can never escape the memory
@@ -56,14 +73,50 @@ fn io(what: &str, path: &Path, e: &std::io::Error) -> StoreError {
     }
 }
 
-/// Commit an entry: create the store dir, write a temp sibling, rename over
-/// the final name (same content ⇒ same name ⇒ the write is idempotent).
+/// Create the store dir chain (0700 for the dirs WE create on unix —
+/// entry frames may carry secrets, the house convention for
+/// secret-bearing paths; a pre-existing dir keeps its mode: the engine
+/// never tightens what it did not create).
+fn create_store_dir(dir: &Path) -> Result<(), StoreError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)
+            .map_err(|e| io("create", dir, &e))
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(dir).map_err(|e| io("create", dir, &e))
+    }
+}
+
+/// Commit an entry: create the store dir, write a temp sibling (0600 on
+/// unix — set BEFORE the rename so the landed file is born tight, the
+/// `write_0600` convention), rename over the final name. The rename is
+/// IDEMPOTENT BY CONTENT, the claim made true by reading first — where
+/// the content that counts is the PREIMAGE (the entry's identity, what
+/// the digest and therefore the file NAME commit to), never the raw
+/// bytes: minisign randomizes the sig box (a nonce + a `timestamp:`
+/// trusted comment), so two honest signings of ONE entry differ in bytes
+/// while being the same attestation. A final name holding the same
+/// preimage is a no-op Ok; a name holding a divergent — or undecodable —
+/// envelope fails with a named [`StoreError::Conflict`]: an out-of-engine
+/// plant at the canonical name is tamper evidence, never a silent
+/// clobber.
 /// The temp rides `create_new` — a leftover from a crashed write (or a
 /// symlink planted at the temp name) FAILS the commit, never a silent
 /// clobber / a followed symlink; a failed rename removes the temp
 /// best-effort (a stale temp would fail every later `create_new`).
+///
+/// Durability, named: nothing fsyncs — the guarantee is rename-level
+/// ATOMICITY (a reader never sees a torn write), not survival of a crash:
+/// a crash post-rename can lose the entry. Loss is not forgery — the fold
+/// attests what is present, and an absent entry is honest.
 pub(crate) fn commit(dir: &Path, entry: &StoreEntry) -> Result<PathBuf, StoreError> {
-    std::fs::create_dir_all(dir).map_err(|e| io("create", dir, &e))?;
+    create_store_dir(dir)?;
     let name = entry_file_name(entry);
     let body =
         serde_json::to_string_pretty(&entry.file_value()).map_err(|e| StoreError::Serialize {
@@ -76,10 +129,41 @@ pub(crate) fn commit(dir: &Path, entry: &StoreEntry) -> Result<PathBuf, StoreErr
             .create_new(true)
             .open(&tmp)
             .map_err(|e| io("write", &tmp, &e))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| io("chmod", &tmp, &e))?;
+        }
         file.write_all(body.as_bytes())
             .map_err(|e| io("write", &tmp, &e))?;
     }
     let path = dir.join(&name);
+    if path.exists() {
+        // The read the idempotence claim needs: same PREIMAGE (the entry's
+        // identity — the sig box is randomized, so bytes never compare) is
+        // a no-op; divergent or undecodable bytes are a NAMED conflict (a
+        // planted dir reads as the io error it is).
+        let held = std::fs::read(&path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp);
+            io("read", &path, &e)
+        })?;
+        let _ = std::fs::remove_file(&tmp); // the name is taken either way — the temp never lingers
+        let same_entry = serde_json::from_slice::<serde_json::Value>(&held)
+            .ok()
+            .and_then(|v| StoreEntry::from_file_value(&v).ok())
+            .is_some_and(|existing| existing.preimage() == entry.preimage());
+        return if same_entry {
+            Ok(path)
+        } else {
+            Err(StoreError::Conflict {
+                reason: format!(
+                    "{} already holds a DIFFERENT entry — an out-of-engine plant at the canonical name is tamper evidence, never silently clobbered",
+                    path.display()
+                ),
+            })
+        };
+    }
     if let Err(e) = std::fs::rename(&tmp, &path) {
         let _ = std::fs::remove_file(&tmp); // best-effort — the error to name is the rename's
         return Err(io("rename", &path, &e));
@@ -87,9 +171,40 @@ pub(crate) fn commit(dir: &Path, entry: &StoreEntry) -> Result<PathBuf, StoreErr
     Ok(path)
 }
 
+/// Read + decode one entry file within the size bound: a CAPPED read
+/// ([`MAX_ENTRY_BYTES`] + 1 — the planted multi-GB file never lands in
+/// memory), over the cap named [`RejectReason::Oversized`]. Non-UTF-8 /
+/// non-JSON bytes are not an IO failure — the file is not a decodable
+/// envelope: recall names it Malformed (never silent). A real read error
+/// aborts the walk ([`StoreError::Io`]) — the fold names the store's error.
+fn read_entry(path: &Path) -> Result<Result<StoreEntry, RejectReason>, StoreError> {
+    use std::io::Read as _;
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)
+        .and_then(|f| f.take(MAX_ENTRY_BYTES as u64 + 1).read_to_end(&mut bytes))
+        .map_err(|e| io("read", path, &e))?;
+    if bytes.len() > MAX_ENTRY_BYTES {
+        return Ok(Err(RejectReason::Oversized));
+    }
+    Ok(String::from_utf8(bytes)
+        .ok()
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
+        .map_or(Err(RejectReason::Malformed), |v| {
+            StoreEntry::from_file_value(&v)
+        }))
+}
+
 /// Walk a store dir's entry files (`.json` only — temp siblings never ride),
 /// sorted by path for determinism. A missing dir is an EMPTY store, never an
 /// error (absent is honest); a non-dir at the store path is a layout error.
+///
+/// The bounds (NEP-0012 law 1 for the memory lane — a stuffed store must
+/// never turn a run's teardown into seconds of verify + a memory blow): an
+/// entry file over [`MAX_ENTRY_BYTES`] rides as [`RejectReason::Oversized`]
+/// (capped read — never fully loaded), and every `.json` past the first
+/// [`MAX_WALK_ENTRIES`] (path-sorted) rides UNREAD as
+/// [`RejectReason::Overflow`] — the overflow is NAMED per file (path +
+/// reason) and counted in the fold's `rejected`, never silently dropped.
 pub(crate) fn walk(dir: &Path) -> Result<Vec<EntryFile>, StoreError> {
     if !dir.exists() {
         return Ok(Vec::new());
@@ -99,26 +214,29 @@ pub(crate) fn walk(dir: &Path) -> Result<Vec<EntryFile>, StoreError> {
             reason: format!("{} is not a directory", dir.display()),
         });
     }
-    let mut out = Vec::new();
+    let mut paths = Vec::new();
     for item in std::fs::read_dir(dir).map_err(|e| io("read_dir", dir, &e))? {
         let path = item.map_err(|e| io("read_dir", dir, &e))?.path();
         if path.extension().is_none_or(|x| x != "json") {
             continue;
         }
-        // Non-UTF-8 / non-JSON bytes are not an IO failure — the file is
-        // not a decodable envelope: recall names it Malformed (never silent).
-        let decoded = match std::fs::read(&path) {
-            Err(e) => return Err(io("read", &path, &e)),
-            Ok(bytes) => String::from_utf8(bytes)
-                .ok()
-                .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
-                .map_or(Err(RejectReason::Malformed), |v| {
-                    StoreEntry::from_file_value(&v)
-                }),
-        };
+        paths.push(path);
+    }
+    paths.sort();
+    let mut out = Vec::with_capacity(paths.len());
+    for (index, path) in paths.into_iter().enumerate() {
+        // The entry-count bound: past the cap the file is never opened —
+        // named Overflow (unexamined ⇒ not admitted), never a silent skip.
+        if index >= MAX_WALK_ENTRIES {
+            out.push(EntryFile {
+                path,
+                decoded: Err(RejectReason::Overflow),
+            });
+            continue;
+        }
+        let decoded = read_entry(&path)?;
         out.push(EntryFile { path, decoded });
     }
-    out.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(out)
 }
 

--- a/crates/nika-store/src/errors.rs
+++ b/crates/nika-store/src/errors.rs
@@ -35,6 +35,16 @@ pub enum StoreError {
         /// What violates the layout.
         reason: String,
     },
+    /// A commit's canonical file name already holds DIFFERENT bytes — an
+    /// out-of-engine plant at that name is tamper evidence: the write is
+    /// refused, never a silent clobber (identical bytes are the idempotent
+    /// rewrite — a no-op, not an error).
+    #[error("memory entry conflict: {reason}")]
+    #[diagnostic(help("{}", codes::code_help(codes::NIKA_605)))]
+    Conflict {
+        /// Which name carries divergent bytes.
+        reason: String,
+    },
 }
 
 impl NikaErrorCode for StoreError {

--- a/crates/nika-store/src/lib.rs
+++ b/crates/nika-store/src/lib.rs
@@ -12,10 +12,11 @@
 //! no-provenance-free-filter theorem: unsigned admission floor = 0 %).
 //! Rejections are named ([`RejectReason`]), journaled
 //! (`memory_entry_rejected`), and counted in the seal's `covers["memory"]`
-//! beside the admitted-set digests ([`seal_fold`]). The envelope and the
-//! fold carry `"v": 1` (the envelope's INSIDE the signed preimage —
-//! FCI-003/011/022 · decode dispatches on it, an unknown version
-//! rejecting [`RejectReason::UnsupportedVersion`]).
+//! beside the admitted set's ONE constant-size digest ([`seal_fold`] — the
+//! set's digest is its name, so the seal line never grows with the store).
+//! The envelope and the fold carry `"v": 1` (the envelope's INSIDE the
+//! signed preimage — FCI-003/011/022 · decode dispatches on it, an unknown
+//! version rejecting [`RejectReason::UnsupportedVersion`]).
 //!
 //! Named deviations (`docs/crate-specs/nika-store.md` §2): canonical bytes
 //! = JCS (the engine's ONE canonicalization voice — the `serde_json`

--- a/crates/nika-store/src/sign.rs
+++ b/crates/nika-store/src/sign.rs
@@ -25,6 +25,16 @@ pub enum RejectReason {
     /// The file is not a decodable envelope (bad bytes · missing content
     /// fields — a missing `sig` alone is [`Self::Unsigned`], not this).
     Malformed,
+    /// The file exceeds the walk's per-entry size bound — the malformed
+    /// FAMILY (not a decodable envelope within the walk's bounds), named
+    /// apart so the bound itself is visible in the journal. Never read in
+    /// full: a stuffed multi-GB `.json` can never blow the teardown.
+    Oversized,
+    /// The file rode beyond the walk's per-store entry-count bound —
+    /// UNEXAMINED, never admitted (an unexamined entry can never be
+    /// filtered into trustworthiness — the SMSR floor again), never
+    /// silently dropped: it is counted and named like every rejection.
+    Overflow,
     /// The envelope's format version `"v"` is one this version does not
     /// know — named, never masqueraded as a signature failure (the
     /// signature commits to `v`, so only an honestly-signed NEWER
@@ -55,6 +65,8 @@ impl RejectReason {
         match self {
             Self::Unsigned => "unsigned",
             Self::Malformed => "malformed",
+            Self::Oversized => "oversized",
+            Self::Overflow => "overflow",
             Self::UnsupportedVersion => "unsupported_version",
             Self::KeyMismatch => "key_mismatch",
             Self::StoreMismatch => "store_mismatch",
@@ -214,20 +226,58 @@ pub fn seal_fold(memory_root: &Path, pubkey: &minisign::PublicKey) -> Option<ser
     seal_fold_detailed(memory_root, pubkey).0
 }
 
+/// The admitted set's ONE name: blake3 over the sorted digest hex words,
+/// concatenated (fixed-width 64-hex fields, so the framing is the width).
+/// O(1) in the set's size — the fold line stays constant-size however many
+/// entries admit, so a long-lived store can never grow a seal line the
+/// chain walk's own `MAX_LINE_BYTES` (1 MiB) would refuse: an inline
+/// `[digest…]` list crosses that bound at ~15k admitted entries and the
+/// engine would write a seal its own verifier rejects (H13). The receipt's
+/// claim is kept — "the verified set, named": the set's digest IS its
+/// name. The empty set's digest is blake3 of the empty input (constant) —
+/// `admitted_count: 0` beside it says the size.
+fn admitted_set_digest(admitted: &[String]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for digest in admitted {
+        hasher.update(digest.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+/// Strip terminal control characters (C0 · C1 · DEL) from a string born
+/// from attacker-plantable bytes (a store dir name riding an io-error
+/// text). The TWIN of `nika_dap::escape_tty`: nika-store is L1 and cannot
+/// import the L4 helper, so the one-liner is replicated here — the same
+/// move the receipt fix used — with the twin named so the two never
+/// diverge silently (both STRIP, neither escapes).
+fn strip_control(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
 /// Walk every store under a memory root, verify per entry, and shape what
-/// the run's seal pins — `{"v": 1, "stores": [{"store", "admitted":
-/// [digest…], "rejected": n}]}` — the admitted set NAMED by digest, the
-/// rejections counted AND returned (the [`FoldRejection`] list the
-/// teardown journals one `memory_entry_rejected` event each).
+/// the run's seal pins — `{"v": 1, "stores": [{"store", "set_digest",
+/// "admitted_count", "rejected"}]}` — the admitted set NAMED by one
+/// constant-size digest (the `admitted_set_digest` construction), the
+/// rejections counted
+/// AND returned (the [`FoldRejection`] list the teardown journals one
+/// `memory_entry_rejected` event each).
 ///
 /// Failure is NEVER collapsed to `None` (a `None` reads as "no memory" —
 /// it would erase tamper evidence): a store whose walk fails rides the
 /// fold as `{"store": s, "error": "<reason>"}` beside the
-/// admitted/rejected shape; a per-item `read_dir` error at the root rides
+/// set-digest/counts shape; a per-item `read_dir` error at the root rides
 /// the same way with `store: null` (the name is what the error denies);
-/// a wholly-unreadable root still yields `Some` with the error entry.
+/// a wholly-unreadable root still yields `Some` with the error entry. The
+/// error text embeds paths born from attacker-plantable dir names, so it
+/// is control-stripped AT BIRTH (the `strip_control` twin) — the receipt
+/// field has no machine consumer, the escape is unconditional.
 /// `None` is kept STRICTLY for "no memory root / no stores" (absent is
 /// honest) — the `memory` key then stays OUT of the covers.
+///
+/// The claim's edge, named: entry DELETION is unattested — the fold
+/// attests the integrity of what is present, not the completeness of what
+/// once was (availability sits outside the SMSR integrity claim; the
+/// lineage digest is the v2 hook for it).
 #[must_use]
 pub fn seal_fold_detailed(
     memory_root: &Path,
@@ -235,7 +285,7 @@ pub fn seal_fold_detailed(
 ) -> (Option<serde_json::Value>, Vec<FoldRejection>) {
     let mut rejections = Vec::new();
     let mut folds: Vec<serde_json::Value> = Vec::new();
-    let error_entry = |store: Option<&str>, reason: String| json!({ "store": store.map_or(serde_json::Value::Null, serde_json::Value::from), "error": reason });
+    let error_entry = |store: Option<&str>, reason: String| json!({ "store": store.map_or(serde_json::Value::Null, serde_json::Value::from), "error": strip_control(&reason) });
     if !memory_root.exists() {
         return (None, rejections); // absent is honest — no attestation at all
     }
@@ -285,16 +335,19 @@ pub fn seal_fold_detailed(
                                 }
                             }
                         }
-                        // The receipt pins a SET: sorted + deduped. The
-                        // name binding (RejectReason::NameMismatch) makes
-                        // a repeated digest unreachable through the fs —
-                        // the dedup is the belt-and-braces the SET law
-                        // buys for free.
+                        // The receipt pins a SET, NAMED in O(1): sorted +
+                        // deduped (the name binding — RejectReason::NameMismatch
+                        // — makes a repeated digest unreachable through the
+                        // fs, so the dedup is the belt-and-braces the SET
+                        // law buys for free), then ONE digest of the set
+                        // beside its size — the fold line never grows with
+                        // the admitted set (H13 · [`admitted_set_digest`]).
                         admitted.sort();
                         admitted.dedup();
                         folds.push(json!({
                             "store": store,
-                            "admitted": admitted,
+                            "set_digest": admitted_set_digest(&admitted),
+                            "admitted_count": admitted.len(),
                             "rejected": rejected,
                         }));
                     }

--- a/crates/nika-store/src/tests.rs
+++ b/crates/nika-store/src/tests.rs
@@ -15,4 +15,22 @@ mod acceptance;
 #[cfg(test)]
 mod api;
 #[cfg(test)]
+mod hardening;
+#[cfg(test)]
 mod tamper_property;
+
+/// The test-side re-construction of the fold's set digest (H13): sort +
+/// dedup, then blake3 over the concatenated 64-hex words. A sibling of
+/// the impl's construction, written twice on purpose — a divergence in
+/// either (the sort · the dedup · the framing) fails the cross-check.
+#[cfg(test)]
+pub(crate) fn set_digest(digests: &[String]) -> String {
+    let mut sorted = digests.to_vec();
+    sorted.sort();
+    sorted.dedup();
+    let mut hasher = blake3::Hasher::new();
+    for digest in &sorted {
+        hasher.update(digest.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}

--- a/crates/nika-store/src/tests/acceptance.rs
+++ b/crates/nika-store/src/tests/acceptance.rs
@@ -42,7 +42,7 @@ fn write_outside(dir: &Path, name: &str, value: &serde_json::Value) {
 }
 
 /// **positive** — a legit write is signed + labeled; recall admits it; the
-/// seal fold pins the admitted digest + the rejection count.
+/// seal fold pins the admitted set's digest + the counts.
 #[test]
 fn a_signed_write_is_admitted_and_its_digest_lands_in_the_fold() {
     let root = tempfile::tempdir().expect("tempdir");
@@ -99,16 +99,17 @@ fn a_signed_write_is_admitted_and_its_digest_lands_in_the_fold() {
         "digest stable across decode"
     );
 
-    // The fold pins the admitted digest + the zero rejection count (and
+    // The fold pins the admitted set's ONE digest + the counts (and
     // carries its own format version beside the stores).
     let fold = seal_fold(&root, &pk).expect("a memory root folds");
     assert_eq!(fold["v"], serde_json::json!(1), "the fold is versioned");
     assert_eq!(fold["stores"][0]["store"], serde_json::json!("default"));
     assert_eq!(
-        fold["stores"][0]["admitted"],
-        serde_json::json!([written.digest()]),
-        "the receipt names the verified SET"
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[written.digest()])),
+        "the receipt names the verified SET — its digest IS the name (O(1))"
     );
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(1));
     assert_eq!(fold["stores"][0]["rejected"], serde_json::json!(0));
 }
 
@@ -142,7 +143,12 @@ fn a_direct_file_edit_is_rejected_bad_signature() {
         "one flipped byte anywhere in the envelope = rejected"
     );
     let fold = seal_fold(&root, &pk).expect("a memory root folds");
-    assert_eq!(fold["stores"][0]["admitted"], serde_json::json!([]));
+    assert_eq!(
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[])),
+        "no admission — the empty set's digest"
+    );
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(0));
     assert_eq!(fold["stores"][0]["rejected"], serde_json::json!(1));
 }
 
@@ -250,9 +256,10 @@ fn an_unsigned_entry_is_zero_percent_admission() {
     assert_eq!(unsigned, 2, "both unsigned shapes are NAMED: {verdicts:?}");
     let fold = seal_fold(&root, &pk).expect("a memory root folds");
     assert_eq!(
-        fold["stores"][0]["admitted"],
-        serde_json::json!([honest.digest()])
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[honest.digest()]))
     );
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(1));
     assert_eq!(
         fold["stores"][0]["rejected"],
         serde_json::json!(2),

--- a/crates/nika-store/src/tests/api.rs
+++ b/crates/nika-store/src/tests/api.rs
@@ -19,13 +19,13 @@ use nika_kernel::memory::{
     MemoryForget, MemoryFrame, MemoryLevel, MemoryRecall, MemoryRemember, MemoryStore, RecallQuery,
 };
 
-fn keypair() -> (minisign::PublicKey, minisign::SecretKey) {
+pub(crate) fn keypair() -> (minisign::PublicKey, minisign::SecretKey) {
     let pair =
         minisign::KeyPair::generate_encrypted_keypair(Some(String::new())).expect("keypair mints");
     (pair.pk, pair.sk)
 }
 
-fn entry(store: &str, ts: u64, label: Integrity) -> UnsignedEntry {
+pub(crate) fn entry(store: &str, ts: u64, label: Integrity) -> UnsignedEntry {
     UnsignedEntry::new(
         serde_json::json!({"content": format!("fact {store} {ts}")}),
         label,
@@ -35,7 +35,7 @@ fn entry(store: &str, ts: u64, label: Integrity) -> UnsignedEntry {
     )
 }
 
-fn signed_dir() -> (
+pub(crate) fn signed_dir() -> (
     tempfile::TempDir,
     PathBuf,
     minisign::PublicKey,
@@ -100,7 +100,12 @@ fn a_validly_signed_entry_replayed_across_stores_is_store_mismatch() {
         .iter()
         .find(|s| s["store"] == "beta")
         .expect("beta rides the fold");
-    assert_eq!(beta["admitted"], serde_json::json!([]));
+    assert_eq!(
+        beta["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[])),
+        "an empty admitted set is the empty-input digest"
+    );
+    assert_eq!(beta["admitted_count"], serde_json::json!(0));
     assert_eq!(beta["rejected"], serde_json::json!(1));
 }
 
@@ -197,14 +202,17 @@ fn the_error_family_speaks_nika_605_with_the_one_voice() {
     let lay = StoreError::DirLayout {
         reason: "x".to_owned(),
     };
-    for e in [&io, &ser, &lay] {
+    let con = StoreError::Conflict {
+        reason: "x".to_owned(),
+    };
+    for e in [&io, &ser, &lay, &con] {
         assert_eq!(e.nika_code(), nika_error::codes::NIKA_605);
         let help = e.help().map(|h| h.to_string()).expect("help rides");
         assert!(help.contains("Signed-memory store"), "the 605 row: {help}");
     }
     assert!(io.is_transient(), "IO retries");
     assert!(
-        !ser.is_transient() && !lay.is_transient(),
+        !ser.is_transient() && !lay.is_transient() && !con.is_transient(),
         "deterministic classes never retry"
     );
 }
@@ -214,6 +222,8 @@ fn reject_reasons_have_stable_wire_words() {
     let words = [
         (RejectReason::Unsigned, "unsigned"),
         (RejectReason::Malformed, "malformed"),
+        (RejectReason::Oversized, "oversized"),
+        (RejectReason::Overflow, "overflow"),
         (RejectReason::UnsupportedVersion, "unsupported_version"),
         (RejectReason::KeyMismatch, "key_mismatch"),
         (RejectReason::StoreMismatch, "store_mismatch"),
@@ -228,7 +238,11 @@ fn reject_reasons_have_stable_wire_words() {
 
 // ─── The kernel trait surface (ADR-078) ─────────────────────────────
 
-fn store(dir: PathBuf, sk: minisign::SecretKey, pk: minisign::PublicKey) -> SignedMemoryStore {
+pub(crate) fn store(
+    dir: PathBuf,
+    sk: minisign::SecretKey,
+    pk: minisign::PublicKey,
+) -> SignedMemoryStore {
     SignedMemoryStore::new(
         dir,
         "default".to_owned(),
@@ -402,18 +416,20 @@ fn a_verified_entry_riding_a_second_name_is_name_mismatch() {
         (1, 1),
         "the original admits, the copy is NAMED: {verdicts:?}"
     );
-    // …and the fold pins the digest exactly ONCE beside the count (the
-    // admitted set never dupes — the receipt names the verified SET).
+    // …and the fold pins the set's digest exactly once beside the counts
+    // (the admitted set never dupes — the receipt names the verified SET
+    // in O(1): one constant-size digest + its size).
     let fold = seal_fold(&root, &pk).expect("a memory root folds");
     assert_eq!(
-        fold["stores"][0]["admitted"],
-        serde_json::json!([written.digest()])
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[written.digest()]))
     );
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(1));
     assert_eq!(fold["stores"][0]["rejected"], serde_json::json!(1));
 }
 
 #[test]
-fn the_detailed_fold_names_each_rejection_and_sorts_the_admitted_set() {
+fn the_detailed_fold_names_each_rejection_and_digests_the_sorted_set() {
     let root = tempfile::tempdir().expect("tempdir");
     let root = root.path().join(MEMORY_ROOT);
     let (pk, sk) = keypair();
@@ -442,13 +458,12 @@ fn the_detailed_fold_names_each_rejection_and_sorts_the_admitted_set() {
 
     let (fold, rejections) = seal_fold_detailed(&root, &pk);
     let fold = fold.expect("a memory root folds");
-    let mut digests = [one.digest(), two.digest()];
-    digests.sort();
     assert_eq!(
-        fold["stores"][0]["admitted"],
-        serde_json::json!(digests),
-        "the admitted SET is sorted"
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[one.digest(), two.digest()])),
+        "the admitted SET is sorted + deduped, then digested once"
     );
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(2));
     assert_eq!(fold["stores"][0]["rejected"], serde_json::json!(1));
     assert_eq!(rejections.len(), 1, "one rejection, named for the journal");
     assert_eq!(rejections[0].store, "default");
@@ -478,14 +493,18 @@ fn the_fold_names_a_store_it_cannot_walk_never_collapses() {
     let stores = fold["stores"].as_array().expect("stores");
     assert_eq!(stores.len(), 2, "both stores ride: {stores:?}");
     assert_eq!(stores[0]["store"], serde_json::json!("alpha"));
-    assert_eq!(stores[0]["admitted"], serde_json::json!([written.digest()]));
+    assert_eq!(
+        stores[0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[written.digest()]))
+    );
+    assert_eq!(stores[0]["admitted_count"], serde_json::json!(1));
     assert_eq!(stores[1]["store"], serde_json::json!("broken"));
     assert!(
         stores[1]["error"].as_str().is_some(),
         "the failed walk rides as an explicit error entry: {stores:?}"
     );
     assert!(
-        stores[1].get("admitted").is_none(),
+        stores[1].get("set_digest").is_none(),
         "no fabricated empty set beside the error"
     );
 }
@@ -588,8 +607,11 @@ fn a_leftover_tmp_fails_the_commit_never_a_silent_clobber() {
     );
 }
 
+/// A DIRECTORY planted at the canonical name fails the commit's pre-rename
+/// read (a dir is not readable bytes) with the IO class — and the temp is
+/// cleaned up either way, never wedging later commits.
 #[test]
-fn a_failed_rename_cleans_the_tmp_up() {
+fn a_planted_dir_at_the_final_name_fails_and_cleans_the_tmp_up() {
     let (_root, dir, _pk, sk) = signed_dir();
     let first = remember_signed(
         &dir,
@@ -605,7 +627,7 @@ fn a_failed_rename_cleans_the_tmp_up() {
         entry("default", 1_700_000_000_000, Integrity::trusted()),
         &sk,
     )
-    .expect_err("renaming over a directory fails");
+    .expect_err("a directory at the canonical name fails");
     assert!(matches!(err, StoreError::Io { .. }), "{err}");
     assert!(
         !dir.join(format!(".{name}.tmp")).exists(),

--- a/crates/nika-store/src/tests/hardening.rs
+++ b/crates/nika-store/src/tests/hardening.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+//! Audit wave B (2026-07-30 · the nika-store hardening findings): the
+//! commit's read-before-rename (H1 — the identical-entry idempotence ·
+//! the named `Conflict`), the walk's two named bounds (`Oversized` ·
+//! `Overflow`), the secret-bearing modes (0600 entry files · 0700 fresh
+//! dirs — H2), the fold error entries' escape-at-birth (H15), and the
+//! trait surface's applied filters (`min_score` · the observed window ·
+//! the ts-ranked limit · non-string content · the fail-closed reserved
+//! fields). One suite per wave, split out of `api.rs` under the
+//! [800, 1500) file-cohesion ratchet; the helpers ride `super::api`.
+
+use super::api::{entry, keypair, signed_dir, store};
+use crate::{
+    MEMORY_ROOT, RecallVerdict, RejectReason, StoreError, UnsignedEntry, recall_verified,
+    remember_signed, seal_fold, store_dir,
+};
+use nika_cap::Integrity;
+use nika_kernel::memory::{MemoryFrame, MemoryLevel, MemoryRecall, MemoryRemember, RecallQuery};
+
+/// H1 · the idempotence claim made true: the canonical name already
+/// holding DIFFERENT bytes (an out-of-engine plant) fails with the NAMED
+/// conflict — never a silent clobber of what is tamper evidence.
+#[test]
+fn a_divergent_plant_at_the_canonical_name_is_a_named_conflict() {
+    let (_root, dir, _pk, sk) = signed_dir();
+    let first = remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect("the first write lands");
+    let name = crate::entry_file_name(&first);
+    std::fs::write(dir.join(&name), "{\"planted\": \"evidence\"}").expect("the plant lands");
+    let err = remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect_err("divergent bytes at the canonical name are a conflict");
+    assert!(matches!(err, StoreError::Conflict { .. }), "{err}");
+    assert!(
+        err.to_string().contains("DIFFERENT entry"),
+        "the refusal names why: {err}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join(&name)).expect("the plant reads"),
+        "{\"planted\": \"evidence\"}",
+        "the evidence is NEVER silently clobbered"
+    );
+    assert!(
+        !dir.join(format!(".{name}.tmp")).exists(),
+        "the tmp goes with the named conflict"
+    );
+}
+
+/// H1, the honest half: an identical rewrite is a no-op Ok (same content
+/// ⇒ same name — read + compare, no rename needed), the file count stays
+/// one. (The determinism test pins the name/digest side; this pins the
+/// commit's early-Ok path.)
+#[test]
+fn an_identical_rewrite_is_a_noop_ok() {
+    let (_root, dir, _pk, sk) = signed_dir();
+    let first = remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect("the first write lands");
+    let second = remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect("an identical rewrite is Ok — true idempotence");
+    assert_eq!(first.digest(), second.digest());
+    assert_eq!(
+        std::fs::read_dir(&dir).expect("dir").count(),
+        1,
+        "one file, no temp sibling left"
+    );
+}
+
+/// The walk's per-entry size bound: a stuffed `.json` past
+/// `MAX_ENTRY_BYTES` is rejected `oversized` (capped read — the multi-GB
+/// plant never lands in memory) and counted in the fold, while the honest
+/// entries still admit (a bound never collapses the store).
+#[test]
+fn an_oversized_entry_is_rejected_within_the_bound() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let root = root.path().join(MEMORY_ROOT);
+    let (pk, sk) = keypair();
+    let dir = store_dir(&root, "default").expect("the store dir");
+    remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect("the honest write lands");
+    let stuffed = vec![b'x'; crate::dir::MAX_ENTRY_BYTES + 1];
+    std::fs::write(dir.join("1700000000099-eeeeeeeeeeeeeeee.json"), stuffed).expect("the plant");
+    let verdicts = recall_verified(&dir, "default", &pk).expect("recall walks");
+    assert_eq!(verdicts.len(), 2);
+    let oversized = verdicts
+        .iter()
+        .filter(|v| v.verdict == RecallVerdict::Rejected(RejectReason::Oversized))
+        .count();
+    assert_eq!(oversized, 1, "the stuffed file is NAMED: {verdicts:?}");
+    let fold = seal_fold(&root, &pk).expect("a memory root folds");
+    assert_eq!(fold["stores"][0]["admitted_count"], serde_json::json!(1));
+    assert_eq!(
+        fold["stores"][0]["rejected"],
+        serde_json::json!(1),
+        "the oversize rejection is counted, never silent"
+    );
+}
+
+/// The walk's per-store count bound: every `.json` past the first
+/// `MAX_WALK_ENTRIES` rides UNREAD as `overflow` — named per file, counted
+/// in the fold, and the honest entries below the cap still admit (the
+/// overflow is named, never a silent drop and never a store collapse).
+#[test]
+fn the_entry_count_bound_names_the_overflow() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let root = root.path().join(MEMORY_ROOT);
+    let (pk, sk) = keypair();
+    let dir = store_dir(&root, "default").expect("the store dir");
+    let honest = remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect("the honest write lands");
+    // The honest name sorts FIRST (ts 1_700_000_000_000 < the junk's
+    // 1_800_… prefix), so the cap falls strictly on the planted junk.
+    let extra = 3_usize;
+    for i in 0..crate::dir::MAX_WALK_ENTRIES + extra - 1 {
+        std::fs::write(
+            dir.join(format!("1800000000000-{i:016x}.json")),
+            "{not json",
+        )
+        .expect("junk");
+    }
+    let verdicts = recall_verified(&dir, "default", &pk).expect("recall walks");
+    let count = |want: RejectReason| {
+        verdicts
+            .iter()
+            .filter(|v| v.verdict == RecallVerdict::Rejected(want.clone()))
+            .count()
+    };
+    assert_eq!(
+        verdicts.len(),
+        crate::dir::MAX_WALK_ENTRIES + extra,
+        "every file rides — nothing silently dropped"
+    );
+    assert_eq!(
+        count(RejectReason::Overflow),
+        extra,
+        "exactly the beyond-cap files are named Overflow"
+    );
+    assert_eq!(
+        count(RejectReason::Malformed),
+        crate::dir::MAX_WALK_ENTRIES - 1,
+        "the in-cap junk is read and named Malformed"
+    );
+    let fold = seal_fold(&root, &pk).expect("a memory root folds");
+    assert_eq!(
+        fold["stores"][0]["set_digest"],
+        serde_json::json!(crate::tests::set_digest(&[honest.digest()])),
+        "the honest set still pins in O(1)"
+    );
+    assert_eq!(
+        fold["stores"][0]["rejected"],
+        serde_json::json!(crate::dir::MAX_WALK_ENTRIES + extra - 1),
+        "the overflow is counted like every rejection"
+    );
+}
+
+/// H2 · the house convention for secret-bearing paths: entry files land
+/// 0600 (set before the rename — born tight) and the dirs the commit
+/// creates ride 0700.
+#[cfg(unix)]
+#[test]
+fn entry_files_are_0600_and_fresh_dirs_0700_on_unix() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let root = tempfile::tempdir().expect("tempdir");
+    let root = root.path().join(MEMORY_ROOT);
+    let (_pk, sk) = keypair();
+    let dir = store_dir(&root, "default").expect("the store dir");
+    let written = remember_signed(
+        &dir,
+        entry("default", 1_700_000_000_000, Integrity::trusted()),
+        &sk,
+    )
+    .expect("the write lands");
+    let mode =
+        |p: &std::path::Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(
+        mode(&dir.join(crate::entry_file_name(&written))),
+        0o600,
+        "the entry file is born owner-only"
+    );
+    assert_eq!(mode(&dir), 0o700, "the store dir the commit created");
+    assert_eq!(mode(&root), 0o700, "…and the memory root on the chain");
+}
+
+/// The fold's error entries are control-stripped AT BIRTH (H15): an
+/// io-error text embedding a path with an OSC escape sequence can never
+/// reach a terminal through the receipt.
+#[cfg(unix)]
+#[test]
+fn the_fold_error_entries_strip_control_bytes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (pk, _sk) = keypair();
+    // A FILE where the root must be, its path carrying an OSC introducer.
+    let root = tmp.path().join(".nika/mem\u{1b}]52;;pwn\u{7}ory");
+    std::fs::create_dir_all(root.parent().expect("the parent")).expect("the parent dir");
+    std::fs::write(&root, "a file where the root must be").expect("the blocker");
+    let fold = seal_fold(&root, &pk).expect("the error entry rides");
+    let error = fold["stores"][0]["error"].as_str().expect("the error text");
+    assert!(
+        !error.chars().any(char::is_control),
+        "no live control byte survives: {error:?}"
+    );
+    assert!(
+        error.contains("]52;;pwn"),
+        "the text stays readable: {error}"
+    );
+}
+
+// ─── The query-facet honesty (audit wave B · item 8) ─────────────────
+
+/// `min_score` binds UNIFORMLY against v1's constant 1.0 score: a
+/// threshold above 1.0 — or a NaN — recalls NOTHING (the placeholder
+/// never fails open), an in-range threshold still binds.
+#[tokio::test]
+async fn a_min_score_above_one_recalls_nothing_never_failing_open() {
+    let (_root, dir, pk, sk) = signed_dir();
+    let store = store(dir, sk, pk);
+    store
+        .remember(MemoryFrame::new("a butterfly fact", MemoryLevel::Semantic))
+        .await
+        .expect("remember");
+    for m in [1.5, f32::NAN] {
+        let mut q = RecallQuery::new("butterfly");
+        q.min_score = Some(m);
+        assert!(
+            store.recall(q).await.expect("recall").is_empty(),
+            "min_score {m} must admit nothing (score is a constant 1.0)"
+        );
+    }
+    let mut q = RecallQuery::new("butterfly");
+    q.min_score = Some(0.5);
+    assert_eq!(
+        store.recall(q).await.expect("recall").len(),
+        1,
+        "an in-range threshold binds against the constant score"
+    );
+}
+
+/// The observed window binds when the frame carries the stamp (strictly
+/// inside); a stamp-less entry under a WINDOWED query is SKIPPED — the
+/// named class (the window cannot bind what it cannot read).
+#[tokio::test]
+async fn the_observed_window_binds_and_names_the_stamp_less_skip() {
+    let (_root, dir, pk, sk) = signed_dir();
+    let store = store(dir, sk, pk);
+    let mut old = MemoryFrame::new("an old butterfly fact", MemoryLevel::Semantic);
+    old.observed_at = Some(100); // ns-canonical
+    let mut new = MemoryFrame::new("a new butterfly fact", MemoryLevel::Semantic);
+    new.observed_at = Some(200);
+    store.remember(old).await.expect("remember old");
+    store.remember(new).await.expect("remember new");
+    store
+        .remember(MemoryFrame::new(
+            "a stamp-less butterfly fact",
+            MemoryLevel::Semantic,
+        ))
+        .await
+        .expect("remember stamp-less");
+
+    let mut windowed = RecallQuery::new("butterfly");
+    windowed.observed_after = Some(150);
+    let hits = store.recall(windowed).await.expect("recall");
+    assert_eq!(hits.len(), 1, "only the in-window stamp rides: {hits:?}");
+    assert_eq!(hits[0].content, "a new butterfly fact");
+    assert_eq!(hits[0].observed_at, Some(200));
+
+    // Both bounds + the strict edge (after is exclusive).
+    let mut closed = RecallQuery::new("butterfly");
+    closed.observed_after = Some(200);
+    closed.observed_before = Some(201);
+    assert!(
+        store.recall(closed).await.expect("recall").is_empty(),
+        "observed_at == after is outside (strictly-after semantics)"
+    );
+    let mut unwindowed = RecallQuery::new("butterfly");
+    unwindowed.limit = Some(10);
+    assert_eq!(
+        store.recall(unwindowed).await.expect("recall").len(),
+        3,
+        "an unwindowed query never asks for the stamp"
+    );
+}
+
+/// `limit` keeps the NEWEST: recall ranks ts-descending (the constant
+/// score leaves recency as the honest "ranked") before truncating.
+#[tokio::test]
+async fn the_limit_keeps_the_newest_first() {
+    let (_root, dir, pk, sk) = signed_dir();
+    for (ts, fact) in [
+        (1_700_000_000_001, "fact alpha"),
+        (1_700_000_000_002, "fact beta"),
+        (1_700_000_000_003, "fact gamma"),
+    ] {
+        remember_signed(
+            &dir,
+            UnsignedEntry::new(
+                serde_json::json!({"content": fact}),
+                Integrity::trusted(),
+                "default".to_owned(),
+                "run-1".to_owned(),
+                ts,
+            ),
+            &sk,
+        )
+        .expect("write");
+    }
+    let store = store(dir, sk, pk);
+    let mut q = RecallQuery::new("fact");
+    q.limit = Some(2);
+    let hits = store.recall(q).await.expect("recall");
+    let contents: Vec<&str> = hits.iter().map(|h| h.content.as_str()).collect();
+    assert_eq!(
+        contents,
+        ["fact gamma", "fact beta"],
+        "ts-descending, truncated to the newest — never the oldest"
+    );
+}
+
+/// A non-string `content` (an honestly-signed non-text frame) is ADMITTED
+/// by the substrate and SKIPPED by the trait projection — never a silent
+/// empty-content hit, never a vanishing entry.
+#[tokio::test]
+async fn a_non_string_content_is_skipped_never_an_empty_hit() {
+    let (_root, dir, pk, sk) = signed_dir();
+    remember_signed(
+        &dir,
+        UnsignedEntry::new(
+            serde_json::json!({"content": {"nested": true}}),
+            Integrity::trusted(),
+            "default".to_owned(),
+            "run-1".to_owned(),
+            1_700_000_000_000,
+        ),
+        &sk,
+    )
+    .expect("the honest non-text write signs");
+    let verdicts = recall_verified(&dir, "default", &pk).expect("recall walks");
+    assert_eq!(
+        verdicts[0].verdict,
+        RecallVerdict::Admitted,
+        "the substrate admits it (the signature is honest)"
+    );
+    let store = store(dir, sk, pk);
+    assert!(
+        store
+            .recall(RecallQuery::new(""))
+            .await
+            .expect("recall")
+            .is_empty(),
+        "the projection skips it — an empty-content hit is the failure mode"
+    );
+}
+
+/// The reserved frame fields REFUSE the write (fail-closed): the v1
+/// envelope has no slot for them, so signing anyway would drop them
+/// inside the signature's own attestation.
+#[tokio::test]
+async fn a_reserved_field_refuses_the_write_fail_closed() {
+    let (_root, dir, pk, sk) = signed_dir();
+    let store = store(dir.clone(), sk, pk.clone());
+    for (i, frame) in [
+        {
+            let mut f = MemoryFrame::new("ciphered", MemoryLevel::Working);
+            f.cipher = Some("aes-gcm".to_owned());
+            f
+        },
+        {
+            let mut f = MemoryFrame::new("provenanced", MemoryLevel::Working);
+            f.provenance = Some("hand-crafted".to_owned());
+            f
+        },
+        {
+            let mut f = MemoryFrame::new("retained", MemoryLevel::Working);
+            f.retention = Some("ttl:1h".to_owned());
+            f
+        },
+        {
+            let mut f = MemoryFrame::new("redacted", MemoryLevel::Working);
+            f.redactions = Some(vec!["$.pii".to_owned()]);
+            f
+        },
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let err = store.remember(frame).await.expect_err("reserved refuses");
+        assert!(
+            err.to_string().contains("reserved frame fields"),
+            "the refusal names the class ({i}): {err}"
+        );
+    }
+    assert!(
+        recall_verified(&dir, "default", &pk)
+            .expect("recall walks")
+            .is_empty(),
+        "nothing ever landed — the refusal is total"
+    );
+}

--- a/crates/nika-store/src/traits.rs
+++ b/crates/nika-store/src/traits.rs
@@ -10,14 +10,23 @@
 //! ADMITTED entries only — rejections are never hits; they stay named in
 //! [`crate::recall_verified`] and counted in the seal fold.
 //!
-//! Three query facets are named, never silently half-applied: **v1 is
+//! The query facets are named, never silently half-applied: **v1 is
 //! single-tenant** — a non-default [`RecallQuery::tenant`] scope recalls
 //! NOTHING, never everything (ADR-031's mandatory keyspace scope, failed
-//! closed); **`min_score`** is a placeholder (v1 recall is substring, not
-//! similarity — the score is a constant 1.0, so no threshold can bind);
-//! **`observed_after`/`observed_before`** stay deferred (reserved for the
-//! temporal satellite — the frame carries the stamp, v1 does not filter
-//! on it).
+//! closed); **`min_score`** binds UNIFORMLY against v1's constant 1.0
+//! score (substring recall carries no similarity — a threshold above 1.0,
+//! or a NaN, admits nothing; the placeholder never fails open);
+//! **`observed_after`/`observed_before`** bind when the frame carries the
+//! stamp — a stamp-less entry under a WINDOWED query is SKIPPED (the
+//! window cannot bind what it cannot read), never silently windowed-in;
+//! **`limit`** keeps the NEWEST hits (recall ranks ts-descending — the
+//! constant score leaves recency as the honest "ranked" the kernel
+//! contract names). The projection's skip classes — a non-string
+//! `content`, an unknown level word — are named on the recall impl, and
+//! the reserved frame fields (`cipher` · `provenance` · `retention` ·
+//! `redactions`) REFUSE the write (fail-closed — the signed envelope
+//! carries no slot for them, so writing would drop them INSIDE a
+//! signature).
 
 use std::path::PathBuf;
 
@@ -112,7 +121,12 @@ fn frame_value(frame: &MemoryFrame) -> Value {
 }
 
 /// The `MemoryLevel` wire word (mirrors its serde `snake_case` — the frame
-/// value stays readable without the nika-types serde feature).
+/// value stays readable without the nika-types serde feature). The
+/// asymmetry, named: the WRITE side maps a future level to `"working"` —
+/// the signed envelope must stamp SOME word and the future tier's real
+/// name is unknowable here — while the READ side SKIPS an unknown word
+/// (`level_from_str` returns `None`, never a silent downgrade); the
+/// round-trip holds exactly for the tiers this version knows.
 fn level_str(level: MemoryLevel) -> &'static str {
     match level {
         MemoryLevel::Episodic => "episodic",
@@ -140,6 +154,24 @@ fn level_from_str(word: &str) -> Option<MemoryLevel> {
 
 impl MemoryRemember for SignedMemoryStore {
     async fn remember(&self, frame: MemoryFrame) -> Result<MemoryId, MemoryError> {
+        // Fail CLOSED on the reserved fields (cipher · provenance ·
+        // retention · redactions): the v1 envelope carries no slot for
+        // them, so writing anyway would DROP them inside a SIGNED
+        // envelope — a silent loss the signature would then attest.
+        // (Storage is the write path's error class; this refusal is
+        // deterministic — a retry of the same frame refuses again.)
+        if frame.cipher.is_some()
+            || frame.provenance.is_some()
+            || frame.retention.is_some()
+            || frame.redactions.is_some()
+        {
+            return Err(MemoryError::Storage {
+                reason: "reserved frame fields (cipher · provenance · retention · redactions) \
+                     have no slot in the v1 signed envelope — the write is refused, \
+                     never silently dropped inside a signature"
+                    .to_owned(),
+            });
+        }
         let entry = crate::UnsignedEntry::new(
             frame_value(&frame),
             self.label.clone(),
@@ -153,7 +185,101 @@ impl MemoryRemember for SignedMemoryStore {
     }
 }
 
+/// The trait projection of one ADMITTED entry — `None` = the hit is
+/// SKIPPED, the class named where it happens (the trait surface carries
+/// no skip-count channel, so the naming lives in these comments): a
+/// non-string `content` (an honestly-signed non-text frame is not
+/// recallable as text — never a silent empty-content hit, never a
+/// vanishing entry) · an unknown level word (fail-closed tier — skipped,
+/// never downgraded to `Working`; the entry stays ADMITTED in
+/// `recall_verified`, only this projection declines it) · a stamp-less
+/// entry under an observed-window query (the window cannot bind what it
+/// cannot read).
+fn project_hit(entry: &crate::StoreEntry, query: &RecallQuery, needle: &str) -> Option<MemoryHit> {
+    let content = entry
+        .frame
+        .get("content")
+        .and_then(Value::as_str)?
+        .to_owned();
+    if !needle.is_empty() && !content.to_lowercase().contains(needle) {
+        return None;
+    }
+    let level = match entry.frame.get("level").and_then(Value::as_str) {
+        // A v1 writer always stamps the level; a missing word stays the
+        // v1 default (named, not silent).
+        None => MemoryLevel::Working,
+        Some(word) => level_from_str(word)?, // fail-closed tier (the fn doc)
+    };
+    if query.levels.as_ref().is_some_and(|ls| !ls.contains(&level)) {
+        return None;
+    }
+    // min_score binds UNIFORMLY against v1's constant score (every hit
+    // scores 1.0): a threshold above 1.0 admits nothing, and a NaN
+    // threshold admits nothing either (every NaN comparison is false) —
+    // the placeholder never fails open.
+    if query.min_score.is_some_and(|m| m > 1.0 || m.is_nan()) {
+        return None;
+    }
+    // The observed window binds when the frame carries the stamp (the
+    // kernel's ns-canonical `observed_at`), STRICTLY inside: a stamp-less
+    // entry under a windowed query is skipped (the fn doc names the
+    // class); an unwindowed query never asks.
+    if query.observed_after.is_some() || query.observed_before.is_some() {
+        let observed = entry.frame.get("observed_at").and_then(Value::as_u64)?;
+        if query.observed_after.is_some_and(|after| observed <= after) {
+            return None;
+        }
+        if query
+            .observed_before
+            .is_some_and(|before| observed >= before)
+        {
+            return None;
+        }
+    }
+    let tags: Vec<String> = entry
+        .frame
+        .get("tags")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|t| t.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+    if query
+        .tags
+        .as_ref()
+        .is_some_and(|want| !want.iter().all(|t| tags.contains(t)))
+    {
+        return None;
+    }
+    let mut hit = MemoryHit::new(entry.memory_id(), content, level, 1.0);
+    hit.tags = tags;
+    hit.metadata = entry
+        .frame
+        .get("metadata")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    hit.source = entry
+        .frame
+        .get("source")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    hit.observed_at = entry.frame.get("observed_at").and_then(Value::as_u64);
+    Some(hit)
+}
+
 impl MemoryRecall for SignedMemoryStore {
+    /// v1 recall is substring over ADMITTED entries, ranked MOST-RECENT
+    /// FIRST (ts descending — the constant score carries no similarity
+    /// signal, so recency is the honest "ranked" the kernel contract
+    /// names): `limit` then keeps the NEWEST hits, never the oldest.
+    /// `tags` is conjunctive-ALL (every wanted tag must ride the frame —
+    /// an EMPTY wanted set admits everything, the vacuous truth), while
+    /// `levels: Some([])` filters EVERYTHING (`contains` on an empty set
+    /// is false) — two different empty-set postures, both named. The skip
+    /// classes are named on the `project_hit` projection (non-string
+    /// content · unknown level word · stamp-less under a window).
     async fn recall(&self, query: RecallQuery) -> Result<Vec<MemoryHit>, MemoryError> {
         // ADR-031 fail-CLOSED: v1 is single-tenant — a non-default scope
         // recalls NOTHING, never everything (an unscoped sweep would leak
@@ -169,68 +295,15 @@ impl MemoryRecall for SignedMemoryStore {
             let (crate::RecallVerdict::Admitted, Some(entry)) = (ev.verdict, ev.entry) else {
                 continue;
             };
-            let content = entry
-                .frame
-                .get("content")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_owned();
-            if !needle.is_empty() && !content.to_lowercase().contains(&needle) {
-                continue;
+            if let Some(hit) = project_hit(&entry, &query, &needle) {
+                hits.push((entry.ts_ms, hit));
             }
-            let level = match entry.frame.get("level").and_then(Value::as_str) {
-                // A v1 writer always stamps the level; a missing word
-                // stays the v1 default (named, not silent).
-                None => MemoryLevel::Working,
-                Some(word) => {
-                    let Some(level) = level_from_str(word) else {
-                        // Fail-closed tier: the signature VERIFIED (the
-                        // content is honest) but the level word is one
-                        // this version does not know — the hit is SKIPPED,
-                        // never downgraded to Working. The entry stays
-                        // ADMITTED in `recall_verified`; only this trait
-                        // projection declines it (named here — the trait
-                        // surface carries no skip-count channel).
-                        continue;
-                    };
-                    level
-                }
-            };
-            if query.levels.as_ref().is_some_and(|ls| !ls.contains(&level)) {
-                continue;
-            }
-            let tags: Vec<String> = entry
-                .frame
-                .get("tags")
-                .and_then(Value::as_array)
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|t| t.as_str().map(str::to_owned))
-                        .collect()
-                })
-                .unwrap_or_default();
-            if query
-                .tags
-                .as_ref()
-                .is_some_and(|want| !want.iter().all(|t| tags.contains(t)))
-            {
-                continue;
-            }
-            let mut hit = MemoryHit::new(entry.memory_id(), content, level, 1.0);
-            hit.tags = tags;
-            hit.metadata = entry
-                .frame
-                .get("metadata")
-                .and_then(|v| serde_json::from_value(v.clone()).ok())
-                .unwrap_or_default();
-            hit.source = entry
-                .frame
-                .get("source")
-                .and_then(Value::as_str)
-                .map(str::to_owned);
-            hit.observed_at = entry.frame.get("observed_at").and_then(Value::as_u64);
-            hits.push(hit);
         }
+        // Most-recent first (the impl doc names why recency is the rank);
+        // the stable sort keeps the walk's deterministic path order
+        // inside one timestamp.
+        hits.sort_by(|a, b| b.0.cmp(&a.0));
+        let mut hits: Vec<MemoryHit> = hits.into_iter().map(|(_, hit)| hit).collect();
         if let Some(limit) = query.limit {
             hits.truncate(limit);
         }

--- a/docs/crate-specs/nika-store.md
+++ b/docs/crate-specs/nika-store.md
@@ -6,7 +6,7 @@
 | Layer | L1 — memory satellite · the signed-write/verified-recall substrate · `Send + Sync` |
 | Sub-tier | L1-deterministic — pure sign/verify + atomic file envelope · no async at the trait boundary |
 | Design | **F-P8 (SMSR arXiv:2606.12703 · TMA-NM 2606.24322 · MemLineage 2605.14421)** — every store write is SIGNED at write, the label INSIDE the signature; every recall VERIFIES per entry — unsigned · bad signature · rewritten label = REJECTED (never filtered) |
-| LOC budget | ≤1,020 src measured (entry ~220 · dir ~135 · sign ~310 · traits ~255 · errors ~50 · lib ~45) — re-allocated TWICE, honestly: the first sketch's ≤600 missed what the review swarm then priced (the filters and verdict classes the law requires: tenant fail-closed · level skip · name binding · version dispatch → ~820 estimated), and the implementation priced what the estimate still missed (the fold's failure-honesty walk · the third-leg rejection substrate · and the rustdoc the named-not-silent posture writes in full — no fake-compression to fit a number) |
+| LOC budget | ≤1,270 src measured (entry ~220 · dir ~255 · sign ~360 · traits ~325 · errors ~60 · lib ~45) — re-allocated THREE times, honestly: the first sketch's ≤600 missed what the review swarm then priced (the filters and verdict classes the law requires: tenant fail-closed · level skip · name binding · version dispatch → ~820 estimated), the implementation priced what the estimate still missed (the fold's failure-honesty walk · the third-leg rejection substrate · and the rustdoc the named-not-silent posture writes in full — no fake-compression to fit a number), and audit wave B (2026-07-30) priced the hardening the first ship deferred: the O(1) set-digest fold (H13) · the walk's two named bounds (oversize + overflow) · the commit's read-before-rename with the named Conflict · 0600/0700 secret-bearing modes · the trait surface's applied filters (min_score · observed window · ts-ranked limit · the fail-closed reserved fields) → ~1,265 real |
 | File cap | ≤1,500 LOC each |
 | Function cap | ≤100 lines each |
 | Crate version | tracks workspace |
@@ -46,9 +46,14 @@ touches the key). At recall, every entry is verified **per entry**:
   the signed preimage, so a relabel IS a signature mismatch.
 
 Rejections are never silent filtering: each is a named verdict, a
-journaled event (`memory_entry_rejected` · additive EventKind), and a
-count the run's seal pins in `covers["memory"]` beside the admitted-set
-digests — the receipt names the verified SET.
+journaled event (`memory_entry_rejected` · additive EventKind — bounded,
+the first 32 named + one `memory_rejections_summary` with the true
+total), and a count the run's seal pins in `covers["memory"]` beside the
+admitted set's ONE constant-size digest — the receipt names the verified
+SET, and the set's digest IS its name: blake3 over the sorted digests +
+`admitted_count` keeps the seal line O(1), so a long-lived store can
+never grow a seal line the chain walk's own 1 MiB bound would reject
+(H13 — an inline `[digest…]` list crosses it at ~15k entries).
 
 The crate implements the kernel memory traits
 (`MemoryRemember · MemoryRecall · MemoryForget` + `Sealed` per ADR-078)
@@ -92,11 +97,22 @@ without knowing the signature exists.
    named v2 owe above changes the preimage, decode dispatches on `v`,
    and an unknown version rejects with the named
    `unsupported_version` (never a masquerading `bad_signature`). The seal
-   fold carries its own `"v": 1` beside the store entries. Rejections
-   are journaled one `memory_entry_rejected` event each BEFORE the seal
-   (the law's third leg — the chain covers the names the fold counts),
-   and a store whose walk fails rides the fold as a named
-   `{"store", "error"}` entry, never a collapsed `None`.
+   fold carries its own `"v": 1` beside the store entries — per store
+   `{"store", "set_digest", "admitted_count", "rejected"}` (the O(1)
+   shape, audit wave B · H13) or `{"store", "error"}`. The `"v"` stays
+   **1** across the wave-B shape change, decided honestly: the fold
+   shipped only in #755 and NO tagged release contains it
+   (`git tag --contains 62728587b` is empty — v0.106.1 predates it), so
+   the only consumers ride the same unreleased `main` and move in the
+   same wave; a bump would claim a compatibility boundary with a shape
+   that never reached a release. `v: 1` IS the shipped form, documented
+   here. Rejections are journaled BEFORE the seal, BOUNDED: the first
+   `MAX_JOURNALED_REJECTIONS` (32) ride one `memory_entry_rejected`
+   event each, a flood beyond gets ONE `memory_rejections_summary`
+   carrying the true total (H14 · the law's third leg — the chain
+   covers the names the fold counts), and a store whose walk fails
+   rides the fold as a named `{"store", "error"}` entry, never a
+   collapsed `None`.
 
 ## 3. Public API (draft — the only surface v1 admits)
 
@@ -142,8 +158,8 @@ pub enum StoreError { /* Io · Serialize · KeyMismatch · DirLayout */ }
 ## 4. Acceptance (the law's own pairs)
 
 - **positive** — a legit write is signed + labeled; recall admits it;
-  the seal's `covers["memory"]` pins the admitted digests + the
-  rejection count.
+  the seal's `covers["memory"]` pins the admitted set's digest + the
+  counts.
 - **negative 1** — an entry added OUTSIDE the engine (a direct file
   edit in the store dir) is REJECTED at recall (verify KO) — never
   admitted, never filtered.

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4237
+  classified_files: 4239
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1320
+    authored: 1322
     authored-pin: 2
     generated: 114
     pinned-copy: 105
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 7626fe82839a770d242fb6aa981df7d110fafeb596795cb7f6feaed0a94af067
+  sha256: 6ef2d9454655504834e29570c4f9d5940aa7b0b56bc41144892919e6ff166ef6
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -125,7 +125,7 @@ patterns:
 - glob: "crates/nika-runtime/fixtures/adversarial/**"
   class: testimonial
   match_count: 32
-  aggregate_sha256: bcdd0e2ed4eed0e5b0fd42bd8c4e33de12028742c26012926ed025881bd0eef8
+  aggregate_sha256: 02849aecb27bf7d742a14f588bb5d5e483a4241d79164e780e8b11a74f892576
   evidence: "attack.nika.yaml + expected.json pairs consumed by crates/nika-runtime/src/adversarial/tests.rs — the injection red-team battery owned by the runtime"
 - glob: "fuzz/corpus/**"
   class: testimonial
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 58
-  aggregate_sha256: fa5d0701f2ba8711e7514a1bddb053e8e30a4e430864c0beae64c149c4d45954
+  aggregate_sha256: 20083686129c6f89f932836a5c551362338a35a0a134aac7b3e258af2b08be0d
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --all-features --omit auto-trait-impls > crates/<crate>/public-api.txt (cargo-public-api 0.51.0 pinned · regenerate from the public-api-actual CI artifact)"
@@ -151,18 +151,18 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 660
-  aggregate_sha256: 0bce1c2530cad815b445c644ee31e2561c47091e2a89c13ce3b50af6e49925f8
+  match_count: 661
+  aggregate_sha256: c29c24899b7be3126d6ff07c92b37929570a78da65897adb4cd89291af8996e2
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 115
-  aggregate_sha256: 20d32eb60c997074cd6c9b14a7e1b0b0ef76b5747f2a53967a1320e23c769aba
+  aggregate_sha256: 13967911304c22a1d7e581a2b47ae43dbbd54f667f2774c6e40091515775fb4e
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
   match_count: 123
-  aggregate_sha256: a59653bf8cf18bb33b101a1d4d7533d035e32c3ebe89f38bcbb1ea39de89ba11
+  aggregate_sha256: 56e6a659f6328e1708a6835775bda1b83b0e19449e7578e504f7686361652824
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -177,13 +177,13 @@ patterns:
   evidence: "per-decision records authored at decision time (scripts/adr/new.sh scaffolds · adr-seal-check hook seals); index.toml excepted in files:"
 - glob: "docs/**"
   class: authored
-  match_count: 96
-  aggregate_sha256: 027358364374a91b9e7beb4e8e5be83fa3f9a38af6b67583a6486d46c6eed925
+  match_count: 97
+  aggregate_sha256: e59f01b1604cfe476876d97f9714b2a5ca7783439ca559644976d61ba3252c21
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 129
-  aggregate_sha256: f6832e910bdf737fa15017c5c3e2a5f48a053862de3e9fa998a4ee026bab6341
+  aggregate_sha256: a4a7b31790ad0cf7768ffef3f258b973e766aea9bf29c42e2bd2709eefadee17
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored


### PR DESCRIPTION
The admission's own audit, second wave — the substrate can no longer hurt itself:

- **the fold is O(1)**: per store, set_digest (blake3 over the sorted admitted set) + admitted_count + rejected — the seal line is constant-size and can never meet the chain walk's 1 MiB cap (~15k entries would have self-DoSed the verifier). Kept v:1 with the decision documented: no tag ever carried the old shape.
- **bounded rejection journal**: first 32 named events + one memory_rejections_summary with the true total.
- **escape at birth** (NEP-0012 law 2): store names, entry paths, fold error entries strip control bytes where they're born.
- **attend never collapses**: a planted file at .nika/memory is a named error entry, not absence.
- **honest idempotence**: same preimage = no-op; divergent same-name = StoreError::Conflict (minisign's randomized sig box makes a byte-compare lie — documented).
- **walk bounds**: 1 MiB/entry (oversized named) · 1024 entries/store (overflow named) · entries 0600 · dirs 0700.
- **trait surface honors the query contract**: min_score fail-closed · strict observed window · ranked most-recent-first · named skip classes · reserved frame fields refuse the write.

42 store tests · 5,195 workspace · E2E 6/6 at the real binary · clippy 0 · fmt · doc clean · spec budget amended with reasons itemized.