### PR TITLE
feat(nika-verb-agent): the harness path — external execution, gated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4892,6 +4892,7 @@ dependencies = [
 name = "nika-verb-agent"
 version = "0.108.0"
 dependencies = [
+ "futures-core",
  "futures-util",
  "jsonschema",
  "miette",

--- a/crates/nika-kernel-ai/public-api.txt
+++ b/crates/nika-kernel-ai/public-api.txt
@@ -655,6 +655,10 @@ impl<TraitVariantBlanketType: nika_kernel_ai::harness::AgentBackendDyn> nika_ker
 pub async fn TraitVariantBlanketType::run_agent(&self, request: nika_kernel_ai::harness::HarnessRequest) -> core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>
 pub trait nika_kernel_ai::harness::AgentBackendDyn: core::marker::Send + core::marker::Sync + core::marker::Send
 pub fn nika_kernel_ai::harness::AgentBackendDyn::run_agent(&self, request: nika_kernel_ai::harness::HarnessRequest) -> impl core::future::future::Future<Output = core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>> + core::marker::Send
+pub trait nika_kernel_ai::harness::DynAgentBackend: core::marker::Send + core::marker::Sync
+pub fn nika_kernel_ai::harness::DynAgentBackend::run_agent_boxed(&self, request: nika_kernel_ai::harness::HarnessRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>> + core::marker::Send + '_)>>
+impl<B: nika_kernel_ai::harness::AgentBackendDyn + core::marker::Sync> nika_kernel_ai::harness::DynAgentBackend for B
+pub fn B::run_agent_boxed(&self, request: nika_kernel_ai::harness::HarnessRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<nika_kernel_ai::harness::HarnessEventStream, nika_kernel_ai::harness::HarnessError>> + core::marker::Send + '_)>>
 pub type nika_kernel_ai::harness::HarnessEventStream = core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::harness::HarnessEvent, nika_kernel_ai::harness::HarnessError>> + core::marker::Send)>>
 pub mod nika_kernel_ai::memory
 pub use nika_kernel_ai::memory::MemoryDirective

--- a/crates/nika-kernel-ai/src/harness.rs
+++ b/crates/nika-kernel-ai/src/harness.rs
@@ -20,6 +20,7 @@
 //! grants and pauses outside them; `allow_always` is NEVER granted
 //! (A-5 · the `GOOSE_MODE=auto` anti-pattern is the named counter-example).
 
+use core::future::Future;
 use std::pin::Pin;
 
 use futures_core::Stream;
@@ -235,6 +236,29 @@ pub trait AgentBackend: Send + Sync {
     /// Run ONE delegated agentic turn; events stream until
     /// [`HarnessEvent::Completed`].
     async fn run_agent(&self, request: HarnessRequest) -> Result<HarnessEventStream, HarnessError>;
+}
+
+/// The OBJECT-SAFE erasure of [`AgentBackendDyn`] — an async-fn trait
+/// cannot ride behind `dyn`, and the verb's optional 4th seam must
+/// (the observer precedent: a generic would infect every embedder
+/// signature). The blanket impl makes every backend an
+/// `Arc<dyn DynAgentBackend>` for free; consumers never implement
+/// this trait directly.
+pub trait DynAgentBackend: Send + Sync {
+    /// [`AgentBackend::run_agent`], boxed.
+    fn run_agent_boxed(
+        &self,
+        request: HarnessRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<HarnessEventStream, HarnessError>> + Send + '_>>;
+}
+
+impl<B: AgentBackendDyn + Sync> DynAgentBackend for B {
+    fn run_agent_boxed(
+        &self,
+        request: HarnessRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<HarnessEventStream, HarnessError>> + Send + '_>> {
+        Box::pin(self.run_agent(request))
+    }
 }
 
 #[cfg(test)]

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -38,5 +38,17 @@ voice_pattern = "spoken"
 layer         = "L2"
 err_prefix    = "NIKA-46x"
 
+[dependencies.futures-core]
+workspace = true
+optional = true
+
+[features]
+# The harness access class (D-2026-08-04-N1 · P3 B4): agent tasks may
+# delegate to the user's own authenticated harness through the kernel
+# DynAgentBackend seam. DEFAULT OFF (feature-defaults law) — the native
+# loop is byte-unchanged without it; the runtime composer injects the
+# backend only when the feature is on AND an adapter is configured.
+access-harness = ["dep:futures-core"]
+
 [lints]
 workspace = true

--- a/crates/nika-verb-agent/src/harness_path.rs
+++ b/crates/nika-verb-agent/src/harness_path.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The EXTERNAL execution path (D-2026-08-04-N1 · P3 B4 · feature
+//! `access-harness`, default OFF) — the `agent:` task delegated to the
+//! user's own authenticated harness through the kernel's
+//! [`DynAgentBackend`] seam.
+//!
+//! The native loop is untouched: without the feature this module does
+//! not compile; with it but no seat configured, `run` still takes the
+//! native loop. What this path never does (B4 honesty · refusals with
+//! witnesses, not silent degradation):
+//!
+//! - a task `schema:` refuses — structured output on a harness is P4's
+//!   capability attestation, never assumed;
+//! - a `tools:` whitelist refuses — the harness runs its OWN tools;
+//!   the enforceable boundary is the permission bridge (B5), and a
+//!   declared whitelist the engine cannot enforce would be a lie;
+//! - a permission ask is answered **Deny** (fail-closed) — B5 replaces
+//!   this constant with the runtime's permits bridge; until then no
+//!   harness action escapes the engine's authority by default.
+
+use std::sync::Arc;
+
+use nika_kernel::ai::harness::{
+    DynAgentBackend, HarnessError, HarnessEvent, HarnessRequest, PermissionDecision,
+};
+use nika_kernel::runtime::agent::AgentStopReason;
+
+use crate::{AgentInput, AgentOutput, AgentValue, VerbAgentError};
+
+/// The configured harness seat — the backend plus the session facts
+/// the VERB cannot know (the composer owns cwd · the runtime owns the
+/// permits bridge at B5).
+#[derive(Clone)]
+pub struct HarnessSeat {
+    /// The erased backend (a [`SpawnedHarness`] in production ·
+    /// scripted mocks in tests).
+    ///
+    /// [`SpawnedHarness`]: https://docs.rs/nika-harness
+    pub backend: Arc<dyn DynAgentBackend>,
+    /// The session's working directory (absolute · the composer's
+    /// sandbox root in production).
+    pub cwd: std::path::PathBuf,
+}
+
+impl std::fmt::Debug for HarnessSeat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HarnessSeat")
+            .field("cwd", &self.cwd)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HarnessSeat {
+    /// Construct (INV-019).
+    #[must_use]
+    pub fn new(backend: Arc<dyn DynAgentBackend>, cwd: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            backend,
+            cwd: cwd.into(),
+        }
+    }
+}
+
+/// Run the task on the harness seat — the external half of
+/// `run_observed`.
+pub(crate) async fn run_on_harness(
+    seat: &HarnessSeat,
+    input: AgentInput,
+) -> Result<AgentOutput, VerbAgentError> {
+    if input.schema.is_some() {
+        return Err(VerbAgentError::InvalidParam {
+            param: "schema",
+            detail: "not attested on a harness access (P3) — structured output \
+                     arrives with P4's capability attestation; drop the schema \
+                     or pick an infer-grade access"
+                .to_owned(),
+        });
+    }
+    if !input.tools.is_empty() {
+        return Err(VerbAgentError::InvalidParam {
+            param: "tools",
+            detail: "a whitelist is not enforceable on a harness access — the \
+                     harness runs its OWN tools under the permission bridge; \
+                     drop `tools:` or drop the harness pin"
+                .to_owned(),
+        });
+    }
+
+    let mut request = HarnessRequest::new(input.prompt.clone(), seat.cwd.clone());
+    if let Some(system) = &input.system {
+        request = request.with_system(system.clone());
+    }
+    if let Some(model) = &input.model {
+        request = request.with_requested_model(model.clone());
+    }
+
+    let mut stream = seat
+        .backend
+        .run_agent_boxed(request)
+        .await
+        .map_err(|e| harness_err(&e))?;
+
+    loop {
+        let next = std::future::poll_fn(|cx| stream.as_mut().poll_next(cx)).await;
+        match next {
+            Some(Ok(HarnessEvent::PermissionAsked { reply, .. })) => {
+                // B4 fail-closed constant — B5 swaps in the permits
+                // bridge (auto-answer inside grants · pause outside).
+                reply.respond(PermissionDecision::Deny);
+            }
+            Some(Ok(HarnessEvent::Completed { outcome })) => {
+                let mut out = AgentOutput::new(
+                    AgentValue::Text(outcome.output.clone()),
+                    AgentStopReason::Completed,
+                    1,
+                    outcome
+                        .usage
+                        .as_ref()
+                        .map_or(0, |u| u.input_tokens + u.output_tokens),
+                );
+                // Harness-built output honesty (the pre-shaped AgentOutput
+                // docs): usage stays harness-reported-or-zero ·
+                // model_resolved stays None — the receipt records the
+                // REQUESTED model; an observed identity is the trace's
+                // fact, never reconciled here (A-2/A-7).
+                if let Some(usage) = outcome.usage {
+                    out.usage = usage;
+                }
+                return Ok(out);
+            }
+            Some(Ok(_)) => {
+                // Chunks (the outcome carries the accumulated text ·
+                // per-chunk observer taps arrive with B5) and any
+                // future event kind: observed, never fatal.
+            }
+            Some(Err(e)) => return Err(harness_err(&e)),
+            None => {
+                return Err(harness_err(&HarnessError::Session {
+                    reason: "the harness stream ended without a Completed beat".to_owned(),
+                }));
+            }
+        }
+    }
+}
+
+/// Harness failures speak the verb's inference-family error — the
+/// provider seam's own class (a harness IS this task's provider). The
+/// spend box is empty-honest: a failed harness run reports no usage.
+fn harness_err(e: &HarnessError) -> VerbAgentError {
+    VerbAgentError::Inference {
+        source: nika_kernel::ProviderError::Other {
+            reason: e.to_string(),
+        },
+        spend: Box::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+    use std::task::{Context, Poll};
+
+    use nika_kernel::ai::harness::{HarnessEventStream, HarnessOutcome, PermissionReply};
+
+    /// A scripted backend: plays a fixed event tape (permission
+    /// verdicts are recorded by the reply closures the tape carries).
+    struct TapeBackend {
+        tape: Mutex<Vec<HarnessEvent>>,
+    }
+
+    struct TapeStream {
+        tape: Vec<HarnessEvent>,
+    }
+
+    impl futures_core::Stream for TapeStream {
+        type Item = Result<HarnessEvent, HarnessError>;
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if self.tape.is_empty() {
+                Poll::Ready(None)
+            } else {
+                Poll::Ready(Some(Ok(self.tape.remove(0))))
+            }
+        }
+    }
+
+    impl DynAgentBackend for TapeBackend {
+        fn run_agent_boxed(
+            &self,
+            _request: HarnessRequest,
+        ) -> Pin<Box<dyn Future<Output = Result<HarnessEventStream, HarnessError>> + Send + '_>>
+        {
+            let tape = std::mem::take(&mut *self.tape.lock().expect("tape lock"));
+            Box::pin(async move { Ok(Box::pin(TapeStream { tape }) as HarnessEventStream) })
+        }
+    }
+
+    use core::future::Future;
+
+    fn seat_with(tape: Vec<HarnessEvent>) -> HarnessSeat {
+        let backend = TapeBackend {
+            tape: Mutex::new(tape),
+        };
+        HarnessSeat::new(Arc::new(backend), "/tmp")
+    }
+
+    fn completed(text: &str) -> HarnessEvent {
+        HarnessEvent::Completed {
+            outcome: Box::new(HarnessOutcome::new(text)),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_completed_tape_yields_the_pre_shaped_honest_output() {
+        let seat = seat_with(vec![
+            HarnessEvent::MessageChunk {
+                text: "partial".to_owned(),
+            },
+            completed("the harness answered"),
+        ]);
+        let out = run_on_harness(&seat, AgentInput::new("do it"))
+            .await
+            .expect("a completed tape succeeds");
+        let AgentValue::Text(text) = &out.output else {
+            panic!("harness output is text in P3");
+        };
+        assert_eq!(text, "the harness answered");
+        assert_eq!(out.turns, 1);
+        assert_eq!(
+            out.total_tokens, 0,
+            "no usage reported → honest zero, never invented"
+        );
+        assert!(
+            out.model_resolved.is_none(),
+            "the pre-shaped None (pricing key absent)"
+        );
+        assert!(out.tools_cost_usd.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_permission_ask_is_denied_fail_closed_in_b4() {
+        let verdicts = Arc::new(Mutex::new(Vec::new()));
+        let verdicts_in = Arc::clone(&verdicts);
+        let ask = HarnessEvent::PermissionAsked {
+            question: "run `rm -rf /`".to_owned(),
+            reply: PermissionReply::new(Box::new(move |d| {
+                verdicts_in.lock().expect("verdict lock").push(d);
+            })),
+        };
+        let seat2 = seat_with(vec![ask, completed("done")]);
+        let out = run_on_harness(&seat2, AgentInput::new("try"))
+            .await
+            .expect("the run completes past the denied ask");
+        let AgentValue::Text(text) = &out.output else {
+            panic!("text output");
+        };
+        assert_eq!(text, "done");
+        assert_eq!(
+            verdicts.lock().expect("verdict lock").as_slice(),
+            &[PermissionDecision::Deny],
+            "B4 answers every ask Deny — fail-closed until the B5 bridge"
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_and_tools_refuse_with_witnesses() {
+        let seat = seat_with(vec![completed("never reached")]);
+        let schema_err = run_on_harness(&seat, {
+            let mut i = AgentInput::new("x");
+            i.schema = Some(serde_json::json!({"type": "object"}));
+            i
+        })
+        .await
+        .expect_err("schema refuses on a harness in P3");
+        assert!(schema_err.to_string().contains("P4"), "{schema_err}");
+
+        let seat2 = seat_with(vec![completed("never reached")]);
+        let tools_err = run_on_harness(&seat2, {
+            let mut i = AgentInput::new("x");
+            i.tools = vec!["nika:*".to_owned()];
+            i
+        })
+        .await
+        .expect_err("tools refuse on a harness");
+        assert!(
+            tools_err.to_string().contains("permission bridge"),
+            "{tools_err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_tape_without_completed_is_a_session_death() {
+        let seat = seat_with(vec![HarnessEvent::MessageChunk {
+            text: "then silence".to_owned(),
+        }]);
+        let err = run_on_harness(&seat, AgentInput::new("x"))
+            .await
+            .expect_err("no Completed beat is an error");
+        assert!(err.to_string().contains("without a Completed"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn harness_reported_usage_rides_the_output() {
+        use nika_kernel::ai::harness::TokenUsage;
+        let mut usage = TokenUsage::default();
+        usage.input_tokens = 100;
+        usage.output_tokens = 40;
+        let outcome = HarnessOutcome::new("counted").with_usage(usage);
+        let seat = seat_with(vec![HarnessEvent::Completed {
+            outcome: Box::new(outcome),
+        }]);
+        let out = run_on_harness(&seat, AgentInput::new("x"))
+            .await
+            .expect("completes");
+        assert_eq!(out.total_tokens, 140);
+        assert_eq!(out.usage.input_tokens, 100);
+    }
+}

--- a/crates/nika-verb-agent/src/io.rs
+++ b/crates/nika-verb-agent/src/io.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The verb's input/output DTOs — descended from `lib.rs` at the
+//! 1500-line file cap (the `task/failed.rs` precedent · the B4 harness
+//! seat was the straw). Every public path is preserved by the `lib.rs`
+//! re-export; nothing here changed shape in the move.
+
+use nika_kernel::ai::provider::TokenUsage;
+use nika_kernel::runtime::agent::AgentStopReason;
+use nika_types::blame::BlamePolarity;
+
+/// The `agent` task input — spec fields, already CEL-resolved.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct AgentInput {
+    /// The initial user message (required · spec §agent).
+    pub prompt: String,
+    /// Optional system prompt.
+    pub system: Option<String>,
+    /// Optional model override of the verb's default.
+    pub model: Option<String>,
+    /// Tool whitelist · gitignore-style globs · DEFAULT-DENY (empty =
+    /// pure conversation, no tools).
+    pub tools: Vec<String>,
+    /// Turn budget (default [`crate::DEFAULT_MAX_TURNS`]).
+    pub max_turns: Option<u32>,
+    /// Cumulative token budget across all turns.
+    pub max_tokens_total: Option<u64>,
+    /// Sampling temperature (0-2 · validated here).
+    pub temperature: Option<f32>,
+    /// JSON Schema validating the FINAL output (spec `schema:`).
+    pub schema: Option<serde_json::Value>,
+}
+
+impl AgentInput {
+    /// A tool-less conversation with every optional field unset.
+    #[must_use]
+    pub fn new(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            system: None,
+            model: None,
+            tools: Vec::new(),
+            max_turns: None,
+            max_tokens_total: None,
+            temperature: None,
+            schema: None,
+        }
+    }
+}
+
+/// The resolved turn budget with its F-P22 (NEP-0017) blame polarity —
+/// computed ONCE at arm time as a match on `input.max_turns`: a
+/// `max_turns:` the task wrote is imputed « by the caller » (F-A5); the
+/// [`crate::DEFAULT_MAX_TURNS`] the engine applies on an absent key is imputed
+/// « by the contract » that DECLARES it (spec 02-verbs.md §agent ·
+/// `max_turns` default 10) — the failure's Display names that faulty
+/// contract, so the journal's `task_failed` detail attests it.
+#[derive(Clone, Copy)]
+pub(crate) struct TurnBudget {
+    /// The turn budget the loop enforces.
+    pub(crate) max_turns: u32,
+    /// Who an exhausted budget is imputed to.
+    pub(crate) blame: BlamePolarity,
+    /// The faulty contract the blame names.
+    pub(crate) blame_source: &'static str,
+}
+
+/// The verb's result value — text, or the validated JSON value when the
+/// task carried a `schema:` (or `nika:done` carried a `result:`).
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum AgentValue {
+    /// Free-form final assistant text.
+    Text(String),
+    /// Schema-validated structured output.
+    Structured(serde_json::Value),
+}
+
+/// The `agent` verb output.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct AgentOutput {
+    /// The shaped output value (`.output` in spec terms).
+    pub output: AgentValue,
+    /// Why the loop ended (success reasons only — failures are errors).
+    pub stop_reason: AgentStopReason,
+    /// How many model turns ran.
+    pub turns: u32,
+    /// Cumulative tokens across all turns (input + output).
+    pub total_tokens: u64,
+    /// Real spend reported by the loop's TOOLS (a tool whose structured
+    /// output carries a top-level numeric `cost_usd` — the image builtin
+    /// on tick-billed providers · future paid tools). `None` when no tool
+    /// reported spend — never a fake zero. The LLM turns' own cost is
+    /// priced by the DISPATCH layer from [`Self::usage`].
+    pub tools_cost_usd: Option<f64>,
+    /// The absorbed usage split across every provider round-trip of the
+    /// loop (turns + schema re-asks) — the input/output/cache meters the
+    /// cost layer prices with the same resolver `infer` uses. Zero-valued
+    /// on harness-built outputs that never touched a provider.
+    pub usage: TokenUsage,
+    /// The model the loop resolved and ran (`provider/name`) — the
+    /// pricing/attribution key. `None` on harness-built outputs.
+    pub model_resolved: Option<String>,
+}
+
+impl AgentOutput {
+    /// Construct an output (INV-019 · per-crate `new()` on every
+    /// `#[non_exhaustive]` struct so L3/test harnesses can build one).
+    #[must_use]
+    pub fn new(
+        output: AgentValue,
+        stop_reason: AgentStopReason,
+        turns: u32,
+        total_tokens: u64,
+    ) -> Self {
+        Self {
+            output,
+            stop_reason,
+            turns,
+            total_tokens,
+            tools_cost_usd: None,
+            usage: TokenUsage::default(),
+            model_resolved: None,
+        }
+    }
+
+    /// Attach the loop's accumulated tool spend (builder — `new()` stays
+    /// stable for existing callers).
+    #[must_use]
+    pub fn with_tools_cost_usd(mut self, cost: Option<f64>) -> Self {
+        self.tools_cost_usd = cost;
+        self
+    }
+
+    /// Attach the loop's absorbed usage split + resolved model (builder —
+    /// decorated once at the loop's single return site).
+    #[must_use]
+    pub fn with_spend_identity(mut self, usage: TokenUsage, model_resolved: String) -> Self {
+        self.usage = usage;
+        self.model_resolved = Some(model_resolved);
+        self
+    }
+}

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -93,7 +93,10 @@ pub mod observe;
 pub mod whitelist;
 
 mod guard;
+#[cfg(feature = "access-harness")]
+pub mod harness_path;
 mod intrinsic;
+mod io;
 mod router;
 mod shape;
 
@@ -147,140 +150,8 @@ pub const MAX_TURNS_CEILING: u32 = 1000;
 /// `nika:x`/`mcp:server/tool` id is well under this).
 const MAX_TOOL_NAME_LEN: usize = 256;
 
-/// The `agent` task input — spec fields, already CEL-resolved.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct AgentInput {
-    /// The initial user message (required · spec §agent).
-    pub prompt: String,
-    /// Optional system prompt.
-    pub system: Option<String>,
-    /// Optional model override of the verb's default.
-    pub model: Option<String>,
-    /// Tool whitelist · gitignore-style globs · DEFAULT-DENY (empty =
-    /// pure conversation, no tools).
-    pub tools: Vec<String>,
-    /// Turn budget (default [`DEFAULT_MAX_TURNS`]).
-    pub max_turns: Option<u32>,
-    /// Cumulative token budget across all turns.
-    pub max_tokens_total: Option<u64>,
-    /// Sampling temperature (0-2 · validated here).
-    pub temperature: Option<f32>,
-    /// JSON Schema validating the FINAL output (spec `schema:`).
-    pub schema: Option<serde_json::Value>,
-}
-
-impl AgentInput {
-    /// A tool-less conversation with every optional field unset.
-    #[must_use]
-    pub fn new(prompt: impl Into<String>) -> Self {
-        Self {
-            prompt: prompt.into(),
-            system: None,
-            model: None,
-            tools: Vec::new(),
-            max_turns: None,
-            max_tokens_total: None,
-            temperature: None,
-            schema: None,
-        }
-    }
-}
-
-/// The resolved turn budget with its F-P22 (NEP-0017) blame polarity —
-/// computed ONCE at arm time as a match on `input.max_turns`: a
-/// `max_turns:` the task wrote is imputed « by the caller » (F-A5); the
-/// [`DEFAULT_MAX_TURNS`] the engine applies on an absent key is imputed
-/// « by the contract » that DECLARES it (spec 02-verbs.md §agent ·
-/// `max_turns` default 10) — the failure's Display names that faulty
-/// contract, so the journal's `task_failed` detail attests it.
-#[derive(Clone, Copy)]
-struct TurnBudget {
-    /// The turn budget the loop enforces.
-    max_turns: u32,
-    /// Who an exhausted budget is imputed to.
-    blame: BlamePolarity,
-    /// The faulty contract the blame names.
-    blame_source: &'static str,
-}
-
-/// The verb's result value — text, or the validated JSON value when the
-/// task carried a `schema:` (or `nika:done` carried a `result:`).
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-pub enum AgentValue {
-    /// Free-form final assistant text.
-    Text(String),
-    /// Schema-validated structured output.
-    Structured(serde_json::Value),
-}
-
-/// The `agent` verb output.
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct AgentOutput {
-    /// The shaped output value (`.output` in spec terms).
-    pub output: AgentValue,
-    /// Why the loop ended (success reasons only — failures are errors).
-    pub stop_reason: AgentStopReason,
-    /// How many model turns ran.
-    pub turns: u32,
-    /// Cumulative tokens across all turns (input + output).
-    pub total_tokens: u64,
-    /// Real spend reported by the loop's TOOLS (a tool whose structured
-    /// output carries a top-level numeric `cost_usd` — the image builtin
-    /// on tick-billed providers · future paid tools). `None` when no tool
-    /// reported spend — never a fake zero. The LLM turns' own cost is
-    /// priced by the DISPATCH layer from [`Self::usage`].
-    pub tools_cost_usd: Option<f64>,
-    /// The absorbed usage split across every provider round-trip of the
-    /// loop (turns + schema re-asks) — the input/output/cache meters the
-    /// cost layer prices with the same resolver `infer` uses. Zero-valued
-    /// on harness-built outputs that never touched a provider.
-    pub usage: TokenUsage,
-    /// The model the loop resolved and ran (`provider/name`) — the
-    /// pricing/attribution key. `None` on harness-built outputs.
-    pub model_resolved: Option<String>,
-}
-
-impl AgentOutput {
-    /// Construct an output (INV-019 · per-crate `new()` on every
-    /// `#[non_exhaustive]` struct so L3/test harnesses can build one).
-    #[must_use]
-    pub fn new(
-        output: AgentValue,
-        stop_reason: AgentStopReason,
-        turns: u32,
-        total_tokens: u64,
-    ) -> Self {
-        Self {
-            output,
-            stop_reason,
-            turns,
-            total_tokens,
-            tools_cost_usd: None,
-            usage: TokenUsage::default(),
-            model_resolved: None,
-        }
-    }
-
-    /// Attach the loop's accumulated tool spend (builder — `new()` stays
-    /// stable for existing callers).
-    #[must_use]
-    pub fn with_tools_cost_usd(mut self, cost: Option<f64>) -> Self {
-        self.tools_cost_usd = cost;
-        self
-    }
-
-    /// Attach the loop's absorbed usage split + resolved model (builder —
-    /// decorated once at the loop's single return site).
-    #[must_use]
-    pub fn with_spend_identity(mut self, usage: TokenUsage, model_resolved: String) -> Self {
-        self.usage = usage;
-        self.model_resolved = Some(model_resolved);
-        self
-    }
-}
+use io::TurnBudget;
+pub use io::{AgentInput, AgentOutput, AgentValue};
 
 /// The multi-turn agentic loop — the `agent` verb executor.
 pub struct AgentVerb<P, T, D> {
@@ -298,6 +169,10 @@ pub struct AgentVerb<P, T, D> {
     // embedder signature (Runtime::new already carries the verb generics);
     // the observer is telemetry, never on the data path's hot types.
     observer: Arc<dyn AgentObserver>,
+    // The harness seat (P3 B4): delegates to the user's own harness —
+    // same dyn-seam rationale as the observer.
+    #[cfg(feature = "access-harness")]
+    harness: Option<harness_path::HarnessSeat>,
 }
 
 impl<P, T, D> std::fmt::Debug for AgentVerb<P, T, D> {
@@ -327,7 +202,19 @@ impl<P, T, D> AgentVerb<P, T, D> {
             config: AgentConfig::new(),
             schema_retry_budget: DEFAULT_SCHEMA_RETRY_BUDGET,
             observer: Arc::new(NoopObserver),
+            #[cfg(feature = "access-harness")]
+            harness: None,
         }
+    }
+
+    /// Seat the harness backend (P3 B4): every run then delegates to
+    /// the user's own harness (one verb instance per access plan · the
+    /// resolver never re-selects).
+    #[cfg(feature = "access-harness")]
+    #[must_use]
+    pub fn with_harness_seat(mut self, seat: harness_path::HarnessSeat) -> Self {
+        self.harness = Some(seat);
+        self
     }
 
     /// Override the intelligence-layer tuning (ADR-096).
@@ -407,6 +294,13 @@ where
         input: AgentInput,
         observer: &dyn AgentObserver,
     ) -> Result<AgentOutput, VerbAgentError> {
+        // The harness seat wins when configured (P3 B4) — the native
+        // loop's arm/whitelist/budget machinery governs the native
+        // path only; the harness boundary is the permission bridge.
+        #[cfg(feature = "access-harness")]
+        if let Some(seat) = &self.harness {
+            return harness_path::run_on_harness(seat, input).await;
+        }
         // arm_run failures precede any billed call — no spend to decorate.
         let (whitelist, defs, model, budget) = self.arm_run(&input).await?;
         // The pricing-grade accumulators live HERE so the failure path

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4334
+  classified_files: 4336
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1405
+    authored: 1407
     authored-pin: 2
     generated: 117
     pinned-copy: 114
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 63c923b9855807ad6d2ae41d29074f00ecba0e09e8f6d66b48615ba939385bcb
+  sha256: bfa22ed338128debf0a31c0d3328a57e45d2acfb33d7b74e3cd72f12c307f3f5
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 61
-  aggregate_sha256: b0c925bd32a93e2c643c513ebf45872765107f802befb0c45777fef92d83c5ba
+  aggregate_sha256: ccf1405e8fce19de578ded87ff74f7c9d7e45f8beab1766b1be5e3653c5426e5
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 710
-  aggregate_sha256: b9601381bd8da537b9d566bdb23c8c5d4fae79c58b6dd1be4e8373536ecaa5d9
+  match_count: 712
+  aggregate_sha256: ffd76054215e326a5c99dbfc9e9cd0120e85181fb6631060eb23d5d579fcc651
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 131
-  aggregate_sha256: d31a20d7f22a34f85724b08814d5037ecdbe7ecab38414314dd85a78c5dcab56
+  aggregate_sha256: 49f6985c03a79c04505d39cd7c0f83d38588befc3eb19c4ab51c8ef8123c96f7
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"


### PR DESCRIPTION
B4 of the access P3 arc (D-2026-08-04-N1).

The agent verb learns to delegate to the user's own harness through the kernel's new `DynAgentBackend` erasure (an async-fn trait cannot ride behind `dyn`; the blanket impl makes every backend an `Arc<dyn _>` for free — the observer-seam precedent). Behind the `access-harness` cargo feature, **default OFF**: without it the native loop is byte-unchanged, and the default public-api baseline proves it — zero pub lines moved.

The path's honesty is refusals with witnesses, never silent degradation: a task `schema:` refuses (structured output on a harness is P4's capability attestation), a `tools:` whitelist refuses (the harness runs its OWN tools; the enforceable boundary is the B5 permission bridge), and every permission ask is answered **Deny fail-closed** until the bridge lands. The harness-built `AgentOutput` fills exactly the shape its docs pre-carved: usage harness-reported-or-zero, `model_resolved` `None`. Five tape-scripted tests pin the contract, the Deny recording among them.

The 1500-line file cap bit third: the input/output DTO block descends to `io.rs` (the `task/failed.rs` precedent), `lib.rs` lands at 1383 with headroom for B5, every public path re-exported unchanged.

Next: B5 — the authority bridge (permits auto-answer inside grants · pause outside · the B0 runtime descent first).

🦋