### PR TITLE
ci: un commit de main ne peut plus etre EVINCE de la file

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -11,20 +11,43 @@ on:
     branches: [main]
 
 concurrency:
-  group: diamond-${{ github.ref }}
+  # THE GROUP IS PER-SHA ON MAIN, PER-REF EVERYWHERE ELSE.
+  #
   # On a branch the next run REPLACES the previous one — cancelling saves
   # minutes and loses nothing. On main every commit is its own subject and
-  # must be judged before it is replaced. With a constant `github.ref`, two
-  # merges close together share one group and the first is cancelled unjudged,
-  # so a commit that breaks the build can go unmeasured while the RED surfaces
-  # on the next commit, usually innocent. Measured 2026-08-13: a two-line
-  # SPEC_PIN bump had its run cancelled 4 minutes later; the failure appeared
-  # on a docs commit, which cannot break a Rust suite.
+  # must be judged before it is replaced.
+  #
+  # `cancel-in-progress: false` was the first attempt at that (2026-08-13)
+  # and it is NOT enough: it protects a run that is RUNNING, never one that
+  # is QUEUED. GitHub keeps exactly one *pending* run per group and cancels
+  # the earlier one when a newer arrives — the flag does not apply, because
+  # that run was never in progress. Merges landing close together therefore
+  # still dropped main commits, which is the very thing the old comment here
+  # claimed to have fixed.
+  #
+  # Measured 2026-08-18 — mechanism, not correlation: FOUR of seven main runs
+  # cancelled in one evening, and the cancelled run 32166885428 (sha
+  # 6946fd36) carries `n_jobs: 0` — it never started a single job. The
+  # trigger is merge RHYTHM, not content: a session landing eight PRs
+  # manufactures its own cancellations. The failure is silent in the worst
+  # direction — no red and no green; an absent verdict reads like nothing to
+  # report.
+  #
+  # A per-sha group on main gives every commit its own queue, so there is
+  # nothing to evict. It costs parallel runs when merges are rapid; that is
+  # the price of judging each commit, and this repo already said that is the
+  # price it wants to pay.
+  #
   # An expression is supported here (GitHub's actions-group-concurrency docs
   # ship the `release/` example); a path filter is NOT — `concurrency` is
-  # evaluated at workflow level, before any job, with no changed-file context.
-  # No injection surface: this value is compared, never interpolated into a
-  # `run:` shell.
+  # evaluated at workflow level, before any job, with no changed-file
+  # context. No injection surface: `github.ref` and `github.sha` are
+  # repo-controlled, compared and concatenated into a GROUP NAME, never
+  # interpolated into a `run:` shell.
+  group: diamond-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  # Kept, and redundant on main by construction now (a per-sha group has no
+  # sibling to cancel). It stays because it is the load-bearing half on every
+  # OTHER ref, where the group IS shared across pushes.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4457
+  classified_files: 4460
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1521
+    authored: 1524
     authored-pin: 2
     generated: 121
     pinned-copy: 117
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 65
-  aggregate_sha256: dae9b870d8144daa3e9bcd7d3ad974e8b71eaf1149d1229e16d25cc4f4364cc5
+  aggregate_sha256: e5283c58aee9fd927a98ddaa025ff3a39cd2582b94df9bcbe8e2417cf3fe0f12
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,13 +151,13 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 766
-  aggregate_sha256: 6d059c15c1d071f4fcf66f8adca6bc7c7bc2edcedb23d19d7277390c14a66e15
+  match_count: 768
+  aggregate_sha256: 5d769ce4e6f912031a8f49fc95a8319927905ba178de3ab4d89f14e573bbc8cb
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 153
-  aggregate_sha256: 6eac80deb337dfbf79827b2cca27f27ae2fbca3e77dffd82120c93b15d23d500
+  match_count: 154
+  aggregate_sha256: 396ffe947d35b038b7a10a66f5d2cf024dbed9df3edb27fe27a5844947c8504f
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: bce68e93e48ad1283e612655ee2b3800a127d06b4dced01202389d89273ceafa
+  aggregate_sha256: 5a32de6f670e3e23c2b7f19d596a95ba104a17de09d844aeda7f4ac5fe4f7314
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
**Four of seven `main` runs were cancelled on 2026-08-18 — never judged.** The guard added 2026-08-13 aims at exactly this and does not cover it.

## What the flag does not do

`cancel-in-progress: false` protects a run that is **running**. It does not protect one that is **queued**. GitHub keeps exactly one *pending* run per concurrency group and cancels the earlier one when a newer arrives — the flag never applies, because that run was never "in progress".

## Mechanism, not correlation

The cancelled run `32166885428` (sha `6946fd36`) carries **`n_jobs: 0`** — it never started a single job. Cancelled in the queue, not in flight.

The trigger is merge **rhythm**, not content: a session landing eight PRs manufactures its own cancellations. And the failure is silent in the worst direction — no red *and* no green. An absent verdict reads like "nothing to report", so a green `main` gets read as "the series is green" while commits in the middle were never measured at all.

## The fix

The group becomes **per-sha on `main`, per-ref everywhere else**. Every main commit gets its own queue, so there is nothing to evict. On any other ref the group stays shared and the flag keeps its job — the next push replaces the previous one.

```yaml
group: diamond-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
```

**What it costs:** parallel runs when merges come fast. That is the price of "every commit is judged", which this repo had already chosen to pay — the old comment says so in its own words.

## Safety

`github.ref` and `github.sha` are repo-controlled, compared and concatenated into a **group name**, never interpolated into a `run:` shell. YAML parses; 9 jobs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)