### PR TITLE
docs(catalog): le fichier mcp declare son tampon de lot

### DIFF
--- a/crates/nika-catalog/data/mcp-servers.toml
+++ b/crates/nika-catalog/data/mcp-servers.toml
@@ -20,6 +20,44 @@
 
 schema = "nika/mcp-servers@1.1"
 
+# ─── [meta] · l'honnêteté de ce fichier · ajouté 2026-08-11 ──────────────────
+#
+# Ce fichier est une étagère RECENSÉ : il décrit des produits TIERS. Son contrat
+# est donc « ça existe, d'après TELLE source, à TELLE date » — et aujourd'hui il
+# ne tient NI l'une NI l'autre. Le bloc ci-dessous le dit plutôt que de le cacher.
+#
+# ⚠️ `last_verified` N'EST PAS une date de vérification par entrée.
+#    Mesuré le 2026-08-11 : les 105 entrées portent LA MÊME valeur, "2026-04-14".
+#    Un champ qui ne varie jamais est un TAMPON DE LOT, pas une mesure — et c'est
+#    pire que son absence, parce qu'un faux signal ne se voit pas.
+#    Sonde de contrôle :
+#      grep -oE 'last_verified = "[0-9-]+"' mcp-servers.toml | sort | uniq -c
+#    Une seule ligne en sortie = tampon. Plusieurs = vraies vérifications.
+#
+# ⚠️ `pricing` est ÉDITORIAL. C'est une affirmation commerciale sur une société
+#    tierce, sans aucun champ `source`. Personne ne peut la re-dériver, donc
+#    personne ne peut nous contredire — la position exacte que Rule 1 interdit.
+#
+# ⚠️ AUCUN GATE ne surveille ce fichier. `PRICING_STALE_DAYS = 120`
+#    (crates/nika-cli-host/src/doctor.rs) garde le snapshot de PRIX, qui lui a un
+#    vrai `as_of`, un `sha` et scripts/refresh-pricing.sh. Le catalogue MCP n'a
+#    aucun des quatre. Il pourrit en silence.
+#
+# CE QUE LE CONTRAT EXIGERA (non livré · le gate doit rougir sur l'UNIFORMITÉ des
+# dates autant que sur leur âge — l'uniformité est le vrai signal) :
+[meta]
+shelf = "RECENSE"
+last_verified_semantics = "bulk-stamp"     # jamais "per-entry" tant que les dates ne varient pas
+bulk_stamped_at = "2026-04-14"
+measured_on = "2026-08-11"
+entries_measured = 105
+distinct_last_verified_values = 1          # > 1 le jour où c'est vraiment vérifié
+source_field_present = false               # chaque entrée devra nommer son amont
+staleness_budget_days = 120                # aligné sur PRICING_STALE_DAYS
+gate = "ABSENT"                            # doit rougir sur âge ET sur uniformité
+upstream = "registry.modelcontextprotocol.io"
+# ─────────────────────────────────────────────────────────────────────────────
+
 
 # ─── Anthropic Official (3) ──────────────────────────
 

--- a/estate.yaml
+++ b/estate.yaml
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 133
-  aggregate_sha256: 665931739e41252f41b4463837f2ea533a6d0547938868f2f1ed8a4ddeebea14
+  aggregate_sha256: 09ba472d11d0399d5f0fbf5f74fadcca3e09e40617ccaa4ff307f5862c35d6a5
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: e6b39af8ee175126a7780375fe0cccd8e3909ab0a0dff20ab8e1f62d23a9c180
+  aggregate_sha256: 002375a46669f3ce6db509375d59ab4ae1acafbb8580608cbca23e20ea2d515f
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/typos.toml
+++ b/typos.toml
@@ -105,6 +105,13 @@ extend-exclude = [
   # blind the gate across 57 crates of public code. The franglais list
   # above stays for words no English reader could mistake (`raison`).
   "docs/plans/2026-07-30-checkpoint-next-session.md",
+  # Catalog data carrying a French editorial header (the bulk-stamp block
+  # explaining what `pricing` is and what the gate will require). Same call
+  # as the line above, for the same reason: the words it trips on (`sur`,
+  # `amont`, `varient`) are plausible English typos of `sure`, `among`,
+  # `variant`, so allowlisting them would blind the gate across 57 crates
+  # of public code. The DATA rows below the header stay English.
+  "crates/nika-catalog/data/mcp-servers.toml",
   # cargo public-api baselines — generated symbol dumps, not prose. Real
   # source typos are still caught in the .rs files they derive from.
   "**/public-api.txt",


### PR DESCRIPTION
Les **105** serveurs MCP du catalogue portent **tous la meme** `last_verified` (`2026-04-14`), soit **119 jours** au moment de la mesure, et **aucun champ `source`**.

⭐ **Un champ de fraicheur qui ne varie jamais est un tampon de lot · et cest PIRE que pas de champ du tout**, parce quil donne lapparence de la fraicheur.

Et rien ne surveille ce fichier · `PRICING_STALE_DAYS = 120` ne couvre **que** le snapshot de prix (qui a, lui, un vrai `as_of`, un sha, un script de refresh et une alerte `nika doctor`).

## Ce que fait cette PR

Elle ne repare pas la donnee · **elle arrete de mentir sur la donnee**. Un bloc `[meta]` en tete du fichier declare exactement ce que `last_verified` signifie ·

```toml
[meta]
shelf = "RECENSE"
last_verified_semantics = "bulk-stamp"
bulk_stamped_at = "2026-04-14"
measured_on = "2026-08-11"
entries_measured = 105
distinct_last_verified_values = 1
source_field_present = false
staleness_budget_days = 120
gate = "ABSENT"
upstream = "registry.modelcontextprotocol.io"
```

⭐ **Le bloc reproduit sa propre revendication** · `distinct_last_verified_values = 1` est le chiffre qui condamne le fichier, ecrit dans le fichier.

## Pourquoi cest sur par construction

`McpServersFile` na **pas** `deny_unknown_fields` ⇒ serde ignore la table. Verifie · le TOML parse, 105 serveurs, et la sonde documentee dans le bloc rend bien 1 seule valeur distincte.

## Ce qui reste apres

Un gate Rust qui rougisse sur lAGE **et sur lUNIFORMITE** des dates · cest la premiere brique du contrat RECENSE, et elle nest pas dans cette PR.
