### PR TITLE
fix(cli): a closed pipe dies clean · the panic leaves the screen (A-4)

### DIFF
--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -18,6 +18,7 @@ mod examples_args;
 mod init_args;
 mod lazy;
 mod model_args;
+mod pipe_hygiene;
 mod registry_args;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -631,6 +632,10 @@ fn concierge(plain_theme: Theme) -> std::process::ExitCode {
 }
 
 fn main() -> std::process::ExitCode {
+    pipe_hygiene::guard(real_main)
+}
+
+fn real_main() -> std::process::ExitCode {
     // RAMS-13 · the full surface on demand: `--help --all` prints the
     // SAME tree with nothing hidden (12 craft verbs lead the default
     // help; protocols · trust cycle · plumbing stay one flag away —

--- a/crates/nika-cli/src/pipe_hygiene.rs
+++ b/crates/nika-cli/src/pipe_hygiene.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Pipe hygiene (A-4 · F-08): `nika run … | head` used to spill a raw
+//! Rust panic (`failed printing to stdout: Broken pipe`) and exit 101
+//! once the reader closed. The workspace forbids unsafe code, so the
+//! unix reset (`SIGPIPE` → `SIG_DFL`) is out of reach; the equivalent safe
+//! seam is the panic plane: the hook keeps the screen clean, the catch
+//! in [`guard`] turns the death into 141 — the exact code a
+//! SIGPIPE-killed process reports, which is what every unix tool in a
+//! pipeline says. Scope is honest: the std print macros on the MAIN
+//! thread (the renderer's thread — measured, the F-08 panic lives
+//! there). Any other panic re-raises untouched.
+
+/// Run the real entry under the pipe guard: install the silencer, turn
+/// a broken-pipe print death into the honest unix exit, re-raise
+/// everything else. `panic = "unwind"` is a workspace commitment
+/// (Cargo.toml pins it for test panic-catching), so the catch always
+/// sees the payload.
+pub(crate) fn guard(real_main: fn() -> std::process::ExitCode) -> std::process::ExitCode {
+    install_pipe_panic_silencer();
+    match std::panic::catch_unwind(real_main) {
+        Ok(code) => code,
+        Err(payload) => {
+            if is_broken_pipe_payload(payload.as_ref()) {
+                std::process::ExitCode::from(141)
+            } else {
+                std::panic::resume_unwind(payload)
+            }
+        }
+    }
+}
+
+/// The std print-macro panic for a closed pipe, and nothing else — the
+/// message shape is std's own (`failed printing to <stream>: <error>`),
+/// so a real defect that merely mentions a pipe never matches.
+fn is_broken_pipe_payload(payload: &dyn std::any::Any) -> bool {
+    let text = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied());
+    text.is_some_and(|s| s.starts_with("failed printing to") && s.contains("Broken pipe"))
+}
+
+/// Silence ONLY the broken-pipe print panic (the catch in [`guard`]
+/// turns it into the honest exit); every other panic keeps the default
+/// hook's full report.
+fn install_pipe_panic_silencer() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if !is_broken_pipe_payload(info.payload()) {
+            default_hook(info);
+        }
+    }));
+}

--- a/crates/nika-cli/tests/pipe_hygiene.rs
+++ b/crates/nika-cli/tests/pipe_hygiene.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// The workspace bans std::process::Command (production spawns ride the
+// kernel ShellExecutor seam). This test's WHOLE JOB is to execute the
+// real `nika-cli` binary (CARGO_BIN_EXE) — the bin_smoke carve-out
+// class: the contract under test IS the binary's pipeline behavior.
+#![allow(clippy::disallowed_types)]
+
+//! A-4 (F-08) · pipe hygiene: a reader that closes early (`| head`)
+//! must never spill a raw Rust panic. The honest death is silent
+//! stderr + exit 141 — the code a SIGPIPE-killed process reports, what
+//! every unix tool in a pipeline says.
+
+#[cfg(unix)]
+#[test]
+fn a_closed_pipe_dies_clean_with_the_unix_code() {
+    use std::fmt::Write as _;
+    use std::io::{BufRead as _, BufReader, Write as _};
+    use std::process::{Command, Stdio};
+
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("target")
+        .join("tmp")
+        .join(format!("pipe-hygiene-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("tmp dir");
+
+    // Enough streaming frames that the renderer still writes after the
+    // reader is gone — the live card redraws per task.
+    let mut yaml = String::from(
+        "nika: v1\nworkflow:\n  id: pipe-drill\nmodel: mock/echo\npermits: {}\ntasks:\n",
+    );
+    for i in 0..40 {
+        let _ = write!(
+            yaml,
+            "  t{i:02}:\n    infer:\n      prompt: \"line {i} long enough to keep the frames coming for the drill\"\n      max_tokens: 32\n"
+        );
+    }
+    let wf = dir.join("pipe-drill.nika.yaml");
+    std::fs::File::create(&wf)
+        .expect("fixture file")
+        .write_all(yaml.as_bytes())
+        .expect("fixture body");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+        .arg("run")
+        .arg(&wf)
+        .args(["--model", "mock/echo"])
+        .current_dir(&dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("binary spawns");
+    // Read ONE line, then drop the handle: the pipe closes while the
+    // renderer is mid-stream — the exact F-08 shape.
+    {
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut first = String::new();
+        let _ = BufReader::new(stdout).read_line(&mut first);
+    }
+    let out = child.wait_with_output().expect("child settles");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "a closed pipe is the caller's choice, never a crash:\n{stderr}"
+    );
+    // Either the run finished before the close (0) or it died the unix
+    // way (141) — never the panic exit (101), never a raw abort.
+    let code = out.status.code();
+    assert!(
+        code == Some(141) || code == Some(0),
+        "honest pipe death (141) or a clean finish (0) · got {code:?}\nstderr: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4284
+  classified_files: 4286
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1366
+    authored: 1368
     authored-pin: 2
     generated: 115
     pinned-copy: 105
@@ -151,13 +151,13 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 691
-  aggregate_sha256: 9f75fd8a8dbdb6943a6c98fb2425d7f6db9b91823250c13908e1e8c6f145da7e
+  match_count: 692
+  aggregate_sha256: 3bd36b8d22d349a5fe59bc6be2498460a0063d6e58c6ab0da05509472b3b71ec
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 121
-  aggregate_sha256: 6a433a6d73b9bc855a4555e5f5631a33be1f96740e2d356d130cc779bb8f0c6c
+  match_count: 122
+  aggregate_sha256: 4c0aea93bf2cbf8b8d1048bcc8625047a87af3d6bd733b94ca8c271913122f90
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored


### PR DESCRIPTION
## The wound (F-08 · gauntlet)

`nika run … | head` spilled a raw Rust panic the moment the reader closed — measured on the live renderer, which keeps redrawing after `head` is gone:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
```

exit 101, panic text on a first-run user's screen.

## The fix (zero unsafe · own module)

The workspace forbids unsafe code, so the classic unix reset (`SIGPIPE → SIG_DFL`) is out of reach. The safe seam is the **panic plane**, at the one choke point every verb passes — `pipe_hygiene::guard` wraps the real entry:

- a panic **hook** that silences exactly the std print-macro broken-pipe payload (`failed printing to … Broken pipe`) — every other panic keeps the default report untouched;
- `catch_unwind` that turns that death into **exit 141** — the code a SIGPIPE-killed process reports, what every unix tool in a pipeline says. `panic=unwind` is already a workspace commitment, so the catch always sees the payload.

Own module because the loc gate said so: main.rs sits at the 1500-LOC cap and the first push tripped `file-loc-cap` RED — the seam got its own file (`src/pipe_hygiene.rs`), and the drill its own test file (`tests/pipe_hygiene.rs`, bin_smoke was one test from the cap too).

## Proof

- **`tests/pipe_hygiene.rs`** (unix-only): spawns the real binary against a 40-task mock run, reads ONE line, closes the pipe — stderr must carry no `panicked`, exit must be 141 (or 0 when the run wins the race).
- At the shell: `nika run many.nika.yaml --model mock/echo | head -2` → two lines, **silence**, pipeline rc=0 — the `grep|head` behavior.
- clippy `-D warnings` ✓ · full pre-push gate ✓ (tests · ratchets · loc-cap back under) · estate ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)