### PR TITLE
fix(public-api): une arête de dépendance re-rend la surface de deux crates

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -34,6 +34,9 @@ pub use nika_cli::verbs::trace_reproduce
 pub use nika_cli::verbs::trace_verify
 pub use nika_cli::verbs::welcome
 pub use nika_cli::verbs::wire
+pub mod nika_cli::verbs::arm
+pub fn nika_cli::verbs::arm::run() -> nika_cli_host::output::VerbOutput
+pub fn nika_cli::verbs::arm::run_at(start: &std::path::Path) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli::verbs::catalog
 pub fn nika_cli::verbs::catalog::run(json: bool, theme: nika_display::theme::Theme) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli::verbs::check
@@ -59,6 +62,7 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::check::Profile where Q
 pub fn nika_cli::verbs::check::Profile::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::check::Profile where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::check::Profile::equivalent(&self, key: &K) -> bool
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::check::Profile where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::check::Profile where U: core::convert::From<T>
 pub fn nika_cli::verbs::check::Profile::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::check::Profile where U: core::convert::Into<T>
@@ -115,6 +119,7 @@ pub fn nika_cli::verbs::check::CheckArgs::from_arg_matches_mut(__clap_arg_matche
 pub fn nika_cli::verbs::check::CheckArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_cli::verbs::check::CheckArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::check::CheckArgs
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::check::CheckArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::check::CheckArgs where U: core::convert::From<T>
 pub fn nika_cli::verbs::check::CheckArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::check::CheckArgs where U: core::convert::Into<T>
@@ -146,6 +151,7 @@ pub nika_cli::verbs::check::CheckFlags::json: bool
 pub nika_cli::verbs::check::CheckFlags::native_strict: bool
 pub nika_cli::verbs::check::CheckFlags::profile: nika_cli::verbs::check::Profile
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::check::CheckFlags
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::check::CheckFlags where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::check::CheckFlags where U: core::convert::From<T>
 pub fn nika_cli::verbs::check::CheckFlags::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::check::CheckFlags where U: core::convert::Into<T>
@@ -216,6 +222,7 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::graph::GraphFormat whe
 pub fn nika_cli::verbs::graph::GraphFormat::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::graph::GraphFormat where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::graph::GraphFormat::equivalent(&self, key: &K) -> bool
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::graph::GraphFormat where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::graph::GraphFormat where U: core::convert::From<T>
 pub fn nika_cli::verbs::graph::GraphFormat::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::graph::GraphFormat where U: core::convert::Into<T>
@@ -275,6 +282,7 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::graph::GraphFormatArg 
 pub fn nika_cli::verbs::graph::GraphFormatArg::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::graph::GraphFormatArg where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::graph::GraphFormatArg::equivalent(&self, key: &K) -> bool
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::graph::GraphFormatArg where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::graph::GraphFormatArg where U: core::convert::From<T>
 pub fn nika_cli::verbs::graph::GraphFormatArg::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::graph::GraphFormatArg where U: core::convert::Into<T>
@@ -342,6 +350,7 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::init::CanvasTheme wher
 pub fn nika_cli::verbs::init::CanvasTheme::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::init::CanvasTheme where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::init::CanvasTheme::equivalent(&self, key: &K) -> bool
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::init::CanvasTheme where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::init::CanvasTheme where U: core::convert::From<T>
 pub fn nika_cli::verbs::init::CanvasTheme::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::init::CanvasTheme where U: core::convert::Into<T>
@@ -399,6 +408,7 @@ impl core::clone::Clone for nika_cli::verbs::key::KeyAction
 pub fn nika_cli::verbs::key::KeyAction::clone(&self) -> nika_cli::verbs::key::KeyAction
 impl core::marker::Copy for nika_cli::verbs::key::KeyAction
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::key::KeyAction
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::key::KeyAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::key::KeyAction where U: core::convert::From<T>
 pub fn nika_cli::verbs::key::KeyAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::key::KeyAction where U: core::convert::Into<T>
@@ -451,6 +461,7 @@ pub fn nika_cli::verbs::mcp_pins::McpAction::has_subcommand(__clap_name: &str) -
 impl core::clone::Clone for nika_cli::verbs::mcp_pins::McpAction
 pub fn nika_cli::verbs::mcp_pins::McpAction::clone(&self) -> nika_cli::verbs::mcp_pins::McpAction
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::mcp_pins::McpAction
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::mcp_pins::McpAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::mcp_pins::McpAction where U: core::convert::From<T>
 pub fn nika_cli::verbs::mcp_pins::McpAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::mcp_pins::McpAction where U: core::convert::Into<T>
@@ -504,6 +515,7 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::mcp_pins::McpTransport
 pub fn nika_cli::verbs::mcp_pins::McpTransportArg::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::mcp_pins::McpTransportArg where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::mcp_pins::McpTransportArg::equivalent(&self, key: &K) -> bool
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::mcp_pins::McpTransportArg where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::mcp_pins::McpTransportArg where U: core::convert::From<T>
 pub fn nika_cli::verbs::mcp_pins::McpTransportArg::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::mcp_pins::McpTransportArg where U: core::convert::Into<T>
@@ -578,6 +590,7 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::run::RenderMode where 
 pub fn nika_cli::verbs::run::RenderMode::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::run::RenderMode where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::run::RenderMode::equivalent(&self, key: &K) -> bool
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::run::RenderMode where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::RenderMode where U: core::convert::From<T>
 pub fn nika_cli::verbs::run::RenderMode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::run::RenderMode where U: core::convert::Into<T>
@@ -626,6 +639,7 @@ pub fn nika_cli::verbs::run::FoldSink<W>::view(&self) -> &nika_display::state::R
 impl<W: core::io::write::Write> nika_event::stamp::EventSink for nika_cli::verbs::run::FoldSink<W>
 pub fn nika_cli::verbs::run::FoldSink<W>::emit(&mut self, event: nika_event::event::Event)
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::FoldSink<W>
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::run::FoldSink<W> where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::FoldSink<W> where U: core::convert::From<T>
 pub fn nika_cli::verbs::run::FoldSink<W>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::run::FoldSink<W> where U: core::convert::Into<T>
@@ -667,6 +681,7 @@ pub fn nika_cli::verbs::sign::SignArgs::from_arg_matches_mut(__clap_arg_matches:
 pub fn nika_cli::verbs::sign::SignArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_cli::verbs::sign::SignArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::sign::SignArgs
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::sign::SignArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::From<T>
 pub fn nika_cli::verbs::sign::SignArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::Into<T>

--- a/crates/nika-trace/public-api.txt
+++ b/crates/nika-trace/public-api.txt
@@ -20,6 +20,7 @@ pub fn nika_trace::evidence::EvidenceArgs::from_arg_matches_mut(__clap_arg_match
 pub fn nika_trace::evidence::EvidenceArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_trace::evidence::EvidenceArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_trace::evidence::EvidenceArgs
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::evidence::EvidenceArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::evidence::EvidenceArgs where U: core::convert::From<T>
 pub fn nika_trace::evidence::EvidenceArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::evidence::EvidenceArgs where U: core::convert::Into<T>
@@ -56,6 +57,7 @@ pub fn nika_trace::forecast::gather::Gathered::default() -> nika_trace::forecast
 impl core::fmt::Debug for nika_trace::forecast::gather::Gathered
 pub fn nika_trace::forecast::gather::Gathered::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::gather::Gathered
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::gather::Gathered where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::gather::Gathered where U: core::convert::From<T>
 pub fn nika_trace::forecast::gather::Gathered::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::gather::Gathered where U: core::convert::Into<T>
@@ -97,6 +99,7 @@ pub fn nika_trace::forecast::gather::RunSample::clone(&self) -> nika_trace::fore
 impl core::fmt::Debug for nika_trace::forecast::gather::RunSample
 pub fn nika_trace::forecast::gather::RunSample::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::gather::RunSample
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::gather::RunSample where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::gather::RunSample where U: core::convert::From<T>
 pub fn nika_trace::forecast::gather::RunSample::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::gather::RunSample where U: core::convert::Into<T>
@@ -144,6 +147,7 @@ pub fn nika_trace::forecast::gather::TaskSample::clone(&self) -> nika_trace::for
 impl core::fmt::Debug for nika_trace::forecast::gather::TaskSample
 pub fn nika_trace::forecast::gather::TaskSample::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::gather::TaskSample
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::gather::TaskSample where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::gather::TaskSample where U: core::convert::From<T>
 pub fn nika_trace::forecast::gather::TaskSample::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::gather::TaskSample where U: core::convert::Into<T>
@@ -194,6 +198,7 @@ pub fn nika_trace::forecast::ForecastReport::fmt(&self, f: &mut core::fmt::Forma
 impl serde_core::ser::Serialize for nika_trace::forecast::ForecastReport
 pub fn nika_trace::forecast::ForecastReport::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::ForecastReport
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::ForecastReport where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::ForecastReport where U: core::convert::From<T>
 pub fn nika_trace::forecast::ForecastReport::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::ForecastReport where U: core::convert::Into<T>
@@ -247,6 +252,7 @@ impl core::marker::Copy for nika_trace::forecast::RunCensus
 impl serde_core::ser::Serialize for nika_trace::forecast::RunCensus
 pub fn nika_trace::forecast::RunCensus::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::RunCensus
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::RunCensus where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::RunCensus where U: core::convert::From<T>
 pub fn nika_trace::forecast::RunCensus::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::RunCensus where U: core::convert::Into<T>
@@ -302,6 +308,7 @@ pub fn nika_trace::forecast::TaskPrior::fmt(&self, f: &mut core::fmt::Formatter<
 impl serde_core::ser::Serialize for nika_trace::forecast::TaskPrior
 pub fn nika_trace::forecast::TaskPrior::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::TaskPrior
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::TaskPrior where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::TaskPrior where U: core::convert::From<T>
 pub fn nika_trace::forecast::TaskPrior::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::TaskPrior where U: core::convert::Into<T>
@@ -353,6 +360,7 @@ impl core::marker::Copy for nika_trace::forecast::Window
 impl serde_core::ser::Serialize for nika_trace::forecast::Window
 pub fn nika_trace::forecast::Window::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::Window
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::Window where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::Window where U: core::convert::From<T>
 pub fn nika_trace::forecast::Window::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::Window where U: core::convert::Into<T>
@@ -400,6 +408,7 @@ pub fn nika_trace::forecast::WorkflowIdentity::clone(&self) -> nika_trace::forec
 impl core::fmt::Debug for nika_trace::forecast::WorkflowIdentity
 pub fn nika_trace::forecast::WorkflowIdentity::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::WorkflowIdentity
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::WorkflowIdentity where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::WorkflowIdentity where U: core::convert::From<T>
 pub fn nika_trace::forecast::WorkflowIdentity::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::WorkflowIdentity where U: core::convert::Into<T>
@@ -449,6 +458,7 @@ pub fn nika_trace::receipt::ReceiptAction::augment_subcommands<'b>(__clap_app: c
 pub fn nika_trace::receipt::ReceiptAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
 pub fn nika_trace::receipt::ReceiptAction::has_subcommand(__clap_name: &str) -> bool
 impl<D> owo_colors::OwoColorize for nika_trace::receipt::ReceiptAction
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::receipt::ReceiptAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::receipt::ReceiptAction where U: core::convert::From<T>
 pub fn nika_trace::receipt::ReceiptAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::receipt::ReceiptAction where U: core::convert::Into<T>
@@ -510,6 +520,9 @@ pub nika_trace::trace::action::TraceAction::Rm::all: bool
 pub nika_trace::trace::action::TraceAction::Rm::force: bool
 pub nika_trace::trace::action::TraceAction::Rm::older_than: core::option::Option<alloc::string::String>
 pub nika_trace::trace::action::TraceAction::Rm::trace: core::option::Option<alloc::string::String>
+pub nika_trace::trace::action::TraceAction::Session
+pub nika_trace::trace::action::TraceAction::Session::trace: std::path::PathBuf
+pub nika_trace::trace::action::TraceAction::Session::workflow: alloc::string::String
 pub nika_trace::trace::action::TraceAction::Show(nika_trace::trace::action::TraceArgs)
 pub nika_trace::trace::action::TraceAction::Verify
 pub nika_trace::trace::action::TraceAction::Verify::anchored: bool
@@ -526,6 +539,7 @@ pub fn nika_trace::trace::action::TraceAction::augment_subcommands<'b>(__clap_ap
 pub fn nika_trace::trace::action::TraceAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
 pub fn nika_trace::trace::action::TraceAction::has_subcommand(__clap_name: &str) -> bool
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceAction
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceAction where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceAction where U: core::convert::Into<T>
@@ -567,6 +581,7 @@ pub fn nika_trace::trace::action::TraceArgs::from_arg_matches_mut(__clap_arg_mat
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceArgs
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceArgs where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceArgs where U: core::convert::Into<T>
@@ -603,6 +618,7 @@ pub fn nika_trace::trace::manage::RmTarget::clone(&self) -> nika_trace::trace::m
 impl core::fmt::Debug for nika_trace::trace::manage::RmTarget
 pub fn nika_trace::trace::manage::RmTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::trace::manage::RmTarget
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::manage::RmTarget where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::manage::RmTarget where U: core::convert::From<T>
 pub fn nika_trace::trace::manage::RmTarget::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::manage::RmTarget where U: core::convert::Into<T>
@@ -644,6 +660,8 @@ pub fn nika_trace::trace::manage::ls(theme: nika_display::theme::Theme) -> nika_
 pub fn nika_trace::trace::manage::resolve_store_handle(handle: &std::path::Path) -> std::path::PathBuf
 pub fn nika_trace::trace::manage::resolve_trace(given: core::option::Option<std::path::PathBuf>) -> core::result::Result<std::path::PathBuf, u8>
 pub fn nika_trace::trace::manage::rm(target: &nika_trace::trace::manage::RmTarget, force: bool, theme: nika_display::theme::Theme) -> nika_cli_host::output::VerbOutput
+pub mod nika_trace::trace::session
+pub fn nika_trace::trace::session::session(trace: &str, workflow: &str, theme: nika_display::theme::Theme) -> nika_cli_host::output::VerbOutput
 pub enum nika_trace::trace::TraceAction
 pub nika_trace::trace::TraceAction::Anchor
 pub nika_trace::trace::TraceAction::Anchor::rekor_url: alloc::string::String
@@ -676,6 +694,9 @@ pub nika_trace::trace::TraceAction::Rm::all: bool
 pub nika_trace::trace::TraceAction::Rm::force: bool
 pub nika_trace::trace::TraceAction::Rm::older_than: core::option::Option<alloc::string::String>
 pub nika_trace::trace::TraceAction::Rm::trace: core::option::Option<alloc::string::String>
+pub nika_trace::trace::TraceAction::Session
+pub nika_trace::trace::TraceAction::Session::trace: std::path::PathBuf
+pub nika_trace::trace::TraceAction::Session::workflow: alloc::string::String
 pub nika_trace::trace::TraceAction::Show(nika_trace::trace::action::TraceArgs)
 pub nika_trace::trace::TraceAction::Verify
 pub nika_trace::trace::TraceAction::Verify::anchored: bool
@@ -692,6 +713,7 @@ pub fn nika_trace::trace::action::TraceAction::augment_subcommands<'b>(__clap_ap
 pub fn nika_trace::trace::action::TraceAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
 pub fn nika_trace::trace::action::TraceAction::has_subcommand(__clap_name: &str) -> bool
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceAction
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceAction where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceAction where U: core::convert::Into<T>
@@ -733,6 +755,7 @@ pub fn nika_trace::trace::action::TraceArgs::from_arg_matches_mut(__clap_arg_mat
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceArgs
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceArgs where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceArgs where U: core::convert::Into<T>
@@ -779,6 +802,7 @@ pub fn nika_trace::trace_verify::VerifyOptions::default() -> nika_trace::trace_v
 impl core::fmt::Debug for nika_trace::trace_verify::VerifyOptions
 pub fn nika_trace::trace_verify::VerifyOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::trace_verify::VerifyOptions
+impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace_verify::VerifyOptions where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace_verify::VerifyOptions where U: core::convert::From<T>
 pub fn nika_trace::trace_verify::VerifyOptions::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace_verify::VerifyOptions where U: core::convert::Into<T>

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 65
-  aggregate_sha256: 7f80333983ce6c544d7688c52dc20ac8aa67d9e721dc6c2872e9a2cb4b52d43e
+  aggregate_sha256: 2001c6017776114b2bdbca6c1e21c042a89749f45fcc5993c666613215c711ab
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"


### PR DESCRIPTION
`main` est rouge sur `public-api` depuis `a55486dd8`. Ça débloque.

## L'attribution reçue était juste, mais minoritaire

On me l'a passée ainsi : « #929 ajoute de la surface publique à `nika-trace`
sans régénérer son verrou ». C'est vrai — et ça ne couvre que **6 des 39 lignes**.
Personne n'avait lu le diff ; la corrélation (`vert → #929 → rouge`) plus un
mécanisme plausible suffisaient à convaincre.

Le diff nomme **deux** crates, pas un. Et il est dominé par des impls blanket
`wasm_bindgen::Upcast` posés sur des types que je n'ai jamais touchés.

## Le mécanisme réel, mesuré

```
wasm-bindgen v0.2.118
└── nika-tui-core          ← porte wasm-bindgen SANS condition
    └── nika-trace         ← l'arête ajoutée par la vague A
        └── nika-cli
```

`nika-tui-core` est bi-usage par design (pack npm *et* dépendance Rust), donc
`wasm-bindgen` y est inconditionnel. Ajouter **une seule arête** fait acquérir
un impl blanket à *chaque* type public de *chaque* crate en aval.

> **La surface publique d'une crate peut bouger sans qu'un seul de ses items
> ne change.** C'est ce qu'aucune des deux lectures précédentes ne pouvait
> voir en regardant les commits.

## Ce que ce commit fait, et ne fait pas

Le diff est **purement additif** (zéro `<`) — aucune surface ne disparaît, donc
l'accepter ne cache aucune régression. Les deux verrous sont **reconstruits
depuis le diff imprimé par la CI**, jamais régénérés localement : la nightly et
la plateforme divergent, et un verrou régénéré à l'aveugle ne verrouille plus rien.

Vérifié · base identique à `origin/main` · 39 lignes annoncées, 39 appliquées,
zéro directive orpheline · insertions en position structurelle · 0 doublon
introduit côté `nika-cli`, 2 côté `nika-trace` de la même forme que les 70
préexistants (blanket rendus à l'identique).

## La vraie correction n'est pas ici

Rendre `wasm-bindgen` **optionnel derrière une feature** dans `nika-tui-core`
supprimerait les 30 lignes au lieu de les ratifier — un CLI natif n'a rien à
faire avec des impls wasm dans son contrat public. La surface wasm est confinée
à un seul fichier (`src/wasm.rs`), donc c'est propre.

Je ne le prends pas ici · ça cascade sur **trois** verrous et sur le job
`npm-wasm-pack`, que je ne peux pas tester dans cette session. Troquer un rouge
de CI contre un risque non testé sur le chemin de release serait un mauvais
échange. À arbitrer séparément.
