### PR TITLE
fix(access): the refuter's two P0s — the leak and the wedge

### DIFF
--- a/crates/nika-acp/Cargo.lock
+++ b/crates/nika-acp/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +210,15 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -501,6 +519,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +649,12 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -630,17 +675,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "serde",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "nika-acp"
-version = "0.107.2"
+version = "0.108.0"
 dependencies = [
  "agent-client-protocol",
+ "futures-core",
+ "nika-harness",
+ "nika-kernel",
  "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "nika-cap"
+version = "0.108.0"
+dependencies = [
+ "nika-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "nika-error"
+version = "0.108.0"
+dependencies = [
+ "miette",
+ "nika-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "nika-harness"
+version = "0.108.0"
+dependencies = [
+ "futures-core",
+ "nika-kernel",
+ "nika-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "nika-kernel"
+version = "0.108.0"
+dependencies = [
+ "nika-error",
+ "nika-kernel-ai",
+ "nika-kernel-core",
+ "nika-kernel-plugin",
+ "nika-kernel-runtime",
+]
+
+[[package]]
+name = "nika-kernel-ai"
+version = "0.108.0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "miette",
+ "nika-error",
+ "nika-kernel-core",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "trait-variant",
+ "uuid",
+]
+
+[[package]]
+name = "nika-kernel-core"
+version = "0.108.0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "miette",
+ "nika-cap",
+ "nika-error",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "trait-variant",
+ "zeroize",
+]
+
+[[package]]
+name = "nika-kernel-plugin"
+version = "0.108.0"
+dependencies = [
+ "miette",
+ "nika-error",
+ "nika-kernel-core",
+ "thiserror",
+ "trait-variant",
+]
+
+[[package]]
+name = "nika-kernel-runtime"
+version = "0.108.0"
+dependencies = [
+ "miette",
+ "nika-error",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "trait-variant",
+]
+
+[[package]]
+name = "nika-types"
+version = "0.108.0"
+dependencies = [
+ "loom",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -663,6 +892,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking"
@@ -772,6 +1007,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1093,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "semver"
@@ -936,6 +1194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1264,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1304,55 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1069,8 +1406,13 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1082,6 +1424,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1113,6 +1469,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1122,10 +1519,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1141,8 +1556,21 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1256,6 +1684,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/crates/nika-acp/Cargo.toml
+++ b/crates/nika-acp/Cargo.toml
@@ -27,8 +27,19 @@ publish       = false
 agent-client-protocol = "2.0.0"   # wire v1 (SDK 2.x) · pin per spec §2
 
 [dev-dependencies]
-# The mock/conformance tests only — the lib carries no runtime of its own yet.
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+# The mock + conformance tests only — the lib carries no runtime of its own yet.
+tokio        = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+futures-core = "0.3"
+tokio-util   = { version = "0.7", features = ["compat"] }
+nika-kernel  = { path = "../nika-kernel" }
 
 [lints.rust]
 unsafe_code = "forbid"
+
+[dev-dependencies.nika-harness]
+# The engine's hand-rolled wire-v1 client — judged HERE, from the
+# quarantine, by the official SDK's Agent role (spec §2bis Lane A: the
+# SDK is the JUDGE, never a link-time dependency of the engine). The
+# path dep is test-only and lives in THIS workspace's lockfile, so the
+# SDK's serde_json/preserve_order never reaches the engine build.
+path = "../nika-harness"

--- a/crates/nika-acp/tests/conformance.rs
+++ b/crates/nika-acp/tests/conformance.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! **The Lane A promise, kept** (spec §2bis) — the OFFICIAL SDK judges
+//! the engine's hand-rolled wire-v1 client.
+//!
+//! The engine never links the SDK (its `serde_json/preserve_order`
+//! would flip every byte-attested surface); instead the SDK lives here,
+//! in the quarantined workspace, plays the AGENT role, and the engine's
+//! `nika_harness::drive` (a dev-dependency of THIS workspace only)
+//! plays the client against it over real pipes. A frame the engine
+//! emits that the SDK cannot deserialize fails the test — which is the
+//! whole point: conformance proven by the authority, not by our own
+//! mock talking to itself.
+//!
+//! Instrument note: the two sides are wired over `tokio::io::duplex`
+//! (the SDK's transport takes byte streams). Zero network, zero spawn.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use agent_client_protocol::schema::v1::{
+    AgentCapabilities, ContentBlock, ContentChunk, InitializeRequest, InitializeResponse,
+    NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SessionId,
+    SessionNotification, SessionUpdate, StopReason, TextContent,
+};
+use agent_client_protocol::{Agent, ByteStreams};
+use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
+use futures_core::Stream as _;
+use nika_kernel::ai::harness::{HarnessEvent, HarnessRequest};
+
+/// The SDK-side agent: asserts the ENGINE's frames deserialize into the
+/// official types (that is the judgment), then answers the dialogue.
+fn spawn_sdk_agent(
+    reader: tokio::io::ReadHalf<tokio::io::DuplexStream>,
+    writer: tokio::io::WriteHalf<tokio::io::DuplexStream>,
+    seen: Arc<AtomicUsize>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let seen_init = Arc::clone(&seen);
+        let seen_new = Arc::clone(&seen);
+        let seen_prompt = Arc::clone(&seen);
+        let _ = Agent
+            .builder()
+            .name("sdk-conformance-judge")
+            .on_receive_request(
+                async move |initialize: InitializeRequest, responder, _connection| {
+                    // JUDGMENT 1: the engine's `initialize` frame parsed
+                    // into the official InitializeRequest — camelCase
+                    // keys and the integer protocol version included.
+                    seen_init.fetch_add(1, Ordering::SeqCst);
+                    responder.respond(
+                        InitializeResponse::new(initialize.protocol_version)
+                            .agent_capabilities(AgentCapabilities::new()),
+                    )
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |new_session: NewSessionRequest, responder, _connection| {
+                    // JUDGMENT 2: `session/new` parsed — the cwd is an
+                    // absolute path the official type accepted.
+                    assert!(
+                        new_session.cwd.is_absolute(),
+                        "the engine must send an absolute cwd: {:?}",
+                        new_session.cwd
+                    );
+                    seen_new.fetch_add(1, Ordering::SeqCst);
+                    responder.respond(NewSessionResponse::new(SessionId::new("sdk-judged")))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |prompt: PromptRequest, responder, connection| {
+                    // JUDGMENT 3: `session/prompt` parsed — the session
+                    // id round-tripped and the content block is the
+                    // baseline text variant every agent MUST support.
+                    assert_eq!(prompt.session_id, SessionId::new("sdk-judged"));
+                    assert!(
+                        matches!(prompt.prompt.first(), Some(ContentBlock::Text(_))),
+                        "the engine must send a text content block"
+                    );
+                    seen_prompt.fetch_add(1, Ordering::SeqCst);
+                    let _ = connection.send_notification(SessionNotification::new(
+                        prompt.session_id.clone(),
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                            TextContent::new("judged by the official sdk"),
+                        ))),
+                    ));
+                    responder.respond(PromptResponse::new(StopReason::EndTurn))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_to(ByteStreams::new(writer.compat_write(), reader.compat()))
+            .await;
+    })
+}
+
+#[tokio::test]
+async fn the_official_sdk_judges_the_engines_wire_client() {
+    let (engine_side, sdk_side) = tokio::io::duplex(64 * 1024);
+    let (engine_read, engine_write) = tokio::io::split(engine_side);
+    let (sdk_read, sdk_write) = tokio::io::split(sdk_side);
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    let agent = spawn_sdk_agent(sdk_read, sdk_write, Arc::clone(&seen));
+
+    // The ENGINE's own client — the thing under judgment.
+    let mut stream = nika_harness::drive(
+        engine_read,
+        engine_write,
+        HarnessRequest::new("hello from the engine", "/tmp"),
+    );
+
+    let mut chunks = Vec::new();
+    let mut output = None;
+    loop {
+        let next = std::future::poll_fn(|cx| Pin::new(&mut stream).poll_next(cx)).await;
+        match next {
+            Some(Ok(HarnessEvent::MessageChunk { text })) => chunks.push(text),
+            Some(Ok(HarnessEvent::Completed { outcome })) => output = Some(outcome.output.clone()),
+            Some(Ok(_)) => {}
+            Some(Err(e)) => panic!("the engine's client failed against the SDK: {e}"),
+            None => break,
+        }
+    }
+    let _ = agent.await;
+
+    // Every judgment fired: three official types deserialized the
+    // engine's three frames.
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        3,
+        "the SDK must have parsed initialize + session/new + session/prompt"
+    );
+    // And the engine read the SDK's own frames back correctly.
+    assert_eq!(chunks, vec!["judged by the official sdk"]);
+    assert_eq!(output.as_deref(), Some("judged by the official sdk"));
+}

--- a/crates/nika-harness/Cargo.toml
+++ b/crates/nika-harness/Cargo.toml
@@ -17,12 +17,13 @@ nika-types  = { path = "../nika-types", version = "0.108.0" }
 serde       = { workspace = true }
 thiserror   = { workspace = true }
 serde_json  = { workspace = true }
-tokio       = { workspace = true, features = ["io-util", "sync", "rt", "macros", "process"] }
+tokio       = { workspace = true, features = ["io-util", "sync", "rt", "macros", "process", "time"] }
 futures-core = { workspace = true }
 
 [dev-dependencies]
 futures-core = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "sync", "rt", "macros", "rt-multi-thread", "time"] }
+# `start_paused` (virtual time) proves the idle deadline in ms, not 5min.
+tokio = { workspace = true, features = ["io-util", "sync", "rt", "macros", "process", "time", "test-util", "rt-multi-thread"] }
 
 [package.metadata.lore]
 daemon        = "messager"

--- a/crates/nika-harness/public-api.txt
+++ b/crates/nika-harness/public-api.txt
@@ -1,7 +1,9 @@
 pub mod nika_harness
 pub mod nika_harness::client
+pub const nika_harness::client::IDLE_TIMEOUT_SECS: u64
 pub const nika_harness::client::MAX_LINE_BYTES: usize
 pub fn nika_harness::client::drive<R, W>(reader: R, writer: W, request: nika_kernel_ai::harness::HarnessRequest) -> nika_kernel_ai::harness::HarnessEventStream where R: tokio::io::async_read::AsyncRead + core::marker::Unpin + core::marker::Send + 'static, W: tokio::io::async_write::AsyncWrite + core::marker::Unpin + core::marker::Send + 'static
+pub fn nika_harness::client::drive_with_idle<R, W>(reader: R, writer: W, request: nika_kernel_ai::harness::HarnessRequest, idle: core::time::Duration) -> nika_kernel_ai::harness::HarnessEventStream where R: tokio::io::async_read::AsyncRead + core::marker::Unpin + core::marker::Send + 'static, W: tokio::io::async_write::AsyncWrite + core::marker::Unpin + core::marker::Send + 'static
 pub mod nika_harness::spawn
 #[non_exhaustive] pub struct nika_harness::spawn::HarnessAdapter
 pub nika_harness::spawn::HarnessAdapter::args: alloc::vec::Vec<alloc::string::String>
@@ -573,6 +575,8 @@ impl<T> core::convert::From<T> for nika_harness::spawn::SpawnedHarness
 pub fn nika_harness::spawn::SpawnedHarness::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_harness::spawn::SpawnedHarness where T: 'static
 pub fn nika_harness::spawn::SpawnedHarness::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_harness::IDLE_TIMEOUT_SECS: u64
 pub const nika_harness::MAX_LINE_BYTES: usize
 pub fn nika_harness::compose_env(parent: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>, passthrough: &[alloc::string::String]) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
 pub fn nika_harness::drive<R, W>(reader: R, writer: W, request: nika_kernel_ai::harness::HarnessRequest) -> nika_kernel_ai::harness::HarnessEventStream where R: tokio::io::async_read::AsyncRead + core::marker::Unpin + core::marker::Send + 'static, W: tokio::io::async_write::AsyncWrite + core::marker::Unpin + core::marker::Send + 'static
+pub fn nika_harness::drive_with_idle<R, W>(reader: R, writer: W, request: nika_kernel_ai::harness::HarnessRequest, idle: core::time::Duration) -> nika_kernel_ai::harness::HarnessEventStream where R: tokio::io::async_read::AsyncRead + core::marker::Unpin + core::marker::Send + 'static, W: tokio::io::async_write::AsyncWrite + core::marker::Unpin + core::marker::Send + 'static

--- a/crates/nika-harness/src/client.rs
+++ b/crates/nika-harness/src/client.rs
@@ -38,6 +38,15 @@ use crate::wire::{
 /// hostile or broken peer overflows into a refusal, never an OOM.
 pub const MAX_LINE_BYTES: usize = 1024 * 1024;
 
+/// How long the driver waits for the NEXT byte before calling the
+/// session dead. A size bound alone leaves the wedge the refuter
+/// found (2026-08-06): a peer that writes half a line and goes silent
+/// without closing its pipe hangs the driver forever — no EOF, no
+/// overflow, no newline. Agent turns are long (a harness may think for
+/// minutes), so the bound is on SILENCE between bytes, never on the
+/// turn: any progress resets it.
+pub const IDLE_TIMEOUT_SECS: u64 = 300;
+
 const ID_INITIALIZE: u64 = 1;
 const ID_SESSION_NEW: u64 = 2;
 const ID_PROMPT: u64 = 3;
@@ -49,6 +58,28 @@ where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
+    drive_with_idle(
+        reader,
+        writer,
+        request,
+        std::time::Duration::from_secs(IDLE_TIMEOUT_SECS),
+    )
+}
+
+/// [`drive`] with an explicit idle deadline — the seam the wedge tests
+/// drive at millisecond scale (a five-minute constant cannot be proven
+/// by a test that must finish; virtual time does not compose with the
+/// spawned driver task).
+pub fn drive_with_idle<R, W>(
+    reader: R,
+    writer: W,
+    request: HarnessRequest,
+    idle: std::time::Duration,
+) -> HarnessEventStream
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
     let (event_tx, event_rx) = mpsc::channel::<Result<HarnessEvent, HarnessError>>(64);
     tokio::spawn(async move {
         let mut driver = Driver {
@@ -56,6 +87,7 @@ where
             writer,
             event_tx,
             output: String::new(),
+            idle,
         };
         if let Err(e) = driver.run(request).await {
             // The stream may already be dropped — best-effort final word.
@@ -79,6 +111,8 @@ struct Driver<R, W> {
     writer: W,
     event_tx: mpsc::Sender<Result<HarnessEvent, HarnessError>>,
     output: String,
+    /// How long a silence may last before the session is abandoned.
+    idle: std::time::Duration,
 }
 
 impl<R, W> Driver<R, W>
@@ -150,7 +184,7 @@ where
         let mut reply_rx = prx;
         loop {
             tokio::select! {
-                line = read_bounded_line(&mut self.reader) => {
+                line = read_bounded_line(&mut self.reader, self.idle) => {
                     let line = line?;
                     match wire::parse_line(&line).map_err(|e| HarnessError::Session {
                         reason: e.to_string(),
@@ -287,7 +321,7 @@ where
         what: &str,
     ) -> Result<T, HarnessError> {
         loop {
-            let line = read_bounded_line(&mut self.reader).await?;
+            let line = read_bounded_line(&mut self.reader, self.idle).await?;
             match wire::parse_line(&line).map_err(session_err)? {
                 Incoming::Response { id: got, result } if got == id => {
                     return parse_payload(result, what);
@@ -365,14 +399,27 @@ fn parse_payload<T: serde::de::DeserializeOwned>(v: Value, what: &str) -> Result
 /// overflow and EOF are both session deaths with their own words.
 async fn read_bounded_line<R: AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
+    idle: std::time::Duration,
 ) -> Result<String, HarnessError> {
     let mut buf: Vec<u8> = Vec::new();
     loop {
         let budget = (MAX_LINE_BYTES + 1).saturating_sub(buf.len());
         let mut limited = reader.take(budget as u64);
-        let n = limited
-            .read_until(b'\n', &mut buf)
+        // The idle deadline (the anti-wedge · refuted 2026-08-06): the
+        // size bound alone let a peer write half a line and go silent
+        // WITHOUT closing its pipe — no EOF, no overflow, no newline,
+        // a driver hung forever. Each read waits at most `idle` for
+        // progress; any byte resets it, so a long thinking turn is
+        // never killed, only a dead one.
+        let n = tokio::time::timeout(idle, limited.read_until(b'\n', &mut buf))
             .await
+            .map_err(|_| HarnessError::Session {
+                reason: format!(
+                    "transport: the agent sent nothing for {}s (idle deadline) \
+                     — the session is abandoned",
+                    idle.as_secs_f32()
+                ),
+            })?
             .map_err(|e| io_err(&e))?;
         if buf.last() == Some(&b'\n') {
             buf.pop();
@@ -700,6 +747,100 @@ mod tests {
         assert!(
             matches!(next, Some(Err(HarnessError::Session { .. }))),
             "EOF mid-handshake is a session death, got {next:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod wedge_tests {
+    use super::*;
+    use nika_kernel::ai::harness::HarnessRequest;
+    const FAST_IDLE: std::time::Duration = std::time::Duration::from_millis(80);
+
+    /// The refuter's counterexample (2026-08-06), pinned: a peer that
+    /// writes half a line and goes silent WITHOUT closing its pipe used
+    /// to hang the driver forever (a size bound, no time bound).
+    #[tokio::test]
+    async fn a_silent_partial_line_ends_at_the_idle_deadline() {
+        let (ours, theirs) = tokio::io::duplex(4096);
+        let (client_read, client_write) = tokio::io::split(ours);
+        let (_agent_read, mut agent_write) = tokio::io::split(theirs);
+        agent_write
+            .write_all(b"{\"jsonrpc\":\"2.0\"")
+            .await
+            .expect("partial write");
+
+        let mut stream = drive_with_idle(
+            client_read,
+            client_write,
+            HarnessRequest::new("hi", "/tmp"),
+            FAST_IDLE,
+        );
+        let next = std::future::poll_fn(|cx| Pin::new(&mut stream).poll_next(cx)).await;
+        let Some(Err(HarnessError::Session { reason })) = next else {
+            panic!("the idle deadline must end a silent peer, got {next:?}");
+        };
+        assert!(reason.contains("idle deadline"), "{reason}");
+        drop(agent_write); // the pipe stayed OPEN for the whole wait
+    }
+
+    /// Progress resets the deadline: an agent that answers slowly (each
+    /// beat inside the window) is never killed mid-turn.
+    #[tokio::test]
+    async fn progress_resets_the_idle_deadline() {
+        let (ours, theirs) = tokio::io::duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(ours);
+        let (agent_read, mut agent_write) = tokio::io::split(theirs);
+
+        let agent = tokio::spawn(async move {
+            use tokio::io::AsyncBufReadExt as _;
+            let mut r = tokio::io::BufReader::new(agent_read);
+            let mut line = String::new();
+            let answer = async |w: &mut tokio::io::WriteHalf<tokio::io::DuplexStream>, v: Value| {
+                let mut s = serde_json::to_string(&v).expect("json");
+                s.push('\n');
+                w.write_all(s.as_bytes()).await.expect("write");
+            };
+            for step in 0..3 {
+                // Each beat lands at 60% of the window: three gaps in a
+                // row, none fatal — the reset is what proves it.
+                tokio::time::sleep(FAST_IDLE.mul_f32(0.6)).await;
+                line.clear();
+                r.read_line(&mut line).await.expect("read");
+                let req: Value = serde_json::from_str(line.trim_end()).expect("json");
+                let result = match step {
+                    0 => serde_json::json!({"protocolVersion": 1}),
+                    1 => serde_json::json!({"sessionId": "s-slow"}),
+                    _ => serde_json::json!({"stopReason": "end_turn"}),
+                };
+                answer(
+                    &mut agent_write,
+                    serde_json::json!({"jsonrpc":"2.0","id":req["id"],"result":result}),
+                )
+                .await;
+            }
+        });
+
+        let mut stream = drive_with_idle(
+            client_read,
+            client_write,
+            HarnessRequest::new("slow", "/tmp"),
+            FAST_IDLE,
+        );
+        let mut completed = false;
+        loop {
+            let next = std::future::poll_fn(|cx| Pin::new(&mut stream).poll_next(cx)).await;
+            match next {
+                Some(Ok(HarnessEvent::Completed { .. })) => completed = true,
+                Some(Ok(_)) => {}
+                Some(Err(e)) => panic!("a slow BUT ALIVE agent must survive: {e}"),
+                None => break,
+            }
+        }
+        agent.await.expect("scripted slow agent");
+        assert!(
+            completed,
+            "the turn completes across three near-deadline gaps"
         );
     }
 }

--- a/crates/nika-harness/src/lib.rs
+++ b/crates/nika-harness/src/lib.rs
@@ -24,5 +24,5 @@ pub mod client;
 pub mod spawn;
 pub mod wire;
 
-pub use client::{MAX_LINE_BYTES, drive};
+pub use client::{IDLE_TIMEOUT_SECS, MAX_LINE_BYTES, drive, drive_with_idle};
 pub use spawn::{HarnessAdapter, SpawnedHarness, compose_env};

--- a/crates/nika-harness/src/spawn.rs
+++ b/crates/nika-harness/src/spawn.rs
@@ -28,14 +28,45 @@ use crate::client::drive;
 /// CLI needs to run at all, none of them a secret channel.
 const ENV_FLOOR: [&str; 7] = ["HOME", "PATH", "TERM", "LANG", "LC_ALL", "USER", "TMPDIR"];
 
-/// A parent variable whose NAME is credential-shaped never rides the
-/// floor or a passthrough — nika's own keys above all (A-3: the
-/// harness owns ITS auth; nika's never crosses).
+/// Credential-shaped NAME fragments — a suffix list is not enough:
+/// the single most common cloud family (`AWS_SECRET_ACCESS_KEY` ·
+/// `AWS_ACCESS_KEY_ID`) ends in neither `_API_KEY` nor `_SECRET`, and
+/// the refuter proved it crossed. The predicate is now SUBSTRING-based
+/// over the vocabulary that names authority, plus the explicit
+/// ambient-authority handles no pattern would catch.
+const CREDENTIAL_FRAGMENTS: [&str; 10] = [
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "CREDENTIAL",
+    "API_KEY",
+    "ACCESS_KEY",
+    "PRIVATE_KEY",
+    "SESSION_KEY",
+    "AUTH",
+];
+
+/// Ambient-authority handles: not static secrets, but LIVE authority a
+/// child could wield (an agent socket · a connection string that
+/// commonly embeds a password).
+const AMBIENT_AUTHORITY: [&str; 4] = [
+    "SSH_AUTH_SOCK",
+    "GPG_AGENT_INFO",
+    "DATABASE_URL",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+];
+
+/// A parent variable whose NAME carries authority never rides the floor
+/// or a passthrough — nika's own keys above all (A-3: the harness owns
+/// ITS auth; nika's never crosses). Deliberately over-broad: a false
+/// positive costs a harness one env var it can ask for by another name;
+/// a false negative hands a child a live credential.
 fn credential_shaped(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
     name.starts_with("NIKA_")
-        || name.ends_with("_API_KEY")
-        || name.ends_with("_TOKEN")
-        || name.ends_with("_SECRET")
+        || AMBIENT_AUTHORITY.contains(&upper.as_str())
+        || CREDENTIAL_FRAGMENTS.iter().any(|f| upper.contains(f))
 }
 
 /// Compose the child environment — PURE (the negative test's whole
@@ -253,6 +284,34 @@ mod tests {
         }
         // Non-floor, non-passthrough plain vars do not cross either.
         assert!(!env.contains_key("NO_COLOR"));
+    }
+
+    #[test]
+    fn the_refuters_counterexamples_never_cross() {
+        // The suffix heuristic let these through (refuted 2026-08-06):
+        // AWS's canonical pair ends in `_KEY`/`_KEY_ID`, GCP's in
+        // `_CREDENTIALS`, and the ambient handles match no pattern.
+        let parent: BTreeMap<String, String> = [
+            ("AWS_SECRET_ACCESS_KEY", "AKIA-never"),
+            ("AWS_ACCESS_KEY_ID", "AKIA-id-never"),
+            ("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/sa.json"),
+            ("DATABASE_URL", "postgres://u:p@h/db"),
+            ("SSH_AUTH_SOCK", "/tmp/agent.sock"),
+            ("ANTHROPIC_AUTH_TOKEN", "sk-never"),
+            ("MY_PASSWORD", "hunter2"),
+            ("SERVICE_PRIVATE_KEY", "-----BEGIN"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .collect();
+        // Even DECLARED as passthrough (the config-mistake path), none
+        // may cross.
+        let declared: Vec<String> = parent.keys().cloned().collect();
+        let env = compose_env(&parent, &declared);
+        assert!(
+            env.is_empty(),
+            "every authority-shaped name must stay on nika's side, got {env:?}"
+        );
     }
 
     #[test]

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4336
+  classified_files: 4337
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1407
+    authored: 1408
     authored-pin: 2
     generated: 117
     pinned-copy: 114
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 61
-  aggregate_sha256: ccf1405e8fce19de578ded87ff74f7c9d7e45f8beab1766b1be5e3653c5426e5
+  aggregate_sha256: d24073fce824198e28abd1f90cd33e56168f96f957c70c94a6847d3125c4c657
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -152,17 +152,17 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 712
-  aggregate_sha256: ffd76054215e326a5c99dbfc9e9cd0120e85181fb6631060eb23d5d579fcc651
+  aggregate_sha256: 7b8272a9fc4fccfc076e3c07afa5169f8bd8613d1148324801430a2ec57a9b06
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 129
-  aggregate_sha256: 8e4773092ab12c06e61b15add5447864e89f8f7f469e84d5651d473843629f57
+  match_count: 130
+  aggregate_sha256: 431bc19c8be487dc2b3c6855f0dbb5e86e4ee8d73f88ce03664771a54c03e7be
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
   match_count: 131
-  aggregate_sha256: 49f6985c03a79c04505d39cd7c0f83d38588befc3eb19c4ab51c8ef8123c96f7
+  aggregate_sha256: ac4d5ae7ce4d23fe3b510500e4fb91df74d50b50c3fc06ea86bb68510e9dc7e9
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"


### PR DESCRIPTION
An adversarial pass broke two claims this arc had made in prose. Both are fixed, both counterexamples pinned as tests, and the Lane A promise is finally kept.

**P0 · the credential leak.** The ban was a SUFFIX heuristic and the most common cloud family walks past it: `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` end in neither `_API_KEY` nor `_SECRET`; `GOOGLE_APPLICATION_CREDENTIALS`, `DATABASE_URL` and `SSH_AUTH_SOCK` match no pattern at all — every one crossed into a spawned harness the moment an adapter declared it as passthrough. The predicate is now substring-based over the vocabulary that names authority plus an explicit ambient-authority list, deliberately over-broad: a false positive costs a harness one variable it can ask for by another name; a false negative hands a child a live credential.

**P0 · the wedge.** The wire client bounded a line's SIZE but never its TIME: a peer that wrote half a frame and went silent without closing its pipe hung the driver forever. Reads now carry an idle deadline that any byte resets — a harness thinking for minutes is never killed, a dead one ends with its own words. The deadline is injectable so the wedge is proven in milliseconds; both halves pinned (silence dies · slow-but-alive survives).

**The Lane A promise, kept.** The quarantined workspace now dev-depends on the engine's client, so the OFFICIAL SDK — in its Agent role, over real pipes — deserializes the engine's `initialize`, `session/new` and `session/prompt` frames and answers them. Conformance proven by the authority, not by our own mock talking to itself. The engine still never links the SDK; the dep lives in the quarantine's own lockfile.

🦋