### PR TITLE
fix(nika-bm25): the IDF moves to ln_1p, where it decides ties

### DIFF
--- a/crates/nika-bm25/src/scorer.rs
+++ b/crates/nika-bm25/src/scorer.rs
@@ -25,6 +25,16 @@
 /// for terms appearing in every document.
 ///
 /// Returns `0.0` if `n == 0` or `df > n` (defensive · empty corpus).
+///
+/// Computed with [`f64::ln_1p`] rather than `(1.0 + x).ln()`. The two
+/// agree bit-for-bit while `x` is large — a RARE term, where `df` is
+/// small and the ratio is huge — and diverge exactly where the IDF is
+/// smallest: a term in (almost) every document gives `x ≈ 0.5/n`, and
+/// `1.0 + x` rounds that away. Measured 2026-08-13 · relative error of
+/// the naive form against `ln_1p`, at `df == n` · `1.2e-15` at n=10 ·
+/// `1.9e-11` at n=10^5 · `8.3e-8` at n=10^10; and `0.0` for `df == 1`
+/// at every n. The near-zero end is where near-stopwords compete, so
+/// it is the end that decides ties.
 #[must_use]
 #[inline]
 pub(crate) fn idf_robertson(n: usize, df: usize) -> f64 {
@@ -35,7 +45,7 @@ pub(crate) fn idf_robertson(n: usize, df: usize) -> f64 {
     let n_f = n as f64;
     #[allow(clippy::cast_precision_loss)]
     let df_f = df as f64;
-    ((n_f - df_f + 0.5) / (df_f + 0.5) + 1.0).ln()
+    ((n_f - df_f + 0.5) / (df_f + 0.5)).ln_1p()
 }
 
 /// Per-term BM25 score contribution.
@@ -98,6 +108,51 @@ mod tests {
         let idf = idf_robertson(4, 4);
         assert!(idf > 0.0);
         assert!(idf.is_finite());
+    }
+
+    /// The `ln_1p` law, and the test dies if the naive form comes back.
+    ///
+    /// At `df == n` the log's argument is `x = 0.5 / (n + 0.5)`, which
+    /// `1.0 + x` rounds away — so `(1.0 + x).ln()` and `x.ln_1p()`
+    /// part company precisely where the IDF is smallest. This asserts
+    /// BOTH halves: the implementation matches `ln_1p`, and the naive
+    /// form does NOT match it at the same tolerance. Without the second
+    /// half the first would pass under either implementation, and the
+    /// green would be worth nothing.
+    #[test]
+    fn idf_uses_ln_1p_where_the_naive_form_loses_the_bits() {
+        let n = 10_000_000_000_usize; // 10^10 · the divergence is ~8e-8 relative
+        let got = idf_robertson(n, n);
+
+        #[allow(clippy::cast_precision_loss)]
+        let x = 0.5 / (n as f64 + 0.5);
+        let exact = x.ln_1p();
+        let naive = (1.0 + x).ln();
+
+        let tol = exact * 1e-12;
+        assert!(
+            (got - exact).abs() < tol,
+            "the implementation must BE the ln_1p form: got {got:e} want {exact:e}"
+        );
+        assert!(
+            (naive - exact).abs() > tol,
+            "the naive form must MISS at this tolerance, else this test proves nothing: \
+             naive {naive:e} exact {exact:e}"
+        );
+    }
+
+    /// The other end of the same law: for a rare term the two forms are
+    /// bit-identical, so `ln_1p` costs nothing where it buys nothing.
+    #[test]
+    fn idf_ln_1p_is_bit_identical_for_a_rare_term() {
+        for n in [1_000_usize, 1_000_000] {
+            #[allow(clippy::cast_precision_loss)]
+            let x = (n as f64 - 1.0 + 0.5) / 1.5;
+            assert!(
+                (x.ln_1p().to_bits() == (1.0 + x).ln().to_bits()),
+                "df == 1 · the two forms must agree exactly at n={n}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nika-harness/src/client.rs
+++ b/crates/nika-harness/src/client.rs
@@ -36,6 +36,23 @@ use crate::wire::{
 
 /// One incoming line may not exceed this (bounded reads · spec §4): a
 /// hostile or broken peer overflows into a refusal, never an OOM.
+///
+/// **This is a TRANSPORT bound and it is not the forensics decode
+/// grain**, even though both are 1 MiB today. It guards one line off a
+/// live wire from a peer this process is talking to; `nika_dap`'s
+/// `bounded::MAX_ARTIFACT_BYTES` guards a stored artifact a verifier
+/// reads whole. Two readers, two threat models, two bounds that happen
+/// to agree on a number.
+///
+/// Do not "de-duplicate" them onto one constant. A grep finds three
+/// `1024 * 1024` in this tree and reads like a single value restated
+/// three times; it is not (measured 2026-08-13 · nika-spec
+/// `conformance/FINDINGS.md` F-4). Aliasing this to a forensics
+/// constant would couple a wire protocol to a decoder, so raising one
+/// bound would move the other for no stated reason — the coupling
+/// costs more than the repetition. The one real duplicate is
+/// `nika-registry-client`'s own artifact bound, which shares this
+/// crate's number *and* `nika-dap`'s meaning.
 pub const MAX_LINE_BYTES: usize = 1024 * 1024;
 
 /// How long the driver waits for the NEXT byte before calling the

--- a/estate.yaml
+++ b/estate.yaml
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 9a6912dbc51fe09a2a65982041ffef4ed46ab5a0bc4c246660229b3e164286ab
+  sha256: be3dc18d9cdfe321646e6998857d9746525123b736b078c38e56e965e7f02367
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 766
-  aggregate_sha256: bb5c763f502273903bc8e8b4cc38965d85435b1e9a6f0651ecbf18ed25a96cf5
+  aggregate_sha256: 6d059c15c1d071f4fcf66f8adca6bc7c7bc2edcedb23d19d7277390c14a66e15
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: f3057844970d388911105a16a5f9f3b8c79c42fdc6bf51069a909bcd7716f7cc
+  aggregate_sha256: 02389fdd83573918be0cfaa14f7a4241fb60943a56c60df66083e857e7de83b0
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored


### PR DESCRIPTION
Re-lands **#906** on current `main` — the two content commits, plus a freshly **generated** `estate.yaml` in place of the branch's stale one.

## Why a new branch

`estate.yaml` is a whole-tree fingerprint, so every merge into `main` re-conflicts every open branch that carries it; #906 sat `CONFLICTING` on that one file. Merging `main` in was refused by a diff-judging gate that reads main's inherited content as new work. Cherry-picking onto a fresh base gives the gates only the real change and needs no force-push.

## What ships

- **`nika-bm25`** — the IDF moves to `ln_1p`, which is exactly where it decides ties.
- **`nika-harness`** — the line bound is *not* the decode granularity (docs).

> ⚠️ **`nika-bm25` has an out-of-repo consumer.** `olympus-os-memory-index` and `olympus-os-search` depend on it as a library crate — a ranking change lands there too. That dependency is the allowed shape (a pure-algorithm library crate, Nika → Olympus, the asymmetric cross-flow holds), but the effect is not confined to this repo.

## Proof

- 42 `nika-bm25` tests green
- `python3 scripts/estate.py --check` → *in sync with the tracked tree*
- full pre-push gate green — tests · clippy · 15 hygiene vectors · 9 ratchets

Closes #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)