### PR TITLE
docs(kit): the changelog folds its unreleased into 0.107.0 (train carrier)

### DIFF
--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -5,6 +5,8 @@ Versions move together across all manifests (the mirror gate pins it).
 
 ## Unreleased
 
+## 0.107.0 — 2026-08-01
+
 The agent-run contract lands (the friction was WRITTEN, not
 technical). The old law — « running is the human's move » — predates
 `nika guard`: prose said the agent never launches while the structure
@@ -33,10 +35,6 @@ command. A sixth slash command lands: `/nika:doctor` — the agent-side
 "is my suite coherent?" gesture, riding the binary's kit↔binary
 handshake (`nika doctor` now probes the three kit landings and prints
 the per-client refresh, both rungs named for Claude Code).
-
-## 0.107.0 — 2026-07-31
-
-Lockstep on the engine wave.
 
 ## 0.106.0 — 2026-07-27
 

--- a/estate.yaml
+++ b/estate.yaml
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 29
-  aggregate_sha256: d5c876f26b640e44def1ffa7e5138852afaea22b20721b92e2bb54661af5d4b8
+  aggregate_sha256: c9f0da494192136f2255f3d5b11b6c3a4b753fa10b1594201561ef08d22f5846
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-agents (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
Last carrier before the v0.107.0 tag: the kit CHANGELOG carried a full Unreleased section (the #779 agent-run contract — which SHIPS in this wave) above a 0.107.0 heading dated 07-31. Folded under the heading, re-dated to release day, duplicate lockstep line dropped. All other carriers verified at 0.107.0 (workspace Cargo.toml · Dockerfile · plugin.json ×3 · ROADMAP row · engine CHANGELOG #800).

🤖 Generated with [Claude Code](https://claude.com/claude-code)