### PR TITLE
fix(security,nika-schema): le balayage plein-arbre voit ce que le hook garde, et l enveloppe s enseigne

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,8 +400,8 @@ expectrl    = "0.9"  # PTY e2e — the wizard's TTY-gated conversation (unix-onl
 # Cost · 2× build time at release · `cargo build --release` only · dev builds
 # unaffected. strip=symbols matches ADR-061 SLSA L3 byte-determinism target.
 # panic=unwind KEPT · panic=abort breaks `cargo test` panic-catching + violates
-# security.md §Propagate errors discipline (forbidden at dx/ level · ambiguous
-# at engine/ · default unwind is the conservative choice). debug=line-tables-only
+# the propagate-errors discipline (forbidden for the surrounding tooling ·
+# ambiguous for the engine · default unwind is the conservative choice). debug=line-tables-only
 # preserves enough symbols for `cargo flamegraph` without bloating release binary.
 
 [profile.release]

--- a/crates/nika-event/README.md
+++ b/crates/nika-event/README.md
@@ -31,8 +31,9 @@ assert_eq!(sink.len(), 1);
 
 ## Domain boundary
 
-This is the **engine** chronicle (runtime events). The **studio** chronicle
-(`dx/journal/`) is a disjoint domain — same NDJSON spirit, disjoint taxonomy.
+This is the **engine** chronicle (runtime events). The **studio** keeps a
+separate chronicle in its own private tree — same NDJSON spirit, disjoint
+taxonomy, never conflated.
 
 ## Error codes
 

--- a/crates/nika-event/src/kind.rs
+++ b/crates/nika-event/src/kind.rs
@@ -16,8 +16,8 @@ use core::fmt;
 /// The kind of an emitted [`crate::Event`].
 ///
 /// Mirrors the studio journal taxonomy in spirit but scoped to the
-/// **engine runtime** (the studio chronicle lives in `dx/journal/` — a
-/// disjoint domain, per `journal-storage-tiers.md`).
+/// **engine runtime**. The studio keeps its own chronicle, in its own
+/// private tree — a disjoint domain, never conflated with this one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]

--- a/crates/nika-event/src/lib.rs
+++ b/crates/nika-event/src/lib.rs
@@ -33,8 +33,8 @@
 //! # Domain boundary
 //!
 //! This is the **engine** chronicle (runtime events). The **studio**
-//! chronicle (`dx/journal/`) is a disjoint domain per
-//! `journal-storage-tiers.md` — do not conflate them.
+//! keeps a separate chronicle in its own private tree: a disjoint
+//! domain, same NDJSON spirit, different taxonomy — never conflated.
 
 #![cfg_attr(
     test,

--- a/crates/nika-kernel/src/errors.rs
+++ b/crates/nika-kernel/src/errors.rs
@@ -20,7 +20,7 @@
 //!   `nika_error::codes::NIKA_234` · the agent-loop tool-definition seam)
 //! - 330–379: Provider (`ProviderError`) — `nika-kernel-ai` (moved from
 //!   380-429 2026-05-11 to free the Shield-reserved 380-389 slot per
-//!   `dx/.claude/rules/security.md` §"Nika Shield" canonical mapping.
+//!   the Shield's canonical code mapping.
 //!   Historical `NIKA_380..389` names dropped per
 //!   `no-legacy-no-back-compat.md` · zero alias · git is archive.)
 //! - 430–479: Verb — impls live in the verb crates · constants in

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -409,7 +409,16 @@ impl Cx<'_> {
                         // sets (a task's keys) stay silent: a 20-item dump
                         // is noise, not teaching.
                         .or_else(|| {
-                            (known.len() <= 8)
+                            // 9, not 8. Measured 2026-08-15: exactly two sets
+                            // sit at nine — TOP_LEVEL_KEYS (the envelope) and
+                            // AGENT_KEYS — and both were silent for the sake
+                            // of one key over a round number. The envelope is
+                            // the set an author meets first and the one whose
+                            // vocabulary they are least likely to hold; it has
+                            // never taught itself, at fourteen keys or at nine.
+                            // A task's twenty keys still stay silent, which is
+                            // the line this threshold exists to draw.
+                            (known.len() <= 9)
                                 .then(|| format!("the fields here: {}", known.join(" · ")))
                         })
                 };
@@ -844,6 +853,40 @@ tasks:
         let far = "nika: h\ntasks:\n  g:\n    zzzqx:\n      prompt: \"hi\"\n";
         let msg = parse_strict(far).expect_err("unknown key").to_string();
         assert!(!msg.contains("did you mean"), "{msg}");
+    }
+
+    #[test]
+    fn the_envelope_teaches_its_own_vocabulary() {
+        // Measured 2026-08-15. The set-listing fallback fired at `<= 8`, and
+        // the envelope has NINE keys — so the one set an author meets first,
+        // and the one whose vocabulary they are least likely to hold, said
+        // « unknown field » and nothing else. At fourteen keys it was silent
+        // too; the nuke did not cause this, it only brought the envelope
+        // close enough to a round number for the silence to look deliberate.
+        //
+        // `config:` is the case that exposed it: a value authority that
+        // SHIPPED in v0.108.0, so authors hold files carrying it, and its
+        // replacement (an `inputs:` entry) is not guessable from a bare
+        // refusal. It is too far from any envelope key for did-you-mean.
+        let err = parse_strict(
+            "nika: h\nconfig:\n  a: 1\ntasks:\n  g:\n    exec:\n      run: \"true\"\n",
+        )
+        .expect_err("config is not an envelope key");
+        let SchemaError::UnknownField { suggestion, .. } = err else {
+            panic!("expected UnknownField, got {err:?}");
+        };
+        let taught = suggestion.expect("the envelope must teach its set");
+        assert!(taught.starts_with("the fields here:"), "{taught}");
+        for key in TOP_LEVEL_KEYS {
+            assert!(taught.contains(key), "`{key}` missing from: {taught}");
+        }
+
+        // The other side of the threshold, and the reason it exists: a task
+        // carries far more keys than a reader can use as a hint, so that set
+        // stays silent. A dump is not teaching.
+        let far = "nika: h\ntasks:\n  g:\n    zzzqx: 1\n    exec:\n      run: \"true\"\n";
+        let msg = parse_strict(far).expect_err("unknown task key").to_string();
+        assert!(!msg.contains("the fields here"), "{msg}");
     }
 
     #[test]

--- a/docs/architecture/BLUEPRINT_2036.md
+++ b/docs/architecture/BLUEPRINT_2036.md
@@ -498,8 +498,8 @@ later = **singleton in 2030**. Nothing else combines this stack.
 
 ## §4.7 · Guardian AI · anti-Palantir · Nika + Olympus integration (v1.2)
 
-Per `studio/council/research/2026-04-29-ai-2027-trajectory.md` empirical
-research + ai-2027.com modal-year scenario (modal 2027 · median 2029-2032 ·
+Per the studio's own 2026-04-29 AI-trajectory research (private) +
+ai-2027.com modal-year scenario (modal 2027 · median 2029-2032 ·
 METR HCAST doubling 4.5 months · 5-milestone ladder SC → SAR → SIAR → ASI) ·
 Nika's 7-axes structural position (Rust + YAML + Memory native + MCP+Shield
 + AGPL + local-first + BYO-LLM) is **the distributed third path** between
@@ -519,7 +519,7 @@ Nika Diamond is the **structural inverse** ·
 | Inference provider     | Single-vendor       | **14-provider catalog · user picks**           |
 | Threat model           | Surveillance        | Sovereignty + capability-scoped agents        |
 
-**Framing lens-pair** · « unified Rust runtime contract » (per `dx/.claude/rules/naming-memory-subsystem.md` substrate lens · one Rust binary · one ABI · zero runtime fragmentation) + « 7-axes distributed third path » (this §4.7 strategic lens · anti-Palantir surface positioning) are SAME structural commitment from different altitudes · NOT contradictory.
+**Framing lens-pair** · « unified Rust runtime contract » (the substrate lens · one Rust binary · one ABI · zero runtime fragmentation) + « 7-axes distributed third path » (this §4.7 strategic lens · anti-Palantir surface positioning) are SAME structural commitment from different altitudes · NOT contradictory.
 
 Per `olympus-vs-nika-distinction.md` D-2026-05-08-N1 · **Nika engine = public
 moat** (competes with GPT/Claude/Cursor/LangGraph/Temporal) · **Olympus =

--- a/docs/crate-specs/nika-chart.md
+++ b/docs/crate-specs/nika-chart.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **CANDIDATE** — Gate 1 (this document) authored 2026-07-09. Crafted standalone (89 tests · clippy 0 under workspace pedantic · rustdoc 0) at `ventures/nika/02-engineering/playground/nika-chart/`, moved in whole per CHT master plan W2. |
+| Status | **CANDIDATE** — Gate 1 (this document) authored 2026-07-09. Crafted standalone (89 tests · clippy 0 under workspace pedantic · rustdoc 0) in a private playground tree, moved in whole per CHT master plan W2. |
 | Layer | L0 — pure, zero I/O, zero async |
 | Design | Deterministic chart compiler+renderer: rows + semantic spec → byte-identical artifacts. Two-stage pure pipeline (`compile → render`), 5 chart types, 5 surfaces (SVG · Vega-Lite JSON · TTY · PNG · terminal-inline escapes). The artifact's sha256 is the trace-chain receipt (« your workflow draws its own receipts »). |
 | LOC budget | ≤6,000 src prod (at authoring ~5.3k total incl. cfg(test) — prod well under) · ≤15,000 hard cap |

--- a/docs/crate-specs/nika-event.md
+++ b/docs/crate-specs/nika-event.md
@@ -30,7 +30,7 @@ deterministic and trivially testable — the clock is an **L1** effect
 (`nika-clock`), never read here.
 
 **Domain boundary** · this is the *engine* chronicle (runtime events). The
-*studio* chronicle (`dx/journal/`) is a disjoint domain per
+*studio* keeps a separate chronicle in its own private tree, disjoint per
 `journal-storage-tiers.md` — they share the NDJSON serialization spirit but
 have disjoint taxonomies. Do not conflate.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,7 +68,7 @@ Vectors:
 | 11 | unwraps-in-src | Zero `.unwrap()`/`.expect(` outside tests |
 | 12 | file-loc-cap | No src/*.rs file > 1,500 LOC |
 | 13 | claude-coauthor-leak | No `Co-Authored-By: Claude` on diamond branch |
-| 14 | private-path-leak | No `/.claude/projects/…` in tracked code |
+| 14 | private-path-leak | No private monorepo path in tracked code · same patterns as the pre-commit hook (`scripts/lib/private-patterns.sh`) · frozen ADRs exempt |
 | 15 | cargo-audit-rustsec | RustSec advisories |
 
 ## Naming convention

--- a/scripts/hooks/block-private-paths.sh
+++ b/scripts/hooks/block-private-paths.sh
@@ -49,30 +49,31 @@ set -Eeuo pipefail
 # `lmstudio/` and `~/.cache/lm-studio/` — real, public LM Studio provider
 # paths — so the gate also blocked legitimate work. `[^a-zA-Z0-9._-]` keeps
 # `https://supernovae.studio/` out too, while still matching `/studio/`.
-readonly BOUNDARY='(^|[^a-zA-Z0-9._-])'
-readonly PRIVATE_PATTERNS=(
-  # The studio + the agent substrate, at the root.
-  "${BOUNDARY}studio/"
-  "${BOUNDARY}dx/"
-  "${BOUNDARY}\.claude/projects/"
-  # The pre-migration spellings — frozen citations still leak the fact.
-  "${BOUNDARY}nika/hq/"
-  "${BOUNDARY}studio-spn/"
-  "${BOUNDARY}jungo/hq/"
-  "${BOUNDARY}novanet/hq/"
-  "${BOUNDARY}qrcodeai/hq/"
-  "${BOUNDARY}supernovae-hq/"
-)
+# The patterns themselves live in ONE file, shared with the full-tree twin
+# (`scripts/hygiene/check-private-leaks.sh`, vector 14). Measured 2026-08-15:
+# they had drifted to TEN patterns here against ONE there, so the sweep that
+# looks everywhere searched for almost nothing and a private path slept in a
+# user-facing error hint of this PUBLIC engine. Two lists drift; one cannot.
+# Resolved from THIS script's location, never from `git rev-parse
+# --show-toplevel`: the hook's own test harness runs it inside throwaway
+# repos where that root has no scripts/ tree, and the source then failed —
+# turning the gate RED on everything, including the cases it must pass.
+# A script knows where it lives; it does not know whose repo it is in.
+# shellcheck source=scripts/lib/private-patterns.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/private-patterns.sh"
 
-# The venture tree, as a shape. Everything under `ventures/<name>/` is
-# private — the 9 poles, for every venture that exists or ever will —
-# EXCEPT the one public tier, which is where this very repo lives.
-readonly VENTURE_SHAPE='ventures/[a-z0-9][a-z0-9-]*/[a-zA-Z0-9._/-]*'
-readonly VENTURE_PUBLIC='^ventures/nika/02-engineering/repos/'
+readonly PRIVATE_PATTERNS=("${NIKA_PRIVATE_PATTERNS[@]}")
+readonly VENTURE_SHAPE="$NIKA_VENTURE_SHAPE"
+readonly VENTURE_PUBLIC="$NIKA_VENTURE_PUBLIC"
 
 # Get staged files in the engine context (exclude deleted files).
 # Self-exclusion — these directories legitimately enumerate the very patterns
 # we guard against, which would cause self-referential false-positives:
+#   scripts/lib/       the shared pattern list itself (added 2026-08-15 · the
+#                      gate blocked the very commit that introduced it, which
+#                      is the correct reflex on a directory it had never been
+#                      told about — a new home for the constants needs the
+#                      same carve-out the old one had, not an obfuscation)
 #   scripts/hooks/     the guarding code + its PRIVATE_PATTERNS constants
 #   scripts/hygiene/   vectors that spot-check privacy (patterns.conf, tests)
 #   scripts/test/      red-team fixtures that describe blocked scenarios
@@ -81,7 +82,7 @@ readonly VENTURE_PUBLIC='^ventures/nika/02-engineering/repos/'
 STAGED=()
 while IFS= read -r _f; do
   case "$_f" in
-    '' | scripts/hooks/* | scripts/hygiene/* | scripts/test/* | scripts/ci/*) ;;
+    '' | scripts/lib/* | scripts/hooks/* | scripts/hygiene/* | scripts/test/* | scripts/ci/*) ;;
     *) STAGED+=("$_f") ;;
   esac
   # ACMR, not ACM: a `git mv` of a private doc into the engine stages as R

--- a/scripts/hygiene/check-private-leaks.sh
+++ b/scripts/hygiene/check-private-leaks.sh
@@ -1,16 +1,72 @@
 #!/usr/bin/env bash
-# Vector 14: no private memory paths referenced in PUBLIC tracked files.
-# .claude/projects/.../memory/ is private; public code must never reference it.
-# `.claude/CLAUDE.md` is allowed to reference `~/.claude/...` as pointer —
-# it's the local-dev onboarding doc, user path is expected context.
+# Vector 14: no private monorepo paths referenced in this PUBLIC tree.
+#
+# 2026-08-15 · this vector guarded ONE hardcoded pattern
+# (`.claude/projects/-Users-thibaut`) while the pre-commit hook guarded TEN
+# plus the venture shape. The sweep that looks EVERYWHERE searched for almost
+# nothing — so 18 occurrences of a private path, one of them in a user-facing
+# error hint of the public engine, slept here until a merge happened to put
+# them in someone's staged diff. Both now read the SAME list.
+#
+# FLOW vs STOCK — the two gates are not redundant, they are complementary:
+#   the hook judges the staged diff, so it only ever sees the commit it runs
+#   on. Anything committed on a base older than the hook escapes it forever,
+#   and a squash-merge runs no local hook at all. This vector is the twin
+#   that judges the STOCK. One without the other guards half the repo.
 set -uo pipefail
-leaks=$(git grep -l -E '\.claude/projects/-Users-thibaut' \
-        -- ':!.gitignore' ':!*.lock' \
-           ':!.claude/CLAUDE.md' ':!.claude/rules/*.md' \
-           ':!scripts/hygiene/*.sh' \
-        2>/dev/null || true)
+
+# Resolved from THIS script's location, not from the git root: a script
+# knows where it lives, it does not know whose repo it is in.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/private-patterns.sh
+. "$HERE/../lib/private-patterns.sh"
+
+# Exemptions, each with its reason — an unexplained exemption is a hole.
+#   .claude/CLAUDE.md · .claude/rules/  the local-dev onboarding surface; a
+#       user path is the expected context there, not a leak.
+#   scripts/lib · hooks · hygiene · test · ci   these ENUMERATE the patterns
+#       (or test them), so they match themselves by construction.
+#   docs/adr/   frozen decision records. The monorepo's path-resolution law
+#       keeps frozen citations forever — rewriting an ADR to satisfy a gate
+#       would falsify the record it exists to preserve. New private-path
+#       citations are still refused at commit time by the hook, which does
+#       NOT exempt this directory: the stock is grandfathered, the flow is not.
+EXCLUDES=(
+  ':!.gitignore' ':!*.lock'
+  ':!.claude/CLAUDE.md' ':!.claude/rules/*.md'
+  ':!scripts/lib/*' ':!scripts/hooks/*' ':!scripts/hygiene/*'
+  ':!scripts/test/*' ':!scripts/ci/*'
+  ':!docs/adr/*'
+)
+
+ALTERNATION="$(nika_private_alternation)"
+
+leaks="$(git grep -l -E "$ALTERNATION" -- "${EXCLUDES[@]}" 2>/dev/null || true)"
+
+# The venture tree, matched by shape, with the one public tier carved out.
+#
+# Per OCCURRENCE, not per file. The first cut of this block asked
+# `git grep -l` for the SHAPE and reported every file it named — which
+# includes every file that legitimately cites the PUBLIC tier, since the
+# public tier is itself of that shape. It reported a clean handoff doc as a
+# leak. A gate that names a file it never proved guilty is worse than no
+# gate: it teaches the reader to disbelieve it.
+#
+# So: ask each candidate file for its occurrences, drop the public ones, and
+# keep the file only if something private survives.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if git grep -h -oE "$NIKA_VENTURE_SHAPE" -- "$f" 2>/dev/null \
+    | grep -qvE "$NIKA_VENTURE_PUBLIC"; then
+    leaks="$(printf '%s\n%s' "$leaks" "$f")"
+  fi
+done < <(git grep -l -E "$NIKA_VENTURE_SHAPE" -- "${EXCLUDES[@]}" 2>/dev/null || true)
+leaks="$(printf '%s' "$leaks" | grep -v '^$' | sort -u || true)"
 
 if [ -n "$leaks" ]; then
-  echo "private path leak in: ${leaks}"; exit 2
+  echo "private path leak in:"
+  printf '%s\n' "$leaks" | sed 's/^/  /'
+  exit 2
 fi
-echo "OK (no private paths in tracked code)"; exit 0
+echo "OK (no private paths in tracked code · $(printf '%s' "${#NIKA_PRIVATE_PATTERNS[@]}") patterns + the venture shape)"
+exit 0

--- a/scripts/hygiene/tests/private-leaks.test.sh
+++ b/scripts/hygiene/tests/private-leaks.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# COVERS: scripts/hygiene/check-private-leaks.sh
+# Mutation proof for vector 14 — the FULL-TREE half of the privacy boundary.
+#
+# Why this test exists, measured 2026-08-15. Vector 14 guarded ONE hardcoded
+# pattern while the pre-commit hook guarded TEN plus the venture shape. The
+# sweep that looks EVERYWHERE searched for almost nothing, so 18 occurrences
+# of a private monorepo path — one of them in a user-facing error hint of the
+# PUBLIC engine — slept in this tree until a merge happened to drop them into
+# someone's staged diff. Widening it without a mutation proof would just move
+# the trust, not earn it.
+#
+# The properties, and each one is a defect this vector actually had:
+#
+#   1. IT LOOKS. A private path anywhere in the tracked tree turns it red.
+#      With one pattern, nine families were invisible.
+#   2. IT DOES NOT OVER-LOOK. The public repos tier is of the same SHAPE as
+#      a private pole; the first cut of the widening reported every file
+#      citing the public tier as a leak — it named a clean handoff doc guilty.
+#      A gate that names a file it never proved guilty teaches the reader to
+#      disbelieve it.
+#   3. THE WORD BOUNDARY HOLDS. Unanchored `studio/` matched `lmstudio/` and
+#      `~/.cache/lm-studio/` — real, public provider paths — so the gate
+#      blocked legitimate work.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+VECTOR="$ROOT/scripts/hygiene/check-private-leaks.sh"
+
+# A tracked file the vector reads, restored after every case.
+PROBE="$ROOT/crates/nika-error/src/lib.rs"
+BACKUP="$(mktemp)"
+cp "$PROBE" "$BACKUP"
+restore() { cp "$BACKUP" "$PROBE"; }
+trap 'restore; rm -f "$BACKUP"' EXIT
+
+pass=0
+fail=0
+
+expect() { # label, expected_rc, injected_line ("" = clean tree)
+  local label="$1" want="$2" line="${3:-}"
+  [ -n "$line" ] && printf '\n// %s\n' "$line" >>"$PROBE"
+  (cd "$ROOT" && bash "$VECTOR") >/dev/null 2>&1
+  local got=$?
+  restore
+  if [ "$got" = "$want" ]; then
+    printf '  ok    %s (rc=%s)\n' "$label" "$got"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %s — expected rc=%s, got rc=%s\n' "$label" "$want" "$got"
+    fail=$((fail + 1))
+  fi
+}
+
+expect "clean tree is green" 0 ""
+expect "a dx/ path turns it red" 2 "see dx/journal/ for the studio chronicle"
+expect "a studio/ path turns it red" 2 "see studio/04-identity/brand/ for the palette"
+expect "a private venture pole turns it red" 2 "ventures/nika/01-product/strategy/NORTH_STAR.md"
+expect "a pre-migration spelling turns it red" 2 "nika/hq/strategy.md"
+expect "the PUBLIC venture tier stays green" 0 "ventures/nika/02-engineering/repos/engine/README.md"
+expect "lmstudio keeps the word boundary green" 0 "/home/u/.cache/lm-studio/models and the lmstudio/ provider"
+
+# The gate and its full-tree twin must read the SAME list, or they drift back
+# apart — which is the whole reason the leak slept.
+SHARED="$ROOT/scripts/lib/private-patterns.sh"
+for consumer in "$VECTOR" "$ROOT/scripts/hooks/block-private-paths.sh"; do
+  if grep -q 'private-patterns.sh' "$consumer"; then
+    printf '  ok    %s sources the shared pattern list\n' "$(basename "$consumer")"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %s does NOT source %s\n' "$(basename "$consumer")" "$SHARED"
+    fail=$((fail + 1))
+  fi
+done
+
+printf '\n%s/%s cases correct.\n' "$pass" "$((pass + fail))"
+[ "$fail" -eq 0 ]

--- a/scripts/lib/private-patterns.sh
+++ b/scripts/lib/private-patterns.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# The private-path patterns, in ONE place, for the two gates that need them.
+#
+# Why this file exists — measured 2026-08-15. The pre-commit hook
+# (`scripts/hooks/block-private-paths.sh`) guarded TEN patterns plus the
+# venture shape. The full-tree sweep (`scripts/hygiene/check-private-leaks.sh`)
+# guarded ONE, hardcoded. So the sweep that looks EVERYWHERE searched for
+# almost nothing, and 18 occurrences of a private path — one of them in a
+# user-facing error hint of the PUBLIC engine — slept on main until a merge
+# happened to put them in someone's staged diff.
+#
+# The class · a diff gate only ever sees the index of the commit it runs on.
+# Anything committed on a base older than the gate escapes it forever, and a
+# squash-merge runs no local hook at all. A gate that matters needs a
+# full-tree twin with the SAME patterns, or it guards the flow and never the
+# stock. Two pattern lists drift; one does not.
+#
+# Sourced, never executed. Consumers:
+#   scripts/hooks/block-private-paths.sh    (staged diff · blocks the commit)
+#   scripts/hygiene/check-private-leaks.sh  (whole tree · vector 14)
+#
+# SC2034 · every constant here is "unused" from this file's point of view.
+# That is what a shared constant file IS; the consumers are named above and
+# the test asserts both of them source it.
+# shellcheck disable=SC2034
+
+# Anchored at a path boundary. Unanchored `studio/` matched `lmstudio/` and
+# `~/.cache/lm-studio/` — real, public LM Studio provider paths — so the gate
+# blocked legitimate work. This also keeps `https://supernovae.studio/` out
+# while still matching `/studio/`.
+readonly NIKA_PRIVATE_BOUNDARY='(^|[^a-zA-Z0-9._-])'
+
+# The studio + the agent substrate are named at the ROOT — the only spelling
+# a rename inside them cannot invalidate. Enumerating their children would
+# itself be the leak these patterns exist to stop, in a PUBLIC file.
+# The `*/hq/` spellings are pre-migration: a frozen citation still leaks.
+readonly NIKA_PRIVATE_PATTERNS=(
+  "${NIKA_PRIVATE_BOUNDARY}studio/"
+  "${NIKA_PRIVATE_BOUNDARY}dx/"
+  "${NIKA_PRIVATE_BOUNDARY}\.claude/projects/"
+  "${NIKA_PRIVATE_BOUNDARY}nika/hq/"
+  "${NIKA_PRIVATE_BOUNDARY}studio-spn/"
+  "${NIKA_PRIVATE_BOUNDARY}jungo/hq/"
+  "${NIKA_PRIVATE_BOUNDARY}novanet/hq/"
+  "${NIKA_PRIVATE_BOUNDARY}qrcodeai/hq/"
+  "${NIKA_PRIVATE_BOUNDARY}supernovae-hq/"
+)
+
+# The venture tree, as a shape: everything under `ventures/<name>/` is
+# private — the 9 poles, for every venture that exists or ever will — EXCEPT
+# the one public tier, which is where this very repo lives.
+readonly NIKA_VENTURE_SHAPE='ventures/[a-z0-9][a-z0-9-]*/[a-zA-Z0-9._/-]*'
+readonly NIKA_VENTURE_PUBLIC='^ventures/nika/02-engineering/repos/'
+
+# One alternation, for callers that grep a whole tree rather than a diff.
+nika_private_alternation() {
+  local IFS='|'
+  printf '%s' "${NIKA_PRIVATE_PATTERNS[*]}"
+}


### PR DESCRIPTION
Deux correctifs, un thème · **une porte qui ne regarde pas tout ne garde
que ce qu'elle croise**.

## 1 · Le balayage plein-arbre cherchait 1 motif, le hook en garde 10

Le hook pre-commit gardait **dix** motifs plus la forme des ventures ; le
vecteur 14, qui balaie l'arbre **entier**, en gardait **un**, codé en dur.
Celui qui regarde partout ne cherchait presque rien — et c'est pour ça
qu'un chemin privé a dormi jusque dans un **hint d'erreur du moteur
public**.

**FLUX contre STOCK.** Les deux portes sont complémentaires, pas
redondantes · le hook lit `git diff --cached`, donc il ne voit que le
commit sur lequel il tourne. Ce qui a été committé sur une base plus
ancienne que lui lui échappe **pour toujours**, et un squash-merge
n'exécute aucun hook local. Le vecteur est le jumeau qui juge le stock.

Un seul fichier de motifs · `scripts/lib/private-patterns.sh`, sourcé par
les deux, et le test vérifie qu'ils le sourcent. Deux listes dérivent ;
une seule ne peut pas.

**Neuf citations vivantes retirées.** Un chemin privé dans un dépôt
public n'a pas de lecteur · il ne renseigne personne dehors et expose la
structure du monorepo. Le concept reste, le chemin part. Dont un pôle de
venture privé que l'ancien vecteur ne pouvait pas voir.

## 2 · L'enveloppe enseigne enfin son propre vocabulaire

Le refus de clé inconnue liste le vocabulaire quand l'ensemble est petit
(`known.len() <= 8`). L'enveloppe en porte **neuf**. Donc l'ensemble
qu'un auteur rencontre en premier, et celui dont il a le moins de
chances de connaître le vocabulaire, rendait « unknown field » et rien
d'autre.

**Portée mesurée avant de bouger le nombre** · exactement **deux**
ensembles sont à neuf (`TOP_LEVEL_KEYS`, `AGENT_KEYS`). `INFER_KEYS` (8)
enseignait déjà. Les vingt clés d'une tâche restent muettes — c'est la
ligne que ce seuil existe pour tracer.

Le cas qui l'a révélé · **`config:`**, une autorité de valeurs **publiée
en v0.108.0**, donc des auteurs ont des fichiers qui la portent, et son
remplaçant (une entrée `inputs:` avec `required: false` + `default:`) ne
se devine pas depuis un refus nu. Trop loin de toute clé pour le
did-you-mean.

## Deux recommandations que je retire, mesure à l'appui

**Le tombstone `config:` que j'annonçais dû.** La question était déjà
tranchée — **par moi**, dans #909 · `description:` est mort dans le même
nuke et tombe volontairement au refus générique (`NIKA-PARSE-021`
retiré, jamais réutilisé). Une exception pour une seule clé aurait
ajouté une règle là où le défaut était juste et seulement muet. Un seuil
à neuf sert **toute** clé d'enveloppe fautive.

**« Le nuke a éteint l'enseignement de l'enveloppe. »** Faux. À
**quatorze** clés elle était muette aussi. Le nuke l'a seulement
rapprochée d'un nombre rond. La phrase est dans le test, pour que
personne n'hérite de la version plus jolie.

## Preuve

| | |
|---|---|
| vecteur 14 | RC 0 · **9 motifs** + la forme venture (contre 1) |
| son test | **9/9** · rouge sur `dx/` `studio/` un pôle privé une graphie pré-migration · vert sur le tier public et `lmstudio/` |
| test du hook | **16/16 dans les deux sens** |
| seuil | **mutation-prouvé** · le test panique à 8, verdit à 9 |
| nika-schema | 203/203 · `shellcheck -x` 0 · `cargo fmt --check` 0 |

Un vecteur de moins dans la colonne « sans preuve de mutation ».

## Ce que je ne tranche pas

`docs/adr/` est exempté du **balayage** mais **pas du hook** · les ADR
sont des enregistrements gelés et la loi de résolution de chemins du
monorepo garde leurs citations pour toujours — réécrire un ADR pour
satisfaire une porte falsifierait l'enregistrement qu'il existe pour
préserver. **Le stock est acquis, le flux ne l'est pas.** La raison est
écrite dans la liste d'exemptions · une exemption sans raison est un trou.

Restent, et ce sont des arbitrages, pas des mesures ·
`scripts/version-coherence.sh:5` (doctrine de versionnage · **deux**
enveloppes existent, laquelle cette ligne désigne ?) · quatre `dx/` en
rustdoc publié (de vraies références d'architecture, pas des exemples à
recopier).
