### PR TITLE
fix(nika-cadence): le moteur PUBLIC enseignait un chemin du monorepo privé

### DIFF
--- a/crates/nika-cadence/src/parse.rs
+++ b/crates/nika-cadence/src/parse.rs
@@ -101,7 +101,7 @@ fn validate_beat(beat: &Beat, faults: &mut Vec<CadenceError>) {
             w,
             CadenceErrorKind::WorkflowPath,
             "workflow: · un chemin `*.nika.yaml` relatif au registre (ni absolu, ni `..`, un vrai basename)",
-            "workflow: dx/workflows/mon-beat.nika.yaml",
+            "workflow: audits/site-audit.nika.yaml — le chemin part du dossier du registre",
         ));
     }
     if let Err(fault) = Cadence::parse(&beat.cadence) {

--- a/crates/nika-cadence/src/tests.rs
+++ b/crates/nika-cadence/src/tests.rs
@@ -52,7 +52,7 @@ const HEALTHY: &str = "
 nika: v1
 ceiling: 0.50
 arm:
-  - workflow: dx/workflows/geo-probe.nika.yaml
+  - workflow: workflows/geo-probe.nika.yaml
     cadence: TZ=Europe/Paris 0 9 * * 1
     plafond: 0.35
     manqué: sauter
@@ -403,7 +403,7 @@ fn the_ceiling_guard_refuses_zero_negative_infinite_and_nan() {
 nika: v1
 ceiling: 0.50
 arm:
-  - workflow: dx/workflows/geo-probe.nika.yaml
+  - workflow: workflows/geo-probe.nika.yaml
     cadence: TZ=Europe/Paris 0 9 * * 1
     plafond: {value}
     manqué: sauter
@@ -723,7 +723,7 @@ fn manque_and_plafond_are_required_without_default() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
 ",
     );
@@ -744,7 +744,7 @@ fn a_suspension_tells_its_reason_and_its_expiry() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -759,7 +759,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -778,7 +778,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -796,7 +796,7 @@ fn apres_saut_only_rides_a_sauter_overlap() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -810,7 +810,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -828,7 +828,7 @@ fn round_two_keys_are_refused_by_name() {
             "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -857,11 +857,11 @@ fn a_workflow_armed_twice_is_a_refusal() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -884,7 +884,7 @@ fn an_unknown_key_dies_at_parse() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -901,7 +901,7 @@ fn tolerance_is_the_m_over_k_firm_form() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -917,7 +917,7 @@ arm:
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -933,7 +933,7 @@ fn only_hash_jitter_exists() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: on-webhook
     plafond: 0.35
     manqué: sauter
@@ -974,7 +974,7 @@ fn the_span_survives_the_law_pass() {
         "
 nika: v1
 arm:
-  - workflow: dx/workflows/a.nika.yaml
+  - workflow: workflows/a.nika.yaml
     cadence: TZ=UTC 61 9 * * 1
     plafond: 0.35
     manqué: sauter
@@ -989,7 +989,7 @@ arm:
         Some((7, 9)),
         "le span survit à validate — sinon il ne peint jamais"
     );
-    assert_eq!(faults[0].on(), Some("dx/workflows/a.nika.yaml"));
+    assert_eq!(faults[0].on(), Some("workflows/a.nika.yaml"));
 }
 
 #[test]
@@ -1031,7 +1031,7 @@ fn the_workflow_path_is_relative_to_the_registry() {
     for path in [
         "/etc/cron.d/a.nika.yaml",
         "../hors-registre/a.nika.yaml",
-        "dx/.nika.yaml",
+        "beats/.nika.yaml",
         "sub/.nika.yaml",
     ] {
         let yaml = format!(
@@ -1076,6 +1076,57 @@ arm:
         );
         assert!(fault.kind().spec_code().starts_with("cadence."));
     }
+}
+
+/// ⭐ Un remède MONTRÉ doit être lui-même LÉGAL.
+///
+/// Le test au-dessus vérifie que le remède est NON VIDE, jamais qu il est
+/// JUSTE — le remède était donc décoratif. Il a longtemps montré un chemin
+/// pris dans l arbre privé du monorepo · illisible pour qui n est pas nous,
+/// et refusé par le garde-fou de confidentialité (`block-private-paths`)
+/// dès qu une ligne le réintroduit.
+///
+/// La confidentialité reste le travail de ce garde-fou · il voit très bien
+/// les lignes AJOUTÉES, et une régression en serait une. Ce test couvre ce
+/// que lui ne peut pas voir · que le chemin affiché comme LA réparation
+/// passe la règle qu il prétend enseigner.
+#[test]
+fn the_workflow_remedy_is_itself_a_legal_path() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: /absolu/interdit.nika.yaml
+    cadence: on-webhook
+    plafond: 0.35
+    manqué: sauter
+",
+    )
+    .expect("le registre de test se parse");
+    let remedy = validate(&reg)
+        .find(|f| f.kind() == CadenceErrorKind::WorkflowPath)
+        .map(|f| f.remedy().to_owned())
+        .expect("la loi du chemin refuse un absolu");
+
+    let montre = remedy
+        .trim_start_matches("workflow: ")
+        .split(' ')
+        .next()
+        .expect("le remède montre un chemin");
+    let yaml = format!(
+        "
+nika: v1
+arm:
+  - workflow: {montre}
+    cadence: on-webhook
+    plafond: 0.35
+    manqué: sauter
+"
+    );
+    assert!(
+        !kinds(&yaml).contains(&CadenceErrorKind::WorkflowPath),
+        "`{montre}` est montré comme LA réparation · il doit passer la règle qu il enseigne"
+    );
 }
 
 // ── trap ③ · the EMBEDDED tzdb, never the host ─────────────────────

--- a/crates/nika-cadence/src/tests.rs
+++ b/crates/nika-cadence/src/tests.rs
@@ -1082,11 +1082,11 @@ arm:
 ///
 /// Le test au-dessus vérifie que le remède est NON VIDE, jamais qu il est
 /// JUSTE — le remède était donc décoratif. Il a longtemps montré un chemin
-/// pris dans l arbre privé du monorepo · illisible pour qui n est pas nous,
+/// emprunté à l arbre privé du monorepo · illisible pour qui n est pas nous,
 /// et refusé par le garde-fou de confidentialité (`block-private-paths`)
 /// dès qu une ligne le réintroduit.
 ///
-/// La confidentialité reste le travail de ce garde-fou · il voit très bien
+/// La confidentialité demeure le travail de ce garde-fou · il voit très bien
 /// les lignes AJOUTÉES, et une régression en serait une. Ce test couvre ce
 /// que lui ne peut pas voir · que le chemin affiché comme LA réparation
 /// passe la règle qu il prétend enseigner.

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: 0db427a29f3f0aa8a4c79df6f08f71baf597b93f7efd20b75156ad52d30610da
+  aggregate_sha256: bb11672f7bafdb3dc19bb219ba1c5e27d0d053b7700e4a1dff62c2a9c0301cdc
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: bb11672f7bafdb3dc19bb219ba1c5e27d0d053b7700e4a1dff62c2a9c0301cdc
+  aggregate_sha256: 62f657c40fc5e8a211a47ab0941e358b193970772a98e1e8f4fc61c53c42b368
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Le moteur est **public**. Le champ *remède* de la loi `WorkflowPath` montrait à
l'utilisateur un chemin pris dans l'arbre **privé** du monorepo.

Deux défauts en un · une fuite dans un dépôt public, et un exemple qui **ne veut
rien dire** pour quelqu'un qui n'est pas nous. Il devient un chemin public et
parlant, avec la glose que tous ses voisins portent déjà — c'était d'ailleurs le
seul exemple du fichier sans glose.

Les fixtures de test portaient le même préfixe (17 fois). Préfixes neutres,
couverture identique · les quatre formes du test de chemin restent distinctes.

## Pourquoi ça vivait sur `main`

Le garde-fou de confidentialité **refuse** bien cette chaîne — vérifié
bout-en-bout, `rc=1`, message « Engine … is PUBLIC » mot pour mot.

Mais il ne lit que `git diff --cached`, et il ne prend aucun argument de
fichier. Il n'a donc **jamais eu l'occasion** de regarder cette ligne, committée
avant lui.

> **Une porte qui juge le diff est aveugle au passif.**

La même loi frappe deux fois de plus dans le voisinage · la porte ADR est
*warn-only*, et sa seule branche bloquante vit dans un hook **local** — qu'un
squash-merge GitHub n'exécute jamais. C'est ainsi que `nika-cadence` a atterri
sans ADR. Remonté séparément, pas corrigé ici.

## Le test ajouté

Le test voisin (`every_refusal_teaches_its_fix`) vérifie que le remède est **non
vide**, jamais qu'il est **juste** — le remède était donc décoratif. Celui-ci
couvre ce que la porte ne peut pas voir ·

> le chemin affiché comme **LA** réparation doit passer la règle qu'il prétend
> enseigner.

Prouvé par mutation dans les deux sens · un remède absolu et un remède qui
remonte tuent le test, chacun avec sa propre phrase. 59 tests verts.

## Ce que je n'ai pas fait, et pourquoi

Ma première version du test listait les préfixes privés pour les interdire. Elle
a été **refusée par la porte elle-même** — les littéraux vivaient dans mon
propre code. Je n'ai pas obfusqué les chaînes pour passer : obfusquer pour
franchir une porte de sécurité est exactement le mauvais réflexe.

Les responsabilités sont donc séparées · la **confidentialité reste le travail
de la porte**, qui voit très bien les lignes *ajoutées* — et une régression en
serait une. Le test couvre la loi orthogonale, que la porte ne peut pas juger.
