### PR TITLE
fix(access): the two CI lanes the bridge merge reddened

### DIFF
--- a/crates/nika-providers/public-api.txt
+++ b/crates/nika-providers/public-api.txt
@@ -564,6 +564,7 @@ impl<T> core::convert::From<T> for nika_providers::resolve_access::AccessRefusal
 pub fn nika_providers::resolve_access::AccessRefusal::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_providers::resolve_access::AccessRefusal where T: 'static
 pub fn nika_providers::resolve_access::AccessRefusal::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub fn nika_providers::resolve_access::access_plan_map(models: &[alloc::string::String], probes: &[nika_providers::probe::ProviderProbe], pin: core::option::Option<&str>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::access::AccessPlan>
 pub fn nika_providers::resolve_access::candidates_for(probes: &[nika_providers::probe::ProviderProbe], provider: &str) -> alloc::vec::Vec<nika_providers::resolve_access::AccessCandidate>
 pub fn nika_providers::resolve_access::provider_of(model: &str) -> &str
 pub fn nika_providers::resolve_access::refuse_pin<'m>(models: impl core::iter::traits::collect::IntoIterator<Item = &'m str>, probes: &[nika_providers::probe::ProviderProbe], pin: &str) -> core::option::Option<nika_providers::resolve_access::PinRefusal>
@@ -918,6 +919,7 @@ pub async fn nika_providers::registry::ResolvedProvider<H>::infer(&self, request
 impl<TraitVariantBlanketType> nika_kernel_ai::provider::ProviderStream for nika_providers::registry::ResolvedProvider<H> where TraitVariantBlanketType: nika_kernel_ai::provider::ProviderStreamDyn
 pub async fn nika_providers::registry::ResolvedProvider<H>::infer_stream(&self, request: nika_kernel_ai::provider::InferRequest) -> core::result::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<nika_kernel_ai::provider::InferEvent, nika_kernel_ai::provider::ProviderError>> + core::marker::Send)>>, nika_kernel_ai::provider::ProviderError>
 pub const nika_providers::CANONICAL_IDS: [&str; 16]
+pub fn nika_providers::access_plan_map(models: &[alloc::string::String], probes: &[nika_providers::probe::ProviderProbe], pin: core::option::Option<&str>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_types::access::AccessPlan>
 pub fn nika_providers::candidates_for(probes: &[nika_providers::probe::ProviderProbe], provider: &str) -> alloc::vec::Vec<nika_providers::resolve_access::AccessCandidate>
 pub fn nika_providers::catalog_warning(model: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_providers::provider_of(model: &str) -> &str

--- a/crates/nika-verb-agent/src/harness_path.rs
+++ b/crates/nika-verb-agent/src/harness_path.rs
@@ -425,8 +425,8 @@ mod tests {
         assert!(out.tools_cost_usd.is_none());
     }
 
-    /// B5 · inside the grants, the bridge answers AllowOnce itself and
-    /// witnesses the decision (the permit_checked channel's verb half).
+    /// B5 · inside the grants, the bridge answers `AllowOnce` itself and
+    /// witnesses the decision (the `permit_checked` channel's verb half).
     #[tokio::test]
     async fn an_ask_inside_the_grants_is_allowed_once_and_witnessed() {
         let verdicts = Arc::new(Mutex::new(Vec::new()));
@@ -473,7 +473,7 @@ mod tests {
     }
 
     /// B5 · outside the grants with NO operator answer: the run pauses
-    /// (HarnessGate error), the question rides VERBATIM, and the reply
+    /// (`HarnessGate` error), the question rides VERBATIM, and the reply
     /// lane was never answered — zero harness action before a human.
     #[tokio::test]
     async fn an_ask_outside_the_grants_pauses_with_the_question_verbatim() {

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 62
-  aggregate_sha256: 1fa6cdf2eae5dd2436d671eecacfc169c1392762af26e73b388577aaedec634f
+  aggregate_sha256: a7e1af02ad03d4af8d6950c3cd7a7c3f334bd9a737650d4f7539947204da0866
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 719
-  aggregate_sha256: f7fe8716850d5a24fb6b713f12b1cef2098eab08bd6046032b91b84a807899dd
+  aggregate_sha256: 4d8366d800aabea2ab2c98be576ff08c57c1b539070fb3ff560cbb31a1bc2bcd
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
856 merged with two observation lanes red (the #849 trap, third form — auto-merge fires on the required set while Diamond CI's clippy leg and the public-api diff are not in it):

- **clippy `--all-features`** (the CI ratchet's shape · the local pre-push gate runs featureless and never saw the feature-gated test docs): three doc_markdown backtick fixes in harness_path.rs tests (`AllowOnce` · `permit_checked` · `HarnessGate`).
- **public-api**: the nika-providers baseline lacked the two `access_plan_map` rows (the B5 branch regenerated five baselines and missed this one).

Main is red on exactly these two lanes at b07d8d8c1; this PR turns them green.

🦋