### PR TITLE
feat(nika-migrate): the identity codemod — the fourteen-key envelope moves onto nika: (LOT 3 · R1)

### DIFF
--- a/crates/nika-cli-host/src/fix_ladder.rs
+++ b/crates/nika-cli-host/src/fix_ladder.rs
@@ -136,12 +136,23 @@ pub fn apply_dead_form_arm(
         // (2026-08-12): their teachings pointed at the `workflow:`
         // object, and repairing a file INTO a form the parser now
         // refuses would be a fix that breaks its own output. The
-        // `workflow:`/`description:` keys refuse as unknown keys now,
-        // which is not a dead form this ladder can mechanically repair —
-        // the id must be MOVED onto `nika:`, and only the author knows
-        // whether an existing `nika:` line already holds the name.
+        // `workflow:`/`description:` keys refuse as UNKNOWN keys now and
+        // ride the R1 identity arm below (equivalence-or-stop: the id
+        // moves onto `nika:` only when the answer is forced).
         SchemaError::W1TasksSequence { .. } | SchemaError::W1TaskIdField { .. } => {
             Some(apply_w1_map(source, repairs))
+        }
+        // R1 « the identity » (the nine-key envelope · 2026-08-12): a
+        // top-level `workflow:` block (or a bare `description:`) refuses
+        // as an unknown envelope key. The codemod moves `workflow.id`
+        // onto `nika:` and demotes the prose to a `#` comment ABOVE it —
+        // never dropped — and STOPS (never guesses) when `nika:` already
+        // names something else, when the block carries a foreign key,
+        // when the id is not kebab-case, or when there is no id at all.
+        SchemaError::UnknownField {
+            field, location, ..
+        } if (field == "workflow" || field == "description") && location.contains("envelope") => {
+            Some(apply_identity(source, repairs, stop_notes))
         }
         // W2 « the flow » dead form (PARSE-024) — the equivalence-or-
         // stop migration (spec 03 §depends_on): data → with: bindings ·
@@ -215,6 +226,33 @@ pub fn render_stops(stop_notes: &StopNotes, theme: Theme) -> String {
         );
     }
     stops
+}
+
+/// The R1 identity arm — `nika: v1` + `workflow: {id, description}` (or
+/// the scalar / flow forms · a bare `description:`) become `nika: <id>`
+/// with the prose demoted to a `#` comment. `true` = applied (the round
+/// restarts) · `false` = STOP (each note names the case) or Clean.
+fn apply_identity(
+    source: &mut String,
+    repairs: &mut Vec<Repair>,
+    stop_notes: &mut StopNotes,
+) -> bool {
+    match nika_migrate::identity(source) {
+        nika_migrate::IdentityOutcome::Changed(migrated) => {
+            *source = migrated;
+            repairs.push(Repair::applied(
+                "the fourteen-key identity (nika: v1 · workflow: {id, description})",
+                "nika: <id> · the description as a # comment above it",
+                "r1-identity",
+            ));
+            true
+        }
+        nika_migrate::IdentityOutcome::Stop(notes) => {
+            stop_notes.0 = notes;
+            false
+        }
+        nika_migrate::IdentityOutcome::Clean => false,
+    }
 }
 
 /// The W1 dead-form arm — the shared map migration. `true` = applied.

--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -313,19 +313,23 @@ mod tests {
     #[test]
     fn a_teaching_only_refusal_never_touches_the_file() {
         // The 2026-08-18 corruption class, both shapes. A dead envelope
-        // key (`workflow:` · retired 2026-08-12) and a de-commented
-        // modeline each refuse with PROSE — the retired-key migration,
-        // the set listing, the modeline fix — and no rename. `--fix` used
-        // to splice that prose in as a key ("the fields here: nika · …:")
-        // and announce one repair applied on a file that no longer parsed;
-        // the shipped 0.108.0 did the same with the modeline sentence.
-        // Now: byte-identical file, the honest note, the check still red.
+        // key with NO mechanical repair (`policy:` · retired 2026-08-11 ·
+        // a vocabulary is not a policy · nothing to move) and a
+        // de-commented modeline each refuse with PROSE — the retired-key
+        // teaching, the set listing, the modeline fix — and no rename.
+        // `--fix` used to splice that prose in as a key ("the fields
+        // here: nika · …:") and announce one repair applied on a file that
+        // no longer parsed; the shipped 0.108.0 did the same with the
+        // modeline sentence. Now: byte-identical file, the honest note,
+        // the check still red. (`workflow:` left this fixture when the R1
+        // identity rung made it mechanically repairable — see
+        // `identity_moves_the_fourteen_key_envelope_onto_nika_…`.)
         let dir = std::env::temp_dir().join(format!("nika-fix-prose-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmpdir");
         for (name, body) in [
             (
                 "dead-key.nika.yaml",
-                "nika: v1\nworkflow:\n  id: hello\ntasks:\n  say:\n    exec:\n      command: [echo, hi]\n",
+                "nika: hello\npolicy: {}\ntasks:\n  say:\n    exec:\n      command: [echo, hi]\n",
             ),
             (
                 "modeline.nika.yaml",
@@ -545,6 +549,68 @@ mod tests {
             "no rewrite without an applicable repair"
         );
         assert_ne!(out.code, exit::OK, "the unknown predicate still reds");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn identity_moves_the_fourteen_key_envelope_onto_nika_and_converges_green() {
+        // The nine-key flag-day repair loop: a 0.108.0 file (`nika: v1` +
+        // a `workflow:` block) is refused as an unknown envelope key —
+        // --fix moves the id onto `nika:`, demotes the description to a
+        // comment above it, then the ordinary rungs (w1-map for the tasks
+        // list) run in the SAME loop, and the final audit is clean.
+        let dir = std::env::temp_dir().join(format!("nika-fix-identity-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let path = dir.join("pre-r1.nika.yaml");
+        std::fs::write(
+            &path,
+            "nika: v1\nworkflow:\n  id: hello-world\n  description: \"says hi\"\nmodel: mock/echo\ntasks:\n  - id: t\n    infer: { prompt: \"hi\", max_tokens: 5 }\n",
+        )
+        .expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let healed = std::fs::read_to_string(&path).expect("re-read");
+        assert!(
+            healed.starts_with("# says hi\nnika: hello-world\n"),
+            "{healed}"
+        );
+        assert!(!healed.contains("workflow:"), "{healed}");
+        assert!(
+            healed.contains("tasks:\n  t:\n"),
+            "the tasks list migrated in the same loop · {healed}"
+        );
+        assert!(out.text.contains("r1-identity"), "{}", out.text);
+        assert_eq!(
+            out.code,
+            exit::OK,
+            "clean after the identity move: {}",
+            out.text
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn identity_stops_and_leaves_the_file_untouched_when_two_names_compete() {
+        let dir =
+            std::env::temp_dir().join(format!("nika-fix-identity-stop-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let path = dir.join("two-names.nika.yaml");
+        let src = "nika: other-name\nworkflow:\n  id: hello\ntasks:\n  t:\n    exec: { command: [\"true\"] }\n";
+        std::fs::write(&path, src).expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let after = std::fs::read_to_string(&path).expect("re-read");
+        assert_eq!(after, src, "a STOP never touches the file");
+        assert!(out.text.contains("two names"), "{}", out.text);
+        assert_ne!(out.code, exit::OK, "the refusal stands: {}", out.text);
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/nika-migrate/public-api.txt
+++ b/crates/nika-migrate/public-api.txt
@@ -45,6 +45,40 @@ impl<T> core::borrow::BorrowMut<T> for nika_migrate::EsplitOutcome where T: ?cor
 pub fn nika_migrate::EsplitOutcome::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for nika_migrate::EsplitOutcome
 pub fn nika_migrate::EsplitOutcome::from(t: T) -> T
+pub enum nika_migrate::IdentityOutcome
+pub nika_migrate::IdentityOutcome::Changed(alloc::string::String)
+pub nika_migrate::IdentityOutcome::Clean
+pub nika_migrate::IdentityOutcome::Stop(alloc::vec::Vec<alloc::string::String>)
+impl core::clone::Clone for nika_migrate::IdentityOutcome
+pub fn nika_migrate::IdentityOutcome::clone(&self) -> nika_migrate::IdentityOutcome
+impl core::cmp::Eq for nika_migrate::IdentityOutcome
+impl core::cmp::PartialEq for nika_migrate::IdentityOutcome
+pub fn nika_migrate::IdentityOutcome::eq(&self, other: &nika_migrate::IdentityOutcome) -> bool
+impl core::fmt::Debug for nika_migrate::IdentityOutcome
+pub fn nika_migrate::IdentityOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_migrate::IdentityOutcome
+impl<T, U> core::convert::Into<U> for nika_migrate::IdentityOutcome where U: core::convert::From<T>
+pub fn nika_migrate::IdentityOutcome::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_migrate::IdentityOutcome where U: core::convert::Into<T>
+pub type nika_migrate::IdentityOutcome::Error = core::convert::Infallible
+pub fn nika_migrate::IdentityOutcome::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_migrate::IdentityOutcome where U: core::convert::TryFrom<T>
+pub type nika_migrate::IdentityOutcome::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_migrate::IdentityOutcome::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_migrate::IdentityOutcome where T: core::clone::Clone
+pub type nika_migrate::IdentityOutcome::Owned = T
+pub fn nika_migrate::IdentityOutcome::clone_into(&self, target: &mut T)
+pub fn nika_migrate::IdentityOutcome::to_owned(&self) -> T
+impl<T> core::any::Any for nika_migrate::IdentityOutcome where T: 'static + ?core::marker::Sized
+pub fn nika_migrate::IdentityOutcome::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_migrate::IdentityOutcome where T: ?core::marker::Sized
+pub fn nika_migrate::IdentityOutcome::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_migrate::IdentityOutcome where T: ?core::marker::Sized
+pub fn nika_migrate::IdentityOutcome::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_migrate::IdentityOutcome where T: core::clone::Clone
+pub unsafe fn nika_migrate::IdentityOutcome::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_migrate::IdentityOutcome
+pub fn nika_migrate::IdentityOutcome::from(t: T) -> T
 pub enum nika_migrate::W2Outcome
 pub nika_migrate::W2Outcome::Changed(alloc::string::String)
 pub nika_migrate::W2Outcome::Stop(alloc::vec::Vec<alloc::string::String>)
@@ -66,6 +100,7 @@ impl<T> core::convert::From<T> for nika_migrate::W2Outcome
 pub fn nika_migrate::W2Outcome::from(t: T) -> T
 pub fn nika_migrate::d1(source: &str) -> nika_migrate::D1Outcome
 pub fn nika_migrate::esplit(source: &str) -> nika_migrate::EsplitOutcome
+pub fn nika_migrate::identity(source: &str) -> nika_migrate::IdentityOutcome
 pub fn nika_migrate::predicates(source: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_migrate::w1(source: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_migrate::w2(source: &str) -> nika_migrate::W2Outcome

--- a/crates/nika-migrate/src/identity.rs
+++ b/crates/nika-migrate/src/identity.rs
@@ -1,0 +1,571 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! R1 « the identity » codemod — the fourteen-key envelope's identity
+//! block becomes the nine-key one's single key.
+//!
+//! ```yaml
+//! # before                          # after
+//! nika: v1                          # Parse one booking into the import shape.
+//! workflow:                         nika: booking-parse
+//!   id: booking-parse
+//!   description: "Parse one booking into the import shape."
+//! ```
+//!
+//! Three source shapes are recognised, all top-level: the block
+//! (`workflow:` + indented `id:` / `description:`), the pre-W1 scalar
+//! (`workflow: <id>`), and the one-line flow form
+//! (`workflow: { id: x, description: y }`); a bare top-level
+//! `description:` (the pre-W1 hoist era) is folded the same way. The
+//! `nika:` line is REWRITTEN in place (its trailing comment kept) and the
+//! description prose is DEMOTED to `#` comment lines directly above it —
+//! never dropped, never guessed. Everything else is byte-identical.
+//!
+//! Equivalence-or-stop, like every rung of the ladder: the migration
+//! applies only when the answer is forced. `nika:` already naming
+//! something other than the old version literal while `workflow.id` names
+//! another thing is TWO names in one file (STOP · only the author knows
+//! which one is the identity); a `workflow:` block carrying a key other
+//! than `id`/`description` has no destination the parser admits (STOP);
+//! an id that is not kebab-case would only move the refusal from one key
+//! to another (STOP · the parser's `BadNikaId` teaching then names the
+//! grammar); a block without an `id:` has nothing to move (STOP). A
+//! document already in the nine-key shape returns [`IdentityOutcome::Clean`]
+//! — the transform is idempotent by contract.
+
+/// The outcome of one identity migration pass over one document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityOutcome {
+    /// Mechanically migrated (the identity moved · the prose demoted).
+    Changed(String),
+    /// Nothing to migrate: no `workflow:` block, no bare `description:`.
+    Clean,
+    /// Ambiguous or non-mechanical — each diagnostic names the case.
+    Stop(Vec<String>),
+}
+
+/// A top-level line: its index and the text after the `key:`.
+struct TopLevel<'a> {
+    idx: usize,
+    key: &'a str,
+    rest: &'a str,
+}
+
+/// The kebab-case grammar the parser admits for `nika: <id>`
+/// (`^[a-z][a-z0-9-]*$` · spec 01 §nika).
+fn is_kebab_id(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Strip one layer of matching quotes.
+fn unquote(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Split `key: rest` on the FIRST colon of an unindented, non-comment line.
+fn top_level(idx: usize, line: &str) -> Option<TopLevel<'_>> {
+    if line.starts_with(' ')
+        || line.starts_with('\t')
+        || line.starts_with('#')
+        || line.trim().is_empty()
+    {
+        return None;
+    }
+    let colon = line.find(':')?;
+    let key = &line[..colon];
+    if key.is_empty() || key.contains(' ') || key.contains('"') {
+        return None;
+    }
+    // `key:` must be followed by end, a space, or a flow opener — `a:b`
+    // is a scalar, not a mapping key.
+    let rest = &line[colon + 1..];
+    if !(rest.is_empty() || rest.starts_with(' ') || rest.starts_with('{')) {
+        return None;
+    }
+    Some(TopLevel {
+        idx,
+        key,
+        rest: rest.trim_start(),
+    })
+}
+
+/// The lines of an indented block under `start` (exclusive), up to but
+/// not including the next top-level line. Blank lines inside the block
+/// belong to it.
+fn block_end(lines: &[&str], start: usize) -> usize {
+    let mut end = start + 1;
+    while end < lines.len() {
+        let l = lines[end];
+        if l.trim().is_empty() || l.starts_with(' ') || l.starts_with('\t') {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+    // Trailing blank lines are NOT part of the block (they separate it
+    // from what follows and stay in the file).
+    while end > start + 1 && lines[end - 1].trim().is_empty() {
+        end -= 1;
+    }
+    end
+}
+
+/// The parsed identity block: the id and the description lines (already
+/// unquoted / dedented · one string per output comment line).
+struct Identity {
+    id: Option<String>,
+    description: Vec<String>,
+}
+
+/// Parse `workflow: { id: x, description: y }` — one line, no nesting.
+fn parse_flow(rest: &str, notes: &mut Vec<String>) -> Option<Identity> {
+    let inner = rest.trim().strip_prefix('{')?.strip_suffix('}')?;
+    if inner.contains('{') || inner.contains('[') {
+        notes.push(
+            "`workflow: {…}` carries a nested value — migrate the identity by hand (`nika: <id>` · the description as a `#` comment)"
+                .to_owned(),
+        );
+        return None;
+    }
+    let mut out = Identity {
+        id: None,
+        description: Vec::new(),
+    };
+    for entry in inner.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let Some((k, v)) = entry.split_once(':') else {
+            notes.push(format!(
+                "`workflow: {{…}}` entry `{entry}` is not `key: value` — migrate the identity by hand"
+            ));
+            return None;
+        };
+        match k.trim() {
+            "id" => out.id = Some(unquote(v).to_owned()),
+            "description" => out.description = vec![unquote(v).to_owned()],
+            other => {
+                notes.push(format!(
+                    "`workflow:` carries `{other}:` — the nine-key envelope has no home for it (only `id` and `description` moved) · migrate by hand"
+                ));
+                return None;
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Whether a scalar opens a YAML block scalar (`|` · `>` and their chomping forms).
+fn opens_block_scalar(value: &str) -> bool {
+    matches!(value, "|" | ">" | "|-" | ">-" | "|+" | ">+")
+}
+
+/// The prose lines of a block scalar whose header sits at `header_idx`
+/// (deeper-indented lines that follow · blank lines allowed inside),
+/// dedented to their common indent · plus the index of the first line
+/// after the scalar.
+fn block_scalar_lines(lines: &[&str], header_idx: usize, end: usize) -> (Vec<String>, usize) {
+    let header = lines[header_idx];
+    let base = header.len() - header.trim_start().len();
+    let mut next = header_idx + 1;
+    while next < end {
+        let candidate = lines[next];
+        let indent = candidate.len() - candidate.trim_start().len();
+        if candidate.trim().is_empty() || indent > base {
+            next += 1;
+        } else {
+            break;
+        }
+    }
+    let body: Vec<&str> = lines[header_idx + 1..next]
+        .iter()
+        .copied()
+        .filter(|candidate| !candidate.trim().is_empty())
+        .collect();
+    let min_indent = body
+        .iter()
+        .map(|candidate| candidate.len() - candidate.trim_start().len())
+        .min()
+        .unwrap_or(0);
+    let prose = body
+        .iter()
+        .map(|candidate| candidate[min_indent..].trim_end().to_owned())
+        .collect();
+    (prose, next)
+}
+
+/// Parse the indented `workflow:` block · `id:` and `description:` only.
+fn parse_block(
+    lines: &[&str],
+    start: usize,
+    end: usize,
+    notes: &mut Vec<String>,
+) -> Option<Identity> {
+    let mut out = Identity {
+        id: None,
+        description: Vec::new(),
+    };
+    let mut cursor = start + 1;
+    while cursor < end {
+        let line = lines[cursor].trim();
+        if line.is_empty() || line.starts_with('#') {
+            cursor += 1;
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            notes.push(format!(
+                "`workflow:` block line `{line}` is not `key: value` — migrate the identity by hand"
+            ));
+            return None;
+        };
+        let value = value.trim();
+        match key.trim() {
+            "id" => {
+                out.id = Some(unquote(value).to_owned());
+                cursor += 1;
+            }
+            "description" if opens_block_scalar(value) => {
+                let (prose, next) = block_scalar_lines(lines, cursor, end);
+                out.description = prose;
+                cursor = next;
+            }
+            "description" => {
+                out.description = vec![unquote(value).to_owned()];
+                cursor += 1;
+            }
+            other => {
+                notes.push(format!(
+                    "`workflow:` carries `{other}:` — the nine-key envelope has no home for it (only `id` and `description` moved) · migrate by hand"
+                ));
+                return None;
+            }
+        }
+    }
+    Some(out)
+}
+
+/// What the source carries · the identity block, the line ranges to
+/// remove, and the `nika:` line (index · value · trailing comment).
+struct Collected {
+    block: Identity,
+    removals: Vec<(usize, usize)>,
+    nika_idx: usize,
+    nika_value: String,
+    nika_comment: Option<String>,
+    had_workflow: bool,
+}
+
+/// Read the identity block(s) out of the top-level lines · `Err(notes)`
+/// on a STOP · `Ok(None)` when there is nothing to migrate (Clean).
+fn collect(lines: &[&str], tops: &[TopLevel<'_>]) -> Result<Option<Collected>, Vec<String>> {
+    let nika = tops.iter().find(|top| top.key == "nika");
+    let workflow = tops.iter().find(|top| top.key == "workflow");
+    let bare_description = tops.iter().find(|top| top.key == "description");
+    if workflow.is_none() && bare_description.is_none() {
+        return Ok(None);
+    }
+    let mut notes = Vec::new();
+    let mut block = Identity {
+        id: None,
+        description: Vec::new(),
+    };
+    let mut removals: Vec<(usize, usize)> = Vec::new();
+
+    if let Some(wf) = workflow {
+        let parsed = if wf.rest.starts_with('{') {
+            removals.push((wf.idx, wf.idx + 1));
+            parse_flow(wf.rest, &mut notes)
+        } else if wf.rest.is_empty() || wf.rest.starts_with('#') {
+            let end = block_end(lines, wf.idx);
+            removals.push((wf.idx, end));
+            parse_block(lines, wf.idx, end, &mut notes)
+        } else {
+            // the pre-W1 scalar · `workflow: <id>` (a trailing comment allowed)
+            let scalar = wf.rest.split('#').next().unwrap_or("").trim();
+            removals.push((wf.idx, wf.idx + 1));
+            Some(Identity {
+                id: Some(unquote(scalar).to_owned()),
+                description: Vec::new(),
+            })
+        };
+        block = parsed.ok_or_else(|| notes.clone())?;
+    }
+
+    if let Some(bare) = bare_description {
+        if !block.description.is_empty() {
+            notes.push(
+                "two descriptions (a bare top-level `description:` AND `workflow.description`) — keep one by hand as the `#` comment above `nika:`"
+                    .to_owned(),
+            );
+            return Err(notes);
+        }
+        let value = bare.rest.split('#').next().unwrap_or("").trim();
+        if opens_block_scalar(value) {
+            let end = block_end(lines, bare.idx);
+            let (prose, _) = block_scalar_lines(lines, bare.idx, end);
+            block.description = prose;
+            removals.push((bare.idx, end));
+        } else {
+            block.description = vec![unquote(value).to_owned()];
+            removals.push((bare.idx, bare.idx + 1));
+        }
+    }
+
+    let Some(nika) = nika else {
+        notes.push(
+            "no top-level `nika:` line — the identity has no key to move onto · write `nika: <id>` by hand"
+                .to_owned(),
+        );
+        return Err(notes);
+    };
+    let nika_value = unquote(nika.rest.split('#').next().unwrap_or("").trim()).to_owned();
+    let nika_comment = nika.rest.find('#').map(|at| nika.rest[at..].to_owned());
+    Ok(Some(Collected {
+        block,
+        removals,
+        nika_idx: nika.idx,
+        nika_value,
+        nika_comment,
+        had_workflow: workflow.is_some(),
+    }))
+}
+
+/// The one forced answer for the id · or the STOP that names why not.
+fn resolve_id(collected: &mut Collected) -> Result<String, Vec<String>> {
+    let id = if let Some(id) = collected.block.id.take() {
+        id
+    } else {
+        // A bare description with an already-named `nika:` · the name
+        // stands · only the prose moves.
+        let named = !collected.had_workflow
+            && !collected.nika_value.is_empty()
+            && !is_version_literal(&collected.nika_value);
+        if !named {
+            return Err(vec![
+                "the `workflow:` block carries no `id:` — there is nothing to move onto `nika:` · choose the name by hand"
+                    .to_owned(),
+            ]);
+        }
+        collected.nika_value.clone()
+    };
+    if !is_kebab_id(&id) {
+        return Err(vec![format!(
+            "`workflow.id` `{id}` is not a kebab-case name (`^[a-z][a-z0-9-]*$`) — moving it onto `nika:` would only move the refusal · choose the name by hand"
+        )]);
+    }
+    if !(is_version_literal(&collected.nika_value) || collected.nika_value == id) {
+        return Err(vec![format!(
+            "`nika:` already names `{}` while `workflow.id` names `{id}` — one file, two names · keep one by hand",
+            collected.nika_value
+        )]);
+    }
+    Ok(id)
+}
+
+/// Rebuild the document · byte-identical outside the touched lines.
+fn render(lines: &[&str], collected: &Collected, id: &str) -> String {
+    let removed = |idx: usize| {
+        collected
+            .removals
+            .iter()
+            .any(|(start, end)| idx >= *start && idx < *end)
+    };
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + collected.block.description.len());
+    for (idx, line) in lines.iter().enumerate() {
+        if removed(idx) {
+            continue;
+        }
+        if idx == collected.nika_idx {
+            for prose in &collected.block.description {
+                if prose.is_empty() {
+                    out.push("#".to_owned());
+                } else {
+                    out.push(format!("# {prose}"));
+                }
+            }
+            match &collected.nika_comment {
+                Some(comment) => out.push(format!("nika: {id}  {comment}")),
+                None => out.push(format!("nika: {id}")),
+            }
+            continue;
+        }
+        out.push((*line).to_owned());
+    }
+    out.join("\n")
+}
+
+/// The R1 identity migration. See the module doc for the contract.
+#[must_use]
+pub fn identity(source: &str) -> IdentityOutcome {
+    let lines: Vec<&str> = source.split('\n').collect();
+    let tops: Vec<TopLevel<'_>> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| top_level(idx, line))
+        .collect();
+    let mut collected = match collect(&lines, &tops) {
+        Ok(Some(collected)) => collected,
+        Ok(None) => return IdentityOutcome::Clean,
+        Err(notes) => return IdentityOutcome::Stop(notes),
+    };
+    let id = match resolve_id(&mut collected) {
+        Ok(id) => id,
+        Err(notes) => return IdentityOutcome::Stop(notes),
+    };
+    IdentityOutcome::Changed(render(&lines, &collected, &id))
+}
+
+/// The old era's `nika:` values were version literals (`v1` · `v2` · a
+/// quoted `"1"`) — those are safe to overwrite; anything else is a name.
+fn is_version_literal(s: &str) -> bool {
+    let s = s.trim();
+    s.is_empty()
+        || (s.starts_with('v')
+            && s[1..].chars().all(|c| c.is_ascii_digit() || c == '.')
+            && s.len() > 1)
+        || s.chars().all(|c| c.is_ascii_digit() || c == '.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn changed(src: &str) -> String {
+        match identity(src) {
+            IdentityOutcome::Changed(s) => s,
+            other => panic!("expected Changed · got {other:?}"),
+        }
+    }
+
+    fn stop(src: &str) -> Vec<String> {
+        match identity(src) {
+            IdentityOutcome::Stop(n) => n,
+            other => panic!("expected Stop · got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_block_form_moves_the_id_and_demotes_the_prose() {
+        let src = "nika: v1\nworkflow:\n  id: hello\n  description: \"says hi\"\n\ntasks:\n  t:\n    exec: { shell: \"true\" }\n";
+        let out = changed(src);
+        assert_eq!(
+            out,
+            "# says hi\nnika: hello\n\ntasks:\n  t:\n    exec: { shell: \"true\" }\n"
+        );
+        assert_eq!(
+            identity(&out),
+            IdentityOutcome::Clean,
+            "idempotent · a migrated document is Clean"
+        );
+    }
+
+    #[test]
+    fn a_block_without_description_leaves_no_comment() {
+        let src = "nika: v1\nworkflow:\n  id: hello\ntasks:\n  t:\n    exec: { shell: \"true\" }\n";
+        assert_eq!(
+            changed(src),
+            "nika: hello\ntasks:\n  t:\n    exec: { shell: \"true\" }\n"
+        );
+    }
+
+    #[test]
+    fn the_scalar_and_flow_forms_are_recognised() {
+        let scalar = "nika: v1\nworkflow: hello\ntasks: {}\n";
+        assert_eq!(changed(scalar), "nika: hello\ntasks: {}\n");
+        let flow = "nika: v1\nworkflow: { id: hello, description: \"says hi\" }\ntasks: {}\n";
+        assert_eq!(changed(flow), "# says hi\nnika: hello\ntasks: {}\n");
+    }
+
+    #[test]
+    fn a_block_scalar_description_becomes_one_comment_per_line() {
+        let src = "nika: v1\nworkflow:\n  id: hello\n  description: |\n    first line\n    second line\ntasks: {}\n";
+        assert_eq!(
+            changed(src),
+            "# first line\n# second line\nnika: hello\ntasks: {}\n"
+        );
+    }
+
+    #[test]
+    fn a_bare_top_level_description_folds_the_same_way() {
+        let src = "nika: v1\nworkflow: hello\ndescription: \"the pre-W1 hoist era\"\ntasks: {}\n";
+        assert_eq!(
+            changed(src),
+            "# the pre-W1 hoist era\nnika: hello\ntasks: {}\n"
+        );
+        // an already-named `nika:` with only a bare description · the name stands
+        let named = "nika: hello\ndescription: prose\ntasks: {}\n";
+        assert_eq!(changed(named), "# prose\nnika: hello\ntasks: {}\n");
+    }
+
+    #[test]
+    fn everything_else_is_byte_identical_including_comments_and_the_modeline() {
+        let src = "# SPDX-License-Identifier: Apache-2.0\n# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json\n#\n# a header comment\nnika: v1  # the old marker\nworkflow:\n  id: hello\n  # a comment inside the block\n  description: 'says hi'\n\nmodel: mock/echo\n\ntasks:\n  t:\n    exec: { shell: \"true\" }\n";
+        let out = changed(src);
+        assert_eq!(
+            out,
+            "# SPDX-License-Identifier: Apache-2.0\n# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json\n#\n# a header comment\n# says hi\nnika: hello  # the old marker\n\nmodel: mock/echo\n\ntasks:\n  t:\n    exec: { shell: \"true\" }\n"
+        );
+    }
+
+    #[test]
+    fn a_nine_key_document_is_clean() {
+        assert_eq!(identity("nika: hello\ntasks: {}\n"), IdentityOutcome::Clean);
+        assert_eq!(
+            identity("# prose\nnika: hello\nmodel: mock/echo\ntasks: {}\n"),
+            IdentityOutcome::Clean
+        );
+    }
+
+    #[test]
+    fn two_names_in_one_file_stop() {
+        let notes = stop("nika: other-name\nworkflow:\n  id: hello\ntasks: {}\n");
+        assert!(notes[0].contains("two names"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_foreign_key_in_the_block_stops() {
+        let notes = stop("nika: v1\nworkflow:\n  id: hello\n  version: 3\ntasks: {}\n");
+        assert!(notes[0].contains("`version:`"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_non_kebab_id_stops_instead_of_moving_the_refusal() {
+        let notes = stop("nika: v1\nworkflow:\n  id: My_Flow\ntasks: {}\n");
+        assert!(notes[0].contains("kebab-case"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_block_without_an_id_stops() {
+        let notes = stop("nika: v1\nworkflow:\n  description: prose only\ntasks: {}\n");
+        assert!(notes[0].contains("no `id:`"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_missing_nika_line_stops() {
+        let notes = stop("workflow:\n  id: hello\ntasks: {}\n");
+        assert!(notes[0].contains("no top-level `nika:`"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_nested_flow_value_stops() {
+        let notes = stop("nika: v1\nworkflow: { id: hello, meta: { a: 1 } }\ntasks: {}\n");
+        assert!(notes[0].contains("nested"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_task_level_workflow_key_is_not_the_envelope() {
+        // `workflow:` indented (an invoke child call) is not the identity block
+        let src = "nika: hello\ntasks:\n  child:\n    invoke:\n      workflow: ./other.nika.yaml\n";
+        assert_eq!(identity(src), IdentityOutcome::Clean);
+    }
+}

--- a/crates/nika-migrate/src/lib.rs
+++ b/crates/nika-migrate/src/lib.rs
@@ -59,11 +59,13 @@
 
 mod d1;
 mod esplit;
+mod identity;
 mod predicates;
 pub mod repair;
 
 pub use d1::{D1Outcome, d1};
 pub use esplit::{EsplitOutcome, esplit};
+pub use identity::{IdentityOutcome, identity};
 pub use predicates::predicates;
 
 /// Apply the W1 migration. `Some(new)` when the document changed,

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4466
+  classified_files: 4467
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1529
+    authored: 1530
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: 531f390057a2fec40791ea74d16abab2acae6560e53c4b8f85f9d7ed3fe488ca
+  aggregate_sha256: 30e1184a92f3a8d430385f2e4a357eb5c9e27974c90da3533b5ef9e508b79efe
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 768
-  aggregate_sha256: e7451fac0860914f355cb1ca77b68b976ae9d8ce5f29eb15e0c87a5e3c39cfdb
+  match_count: 769
+  aggregate_sha256: 421e6e32dbdadd85bf7d924bc889e32b4c0f4b32bd777e460f4cb037bf353b2c
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## Defect

`nika check --fix` had no rung for the nine-key flag-day's biggest move. A 0.108.0 file (`nika: v1` + `workflow: {id, description}`) refuses on the nine-key engine, and the ladder's own comment said the identity "is not a dead form this ladder can mechanically repair — only the author knows whether an existing `nika:` line already holds the name". True for the ambiguous case; false for the forced one, which is nearly every file: `nika:` holds the old version literal (`v1`) and `workflow.id` holds the one name.

Measured on the census of 2026-08-13: 562 files carry `nika: v1` and 630 a `workflow:` block — 1,192 hand edits without this rung, one command per file with it.

## Mechanism

`nika_migrate::identity` (R1), line-based and structure-aware like w1/esplit. Three source shapes — the block, the pre-W1 scalar (`workflow: <id>`), the one-line flow form — plus a bare top-level `description:` (the hoist era). The `nika:` line is rewritten in place (its trailing comment kept) and the description prose is DEMOTED to `#` comment lines directly above it, never dropped; everything else is byte-identical; a nine-key document returns `Clean` (idempotent by contract).

Equivalence-or-stop, never a guess:
- `nika:` already naming something other than a version literal while `workflow.id` names another thing → two names in one file (STOP)
- a `workflow:` block carrying a key other than `id`/`description` → no destination (STOP)
- an id that is not kebab-case → would only move the refusal (STOP · the parser's `BadNikaId` then teaches the grammar)
- a block without an `id:` → nothing to move (STOP)

The ladder (nika-cli-host) gains the R1 arm on `UnknownField { field: workflow | description, location: envelope }` — the exact refusal a 0.108.0 file meets first — and the ordinary rungs (w1-map for the tasks list, esplit, predicates) run in the SAME `--fix` loop, so a 0.108.0 file heals to green in one command. Post-#971 shape: the arm sits behind `rename_repair()`, inside the transaction. The public API of nika-migrate gains `identity` + `IdentityOutcome` (snapshot regenerated).

## Evidence

- 14 unit tests (block · scalar · flow · block-scalar prose · bare description · byte-identity incl. modeline and trailing comment · Clean · the six STOP cases · a task-level `workflow:` is not the envelope)
- two hand mutations RED (prose demotion dropped → 5 red · two-names guard dropped → 1 red)
- 2 fix-loop integration tests (heal-to-green in one loop with the tasks list · a STOP leaves the file byte-identical and the refusal stands)
- nika-migrate 75/75 · clippy `-D warnings` clean · functions ≤100 LOC (identity split into collect · resolve_id · render)

## Deliberately unchanged

The other LOT 3 rungs (`for_each` re-nesting · `output` → `extract` · `declassify`/`inert` → `lift` · `config` → `inputs` · `on_finally` → an unwind task) — each its own rung, next.

Rides 0.109.0 if it lands first · the release whose first contact with every existing file is exactly this refusal, and now its repair.
