### PR TITLE
fix(new): every taught line survives the paste-back (gauntlet night wave)

### DIFF
--- a/crates/nika-onboard/src/guided.rs
+++ b/crates/nika-onboard/src/guided.rs
@@ -187,9 +187,14 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
     // contract (`unknown()`), so listing the set must not require a dummy
     // path (the help promises `nika new '?'` works bare).
     let Some(dest) = dest else {
+        // The taught line must be the command that WORKS pasted back: a
+        // plain-words intent carries spaces, so it is re-echoed QUOTED
+        // (gauntlet 2026-08-01 · Marco: the unquoted echo was a
+        // different shell command than the one that resolved).
         return Outcome {
             text: format!(
-                "template `{name}` resolved — pass a destination: nika new {template} <dest>.nika.yaml"
+                "template `{name}` resolved — pass a destination: nika new {} <dest>.nika.yaml",
+                shell_quote(template)
             ),
             code: codes::ENV,
         };
@@ -251,10 +256,19 @@ fn clarify(intent: &str, candidates: &[String]) -> Outcome {
             }
         })
         .collect();
+    // The taught command must WORK in the taught context (gauntlet
+    // 2026-08-01 · Priya: `nika new human-gated-ship` — a skeleton —
+    // exited rc=3 asking for the destination the hint never mentioned).
+    // An example lands bare; a skeleton carries its dest.
+    let first = candidates.first().map_or("chain", String::as_str);
+    let taught = if nika_pack::example(first).is_some() {
+        format!("nika new {first}")
+    } else {
+        format!("nika new {first} <dest>.nika.yaml")
+    };
     Outcome {
         text: format!(
-            "`{intent}` doesn't route confidently — closest matches:{rows}\n  hint: take one by name (`nika new {}`) or rephrase with what goes in and what comes out",
-            candidates.first().map_or("chain", String::as_str),
+            "`{intent}` doesn't route confidently — closest matches:{rows}\n  hint: take one by name (`{taught}`) or rephrase with what goes in and what comes out",
         ),
         code: codes::FILE,
     }

--- a/crates/nika-onboard/src/guided/tests.rs
+++ b/crates/nika-onboard/src/guided/tests.rs
@@ -696,3 +696,50 @@ fn a_confident_route_lands_a_draft_that_hands_over_to_check() {
     assert!(out.text.contains("nika check"), "{}", out.text);
     std::fs::remove_file(&d).ok();
 }
+
+/// Gauntlet 2026-08-01 (Priya + Marco · the teach-a-command-that-breaks
+/// class): every taught line WORKS pasted back in the taught context.
+/// A skeleton clarify-hint carries its <dest>; an example lands bare;
+/// a spaced intent is re-echoed shell-quoted.
+#[test]
+fn taught_lines_survive_the_paste_back() {
+    // A skeleton-first clarify teaches the dest.
+    let out = run(
+        "check disk space, restart the stuck service, notify the team",
+        None,
+        false,
+    );
+    assert_eq!(out.code, codes::FILE, "{}", out.text);
+    let rest = out
+        .text
+        .split("take one by name (`")
+        .nth(1)
+        .expect("the clarify hint is present");
+    let taught = rest.split('`').next().unwrap_or("");
+    let name = taught
+        .trim_start_matches("nika new ")
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    if nika_pack::template(name).is_some() {
+        assert!(
+            taught.ends_with("<dest>.nika.yaml"),
+            "a skeleton hint must teach its destination: {taught}"
+        );
+    } else {
+        assert!(
+            nika_pack::example(name).is_some(),
+            "the taught name must exist: {taught}"
+        );
+    }
+
+    // The dest-missing hint re-echoes a spaced intent QUOTED.
+    let out = run("summarize weekly sales from a csv", None, false);
+    assert_eq!(out.code, codes::ENV, "{}", out.text);
+    assert!(
+        out.text
+            .contains("nika new 'summarize weekly sales from a csv' <dest>.nika.yaml"),
+        "the taught paste-back is ONE shell argument: {}",
+        out.text
+    );
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 695
-  aggregate_sha256: ef8dc81ea86f57491bcd20664357a43c6e3798de2c803319f74ae0920d1b616e
+  aggregate_sha256: 30a9e62639741bf40d42ba4adf74280b67767df0990e28322af0f218a1c1116f
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
The night gauntlet wave (4 fresh personas at the merged V5 tip · 4/4 grounded, zero confabulation) caught the teach-a-command-that-breaks class twice in text shipped this same night:

- **Priya (SRE)**: the clarify hint taught `nika new human-gated-ship` — a SKELETON — which then exited rc=3 asking for the destination the hint never mentioned. The taught form is now **facet-aware**: an example lands bare (`nika new invoice-chaser` works as taught), a skeleton carries its `<dest>.nika.yaml`.
- **Marco (analyst)**: the dest-missing hint re-echoed his spaced intent UNQUOTED (`nika new summarize weekly sales from a csv <dest>.nika.yaml`), a different shell command than the quoted one that resolved. The echo is now `shell_quote`d — the paste-back is ONE argument.

Pinned by `taught_lines_survive_the_paste_back` (both halves, derives the verdict from the pack so a future first-candidate flip keeps the law). Replayed at the rebuilt binary in the wave's exact contexts: the skeleton hint now names the dest, the quoted echo pastes back rc=0.

Wave verdicts for the record: sre success (full on-call loop: gates → durable pause → resume line → act, offline $0) · analyst success (mock-first then real local seat, teach-chain unbroken) · teen success (real ollama hello + heartbeat) · founder-fr partial. The remaining grounded findings (tiny-model fabrication caveat · invoice-chaser 0-byte green deliverable · French intent bounce · welcome "no inference path" vs live ollama · try 06 empty no-op · when-skip missing from the bar · trace <path> routing · truncated-output signal · INFER-001 closer over-claim) are board material, filed at the V7 board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
