### PR TITLE
fix(hygiene): la bande de descente disait quon y est, jamais OU on en est

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4464
+  classified_files: 4465
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1527
+    authored: 1528
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -182,8 +182,8 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 150
-  aggregate_sha256: 59a87dbc359d2d9f8967e42a8090451e5897c98a8a54324c859588ca6bfe4ab1
+  match_count: 151
+  aggregate_sha256: c698724c36139b53caf45ed72f9959d3c22f875f4b8115d1a41cfc6582dc6c72
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/hygiene/check-crate-size.sh
+++ b/scripts/hygiene/check-crate-size.sh
@@ -54,8 +54,21 @@ BAND_OUTPUT=$(CRATE_SIZE_MAX="$WARN_AT" bash scripts/ci/check-crate-size.sh 2>&1
 BAND_STATUS=$?
 
 if [ "$BAND_STATUS" -ne 0 ]; then
-  printf "YELLOW: crate(s) in [%d, 15000) LOC range (the descent window):\n" "$WARN_AT"
-  echo "$BAND_OUTPUT" | grep '^FAIL' | sed -E "s/^FAIL  (.*)  ([0-9]+) LOC .*/  \1: \2 LOC (≥ $WARN_AT warn)/"
+  # The dashboard (check-all.sh) shows ONE line per vector — the FIRST one.
+  # A generic band header therefore printed 12001 and 14995 identically, and
+  # the band's whole purpose is that the red is not discovered AT the push.
+  # Measured 2026-08-18 · nika-check sat at 14995/15000 (5 LOC of headroom)
+  # and read, on the dashboard, exactly like a crate with 3000 to spare.
+  # So the header carries the TIGHTEST crate and its remaining headroom.
+  BAND_ROWS=$(echo "$BAND_OUTPUT" | grep '^FAIL' \
+    | sed -E 's/^FAIL  ([^ ]+)  ([0-9]+) LOC .*/\2 \1/' | LC_ALL=C sort -rn)
+  BAND_N=$(printf '%s\n' "$BAND_ROWS" | grep -c .)
+  TIGHT_LOC=$(printf '%s\n' "$BAND_ROWS" | head -1 | cut -d' ' -f1)
+  TIGHT_CRATE=$(printf '%s\n' "$BAND_ROWS" | head -1 | cut -d' ' -f2)
+  printf "YELLOW: %d crate(s) in the descent window · tightest %s at %d/15000 — %d LOC of headroom\n" \
+    "$BAND_N" "$TIGHT_CRATE" "$TIGHT_LOC" "$((15000 - TIGHT_LOC))"
+  printf '%s\n' "$BAND_ROWS" \
+    | awk '{ printf "  %s: %s LOC · %s left before the wall\n", $2, $1, 15000-$1 }'
   echo ""
   echo "Hint: the wall is where a push BLOCKS — plan the descent in a calm"
   echo "window instead: one unit, two members, boundary drawn with an ADR"

--- a/scripts/hygiene/tests/crate-size.test.sh
+++ b/scripts/hygiene/tests/crate-size.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# COVERS: scripts/hygiene/check-crate-size.sh
+#
+# Mutation proof for vector 24's DESCENT WINDOW (the [12000, 15000) band).
+#
+# The band exists so the red is not discovered AT the push, mid-merge-train.
+# But the hygiene dashboard (check-all.sh) renders ONE line per vector — the
+# FIRST one — and that line said only:
+#
+#     YELLOW: crate(s) in [12000, 15000) LOC range (the descent window):
+#
+# which is the SAME sentence at 12001 LOC and at 14999 LOC. The band was
+# 3000 wide and reported as a single bit. Measured 2026-08-18 · nika-check
+# sat at 14995/15000 — five lines of headroom — and read exactly like a
+# crate with three thousand to spare. A warning that cannot say how close
+# the wall is has already failed at the one job the band was added for.
+#
+# The header now names the TIGHTEST crate and its remaining headroom. These
+# cases pin that, and the first one is the case that matters: the tightest
+# crate is NOT the first row the counter emits, so a naive `head -1` on
+# unsorted input names the wrong crate and still looks plausible.
+#
+# shellcheck disable=SC2329
+set -uo pipefail
+
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+VECTOR="$ROOT/scripts/hygiene/check-crate-size.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+cases=0
+
+# Builds a fake repo whose scripts/ci/check-crate-size.sh is a stub:
+#   · called plain          → replays $red_rows,  rc = $red_rc   (the 15000 probe)
+#   · called CRATE_SIZE_MAX → replays $band_rows, rc = $band_rc  (the 12000 probe)
+# The stub emits the real counter's line shape: `FAIL  <dir>  <n> LOC (max <m>)`.
+scaffold() {
+  local dir="$1" red_rows="$2" red_rc="$3" band_rows="$4" band_rc="$5"
+  mkdir -p "$dir/scripts/hygiene" "$dir/scripts/ci"
+  cp "$VECTOR" "$dir/scripts/hygiene/"
+  printf '%s' "$red_rows" >"$dir/red.rows"
+  printf '%s' "$band_rows" >"$dir/band.rows"
+  printf '%s\n' "$red_rc" >"$dir/red.rc"
+  printf '%s\n' "$band_rc" >"$dir/band.rc"
+  cat >"$dir/scripts/ci/check-crate-size.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub of the ONE prod-LOC counter. Replays fixed rows so the wrapper's
+# band arithmetic is what is under test, never the counting itself.
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [ -n "${CRATE_SIZE_MAX:-}" ]; then
+  cat "$here/band.rows"
+  exit "$(cat "$here/band.rc")"
+fi
+cat "$here/red.rows"
+exit "$(cat "$here/red.rc")"
+STUB
+  chmod +x "$dir/scripts/ci/check-crate-size.sh"
+}
+
+# expect_rc <want-rc> <label> <red_rows> <red_rc> <band_rows> <band_rc>
+expect_rc() {
+  local want="$1" label="$2"
+  cases=$((cases + 1))
+  local dir="$WORK/case-$cases"
+  scaffold "$dir" "$3" "$4" "$5" "$6"
+  local rc
+  bash "$dir/scripts/hygiene/check-crate-size.sh" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$want" ]; then
+    printf '  ok   %s (rc=%d)\n' "$label" "$rc"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL %s — wanted rc=%s, got rc=%d\n' "$label" "$want" "$rc" >&2
+  fi
+}
+
+# expect_says <needle> <label> <red_rows> <red_rc> <band_rows> <band_rc>
+# Asserts the needle appears on the FIRST line — the only line the dashboard
+# renders. A needle found further down would not reach the operator.
+expect_says() {
+  local needle="$1" label="$2"
+  cases=$((cases + 1))
+  local dir="$WORK/case-$cases"
+  scaffold "$dir" "$3" "$4" "$5" "$6"
+  local head_line
+  head_line=$(bash "$dir/scripts/hygiene/check-crate-size.sh" 2>/dev/null | head -1)
+  case "$head_line" in
+    *"$needle"*)
+      printf '  ok   %s\n' "$label"
+      ;;
+    *)
+      fails=$((fails + 1))
+      printf '  FAIL %s — first line lacks %s\n       got: %s\n' \
+        "$label" "$needle" "$head_line" >&2
+      ;;
+  esac
+}
+
+# The counter emits in workspace order, NOT sorted by size: the tightest crate
+# (nika-check) is the LAST row here, and a comfortable one is first.
+UNSORTED='FAIL  crates/nika-builtin  13302 LOC (max 12000)
+FAIL  crates/nika-runtime  14929 LOC (max 12000)
+FAIL  crates/nika-check  14995 LOC (max 12000)
+'
+ONE='FAIL  crates/nika-solo  12500 LOC (max 12000)
+'
+OVER='FAIL  crates/nika-over  15400 LOC (max 15000)
+'
+
+echo "vector 24 · descent-window mutation proof"
+
+# THE case · the header must name the TIGHTEST crate, not the first row.
+expect_says 'crates/nika-check' 'header names the tightest crate' \
+  '' 0 "$UNSORTED" 1
+
+# ...and it must say HOW CLOSE. 15000 - 14995 = 5. This is the number whose
+# absence let a crate sit five lines from a blocking push, unseen.
+expect_says '5 LOC of headroom' 'header states the remaining headroom' \
+  '' 0 "$UNSORTED" 1
+
+# Control · the comfortable crate must NOT be the one promoted to the header.
+expect_says '14995/15000' 'header carries the tightest figure, not a band label' \
+  '' 0 "$UNSORTED" 1
+
+# Control · a single crate in the band still names itself.
+expect_says 'crates/nika-solo' 'a lone crate in the band is named' \
+  '' 0 "$ONE" 1
+
+# The verdict semantics are untouched by the message change.
+expect_rc 1 'band is YELLOW, never blocking' '' 0 "$UNSORTED" 1
+expect_rc 2 'over budget is RED' "$OVER" 1 '' 0
+expect_rc 0 'all crates under the warn line is GREEN' '' 0 '' 0
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d case(s) wrong — a band that cannot say how close the wall is.\n' \
+    "$fails" "$cases" >&2
+  exit 1
+fi
+
+printf '\n%d/%d cases correct.\n' "$cases" "$cases"
+exit 0


### PR DESCRIPTION
Le tableau de bord dhygiene rend **une** ligne par vecteur · la premiere. Celle du vecteur 24 disait seulement `YELLOW: crate(s) in [12000, 15000) LOC range` — exactement la meme phrase a **12001** quen **14999**. Une bande de 3000 de large rapportee comme **un seul bit**, alors quelle existe precisement pour que le rouge ne soit pas decouvert AU push.

## Ce que ca donne sur cette tete (post-descente #967)

```
YELLOW: 3 crate(s) in the descent window · tightest crates/nika-runtime at 14929/15000 — 71 LOC of headroom
  crates/nika-runtime: 14929 LOC · 71 left before the wall
  crates/nika-builtin: 13302 LOC · 1698 left before the wall
  crates/nika-check: 12455 LOC · 2545 left before the wall
```

Le mur suivant se nomme tout seul · `nika-runtime`, **71 lignes**.

**Aucune semantique de verdict ne bouge** · 12000 reste jaune, 15000 reste rouge, le compteur reste lunique compteur (`scripts/ci/check-crate-size.sh`). Seuls le message et lordre changent (trie par serrage, plus lordre du workspace).

## La preuve

`scripts/hygiene/tests/crate-size.test.sh` · 7 cas. Remets le vecteur davant et **4 rougissent** · les **3 autres restent verts** (la semantique des codes de retour, non touchee) ⇒ il discrimine au lieu de rougir sur tout.

Le cas qui compte donne au compteur des lignes **non triees**, ou le crate le plus serre est le **dernier** · un `head -1` naif nomme alors le mauvais crate et reste parfaitement plausible. Les fixtures sont **synthetiques**, donc le test ne bouge pas quand les vrais chiffres bougent.

Le vecteur 24 quitte la liste des gardes sans preuve (`a vector nobody has seen fail is decoration`).

## Historique des bases

Troisieme base (apres #966 puis #968) · les deux precedentes sont passees `DIRTY` sur leur delta `estate.yaml` des quun commit atterrissait sur `main`. Rejoue par **cherry-pick sur base fraiche** a chaque fois · zero force-push, zero fusion de `main` dans la branche.