### PR TITLE
fix(docs): le nom mort Cortex quittait le depot dans la doc publique

### DIFF
--- a/crates/nika-catalog/README.md
+++ b/crates/nika-catalog/README.md
@@ -1,7 +1,17 @@
 # nika-catalog
 
-Compile-time capability vocabulary — 32 LLM providers, 105 MCP servers,
-13 embeddings, 63 builtins, 49 capability rules.
+Compile-time capability vocabulary — 38 LLM providers, 105 MCP servers,
+13 embeddings, 28 builtins, 49 capability rules.
+
+<!-- The five counts above are not typed from memory. Three of them are
+     asserted by this crate's own tests (`src/lib.rs` · `all_providers`,
+     `all_mcp_servers`, `all_builtins`) — the truth sat 15 lines from the
+     lie until 2026-08-12, when the header still read 32 providers and 63
+     builtins against asserts of 38 and 28. The remaining two derive from
+     the TOML data (`data/embeddings.toml` · `data/model-capabilities.toml`,
+     one `[[…]]` per entry) and are guarded by NOTHING — re-derive them
+     before trusting them. -->
+
 
 Layer **L0** crate. Ships TOML-driven catalog data baked into the binary
 via `phf` perfect-hash tables (build-time codegen by `nika-catalog-codegen`).

--- a/crates/nika-catalog/src/types/capabilities.rs
+++ b/crates/nika-catalog/src/types/capabilities.rs
@@ -4,7 +4,7 @@
 //! Runtime types backing the TOML-driven `model_capabilities` resolver.
 //!
 //! The three core types — [`CapPatch`], [`Matcher`], and [`CapRule`] — are
-//! public and `#[non_exhaustive]` so that overlay crates (pck, Cortex) can
+//! public and `#[non_exhaustive]` so that overlay crates (pck, the Connectome) can
 //! build alternative capability sources without coupling to crate internals.
 //!
 //! The TOML-generated tables are emitted by `build.rs` into

--- a/crates/nika-catalog/src/types/capabilities_view.rs
+++ b/crates/nika-catalog/src/types/capabilities_view.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! Read-only capability view trait for Cortex forward-compat (v0.95).
+//! Read-only capability view trait for the Connectome's forward-compat.
 //!
 //! [`ModelCapabilitiesView`] abstracts over [`ModelCapabilities`] so that
-//! v0.95 Cortex can provide alternative capability sources (overlay from
+//! the Connectome can provide alternative capability sources (overlay from
 //! `pck`, runtime discovery, etc.) without coupling to the concrete struct.
 
 use super::model::{ModelCapabilities, TokenLimitParam};
@@ -12,7 +12,7 @@ use super::{JsonMode, Modality, ParamFlag, TokenizerFamily};
 
 /// Read-only view of a model's capabilities.
 ///
-/// Blanket-implemented for [`ModelCapabilities`]. The v0.95 Cortex
+/// Blanket-implemented for [`ModelCapabilities`]. The Connectome
 /// subsystem will implement this for overlay capability sources
 /// (package-provided caps, runtime-discovered caps) so the runtime
 /// can program against capabilities without knowing the concrete

--- a/crates/nika-catalog/src/types/tags.rs
+++ b/crates/nika-catalog/src/types/tags.rs
@@ -93,7 +93,7 @@ pub enum Tag {
     /// Context window ≥ 200 k tokens.
     LongContext,
     /// Anthropic / `OpenAI` / `Gemini` prompt-cache support (50-90 % cost
-    /// savings on repeated prefix — big impact on Cortex projections).
+    /// savings on repeated prefix · big impact on the Connectome's projections).
     PromptCaching,
     /// Built-in web grounding (Perplexity Sonar, Gemini grounding).
     /// Distinct from `Rag` which is user-provided context.

--- a/crates/nika-kernel-ai/src/memory.rs
+++ b/crates/nika-kernel-ai/src/memory.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! Memory traits + types — Cortex kernel hooks.
+//! Memory traits + types — the Connectome's kernel hooks.
 //!
 //! ISP decomposition: `MemoryRemember`, `MemoryRecall`, `MemoryForget`.
 //! Super-trait: `MemoryStore` (blanket for all 3).
@@ -9,7 +9,8 @@
 //!
 //! These hooks land Phase 1 to avoid breaking-change cascades on
 //! `#[non_exhaustive]` structs (ROI 6.7x per `POST_AUDIT` decision 3).
-//! Business logic lives in `nika-memory` (Phase 9+).
+//! No business-logic crate exists in this repo today — the Connectome
+//! layer owns it when it lands (the `nika-memory` name is retired).
 
 use std::collections::BTreeMap;
 
@@ -38,17 +39,17 @@ pub struct MemoryFrame {
     /// (cohérent `screen.rs` `captured_at_ns` + cockpit `nano_now()` ·
     /// EC-4 ratchet 2026-05-14 · USER GATE OUI ns canonical).
     pub observed_at: Option<u64>,
-    /// Encryption cipher used (v0.95 Cortex — encrypted memory).
-    /// Reserved: always `None` until nika-memory crate ships.
+    /// Encryption cipher used (the Connectome · encrypted memory).
+    /// Reserved: always `None` at v1 — the Connectome layer owns this when it lands.
     pub cipher: Option<String>,
-    /// Provenance chain (v0.95 Cortex — who created this memory).
-    /// Reserved: always `None` until nika-memory crate ships.
+    /// Provenance chain (the Connectome · who created this memory).
+    /// Reserved: always `None` at v1 — the Connectome layer owns this when it lands.
     pub provenance: Option<String>,
-    /// Retention policy tag (v0.95 Cortex — TTL / archival).
-    /// Reserved: always `None` until nika-memory crate ships.
+    /// Retention policy tag (the Connectome · TTL / archival).
+    /// Reserved: always `None` at v1 — the Connectome layer owns this when it lands.
     pub retention: Option<String>,
-    /// Redacted field paths (v0.95 Cortex — PII scrubbing).
-    /// Reserved: always `None` until nika-memory crate ships.
+    /// Redacted field paths (the Connectome · PII scrubbing).
+    /// Reserved: always `None` at v1 — the Connectome layer owns this when it lands.
     pub redactions: Option<Vec<String>>,
 }
 
@@ -82,7 +83,7 @@ impl MemoryFrame {
 #[non_exhaustive]
 pub struct RecallQuery {
     /// Tenant keyspace — reserved at v0.81 for v0.95 multi-tenant
-    /// Cortex (ADR-031). Every recall MUST scope by tenant.
+    /// the Connectome (ADR-031). Every recall MUST scope by tenant.
     pub tenant: TenantId,
     /// Text to search for (semantic similarity).
     pub text: String,
@@ -150,7 +151,7 @@ pub struct MemoryHit {
     /// Reserved for nika-memory-temporal ranking (v0.95).
     pub observed_at: Option<u64>,
     /// Source of this memory (parity with `MemoryFrame`).
-    /// Reserved for v0.95 Cortex provenance tracking.
+    /// Reserved for the Connectome's provenance tracking.
     pub source: Option<String>,
 }
 
@@ -282,13 +283,13 @@ pub trait MemoryForget: Send + Sync + nika_kernel_core::sealed::Sealed {
     async fn forget(&self, id: MemoryId) -> Result<(), MemoryError>;
 }
 
-// ─── Cortex lifecycle reservation (Wave 4A R5, ADR-033 amendment) ────
+// ─── Connectome lifecycle reservation (Wave 4A R5, ADR-033 amendment) ─
 //
 // Cognitive consolidation + retention pruning are the two background
 // duties the v0.95 nika-memory orchestrator drives. Reserving them on
 // the MemoryStore surface at v0.81 (with default no-op impls) avoids
 // a breaking change every external Store impl would have to absorb
-// when Cortex lands.
+// when the Connectome lands.
 
 /// Scope selector for a consolidation pass.
 ///
@@ -339,7 +340,7 @@ impl ConsolidationReport {
 
 /// Retention pruning policy.
 ///
-/// Cortex pruning removes frames that fall below a retention threshold
+/// the Connectome's pruning removes frames below a retention threshold
 /// (e.g., FSRS stability below X, age above Y, unaccessed for Z).
 /// Defaults to "no-op" — impls override with their retention model.
 #[derive(Debug, Clone, Default)]
@@ -380,7 +381,7 @@ impl PruneReport {
     }
 }
 
-/// Cortex lifecycle operations — consolidation + prune.
+/// Connectome lifecycle operations · consolidation + prune.
 ///
 /// Reserved at v0.81 as a STANDALONE trait (not a super-trait of
 /// `MemoryStore`) with default no-op implementations. Impls opt in
@@ -392,7 +393,7 @@ impl PruneReport {
 /// separate means external `MemoryStore` impls aren't forced to add an
 /// `impl MemoryLifecycle` until they actually want the behaviour — no
 /// migration burden for crates that only care about remember/recall/
-/// forget. v0.95 Cortex will use `T: MemoryStore + MemoryLifecycle` as
+/// forget. The Connectome will use `T: MemoryStore + MemoryLifecycle` as
 /// its bound, making the opt-in explicit at the consumer boundary.
 pub trait MemoryLifecycle: Send + Sync {
     /// Run a consolidation pass on the given scope.

--- a/crates/nika-kernel-ai/src/provider.rs
+++ b/crates/nika-kernel-ai/src/provider.rs
@@ -205,7 +205,7 @@ pub struct InferRequest {
     pub thinking_budget: Option<u32>,
     /// Provider-specific extra parameters.
     pub extra: ProviderExtras,
-    /// Memory directive (Cortex hook, Phase 1).
+    /// Memory directive (Connectome hook, Phase 1).
     pub memory: Option<MemoryDirective>,
     /// Cancellation context (v0.95 structured cancellation hook).
     /// Reserved: always `None` until DAG propagation ships.
@@ -310,7 +310,7 @@ pub struct InferResponse {
     pub cost: Option<Cost>,
     /// Raw finish reason from the provider.
     pub finish_reason_raw: Option<String>,
-    /// Memory frames created during inference (Cortex hook, Phase 1).
+    /// Memory frames created during inference (Connectome hook, Phase 1).
     pub memory_frames: Vec<MemoryFrameRef>,
     /// Trace ID for distributed tracing (W3C Trace Context).
     pub trace_id: Option<nika_error::id::TraceId>,

--- a/crates/nika-kernel-core/src/sealed.rs
+++ b/crates/nika-kernel-core/src/sealed.rs
@@ -34,7 +34,7 @@
 //! - `WasmPluginHost`, `Sandbox` — open per ADR-020 (community WASM/sandbox
 //!   backends).
 //! - `MemoryRemember`, `MemoryRecall`, `MemoryForget`, `EmbeddingProvider` —
-//!   Cortex sub-system (v0.95), open for community memory stores
+//!   the Connectome sub-system, open for community memory stores
 //!   (HNSW/BM25/RRF backends ship separately per ADR-033).
 //! - `ToolExecute`, `ToolBatch`, `ContextCompressor` — open for the
 //!   third-party MCP ecosystem.

--- a/crates/nika-kernel-mock/src/memory.rs
+++ b/crates/nika-kernel-mock/src/memory.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! `NullMemoryStore` + `NullEmbeddingProvider` — no-op Cortex stubs.
+//! `NullMemoryStore` + `NullEmbeddingProvider` — no-op Connectome stubs.
 
 use nika_kernel::memory::{
     EmbeddingProvider, MemoryError, MemoryForget, MemoryFrame, MemoryHit, MemoryId, MemoryRecall,

--- a/crates/nika-types/src/embedding.rs
+++ b/crates/nika-types/src/embedding.rs
@@ -3,7 +3,7 @@
 
 //! Embedding shape — dim/dtype/metric/model trio.
 //!
-//! Reserved at v0.81 so that v0.95 Cortex can land embedding storage
+//! Reserved at v0.81 so that the Connectome can land embedding storage
 //! without breaking-change migrations. The embedding landscape evolves
 //! monthly (Matryoshka, 256/384/512/768/1024/1536/3072 dims; f32/f16/
 //! bf16/i8/binary dtypes; cosine/dot-product/euclidean/hamming metrics)

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 733
-  aggregate_sha256: 27c60117e4682b7bd78b608c515cbb5f48ecaaa9f6ce31ddd1ce483f4c927a58
+  aggregate_sha256: 7f2d967615ca024076f238a284d9098b20e35842b27648e3c0a39564b0a3ae35
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 133
-  aggregate_sha256: 14c925d6a16110a1e6bc0c178eaf70e90a5798f7af5bf0e52bc1f0e19718eda2
+  aggregate_sha256: 665931739e41252f41b4463837f2ea533a6d0547938868f2f1ed8a4ddeebea14
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"


### PR DESCRIPTION
## Le défaut

Le sous-système de mémoire s'appelle **the Connectome**. `Cortex` est retiré du vocabulaire depuis longtemps — et pourtant **21 occurrences** vivaient encore dans des commentaires de doc, sur **8 crates**.

Ce ne sont pas des notes internes : ce sont des `///` et `//!`, donc **un lecteur de la doc générée voit un nom qui n'existe plus**.

## Ce que ça change

**Zéro symbole de code.** Les 21 occurrences sont toutes dans de la documentation ⇒ le renommage est textuel, sans effet de bord sur une signature.

Le **README public du catalogue** est corrigé dans le même acte, parce qu'il portait deux comptes faux **avec leur vérité à quinze lignes de là** ·

| annoncé | réel | source |
|---|---|---|
| 32 LLM providers | **38** | `assert_eq!(all_providers().len(), 38)` · `src/lib.rs:154` |
| 63 builtins | **28** | `assert_eq!(all_builtins().len(), 28)` · `src/lib.rs:172` |
| 105 MCP servers | 105 ✓ | `src/lib.rs:159` |
| 13 embeddings | 13 ✓ | `data/embeddings.toml` (dérivé) |
| 49 capability rules | 49 ✓ | `data/model-capabilities.toml` (dérivé) |

Une note dit désormais **lesquels sont gardés par un test et lesquels ne le sont par rien** — deux des cinq n'ont aucun gate, et le lecteur a le droit de le savoir avant de les croire.

## La preuve

- `git grep 'Cortex' -- 'crates/*/src/**/*.rs'` → **0**
- `cargo check` → **rc=0** sur les 5 crates touchés
- `cargo doc --no-deps` → **rc=0** sur les 3 qui publient
- `clippy-touched` → **5 crates clean** (hook pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
