### PR TITLE
fix(security): the public engine stops teaching a private path

### DIFF
--- a/crates/nika-cadence/src/parse.rs
+++ b/crates/nika-cadence/src/parse.rs
@@ -101,7 +101,7 @@ fn validate_beat(beat: &Beat, faults: &mut Vec<CadenceError>) {
             w,
             CadenceErrorKind::WorkflowPath,
             "workflow: · un chemin `*.nika.yaml` relatif au registre (ni absolu, ni `..`, un vrai basename)",
-            "workflow: dx/workflows/mon-beat.nika.yaml",
+            "workflow: workflows/mon-beat.nika.yaml",
         ));
     }
     if let Err(fault) = Cadence::parse(&beat.cadence) {

--- a/crates/nika-cadence/src/tests.rs
+++ b/crates/nika-cadence/src/tests.rs
@@ -52,7 +52,7 @@ const HEALTHY: &str = "
 nika: v1
 ceiling: 0.50
 arm:
-  - workflow: dx/workflows/geo-probe.nika.yaml
+  - workflow: workflows/geo-probe.nika.yaml
     cadence: TZ=Europe/Paris 0 9 * * 1
     plafond: 0.35
     manqué: sauter
@@ -403,7 +403,7 @@ fn the_ceiling_guard_refuses_zero_negative_infinite_and_nan() {
 nika: v1
 ceiling: 0.50
 arm:
-  - workflow: dx/workflows/geo-probe.nika.yaml
+  - workflow: workflows/geo-probe.nika.yaml
     cadence: TZ=Europe/Paris 0 9 * * 1
     plafond: {value}
     manqué: sauter
@@ -723,7 +723,7 @@ fn manque_and_plafond_are_required_without_default() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
 ",
     );
@@ -744,7 +744,7 @@ fn a_suspension_tells_its_reason_and_its_expiry() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -759,7 +759,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -778,7 +778,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -796,7 +796,7 @@ fn apres_saut_only_rides_a_sauter_overlap() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -810,7 +810,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -828,7 +828,7 @@ fn round_two_keys_are_refused_by_name() {
             "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -857,11 +857,11 @@ fn a_workflow_armed_twice_is_a_refusal() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -884,7 +884,7 @@ fn an_unknown_key_dies_at_parse() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -901,7 +901,7 @@ fn tolerance_is_the_m_over_k_firm_form() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -917,7 +917,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -933,7 +933,7 @@ fn only_hash_jitter_exists() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -974,7 +974,7 @@ fn the_span_survives_the_law_pass() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: TZ=UTC 61 9 * * 1
     plafond: 0.35
     manqué: sauter
@@ -989,7 +989,7 @@ arm:
         Some((7, 9)),
         "le span survit à validate — sinon il ne peint jamais"
     );
-    assert_eq!(faults[0].on(), Some("dx/workflows/a.nika.yaml"));
+    assert_eq!(faults[0].on(), Some("workflows/a.nika.yaml"));
 }
 
 #[test]
@@ -1031,7 +1031,7 @@ fn the_workflow_path_is_relative_to_the_registry() {
     for path in [
         "/etc/cron.d/a.nika.yaml",
         "../hors-registre/a.nika.yaml",
-        "dx/.nika.yaml",
+        "workflows/.nika.yaml",
         "sub/.nika.yaml",
     ] {
         let yaml = format!(

--- a/crates/nika-vocab/src/project/parse.rs
+++ b/crates/nika-vocab/src/project/parse.rs
@@ -233,7 +233,7 @@ fn parse_arm_entry(node: &Node) -> Result<ArmEntry, ProjectError> {
             missing(
                 "workflow",
                 "REQUIRED — what fires",
-                "workflow: dx/workflows/mon-beat.nika.yaml",
+                "workflow: workflows/mon-beat.nika.yaml",
             )
         })?,
         cadence: cadence.ok_or_else(|| {
@@ -269,7 +269,7 @@ fn workflow_path(value: &Node) -> Result<String, ProjectError> {
         return Err(ProjectError::at(
             ProjectErrorKind::BadValue,
             format!("`workflow: {raw}` — a `*.nika.yaml` path relative to the registry"),
-            "workflow: dx/workflows/mon-beat.nika.yaml",
+            "workflow: workflows/mon-beat.nika.yaml",
             line_of(value.span()),
         ));
     }

--- a/crates/nika-vocab/src/project/tests.rs
+++ b/crates/nika-vocab/src/project/tests.rs
@@ -26,7 +26,7 @@ nika: v1
 ceiling: 0.50          # default max-cost-usd · the per-invocation --max-cost-usd flag ALWAYS wins
 
 arm:                   # the TEAM arming registry (the personal one stays at ~/.nika/arm.yaml)
-  - workflow: dx/workflows/compost-beat.nika.yaml
+  - workflow: workflows/compost-beat.nika.yaml
     cadence: "dimanche 18h07"
     où:      local     # local | cloud
     plafond: 2.00      # overrides ceiling for this beat
@@ -63,7 +63,7 @@ fn the_canonical_example_parses_verbatim() {
     let arm = p.arm();
     assert_eq!(arm.len(), 1, "one beat armed: {arm:?}");
     let beat = &arm[0];
-    assert_eq!(beat.workflow, "dx/workflows/compost-beat.nika.yaml");
+    assert_eq!(beat.workflow, "workflows/compost-beat.nika.yaml");
     assert_eq!(beat.cadence, "dimanche 18h07");
     assert_eq!(beat.ou, Some(ArmLocus::Local));
     assert_eq!(beat.plafond, 2.00);
@@ -229,7 +229,7 @@ fn the_floor_spellings_round_trip() {
 /// for the cadence arc to consume.
 #[test]
 fn arm_entries_validate_their_shape() {
-    let ok = "nika: v1\narm:\n  - workflow: dx/workflows/w.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 9 * * 1\"\n    plafond: 0.35\n    manqué: rattraper\n  - workflow: dx/workflows/v.nika.yaml\n    cadence: on-webhook\n    où: cloud\n    plafond: 2.00\n    manqué: rattraper-une-fois\n";
+    let ok = "nika: v1\narm:\n  - workflow: workflows/w.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 9 * * 1\"\n    plafond: 0.35\n    manqué: rattraper\n  - workflow: workflows/v.nika.yaml\n    cadence: on-webhook\n    où: cloud\n    plafond: 2.00\n    manqué: rattraper-une-fois\n";
     let p = parse(ok).expect("two beats parse");
     assert_eq!(p.arm().len(), 2);
     assert_eq!(
@@ -389,7 +389,7 @@ proptest::proptest! {
             for (slug, ou, manque, plafond) in &beats {
                 write!(
                     doc,
-                    "  - workflow: dx/workflows/{slug}.nika.yaml\n    cadence: \"dimanche 18h07\"\n    où: {ou}\n    plafond: {plafond}\n    manqué: {manque}\n"
+                    "  - workflow: workflows/{slug}.nika.yaml\n    cadence: \"dimanche 18h07\"\n    où: {ou}\n    plafond: {plafond}\n    manqué: {manque}\n"
                 ).unwrap();
             }
         }
@@ -399,7 +399,7 @@ proptest::proptest! {
         assert_eq!(p.registry.map(|r| r.floor), Some(tier));
         assert_eq!(p.arm().len(), beats.len());
         for (beat, (slug, ou, manque, plafond)) in p.arm().iter().zip(&beats) {
-            assert_eq!(beat.workflow, format!("dx/workflows/{slug}.nika.yaml"));
+            assert_eq!(beat.workflow, format!("workflows/{slug}.nika.yaml"));
             assert_eq!(beat.ou.map(ArmLocus::as_str), Some(*ou));
             assert_eq!(beat.manque.as_str(), *manque);
             assert_eq!(beat.plafond.to_bits(), plafond.to_bits());

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: 0db427a29f3f0aa8a4c79df6f08f71baf597b93f7efd20b75156ad52d30610da
+  aggregate_sha256: ec16ea45dc9a2fb60b347a9723ccd77ec03bf4a5dd8c5bf117d3bb47f9c8ff69
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
`nika-cadence` told **every user**, in the hint printed beside a bad `workflow:` value:

```
workflow: dx/workflows/mon-beat.nika.yaml
```

`dx/` is the private monorepo's agent substrate. That is a path from a repo the reader cannot have, **offered as the example to copy**, from a PUBLIC binary.

Two more sat in `nika-vocab`'s equivalent hints, and 22 in YAML fixtures across both crates. **25 in all, now zero.**

The prefix becomes `workflows/`. The hint teaches the same rule it illustrates — *"a `*.nika.yaml` path relative to the registry, neither absolute nor `..`, a real basename"* — and the fixtures parse identically, because the validator never cared about the prefix. **147 tests green** across both crates (58 + 89), unchanged in count.

## How it surfaced — the more useful half

This content reached main through #928 on a base that **predated the repaired private-path gate**, so the gate had never had the occasion to look at it: it reads `git diff --cached`, and content already committed is invisible to it forever. A peer session hit the refusal on a merge and reported it rather than passing it with `--no-verify`.

That is a real class, and it is the sister of the one this arc has been closing:

> A gate that reddens where nobody is required to look is one failure. **A gate that never got the chance to look is the other.** Both end in a green nobody earned.

## Measured on the structural gap — and NOT fixed here

The full-tree sweep (vector 14, `check-private-leaks`) scans tracked code with **one** pattern: `.claude/projects/-Users-thibaut`. The pre-commit hook guards **ten** shapes.

**The tree-wide surface is nine shapes narrower than the per-commit one** — which is exactly how 25 occurrences slept on main.

The obvious repair — teach vector 14 the hook's shapes — needs care I did not want to fake: a naive widening reddens on **6 files under `docs/adr/`** that cite the old paths legitimately, and the monorepo's own path-resolution law says frozen archives keep their citations forever. Done properly it wants a shared pattern SSOT plus a scope that distinguishes shipped code from frozen history.

## NOT fixed — operator's call

Four `dx/` references remain under `crates/`, all in **prose rather than in anything a user copies**:

| file | form |
|---|---|
| `crates/nika-event/src/kind.rs:19` | `///` doc comment |
| `crates/nika-event/src/lib.rs:36` | `//!` module doc |
| `crates/nika-event/README.md:35` | prose |
| `crates/nika-kernel/src/errors.rs:23` | `//!` module doc |

The three doc-comments ship in rustdoc, so they are public. They are also genuine architectural cross-references — they explain that the engine's events and the studio's chronicle are **disjoint domains**.

That is a policy judgement about how much private structure the public docs may name, and **it is not mine to make silently on four crates I do not own**. The unambiguous case — a private path offered as an example to copy — is the one this PR closes.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
