### PR TITLE
ci: les deux autres voies de re-vendorisation se jugent elles-memes

### DIFF
--- a/.github/workflows/clients-resync.yml
+++ b/.github/workflows/clients-resync.yml
@@ -9,8 +9,11 @@ name: clients-resync
 # happen to sit beside the checkout; it blocked two unrelated engine
 # pushes 2026-07-31). The assertion is gone from cargo test; the drift
 # surfaces here instead. Daily: clone nika-plugins@main, re-vendor, open
-# ONE idempotent PR on drift — Diamond CI (the vendored-bytes tests
-# included) judges the new snapshot, never a direct push.
+# ONE idempotent PR on drift — never a direct push. The job RUNS
+# `nika-cli-host`'s own tests before it opens anything (see the guard
+# below): a bot PR carries no Rust job, so delegating that judgement to
+# CI would delegate it to nobody — the wrong-judge class this lane was
+# created to escape, landed on again one layer out.
 # SECURITY: no github.event data reaches the shell.
 
 on:
@@ -27,9 +30,20 @@ jobs:
     permissions:
       contents: write # push the heal branch
       pull-requests: write # open the heal PR
-    timeout-minutes: 10
+    # Raised from 10: this job now RUNS its own tests before it opens
+    # anything, instead of delegating to a CI run that never comes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        with:
+          shared-key: diamond
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        with:
+          tool: cargo-nextest
       - name: The vendored matrix follows the agents SSOT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,6 +55,24 @@ jobs:
           if git diff --cached --quiet; then echo "matrix current — nothing to resync"; exit 0; fi
           python3 scripts/estate.py --write   # the manifest rides the heal (staged files first — estate.py reads the INDEX)
           git add estate.yaml
+
+          # THE JOB JUDGES ITSELF — the header above promised "Diamond CI (the
+          # vendored-bytes tests included) judges". That judgement cannot
+          # happen: GitHub does not start workflow runs from events raised with
+          # the repository's GITHUB_TOKEN (anti-recursion), so a bot PR carries
+          # no Rust job. Note the irony this lane already documents: the drift
+          # check was MOVED here from a unit test to escape the wrong-judge
+          # class, and landed on a judge that never shows up.
+          # Scope: the whole `nika-cli-host` crate (it owns the vendored file
+          # written just above), not a list of test names — a list goes stale
+          # the day a fourth test lands.
+          echo "::group::the vendored matrix at the candidate snapshot"
+          if ! cargo nextest run -p nika-cli-host --no-fail-fast; then
+            echo "::endgroup::"
+            echo "::error::the vendored matrix does not pass its own tests — NOT vendored, no PR opened"
+            exit 1   # loud, not silent: a red cron run is the signal a human sees
+          fi
+          echo "::endgroup::"
           git config user.name "nika-release[bot]"
           git config user.email "nika@supernovae.studio"
           git checkout -B bot/clients-resync

--- a/.github/workflows/pack-resync.yml
+++ b/.github/workflows/pack-resync.yml
@@ -5,8 +5,10 @@ name: pack-resync
 # sweep (2026-07-13) materialized it and found the pack ALREADY stale in
 # two files the coherence bot's canon-hash probe was blind to. Daily:
 # clone spec@main, run the ONE vendoring lane, open ONE idempotent PR on
-# drift — the 12-gate CI (pack integrity tests included) judges, never a
-# direct push. SECURITY: no github.event data reaches the shell.
+# drift — never a direct push. The job RUNS `nika-pack`'s own tests before
+# it opens anything (see the guard below): a bot PR carries no Rust job, so
+# delegating that judgement to CI would delegate it to nobody.
+# SECURITY: no github.event data reaches the shell.
 
 on:
   schedule:
@@ -22,9 +24,20 @@ jobs:
     permissions:
       contents: write # push the heal branch
       pull-requests: write # open the heal PR
-    timeout-minutes: 10
+    # Raised from 10: this job now RUNS its own tests before it opens
+    # anything, instead of delegating to a CI run that never comes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        with:
+          shared-key: diamond
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
+        with:
+          tool: cargo-nextest
       - name: The pack follows the spec
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,6 +49,24 @@ jobs:
           if git diff --cached --quiet; then echo "pack current — nothing to resync"; exit 0; fi
           python3 scripts/estate.py --write   # the manifest rides the heal (staged files first — estate.py reads the INDEX)
           git add estate.yaml
+
+          # THE JOB JUDGES ITSELF — the header above promised "the 12-gate CI
+          # (pack integrity tests included) judges". That judgement cannot
+          # happen: GitHub does not start workflow runs from events raised with
+          # the repository's GITHUB_TOKEN (anti-recursion), so a bot PR carries
+          # no Rust job. Measured 2026-08-13 on the sibling spec-pin lane: PR
+          # #904 held three checks (semgrep + 2 CodeQL), advanced the pin across
+          # an engine-breaking spec change, and reddened main with 240 failures.
+          # Scope: the whole `nika-pack` crate, not a list of test names — the
+          # list goes stale the day a fourth pack test lands, and a guard that
+          # names its subjects is a guard that misses the next one.
+          echo "::group::pack integrity at the candidate vendoring"
+          if ! cargo nextest run -p nika-pack --no-fail-fast; then
+            echo "::endgroup::"
+            echo "::error::the vendored pack does not pass its own tests — NOT vendored, no PR opened"
+            exit 1   # loud, not silent: a red cron run is the signal a human sees
+          fi
+          echo "::endgroup::"
           git config user.name "nika-release[bot]"
           git config user.email "nika@supernovae.studio"
           git checkout -B bot/pack-resync

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: f0060e94f1b90213d905e76e1c908b19bada7af87e76344122ccf9c0550b27dc
+  aggregate_sha256: 6ba0cf666b025dd17963ba19b9a9d31e3ffbff55080dd1dfe58b3359c4d5427b
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
`pack-resync` and `clients-resync` carried **the same false promise as
`spec-pin-heal`**, in their own headers:

| lane | header claim |
|---|---|
| `pack-resync` | *"the 12-gate CI (pack integrity tests included) judges"* |
| `clients-resync` | *"Diamond CI (the vendored-bytes tests included) judges"* |

**That judgement is impossible.** GitHub does not start workflow runs from
events raised with the repository's `GITHUB_TOKEN` (anti-recursion, documented
explicitly), so a bot PR carries no Rust job.

Measured 2026-08-13 on the sibling lane: PR #904 held **three checks** (semgrep
+ 2 CodeQL), advanced the conformance pin **across a change the engine does not
implement**, and reddened `main` with 240 failures. Its verification run on
`main` was then cancelled by the next merge, so the red surfaced on an innocent
docs commit.

## What this does

Each job now **runs the tests of the crate it vendors**, before any push and
before any PR. On failure: no PR at all, and a **non-zero exit** so the cron run
goes red and a human sees it.

| lane | writes | judged by |
|---|---|---|
| `pack-resync` | `crates/nika-pack/pack` | `nika-pack` |
| `clients-resync` | `crates/nika-cli-host/data/clients.registry.yaml` | `nika-cli-host` |

**Scope: the whole crate, never a list of test names.** A list goes stale the
day a fourth test lands — a guard that names its subjects is a guard that misses
the next one.

## The headers are corrected too, not just the code

Leaving the false promise at the top of the file and contradicting it thirty
lines down builds two surfaces that diverge. Both headers now state what the job
does.

An irony `clients-resync` already documented in its own header: its drift check
was **moved here from a unit test to escape the wrong-judge class** — and landed
on a judge that never shows up.

## Proof

The same guard, on the sibling lane, was proven on the wire: run `31738556119`
concluded `failure` with `the engine does not implement spec e6ab9793 — pin NOT
advanced, no PR opened`, and `bot/spec-pin` was **absent before and after**.
These two guards sit at the same point in the sequence — before `git checkout
-B`, before `git push`, before `gh pr create`.

Companion already on `main`: #912.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>