### PR TITLE
revert(ci): le curseur de conformance revient au niveau du moteur

### DIFF
--- a/SPEC_PIN
+++ b/SPEC_PIN
@@ -1,4 +1,4 @@
 # The nika-spec commit this repo's conformance fixtures + CI are proven at.
 # Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI
 # tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.
-4aab5d8bcac4ba92c69deed8b9e2847729a592ab
+16bedd0a386edced5b9c4bbb87e044d2d2e66ff3

--- a/estate.yaml
+++ b/estate.yaml
@@ -67,7 +67,7 @@ files:
   note: "ROADMAP.md:98 carries the same refresh-status.sh AUTO-GENERATED status block — a tool-maintained block inside an authored file"
 - path: "SPEC_PIN"
   class: authored-pin
-  sha256: 0eaa9307fbe0bf7b23a4e51010d35a648fe4f32ab0e08493b65ed9f15bba8bab
+  sha256: ba4a50a97bfeb354ff1c558e08e07245c1e4ae35233ade469e296f7b6ccd1527
   evidence: "its own header: 'Advanced by .github/workflows/spec-pin-heal.yml (PR-only · the Diamond CI tests leg judges at the new pin). Consumed by diamond-ci.yml. Never HEAD.'"
 - path: "crates/nika-catalog/data/model-pricing.toml"
   class: generated


### PR DESCRIPTION
`main` is red on `rust (tests)`. This puts `SPEC_PIN` back to `16bedd0a` — the
last point the engine actually implements — and reverts #904.

## What the pin had jumped over

`16bedd0a..4aab5d8b` is **44 commits, 532 conformance files**, and the range
**contains the envelope freeze itself** (`d20b139` — the envelope drops from 13
keys to 9, `nika:` carries the identity). The engine does not implement it yet,
hence **240 failures, all `NIKA-PARSE-003`**: the fixtures speak the new
language, the parser still wants the old one.

Not an arbitrary rollback — it puts the exam back at the student's level. The
pin moves forward again once the engine has caught up, and *that* advance will
prove something.

## Why nobody caught #904 — the guard could not fire

#904 is a **bot PR** (`app/github-actions`, from `spec-pin-heal.yml`, daily
cron 06:51). The bot runs no verification. Its own header states that the
Diamond CI, with fixtures checked out at the new pin, judges.

That judgement never happened and **could not** happen. GitHub's docs are
explicit: *"when using the repository's `GITHUB_TOKEN` to perform tasks, events
triggered by this token will generally not create new workflow runs"*
(anti-recursion). #904's rollup carries three checks — semgrep and two CodeQL.
**Zero Rust jobs.** The CI cannot judge the PR that changes what it judges
against.

The guard was decorative from day one, and its prose claimed the opposite. I
merged it reading a green that covered nothing.

## Sequence, for the record

```
12:10  8b94624e  a docs commit        success
12:21  f2745280  SPEC_PIN, 2 lines    CANCELLED
12:25  a0debc35  a docs commit        failure
```

The middle commit is the one that breaks. Its run was cancelled 4 minutes later
by the next merge, so the red surfaced on a docs commit that cannot break a Rust
suite.

## What this does NOT fix

The cron fires again tomorrow at 06:51 and will re-advance the pin. The chosen
remedy is for the bot to **run the conformance suite itself before opening the
PR** — no secret, no widened permission; it judges instead of delegating to a
judge that never comes. Separate PR.

Companion, also separate: `diamond-ci.yml`'s `concurrency` block, which
cancelled `f2745280`'s run.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>