### PR TITLE
feat(kit): the portable Agent Plugins 1.0.0 manifest, and nika-plugins

### DIFF
--- a/.agents/plugins/nika/.cursor-plugin/plugin.json
+++ b/.agents/plugins/nika/.cursor-plugin/plugin.json
@@ -8,7 +8,7 @@
     "email": "nika@supernovae.studio"
   },
   "homepage": "https://docs.nika.sh",
-  "repository": "https://github.com/supernovae-st/nika-agents",
+  "repository": "https://github.com/supernovae-st/nika-plugins",
   "license": "AGPL-3.0-or-later",
   "logo": "./assets/nika-logo.png",
   "keywords": [

--- a/.agents/plugins/nika/mcp.json
+++ b/.agents/plugins/nika/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "nika": {
+      "type": "stdio",
+      "command": "nika",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/.agents/plugins/nika/plugin.json
+++ b/.agents/plugins/nika/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "nika",
+  "version": "0.108.0",
+  "description": "Nika — intent-as-code for AI workflows: author a reviewable DAG in YAML, audit cost and permits before running, keep tamper-evident traces after. This package carries the authoring, debugging, operating and migration skills plus the read-only Nika MCP oracle. Requires the nika binary: brew install supernovae-st/tap/nika",
+  "author": {
+    "name": "SuperNovae Studio",
+    "email": "nika@supernovae.studio",
+    "url": "https://nika.sh"
+  },
+  "homepage": "https://docs.nika.sh",
+  "repository": "https://github.com/supernovae-st/nika",
+  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "nika",
+    "workflow",
+    "yaml",
+    "ai-workflows",
+    "agent",
+    "audit",
+    "mcp"
+  ]
+}

--- a/.github/workflows/clients-resync.yml
+++ b/.github/workflows/clients-resync.yml
@@ -3,12 +3,12 @@ name: clients-resync
 # The vendored client matrix follows the agents SSOT without blocking
 # unrelated pushes: the snapshot at
 # crates/nika-cli-host/data/clients.registry.yaml is a byte-copy of
-# nika-agents/clients.yaml, and drift used to be judged by a unit test
+# nika-plugins/clients.yaml, and drift used to be judged by a unit test
 # reading the LIVE sibling checkout on the developer's machine — the
 # wrong-judge class (one test binary, two verdicts, whichever repos
 # happen to sit beside the checkout; it blocked two unrelated engine
 # pushes 2026-07-31). The assertion is gone from cargo test; the drift
-# surfaces here instead. Daily: clone nika-agents@main, re-vendor, open
+# surfaces here instead. Daily: clone nika-plugins@main, re-vendor, open
 # ONE idempotent PR on drift — Diamond CI (the vendored-bytes tests
 # included) judges the new snapshot, never a direct push.
 # SECURITY: no github.event data reaches the shell.
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git clone --depth 1 https://github.com/supernovae-st/nika-agents ../agents
+          git clone --depth 1 https://github.com/supernovae-st/nika-plugins ../agents
           cp ../agents/clients.yaml crates/nika-cli-host/data/clients.registry.yaml
           git add crates/nika-cli-host/data/clients.registry.yaml
           if git diff --cached --quiet; then echo "matrix current — nothing to resync"; exit 0; fi

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ limit](https://docs.nika.sh/guides/resume).
     │ the release train                  🖥️ nika.sh · 📖 nika-docs
     ▼                                     the showroom · the manual
 📦 homebrew-tap · npm · Docker ── the docks
-🔌 nika-client · 🎨 nika-vscode · 🤖 nika-agents · ⚡ gh-nika ── the doors
+🔌 nika-client · 🎨 nika-vscode · 🤖 nika-plugins · ⚡ gh-nika ── the doors
 🏭 nika-action · 🧪 nika-actions-starter ── the CI district
 🏪 nika-registry ── the market · 🏛 nika-estate ── the land registry
 ```
@@ -269,7 +269,7 @@ limit](https://docs.nika.sh/guides/resume).
 
 **Truth lives** · engine numbers come from the binary, never from prose · `crates/nika-pack/pack/` is a byte-gated MIRROR of the spec — editing it is a lost gesture.
 
-All the buildings: [nika-spec](https://github.com/supernovae-st/nika-spec) · [nika](https://github.com/supernovae-st/nika) · [nika.sh](https://github.com/supernovae-st/nika.sh) · [nika-docs](https://github.com/supernovae-st/nika-docs) · [nika-client](https://github.com/supernovae-st/nika-client) · [nika-vscode](https://github.com/supernovae-st/nika-vscode) · [nika-agents](https://github.com/supernovae-st/nika-agents) · [gh-nika](https://github.com/supernovae-st/gh-nika) · [homebrew-tap](https://github.com/supernovae-st/homebrew-tap) · [nika-action](https://github.com/supernovae-st/nika-action) · [nika-actions-starter](https://github.com/supernovae-st/nika-actions-starter) · [nika-registry](https://github.com/supernovae-st/nika-registry) · [nika-estate](https://github.com/supernovae-st/nika-estate)
+All the buildings: [nika-spec](https://github.com/supernovae-st/nika-spec) · [nika](https://github.com/supernovae-st/nika) · [nika.sh](https://github.com/supernovae-st/nika.sh) · [nika-docs](https://github.com/supernovae-st/nika-docs) · [nika-client](https://github.com/supernovae-st/nika-client) · [nika-vscode](https://github.com/supernovae-st/nika-vscode) · [nika-plugins](https://github.com/supernovae-st/nika-plugins) · [gh-nika](https://github.com/supernovae-st/gh-nika) · [homebrew-tap](https://github.com/supernovae-st/homebrew-tap) · [nika-action](https://github.com/supernovae-st/nika-action) · [nika-actions-starter](https://github.com/supernovae-st/nika-actions-starter) · [nika-registry](https://github.com/supernovae-st/nika-registry) · [nika-estate](https://github.com/supernovae-st/nika-estate)
 
 Every fact has one home · everything else is a gated projection.
 The living map: [nika.sh/map](https://nika.sh/map).
@@ -513,8 +513,8 @@ authoring skill · the `nika-author` subagent · three commands · a
 check-on-edit hook · the read-only MCP oracle) for three ecosystems:
 
 ```sh
-codex plugin marketplace add supernovae-st/nika-agents && codex plugin add nika@nika
-claude plugin marketplace add supernovae-st/nika-agents && claude plugin install nika@nika
+codex plugin marketplace add supernovae-st/nika-plugins && codex plugin add nika@nika
+claude plugin marketplace add supernovae-st/nika-plugins && claude plugin install nika@nika
 # Cursor: search "nika" in Settings → Plugins · one Add installs the bundle
 ```
 
@@ -558,7 +558,7 @@ each with one job:
 | [nika-docs](https://github.com/supernovae-st/nika-docs) | the source of [docs.nika.sh](https://docs.nika.sh) |
 | [nika.sh](https://github.com/supernovae-st/nika.sh) | the source of [nika.sh](https://nika.sh) |
 | [nika-vscode](https://github.com/supernovae-st/nika-vscode) | the editor extension: VS Code, Cursor, Windsurf, VSCodium |
-| [nika-agents](https://github.com/supernovae-st/nika-agents) | the plugin marketplace: skill + subagent + commands + hooks + the read-only MCP oracle · Claude Code, Codex, Cursor |
+| [nika-plugins](https://github.com/supernovae-st/nika-plugins) | the plugin marketplace: skill + subagent + commands + hooks + the read-only MCP oracle · Claude Code, Codex, Cursor |
 | [nika-registry](https://github.com/supernovae-st/nika-registry) | the verifiable workflow registry: every entry pinned and re-proven in CI |
 | [nika-client](https://github.com/supernovae-st/nika-client) | the TypeScript SDK (targets the `nika serve` HTTP surface) |
 | [homebrew-tap](https://github.com/supernovae-st/homebrew-tap) | the brew formula: `brew install supernovae-st/tap/nika` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,7 +217,7 @@ Real semver toward a 1.0 launch, then `MAJOR.MINOR.PATCH`:
 | Tag        | Meaning                                                              |
 |------------|----------------------------------------------------------------------|
 | `0.91.0`   | release-candidate grade — usable vertical slice works (4 verbs · 14 providers · effects · static-check · MCP/LSP · CLI) · headless workspace build |
-| `0.92.0`   | **agent-native** — `nika wire codex` · `nika init` ships the repo-level agent skill (`.agents/skills/nika-authoring`) · the plugin marketplaces (Codex + Claude Code · `supernovae-st/nika-agents`) · MCP learning tools (schema · examples · template · canon) · cold-first-run fixes |
+| `0.92.0`   | **agent-native** — `nika wire codex` · `nika init` ships the repo-level agent skill (`.agents/skills/nika-authoring`) · the plugin marketplaces (Codex + Claude Code · `supernovae-st/nika-plugins`) · MCP learning tools (schema · examples · template · canon) · cold-first-run fixes |
 | `0.93.0`   | `nika-cap` admitted (capability tokens · L0) — 40/42 · `nika run --resume` durable-lite (ADR-099) · `nika test` harness · 180s provider-plane timeout unbricks local thinking models |
 | `0.94.0`   | **the media suite** — `nika:image_generate` + `nika:tts_generate` (stdlib 25) · trace files by default · `catalog`/`tools --json` + their MCP twins (protocol 2026-07-28) · per-task `cost_usd` · huggingface + nvidia join (16 canonical providers) |
 | `0.95.0`   | **local-first catalog** — the 5 local servers get their catalog face (keyless by construction · sovereign models stay unpriced) · seam-discipline hygiene vector |
@@ -654,7 +654,7 @@ Per D-2026-05-22-N18.)
 - Getting started, concepts, guides, reference
 - 2-tab navigation (Guide / Reference), live snapshot of workspace state
 
-**Agent skill surface** ([`supernovae-st/nika-agents`](https://github.com/supernovae-st/nika-agents)):
+**Agent skill surface** ([`supernovae-st/nika-plugins`](https://github.com/supernovae-st/nika-plugins)):
 - The public skill + read-only MCP oracle ("make your AI agent a Nika expert")
 - Design tokens + motion ride the spec SSOT (`nika-spec` `design/`,
   vendored into the engine pack by `scripts/sync-pack.sh`)

--- a/crates/nika-cli-host/data/clients.registry.yaml
+++ b/crates/nika-cli-host/data/clients.registry.yaml
@@ -32,7 +32,7 @@ clients:
     name: Claude Code
     class: A
     status: proven
-    install: "claude plugin marketplace add supernovae-st/nika-agents && claude plugin install nika@nika"
+    install: "claude plugin marketplace add supernovae-st/nika-plugins && claude plugin install nika@nika"
     components: {manifest: native-manifest, skills: native-manifest,
                  subagents: native-manifest, commands: native-manifest,
                  hooks: native-manifest, mcp: native-manifest,
@@ -47,7 +47,7 @@ clients:
     name: Codex
     class: A
     status: proven
-    install: "codex plugin marketplace add supernovae-st/nika-agents && codex plugin add nika@nika"
+    install: "codex plugin marketplace add supernovae-st/nika-plugins && codex plugin add nika@nika"
     components: {manifest: native-manifest, skills: native-manifest,
                  commands: native-manifest, hooks: native-manifest,
                  mcp: native-manifest, presentation: native-manifest,
@@ -77,7 +77,7 @@ clients:
     name: OpenClaude
     class: A
     status: wired
-    install: "openclaude plugin marketplace add supernovae-st/nika-agents && openclaude plugin install nika@nika"
+    install: "openclaude plugin marketplace add supernovae-st/nika-plugins && openclaude plugin install nika@nika"
     components: {manifest: claude-layout, skills: claude-layout,
                  subagents: claude-layout, commands: claude-layout,
                  hooks: claude-layout, mcp: claude-layout, scaffold: init}
@@ -91,7 +91,7 @@ clients:
     name: Grok Build (xAI)
     class: A
     status: proven
-    install: "grok plugin marketplace add supernovae-st/nika-agents && grok plugin install nika@nika --trust"
+    install: "grok plugin marketplace add supernovae-st/nika-plugins && grok plugin install nika@nika --trust"
     components: {manifest: claude-layout, skills: claude-layout,
                  subagents: claude-layout, commands: claude-layout,
                  hooks: claude-layout, mcp: claude-layout, scaffold: init}
@@ -288,7 +288,7 @@ clients:
     name: Hermes · skills.sh clients
     class: B
     status: proven
-    install: "hermes skills tap add supernovae-st/nika-agents · or npx skills add supernovae-st/nika-agents"
+    install: "hermes skills tap add supernovae-st/nika-plugins · or npx skills add supernovae-st/nika-plugins"
     components: {skills: skill-pack, mcp: wire, scaffold: init}
     class_gap: "skills-first client · the delegation skill carries the teaching · no manifest/commands/hooks surfaces"
     wire: hermes

--- a/crates/nika-cli-host/src/clients_registry.rs
+++ b/crates/nika-cli-host/src/clients_registry.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The client registry — the engine CONSUMES the nika-agents matrix
+//! The client registry — the engine CONSUMES the nika-plugins matrix
 //! (H6 · operator decision Q1 2026-07-31: `clients.yaml` in the agents
 //! repo stays the ONE SSOT of client × component coverage; the binary
 //! reads a vendored snapshot of it, never a second hand-maintained
@@ -296,7 +296,7 @@ mod tests {
     // depending on what unrelated repos sit on the machine (the
     // wrong-judge class — it blocked two unrelated engine pushes
     // 2026-07-31). The drift surfaces in CI instead: the daily
-    // `clients-resync.yml` lane clones nika-agents@main, re-vendors, and
+    // `clients-resync.yml` lane clones nika-plugins@main, re-vendors, and
     // opens ONE heal PR on drift — the 12-gate CI judges the new
     // snapshot. Manual heal when the PR can't wait:
     //   cp <agents>/repo/clients.yaml crates/nika-cli-host/data/clients.registry.yaml

--- a/crates/nika-cli-host/src/doctor.rs
+++ b/crates/nika-cli-host/src/doctor.rs
@@ -397,7 +397,7 @@ fn major_minor(v: &str) -> Option<(u64, u64)> {
 
 /// One installed plugin-kit row — the kit↔binary handshake nothing
 /// client-side used to surface (the drift contract lived only in the
-/// nika-agents CI). Same train → ✔. A lagging kit names the refresh
+/// nika-plugins CI). Same train → ✔. A lagging kit names the refresh
 /// command for ITS client (Claude Code climbs TWO rungs); a kit riding
 /// ahead names the binary upgrade. An unparseable manifest version
 /// warns and never guesses a train.
@@ -430,7 +430,7 @@ fn kit_finding(kit: &KitProbe, bin_version: &str) -> Finding {
                 "claude plugin marketplace update nika, then claude plugin update nika@nika"
             }
             "codex" => "codex plugin marketplace upgrade nika",
-            "cursor" => "re-sync the local drop: scripts/update-mirrors.sh (nika-agents checkout)",
+            "cursor" => "re-sync the local drop: scripts/update-mirrors.sh (nika-plugins checkout)",
             _ => "refresh the nika plugin from its marketplace",
         };
         return Finding {

--- a/crates/nika-cli-host/src/probe.rs
+++ b/crates/nika-cli-host/src/probe.rs
@@ -36,7 +36,7 @@ pub struct Probe {
     /// the kit is optional).
     pub kits: Vec<KitProbe>,
     /// The client-matrix coverage (H6 · Q1 2026-07-31): derived from
-    /// the vendored nika-agents registry — the counts doctor renders
+    /// the vendored nika-plugins registry — the counts doctor renders
     /// are read-time derivations of the ONE SSOT, never hand counts.
     pub clients_registry: RegistryCoverage,
     /// The `nika:image_generate` plane — key/URL PRESENCE only.
@@ -106,7 +106,7 @@ pub struct ImageProbe {
     pub local_url: Option<String>,
 }
 
-/// One installed plugin-kit surface (the nika-agents bundle a client
+/// One installed plugin-kit surface (the nika-plugins bundle a client
 /// cloned): which client landed it and the version its manifest
 /// declares. Found kits only — a client without the kit is not a
 /// finding (the MCP wire via `nika wire` needs no kit).
@@ -178,7 +178,7 @@ impl ClientProbe {
     }
 }
 
-/// The nika-agents kit ships its hook definitions INSIDE the same drop
+/// The nika-plugins kit ships its hook definitions INSIDE the same drop
 /// as the manifest (`hooks/<client>-hooks.json` next to
 /// `.claude-plugin/plugin.json` — verified against the bundle
 /// 2026-07-31): finding the manifest proves the hooks landed with it.
@@ -407,7 +407,7 @@ fn client_probes() -> Vec<ClientProbe> {
         .collect()
 }
 
-/// The known kit landings (`update-mirrors.sh` in nika-agents climbs the
+/// The known kit landings (`update-mirrors.sh` in nika-plugins climbs the
 /// same ladder). Each client is probed at the rung its SESSIONS load —
 /// the install, not the clone — because that is the drift the operator
 /// lives (empirical 2026-07-29: a fresh clone sat next to a 0.105
@@ -1402,7 +1402,7 @@ mod tests {
     }
 
     // ── The client registry (H6 · Q1 2026-07-31 — the binary consumes
-    // the vendored nika-agents matrix) ──
+    // the vendored nika-plugins matrix) ──
 
     #[test]
     fn the_real_probe_derives_registry_coverage_from_the_vendored_matrix() {

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4358
+  classified_files: 4363
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1427
+    authored: 1432
     authored-pin: 2
     generated: 118
     pinned-copy: 115
@@ -62,7 +62,7 @@ files:
   evidence: "its own header: 'Bump deliberately: edit this' · the rev the shared estate tool is mirrored from, and the INPUT the mirror gate compares against"
 - path: "ROADMAP.md"
   class: authored
-  sha256: 7135aad7760d58e509077d9bd8693c20b9b46db1a435ebf8c4ce1912d3b9a2ff
+  sha256: 5c9b6a64fd35fbb482f379665ce26f266dc088b097e5ae096c717e417c7b1a4f
   evidence: "hand-written roadmap prose (real-semver ladder · layer plan)"
   note: "ROADMAP.md:98 carries the same refresh-status.sh AUTO-GENERATED status block — a tool-maintained block inside an authored file"
 - path: "SPEC_PIN"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 722
-  aggregate_sha256: 88348e33a84d5bbe0123004c79a50687909113fcce75478ca204add8ead2a0ea
+  aggregate_sha256: 0711361a6d1c5e866ced27266624367b5271a02dc63faba3e33cf81938b68cc9
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 132
-  aggregate_sha256: b74233e3eda9951853cb69b57f1fa52d98e5c73531c0dc466c5656005529e0f3
+  aggregate_sha256: b7da702fbb4d59c102bde02586f9fbe065e938829e820d5ffa15c10c28b8085f
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -182,13 +182,13 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 135
-  aggregate_sha256: 54010611a244ba45a21690c4785026856c66e2bb69007fa2ff2eaeffa5294b48
+  match_count: 138
+  aggregate_sha256: 214f0018a8fcd13e182ecc1b1069321df29393a25727db82ae7216740c7a95f6
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 21
-  aggregate_sha256: 545eb0751b3524890a76dcff4469a34543648c6145aeee88abd338c9d4fc0496
+  aggregate_sha256: 0e81db3185a94024c204a55aee2e50fd1099dcbb6190721da65e7ee34bfdb360
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -197,8 +197,8 @@ patterns:
   evidence: "issue/PR templates · CODEOWNERS · dependabot config — hand-written review policy"
 - glob: ".agents/**"
   class: authored
-  match_count: 30
-  aggregate_sha256: d6a82273304f6e0732dfe4cffffdc00f098b34c4e3cb7a06c4a3ce5179db91c9
+  match_count: 32
+  aggregate_sha256: 635d1a2a76b6b5989e826fe00a8d31939db69a5e003b0dd512124e8bfc218fa9
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: e2a148bc6de1ec2881e302055e24c3188bfc4a97cf345a9e7ecd7dd755843780
+  aggregate_sha256: 20bd229be03706dc0131de4497013b5bcfbacb0255c05217fd539857d49350fe
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -199,7 +199,7 @@ patterns:
   class: authored
   match_count: 30
   aggregate_sha256: d6a82273304f6e0732dfe4cffffdc00f098b34c4e3cb7a06c4a3ce5179db91c9
-  evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-agents (its plugins/ is a byte-pinned copy healed on releases)"
+  evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored
   match_count: 15

--- a/scripts/ci/ecosystem-coherence.py
+++ b/scripts/ci/ecosystem-coherence.py
@@ -112,15 +112,15 @@ def main():
         FINDINGS.append(("WARN", "pack content",
                          f"vendored canon {ph} != spec canon {sh} (same VERSION possible) — sync-pack before the next tag"))
 
-    # The marketplace mirror (nika-agents) claims byte-parity with engine
+    # The marketplace mirror (nika-plugins) claims byte-parity with engine
     # main; its own gate only fires on push/PR + a daily cron. This pin
     # gives the nightly issue the same eye (drift proven to reappear
     # within 24h of a resync, 2026-07-09).
     eng_skill = grab(f"{RAW}/supernovae-st/nika/main/.agents/plugins/nika/skills/nika-authoring/SKILL.md", str, "agents mirror")
-    mir_skill = grab(f"{RAW}/supernovae-st/nika-agents/main/.agents/plugins/nika/skills/nika-authoring/SKILL.md", str, "agents mirror")
+    mir_skill = grab(f"{RAW}/supernovae-st/nika-plugins/main/.agents/plugins/nika/skills/nika-authoring/SKILL.md", str, "agents mirror")
     if eng_skill and mir_skill and eng_skill != mir_skill:
         FINDINGS.append(("WARN", "agents mirror",
-                         "nika-agents SKILL.md != engine main — the byte-parity claim drifted; resync the mirror"))
+                         "nika-plugins SKILL.md != engine main — the byte-parity claim drifted; resync the mirror"))
 
     vscode_repo = grab(f"{RAW}/supernovae-st/nika-vscode/main/package.json",
                        lambda t: json.loads(t)["version"], "vscode repo")
@@ -193,7 +193,7 @@ def main():
         ("nika-action", "release-heal.yml"),
         ("nika-actions-starter", "release-heal.yml"),
         ("nika-client", "release-heal.yml"),
-        ("nika-agents", "release-heal.yml"),
+        ("nika-plugins", "release-heal.yml"),
         ("nika-registry", "release-heal.yml"),
         ("nika-vscode", "spec-pin-heal.yml"),
         ("nika", "pack-resync.yml"),

--- a/scripts/ci/test-ecosystem-coherence.py
+++ b/scripts/ci/test-ecosystem-coherence.py
@@ -62,7 +62,7 @@ def fixtures(*, tag="0.95.0", age_h=48.0, tap="0.95.0", site="0.95.0",
            for repo, wf in (("nika-docs","release-heal.yml"),("nika.sh","release-heal.yml"),
                             ("nika.sh","spec-resync.yml"),("nika-action","release-heal.yml"),
                             ("nika-actions-starter","release-heal.yml"),("nika-client","release-heal.yml"),
-                            ("nika-agents","release-heal.yml"),("nika-registry","release-heal.yml"),
+                            ("nika-plugins","release-heal.yml"),("nika-registry","release-heal.yml"),
                             ("nika-vscode","spec-pin-heal.yml"),("nika","pack-resync.yml"))},
     }
 
@@ -136,11 +136,11 @@ check("T6c deliberate-bump surfaces stay WARN",
 # (fetch miss), never a crash; a trigger-less one is named.
 tbl = fixtures(age_h=48.0)
 del tbl[bot.RAW + "/supernovae-st/nika-registry/main/.github/workflows/release-heal.yml"]
-tbl[bot.RAW + "/supernovae-st/nika-agents/main/.github/workflows/release-heal.yml"] = "name: dead\n"
+tbl[bot.RAW + "/supernovae-st/nika-plugins/main/.github/workflows/release-heal.yml"] = "name: dead\n"
 code, f = run(tbl)
 check("T7 immune legs watched (missing=WARN · trigger-less named)",
       any(x[1] == "immune nika-registry" for x in f)
-      and any(x[1] == "immune nika-agents" and "no trigger" in x[2] for x in f)
+      and any(x[1] == "immune nika-plugins" and "no trigger" in x[2] for x in f)
       and all(x[0] == "WARN" for x in f if x[1].startswith("immune")), f)
 
 print(f"\nself-test: {'PASS (10/10)' if not fails else 'FAIL ' + str(fails)}")

--- a/scripts/estate_rules.py
+++ b/scripts/estate_rules.py
@@ -191,7 +191,7 @@ PATTERNS = [
     {
         "glob": ".agents/**",
         "class": "authored",
-        "evidence": "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-agents (its plugins/ is a byte-pinned copy healed on releases)",
+        "evidence": "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)",
     },
     {
         "glob": ".claude/**",

--- a/scripts/hygiene/check-agent-plugins.sh
+++ b/scripts/hygiene/check-agent-plugins.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Vector 48: the kit stays loadable by an Agent Plugins 1.0.0 client.
+#
+# Agent Plugins 1.0.0 (published 2026-08-06 · agent-plugins.org) is the
+# portable package format Cursor, GitHub Copilot, Kiro, VS Code and
+# ChatGPT/Codex read. We already shipped three client-native manifests in
+# hidden directories; this vector guards the fourth, portable one at the
+# plugin root.
+#
+# It matters because the portable manifest fails CLOSED. §5.2: the schema
+# is closed, and "any schema violation other than an unknown top-level
+# field or a non-object extensions field is fatal: the client MUST reject
+# the plugin and MUST NOT discover or execute any of its components."
+# One stray key of the shape the OTHER three manifests use — "skills",
+# "hooks", "mcpServers", "logo" — is reported and ignored; one bad `name`
+# character or one wrong `$schema` and every client drops the whole kit
+# silently. Nothing else in this repo would notice.
+#
+# The rules are encoded here rather than fetched: a gate that needs the
+# network is a gate that goes yellow on a plane. The spec text is
+# authoritative and the version is pinned in SPEC_VERSION below; when
+# 1.1.0 lands, this file is where the diff goes.
+#
+# Checked (spec section in parentheses):
+#   plugin.json  present · valid JSON · $schema canonical (§5.2)
+#                name present, 1-64, [a-z0-9.-], alnum ends, no -- or ..
+#                (§5.5) · top-level keys within the closed set (§5.2)
+#                author sub-keys within {name,email,url}, strings (§5.4)
+#                version agrees with the workspace (vector 47's law)
+#   mcp.json     present · valid JSON · $schema canonical, SAME version as
+#                plugin.json (§10.1) · exactly {$schema, mcpServers} (§7.2.1)
+#                each server: closed variant, required fields, no unknown
+#                field, no PLUGIN_ROOT/PLUGIN_DATA in env (§7.2.1, §9.2)
+#   skills/      each immediate child with SKILL.md conforms to the Agent
+#                Skills spec the format defers to (§7.1): name 1-64,
+#                [a-z0-9-], no leading/trailing/double hyphen, MATCHES the
+#                directory name, description 1-1024 non-empty
+#
+# Exit: 0 GREEN · 2 RED (a client would reject or skip something) ·
+#       1 YELLOW (cannot read the authority — not a clean bill).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$ROOT" || exit 1
+
+PLUGIN_DIR=".agents/plugins/nika"
+
+want="$(grep -m1 -E '^version[[:space:]]*=' Cargo.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^"]*')"
+if [ -z "$want" ]; then
+  echo "YELLOW: no workspace version in Cargo.toml — cannot compare"
+  exit 1
+fi
+
+PLUGIN_DIR="$PLUGIN_DIR" WORKSPACE_VERSION="$want" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+SPEC_VERSION = "1.0.0"
+PLUGIN_SCHEMA = f"https://agent-plugins.org/schemas/{SPEC_VERSION}/plugin.schema.json"
+MCP_SCHEMA = f"https://agent-plugins.org/schemas/{SPEC_VERSION}/mcp.schema.json"
+
+# §5.2 — the closed top-level set. Order is the spec's.
+MANIFEST_KEYS = {
+    "$schema", "name", "version", "description", "author",
+    "homepage", "repository", "license", "keywords", "extensions",
+}
+AUTHOR_KEYS = {"name", "email", "url"}  # §5.4
+
+# §5.5 plugin name · §7.1 defers skill names to the Agent Skills spec.
+PLUGIN_NAME = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$")
+SKILL_NAME = re.compile(r"^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
+# §7.2.1 — the closed server union: required fields, then optional ones.
+SERVER_VARIANTS = {
+    "stdio": ({"type", "command"}, {"args", "env", "cwd"}),
+    "streamable-http": ({"type", "url"}, {"headers"}),
+    "sse": ({"type", "url"}, {"headers"}),
+}
+RESERVED_ENV = {"PLUGIN_ROOT", "PLUGIN_DATA"}  # §9.2
+
+root = os.environ["PLUGIN_DIR"]
+workspace_version = os.environ["WORKSPACE_VERSION"]
+reds = []
+
+
+def red(msg):
+    reds.append(msg)
+
+
+def load(path, label):
+    """Read JSON or record why a client would reject the plugin."""
+    full = os.path.join(root, path)
+    if not os.path.isfile(full):
+        red(f"{full} is missing — {label}")
+        return None
+    try:
+        with open(full, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, ValueError) as exc:
+        red(f"{full} is not readable JSON ({exc}) — a client rejects the plugin")
+        return None
+
+
+def schema_version(value):
+    """Pull the version out of a canonical schema id, or None."""
+    match = re.match(
+        r"^https://agent-plugins\.org/schemas/([0-9.]+)/(plugin|mcp)\.schema\.json$",
+        value if isinstance(value, str) else "",
+    )
+    return match.group(1) if match else None
+
+
+# ── plugin.json (§5) ────────────────────────────────────────────────────
+manifest = load("plugin.json", "the portable Agent Plugins manifest (§5.1)")
+if manifest is not None:
+    if not isinstance(manifest, dict):
+        red("plugin.json is not a JSON object (§5.2) — fatal")
+        manifest = {}
+
+    got_schema = manifest.get("$schema")
+    if got_schema != PLUGIN_SCHEMA:
+        red(f"plugin.json $schema is {got_schema!r}, must be {PLUGIN_SCHEMA!r} (§5.2) — fatal")
+
+    unknown = sorted(set(manifest) - MANIFEST_KEYS)
+    if unknown:
+        red(
+            f"plugin.json carries {unknown} — the schema is closed (§5.2). "
+            "Client-specific data belongs under `extensions` or in the client's own directory"
+        )
+
+    name = manifest.get("name")
+    if not isinstance(name, str) or not name:
+        red(f"plugin.json name is {name!r} — required, non-empty string (§5.3) — fatal")
+    elif len(name) > 64 or not PLUGIN_NAME.match(name):
+        red(f"plugin.json name {name!r} breaks the naming constraints (§5.5) — fatal")
+
+    author = manifest.get("author")
+    if author is not None:
+        if not isinstance(author, dict):
+            red("plugin.json author is not an object (§5.4) — fatal")
+        else:
+            extra = sorted(set(author) - AUTHOR_KEYS)
+            if extra:
+                red(f"plugin.json author carries {extra} — only name/email/url (§5.4) — fatal")
+            for key, value in author.items():
+                if not isinstance(value, str):
+                    red(f"plugin.json author.{key} is not a string (§5.4) — fatal")
+
+    for key in ("version", "description", "homepage", "repository", "license"):
+        if key in manifest and not isinstance(manifest[key], str):
+            red(f"plugin.json {key} is not a string (§5.4) — fatal")
+    keywords = manifest.get("keywords")
+    if keywords is not None and (
+        not isinstance(keywords, list) or any(not isinstance(k, str) for k in keywords)
+    ):
+        red("plugin.json keywords is not a string array (§5.4) — fatal")
+
+    # Vector 47's law, extended to the surface it does not know about.
+    version = manifest.get("version")
+    if isinstance(version, str) and version != workspace_version:
+        red(
+            f"plugin.json says {version}, the workspace says {workspace_version} "
+            "— the portable manifest is a version surface too"
+        )
+
+# ── mcp.json (§7.2) ─────────────────────────────────────────────────────
+mcp = load("mcp.json", "the portable MCP configuration (§7.2.1)")
+if mcp is not None:
+    if not isinstance(mcp, dict):
+        red("mcp.json is not a JSON object (§7.2.1) — MCP disabled for the plugin")
+        mcp = {}
+
+    got_mcp_schema = mcp.get("$schema")
+    if got_mcp_schema != MCP_SCHEMA:
+        red(f"mcp.json $schema is {got_mcp_schema!r}, must be {MCP_SCHEMA!r} (§7.2.1)")
+
+    extra_top = sorted(set(mcp) - {"$schema", "mcpServers"})
+    if extra_top:
+        red(f"mcp.json carries {extra_top} — only $schema and mcpServers (§7.2.1)")
+
+    if manifest:
+        plugin_v = schema_version(manifest.get("$schema"))
+        mcp_v = schema_version(got_mcp_schema)
+        if plugin_v and mcp_v and plugin_v != mcp_v:
+            red(
+                f"mcp.json targets Agent Plugins {mcp_v} but plugin.json targets {plugin_v} "
+                "— a mismatch invalidates the MCP configuration (§10.1)"
+            )
+
+    servers = mcp.get("mcpServers")
+    if servers is None:
+        red("mcp.json has no mcpServers (§7.2.1) — required, may be empty")
+    elif not isinstance(servers, dict):
+        red("mcp.json mcpServers is not an object (§7.2.1)")
+    else:
+        for server_name, config in sorted(servers.items()):
+            where = f"mcp.json server {server_name!r}"
+            if not isinstance(config, dict):
+                red(f"{where} is not an object (§7.2.1) — the server is skipped")
+                continue
+            kind = config.get("type")
+            if kind not in SERVER_VARIANTS:
+                red(f"{where} has type {kind!r} — not one of {sorted(SERVER_VARIANTS)} (§7.2.1)")
+                continue
+            required, optional = SERVER_VARIANTS[kind]
+            missing = sorted(required - set(config))
+            if missing:
+                red(f"{where} is missing {missing} for type {kind!r} (§7.2.1)")
+            foreign = sorted(set(config) - required - optional)
+            if foreign:
+                red(f"{where} carries {foreign} — the {kind!r} variant is closed (§7.2.1)")
+            command = config.get("command")
+            if kind == "stdio" and isinstance(command, str):
+                if not command:
+                    red(f"{where} command is empty (§7.2.1)")
+                elif " " in command:
+                    red(
+                        f"{where} command {command!r} is a shell string — it MUST be one "
+                        "executable token, arguments go in args (§7.2.1)"
+                    )
+                elif command.startswith("../") or command.startswith("/"):
+                    red(
+                        f"{where} command {command!r} must be a bare name or a ./ path "
+                        "inside the plugin root (§4.1, §7.2.1)"
+                    )
+            env = config.get("env")
+            if isinstance(env, dict):
+                reserved = sorted(RESERVED_ENV & set(env))
+                if reserved:
+                    red(f"{where} env sets {reserved} — the client supplies those (§9.2)")
+
+# ── skills/ (§7.1 → the Agent Skills spec) ──────────────────────────────
+skills_dir = os.path.join(root, "skills")
+if not os.path.isdir(skills_dir):
+    red(f"{skills_dir} is not a directory — the fixed skills location (§6.1, §6.2)")
+else:
+    found = 0
+    for entry in sorted(os.listdir(skills_dir)):
+        skill_md = os.path.join(skills_dir, entry, "SKILL.md")
+        if not os.path.isfile(skill_md):
+            continue
+        found += 1
+        with open(skill_md, encoding="utf-8") as handle:
+            text = handle.read()
+        block = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+        if not block:
+            red(f"{skill_md} has no YAML frontmatter — the client skips this skill (§7.1)")
+            continue
+        front = block.group(1)
+        name_line = re.search(r"^name:[ \t]*(.+?)[ \t]*$", front, re.M)
+        desc_line = re.search(r"^description:[ \t]*(.+?)[ \t]*$", front, re.M | re.S)
+        if not name_line:
+            red(f"{skill_md} frontmatter has no name — required (§7.1)")
+        else:
+            skill_name = name_line.group(1).strip().strip("\"'")
+            if len(skill_name) > 64 or not SKILL_NAME.match(skill_name):
+                red(f"{skill_md} name {skill_name!r} breaks the Agent Skills naming rules")
+            if skill_name != entry:
+                red(f"{skill_md} name {skill_name!r} must match its directory {entry!r}")
+        if not desc_line:
+            red(f"{skill_md} frontmatter has no description — required (§7.1)")
+        else:
+            description = desc_line.group(1).strip()
+            if not description:
+                red(f"{skill_md} description is empty (§7.1)")
+            elif len(description) > 1024:
+                red(f"{skill_md} description is {len(description)} chars — the ceiling is 1024")
+    if found == 0:
+        # A silent zero is the failure mode this whole file exists to catch.
+        red(f"{skills_dir} holds no SKILL.md — an empty harvest is blind, not clean")
+
+if reds:
+    for message in reds:
+        print(f"RED: {message}", file=sys.stderr)
+    print(
+        f"\n{len(reds)} Agent Plugins {SPEC_VERSION} violation(s). "
+        "A conformant client rejects the plugin outright on a fatal manifest error;\n"
+        "the portable surface is the one that reaches Cursor, Copilot, Kiro, VS Code "
+        "and ChatGPT/Codex.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+print(f"OK: the kit conforms to Agent Plugins {SPEC_VERSION} (manifest · mcp · skills)")
+PY

--- a/scripts/hygiene/check-all.sh
+++ b/scripts/hygiene/check-all.sh
@@ -144,6 +144,8 @@ run_check "44 script-path-refs     " "check-script-path-refs.sh"
 run_check "45 taught-commands      " "check-taught-commands.sh"
 run_check "46 kit-script-tests     " "check-kit-script-tests.sh"
 run_check "47 version-surfaces     " "check-version-surfaces.sh"
+run_check "48 agent-plugins-1.0.0  " "check-agent-plugins.sh"
+run_check "49 hygiene-self-tests   " "check-hygiene-self-tests.sh"
 
 # --- Output ---
 g=0

--- a/scripts/hygiene/check-hygiene-self-tests.sh
+++ b/scripts/hygiene/check-hygiene-self-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Vector 49: the vectors that carry a self-test are RUN.
+#
+# Sister to vector 46, one level up. Vector 46 runs the kit's shell rails'
+# tests; this one runs the tests some hygiene vectors ship for themselves,
+# in `scripts/hygiene/tests/*.test.sh`.
+#
+# The reason is the same failure that wrote 46: a test file sitting green
+# by never executing. A hygiene vector is the last thing that should be
+# trusted unproven — it is the surface whose whole job is to say "this is
+# fine", and a gate nobody has ever seen fail is decoration. The tests
+# here are mutation proofs: they break the tree on purpose and assert the
+# vector goes red, so a vector that stopped catching anything is caught.
+#
+# A missing directory or an empty one is YELLOW (say so — silence would
+# read as passing), never green.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIR="$HERE/tests"
+
+if [ ! -d "$DIR" ]; then
+  echo "YELLOW: no hygiene self-test directory at scripts/hygiene/tests"
+  exit 1
+fi
+
+tests=$(find "$DIR" -name '*.test.sh' -type f | sort)
+if [ -z "$tests" ]; then
+  echo "YELLOW: scripts/hygiene/tests holds no *.test.sh"
+  exit 1
+fi
+
+fails=0
+count=0
+for t in $tests; do
+  count=$((count + 1))
+  if out=$(bash "$t" 2>&1); then
+    printf '  ok   %s\n' "$(basename "$t")"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL %s\n%s\n' "$(basename "$t")" "$out" >&2
+  fi
+done
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d hygiene self-test(s) failed — a vector no longer catches what it claims.\n' \
+    "$fails" "$count" >&2
+  exit 2
+fi
+
+echo "OK: $count hygiene self-test(s) passed"
+exit 0

--- a/scripts/hygiene/check-org-readme.sh
+++ b/scripts/hygiene/check-org-readme.sh
@@ -14,7 +14,7 @@ content="$(gh api repos/supernovae-st/.github/contents/profile/README.md --jq .c
 
 missing=""
 # homebrew-nika was RENAMED homebrew-tap (canonical per api .full_name · GitHub
-# redirects the old name); nika-agents + nika-registry joined the profile with
+# redirects the old name); nika-plugins + nika-registry joined the profile with
 # the 2026-07-09 storefront-truth pass (.github#1).
 #
 # The list below IS the city (D-2026-07-29-N10 · thirteen buildings). It gained
@@ -24,7 +24,7 @@ missing=""
 # the second because it shared nine of twelve files with nika-actions-starter.
 # An archived repo must NOT be advertised on the front page, so this vector
 # tracks the living city rather than a frozen snapshot of it.
-for repo in nika nika.sh nika-client nika-spec nika-docs nika-vscode nika-agents \
+for repo in nika nika.sh nika-client nika-spec nika-docs nika-vscode nika-plugins \
   gh-nika nika-registry homebrew-tap nika-action nika-actions-starter \
   nika-estate; do
   echo "$content" | grep -q "$repo" || missing="${missing}${repo} "

--- a/scripts/hygiene/check-version-surfaces.sh
+++ b/scripts/hygiene/check-version-surfaces.sh
@@ -32,6 +32,7 @@ checked=0
 
 # <path>|<extraction>|<what it is>
 surfaces=(
+  ".agents/plugins/nika/plugin.json|json|the portable Agent Plugins manifest"
   ".agents/plugins/nika/.claude-plugin/plugin.json|json|the Claude Code plugin manifest"
   ".agents/plugins/nika/.codex-plugin/plugin.json|json|the Codex plugin manifest"
   ".agents/plugins/nika/.cursor-plugin/plugin.json|json|the Cursor plugin manifest"

--- a/scripts/hygiene/tests/agent-plugins.test.sh
+++ b/scripts/hygiene/tests/agent-plugins.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Mutation proof for vector 48 (check-agent-plugins.sh).
+#
+# A gate that has never been seen to fail is decoration. This copies the
+# real plugin tree to a scratch dir, breaks it one way at a time, and
+# asserts the vector goes RED for each break — then asserts the pristine
+# copy is GREEN, so a vector that simply always fails cannot pass either.
+#
+# Each mutation is a real client behaviour: a fatal manifest error makes
+# a conformant client reject the whole plugin (§5.2, §11.3), a bad server
+# entry makes it skip that server (§7.2.2), a bad skill makes it skip that
+# skill (§7.1). All of them are silent in our own CI without this vector.
+#
+# Two shellcheck notes are wrong here by construction. Every mutator
+# reaches its call site through `expect`, which takes the function name as
+# an argument (SC2329), and `$schema` in single quotes is a literal JSON
+# key travelling to python, never a shell variable (SC2016).
+# shellcheck disable=SC2329,SC2016
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+VECTOR="$ROOT/scripts/hygiene/check-agent-plugins.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+cases=0
+
+# The vector resolves its root from its own location, so the scratch tree
+# has to look like the repo: Cargo.toml, the script, the plugin dir.
+seed() {
+  local dest="$1"
+  rm -rf "$dest"
+  mkdir -p "$dest/scripts/hygiene" "$dest/.agents/plugins"
+  cp "$ROOT/Cargo.toml" "$dest/Cargo.toml"
+  cp "$VECTOR" "$dest/scripts/hygiene/check-agent-plugins.sh"
+  cp -R "$ROOT/.agents/plugins/nika" "$dest/.agents/plugins/nika"
+}
+
+# poke <dir> <file> set|del <dotted.path> [json-value]
+poke() {
+  local dir="$1" rel="$2" op="$3" path="$4" value="${5:-null}"
+  M_FILE="$dir/.agents/plugins/nika/$rel" M_OP="$op" M_PATH="$path" M_VALUE="$value" \
+    python3 - <<'PY'
+import json
+import os
+
+path = os.environ["M_FILE"]
+keys = os.environ["M_PATH"].split(".")
+with open(path, encoding="utf-8") as fh:
+    doc = json.load(fh)
+
+node = doc
+for key in keys[:-1]:
+    node = node[key]
+
+if os.environ["M_OP"] == "del":
+    del node[keys[-1]]
+else:
+    node[keys[-1]] = json.loads(os.environ["M_VALUE"])
+
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(doc, fh, indent=2)
+PY
+}
+
+# expect <GREEN|RED> <label> <mutator...>
+expect() {
+  local want="$1" label="$2"
+  shift 2
+  cases=$((cases + 1))
+  local dir="$WORK/case-$cases"
+  seed "$dir"
+  "$@" "$dir"
+  bash "$dir/scripts/hygiene/check-agent-plugins.sh" >/dev/null 2>&1
+  local rc=$?
+  local got="RED"
+  [ "$rc" -eq 0 ] && got="GREEN"
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %s (%s, rc=%d)\n' "$label" "$got" "$rc"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL %s — wanted %s, got %s (rc=%d)\n' "$label" "$want" "$got" "$rc" >&2
+  fi
+}
+
+untouched() { :; }
+m_unknown_key() { poke "$1" plugin.json set skills '"./skills/"'; }
+m_bad_name() { poke "$1" plugin.json set name '"Nika"'; }
+m_double_hyphen() { poke "$1" plugin.json set name '"ni--ka"'; }
+m_no_schema() { poke "$1" plugin.json del '$schema'; }
+m_old_schema() { poke "$1" plugin.json set '$schema' '"https://agent-plugins.org/schemas/0.9.0/plugin.schema.json"'; }
+m_author_extra() { poke "$1" plugin.json set author.twitter '"@nika"'; }
+m_version_drift() { poke "$1" plugin.json set version '"0.0.1"'; }
+m_mcp_no_schema() { poke "$1" mcp.json del '$schema'; }
+m_mcp_no_type() { poke "$1" mcp.json del mcpServers.nika.type; }
+m_mcp_foreign() { poke "$1" mcp.json set mcpServers.nika.url '"https://example.com"'; }
+m_mcp_shell() { poke "$1" mcp.json set mcpServers.nika.command '"nika mcp"'; }
+m_mcp_reserved() { poke "$1" mcp.json set mcpServers.nika.env '{"PLUGIN_ROOT": "/tmp"}'; }
+m_mcp_extra_top() { poke "$1" mcp.json set inputs '[]'; }
+m_mcp_mismatch() { poke "$1" mcp.json set '$schema' '"https://agent-plugins.org/schemas/1.1.0/mcp.schema.json"'; }
+
+m_plugin_gone() { rm -f "$1/.agents/plugins/nika/plugin.json"; }
+m_mcp_gone() { rm -f "$1/.agents/plugins/nika/mcp.json"; }
+m_skill_rename() { mv "$1/.agents/plugins/nika/skills/nika-authoring" "$1/.agents/plugins/nika/skills/nika-writing"; }
+m_skill_no_front() { printf '# no frontmatter\n' >"$1/.agents/plugins/nika/skills/nika-authoring/SKILL.md"; }
+m_skills_empty() {
+  rm -rf "$1/.agents/plugins/nika/skills"
+  mkdir -p "$1/.agents/plugins/nika/skills"
+}
+
+echo "vector 48 · mutation proof"
+
+expect GREEN "pristine tree" untouched
+expect RED "plugin.json unknown top-level key" m_unknown_key
+expect RED "plugin.json uppercase name" m_bad_name
+expect RED "plugin.json consecutive hyphens" m_double_hyphen
+expect RED "plugin.json missing \$schema" m_no_schema
+expect RED "plugin.json stale \$schema version" m_old_schema
+expect RED "plugin.json author extra field" m_author_extra
+expect RED "plugin.json version drifts" m_version_drift
+expect RED "plugin.json deleted" m_plugin_gone
+expect RED "mcp.json missing \$schema" m_mcp_no_schema
+expect RED "mcp.json server without type" m_mcp_no_type
+expect RED "mcp.json stdio server with url" m_mcp_foreign
+expect RED "mcp.json command as shell string" m_mcp_shell
+expect RED "mcp.json env sets PLUGIN_ROOT" m_mcp_reserved
+expect RED "mcp.json extra top-level field" m_mcp_extra_top
+expect RED "mcp.json targets another spec" m_mcp_mismatch
+expect RED "mcp.json deleted" m_mcp_gone
+expect RED "skill name no longer matches dir" m_skill_rename
+expect RED "skill without frontmatter" m_skill_no_front
+expect RED "skills/ empty — a blind harvest" m_skills_empty
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d mutation(s) survived — the vector does not catch what it claims.\n' \
+    "$fails" "$cases" >&2
+  exit 1
+fi
+
+printf '\n%d/%d mutations killed.\n' "$cases" "$cases"
+exit 0


### PR DESCRIPTION
Two changes to the agent kit: the repo it ships from was renamed, and the kit now carries the portable Agent Plugins manifest alongside the three client-native ones.

## The rename

`supernovae-st/nika-agents` → `supernovae-st/nika-plugins`. The old name said what the kit is made of, not what it is, and "agent" already carries three meanings in this repo — the `agent:` verb frozen in the language, the products other people ship, and the repo itself.

GitHub redirects the URL and `raw.githubusercontent.com` still serves the old path, so nothing was broken. Leaning on a redirect is not the same as being right, so every live surface follows: the install lines the CLI prints, the daily `clients-resync` clone, the `ecosystem-coherence` mirror probe, the org-readme repo list, the estate evidence, README, ROADMAP.

`CHANGELOG.md` and `docs/plans/2026-07-29-HANDOFF.md` keep the old name. They are history.

The org profile README was updated in the same move (`supernovae-st/.github@1960f3d`), which is what vector `check-org-readme` measures — it went red on this branch until that landed, and is green now.

## Agent Plugins 1.0.0

[Agent Plugins 1.0.0](https://agent-plugins.org) published 2026-08-06. This adds `.agents/plugins/nika/plugin.json` and `.agents/plugins/nika/mcp.json` at the plugin root, where every conformant client is required to look.

Purely additive. The format standardises exactly two component types — skills and MCP servers (§7) — and says so deliberately: commands, hooks, agents, rules and LSP are *"too client-specific for a stable portable contract"*. Those stay in `.claude-plugin/` and `.cursor-plugin/`, untouched; a conformant client never looks there.

Verified against primary sources rather than the announcement:

- **VS Code** — *"A root `plugin.json` that declares the canonical Agent Plugins `$schema` uses Agent Plugins semantics"*; skills from `skills/`, MCP from `mcp.json`; gated by `chat.plugins.enabled`.
- **Cursor** — detects the format by manifest location: root `plugin.json` is Agent Plugins, `.cursor-plugin/plugin.json` is a Cursor Plugin. *"A plugin that follows the Agent Plugins specification loads in Cursor without changes."*
- **GitHub Copilot** — reads a root `plugin.json` too, but in **its own** format (`agents/`, `.mcp.json`, `hooks.json`, `lsp.json`). Same filename, different contract. Not claimed here.

Measured, not assumed: `npx plugins discover` on the bundle with and without the new files reports the identical surface (`4 skills, 6 cmds, 3 agents, 2 rules, mcp`), so the portable manifest does not shrink what an installer sees.

`mcp.json` is not a copy of `.mcp.json` — the portable form requires its own `$schema` and a `type` discriminant per server (§7.2.1), and the two `$schema` versions must agree (§10.1).

Nothing renames to a reverse-domain namespace. §8 gives that namespace to the client that owns the domain; we own neither `com.anthropic` nor `com.cursor`, and inventing `sh.nika.claude` would mean nothing to anyone.

## Gates

The portable manifest **fails closed**: §5.2 makes any schema violation other than an unknown top-level field fatal, so one wrong character in `name` and every client drops the whole kit in silence. Nothing else in this repo would notice.

- **Vector 48** `check-agent-plugins.sh` — manifest, MCP config and skill frontmatter against the encoded 1.0.0 rules. Encoded rather than fetched: a gate that needs the network goes yellow on a plane.
- **Vector 49** `check-hygiene-self-tests.sh` — runs `scripts/hygiene/tests/*.test.sh`, sister to 46 one level up, because a gate nobody has seen fail is decoration.
- **Vector 47** gains the new file as a fifth version surface.

Vector 48 ships with a mutation proof: **20 breaks, 20 reds**, plus a pristine case so a vector that always fails cannot pass either.

```
vector 48 · mutation proof
  ok   pristine tree (GREEN, rc=0)
  ok   plugin.json unknown top-level key (RED, rc=2)
  ok   plugin.json uppercase name (RED, rc=2)
  ...
  ok   skills/ empty — a blind harvest (RED, rc=2)

20/20 mutations killed.
```

## Downstream

`nika-plugins` mirrors `.agents/plugins/nika/**` byte-for-byte, pinned by sha256. Once this merges, `scripts/resync-mirror.py` picks up both new files through its addition-blindness ratchet and re-pins. The kit's `.cursor-plugin/plugin.json` still says `nika-agents` until then — by design, since a mirrored file is never hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
