### PR TITLE
feat(check): the judge-night lane lands — judged defaults, energy aggregate, adversarial greens

### DIFF
--- a/.github/workflows/forward-compat.yml
+++ b/.github/workflows/forward-compat.yml
@@ -57,8 +57,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
-          # nika-fx and nika-onboard are publish=true (nika-bm25 class) but
-          # have no crates.io release yet — the action hard-errors on the
-          # registry lookup for a never-published crate. Remove each at its
-          # first release.
-          exclude: nika-fx,nika-onboard,nika-graph
+          # nika-fx, nika-onboard and nika-store are publish=true (nika-bm25
+          # class) but have no crates.io release yet — the action hard-errors
+          # on the registry lookup for a never-published crate. Remove each at
+          # its first release.
+          exclude: nika-fx,nika-onboard,nika-graph,nika-store

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -2658,6 +2658,7 @@ pub fn nika_check::lowered_returns(wf: &nika_schema::raw::workflow::RawWorkflow)
 pub fn nika_check::named_types(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::types::NikaType>
 pub fn nika_check::policy_wire_code(rule: &str) -> &'static str
 pub fn nika_check::returns_type(task: &nika_schema::raw::task::RawTask, wf: &nika_schema::raw::workflow::RawWorkflow) -> core::option::Option<nika_types::types::NikaType>
+pub fn nika_check::static_literal_of<'w>(wf: &'w nika_schema::raw::workflow::RawWorkflow, expr: &str) -> core::option::Option<&'w serde_json::value::Value>
 pub fn nika_check::static_read_paths(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
 pub fn nika_check::task_permits(task: &nika_schema::raw::task::RawTask) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_check::with_model_override(wf: &nika_schema::raw::workflow::RawWorkflow, model: &str) -> nika_schema::raw::workflow::RawWorkflow

--- a/crates/nika-check/src/analysis.rs
+++ b/crates/nika-check/src/analysis.rs
@@ -20,18 +20,19 @@
 //! - **blast radius** — AND-join makes failure analysis exact: a failed
 //!   task blocks EVERY transitive dependent;
 //! - **write-write conflicts** (F-P15 · NEP-0014 law 1) — two tasks that
-//!   CAN run concurrently (incomparable) and both target the same literal
-//!   `nika:write`/`nika:edit` path, compared under LEXICAL normalization
-//!   (`./out/x.md` ≡ `out//x.md` ≡ `out/d/../x.md` ≡ `out/x.md` — pure
-//!   text, no filesystem claim; see [`normalize_lexical`]):
-//!   last-writer-wins is a race the file never declares. The LAW (a
-//!   `NIKA-SEC-012` finding · deterministic) — promoted from its
-//!   advisory-hint era 2026-07-29: parallelism is safe exactly where the
-//!   effects are provably disjoint, and a hint is not a boundary. Above
-//!   [`ANALYSIS_TASK_CAP`] the closure-based pair scan is skipped and
-//!   the skip is STATED ([`DagRead::stated_miss`] — the report carries
-//!   it as a hint, never a silent no-claim); the closure-free
-//!   `for_each` same-path flavor still judges.
+//!   CAN run concurrently (incomparable) and both write the same STATIC
+//!   `nika:write`/`nika:edit` key (literal · resolved bare ref ·
+//!   identical immutable ref — [`static_write_key`]), compared under
+//!   LEXICAL normalization (`./out/x.md` ≡ `out//x.md` ≡
+//!   `out/d/../x.md` ≡ `out/x.md` — pure text, no filesystem claim; see
+//!   [`normalize_lexical`]): last-writer-wins is a race the file never
+//!   declares. The LAW (a `NIKA-SEC-012` finding · deterministic) —
+//!   promoted from its advisory-hint era 2026-07-29: parallelism is safe
+//!   exactly where the effects are provably disjoint, and a hint is not
+//!   a boundary. Above [`ANALYSIS_TASK_CAP`] the closure-based pair scan
+//!   is skipped and the skip is STATED ([`DagRead::stated_miss`] — the
+//!   report carries it as a hint, never a silent no-claim); the
+//!   closure-free `for_each` same-path flavor still judges.
 //!
 //! Width can EXCEED the largest wave — witness `p→a1→x2 · p→x1 ·
 //! isolated x0`: waves peak at 2, width is 3 (`{x0, x1, x2}`). The
@@ -50,8 +51,8 @@ use nika_schema::source::Spanned;
 const WRITE_CONFLICT_CODE: &str = "NIKA-SEC-012";
 
 /// One write-write conflict (F-P15 · NEP-0014 law 1): two tasks
-/// incomparable in the DAG closure whose literal `nika:write` /
-/// `nika:edit` paths collide under lexical normalization, or a
+/// incomparable in the DAG closure whose STATIC `nika:write` /
+/// `nika:edit` keys collide under lexical normalization, or a
 /// `for_each` fan writing one constant path — the last-writer-wins
 /// race, refused at check.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -63,9 +64,11 @@ pub struct WriteConflict {
     /// The second writer — `None` for the `for_each` flavor (the task
     /// races its own iterations).
     pub other: Option<String>,
-    /// The colliding path in its LEXICAL normal form (the pair flavor —
-    /// both literals reduce to it) · the literal as spelled (the
-    /// `for_each` flavor — nothing is compared).
+    /// The colliding key in its LEXICAL normal form (the pair flavor —
+    /// both keys reduce to it) · the key as spelled (the `for_each`
+    /// flavor — nothing is compared). A key is a literal path, or the
+    /// canonical bare-ref form (`${{ inputs.f }}`) when the shared
+    /// value is not statically known ([`static_write_key`]).
     pub path: String,
     /// The witness sentence (the race, named — both spellings when the
     /// literals differ textually).
@@ -436,13 +439,27 @@ fn koenig_witness(
     (0..n).filter(|&i| z_left[i] && !z_right[i]).collect()
 }
 
-/// The literal `nika:write`/`nika:edit` target of a task, when
-/// statically known — island-bearing paths are dynamic and make no
-/// static claim. (H4 · the canon text names BOTH writer builtins: they
-/// take `path:` identically and return it as their output, and the
-/// edit's read-modify-write loses updates to a concurrent writer
-/// exactly like the write's rename does.)
-fn literal_write_path(task: &RawTask) -> Option<&str> {
+/// The STATIC write key of a task's `nika:write`/`nika:edit` target —
+/// two equal keys provably denote the same runtime path:
+///
+/// - a **literal** path (no template) — the key is the path;
+/// - a bare immutable-authority ref whose declaration carries a string
+///   literal — resolved through the ONE shared resolver
+///   ([`crate::static_literal_of`]), so a literal writer and a
+///   `${{ const.p }}` writer on the same path collide;
+/// - a bare immutable-authority ref with NO declared literal — the key
+///   is its canonical form: two IDENTICAL `${{ inputs.f }}` writers
+///   target the same file even while its value is unknown (inputs bind
+///   once per run · const/config never change). Measured 2026-07-30:
+///   this exact shape rendered green while its literal twin was
+///   refused.
+///
+/// Anything else (task refs · `with:` bindings · `${{ item }}` ·
+/// concatenations) is dynamic and makes no static claim. (H4 · both
+/// writer builtins take `path:` identically, and the edit's
+/// read-modify-write loses updates to a concurrent writer exactly like
+/// the write's rename does.)
+fn static_write_key(wf: &RawWorkflow, task: &RawTask) -> Option<String> {
     let RawAction::Invoke(invoke) = &task.action else {
         return None;
     };
@@ -452,13 +469,15 @@ fn literal_write_path(task: &RawTask) -> Option<&str> {
     ) {
         return None;
     }
-    invoke
-        .args
-        .as_ref()?
-        .value
-        .get("path")?
-        .as_str()
-        .filter(|p| !p.contains("${{"))
+    let path = invoke.args.as_ref()?.value.get("path")?.as_str()?;
+    if !path.contains("${{") {
+        return Some(path.to_owned());
+    }
+    if let Some(lit) = crate::static_literal_of(wf, path).and_then(|v| v.as_str()) {
+        return Some(lit.to_owned());
+    }
+    crate::walk::bare_static_ref(path)
+        .map(|(authority, name)| format!("${{{{ {authority}{name} }}}}"))
 }
 
 /// The LEXICAL normal form two write paths are compared under (H5 ·
@@ -509,18 +528,25 @@ fn normalize_lexical(path: &str) -> String {
 
 /// Write-write races, statically (F-P15 · NEP-0014 law 1): two tasks
 /// that CAN run concurrently (incomparable in the closure) and both
-/// target the same literal path under lexical normalization — plus the
-/// fan-out flavor ([`scan_for_each_fans`]). The LAW: each conflict is a
-/// finding (an ordering edge — `after:` / `with:` — discharges it;
-/// parallelism is safe exactly where the writes are provably disjoint).
+/// write the same STATIC key ([`static_write_key`] — a literal, a
+/// resolved bare ref, or two identical bare immutable refs) under
+/// lexical normalization — plus the fan-out flavor
+/// ([`scan_for_each_fans`]). The LAW: each conflict is a finding (an
+/// ordering edge — `after:` / `with:` — discharges it; parallelism is
+/// safe exactly where the writes are provably disjoint).
 fn scan_parallel_writers(wf: &RawWorkflow, desc: &[Vec<u64>]) -> Vec<WriteConflict> {
     let mut conflicts = scan_for_each_fans(wf);
-    // (task index · the literal as spelled · its lexical normal form).
-    let writers: Vec<(usize, &str, String)> = wf
+    // (task index · the key as spelled · its lexical normal form).
+    let writers: Vec<(usize, String, String)> = wf
         .tasks
         .iter()
         .enumerate()
-        .filter_map(|(i, t)| literal_write_path(&t.value).map(|p| (i, p, normalize_lexical(p))))
+        .filter_map(|(i, t)| {
+            static_write_key(wf, &t.value).map(|p| {
+                let n = normalize_lexical(&p);
+                (i, p, n)
+            })
+        })
         .collect();
 
     let comparable = |a: usize, b: usize| -> bool {
@@ -569,15 +595,15 @@ fn scan_for_each_fans(wf: &RawWorkflow) -> Vec<WriteConflict> {
     let mut conflicts = Vec::new();
     for t in &wf.tasks {
         if t.value.for_each.is_some()
-            && let Some(path) = literal_write_path(&t.value)
+            && let Some(path) = static_write_key(wf, &t.value)
         {
             let task = t.value.id.value.clone();
             conflicts.push(WriteConflict {
                 task: task.clone(),
                 other: None,
-                path: path.to_owned(),
+                path: path.clone(),
                 detail: format!(
-                    "every `for_each` iteration of `{task}` writes the SAME literal \
+                    "every `for_each` iteration of `{task}` writes the SAME \
                      path `{path}` — the last iteration silently wins"
                 ),
                 fix: "derive the path from `${{ item }}` so each iteration writes \
@@ -930,6 +956,52 @@ mod tests {
         );
         assert_eq!(report.write_conflicts.len(), 1);
         assert_eq!(report.write_conflicts[0].task, "fan");
+    }
+
+    #[test]
+    fn identical_immutable_ref_writers_are_a_finding() {
+        // Probe 2026-07-30: two unordered writers on the IDENTICAL
+        // `${{ inputs.f }}` rendered green while the literal twin was
+        // refused — inputs bind once per run, so the two provably
+        // target the same file even though its value is unknown.
+        let yaml = "nika: v1\nworkflow:\n  id: t\n\nmodel: mock/echo\n\ninputs:\n  f: { type: string, required: true }\n\ntasks:\n  a:\n    invoke:\n      tool: nika:write\n      args:\n        path: \"${{ inputs.f }}\"\n        content: \"a\"\n  b:\n    invoke:\n      tool: nika:write\n      args:\n        path: \"${{ inputs.f }}\"\n        content: \"b\"\n";
+        let conflicts = read(yaml).conflicts;
+        assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+        let c = &conflicts[0];
+        assert_eq!(c.path, "${{ inputs.f }}", "the canonical ref IS the key");
+        assert_eq!(c.wire_code(), "NIKA-SEC-012");
+    }
+
+    #[test]
+    fn a_literal_writer_and_a_resolved_ref_writer_collide() {
+        // The shared resolver arm: `${{ const.p }}` declares the SAME
+        // literal another task writes directly — one path, two spellings.
+        let yaml = "nika: v1\nworkflow:\n  id: t\n\nmodel: mock/echo\n\nconst:\n  p: out/report.md\n\ntasks:\n  a:\n    invoke:\n      tool: nika:write\n      args:\n        path: out/report.md\n        content: \"a\"\n  b:\n    invoke:\n      tool: nika:write\n      args:\n        path: \"${{ const.p }}\"\n        content: \"b\"\n";
+        let conflicts = read(yaml).conflicts;
+        assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+        assert_eq!(
+            conflicts[0].path, "out/report.md",
+            "resolved to the literal"
+        );
+    }
+
+    #[test]
+    fn distinct_immutable_refs_make_no_claim() {
+        // Two DIFFERENT bare refs may or may not collide at run — the
+        // scan never guesses.
+        let yaml = "nika: v1\nworkflow:\n  id: t\n\nmodel: mock/echo\n\ninputs:\n  f: { type: string, required: true }\n  g: { type: string, required: true }\n\ntasks:\n  a:\n    invoke:\n      tool: nika:write\n      args:\n        path: \"${{ inputs.f }}\"\n        content: \"a\"\n  b:\n    invoke:\n      tool: nika:write\n      args:\n        path: \"${{ inputs.g }}\"\n        content: \"b\"\n";
+        assert!(read(yaml).conflicts.is_empty());
+    }
+
+    #[test]
+    fn a_for_each_fan_over_one_immutable_ref_races_itself() {
+        // The fan flavor reaches the ref class too: every iteration
+        // writes `${{ inputs.f }}` — one file, N writers.
+        let yaml = "nika: v1\nworkflow:\n  id: t\n\nmodel: mock/echo\n\ninputs:\n  f: { type: string, required: true }\n\ntasks:\n  fan:\n    for_each: [1, 2]\n    invoke:\n      tool: nika:write\n      args:\n        path: \"${{ inputs.f }}\"\n        content: \"x\"\n";
+        let conflicts = read(yaml).conflicts;
+        assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+        assert_eq!(conflicts[0].other, None);
+        assert_eq!(conflicts[0].path, "${{ inputs.f }}");
     }
 
     #[test]

--- a/crates/nika-check/src/analysis.rs
+++ b/crates/nika-check/src/analysis.rs
@@ -68,7 +68,7 @@ pub struct WriteConflict {
     /// both keys reduce to it) · the key as spelled (the `for_each`
     /// flavor — nothing is compared). A key is a literal path, or the
     /// canonical bare-ref form (`${{ inputs.f }}`) when the shared
-    /// value is not statically known ([`static_write_key`]).
+    /// value is not statically known (`static_write_key`).
     pub path: String,
     /// The witness sentence (the race, named — both spellings when the
     /// literals differ textually).

--- a/crates/nika-check/src/cost.rs
+++ b/crates/nika-check/src/cost.rs
@@ -22,7 +22,6 @@
 //! the floor of your *exposure*, not of the actual spend.
 
 use nika_schema::raw::{ForEachValue, RawAction, RawWorkflow};
-use nika_schema::types::VarDecl;
 
 /// Per-task cost envelope.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -267,38 +266,16 @@ pub(super) fn output_price_per_million(model: &str) -> Option<f64> {
     nika_catalog::find_pricing_for(model).map(|p| p.output_per_million)
 }
 
-/// A `for_each:` count that is statically known: the expression is exactly
-/// `${{ <authority>.<name> }}` (inputs · config · const — the value
-/// authorities whose declared value is static) and that name declares a
-/// LITERAL array (an untyped array value, or a typed-array with a literal
-/// `default:`). Returns `None` for anything else — a task-output ref, a
+/// A `for_each:` count that is statically known: the expression resolves
+/// through the ONE shared resolver ([`crate::static_literal_of`] — a bare
+/// `${{ <authority>.<name> }}` whose declaration carries a literal) to an
+/// ARRAY literal. Returns `None` for anything else — a task-output ref, a
 /// computed/navigated expression, a typed input with no default, or a
 /// non-array value — which stays an unknown count (`UnknownIterations`).
 pub(super) fn static_vars_array_len(wf: &RawWorkflow, expr: &str) -> Option<u64> {
-    let inner = expr.trim().strip_prefix("${{")?.strip_suffix("}}")?.trim();
-    let (authority, name) = ["const.", "inputs.", "config."]
-        .into_iter()
-        .find_map(|ns| inner.strip_prefix(ns).map(|n| (ns, n)))?;
-    // A BARE `<authority>.<name>` only — reject further navigation
-    // (`.field` · `[0]`) or operators, whose runtime value is not
-    // statically known.
-    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
-        return None;
-    }
-    let block = match authority {
-        "const." => &wf.consts,
-        "inputs." => &wf.inputs,
-        _ => &wf.config,
-    };
-    let (_, decl) = block.iter().find(|(k, _)| k.value == name)?;
-    let value = match decl {
-        VarDecl::Untyped(v)
-        | VarDecl::Typed {
-            default: Some(v), ..
-        } => v,
-        VarDecl::Typed { default: None, .. } => return None,
-    };
-    value.as_array().map(|a| a.len() as u64)
+    crate::static_literal_of(wf, expr)?
+        .as_array()
+        .map(|a| a.len() as u64)
 }
 
 #[cfg(test)]
@@ -691,6 +668,7 @@ mod static_vars_array_len_unit {
     use super::*;
     use nika_schema::raw::RawWorkflow;
     use nika_schema::source::{Span, Spanned};
+    use nika_schema::types::VarDecl;
 
     fn var(name: &str, value: serde_json::Value) -> (Spanned<String>, VarDecl) {
         (

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -138,43 +138,15 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
         push_redundant_gate_hints(&mut hints, t, id);
         match &t.action {
             RawAction::Infer(a) => {
-                if a.max_tokens.is_none() {
-                    hints.push(hint("cost", id, format!(
-                        "declare `max_tokens` on `{id}` — the cost report becomes a hard ceiling instead of UNBOUNDED"
-                    )));
-                }
-                // The degenerate cap (probe 2026-07-30): `max_tokens: 0`
-                // parses, prices to a true-$0 output ceiling, and sailed
-                // through green — but a zero budget forbids ALL output,
-                // so the call cannot produce anything (providers refuse
-                // it). The COST/ENERGY zeros are arithmetically true;
-                // the declaration is still a bug worth naming.
-                if a.max_tokens.as_ref().is_some_and(|t| t.value == 0) {
-                    hints.push(hint("zero-cap", id, format!(
-                        "`max_tokens: 0` on `{id}` forbids all output — the call cannot produce anything (providers refuse a zero budget); set a real cap or remove the task"
-                    )));
-                }
-                if !consumed.contains(id) && !envelope_ids.contains(id) {
-                    hints.push(hint("dead-spend", id, format!(
-                        "no task or output consumes `tasks.{id}.output` — every token this infer spends is unread; consume it or remove the task"
-                    )));
-                }
-                // `returns:` is a declared shape too — and the PREFERRED one
-                // (one-obvious-way/011): advising `schema:` on a task that
-                // already carries `returns:` would advise the exact pair
-                // NIKA-TYPE-003 refuses. Measured 2026-07-29 on a corpus
-                // lesson: `returns: Entities` + a deep ref drew this hint.
-                if deep_referenced.contains(id)
-                    && a.schema.is_none()
-                    && t.returns.is_none()
-                    && t.output.is_empty()
-                {
-                    hints.push(hint("typing", id, format!(
-                        "deep references into `tasks.{id}.output.<field>` exist but `{id}` declares no output shape — declare `returns:` and `nika check` starts proving those field names"
-                    )));
-                }
-                push_strictness_hint(&mut hints, id, a.schema.as_ref().map(|s| &s.value));
-                push_portability_hint(&mut hints, id, a.schema.as_ref().map(|s| &s.value));
+                push_infer_hints(
+                    &mut hints,
+                    t,
+                    id,
+                    a,
+                    &consumed,
+                    &envelope_ids,
+                    &deep_referenced,
+                );
             }
             RawAction::Agent(a) => {
                 if a.max_tokens_total.is_none() {
@@ -214,6 +186,56 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
     push_swallowed_exit_hints(&mut hints, wf);
     push_run_clock_hint(&mut hints, wf);
     hints
+}
+
+/// The infer arm of [`scan_hints`] — cost cap · degenerate zero-cap ·
+/// dead-spend · deep-ref typing · the shared schema pair (split at the
+/// 100-line function law).
+fn push_infer_hints(
+    hints: &mut Vec<Hint>,
+    t: &nika_schema::raw::RawTask,
+    id: &str,
+    a: &nika_schema::raw::RawInferAction,
+    consumed: &BTreeSet<String>,
+    envelope_ids: &BTreeSet<&str>,
+    deep_referenced: &BTreeSet<String>,
+) {
+    if a.max_tokens.is_none() {
+        hints.push(hint("cost", id, format!(
+            "declare `max_tokens` on `{id}` — the cost report becomes a hard ceiling instead of UNBOUNDED"
+        )));
+    }
+    // The degenerate cap (probe 2026-07-30): `max_tokens: 0` parses,
+    // prices to a true-$0 output ceiling, and sailed through green —
+    // but a zero budget forbids ALL output, so the call cannot produce
+    // anything (providers refuse it). The COST/ENERGY zeros are
+    // arithmetically true; the declaration is still a bug worth naming.
+    if a.max_tokens.as_ref().is_some_and(|t| t.value == 0) {
+        hints.push(hint("zero-cap", id, format!(
+            "`max_tokens: 0` on `{id}` forbids all output — the call cannot produce anything (providers refuse a zero budget); set a real cap or remove the task"
+        )));
+    }
+    if !consumed.contains(id) && !envelope_ids.contains(id) {
+        hints.push(hint("dead-spend", id, format!(
+            "no task or output consumes `tasks.{id}.output` — every token this infer spends is unread; consume it or remove the task"
+        )));
+    }
+    // `returns:` is a declared shape too — and the PREFERRED one
+    // (one-obvious-way/011): advising `schema:` on a task that
+    // already carries `returns:` would advise the exact pair
+    // NIKA-TYPE-003 refuses. Measured 2026-07-29 on a corpus
+    // lesson: `returns: Entities` + a deep ref drew this hint.
+    if deep_referenced.contains(id)
+        && a.schema.is_none()
+        && t.returns.is_none()
+        && t.output.is_empty()
+    {
+        hints.push(hint("typing", id, format!(
+            "deep references into `tasks.{id}.output.<field>` exist but `{id}` declares no output shape — declare `returns:` and `nika check` starts proving those field names"
+        )));
+    }
+    push_strictness_hint(hints, id, a.schema.as_ref().map(|s| &s.value));
+    push_portability_hint(hints, id, a.schema.as_ref().map(|s| &s.value));
 }
 
 /// The deadline-vs-undeclared-clock hint (F-P3 finding (b)): a task

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -14,6 +14,9 @@
 //!
 //! - **unbounded cost** (`cost`) — an `infer:`/`agent:` task with no
 //!   token bound: add one and the cost report becomes a hard ceiling.
+//! - **degenerate cap** (`zero-cap`) — a declared `max_tokens: 0` /
+//!   `max_tokens_total: 0`: arithmetically a true $0/0 Wh output
+//!   ceiling, practically a call no provider will honor.
 //! - **unconsumed output** (`dead-spend`) — a pure `infer:` task whose
 //!   output no one reads (no task references it · not in `outputs:`):
 //!   every token it spends is dead spend.
@@ -79,7 +82,8 @@ use nika_schema::types::CaptureMode;
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[non_exhaustive]
 pub struct Hint {
-    /// The hint class — the closed set today: `cost` · `dead-spend` ·
+    /// The hint class — the closed set today: `cost` · `zero-cap` ·
+    /// `dead-spend` ·
     /// `typing` · `permits` · `strictness` · `schema-portability` ·
     /// `redundant-gate` · `retry-effects` ·
     /// `secrets-store` · `native-first` · `exec-json-capture` ·
@@ -139,6 +143,17 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
                         "declare `max_tokens` on `{id}` — the cost report becomes a hard ceiling instead of UNBOUNDED"
                     )));
                 }
+                // The degenerate cap (probe 2026-07-30): `max_tokens: 0`
+                // parses, prices to a true-$0 output ceiling, and sailed
+                // through green — but a zero budget forbids ALL output,
+                // so the call cannot produce anything (providers refuse
+                // it). The COST/ENERGY zeros are arithmetically true;
+                // the declaration is still a bug worth naming.
+                if a.max_tokens.as_ref().is_some_and(|t| t.value == 0) {
+                    hints.push(hint("zero-cap", id, format!(
+                        "`max_tokens: 0` on `{id}` forbids all output — the call cannot produce anything (providers refuse a zero budget); set a real cap or remove the task"
+                    )));
+                }
                 if !consumed.contains(id) && !envelope_ids.contains(id) {
                     hints.push(hint("dead-spend", id, format!(
                         "no task or output consumes `tasks.{id}.output` — every token this infer spends is unread; consume it or remove the task"
@@ -165,6 +180,12 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
                 if a.max_tokens_total.is_none() {
                     hints.push(hint("cost", id, format!(
                         "declare `max_tokens_total` on `{id}` — the agent loop gets a hard budget instead of UNBOUNDED"
+                    )));
+                }
+                // Same degenerate-cap class as the infer arm.
+                if a.max_tokens_total.as_ref().is_some_and(|t| t.value == 0) {
+                    hints.push(hint("zero-cap", id, format!(
+                        "`max_tokens_total: 0` on `{id}` forbids all output — the agent loop cannot spend anything; set a real budget or remove the task"
                     )));
                 }
                 push_strictness_hint(&mut hints, id, a.schema.as_ref().map(|s| &s.value));

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -165,7 +165,7 @@ pub use schema_lint::SchemaLintFinding;
 pub use schema_typing::{SchemaTypeFinding, UnverifiableOutputRef};
 pub use secrets::{SecretEgress, SecretLeak};
 pub use tools::{MissingArg, UnknownArg, UnknownTool};
-pub use walk::static_read_paths;
+pub use walk::{static_literal_of, static_read_paths};
 
 // The analyzer's surface at the crate root — the same shape `nika-schema`
 // re-exported before the split (`analyze` · `AnalyzedWorkflow` · the

--- a/crates/nika-check/src/walk.rs
+++ b/crates/nika-check/src/walk.rs
@@ -176,15 +176,7 @@ pub(crate) fn visit_json(value: &serde_json::Value, visit: &mut dyn FnMut(&str))
 /// `default:` — which stays statically unknown: analysis never guesses.
 #[must_use]
 pub fn static_literal_of<'w>(wf: &'w RawWorkflow, expr: &str) -> Option<&'w serde_json::Value> {
-    let inner = expr.trim().strip_prefix("${{")?.strip_suffix("}}")?.trim();
-    let (authority, name) = ["const.", "inputs.", "config."]
-        .into_iter()
-        .find_map(|ns| inner.strip_prefix(ns).map(|n| (ns, n)))?;
-    // A BARE `<authority>.<ident>` only — further navigation or
-    // operators mean the runtime value is not the declared literal.
-    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
-        return None;
-    }
+    let (authority, name) = bare_static_ref(expr)?;
     let block = match authority {
         "const." => &wf.consts,
         "inputs." => &wf.inputs,
@@ -198,6 +190,24 @@ pub fn static_literal_of<'w>(wf: &'w RawWorkflow, expr: &str) -> Option<&'w serd
         } => Some(v),
         VarDecl::Typed { default: None, .. } => None,
     }
+}
+
+/// The parse half of [`static_literal_of`]: a whole-string bare
+/// `${{ <authority>.<ident> }}` over the three IMMUTABLE value
+/// authorities → `(authority-with-dot, name)`. Two identical such refs
+/// denote the same runtime value even when no literal is declared —
+/// inputs bind once per run, const/config never change — which is what
+/// the write-conflict scan keys on. Further navigation (`.field` ·
+/// `[0]`), operators, or a name outside the identifier grammar → `None`.
+pub(crate) fn bare_static_ref(expr: &str) -> Option<(&'static str, &str)> {
+    let inner = expr.trim().strip_prefix("${{")?.strip_suffix("}}")?.trim();
+    let (authority, name) = ["const.", "inputs.", "config."]
+        .into_iter()
+        .find_map(|ns| inner.strip_prefix(ns).map(|n| (ns, n)))?;
+    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        return None;
+    }
+    Some((authority, name))
 }
 
 /// Resolve an invoke arg to a STATIC string when it is a plain literal

--- a/crates/nika-check/src/walk.rs
+++ b/crates/nika-check/src/walk.rs
@@ -158,22 +158,31 @@ pub(crate) fn visit_json(value: &serde_json::Value, visit: &mut dyn FnMut(&str))
     }
 }
 
-/// Resolve an invoke arg to a STATIC string when it is a plain literal
-/// or a single `${{ const.X }}` / `${{ inputs.X }}` / `${{ config.X }}`
-/// whose declaration carries a literal value — the shapes a scaffold
-/// ships. Anything dynamic (task refs · concatenations) resolves to
-/// `None`: analysis never guesses.
-fn static_string_arg(wf: &RawWorkflow, value: &serde_json::Value) -> Option<String> {
-    let s = value.as_str()?;
-    let trimmed = s.trim();
-    if !trimmed.contains("${{") {
-        return Some(trimmed.to_owned());
-    }
-    let inner = trimmed.strip_prefix("${{")?.strip_suffix("}}")?.trim();
+/// THE shared static-value resolver: a whole-string bare
+/// `${{ <authority>.<name> }}` over the three value authorities whose
+/// declared value is static (`const.` · `inputs.` · `config.`), resolved
+/// to the LITERAL it declares — an untyped value, or a typed
+/// declaration's literal `default:`. One resolver, every lane: the cost
+/// ceiling counts `for_each` fan-outs through it, the read-path lint
+/// resolves `nika:read` args through it, and the CLI's MODELS rung
+/// judges a templated `model:`'s declared default through it. A private
+/// per-lane copy is how lanes drift (measured 2026-07-29: the cost lane
+/// resolved `${{ const.model }}`-class refs while MODELS skipped them
+/// wholesale — same expression, two verdicts).
+///
+/// `None` for everything else — navigation (`.field` · `[0]`),
+/// operators, concatenations, task refs, a name outside the expression
+/// identifier grammar (`[A-Za-z0-9_]`), or a typed declaration with no
+/// `default:` — which stays statically unknown: analysis never guesses.
+#[must_use]
+pub fn static_literal_of<'w>(wf: &'w RawWorkflow, expr: &str) -> Option<&'w serde_json::Value> {
+    let inner = expr.trim().strip_prefix("${{")?.strip_suffix("}}")?.trim();
     let (authority, name) = ["const.", "inputs.", "config."]
         .into_iter()
         .find_map(|ns| inner.strip_prefix(ns).map(|n| (ns, n)))?;
-    if name.contains(['.', '[']) {
+    // A BARE `<authority>.<ident>` only — further navigation or
+    // operators mean the runtime value is not the declared literal.
+    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
         return None;
     }
     let block = match authority {
@@ -181,16 +190,27 @@ fn static_string_arg(wf: &RawWorkflow, value: &serde_json::Value) -> Option<Stri
         "inputs." => &wf.inputs,
         _ => &wf.config,
     };
-    block.iter().find_map(|(decl_name, decl)| {
-        if decl_name.value != name {
-            return None;
-        }
-        let default = match decl {
-            VarDecl::Untyped(v) => Some(v),
-            VarDecl::Typed { default, .. } => default.as_ref(),
-        };
-        default.and_then(|d| d.as_str()).map(str::to_owned)
-    })
+    let (_, decl) = block.iter().find(|(k, _)| k.value == name)?;
+    match decl {
+        VarDecl::Untyped(v)
+        | VarDecl::Typed {
+            default: Some(v), ..
+        } => Some(v),
+        VarDecl::Typed { default: None, .. } => None,
+    }
+}
+
+/// Resolve an invoke arg to a STATIC string when it is a plain literal
+/// or a bare authority ref [`static_literal_of`] resolves to a string
+/// literal — the shapes a scaffold ships. Anything dynamic (task refs ·
+/// concatenations) resolves to `None`: analysis never guesses.
+fn static_string_arg(wf: &RawWorkflow, value: &serde_json::Value) -> Option<String> {
+    let s = value.as_str()?;
+    let trimmed = s.trim();
+    if !trimmed.contains("${{") {
+        return Some(trimmed.to_owned());
+    }
+    static_literal_of(wf, trimmed)?.as_str().map(str::to_owned)
 }
 
 /// Every `nika:read` whose `path` arg resolves STATICALLY — the pure

--- a/crates/nika-cli/src/text.rs
+++ b/crates/nika-cli/src/text.rs
@@ -10,3 +10,10 @@
 pub(crate) fn count(n: usize, noun: &str) -> String {
     crate::display::vocab::count(n, noun)
 }
+
+/// See [`crate::display::vocab::usd`] — the 4-decimal USD grain,
+/// ceiling-honest at the bottom (`0.0001`, never a fabricated
+/// `0.0000`; an exact zero stays `0.0000`: that zero is true).
+pub(crate) fn usd(amount: f64) -> String {
+    crate::display::vocab::usd(amount)
+}

--- a/crates/nika-cli/src/verbs/check/energy.rs
+++ b/crates/nika-cli/src/verbs/check/energy.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `nika inspect` energy aggregate (NEP-0018 §4 — « the MARKERS are
+//! the contract, not the view name »). Consumes the report's OWN energy
+//! reading (`nika_check::energy` · one classification, both surfaces —
+//! the check ladder's rung renders the same reading in
+//! `nika_display::check_render`). Same four words on both: floor ·
+//! ceiling · UNBOUNDED · unpriced — and never `0 Wh`.
+
+use nika_check::CheckReport;
+
+use crate::display::vocab::at_most;
+
+/// `≤ N Wh` at a ceiling-honest display grain: a tiny bound rounds UP
+/// to 0.001 — this fragment never prints `0.0 Wh` (a zero would claim
+/// free inference · NEP-0018 « unknown stays unknown »).
+fn fmt_wh(wh: f64) -> String {
+    if wh >= 1.0 {
+        format!("{wh:.1}")
+    } else {
+        format!("{:.3}", (wh * 1000.0).ceil() / 1000.0)
+    }
+}
+
+/// One class → `≤ X Wh` · several → `gpu ≤ X Wh · fleet ≤ Y Wh`, each
+/// subtotal wearing its class (watt-hours sum WITHIN a scope class and
+/// never across one — the reading's own partition). The comparison mark
+/// rides the vocab seam (`≤` · `<=` under `--ascii`).
+fn fmt_scope_totals(subs: &[(String, f64)], ascii: bool) -> String {
+    let le = at_most(ascii);
+    match subs {
+        [] => String::new(),
+        [(_, wh)] => format!("{le} {} Wh", fmt_wh(*wh)),
+        many => many
+            .iter()
+            .map(|(scope, wh)| format!("{scope} {le} {} Wh", fmt_wh(*wh)))
+            .collect::<Vec<_>>()
+            .join(" · "),
+    }
+}
+
+/// The fragment's totals: the per-class sums, with a single class named
+/// beside its number (`≤ 0.087 Wh (gpu)`) — the rung puts the class on
+/// its count line, the one-line fragment has nowhere else to put it.
+fn scoped_totals(subs: &[(String, f64)], ascii: bool) -> String {
+    match subs {
+        [(scope, _)] => format!("{} ({scope})", fmt_scope_totals(subs, ascii)),
+        _ => fmt_scope_totals(subs, ascii),
+    }
+}
+
+/// The `nika inspect` energy aggregate: one compact fragment for the
+/// anatomy header, same markers as the check rung — a per-scope ceiling
+/// qualified by its coverage, `unbounded` with the bounded portion
+/// named, `unpriced` for a figure that does not exist (never `0 Wh`),
+/// and « nothing to bound » for a workflow whose tasks provably never
+/// run. `None` when the workflow has no inference task (the cost
+/// fragment already says so).
+pub(crate) fn inspect_fragment(report: &CheckReport, ascii: bool) -> Option<String> {
+    if report.cost.tasks.is_empty() {
+        return None;
+    }
+    let e = &report.energy;
+    let n = &e.counts;
+    let totals = scoped_totals(&e.scope_subtotals, ascii);
+    if n.uncapped > 0 {
+        return Some(if e.tasks.is_empty() {
+            "energy unbounded".to_owned()
+        } else {
+            format!("energy unbounded · bounded {totals}")
+        });
+    }
+    if e.tasks.is_empty() {
+        return Some(if n.unpriced == 0 && n.never_runs > 0 {
+            "no energy to bound (no task runs)".to_owned()
+        } else {
+            "energy unpriced".to_owned()
+        });
+    }
+    // A ceiling that covers PART of the tasks must say so — an
+    // unqualified number reads as the workflow's ceiling (the same
+    // « N of M tasks measured » the rung's headline carries).
+    if e.tasks.len() < n.total {
+        Some(format!(
+            "{totals} ({} of {} measured)",
+            e.tasks.len(),
+            n.total
+        ))
+    } else {
+        Some(totals)
+    }
+}
+
+#[cfg(test)]
+mod fragment_tests {
+    use super::inspect_fragment;
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    fn report_of(yaml: &str) -> nika_check::CheckReport {
+        nika_check::check(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
+    }
+
+    /// No inference task → no fragment (the cost fragment already says
+    /// « no infer/agent tasks » — nothing to double).
+    #[test]
+    fn no_inference_tasks_yield_no_fragment() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  sh:\n    exec: { command: [\"true\"] }\n",
+        );
+        assert_eq!(inspect_fragment(&r, false), None);
+    }
+
+    /// A capped task on a measured model → a scoped ceiling, full
+    /// coverage → no fraction qualifier.
+    #[test]
+    fn a_measured_capped_task_states_a_scoped_ceiling() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\nmodel: groq/qwen/qwen3-32b\ntasks:\n  t:\n    infer: { prompt: \"x\", max_tokens: 1000 }\n",
+        );
+        let frag = inspect_fragment(&r, false).expect("fragment");
+        assert!(
+            frag.starts_with("≤ ") && frag.ends_with(" Wh (gpu)"),
+            "scoped ceiling: {frag}"
+        );
+        assert!(
+            !frag.contains("measured"),
+            "full coverage is unqualified: {frag}"
+        );
+        let ascii = inspect_fragment(&r, true).expect("fragment");
+        assert!(
+            ascii.starts_with("<= ") && !ascii.contains('≤'),
+            "ascii parity: {ascii}"
+        );
+    }
+
+    /// Partial coverage must be QUALIFIED — an unqualified number reads
+    /// as the workflow's ceiling while a task's figure is missing.
+    #[test]
+    fn partial_coverage_names_its_fraction() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    infer: { prompt: \"x\", max_tokens: 1000, model: groq/qwen/qwen3-32b }\n  b:\n    infer: { prompt: \"x\", max_tokens: 1000, model: anthropic/claude-sonnet-4-6 }\n",
+        );
+        let frag = inspect_fragment(&r, false).expect("fragment");
+        assert!(
+            frag.contains("(1 of 2 measured)"),
+            "the fraction rides the fragment: {frag}"
+        );
+    }
+
+    /// An uncapped task → no total ceiling, and the string `0 Wh`
+    /// appears nowhere (NEP-0018 conformance shape #3).
+    #[test]
+    fn an_uncapped_task_is_unbounded_never_zero() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\nmodel: groq/qwen/qwen3-32b\ntasks:\n  t:\n    infer: { prompt: \"x\" }\n",
+        );
+        let frag = inspect_fragment(&r, false).expect("fragment");
+        assert_eq!(frag, "energy unbounded");
+        assert!(!frag.contains("0 Wh"));
+    }
+
+    /// Uncapped beside a measured task → the bounded portion is named
+    /// (the marker set: unbounded, with what IS provable shown).
+    #[test]
+    fn unbounded_with_a_measured_task_names_the_bounded_portion() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\ntasks:\n  a:\n    infer: { prompt: \"x\", max_tokens: 1000, model: groq/qwen/qwen3-32b }\n  b:\n    infer: { prompt: \"x\", model: groq/qwen/qwen3-32b }\n",
+        );
+        let frag = inspect_fragment(&r, false).expect("fragment");
+        assert!(
+            frag.starts_with("energy unbounded · bounded ≤ ") && frag.ends_with(" Wh (gpu)"),
+            "bounded portion named: {frag}"
+        );
+    }
+
+    /// An unmeasured model → `unpriced`, never `0 Wh` (NEP-0018
+    /// conformance shape #2).
+    #[test]
+    fn an_unmeasured_model_is_unpriced_never_zero() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\nmodel: anthropic/claude-sonnet-4-6\ntasks:\n  t:\n    infer: { prompt: \"x\", max_tokens: 1000 }\n",
+        );
+        let frag = inspect_fragment(&r, false).expect("fragment");
+        assert_eq!(frag, "energy unpriced");
+        assert!(!frag.contains("0 Wh"));
+    }
+
+    /// A workflow whose only task provably never runs (literal empty
+    /// `for_each`) has nothing to bound — a claim of absence, not a
+    /// `0 Wh` figure.
+    #[test]
+    fn a_never_running_workflow_has_nothing_to_bound() {
+        let r = report_of(
+            "nika: v1\nworkflow:\n  id: w\nmodel: groq/qwen/qwen3-32b\ntasks:\n  t:\n    for_each: []\n    infer: { prompt: \"x ${{ item }}\", max_tokens: 1000 }\n",
+        );
+        let frag = inspect_fragment(&r, false).expect("fragment");
+        assert_eq!(frag, "no energy to bound (no task runs)");
+    }
+}

--- a/crates/nika-cli/src/verbs/check/energy.rs
+++ b/crates/nika-cli/src/verbs/check/energy.rs
@@ -12,14 +12,18 @@ use nika_check::CheckReport;
 
 use crate::display::vocab::at_most;
 
-/// `≤ N Wh` at a ceiling-honest display grain: a tiny bound rounds UP
-/// to 0.001 — this fragment never prints `0.0 Wh` (a zero would claim
-/// free inference · NEP-0018 « unknown stays unknown »).
+/// `≤ N Wh` at a ceiling-honest display grain: a zero-or-tiny bound
+/// rounds UP to the 0.001 grain — this surface never prints `0.000 Wh`,
+/// even for a declared `max_tokens: 0` (probe 2026-07-30: that shape
+/// rendered `✔ ENERGY ≤ 0.000 Wh` — an arithmetically-true zero that
+/// still speaks the exact « free inference » form NEP-0018 bans; a
+/// loose ceiling is true, a printed zero misleads · the `zero-cap`
+/// hint names the degenerate declaration itself).
 fn fmt_wh(wh: f64) -> String {
     if wh >= 1.0 {
         format!("{wh:.1}")
     } else {
-        format!("{:.3}", (wh * 1000.0).ceil() / 1000.0)
+        format!("{:.3}", ((wh * 1000.0).ceil() / 1000.0).max(0.001))
     }
 }
 
@@ -89,6 +93,51 @@ pub(crate) fn inspect_fragment(report: &CheckReport, ascii: bool) -> Option<Stri
         ))
     } else {
         Some(totals)
+    }
+}
+
+#[cfg(test)]
+mod fmt_tests {
+    use super::{fmt_scope_totals, fmt_wh, scoped_totals};
+
+    fn subs(rows: &[(&str, f64)]) -> Vec<(String, f64)> {
+        rows.iter().map(|(s, w)| ((*s).to_owned(), *w)).collect()
+    }
+
+    /// The display grain is ceiling-honest: rounding is UP, the floor
+    /// of the grain is 0.001, and a ZERO bound still prints 0.001 —
+    /// `0.000` would speak the exact « free inference » form NEP-0018
+    /// bans (probe 2026-07-30: a declared `max_tokens: 0` rendered
+    /// `≤ 0.000 Wh` before the grain gained its floor).
+    #[test]
+    fn fmt_wh_never_prints_zero() {
+        assert_eq!(fmt_wh(0.0), "0.001");
+        assert_eq!(fmt_wh(0.0004), "0.001");
+        assert_eq!(fmt_wh(0.004), "0.004");
+        assert_eq!(fmt_wh(0.087), "0.087");
+        assert_eq!(fmt_wh(2.34), "2.3");
+        assert_eq!(fmt_wh(660.1), "660.1");
+    }
+
+    /// Watt-hours stay partitioned per scope class (a `gpu` and a
+    /// `fleet` figure describe different perimeters — no grand total),
+    /// a single class states the number bare, and the comparison mark
+    /// rides the vocab seam (`≤` · `<=` under `--ascii`).
+    #[test]
+    fn scope_totals_speak_per_class_with_ascii_parity() {
+        let multi = subs(&[("fleet", 4.0), ("gpu", 1.5)]);
+        assert_eq!(
+            fmt_scope_totals(&multi, false),
+            "fleet ≤ 4.0 Wh · gpu ≤ 1.5 Wh"
+        );
+        assert_eq!(
+            fmt_scope_totals(&multi, true),
+            "fleet <= 4.0 Wh · gpu <= 1.5 Wh"
+        );
+        let single = subs(&[("gpu", 0.087)]);
+        assert_eq!(fmt_scope_totals(&single, false), "≤ 0.087 Wh");
+        assert_eq!(scoped_totals(&single, false), "≤ 0.087 Wh (gpu)");
+        assert_eq!(fmt_scope_totals(&[], false), "");
     }
 }
 

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -94,9 +94,9 @@ use crate::display::theme::{Role, Theme};
 use crate::verbs::{VerbOutput, load_checked, load_checked_with_source};
 
 mod drift;
+pub(crate) mod energy;
 mod models_rung;
-use models_rung::{pricing_section, unresolvable_models};
-use nika_display::check_render::ModelFinding;
+use models_rung::{ModelsAudit, pricing_section, unresolvable_models};
 
 use nika_display::check_render::render;
 #[cfg(test)]
@@ -146,16 +146,16 @@ pub fn run(
     // The MODELS rung (#320): the ladder validated TOOLS but not MODELS —
     // the exact asymmetry a hallucinating agent hits. A `model:` this
     // binary cannot resolve is a FINDING (exit 2), never a green audit.
-    let model_findings = unresolvable_models(&report);
+    let models_audit = unresolvable_models(&report, &wf);
     // SKILLS rung (#473 · MODELS pattern): a bad SKILL.md is a FINDING.
     let skills = super::resolve_workflow_skills(&wf);
-    let clean = report.is_clean() && model_findings.is_empty() && skills.findings.is_empty();
+    let clean = report.is_clean() && models_audit.findings.is_empty() && skills.findings.is_empty();
     let strict_clean = clean && (!native_strict || native_hints == 0);
 
     if json {
         return json_verdict(
             &report,
-            &model_findings,
+            &models_audit,
             &skills,
             &drift_hints,
             clean,
@@ -170,7 +170,7 @@ pub fn run(
         &source,
         path,
         theme,
-        &model_findings,
+        &models_audit,
         &skills,
         &drift_hints,
     );
@@ -242,19 +242,21 @@ fn parse_fatal_json(out: &VerbOutput) -> VerbOutput {
 }
 
 /// The `--json` verdict: the full report + the machine keys (`clean` ·
-/// `models_resolve` · `model_findings[]` · `skills_resolve` ·
-/// `skill_findings[]` · `pricing` · the strict flag) — never coloured,
-/// the contract bytes are the contract. The drift rows (NIKA-DRIFT-001)
-/// append to `hints[]` in the report's row shape plus their `code`.
+/// `models_resolve` · `models_unjudged` (presence-gated) ·
+/// `model_findings[]` · `skills_resolve` · `skill_findings[]` ·
+/// `pricing` · the strict flag) — never coloured, the contract bytes are
+/// the contract. The drift rows (NIKA-DRIFT-001) append to `hints[]` in
+/// the report's row shape plus their `code`.
 fn json_verdict(
     report: &CheckReport,
-    model_findings: &[ModelFinding],
+    models_audit: &ModelsAudit,
     skills: &nika_schema::ResolvedSkills,
     drift_hints: &[String],
     clean: bool,
     strict_clean: bool,
     native_strict: bool,
 ) -> VerbOutput {
+    let model_findings = &models_audit.findings;
     let mut payload = match serde_json::to_value(report) {
         Ok(v) => v,
         Err(e) => return VerbOutput::env(format!("cannot serialize report: {e}")),
@@ -273,6 +275,17 @@ fn json_verdict(
             "models_resolve".to_owned(),
             serde_json::Value::Bool(model_findings.is_empty()),
         );
+        // The machine twin of the narrowed headline (presence-gated like
+        // `model_findings`): `models_resolve: true` beside a non-zero
+        // `models_unjudged` reads as « every JUDGED model resolves » —
+        // without the count, a consumer cannot tell judged-green from
+        // never-judged.
+        if models_audit.unjudged > 0 {
+            obj.insert(
+                "models_unjudged".to_owned(),
+                serde_json::json!(models_audit.unjudged),
+            );
+        }
         if !model_findings.is_empty() {
             obj.insert(
                 "model_findings".to_owned(),
@@ -458,7 +471,7 @@ mod tests {
             "nika: v1\nworkflow:\n  id: priced\nmodel: anthropic/claude-opus-4-5\ntasks:\n  think:\n    infer:\n      prompt: hi\n  odd:\n    infer:\n      model: custom/never-heard-of-it\n      prompt: hi\n",
         );
         let report = nika_check::check(&wf);
-        let section = pricing_section(&report, &unresolvable_models(&report));
+        let section = pricing_section(&report, &unresolvable_models(&report, &wf).findings);
         let models = section["models"].as_array().expect("array");
         assert_eq!(models.len(), 2, "one row per requirements model");
         let by_model = |name: &str| {
@@ -736,28 +749,36 @@ mod tests {
     }
 
     /// The parameterization pin (found 2026-07-29 rendering the
-    /// conformance parity through the reference harness): a TEMPLATED
-    /// `model:` is a run-time fact, so the rung must SKIP it — refusing
-    /// it meant refusing the pattern spec 08 §H8 recommends by name
-    /// (« one workflow, any backend »), on the spec's own fixture
-    /// `stdlib/providers/005-valid-parameterized-model`.
+    /// conformance parity through the reference harness, sharpened
+    /// 2026-07-30 with the shared resolver): a TEMPLATED `model:` is a
+    /// run-time fact, but its DECLARED DEFAULT is not — the rung judges
+    /// the default through `nika_check::static_literal_of` (spec 08 §H8
+    /// « one workflow, any backend » · the spec's own fixture
+    /// `stdlib/providers/005-valid-parameterized-model`), and the green
+    /// line names the via-default judgement.
     #[test]
-    fn models_rung_skips_a_templated_model_and_keeps_its_teeth_on_a_literal() {
-        // The exact shape of the spec fixture: a const-declared pair,
-        // read through `${{ }}` at the task.
+    fn models_rung_judges_a_templated_models_declared_default() {
+        // A bare-literal const (spec 01 §const), read through `${{ }}`
+        // at the task — the parameterization pattern in its simplest
+        // canonical form.
         let out = checked_output(
             "models-param.nika.yaml",
-            "nika: v1\nworkflow:\n  id: p\nconst:\n  model: { type: string, default: \"anthropic/claude-sonnet-4-6\" }\ntasks:\n  ask:\n    infer: { prompt: hi, max_tokens: 10, model: \"${{ const.model }}\" }\n",
+            "nika: v1\nworkflow:\n  id: p\nconst:\n  model: \"anthropic/claude-sonnet-4-6\"\ntasks:\n  ask:\n    infer: { prompt: hi, max_tokens: 10, model: \"${{ const.model }}\" }\n",
             false,
         );
         assert_eq!(
             out.code, 0,
-            "a parameterized model is not a finding: {}",
+            "a resolvable declared default is not a finding: {}",
             out.text
         );
         assert!(
             !out.text.contains("bare model id"),
             "the raw template is never read as an id: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("via declared default"),
+            "the green names WHAT resolved (the default, not the run-time value): {}",
             out.text
         );
         // The teeth stay on what IS statically decidable.
@@ -772,6 +793,88 @@ mod tests {
             literal.text
         );
         assert!(literal.text.contains("bare model id"), "{}", literal.text);
+    }
+
+    /// The sharper half of the same pin: `${{ const.model }}` whose
+    /// const declares a BAD id is a finding — the skip-everything fix
+    /// (69c402333) let a refusable declared default sail through green.
+    /// The fixture uses the TYPED constant form (`{ type, value }` ·
+    /// spec 01 §const normative discriminator) so both resolver arms
+    /// are exercised across this test pair.
+    #[test]
+    fn models_rung_reds_a_templated_models_refusable_default() {
+        let out = checked_output(
+            "models-param-bad.nika.yaml",
+            "nika: v1\nworkflow:\n  id: p\nconst:\n  model: { type: string, value: \"gpt-5-turbo\" }\ntasks:\n  ask:\n    infer: { prompt: hi, max_tokens: 10, model: \"${{ const.model }}\" }\n",
+            false,
+        );
+        assert_eq!(
+            out.code, 2,
+            "a refusable declared default is a finding: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("declared default `gpt-5-turbo`"),
+            "the finding names BOTH halves (template + judged default): {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("${{ const.model }}"),
+            "the row shows the model as written: {}",
+            out.text
+        );
+    }
+
+    /// A `{ type, default }` const is a BARE LITERAL OBJECT per the
+    /// spec 01 §const normative discriminator (typed constants carry
+    /// `value:`, not `default:`) — so `${{ const.model }}` over it
+    /// resolves to an object, not a string, and the rung makes NO
+    /// claim. Pinned because the spec's own fixture
+    /// (`stdlib/providers/005-valid-parameterized-model`) writes this
+    /// exact shape: the resolver must never « helpfully » read the
+    /// object's `default` key — analysis never guesses.
+    #[test]
+    fn models_rung_never_guesses_inside_a_literal_object_const() {
+        let out = checked_output(
+            "models-param-object.nika.yaml",
+            "nika: v1\nworkflow:\n  id: p\nconst:\n  model: { type: string, default: \"gpt-5-turbo\" }\ntasks:\n  ask:\n    infer: { prompt: hi, max_tokens: 10, model: \"${{ const.model }}\" }\n",
+            false,
+        );
+        assert_eq!(
+            out.code, 0,
+            "a literal-object const is not judgeable — no claim, no finding: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("run-time model") && out.text.contains("unjudged"),
+            "the no-claim posture is named: {}",
+            out.text
+        );
+    }
+
+    /// A templated model with NO static default is UNJUDGED, and the
+    /// headline says so — measured 2026-07-30 before this fix: the same
+    /// file printed `✔ MODELS 1 model resolves in this binary` while the
+    /// rung had skipped its only model wholesale (nothing resolved ·
+    /// nobody looked — the false-green class, MODELS edition).
+    #[test]
+    fn models_rung_makes_no_claim_over_a_defaultless_run_time_model() {
+        let out = checked_output(
+            "models-param-runtime.nika.yaml",
+            "nika: v1\nworkflow:\n  id: p\ninputs:\n  model: { type: string, required: true }\ntasks:\n  ask:\n    infer: { prompt: hi, max_tokens: 10, model: \"${{ inputs.model }}\" }\n",
+            false,
+        );
+        assert_eq!(out.code, 0, "no claim is not a finding: {}", out.text);
+        assert!(
+            !out.text.contains("resolves in this binary"),
+            "an unjudged model is never counted as resolving: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains("run-time model") && out.text.contains("unjudged"),
+            "the no-claim posture is named: {}",
+            out.text
+        );
     }
 
     /// `--json --native-strict`: the payload's `native_strict_clean` and

--- a/crates/nika-cli/src/verbs/check/models_rung.rs
+++ b/crates/nika-cli/src/verbs/check/models_rung.rs
@@ -6,49 +6,63 @@
 //! bodies moved verbatim. The finding TYPE lives beside its renderer
 //! (`nika_display::check_render` · the 15k descent).
 
-pub(crate) use nika_display::check_render::ModelFinding;
+pub(crate) use nika_display::check_render::{ModelFinding, ModelsAudit};
 
 /// Cross `requirements.models` against the RESOLVER (the runnable
 /// provider set, [`nika_providers::CANONICAL_IDS`]) — never the vendor
 /// catalog, which advertises providers this binary cannot drive (the
 /// azure class: cataloged, unresolvable, green until the run died).
-pub(crate) fn unresolvable_models(report: &nika_check::CheckReport) -> Vec<ModelFinding> {
-    report
-        .requirements
-        .models
-        .iter()
-        .filter_map(|m| {
-            // A TEMPLATED `model:` is not a static fact — its value
-            // arrives at run time (`--var`), so this rung cannot decide
-            // it and must not refuse it: the same « unanalyzable yields
-            // NO claim » law the policy and trifecta lanes follow
-            // (skipped, never wrong).
-            //
-            // Measured 2026-07-29 while rendering the conformance parity
-            // through the reference harness: `model: "${{ const.model }}"`
-            // — whose const declares `anthropic/claude-sonnet-4-6`, a
-            // perfectly runnable pair — was refused as « a bare model id ».
-            // The engine was refusing the parameterization pattern the
-            // spec recommends BY NAME (08 §H8 · « one workflow, any
-            // backend »), on the spec's own fixture
-            // (`stdlib/providers/005-valid-parameterized-model`).
-            //
-            // Judging the declared DEFAULT instead of skipping is the
-            // sharper follow-on (the cost lane already resolves a bare
-            // `${{ authority.name }}` to its literal · `cost.rs`
-            // `static_vars_array_len`): it wants ONE shared resolver in
-            // `nika-check`, not a third private copy — trigger, not a
-            // TODO.
-            if m.model.contains("${{") {
-                return None;
-            }
-            // The ONE law, shared with the MCP lane (#320 follow-up:
-            // the two machine surfaces consult the same fn beside the
-            // resolver — they cannot drift apart again).
-            let why = nika_providers::resolve_refusal(&m.model)?;
-            Some(ModelFinding::new(m.model.clone(), m.tasks.clone(), why))
-        })
-        .collect()
+pub(super) fn unresolvable_models(
+    report: &nika_check::CheckReport,
+    wf: &nika_schema::raw::RawWorkflow,
+) -> ModelsAudit {
+    let mut audit = ModelsAudit::new(Vec::new(), 0, 0);
+    for m in &report.requirements.models {
+        // A TEMPLATED `model:` is not a static fact — its value arrives
+        // at run time (`--var`) — but its DECLARED DEFAULT is: a bare
+        // `${{ <authority>.<name> }}` whose declaration carries a
+        // literal string is judged AS that default, through the ONE
+        // shared resolver ([`nika_check::static_literal_of`] — the same
+        // fn the cost lane counts `for_each` fan-outs with; a third
+        // private copy is how lanes drift). This keeps the rung's teeth
+        // on the parameterization pattern the spec recommends BY NAME
+        // (08 §H8 · measured 2026-07-29: the fix before this one skipped
+        // `${{ const.model }}` wholesale, and the fix before THAT
+        // refused it as « a bare model id » on the spec's own fixture,
+        // `stdlib/providers/005-valid-parameterized-model`). Anything
+        // the resolver cannot answer gets NO claim — skipped, never
+        // wrong — and is COUNTED, so the headline says so.
+        let (judged, via_default) = if m.model.contains("${{") {
+            let Some(default_model) =
+                nika_check::static_literal_of(wf, &m.model).and_then(serde_json::Value::as_str)
+            else {
+                audit.unjudged += 1;
+                continue;
+            };
+            (default_model, true)
+        } else {
+            (m.model.as_str(), false)
+        };
+        // The ONE law, shared with the MCP lane (#320 follow-up: the two
+        // machine surfaces consult the same fn beside the resolver —
+        // they cannot drift apart again).
+        match nika_providers::resolve_refusal(judged) {
+            Some(why) => audit.findings.push(ModelFinding::new(
+                m.model.clone(),
+                m.tasks.clone(),
+                // A via-default refusal names BOTH halves: the template
+                // the author wrote and the default that was judged.
+                if via_default {
+                    format!("declared default `{judged}` — {why}")
+                } else {
+                    why
+                },
+            )),
+            None if via_default => audit.via_default += 1,
+            None => {}
+        }
+    }
+    audit
 }
 
 /// The rates the preflight shows BEFORE the first run: each model the

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -83,11 +83,26 @@ pub fn run(path: &str, theme: Theme) -> VerbOutput {
             report.cost.bounded_total_usd
         )
     } else {
-        format!("≤ ${:.4}", report.cost.bounded_total_usd)
+        // `est out` + the vocab seam, one voice with the audited card:
+        // a flat `≤ $X` read as the whole bill (render.rs documents the
+        // 328× measurement — prompts, exec + mcp are unpriced), and the
+        // hardcoded `≤` leaked unicode under `--ascii` (the same class
+        // as the verdict glyph the card already fixed).
+        format!(
+            "est out {}${:.4}",
+            crate::display::vocab::at_most(theme.ascii),
+            report.cost.bounded_total_usd
+        )
     };
+    // The NEP-0018 §4 aggregate — energy beside cost, same honesty
+    // markers, computed by the SAME classification the check ladder's
+    // ENERGY rung renders (one classifier · two surfaces).
+    let energy = crate::verbs::check::energy::inspect_fragment(&report, theme.ascii)
+        .map(|f| format!(" · {f}"))
+        .unwrap_or_default();
 
     let mut out = format!(
-        "{} · {} · {} · {ceiling}\n",
+        "{} · {} · {} · {ceiling}{energy}\n",
         theme.paint(Role::Strong, &doc.workflow),
         crate::text::count(doc.nodes.len(), "task"),
         crate::text::count(report.waves.len(), "wave"),
@@ -379,6 +394,48 @@ mod tests {
             2,
             "two flow arrows join three waves: {}",
             out.text
+        );
+    }
+
+    /// The header aggregates BOTH honesty ladders (NEP-0018 §4): the
+    /// cost ceiling speaks `est out` + the vocab seam (a flat `≤ $X`
+    /// read as the whole bill · 328× measured — and leaked unicode
+    /// under `--ascii`), and the energy aggregate rides beside it, from
+    /// the SAME classification the check ladder renders.
+    #[test]
+    fn header_carries_cost_and_energy_aggregates() {
+        let body = "nika: v1\nworkflow:\n  id: agg\n\nmodel: groq/qwen/qwen3-32b\n\ntasks:\n  only:\n    infer: { prompt: \"x\", max_tokens: 1000 }\noutputs:\n  result: ${{ tasks.only.output }}\n";
+        let path = tmp(body);
+        let out = run(
+            path.to_str().expect("utf-8 tmp path"),
+            Theme::new(false, false, false),
+        );
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(
+            out.text.contains("est out ≤$"),
+            "cost speaks est-out, never a bare bill: {}",
+            out.text
+        );
+        assert!(
+            out.text.contains(" Wh (gpu)"),
+            "the energy aggregate rides the header with its scope: {}",
+            out.text
+        );
+        let ascii = run(
+            path.to_str().expect("utf-8 tmp path"),
+            Theme::new(false, true, false),
+        );
+        std::fs::remove_file(&path).ok();
+        assert_eq!(ascii.code, exit::OK, "{}", ascii.text);
+        assert!(
+            ascii.text.contains("est out <=$") && ascii.text.contains("<= "),
+            "ascii twins ride the seam: {}",
+            ascii.text
+        );
+        assert!(
+            !ascii.text.contains('≤'),
+            "no unicode bound mark under --ascii: {}",
+            ascii.text
         );
     }
 

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -79,8 +79,8 @@ pub fn run(path: &str, theme: Theme) -> VerbOutput {
         // documents the 126× measurement. Claim neither bound; show the
         // priced portion.
         format!(
-            "est unbounded · bounded portion ${:.4}",
-            report.cost.bounded_total_usd
+            "est unbounded · bounded portion ${}",
+            crate::text::usd(report.cost.bounded_total_usd)
         )
     } else {
         // `est out` + the vocab seam, one voice with the audited card:
@@ -89,9 +89,9 @@ pub fn run(path: &str, theme: Theme) -> VerbOutput {
         // hardcoded `≤` leaked unicode under `--ascii` (the same class
         // as the verdict glyph the card already fixed).
         format!(
-            "est out {}${:.4}",
+            "est out {}${}",
             crate::display::vocab::at_most(theme.ascii),
-            report.cost.bounded_total_usd
+            crate::text::usd(report.cost.bounded_total_usd)
         )
     };
     // The NEP-0018 §4 aggregate — energy beside cost, same honesty
@@ -184,7 +184,11 @@ fn node_meta(node: &Node) -> String {
         meta.push(model.clone());
     }
     if let Some([min, max]) = node.cost_interval {
-        meta.push(format!("~${min:.4}-{max:.4}"));
+        meta.push(format!(
+            "~${}-{}",
+            crate::text::usd(min),
+            crate::text::usd(max)
+        ));
     }
     if let Some(fan) = &node.fan_out {
         match fan.count {

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -276,7 +276,7 @@ fn check_clean_file_exits_0_with_grep_stable_sections() {
         "the audited card line closes a clean report: {}",
         out.text
     );
-    // mock/echo is unpriced: the cost lane names the uncapped task,
+    // mock/echo is unpriced: the cost lane names the unpriced task,
     // never invents a bound.
     assert!(out.text.contains("UNBOUNDED"), "{}", out.text);
 }

--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -54,9 +54,63 @@ impl<T> tracing::instrument::Instrument for nika_display::check_render::ModelFin
 impl<T> tracing::instrument::WithSubscriber for nika_display::check_render::ModelFinding
 impl<T> typenum::type_operators::Same for nika_display::check_render::ModelFinding
 pub type nika_display::check_render::ModelFinding::Output = T
+#[non_exhaustive] pub struct nika_display::check_render::ModelsAudit
+pub nika_display::check_render::ModelsAudit::findings: alloc::vec::Vec<nika_display::check_render::ModelFinding>
+pub nika_display::check_render::ModelsAudit::unjudged: usize
+pub nika_display::check_render::ModelsAudit::via_default: usize
+impl nika_display::check_render::ModelsAudit
+pub fn nika_display::check_render::ModelsAudit::new(findings: alloc::vec::Vec<nika_display::check_render::ModelFinding>, unjudged: usize, via_default: usize) -> Self
+impl core::clone::Clone for nika_display::check_render::ModelsAudit
+pub fn nika_display::check_render::ModelsAudit::clone(&self) -> nika_display::check_render::ModelsAudit
+impl core::cmp::Eq for nika_display::check_render::ModelsAudit
+impl core::cmp::PartialEq for nika_display::check_render::ModelsAudit
+pub fn nika_display::check_render::ModelsAudit::eq(&self, other: &nika_display::check_render::ModelsAudit) -> bool
+impl core::fmt::Debug for nika_display::check_render::ModelsAudit
+pub fn nika_display::check_render::ModelsAudit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_display::check_render::ModelsAudit
+impl<D> owo_colors::OwoColorize for nika_display::check_render::ModelsAudit
+impl<Q, K> equivalent::Equivalent<K> for nika_display::check_render::ModelsAudit where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_display::check_render::ModelsAudit::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_display::check_render::ModelsAudit where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_display::check_render::ModelsAudit where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_display::check_render::ModelsAudit::equivalent(&self, key: &K) -> bool
+pub fn nika_display::check_render::ModelsAudit::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_display::check_render::ModelsAudit where U: core::convert::From<T>
+pub fn nika_display::check_render::ModelsAudit::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_display::check_render::ModelsAudit where U: core::convert::Into<T>
+pub type nika_display::check_render::ModelsAudit::Error = core::convert::Infallible
+pub fn nika_display::check_render::ModelsAudit::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_display::check_render::ModelsAudit where U: core::convert::TryFrom<T>
+pub type nika_display::check_render::ModelsAudit::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_display::check_render::ModelsAudit::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_display::check_render::ModelsAudit where T: core::clone::Clone
+pub type nika_display::check_render::ModelsAudit::Owned = T
+pub fn nika_display::check_render::ModelsAudit::clone_into(&self, target: &mut T)
+pub fn nika_display::check_render::ModelsAudit::to_owned(&self) -> T
+impl<T> core::any::Any for nika_display::check_render::ModelsAudit where T: 'static + ?core::marker::Sized
+pub fn nika_display::check_render::ModelsAudit::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_display::check_render::ModelsAudit where T: ?core::marker::Sized
+pub fn nika_display::check_render::ModelsAudit::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_display::check_render::ModelsAudit where T: ?core::marker::Sized
+pub fn nika_display::check_render::ModelsAudit::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_display::check_render::ModelsAudit where T: core::clone::Clone
+pub unsafe fn nika_display::check_render::ModelsAudit::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_display::check_render::ModelsAudit
+pub fn nika_display::check_render::ModelsAudit::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_display::check_render::ModelsAudit where T: core::clone::Clone
+pub fn nika_display::check_render::ModelsAudit::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_display::check_render::ModelsAudit where T: 'static
+pub fn nika_display::check_render::ModelsAudit::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_display::check_render::ModelsAudit where T: ?core::marker::Sized
+pub fn nika_display::check_render::ModelsAudit::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_display::check_render::ModelsAudit::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_display::check_render::ModelsAudit
+impl<T> tracing::instrument::WithSubscriber for nika_display::check_render::ModelsAudit
+impl<T> typenum::type_operators::Same for nika_display::check_render::ModelsAudit
+pub type nika_display::check_render::ModelsAudit::Output = T
 pub fn nika_display::check_render::mark(theme: nika_display::theme::Theme, ok: bool) -> alloc::string::String
 pub fn nika_display::check_render::permits(out: &mut alloc::string::String, report: &nika_check::CheckReport, wf: &nika_schema::raw::workflow::RawWorkflow, t: nika_display::theme::Theme)
-pub fn nika_display::check_render::render(report: &nika_check::CheckReport, wf: &nika_schema::raw::workflow::RawWorkflow, source: &str, path: &str, t: nika_display::theme::Theme, model_findings: &[nika_display::check_render::ModelFinding], skills: &nika_schema::skill::ResolvedSkills, drift_hints: &[alloc::string::String]) -> alloc::string::String
+pub fn nika_display::check_render::render(report: &nika_check::CheckReport, wf: &nika_schema::raw::workflow::RawWorkflow, source: &str, path: &str, t: nika_display::theme::Theme, models_audit: &nika_display::check_render::ModelsAudit, skills: &nika_schema::skill::ResolvedSkills, drift_hints: &[alloc::string::String]) -> alloc::string::String
 pub fn nika_display::check_render::required_inputs(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<&str>
 pub mod nika_display::chrome
 pub const nika_display::chrome::PULSE: [char; 3]
@@ -632,6 +686,7 @@ pub fn nika_display::vocab::at_least(ascii: bool) -> &'static str
 pub fn nika_display::vocab::at_most(ascii: bool) -> &'static str
 pub fn nika_display::vocab::count(n: usize, noun: &str) -> alloc::string::String
 pub fn nika_display::vocab::hint(theme: nika_display::theme::Theme, label: &str, command: &str) -> alloc::string::String
+pub fn nika_display::vocab::usd(amount: f64) -> alloc::string::String
 pub mod nika_display::wires
 pub struct nika_display::wires::WireGraph
 pub nika_display::wires::WireGraph::edges: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>

--- a/crates/nika-display/src/check_models.rs
+++ b/crates/nika-display/src/check_models.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The MODELS rung of the `nika check` render (#320) — the finding
+//! types and their row builder, split from `check_render.rs` at the
+//! 1,500-line file wall (the same wall that moved the render itself
+//! out of nika-cli · 2026-07-29). The public path stays
+//! `check_render::{ModelFinding, ModelsAudit}` through the re-export:
+//! the types live beside their renderer either way.
+
+use std::fmt::Write as _;
+
+use nika_check::CheckReport;
+
+use crate::check_render::mark;
+use crate::theme::{Role, Theme};
+
+/// One MODELS-rung finding — a `model:` the binary cannot run (#320).
+/// The gather (resolver-side) stays with the caller; the render takes
+/// the rows (the `PricingPin` precedent: the judge is pure, the identity
+/// is injected).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModelFinding {
+    /// The unresolvable model string.
+    pub model: String,
+    /// The tasks carrying it.
+    pub tasks: Vec<String>,
+    /// The resolver's own refusal reason.
+    pub why: String,
+}
+
+impl ModelFinding {
+    /// Construct a finding (INV-019 · `new()` on every `#[non_exhaustive]`
+    /// struct).
+    #[must_use]
+    pub fn new(model: String, tasks: Vec<String>, why: String) -> Self {
+        Self { model, tasks, why }
+    }
+}
+
+/// The MODELS-rung audit: the findings PLUS the count of entries the
+/// rung made no claim about — so the green line can never cover a model
+/// it never judged (the old headline counted a skipped templated model
+/// as « resolves in this binary »). Lives beside its renderer like
+/// [`ModelFinding`]: the gather stays with the caller, the render takes
+/// the rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModelsAudit {
+    /// Models this binary cannot run (literal, or via declared default).
+    pub findings: Vec<ModelFinding>,
+    /// Templated `model:` entries with NO static declared default — the
+    /// value arrives at run time (`--var`); no claim was made.
+    pub unjudged: usize,
+    /// Models judged THROUGH a declared default (`${{ const.model }}`
+    /// whose declaration carries a literal string) that resolve — named
+    /// on the green line because a `--var` can swap the value at run.
+    pub via_default: usize,
+}
+
+impl ModelsAudit {
+    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
+    #[must_use]
+    pub fn new(findings: Vec<ModelFinding>, unjudged: usize, via_default: usize) -> Self {
+        Self {
+            findings,
+            unjudged,
+            via_default,
+        }
+    }
+}
+
+/// The MODELS rung (#320): every `model:` must resolve in THIS binary —
+/// green means runnable, never merely cataloged. Renders between PLAN
+/// and COST (resolvability before price).
+///
+/// The green line counts what was JUDGED, never what was skipped. The
+/// old headline said « N models resolve in this binary » over the whole
+/// requirements list — measured 2026-07-30: a workflow whose only model
+/// is `${{ inputs.model }}` (required · no default) printed
+/// `✔ 1 model resolves in this binary` while the rung had skipped it
+/// wholesale. Nothing resolved; nobody looked. An all-unjudged list now
+/// renders `○` (no claim), and a mixed list names its unjudged rest.
+pub(crate) fn models(out: &mut String, report: &CheckReport, audit: &ModelsAudit, t: Theme) {
+    if report.requirements.models.is_empty() {
+        return; // no inference tasks — the ladder says so at COST already
+    }
+    if !audit.findings.is_empty() {
+        for f in &audit.findings {
+            let _ = writeln!(
+                out,
+                " {} {}   `{}` (task{} {}) — {}",
+                mark(t, false),
+                t.paint(Role::Strong, "MODELS"),
+                f.model,
+                if f.tasks.len() == 1 { "" } else { "s" },
+                f.tasks.join(", "),
+                f.why
+            );
+        }
+        return;
+    }
+    let n = report.requirements.models.len();
+    let judged = n - audit.unjudged;
+    if judged == 0 {
+        // Every model is a run-time value — this rung made NO claim,
+        // and a ✔ would be one (the same ○ posture as an undeclared
+        // PERMITS block).
+        let _ = writeln!(
+            out,
+            " {} {}   {}",
+            t.paint(Role::Dim, "○"),
+            t.paint(Role::Strong, "MODELS"),
+            t.paint(
+                Role::Dim,
+                &format!(
+                    "{} — value arrives at run (--var) · unjudged",
+                    crate::vocab::count(n, "run-time model")
+                )
+            )
+        );
+        return;
+    }
+    let via = if audit.via_default > 0 {
+        format!(" ({} via declared default)", audit.via_default)
+    } else {
+        String::new()
+    };
+    let line = if audit.unjudged > 0 {
+        format!(
+            "{judged} of {n} models resolve in this binary{via} · {} run-time · unjudged",
+            audit.unjudged
+        )
+    } else {
+        let noun = if n == 1 {
+            "model resolves"
+        } else {
+            "models resolve"
+        };
+        format!("{n} {noun} in this binary{via}")
+    };
+    let _ = writeln!(
+        out,
+        " {} {}   {}",
+        mark(t, true),
+        t.paint(Role::Strong, "MODELS"),
+        t.paint(Role::Dim, &line)
+    );
+}

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -369,7 +369,15 @@ fn writes_rung(out: &mut String, report: &CheckReport, t: Theme) {
         out,
         t,
         "WRITES",
-        "no two unordered tasks write the same path",
+        // « the same path » alone overreached: the scan proves equality
+        // for STATIC keys only (a literal · a bare immutable-authority
+        // ref, resolved or identical) — a computed path can still
+        // collide at run. Measured 2026-07-30: two unordered writers on
+        // the identical `${{ inputs.f }}` — provably the same file,
+        // inputs bind once per run — rendered the old green while the
+        // literal twin was refused; the scan now catches that class,
+        // and the headline names the computed rest it cannot judge.
+        "no two unordered tasks write the same static path · computed paths at run",
         report
             .write_conflicts
             .iter()
@@ -553,6 +561,42 @@ fn hints_and_verdict(
     }
 }
 
+/// The unbounded-cost census, split by WHY (probe 2026-07-30: a capped
+/// local-model task was announced as « 1 uncapped task » — its cap was
+/// already declared; the missing thing was a PRICE. A count that points
+/// at the wrong repair wastes the one edit it asks for). `uncapped` =
+/// no token bound, or an unknown `for_each` count · `unpriced` =
+/// capped, no catalog price · `unbounded child call` = a composed
+/// child carrying uncapped spend of its own (the reason is unknowable
+/// across the composition wall).
+fn unbounded_census(report: &CheckReport) -> String {
+    let (mut uncapped, mut unpriced) = (0usize, 0usize);
+    for c in &report.cost.tasks {
+        match c.unbounded_reason {
+            Some(UnboundedReason::NoPrice) => unpriced += 1,
+            Some(_) => uncapped += 1,
+            None => {}
+        }
+    }
+    let children = report
+        .cost
+        .composed
+        .iter()
+        .filter(|c| c.has_unbounded)
+        .count();
+    let mut parts = Vec::new();
+    if uncapped > 0 {
+        parts.push(crate::vocab::count(uncapped, "uncapped task"));
+    }
+    if unpriced > 0 {
+        parts.push(crate::vocab::count(unpriced, "unpriced task"));
+    }
+    if children > 0 {
+        parts.push(crate::vocab::count(children, "unbounded child call"));
+    }
+    parts.join(" · ")
+}
+
 /// The clean verdict as ONE informative card line — what was proven,
 /// at a glance: `✔ audited · N tasks · M waves · permits <state> ·
 /// est ≥$X · K hints`. The hints themselves stay above; this line
@@ -579,24 +623,9 @@ fn audited_line(report: &CheckReport, wf: &RawWorkflow, hints: usize, t: Theme) 
     // Bounded: quote the ceiling the section already computed, with `≤`.
     // Unbounded: no ceiling exists, and no floor is computable either
     // (every bounded task is itself priced at its cap), so claim neither
-    // — name the uncapped tasks instead.
-    let uncapped = report
-        .cost
-        .tasks
-        .iter()
-        .filter(|c| c.unbounded_reason.is_some())
-        .count()
-        + report
-            .cost
-            .composed
-            .iter()
-            .filter(|c| c.has_unbounded)
-            .count();
+    // — name WHAT is unbounded, split by why (unbounded_census).
     let est = if report.cost.has_unbounded {
-        format!(
-            "est unbounded · {}",
-            crate::vocab::count(uncapped, "uncapped task")
-        )
+        format!("est unbounded · {}", unbounded_census(report))
     } else {
         // `out` is the narrowing, and it is the same one the COST section
         // carries three lines up. That section already says "worst-case
@@ -607,7 +636,10 @@ fn audited_line(report: &CheckReport, wf: &RawWorkflow, hints: usize, t: Theme) 
         // $0.0075). The card is the line people quote, so it is the line
         // that must not overreach.
         let at_most = crate::vocab::at_most(t.ascii);
-        format!("est out {at_most}${:.4}", report.cost.bounded_total_usd)
+        format!(
+            "est out {at_most}${}",
+            crate::vocab::usd(report.cost.bounded_total_usd)
+        )
     };
     t.paint(
         Role::Good,
@@ -937,12 +969,6 @@ fn models(out: &mut String, report: &CheckReport, audit: &ModelsAudit, t: Theme)
 /// explains at `≤$X`. The totals already carry the children; the uncapped
 /// count names the composed half only (no own task exists to count).
 fn cost_composed_only(out: &mut String, report: &CheckReport, t: Theme) {
-    let uncapped = report
-        .cost
-        .composed
-        .iter()
-        .filter(|c| c.has_unbounded)
-        .count();
     let calls = crate::vocab::count(report.cost.composed.len(), "composed child call");
     if report.cost.has_unbounded {
         let _ = writeln!(
@@ -953,17 +979,19 @@ fn cost_composed_only(out: &mut String, report: &CheckReport, t: Theme) {
             t.paint(
                 Role::Warn,
                 &format!(
-                    "bounded portion ${:.4} · no total ceiling · {} · {} uncapped",
-                    report.cost.bounded_total_usd,
+                    "bounded portion ${} · no total ceiling · {} · {}",
+                    crate::vocab::usd(report.cost.bounded_total_usd),
                     calls,
-                    crate::vocab::count(uncapped, "child")
+                    unbounded_census(report)
                 )
             )
         );
     } else {
         let money = format!(
-            "${:.4} – ${:.4} worst-case output ceiling · {} · own inference $0.00",
-            report.cost.min_path_total_usd, report.cost.bounded_total_usd, calls
+            "${} – ${} worst-case output ceiling · {} · own inference $0.00",
+            crate::vocab::usd(report.cost.min_path_total_usd),
+            crate::vocab::usd(report.cost.bounded_total_usd),
+            calls
         );
         let _ = writeln!(
             out,
@@ -1004,16 +1032,18 @@ fn cost_empty_arm(out: &mut String, report: &CheckReport, t: Theme) {
 /// The per-task rows of [`cost`] — a priced row at its cap, or the
 /// UNBOUNDED row with its named reason (extracted under the fn-length law).
 fn cost_task_rows(out: &mut String, report: &CheckReport, t: Theme) {
+    let le = crate::vocab::at_most(t.ascii);
     for c in &report.cost.tasks {
         let model = c.model.as_deref().unwrap_or("?");
         match (&c.usd, &c.unbounded_reason) {
-            (Some(usd), _) => {
+            (Some(worst), _) => {
                 let _ = writeln!(
                     out,
-                    "   {}  {}  ≤{} tk  ${usd:.4}",
+                    "   {}  {}  {le}{} tk  ${}",
                     c.task,
                     t.paint(Role::Dim, model),
                     c.max_tokens.unwrap_or(0),
+                    crate::vocab::usd(*worst),
                 );
             }
             (None, reason) => {
@@ -1069,36 +1099,25 @@ fn cost(out: &mut String, report: &CheckReport, t: Theme) {
     // (`min_path_total_usd` bounds nothing from below · measured 126× the
     // other way). Same decision as there: claim neither bound, show the
     // only true number (the priced portion), and name the uncapped tasks.
-    let uncapped = report
-        .cost
-        .tasks
-        .iter()
-        .filter(|c| c.unbounded_reason.is_some())
-        .count()
-        + report
-            .cost
-            .composed
-            .iter()
-            .filter(|c| c.has_unbounded)
-            .count();
     let (cost_mark, money, bound) = if report.cost.has_unbounded {
         (
             t.paint(Role::Warn, if t.ascii { "! " } else { "⚠ " }),
-            format!("bounded portion ${:.4}", report.cost.bounded_total_usd),
+            format!(
+                "bounded portion ${}",
+                crate::vocab::usd(report.cost.bounded_total_usd)
+            ),
             t.paint(
                 Role::Warn,
-                &format!(
-                    "no total ceiling · {}",
-                    crate::vocab::count(uncapped, "uncapped task")
-                ),
+                &format!("no total ceiling · {}", unbounded_census(report)),
             ),
         )
     } else {
         (
             mark(t, true),
             format!(
-                "${:.4} – ${:.4}",
-                report.cost.min_path_total_usd, report.cost.bounded_total_usd
+                "${} – ${}",
+                crate::vocab::usd(report.cost.min_path_total_usd),
+                crate::vocab::usd(report.cost.bounded_total_usd)
             ),
             "worst-case output ceiling".to_owned(),
         )

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -43,6 +43,38 @@ impl ModelFinding {
     }
 }
 
+/// The MODELS-rung audit: the findings PLUS the count of entries the
+/// rung made no claim about — so the green line can never cover a model
+/// it never judged (the old headline counted a skipped templated model
+/// as « resolves in this binary »). Lives beside its renderer like
+/// [`ModelFinding`]: the gather stays with the caller, the render takes
+/// the rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModelsAudit {
+    /// Models this binary cannot run (literal, or via declared default).
+    pub findings: Vec<ModelFinding>,
+    /// Templated `model:` entries with NO static declared default — the
+    /// value arrives at run time (`--var`); no claim was made.
+    pub unjudged: usize,
+    /// Models judged THROUGH a declared default (`${{ const.model }}`
+    /// whose declaration carries a literal string) that resolve — named
+    /// on the green line because a `--var` can swap the value at run.
+    pub via_default: usize,
+}
+
+impl ModelsAudit {
+    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
+    #[must_use]
+    pub fn new(findings: Vec<ModelFinding>, unjudged: usize, via_default: usize) -> Self {
+        Self {
+            findings,
+            unjudged,
+            via_default,
+        }
+    }
+}
+
 /// Section mark: `✔`-class verdict glyphs through the theme seam.
 #[must_use]
 pub fn mark(theme: Theme, ok: bool) -> String {
@@ -90,7 +122,7 @@ pub fn render(
     source: &str,
     path: &str,
     t: Theme,
-    model_findings: &[ModelFinding],
+    models_audit: &ModelsAudit,
     skills: &nika_schema::ResolvedSkills,
     drift_hints: &[String],
 ) -> String {
@@ -108,7 +140,7 @@ pub fn render(
     }
 
     plan(&mut out, report, wf, t);
-    models(&mut out, report, model_findings, t);
+    models(&mut out, report, models_audit, t);
     // SKILLS (#473) · silent when nothing is referenced (rows self-teach).
     if let Some((ok_msg, rows)) = skills.rung() {
         section_list(&mut out, t, "SKILLS", &ok_msg, rows);
@@ -824,38 +856,79 @@ fn verb_of<'w>(action: &'w RawAction, wf: &'w RawWorkflow) -> (&'static str, Opt
 /// The MODELS rung (#320): every `model:` must resolve in THIS binary —
 /// green means runnable, never merely cataloged. Renders between PLAN
 /// and COST (resolvability before price).
-fn models(out: &mut String, report: &CheckReport, findings: &[ModelFinding], t: Theme) {
+///
+/// The green line counts what was JUDGED, never what was skipped. The
+/// old headline said « N models resolve in this binary » over the whole
+/// requirements list — measured 2026-07-30: a workflow whose only model
+/// is `${{ inputs.model }}` (required · no default) printed
+/// `✔ 1 model resolves in this binary` while the rung had skipped it
+/// wholesale. Nothing resolved; nobody looked. An all-unjudged list now
+/// renders `○` (no claim), and a mixed list names its unjudged rest.
+fn models(out: &mut String, report: &CheckReport, audit: &ModelsAudit, t: Theme) {
     if report.requirements.models.is_empty() {
         return; // no inference tasks — the ladder says so at COST already
     }
-    if findings.is_empty() {
-        let n = report.requirements.models.len();
+    if !audit.findings.is_empty() {
+        for f in &audit.findings {
+            let _ = writeln!(
+                out,
+                " {} {}   `{}` (task{} {}) — {}",
+                mark(t, false),
+                t.paint(Role::Strong, "MODELS"),
+                f.model,
+                if f.tasks.len() == 1 { "" } else { "s" },
+                f.tasks.join(", "),
+                f.why
+            );
+        }
+        return;
+    }
+    let n = report.requirements.models.len();
+    let judged = n - audit.unjudged;
+    if judged == 0 {
+        // Every model is a run-time value — this rung made NO claim,
+        // and a ✔ would be one (the same ○ posture as an undeclared
+        // PERMITS block).
+        let _ = writeln!(
+            out,
+            " {} {}   {}",
+            t.paint(Role::Dim, "○"),
+            t.paint(Role::Strong, "MODELS"),
+            t.paint(
+                Role::Dim,
+                &format!(
+                    "{} — value arrives at run (--var) · unjudged",
+                    crate::vocab::count(n, "run-time model")
+                )
+            )
+        );
+        return;
+    }
+    let via = if audit.via_default > 0 {
+        format!(" ({} via declared default)", audit.via_default)
+    } else {
+        String::new()
+    };
+    let line = if audit.unjudged > 0 {
+        format!(
+            "{judged} of {n} models resolve in this binary{via} · {} run-time · unjudged",
+            audit.unjudged
+        )
+    } else {
         let noun = if n == 1 {
             "model resolves"
         } else {
             "models resolve"
         };
-        let _ = writeln!(
-            out,
-            " {} {}   {}",
-            mark(t, true),
-            t.paint(Role::Strong, "MODELS"),
-            t.paint(Role::Dim, &format!("{n} {noun} in this binary"))
-        );
-        return;
-    }
-    for f in findings {
-        let _ = writeln!(
-            out,
-            " {} {}   `{}` (task{} {}) — {}",
-            mark(t, false),
-            t.paint(Role::Strong, "MODELS"),
-            f.model,
-            if f.tasks.len() == 1 { "" } else { "s" },
-            f.tasks.join(", "),
-            f.why
-        );
-    }
+        format!("{n} {noun} in this binary{via}")
+    };
+    let _ = writeln!(
+        out,
+        " {} {}   {}",
+        mark(t, true),
+        t.paint(Role::Strong, "MODELS"),
+        t.paint(Role::Dim, &line)
+    );
 }
 
 /// The composition arm of [`cost`] (spec 14 · the 2026-07-29 finding): no
@@ -1395,7 +1468,7 @@ mod policy_rung_tests {
             yaml,
             "w.nika.yaml",
             Theme::new(false, false, false),
-            &[],
+            &ModelsAudit::new(Vec::new(), 0, 0),
             &nika_schema::ResolvedSkills::default(),
             &[],
         )

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -19,61 +19,7 @@ use nika_schema::types::VarDecl;
 use crate::claims::types_claim;
 use crate::theme::{Role, Theme};
 
-/// One MODELS-rung finding — a `model:` the binary cannot run (#320).
-/// The gather (resolver-side) stays with the caller; the render takes
-/// the rows (the `PricingPin` precedent: the judge is pure, the identity
-/// is injected).
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct ModelFinding {
-    /// The unresolvable model string.
-    pub model: String,
-    /// The tasks carrying it.
-    pub tasks: Vec<String>,
-    /// The resolver's own refusal reason.
-    pub why: String,
-}
-
-impl ModelFinding {
-    /// Construct a finding (INV-019 · `new()` on every `#[non_exhaustive]`
-    /// struct).
-    #[must_use]
-    pub fn new(model: String, tasks: Vec<String>, why: String) -> Self {
-        Self { model, tasks, why }
-    }
-}
-
-/// The MODELS-rung audit: the findings PLUS the count of entries the
-/// rung made no claim about — so the green line can never cover a model
-/// it never judged (the old headline counted a skipped templated model
-/// as « resolves in this binary »). Lives beside its renderer like
-/// [`ModelFinding`]: the gather stays with the caller, the render takes
-/// the rows.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct ModelsAudit {
-    /// Models this binary cannot run (literal, or via declared default).
-    pub findings: Vec<ModelFinding>,
-    /// Templated `model:` entries with NO static declared default — the
-    /// value arrives at run time (`--var`); no claim was made.
-    pub unjudged: usize,
-    /// Models judged THROUGH a declared default (`${{ const.model }}`
-    /// whose declaration carries a literal string) that resolve — named
-    /// on the green line because a `--var` can swap the value at run.
-    pub via_default: usize,
-}
-
-impl ModelsAudit {
-    /// Construct (INV-019 · `new()` on every `#[non_exhaustive]` struct).
-    #[must_use]
-    pub fn new(findings: Vec<ModelFinding>, unjudged: usize, via_default: usize) -> Self {
-        Self {
-            findings,
-            unjudged,
-            via_default,
-        }
-    }
-}
+pub use crate::check_models::{ModelFinding, ModelsAudit};
 
 /// Section mark: `✔`-class verdict glyphs through the theme seam.
 #[must_use]
@@ -140,7 +86,7 @@ pub fn render(
     }
 
     plan(&mut out, report, wf, t);
-    models(&mut out, report, models_audit, t);
+    crate::check_models::models(&mut out, report, models_audit, t);
     // SKILLS (#473) · silent when nothing is referenced (rows self-teach).
     if let Some((ok_msg, rows)) = skills.rung() {
         section_list(&mut out, t, "SKILLS", &ok_msg, rows);
@@ -883,84 +829,6 @@ fn verb_of<'w>(action: &'w RawAction, wf: &'w RawWorkflow) -> (&'static str, Opt
         // #[non_exhaustive] — a future verb must not break this build.
         _ => ("task", None),
     }
-}
-
-/// The MODELS rung (#320): every `model:` must resolve in THIS binary —
-/// green means runnable, never merely cataloged. Renders between PLAN
-/// and COST (resolvability before price).
-///
-/// The green line counts what was JUDGED, never what was skipped. The
-/// old headline said « N models resolve in this binary » over the whole
-/// requirements list — measured 2026-07-30: a workflow whose only model
-/// is `${{ inputs.model }}` (required · no default) printed
-/// `✔ 1 model resolves in this binary` while the rung had skipped it
-/// wholesale. Nothing resolved; nobody looked. An all-unjudged list now
-/// renders `○` (no claim), and a mixed list names its unjudged rest.
-fn models(out: &mut String, report: &CheckReport, audit: &ModelsAudit, t: Theme) {
-    if report.requirements.models.is_empty() {
-        return; // no inference tasks — the ladder says so at COST already
-    }
-    if !audit.findings.is_empty() {
-        for f in &audit.findings {
-            let _ = writeln!(
-                out,
-                " {} {}   `{}` (task{} {}) — {}",
-                mark(t, false),
-                t.paint(Role::Strong, "MODELS"),
-                f.model,
-                if f.tasks.len() == 1 { "" } else { "s" },
-                f.tasks.join(", "),
-                f.why
-            );
-        }
-        return;
-    }
-    let n = report.requirements.models.len();
-    let judged = n - audit.unjudged;
-    if judged == 0 {
-        // Every model is a run-time value — this rung made NO claim,
-        // and a ✔ would be one (the same ○ posture as an undeclared
-        // PERMITS block).
-        let _ = writeln!(
-            out,
-            " {} {}   {}",
-            t.paint(Role::Dim, "○"),
-            t.paint(Role::Strong, "MODELS"),
-            t.paint(
-                Role::Dim,
-                &format!(
-                    "{} — value arrives at run (--var) · unjudged",
-                    crate::vocab::count(n, "run-time model")
-                )
-            )
-        );
-        return;
-    }
-    let via = if audit.via_default > 0 {
-        format!(" ({} via declared default)", audit.via_default)
-    } else {
-        String::new()
-    };
-    let line = if audit.unjudged > 0 {
-        format!(
-            "{judged} of {n} models resolve in this binary{via} · {} run-time · unjudged",
-            audit.unjudged
-        )
-    } else {
-        let noun = if n == 1 {
-            "model resolves"
-        } else {
-            "models resolve"
-        };
-        format!("{n} {noun} in this binary{via}")
-    };
-    let _ = writeln!(
-        out,
-        " {} {}   {}",
-        mark(t, true),
-        t.paint(Role::Strong, "MODELS"),
-        t.paint(Role::Dim, &line)
-    );
 }
 
 /// The composition arm of [`cost`] (spec 14 · the 2026-07-29 finding): no

--- a/crates/nika-display/src/lib.rs
+++ b/crates/nika-display/src/lib.rs
@@ -19,6 +19,7 @@
 // nika-cli crate holds at its root — inherited by the descent).
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod check_models;
 pub mod check_render;
 pub mod chrome;
 mod claims;

--- a/crates/nika-display/src/vocab.rs
+++ b/crates/nika-display/src/vocab.rs
@@ -70,6 +70,23 @@ pub fn count(n: usize, noun: &str) -> String {
     }
 }
 
+/// A USD amount at the 4-decimal display grain, ceiling-honest at the
+/// bottom: a positive amount smaller than the grain rounds UP to
+/// `0.0001` instead of printing `0.0000` — a fabricated zero for money
+/// the run WILL spend (probe 2026-07-30: a couple of output tokens on a
+/// priced model bill real money under an `est out ≤$0.0000` card; the
+/// ENERGY lane's display grain paid for the same lesson first). An
+/// EXACT zero — a provably-never-runs task, a declared zero cap — still
+/// prints `0.0000`: that zero is true.
+#[must_use]
+pub fn usd(amount: f64) -> String {
+    if amount > 0.0 && amount < 0.000_05 {
+        "0.0001".to_owned()
+    } else {
+        format!("{amount:.4}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nika-graph/src/lib.rs
+++ b/crates/nika-graph/src/lib.rs
@@ -93,9 +93,12 @@ pub struct Node {
 /// `for_each` fan-out description.
 #[derive(Debug, Serialize)]
 pub struct FanOut {
-    /// `"list"` (literal · known count) or `"expression"` (unknown).
+    /// `"list"` (literal) or `"expression"` (source computed at run).
     pub kind: &'static str,
-    /// Element count for the literal-list form.
+    /// Element count when statically known — a literal list, or an
+    /// expression that is a bare immutable-authority ref over a
+    /// declared literal array (`nika_check::static_literal_of` · the
+    /// same count the cost lane bounds with).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<u64>,
 }
@@ -160,9 +163,17 @@ pub fn project(wf: &RawWorkflow, report: &CheckReport) -> GraphDoc {
                         kind: "list",
                         count: items.as_array().map(|a| a.len() as u64),
                     },
-                    nika_schema::raw::ForEachValue::Expression(_) => FanOut {
+                    // A bare immutable-authority ref over a declared
+                    // literal array has a statically-known count — the
+                    // ONE shared resolver, the same count the cost lane
+                    // bounds with (probe 2026-07-30: the inspect header
+                    // said « no task runs » while this node row said
+                    // `for_each ×?` — one surface, two voices).
+                    nika_schema::raw::ForEachValue::Expression(expr) => FanOut {
                         kind: "expression",
-                        count: None,
+                        count: nika_check::static_literal_of(wf, expr)
+                            .and_then(|v| v.as_array())
+                            .map(|a| a.len() as u64),
                     },
                     #[allow(
                         clippy::unreachable,

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4245
+  classified_files: 4247
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1328
+    authored: 1330
     authored-pin: 2
     generated: 114
     pinned-copy: 105
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 58
-  aggregate_sha256: c3ff687d88a2fd6d42924bdc4119de663e1d47cee11e2d8d9b828ef20b75a79e
+  aggregate_sha256: ea072fee69915cfa02888151e8a5e1d9d2dee267b2dac1d1b541ed3e4216e18d
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --all-features --omit auto-trait-impls > crates/<crate>/public-api.txt (cargo-public-api 0.51.0 pinned · regenerate from the public-api-actual CI artifact)"
@@ -151,13 +151,13 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 664
-  aggregate_sha256: 05351f46e91d8cbad982f87f010b83d606ab02561a818f3d15c812aa5feb1724
+  match_count: 666
+  aggregate_sha256: 379e47740ef6e52317818ff76e1a07d35cce3fbeb96a98849bc8a57178981a48
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 116
-  aggregate_sha256: 1ed2c568a34407ee2232b65eeb29d075ee8058b4c31c7f1eb21b2958b7b541b1
+  aggregate_sha256: df8810624f449660a8a713c753750450a5f07e4de8cf26c613293fad250d051c
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 20
-  aggregate_sha256: b1bd0eb79efcf60e1b45865ea0ac9ab718fa151a5f146e6f5820bc70801ea70a
+  aggregate_sha256: 06d77f698944814b4548b3bb00fc2477be824fb4a004918686f0d7c925cf1633
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
Lands the 2026-07-30 judge-night lane (rescued from local-only `judge-night-2026-07-30`, rebased --signoff onto post-descent main). Four commits survived the replay; the old baseline commit evaporated against main's own.

## What lands

- **One static-literal resolver** (`nika_check::static_literal_of`) — the shared fn the cost lane wanted; five lanes consult it instead of growing private copies.
- **MODELS judges declared defaults**: a templated `model:` whose declaration carries a literal is judged AS that default; the green line counts what was JUDGED (the `1 model resolves` over a wholesale-skipped list is dead). `ModelsAudit` lives beside its renderer in `nika-display::check_render` (path kept stable through a re-export).
- **inspect aggregates energy** (NEP-0018 §4) — the fragment consumes the report's OWN `report.energy` reading (one classification, both surfaces; the branch's private re-classification died in the merge).
- **The adversarial pass, transposed onto the descended tree**: `unbounded_census` (uncapped ≠ unpriced ≠ unbounded-child), the honest `usd` grain (`0.0001` floor, an exact zero stays true), the zero-cap hint, ascii parity on the cost rows.
- **SEC-012 write-race: both generalizations united** — main's lexical normalization + `nika:edit` coverage × the branch's static write key (literal · resolved bare ref · identical `${{ inputs.f }}` refs). Both worlds' test suites kept (zero name collisions).
- Two wall splits en route: `check_models` module (file cap) · `push_infer_hints` (fn cap).

## Proof

- workspace lib + clippy -D warnings + hygiene + ratchets: the pre-push gate, green.
- `nika-check` 582 lib · conformance core+deep green against the spec checkout · `verbs_static` 22/22.

## Known follow-up (this PR)

The `diff` job will flag `nika-display` — the baseline is stale by exactly this PR's surface (`ModelsAudit`, `vocab::usd`, the render signature). Baselines are canonical on ubuntu (zvariant blanket impls don't render on a mac), so the repair is the repo's own flow: regenerate from the `public-api-actual` artifact of the failing run, commit it here.