### PR TITLE
fix(nika-schema): une clé qui a ÉTÉ PUBLIÉE ne doit pas se lire comme une faute de frappe

### DIFF
--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -347,6 +347,42 @@ pub(super) struct Cx<'a> {
     pub(super) mode: ParseMode,
 }
 
+/// A key that ONCE SHIPPED and no longer exists — not a typo.
+///
+/// The Damerau-Levenshtein guess treats a RETIRED key exactly like a
+/// misspelling, so a key that shipped in v0.108.0's fourteen-key
+/// envelope reads to its author exactly like `zzz:`. `vars:` and `env:`
+/// each got a named tombstone (`NIKA-VALUES-001/002`) carrying a
+/// migration path; this one was published without any.
+///
+/// The path is carried WITHOUT minting a spec code: the error stays
+/// `NIKA-PARSE-005` and only the suggestion clause changes. A real
+/// tombstone (its own `NIKA-VALUES-` number, byte-mirrored from the
+/// spec's oracle like the other two) is the SPEC's to declare, not this
+/// parser's.
+///
+/// Where the role went is MEASURED, not guessed — the engine says it in
+/// three independent places: "a LIVE authority — `inputs:` since
+/// `config:` died" (the check analyzer), "It rides `inputs:` now"
+/// (`permit_taint`), and #909's own diff comment.
+fn retired_key_teaching(key: &str, location: &str) -> Option<&'static str> {
+    // Envelope-scoped on purpose: the same word is a plausible field name
+    // inside a task body or a future block, and teaching the envelope's
+    // migration there would send a repairer the wrong way.
+    if !location.contains("envelope") {
+        return None;
+    }
+    match key {
+        "config" => Some(
+            "this key shipped in the fourteen-key envelope and died with the \
+             nine-key one (2026-08-13) — a deployment-supplied value is now an \
+             `inputs:` entry with `required: false` and a `default:`; a value \
+             baked into the file is a `const:` entry",
+        ),
+        _ => None,
+    }
+}
+
 impl Cx<'_> {
     /// Translate a marked-yaml span.
     pub(super) fn span(&self, span: &YamlSpan) -> Option<Span> {
@@ -398,6 +434,8 @@ impl Cx<'_> {
                          line; it is editor-only)"
                             .to_owned(),
                     )
+                } else if let Some(teaching) = retired_key_teaching(key.as_str(), location) {
+                    Some(teaching.to_owned())
                 } else {
                     nika_types::suggest::did_you_mean(key.as_str(), known.iter().copied())
                         .map(str::to_owned)
@@ -1172,5 +1210,58 @@ tasks:
         check_source_bounds("nika: w\n").expect("a normal file passes");
         check_source_bounds(&format!("{}k: v", " ".repeat(MAX_INDENT_BYTES - 1)))
             .expect("just under the indent cap passes");
+    }
+
+    /// ⭐ A key that SHIPPED must not read like a typo.
+    ///
+    /// Measured before the fix: `config:` — published in the fourteen-key
+    /// envelope of v0.108.0 — produced a bare `NIKA-PARSE-005 unknown
+    /// field`, byte-identical to what a nonsense key produces. `vars:` and
+    /// `env:` each carry a named tombstone; this one shipped without any,
+    /// so an author who wrote it was told nothing.
+    ///
+    /// The three arms are the whole contract: the retired key teaches, a
+    /// near-miss keeps its spelling guess, and a nonsense key still gets
+    /// silence (a wrong guess is worse than none).
+    #[test]
+    fn a_retired_envelope_key_teaches_its_migration_not_a_spelling_guess() {
+        let sees = |key: &str| {
+            let yaml = format!(
+                "nika: w\n{key}: {{}}\ntasks:\n  t:\n    exec: {{ command: [\"true\"] }}\n"
+            );
+            parse(&yaml, FileId::new(0), ParseMode::Strict)
+                .expect_err("an unknown envelope key refuses")
+                .to_string()
+        };
+
+        let retired = sees("config");
+        assert!(
+            retired.contains("`inputs:`") && retired.contains("`const:`"),
+            "a retired key names where its role WENT · {retired}"
+        );
+        assert!(
+            !retired.contains("did you mean"),
+            "a retired key is not a misspelling · {retired}"
+        );
+
+        assert!(
+            sees("conts").contains("did you mean `const`"),
+            "a near-miss keeps its spelling guess"
+        );
+        let nonsense = sees("zzz");
+        assert!(
+            !nonsense.contains("did you mean") && !nonsense.contains("`inputs:`"),
+            "a nonsense key still gets silence · {nonsense}"
+        );
+    }
+
+    /// The teaching is ENVELOPE-scoped. The same word is a plausible field
+    /// name elsewhere, and teaching the envelope's migration inside a task
+    /// body would send a repairer the wrong way.
+    #[test]
+    fn the_retired_teaching_does_not_leak_out_of_the_envelope() {
+        assert!(retired_key_teaching("config", "the workflow envelope").is_some());
+        assert!(retired_key_teaching("config", "`exec:`").is_none());
+        assert!(retired_key_teaching("config", "task t").is_none());
     }
 }

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -434,8 +434,6 @@ impl Cx<'_> {
                          line; it is editor-only)"
                             .to_owned(),
                     )
-                } else if let Some(teaching) = retired_key_teaching(key.as_str(), location) {
-                    Some(teaching.to_owned())
                 } else {
                     nika_types::suggest::did_you_mean(key.as_str(), known.iter().copied())
                         .map(str::to_owned)
@@ -459,6 +457,18 @@ impl Cx<'_> {
                             (known.len() <= 9)
                                 .then(|| format!("the fields here: {}", known.join(" · ")))
                         })
+                };
+                // A RETIRED key leads with its migration and KEEPS the
+                // ordinary teaching behind it — the two answer different
+                // questions and neither replaces the other. The set listing
+                // says what is valid NOW; only this says the key once
+                // existed and where its role went. Composed, not preempted:
+                // an earlier draft returned the migration INSTEAD, and the
+                // sibling law's own test caught it.
+                let suggestion = match (retired_key_teaching(key.as_str(), location), suggestion) {
+                    (Some(retired), Some(ordinary)) => Some(format!("{retired} · {ordinary}")),
+                    (Some(retired), None) => Some(retired.to_owned()),
+                    (None, ordinary) => ordinary,
                 };
                 return Err(SchemaError::UnknownField {
                     field: key.as_str().to_owned(),
@@ -914,10 +924,20 @@ tasks:
             panic!("expected UnknownField, got {err:?}");
         };
         let taught = suggestion.expect("the envelope must teach its set");
-        assert!(taught.starts_with("the fields here:"), "{taught}");
+        // `starts_with` → `contains` (2026-08-15, same day, sibling change):
+        // this fixture is a RETIRED key, so the migration now LEADS and the
+        // set listing follows. The law under test is unchanged — the set is
+        // still taught, whole — and the fixture stays `config:` on purpose,
+        // since it is the case that exposed the silence. The two teachings
+        // compose; neither replaces the other.
+        assert!(taught.contains("the fields here:"), "{taught}");
         for key in TOP_LEVEL_KEYS {
             assert!(taught.contains(key), "`{key}` missing from: {taught}");
         }
+        assert!(
+            taught.contains("`inputs:`"),
+            "a retired key ALSO names where its role went · {taught}"
+        );
 
         // The other side of the threshold, and the reason it exists: a task
         // carries far more keys than a reader can use as a hint, so that set

--- a/estate.yaml
+++ b/estate.yaml
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 116
-  aggregate_sha256: 4a00ff02bdb8446d14b981849831722e69093b598d564efcf8304f875340ab22
+  aggregate_sha256: c3f8ae3b348bb1d57ddb559a4426d0c84eb70716b4c54792ca6e074af473b74b
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: e93b88fc7ff472422d1d4047b1bc32648cd6141f1c4558f232a3131778757ede
+  aggregate_sha256: 82b0a37792c88dc1e81671b196d3dfb765697abff07285a7a25f86edaf695ad5
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: f8f3dd9eed0d9d3e366693bad3e2d190fb2e6c94326f088a741cb4d8ffbd6212
+  aggregate_sha256: d5b466892aa17a3f0a8e7976b4b7b58e6750c523a282db50315349fecd4057e5
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 765
-  aggregate_sha256: 25cd775384cfeff36f4d2a2890aaee5a4f3c145968cb2a596199c3736e631481
+  aggregate_sha256: 670802097e67d8a89301cd85de8dc89a1b335098aad1d0ec28c88c34a2b7dc8d
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Première des deux **dettes nommées** du plan.

> **⚠️ Mesure actualisée 2026-08-15.** La #948 d'une session voisine a atterri
> entre-temps sur la même fonction : le repli « liste l'ensemble » se déclenchait
> à `known.len() <= 8` et l'enveloppe en porte neuf, donc elle ne disait jamais
> son vocabulaire. Ma mesure d'origine (« octet pour octet la même chose qu'une
> clé absurde ») n'est plus exacte au pied de la lettre. Elle l'est encore sur
> le fond, et c'est le sujet de cette PR — la version d'aujourd'hui est ci-dessous.

## Le défaut

La clé `config` est partie dans l'enveloppe à neuf clés (2026-08-13) **après
avoir été publiée** dans celle à quatorze. `vars` et `env` portent chacune un
tombstone nommé (`NIKA-VALUES-001/002`) avec son chemin de migration. Celle-ci
n'en a jamais eu.

Avec la #948 en place, un auteur qui l'avait écrite reçoit ·

```
config → … — the fields here: nika · model · inputs · const · secrets · …
zzz    → … — the fields here: nika · model · inputs · const · secrets · …
```

**Toujours identiques entre elles.** La liste dit ce qui est valide *maintenant*
— elle ne dit ni que `config` a **existé**, ni qu'elle a été **retirée**, ni
vers quoi migrer. Et sa migration n'est pas devinable : `inputs:` + `required:
false` + `default:`.

## Composé, pas préempté

Un premier jet renvoyait la migration **à la place** de l'enseignement ordinaire
— et le test de la loi sœur l'a attrapé. Les deux répondent à deux questions
différentes et aucun ne remplace l'autre ·

```
config → … — this key shipped in the fourteen-key envelope and died with the
         nine-key one (2026-08-13) — a deployment-supplied value is now an
         `inputs:` entry with `required: false` and a `default:`; a value baked
         into the file is a `const:` entry
         · the fields here: nika · model · inputs · const · secrets · …
zzz    → … — the fields here: …          ← le vocabulaire seul
conts  → … — did you mean `const`?       ← la devinette seule
```

La clé retirée **mène** (c'est la réponse spécifique) et le vocabulaire suit
(c'est le contexte). Le test de la loi sœur garde sa fixture `config:` — c'est
le cas qui a exposé le silence — et gagne une assertion sur la moitié qui lui
manquait.

## Ce que je n'ai délibérément PAS fait

**Aucun code de spec n'est frappé.** Le code reste `NIKA-PARSE-005` ; seule la
clause de suggestion change. Un **vrai** tombstone — son propre numéro
`NIKA-VALUES-`, byte-mirroré depuis l'oracle côté spec comme les deux autres —
appartient à la **spec**, pas à ce parseur.

## Où le rôle est parti · mesuré, pas deviné

| source | ce qu'elle dit |
|---|---|
| l'analyzer du check | « a LIVE authority — `inputs:` since `config:` died » |
| `permit_taint` | « It rides `inputs:` now; `config:` is gone » |
| le diff de #909 | « `config:` → an `inputs:` entry » |

## Portée

L'enseignement est **scopé à l'enveloppe** — le même mot est un nom de champ
plausible dans un corps de tâche, et l'y enseigner enverrait un réparateur dans
la mauvaise direction. Un test le pin.

Les deux tests tombent sous mutation. 205 tests verts sur `nika-schema`.
