### PR TITLE
ci: le bot de curseur se juge lui-meme avant d ouvrir

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -12,7 +12,20 @@ on:
 
 concurrency:
   group: diamond-${{ github.ref }}
-  cancel-in-progress: true
+  # On a branch the next run REPLACES the previous one — cancelling saves
+  # minutes and loses nothing. On main every commit is its own subject and
+  # must be judged before it is replaced. With a constant `github.ref`, two
+  # merges close together share one group and the first is cancelled unjudged,
+  # so a commit that breaks the build can go unmeasured while the RED surfaces
+  # on the next commit, usually innocent. Measured 2026-08-13: a two-line
+  # SPEC_PIN bump had its run cancelled 4 minutes later; the failure appeared
+  # on a docs commit, which cannot break a Rust suite.
+  # An expression is supported here (GitHub's actions-group-concurrency docs
+  # ship the `release/` example); a path filter is NOT — `concurrency` is
+  # evaluated at workflow level, before any job, with no changed-file context.
+  # No injection surface: this value is compared, never interpolated into a
+  # `run:` shell.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/spec-pin-heal.yml
+++ b/.github/workflows/spec-pin-heal.yml
@@ -22,9 +22,20 @@ jobs:
     permissions:
       contents: write # push the heal branch
       pull-requests: write # open the heal PR
-    timeout-minutes: 10
+    # Raised from 10: this job now RUNS the conformance suites before it opens
+    # anything, instead of delegating that to a CI run that never comes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        with:
+          shared-key: diamond
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        with:
+          tool: cargo-nextest
       - name: The pin follows the spec
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,6 +54,26 @@ jobs:
           git add SPEC_PIN
           python3 scripts/estate.py --write   # the manifest rides the heal (staged files first — estate.py reads the INDEX)
           git add estate.yaml
+
+          # THE JOB JUDGES ITSELF — it used to delegate to a judge that never came.
+          # This body previously ended by opening a PR that said "the Diamond CI
+          # conformance leg judges at the new pin; merge on green". That judgement
+          # was impossible: GitHub does not start workflow runs from events raised
+          # with the repository's GITHUB_TOKEN (anti-recursion), so a bot PR carries
+          # no Rust job at all. On 2026-08-13 one such PR advanced the pin ACROSS
+          # the envelope freeze and reddened main with 240 NIKA-PARSE-003 — its
+          # rollup held three checks, none of them Rust.
+          # Scope: the whole `nika-check` crate, NOT a hand-listed set of suite
+          # names. A list would go stale the day a fourth conformance suite lands,
+          # and a guard that names its subjects is a guard that misses the next one.
+          git -C ../spec checkout --detach "$head"
+          echo "::group::conformance at the candidate pin"
+          if ! NIKA_SPEC_DIR="$PWD/../spec" cargo nextest run -p nika-check --no-fail-fast; then
+            echo "::endgroup::"
+            echo "::error::the engine does not implement spec $head — pin NOT advanced, no PR opened"
+            exit 1   # loud, not silent: a red cron run is the signal a human sees
+          fi
+          echo "::endgroup::"
           git config user.name "nika-release[bot]"
           git config user.email "nika@supernovae.studio"
           git checkout -B bot/spec-pin

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 9b78c1aa438a98695a00440cd30719d6f1a5e9038257794a9743034fa3687d5e
+  aggregate_sha256: f0060e94f1b90213d905e76e1c908b19bada7af87e76344122ccf9c0550b27dc
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
`spec-pin-heal` advanced `SPEC_PIN` and opened a PR saying *"the Diamond CI
conformance leg judges at the new pin; merge on green."*

**That judgement was impossible.** GitHub does not start workflow runs from
events raised with the repository's `GITHUB_TOKEN` — anti-recursion, documented
explicitly. So a bot PR carries **no Rust job at all**. Verified on #904: its
rollup holds three checks, semgrep and two CodeQL. Zero Rust.

The guard was **decorative from day one, and its prose claimed the opposite**.
On 2026-08-13 it advanced the pin across the envelope freeze and reddened `main`
with 240 `NIKA-PARSE-003`.

## What this changes

The job now **runs the conformance suites at the candidate pin**, before any
push and before any PR. On failure: no PR at all, and a **non-zero exit** so the
cron run goes red and a human sees it. A silent `exit 0` would have been a
second decorative guard.

**Scope: the whole `nika-check` crate, not a hand-listed set of suite names.**
A list goes stale the day a fourth conformance suite lands — a guard that names
its subjects is a guard that misses the next one.

Cost: toolchain, shared cache and nextest added to the job, timeout 10 → 30. The
cache is Diamond CI's own (`shared-key: diamond`), so most dependencies are warm.

## How to prove it

Run it by hand (`workflow_dispatch`) while `main` still carries the old engine
and the spec is ahead: the job must go **red and open nothing**. Today's state
is exactly that fixture — which is why it is worth firing before #910 merges.

Companions: #910 (the pin returns to what the engine implements) and #911 (no
cancelling on `main`).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>