### PR TITLE
feat(mcp): the oracle walks the CLI's routing door (RAMS-11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4474,6 +4474,7 @@ dependencies = [
  "nika-error",
  "nika-graph",
  "nika-kernel",
+ "nika-onboard",
  "nika-pack",
  "nika-providers",
  "nika-sandbox-landlock",

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -21,6 +21,7 @@ nika-pack   = { path = "../nika-pack", version = "0.107.0" }    # embedded canon
 # versioned projections `nika catalog|tools --json` emit (one builder per
 # owning crate · zero duplication). L4→L0 / L4→L1.5, strictly downward.
 nika-catalog = { path = "../nika-catalog", version = "0.107.0", default-features = false, features = ["serde", "capabilities"] }
+nika-onboard = { path = "../nika-onboard", version = "0.107.0" }  # the ONE routing door (RAMS-11 · MCP follows the CLI's router)
 nika-builtin = { path = "../nika-builtin", version = "0.107.0" }
 # The exec verb's OS sandbox (ADR-095 Layer 6) — a spawned MCP server rides
 # the SAME confinement (never a bespoke second sandbox). L4→L0.5/L1, strictly

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -426,12 +426,34 @@ fn check(args: &Value) -> Result<String, String> {
 fn examples(args: &Value) -> Result<String, String> {
     match args.get("slug").and_then(Value::as_str) {
         None => Ok(nika_pack::example_slugs().join("\n")),
-        Some(slug) => nika_pack::example(slug).map(str::to_owned).ok_or_else(|| {
-            format!(
+        Some(slug) => match nika_pack::example(slug) {
+            Some(body) => Ok(body.to_owned()),
+            // RAMS-11: a PLAIN-WORDS miss routes through the SAME door
+            // the CLI walks (`nika new <words>` · whole catalog) — one
+            // router, one calibration. Only multi-word queries route:
+            // a single token is a slug (typo'd or adversarial) and the
+            // unknown-key contract holds — the router never sees the
+            // traversal-shaped garbage the adversarial pin feeds.
+            None if !slug.trim().contains(' ') => Err(format!(
                 "unknown example `{slug}` — call nika_examples without arguments \
                  for the list"
-            )
-        }),
+            )),
+            None => match nika_onboard::routing::route_query(slug) {
+                nika_onboard::routing::RoutedEntry::Example(name) => {
+                    let body = nika_pack::example(&name).unwrap_or_default();
+                    Ok(format!("# routed: `{slug}` → example `{name}`\n{body}"))
+                }
+                nika_onboard::routing::RoutedEntry::Skeleton(name) => {
+                    let body = nika_pack::template(&name).unwrap_or_default();
+                    Ok(format!("# routed: `{slug}` → template `{name}`\n{body}"))
+                }
+                nika_onboard::routing::RoutedEntry::Clarify(candidates) => Err(format!(
+                    "`{slug}` doesn't route confidently — closest: {} · call \
+                     nika_examples without arguments for the list",
+                    candidates.join(" · ")
+                )),
+            },
+        },
     }
 }
 
@@ -440,12 +462,31 @@ fn examples(args: &Value) -> Result<String, String> {
 fn template(args: &Value) -> Result<String, String> {
     match args.get("name").and_then(Value::as_str) {
         None => Ok(nika_pack::template_names().join("\n")),
-        Some(name) => nika_pack::template(name).map(str::to_owned).ok_or_else(|| {
-            format!(
+        Some(name) => match nika_pack::template(name) {
+            Some(body) => Ok(body.to_owned()),
+            // RAMS-11: a PLAIN-WORDS miss routes within the SKELETON set
+            // — the CLI wizard's door (SLOTs to fill). Single tokens keep
+            // the unknown-key contract (see nika_examples).
+            None if !name.trim().contains(' ') => Err(format!(
                 "unknown template `{name}` — call nika_template without arguments \
                  for the list"
-            )
-        }),
+            )),
+            None => match nika_onboard::routing::route_skeleton_query(name) {
+                nika_onboard::routing::RoutedEntry::Skeleton(routed) => {
+                    let body = nika_pack::template(&routed).unwrap_or_default();
+                    Ok(format!("# routed: `{name}` → template `{routed}`\n{body}"))
+                }
+                nika_onboard::routing::RoutedEntry::Example(routed) => {
+                    let body = nika_pack::example(&routed).unwrap_or_default();
+                    Ok(format!("# routed: `{name}` → example `{routed}`\n{body}"))
+                }
+                nika_onboard::routing::RoutedEntry::Clarify(candidates) => Err(format!(
+                    "`{name}` doesn't route confidently — closest: {} · call \
+                     nika_template without arguments for the list",
+                    candidates.join(" · ")
+                )),
+            },
+        },
     }
 }
 
@@ -934,6 +975,30 @@ mod tests {
         let err = execute("nika_examples", &json!({ "slug": "no-such-example" }))
             .expect_err("unknown slug");
         assert!(err.contains("unknown example"), "{err}");
+    }
+
+    /// RAMS-11: the oracle walks the CLI's routing door on plain words —
+    /// the SAME query `nika new` routes lands the SAME entry here, and
+    /// the interpretation is SAID in a leading YAML comment.
+    #[test]
+    fn examples_route_plain_words_through_the_one_door() {
+        let out =
+            execute("nika_examples", &json!({ "slug": "chase unpaid invoices" })).expect("routes");
+        assert!(
+            out.starts_with("# routed: `chase unpaid invoices` → example `invoice-chaser`"),
+            "the routing is said: {out}"
+        );
+        assert!(out.contains("nika: v1"), "the body follows: {out}");
+    }
+
+    /// RAMS-11, the honest floor: plain words below the confidence bar
+    /// clarify with the closest names — never a silent guess.
+    #[test]
+    fn examples_clarify_below_the_bar_instead_of_guessing() {
+        let err = execute("nika_examples", &json!({ "slug": "do stuff with things" }))
+            .expect_err("vague words clarify");
+        assert!(err.contains("doesn't route confidently"), "{err}");
+        assert!(err.contains("·"), "names candidates: {err}");
     }
 
     /// The slug/name is a KEY into the compile-time embedded pack

--- a/crates/nika-onboard/public-api.txt
+++ b/crates/nika-onboard/public-api.txt
@@ -75,6 +75,51 @@ pub fn nika_onboard::guided::dispatch(from: core::option::Option<&str>, dest: co
 pub fn nika_onboard::guided::run(template: &str, dest: core::option::Option<&str>, force: bool) -> nika_onboard::Outcome
 pub fn nika_onboard::guided::wizard_io(base: &str, dest_hint: core::option::Option<&str>, force: bool, theme: nika_display::theme::Theme, input: &mut dyn alloc::io::buf_read::BufRead, out: &mut dyn core::io::write::Write, audit: &nika_onboard::Audit<'_>) -> nika_onboard::Outcome
 pub mod nika_onboard::recipes
+pub mod nika_onboard::routing
+pub enum nika_onboard::routing::RoutedEntry
+pub nika_onboard::routing::RoutedEntry::Clarify(alloc::vec::Vec<alloc::string::String>)
+pub nika_onboard::routing::RoutedEntry::Example(alloc::string::String)
+pub nika_onboard::routing::RoutedEntry::Skeleton(alloc::string::String)
+impl core::cmp::Eq for nika_onboard::routing::RoutedEntry
+impl core::cmp::PartialEq for nika_onboard::routing::RoutedEntry
+pub fn nika_onboard::routing::RoutedEntry::eq(&self, other: &nika_onboard::routing::RoutedEntry) -> bool
+impl core::fmt::Debug for nika_onboard::routing::RoutedEntry
+pub fn nika_onboard::routing::RoutedEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_onboard::routing::RoutedEntry
+impl<D> owo_colors::OwoColorize for nika_onboard::routing::RoutedEntry
+impl<Q, K> equivalent::Equivalent<K> for nika_onboard::routing::RoutedEntry where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_onboard::routing::RoutedEntry::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_onboard::routing::RoutedEntry where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+impl<Q, K> hashbrown::Equivalent<K> for nika_onboard::routing::RoutedEntry where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_onboard::routing::RoutedEntry::equivalent(&self, key: &K) -> bool
+pub fn nika_onboard::routing::RoutedEntry::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_onboard::routing::RoutedEntry where U: core::convert::From<T>
+pub fn nika_onboard::routing::RoutedEntry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_onboard::routing::RoutedEntry where U: core::convert::Into<T>
+pub type nika_onboard::routing::RoutedEntry::Error = core::convert::Infallible
+pub fn nika_onboard::routing::RoutedEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_onboard::routing::RoutedEntry where U: core::convert::TryFrom<T>
+pub type nika_onboard::routing::RoutedEntry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_onboard::routing::RoutedEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_onboard::routing::RoutedEntry where T: 'static + ?core::marker::Sized
+pub fn nika_onboard::routing::RoutedEntry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_onboard::routing::RoutedEntry where T: ?core::marker::Sized
+pub fn nika_onboard::routing::RoutedEntry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_onboard::routing::RoutedEntry where T: ?core::marker::Sized
+pub fn nika_onboard::routing::RoutedEntry::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_onboard::routing::RoutedEntry
+pub fn nika_onboard::routing::RoutedEntry::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_onboard::routing::RoutedEntry where T: 'static
+pub fn nika_onboard::routing::RoutedEntry::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_onboard::routing::RoutedEntry where T: ?core::marker::Sized
+pub fn nika_onboard::routing::RoutedEntry::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_onboard::routing::RoutedEntry::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_onboard::routing::RoutedEntry
+impl<T> tracing::instrument::WithSubscriber for nika_onboard::routing::RoutedEntry
+impl<T> typenum::type_operators::Same for nika_onboard::routing::RoutedEntry
+pub type nika_onboard::routing::RoutedEntry::Output = T
+pub fn nika_onboard::routing::route_query(query: &str) -> nika_onboard::routing::RoutedEntry
+pub fn nika_onboard::routing::route_skeleton_query(query: &str) -> nika_onboard::routing::RoutedEntry
 pub mod nika_onboard::wizard
 pub fn nika_onboard::wizard::wizard_io(dir: &str, force: bool, theme: nika_display::theme::Theme, input: &mut dyn alloc::io::buf_read::BufRead, out: &mut dyn core::io::write::Write, audit: &nika_onboard::Audit<'_>, wire: &nika_onboard::Wire<'_>) -> nika_onboard::Outcome
 pub struct nika_onboard::Outcome

--- a/crates/nika-onboard/src/lib.rs
+++ b/crates/nika-onboard/src/lib.rs
@@ -27,6 +27,7 @@ pub mod founding;
 pub mod guided;
 mod intent;
 pub mod recipes;
+pub mod routing;
 pub mod wizard;
 
 /// A finished verb's text + exit code — the shape the composition root

--- a/crates/nika-onboard/src/routing.rs
+++ b/crates/nika-onboard/src/routing.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The one routing door, exposed for sibling surfaces (RAMS-11): the
+//! MCP oracle follows the SAME door the CLI walks — one router, one
+//! calibration, zero drift between what `nika new` routes and what an
+//! agent's `nika_examples`/`nika_template` tool routes.
+
+use crate::intent::RoutingOutcome;
+
+/// Where a plain-words query landed.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RoutedEntry {
+    /// A complete example (a lesson — lands verbatim on the CLI side).
+    Example(String),
+    /// A skeleton template (SLOTs to fill).
+    Skeleton(String),
+    /// Below the confidence bar — the closest names, for recognition.
+    Clarify(Vec<String>),
+}
+
+/// Route plain words through the WHOLE catalog (examples + skeletons) —
+/// the `nika new <intent>` door (G-16).
+#[must_use]
+pub fn route_query(query: &str) -> RoutedEntry {
+    classify(crate::intent::route(query))
+}
+
+/// Route plain words within the SKELETON set only — the wizard's door
+/// (its whole gesture is a file of SLOTs to fill).
+#[must_use]
+pub fn route_skeleton_query(query: &str) -> RoutedEntry {
+    classify(crate::intent::route_skeletons(query))
+}
+
+fn classify(outcome: RoutingOutcome) -> RoutedEntry {
+    match outcome {
+        RoutingOutcome::Routed { template: name, .. } => {
+            if nika_pack::example(&name).is_some() {
+                RoutedEntry::Example(name)
+            } else {
+                RoutedEntry::Skeleton(name)
+            }
+        }
+        RoutingOutcome::NeedsClarification { candidates, .. } => RoutedEntry::Clarify(candidates),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two doors agree with the CLI's: a job phrase routes to the
+    /// example (whole catalog) · the same phrase in the skeleton door
+    /// stays within skeletons · nonsense clarifies, never guesses.
+    #[test]
+    fn the_doors_route_like_the_cli() {
+        assert_eq!(
+            route_query("chase unpaid invoices"),
+            RoutedEntry::Example("invoice-chaser".to_owned())
+        );
+        assert!(
+            !matches!(
+                route_skeleton_query("chase unpaid invoices"),
+                RoutedEntry::Example(_)
+            ),
+            "the skeleton door must never leak an example"
+        );
+        assert!(
+            matches!(route_query("zzz qqq xxx"), RoutedEntry::Clarify(_)),
+            "nonsense must clarify, never guess"
+        );
+    }
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4293
+  classified_files: 4294
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1375
+    authored: 1376
     authored-pin: 2
     generated: 115
     pinned-copy: 105
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 1c6bbd2cca1b33f53bdd3c7e48e81701d5d9936e1e2df1e953c267851635857d
+  sha256: 891b484dd3c0fbc653838f44f78f2d47530ec65bdf7073bd362faea34d8fd1cc
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 59
-  aggregate_sha256: 77e136ab73fa3d291b3fdfc8d7533bcf5c0bf873bb2922cc41be99c9983c8198
+  aggregate_sha256: 65b74756f41ab26bc72652acf53c333d99b879783d0b74886f138311eef14c9a
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 694
-  aggregate_sha256: bc66678223f4330563aa00878afcad41d789c299bb066b52703e5c2066023e92
+  match_count: 695
+  aggregate_sha256: b5da5811df4fbdcc6e541cdeec49c48c9d00ae950ab251d8d386da4c6feb2d53
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 126
-  aggregate_sha256: d594179f3ba6c3374b69ad928ca50504d581f5395abc3697874a207c486a2b39
+  aggregate_sha256: 0981281518b829a05acf5b4c58424810e9e3a1a8a083ea0c3745152189a60804
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"


### PR DESCRIPTION
One router, one calibration (RAMS-11 · unblocked by #778): a plain-words miss on the MCP oracle's `nika_examples` / `nika_template` now routes through the SAME door `nika new` walks — the whole catalog for examples (G-16), the skeleton set for templates (the wizard's world).

- The interpretation is SAID: the returned source opens with `# routed: `query` → example|template `name`` — honest about interpretation, still valid YAML.
- Below the confidence bar: the tool errors with the closest names (recognition, never a silent guess) — the same clarify floor the CLI holds.
- **Single tokens keep the unknown-key contract**: only multi-word queries route, so the adversarial-keys pin (traversal shapes → clean unknown errors, zero fs reach) holds verbatim.
- The door ships as `nika_onboard::routing` (`RoutedEntry` · `route_query` · `route_skeleton_query`) — a pub seam over the private intent module; same-layer L4→L4 dep per the layering law's explicit same-rank allowance.
- Baseline adopted with the runner's exact flags (`--omit auto-trait-impls`): the delta is exactly the 45 routing rows.

Pins: `examples_route_plain_words_through_the_one_door` ("chase unpaid invoices" → invoice-chaser, header said) · `examples_clarify_below_the_bar_instead_of_guessing` · `the_doors_route_like_the_cli` (onboard side: whole-catalog vs skeleton-only vs nonsense-clarifies) · adversarial pin untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
