### PR TITLE
fix(hygiene): vector 2 compares sets, not counts

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4453
+  classified_files: 4454
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1517
+    authored: 1518
     authored-pin: 2
     generated: 121
     pinned-copy: 117
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 116
-  aggregate_sha256: 4a00ff02bdb8446d14b981849831722e69093b598d564efcf8304f875340ab22
+  aggregate_sha256: c3f8ae3b348bb1d57ddb559a4426d0c84eb70716b4c54792ca6e074af473b74b
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: e93b88fc7ff472422d1d4047b1bc32648cd6141f1c4558f232a3131778757ede
+  aggregate_sha256: 1534e69830a6678822e9abcb88755de9b4ececb80c01cd49a7afdd3801aee54a
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -182,8 +182,8 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 147
-  aggregate_sha256: c4e5c263c42cd2f962d7a0e67720882514cce5ecd9615ebbca23201787a315a4
+  match_count: 148
+  aggregate_sha256: 5cb9f5002b35aa2c22e3872f8841ec70ce9f678a2aa646966ccc04f52a48feb4
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: f8f3dd9eed0d9d3e366693bad3e2d190fb2e6c94326f088a741cb4d8ffbd6212
+  aggregate_sha256: d5b466892aa17a3f0a8e7976b4b7b58e6750c523a282db50315349fecd4057e5
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored

--- a/scripts/hygiene/check-crate-count.sh
+++ b/scripts/hygiene/check-crate-count.sh
@@ -6,6 +6,15 @@
 # crates added without the layer discipline + crates removed from the
 # workspace but still tagged.
 #
+# It compares SETS, not counts. Counting was the original form and it was
+# green on the realistic case: add `nika-b` without a layer, drop
+# `nika-old` while its layer stays, and 2 members vs 2 layers matches
+# while BOTH halves of the invariant are broken. Measured 2026-08-15 —
+# `OK (2 workspace members, all layer-classified)`, rc=0, with one crate
+# unclassified and one layer pointing at nothing. Each fault alone
+# reddened; only together did they cancel. A parity that two errors can
+# satisfy is arithmetic, not enforcement.
+#
 # Replaces the old MEMORY.md-text-grep approach (which broke when MEMORY
 # format changed and the path had a typo `-supernovae-nika` vs `-supernovae-hq`).
 # Status drift between MEMORY and reality is now covered by vector 23
@@ -23,18 +32,38 @@ cd "$SCRIPT_DIR/../.." || exit 2
 # Count crates in the workspace `members = [...]` array. Read the first
 # `^members` line and count `"crates/X"` entries. Brittle to multi-line
 # arrays, but the canonical Cargo.toml uses a single-line members list.
-members_count=$(grep -m1 '^members' Cargo.toml | grep -oE '"crates/[^"]+"' | wc -l | tr -d ' ')
+members=$(grep -m1 '^members' Cargo.toml | grep -oE '"crates/[^"]+"' \
+  | tr -d '"' | sed 's|^crates/||' | sort -u)
 
-# Count layer assignments (one per crate, e.g. layers.nika-types = "L0").
-layer_count=$(grep -cE '^layers\.[a-z0-9-]+ = "L[0-9.]+"$' Cargo.toml)
+# Layer assignments, one per crate (e.g. layers.nika-types = "L0").
+layers=$(grep -oE '^layers\.[a-z0-9-]+ = "L[0-9.]+"$' Cargo.toml \
+  | sed -e 's|^layers\.||' -e 's| = .*||' | sort -u)
 
-if [ "$members_count" -eq 0 ]; then
+members_count=$(printf '%s\n' "$members" | grep -c . || true)
+
+if [ "${members_count:-0}" -eq 0 ]; then
   echo "RED: no workspace members detected (parser drift?)"
   exit 2
 fi
 
-if [ "$members_count" != "$layer_count" ]; then
-  echo "RED: $members_count workspace members vs $layer_count layer assignments"
+# Both directions, named separately: a member with no layer is undisciplined,
+# a layer with no member is a zombie. Counting could not tell them apart, and
+# one of each cancelled out.
+unclassified=$(comm -23 <(printf '%s\n' "$members") <(printf '%s\n' "$layers"))
+zombies=$(comm -13 <(printf '%s\n' "$members") <(printf '%s\n' "$layers"))
+
+if [ -n "$unclassified" ] || [ -n "$zombies" ]; then
+  echo "RED: workspace members and layer assignments disagree"
+  if [ -n "$unclassified" ]; then
+    echo ""
+    echo "  member(s) with NO layer:"
+    printf '%s\n' "$unclassified" | sed 's/^/    · /'
+  fi
+  if [ -n "$zombies" ]; then
+    echo ""
+    echo "  layer(s) naming no member:"
+    printf '%s\n' "$zombies" | sed 's/^/    · /'
+  fi
   echo ""
   echo "Hint: add a 'layers.nika-X = \"L?\"' entry under"
   echo "[workspace.metadata.diamond] for every member crate, OR remove"

--- a/scripts/hygiene/tests/crate-count.test.sh
+++ b/scripts/hygiene/tests/crate-count.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# COVERS: scripts/hygiene/check-crate-count.sh
+#
+# Mutation proof for vector 2 (every workspace member is layer-classified).
+#
+# It compared COUNTS. Each fault alone reddened, so it looked enforced —
+# but the realistic refactor breaks both halves at once: you add a crate
+# without a layer AND drop another whose layer stays behind. Two members,
+# two layers, parity satisfied, invariant broken twice.
+#
+# Measured before the fix · `OK (2 workspace members, all layer-classified)`,
+# rc=0, with one crate unclassified and one layer naming nothing.
+#
+# A parity that two errors can satisfy is arithmetic, not enforcement — the
+# same family as a runner announcing "all 8 ratchets passed" after skipping
+# the ninth. The swap case below is the one that matters; the two solo cases
+# are the controls that prove the probe discriminates rather than reddening
+# on everything.
+#
+# shellcheck disable=SC2329
+set -uo pipefail
+
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+VECTOR="$ROOT/scripts/hygiene/check-crate-count.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+cases=0
+
+# expect <want-rc> <label> <members> <layers>
+expect() {
+  local want="$1" label="$2" members="$3" layers="$4"
+  cases=$((cases + 1))
+  local dir="$WORK/case-$cases"
+  mkdir -p "$dir/scripts/hygiene"
+  cp "$VECTOR" "$dir/scripts/hygiene/"
+  {
+    printf '[workspace]\nmembers = [%s]\n\n[workspace.metadata.diamond]\n' "$members"
+    printf '%s\n' "$layers"
+  } >"$dir/Cargo.toml"
+  local rc
+  bash "$dir/scripts/hygiene/check-crate-count.sh" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$want" ]; then
+    printf '  ok   %s (rc=%d)\n' "$label" "$rc"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL %s — wanted rc=%s, got rc=%d\n' "$label" "$want" "$rc" >&2
+  fi
+}
+
+BOTH='"crates/nika-a", "crates/nika-b"'
+
+echo "vector 2 · mutation proof"
+
+expect 0 "every member classified" "$BOTH" 'layers.nika-a = "L0"
+layers.nika-b = "L1"'
+
+# THE case: one member unclassified AND one layer naming no member. The
+# counts match; both halves of the invariant are broken.
+expect 2 "a member with no layer AND a zombie layer" "$BOTH" 'layers.nika-a = "L0"
+layers.nika-zombie = "L1"'
+
+# Controls — each fault alone. A count check caught these, which is exactly
+# why it looked like it worked.
+expect 2 "a member with no layer, alone" "$BOTH" 'layers.nika-a = "L0"'
+expect 2 "a zombie layer, alone" '"crates/nika-a"' 'layers.nika-a = "L0"
+layers.nika-zombie = "L1"'
+
+# The empty harvest was already guarded; keep it pinned.
+expect 2 "no members parsed at all" '' 'layers.nika-a = "L0"'
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d case(s) wrong — a parity two errors can satisfy.\n' \
+    "$fails" "$cases" >&2
+  exit 1
+fi
+
+printf '\n%d/%d cases correct.\n' "$cases" "$cases"
+exit 0


### PR DESCRIPTION
Vector 2 checked that the **number** of workspace members equals the **number** of layer assignments. Each fault alone reddened, so it looked enforced.

The realistic refactor breaks both halves at once: you add a crate without a layer **and** drop another whose layer stays behind.

```
members = nika-a, nika-b        layers = nika-a, nika-zombie
→ OK (2 workspace members, all layer-classified)      rc=0
```

`nika-b` has no layer. `nika-zombie` names no crate. **The gate is green.**

Its own header claimed to catch *"new crates added without the layer discipline + crates removed from the workspace but still tagged"* — it caught each **separately** and neither **together**, which is the only way they actually occur.

> A parity that two errors can satisfy is arithmetic, not enforcement.

Same family as a runner announcing `all 8 ratchets passed` after skipping the ninth: the number stays true while the meaning leaves.

## The fix

It diffs the two **sets** and names both directions separately — a member with no layer is *undisciplined*, a layer with no member is a *zombie*. Counting could not tell them apart. The empty-harvest guard already present is kept and pinned by a case.

## Proof

| arm | result |
|---|---|
| **OLD** | **1/5 wrong** |
| **NEW** | **5/5 correct** |

**Four cases pass in both arms** — the swap is the only difference, which is the finding stated as a measurement.

On the real tree: `OK (65 workspace members, all layer-classified)`, unchanged. `shellcheck -x` and `shfmt -d -i 2 -ci -bn` clean.

## Noted, not fixed

The members parser reads only the **first** `^members` line, so a multi-line array would be misread. The canonical `Cargo.toml` keeps it on one line and the original comment already says so — widening the parser without a fixture that reproduces the multi-line shape would be a change I could not prove.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
