### PR TITLE
fix(hygiene): le compteur de prod facturait 951 lignes de code de test

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4468
+  classified_files: 4469
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1531
+    authored: 1532
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -182,8 +182,8 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 152
-  aggregate_sha256: affe85c7387ee76b5d20e119456b39ad4b4d5a1f5bc90d6d591abef850da1292
+  match_count: 153
+  aggregate_sha256: 58d3c432aa5bc759636157cfe36ef92fa92c419da9ad61a048932550070bcf52
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/ci/_lib.sh
+++ b/scripts/ci/_lib.sh
@@ -33,8 +33,21 @@
 # Set NIKA_SKIP_FILTER_SELFTEST=1 only inside the self-test itself (it
 # sources this file, and must not recurse).
 _lib_prove_filter() {
-  local selftest="${BASH_SOURCE[0]%/*}/test-strip-test-items.sh"
+  # TWO filters ship from this file and both decide what the ratchets see:
+  # `strip_test_items` hides test items INSIDE a file, `rs_prod_files` hides
+  # whole FILES. Each has its own self-test and each must prove itself, or the
+  # ratchets built on it render a verdict they cannot back.
+  local selftest
   [ -n "${NIKA_SKIP_FILTER_SELFTEST:-}" ] && return 0
+  for selftest in \
+    "${BASH_SOURCE[0]%/*}/test-strip-test-items.sh" \
+    "${BASH_SOURCE[0]%/*}/test-rs-prod-files.sh"; do
+    _lib_prove_one "$selftest"
+  done
+}
+
+_lib_prove_one() {
+  local selftest="$1"
   # Fail CLOSED. This read `[ -x "$selftest" ] || return 0`, which skipped the
   # proof and reported success when the self-test was absent OR merely not
   # executable — so `chmod -x` on one file disarmed four ratchets at once and
@@ -58,11 +71,80 @@ rs_src_files() {
   git ls-files '*.rs' | grep -E '(^|/)src/' | grep -vE '(^|/)(tests|benches|examples)/' || true
 }
 
-# Like rs_src_files but also excludes files whose basename is `tests.rs`
-# (convention: `src/tests.rs` and `src/foo/tests.rs` are 100% test code).
+# List src files whose MODULE is declared under `#[cfg(test)]` — test-only by
+# construction: the compiler never builds them outside a test profile, whatever
+# their basename.
+#
+# `rs_prod_files` has always promised to "mirror clippy's `#[cfg(test)]`
+# exclusion" and until 2026-08-18 delivered only the `tests.rs` BASENAME half.
+# The other half leaked: 951 lines of test-only code across five crates were
+# charged to the production budget — nika-providers 638 (`parity_tests.rs` ·
+# `test_support.rs`) · nika-dap 122 (`anchor/fixtures.rs`) · nika-runtime 109
+# (`adversarial/mod.rs`, whose own doc says "Test-only: no public surface, no
+# production code") · nika-trace 58 · nika-verb-infer 24. That is a MISCOUNT,
+# not a budget: the promise was already written above the function.
+#
+# The exemption is TIGHTENED, not merely widened: a module declared under
+# `#[cfg(test)]` in one place AND normally in another stays production. A
+# declaration only counts when `#[cfg(test)]` is the attribute that reaches it
+# (other attributes and comments may sit between), so `#[cfg(test)] use …`
+# never triggers it.
+rs_test_only_files() {
+  rs_src_files | python3 -c '
+import os, re, sys
+
+files = [l.strip() for l in sys.stdin if l.strip()]
+known = set(files)
+
+DECL = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+([a-z_][a-z0-9_]*)\s*;")
+CFG  = re.compile(r"^\s*#\[cfg\(test\)\]\s*$")
+ATTR = re.compile(r"^\s*(#\[|//)")
+
+test_roots, prod_roots = set(), set()
+
+for f in files:
+    try:
+        lines = open(f, encoding="utf-8", errors="replace").read().split("\n")
+    except OSError:
+        continue
+    stem = os.path.basename(f)[:-3]
+    moddir = os.path.dirname(f) if stem in ("mod", "lib", "main") \
+             else os.path.join(os.path.dirname(f), stem)
+    pending = False
+    for ln in lines:
+        if CFG.match(ln):
+            pending = True
+            continue
+        if not ln.strip() or ATTR.match(ln):
+            continue                      # attributes/comments do not break the pairing
+        m = DECL.match(ln)
+        if m:
+            (test_roots if pending else prod_roots).add(os.path.join(moddir, m.group(1)))
+        pending = False
+
+out = set()
+for r in sorted(test_roots - prod_roots):   # declared BOTH ways ⇒ stays production
+    out.add(r + ".rs")
+    out.add(os.path.join(r, "mod.rs"))
+    out.update(f for f in files if f.startswith(r + os.sep))
+
+for f in sorted(out & known):
+    print(f)
+' || true
+}
+
+# Like rs_src_files but also excludes (a) files whose basename is `tests.rs`
+# (convention: `src/tests.rs` and `src/foo/tests.rs` are 100% test code) and
+# (b) files whose module is declared under `#[cfg(test)]` (see above).
 # Use this for ratchets that should mirror clippy's `#[cfg(test)]` exclusion.
 rs_prod_files() {
-  rs_src_files | grep -vE '(^|/)tests\.rs$' || true
+  local excluded
+  excluded="$(rs_test_only_files)"
+  if [ -z "$excluded" ]; then
+    rs_src_files | grep -vE '(^|/)tests\.rs$' || true
+  else
+    rs_src_files | grep -vE '(^|/)tests\.rs$' | grep -vxF "$excluded" || true
+  fi
 }
 
 # List every tracked .rs file (any location).

--- a/scripts/ci/check-crate-size.sh
+++ b/scripts/ci/check-crate-size.sh
@@ -22,20 +22,28 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAX="${CRATE_SIZE_MAX:-15000}"
 violations=0
 
+# The prod-file set is the SHARED one, computed ONCE for the whole workspace.
+#
+# It used to be re-implemented inline here — `git ls-files … | grep -v
+# '/tests\.rs$'` — under a comment claiming to follow "the rs_prod_files
+# convention in _lib.sh". One rule, three readers (this, _lib.sh,
+# check-seam-discipline), and the copies drifted the moment the shared one
+# learned something: on 2026-08-18 `rs_prod_files` started honouring modules
+# declared under `#[cfg(test)]`, and this copy kept charging 951 lines of
+# test-only code to five crates' production budget. The copy is gone; the
+# measure is read from its single source.
+PROD_FILES="$(rs_prod_files)"
+
 while IFS= read -r manifest; do
   [ -z "$manifest" ] && continue
   crate_dir=$(dirname "$manifest")
-  # P1-6 Batch H+: recurse via trailing /. Prod scope: src/ only, minus
-  # in-file #[cfg(test)] regions (counted by the python block below) AND
-  # files whose basename is `tests.rs` (the rs_prod_files convention in
-  # _lib.sh — a `tests.rs` sibling/dir-module is 100% test code, already
-  # honoured by check-expect/check-unwraps). Aligned here so a test module
-  # split out of an oversized file (no in-file #[cfg(test)] marker) is not
-  # miscounted as production.
+  # Prod scope: src/ only, minus in-file #[cfg(test)] regions (counted by the
+  # python block below) — the FILE-level exclusions are already applied by
+  # rs_prod_files (basename `tests.rs` + `#[cfg(test)] mod` declarations).
   # `|| true` keeps an src-less crate from killing the loop under pipefail
   # (grep exits 1 on zero matches); python prints 0 on empty stdin then.
   total=$(
-    { git ls-files -- "$crate_dir/src/" 2>/dev/null | grep '\.rs$' | grep -v '/tests\.rs$' || true; } \
+    { printf '%s\n' "$PROD_FILES" | grep -- "^$crate_dir/src/" || true; } \
       | python3 -c '
 import re, sys
 total = 0

--- a/scripts/ci/test-rs-prod-files.sh
+++ b/scripts/ci/test-rs-prod-files.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# test-rs-prod-files.sh — the FILE-level filter self-tests before it judges.
+#
+# Sibling of test-strip-test-items.sh, which pins the IN-FILE filter. This one
+# pins `rs_test_only_files` / `rs_prod_files`: which whole FILES four ratchets
+# (crate-size, unwrap, expect, dead-code) are allowed to see.
+#
+# `rs_prod_files` documented itself as mirroring clippy's `#[cfg(test)]`
+# exclusion and delivered only the `tests.rs` BASENAME half. Measured
+# 2026-08-18: six files declared `#[cfg(test)] mod <name>;` — among them
+# `nika-runtime/src/adversarial/mod.rs`, whose own doc-comment reads
+# "Test-only: no public surface, no production code" — were charged to the
+# production budget of five crates. The direction of that bug is the bad one:
+# it does not fail a gate loudly, it inflates a budget quietly.
+#
+# Both directions are pinned here, and the LAST case is the one that matters:
+# a module declared under `#[cfg(test)]` in one place AND normally in another
+# must stay PRODUCTION. Widening an exclusion without tightening its exemption
+# is how a correction becomes a hole.
+# shellcheck disable=SC2329  # rs_src_files is invoked indirectly, through rs_test_only_files
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export NIKA_SKIP_FILTER_SELFTEST=1 # we source the lib; it must not recurse
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./_lib.sh
+. "$HERE/_lib.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+cases=0
+
+# The fixtures live under $TMP; rs_src_files is replaced below so the filter is
+# tested on a KNOWN file set instead of the repo's — no git fixture needed, and
+# no dependency on what the workspace happens to contain today.
+#
+# expect <hidden|shown> <relative-path> <label>
+expect() {
+  local want="$1" path="$2" label="$3"
+  cases=$((cases + 1))
+  local hidden
+  hidden=$(cd "$TMP" && rs_test_only_files | grep -cxF "$path" || true)
+  local got="shown"
+  [ "$hidden" != "0" ] && got="hidden"
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %s (%s)\n' "$label" "$got"
+  else
+    fails=$((fails + 1))
+    printf '  FAIL %s — wanted %s, got %s\n' "$label" "$want" "$got" >&2
+  fi
+}
+
+mkdir -p "$TMP/src/dirmod" "$TMP/src/both"
+
+# The declaring roots.
+cat >"$TMP/src/lib.rs" <<'RS'
+#[cfg(test)]
+mod solo;
+
+#[cfg(test)]
+#[path = "elsewhere.rs"]
+mod attributed;
+
+#[cfg(test)]
+mod dirmod;
+
+mod production;
+
+#[cfg(test)]
+use std::fmt::Debug;
+
+#[cfg(test)]
+mod both;
+RS
+
+cat >"$TMP/src/both/mod.rs" <<'RS'
+// Declared #[cfg(test)] in lib.rs and plainly in main.rs — BOTH resolve to the
+// SAME root (`src/both`), which is the only shape where the exemption can fire.
+RS
+
+# The production half of the both-ways pair. `main.rs` is a module ROOT like
+# lib.rs/mod.rs, so its declarations resolve into `src/` — the same directory
+# lib.rs declares into. An earlier version of this fixture put the second
+# declaration in `src/other.rs`, whose declarations resolve into `src/other/`:
+# two DIFFERENT roots, no overlap, and the case passed with the exemption
+# deleted. It was a decorative assertion; the mutation below is what caught it.
+cat >"$TMP/src/main.rs" <<'RS'
+mod both;
+RS
+
+: >"$TMP/src/solo.rs"
+: >"$TMP/src/attributed.rs"
+: >"$TMP/src/production.rs"
+: >"$TMP/src/dirmod/mod.rs"
+: >"$TMP/src/dirmod/child.rs"
+: >"$TMP/src/tests.rs"
+
+# rs_src_files normally shells out to `git ls-files`; replace it with the
+# fixture list so the unit under test is the DECLARATION logic, not git.
+rs_src_files() {
+  printf '%s\n' \
+    src/lib.rs src/main.rs src/solo.rs src/attributed.rs src/production.rs \
+    src/dirmod/mod.rs src/dirmod/child.rs src/both/mod.rs src/tests.rs
+}
+
+echo "rs_prod_files · file-level filter self-test"
+
+# --- the filter must HIDE test-only modules --------------------------------
+expect hidden src/solo.rs 'a #[cfg(test)] mod hides its file'
+expect hidden src/attributed.rs 'an attribute between cfg(test) and mod does not break the pairing'
+expect hidden src/dirmod/mod.rs 'a #[cfg(test)] dir-module hides its root'
+expect hidden src/dirmod/child.rs 'a #[cfg(test)] dir-module hides its subtree'
+
+# --- the filter must SHOW production code ----------------------------------
+expect shown src/production.rs 'a plain mod stays production'
+expect shown src/lib.rs 'the declaring file itself stays production'
+
+# --- THE case: the exemption is tightened, not merely widened --------------
+expect shown src/both/mod.rs 'a module declared BOTH ways stays production'
+
+# --- the older half must not regress ---------------------------------------
+# `tests.rs` is excluded by BASENAME in rs_prod_files, not by declaration; it
+# is pinned here so a future refactor cannot drop one half while fixing the
+# other.
+if rs_prod_files | grep -qxF src/tests.rs; then
+  fails=$((fails + 1))
+  cases=$((cases + 1))
+  printf '  FAIL the tests.rs basename half regressed — it reached rs_prod_files\n' >&2
+else
+  cases=$((cases + 1))
+  printf '  ok   the tests.rs basename half still holds\n'
+fi
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d/%d case(s) wrong — a budget inflated quietly is worse than a gate that fails loudly.\n' \
+    "$fails" "$cases" >&2
+  exit 1
+fi
+
+printf '\n%d/%d cases correct.\n' "$cases" "$cases"
+exit 0

--- a/scripts/hygiene/tests/ci-lib.test.sh
+++ b/scripts/hygiene/tests/ci-lib.test.sh
@@ -33,12 +33,19 @@ fails=0
 cases=0
 
 # A scratch scripts/ci/ holding _lib.sh, its self-test, and one consumer.
-# selftest: ok | noexec | gone     filter: honest | broken
+# selftest: ok | noexec | gone | gone-files    filter: honest | broken
+#
+# `gone-files` removes the SECOND self-test. `_lib.sh` ships two filters —
+# `strip_test_items` (hides test items inside a file) and `rs_prod_files`
+# (hides whole files) — and since 2026-08-18 it proves BOTH before any ratchet
+# reads a verdict. Seeding only the first one is what this fixture used to do,
+# and it is exactly how a new proof requirement gets silently un-enforced.
 seed() {
   local dir="$1" selftest="$2" filter="$3"
   mkdir -p "$dir/scripts/ci" "$dir/crates/demo/src"
   cp "$ROOT/scripts/ci/_lib.sh" "$dir/scripts/ci/"
   cp "$ROOT/scripts/ci/test-strip-test-items.sh" "$dir/scripts/ci/"
+  cp "$ROOT/scripts/ci/test-rs-prod-files.sh" "$dir/scripts/ci/"
   cp "$ROOT/scripts/ci/check-unwrap.sh" "$dir/scripts/ci/"
   chmod +x "$dir/scripts/ci/"*.sh
   if [ "$filter" = broken ]; then
@@ -52,6 +59,7 @@ BROKEN
   case "$selftest" in
     noexec) chmod -x "$dir/scripts/ci/test-strip-test-items.sh" ;;
     gone) rm -f "$dir/scripts/ci/test-strip-test-items.sh" ;;
+    gone-files) rm -f "$dir/scripts/ci/test-rs-prod-files.sh" ;;
   esac
   printf 'pub fn boom() { let x: Option<u8> = None; let _ = x.unwrap(); }\n' \
     >"$dir/crates/demo/src/lib.rs"
@@ -86,6 +94,10 @@ expect_rc 2 "broken filter, self-test present" ok broken
 expect_rc 2 "broken filter, self-test NOT EXECUTABLE" noexec broken
 expect_rc 2 "broken filter, self-test DELETED" gone broken
 expect_rc 2 "honest filter, self-test DELETED (cannot prove itself)" gone honest
+# The SECOND filter's proof is load-bearing too. `_lib.sh` gained rs_prod_files'
+# self-test on 2026-08-18; without this case, deleting that file would leave
+# every ratchet judging on an unproven file-level filter and still printing OK.
+expect_rc 2 "honest filter, the FILE-level self-test DELETED" gone-files honest
 # Negative control: nothing wrong, and the real .unwrap() is still found.
 expect_rc 1 "honest filter, self-test present — finds the unwrap" ok honest
 


### PR DESCRIPTION
Rejoue de #976 sur `ca61bf624` · sa base est passee `DIRTY` quand quatre commits ont atterri sur `main`, dont un touchant `estate.yaml`. Cherry-pick sur base fraiche, zero force-push. Contenu identique.

---

`rs_prod_files` documentait depuis toujours quil refletait lexclusion `#[cfg(test)]` de clippy. Il nen livrait que la **moitie** · la convention de nom `tests.rs`.

Lautre moitie fuyait · un module declare `#[cfg(test)] mod <nom>;` est test-only **par construction** — le compilateur ne le batit jamais hors profil de test — quel que soit son nom de fichier.

## La mesure

| fichier | lignes |
|---|---:|
| `nika-providers/src/parity_tests.rs` | 492 |
| `nika-providers/src/test_support.rs` | 146 |
| `nika-dap/src/anchor/fixtures.rs` | 122 |
| `nika-runtime/src/adversarial/mod.rs` | 109 |
| `nika-trace/src/trace/retention_tests.rs` | 58 |
| `nika-verb-infer/src/proptests.rs` | 24 |

`adversarial/mod.rs` porte lui-meme, en doc-comment · *« Test-only: no public surface, no production code »*.

**Ce nest pas un budget, cest un MISCOMPTE** · la promesse etait deja ecrite au-dessus de la fonction.

## Effet

```
nika-runtime  14929 → 14822   marge 71 → 178
nika-providers 5350 →  4710
nika-dap      10373 → 10319
nika-trace     3630 →  3571
nika-verb-infer 1425 → 1400
```

## Une regle, un lecteur

`check-crate-size` **re-implementait le filtre en ligne**, sous un commentaire disant quil suivait « la convention `rs_prod_files` de `_lib.sh` ». La copie est retiree · la mesure se lit de sa source unique, calculee **une** fois pour tout le workspace au lieu dune fois par crate.

## Lexemption est RESSERREE, pas seulement elargie

Un module declare `#[cfg(test)]` a un endroit **et normalement a un autre** reste production. Une declaration ne compte que si cest bien `#[cfg(test)]` qui latteint (dautres attributs et commentaires peuvent sinterposer), donc `#[cfg(test)] use …` ne declenche rien.

## La preuve

`scripts/ci/test-rs-prod-files.sh` · **8 cas**, les deux directions, cable dans le mecanisme **fail-closed** de `_lib.sh` (auto-test absent ⇒ le ratchet **refuse** de rendre un verdict · prouve `rc=2`).

Deux mutations ·
- retirer la detection ⇒ **4 cas sur 8 rougissent**, les 4 controles de production restent verts
- retirer **la seule ligne dexemption** ⇒ **exactement 1 cas rougit**, celui qui compte

⚠️ **La premiere version de ce cas etait DECORATIVE.** Ses deux declarations resolvaient vers des racines differentes (`src/both` vs `src/other/both`), donc lexemption ne se declenchait jamais et le cas passait meme avec la ligne supprimee. **Cest la mutation qui la trouve, pas la relecture.** La fixture porte lexplication.

`ci-lib.test.sh` gagne son cas jumeau · supprimer le **nouvel** auto-test doit aussi faire refuser le ratchet (`rc=2`), sinon une exigence de preuve neuve se desarme en silence. **7/7.**

## Verifie

hygiene `check-all` **ZERO ROUGE** · les 4 consommateurs (`unwrap` · `expect` · `dead-code` · `crate-size`) rendent 0 · `shellcheck -x` et `shfmt` propres · gate pre-push vert.

⚠️ **Trouve, pas corrige ici** · `test-strip-test-items.sh` porte la meme directive fragile (`# shellcheck source=./_lib.sh`, resolue depuis le CWD). Elle ne casse pas aujourdhui parce que ce fichier nest jamais staged — le prochain qui le touche se prendra le meme SC1091. La forme robuste (`# shellcheck source-path=SCRIPTDIR`) est appliquee ici sur le fichier neuf.