### PR TITLE
docs(kit): the 0.108.0 changelog entry

### DIFF
--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -5,6 +5,47 @@ Versions move together across all manifests (the mirror gate pins it).
 
 ## Unreleased
 
+## 0.108.0 — 2026-08-07
+
+The bundle becomes portable. [Agent Plugins 1.0.0](https://agent-plugins.org)
+published 2026-08-06 — the package format Cursor, GitHub Copilot, Kiro,
+VS Code and ChatGPT/Codex read — and the kit now carries its manifest at
+the plugin root beside the three client-native ones: `plugin.json` and
+`mcp.json`.
+
+Purely additive, and that is the format's own doing. v1 standardises
+exactly two component types, skills and MCP servers, and says why in its
+own text: commands, hooks, agents, rules and LSP are « too
+client-specific for a stable portable contract ». So `.claude-plugin/`
+and `.cursor-plugin/` keep every reason they had — a conformant client
+never looks there, and the client that reads the richer layout still
+gets all of it.
+
+`mcp.json` is not a copy of `.mcp.json`. The portable form carries its
+own `$schema` and a `type` discriminant per server that the Claude Code
+shape has no field for, and the two schema versions must agree or the
+MCP half is refused on its own.
+
+What this deliberately did NOT do: rename anything to a reverse-domain
+namespace (that namespace belongs to the client owning the domain, and
+we own none of them), and claim GitHub Copilot — it reads a root
+`plugin.json` too, but in its own format. Same filename, different
+contract. VS Code and Cursor were verified from their own documentation
+before a single matrix cell moved.
+
+Guarded, not hoped: the portable manifest fails CLOSED — one wrong
+character in `name` and a conformant client drops the whole kit in
+silence — so hygiene vector 48 checks the manifest, the MCP config and
+every skill's frontmatter against the encoded 1.0.0 rules, and vector 49
+runs the mutation proof that keeps 48 honest.
+
+Same wave, the repo this kit ships from was renamed
+`supernovae-st/nika-agents` → `supernovae-st/nika-plugins`. The old name
+said what the kit is made of, not what it is, and « agent » already meant
+three other things here: the frozen `agent:` verb, other vendors'
+products, and the repo. Every install line, marketplace card and teaching
+page follows; GitHub redirects the rest.
+
 ## 0.107.0 — 2026-08-01
 
 The agent-run contract lands (the friction was WRITTEN, not

--- a/estate.yaml
+++ b/estate.yaml
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: 635d1a2a76b6b5989e826fe00a8d31939db69a5e003b0dd512124e8bfc218fa9
+  aggregate_sha256: 79fb782ea2e6b765950dc71d100eda9e3c1fb500ff4df16af5317570ce438cc2
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
The kit's manifests already say `0.108.0` — the mirror re-synced after #861 merged — but the last kit release is `v0.107.0`. So every installed kit still serves 0.107.0, the portable Agent Plugins manifest reaches nobody, and `nika doctor` says so out loud on the operator's own machine:

```
⚠ kit  cursor plugin kit 0.107.0 lags the binary (0.108.0)
⚠ kit  claude plugin kit 0.107.0 lags the binary (0.108.0)
⚠ kit  codex  plugin kit 0.107.2 lags the binary (0.108.0)
```

This is the changelog entry that release needs. It covers the Agent Plugins 1.0.0 landing (what it standardises and what it deliberately refuses to carry, why `mcp.json` is not a copy of `.mcp.json`, what was NOT claimed and why) and the `nika-agents` → `nika-plugins` rename.

**Written here, not in the kit.** `.agents/plugins/nika/CHANGELOG.md` is `engine-mirror` class · the kit receives it through `resync-mirror.py`, never by hand. The first attempt edited it kit-side and was reverted.

**Estate staged before `--write`.** `estate.py` reads the INDEX, not the working tree (the `clients-resync.yml` comment says so in its own words). Running it on an unstaged edit compares the old bytes and hands back a green CI does not share — that cost two red rounds on #862 today.

Vectors 48 and 49 green, `estate.py --check` green.

Cutting the tag is a separate, operator-held gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
