### PR TITLE
fix(hygiene): a ratchet that cannot prove itself must not print a green

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 4f110974fecc1ca01fe3c2faca8d40648d8a0faf8dbee51e4947136261b550ad
+  aggregate_sha256: 6faa1c08418fe9ab51d7f2fd82015bced00e79a57d76683ca6d461d4ca97d5d0
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/ci/_lib.sh
+++ b/scripts/ci/_lib.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 # Shared helpers for diamond CI ratchets.
 # Source, do not execute.
-
-set -euo pipefail
+#
+# This file deliberately sets NO shell options. It is sourced, so `set -euo
+# pipefail` here does not configure this library — it reconfigures the
+# CALLER, at source time, overwriting the options the caller chose a few
+# lines above. Six hygiene vectors declare `set -uo pipefail` with errexit
+# OFF on purpose (they accumulate findings across greps and tools that
+# return non-zero as their normal way of saying "found something"), and
+# every one of them had errexit forced back on by this line.
+#
+# The damage is not a crash, it is a DOWNGRADE. The script dies at the first
+# command that reports a finding, so the `if [ "$red" -ne 0 ]; then echo
+# "...FAILED:"; exit 2; fi` block below it becomes unreachable code and a red
+# verdict surfaces as a bare, unlabelled non-zero. check-gate5-attestation.sh
+# had already found this and re-disabled errexit by hand — one net, in one of
+# six places that needed it.
+#
+# Every caller sets its own options before sourcing this file. Keep it so.
 
 # The filter below decides what four ratchets are allowed to SEE, so it
 # proves itself honest before any of them reads a verdict from it. A
@@ -20,7 +35,16 @@ set -euo pipefail
 _lib_prove_filter() {
   local selftest="${BASH_SOURCE[0]%/*}/test-strip-test-items.sh"
   [ -n "${NIKA_SKIP_FILTER_SELFTEST:-}" ] && return 0
-  [ -x "$selftest" ] || return 0
+  # Fail CLOSED. This read `[ -x "$selftest" ] || return 0`, which skipped the
+  # proof and reported success when the self-test was absent OR merely not
+  # executable — so `chmod -x` on one file disarmed four ratchets at once and
+  # they carried on printing OK. It also tested the wrong bit: the self-test is
+  # run as `bash "$selftest"` below, an invocation that never needs +x. A guard
+  # that cannot prove itself must refuse to render a verdict, not emit a green.
+  if [ ! -f "$selftest" ]; then
+    printf 'FAIL  the shared test-item filter has no self-test at %s — this ratchet cannot be trusted\n' "$selftest" >&2
+    exit 2
+  fi
   if ! NIKA_SKIP_FILTER_SELFTEST=1 bash "$selftest" >/dev/null 2>&1; then
     printf 'FAIL  the shared test-item filter is not honest — this ratchet cannot be trusted:\n' >&2
     NIKA_SKIP_FILTER_SELFTEST=1 bash "$selftest" >&2 || true

--- a/scripts/hygiene/check-gate5-attestation.sh
+++ b/scripts/hygiene/check-gate5-attestation.sh
@@ -25,6 +25,9 @@
 #
 # Exit: 0 green (no admitted crate defers Gate 5) · 1 yellow (some do · listed ·
 # informational ratchet, does NOT gate the push) · 2 red (reserved · unused).
+#
+# errexit stays OFF on purpose: this warn-tier vector tolerates the non-zero
+# greps below (a crate with no Gate-5 row is a normal, handled case).
 set -uo pipefail
 
 ENGINE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -32,9 +35,6 @@ cd "$ENGINE_ROOT" || exit 2
 
 # shellcheck source=scripts/ci/_lib.sh
 . "$ENGINE_ROOT/scripts/ci/_lib.sh"
-# _lib.sh sets `-e`; re-disable it — this warn-tier vector tolerates the
-# non-zero greps (a crate with no Gate-5 row is a normal, handled case).
-set +e
 
 deferred=""
 attested_n=0


### PR DESCRIPTION
`scripts/ci/_lib.sh` is sourced by **13 guards**. It carried two defects, and both failed open.

## 1 · The filter honesty proof failed open

```bash
[ -x "$selftest" ] || return 0
```

`strip_test_items` decides what four ratchets are allowed to *see* — `.unwrap()`, `.expect(`, dead-code, error-one-voice. The self-test exists because a broken filter does not make a gate fail, it makes a gate **pass quietly** (proven 2026-08-02: one brace in a string blanked whole files).

That line skipped the proof and returned **success** when the self-test was absent *or merely not executable*. One mode bit disarmed four ratchets at once.

It also tested the wrong bit: the self-test is invoked as `bash "$selftest"`, which never needs `+x`. The test and the use disagreed.

### Proof — OLD vs NEW, same fixture

A real production `.unwrap()` planted in `crates/demo/src/lib.rs`; the filter sabotaged into the 2026-08-02 shape:

| fixture | OLD rc | OLD says | NEW rc |
|---|---|---|---|
| self-test present + exec | 2 | FAIL, filter not honest | 2 |
| self-test `chmod -x` | **0** | **`OK  zero .unwrap()`** | **2** |
| self-test deleted | **0** | **`OK  zero .unwrap()`** | **2** |

Rows 2 and 3 are green verdicts issued with a real `.unwrap()` sitting in the tree.

### Negative controls — both arms agree

| fixture | OLD rc | NEW rc | |
|---|---|---|---|
| honest filter + real `.unwrap()` | 1 | 1 | it is found |
| honest filter + clean source | 0 | 0 | no false alarm |

rc values 0, 1 and 2 all appear, so the probe discriminates.

## 2 · `set -euo pipefail` reconfigured the caller

Line 5 ran at **source** time, so it set errexit in the **caller's** shell — overwriting the options the caller chose a few lines above.

All **six** `scripts/hygiene/` consumers declare `set -uo pipefail`, errexit off deliberately (they accumulate findings across greps and tools that return non-zero as their normal way of saying "found something"), and every one sources `_lib.sh` six lines later:

| consumer | own `set` | source |
|---|---|---|
| check-adr-081-guards.sh | `set -uo pipefail` (L29) | L35 |
| check-error-one-voice.sh | `set -uo pipefail` (L25) | L31 |
| check-gate5-attestation.sh | `set -uo pipefail` (L28) | L34 |
| check-public-api-coverage.sh | `set -uo pipefail` (L31) | L37 |
| check-seam-discipline.sh | `set -uo pipefail` (L50) | L57 |
| check-unused-deps.sh | `set -uo pipefail` (L17) | L23 |

The damage is a **downgrade, not a crash**. Each of the six has the shape:

```bash
...accumulate findings...
if [ "$red" -ne 0 ]; then echo "... FAILED:"; exit 2; fi
echo "OK ..."; exit 0
```

With errexit forced on, the script dies at the first command that *reports a finding*, so the `exit 2` red verdict is unreachable code and the failure surfaces as a bare, unlabelled non-zero.

### Proof — the real guard, `check-unused-deps.sh`

`out="$(cargo machete 2>&1)"; status=$?` — machete exits 1 **exactly when it finds unused deps**, so under errexit the assignment kills the script and `status=$?` is never reached. Measured with `cargo` shimmed (nothing compiles):

| fixture | OLD | NEW |
|---|---|---|
| machete finds an unused dep | rc=1, **output empty** | rc=2, names the offending crate |
| machete clean | rc=0 | rc=0 |

The OLD arm printing *nothing* is the whole finding: red degraded to a mute yellow.

### This was already discovered once

`check-gate5-attestation.sh` carried a hand-written workaround:

```bash
. "$ENGINE_ROOT/scripts/ci/_lib.sh"
# _lib.sh sets `-e`; re-disable it — this warn-tier vector tolerates the
# non-zero greps (a crate with no Gate-5 row is a normal, handled case).
set +e
```

One net, in one of the six places that needed it. This PR removes it — and its comment, which the fix would otherwise have turned into a false statement — and keeps the rationale on the script's own `set -uo pipefail`.

## Regression

All 13 consumers run against the **real tree**, OLD vs NEW, same worktree:

**Identical rc on all 13. No verdict flipped.** (12 green, plus `check-adr-081-guards` at its pre-existing yellow rc=1 "1 owed at future admission" — same in both arms.)

`shellcheck -x`: clean. `shfmt -d -i 2 -ci -bn` (the exact flags `lefthook.yml` enforces at pre-commit): clean on both files.

## What I did NOT prove

- **The new strictness is deliberate and is a behaviour change**: an absent self-test now blocks all 13 consumers where before it blocked none. I did not test a sparse or partial checkout that ships `scripts/ci/` without its self-test.
- I did **not** run the workspace test battery — only the guards themselves. This change touches no Rust.
- I did not verify the six `scripts/ci/` consumers are unaffected by argument; they set their own `set -euo pipefail` **before** sourcing, so removing the line cannot change them — and the 13-consumer regression confirms it empirically.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
