### PR TITLE
fix(ci): the doc-markdown backticks, and the fuzz lock follows the descent

### DIFF
--- a/crates/nika-verb-agent/src/harness_path.rs
+++ b/crates/nika-verb-agent/src/harness_path.rs
@@ -400,7 +400,7 @@ mod tests {
     }
 
     /// The seat's Debug shows the cwd and never the backend (the
-    /// finish_non_exhaustive shape — mutation-pinned).
+    /// `finish_non_exhaustive` shape — mutation-pinned).
     #[test]
     fn the_seat_debug_is_cwd_only_and_non_exhaustive() {
         let seat = seat_with(vec![]);

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2445,6 +2445,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -2617,6 +2618,7 @@ dependencies = [
  "nika-sandbox-landlock",
  "nika-sandbox-seatbelt",
  "nika-schema",
+ "nika-secret",
  "nika-tmpl",
  "nika-types",
  "nika-verb-agent",
@@ -2673,6 +2675,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nika-secret"
+version = "0.108.0"
+dependencies = [
+ "nika-schema",
+ "serde_json",
+]
+
+[[package]]
 name = "nika-source"
 version = "0.108.0"
 dependencies = [
@@ -2716,6 +2726,7 @@ dependencies = [
  "jsonschema",
  "miette",
  "nika-bm25",
+ "nika-cap",
  "nika-catalog",
  "nika-check",
  "nika-error",


### PR DESCRIPTION
Two reds die in one PR:

1. **Diamond CI rust (clippy)** — red on main since #860: the `--all-features` clippy shape caught `finish_non_exhaustive` bare in a nika-verb-agent test doc-comment (the file is feature-gated, the featureless local gate never saw it). Verified locally at the exact CI shape: `cargo clippy -p nika-verb-agent --all-targets --all-features -- -D warnings` clean.
2. **fuzz/Cargo.lock** — the standalone fuzz workspace's lock had not learned the B0 descent (nika-secret into nika-runtime, nika-cap into nika-verify). Cargo regenerated it; no hand edits.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>