### PR TITLE
fix(security): the private-path gate stayed at an address the rules had left

### DIFF
--- a/docs/plans/2026-07-29-ARC-RECORD.md
+++ b/docs/plans/2026-07-29-ARC-RECORD.md
@@ -162,7 +162,7 @@ instances cleared the house stress-to-ratchet threshold.
 
 ### 2.8 · The dogfood doctrine · monorepo
 
-`dx/doctrine/rules/nika-first-automation.md` §4bis — the reciprocal law. The
+The `nika-first-automation` rule (monorepo-internal), §4bis — the reciprocal law. The
 atelier runs the product it ships (§0-§4); §4bis says friction writing a
 workflow REMOVES upward into the spec and engine. 7 triggers, a 5-step gesture,
 4 anti-patterns, and the empirical proof: one workflow, twenty minutes, three

--- a/docs/plans/adversarial-audit-protocol.md
+++ b/docs/plans/adversarial-audit-protocol.md
@@ -542,7 +542,7 @@ Stated so the curve is not over-read.
   unaudited surfaces, §8 the twelve method lessons, §5 the twenty retractions
 - `docs/plans/2026-07-28-resource-algebra.md` — §1.7 the security-gate
   measurements, §4 what is not tested, §7 the method
-- `dx/doctrine/rules/nika-first-automation.md` §4bis — the reciprocal dogfood
+- the `nika-first-automation` rule (monorepo-internal) §4bis — the reciprocal dogfood
   law: an authoring friction is a finding, not an inconvenience
 
 ---

--- a/scripts/hooks/block-private-paths.sh
+++ b/scripts/hooks/block-private-paths.sh
@@ -56,6 +56,13 @@ readonly PRIVATE_PATTERNS=(
   # The studio + the agent substrate.
   'studio/'
   'dx/.claude/'
+  # Added 2026-08-13 · the TIER-2/3 rules MOVED from `dx/.claude/rules/` to
+  # `dx/doctrine/rules/` in June, and this list stayed at the old address.
+  # The gate blocked a door nobody used any more while the new one stood open ·
+  # measured the same day, 71 private files behind it, and two public docs in
+  # THIS repo already citing the new path. A blocklist is a projection of a
+  # tree · when the tree moves, the list is stale until someone re-derives it.
+  'dx/doctrine/'
   'dx/journal/'
   'dx/state/'
   '.claude/projects/'


### PR DESCRIPTION
## What

`block-private-paths.sh` — the public/private boundary guard on this repo —
blocks `dx/.claude/`, `dx/journal/`, `dx/state/`. It did **not** block
`dx/doctrine/`.

The TIER-2/3 rules **moved** there in June 2026. The blocklist stayed at the
old address, so the gate guarded a door nobody used any more while the new one
stood open.

## Measured, not assumed

- **71** private files live behind `dx/doctrine/`
- **2** public docs in this repo already cited it, by full path:
  - `docs/plans/2026-07-29-ARC-RECORD.md`
  - `docs/plans/adversarial-audit-protocol.md`
- the gate had **0** occurrences of the path

The rule's *name* is not the leak. The *address* is — it publishes the shape of
a private tree. Both citations keep the name and drop the path.

## Two fixes, and the second matters more

The citations are today's leak. The blocklist is every future one.

## Proof

Mutation, injection and cleanup in the **same script** (a timeout between two
commands would leave the probe file staged):

```
leak staged     rc=1 · the gate names the exact offending line
after cleanup   rc=0
```

`bash -n` and `shellcheck` both clean on the modified gate.

## Root cause worth naming

A blocklist is a **projection of a tree**. When the tree moves, the list is
stale until someone re-derives it — and nothing in the gate says so out loud.

Same class as a parse error that skips the twelve checks behind it: **a guard
that cannot see a surface reports GREEN on it, and a GREEN is indistinguishable
from safety.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
