### PR TITLE
fix(security): nika-vocab stops teaching a private path too

### DIFF
--- a/crates/nika-vocab/src/project/parse.rs
+++ b/crates/nika-vocab/src/project/parse.rs
@@ -233,7 +233,7 @@ fn parse_arm_entry(node: &Node) -> Result<ArmEntry, ProjectError> {
             missing(
                 "workflow",
                 "REQUIRED — what fires",
-                "workflow: dx/workflows/mon-beat.nika.yaml",
+                "workflow: workflows/mon-beat.nika.yaml",
             )
         })?,
         cadence: cadence.ok_or_else(|| {
@@ -269,7 +269,7 @@ fn workflow_path(value: &Node) -> Result<String, ProjectError> {
         return Err(ProjectError::at(
             ProjectErrorKind::BadValue,
             format!("`workflow: {raw}` — a `*.nika.yaml` path relative to the registry"),
-            "workflow: dx/workflows/mon-beat.nika.yaml",
+            "workflow: workflows/mon-beat.nika.yaml",
             line_of(value.span()),
         ));
     }

--- a/crates/nika-vocab/src/project/tests.rs
+++ b/crates/nika-vocab/src/project/tests.rs
@@ -26,7 +26,7 @@ nika: v1
 ceiling: 0.50          # default max-cost-usd · the per-invocation --max-cost-usd flag ALWAYS wins
 
 arm:                   # the TEAM arming registry (the personal one stays at ~/.nika/arm.yaml)
-  - workflow: dx/workflows/compost-beat.nika.yaml
+  - workflow: workflows/compost-beat.nika.yaml
     cadence: "dimanche 18h07"
     où:      local     # local | cloud
     plafond: 2.00      # overrides ceiling for this beat
@@ -63,7 +63,7 @@ fn the_canonical_example_parses_verbatim() {
     let arm = p.arm();
     assert_eq!(arm.len(), 1, "one beat armed: {arm:?}");
     let beat = &arm[0];
-    assert_eq!(beat.workflow, "dx/workflows/compost-beat.nika.yaml");
+    assert_eq!(beat.workflow, "workflows/compost-beat.nika.yaml");
     assert_eq!(beat.cadence, "dimanche 18h07");
     assert_eq!(beat.ou, Some(ArmLocus::Local));
     assert_eq!(beat.plafond, 2.00);
@@ -229,7 +229,7 @@ fn the_floor_spellings_round_trip() {
 /// for the cadence arc to consume.
 #[test]
 fn arm_entries_validate_their_shape() {
-    let ok = "nika: v1\narm:\n  - workflow: dx/workflows/w.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 9 * * 1\"\n    plafond: 0.35\n    manqué: rattraper\n  - workflow: dx/workflows/v.nika.yaml\n    cadence: on-webhook\n    où: cloud\n    plafond: 2.00\n    manqué: rattraper-une-fois\n";
+    let ok = "nika: v1\narm:\n  - workflow: workflows/w.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 9 * * 1\"\n    plafond: 0.35\n    manqué: rattraper\n  - workflow: workflows/v.nika.yaml\n    cadence: on-webhook\n    où: cloud\n    plafond: 2.00\n    manqué: rattraper-une-fois\n";
     let p = parse(ok).expect("two beats parse");
     assert_eq!(p.arm().len(), 2);
     assert_eq!(
@@ -389,7 +389,7 @@ proptest::proptest! {
             for (slug, ou, manque, plafond) in &beats {
                 write!(
                     doc,
-                    "  - workflow: dx/workflows/{slug}.nika.yaml\n    cadence: \"dimanche 18h07\"\n    où: {ou}\n    plafond: {plafond}\n    manqué: {manque}\n"
+                    "  - workflow: workflows/{slug}.nika.yaml\n    cadence: \"dimanche 18h07\"\n    où: {ou}\n    plafond: {plafond}\n    manqué: {manque}\n"
                 ).unwrap();
             }
         }
@@ -399,7 +399,7 @@ proptest::proptest! {
         assert_eq!(p.registry.map(|r| r.floor), Some(tier));
         assert_eq!(p.arm().len(), beats.len());
         for (beat, (slug, ou, manque, plafond)) in p.arm().iter().zip(&beats) {
-            assert_eq!(beat.workflow, format!("dx/workflows/{slug}.nika.yaml"));
+            assert_eq!(beat.workflow, format!("workflows/{slug}.nika.yaml"));
             assert_eq!(beat.ou.map(ArmLocus::as_str), Some(*ou));
             assert_eq!(beat.manque.as_str(), *manque);
             assert_eq!(beat.plafond.to_bits(), plafond.to_bits());

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: 62f657c40fc5e8a211a47ab0941e358b193970772a98e1e8f4fc61c53c42b368
+  aggregate_sha256: 35cad0c2516c98f27907566a790a707ee25d3167e67b329cc4475ff2c88848f4
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
**#940 closed the `nika-cadence` half of this leak. The `nika-vocab` half is still on main** — seven occurrences of `dx/workflows/`, two of them in hints the user is shown.

```
crates/nika-vocab/src/project/parse.rs:236
crates/nika-vocab/src/project/parse.rs:272
```

Line 236 is the third argument of:

```rust
missing("workflow", "REQUIRED — what fires",
        "workflow: dx/workflows/mon-beat.nika.yaml")
```

— the example printed when the `workflow:` key is absent. `dx/` is the private monorepo's agent substrate, so a **PUBLIC binary was offering a path from a repo the reader cannot have, as the thing to copy.** Same class as the cadence one, same severity, different crate.

Prefix becomes `workflows/`, matching what #940 chose for cadence rather than inventing a second convention. The five fixtures follow. **89 tests green** in `nika-vocab`, unchanged in count — the validator never looked at the prefix.

With this, `git grep dx/workflows/ -- crates/` returns **nothing**.

## Not touched, unchanged from the earlier report

Four `dx/` references remain under `crates/` **in prose**: `nika-event/src/{kind.rs,lib.rs}`, its README, `nika-kernel/src/errors.rs`. The three doc-comments ship in rustdoc, so they are public — but they are genuine architectural cross-references (engine events vs studio chronicle are disjoint domains). **How much private structure the public docs may name is a policy call, not a leak to patch silently.**

## Supersedes #938

#938 covered both halves. #940 landed the cadence half first, so #938 would have re-conflicted it for no gain. This PR is the remainder, scoped to `nika-vocab`. Closing #938.

*Context: this surfaced because the repaired private-path gate reads `git diff --cached` — content committed before the gate existed is invisible to it forever. The full-tree sweep that should have caught it (vector 14) searches **one** pattern where the hook guards **ten**.*

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
