### PR TITLE
fix(estate): le cadastre cesse de revendiquer un gate qui ne tire pas

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -75,7 +75,7 @@ files:
   evidence: "in-file marker '── GENERATED · do not hand-edit' + [meta] source=https://models.dev/api.json · as_of · source_sha256_16 — a vendored snapshot, refreshed at maintenance time, never a runtime fetch"
   derivation:
     tool: "bash scripts/refresh-pricing.sh (emission laws matched to src/data/models.rs lookup semantics)"
-    gate: ".github/workflows/catalog-verify.yml (daily probe of catalog entries against upstream registries)"
+    gate: "NONE. catalog-verify.yml probes embeddings + mcp servers only (all_embeddings, all_mcp_servers) and never a pricing rule, so this snapshot is UNWATCHED. Two guards EXIST and neither runs: drift-watch.nika.yaml hashes upstream against [meta].sha256 (no cron calls it) and pricing-differential.py cross-checks models.dev against LiteLLM (its workflow has no schedule)."
     inputs:
     - "https://models.dev/api.json (MIT · sst/models.dev)"
 - path: "docs/adr/index.toml"

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 214f0018a8fcd13e182ecc1b1069321df29393a25727db82ae7216740c7a95f6
+  aggregate_sha256: 0c7d72997b8f8affba54f042c674a2b8dc65920710e89aff8c4ce1a0fb4b3a45
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/estate_rules.py
+++ b/scripts/estate_rules.py
@@ -80,7 +80,12 @@ FILES = [
         "evidence": "in-file marker '── GENERATED · do not hand-edit' + [meta] source=https://models.dev/api.json · as_of · source_sha256_16 — a vendored snapshot, refreshed at maintenance time, never a runtime fetch",
         "derivation": {
             "tool": "bash scripts/refresh-pricing.sh (emission laws matched to src/data/models.rs lookup semantics)",
-            "gate": ".github/workflows/catalog-verify.yml (daily probe of catalog entries against upstream registries)",
+            # MEASURED 2026-08-12: catalog-verify.yml imports all_embeddings
+            # and all_mcp_servers ONLY (crates/nika-catalog-verify/src/main.rs:36)
+            # and never reads a pricing rule. The old string here named it as
+            # this snapshot's gate, which made every reader believe the price
+            # was watched. A claimed-but-unfired gate is worse than no gate.
+            "gate": "NONE. catalog-verify.yml probes embeddings + mcp servers only (all_embeddings, all_mcp_servers) and never a pricing rule, so this snapshot is UNWATCHED. Two guards EXIST and neither runs: drift-watch.nika.yaml hashes upstream against [meta].sha256 (no cron calls it) and pricing-differential.py cross-checks models.dev against LiteLLM (its workflow has no schedule).",
             "inputs": ["https://models.dev/api.json (MIT · sst/models.dev)"],
         },
     },


### PR DESCRIPTION
Le cadastre declarait `catalog-verify.yml` comme gardien du snapshot de prix. **Mesure du jour** : ce verificateur importe `all_embeddings` et `all_mcp_servers` (`crates/nika-catalog-verify/src/main.rs:36`) et **ne lit jamais une regle de prix**.

## Le fichier se contredisait deja lui-meme

```
estate.yaml:78   gate: catalog-verify.yml (daily probe of catalog entries...)
estate.yaml:166  ...probed daily by catalog-verify.yml); the pricing snapshot
                 is EXCEPTED in files:
```

Un lecteur qui sarretait a la premiere ligne croyait le prix surveille.

⭐ **Un gate revendique et jamais tire est pire quaucun gate.** Labsence est honnete ; la fausse presence endort.

## Ce que la ligne dit desormais

Elle dit `NONE`, nomme ce que le verificateur couvre **reellement**, et nomme surtout les **deux gardiens qui existent et que rien ne lance** ·

- `drift-watch.nika.yaml` hache lamont contre `[meta].sha256` · **aucun cron ne lappelle**
- `pricing-differential.py` croise models.dev et LiteLLM et sort en 4 sur ecart inexplique · **son workflow na pas de schedule**

Cest la que le travail restant devient visible : la contre-source EXISTE, elle nest jamais interrogee.

## Note de methode

Jai dabord edite `estate.yaml`. `estate.py --write` a **efface mon edition sans un mot**, parce que le champ est DERIVE. Une donnee derivee na pas de chemin decriture manuel · la verite vit dans `scripts/estate_rules.py` et la projection suit.

Le generateur ma corrige, et cest exactement son travail.
