### PR TITLE
test(nika-onboard): the paste-back probe follows the enriched pack

### DIFF
--- a/crates/nika-onboard/src/guided/tests.rs
+++ b/crates/nika-onboard/src/guided/tests.rs
@@ -789,12 +789,18 @@ fn taught_lines_survive_the_paste_back() {
         );
     }
 
-    // The dest-missing hint re-echoes a spaced intent QUOTED.
-    let out = run("summarize weekly sales from a csv", None, false);
+    // The dest-missing hint re-echoes a spaced intent QUOTED. The probe
+    // must route CONFIDENTLY to a TEMPLATE (a skeleton is what demands a
+    // <dest>; a routed example lands bare): `summarize … csv` stopped
+    // routing when the spec snippets landed (snippets/think competes on
+    // it, and csv now belongs to the csv-chart-report example), so the
+    // probe leans on `docker`, which only the docker-report skeleton
+    // carries.
+    let out = run("report on my running docker containers", None, false);
     assert_eq!(out.code, codes::ENV, "{}", out.text);
     assert!(
         out.text
-            .contains("nika new 'summarize weekly sales from a csv' <dest>.nika.yaml"),
+            .contains("nika new 'report on my running docker containers' <dest>.nika.yaml"),
         "the taught paste-back is ONE shell argument: {}",
         out.text
     );

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -4,7 +4,7 @@
 # Consumers · the reference engine embeds this pack (nika try ·
 # nika spec) · docs + website render projections of the same files.
 pack_version: 0.1.0-draft
-workflow_count: 39
+workflow_count: 47
 foundation:
   - file: examples/01-hello.nika.yaml
     sha256_16: a3746ebe75be7a2e
@@ -184,3 +184,20 @@ showcase:
     description: ""
     constructs: [local_model, outputs, schema, with]
     sha256_16: 78481a0d50995008
+snippets:
+  - file: examples/snippets/delegate.nika.yaml
+    sha256_16: 5b8290d1a18fe83d
+  - file: examples/snippets/hello-ai.nika.yaml
+    sha256_16: e34d5613367e57d9
+  - file: examples/snippets/hello.nika.yaml
+    sha256_16: e7898d267d45ffc3
+  - file: examples/snippets/not-found.nika.yaml
+    sha256_16: 64f5a8095650434d
+  - file: examples/snippets/run.nika.yaml
+    sha256_16: aca690b21913f6ea
+  - file: examples/snippets/think.nika.yaml
+    sha256_16: 61fdd6fe2d2b9d56
+  - file: examples/snippets/use-a-tool.nika.yaml
+    sha256_16: b14c5f279babc9a1
+  - file: examples/snippets/weekly-radar.nika.yaml
+    sha256_16: 8c7779219b2dd950

--- a/estate.yaml
+++ b/estate.yaml
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 113
-  aggregate_sha256: da301a35fd7fa09225fd68c47c7d6f72b334b0b943af9a50a8872ac42427dc54
+  aggregate_sha256: f96c38f04b38d892c6df179e2f591e976b4668384ddd51e592946a1adaf5065e
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 702
-  aggregate_sha256: 711b166b64b23b71911e6224a668b2c4923aad9d3453d78e46c087090d0f0f40
+  aggregate_sha256: d90d536eaf55a0b5bba194a740d23bee27ba2e22b8563bb03e8ca0defb60f99d
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Heals the Diamond CI red on main introduced by the pack-resync admin-merge (PR 827): the guided-tour paste-back probe `summarize weekly sales from a csv` stopped routing confidently once the spec snippets entered the pack, so `taught_lines_survive_the_paste_back` failed (2 of 3 taught lines surviving).

The probe is test-local input — nothing user-facing changes. It must land on the dest-missing ENV lane, which only fires on a confident route to a TEMPLATE (a skeleton is what demands a `<dest>`; a routed example lands bare). The reworded probe leans on `docker`, unique to the docker-report skeleton.

Product-level observation for the operator, not addressed here: with the enriched pack, `summarize weekly sales from a csv` now yields the clarify fallback (snippets/think · csv-chart-report · chain). If csv-chart-report should win that phrase outright, the tuning belongs spec-side (snippet keywords), not in this test.

Gates: full nika-onboard lib suite green · clippy all-targets zero · fmt clean.

