### PR TITLE
fix(hygiene): estate acquiert une prise locale

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: 002375a46669f3ce6db509375d59ab4ae1acafbb8580608cbca23e20ea2d515f
+  aggregate_sha256: d47c19e2cc82aaed19648277dc9c7f97d41acddb59ab7bd5ccc57f27f21c1a37
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: d47c19e2cc82aaed19648277dc9c7f97d41acddb59ab7bd5ccc57f27f21c1a37
+  aggregate_sha256: 6d24cad8e56fbd7a4440e86da23bf7903fee6221d07c11fdcd61ec844c59691b
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -59,6 +59,19 @@ pre-commit:
       glob: '**/*.sh'
       run: shfmt -d -i 2 -ci -bn {staged_files}
 
+    # estate.yaml hache l arbre suivi. Rien en local ne le controlait, alors
+    # que la CI le fait : chaque oubli coutait un push et une attente de CI.
+    # Mesure du 2026-08-13 · QUATRE allers-retours en une soiree, et la
+    # quatrieme fois la cause etait subtile — l inventaire avait bien ete
+    # regenere, puis `shfmt -w` a reformate le fichier APRES, l invalidant.
+    # Le bon moment n est donc pas « quand on y pense » mais « apres le
+    # dernier formatage » : un hook le sait, un humain non.
+    # --check, jamais --write : un hook qui REPARE en silence cache la derive
+    # au lieu de l apprendre, et il ecrirait un fichier que personne n a relu.
+    estate-manifest:
+      run: python3 scripts/estate.py --check
+      fail_text: 'estate.yaml diverge de l arbre suivi. Lancer: python3 scripts/estate.py --write puis rejouer le commit.'
+
     block-private-paths:
       run: bash scripts/hooks/block-private-paths.sh
       fail_text: 'Private path reference in public engine files. Engine is PUBLIC.'

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -59,18 +59,21 @@ pre-commit:
       glob: '**/*.sh'
       run: shfmt -d -i 2 -ci -bn {staged_files}
 
-    # estate.yaml hache l arbre suivi. Rien en local ne le controlait, alors
-    # que la CI le fait : chaque oubli coutait un push et une attente de CI.
-    # Mesure du 2026-08-13 · QUATRE allers-retours en une soiree, et la
-    # quatrieme fois la cause etait subtile — l inventaire avait bien ete
-    # regenere, puis `shfmt -w` a reformate le fichier APRES, l invalidant.
-    # Le bon moment n est donc pas « quand on y pense » mais « apres le
-    # dernier formatage » : un hook le sait, un humain non.
-    # --check, jamais --write : un hook qui REPARE en silence cache la derive
-    # au lieu de l apprendre, et il ecrirait un fichier que personne n a relu.
+    # estate.yaml hashes the tracked tree. CI checks it; nothing local did, so
+    # every miss surfaced only after a push and a CI wait.
+    # Measured 2026-08-13: FOUR round-trips in one evening. The fourth cause was
+    # subtle — the manifest HAD been regenerated, then `shfmt -w` reformatted the
+    # file afterwards and invalidated it. So the right moment is not "when you
+    # think of it", it is "after the last reformatting": a hook knows that, a
+    # human does not.
+    # `--check`, never `--write`: a hook that silently repairs hides the drift
+    # instead of teaching it, and would write a file nobody reviewed.
+    # Order matters — estate.py reads the INDEX: stage the file, THEN derive,
+    # THEN stage the manifest. This hook caught that very mistake on the commit
+    # that installs it, in 0.16 s.
     estate-manifest:
       run: python3 scripts/estate.py --check
-      fail_text: 'estate.yaml diverge de l arbre suivi. Lancer: python3 scripts/estate.py --write puis rejouer le commit.'
+      fail_text: 'estate.yaml diverges from the tracked tree. Run: git add <file> && python3 scripts/estate.py --write && git add estate.yaml (estate.py reads the INDEX, so stage first).'
 
     block-private-paths:
       run: bash scripts/hooks/block-private-paths.sh


### PR DESCRIPTION
`estate.yaml` hashes the tracked tree. CI checks it; **nothing local did** — so
every miss was discovered after a push and a CI wait.

**Measured: four round-trips in one evening** (2026-08-13), same cause each time.

## The fourth one is why a vigilance remedy cannot work

The manifest **had** been regenerated — then `shfmt -w` reformatted the file
**afterwards**, invalidating it. So the right moment is not *"when you think of
it"*, it is *"after the last reformatting"*. A hook knows that; a human does not.

## `--check`, never `--write`

A hook that silently repairs hides the drift instead of teaching it, and writes
a file nobody reviewed. This one refuses and **names the command to run**.
Measured cost: **0.30 s**.

## Proof by mutation, through lefthook — not just against the script

```
lefthook run pre-commit --command estate-manifest --force
  broken manifest   rc=1   the hook REFUSES
  healthy manifest  rc=0   the hook passes
```

Mutation and restore in the same script, so a timeout cannot leave the mutation
in the tree.

## It proved itself on its own author, before this PR existed

The commit that installs this hook was **blocked by it** — I had run
`estate.py --write` *before* staging `lefthook.yml`, and the tool reads the
**index**, not the worktree. Fifth instance of the same class tonight, and the
first one that cost **0.16 s** instead of a CI round-trip. Correct order:
stage, then derive, then stage the manifest.

⚠️ Method note, worth keeping: my first probe used `--commands` (plural), a flag
that does not exist. **Both arms returned 1** — indistinguishable from a test
that finds no difference. A differential whose two arms coincide has measured
nothing.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>