### PR TITLE
feat: run-a-nika-workflow GitHub Action + dogfood CI

### DIFF
--- a/.github/workflows/action-dogfood.yml
+++ b/.github/workflows/action-dogfood.yml
@@ -1,0 +1,58 @@
+# Dogfood: the composite action runs itself against a $0 mock workflow.
+# Proves the whole chain end-to-end — install the released binary, check,
+# run cost-capped, name the trace — through the SAME door a user gets
+# (the binary boundary · nika.sh/install.sh · no local build).
+name: action-dogfood
+
+on:
+  push:
+    paths:
+      - "action/**"
+      - ".github/workflows/action-dogfood.yml"
+  pull_request:
+    paths:
+      - "action/**"
+      - ".github/workflows/action-dogfood.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  dogfood:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Write a $0 mock workflow
+        shell: bash
+        run: |
+          mkdir -p wf
+          cat > wf/smoke.nika.yaml <<'YAML'
+          nika: v1
+
+          workflow:
+            id: action-dogfood
+            description: A zero-cost mock run proving the action end-to-end.
+
+          tasks:
+            greet:
+              infer:
+                model: mock/echo
+                prompt: "hello from the action"
+          YAML
+
+      - name: Run via the local composite action
+        id: nika
+        uses: ./action
+        with:
+          file: wf/smoke.nika.yaml
+          max-cost-usd: "0.01"
+
+      - name: Assert the trace exists and verifies
+        shell: bash
+        env:
+          TRACE: ${{ steps.nika.outputs.trace }}
+        run: |
+          test -n "$TRACE" || { echo "no trace output"; exit 1; }
+          test -f "$TRACE" || { echo "trace file missing"; exit 1; }
+          nika trace verify "$TRACE"

--- a/action/README.md
+++ b/action/README.md
@@ -1,0 +1,56 @@
+# Run Nika Workflow · GitHub Action
+
+Runs one `.nika.yaml` in CI the way Nika always runs: **audited before a
+token is spent** (`nika check` gates the job), **cost-bounded while it
+runs** (`--max-cost-usd` is required, not optional), **hash-chain traced
+after** (the trace path is an output — upload it as an artifact and the
+run's evidence travels with the build).
+
+```yaml
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the review workflow
+        id: nika
+        uses: supernovae-st/nika/action@main
+        with:
+          file: workflows/pr-review.nika.yaml
+          max-cost-usd: "0.50"
+          args: --var pr=${{ github.event.number }}
+
+      - name: Keep the evidence
+        if: always() && steps.nika.outputs.trace != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nika-trace
+          path: ${{ steps.nika.outputs.trace }}
+```
+
+## Inputs
+
+| Input | Required | What it does |
+|---|---|---|
+| `file` | yes | the workflow file to check and run |
+| `max-cost-usd` | yes | hard USD ceiling — the run stops at the cap |
+| `args` | no | extra `nika run` arguments (`--var k=v` · `--answer task=value` to pre-seed a human gate for CI) |
+| `version` | no | pin a Nika version (default: latest release) |
+
+## Outputs
+
+| Output | What it is |
+|---|---|
+| `trace` | path of the run's NDJSON trace (verify it later with `nika trace verify`) |
+
+## Exit behavior
+
+The job fails when `nika check` refuses the file (findings before any
+execution) or the run fails. Exit 4 (paused on a human gate) also stops
+the job with a loud error: CI has no human — pre-seed the answer via
+`args: --answer <task>=<value>` when the gate's outcome is known.
+
+Secrets ride the normal way — export them as env vars in the step and
+reference them from the workflow's `secrets:` block. The action adds no
+secret surface of its own.

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,65 @@
+# Run Nika Workflow — the composite action (in-repo · `uses: supernovae-st/nika/action@<tag>`)
+#
+# Check-gates then runs one .nika.yaml with a mandatory cost ceiling, and
+# names the trace path for upload. The action consumes the PUBLIC binary
+# via the sha256-verified installer — the same door every user walks
+# through (the binary boundary · dogfooding pure).
+name: "Run Nika Workflow"
+description: "nika check, then nika run with a cost ceiling — audited before it runs, hash-chain traced after"
+branding:
+  icon: "check-circle"
+  color: "purple"
+
+inputs:
+  file:
+    description: "Path to the .nika.yaml workflow file"
+    required: true
+  max-cost-usd:
+    description: "Hard USD ceiling for the run (cost honesty: local models are unpriced, never free)"
+    required: true
+  args:
+    description: "Extra arguments appended to nika run (e.g. --var key=value)"
+    required: false
+    default: ""
+  version:
+    description: "Nika version to install (default: latest release)"
+    required: false
+    default: ""
+
+outputs:
+  trace:
+    description: "Path of the run's trace file (empty when the run never started)"
+    value: ${{ steps.run.outputs.trace }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install nika
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          curl -fsSL https://nika.sh/install.sh | NIKA_VERSION="${{ inputs.version }}" sh
+        else
+          curl -fsSL https://nika.sh/install.sh | sh
+        fi
+        echo "$HOME/.nika/bin" >> "$GITHUB_PATH"
+
+    - name: Check (audit before run)
+      shell: bash
+      run: nika check "${{ inputs.file }}"
+
+    - name: Run (cost-capped · traced)
+      id: run
+      shell: bash
+      run: |
+        rc=0
+        nika run "${{ inputs.file }}" --max-cost-usd "${{ inputs.max-cost-usd }}" --json ${{ inputs.args }} || rc=$?
+        # The newest trace is this run's journal — name it for upload.
+        trace=$(ls -t .nika/traces/*.ndjson 2>/dev/null | head -1 || true)
+        echo "trace=$trace" >> "$GITHUB_OUTPUT"
+        # Exit 4 = paused on a human gate: a real state, not a failure —
+        # but CI has no human, so surface it loudly and stop the job.
+        if [ "$rc" -eq 4 ]; then
+          echo "::error::run paused on a human gate — answer with --answer <task>=<value> (pre-seed it in `args` for CI)"
+        fi
+        exit "$rc"

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,17 +18,17 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4363
+  classified_files: 4366
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1432
+    authored: 1435
     authored-pin: 2
     generated: 118
     pinned-copy: 115
     testimonial: 2696
     foreign: 0
-  unverified-default: 5
+  unverified-default: 7
 files:
 - path: ".claude/CLAUDE.md"
   class: authored
@@ -187,8 +187,8 @@ patterns:
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
-  match_count: 21
-  aggregate_sha256: 0e81db3185a94024c204a55aee2e50fd1099dcbb6190721da65e7ee34bfdb360
+  match_count: 22
+  aggregate_sha256: 294a6aced13a5e5bf546c525c09037878d5794415835761ea079f8e8d20fb054
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -241,11 +241,13 @@ patterns:
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored
-  match_count: 5
-  aggregate_sha256: de9c042a389476192b19b6d036ea70660f6ce6235aac4ce142f8f6c90a3fd904
+  match_count: 7
+  aggregate_sha256: 43af5b947d6c96ad649adf3d8c64016fb40a876eb562e6aac51a11e89cc60945
   evidence: "no evidence gathered — honesty over completeness (the catchall; anything landing here is reported under unverified:)"
   note: "unverified-default"
 unverified:
+- "action/README.md"
+- "action/action.yml"
 - "workflows/catalog-pricing-probe.nika.yaml"
 - "workflows/catalog/deprecated-models.nika.yaml"
 - "workflows/catalog/drift-watch.nika.yaml"


### PR DESCRIPTION
## Run-a-Nika-Workflow · GitHub Action (in-repo)

A composite action that runs one `.nika.yaml` the way Nika always runs:
**`nika check` gates the job** (audited before a token is spent),
**`--max-cost-usd` is required** (cost honesty, not optional), and the
**trace path is an output** — upload it and the run's hash-chained
evidence travels with the build.

It consumes the **public binary** through `nika.sh/install.sh` — the
same door a user walks through (the binary boundary · dogfooding pure ·
no engine-crate linkage). Exit 4 (paused on a human gate) stops the job
loudly, since CI has no human; pre-seed the answer via `args:
--answer <task>=<value>`.

```yaml
- uses: supernovae-st/nika/action@<tag>
  with:
    file: workflows/pr-review.nika.yaml
    max-cost-usd: "0.50"
```

### Proof
`.github/workflows/action-dogfood.yml` runs the whole chain end-to-end
against a `$0` `mock/echo` file via `uses: ./action`, then
`nika trace verify` on the emitted trace. actionlint clean.

### Why it matters
A distribution door for the first-100 program: **every external run of
this action is an external re-run** — the North Star metric. The
reciprocal to `nika export --target …` (D-2026-05-25-N3): embedding a
*file* everywhere is trivial; embedding a *platform* is not.

R2 (gated): a dedicated `supernovae-st/nika-action` repo + Marketplace
listing — trigger on ≥3 external usages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
