### PR TITLE
ci(semver-checks): pin cargo-semver-checks to the repo toolchain

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,7 +28,10 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: install cargo-semver-checks
-        run: cargo install --locked cargo-semver-checks
+        # Pin to the repo toolchain (rust-toolchain.toml · 1.91): a bare
+        # install resolves latest (0.50.0 needs rustc 1.93 → rc=101 fleet-
+        # wide 2026-08-04). Re-pin when the toolchain channel advances.
+        run: cargo install --locked cargo-semver-checks --version 0.49.0
       - name: check every covered lib crate
         # The crate list is PROJECTED from the coverage floor (ADR-090: one SSOT,
         # three consumers — this job, public-api.yml, and hygiene vector 38). Reads

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 21
-  aggregate_sha256: 7c0d9142f53f79aba24bd149b49a8cf9c5b3cb9a1bf393eb70efd00c946b23ce
+  aggregate_sha256: 545eb0751b3524890a76dcff4469a34543648c6145aeee88abd338c9d4fc0496
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
A bare `cargo install --locked cargo-semver-checks` resolves latest — 0.50.0 requires rustc 1.93 while `rust-toolchain.toml` pins 1.91, so the `check` leg failed fleet-wide at the install step (rc=101 on every PR since the 0.50 release, including #828 and #829).\n\nPin `--version 0.49.0` (the 1.91-compatible line, per the install error's own hint) with a comment to re-pin when the toolchain channel advances. The leg is not in the main-protection ruleset, but its red masked the signal on every PR's check list.\n\nProof on the next src-touching PR: the leg's paths filter (`crates/**/src/**` · `Cargo.toml`) means it does not run on this workflow-only diff.