### PR TITLE
ci: sur main chaque commit est son propre sujet, on ne l annule pas

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -12,7 +12,20 @@ on:
 
 concurrency:
   group: diamond-${{ github.ref }}
-  cancel-in-progress: true
+  # On a branch the next run REPLACES the previous one — cancelling saves
+  # minutes and loses nothing. On main every commit is its own subject and
+  # must be judged before it is replaced. With a constant `github.ref`, two
+  # merges close together share one group and the first is cancelled unjudged,
+  # so a commit that breaks the build can go unmeasured while the RED surfaces
+  # on the next commit, usually innocent. Measured 2026-08-13: a two-line
+  # SPEC_PIN bump had its run cancelled 4 minutes later; the failure appeared
+  # on a docs commit, which cannot break a Rust suite.
+  # An expression is supported here (GitHub's actions-group-concurrency docs
+  # ship the `release/` example); a path filter is NOT — `concurrency` is
+  # evaluated at workflow level, before any job, with no changed-file context.
+  # No injection surface: this value is compared, never interpolated into a
+  # `run:` shell.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 9b78c1aa438a98695a00440cd30719d6f1a5e9038257794a9743034fa3687d5e
+  aggregate_sha256: d71fd4f4384b3915083f790e3ab807074209679c5355903d835baf15d26bfc8b
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
On 2026-08-13 `main` went red on `rust (tests)` and the dashboard named the
wrong commit:

```
12:10  8b94624e  a docs commit                success
12:21  f2745280  SPEC_PIN, 2 lines            CANCELLED
12:25  a0debc35  a docs commit                failure
```

The middle one is what breaks — it moves the reference the conformance suites
judge against. Its run was cancelled 4 minutes later by the next merge, so the
red surfaced on a docs commit, which cannot break a Rust suite.

Structural, not accidental: on `push: main`, `github.ref` is constant, so every
commit shares one concurrency group and each merge cancels the previous run
whatever it contains.

## The property this encodes

On a branch the next run **replaces** the previous one — cancelling saves
minutes and loses nothing. On `main` **every commit is its own subject and must
be judged before it is replaced.**

## Form rejected, and why

A path exemption (SPEC_PIN, canon, estate) would be narrower but it is **not
expressible**: `concurrency` is evaluated at workflow level, before any job,
with no changed-file context. Measured, not assumed.

An expression, however, is supported — GitHub's `actions-group-concurrency`
docs ship the `!contains(github.ref, 'release/')` example. No injection surface
here: the value is compared, never interpolated into a `run:` shell.

## Proof, which can only be run after merge

Push two commits a few seconds apart on `main` and check that **both** runs
conclude. If the first is still cancelled, the expression was not evaluated the
way we think.

Companions: #910 (the pin returns to what the engine implements) and the
spec-pin bot learning to judge itself.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>