### PR TITLE
fix(hygiene): le sceau des ADR derive sa portee au lieu de la taper

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 9a6912dbc51fe09a2a65982041ffef4ed46ab5a0bc4c246660229b3e164286ab
+  sha256: be3dc18d9cdfe321646e6998857d9746525123b736b078c38e56e965e7f02367
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 150
-  aggregate_sha256: a37bced46e69afacff334299dd0aff4056aa429427bf7f300a7148f67c8cb900
+  aggregate_sha256: d1d1c49a7122fc48b76b398867b8749d94e1401f46c2e4b1da4538891400901a
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: f3057844970d388911105a16a5f9f3b8c79c42fdc6bf51069a909bcd7716f7cc
+  aggregate_sha256: 548fdc1b250fd02b604725fb1e3215805fb6e152a7c0eb8c2423eb7dab54cf43
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 10e32e0c5717cb34573b2f7363aa6ebc64d55873ef11309bc786643e68afff2a
+  sha256: be3dc18d9cdfe321646e6998857d9746525123b736b078c38e56e965e7f02367
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -89,7 +89,7 @@ files:
     - "docs/adr/adr-*.md YAML frontmatter"
 - path: "fuzz/Cargo.lock"
   class: generated
-  sha256: aac86fb19fd4340b3550300e5e1392af11463248adb179b592ddea61f75bad75
+  sha256: 299a596f0822fed3054cf88c301fb2dbff5c09b2a16df51d4cbfbe48e1a7b087
   evidence: "cargo's resolver writes it for the fuzz workspace; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against fuzz/Cargo.toml)"
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 138
-  aggregate_sha256: 56f1f0d8e7c85366614e0a9e1103f899b55da8536b806dd51ee967208aeaa58f
+  aggregate_sha256: 9447d41cdec41c413c13fc3b40c391130951327a9f35219fcc627e3ec277124d
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"
@@ -183,12 +183,12 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 150
-  aggregate_sha256: a37bced46e69afacff334299dd0aff4056aa429427bf7f300a7148f67c8cb900
+  aggregate_sha256: d1d1c49a7122fc48b76b398867b8749d94e1401f46c2e4b1da4538891400901a
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: f3f2f23869cb0866e8e09ea65fb605f95b1468b7342cae58c42f951a97d565b6
+  aggregate_sha256: bce68e93e48ad1283e612655ee2b3800a127d06b4dced01202389d89273ceafa
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: d10f025e02073f78252c534abb78db3f70f9c37f8133bcafad7ed76cf2cdbdbf
+  aggregate_sha256: 548fdc1b250fd02b604725fb1e3215805fb6e152a7c0eb8c2423eb7dab54cf43
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: be3dc18d9cdfe321646e6998857d9746525123b736b078c38e56e965e7f02367
+  sha256: 9a6912dbc51fe09a2a65982041ffef4ed46ab5a0bc4c246660229b3e164286ab
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 150
-  aggregate_sha256: d1d1c49a7122fc48b76b398867b8749d94e1401f46c2e4b1da4538891400901a
+  aggregate_sha256: a37bced46e69afacff334299dd0aff4056aa429427bf7f300a7148f67c8cb900
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: 548fdc1b250fd02b604725fb1e3215805fb6e152a7c0eb8c2423eb7dab54cf43
+  aggregate_sha256: f3057844970d388911105a16a5f9f3b8c79c42fdc6bf51069a909bcd7716f7cc
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/scripts/hooks/adr-seal-check.sh
+++ b/scripts/hooks/adr-seal-check.sh
@@ -20,8 +20,41 @@
 set -uo pipefail
 
 readonly CONTEXT="${1:-post-merge}"
-readonly ADR_PATTERN='docs/adr/ADR-0(0[1-9]|1[0-5])'
-readonly SEALED_COUNT=15
+
+# The scope DERIVES, it is never typed.
+#
+# Until 2026-08-13 this read:
+#   ADR_PATTERN='docs/adr/ADR-0(0[1-9]|1[0-5])'   SEALED_COUNT=15
+# Two hand-typed constants, and the guard had never warned once. Measured:
+#   the uppercase pattern matched  0  of the 73 tracked ADR files
+#   the same pattern in lowercase  15 — exactly SEALED_COUNT
+# The files are named `adr-001-…md`. The guard was written for a spelling
+# that does not exist here, so it protected nothing, ever — a gate whose
+# own prose claimed a seal it could not enforce.
+#
+# The range was wrong too, independently: 59 ADRs carry `Accepted` today,
+# not 15. Both defects have one cause — a scope typed once instead of read
+# from the thing it describes. So the pattern now matches ANY ADR file
+# (either spelling), and `sealed_only` keeps the ones whose own Status says
+# Accepted. Adding an ADR, accepting one, or renaming the directory's case
+# cannot silence this guard again.
+readonly ADR_PATTERN='docs/adr/[Aa][Dd][Rr]-[0-9]{3}-'
+
+# Read the seal from each file rather than from a number kept in this script.
+sealed_only() {
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    # The file may be gone (a deletion is still a modification worth naming).
+    [[ -f "$f" ]] || {
+      printf '%s\n' "$f"
+      continue
+    }
+    grep -qiE '^[[:space:]]*(\*\*)?status(\*\*)?[[:space:]]*:?.*accepted' "$f" \
+      && printf '%s\n' "$f"
+  done
+  return 0
+}
 
 warn_adr_modified() {
   local files="$1"
@@ -29,7 +62,7 @@ warn_adr_modified() {
   printf '╔══════════════════════════════════════════════════════════╗\n' >&2
   printf '║  [adr-seal-check] WARNING: SEALED ADR MODIFIED          ║\n' >&2
   printf '╚══════════════════════════════════════════════════════════╝\n' >&2
-  printf '\nADR-001..%03d are SEALED (Accepted status). Modified:\n' "$SEALED_COUNT" >&2
+  printf '\nThese ADRs carry Status: Accepted — they are SEALED. Modified:\n' >&2
   printf '  %s\n' "$files" >&2
   printf '\nIf this was intentional (rare — architecture reversal):\n' >&2
   printf '  1. Create a new ADR-NNN superseding the old one\n' >&2
@@ -44,7 +77,7 @@ case "$CONTEXT" in
       exit 0 # No ORIG_HEAD (first commit, initial clone, etc.)
     fi
     MODIFIED="$(git diff --name-only ORIG_HEAD..HEAD 2>/dev/null \
-      | grep -E "$ADR_PATTERN" || true)"
+      | grep -E "$ADR_PATTERN" | sealed_only || true)"
     if [[ -n "$MODIFIED" ]]; then
       warn_adr_modified "$MODIFIED"
     fi
@@ -58,7 +91,7 @@ case "$CONTEXT" in
       if git diff --name-only "${old_sha}..${new_sha}" 2>/dev/null \
         | grep -qE "$ADR_PATTERN"; then
         MODIFIED="${MODIFIED}$(git diff --name-only "${old_sha}..${new_sha}" 2>/dev/null \
-          | grep -E "$ADR_PATTERN")"$'\n'
+          | grep -E "$ADR_PATTERN" | sealed_only)"$'\n'
       fi
     done
     if [[ -n "$MODIFIED" ]]; then


### PR DESCRIPTION
Re-lands **#914** on current `main`. Same two commits, same content — only the base moved.

`estate.yaml` is a whole-tree fingerprint, so every merge into `main` re-conflicts every open branch carrying it; #914 sat `CONFLICTING` on that one file. Merging `main` in was refused by a diff-judging gate that read main's inherited content as new work, so the lane was cherry-picked onto a fresh base instead — the gates then see only the real change, and no force-push is needed. `estate.yaml` was re-**generated** (`python3 scripts/estate.py --write`), never hand-resolved.

## Proof

- `python3 scripts/estate.py --check` → *in sync with the tracked tree*
- full pre-push gate green — tests · clippy · 15 hygiene vectors · 9 ratchets

Closes #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)