### PR TITLE
fix(nika-cli): un chemin de skill se résout contre SON workflow, pas contre le CWD

### DIFF
--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -296,7 +296,7 @@ pub fn run_with_profile(
     // binary cannot resolve is a FINDING (exit 2), never a green audit.
     let models_audit = unresolvable_models(&report, &wf);
     // SKILLS rung (#473 · MODELS pattern): a bad SKILL.md is a FINDING.
-    let skills = super::resolve_workflow_skills(&wf);
+    let skills = super::resolve_workflow_skills(&wf, super::workflow_base(path));
     let clean = report.is_clean() && models_audit.findings.is_empty() && skills.findings.is_empty();
     // The risk grade (P0-6): a pure projection of the report — uncapped
     // spend or wildcard grants never turn the verdict green by silence.

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -102,10 +102,43 @@ pub(crate) fn stamp_judged_semantic(wf: &RawWorkflow, report: &mut CheckReport) 
         nika_runtime::proof::ir::semantic_ir_hash(wf).map(|h| h.as_hex().to_owned());
 }
 
+/// The directory a workflow's relative references resolve against — the
+/// folder holding the file the operator named. An empty parent (a bare
+/// `wf.nika.yaml`) joins to the path itself, which is the CWD-relative
+/// form and stays correct.
+pub(crate) fn workflow_base(path: &str) -> &std::path::Path {
+    std::path::Path::new(path)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new(""))
+}
+
 /// The `skills:` fs edge (#473) — the ONE reader check · run · test share.
-pub(crate) fn resolve_workflow_skills(wf: &RawWorkflow) -> nika_schema::ResolvedSkills {
+///
+/// `base` is the DIRECTORY of the workflow the operator named. A
+/// `skills:` path is relative to the FILE that names it, exactly like a
+/// composed child target — `check_composed` has taken that base since
+/// spec 14, and this reader, its declared twin, took none. So
+/// `nika check sub/wf.nika.yaml` run from the repo root read `./s.md`
+/// from the ROOT, not from `sub/`.
+///
+/// **What deliberately does NOT move: the permits subject.**
+/// `resolve_skills` judges the grant on the path AS WRITTEN
+/// (`allows_path(key, false)`), and `path_glob_matches` is purely
+/// lexical — it normalizes two strings and walks segments, with no
+/// filesystem and no CWD. That is what makes check ≡ run decidable
+/// without touching a disk, and rebasing the SUBJECT would move a
+/// security boundary. Rebasing the READ moves the opposite way: the file
+/// actually opened now agrees with the grant the author wrote, instead of
+/// depending on where the operator happened to stand. NIKA-SEC-004 was
+/// falsified in this exact zone at 0.108.0; the gate stays where it is.
+pub(crate) fn resolve_workflow_skills(
+    wf: &RawWorkflow,
+    base: &std::path::Path,
+) -> nika_schema::ResolvedSkills {
     nika_schema::resolve_skills(wf, &mut |p| {
-        std::fs::read_to_string(p).map_err(|e| e.to_string())
+        // An ABSOLUTE skill path joins to itself — it keeps naming the
+        // file it names, and the lexical grant still has to admit it.
+        std::fs::read_to_string(base.join(p)).map_err(|e| e.to_string())
     })
 }
 
@@ -142,6 +175,68 @@ mod tests {
     /// MALFORMATION, not by a boundary refusal · a reference that does not
     /// sit outside the measured function agrees with itself.
     ///
+    /// ⭐ A `skills:` path is relative to the FILE that names it, never to
+    /// wherever the operator happens to stand.
+    ///
+    /// `check_composed` has taken the workflow's own path as its base since
+    /// spec 14, and its own comment calls the skills reader « the fs edge
+    /// is the skills reader's twin » — but the twin took NO base, so it
+    /// resolved against the process CWD. `nika check sub/wf.nika.yaml` from
+    /// the repo root looked for `s.md` in the ROOT.
+    ///
+    /// The fixture is discriminating by construction: the skill exists ONLY
+    /// in the workflow's directory, and the test's CWD is not that
+    /// directory. Under the old reader the read misses and `texts` is
+    /// empty; only a correctly based read populates it.
+    ///
+    /// The GRANT is unchanged and still lexical (`s.md` as written) — that
+    /// is the half that must not move.
+    #[test]
+    fn a_skill_path_resolves_against_the_workflow_not_the_cwd() {
+        let dir = std::env::temp_dir().join(format!("nika-skill-base-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("fixture dir");
+        std::fs::write(
+            dir.join("s.md"),
+            "---\nname: probe\ndescription: a valid Agent Skill beside its workflow\n---\nbody\n",
+        )
+        .expect("skill beside the workflow");
+        let wf_path = dir.join("wf.nika.yaml");
+        let yaml = concat!(
+            "nika: w\n",
+            "model: mock/echo\n",
+            "permits:\n  fs:\n    read: [\"s.md\"]\n",
+            "tasks:\n  t:\n    agent:\n",
+            "      prompt: p\n",
+            "      skills: [\"s.md\"]\n",
+        );
+        std::fs::write(&wf_path, yaml).expect("workflow beside its skill");
+
+        let wf = nika_schema::parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let named = wf_path.to_string_lossy();
+        let resolved = resolve_workflow_skills(&wf, workflow_base(&named));
+
+        assert!(
+            resolved.findings.is_empty(),
+            "the skill sits beside its workflow and is granted · {:?}",
+            resolved.findings
+        );
+        assert!(
+            resolved.texts.contains_key("s.md"),
+            "the read must resolve against the workflow's directory, not the CWD"
+        );
+
+        // The CWD-based reader is what shipped. Pinned here so the fix is
+        // not silently undone: with no base, the same fixture misses.
+        let cwd_based = resolve_workflow_skills(&wf, std::path::Path::new(""));
+        assert!(
+            cwd_based.texts.is_empty(),
+            "the fixture must be discriminating — if this populates, the \
+             test's CWD happens to hold an `s.md` and proves nothing"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// The discriminating fixture is a **valid** skill placed outside the
     /// boundary: only a refusal keeps `texts` empty · a read populates it.
     #[test]
@@ -172,7 +267,9 @@ mod tests {
         let wf = nika_schema::parse(&yaml, FileId::new(0), ParseMode::Strict)
             .expect("the fixture parses");
 
-        let resolved = resolve_workflow_skills(&wf);
+        // The fixture names an ABSOLUTE path, so the base is moot (`join`
+        // on an absolute returns it unchanged) — the grant still decides.
+        let resolved = resolve_workflow_skills(&wf, std::path::Path::new(""));
 
         // The whole point: the skill PARSES, so the only thing that can keep
         // it out of `texts` is the boundary refusing the read.

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -889,7 +889,7 @@ fn scoped_clean_gate(
         return Err(refuse());
     }
     // `skills:` gate (#473 · pre-effect · the SAME rows check renders).
-    let resolved = crate::verbs::resolve_workflow_skills(&wf);
+    let resolved = crate::verbs::resolve_workflow_skills(&wf, crate::verbs::workflow_base(file));
     if !resolved.findings.is_empty() {
         return Err(refuse());
     }

--- a/crates/nika-cli/src/verbs/run/tests.rs
+++ b/crates/nika-cli/src/verbs/run/tests.rs
@@ -330,7 +330,8 @@ fn capture_mock_outputs_carries_the_resolved_skills() {
     let report = nika_check::check(&wf);
     assert!(report.is_clean(), "the pure ladder is fs-free");
 
-    let resolved = crate::verbs::resolve_workflow_skills(&wf);
+    // Absolute fixture path — the base is moot here.
+    let resolved = crate::verbs::resolve_workflow_skills(&wf, std::path::Path::new(""));
     assert!(resolved.findings.is_empty(), "the skill file resolves");
     let theme = Theme::new(false, true, false);
     let (code, _) =

--- a/crates/nika-cli/src/verbs/test.rs
+++ b/crates/nika-cli/src/verbs/test.rs
@@ -64,7 +64,7 @@ pub fn run(file: &str, update: bool, theme: Theme) -> u8 {
         }
     };
     // #473 · a golden pins the run WITH its skills composed, never without.
-    let resolved = crate::verbs::resolve_workflow_skills(&wf);
+    let resolved = crate::verbs::resolve_workflow_skills(&wf, crate::verbs::workflow_base(file));
     if !report.is_clean() || !resolved.findings.is_empty() {
         // The SAME findings `nika check` renders — a dirty file never
         // pins (or judges) a golden.

--- a/estate.yaml
+++ b/estate.yaml
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 116
-  aggregate_sha256: 4a00ff02bdb8446d14b981849831722e69093b598d564efcf8304f875340ab22
+  aggregate_sha256: c3f8ae3b348bb1d57ddb559a4426d0c84eb70716b4c54792ca6e074af473b74b
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: e93b88fc7ff472422d1d4047b1bc32648cd6141f1c4558f232a3131778757ede
+  aggregate_sha256: 51a7dde695b607f28c682e46855d811030c05aaad0af7784d9d354d7bd21ae25
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: f8f3dd9eed0d9d3e366693bad3e2d190fb2e6c94326f088a741cb4d8ffbd6212
+  aggregate_sha256: d5b466892aa17a3f0a8e7976b4b7b58e6750c523a282db50315349fecd4057e5
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
**C2** du plan. Il était marqué « ⚠️ arbitrage, pas ménage · attend un D-lock »
— avec raison : c'est la zone où **NIKA-SEC-004 a été falsifié en 0.108.0**. En
la mesurant, l'arbitrage se dissout, et voici pourquoi.

## Le bug

`check_composed` prend le chemin nommé par l'opérateur comme base depuis la spec
14, et son propre commentaire appelle le lecteur de skills « **son jumeau** ».
Le jumeau ne prenait **aucune base**. Il résolvait donc contre le CWD du
processus ·

```
nika check sous/wf.nika.yaml     lancé depuis la racine
skills: ["s.md"]                 → cherché À LA RACINE, pas dans sous/
```

## L'arbitrage, mesuré plutôt que supposé

Le plan annonçait « `resolve_skills` donne la même chaîne au match
`permits.fs.read` ». **C'est exact** — la ligne existe, `allows_path(key, false)`
sur le chemin tel qu'écrit. (J'avais d'abord conclu l'inverse, en grepant
`nika-cli` et `nika-runtime` mais pas `nika-schema` lui-même. Sonde trop
étroite.)

Ce qui n'était pas dit, et qui décide · **`path_glob_matches` est purement
lexical**. Il normalise deux chaînes et parcourt des segments — aucun
filesystem, aucun CWD. Le permis est donc un contrat **sur les chaînes du
fichier**, et c'est exactement ce qui rend `check ≡ run` décidable sans toucher
un disque.

> Conséquence · le bug n'est **que dans la lecture**. Le grant est déjà correct
> et CWD-indépendant.

## Ce qui bouge, et ce qui ne bouge surtout pas

| | |
|---|---|
| la chaîne telle-qu'écrite | reste le **sujet du permis** ET la clé de la map (le runtime fait `skills.get(&path.value)`) |
| l'argument du **lecteur** | seul rebasé, contre le dossier du workflow |

Rebaser le **sujet** aurait déplacé une frontière de sécurité. Rebaser la
**lecture** va dans l'autre sens : le fichier réellement ouvert **s'accorde**
désormais avec le grant que l'auteur a écrit, au lieu de dépendre de l'endroit
où l'opérateur se tenait. La porte NIKA-SEC-004 reste où elle est, et son test
aussi (il passe inchangé — son fixture est absolu, donc la base lui est
indifférente).

Un chemin **absolu** joint à lui-même : il continue de nommer ce qu'il nomme, et
le grant lexical doit toujours l'admettre.

## Preuve

Le fixture est discriminant **par construction** — le skill n'existe que dans le
dossier du workflow, et le CWD du test n'est pas ce dossier. Le test porte en
plus sa propre garde : il re-résout avec une base vide et exige que ça **rate**,
sinon il s'accuse lui-même de ne rien prouver.

Tombe sous mutation quand le lecteur reprend le CWD. Workspace **5813 tests**
verts, zéro constat clippy.
