### PR TITLE
fix(hygiene): le sceau des ADR derive sa portee au lieu de la taper

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 4f110974fecc1ca01fe3c2faca8d40648d8a0faf8dbee51e4947136261b550ad
+  aggregate_sha256: 94f8becbbcadc814f092d36429f13100f2c32418888e3540564da7ab8d0f71b2
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/hooks/adr-seal-check.sh
+++ b/scripts/hooks/adr-seal-check.sh
@@ -20,8 +20,41 @@
 set -uo pipefail
 
 readonly CONTEXT="${1:-post-merge}"
-readonly ADR_PATTERN='docs/adr/ADR-0(0[1-9]|1[0-5])'
-readonly SEALED_COUNT=15
+
+# The scope DERIVES, it is never typed.
+#
+# Until 2026-08-13 this read:
+#   ADR_PATTERN='docs/adr/ADR-0(0[1-9]|1[0-5])'   SEALED_COUNT=15
+# Two hand-typed constants, and the guard had never warned once. Measured:
+#   the uppercase pattern matched  0  of the 73 tracked ADR files
+#   the same pattern in lowercase  15 — exactly SEALED_COUNT
+# The files are named `adr-001-…md`. The guard was written for a spelling
+# that does not exist here, so it protected nothing, ever — a gate whose
+# own prose claimed a seal it could not enforce.
+#
+# The range was wrong too, independently: 59 ADRs carry `Accepted` today,
+# not 15. Both defects have one cause — a scope typed once instead of read
+# from the thing it describes. So the pattern now matches ANY ADR file
+# (either spelling), and `sealed_only` keeps the ones whose own Status says
+# Accepted. Adding an ADR, accepting one, or renaming the directory's case
+# cannot silence this guard again.
+readonly ADR_PATTERN='docs/adr/[Aa][Dd][Rr]-[0-9]{3}-'
+
+# Read the seal from each file rather than from a number kept in this script.
+sealed_only() {
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    # The file may be gone (a deletion is still a modification worth naming).
+    [[ -f "$f" ]] || {
+      printf '%s\n' "$f"
+      continue
+    }
+    grep -qiE '^[[:space:]]*(\*\*)?status(\*\*)?[[:space:]]*:?.*accepted' "$f" \
+      && printf '%s\n' "$f"
+  done
+  return 0
+}
 
 warn_adr_modified() {
   local files="$1"
@@ -29,7 +62,7 @@ warn_adr_modified() {
   printf '╔══════════════════════════════════════════════════════════╗\n' >&2
   printf '║  [adr-seal-check] WARNING: SEALED ADR MODIFIED          ║\n' >&2
   printf '╚══════════════════════════════════════════════════════════╝\n' >&2
-  printf '\nADR-001..%03d are SEALED (Accepted status). Modified:\n' "$SEALED_COUNT" >&2
+  printf '\nThese ADRs carry Status: Accepted — they are SEALED. Modified:\n' >&2
   printf '  %s\n' "$files" >&2
   printf '\nIf this was intentional (rare — architecture reversal):\n' >&2
   printf '  1. Create a new ADR-NNN superseding the old one\n' >&2
@@ -44,7 +77,7 @@ case "$CONTEXT" in
       exit 0 # No ORIG_HEAD (first commit, initial clone, etc.)
     fi
     MODIFIED="$(git diff --name-only ORIG_HEAD..HEAD 2>/dev/null \
-      | grep -E "$ADR_PATTERN" || true)"
+      | grep -E "$ADR_PATTERN" | sealed_only || true)"
     if [[ -n "$MODIFIED" ]]; then
       warn_adr_modified "$MODIFIED"
     fi
@@ -58,7 +91,7 @@ case "$CONTEXT" in
       if git diff --name-only "${old_sha}..${new_sha}" 2>/dev/null \
         | grep -qE "$ADR_PATTERN"; then
         MODIFIED="${MODIFIED}$(git diff --name-only "${old_sha}..${new_sha}" 2>/dev/null \
-          | grep -E "$ADR_PATTERN")"$'\n'
+          | grep -E "$ADR_PATTERN" | sealed_only)"$'\n'
       fi
     done
     if [[ -n "$MODIFIED" ]]; then


### PR DESCRIPTION
`adr-seal-check` guards the sealed architecture decisions. **It had never warned
once.** Measured:

```
pattern in the file   docs/adr/ADR-0(0[1-9]|1[0-5])   matches   0  of 73 tracked ADRs
the same in lowercase                                 matches  15  = SEALED_COUNT
```

The files are named `adr-001-….md`. The guard was written for a spelling that
does not exist here, so it protected nothing, ever — while printing a banner
announcing a seal it could not enforce.

The scope was wrong a second time, independently: **59 ADRs carry
`Status: Accepted` today, not 15.**

## One cause for both

A scope **typed once** instead of **read from the thing it describes**. The
pattern now matches any ADR file (either spelling), and `sealed_only` keeps the
ones whose own `Status` says Accepted. Adding an ADR, accepting one, or changing
the directory's case cannot silence this guard again.

## Proof by mutation, with a negative control

Inside the guard's declared domain (`post-merge`, `ORIG_HEAD..HEAD`). The old
guard is extracted from `main` and fired **side by side** with the new one on the
same fixture — without that, a new guard speaking proves only that the fixture is
loud. Fixture and teardown in the same script, so a timeout cannot leave the
fixture behind.

| | |
|---|---|
| **old** guard · sealed ADR modified | **MUTE** ← the defect |
| **new** guard · sealed ADR modified | **SPEAKS** ← repaired |
| **new** guard · non-sealed ADR modified | **MUTE** ← no false positive |

Re-run after `shfmt -w` reformatted the file: all three still hold.

## Scope of the change

The guard stays advisory (`exit 0` — a post-hook cannot undo a completed
operation). That is unchanged and deliberate. But a warning that never speaks is
worse than an absent one: it occupies the slot.

Third dead guard found tonight, after `spec-pin-heal` (#912) and the two
re-vendoring lanes (#913). All three announced in their own prose a protection
they could not exercise.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>