### PR TITLE
fix(check): the models rung consults the catalog before saying resolves

### DIFF
--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -115,7 +115,7 @@ use crate::verbs::{VerbOutput, load_checked, load_checked_with_source};
 mod drift;
 pub(crate) mod energy;
 mod models_rung;
-use models_rung::{ModelsAudit, pricing_section, unresolvable_models};
+use models_rung::{ModelFinding, ModelsAudit, pricing_section, unresolvable_models};
 
 use nika_display::check_render::render;
 #[cfg(test)]
@@ -353,6 +353,23 @@ fn parse_fatal_json(out: &VerbOutput) -> VerbOutput {
     }
 }
 
+/// The machine rows both MODELS lists share (resolve findings · catalog
+/// warnings) — one `model`/`tasks`/`why` shape on the `--json` lane.
+fn model_finding_rows(findings: &[ModelFinding]) -> serde_json::Value {
+    serde_json::Value::Array(
+        findings
+            .iter()
+            .map(|f| {
+                serde_json::json!({
+                    "model": f.model,
+                    "tasks": f.tasks,
+                    "why": f.why,
+                })
+            })
+            .collect(),
+    )
+}
+
 /// The `--json` verdict: the full report + the machine keys (`clean` ·
 /// `models_resolve` · `models_unjudged` (presence-gated) ·
 /// `model_findings[]` · `skills_resolve` · `skill_findings[]` ·
@@ -405,18 +422,16 @@ fn json_verdict(
         if !model_findings.is_empty() {
             obj.insert(
                 "model_findings".to_owned(),
-                serde_json::Value::Array(
-                    model_findings
-                        .iter()
-                        .map(|f| {
-                            serde_json::json!({
-                                "model": f.model,
-                                "tasks": f.tasks,
-                                "why": f.why,
-                            })
-                        })
-                        .collect(),
-                ),
+                model_finding_rows(model_findings),
+            );
+        }
+        // Presence-gated like its siblings: the catalog cross-check
+        // (advisory — `clean` is untouched; a machine consumer that
+        // wants to block on it can).
+        if !models_audit.catalog_warnings.is_empty() {
+            obj.insert(
+                "models_catalog_warnings".to_owned(),
+                model_finding_rows(&models_audit.catalog_warnings),
             );
         }
         skills.extend_check_json(obj);

--- a/crates/nika-cli/src/verbs/check/models_rung.rs
+++ b/crates/nika-cli/src/verbs/check/models_rung.rs
@@ -61,6 +61,15 @@ pub(super) fn unresolvable_models(
             None if via_default => audit.via_default += 1,
             None => {}
         }
+        // The sister law, same home (audit UX 2026-07-31): a model that
+        // RESOLVES but matches nothing the snapshot prices for its
+        // provider warned nobody — the user bought the key, then met
+        // the typo. Advisory beside the green line, never a finding.
+        if let Some(why) = nika_providers::catalog_warning(judged) {
+            audit
+                .catalog_warnings
+                .push(ModelFinding::new(m.model.clone(), m.tasks.clone(), why));
+        }
     }
     audit
 }

--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -55,11 +55,13 @@ impl<T> tracing::instrument::WithSubscriber for nika_display::check_render::Mode
 impl<T> typenum::type_operators::Same for nika_display::check_render::ModelFinding
 pub type nika_display::check_render::ModelFinding::Output = T
 #[non_exhaustive] pub struct nika_display::check_render::ModelsAudit
+pub nika_display::check_render::ModelsAudit::catalog_warnings: alloc::vec::Vec<nika_display::check_render::ModelFinding>
 pub nika_display::check_render::ModelsAudit::findings: alloc::vec::Vec<nika_display::check_render::ModelFinding>
 pub nika_display::check_render::ModelsAudit::unjudged: usize
 pub nika_display::check_render::ModelsAudit::via_default: usize
 impl nika_display::check_render::ModelsAudit
 pub fn nika_display::check_render::ModelsAudit::new(findings: alloc::vec::Vec<nika_display::check_render::ModelFinding>, unjudged: usize, via_default: usize) -> Self
+pub fn nika_display::check_render::ModelsAudit::with_catalog_warnings(self, warnings: alloc::vec::Vec<nika_display::check_render::ModelFinding>) -> Self
 impl core::clone::Clone for nika_display::check_render::ModelsAudit
 pub fn nika_display::check_render::ModelsAudit::clone(&self) -> nika_display::check_render::ModelsAudit
 impl core::cmp::Eq for nika_display::check_render::ModelsAudit

--- a/crates/nika-display/src/check_models.rs
+++ b/crates/nika-display/src/check_models.rs
@@ -57,6 +57,11 @@ pub struct ModelsAudit {
     /// whose declaration carries a literal string) that resolve — named
     /// on the green line because a `--var` can swap the value at run.
     pub via_default: usize,
+    /// Models that RESOLVE but match nothing the pricing snapshot
+    /// carries for their (priced) provider — the two-strike class
+    /// (audit UX 2026-07-31: buy the key, then meet the typo). A ⚠,
+    /// never a ✖: the snapshot is dated, providers ship models weekly.
+    pub catalog_warnings: Vec<ModelFinding>,
 }
 
 impl ModelsAudit {
@@ -67,7 +72,16 @@ impl ModelsAudit {
             findings,
             unjudged,
             via_default,
+            catalog_warnings: Vec::new(),
         }
+    }
+
+    /// Attach the catalog cross-check warnings (consuming builder — the
+    /// `new()` signature stays frozen, INV-019).
+    #[must_use]
+    pub fn with_catalog_warnings(mut self, warnings: Vec<ModelFinding>) -> Self {
+        self.catalog_warnings = warnings;
+        self
     }
 }
 
@@ -147,4 +161,16 @@ pub(crate) fn models(out: &mut String, report: &CheckReport, audit: &ModelsAudit
         t.paint(Role::Strong, "MODELS"),
         t.paint(Role::Dim, &line)
     );
+    // The catalog cross-check rides UNDER the green line (the audit
+    // stays clean — advisory): the model resolves, the snapshot has
+    // never heard of it, and the user deserves to know BEFORE the key.
+    for w in &audit.catalog_warnings {
+        let _ = writeln!(
+            out,
+            " {} {}   {}",
+            t.paint(Role::Warn, if t.ascii { "!" } else { "⚠" }),
+            t.paint(Role::Strong, "MODELS"),
+            w.why
+        );
+    }
 }

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -182,3 +182,50 @@ mod energy_tests {
         assert_eq!(fmt_scope_totals(&[]), "");
     }
 }
+
+mod models_rung_tests {
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    use crate::check_render::*;
+
+    /// The two-strike class, rendered (audit UX 2026-07-31): the rung
+    /// stays GREEN (the provider resolves — the catalog cross-check is
+    /// advisory) and the ⚠ rides UNDER the green line, never instead
+    /// of it — the user sees « resolves » AND « unheard of » together.
+    #[test]
+    fn a_catalog_warning_rides_under_the_green_models_line() {
+        let yaml = "nika: v1\nworkflow:\n  id: t\ntasks:\n  probe:\n    infer: { model: anthropic/claude-4-nonexistent, prompt: \"x\" }\n";
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let report = nika_check::check(&wf);
+        let audit =
+            ModelsAudit::new(Vec::new(), 0, 0).with_catalog_warnings(vec![ModelFinding::new(
+                "anthropic/claude-4-nonexistent".to_owned(),
+                vec!["probe".to_owned()],
+                "matches none of `anthropic`'s known models".to_owned(),
+            )]);
+        let out = render(
+            &report,
+            &wf,
+            yaml,
+            "w.nika.yaml",
+            Theme::new(false, false, false),
+            &audit,
+            &nika_schema::ResolvedSkills::default(),
+            &[],
+            report.is_clean(),
+        );
+        let green = out
+            .lines()
+            .position(|l| l.contains("MODELS") && l.contains('✔'))
+            .expect("the green line stays");
+        let warn = out
+            .lines()
+            .position(|l| l.contains("MODELS") && l.contains('⚠'))
+            .expect("the ⚠ rides");
+        assert!(warn > green, "the ⚠ rides UNDER the green line:\n{out}");
+        // The advisory never dirties the verdict: the report the rung
+        // rendered stayed clean (the provider resolves).
+        assert!(report.is_clean());
+    }
+}

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -274,6 +274,59 @@ fn native_first_verdict(
     ))
 }
 
+/// The MODELS cross-check rows for both laws (resolver refusals ·
+/// catalog warnings) — one `model`/`tasks`/`why` shape on every machine
+/// lane (this oracle and the CLI `--json` twin must not disagree). The
+/// catalog cross-check is the two-strike class (audit UX 2026-07-31): a
+/// model that RESOLVES but matches nothing the snapshot prices for its
+/// provider must be relayed BEFORE the human buys a key — advisory on
+/// both lanes, `clean` untouched.
+fn model_crosscheck(report: &nika_check::CheckReport) -> (Vec<Value>, Vec<Value>) {
+    let findings = report
+        .requirements
+        .models
+        .iter()
+        .filter_map(|m| {
+            nika_providers::resolve_refusal(&m.model)
+                .map(|why| serde_json::json!({ "model": m.model, "tasks": m.tasks, "why": why }))
+        })
+        .collect();
+    let warnings = report
+        .requirements
+        .models
+        .iter()
+        .filter_map(|m| {
+            nika_providers::catalog_warning(&m.model)
+                .map(|why| serde_json::json!({ "model": m.model, "tasks": m.tasks, "why": why }))
+        })
+        .collect();
+    (findings, warnings)
+}
+
+/// The clean short-path — split out of `check` under the house function
+/// cap (the `native_first_verdict` precedent). Still carries the catalog
+/// cross-check: the ghost-model specimen IS clean (the provider
+/// resolves), and a warning that only rode the dirty path would never
+/// be seen.
+fn clean_verdict(
+    native: &[&str],
+    strict: bool,
+    grade: nika_check::RiskGrade,
+    catalog_warnings: &[Value],
+) -> Result<String, String> {
+    let verdict = native_first_verdict(native, strict, grade)?;
+    if catalog_warnings.is_empty() {
+        return Ok(verdict);
+    }
+    let rows = catalog_warnings
+        .iter()
+        .filter_map(|w| w.get("why").and_then(Value::as_str))
+        .map(|why| format!("  ⚠ {why}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(format!("{verdict}\n{rows}"))
+}
+
 fn check(args: &Value) -> Result<String, String> {
     let yaml = args
         .get("workflow")
@@ -292,16 +345,9 @@ fn check(args: &Value) -> Result<String, String> {
     let grade = nika_check::risk_grade(&report);
     // The MODELS rung, MCP lane (#320 repro 3): the schema ladder alone
     // audited a hallucinated model green — cross every requirement against
-    // the RESOLVER law shared with the CLI rung (nika-providers).
-    let model_findings: Vec<Value> = report
-        .requirements
-        .models
-        .iter()
-        .filter_map(|m| {
-            nika_providers::resolve_refusal(&m.model)
-                .map(|why| serde_json::json!({ "model": m.model, "tasks": m.tasks, "why": why }))
-        })
-        .collect();
+    // the RESOLVER law shared with the CLI rung (nika-providers), plus its
+    // sister catalog law (advisory — `clean` is untouched).
+    let (model_findings, catalog_warnings) = model_crosscheck(&report);
     // The is_clean mirror law, applied to the native-first lane. `hints`
     // are NOT part of `is_clean()`, so a workflow whose real work sits in
     // `exec python3 helper.py` used to come back here as a bare "✔ clean"
@@ -325,7 +371,7 @@ fn check(args: &Value) -> Result<String, String> {
         .map(|h| h.advice.as_str())
         .collect();
     if report.is_clean() && model_findings.is_empty() {
-        return native_first_verdict(&native, native_strict, grade);
+        return clean_verdict(&native, native_strict, grade, &catalog_warnings);
     }
     // `is_clean()` checks TEN finding surfaces (conformance · secret leaks +
     // egresses · capability escapes · schema findings + lints · unknown/missing
@@ -349,6 +395,14 @@ fn check(args: &Value) -> Result<String, String> {
         );
         if !model_findings.is_empty() {
             obj.insert("model_findings".to_owned(), Value::Array(model_findings));
+        }
+        // Presence-gated like the CLI twin (`models_catalog_warnings`) —
+        // the same key on both machine surfaces, one voice.
+        if !catalog_warnings.is_empty() {
+            obj.insert(
+                "models_catalog_warnings".to_owned(),
+                Value::Array(catalog_warnings),
+            );
         }
     }
     let detail = serde_json::to_string_pretty(&payload)

--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -249,6 +249,7 @@ pub fn nika_providers::profile::Profile::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::profile::Profile where T: 'static
 pub fn nika_providers::profile::Profile::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub const nika_providers::profile::CANONICAL_IDS: [&str; 16]
+pub fn nika_providers::profile::catalog_warning(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::profile::resolve_refusal(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::profile::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>
 pub mod nika_providers::registry
@@ -623,5 +624,6 @@ pub async fn nika_providers::registry::ResolvedProvider<H>::infer(&self, request
 impl<TraitVariantBlanketType> nika_kernel_ai::provider::ProviderStream for nika_providers::registry::ResolvedProvider<H> where TraitVariantBlanketType: nika_kernel_ai::provider::ProviderStreamDyn
 pub async fn nika_providers::registry::ResolvedProvider<H>::infer_stream(&self, request: nika_kernel_ai::provider::InferRequest) -> core::result::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::provider::InferEvent, nika_kernel_ai::provider::ProviderError>> + core::marker::Send)>>, nika_kernel_ai::provider::ProviderError>
 pub const nika_providers::CANONICAL_IDS: [&str; 16]
+pub fn nika_providers::catalog_warning(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::resolve_refusal(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::seed() -> alloc::vec::Vec<nika_providers::profile::Profile>

--- a/crates/nika-providers/src/lib.rs
+++ b/crates/nika-providers/src/lib.rs
@@ -49,5 +49,5 @@ mod sse;
 mod test_support;
 pub mod wire;
 
-pub use profile::{CANONICAL_IDS, Profile, WireFormat, resolve_refusal, seed};
+pub use profile::{CANONICAL_IDS, Profile, WireFormat, catalog_warning, resolve_refusal, seed};
 pub use registry::{NoHttp, ProviderRegistry, ProvidersConfig, ResolvedProvider};

--- a/crates/nika-providers/src/profile.rs
+++ b/crates/nika-providers/src/profile.rs
@@ -205,6 +205,80 @@ pub fn resolve_refusal(model: &str) -> Option<String> {
     }
 }
 
+/// The MODELS-rung catalog cross-check (audit UX 2026-07-31 · the
+/// two-strike class): `anthropic/claude-4-nonexistent` RESOLVES (the
+/// provider is runnable) and the audit said `✔ MODELS` — the user buys
+/// a key, and only THEN meets the typo at the provider.
+///
+/// `Some(warning)` when the model name matches NOTHING this binary
+/// knows for a PRICED provider — neither of the two lanes the run
+/// itself trusts: the catalog row's nicknames + wire ids (what
+/// [`Profile::resolve_model`] maps at run, so `mistral/small` and
+/// `anthropic/sonnet` are the binary's OWN teaching, never ghosts) and
+/// the pricing snapshot's patterns. `None` otherwise. A warning, never
+/// a refusal: the snapshot is a dated artifact and providers ship new
+/// models weekly — the message says exactly that. Providers with no
+/// priced rows (the local five · mock) are never judged: their models
+/// are whatever the user pulled, and the catalog cannot know them.
+///
+/// Lives beside [`resolve_refusal`] for the same reason it does: ONE
+/// law, consulted by every audit surface (CLI check · MCP `nika_check`).
+#[must_use]
+pub fn catalog_warning(model: &str) -> Option<String> {
+    let (provider, name) = model.split_once('/')?;
+    if !CANONICAL_IDS.contains(&provider) {
+        return None; // resolve_refusal owns the unknown-provider class
+    }
+    // Lane 1 — the run lane's own names. The first cut of this law
+    // consulted the pricing snapshot ONLY and warned on
+    // `anthropic/sonnet` — a nickname the binary itself teaches and
+    // maps to a wire id at run (binary probe, 2026-07-31).
+    let catalog_row = nika_catalog::find_provider(provider);
+    let row_models = catalog_row.map_or(&[][..], |row| row.models);
+    if row_models.iter().any(|m| m.id == name || m.model == name) {
+        return None;
+    }
+    // Lane 2 — the pricing snapshot (exact, then contains: the pass
+    // that prices dated variants absorbs their near-typos too — the
+    // conjured-price trade-off lives in the pricing layer, documented
+    // at `find_pricing`, deliberately not re-judged here).
+    let priced: Vec<&'static str> = nika_catalog::all_pricing()
+        .iter()
+        .filter(|p| p.provider.eq_ignore_ascii_case(provider))
+        .map(|p| p.model_pattern)
+        .collect();
+    if priced.is_empty() {
+        return None; // local/mock class — models are whatever was pulled
+    }
+    if nika_catalog::find_pricing_for(model).is_some() {
+        return None;
+    }
+    // The same shared metric as the provider guess above — over the
+    // UNION of what both lanes know (when the near miss is a nickname,
+    // the nickname is the right suggestion).
+    let guess = nika_types::suggest::did_you_mean(
+        name,
+        row_models
+            .iter()
+            .flat_map(|m| [m.id, m.model])
+            .chain(priced.iter().copied()),
+    )
+    .map(|m| format!(" — did you mean `{provider}/{m}`?"))
+    .unwrap_or_default();
+    let snapshot = nika_catalog::pricing_snapshot();
+    let known = priced.len()
+        + row_models
+            .iter()
+            .filter(|m| !priced.contains(&m.model))
+            .count();
+    Some(format!(
+        "`{model}` resolves (the provider is runnable) but matches none of \
+         `{provider}`'s {known} known models — a typo, or newer than this \
+         binary's snapshot ({}); a run would fail at the provider{guess}",
+        snapshot.as_of,
+    ))
+}
+
 /// The 10 cloud rows (catalog-backed) + the in-process mock.
 ///
 /// gemini's `base_url` is a STEM (`…/v1beta`) — the s8.6 adapter appends
@@ -342,6 +416,48 @@ mod tests {
         assert!(typo.contains("did you mean `anthropic`?"), "{typo}");
         let gemni = resolve_refusal("gemni/gemini-2.5-flash").expect("typo refused");
         assert!(gemni.contains("did you mean `gemini`?"), "{gemni}");
+    }
+
+    /// The two-strike class (audit UX 2026-07-31): a ghost model on a
+    /// RUNNABLE provider resolved green, the user bought a key, and only
+    /// then met the typo. The catalog cross-check warns at audit time —
+    /// and stays honestly a WARNING (the snapshot is dated; providers
+    /// ship new models weekly).
+    #[test]
+    fn catalog_warning_catches_the_ghost_and_spares_the_living() {
+        // The exact audit specimen: provider runnable, model nowhere in
+        // the snapshot — warned, with the snapshot date named.
+        let ghost = catalog_warning("anthropic/claude-4-nonexistent").expect("ghost warned");
+        assert!(
+            ghost.contains("matches none of `anthropic`'s")
+                && ghost.contains("newer than this binary's snapshot"),
+            "{ghost}"
+        );
+        // A cataloged model never warns (exact then contains — the same
+        // one resolution the COST rung prices with).
+        assert!(catalog_warning("openai/gpt-4o-mini").is_none());
+        // The run lane's OWN names never warn: catalog-row nicknames
+        // and wire ids are what `resolve_model` maps at run — the first
+        // cut of this law warned on `anthropic/sonnet`, a nickname the
+        // binary itself teaches (binary probe, 2026-07-31).
+        assert!(catalog_warning("anthropic/sonnet").is_none());
+        assert!(catalog_warning("mistral/small").is_none());
+        assert!(catalog_warning("mistral/mistral-small-latest").is_none());
+        assert!(catalog_warning("anthropic/claude-sonnet-4-20250514").is_none());
+        // A nickname near-miss warns AND suggests the nickname.
+        let sonett = catalog_warning("anthropic/sonett").expect("nickname typo warned");
+        assert!(
+            sonett.contains("did you mean `anthropic/sonnet`?"),
+            "{sonett}"
+        );
+        // Local providers carry whatever was pulled: never judged.
+        assert!(catalog_warning("ollama/qwen3.5:4b").is_none());
+        assert!(catalog_warning("llamacpp/anything-at-all").is_none());
+        // mock and the not-our-class shapes stay silent (resolve_refusal
+        // owns bare ids and unknown providers).
+        assert!(catalog_warning("mock/echo").is_none());
+        assert!(catalog_warning("gpt-4o-mini").is_none());
+        assert!(catalog_warning("azure/gpt-4o").is_none());
     }
 
     use super::*;

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 59
-  aggregate_sha256: 80dcfd343567f644a96654d5180bd5b64698e4a10f008c436d3fe4a909bfe222
+  aggregate_sha256: 46632797739edc287fc3b46cbedf675c6d189d4cd4c0a0f1ce1947533bd2ea9f
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 694
-  aggregate_sha256: d2b5bf683c3c5f0e37f91f9791ba6506b30b52f2268675ff007eb35b77354fcc
+  aggregate_sha256: bf15aacc0b4d42cacaf20fc33ba965b0f94e8f519051e326eb57b0980e4e38fd
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## B-7 · the ghost model passed `✔ MODELS resolves`

First-run-truth arc (user gauntlet 2026-07-31 · A-05 · the two-strike class). A ghost model on a runnable provider passed the MODELS rung — the rung crossed `model:` against the resolver, never against what the binary KNOWS. The user bought the key, and only then met the typo at the provider.

### The law

One `catalog_warning()`, beside its sister `resolve_refusal()` in `nika-providers`, consulted by every audit surface. A name warns only when it matches NOTHING the binary knows for a priced provider:

- the catalog row's **nicknames + wire ids** (what `resolve_model` maps at run — `mistral/small` and `anthropic/sonnet` are the binary's own teaching, never ghosts; the first cut of this law warned on sonnet, caught at the binary probe)
- the **pricing snapshot**'s patterns
- locals and mock are never judged: their models are whatever was pulled

### The surfaces

Advisory by construction (clean untouched, exit codes unchanged):

- `⚠ MODELS` under the green line on the console, with the snapshot named and a did-you-mean
- `models_catalog_warnings` in the `--json` projection (presence-gated)
- the same key on the MCP findings path — and the clean MCP verdict carries it as text (the ghost IS clean, so a warning that only rode the dirty path would never be seen)

### G-21 / G-22

Re-probed on main at `8c1447fbc`: the budget floor under `--model override` and the unpriced-catalog-model-named are both already fixed — B-7 completes with this law.

### Evidence

Replayed at the release binary in a keyless sandbox (HOME isolated, zero keys), on top of current main (`b5a00dd77`):

- **11/11 scenarios green** — the ghost warns with the snapshot named · `anthropic/sonnet`, `mistral/small`, wire ids, priced `openai/gpt-4o-mini`, `ollama/*` and `mock/echo` stay silent · a nickname typo (`anthropic/sonett`) suggests `anthropic/sonnet` · both machine lanes carry the key, on clean and dirty paths
- `cargo test --lib` (nika-providers · nika-display · nika-cli · nika-mcp): 159/159
- `estate.yaml` re-projected and riding the commit

🦋 Generated with the Nika engine repo gates
