### PR TITLE
fix(ci): a ratchet that did not run has not passed

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4380
+  classified_files: 4381
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1449
+    authored: 1450
     authored-pin: 2
     generated: 118
     pinned-copy: 115
@@ -182,8 +182,8 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 138
-  aggregate_sha256: 6faa1c08418fe9ab51d7f2fd82015bced00e79a57d76683ca6d461d4ca97d5d0
+  match_count: 139
+  aggregate_sha256: 9069cf92ca63316df4f81b06be71412753875be6eabc5996069ebcb0f5f2a98c
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/ci/check-tests.sh
+++ b/scripts/ci/check-tests.sh
@@ -20,11 +20,32 @@ if grep -qE '^\s*members\s*=\s*\[\s*\]\s*$' Cargo.toml; then
   exit 0
 fi
 
-if [ -n "${CI:-}" ] && command -v cargo-nextest >/dev/null 2>&1; then
+# The environment and the tool are judged SEPARATELY. They used to share
+# one `&&`, which made a missing cargo-nextest indistinguishable from "not
+# CI": in CI, with the tool absent, the whole condition went false and the
+# script fell through to `cargo test --workspace --lib` — silently
+# reinstating the exact regression the SCOPE note above says was closed on
+# 2026-07-06, with the tests/ suites running nowhere again. `command -v`
+# failing has to read as "I cannot judge", never as "take the narrower
+# path".
+if [ -n "${CI:-}" ]; then
+  if ! command -v cargo-nextest >/dev/null 2>&1; then
+    echo "FAIL  CI requires cargo-nextest for the FULL battery (lib AND tests/)." >&2
+    echo "      Refusing to fall back to --lib: that scope is the 2026-07-06" >&2
+    echo "      regression, and a narrower run is not this gate passing." >&2
+    exit 1
+  fi
   # CI: the FULL battery — lib AND integration targets (tests/).
   exec cargo nextest run --workspace
 fi
+
 if command -v cargo-nextest >/dev/null 2>&1; then
   exec cargo nextest run --workspace --lib
 fi
+
+# Local, no nextest: the fallback stays, but it says what it is NOT running.
+# A reduced scope that announces itself is a choice; one that does not is a
+# false green.
+echo "WARN  cargo-nextest absent — running 'cargo test --workspace --lib'." >&2
+echo "      LIB TARGETS ONLY: the tests/ integration suites are NOT executed." >&2
 exec cargo test --workspace --lib

--- a/scripts/hooks/run-ci-ratchets.sh
+++ b/scripts/hooks/run-ci-ratchets.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # run-ci-ratchets.sh — Tier 2 pre-push, engine context
 #
-# Runs all 9 CI ratchets from scripts/ci/ in parallel (mirrors diamond-ci.yml
+# Runs the CI ratchets from scripts/ci/ in parallel (mirrors diamond-ci.yml
 # matrix). Collects failures and reports them together rather than bailing
 # at the first failure, so the user sees all failures in one push attempt.
 #
-# Ratchets run:
-#   loc-limits, crate-size, fn-length, unwrap, expect,
-#   dead-code, no-default-features, adr-coverage, tests
+# The list lives in the RATCHETS array below and NOWHERE else. This header
+# used to carry a second copy that had drifted out of agreement with it:
+# it said "all 9", listed `tests` — which is explicitly NOT run here — and
+# never named `credential-headers`, which is. A prose list beside the real
+# one is a claim nothing checks.
 #
-# Note: check-tests.sh is excluded here (cargo test runs separately at pre-push
-# to ensure --lib flag and avoid --test which triggers keychain popup on macOS).
+# Note: check-tests.sh is deliberately not in that array (cargo test runs
+# separately at pre-push to keep the --lib flag and avoid --test, which
+# triggers the keychain popup on macOS).
 #
 # Exit: 0 = all pass | 1 = one or more failed
 #
@@ -46,6 +49,34 @@ if ! bash "${CI_DIR}/test-strip-test-items.sh" >/dev/null 2>&1; then
   exit 1
 fi
 
+# Pre-flight: every DECLARED ratchet must be runnable before any of them
+# runs. This used to be decided per-ratchet inside the launch loop, where a
+# missing — or merely non-executable — script printed a WARNING, hit
+# `continue`, and dropped out of RATCHET_NAMES. Since the green line below
+# counts RATCHET_NAMES, the denominator moved with it: `chmod 644` on one
+# file turned "all 9 ratchets passed" into "all 8 ratchets passed", exit 0,
+# and the push went through. The count was arithmetically true the whole
+# time, which is exactly why nobody would catch it.
+#
+# `-x` is the right test here — line ~52 invokes "$script" directly, so the
+# exec bit is genuinely required — it was the VERDICT that was wrong. The
+# fail-closed shape is the one this file already uses above for the filter
+# self-test: a dependency it cannot run means it cannot judge.
+UNRUNNABLE=()
+for ratchet in "${RATCHETS[@]}"; do
+  [[ -x "${CI_DIR}/check-${ratchet}.sh" ]] || UNRUNNABLE+=("$ratchet")
+done
+if ((${#UNRUNNABLE[@]} > 0)); then
+  printf '[ci-ratchets] FAIL — %d of %d declared ratchets cannot run:\n' \
+    "${#UNRUNNABLE[@]}" "${#RATCHETS[@]}" >&2
+  for ratchet in "${UNRUNNABLE[@]}"; do
+    printf '  %-22s %s (missing or not executable)\n' \
+      "$ratchet" "${CI_DIR}/check-${ratchet}.sh" >&2
+  done
+  printf '[ci-ratchets] a ratchet that did not run has not passed\n' >&2
+  exit 1
+fi
+
 TMPDIR_BASE="$(mktemp -d)"
 trap 'rm -rf -- "$TMPDIR_BASE"' EXIT
 
@@ -57,10 +88,6 @@ RATCHET_NAMES=()
 # ---------------------------------------------------------------------------
 for ratchet in "${RATCHETS[@]}"; do
   script="${CI_DIR}/check-${ratchet}.sh"
-  if [[ ! -x "$script" ]]; then
-    printf '[ci-ratchets] WARNING: %s not found or not executable\n' "$script" >&2
-    continue
-  fi
   out_file="${TMPDIR_BASE}/${ratchet}.out"
   # P1-2 Batch H+: the subshell inherits `set -e` from the parent, so if
   # "$script" exits non-zero the subshell terminates before writing .exit.
@@ -102,5 +129,13 @@ if ((${#FAILED[@]} > 0)); then
   exit 1
 fi
 
-printf '[ci-ratchets] all %d ratchets passed\n' "${#RATCHET_NAMES[@]}" >&2
+# The green states the DECLARED count and asserts the attempted count
+# matches it. Belt and braces after the pre-flight above: the number a gate
+# reports must never be one it derived from what happened to run.
+if ((${#RATCHET_NAMES[@]} != ${#RATCHETS[@]})); then
+  printf '[ci-ratchets] FAIL — %d of %d declared ratchets were attempted\n' \
+    "${#RATCHET_NAMES[@]}" "${#RATCHETS[@]}" >&2
+  exit 1
+fi
+printf '[ci-ratchets] all %d ratchets passed\n' "${#RATCHETS[@]}" >&2
 exit 0

--- a/scripts/hygiene/tests/ratchet-runner.test.sh
+++ b/scripts/hygiene/tests/ratchet-runner.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Mutation proof for the two vectors that used to narrow their own scope
+# and stay green doing it — run-ci-ratchets.sh and check-tests.sh.
+#
+# run-ci-ratchets counted the ratchets it ATTEMPTED, not the ones it
+# DECLARES. A ratchet that was missing, or merely not executable, printed a
+# WARNING, hit `continue`, and dropped out of the count — so `chmod 644` on
+# one file turned "all 9 ratchets passed" into "all 8 ratchets passed",
+# exit 0, push accepted. The number stayed arithmetically true, which is
+# precisely why it would never look wrong.
+#
+# check-tests judged the environment and the tool with one `&&`, so a
+# missing cargo-nextest read the same as "not CI" and fell through to
+# `--lib` — reinstating, in CI, the 2026-07-06 regression its own header
+# says was closed.
+#
+# Nothing here compiles: cargo is a shim that prints its argv, so the cases
+# assert on WHICH command would have run.
+#
+# Every builder reaches its call site through `expect`, which takes the
+# function name as an argument; shellcheck cannot see that (SC2329).
+# shellcheck disable=SC2329
+set -uo pipefail
+
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+cases=0
+
+RATCHETS='loc-limits crate-size fn-length unwrap expect dead-code
+no-default-features adr-coverage credential-headers'
+
+# A tree with all nine declared ratchets present, executable, and green.
+seed_runner() {
+  local dir="$1"
+  mkdir -p "$dir/scripts/hooks" "$dir/scripts/ci"
+  cp "$ROOT/scripts/hooks/run-ci-ratchets.sh" "$dir/scripts/hooks/"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/scripts/ci/test-strip-test-items.sh"
+  chmod +x "$dir/scripts/ci/test-strip-test-items.sh"
+  for r in $RATCHETS; do
+    printf '#!/usr/bin/env bash\necho "OK %s"\nexit 0\n' "$r" >"$dir/scripts/ci/check-$r.sh"
+    chmod +x "$dir/scripts/ci/check-$r.sh"
+  done
+}
+
+runner_all_green() { seed_runner "$1"; }
+runner_one_not_executable() {
+  seed_runner "$1"
+  chmod -x "$1/scripts/ci/check-expect.sh"
+}
+runner_one_deleted() {
+  seed_runner "$1"
+  rm -f "$1/scripts/ci/check-expect.sh"
+}
+runner_one_fails() {
+  seed_runner "$1"
+  printf '#!/usr/bin/env bash\necho "boom"\nexit 1\n' >"$1/scripts/ci/check-expect.sh"
+  chmod +x "$1/scripts/ci/check-expect.sh"
+}
+
+# expect_runner <RED|GREEN> <label> <builder>
+expect_runner() {
+  local want="$1" label="$2" builder="$3"
+  cases=$((cases + 1))
+  local dir="$WORK/r-$cases"
+  "$builder" "$dir"
+  local out rc
+  out="$(bash "$dir/scripts/hooks/run-ci-ratchets.sh" 2>&1)"
+  rc=$?
+  local got="RED"
+  [ "$rc" -eq 0 ] && got="GREEN"
+  if [ "$got" = "$want" ]; then
+    printf '  ok   [ratchets] %s (%s, rc=%d)\n' "$label" "$got" "$rc"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL [ratchets] %s — wanted %s, got %s (rc=%d)\n%s\n' \
+      "$label" "$want" "$got" "$rc" "$out" >&2
+  fi
+}
+
+# ---- check-tests ----------------------------------------------------------
+# cargo is a shim: it prints the command line instead of running it.
+seed_tests() { # $1 dir  $2 with-nextest(yes|no)
+  local dir="$1"
+  mkdir -p "$dir/scripts/ci" "$dir/bin"
+  cp "$ROOT/scripts/ci/check-tests.sh" "$dir/scripts/ci/"
+  printf '[workspace]\nmembers = ["crates/demo"]\n' >"$dir/Cargo.toml"
+  printf '#!/usr/bin/env bash\nprintf "CARGO %%s\\n" "$*"\nexit 0\n' >"$dir/bin/cargo"
+  chmod +x "$dir/bin/cargo"
+  if [ "$2" = yes ]; then
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/bin/cargo-nextest"
+    chmod +x "$dir/bin/cargo-nextest"
+  fi
+}
+
+# expect_tests <label> <ci(1|"")> <nextest(yes|no)> <want-rc-zero(y|n)> <want-substring>
+expect_tests() {
+  local label="$1" ci="$2" nx="$3" wantok="$4" needle="$5"
+  cases=$((cases + 1))
+  local dir="$WORK/t-$cases"
+  seed_tests "$dir" "$nx"
+  local out rc
+  out="$(cd "$dir" && PATH="$dir/bin:/usr/bin:/bin" CI="$ci" bash scripts/ci/check-tests.sh 2>&1)"
+  rc=$?
+  local ok=y
+  [ "$rc" -eq 0 ] || ok=n
+  # `--` matters: a needle like `--workspace --lib` is otherwise read as
+  # grep's own options.
+  if [ "$ok" = "$wantok" ] && printf '%s' "$out" | grep -qF -- "$needle"; then
+    printf '  ok   [check-tests] %s (rc=%d)\n' "$label" "$rc"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL [check-tests] %s — wanted rc-zero=%s and %s; got rc=%d, out: %s\n' \
+      "$label" "$wantok" "$needle" "$rc" "$(printf '%s' "$out" | tr '\n' ' ')" >&2
+  fi
+}
+
+echo "scope-narrowing vectors · mutation proof"
+
+expect_runner GREEN "all nine declared ratchets run" runner_all_green
+expect_runner RED "one ratchet not executable" runner_one_not_executable
+expect_runner RED "one ratchet missing" runner_one_deleted
+expect_runner RED "one ratchet genuinely fails (control)" runner_one_fails
+
+expect_tests "CI + nextest -> the FULL battery" 1 yes y "nextest run --workspace"
+expect_tests "CI, nextest ABSENT -> refuses to narrow" 1 no n "Refusing to fall back"
+expect_tests "local + nextest -> --lib, as the Keychain law wants" "" yes y "--workspace --lib"
+expect_tests "local, no nextest -> --lib but SAYS so" "" no y "tests/ integration suites are NOT executed"
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d case(s) wrong — a vector narrows its scope without saying so.\n' \
+    "$fails" "$cases" >&2
+  exit 1
+fi
+
+printf '\n%d/%d cases correct.\n' "$cases" "$cases"
+exit 0


### PR DESCRIPTION
Two vectors narrowed their own scope and stayed green doing it.

## `run-ci-ratchets.sh` — the denominator moved with the numerator

It counted the ratchets it **attempted**, not the ones it **declares**. A ratchet that was missing — or merely not executable — printed a WARNING, hit `continue`, and dropped out of `RATCHET_NAMES`, which is the array the green line counts.

Measured, with `chmod 644` on one of the nine:

```
[ci-ratchets] WARNING: .../check-expect.sh not found or not executable
[ci-ratchets] all 8 ratchets passed
rc=0                                              ← push accepted
```

The count was **arithmetically true the whole time**. That is exactly why nobody would catch it.

Every declared ratchet is now checked **before any of them runs**, and the green states the declared count with an assertion that the attempted count matches it.

`-x` was the right *test* here — the launch loop invokes `"$script"` directly, so the exec bit is genuinely required — it was the *verdict* that was wrong. The fail-closed shape is the one this file already used for its own filter self-test a few lines above.

## `check-tests.sh` — a missing tool read as "take the narrower path"

```bash
if [ -n "${CI:-}" ] && command -v cargo-nextest >/dev/null 2>&1; then
```

One `&&` made *tool absent* indistinguishable from *not CI*. In CI with nextest missing, the whole condition goes false and the script falls through to `cargo test --workspace --lib` — silently reinstating the regression its own header says was closed on 2026-07-06, with the `tests/` suites running nowhere.

All four combinations, traced with a shimmed cargo:

| CI | nextest | old behaviour | scope |
|---|---|---|---|
| set | present | `cargo nextest run --workspace` | full |
| set | **absent** | **`cargo test --workspace --lib`** | **lib only, silently** |
| unset | present | `cargo nextest run --workspace --lib` | lib (intended) |
| unset | absent | `cargo test --workspace --lib` | lib, unannounced |

Environment and tool are judged separately now: absent-in-CI is a hard fail; the local fallback still runs but **names the scope it is not covering**.

## Header rot, fixed in passing

`run-ci-ratchets` carried a prose copy of the ratchet list that had drifted out of agreement with the array: it said "all 9", listed `tests` (explicitly *not* run here), and never named `credential-headers` (which is). The array is the only list now.

## Proof

New self-test `scripts/hygiene/tests/ratchet-runner.test.sh`. Nothing compiles — cargo is a shim that prints its argv, so the cases assert on *which* command would have run.

| arm | result |
|---|---|
| **OLD** | **4/8 wrong** |
| **NEW** | **8/8 correct** |

Four cases pass in **both** arms — including a ratchet that genuinely fails — so the test discriminates rather than reddening on everything.

On the real tree: `[ci-ratchets] all 9 ratchets passed`.

`shellcheck -x` clean. `shfmt -d -i 2 -ci -bn` clean.

## What I did NOT prove

- **Both defects are latent, not live.** All nine declared ratchets are present and executable today, and CI installs nextest via a workflow step that fails loudly on its own. Each vector was one removed step away from a false green, not currently emitting one. I proved them by *planting* the condition, not by observing it.
- I did not change which ratchets are declared. The array is a strict subset of `scripts/ci/` (six scripts there have homes elsewhere — `mutation-floor` in `mutants.yml`, `tests`/`clippy`/`wasm` in `diamond-ci.yml`), so deriving the list from disk would drag `cargo-mutants` into pre-push. That would be a different, worse bug.
- I ran no Rust and no test battery — this change touches shell only.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
