### PR TITLE
fix(security): the private-path gate matches a shape, not an inventory

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4380
+  classified_files: 4381
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1449
+    authored: 1450
     authored-pin: 2
     generated: 118
     pinned-copy: 115
@@ -182,8 +182,8 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 138
-  aggregate_sha256: 4f110974fecc1ca01fe3c2faca8d40648d8a0faf8dbee51e4947136261b550ad
+  match_count: 139
+  aggregate_sha256: ac421b392d248b2ea10d9491f6bebce911ec41cac1259c6d8a1c4e9f316a7031
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/hooks/block-private-paths.sh
+++ b/scripts/hooks/block-private-paths.sh
@@ -5,10 +5,12 @@
 # inside the PUBLIC nika/engine submodule.
 #
 # Blocked path patterns (references, not file locations):
-#   ventures/<name>/0*-*/  — the private venture poles (strategy · brand ·
-#                            revenue · chronicle · internal architecture/docs)
+#   ventures/<name>/…      — every venture tree, EXCEPT the one public tier
+#                            (ventures/nika/02-engineering/repos/, where this
+#                            repo itself lives)
 #   studio/                — cross-product brand · lore · north-star
-#   dx/{.claude,journal,state}/ — the agent substrate + the studio's chronicle
+#   dx/                    — the agent substrate + the studio's chronicle,
+#                            the WHOLE tree, not a list of its children
 #   .claude/projects       — private memory/config
 #   nika/hq/ · *-hq/       — the pre-migration spellings (frozen citations)
 #
@@ -21,59 +23,52 @@
 
 set -Eeuo pipefail
 
-# P0-3 Batch H+: patterns are now plain strings matched via grep -F (fixed
-# strings). The previous `\.claude/projects/` contained a backslash-dot that
-# grep -F treated LITERALLY — so it matched `\.claude/projects/` but NOT the
-# actual path `.claude/projects/`. Plain dot is correct for -F mode.
-# The monorepo moved to `ventures/<name>/<pole>/` and the `hq/` layout
-# died with it. Six of the seven patterns below matched no directory that
-# still exists (2026-08-02), while 63,000 private files sat one rename
-# away, unguarded — a public commit naming a private strategy doc under
-# the venture's product pole sailed straight through.
-# The old spellings STAY: frozen prose keeps its citations forever, so a
-# reference to the pre-migration path is still a leak of the same fact.
-# The private poles are COMPOSED, never spelled out: this file ships in a
-# PUBLIC repo, and a literal `ventures/<v>/0X-<pole>/` here is itself the
-# leak the hook exists to stop. The monorepo's privacy-boundary vector reads
-# raw file content and cannot tell a blocklist from a leak — it flagged the
-# six literals that used to live below. grep -F sees the composed strings
-# byte for byte, so the guard blocks exactly what it blocked before.
-readonly _V='ventures/nika/'
+# Patterns are EXTENDED REGEXES (grep -E), and each one is a SHAPE rather
+# than an inventory. Three times now this list has been an inventory, and
+# three times the tree moved out from under it:
+#
+#   · 2026-08-02 · the monorepo moved to `ventures/<name>/<pole>/` and six
+#     of seven patterns named a directory that no longer existed, while
+#     63,000 private files sat one rename away, unguarded.
+#   · 2026-08-13 · the TIER-2/3 rules moved to `dx/doctrine/` in June; the
+#     list stayed at `dx/.claude/`, guarding a door nobody used any more.
+#   · 2026-08-14 · measured again. `dx/` had NINE children plus three
+#     hidden ones; the list named four, so five private trees had never
+#     been guarded at all. The venture list named FIVE ventures while
+#     SEVEN existed, leaving two whole ventures unguarded. (Counts only —
+#     naming the unguarded children here would be the leak itself.)
+#
+# So neither family is enumerated any more. `dx/` and `studio/` are named
+# at the ROOT — the only spelling a rename inside them cannot invalidate —
+# and the venture tree is matched by its shape below, with the single
+# public tier carved out. That also says LESS in a public file: this hook
+# ships in a PUBLIC repo, and an inventory of private subdirectory names is
+# itself the leak the hook exists to stop.
+#
+# Each pattern is anchored at a path boundary. Unanchored `studio/` matched
+# `lmstudio/` and `~/.cache/lm-studio/` — real, public LM Studio provider
+# paths — so the gate also blocked legitimate work. `[^a-zA-Z0-9._-]` keeps
+# `https://supernovae.studio/` out too, while still matching `/studio/`.
+readonly BOUNDARY='(^|[^a-zA-Z0-9._-])'
 readonly PRIVATE_PATTERNS=(
-  # The 9-pole venture layout — every private pole, for every venture.
-  # (`02-engineering/repos/` is the PUBLIC submodule tier and is not one.)
-  "${_V}01-product/"
-  "${_V}04-identity/"
-  "${_V}06-revenue/"
-  "${_V}07-operations/"
-  "${_V}08-chronicle/"
-  'ventures/nika/02-engineering/architecture/'
-  'ventures/nika/02-engineering/docs/'
-  'ventures/olympus/'
-  'ventures/qrcodeai/'
-  'ventures/rainbo/'
-  'ventures/atlas-seo/'
-  # The studio + the agent substrate.
-  'studio/'
-  'dx/.claude/'
-  # Added 2026-08-13 · the TIER-2/3 rules MOVED from `dx/.claude/rules/` to
-  # `dx/doctrine/rules/` in June, and this list stayed at the old address.
-  # The gate blocked a door nobody used any more while the new one stood open ·
-  # measured the same day, 71 private files behind it, and two public docs in
-  # THIS repo already citing the new path. A blocklist is a projection of a
-  # tree · when the tree moves, the list is stale until someone re-derives it.
-  'dx/doctrine/'
-  'dx/journal/'
-  'dx/state/'
-  '.claude/projects/'
+  # The studio + the agent substrate, at the root.
+  "${BOUNDARY}studio/"
+  "${BOUNDARY}dx/"
+  "${BOUNDARY}\.claude/projects/"
   # The pre-migration spellings — frozen citations still leak the fact.
-  'nika/hq/'
-  'studio-spn/'
-  'jungo/hq/'
-  'novanet/hq/'
-  'qrcodeai/hq/'
-  'supernovae-hq/'
+  "${BOUNDARY}nika/hq/"
+  "${BOUNDARY}studio-spn/"
+  "${BOUNDARY}jungo/hq/"
+  "${BOUNDARY}novanet/hq/"
+  "${BOUNDARY}qrcodeai/hq/"
+  "${BOUNDARY}supernovae-hq/"
 )
+
+# The venture tree, as a shape. Everything under `ventures/<name>/` is
+# private — the 9 poles, for every venture that exists or ever will —
+# EXCEPT the one public tier, which is where this very repo lives.
+readonly VENTURE_SHAPE='ventures/[a-z0-9][a-z0-9-]*/[a-zA-Z0-9._/-]*'
+readonly VENTURE_PUBLIC='^ventures/nika/02-engineering/repos/'
 
 # Get staged files in the engine context (exclude deleted files).
 # Self-exclusion — these directories legitimately enumerate the very patterns
@@ -98,19 +93,34 @@ if ((${#STAGED[@]} == 0)); then
   exit 0
 fi
 
+# Every added line, gathered once. (`^+`, minus the `+++` file headers.)
+ADDED="$(
+  git diff --cached -U0 -- "${STAGED[@]}" 2>/dev/null \
+    | grep '^+' \
+    | grep -v '^+++' \
+    || true
+)"
+
 FOUND=()
 for pattern in "${PRIVATE_PATTERNS[@]}"; do
   while IFS= read -r match; do
     [[ -n "$match" ]] && FOUND+=("$match")
-  done < <(
-    git diff --cached -U0 -- "${STAGED[@]}" 2>/dev/null \
-      | grep '^+' \
-      | grep -v '^+++' \
-      | grep -F "$pattern" \
-      | head -5 \
-      || true
-  )
+  done < <(printf '%s\n' "$ADDED" | grep -E "$pattern" | head -5 || true)
 done
+
+# The venture tree is matched per OCCURRENCE, not per line. A line that
+# names the public repos tier AND a private pole has to be caught for the
+# private half; a line-level `grep -v` would have dropped the whole line on
+# account of the innocent one.
+while IFS= read -r match; do
+  [[ -n "$match" ]] && FOUND+=("$match")
+done < <(
+  printf '%s\n' "$ADDED" \
+    | grep -oE "$VENTURE_SHAPE" \
+    | grep -vE "$VENTURE_PUBLIC" \
+    | head -5 \
+    || true
+)
 
 if ((${#FOUND[@]} > 0)); then
   printf '\n[block-private-paths] BLOCKED — private path reference in staged engine files:\n' >&2

--- a/scripts/hygiene/tests/block-private-paths.test.sh
+++ b/scripts/hygiene/tests/block-private-paths.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Mutation proof for the pre-commit private-path gate.
+#
+# The gate reads `git diff --cached`, so every case here is a real staged
+# change in a throwaway repo: write the line, stage it, run the gate,
+# assert the colour.
+#
+# BOTH directions are pinned, because this gate has failed in both. It
+# missed five private trees under the agent substrate and two whole
+# ventures (an inventory that the tree had moved out from under), while
+# flagging `lmstudio/` — a public provider path — as a leak. A gate that
+# blocks everything is exactly as useless as one that blocks nothing, so
+# the GREEN cases below are not decoration; they are half the proof.
+#
+# No private tree is spelled out here. This file ships in a PUBLIC repo,
+# and an inventory of private names is the very leak the gate exists to
+# stop. Every venture case uses an INVENTED name — which is the stronger
+# proof anyway: the gate matches a shape, so a venture nobody has created
+# yet is covered without editing a line of this file.
+set -uo pipefail
+
+# Git hooks export GIT_DIR, GIT_INDEX_FILE and friends, and vector 49 runs
+# this file from inside the pre-push gate. Inherited, those variables win
+# over `git -C`: the throwaway repos below would resolve to the REAL one,
+# and `git add -A` would stage into the repo's own index instead of the
+# scratch one. Measured on 2026-08-14 — it replaced a 4382-entry index
+# with a single phantom entry. The working tree was untouched and `git
+# reset` restored it, but a test that can do that from a hook is a
+# liability, not a proof. Clear the inheritance once, here.
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+VECTOR="$ROOT/scripts/hooks/block-private-paths.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+cases=0
+
+# expect <RED|GREEN> <label> <payload-line> [staged-path]
+expect() {
+  local want="$1" label="$2" payload="$3" rel="${4:-docs/note.md}"
+  cases=$((cases + 1))
+  local dir="$WORK/case-$cases"
+  mkdir -p "$dir/$(dirname "$rel")"
+  git -C "$dir" init -q
+  printf '%s\n' "$payload" >"$dir/$rel"
+  git -C "$dir" add -A
+  (cd "$dir" && bash "$VECTOR" >/dev/null 2>&1)
+  local rc=$?
+  local got="RED"
+  [ "$rc" -eq 0 ] && got="GREEN"
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %s (%s, rc=%d)\n' "$label" "$got" "$rc"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL %s — wanted %s, got %s (rc=%d)\n' "$label" "$want" "$got" "$rc" >&2
+  fi
+}
+
+echo "private-path gate · mutation proof"
+
+# --- must BLOCK ------------------------------------------------------------
+# Invented venture names: the gate matches the shape, not a list.
+expect RED "a venture pole, invented venture" \
+  'see ventures/example-co/01-product/roadmap.md for the plan'
+expect RED "another invented venture, another pole" \
+  'ventures/second-example/04-identity/brand.md'
+expect RED "a venture that will not exist until tomorrow" \
+  'ventures/not-created-yet/08-chronicle/launch.md'
+# The agent substrate, matched at its ROOT — an invented child proves the
+# gate no longer depends on knowing the children's names.
+expect RED "agent substrate, invented child" \
+  'per dx/example-tree/thing.yaml'
+expect RED "agent substrate, another invented child" \
+  'the ledger at dx/other-example/ledgers/x.yaml'
+expect RED "the studio tree" \
+  'per studio/07-operations/north-star/VISION.md'
+expect RED "private memory" \
+  'lives in .claude/projects/some-slug/memory/'
+expect RED "a pre-migration spelling (frozen citation)" \
+  'the old path nika/hq/strategy.md'
+# The case a line-level filter would have missed: one line naming the
+# PUBLIC tier and a private pole together. Matching per occurrence catches
+# the private half instead of excusing the whole line for the innocent one.
+expect RED "public tier and a private pole on one line" \
+  'ventures/nika/02-engineering/repos/engine/README.md vs ventures/x-co/01-product/a.md'
+
+# --- must NOT block --------------------------------------------------------
+# The false positive that made the gate block legitimate work: unanchored
+# `studio/` matched every LM Studio provider path.
+expect GREEN "lmstudio provider path" \
+  'model: lmstudio/qwen2.5-coder'
+expect GREEN "lm-studio cache path" \
+  'models live in ~/.cache/lm-studio/models'
+expect GREEN "the brand URL, not the studio tree" \
+  'contact us at https://supernovae.studio/ for details'
+# The one public tier: this repo's own home.
+expect GREEN "the public repos tier" \
+  'ventures/nika/02-engineering/repos/engine/src/lib.rs'
+expect GREEN "ordinary prose with no path at all" \
+  'the engine ships a workflow language'
+# Substring collisions the boundary anchor must reject.
+expect GREEN "a word merely ending in the guarded root" \
+  'the sdx/ shim and the index/ dir are fine'
+# The gate deliberately does not scan its own kind — those files
+# legitimately enumerate the patterns.
+expect GREEN "a guarded path inside a self-excluded dir" \
+  'dx/example-tree/thing.yaml' 'scripts/ci/some-check.sh'
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d case(s) wrong — the gate does not block what it claims,\nor blocks what it must not.\n' \
+    "$fails" "$cases" >&2
+  exit 1
+fi
+
+printf '\n%d/%d cases correct in both directions.\n' "$cases" "$cases"
+exit 0


### PR DESCRIPTION
The gate kept a hand-written list of private trees. Measured today, that list was wrong in **both directions at once**.

## Missed — never guarded at all

| family | list said | tree said | unguarded |
|---|---|---|---|
| the agent substrate | 4 children | 9 children + 3 hidden | **5 private trees** |
| the venture tree | 5 ventures | 7 ventures | **2 whole ventures** |

## Flagged — though entirely public

`lmstudio/`, `~/.cache/lm-studio/` and `https://supernovae.studio/` all matched the unanchored fixed string `studio/`. The gate blocked legitimate work on the local-provider surface.

## Why

This is the **third** time the tree has moved out from under the list:

- **2026-08-02** — the monorepo moved to `ventures/<name>/<pole>/`; six of seven patterns named a directory that no longer existed, while 63,000 private files sat one rename away.
- **2026-08-13** — the rules moved to a new address in June; the list stayed at the old one, guarding a door nobody used.
- **2026-08-14** — this PR.

The file's own comment already names the law — *a blocklist is a projection of a tree, stale the moment the tree moves*. So the fix is to stop projecting.

## What changed

Both families are now **shapes**, not inventories:

- the substrate and the studio are named at their **root** — the one spelling a rename inside them cannot invalidate
- the venture tree is matched as `ventures/<name>/…` with the single public tier carved out, so **a venture created tomorrow is covered without editing this file**

Patterns moved from `grep -F` to `grep -E`, anchored at a path boundary. That anchor is what stops `lmstudio/` while still matching `/studio/`.

The venture shape is matched **per occurrence, not per line**: a line naming the public repos tier *and* a private pole must be caught for the private half, and a line-level filter would have excused the whole line on account of the innocent one.

This also says **less** in a public file. The gate ships in a PUBLIC repo, and an inventory of private subdirectory names is the leak it exists to prevent. The shapes name none of them.

## Proof

New self-test at `scripts/hygiene/tests/block-private-paths.test.sh`, run against the old gate and the new one. 16 cases, both directions:

| arm | result | |
|---|---|---|
| **OLD** | **9/16 wrong** | 6 false negatives, 3 false positives |
| **NEW** | **16/16 correct** | |

Seven cases pass in **both** arms, so the test discriminates rather than painting everything one colour. Every venture case uses an **invented** name — the stronger proof, since the gate matches a shape, and nothing private is spelled in a public file.

`shellcheck -x` clean. Vector 49 picks the test up: `OK: 2 hygiene self-test(s) passed`.

## The self-test clears its inherited git environment

Vector 49 runs this test from inside the pre-push gate, and **git hooks export `GIT_DIR` and `GIT_INDEX_FILE`**. Inherited, those beat `git -C`, so the throwaway repos resolved to the **real** one and `git add -A` staged into the repository's own index.

Measured: a 4382-entry index replaced by a single phantom entry. The working tree was untouched and `git reset` restored it, and the commit already made was verified intact — but a proof that can do that from a hook is a liability, not a proof.

Proven against a decoy repo:

| arm | decoy index before | after |
|---|---|---|
| OLD | `alpha.txt beta.txt` | `scripts/ci/some-check.sh` ← **leaked** |
| NEW | `alpha.txt beta.txt` | `alpha.txt beta.txt` ← clean |

## What I did NOT prove

- I did not test the **rename (R)** path. A `git mv` that carries content is inspected like any other staged change, but I built no fixture for it.
- I did not measure whether any commit in history would have been blocked by the wider shape. Existing content is grandfathered either way, since the gate reads only added lines.
- I did not audit the other self-test (`agent-plugins.test.sh`) for the same git-env leak; it uses `git` only indirectly, but I did not verify that.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
