### PR TITLE
docs(readme): the durability bullet — the trace is the checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ Every run writes its own journal to `.nika/traces/` (opt out per run with
 `nika:prompt` journals its question); cache hits on resume are always
 visible: nothing is skipped silently.
 
+Crash-resume without a server: the trace a run already writes **is** the
+checkpoint · `--resume` is a reader of a file, not a client of a run-store.
+Two hashes decide skip-or-rerun, recorded `infer:`/`agent:` work replays
+from the trace instead of re-calling the model, and every agent tool call
+lands in the same hash chain · [the architecture and its honest
+limit](https://docs.nika.sh/guides/resume).
+
 <!-- city:map -->
 ## The city · where this repo sits
 

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,14 +18,14 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4344
+  classified_files: 4345
   file_rows: 11
   pattern_rows: 22
   by_class:
     authored: 1414
     authored-pin: 2
     generated: 118
-    pinned-copy: 114
+    pinned-copy: 115
     testimonial: 2696
     foreign: 0
   unverified-default: 5
@@ -113,8 +113,8 @@ files:
 patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
-  match_count: 113
-  aggregate_sha256: f96c38f04b38d892c6df179e2f591e976b4668384ddd51e592946a1adaf5065e
+  match_count: 114
+  aggregate_sha256: 7076fb2b63092c0784da6ee52371df370186df2cb8adb78692862a3a8f0af124
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: 9b5674f01711cb49bf5309c0221802715347fef5f22be726dedf298f7ffd084b
+  aggregate_sha256: e2a148bc6de1ec2881e302055e24c3188bfc4a97cf345a9e7ecd7dd755843780
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored


### PR DESCRIPTION
## What

The narrative wave (docs + comparison) left the engine README silent on the one story it must tell. One bullet in the trace section:

**Crash-resume without a server** — the trace a run already writes **is** the checkpoint · `--resume` is a reader of a file, not a client of a run-store. Two hashes decide skip-or-rerun, recorded `infer:`/`agent:` work replays from the trace instead of re-calling the model, and every agent tool call lands in the same hash chain · linked to [guides/resume](https://docs.nika.sh/guides/resume) (the architecture and its honest limit).

Vocabulary aligned with `docs/guides/resume.mdx` and the ADR-099 implementation · the tool-call clause matches what the runtime emits per call (`tool_invoked`). Vendor-neutral, no platform claims beyond the shipped fixtures.

## Files

- `README.md` · +7 lines (one bullet)
- `estate.yaml` · re-pinned (the authored-file hash follows)

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
