### PR TITLE
refactor(nika-runtime): the sandbox selection is one, with a decision record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4643,6 +4643,7 @@ dependencies = [
  "nika-onboard",
  "nika-pack",
  "nika-providers",
+ "nika-runtime",
  "nika-sandbox-landlock",
  "nika-sandbox-seatbelt",
  "nika-schema",

--- a/crates/nika-mcp/Cargo.toml
+++ b/crates/nika-mcp/Cargo.toml
@@ -24,9 +24,12 @@ nika-catalog = { path = "../nika-catalog", version = "0.108.0", default-features
 nika-onboard = { path = "../nika-onboard", version = "0.108.0" }  # the ONE routing door (RAMS-11 · MCP follows the CLI's router)
 nika-builtin = { path = "../nika-builtin", version = "0.108.0" }
 # The exec verb's OS sandbox (ADR-095 Layer 6) — a spawned MCP server rides
-# the SAME confinement (never a bespoke second sandbox). L4→L0.5/L1, strictly
+# the SAME confinement (never a bespoke second sandbox). The selection itself
+# lives at the L3 composition root (#888 · the ONE `select_command_sandbox`);
+# the mechanism crates stay the L1 pure mechanisms. L4→L3/L0.5/L1, strictly
 # downward (the nika-cli precedent).
 nika-kernel = { path = "../nika-kernel", version = "0.108.0" }              # the CommandSandbox seam · SandboxSpec · the NetPolicy tri-state · DANGEROUS_ENV_VARS
+nika-runtime = { path = "../nika-runtime", version = "0.108.0" }            # the ONE sandbox selection (#888 · L4→L3 — already transitive via nika-onboard, now explicit)
 nika-sandbox-seatbelt = { path = "../nika-sandbox-seatbelt", version = "0.108.0" }  # the macOS jail (sandbox-exec)
 nika-sandbox-landlock = { path = "../nika-sandbox-landlock", version = "0.108.0" }  # the Linux jail (bwrap)
 

--- a/crates/nika-mcp/src/sandbox.rs
+++ b/crates/nika-mcp/src/sandbox.rs
@@ -11,9 +11,11 @@
 //! binary's behavior). So the spawn is confined by construction, through
 //! the one `CommandSandbox` seam the exec path uses:
 //!
-//! - **Backend** — [`platform_sandbox`] makes the same selection the exec
-//!   composition root makes: Seatbelt on macOS, bwrap on Linux, the
-//!   deliberate loud [`NoopSandbox`](nika_kernel::command_sandbox::NoopSandbox)
+//! - **Backend** — [`platform_sandbox`] delegates to the ONE selection
+//!   (`nika_runtime::sandbox_select` · #888 — the exec composition root and
+//!   this spawn path ride the same decision): Seatbelt on macOS, bwrap on
+//!   Linux, the deliberate loud
+//!   [`NoopSandbox`](nika_kernel::command_sandbox::NoopSandbox)
 //!   elsewhere (named by the note on every connect — never silent).
 //! - **Filesystem** — [`McpServerConfig::sandbox_spec`] anchors the
 //!   boundary at the project dir (the same boundary the exec sandbox
@@ -40,23 +42,18 @@ use nika_kernel::process::{NetPolicy, SandboxSpec};
 
 use crate::client::McpServerConfig;
 
-/// The OS command sandbox for this platform — the same selection the exec
-/// composition root makes (ADR-095 Layer 6): macOS rides Seatbelt, Linux
-/// rides bubblewrap, anything else is the deliberate
-/// [`NoopSandbox`](nika_kernel::command_sandbox::NoopSandbox) — loud via the
-/// connect note ([`StdioMcpClient::sandbox_note`](crate::client::StdioMcpClient::sandbox_note)),
-/// never the silent default.
+/// The OS command sandbox for this platform — delegates to the ONE
+/// selection every composition root rides
+/// ([`nika_runtime::sandbox_select::select_command_sandbox`] · ADR-095
+/// Layer 6 · #888 — the twin selector that used to live here retired):
+/// macOS rides Seatbelt, Linux rides bubblewrap, anything else is the
+/// deliberate [`NoopSandbox`](nika_kernel::command_sandbox::NoopSandbox) —
+/// loud via the connect note ([`StdioMcpClient::sandbox_note`](crate::client::StdioMcpClient::sandbox_note)),
+/// never the silent default. Kept as the crate's stable API spelling over
+/// the shared decision (the record's `into_sandbox`, verbatim).
 #[must_use]
 pub fn platform_sandbox() -> Arc<dyn CommandSandbox> {
-    #[cfg(target_os = "macos")]
-    if nika_sandbox_seatbelt::SeatbeltSandbox::available() {
-        return Arc::new(nika_sandbox_seatbelt::SeatbeltSandbox::new());
-    }
-    #[cfg(target_os = "linux")]
-    if nika_sandbox_landlock::LandlockSandbox::available() {
-        return Arc::new(nika_sandbox_landlock::LandlockSandbox::new());
-    }
-    Arc::new(nika_kernel::command_sandbox::NoopSandbox)
+    nika_runtime::sandbox_select::select_command_sandbox().into_sandbox()
 }
 
 /// The one-line sandbox mode note printed on every connect/verify —

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -786,6 +786,39 @@ pub type nika_runtime::resume::ResumeKey::Output = T
 pub const nika_runtime::resume::KEY_VERSION: u32
 pub fn nika_runtime::resume::referenced_upstreams(task: &nika_schema::raw::task::RawTask) -> alloc::collections::btree::set::BTreeSet<alloc::string::String>
 pub type nika_runtime::resume::ResumePlan = alloc::collections::btree::map::BTreeMap<alloc::string::String, nika_runtime::resume::PriorSuccess>
+pub mod nika_runtime::sandbox_select
+pub struct nika_runtime::sandbox_select::SandboxDecision
+impl nika_runtime::sandbox_select::SandboxDecision
+pub fn nika_runtime::sandbox_select::SandboxDecision::backend(&self) -> &'static str
+pub fn nika_runtime::sandbox_select::SandboxDecision::into_sandbox(self) -> alloc::sync::Arc<dyn nika_kernel_core::io::command_sandbox::CommandSandbox>
+pub fn nika_runtime::sandbox_select::SandboxDecision::is_confined(&self) -> bool
+impl<D> owo_colors::OwoColorize for nika_runtime::sandbox_select::SandboxDecision
+impl<T, U> core::convert::Into<U> for nika_runtime::sandbox_select::SandboxDecision where U: core::convert::From<T>
+pub fn nika_runtime::sandbox_select::SandboxDecision::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_runtime::sandbox_select::SandboxDecision where U: core::convert::Into<T>
+pub type nika_runtime::sandbox_select::SandboxDecision::Error = core::convert::Infallible
+pub fn nika_runtime::sandbox_select::SandboxDecision::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_runtime::sandbox_select::SandboxDecision where U: core::convert::TryFrom<T>
+pub type nika_runtime::sandbox_select::SandboxDecision::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_runtime::sandbox_select::SandboxDecision::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_runtime::sandbox_select::SandboxDecision where T: 'static + ?core::marker::Sized
+pub fn nika_runtime::sandbox_select::SandboxDecision::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_runtime::sandbox_select::SandboxDecision where T: ?core::marker::Sized
+pub fn nika_runtime::sandbox_select::SandboxDecision::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_runtime::sandbox_select::SandboxDecision where T: ?core::marker::Sized
+pub fn nika_runtime::sandbox_select::SandboxDecision::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_runtime::sandbox_select::SandboxDecision
+pub fn nika_runtime::sandbox_select::SandboxDecision::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_runtime::sandbox_select::SandboxDecision where T: 'static
+pub fn nika_runtime::sandbox_select::SandboxDecision::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_runtime::sandbox_select::SandboxDecision where T: ?core::marker::Sized
+pub fn nika_runtime::sandbox_select::SandboxDecision::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_runtime::sandbox_select::SandboxDecision::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_runtime::sandbox_select::SandboxDecision
+impl<T> tracing::instrument::WithSubscriber for nika_runtime::sandbox_select::SandboxDecision
+impl<T> typenum::type_operators::Same for nika_runtime::sandbox_select::SandboxDecision
+pub type nika_runtime::sandbox_select::SandboxDecision::Output = T
+pub fn nika_runtime::sandbox_select::select_command_sandbox() -> nika_runtime::sandbox_select::SandboxDecision
 pub mod nika_runtime::simulated
 pub struct nika_runtime::simulated::SimulatedDispatcher<D>
 impl<D> nika_runtime::simulated::SimulatedDispatcher<D>

--- a/crates/nika-runtime/src/compose.rs
+++ b/crates/nika-runtime/src/compose.rs
@@ -585,23 +585,6 @@ pub fn capabilities_of(wf: &nika_schema::raw::RawWorkflow) -> RuntimeCapabilitie
     }
 }
 
-/// The OS command sandbox for this platform (ADR-095 Layer 6): macOS rides
-/// Seatbelt, Linux rides bubblewrap when the launcher is present, anything
-/// else is the deliberate [`nika_kernel::command_sandbox::NoopSandbox`] —
-/// selected HERE, logged at the call site, never the silent default (the
-/// kernel seam's own law).
-fn command_sandbox() -> Arc<dyn nika_kernel::command_sandbox::CommandSandbox> {
-    #[cfg(target_os = "macos")]
-    if nika_sandbox_seatbelt::SeatbeltSandbox::available() {
-        return Arc::new(nika_sandbox_seatbelt::SeatbeltSandbox::new());
-    }
-    #[cfg(target_os = "linux")]
-    if nika_sandbox_landlock::LandlockSandbox::available() {
-        return Arc::new(nika_sandbox_landlock::LandlockSandbox::new());
-    }
-    Arc::new(nika_kernel::command_sandbox::NoopSandbox)
-}
-
 /// The provider client's transport ceiling — `HttpConfig::timeout` on the
 /// PROVIDER client, which reqwest applies as the client-level idle-read
 /// guard (armed even while AWAITING RESPONSE HEADERS) and as the fallback
@@ -792,21 +775,20 @@ pub fn production_runtime(
     // F-P3 · the run: declaration picks the run's seams (clock · jitter
     // stream) ONCE; every injection below reads the same resolution.
     let seams = RunSeams::of(run);
-    // The OS sandbox for exec children (ADR-095 Layer 6) — selected once:
-    // the note AND the shell read the same backend. A declared boundary
-    // with exec tasks but no backend on this platform = the exec child
-    // runs unconfined; the builtin/fetch seams still enforce, said loudly.
-    let sandbox = command_sandbox();
-    // The backend NAME rides into the journal (`workflow_started.sandbox`)
-    // so the evidence pack reads the run's confinement mode from journal
-    // bytes — captured before the sandbox moves into the shell.
-    let sandbox_backend = sandbox.backend();
+    // The OS sandbox for exec children (ADR-095 Layer 6) — decided once, at
+    // the ONE selection every composition root rides (#888): the note AND
+    // the shell read the same record. No backend on this platform = the
+    // exec child runs unconfined; the builtin/fetch seams enforce, loudly.
+    let decision = crate::sandbox_select::select_command_sandbox();
+    // The backend NAME rides into the journal (`workflow_started.sandbox`).
+    let sandbox_backend = decision.backend();
     if caps.exec_tasks && caps.fs.is_declared() && sandbox_backend == "noop" {
         eprintln!(
             "note: exec runs UNCONFINED (no OS sandbox backend on this platform) — the \
              declared boundary still gates fs/net at the builtin and fetch seams"
         );
     }
+    let sandbox = decision.into_sandbox();
     // The fetch/builtin client enforces SSRF (workflow URLs) AND the
     // declared permits.net.http boundary (NIKA-SEC-004 · per-hop).
     let http = Arc::new(fetch_http(caps.net)?);

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -78,6 +78,9 @@ mod record;
 mod recover;
 pub mod resume;
 mod retry;
+/// The ONE OS-sandbox selection (ADR-095 Layer 6 · #888) — `pub` because
+/// `nika-mcp`'s spawn confinement rides the same decision (L4→L3).
+pub mod sandbox_select;
 mod secret;
 mod settle;
 /// The effects-simulated seams (the `nika test` plane · P0-16) — `pub`

--- a/crates/nika-runtime/src/sandbox_select.rs
+++ b/crates/nika-runtime/src/sandbox_select.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ONE OS-sandbox selection (ADR-095 Layer 6 · #822/#888) — every
+//! composition root rides the same decision: the exec runner (`compose`)
+//! and the MCP spawn (`nika-mcp`) used to carry twin selectors that would
+//! have drifted N×1. The selection lives here once and answers a
+//! [`SandboxDecision`](crate::sandbox_select::SandboxDecision) — the
+//! record the runtime confines with, the doctor
+//! (#891) will report, and the journal witnesses. The selection itself is
+//! unchanged (Seatbelt on macOS · bwrap on Linux · the deliberate loud
+//! [`NoopSandbox`](nika_kernel::command_sandbox::NoopSandbox) elsewhere)
+//! and backend ids stay stable — renaming is a locked non-goal (#822 P3).
+
+use std::sync::Arc;
+
+use nika_kernel::command_sandbox::CommandSandbox;
+
+/// The decision record one selection produces — backend Arc, stable id,
+/// and confinement verdict, so no caller re-decides (#889's policy knob
+/// and #891's doctor row consume this too).
+pub struct SandboxDecision {
+    sandbox: Arc<dyn CommandSandbox>,
+    backend: &'static str,
+}
+
+impl SandboxDecision {
+    /// Consume the decision for the backend — the Arc moves into the shell
+    /// after [`Self::backend`] is read.
+    #[must_use]
+    pub fn into_sandbox(self) -> Arc<dyn CommandSandbox> {
+        self.sandbox
+    }
+
+    /// The stable backend id (`seatbelt` · `landlock` · `noop`) — the impl
+    /// names itself, so note, journal, and shell read one string.
+    #[must_use]
+    pub fn backend(&self) -> &'static str {
+        self.backend
+    }
+
+    /// True when the selection confines — anything but the deliberate
+    /// `noop`, which always answers and confines nothing.
+    #[must_use]
+    pub fn is_confined(&self) -> bool {
+        self.backend != "noop"
+    }
+}
+
+/// Select the OS command sandbox for this platform (ADR-095 Layer 6):
+/// Seatbelt on macOS when `sandbox-exec` answers, bwrap on Linux when the
+/// launcher is present, the deliberate loud `NoopSandbox` anywhere else —
+/// selected HERE, named by the caller, never the silent default (the
+/// kernel seam's law; #889 makes the fail-open refusable at the contract).
+#[must_use]
+pub fn select_command_sandbox() -> SandboxDecision {
+    #[cfg(target_os = "macos")]
+    if nika_sandbox_seatbelt::SeatbeltSandbox::available() {
+        let sandbox: Arc<dyn CommandSandbox> =
+            Arc::new(nika_sandbox_seatbelt::SeatbeltSandbox::new());
+        let backend = sandbox.backend();
+        return SandboxDecision { sandbox, backend };
+    }
+    #[cfg(target_os = "linux")]
+    if nika_sandbox_landlock::LandlockSandbox::available() {
+        let sandbox: Arc<dyn CommandSandbox> =
+            Arc::new(nika_sandbox_landlock::LandlockSandbox::new());
+        let backend = sandbox.backend();
+        return SandboxDecision { sandbox, backend };
+    }
+    let sandbox: Arc<dyn CommandSandbox> = Arc::new(nika_kernel::command_sandbox::NoopSandbox);
+    let backend = sandbox.backend();
+    SandboxDecision { sandbox, backend }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The selection matches the host's probe results — the expectation is
+    /// computed from the RAW cfgs so the test stays the independent oracle.
+    #[test]
+    fn the_selection_matches_the_host() {
+        let expected = if cfg!(target_os = "macos")
+            && nika_sandbox_seatbelt::SeatbeltSandbox::available()
+        {
+            "seatbelt"
+        } else if cfg!(target_os = "linux") && nika_sandbox_landlock::LandlockSandbox::available() {
+            "landlock"
+        } else {
+            "noop"
+        };
+        let decision = select_command_sandbox();
+        assert_eq!(decision.backend(), expected);
+        assert_eq!(decision.is_confined(), expected != "noop");
+    }
+
+    /// The record yields its Arc intact — the id read BEFORE the move is
+    /// the id the moved sandbox still answers.
+    #[test]
+    fn the_decision_yields_the_arc() {
+        let decision = select_command_sandbox();
+        let backend = decision.backend();
+        let sandbox = decision.into_sandbox();
+        assert_eq!(sandbox.backend(), backend);
+    }
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4377
+  classified_files: 4378
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1446
+    authored: 1447
     authored-pin: 2
     generated: 118
     pinned-copy: 115
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 944815c7872e87b6ad9e98b81df68a9c1a3672fa7f9e09a0937cd39a63530513
+  sha256: 274d36be5ff32a8418f1e4f0cbdb88ea354438d7ca0002c0154fe1f891e81815
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 62
-  aggregate_sha256: cfdbf2b818aa88a344de7dcadbb136a5fc8b0e0fe9754e89b29cbeb21f4b7c27
+  aggregate_sha256: aeb196808689c86de1a2b17097645b8ad1b07a7f6c526e70706950e3a0a018d0
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 730
-  aggregate_sha256: 940090427b2124e99e27d4fc302f8e8037d1ee6408dd4f98e82b855d6efbead3
+  match_count: 731
+  aggregate_sha256: 3e2fad75be09ad83b02c1d17f4553da953613044c31c91d8a3505a96ddba4b7f
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 133
-  aggregate_sha256: e15b654fb62046a65894ec40d2db06bd3712a077a1128b8cbfdf536f503f7d57
+  aggregate_sha256: 3d64f81ff22aed1c2b38304b1c0e2039b22329c2d416ca57835dcb2ce5429f39
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"


### PR DESCRIPTION
Child of #822 row 1 · Closes #888.

The exec runner (`compose`) and the external MCP spawn (`nika-mcp`) carried byte-identical twin selectors; the selection now lives once in `nika_runtime::sandbox_select` and answers a `SandboxDecision` (backend Arc · stable id · confinement verdict) — one selector, three lenses: the runtime confines with it, `platform_sandbox()` keeps its stable API spelling as a delegation shim, and #891's doctor row plus #889's policy knob get the same struct to read.

- **Zero behavior change**: same cfg probes, same order, same backend ids (`seatbelt` · `landlock` · `noop` — rename stays a locked non-goal), same notes at the same call sites.
- **nika-mcp → nika-runtime** edge newly explicit but already transitive (via nika-onboard) and legal (L4→L3); the crate's dependency comment updated.
- **Gates**: nika-runtime fits the 15k wall (ADR-023) · fn-length ≤ 100 · `cargo doc --document-private-items` clean · public-api snapshot regenerated (additive only) · estate in sync · hygiene 40 green / 0 red · 409 lib tests green on the two touched crates.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>