### PR TITLE
refactor(errors): docs_url moves under the language world · /errors stays a doorway forever

### DIFF
--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -528,7 +528,7 @@ mod tests {
         assert_eq!(escape.code.as_deref(), Some("NIKA-SEC-004"));
         assert_eq!(
             escape.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-SEC-004")
+            Some("https://nika.sh/language/errors/NIKA-SEC-004")
         );
         assert_eq!(escape.task.as_deref(), Some("a"));
 
@@ -545,7 +545,7 @@ mod tests {
         assert_eq!(leak.code.as_deref(), Some("NIKA-SEC-006"));
         assert_eq!(
             leak.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-SEC-006")
+            Some("https://nika.sh/language/errors/NIKA-SEC-006")
         );
         assert!(
             leak.message.contains("secrets.k"),
@@ -560,7 +560,7 @@ mod tests {
         assert_eq!(egress.code.as_deref(), Some("NIKA-SEC-007"));
         assert_eq!(
             egress.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-SEC-007")
+            Some("https://nika.sh/language/errors/NIKA-SEC-007")
         );
 
         // policy → NIKA-POLICY-001 (spec 10).
@@ -589,7 +589,7 @@ mod tests {
         assert_eq!(tri.code.as_deref(), Some("NIKA-SEC-009"));
         assert_eq!(
             tri.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-SEC-009")
+            Some("https://nika.sh/language/errors/NIKA-SEC-009")
         );
         assert_eq!(tri.task.as_deref(), Some("b"), "the sink is the witness");
     }

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -251,7 +251,7 @@ pub struct ConformanceViolation {
     /// `report_version` stays 1.
     pub severity: FindingSeverity,
     /// The per-code documentation page
-    /// (`https://nika.sh/errors/<CODE>` · [`ERROR_DOCS_BASE`]) —
+    /// (`https://nika.sh/language/errors/<CODE>` · [`ERROR_DOCS_BASE`]) —
     /// editors surface the code as a clickable link. Additive:
     /// `report_version` stays 1.
     pub docs_url: String,
@@ -920,7 +920,7 @@ tasks:
             c["docs_url"]
                 .as_str()
                 .expect("docs_url is a string")
-                .starts_with("https://nika.sh/errors/NIKA-"),
+                .starts_with("https://nika.sh/language/errors/NIKA-"),
         );
     }
 

--- a/crates/nika-check/src/policy.rs
+++ b/crates/nika-check/src/policy.rs
@@ -518,7 +518,7 @@ mod tests {
         assert_eq!(f.code.as_deref(), Some("NIKA-POLICY-001"));
         assert_eq!(
             f.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-POLICY-001")
+            Some("https://nika.sh/language/errors/NIKA-POLICY-001")
         );
         // and the conformance-code surface speaks the same code
         let codes: Vec<String> = r
@@ -565,7 +565,7 @@ mod tests {
         assert_eq!(u.code.as_deref(), Some("NIKA-SEC-013"));
         assert_eq!(
             u.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-SEC-013")
+            Some("https://nika.sh/language/errors/NIKA-SEC-013")
         );
         assert!(
             r.extra_conformance_codes()

--- a/crates/nika-check/src/trifecta.rs
+++ b/crates/nika-check/src/trifecta.rs
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(f.code.as_deref(), Some("NIKA-SEC-009"));
         assert_eq!(
             f.docs_url.as_deref(),
-            Some("https://nika.sh/errors/NIKA-SEC-009")
+            Some("https://nika.sh/language/errors/NIKA-SEC-009")
         );
         // The conformance-code surface speaks the same code (one voice).
         let codes: Vec<String> = r

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -93,7 +93,7 @@ fn canon_row(code: &str) -> Option<String> {
         .unwrap_or_default();
     Some(format!(
         "{code} · {category} · transient: {transient}\n\n  {failure}\n{lesson}\n{fix}\
-         full docs: https://nika.sh/errors/{code} — {closer}\n",
+         full docs: https://nika.sh/language/errors/{code} — {closer}\n",
         category = row.category,
         transient = row.transient,
         failure = row.failure,
@@ -159,7 +159,7 @@ fn retired_row(code: &str) -> Option<String> {
     };
     Some(format!(
         "{code} · retired — never reused\n\n  {teaching}\n\n\
-         full docs: https://nika.sh/errors/{successor} — the successor \
+         full docs: https://nika.sh/language/errors/{successor} — the successor \
          code carries the live page; a retired code's own page is gone \
          with its registry row.\n"
     ))
@@ -365,7 +365,8 @@ mod tests {
         assert!(out.text.contains("NIKA-VAR-021"));
         assert!(out.text.contains("validation_error"));
         assert!(
-            out.text.contains("https://nika.sh/errors/NIKA-VAR-021"),
+            out.text
+                .contains("https://nika.sh/language/errors/NIKA-VAR-021"),
             "the footer links the code's own page:\n{}",
             out.text
         );

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -336,7 +336,7 @@ fn check_json_conformance_carries_severity_and_docs_url() {
     assert_eq!(
         url,
         format!(
-            "https://nika.sh/errors/{}",
+            "https://nika.sh/language/errors/{}",
             c["code"].as_str().expect("code")
         )
     );

--- a/crates/nika-schema/src/error/spec_code.rs
+++ b/crates/nika-schema/src/error/spec_code.rs
@@ -32,7 +32,7 @@ use super::SchemaError;
 /// HERE (beside [`SpecCode`], below every consumer) because both the
 /// parser side (`skill.rs`) and the check ladder (`nika-check`, which
 /// re-exports it unchanged) stamp findings with it.
-pub const ERROR_DOCS_BASE: &str = "https://nika.sh/errors";
+pub const ERROR_DOCS_BASE: &str = "https://nika.sh/language/errors";
 
 /// The closed error-category enum (spec `05-errors.md` §categories ·
 /// `snake_case` on the wire).


### PR DESCRIPTION
Every error code the binary prints carries a `docs_url`, and those URLs pointed at `nika.sh/errors/...` — a world that re-homed under `/language/errors/...` on the site (the register rides with the language it judges). The site keeps 97 permanent doorway redirects, so no shipped binary ever prints a dead link; this wagon makes NEW binaries print the canonical address directly.

One commit, surgical: the `docs_url` base in `nika-schema` + the explain verb + the check trifecta test + the smoke witness walking the fixture door.

Proof: `cargo test --workspace --lib` post-rebase on main · 5545 passed · 0 failed · the full pre-push gate (tests · clippy · hygiene · ratchets) walked green.

Site side already live: the doorways are permanent (the zero-404 law), so old and new binaries are both honest forever.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>