### PR TITLE
refactor(nika-builtin): one verdict judges, one site records

### DIFF
--- a/crates/nika-builtin/src/judged_fs.rs
+++ b/crates/nika-builtin/src/judged_fs.rs
@@ -79,24 +79,18 @@ fn is_eloop(e: &std::io::Error) -> bool {
 }
 
 /// The judged fs view one guarded op runs against: `inner` does the I/O,
-/// `boundary` owns the judgment, `access` is the direction reads are
-/// judged under (always `permits.fs.read` · the pin guards the READ lane;
-/// writes delegate to the atomic lane untouched).
+/// `boundary` owns the judgment (always `permits.fs.read` · the pin guards
+/// the READ lane; writes delegate to the atomic lane untouched).
 pub(crate) struct JudgedFs<'a, F> {
     inner: &'a F,
     boundary: &'a FsBoundary,
-    access: FsAccess,
 }
 
 impl<'a, F> JudgedFs<'a, F> {
     /// Wrap `inner` so every read is boundary-judged at open time and
     /// fd-pinned against the enforce→open swap (NEP-0009 law 6).
     pub(crate) fn new(inner: &'a F, boundary: &'a FsBoundary) -> Self {
-        Self {
-            inner,
-            boundary,
-            access: FsAccess::Read,
-        }
+        Self { inner, boundary }
     }
 }
 
@@ -134,7 +128,7 @@ impl<F: FsReadDyn> JudgedFs<'_, F> {
         // refusal as the dispatch guard — UNWITNESSED: the guard already
         // journaled this op's decision (one fs frame per op).
         self.boundary
-            .enforce_unwitnessed(self.inner, &path.to_string_lossy(), self.access)
+            .enforce_unwitnessed(self.inner, &path.to_string_lossy(), FsAccess::Read)
             .await
             .map_err(PinError::Denied)?;
         let mut current = path.to_path_buf();
@@ -162,7 +156,11 @@ impl<F: FsReadDyn> JudgedFs<'_, F> {
                                 other => PinError::Denied(loop_refusal(&current, &other)),
                             })?;
                     self.boundary
-                        .enforce_unwitnessed(self.inner, &resolved.to_string_lossy(), self.access)
+                        .enforce_unwitnessed(
+                            self.inner,
+                            &resolved.to_string_lossy(),
+                            FsAccess::Read,
+                        )
                         .await
                         .map_err(PinError::Denied)?;
                     current = resolved;
@@ -180,7 +178,7 @@ impl<F: FsReadDyn> JudgedFs<'_, F> {
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     async fn read_pinned(&self, path: &Path) -> Result<Bytes, PinError> {
         self.boundary
-            .enforce_unwitnessed(self.inner, &path.to_string_lossy(), self.access)
+            .enforce_unwitnessed(self.inner, &path.to_string_lossy(), FsAccess::Read)
             .await
             .map_err(PinError::Denied)?;
         self.inner.read(path).await.map_err(PinError::Fs)

--- a/crates/nika-builtin/src/permits.rs
+++ b/crates/nika-builtin/src/permits.rs
@@ -164,73 +164,39 @@ impl FsBoundary {
             return Ok(()); // no boundary in force · no decision to witness
         }
         let effective = resolve_effective(fs, Path::new(path)).await;
+        let verdict = self.judge(fs, path, access, &effective).await;
+        if witness {
+            crate::witness::record_decision(
+                "fs",
+                format!("{} {path}", access.category()),
+                verdict.decision(),
+                verdict.why(&effective, access),
+            );
+        }
+        verdict.into_result(path, &effective, access)
+    }
+
+    /// The glob walk, pure of side effect: the first glob that admits
+    /// wins, else the first exact grant whose identity diverged (NEP-0009
+    /// law 2), else outside.
+    async fn judge<F: FsReadDyn>(
+        &self,
+        fs: &F,
+        path: &str,
+        access: FsAccess,
+        effective: &Path,
+    ) -> FsVerdict {
         let mut mismatch = None; // the first exact grant whose identity diverged
         for glob in self.globs(access) {
-            match confines(fs, glob, path, &effective).await {
-                ConfineVerdict::Admits => {
-                    if witness {
-                        crate::witness::record_decision(
-                            "fs",
-                            format!("{} {path}", access.category()),
-                            "allow",
-                            "the effective identity stays inside the declared set".to_owned(),
-                        );
-                    }
-                    return Ok(());
-                }
+            match confines(fs, glob, path, effective).await {
+                ConfineVerdict::Admits => return FsVerdict::Admitted,
                 ConfineVerdict::Outside => {}
                 ConfineVerdict::IdentityMismatch(judged) => {
                     mismatch = mismatch.or(Some(judged));
                 }
             }
         }
-        // NEP-0009 law 3 — the refusal carries the judged prefix and the
-        // resolved target, in the exec arm's own voice (one verdict on
-        // every enforcement arm · law 4).
-        if let Some(judged) = mismatch {
-            if witness {
-                crate::witness::record_decision(
-                    "fs",
-                    format!("{} {path}", access.category()),
-                    "deny",
-                    format!(
-                        "the resolved target `{}` diverges from the judged grant `{judged}`",
-                        effective.display(),
-                        judged = judged.display(),
-                    ),
-                );
-            }
-            return Err(BuiltinFailure::new(
-                SEC_DENIED,
-                format!(
-                    "fs.path_mismatch · `{path}` resolves to `{}` · the judged grant is \
-                     `{judged}` · outside the declared {} set (NEP-0009)",
-                    effective.display(),
-                    access.category(),
-                    judged = judged.display(),
-                ),
-            ));
-        }
-        if witness {
-            crate::witness::record_decision(
-                "fs",
-                format!("{} {path}", access.category()),
-                "deny",
-                format!(
-                    "the resolved target `{}` is outside the declared {} set",
-                    effective.display(),
-                    access.category()
-                ),
-            );
-        }
-        Err(BuiltinFailure::new(
-            SEC_DENIED,
-            format!(
-                "`{path}` resolves to `{}` — outside the declared {} boundary",
-                effective.display(),
-                access.category()
-            ),
-        ))
+        mismatch.map_or(FsVerdict::Outside, |judged| FsVerdict::Mismatch { judged })
     }
 
     /// #433 option C · create `path`'s parent directory WHEN the boundary
@@ -342,6 +308,79 @@ enum ConfineVerdict {
     /// (NEP-0009 law 2: refuse, never rewrite). Carries the judged
     /// identity the attestation names.
     IdentityMismatch(PathBuf),
+}
+
+/// The boundary's judgment on one op, computed ONCE from the glob set —
+/// the record AND the coded refusal derive from the same value, so the
+/// attested `why` and the `NIKA-SEC-004` message can never drift apart
+/// (NEP-0009 law 3 · one verdict on every enforcement arm, law 4).
+enum FsVerdict {
+    /// The effective identity stays inside a declared glob.
+    Admitted,
+    /// The resolved target is outside every declared glob for the access.
+    Outside,
+    /// An exact grant matched the path yet the resolve landed elsewhere
+    /// (NEP-0009 law 2 · carries the judged identity the attestation names).
+    Mismatch { judged: PathBuf },
+}
+
+impl FsVerdict {
+    /// The witness record's decision word.
+    fn decision(&self) -> &'static str {
+        match self {
+            Self::Admitted => "allow",
+            Self::Outside | Self::Mismatch { .. } => "deny",
+        }
+    }
+
+    /// The witness record's one-line attestation.
+    fn why(&self, effective: &Path, access: FsAccess) -> String {
+        match self {
+            Self::Admitted => "the effective identity stays inside the declared set".to_owned(),
+            Self::Outside => format!(
+                "the resolved target `{}` is outside the declared {} set",
+                effective.display(),
+                access.category()
+            ),
+            Self::Mismatch { judged } => format!(
+                "the resolved target `{}` diverges from the judged grant `{judged}`",
+                effective.display(),
+                judged = judged.display(),
+            ),
+        }
+    }
+
+    /// The enforcement result: `Ok(())` on an admission, the coded
+    /// `NIKA-SEC-004` refusal otherwise (the exact voice the guard has
+    /// always spoken).
+    fn into_result(
+        self,
+        path: &str,
+        effective: &Path,
+        access: FsAccess,
+    ) -> Result<(), BuiltinFailure> {
+        match self {
+            Self::Admitted => Ok(()),
+            Self::Outside => Err(BuiltinFailure::new(
+                SEC_DENIED,
+                format!(
+                    "`{path}` resolves to `{}` — outside the declared {} boundary",
+                    effective.display(),
+                    access.category()
+                ),
+            )),
+            Self::Mismatch { judged } => Err(BuiltinFailure::new(
+                SEC_DENIED,
+                format!(
+                    "fs.path_mismatch · `{path}` resolves to `{}` · the judged grant is \
+                     `{judged}` · outside the declared {} set (NEP-0009)",
+                    effective.display(),
+                    access.category(),
+                    judged = judged.display(),
+                ),
+            )),
+        }
+    }
 }
 
 /// A grant's EFFECTIVE PATH IDENTITY (NEP-0009 law 1 — the exec arm's

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 724
-  aggregate_sha256: ec257f4da861095c489981f67ca225a1e32336bf8e7211efa6a930afeed2ddd4
+  aggregate_sha256: c036e05f463a3ede40dd7edfdf02eba97e621887b784bb157409d83075e38457
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## What

A behavior-identical restructure of the fs boundary's enforcement core, from the post-merge nuclear review of #874:

- **`FsVerdict` — judge once, derive everything.** `enforce_judged` carried its mode as a `witness: bool` and spoke the same record three times (three gate formats, three `if witness`). The glob walk now judges ONCE into `FsVerdict` (`Admitted | Outside | Mismatch { judged }`); the witness record AND the coded `NIKA-SEC-004` refusal both derive from that one value — the attested `why` and the refusal message can never drift apart (NEP-0009 law 3). The repeated conditional and the mode flag are deleted, not centralized (parse-don't-validate · C-CUSTOM-TYPE).
- **`JudgedFs.access` dropped** — a field that was a comment (always `FsAccess::Read`; the pin guards the read lane only).

## Proof

- Byte-identical behavior: `fs_permit_witness_e2e` (counts the op's ONE fs frame · asserts gate/why) and the `permits.rs` security suite hold unchanged — 2/2 and the full lib tier green (1095 tests).
- clippy `-D warnings` on macOS AND the linux target (the pinned 1.91 toolchain — the class that reddened #874's first run is verified locally now).
- 9/9 CI ratchets · seam-discipline green · `estate.py --check` in sync.

## Notes

- No public API change (both files are `pub(crate)` territory) · no CHANGELOG entry (invisible refactor) · the review trail: `spn-nuclear-review` verdict SHIP-AFTER-JUDO, applied.
