### PR TITLE
feat(nika-kernel-ai): the harness seam — AgentBackend, lane-agnostic

### DIFF
--- a/crates/nika-error/public-api.txt
+++ b/crates/nika-error/public-api.txt
@@ -481,6 +481,12 @@ pub const nika_error::codes::NIKA_1801: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_1801: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_1802: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_1802: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1803: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1803: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1804: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1804: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1805: nika_error::codes::NikaCode
+pub const nika_error::codes::NIKA_1805: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_234: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_234: nika_error::codes::NikaCode
 pub const nika_error::codes::NIKA_430: nika_error::codes::NikaCode
@@ -879,6 +885,9 @@ pub const nika_error::prelude::codes::NIKA_1709: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_1800: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_1801: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_1802: nika_error::codes::NikaCode
+pub const nika_error::prelude::codes::NIKA_1803: nika_error::codes::NikaCode
+pub const nika_error::prelude::codes::NIKA_1804: nika_error::codes::NikaCode
+pub const nika_error::prelude::codes::NIKA_1805: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_234: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_430: nika_error::codes::NikaCode
 pub const nika_error::prelude::codes::NIKA_431: nika_error::codes::NikaCode

--- a/crates/nika-error/src/codes.rs
+++ b/crates/nika-error/src/codes.rs
@@ -347,6 +347,15 @@ fn access_code_help(num: u16) -> &'static str {
         1802 => {
             "The `--access` token is neither an access class (local · api · harness · oauth · mock) nor an access id this machine offers. `nika doctor` lists every path with its class and state."
         }
+        1803 => {
+            "The harness adapter is unavailable — its binary is absent or its version sits outside the pin range. `nika doctor` names the adapter's state; install it or move the pin."
+        }
+        1804 => {
+            "The harness session died mid-run (process exit or wire breakdown) — transient: retry, and if it repeats read the adapter's own logs."
+        }
+        1805 => {
+            "The harness refused the request in its own words (its auth may be absent on ITS side, or the capability unsupported). Sign in to the harness itself — nika never holds its credential."
+        }
         _ => {
             "Execution access resolution failed. `model:` picks the intelligence; access picks the path — read the plan's witnesses via `nika explain`, then fix the path the witness names."
         }

--- a/crates/nika-error/src/codes/registry.rs
+++ b/crates/nika-error/src/codes/registry.rs
@@ -886,6 +886,30 @@ pub const NIKA_1802: NikaCode = NikaCode {
     severity: Severity::Error,
     slug: "access-unknown-token",
 };
+/// NIKA-1803: The harness adapter is unavailable — binary absent or its
+/// version sits outside the pin range (P3 · the probe's word).
+pub const NIKA_1803: NikaCode = NikaCode {
+    num: 1803,
+    category: Category::Access,
+    severity: Severity::Error,
+    slug: "access-harness-unavailable",
+};
+/// NIKA-1804: The harness session died mid-run (process exit · wire
+/// breakdown) — the one TRANSIENT row of the family.
+pub const NIKA_1804: NikaCode = NikaCode {
+    num: 1804,
+    category: Category::Access,
+    severity: Severity::Error,
+    slug: "access-harness-session",
+};
+/// NIKA-1805: The harness itself refused (auth absent on ITS side ·
+/// unsupported capability) — its own words ride verbatim.
+pub const NIKA_1805: NikaCode = NikaCode {
+    num: 1805,
+    category: Category::Access,
+    severity: Severity::Error,
+    slug: "access-harness-refused",
+};
 
 /// All registered codes within nika-error's own ranges + the M2
 /// computer-use L1 ranges (Screen/Ocr/A11y · ADR-081 · the impls live
@@ -913,5 +937,6 @@ pub const ALL: &[NikaCode] = &[
     NIKA_1304, NIKA_1305, NIKA_1401, NIKA_1402, NIKA_1403, NIKA_1404, NIKA_1405, NIKA_1406,
     NIKA_1501, NIKA_1502, NIKA_1503, NIKA_1504, NIKA_1505, NIKA_1601, NIKA_1602, NIKA_1603,
     NIKA_1604, NIKA_1605, NIKA_1700, NIKA_1701, NIKA_1702, NIKA_1703, NIKA_1704, NIKA_1705,
-    NIKA_1706, NIKA_1707, NIKA_1708, NIKA_1709, NIKA_1800, NIKA_1801, NIKA_1802,
+    NIKA_1706, NIKA_1707, NIKA_1708, NIKA_1709, NIKA_1800, NIKA_1801, NIKA_1802, NIKA_1803,
+    NIKA_1804, NIKA_1805,
 ];

--- a/crates/nika-kernel-ai/public-api.txt
+++ b/crates/nika-kernel-ai/public-api.txt
@@ -436,6 +436,224 @@ pub fn nika_kernel_ai::genai::GenAiAttrs::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_kernel_ai::genai::GenAiAttrs where T: 'static
 pub fn nika_kernel_ai::genai::GenAiAttrs::as_any(&self) -> &(dyn core::any::Any + 'static)
 impl<T> serde_core::de::DeserializeOwned for nika_kernel_ai::genai::GenAiAttrs where T: for<'de> serde_core::de::Deserialize<'de>
+pub mod nika_kernel_ai::harness
+pub use nika_kernel_ai::harness::TokenUsage
+#[non_exhaustive] pub enum nika_kernel_ai::harness::HarnessError
+pub nika_kernel_ai::harness::HarnessError::Refused
+pub nika_kernel_ai::harness::HarnessError::Refused::reason: alloc::string::String
+pub nika_kernel_ai::harness::HarnessError::Session
+pub nika_kernel_ai::harness::HarnessError::Session::reason: alloc::string::String
+pub nika_kernel_ai::harness::HarnessError::Unavailable
+pub nika_kernel_ai::harness::HarnessError::Unavailable::reason: alloc::string::String
+impl nika_kernel_ai::harness::HarnessError
+pub fn nika_kernel_ai::harness::HarnessError::is_transient(&self) -> bool
+impl core::error::Error for nika_kernel_ai::harness::HarnessError
+impl core::fmt::Debug for nika_kernel_ai::harness::HarnessError
+pub fn nika_kernel_ai::harness::HarnessError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for nika_kernel_ai::harness::HarnessError
+pub fn nika_kernel_ai::harness::HarnessError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl miette::protocol::Diagnostic for nika_kernel_ai::harness::HarnessError
+impl nika_error::traits::NikaErrorCode for nika_kernel_ai::harness::HarnessError
+pub fn nika_kernel_ai::harness::HarnessError::is_transient(&self) -> bool
+pub fn nika_kernel_ai::harness::HarnessError::nika_code(&self) -> nika_error::codes::NikaCode
+impl<D> owo_colors::OwoColorize for nika_kernel_ai::harness::HarnessError
+impl<T, U> core::convert::Into<U> for nika_kernel_ai::harness::HarnessError where U: core::convert::From<T>
+pub fn nika_kernel_ai::harness::HarnessError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_ai::harness::HarnessError where U: core::convert::Into<T>
+pub type nika_kernel_ai::harness::HarnessError::Error = core::convert::Infallible
+pub fn nika_kernel_ai::harness::HarnessError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_ai::harness::HarnessError where U: core::convert::TryFrom<T>
+pub type nika_kernel_ai::harness::HarnessError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_ai::harness::HarnessError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for nika_kernel_ai::harness::HarnessError where T: core::fmt::Display + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for nika_kernel_ai::harness::HarnessError where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_ai::harness::HarnessError where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_ai::harness::HarnessError where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_kernel_ai::harness::HarnessError
+pub fn nika_kernel_ai::harness::HarnessError::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_ai::harness::HarnessError where T: 'static
+pub fn nika_kernel_ai::harness::HarnessError::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub enum nika_kernel_ai::harness::HarnessEvent
+pub nika_kernel_ai::harness::HarnessEvent::Completed
+pub nika_kernel_ai::harness::HarnessEvent::Completed::outcome: alloc::boxed::Box<nika_kernel_ai::harness::HarnessOutcome>
+pub nika_kernel_ai::harness::HarnessEvent::MessageChunk
+pub nika_kernel_ai::harness::HarnessEvent::MessageChunk::text: alloc::string::String
+pub nika_kernel_ai::harness::HarnessEvent::PermissionAsked
+pub nika_kernel_ai::harness::HarnessEvent::PermissionAsked::question: alloc::string::String
+pub nika_kernel_ai::harness::HarnessEvent::PermissionAsked::reply: nika_kernel_ai::harness::PermissionReply
+impl<D> owo_colors::OwoColorize for nika_kernel_ai::harness::HarnessEvent
+impl<T, U> core::convert::Into<U> for nika_kernel_ai::harness::HarnessEvent where U: core::convert::From<T>
+pub fn nika_kernel_ai::harness::HarnessEvent::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_ai::harness::HarnessEvent where U: core::convert::Into<T>
+pub type nika_kernel_ai::harness::HarnessEvent::Error = core::convert::Infallible
+pub fn nika_kernel_ai::harness::HarnessEvent::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_ai::harness::HarnessEvent where U: core::convert::TryFrom<T>
+pub type nika_kernel_ai::harness::HarnessEvent::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_ai::harness::HarnessEvent::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_kernel_ai::harness::HarnessEvent where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessEvent::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_ai::harness::HarnessEvent where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessEvent::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_ai::harness::HarnessEvent where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessEvent::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_kernel_ai::harness::HarnessEvent
+pub fn nika_kernel_ai::harness::HarnessEvent::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_ai::harness::HarnessEvent where T: 'static
+pub fn nika_kernel_ai::harness::HarnessEvent::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub enum nika_kernel_ai::harness::PermissionDecision
+pub nika_kernel_ai::harness::PermissionDecision::AllowOnce
+pub nika_kernel_ai::harness::PermissionDecision::Deny
+impl core::clone::Clone for nika_kernel_ai::harness::PermissionDecision
+pub fn nika_kernel_ai::harness::PermissionDecision::clone(&self) -> nika_kernel_ai::harness::PermissionDecision
+impl core::cmp::Eq for nika_kernel_ai::harness::PermissionDecision
+impl core::cmp::PartialEq for nika_kernel_ai::harness::PermissionDecision
+pub fn nika_kernel_ai::harness::PermissionDecision::eq(&self, other: &nika_kernel_ai::harness::PermissionDecision) -> bool
+impl core::fmt::Debug for nika_kernel_ai::harness::PermissionDecision
+pub fn nika_kernel_ai::harness::PermissionDecision::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_kernel_ai::harness::PermissionDecision
+impl core::marker::StructuralPartialEq for nika_kernel_ai::harness::PermissionDecision
+impl<D> owo_colors::OwoColorize for nika_kernel_ai::harness::PermissionDecision
+impl<T, U> core::convert::Into<U> for nika_kernel_ai::harness::PermissionDecision where U: core::convert::From<T>
+pub fn nika_kernel_ai::harness::PermissionDecision::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_ai::harness::PermissionDecision where U: core::convert::Into<T>
+pub type nika_kernel_ai::harness::PermissionDecision::Error = core::convert::Infallible
+pub fn nika_kernel_ai::harness::PermissionDecision::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_ai::harness::PermissionDecision where U: core::convert::TryFrom<T>
+pub type nika_kernel_ai::harness::PermissionDecision::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_ai::harness::PermissionDecision::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_kernel_ai::harness::PermissionDecision where T: core::clone::Clone
+pub type nika_kernel_ai::harness::PermissionDecision::Owned = T
+pub fn nika_kernel_ai::harness::PermissionDecision::clone_into(&self, target: &mut T)
+pub fn nika_kernel_ai::harness::PermissionDecision::to_owned(&self) -> T
+impl<T> core::any::Any for nika_kernel_ai::harness::PermissionDecision where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::PermissionDecision::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_ai::harness::PermissionDecision where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::PermissionDecision::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_ai::harness::PermissionDecision where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::PermissionDecision::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_kernel_ai::harness::PermissionDecision where T: core::clone::Clone
+pub unsafe fn nika_kernel_ai::harness::PermissionDecision::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_kernel_ai::harness::PermissionDecision
+pub fn nika_kernel_ai::harness::PermissionDecision::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_ai::harness::PermissionDecision where T: 'static
+pub fn nika_kernel_ai::harness::PermissionDecision::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_kernel_ai::harness::HarnessOutcome
+pub nika_kernel_ai::harness::HarnessOutcome::observed_model: core::option::Option<alloc::string::String>
+pub nika_kernel_ai::harness::HarnessOutcome::output: alloc::string::String
+pub nika_kernel_ai::harness::HarnessOutcome::usage: core::option::Option<nika_types::token_usage::TokenUsage>
+impl nika_kernel_ai::harness::HarnessOutcome
+pub fn nika_kernel_ai::harness::HarnessOutcome::new(output: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn nika_kernel_ai::harness::HarnessOutcome::with_observed_model(self, model: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn nika_kernel_ai::harness::HarnessOutcome::with_usage(self, usage: nika_types::token_usage::TokenUsage) -> Self
+impl core::clone::Clone for nika_kernel_ai::harness::HarnessOutcome
+pub fn nika_kernel_ai::harness::HarnessOutcome::clone(&self) -> nika_kernel_ai::harness::HarnessOutcome
+impl core::cmp::PartialEq for nika_kernel_ai::harness::HarnessOutcome
+pub fn nika_kernel_ai::harness::HarnessOutcome::eq(&self, other: &nika_kernel_ai::harness::HarnessOutcome) -> bool
+impl core::fmt::Debug for nika_kernel_ai::harness::HarnessOutcome
+pub fn nika_kernel_ai::harness::HarnessOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_kernel_ai::harness::HarnessOutcome
+impl<D> owo_colors::OwoColorize for nika_kernel_ai::harness::HarnessOutcome
+impl<T, U> core::convert::Into<U> for nika_kernel_ai::harness::HarnessOutcome where U: core::convert::From<T>
+pub fn nika_kernel_ai::harness::HarnessOutcome::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_ai::harness::HarnessOutcome where U: core::convert::Into<T>
+pub type nika_kernel_ai::harness::HarnessOutcome::Error = core::convert::Infallible
+pub fn nika_kernel_ai::harness::HarnessOutcome::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_ai::harness::HarnessOutcome where U: core::convert::TryFrom<T>
+pub type nika_kernel_ai::harness::HarnessOutcome::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_ai::harness::HarnessOutcome::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_kernel_ai::harness::HarnessOutcome where T: core::clone::Clone
+pub type nika_kernel_ai::harness::HarnessOutcome::Owned = T
+pub fn nika_kernel_ai::harness::HarnessOutcome::clone_into(&self, target: &mut T)
+pub fn nika_kernel_ai::harness::HarnessOutcome::to_owned(&self) -> T
+impl<T> core::any::Any for nika_kernel_ai::harness::HarnessOutcome where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessOutcome::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_ai::harness::HarnessOutcome where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessOutcome::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_ai::harness::HarnessOutcome where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessOutcome::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_kernel_ai::harness::HarnessOutcome where T: core::clone::Clone
+pub unsafe fn nika_kernel_ai::harness::HarnessOutcome::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_kernel_ai::harness::HarnessOutcome
+pub fn nika_kernel_ai::harness::HarnessOutcome::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_ai::harness::HarnessOutcome where T: 'static
+pub fn nika_kernel_ai::harness::HarnessOutcome::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_kernel_ai::harness::HarnessRequest
+pub nika_kernel_ai::harness::HarnessRequest::cwd: std::path::PathBuf
+pub nika_kernel_ai::harness::HarnessRequest::prompt: alloc::string::String
+pub nika_kernel_ai::harness::HarnessRequest::requested_model: core::option::Option<alloc::string::String>
+pub nika_kernel_ai::harness::HarnessRequest::system: core::option::Option<alloc::string::String>
+impl nika_kernel_ai::harness::HarnessRequest
+pub fn nika_kernel_ai::harness::HarnessRequest::new(prompt: impl core::convert::Into<alloc::string::String>, cwd: impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn nika_kernel_ai::harness::HarnessRequest::with_requested_model(self, model: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn nika_kernel_ai::harness::HarnessRequest::with_system(self, system: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_kernel_ai::harness::HarnessRequest
+pub fn nika_kernel_ai::harness::HarnessRequest::clone(&self) -> nika_kernel_ai::harness::HarnessRequest
+impl core::cmp::PartialEq for nika_kernel_ai::harness::HarnessRequest
+pub fn nika_kernel_ai::harness::HarnessRequest::eq(&self, other: &nika_kernel_ai::harness::HarnessRequest) -> bool
+impl core::fmt::Debug for nika_kernel_ai::harness::HarnessRequest
+pub fn nika_kernel_ai::harness::HarnessRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_kernel_ai::harness::HarnessRequest
+impl<D> owo_colors::OwoColorize for nika_kernel_ai::harness::HarnessRequest
+impl<T, U> core::convert::Into<U> for nika_kernel_ai::harness::HarnessRequest where U: core::convert::From<T>
+pub fn nika_kernel_ai::harness::HarnessRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_ai::harness::HarnessRequest where U: core::convert::Into<T>
+pub type nika_kernel_ai::harness::HarnessRequest::Error = core::convert::Infallible
+pub fn nika_kernel_ai::harness::HarnessRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_ai::harness::HarnessRequest where U: core::convert::TryFrom<T>
+pub type nika_kernel_ai::harness::HarnessRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_ai::harness::HarnessRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_kernel_ai::harness::HarnessRequest where T: core::clone::Clone
+pub type nika_kernel_ai::harness::HarnessRequest::Owned = T
+pub fn nika_kernel_ai::harness::HarnessRequest::clone_into(&self, target: &mut T)
+pub fn nika_kernel_ai::harness::HarnessRequest::to_owned(&self) -> T
+impl<T> core::any::Any for nika_kernel_ai::harness::HarnessRequest where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_ai::harness::HarnessRequest where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_ai::harness::HarnessRequest where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::HarnessRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_kernel_ai::harness::HarnessRequest where T: core::clone::Clone
+pub unsafe fn nika_kernel_ai::harness::HarnessRequest::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_kernel_ai::harness::HarnessRequest
+pub fn nika_kernel_ai::harness::HarnessRequest::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_ai::harness::HarnessRequest where T: 'static
+pub fn nika_kernel_ai::harness::HarnessRequest::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub struct nika_kernel_ai::harness::PermissionReply
+impl nika_kernel_ai::harness::PermissionReply
+pub fn nika_kernel_ai::harness::PermissionReply::new(respond: alloc::boxed::Box<(dyn core::ops::function::FnOnce(nika_kernel_ai::harness::PermissionDecision) + core::marker::Send)>) -> Self
+pub fn nika_kernel_ai::harness::PermissionReply::respond(self, decision: nika_kernel_ai::harness::PermissionDecision)
+impl core::fmt::Debug for nika_kernel_ai::harness::PermissionReply
+pub fn nika_kernel_ai::harness::PermissionReply::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_kernel_ai::harness::PermissionReply
+impl<T, U> core::convert::Into<U> for nika_kernel_ai::harness::PermissionReply where U: core::convert::From<T>
+pub fn nika_kernel_ai::harness::PermissionReply::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_ai::harness::PermissionReply where U: core::convert::Into<T>
+pub type nika_kernel_ai::harness::PermissionReply::Error = core::convert::Infallible
+pub fn nika_kernel_ai::harness::PermissionReply::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_ai::harness::PermissionReply where U: core::convert::TryFrom<T>
+pub type nika_kernel_ai::harness::PermissionReply::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_ai::harness::PermissionReply::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_kernel_ai::harness::PermissionReply where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_ai::harness::PermissionReply::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_ai::harness::PermissionReply where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::PermissionReply::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_ai::harness::PermissionReply where T: ?core::marker::Sized
+pub fn nika_kernel_ai::harness::PermissionReply::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_kernel_ai::harness::PermissionReply
+pub fn nika_kernel_ai::harness::PermissionReply::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_ai::harness::PermissionReply where T: 'static
+pub fn nika_kernel_ai::harness::PermissionReply::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub trait nika_kernel_ai::harness::AgentBackend: core::marker::Send + core::marker::Sync
+pub async fn nika_kernel_ai::harness::AgentBackend::run_agent(&self, request: nika_kernel_ai::harness::HarnessRequest) -> core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>
+impl<TraitVariantBlanketType: nika_kernel_ai::harness::AgentBackendDyn> nika_kernel_ai::harness::AgentBackend for TraitVariantBlanketType
+pub async fn TraitVariantBlanketType::run_agent(&self, request: nika_kernel_ai::harness::HarnessRequest) -> core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>
+pub trait nika_kernel_ai::harness::AgentBackendDyn: core::marker::Send + core::marker::Sync + core::marker::Send
+pub fn nika_kernel_ai::harness::AgentBackendDyn::run_agent(&self, request: nika_kernel_ai::harness::HarnessRequest) -> impl core::future::future::Future<Output = core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>> + core::marker::Send
+pub type nika_kernel_ai::harness::HarnessEventStream = core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::harness::HarnessEvent, nika_kernel_ai::harness::HarnessError>> + core::marker::Send)>>
 pub mod nika_kernel_ai::memory
 pub use nika_kernel_ai::memory::MemoryDirective
 pub use nika_kernel_ai::memory::MemoryFrameRef

--- a/crates/nika-kernel-ai/src/errors.rs
+++ b/crates/nika-kernel-ai/src/errors.rs
@@ -13,10 +13,14 @@
 //!   `nika_error::codes::NIKA_1501..1505` · ADR-081 M2.6)
 //! - 1600–1699: Audio (`AudioError` · `audio.rs` · constants in
 //!   `nika_error::codes::NIKA_1601..1605` · FCI-005 audio block)
+//! - 1803–1805: Harness (`HarnessError` · `harness.rs` · constants in
+//!   `nika_error::codes::NIKA_1803..1805` · the access family's
+//!   adapter rows · D-2026-08-04-N1 P3)
 
 use nika_error::prelude::*;
 
 use crate::audio::AudioError;
+use crate::harness::HarnessError;
 use crate::provider::ProviderError;
 use crate::vision::VisionError;
 
@@ -79,6 +83,23 @@ impl NikaErrorCode for ProviderError {
                     ..
                 }
         )
+    }
+}
+
+impl NikaErrorCode for HarnessError {
+    fn nika_code(&self) -> NikaCode {
+        use nika_error::codes;
+        match self {
+            Self::Unavailable { .. } => codes::NIKA_1803,
+            Self::Session { .. } => codes::NIKA_1804,
+            Self::Refused { .. } => codes::NIKA_1805,
+        }
+    }
+
+    /// Mirrors [`HarnessError::is_transient`] — only the session death
+    /// may heal on retry; an absent binary or a refusal never does.
+    fn is_transient(&self) -> bool {
+        HarnessError::is_transient(self)
     }
 }
 

--- a/crates/nika-kernel-ai/src/harness.rs
+++ b/crates/nika-kernel-ai/src/harness.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The harness access class seam (D-2026-08-04-N1 · P3 B2) — `agent:`
+//! tasks delegated to the user's OWN authenticated agent harness
+//! (gemini-cli · qwen-code · codex-acp · claude-agent-acp).
+//!
+//! Sibling of [`crate::provider`]: [`AgentBackend`] is to an external
+//! agentic loop what `ProviderStream` is to a raw model — ONE method,
+//! a stream of typed events, the terminal event carrying the outcome.
+//! Lane-agnostic on purpose: the trait never names a wire (the engine's
+//! hand-rolled wire-v1 client implements it; a future SDK-backed impl
+//! could too). The harness owns auth (A-3): nothing in this seam ever
+//! carries a credential.
+//!
+//! Authority stays the ENGINE's: a permission the harness requests
+//! rides the event stream as [`HarnessEvent::PermissionAsked`] and is
+//! answered through the [`PermissionReply`] channel the request
+//! carries — the runtime's permits bridge (P3 B5) answers inside
+//! grants and pauses outside them; `allow_always` is NEVER granted
+//! (A-5 · the `GOOSE_MODE=auto` anti-pattern is the named counter-example).
+
+use std::pin::Pin;
+
+use futures_core::Stream;
+
+pub use nika_error::token_usage::TokenUsage;
+
+/// One agentic run delegated to a harness — the narrow-waist request
+/// (`#[non_exhaustive]` · P3/P4 dimensions join additively).
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct HarnessRequest {
+    /// The initial user message (required · spec §agent).
+    pub prompt: String,
+    /// Optional system prompt — WRAPPED by the harness's own frame
+    /// (`prompt_fidelity` is `wrapped` on this class · never `exact`).
+    pub system: Option<String>,
+    /// The working directory the session is rooted at.
+    pub cwd: std::path::PathBuf,
+    /// The model the AUTHOR asked for, verbatim (`provider/name`) —
+    /// the harness may report a different observed identity; recording
+    /// both is the receipt's job, never a silent substitution (A-2).
+    pub requested_model: Option<String>,
+}
+
+impl HarnessRequest {
+    /// Construct (INV-019).
+    #[must_use]
+    pub fn new(prompt: impl Into<String>, cwd: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            system: None,
+            cwd: cwd.into(),
+            requested_model: None,
+        }
+    }
+
+    /// Attach a system prompt.
+    #[must_use]
+    pub fn with_system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Record the author's requested model id.
+    #[must_use]
+    pub fn with_requested_model(mut self, model: impl Into<String>) -> Self {
+        self.requested_model = Some(model.into());
+        self
+    }
+}
+
+/// The reply lane for ONE permission request — carried BY the event so
+/// the authority decision rides beside the question it answers (a
+/// confused deputy cannot arise from correlating ids across streams).
+/// A boxed once-callback, NOT a channel type: the kernel trait layer
+/// is executor-free (L0.5 bans tokio in prod deps) — the adapter impl
+/// backs it with whatever channel its runtime uses, under the contract
+/// that a responder DROPPED unanswered reads as
+/// [`PermissionDecision::Deny`] (fail-closed · pinned by the adapter's
+/// own tests, the only place a drop can be observed).
+pub struct PermissionReply {
+    respond: Box<dyn FnOnce(PermissionDecision) + Send>,
+}
+
+impl PermissionReply {
+    /// Wrap the adapter's answer lane (INV-019).
+    #[must_use]
+    pub fn new(respond: Box<dyn FnOnce(PermissionDecision) + Send>) -> Self {
+        Self { respond }
+    }
+
+    /// Deliver the engine's verdict — consumes the lane (one question,
+    /// one answer, never two).
+    pub fn respond(self, decision: PermissionDecision) {
+        (self.respond)(decision);
+    }
+}
+
+impl core::fmt::Debug for PermissionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("PermissionReply(..)")
+    }
+}
+
+/// The engine's verdict on a harness permission request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PermissionDecision {
+    /// Inside a `permits:` grant — allowed ONCE (never `allow_always`).
+    AllowOnce,
+    /// Outside every grant and the human said no (or the run is
+    /// non-interactive) — the harness must stop the action.
+    Deny,
+}
+
+/// One observed beat of a delegated run.
+#[non_exhaustive]
+pub enum HarnessEvent {
+    /// A chunk of the agent's message text.
+    MessageChunk {
+        /// The text delta.
+        text: String,
+    },
+    /// The harness asked to do something — the QUESTION verbatim plus
+    /// the reply lane. The engine answers (permits bridge · B5); an
+    /// unanswered drop reads as [`PermissionDecision::Deny`] fail-closed.
+    PermissionAsked {
+        /// The harness's own description of the action.
+        question: String,
+        /// The one-shot reply lane.
+        reply: PermissionReply,
+    },
+    /// The run completed — the terminal beat. Boxed: the outcome is
+    /// the fat variant and every OTHER beat is hot-path (the clippy
+    /// large-variant law · one allocation at the single terminal beat).
+    Completed {
+        /// The final outcome.
+        outcome: Box<HarnessOutcome>,
+    },
+}
+
+/// The terminal facts of a delegated run — what the receipt records.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct HarnessOutcome {
+    /// The agent's final message text.
+    pub output: String,
+    /// Token usage WHEN the harness reports it — `None` stays none
+    /// (`usage_evidence` `harness-reported` or absent · never estimated
+    /// here · A-7).
+    pub usage: Option<TokenUsage>,
+    /// The model identity the harness REPORTED, when observable —
+    /// recorded beside `requested_model`, never reconciled silently.
+    pub observed_model: Option<String>,
+}
+
+impl HarnessOutcome {
+    /// Construct (INV-019).
+    #[must_use]
+    pub fn new(output: impl Into<String>) -> Self {
+        Self {
+            output: output.into(),
+            usage: None,
+            observed_model: None,
+        }
+    }
+
+    /// Attach harness-reported usage.
+    #[must_use]
+    pub fn with_usage(mut self, usage: TokenUsage) -> Self {
+        self.usage = Some(usage);
+        self
+    }
+
+    /// Attach the harness-reported model identity.
+    #[must_use]
+    pub fn with_observed_model(mut self, model: impl Into<String>) -> Self {
+        self.observed_model = Some(model.into());
+        self
+    }
+}
+
+/// Harness backend failure — `#[non_exhaustive]` from day one (INV #25).
+/// `Diagnostic` is the `NikaErrorCode` supertrait (the B5 one-voice
+/// contract · the `ProviderError` precedent).
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+#[non_exhaustive]
+pub enum HarnessError {
+    /// The adapter binary is absent or outside its version pin.
+    #[error("harness unavailable: {reason}")]
+    Unavailable {
+        /// What the probe saw (binary absent · version outside pin).
+        reason: String,
+    },
+    /// The session died mid-run (process exit · wire breakdown).
+    #[error("harness session failed: {reason}")]
+    Session {
+        /// The transport-level cause.
+        reason: String,
+    },
+    /// The harness refused the request (auth absent on ITS side ·
+    /// unsupported capability) — the harness's own words ride verbatim.
+    #[error("harness refused: {reason}")]
+    Refused {
+        /// The harness's own refusal.
+        reason: String,
+    },
+}
+
+impl HarnessError {
+    /// Whether retrying may succeed — only a session/transport death is
+    /// transient; an absent binary or a refusal never heals on retry.
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Session { .. })
+    }
+}
+
+/// The event stream of one delegated run (the [`crate::provider`]
+/// `InferEventStream` idiom — boxed for object safety, one allocation
+/// per run).
+pub type HarnessEventStream =
+    Pin<Box<dyn Stream<Item = Result<HarnessEvent, HarnessError>> + Send>>;
+
+/// An external agentic backend — the harness access class made a seam.
+///
+/// CANCEL SAFETY: dropping the returned stream MUST end the delegated
+/// run (kill-on-drop at the adapter's spawn seam) — a harness never
+/// outlives the task that asked for it.
+#[trait_variant::make(AgentBackendDyn: Send)]
+pub trait AgentBackend: Send + Sync {
+    /// Run ONE delegated agentic turn; events stream until
+    /// [`HarnessEvent::Completed`].
+    async fn run_agent(&self, request: HarnessRequest) -> Result<HarnessEventStream, HarnessError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _assert_send<T: Send>() {}
+
+    #[test]
+    fn the_seam_is_send_and_the_bound_form_compiles() {
+        // The trait_variant contract, as the house USES it: the Dyn
+        // form is a Send-variant GENERIC BOUND (`P: ProviderInferDyn`
+        // in verb-agent — never a `dyn` object). The generic witness
+        // compiling IS the assertion.
+        fn _takes_bound<B: AgentBackendDyn>(_: &B) {}
+        _assert_send::<HarnessRequest>();
+        _assert_send::<HarnessOutcome>();
+        _assert_send::<HarnessError>();
+        _assert_send::<PermissionReply>();
+    }
+
+    #[test]
+    fn request_constructor_carries_the_narrow_waist() {
+        let r = HarnessRequest::new("do the thing", "/tmp/project")
+            .with_system("you are terse")
+            .with_requested_model("qwen/qwen3");
+        assert_eq!(r.prompt, "do the thing");
+        assert_eq!(r.system.as_deref(), Some("you are terse"));
+        assert_eq!(r.cwd, std::path::PathBuf::from("/tmp/project"));
+        assert_eq!(r.requested_model.as_deref(), Some("qwen/qwen3"));
+    }
+
+    #[test]
+    fn outcome_honesty_defaults_are_absent_never_zero() {
+        // usage None stays None (A-7: unknown is never $0/0 tokens) ·
+        // observed_model None means "not observable", never "same as
+        // requested".
+        let o = HarnessOutcome::new("done");
+        assert_eq!(o.output, "done");
+        assert!(o.usage.is_none());
+        assert!(o.observed_model.is_none());
+    }
+
+    #[test]
+    fn only_the_session_death_is_transient() {
+        assert!(
+            HarnessError::Session {
+                reason: "pipe closed".into()
+            }
+            .is_transient()
+        );
+        assert!(
+            !HarnessError::Unavailable {
+                reason: "binary absent".into()
+            }
+            .is_transient()
+        );
+        assert!(
+            !HarnessError::Refused {
+                reason: "auth absent".into()
+            }
+            .is_transient()
+        );
+    }
+
+    #[test]
+    fn the_reply_lane_delivers_exactly_once() {
+        // `respond` consumes the lane — one question, one answer; the
+        // move semantics ARE the never-twice proof (a second call does
+        // not compile). The delivered decision arrives verbatim.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU8, Ordering};
+        let seen = Arc::new(AtomicU8::new(0));
+        let seen_in = Arc::clone(&seen);
+        let reply = PermissionReply::new(Box::new(move |decision| {
+            // Same-crate match: `#[non_exhaustive]` binds downstream
+            // crates only, so the arms stay exhaustive here on purpose
+            // (a new variant is a COMPILE error until this learns it).
+            let code = match decision {
+                PermissionDecision::AllowOnce => 1,
+                PermissionDecision::Deny => 2,
+            };
+            seen_in.store(code, Ordering::SeqCst);
+        }));
+        reply.respond(PermissionDecision::Deny);
+        assert_eq!(
+            seen.load(Ordering::SeqCst),
+            2,
+            "the verdict must arrive verbatim"
+        );
+    }
+}

--- a/crates/nika-kernel-ai/src/lib.rs
+++ b/crates/nika-kernel-ai/src/lib.rs
@@ -30,6 +30,7 @@ pub mod audio;
 pub mod context;
 pub mod errors;
 pub mod genai;
+pub mod harness;
 pub mod memory;
 pub mod provider;
 pub mod tool_defs;

--- a/crates/nika-kernel/public-api.txt
+++ b/crates/nika-kernel/public-api.txt
@@ -122,6 +122,7 @@ pub use nika_kernel::embed_batch_sequential
 pub use nika_kernel::event_sink
 pub use nika_kernel::fs
 pub use nika_kernel::genai
+pub use nika_kernel::harness
 pub use nika_kernel::http
 pub use nika_kernel::id_gen
 pub use nika_kernel::infra

--- a/crates/nika-kernel/src/lib.rs
+++ b/crates/nika-kernel/src/lib.rs
@@ -67,7 +67,7 @@ pub mod checkpoint;
 pub mod errors;
 
 // ─── Backward-compat re-exports (preserve crate::module_name paths) ─
-pub use ai::{audio, context, genai, memory, provider};
+pub use ai::{audio, context, genai, harness, memory, provider};
 pub use infra::{audit, billing, event_sink, id_gen, metrics, secret, trace};
 pub use io::{blob, clock, command_sandbox, fs, http, process};
 pub use plugin::sandbox;

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4326
+  classified_files: 4327
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1398
+    authored: 1399
     authored-pin: 2
     generated: 116
     pinned-copy: 114
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 60
-  aggregate_sha256: 8fcd42a33303dcd057c0dfaa8c2e1a479260229cafe39b39e81d0bd402064062
+  aggregate_sha256: a0c07cbccfe59a8d2ce70cba8c201b91de82e08b2ab60e30e90c32711872435b
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 705
-  aggregate_sha256: fa63ef0d63f8157f127aac35f48dca9c852164079e756c03768f4e44d85fc978
+  match_count: 706
+  aggregate_sha256: c50df72f58cfe11e719834a80c44b62d61e640bf6eb97b5b6e6da44bdba8209b
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 130
-  aggregate_sha256: 8e1a24b5c5afdc1113e186df35e4e9cfb0da86047f962baceb97c09ff03b8cc7
+  aggregate_sha256: f7cbd7627198d2a8b50dd5f81f9838d1831c8e388a756b6eb499ef0915167485
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 135
-  aggregate_sha256: 33cced554daf039261560f0af12fc88bc4e599224669fd6a48ea84077e184080
+  aggregate_sha256: 20c7ee753b341f04c1608c6320811fd4fafdcedbd56a8e4e5b8a92ff537df8b7
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored


### PR DESCRIPTION
B2 of the access P3 arc (D-2026-08-04-N1 · master plan §P3 living state).

The harness access class becomes a kernel seam: `AgentBackend` (+ its Send trait_variant, the `ProviderStream` idiom — one method, a typed event stream, the terminal beat carrying the outcome) plus the narrow-waist DTOs. The trait never names a wire, so the ratified Lane A hand-rolled wire-v1 client and any future SDK-backed impl are both admissible.

The authority inversion lives in the types: a permission request rides the event stream WITH its reply lane (a boxed once-callback — the kernel layer stays executor-free per the L0.5 tokio ban; the adapter backs it with its own channel under the drop-reads-as-Deny fail-closed contract). Honesty defaults are structural: usage `None` stays `None`, `observed_model` is recorded beside `requested_model` and never reconciled silently.

One-voice from day one: `HarnessError` speaks `NikaErrorCode` (NIKA-1803/1804/1805 in the access block, registered + help arms + roundtrip tests — the hygiene vector caught the gap before the push, as designed).

🦋