### PR TITLE
fix(nika-lsp): the capability advertises the graph format it serves · the for_each island inserts the block the parser admits

### DIFF
--- a/crates/nika-graph/public-api.txt
+++ b/crates/nika-graph/public-api.txt
@@ -119,4 +119,5 @@ impl<T> core::convert::From<T> for nika_graph::Node
 pub fn nika_graph::Node::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_graph::Node where T: 'static
 pub fn nika_graph::Node::as_any(&self) -> &(dyn core::any::Any + 'static)
+pub const nika_graph::GRAPH_FORMAT: u32
 pub fn nika_graph::project(wf: &nika_schema::raw::workflow::RawWorkflow, report: &nika_check::CheckReport) -> nika_graph::GraphDoc

--- a/crates/nika-graph/src/lib.rs
+++ b/crates/nika-graph/src/lib.rs
@@ -28,6 +28,16 @@ use nika_check::CheckReport;
 use nika_schema::raw::{RawAction, RawWorkflow};
 use nika_schema::types::{AfterPredicate, OnErrorAction, WhenGate};
 
+/// The projection's format number (spec 03 §graph-projection · `graph_format: 3`).
+///
+/// ONE constant, three readers: the envelope below stamps it, the LSP
+/// capability advertises it (`nika/semanticDocument` · `graphFormat`), and
+/// the MCP surface names it — a literal in each place drifted once (the
+/// LSP advertised 2 while the document it served said 3 · measured
+/// 2026-08-18: a client that honours the advertisement refused a graph
+/// it could have read, or read one it should have refused).
+pub const GRAPH_FORMAT: u32 = 3;
+
 /// The versioned projection envelope (spec 03 §graph-projection · `graph_format: 3`).
 #[derive(Debug, Serialize)]
 pub struct GraphDoc {
@@ -172,7 +182,7 @@ pub fn project(wf: &RawWorkflow, report: &CheckReport) -> GraphDoc {
     }
 
     GraphDoc {
-        graph_format: 3,
+        graph_format: GRAPH_FORMAT,
         workflow,
         nodes,
         edges: typed_edges(wf),

--- a/crates/nika-lsp/src/analysis/completion/tests.rs
+++ b/crates/nika-lsp/src/analysis/completion/tests.rs
@@ -956,6 +956,38 @@ fn for_each_offers_typed_arrays_first_then_the_boundary_import() {
         ],
         "typed array first · the teaching import · other vars honestly"
     );
+    // The INSERTED text is the block the parser admits — the label spells
+    // the collection, the insert wraps it: `{ items: "${{ … }}" }`. The
+    // bare scalar was refused at parse (« for_each must be a block with
+    // items: ») · measured 2026-08-18: this lane offered what check
+    // refused. Every item on the lane inserts the block; the parser
+    // proves the shape below.
+    for item in &items {
+        let inserted = item
+            .insert_text
+            .as_deref()
+            .expect("a for_each island inserts the block");
+        assert_eq!(
+            inserted,
+            format!("{{ items: \"{}\" }}", item.label),
+            "{}",
+            item.label
+        );
+    }
+    let picked = &items[0];
+    let doc = FLOW_DOC.replace(
+        "for_each: { items: \"${{ inputs.urls }}\" }",
+        &format!(
+            "for_each: {}",
+            picked.insert_text.as_deref().expect("insert")
+        ),
+    );
+    nika_schema::parse(
+        &doc,
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("what the island inserts, the parser admits");
     assert!(
         !got.iter().any(|l| l.contains("tasks.")),
         "no tasks.* form — the boundary (VAR-021): {got:?}"

--- a/crates/nika-lsp/src/analysis/islands.rs
+++ b/crates/nika-lsp/src/analysis/islands.rs
@@ -127,6 +127,19 @@ fn island(label: String, detail: String) -> CompletionItem {
     }
 }
 
+/// A `for_each:` island — the label reads as the collection (`${{ … }}`)
+/// but the INSERTED text is the block the parser admits, `{ items: "…" }`
+/// (spec 03 §`for_each` · `items` + the two knobs). The bare scalar the
+/// label spells was refused at parse (« `for_each` must be a block with
+/// `items:` ») — measured 2026-08-18: this lane offered what `check`
+/// refused. Quoted inside the flow mapping: an unquoted `${{ … }}` in
+/// `{ }` is not YAML.
+fn for_each_island(collection: &str, detail: String) -> CompletionItem {
+    let mut item = island(collection.to_owned(), detail);
+    item.insert_text = Some(format!("{{ items: \"{collection}\" }}"));
+    item
+}
+
 /// `for_each:` — the collection candidates: typed array inputs lead,
 /// the task's OWN bindings follow (the collection is a pre-fan-out
 /// LOCAL surface · spec 03 §`for_each` — an upstream array crosses
@@ -137,26 +150,26 @@ pub(super) fn for_each_items(text: &str, offset: usize) -> Vec<CompletionItem> {
     let view = doc_view(text, offset);
     let mut items = Vec::new();
     for (reference, _) in view.vars.iter().filter(|(_, a)| *a) {
-        items.push(island(
-            format!("${{{{ {reference} }}}}"),
+        items.push(for_each_island(
+            &format!("${{{{ {reference} }}}}"),
             "array value — one run per element".to_owned(),
         ));
     }
     for name in &view.bindings {
-        items.push(island(
-            format!("${{{{ with.{name} }}}}"),
+        items.push(for_each_island(
+            &format!("${{{{ with.{name} }}}}"),
             "a with: binding — the boundary import of the collection".to_owned(),
         ));
     }
     if view.bindings.is_empty() && !view.upstream.is_empty() {
-        items.push(island(
-            "${{ with.items }}".to_owned(),
+        items.push(for_each_island(
+            "${{ with.items }}",
             "bind the upstream array first — with: { items: ${{ tasks.<id>.output }} }".to_owned(),
         ));
     }
     for (reference, _) in view.vars.iter().filter(|(_, a)| !*a) {
-        items.push(island(
-            format!("${{{{ {reference} }}}}"),
+        items.push(for_each_island(
+            &format!("${{{{ {reference} }}}}"),
             "runs if it holds a list at launch".to_owned(),
         ));
     }

--- a/crates/nika-lsp/src/capabilities.rs
+++ b/crates/nika-lsp/src/capabilities.rs
@@ -60,10 +60,13 @@ pub fn server_capabilities() -> ServerCapabilities {
         })),
         // Custom extensions, capability-gated the rust-analyzer way —
         // a client (or agent) reads this to know the oracle surface.
-        // `graphFormat` mirrors the IN-PAYLOAD version of the projection
-        // (spec 03 §graph-projection) — additive, spec-first evolution.
+        // `graphFormat` IS the in-payload version of the projection the
+        // document carries (spec 03 §graph-projection · `nika_graph::
+        // GRAPH_FORMAT`) — derived, never retyped: a literal here said 2
+        // while the served document said 3 (2026-08-18), and a client
+        // that honours the advertisement decides adoption on it.
         experimental: Some(serde_json::json!({
-            "nika": { "semanticDocument": { "graphFormat": 2 } }
+            "nika": { "semanticDocument": { "graphFormat": nika_graph::GRAPH_FORMAT } }
         })),
         ..ServerCapabilities::default()
     }
@@ -126,7 +129,14 @@ mod tests {
     fn experimental_advertises_the_semantic_document() {
         let caps = server_capabilities();
         let exp = caps.experimental.expect("experimental block");
-        assert_eq!(exp["nika"]["semanticDocument"]["graphFormat"], 2);
+        // The advertisement IS the projection's own number — pinned to the
+        // constant AND to the value the spec names, so a bump of either
+        // without the other fails here, not in a client.
+        assert_eq!(
+            exp["nika"]["semanticDocument"]["graphFormat"],
+            nika_graph::GRAPH_FORMAT
+        );
+        assert_eq!(exp["nika"]["semanticDocument"]["graphFormat"], 3);
     }
 
     #[test]

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 770
-  aggregate_sha256: 042a4d7b023ee22485b2cba242a972ec25ba05055115272574f9c452e61e7a95
+  aggregate_sha256: da545c47c84ed7ba8c78e28fc21b14edca2808239a85b646f3f2e0a876eda9f5
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: 30e1184a92f3a8d430385f2e4a357eb5c9e27974c90da3533b5ef9e508b79efe
+  aggregate_sha256: bf11e999b2702682cfcacb213a6333703d52ced6af06aeae840ff08d41f92c3e
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 770
-  aggregate_sha256: 2d235f73626dc9df31f478fa259271e07f3fc066e5b713b3d2cad65fc38de691
+  aggregate_sha256: 042a4d7b023ee22485b2cba242a972ec25ba05055115272574f9c452e61e7a95
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Two `nika-lsp` teaching defects, measured 2026-08-18 through the VS Code extension (the consumer that decides adoption on the advertisement and writes what the island inserts).

1. **The capability lied about the format.** `initialize` advertised `experimental.nika.semanticDocument.graphFormat: 2` while `nika/semanticDocument` served `graph.graph_format: 3`. Three literals (capability · projection · MCP text), one stale. Now `nika_graph::GRAPH_FORMAT` (3) is the ONE constant: the projection stamps it, the capability advertises it (derived, never retyped), and the capability test pins the advertisement to the constant AND to the value the spec names.
2. **The `for_each:` island offered a form the parser refuses.** The lane inserted the bare `${{ inputs.urls }}` after `for_each: ` — « for_each must be a block with items: » at parse. Every for_each island keeps its readable label and inserts `{ items: "<collection>" }` (flow block, quoted). The lane test hands the picked insert to `nika_schema::parse` (strict): what the island inserts, the parser admits.

Not here: `nika-tui-core` still reads any `graph_format` without refusing (its board fixtures are format-2 testimonials from an older engine) — noted as its own follow-up.
