### PR TITLE
feat(nika-tui-core): wasm-bindgen optionnel · 48 lignes blanket quittent 3 verrous

### DIFF
--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -62,7 +62,6 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::check::Profile where Q
 pub fn nika_cli::verbs::check::Profile::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::check::Profile where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::check::Profile::equivalent(&self, key: &K) -> bool
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::check::Profile where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::check::Profile where U: core::convert::From<T>
 pub fn nika_cli::verbs::check::Profile::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::check::Profile where U: core::convert::Into<T>
@@ -119,7 +118,6 @@ pub fn nika_cli::verbs::check::CheckArgs::from_arg_matches_mut(__clap_arg_matche
 pub fn nika_cli::verbs::check::CheckArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_cli::verbs::check::CheckArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::check::CheckArgs
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::check::CheckArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::check::CheckArgs where U: core::convert::From<T>
 pub fn nika_cli::verbs::check::CheckArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::check::CheckArgs where U: core::convert::Into<T>
@@ -151,7 +149,6 @@ pub nika_cli::verbs::check::CheckFlags::json: bool
 pub nika_cli::verbs::check::CheckFlags::native_strict: bool
 pub nika_cli::verbs::check::CheckFlags::profile: nika_cli::verbs::check::Profile
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::check::CheckFlags
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::check::CheckFlags where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::check::CheckFlags where U: core::convert::From<T>
 pub fn nika_cli::verbs::check::CheckFlags::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::check::CheckFlags where U: core::convert::Into<T>
@@ -222,7 +219,6 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::graph::GraphFormat whe
 pub fn nika_cli::verbs::graph::GraphFormat::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::graph::GraphFormat where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::graph::GraphFormat::equivalent(&self, key: &K) -> bool
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::graph::GraphFormat where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::graph::GraphFormat where U: core::convert::From<T>
 pub fn nika_cli::verbs::graph::GraphFormat::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::graph::GraphFormat where U: core::convert::Into<T>
@@ -282,7 +278,6 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::graph::GraphFormatArg 
 pub fn nika_cli::verbs::graph::GraphFormatArg::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::graph::GraphFormatArg where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::graph::GraphFormatArg::equivalent(&self, key: &K) -> bool
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::graph::GraphFormatArg where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::graph::GraphFormatArg where U: core::convert::From<T>
 pub fn nika_cli::verbs::graph::GraphFormatArg::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::graph::GraphFormatArg where U: core::convert::Into<T>
@@ -350,7 +345,6 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::init::CanvasTheme wher
 pub fn nika_cli::verbs::init::CanvasTheme::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::init::CanvasTheme where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::init::CanvasTheme::equivalent(&self, key: &K) -> bool
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::init::CanvasTheme where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::init::CanvasTheme where U: core::convert::From<T>
 pub fn nika_cli::verbs::init::CanvasTheme::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::init::CanvasTheme where U: core::convert::Into<T>
@@ -408,7 +402,6 @@ impl core::clone::Clone for nika_cli::verbs::key::KeyAction
 pub fn nika_cli::verbs::key::KeyAction::clone(&self) -> nika_cli::verbs::key::KeyAction
 impl core::marker::Copy for nika_cli::verbs::key::KeyAction
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::key::KeyAction
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::key::KeyAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::key::KeyAction where U: core::convert::From<T>
 pub fn nika_cli::verbs::key::KeyAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::key::KeyAction where U: core::convert::Into<T>
@@ -461,7 +454,6 @@ pub fn nika_cli::verbs::mcp_pins::McpAction::has_subcommand(__clap_name: &str) -
 impl core::clone::Clone for nika_cli::verbs::mcp_pins::McpAction
 pub fn nika_cli::verbs::mcp_pins::McpAction::clone(&self) -> nika_cli::verbs::mcp_pins::McpAction
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::mcp_pins::McpAction
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::mcp_pins::McpAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::mcp_pins::McpAction where U: core::convert::From<T>
 pub fn nika_cli::verbs::mcp_pins::McpAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::mcp_pins::McpAction where U: core::convert::Into<T>
@@ -515,7 +507,6 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::mcp_pins::McpTransport
 pub fn nika_cli::verbs::mcp_pins::McpTransportArg::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::mcp_pins::McpTransportArg where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::mcp_pins::McpTransportArg::equivalent(&self, key: &K) -> bool
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::mcp_pins::McpTransportArg where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::mcp_pins::McpTransportArg where U: core::convert::From<T>
 pub fn nika_cli::verbs::mcp_pins::McpTransportArg::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::mcp_pins::McpTransportArg where U: core::convert::Into<T>
@@ -590,7 +581,6 @@ impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::run::RenderMode where 
 pub fn nika_cli::verbs::run::RenderMode::equivalent(&self, key: &K) -> bool
 impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::run::RenderMode where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_cli::verbs::run::RenderMode::equivalent(&self, key: &K) -> bool
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::run::RenderMode where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::RenderMode where U: core::convert::From<T>
 pub fn nika_cli::verbs::run::RenderMode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::run::RenderMode where U: core::convert::Into<T>
@@ -639,7 +629,6 @@ pub fn nika_cli::verbs::run::FoldSink<W>::view(&self) -> &nika_display::state::R
 impl<W: core::io::write::Write> nika_event::stamp::EventSink for nika_cli::verbs::run::FoldSink<W>
 pub fn nika_cli::verbs::run::FoldSink<W>::emit(&mut self, event: nika_event::event::Event)
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::run::FoldSink<W>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::run::FoldSink<W> where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::run::FoldSink<W> where U: core::convert::From<T>
 pub fn nika_cli::verbs::run::FoldSink<W>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::run::FoldSink<W> where U: core::convert::Into<T>
@@ -681,7 +670,6 @@ pub fn nika_cli::verbs::sign::SignArgs::from_arg_matches_mut(__clap_arg_matches:
 pub fn nika_cli::verbs::sign::SignArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_cli::verbs::sign::SignArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::sign::SignArgs
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_cli::verbs::sign::SignArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::From<T>
 pub fn nika_cli::verbs::sign::SignArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::sign::SignArgs where U: core::convert::Into<T>

--- a/crates/nika-trace/public-api.txt
+++ b/crates/nika-trace/public-api.txt
@@ -20,7 +20,6 @@ pub fn nika_trace::evidence::EvidenceArgs::from_arg_matches_mut(__clap_arg_match
 pub fn nika_trace::evidence::EvidenceArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_trace::evidence::EvidenceArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_trace::evidence::EvidenceArgs
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::evidence::EvidenceArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::evidence::EvidenceArgs where U: core::convert::From<T>
 pub fn nika_trace::evidence::EvidenceArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::evidence::EvidenceArgs where U: core::convert::Into<T>
@@ -57,7 +56,6 @@ pub fn nika_trace::forecast::gather::Gathered::default() -> nika_trace::forecast
 impl core::fmt::Debug for nika_trace::forecast::gather::Gathered
 pub fn nika_trace::forecast::gather::Gathered::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::gather::Gathered
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::gather::Gathered where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::gather::Gathered where U: core::convert::From<T>
 pub fn nika_trace::forecast::gather::Gathered::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::gather::Gathered where U: core::convert::Into<T>
@@ -99,7 +97,6 @@ pub fn nika_trace::forecast::gather::RunSample::clone(&self) -> nika_trace::fore
 impl core::fmt::Debug for nika_trace::forecast::gather::RunSample
 pub fn nika_trace::forecast::gather::RunSample::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::gather::RunSample
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::gather::RunSample where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::gather::RunSample where U: core::convert::From<T>
 pub fn nika_trace::forecast::gather::RunSample::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::gather::RunSample where U: core::convert::Into<T>
@@ -147,7 +144,6 @@ pub fn nika_trace::forecast::gather::TaskSample::clone(&self) -> nika_trace::for
 impl core::fmt::Debug for nika_trace::forecast::gather::TaskSample
 pub fn nika_trace::forecast::gather::TaskSample::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::gather::TaskSample
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::gather::TaskSample where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::gather::TaskSample where U: core::convert::From<T>
 pub fn nika_trace::forecast::gather::TaskSample::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::gather::TaskSample where U: core::convert::Into<T>
@@ -198,7 +194,6 @@ pub fn nika_trace::forecast::ForecastReport::fmt(&self, f: &mut core::fmt::Forma
 impl serde_core::ser::Serialize for nika_trace::forecast::ForecastReport
 pub fn nika_trace::forecast::ForecastReport::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::ForecastReport
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::ForecastReport where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::ForecastReport where U: core::convert::From<T>
 pub fn nika_trace::forecast::ForecastReport::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::ForecastReport where U: core::convert::Into<T>
@@ -252,7 +247,6 @@ impl core::marker::Copy for nika_trace::forecast::RunCensus
 impl serde_core::ser::Serialize for nika_trace::forecast::RunCensus
 pub fn nika_trace::forecast::RunCensus::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::RunCensus
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::RunCensus where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::RunCensus where U: core::convert::From<T>
 pub fn nika_trace::forecast::RunCensus::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::RunCensus where U: core::convert::Into<T>
@@ -308,7 +302,6 @@ pub fn nika_trace::forecast::TaskPrior::fmt(&self, f: &mut core::fmt::Formatter<
 impl serde_core::ser::Serialize for nika_trace::forecast::TaskPrior
 pub fn nika_trace::forecast::TaskPrior::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::TaskPrior
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::TaskPrior where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::TaskPrior where U: core::convert::From<T>
 pub fn nika_trace::forecast::TaskPrior::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::TaskPrior where U: core::convert::Into<T>
@@ -360,7 +353,6 @@ impl core::marker::Copy for nika_trace::forecast::Window
 impl serde_core::ser::Serialize for nika_trace::forecast::Window
 pub fn nika_trace::forecast::Window::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::Window
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::Window where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::Window where U: core::convert::From<T>
 pub fn nika_trace::forecast::Window::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::Window where U: core::convert::Into<T>
@@ -408,7 +400,6 @@ pub fn nika_trace::forecast::WorkflowIdentity::clone(&self) -> nika_trace::forec
 impl core::fmt::Debug for nika_trace::forecast::WorkflowIdentity
 pub fn nika_trace::forecast::WorkflowIdentity::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::forecast::WorkflowIdentity
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::forecast::WorkflowIdentity where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::forecast::WorkflowIdentity where U: core::convert::From<T>
 pub fn nika_trace::forecast::WorkflowIdentity::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::forecast::WorkflowIdentity where U: core::convert::Into<T>
@@ -458,7 +449,6 @@ pub fn nika_trace::receipt::ReceiptAction::augment_subcommands<'b>(__clap_app: c
 pub fn nika_trace::receipt::ReceiptAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
 pub fn nika_trace::receipt::ReceiptAction::has_subcommand(__clap_name: &str) -> bool
 impl<D> owo_colors::OwoColorize for nika_trace::receipt::ReceiptAction
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::receipt::ReceiptAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::receipt::ReceiptAction where U: core::convert::From<T>
 pub fn nika_trace::receipt::ReceiptAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::receipt::ReceiptAction where U: core::convert::Into<T>
@@ -539,7 +529,6 @@ pub fn nika_trace::trace::action::TraceAction::augment_subcommands<'b>(__clap_ap
 pub fn nika_trace::trace::action::TraceAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
 pub fn nika_trace::trace::action::TraceAction::has_subcommand(__clap_name: &str) -> bool
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceAction
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceAction where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceAction where U: core::convert::Into<T>
@@ -581,7 +570,6 @@ pub fn nika_trace::trace::action::TraceArgs::from_arg_matches_mut(__clap_arg_mat
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceArgs
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceArgs where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceArgs where U: core::convert::Into<T>
@@ -618,7 +606,6 @@ pub fn nika_trace::trace::manage::RmTarget::clone(&self) -> nika_trace::trace::m
 impl core::fmt::Debug for nika_trace::trace::manage::RmTarget
 pub fn nika_trace::trace::manage::RmTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::trace::manage::RmTarget
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::manage::RmTarget where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::manage::RmTarget where U: core::convert::From<T>
 pub fn nika_trace::trace::manage::RmTarget::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::manage::RmTarget where U: core::convert::Into<T>
@@ -713,7 +700,6 @@ pub fn nika_trace::trace::action::TraceAction::augment_subcommands<'b>(__clap_ap
 pub fn nika_trace::trace::action::TraceAction::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
 pub fn nika_trace::trace::action::TraceAction::has_subcommand(__clap_name: &str) -> bool
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceAction
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceAction where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceAction where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceAction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceAction where U: core::convert::Into<T>
@@ -755,7 +741,6 @@ pub fn nika_trace::trace::action::TraceArgs::from_arg_matches_mut(__clap_arg_mat
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 pub fn nika_trace::trace::action::TraceArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
 impl<D> owo_colors::OwoColorize for nika_trace::trace::action::TraceArgs
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace::action::TraceArgs where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace::action::TraceArgs where U: core::convert::From<T>
 pub fn nika_trace::trace::action::TraceArgs::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace::action::TraceArgs where U: core::convert::Into<T>
@@ -802,7 +787,6 @@ pub fn nika_trace::trace_verify::VerifyOptions::default() -> nika_trace::trace_v
 impl core::fmt::Debug for nika_trace::trace_verify::VerifyOptions
 pub fn nika_trace::trace_verify::VerifyOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_trace::trace_verify::VerifyOptions
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_trace::trace_verify::VerifyOptions where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_trace::trace_verify::VerifyOptions where U: core::convert::From<T>
 pub fn nika_trace::trace_verify::VerifyOptions::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_trace::trace_verify::VerifyOptions where U: core::convert::Into<T>

--- a/crates/nika-tui-core/Cargo.toml
+++ b/crates/nika-tui-core/Cargo.toml
@@ -28,7 +28,18 @@ serde        = { workspace = true }
 # measures nothing.
 serde_json   = { workspace = true, features = ["float_roundtrip"] }
 thiserror    = { workspace = true }
-wasm-bindgen = { workspace = true }
+# OPTIONAL on purpose. `wasm-bindgen` publishes a BLANKET `Upcast` impl, so
+# the moment it enters a dependency graph EVERY public type of EVERY crate
+# downstream acquires it. This crate is not a leaf (its sibling
+# `nika-check-wasm` is) — `nika-trace` depends on it, and `nika-cli` on that,
+# so a non-optional binding dragged 30 blanket-impl lines into two public-api
+# baselines that had gained no item of their own. The doors below stay
+# ordinary Rust under default features; only the FFI attribute is gated.
+wasm-bindgen = { workspace = true, optional = true }
+
+[features]
+# The browser lot. `build-wasm.sh` passes it; nothing else needs to.
+wasm = ["dep:wasm-bindgen"]
 
 [lints]
 workspace = true

--- a/crates/nika-tui-core/build-wasm.sh
+++ b/crates/nika-tui-core/build-wasm.sh
@@ -19,7 +19,7 @@ cargo test --locked -p nika-tui-core
 
 workspace_root="$(cd ../.. && pwd)"
 RUSTFLAGS="--remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=/cargo --remap-path-prefix=${workspace_root}=/build" \
-  cargo build --locked -p nika-tui-core --target wasm32-unknown-unknown --profile wasm-release
+  cargo build --locked -p nika-tui-core --features wasm --target wasm32-unknown-unknown --profile wasm-release
 
 # the artifact path is DERIVED, never assumed (CARGO_TARGET_DIR moves it)
 target_root="$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')"

--- a/crates/nika-tui-core/public-api.txt
+++ b/crates/nika-tui-core/public-api.txt
@@ -20,7 +20,6 @@ pub fn nika_tui_core::derive::GroupSpan::eq(&self, other: &nika_tui_core::derive
 impl core::fmt::Debug for nika_tui_core::derive::GroupSpan
 pub fn nika_tui_core::derive::GroupSpan::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for nika_tui_core::derive::GroupSpan
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::derive::GroupSpan where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::derive::GroupSpan where U: core::convert::From<T>
 pub fn nika_tui_core::derive::GroupSpan::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::derive::GroupSpan where U: core::convert::Into<T>
@@ -60,7 +59,6 @@ impl serde_core::ser::Serialize for nika_tui_core::derive::Neck
 pub fn nika_tui_core::derive::Neck::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::derive::Neck
 pub fn nika_tui_core::derive::Neck::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::derive::Neck where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::derive::Neck where U: core::convert::From<T>
 pub fn nika_tui_core::derive::Neck::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::derive::Neck where U: core::convert::Into<T>
@@ -95,7 +93,6 @@ impl core::clone::Clone for nika_tui_core::derive::Waves
 pub fn nika_tui_core::derive::Waves::clone(&self) -> nika_tui_core::derive::Waves
 impl core::fmt::Debug for nika_tui_core::derive::Waves
 pub fn nika_tui_core::derive::Waves::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::derive::Waves where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::derive::Waves where U: core::convert::From<T>
 pub fn nika_tui_core::derive::Waves::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::derive::Waves where U: core::convert::Into<T>
@@ -151,7 +148,6 @@ pub fn nika_tui_core::ingress::IngressError::fmt(&self, f: &mut core::fmt::Forma
 impl core::fmt::Display for nika_tui_core::ingress::IngressError
 pub fn nika_tui_core::ingress::IngressError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for nika_tui_core::ingress::IngressError
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::ingress::IngressError where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::ingress::IngressError where U: core::convert::From<T>
 pub fn nika_tui_core::ingress::IngressError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::ingress::IngressError where U: core::convert::Into<T>
@@ -196,7 +192,6 @@ impl serde_core::ser::Serialize for nika_tui_core::ingress::Edge
 pub fn nika_tui_core::ingress::Edge::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::ingress::Edge
 pub fn nika_tui_core::ingress::Edge::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::ingress::Edge where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::ingress::Edge where U: core::convert::From<T>
 pub fn nika_tui_core::ingress::Edge::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::ingress::Edge where U: core::convert::Into<T>
@@ -237,7 +232,6 @@ impl serde_core::ser::Serialize for nika_tui_core::ingress::FanOut
 pub fn nika_tui_core::ingress::FanOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::ingress::FanOut
 pub fn nika_tui_core::ingress::FanOut::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::ingress::FanOut where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::ingress::FanOut where U: core::convert::From<T>
 pub fn nika_tui_core::ingress::FanOut::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::ingress::FanOut where U: core::convert::Into<T>
@@ -280,7 +274,6 @@ impl serde_core::ser::Serialize for nika_tui_core::ingress::GraphDoc
 pub fn nika_tui_core::ingress::GraphDoc::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::ingress::GraphDoc
 pub fn nika_tui_core::ingress::GraphDoc::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::ingress::GraphDoc where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::ingress::GraphDoc where U: core::convert::From<T>
 pub fn nika_tui_core::ingress::GraphDoc::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::ingress::GraphDoc where U: core::convert::Into<T>
@@ -331,7 +324,6 @@ impl serde_core::ser::Serialize for nika_tui_core::ingress::Node
 pub fn nika_tui_core::ingress::Node::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::ingress::Node
 pub fn nika_tui_core::ingress::Node::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::ingress::Node where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::ingress::Node where U: core::convert::From<T>
 pub fn nika_tui_core::ingress::Node::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::ingress::Node where U: core::convert::Into<T>
@@ -377,7 +369,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Family
 pub fn nika_tui_core::model::Family::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Family
 pub fn nika_tui_core::model::Family::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Family where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Family where U: core::convert::From<T>
 pub fn nika_tui_core::model::Family::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Family where U: core::convert::Into<T>
@@ -418,7 +409,6 @@ pub fn nika_tui_core::model::Group::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 impl core::marker::StructuralPartialEq for nika_tui_core::model::Group
 impl serde_core::ser::Serialize for nika_tui_core::model::Group
 pub fn nika_tui_core::model::Group::serialize<S: serde_core::ser::Serializer>(&self, ser: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Group where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Group where U: core::convert::From<T>
 pub fn nika_tui_core::model::Group::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Group where U: core::convert::Into<T>
@@ -460,7 +450,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Origin
 pub fn nika_tui_core::model::Origin::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Origin
 pub fn nika_tui_core::model::Origin::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Origin where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Origin where U: core::convert::From<T>
 pub fn nika_tui_core::model::Origin::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Origin where U: core::convert::Into<T>
@@ -505,7 +494,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Touch
 pub fn nika_tui_core::model::Touch::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Touch
 pub fn nika_tui_core::model::Touch::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Touch where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Touch where U: core::convert::From<T>
 pub fn nika_tui_core::model::Touch::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Touch where U: core::convert::Into<T>
@@ -549,7 +537,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Verb
 pub fn nika_tui_core::model::Verb::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Verb
 pub fn nika_tui_core::model::Verb::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Verb where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Verb where U: core::convert::From<T>
 pub fn nika_tui_core::model::Verb::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Verb where U: core::convert::Into<T>
@@ -590,7 +577,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Failure
 pub fn nika_tui_core::model::Failure::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Failure
 pub fn nika_tui_core::model::Failure::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Failure where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Failure where U: core::convert::From<T>
 pub fn nika_tui_core::model::Failure::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Failure where U: core::convert::Into<T>
@@ -632,7 +618,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Run
 pub fn nika_tui_core::model::Run::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Run
 pub fn nika_tui_core::model::Run::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Run where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Run where U: core::convert::From<T>
 pub fn nika_tui_core::model::Run::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Run where U: core::convert::Into<T>
@@ -679,7 +664,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Step
 pub fn nika_tui_core::model::Step::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Step
 pub fn nika_tui_core::model::Step::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Step where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Step where U: core::convert::From<T>
 pub fn nika_tui_core::model::Step::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Step where U: core::convert::Into<T>
@@ -726,7 +710,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Task
 pub fn nika_tui_core::model::Task::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Task
 pub fn nika_tui_core::model::Task::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Task where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Task where U: core::convert::From<T>
 pub fn nika_tui_core::model::Task::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Task where U: core::convert::Into<T>
@@ -771,7 +754,6 @@ impl serde_core::ser::Serialize for nika_tui_core::model::Workflow
 pub fn nika_tui_core::model::Workflow::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::model::Workflow
 pub fn nika_tui_core::model::Workflow::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::model::Workflow where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::model::Workflow where U: core::convert::From<T>
 pub fn nika_tui_core::model::Workflow::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::model::Workflow where U: core::convert::Into<T>
@@ -814,7 +796,6 @@ impl serde_core::ser::Serialize for nika_tui_core::plan::Mark
 pub fn nika_tui_core::plan::Mark::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::plan::Mark
 pub fn nika_tui_core::plan::Mark::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::plan::Mark where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::plan::Mark where U: core::convert::From<T>
 pub fn nika_tui_core::plan::Mark::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::plan::Mark where U: core::convert::Into<T>
@@ -857,7 +838,6 @@ impl serde_core::ser::Serialize for nika_tui_core::plan::Board
 pub fn nika_tui_core::plan::Board::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for nika_tui_core::plan::Board
 pub fn nika_tui_core::plan::Board::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
-impl<S, T> wasm_bindgen::convert::traits::Upcast<T> for nika_tui_core::plan::Board where T: wasm_bindgen::convert::traits::UpcastFrom<S> + ?core::marker::Sized, S: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for nika_tui_core::plan::Board where U: core::convert::From<T>
 pub fn nika_tui_core::plan::Board::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for nika_tui_core::plan::Board where U: core::convert::Into<T>

--- a/crates/nika-tui-core/src/wasm.rs
+++ b/crates/nika-tui-core/src/wasm.rs
@@ -21,6 +21,7 @@
 //! shim resolves the imported name — a macro-hygiene class). Distinctive
 //! door names are the workaround, and this note is why.
 
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use crate::claims;
@@ -31,7 +32,7 @@ use crate::plan::{self, Board};
 
 /// The engine version this law speaks for — a consumer pins the artifact's
 /// build the way the sibling's `engine_version()` enables (ADR-107).
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[must_use]
 pub fn engine_version() -> String {
     env!("CARGO_PKG_VERSION").to_owned()
@@ -84,7 +85,7 @@ fn admit(door: &str, inputs: &[&str]) -> Result<(), String> {
 
 /// The derivation of one (workflow, run) pair — the same block the parity
 /// fixtures pin, so the browser shows exactly what the studio computed.
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[must_use]
 pub fn derive_run(workflow_json: &str, run_json: &str) -> String {
     if let Err(e) = admit("derive_run", &[workflow_json, run_json]) {
@@ -147,7 +148,7 @@ pub fn derive_run(workflow_json: &str, run_json: &str) -> String {
 }
 
 /// The journal fold — NDJSON bytes to the session's [`Run`].
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[must_use]
 pub fn fold_journal(ndjson: &str) -> String {
     if let Err(e) = admit("fold_journal", &[ndjson]) {
@@ -163,7 +164,7 @@ pub fn fold_journal(ndjson: &str) -> String {
 }
 
 /// The first seating — every slot born.
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[must_use]
 pub fn board_first(graph_json: &str) -> String {
     if let Err(e) = admit("board_first", &[graph_json]) {
@@ -181,7 +182,7 @@ pub fn board_first(graph_json: &str) -> String {
 
 /// The next seating — the caller hands the previous board back (the law
 /// keeps no state between revisions; the board IS the state).
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[must_use]
 pub fn board_next(board_json: &str, graph_json: &str) -> String {
     if let Err(e) = admit("board_next", &[board_json, graph_json]) {

--- a/docs/crate-specs/nika-tui-core.md
+++ b/docs/crate-specs/nika-tui-core.md
@@ -12,7 +12,7 @@
 | License | `AGPL-3.0-or-later` |
 | Edition | 2024 (workspace-inherited) |
 | Publish | `false` — interface crate, jamais sur crates.io (le WASM part vers npm `@supernovae-st`, le précédent check-wasm) |
-| Dependencies | **mesurées sur `Cargo.toml`, pas déclarées ici** · `serde` · `serde_json` (feature `float_roundtrip` — la parité compare des BITS) · `thiserror` · `wasm-bindgen` · dev: `proptest`. **ZÉRO dépendance interne** — ce tableau annonçait `nika-event` et `nika-graph`, la crate n'en a jamais eu aucune : `ingress.rs` porte un miroir typé de `graph_format: 2`, sans lien à la compilation. Corrigé après qu'une lentille Gate-11 ait lu les deux fichiers. |
+| Dependencies | **mesurées sur `Cargo.toml`, pas déclarées ici** · `serde` · `serde_json` (feature `float_roundtrip` — la parité compare des BITS) · `thiserror` · `wasm-bindgen` (**optionnel** · feature `wasm` · son impl blanket `Upcast` atterrissait sinon sur chaque type public en AVAL) · dev: `proptest`. **ZÉRO dépendance interne** — ce tableau annonçait `nika-event` et `nika-graph`, la crate n'en a jamais eu aucune : `ingress.rs` porte un miroir typé de `graph_format: 2`, sans lien à la compilation. Corrigé après qu'une lentille Gate-11 ait lu les deux fichiers. |
 | NIKA codes | **none owed** — la couche ne refuse pas au sens moteur. ⚠️ Cette ligne disait « ses invariants sont des `debug_assert!` » · aucun ne l'était. Les CLAIMS sont des prédicats, et **deux des quatre** voyagent par la porte wasm (`claims.chain_intact` · `claims.bottleneck`) ; les deux autres ne peuvent pas, et `src/claims.rs` dit lesquels et pourquoi. |
 
 ---

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4452
+  classified_files: 4453
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1516
+    authored: 1517
     authored-pin: 2
     generated: 121
     pinned-copy: 117
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 65
-  aggregate_sha256: 2001c6017776114b2bdbca6c1e21c042a89749f45fcc5993c666613215c711ab
+  aggregate_sha256: 8db1048678b3b9c34715ac2064c0653e819220d82052af468e17580816c9cfc3
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: 35cad0c2516c98f27907566a790a707ee25d3167e67b329cc4475ff2c88848f4
+  aggregate_sha256: e93b88fc7ff472422d1d4047b1bc32648cd6141f1c4558f232a3131778757ede
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 8ff3278a921c0e19a95d90c5e1ebb0e9d05832e92c9c8aea7bf300145a976851
+  aggregate_sha256: 88acef3ef864c58e59f731b2d23933b3aa715139376b6a38705ca2ff7c63e316
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -178,12 +178,12 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 105
-  aggregate_sha256: eb084c2d8a6b794a04e55f8d11d6808a4663e0985f02d9e06026a412bd89eb63
+  aggregate_sha256: ee86793106270b92cf6a3f4b38d10cc42dd9c14a1627fd3e519afff5b3177fc2
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
   match_count: 147
-  aggregate_sha256: f9268d25aedc6bfda7bd09b099f28bc03f4ccd436e53ac607783c1dd85e6928c
+  aggregate_sha256: c4e5c263c42cd2f962d7a0e67720882514cce5ecd9615ebbca23201787a315a4
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/ci/public-api-coverage-baseline.txt
+++ b/scripts/ci/public-api-coverage-baseline.txt
@@ -125,7 +125,18 @@ nika-secret
 # --- 2026-08-14: the two session crates, floored AT admission as the WIP rule
 # above requires (both cleared their 12 gates; neither had a snapshot, which is
 # why vector 38 sat at 62/64). Platform-neutral, verified: zero objc/apple/darwin
-# symbols in either snapshot, and nika-tui-core's #[wasm_bindgen] surface is NOT
-# cfg-gated, so its 26 wasm symbols appear identically on macOS and on linux. ---
+# symbols in either snapshot.
+# --- 2026-08-15 AMENDMENT: the line above used to end "and nika-tui-core's
+# #[wasm_bindgen] surface is NOT cfg-gated, so its 26 wasm symbols appear
+# identically on macOS and on linux". That is no longer true, and the reason
+# matters. wasm-bindgen publishes a BLANKET `Upcast` impl, so once it entered
+# the graph it landed on every public type of every crate DOWNSTREAM — 30 lines
+# in nika-trace's and nika-cli's baselines, neither of which had gained an item
+# of its own. The binding is now optional behind a `wasm` feature and only the
+# FFI ATTRIBUTE is gated (`cfg_attr`), so the five doors stay ordinary public
+# Rust and their native tests still run. The count moves 26 -> 6: the 20 blanket
+# `Upcast` lines are gone, the `pub fn`/`pub mod` doors remain. Platform
+# neutrality is unchanged — a FEATURE gate is not a platform gate, and dropping
+# the binder's glue removes the one part that could have differed. ---
 nika-cadence
 nika-tui-core


### PR DESCRIPTION
Suite directe de #939 · j'y avais **ratifié** 30 lignes d'impl blanket dans deux
verrous pour débloquer `main`, en nommant la vraie correction et en la
différant. La voici.

## Le mécanisme

`wasm-bindgen` publie un impl **blanket** (`Upcast`). Dès qu'il entre dans un
graphe, *chaque* type public de *chaque* crate en aval l'acquiert.

Sa sœur `nika-check-wasm` porte le même motif **sans dommage** — parce qu'elle
est une **feuille**. `nika-tui-core` est devenue une **dépendance**
(`nika-trace`, puis `nika-cli`), donc le même motif a fait dériver deux verrous
qui n'avaient gagné **aucun item**.

## Le choix de conception · gater l'ATTRIBUT, pas le MODULE

C'est le point qui a décidé de la forme. Les cinq portes sont appelées
**nativement** par les tests — la bombe de pile dans `security.rs`, « les portes
répondent » dans `mutation_gaps.rs`. Gater le module entier les aurait sorties
du chemin par défaut : une perte de couverture déguisée en nettoyage.

Sur cible native, `#[wasm_bindgen]` ne produit que de la glue. Donc
`#[cfg_attr(feature = "wasm", wasm_bindgen)]` · les fonctions restent du Rust
ordinaire, publiques et testées, et seule la liaison FFI est conditionnelle.

## Mesuré

```
l'arête           cargo tree -p nika-trace -i wasm-bindgen → « nothing to print »
les portes        the_wasm_doors_answer_with_content ... ok
la voie wasm      cargo check --features wasm → Finished
clippy            0 constat, sous les DEUX jeux de features
workspace         5804 tests verts
```

Verrous · **-20** `nika-tui-core` · **-16** `nika-trace` · **-12** `nika-cli`.
Aucune **porte** ne part — seules les lignes blanket. Les 6 `pub fn`/`pub mod`
restent, puisque les fonctions ne sont pas gatées. Le workflow lit les features
**par défaut** (ligne 86 · « not `--all-features` »), donc la feature est OFF au
moment de la mesure.

`nika-check-wasm` garde les siens, et c'est correct · feuille, binding non
optionnel, rien en aval.

## Un commentaire load-bearing, amendé

Le plancher de couverture affirmait ·

> « nika-tui-core's `#[wasm_bindgen]` surface is NOT cfg-gated, so its 26 wasm
> symbols appear identically on macOS and on linux »

Ce commentaire **justifiait la confiance** dans le verrou, et ma modification le
rend faux. Il est amendé sur place, sans réécrire l'original — la neutralité de
plateforme tient toujours (une feature n'est pas une plateforme, et retirer la
glue du binder supprime justement la part qui aurait pu différer). Le compte
passe de 26 à 6.

La fiche de crate listait `wasm-bindgen` en se réclamant de `Cargo.toml` · elle
dit maintenant « optionnel ».
