### PR TITLE
fix(hygiene): estate acquiert une prise locale

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: 8b0a0889a9ef59b140a2a03d523557fb10db69b4ec204c2df894e8a7c3188cfe
+  aggregate_sha256: f3057844970d388911105a16a5f9f3b8c79c42fdc6bf51069a909bcd7716f7cc
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 10e32e0c5717cb34573b2f7363aa6ebc64d55873ef11309bc786643e68afff2a
+  sha256: 9a6912dbc51fe09a2a65982041ffef4ed46ab5a0bc4c246660229b3e164286ab
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -89,7 +89,7 @@ files:
     - "docs/adr/adr-*.md YAML frontmatter"
 - path: "fuzz/Cargo.lock"
   class: generated
-  sha256: aac86fb19fd4340b3550300e5e1392af11463248adb179b592ddea61f75bad75
+  sha256: 299a596f0822fed3054cf88c301fb2dbff5c09b2a16df51d4cbfbe48e1a7b087
   evidence: "cargo's resolver writes it for the fuzz workspace; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against fuzz/Cargo.toml)"
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 56f1f0d8e7c85366614e0a9e1103f899b55da8536b806dd51ee967208aeaa58f
+  aggregate_sha256: 9447d41cdec41c413c13fc3b40c391130951327a9f35219fcc627e3ec277124d
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: f3f2f23869cb0866e8e09ea65fb605f95b1468b7342cae58c42f951a97d565b6
+  aggregate_sha256: bce68e93e48ad1283e612655ee2b3800a127d06b4dced01202389d89273ceafa
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: d10f025e02073f78252c534abb78db3f70f9c37f8133bcafad7ed76cf2cdbdbf
+  aggregate_sha256: 8b0a0889a9ef59b140a2a03d523557fb10db69b4ec204c2df894e8a7c3188cfe
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,6 +65,19 @@ pre-commit:
       glob: '**/*.sh'
       run: shfmt -d -i 2 -ci -bn {staged_files}
 
+    # estate.yaml hache l arbre suivi. Rien en local ne le controlait, alors
+    # que la CI le fait : chaque oubli coutait un push et une attente de CI.
+    # Mesure du 2026-08-13 · QUATRE allers-retours en une soiree, et la
+    # quatrieme fois la cause etait subtile — l inventaire avait bien ete
+    # regenere, puis `shfmt -w` a reformate le fichier APRES, l invalidant.
+    # Le bon moment n est donc pas « quand on y pense » mais « apres le
+    # dernier formatage » : un hook le sait, un humain non.
+    # --check, jamais --write : un hook qui REPARE en silence cache la derive
+    # au lieu de l apprendre, et il ecrirait un fichier que personne n a relu.
+    estate-manifest:
+      run: python3 scripts/estate.py --check
+      fail_text: 'estate.yaml diverge de l arbre suivi. Lancer: python3 scripts/estate.py --write puis rejouer le commit.'
+
     block-private-paths:
       run: bash scripts/hooks/block-private-paths.sh
       fail_text: 'Private path reference in public engine files. Engine is PUBLIC.'

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,18 +65,21 @@ pre-commit:
       glob: '**/*.sh'
       run: shfmt -d -i 2 -ci -bn {staged_files}
 
-    # estate.yaml hache l arbre suivi. Rien en local ne le controlait, alors
-    # que la CI le fait : chaque oubli coutait un push et une attente de CI.
-    # Mesure du 2026-08-13 · QUATRE allers-retours en une soiree, et la
-    # quatrieme fois la cause etait subtile — l inventaire avait bien ete
-    # regenere, puis `shfmt -w` a reformate le fichier APRES, l invalidant.
-    # Le bon moment n est donc pas « quand on y pense » mais « apres le
-    # dernier formatage » : un hook le sait, un humain non.
-    # --check, jamais --write : un hook qui REPARE en silence cache la derive
-    # au lieu de l apprendre, et il ecrirait un fichier que personne n a relu.
+    # estate.yaml hashes the tracked tree. CI checks it; nothing local did, so
+    # every miss surfaced only after a push and a CI wait.
+    # Measured 2026-08-13: FOUR round-trips in one evening. The fourth cause was
+    # subtle — the manifest HAD been regenerated, then `shfmt -w` reformatted the
+    # file afterwards and invalidated it. So the right moment is not "when you
+    # think of it", it is "after the last reformatting": a hook knows that, a
+    # human does not.
+    # `--check`, never `--write`: a hook that silently repairs hides the drift
+    # instead of teaching it, and would write a file nobody reviewed.
+    # Order matters — estate.py reads the INDEX: stage the file, THEN derive,
+    # THEN stage the manifest. This hook caught that very mistake on the commit
+    # that installs it, in 0.16 s.
     estate-manifest:
       run: python3 scripts/estate.py --check
-      fail_text: 'estate.yaml diverge de l arbre suivi. Lancer: python3 scripts/estate.py --write puis rejouer le commit.'
+      fail_text: 'estate.yaml diverges from the tracked tree. Run: git add <file> && python3 scripts/estate.py --write && git add estate.yaml (estate.py reads the INDEX, so stage first).'
 
     block-private-paths:
       run: bash scripts/hooks/block-private-paths.sh


### PR DESCRIPTION
Re-lands **#915** on current `main`. Same two commits, same content — only the base moved.

## Why a new branch instead of an update

`estate.yaml` is a fingerprint of the **whole tree**, so every merge into `main` re-conflicts every open branch that carries it. #915 had been sitting `CONFLICTING` on that one file alone.

Merging `main` in was tried first and refused by `adr-coverage-new-crate`: a merge stages everything `main` gained since the fork, so the gate saw `crates/nika-cadence/**` as *a new crate with no ADR* — while ADR-114 for it is already on `main` (#942). A gate that judges the staged diff cannot tell a merge's inherited content from new work.

Cherry-picking onto a fresh base gives the gates only the real change, and needs no force-push. `estate.yaml` was re-**generated** at each step (`python3 scripts/estate.py --write`), never hand-resolved.

## Proof

- `python3 scripts/estate.py --check` → *in sync with the tracked tree*
- full pre-push gate green — tests · clippy · 15 hygiene vectors · 9 ratchets

Closes #915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)