### PR TITLE
fix(nika-onboard): le kit enseignait l enveloppe que la 909 a tuee

### DIFF
--- a/.agents/plugins/nika/agents/nika-author.md
+++ b/.agents/plugins/nika/agents/nika-author.md
@@ -53,10 +53,9 @@ structure; you instantiate it, then let the checker teach you.
 
 ## Hard lines
 
-- The envelope is `nika: v1`, always — plus a `workflow:` OBJECT
-  (`id:` kebab-case) and a `tasks:` MAP keyed by task id (a scalar
-  `workflow:` refuses `NIKA-PARSE-020`, a `- id:` sequence refuses
-  `NIKA-PARSE-022`). Four verbs only: `infer`, `exec`, `invoke`,
+- The envelope is `nika: <id>` (kebab-case — the workflow id lives ON
+  the tag since 2026-08-12) and a `tasks:` MAP keyed by task id (a
+  `- id:` sequence refuses `NIKA-PARSE-022`). Four verbs only: `infer`, `exec`, `invoke`,
   `agent`. Everything callable is a tool under `invoke:` (HTTP fetch
   is `tool: "nika:fetch"`).
 - Values live in four authorities, a closed family: `inputs:` ·

--- a/.agents/plugins/nika/commands/new.md
+++ b/.agents/plugins/nika/commands/new.md
@@ -13,7 +13,7 @@ Arguments: `$ARGUMENTS` (template + destination; either may be missing).
    kebab-case `<name>.nika.yaml` from the intent.
 2. `nika new <template> <file>` — the scriptable scaffold.
 3. Adapt the file to the user's actual task: the envelope stays
-   `nika: v1` + a `workflow:` OBJECT (`id:`) + a `tasks:` MAP keyed by
+   `nika: <id>` (the id lives ON the tag) + a `tasks:` MAP keyed by
    task id · exactly ONE verb per task · prefer `invoke:` builtins
    over `exec:` (native-first) · every `infer:` carries `max_tokens`
    (the cost ceiling depends on it) · templated inputs ride an

--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -72,9 +72,10 @@ the `.nika.yaml` extension. `nika new <slug>` makes one yours;
    `nika new <slug>` (take the lesson — the file is the read) ·
    `nika new <template> <file>.nika.yaml`. An author who writes
    first and reads second pays the measured 7.5 rounds.
-2. **Write the file.** The envelope is `nika: v1` + a `workflow:` OBJECT
-   (`id:` kebab-case · optional `description:`) + a `tasks:` MAP keyed
-   by task id — the key IS the identity, never a `- id:` sequence. Pick
+2. **Write the file.** The envelope is `nika: <id>` (kebab-case — the
+   workflow id lives ON the tag since 2026-08-12; `description:` died
+   with the `workflow:` object) + a `tasks:` MAP keyed by task id —
+   the key IS the identity, never a `- id:` sequence. Pick
    models and builtins from the embedded catalogs — `nika catalog`
    (providers · models · capabilities · which env var each needs) and
    `nika catalog --tools` (the `nika:*` builtins an `invoke` reaches

--- a/crates/nika-onboard/src/briefs.rs
+++ b/crates/nika-onboard/src/briefs.rs
@@ -34,9 +34,9 @@ Nika is a sovereign AI workflow engine. Workflows are `*.nika.yaml` files,
 
 ## The loop
 - **Author** · `nika new <template> <file>.nika.yaml` (or write one —
-  the envelope is `nika: v1` + a `workflow:` OBJECT carrying `id:` (kebab-case)
-  + a `tasks:` MAP keyed by task id. A scalar `workflow:` refuses
-  `NIKA-PARSE-020`, a `tasks:` sequence refuses `NIKA-PARSE-022`).
+  the envelope is `nika: <id>` (kebab-case — the id lives ON the tag)
+  + a `tasks:` MAP keyed by task id. A `tasks:` sequence refuses
+  `NIKA-PARSE-022`).
 - **Check** · `nika check <file>` — the static audit BEFORE any run (schema ·
   DAG · CEL · effects · permits · cost). Exit `0` clean · `2` findings.
   `--fix` applies the machine-applicable repairs (typed did-you-mean renames —
@@ -88,7 +88,7 @@ multi-turn ReAct loop).
 - `when:` is a `${{ }}` CEL boolean or the literal `true`/`false` — a bare
   string is rejected. `size()` is the only CEL function.
 - `nika:write` needs `content:` · `nika:done` is valid only inside `agent.tools`.
-- snake_case task ids · kebab-case `workflow:`.
+- snake_case task ids · kebab-case workflow id (on `nika:`).
 
 ## Don't invent structure — route to a skeleton
 `nika new '?'` lists the embedded skeletons · `nika try` /
@@ -185,7 +185,7 @@ repair the rest from the diagnostics (`nika explain NIKA-XXXX`) →
 only a clean file reaches a human.
 
 Rules the validator enforces:
-- Envelope `nika: v1` · one verb per task (`infer` · `exec` · `invoke` ·
+- Envelope `nika: <id>` · one verb per task (`infer` · `exec` · `invoke` ·
   `agent`) · the verb IS the task key.
 - `tasks.X` is read at the boundary only: `with: { alias: ${{ tasks.X.output }} }`
   is the data edge · `after: { X: success }` orders without data · the
@@ -418,6 +418,59 @@ mod tests {
         out
     }
 
+    // Banned in every teaching surface — no exemption, ever.
+    const DEAD_USAGE: &[(&str, &str)] = &[
+        (
+            "${{ vars.",
+            "NIKA-VALUES-001 · dead namespace — read `inputs:` or `const:`",
+        ),
+        (
+            "${{ env.",
+            "NIKA-VALUES-002 · dead namespace — read `config:` or `secrets:`",
+        ),
+        (
+            "capture: text",
+            "capture is stdout · stderr · combined · structured",
+        ),
+        (
+            "workflow: <",
+            "the envelope `workflow:` key died 2026-08-12 — the id lives ON `nika:` (NIKA-PARSE-020/021 RETIRED, never reused)",
+        ),
+        // The SAME dead fact, stated in prose. The literal above
+        // matched a YAML placeholder and sailed straight past
+        // « a `workflow:` OBJECT carrying `id:` » — which is how the
+        // brief kept teaching the dead envelope for two days after
+        // the nuke. A denylist keyed on ONE spelling only ever
+        // catches that spelling.
+        (
+            "`workflow:` OBJECT",
+            "the envelope `workflow:` key died 2026-08-12 — say `nika: <id>`",
+        ),
+    ];
+    // NAMING a retired form is not TEACHING it: a port table whose
+    // left column is « dead form » has to spell the dead form, and a
+    // language surface earns its keep by inoculating a model that
+    // still carries 0.105 priors. So these are banned everywhere the
+    // subject is HOW TO WRITE ONE WORKFLOW (the commands, the
+    // task-shaped skills) and allowed on the surfaces whose subject
+    // is the LANGUAGE ITSELF or the port.
+    const DEAD_NAMING: &[(&str, &str)] = &[
+        (
+            "`vars:`",
+            "NIKA-VALUES-001 · classify into `inputs:`/`const:`",
+        ),
+        ("`depends_on`", "dead edge form — `with:` / `after:`"),
+        (": succeeded", "NIKA-DAG-005 · the predicate is `success`"),
+        (": failed", "NIKA-DAG-005 · the predicate is `failure`"),
+    ];
+    const MAY_NAME_THE_RETIRED: &[&str] = &[
+        "skills/nika-migration/SKILL.md",
+        "agents/nika-migrator.md",
+        "agents/nika-author.md",
+        "skills/nika-authoring/SKILL.md",
+        "rules/nika-workflow-language.mdc",
+    ];
+
     /// The kit may never TEACH a form the live engine refuses.
     ///
     /// Found empirically 2026-07-28: three releases after the engine
@@ -435,48 +488,6 @@ mod tests {
     /// may never USE one. That asymmetry is the whole exemption.
     #[test]
     fn the_kit_never_teaches_a_form_the_engine_refuses() {
-        // Banned in every teaching surface — no exemption, ever.
-        const DEAD_USAGE: &[(&str, &str)] = &[
-            (
-                "${{ vars.",
-                "NIKA-VALUES-001 · dead namespace — read `inputs:` or `const:`",
-            ),
-            (
-                "${{ env.",
-                "NIKA-VALUES-002 · dead namespace — read `config:` or `secrets:`",
-            ),
-            (
-                "capture: text",
-                "capture is stdout · stderr · combined · structured",
-            ),
-            (
-                "workflow: <",
-                "NIKA-PARSE-020 · the envelope is an OBJECT carrying `id:`",
-            ),
-        ];
-        // NAMING a retired form is not TEACHING it: a port table whose
-        // left column is « dead form » has to spell the dead form, and a
-        // language surface earns its keep by inoculating a model that
-        // still carries 0.105 priors. So these are banned everywhere the
-        // subject is HOW TO WRITE ONE WORKFLOW (the commands, the
-        // task-shaped skills) and allowed on the surfaces whose subject
-        // is the LANGUAGE ITSELF or the port.
-        const DEAD_NAMING: &[(&str, &str)] = &[
-            (
-                "`vars:`",
-                "NIKA-VALUES-001 · classify into `inputs:`/`const:`",
-            ),
-            ("`depends_on`", "dead edge form — `with:` / `after:`"),
-            (": succeeded", "NIKA-DAG-005 · the predicate is `success`"),
-            (": failed", "NIKA-DAG-005 · the predicate is `failure`"),
-        ];
-        const MAY_NAME_THE_RETIRED: &[&str] = &[
-            "skills/nika-migration/SKILL.md",
-            "agents/nika-migrator.md",
-            "agents/nika-author.md",
-            "skills/nika-authoring/SKILL.md",
-            "rules/nika-workflow-language.mdc",
-        ];
         let surfaces = kit_teaching_surfaces();
         let mut sins: Vec<String> = Vec::new();
 
@@ -495,9 +506,19 @@ mod tests {
             }
 
             // Every COMPLETE workflow the kit prints audits for real.
+            //
+            // ⚠️ The selector used to be `starts_with("nika: v1")`, which
+            // named the envelope the 2026-08-12 nuke retired. It was not
+            // leaking — the kit prints no complete workflow today, so the
+            // loop had no subject either way — but it was ARMED: the next
+            // workflow the kit gained would have started `nika: <id>`,
+            // been skipped in silence, and this test would have kept
+            // printing a green for an audit it never ran. A selector
+            // keyed on a dead spelling is a gate waiting to stop looking.
             for block in body.split("```").skip(1).step_by(2) {
                 let yaml = block.split_once('\n').map_or("", |(_, rest)| rest);
-                if !yaml.trim_start().starts_with("nika: v1") {
+                let head = yaml.trim_start();
+                if !(head.starts_with("nika:") && yaml.contains("tasks:")) {
                     continue;
                 }
                 match nika_schema::parse(

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 763
-  aggregate_sha256: 66fd1747478825b3f8257b3b4bfb614378a581fc52832abc867afab139c5a861
+  aggregate_sha256: ca031e273d391b6eba08844101cf98163f8c6f45095af6eed6187789bd270765
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: b20ec81860a76f5e94a615ff5992f45ac92402b0acb5fd320f531c93e3f89c78
+  aggregate_sha256: f8f3dd9eed0d9d3e366693bad3e2d190fb2e6c94326f088a741cb4d8ffbd6212
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
> **Recouvrement connu** avec `fix/authorities-are-three` (session Lot-2) sur
> **2 fichiers** — `agents/nika-author.md` et `skills/nika-authoring/SKILL.md`.
> Ils sont ici parce qu'un **gate et les correctifs qui le rendent vert forment
> une unité** : le gate renforcé ci-dessous refuse de passer tant que ces deux
> fichiers portent la forme morte. Le reste de leur passe (8 fichiers) ne
> chevauche pas.

## Le trou

#909 a retiré la clé `workflow:` de l'enveloppe — l'id vit sur `nika:` depuis le
2026-08-12, et `NIKA-PARSE-020/021` sont **retirés** (`spec_code.rs` le dit
mot pour mot). Quatre surfaces d'enseignement ne l'avaient pas suivi, dont les
trois qui écrivent **vraiment du YAML chez l'utilisateur** :

| surface | ce qu'elle est |
|---|---|
| `AGENTS.md` | posé par `nika init` dans **chaque nouveau dépôt** |
| `commands/new.md` | la commande slash |
| `agents/nika-author.md` | les instructions du sous-agent **auteur** |
| `skills/nika-authoring/` | la skill d'authoring |

Un agent suivant `nika-author.md` produisait donc un fichier qui **meurt au
parse** — exactement le scénario que le docstring du gate raconte, mot pour mot,
à propos du 2026-07-28.

## ⚠️ Le gate existait, et il a raté

`the_kit_never_teaches_a_form_the_engine_refuses` bannit la chaîne littérale
`workflow: <` (un placeholder YAML). Les quatre surfaces disaient la même chose
**en prose** — « a `workflow:` OBJECT carrying `id:` » — et sont passées
dessous.

> **Une denylist calée sur UNE graphie n'attrape que cette graphie.**

La forme en prose rejoint la liste — et elle a **immédiatement trouvé deux
surfaces** que je n'avais pas encore vues (`new.md`, `nika-author.md`).

## ⚠️ Et le même fichier portait un sélecteur ARMÉ

La boucle « every COMPLETE workflow the kit prints audits for real » filtrait
les blocs sur `starts_with("nika: v1")` — l'enveloppe morte.

**Honnête sur la portée** : elle ne fuyait pas. Mesuré — le kit imprime 11 blocs
clôturés, 2 contiennent `tasks:`, **aucun** ne commence par `nika:`. La boucle
n'avait aucun sujet de toute façon. Mais elle était **armée** : le prochain
workflow ajouté au kit aurait commencé par `nika: <id>`, aurait été sauté **en
silence**, et ce test aurait continué d'imprimer un vert pour un audit jamais
lancé.

**Prouvé que le sélecteur regarde** — en injectant un workflow vivant
volontairement cassé dans le kit, le test rougit ; sonde retirée après.

## Vérifié

```
cargo nextest run --workspace   ✅  6582/6582
clippy -D warnings              ✅
check-fn-length.sh              ✅  (les 3 tables const sortent de la fn)
typos · estate                  ✅  RC 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
