### PR TITLE
docs(kit): the answer ways speak ungated vocabulary (mirror gate catch)

### DIFF
--- a/.agents/plugins/nika/skills/nika-debugging/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-debugging/SKILL.md
@@ -40,7 +40,7 @@ At a terminal, `nika:prompt` asks the human directly and the run
 continues. Headless — which is where an agent lives — a prompt
 without a `default:` **pauses durably** (exit 4 · `workflow_paused`
 in the trace · never a failure frame) and the frame prints its exact
-resume line. Three ways to answer, all attested the same way:
+resume line. Three ways to answer, all recorded tamper-evident the same way:
 
 ```
 nika run <file> --answer <task>=<value>                    # pre-answer at launch

--- a/estate.yaml
+++ b/estate.yaml
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 29
-  aggregate_sha256: eec42ed503a169725e731687c2350cf0835abaefc89ea1cc8e1445516bd5bb6a
+  aggregate_sha256: a31f7931fe04ce454d07c5126abacd97f017c7f3288d2d8724021f1a3d22bb70
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-agents (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
The agents mirror's check-vocab gate refused the F-07 patch word: **attested** is gated until the DSSE trust track ships (description-bank law — say *verified* · *tamper-evident*). One line rewords at the engine source; the mirror resync (held branch train/mirror-0107 · 17 files re-pinned) re-syncs on this and goes green. Maker≠checker across repos: the mirror's own gate caught the maker's train patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)