### PR TITLE
fix(security): the private-path gate stayed at an address the rules had left

### DIFF
--- a/docs/plans/2026-07-29-ARC-RECORD.md
+++ b/docs/plans/2026-07-29-ARC-RECORD.md
@@ -162,7 +162,7 @@ instances cleared the house stress-to-ratchet threshold.
 
 ### 2.8 · The dogfood doctrine · monorepo
 
-`dx/doctrine/rules/nika-first-automation.md` §4bis — the reciprocal law. The
+The `nika-first-automation` rule (monorepo-internal), §4bis — the reciprocal law. The
 atelier runs the product it ships (§0-§4); §4bis says friction writing a
 workflow REMOVES upward into the spec and engine. 7 triggers, a 5-step gesture,
 4 anti-patterns, and the empirical proof: one workflow, twenty minutes, three

--- a/docs/plans/adversarial-audit-protocol.md
+++ b/docs/plans/adversarial-audit-protocol.md
@@ -542,7 +542,7 @@ Stated so the curve is not over-read.
   unaudited surfaces, §8 the twelve method lessons, §5 the twenty retractions
 - `docs/plans/2026-07-28-resource-algebra.md` — §1.7 the security-gate
   measurements, §4 what is not tested, §7 the method
-- `dx/doctrine/rules/nika-first-automation.md` §4bis — the reciprocal dogfood
+- the `nika-first-automation` rule (monorepo-internal) §4bis — the reciprocal dogfood
   law: an authoring friction is a finding, not an inconvenience
 
 ---

--- a/estate.yaml
+++ b/estate.yaml
@@ -178,12 +178,12 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 101
-  aggregate_sha256: 5d73a1f1a3f378efa6ab78bed90d2ea8585cff785ac9c0d8dc7fd00a0af380be
+  aggregate_sha256: 56dcfb2a7001079a2ba90d888f9611a54f122411be02de2d00a7855caa3de6a3
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 0c7d72997b8f8affba54f042c674a2b8dc65920710e89aff8c4ce1a0fb4b3a45
+  aggregate_sha256: 4f110974fecc1ca01fe3c2faca8d40648d8a0faf8dbee51e4947136261b550ad
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/hooks/block-private-paths.sh
+++ b/scripts/hooks/block-private-paths.sh
@@ -56,6 +56,13 @@ readonly PRIVATE_PATTERNS=(
   # The studio + the agent substrate.
   'studio/'
   'dx/.claude/'
+  # Added 2026-08-13 · the TIER-2/3 rules MOVED from `dx/.claude/rules/` to
+  # `dx/doctrine/rules/` in June, and this list stayed at the old address.
+  # The gate blocked a door nobody used any more while the new one stood open ·
+  # measured the same day, 71 private files behind it, and two public docs in
+  # THIS repo already citing the new path. A blocklist is a projection of a
+  # tree · when the tree moves, the list is stale until someone re-derives it.
+  'dx/doctrine/'
   'dx/journal/'
   'dx/state/'
   '.claude/projects/'


### PR DESCRIPTION
Replaces #907, which was blocked on two mechanical checks. Same fix, signed
commits, no force-push.

## What was open

`scripts/hooks/block-private-paths.sh` guards the public/private boundary of
this repo. Its blocklist named `dx/.claude/`, `dx/journal/`, `dx/state/` — but
**not `dx/doctrine/`**, where the TIER-2/3 rules moved in June 2026.

Measured the same day: **71 private files** behind that path, and **two public
docs in this repo already cited it by full path**. The gate had zero
occurrences of the address. It was guarding a door nobody uses any more while
the new one stood open.

A blocklist is not a rule — it is the **projection of a tree at one instant**.
When the tree moves, the list keeps the old address and the gate stays green.

## What this changes

- `dx/doctrine/` added to `PRIVATE_PATTERNS`
- the two public docs lose the private-path citation (the fact is kept, the
  address is dropped — the address is what leaks the shape of a private tree)
- `estate.yaml` regenerated, because it hashes the tracked tree and the hook
  script is in it (`scripts/estate.py --check` → rc 0)

## Proof

Mutation inside the gate's declared domain: a staged line naming
`dx/doctrine/rules/…` is refused with the new pattern and passes without it.
Mutation and restore in the same script, so a timeout cannot leave the mutation
in the tree.

⚠️ Known limit, not fixed here: this gate reads only the `^+` lines of the
staged diff. A leak that predates the gate is invisible to it for life. A
sweep mode over the existing tree is a separate change.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>