### PR TITLE
fix(nika-schema): the retired keys teach where their role went

### DIFF
--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod envelope;
 pub(crate) mod envelope_values;
 pub(crate) mod for_each;
 mod lift;
+mod retired;
 pub(crate) mod tasks;
 mod value;
 pub(crate) mod verbs;
@@ -366,21 +367,19 @@ pub(super) struct Cx<'a> {
 /// `config:` died" (the check analyzer), "It rides `inputs:` now"
 /// (`permit_taint`), and #909's own diff comment.
 fn retired_key_teaching(key: &str, location: &str) -> Option<&'static str> {
-    // Envelope-scoped on purpose: the same word is a plausible field name
-    // inside a task body or a future block, and teaching the envelope's
-    // migration there would send a repairer the wrong way.
-    if !location.contains("envelope") {
-        return None;
+    // Scoped on purpose, and symmetric: the same word is a plausible field
+    // name in another block (`output` reads fine inside `exec:` · `types`
+    // fine in a future block), and teaching one block's migration inside
+    // another would send a repairer the wrong way. Two scopes retired keys
+    // in the 2026-08-11/13 sweep — the envelope and the task body — and
+    // each arm fires in ITS scope only.
+    if location.contains("envelope") {
+        return retired::envelope(key);
     }
-    match key {
-        "config" => Some(
-            "this key shipped in the fourteen-key envelope and died with the \
-             nine-key one (2026-08-13) — a deployment-supplied value is now an \
-             `inputs:` entry with `required: false` and a `default:`; a value \
-             baked into the file is a `const:` entry",
-        ),
-        _ => None,
+    if location.starts_with("task `") {
+        return retired::task(key);
     }
+    None
 }
 
 impl Cx<'_> {

--- a/crates/nika-schema/src/parser/retired.rs
+++ b/crates/nika-schema/src/parser/retired.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The retired keys teach where their role went — the arms behind
+//! `parser::retired_key_teaching` (the dispatcher stays in `mod.rs` · the
+//! vocabulary lives here). Split out under the ADR-023 1,500-LOC ceiling,
+//! which `mod.rs` sat fifteen lines under once the arms landed — the
+//! `declassify.rs` / `lift.rs` / `for_each.rs` precedent.
+//!
+//! Two scopes retired keys in the 2026-08-11/13 sweep — the fourteen-key
+//! ENVELOPE (five keys) and the TASK body (six) — and each arm fires in
+//! its scope only (`output` is a plausible name in both; one of them
+//! retired it). Every teaching is the engine's own words (the pack ·
+//! `nika-migrate` · the LOT 2 diff), never guessed.
+
+/// The fourteen-key envelope's five dead keys — where each role went, in
+/// the engine's own words (the pack, `nika-migrate`, the LOT 2 diff), never
+/// guessed. Measured 2026-08-18: the shipped 0.108.0 passes 0/40 of main's
+/// pack examples and main refuses 40/40 of 0.108.0's, so this refusal is
+/// the FIRST line every existing file meets on the nine-key engine.
+pub(super) fn envelope(key: &str) -> Option<&'static str> {
+    match key {
+        "config" => Some(
+            "this key shipped in the fourteen-key envelope and died with the \
+             nine-key one (2026-08-13) — a deployment-supplied value is now an \
+             `inputs:` entry with `required: false` and a `default:`; a value \
+             baked into the file is a `const:` entry",
+        ),
+        "workflow" => Some(
+            "this block shipped in the fourteen-key envelope and died with the \
+             nine-key one (2026-08-12) — the identity moved onto `nika:` itself \
+             (`nika: <id>` · a kebab-case name, no longer `v1`); its `description:` \
+             prose belongs in a `#` comment above `nika:`, never dropped",
+        ),
+        "description" => Some(
+            "a top-level `description:` shipped twice (bare, then inside \
+             `workflow:`) and both died with the nine-key envelope — write the \
+             prose as a `#` comment above `nika:` (the identity is `nika: <id>`)",
+        ),
+        "types" => Some(
+            "the named-type block died with the nine-key envelope (2026-08-11 · \
+             NIKA-TYPE-002 retired) — a shape rides the verb's own `schema:` \
+             (structured output) or a task's `returns:`; the ten primitives stay \
+             lowercase (spec 09)",
+        ),
+        "policy" => Some(
+            "this block died with the nine-key envelope (2026-08-11) — a \
+             vocabulary is not a policy: the effect boundary is `permits:` \
+             (`fs` · `net` · `exec` · `tools`), a governed value is a `secrets:` \
+             entry, and the ordering laws are unconditional (spec 10)",
+        ),
+        "assert" => Some(
+            "this block died with the nine-key envelope — a run's obligations \
+             are proven on the TRACE, not declared in the file: `nika trace \
+             verify` (spec 15) reads them from the sealed run",
+        ),
+        _ => None,
+    }
+}
+
+/// The task body's dead keys from the same sweep — a task's twenty-key set
+/// stays silent by design (no set listing · no near-miss for these), so
+/// without an arm each reads as `zzz:` to the author who typed it last week.
+pub(super) fn task(key: &str) -> Option<&'static str> {
+    match key {
+        "on_finally" => Some(
+            "cleanup is a TASK now, joined by an unwind edge (2026-08-11) — write \
+             it as its own task with `after: { <parent>: unwind }` (a `finally` \
+             node in `graph_format: 3`); the second grammar for a task body died",
+        ),
+        "output" => Some(
+            "renamed `extract:` (2026-08-11) — same shape, the truthful word for \
+             what it does",
+        ),
+        "declassify" | "inert" => Some(
+            "merged into `lift:` (2026-08-11) — the law is a PARAMETER of one \
+             door, not two spellings; `lift:` names which law the task opens and \
+             why (spec 10 §the authored doors)",
+        ),
+        "max_parallel" | "fail_fast" => Some(
+            "the two fan-out knobs live INSIDE the `for_each:` block now \
+             (`for_each: { items: …, max_parallel: N, fail_fast: false }`) — they \
+             have no meaning without it (spec 03 §for_each)",
+        ),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ParseMode, parse};
+    use crate::source::FileId;
+
+    /// EVERY key the fourteen-key era shipped teaches where its role went
+    /// — not a spelling guess, not the bare set listing (that one says
+    /// what is valid NOW and nothing about the past). Measured 2026-08-18:
+    /// the shipped 0.108.0 passes 0/40 of main's pack examples and main
+    /// refuses 40/40 of 0.108.0's, so this refusal is the FIRST line every
+    /// existing file meets on the nine-key engine · it has to teach.
+    #[test]
+    fn every_retired_envelope_key_teaches_where_its_role_went() {
+        let sees = |key: &str, value: &str| {
+            let yaml = format!(
+                "nika: w\n{key}: {value}\ntasks:\n  t:\n    exec: {{ command: [\"true\"] }}\n"
+            );
+            parse(&yaml, FileId::new(0), ParseMode::Strict)
+                .expect_err("an unknown envelope key refuses")
+                .to_string()
+        };
+        let workflow = sees("workflow", "{ id: old, description: d }");
+        assert!(
+            workflow.contains("`nika: <id>`") && workflow.contains("comment"),
+            "`workflow:` names the identity move AND the prose demotion · {workflow}"
+        );
+        assert!(
+            !workflow.contains("did you mean"),
+            "not a misspelling · {workflow}"
+        );
+        let description = sees("description", "\"prose\"");
+        assert!(
+            description.contains("comment") && description.contains("`nika:`"),
+            "a top-level `description:` becomes a comment above `nika:` · {description}"
+        );
+        let types = sees("types", "{}");
+        assert!(
+            types.contains("`schema:`") && types.contains("`returns:`"),
+            "`types:` names the two shape carriers that survive · {types}"
+        );
+        let policy = sees("policy", "{}");
+        assert!(
+            policy.contains("`permits:`") && policy.contains("vocabulary"),
+            "`policy:` names the boundary that survives it · {policy}"
+        );
+        let obligations = sees("assert", "[]");
+        assert!(
+            obligations.contains("nika trace verify"),
+            "`assert:` sends the obligation to the trace · {obligations}"
+        );
+    }
+
+    /// The task body had its own retired keys (the same 2026-08-11 sweep)
+    /// — a task's twenty-key set stays silent by design, so without an
+    /// arm each of these reads as `zzz:` to the author who typed it last
+    /// week.
+    #[test]
+    fn every_retired_task_key_teaches_where_its_role_went() {
+        let sees = |key: &str, value: &str| {
+            let yaml = format!(
+                "nika: w\ntasks:\n  t:\n    exec: {{ command: [\"true\"] }}\n    {key}: {value}\n"
+            );
+            parse(&yaml, FileId::new(0), ParseMode::Strict)
+                .expect_err("an unknown task key refuses")
+                .to_string()
+        };
+        let on_finally = sees(
+            "on_finally",
+            "{ cleanup: { exec: { command: [\"true\"] } } }",
+        );
+        assert!(
+            on_finally.contains("unwind") && on_finally.contains("after: {"),
+            "`on_finally:` teaches the unwind edge · {on_finally}"
+        );
+        assert!(
+            !on_finally.contains("did you mean"),
+            "not a misspelling · {on_finally}"
+        );
+        assert!(
+            sees("output", "{ x: \".x\" }").contains("`extract:`"),
+            "`output:` → `extract:`"
+        );
+        assert!(
+            sees("declassify", "[]").contains("`lift:`"),
+            "`declassify:` → `lift:`"
+        );
+        assert!(
+            sees("inert", "\"x\"").contains("`lift:`"),
+            "`inert:` → `lift:`"
+        );
+        assert!(
+            sees("max_parallel", "4").contains("`for_each:`"),
+            "`max_parallel:` lives in the block"
+        );
+        assert!(
+            sees("fail_fast", "false").contains("`for_each:`"),
+            "`fail_fast:` lives in the block"
+        );
+    }
+
+    /// Scope is symmetric · an envelope arm never fires in a task body and
+    /// a task arm never fires in the envelope (`output` is a plausible name
+    /// in both places; only ONE of them retired it).
+    #[test]
+    fn the_retired_teachings_stay_in_their_own_scope() {
+        assert!(super::super::retired_key_teaching("workflow", "task `t`").is_none());
+        assert!(super::super::retired_key_teaching("types", "`exec:`").is_none());
+        assert!(
+            super::super::retired_key_teaching("on_finally", "the workflow envelope").is_none()
+        );
+        assert!(super::super::retired_key_teaching("output", "the workflow envelope").is_none());
+        assert!(super::super::retired_key_teaching("output", "`exec:`").is_none());
+        assert!(super::super::retired_key_teaching("output", "task `t`").is_some());
+    }
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4466
+  classified_files: 4467
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1529
+    authored: 1530
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 768
-  aggregate_sha256: e7451fac0860914f355cb1ca77b68b976ae9d8ce5f29eb15e0c87a5e3c39cfdb
+  match_count: 769
+  aggregate_sha256: 6ce9d5c232432ea947d53e452115cff1558ca132bed0cb094c48c8fa2d5768ec
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## Defect

On the nine-key engine, a file written for 0.108.0 (every file that exists outside this repo today) is refused on its first retired key with `unknown field `workflow` in the workflow envelope` followed by the set listing. Only `config:` had a teaching. The set listing says what is valid NOW and nothing about the past; the Damerau-Levenshtein guess treats a key that shipped last week exactly like `zzz:`.

Measured 2026-08-18 with the two binaries side by side: the shipped 0.108.0 passes 0/40 of main's pack examples and main refuses 40/40 of 0.108.0's. This refusal is the FIRST line every existing file meets on 0.109.0, and it taught nothing.

## Mechanism

`retired_key_teaching` gains its two scopes, symmetric and sealed:

- **envelope arm** · `workflow` · `description` · `types` · `policy` · `assert` (beside the existing `config`)
- **task arm** · `on_finally` · `output` · `declassify` · `inert` · `max_parallel` · `fail_fast` (outside `for_each:`)

Each teaching is the engine's own words, never guessed: the identity moved onto `nika: <id>` and the prose becomes a `#` comment (nika-migrate's own note); cleanup is a task on an unwind edge (`after: {parent: unwind}` · graph_format 3); `output` is `extract`; `declassify`/`inert` are `lift`; the two knobs live inside `for_each:`; a shape rides `schema:` or `returns:`; `permits:` + `secrets:` survived `policy:`; obligations are proven by `nika trace verify`. An envelope arm never fires in a task and a task arm never fires in the envelope (`output` is a plausible name in both; one scope retired it).

The arms and their tests descend into `parser/retired.rs` (ADR-023 · mod.rs sat 15 lines under the 1,500 wall with them inline · the lift.rs / for_each.rs precedent) · mod.rs 1485 → 1329.

## Evidence

- 3 tests RED first (each key asserts its destination word and the absence of `did you mean`), then GREEN · nika-schema lib 209/209 · clippy `-D warnings` clean
- no snapshot or golden pinned the generic text (grep over crates/ · tests/)
- no spec code minted · the error stays the unknown-field one, only the suggestion clause leads with the migration (the SPEC's tombstone registry is the spec's to declare)

## Deliberately unchanged

`depends_on` (already typed · W2) · `fail_workflow` inside `on_error:` (already refused typed) · `vars`/`env` (their own NIKA-VALUES tombstones) · the task set stays silent for genuinely unknown keys.

Rides 0.109.0 · the release whose first contact with every existing file is exactly this refusal.
