### PR TITLE
fix(hygiene): le vecteur 44 cessait de croire, il accusait un self-test

### DIFF
--- a/docs/adr/adr-109-composition-proof-receipt.md
+++ b/docs/adr/adr-109-composition-proof-receipt.md
@@ -166,7 +166,7 @@ those two tiers close, and this ADR is re-issued again.
 - `crates/nika-dap/src/anchor/tier.rs` — `SealTier::Buried` (the
   append-after-seal class) + `SealTier::Unattributable` (an absent key is a
   missing input, never forgery)
-- `crates/nika-cli/src/verbs/trace_verify.rs` — the TAMPERED headline that
+- `crates/nika-trace/src/trace_verify.rs` — the TAMPERED headline that
   replaces the walk's crash reading when a seal is buried
 - `crates/nika-runtime/src/child.rs` — child-workflow execution (the composition seam)
 - `crates/nika-runtime/src/dispatch.rs` — `child_budget` law-6 doc + the workflow-call dispatch

--- a/estate.yaml
+++ b/estate.yaml
@@ -173,7 +173,7 @@ patterns:
 - glob: "docs/adr/**"
   class: authored
   match_count: 80
-  aggregate_sha256: 6ea06b5acaeb1af2a71125e2542bb4c347597ea8a857957b86876f11a0e2e2c8
+  aggregate_sha256: 874a89423c5c679b53eb4c8d5a17e3428c7b5c92986f1e2fa0914d55d94f5b5b
   evidence: "per-decision records authored at decision time (scripts/adr/new.sh scaffolds · adr-seal-check hook seals); index.toml excepted in files:"
 - glob: "docs/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 150
-  aggregate_sha256: d1d1c49a7122fc48b76b398867b8749d94e1401f46c2e4b1da4538891400901a
+  aggregate_sha256: c933e9e56e071aad57a0a997aaa07caa14f653134bf4cdc6cfdebdf0737149fe
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/hygiene/check-script-path-refs.sh
+++ b/scripts/hygiene/check-script-path-refs.sh
@@ -43,6 +43,17 @@ checked=0
 #      SSOT (ADR-026)", or an "ex <old path>" provenance citation
 #   3. a placeholder — `docs/crate-specs/nika-X.md`, or any glob/brace
 #   4. an OUTPUT — `printf ... > docs/note.md` creates the file it names
+#   5. a SELF-TEST's fixture — `scripts/hygiene/tests/*.test.sh` builds
+#      fake trees to prove a vector, so its paths must NOT exist: the
+#      names are `check-alpha.sh`, `check-beta.sh`, and one called
+#      `check-gone.sh` precisely because the case under test IS a stale
+#      declaration. Measured 2026-08-18 · 6 findings, all fixtures, zero
+#      real. Same shape as the privacy-boundary sweep accusing the
+#      private-path gate's own red examples the same evening: a gate that
+#      reports another gate's fixtures teaches the reader to stop reading
+#      it, which is the exact cost this vector exists to prevent.
+#      File-wide, like the OUTPUT exemption, and no wider — the sweep
+#      keeps judging every non-test script under `scripts/`.
 # A first draft judged one line at a time and produced four false positives
 # out of five hits — including two that pointed at THIS FILE's own comments.
 # Shipping that would have added a sixth face to the very class it ratchets,
@@ -100,7 +111,8 @@ while IFS= read -r script; do
       fi
     done
   done <"$script"
-done < <(find scripts -type f \( -name '*.sh' -o -name '*.py' \) | sort)
+done < <(find scripts -type f \( -name '*.sh' -o -name '*.py' \) \
+  -not -path 'scripts/hygiene/tests/*' | sort)
 
 if [ "$missing" -gt 0 ]; then
   echo "$missing stale path reference(s) in scripts ($checked checked)"


### PR DESCRIPTION
Two dangling-reference repairs, both YELLOW on the pre-push gate.

## ① Vector 44 was reporting another gate's fixtures

Six findings, six fixtures, **zero real**. It read `scripts/hygiene/tests/self-test-coverage.test.sh` and reported the paths that test *constructs* to prove a different vector: `check-alpha.sh`, `check-beta.sh`, and one named **`check-gone.sh` precisely because the case under test is a stale declaration**. A self-test builds a fake tree — its paths *must not* exist. Reporting them asks a test to lie to satisfy a gate.

**Second time in one evening, same shape:** the monorepo's `privacy-boundary` sweep was accusing the private-path gate's own red examples a few hours earlier. And this file's header already names the cost:

> the cost is never the wrong string: it is that a surface which lies once teaches everyone to stop reading it

It said it, and it was doing it.

**The exemption is the fifth, not a blanket.** Four were already here, each measured 2026-07-30. This one takes the same shape — file-wide, like the OUTPUT exemption, for the same reason (a test names its fixtures across several lines) — and not an inch wider: every script outside `tests/` is still judged.

**Proven by mutation, not by a green.** A stale path injected into a non-test script (`check-crate-size.sh`) reddens the vector; removed, it returns `OK (83 script path references verified)`. Without that half, the exemption could be a blanket and the green would mean nothing.

## ② ADR-109's evidence path followed its file

`crates/nika-cli/src/verbs/trace_verify.rs` moved to `crates/nika-trace/src/trace_verify.rs` in the trace descent. I checked the evidence actually moved with it — 20 `tamper` hits at the new path — before repointing: swapping a dead pointer for a **false** one is worse than leaving it dead.

Vector 20: `OK (191 evidence paths verified)`.

## Proof

- shellcheck + shfmt clean
- full pre-push gate green — tests · clippy · hygiene · 9 ratchets

🤖 Generated with [Claude Code](https://claude.com/claude-code)