### PR TITLE
fix(explain): the wire class stops promising the dial check never made (V7-16a)

### DIFF
--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -118,6 +118,16 @@ fn closer_line(code: &str) -> &'static str {
              computed path (a glob result · an interpolated binding) is \
              judged at RUN — a green PERMITS is not its promise."
         }
+        // The wire refusals: check resolves the MODEL ID in this binary
+        // but never dials the server — measured (gauntlet wave-4,
+        // founder-fr): a green check printed « local servers not probed »
+        // itself, then the run died INFER-001 on a mute endpoint. The
+        // closer must not promise the dial it never made.
+        "NIKA-INFER-001" | "NIKA-INFER-003" => {
+            "`nika check` resolves the model in this binary; the wire \
+             itself — a live server, a valid key, a priced usage block — \
+             is the RUN's verdict (`nika doctor --ping` dials ahead)."
+        }
         _ => "`nika check` catches this before a run ever starts.",
     }
 }
@@ -324,6 +334,21 @@ mod tests {
             dag.text.contains("catches this before a run ever starts"),
             "a statically-caught class keeps its strong closer:\n{}",
             dag.text
+        );
+        // Wave-4 founder-fr: the wire class must not promise the dial
+        // check never made — the closer names the RUN's verdict and the
+        // door that DOES dial ahead.
+        let infer = run("NIKA-INFER-001");
+        assert_eq!(infer.code, exit::OK);
+        assert!(
+            !infer.text.contains("catches this before a run ever starts"),
+            "the over-claim is gone from the wire class:\n{}",
+            infer.text
+        );
+        assert!(
+            infer.text.contains("doctor --ping") && infer.text.contains("RUN's verdict"),
+            "the honest wire split is taught:\n{}",
+            infer.text
         );
     }
 

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 695
-  aggregate_sha256: 311f8ce669a844f319e4b2d4a557e8ea857fad8821180c0dc37f6817582644c6
+  aggregate_sha256: 38245cced866a3dc256bf2bad4cd7597c2a9965c9997dfdc196c27daa9739d65
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Gauntlet wave-4, founder-fr P2 (grounded + reproduced): the INFER-001 page closed with « nika check catches this before a run ever starts » while her green check itself printed « local servers not probed » — the failure only exists at the wire. The per-class closer (#795's machinery) gains the wire arm: INFER-001/003 teach that check resolves the model IN THIS BINARY and the wire — a live server, a valid key, a priced usage block — is the RUN's verdict, with `nika doctor --ping` named as the door that DOES dial ahead. Pinned both ways in the_closer_never_promises_more_than_the_judge_checked; replayed at the rebuilt binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)