### PR TITLE
fix(nika-bm25): the IDF moves to ln_1p, where it decides ties

### DIFF
--- a/crates/nika-bm25/src/scorer.rs
+++ b/crates/nika-bm25/src/scorer.rs
@@ -25,6 +25,16 @@
 /// for terms appearing in every document.
 ///
 /// Returns `0.0` if `n == 0` or `df > n` (defensive · empty corpus).
+///
+/// Computed with [`f64::ln_1p`] rather than `(1.0 + x).ln()`. The two
+/// agree bit-for-bit while `x` is large — a RARE term, where `df` is
+/// small and the ratio is huge — and diverge exactly where the IDF is
+/// smallest: a term in (almost) every document gives `x ≈ 0.5/n`, and
+/// `1.0 + x` rounds that away. Measured 2026-08-13 · relative error of
+/// the naive form against `ln_1p`, at `df == n` · `1.2e-15` at n=10 ·
+/// `1.9e-11` at n=10^5 · `8.3e-8` at n=10^10; and `0.0` for `df == 1`
+/// at every n. The near-zero end is where near-stopwords compete, so
+/// it is the end that decides ties.
 #[must_use]
 #[inline]
 pub(crate) fn idf_robertson(n: usize, df: usize) -> f64 {
@@ -35,7 +45,7 @@ pub(crate) fn idf_robertson(n: usize, df: usize) -> f64 {
     let n_f = n as f64;
     #[allow(clippy::cast_precision_loss)]
     let df_f = df as f64;
-    ((n_f - df_f + 0.5) / (df_f + 0.5) + 1.0).ln()
+    ((n_f - df_f + 0.5) / (df_f + 0.5)).ln_1p()
 }
 
 /// Per-term BM25 score contribution.
@@ -98,6 +108,51 @@ mod tests {
         let idf = idf_robertson(4, 4);
         assert!(idf > 0.0);
         assert!(idf.is_finite());
+    }
+
+    /// The `ln_1p` law, and the test dies if the naive form comes back.
+    ///
+    /// At `df == n` the log's argument is `x = 0.5 / (n + 0.5)`, which
+    /// `1.0 + x` rounds away — so `(1.0 + x).ln()` and `x.ln_1p()`
+    /// part company precisely where the IDF is smallest. This asserts
+    /// BOTH halves: the implementation matches `ln_1p`, and the naive
+    /// form does NOT match it at the same tolerance. Without the second
+    /// half the first would pass under either implementation, and the
+    /// green would be worth nothing.
+    #[test]
+    fn idf_uses_ln_1p_where_the_naive_form_loses_the_bits() {
+        let n = 10_000_000_000_usize; // 10^10 · the divergence is ~8e-8 relative
+        let got = idf_robertson(n, n);
+
+        #[allow(clippy::cast_precision_loss)]
+        let x = 0.5 / (n as f64 + 0.5);
+        let exact = x.ln_1p();
+        let naive = (1.0 + x).ln();
+
+        let tol = exact * 1e-12;
+        assert!(
+            (got - exact).abs() < tol,
+            "the implementation must BE the ln_1p form: got {got:e} want {exact:e}"
+        );
+        assert!(
+            (naive - exact).abs() > tol,
+            "the naive form must MISS at this tolerance, else this test proves nothing: \
+             naive {naive:e} exact {exact:e}"
+        );
+    }
+
+    /// The other end of the same law: for a rare term the two forms are
+    /// bit-identical, so `ln_1p` costs nothing where it buys nothing.
+    #[test]
+    fn idf_ln_1p_is_bit_identical_for_a_rare_term() {
+        for n in [1_000_usize, 1_000_000] {
+            #[allow(clippy::cast_precision_loss)]
+            let x = (n as f64 - 1.0 + 0.5) / 1.5;
+            assert!(
+                (x.ln_1p().to_bits() == (1.0 + x).ln().to_bits()),
+                "df == 1 · the two forms must agree exactly at n={n}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nika-harness/src/client.rs
+++ b/crates/nika-harness/src/client.rs
@@ -36,6 +36,23 @@ use crate::wire::{
 
 /// One incoming line may not exceed this (bounded reads · spec §4): a
 /// hostile or broken peer overflows into a refusal, never an OOM.
+///
+/// **This is a TRANSPORT bound and it is not the forensics decode
+/// grain**, even though both are 1 MiB today. It guards one line off a
+/// live wire from a peer this process is talking to; `nika_dap`'s
+/// `bounded::MAX_ARTIFACT_BYTES` guards a stored artifact a verifier
+/// reads whole. Two readers, two threat models, two bounds that happen
+/// to agree on a number.
+///
+/// Do not "de-duplicate" them onto one constant. A grep finds three
+/// `1024 * 1024` in this tree and reads like a single value restated
+/// three times; it is not (measured 2026-08-13 · nika-spec
+/// `conformance/FINDINGS.md` F-4). Aliasing this to a forensics
+/// constant would couple a wire protocol to a decoder, so raising one
+/// bound would move the other for no stated reason — the coupling
+/// costs more than the repetition. The one real duplicate is
+/// `nika-registry-client`'s own artifact bound, which shares this
+/// crate's number *and* `nika-dap`'s meaning.
 pub const MAX_LINE_BYTES: usize = 1024 * 1024;
 
 /// How long the driver waits for the NEXT byte before calling the

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 733
-  aggregate_sha256: 7f2d967615ca024076f238a284d9098b20e35842b27648e3c0a39564b0a3ae35
+  aggregate_sha256: aae70d7fa1b6348b7ccba4e606539a5b9a9ffc154ff5d57a57532c6415430bb0
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Two small changes in free crates, both born from a measurement rather than a hunch. No behaviour change outside the BM25 IDF's degraded end.

## 1 · `nika-bm25` — the IDF moves to `ln_1p`

Pedantic clippy surfaced three float findings in the scoring core. **One is a repair, two are a preference**, and the difference is the point of this PR.

The IDF computed `(1 + x).ln()` where `x` is Robertson's ratio. Measured, at `df == n` (a term in *every* document, so `x ≈ 0.5/n`):

| n | relative error of `(1+x).ln()` vs `ln_1p` |
|---|---|
| 10 | `1.2e-15` |
| 10^5 | `1.9e-11` |
| 10^10 | `8.3e-8` |

And at `df == 1` (a rare term, `x` large) the two forms are **bit-identical** — verified by comparing `to_bits()`.

So the fix is better exactly where the IDF is smallest — the end where near-stopwords compete and decide ties — and changes nothing elsewhere.

**Three tests, one of which refuses to be hollow.** The main test asserts both that the implementation *is* the `ln_1p` form **and** that the naive form *misses* at the same tolerance; without that second half it would pass under either implementation and its green would be worth nothing. Mutation-proved: restoring the naive form fails it with the exact measured numbers (`got 5.000000413576855e-11 want 4.999999999625e-11`, exit 101), and it goes green again when the mutant is removed.

### What this PR deliberately does NOT take

Clippy also proposes `mul_add` on the length normalisation and the denominator. Different risk profile: FMA yields a result *different* from `a*b+c` (one rounding instead of two), so it would move **every** score to gain about one ulp — whereas `ln_1p` only moves the degraded end and leaves the rest bit-identical. A one-ulp shift across a whole ranked fleet is not a gain, it is a change.

### Consumer check

No golden in the tree pins a BM25 score. The four internal consumers compile. The external consumer (Olympus) reads `BmIndex` / `tokenize_text` with no pinned values.

## 2 · `nika-harness` — the line bound says what it is not

A finding filed earlier today counted three `1024 * 1024` constants in this tree and concluded three duplicates of one value. **Wrong on this one**, and reading its own comment was enough.

This constant bounds **one incoming line off a live wire** from a peer this process is talking to. `nika-dap`'s `bounded::MAX_ARTIFACT_BYTES` bounds a **stored artifact** a verifier reads whole. Two readers, two threat models, two bounds that happen to agree on a number.

The doc now says so, and says explicitly **not** to merge them: aliasing a wire protocol's bound onto a forensics decoder would make raising one move the other for no stated reason. The coupling would cost more than the repetition. The one real duplicate is named in passing — `nika-registry-client`'s, which shares both the number *and* the meaning.

Doc only, no code change.

## Gates

`cargo fmt --all --check` · `cargo clippy -p nika-bm25 -p nika-harness --all-targets -- -D warnings` · `cargo test --lib` (42 bm25 + 46 harness) · `cargo check` on the four internal consumers. All green.
