### PR TITLE
fix(nika-schema): le lecteur de skills passe par la frontiere

### DIFF
--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -118,6 +118,74 @@ pub(crate) fn with_model_override(wf: &RawWorkflow, model: &str) -> RawWorkflow 
 mod tests {
     use super::*;
 
+    /// The `skills:` fs edge lives INSIDE the boundary · the follow-on
+    /// #473 never settled (its "permits question" asked whether a skill
+    /// could WIDEN the inferred boundary, never whether READING it needed
+    /// a grant).
+    ///
+    /// Falsified at 0.108.0, the published binary: under `permits: {}` ·
+    /// the DECLARED ZERO, whose own doc says "this workflow opens no
+    /// file" · a skill path of `/etc/hosts` was READ and the engine
+    /// reported on its CONTENT (`no YAML frontmatter`) while the PERMITS
+    /// and TRIFECTA rungs both stayed green.
+    ///
+    /// Cost of closing it, measured on this tree: 0 of 94 `.nika.yaml`
+    /// files carry `skills:` (92 carry `permits:`, 12 carry `agent:` ·
+    /// the census instrument sees things, so the zero is real).
+    /// ⚠️ The instrument had to be rebuilt once: a first version pointed at
+    /// `/etc/hosts` and went GREEN for the WRONG reason · that file is not a
+    /// valid Agent Skill, so it is READ, then rejected at parse, landing in
+    /// `findings` and never in `texts`. Both assertions were satisfied by the
+    /// MALFORMATION, not by a boundary refusal · a reference that does not
+    /// sit outside the measured function agrees with itself.
+    ///
+    /// The discriminating fixture is a **valid** skill placed outside the
+    /// boundary: only a refusal keeps `texts` empty · a read populates it.
+    #[test]
+    fn skills_read_outside_the_declared_boundary_is_refused() {
+        // A VALID skill, deliberately outside the workflow's tree and outside
+        // any grant the file makes.
+        let dir = std::env::temp_dir().join("nika-skills-boundary-probe");
+        std::fs::create_dir_all(&dir).expect("probe dir");
+        let skill = dir.join("valid-skill.md");
+        std::fs::write(
+            &skill,
+            "---\nname: probe\ndescription: a perfectly valid Agent Skill\n---\nbody\n",
+        )
+        .expect("probe skill");
+        let path = skill.to_string_lossy().into_owned();
+
+        let yaml = format!(
+            concat!(
+                "nika: v1\n",
+                "workflow:\n  id: w\n",
+                "model: mock/echo\n",
+                "permits: {{}}\n",
+                "tasks:\n  t:\n    agent:\n",
+                "      prompt: p\n",
+                "      skills: [\"{}\"]\n",
+            ),
+            path
+        );
+        let wf = nika_schema::parse(&yaml, FileId::new(0), ParseMode::Strict)
+            .expect("the fixture parses");
+
+        let resolved = resolve_workflow_skills(&wf);
+
+        // The whole point: the skill PARSES, so the only thing that can keep
+        // it out of `texts` is the boundary refusing the read.
+        assert!(
+            resolved.texts.is_empty(),
+            "a VALID skill outside the declared boundary was READ · \
+             the fs edge bypasses permits.fs.read · got {} text(s)",
+            resolved.texts.len()
+        );
+        assert!(
+            !resolved.findings.is_empty(),
+            "the refusal must surface as a SKILLS finding, never as silence"
+        );
+    }
+
     /// The pipe-parity pin: with the `links` capability OFF (every sober
     /// register), `linked_path` returns the path VERBATIM — zero escapes.
     /// With it on, the OSC-8 wrapper carries a `file://` URL and keeps

--- a/crates/nika-cli/src/verbs/run/tests.rs
+++ b/crates/nika-cli/src/verbs/run/tests.rs
@@ -314,8 +314,11 @@ fn capture_mock_outputs_carries_the_resolved_skills() {
     let skill = dir.join("SKILL.md");
     std::fs::write(&skill, "---\nname: s\ndescription: d\n---\nBe careful.\n")
         .expect("fixture skill");
+    // The grant is a PRECONDITION since the skills fs edge moved inside the
+    // boundary · the fixture declares exactly the path it reaches.
     let yaml = format!(
-        "nika: v1\nworkflow:\n  id: w\nmodel: mock/echo\ntasks:\n  go:\n    agent: {{ prompt: \"hi\", skills: [\"{}\"] }}\n",
+        "nika: v1\nworkflow:\n  id: w\nmodel: mock/echo\npermits:\n  fs:\n    read: [\"{}\"]\ntasks:\n  go:\n    agent: {{ prompt: \"hi\", skills: [\"{}\"] }}\n",
+        skill.display(),
         skill.display()
     );
     let wf = nika_schema::parse(

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -627,8 +627,11 @@ fn check_skills_rung_greens_reds_and_teaches() {
         std::fs::write(
             &path,
             format!(
-                "nika: v1\nworkflow:\n  id: w\nmodel: mock/echo\ntasks:\n  go:\n    agent: {{ prompt: \"hi\", skills: [\"{}\"] }}\n",
-                skill.display()
+                // the skills: fs edge lives INSIDE the boundary (#473) — the
+                // grant is judged BEFORE the reader runs, so every posture
+                // below tests the RUNG, never the boundary refusal.
+                "nika: v1\nworkflow:\n  id: w\npermits:\n  fs:\n    read: [\"{p}\"]\nmodel: mock/echo\ntasks:\n  go:\n    agent: {{ prompt: \"hi\", skills: [\"{p}\"] }}\n",
+                p = skill.display()
             ),
         )
         .expect("workflow fixture");

--- a/crates/nika-schema/src/skill.rs
+++ b/crates/nika-schema/src/skill.rs
@@ -277,8 +277,30 @@ pub fn resolve_skills(
         if resolved.texts.contains_key(key) {
             continue; // already resolved for an earlier reference
         }
+        // The `skills:` fs edge lives INSIDE the boundary. The grant is
+        // judged BEFORE the reader runs · a refused path is never read,
+        // so nothing of it can reach the agent's prompt. Absent `permits:`
+        // is zero authority (F-O8), and `permits: {}` denies by default
+        // (an omitted `fs` block forbids every path · `nika-cap::fit`).
+        //
+        // Falsified at 0.108.0 before this gate existed: a VALID skill at
+        // an absolute path outside `permits: {}` · whose own doc says the
+        // workflow "opens no file" · was read, and the engine reported on
+        // its CONTENT while the PERMITS and TRIFECTA rungs stayed green.
+        let granted = wf
+            .permits
+            .as_ref()
+            .is_some_and(|p| p.value.allows_path(key, false));
         let (code, detail) = match defects.get(key) {
             Some((code, detail)) => (*code, detail.clone()),
+            None if !granted => {
+                let d = format!(
+                    "`{key}` is outside the permits.fs.read boundary · grant the path, \
+                     or move the skill inside one the file already grants"
+                );
+                defects.insert(key.to_owned(), ("NIKA-SEC-004", d.clone()));
+                ("NIKA-SEC-004", d)
+            }
             None => match read(key) {
                 Ok(text) => match parse_skill(&text) {
                     Ok(_) => {
@@ -396,17 +418,64 @@ mod tests {
         assert_eq!(doc.name, "x");
     }
 
+    /// The `skills:` fs edge is INSIDE the boundary · the reader never runs
+    /// for a path the file does not grant. The fixture is a skill that would
+    /// PARSE FINE · only a refusal can keep it out of `texts`, so the test
+    /// cannot go green on a malformation (the first version of this probe
+    /// pointed at an invalid file and passed for the wrong reason).
+    #[test]
+    fn resolve_skills_refuses_a_path_outside_the_boundary() {
+        let cases = [
+            // the DECLARED ZERO · its own doc says "opens no file"
+            ("permits: {}\n", "declared zero"),
+            // absent · zero authority (F-O8)
+            ("", "absent permits"),
+            // granted, but ELSEWHERE
+            (
+                "permits:\n  fs:\n    read: [\"allowed/SKILL.md\"]\n",
+                "grant elsewhere",
+            ),
+        ];
+        for (permits, label) in cases {
+            let yaml = format!(
+                "nika: v1\nworkflow:\n  id: w\nmodel: mock/echo\n{permits}\
+                 tasks:\n  a:\n    agent: {{ prompt: \"hi\", skills: [\"outside/SKILL.md\"] }}\n"
+            );
+            let wf = crate::parse(&yaml, crate::FileId::new(0), crate::ParseMode::Strict)
+                .expect("fixture parses");
+            let mut reads = 0usize;
+            let resolved = resolve_skills(&wf, &mut |_| {
+                reads += 1;
+                Ok("---\nname: g\ndescription: d\n---\nbody\n".to_owned())
+            });
+            assert_eq!(reads, 0, "{label}: the reader must never run");
+            assert!(resolved.texts.is_empty(), "{label}: nothing may carry");
+            assert_eq!(
+                resolved.findings.first().map(|f| f.code),
+                Some("NIKA-SEC-004"),
+                "{label}: the refusal is a boundary escape, not a read defect"
+            );
+        }
+    }
+
     #[test]
     fn resolve_skills_splits_003_and_004_and_carries_texts() {
         // The pure resolution over an injected reader (the CLI's fs edge
         // stays 3 lines): a good skill carries its raw text; a missing
         // file is NIKA-AGENT-003; an invalid one is NIKA-AGENT-004; a
         // duplicated bad reference gets a row PER TASK without re-reads.
+        // The grant is a PRECONDITION of the read since the boundary gate
+        // landed · this fixture measures the 003/004 split, not the
+        // boundary, so it declares what it reaches (see the sibling test
+        // `resolve_skills_refuses_a_path_outside_the_boundary`).
         let yaml = "\
 nika: v1
 workflow:
   id: w
 model: mock/echo
+permits:
+  fs:
+    read: [\"good/SKILL.md\", \"bad/SKILL.md\", \"ghost/SKILL.md\"]
 tasks:
   a:
     agent: { prompt: \"hi\", skills: [\"good/SKILL.md\", \"ghost/SKILL.md\"] }

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,12 +152,12 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 733
-  aggregate_sha256: 7b3e4e5807fee73b2e2e790d69f3f0f0ea893101a486c803135889d2b9bc7702
+  aggregate_sha256: 27c60117e4682b7bd78b608c515cbb5f48ecaaa9f6ce31ddd1ce483f4c927a58
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 137
-  aggregate_sha256: a1b0120d352a2aa9283add6f3e8b29566e865466da90af94c2664e613b87f555
+  aggregate_sha256: c9980fc7fc1b6b13a9f20f7a0172e9108a9e5771f63f159aaee16742604feb24
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored


### PR DESCRIPTION
Un chemin dans `skills:` etait lu par un `std::fs::read_to_string` brut, **hors de `permits.fs.read`**, et le texte voyageait jusquau prompt dun agent qui, lui, a legress.

## Falsifie au binaire publie (0.108.0), pas seulement au code

Fixture ·  `permits: {}` (le zero DECLARE) + un `agent:` portant `skills: ["/etc/hosts"]`.

```
MUTATION A · le fichier devient MALFORME
  ✖ SKILLS [NIKA-AGENT-004] `hors-portee/canary.md` is not a valid Agent Skill:
    no YAML frontmatter                                              rc=2
  ⇒ on ne peut PAS savoir quun fichier na pas de frontmatter SANS LAVOIR LU

MUTATION B · chemin ABSOLU hors du projet · toujours sous permits: {}
  ✖ SKILLS [NIKA-AGENT-004] task `t` · `/etc/hosts` is not a valid Agent Skill…
  ✔ PERMITS  literal + const: args fit the boundary
  ✔ TRIFECTA no lethal trifecta over the declared permits:           rc=2
```

Le moteur **lit** le fichier et rend un verdict **sur son contenu**, pendant que PERMITS et TRIFECTA restent **verts**, sous le zero declare. La lecture est prouvee par la dependance-au-contenu du verdict, et elle est **non bornee** (chemin absolu, nimporte ou sur le disque).

Ce que ca falsifiait litteralement · la doc du moteur, dans son propre exemple canonique, dit de `permits: {}` · *« an empty block is a statement, not a formality: **this workflow opens no file**, reaches no host, runs no program. »*

## Le correctif

Le gate est pose dans `resolve_skills`, **avant** le lecteur · la ou vit *« the ONE reader check · run · test share »* ⇒ **un seul gate repare les trois surfaces**. Il reutilise `allows_path` (nika-cap → nika-vocab → nika-schema) et `NIKA-SEC-004` · **aucun code minte**. Zero I/O ajoute, donc linvariant L0 de `nika-schema` tient.

Semantique · `permits` absent → refuse (zero autorite) · `permits: {}` → refuse (fs omis = default-deny) · chemin accorde → la lecture procede.

## Le cycle

**RED** · un skill VALIDE hors frontiere etait lu (« got 1 text(s) ») → **GREEN** · 213/213 nika-schema · 296/296 nika-cli · clippy 0 · doc 0 → **MUTANT** · gate neutralise, verifie au `cmp` ⇒ **les DEUX tests meurent**.

Lassertion forte est `reads == 0` · le lecteur nest jamais appele.

⚠️ La premiere version du test pointait `/etc/hosts` et passait **vert pour la mauvaise raison** · ce fichier nest pas un skill valide, il est donc lu PUIS rejete au parse, ce qui satisfaisait les deux assertions **par la malformation**. La fixture discriminante est un skill **VALIDE** hors frontiere.

## Le cout, mesure

**0 fichier `.nika.yaml` sur 94** porte `skills:` (92 ont `permits:`, 12 ont `agent:`). Le correctif est gratuit.

Le correctif ne change pas la doc · **il la rend vraie**.
