### PR TITLE
fix(nika-cadence): the grammar admits the project's other rungs — arm reads a shipped file green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
   stripped before comparing), and the exit code is untouched. The filename is
   a location `git mv` may change; the name is an identity that rides traces.
 
+### Fixed
+
+- **`nika arm` no longer refuses a project that sets its retention or its
+  provenance floor.** Two readers parse `nika.yaml` — the project reader
+  (`ceiling` · `traces.keep` · `registry.floor` · `arm`) and the cadence
+  grammar. The grammar refused `traces:` and `registry:` by name as
+  « round 2 » keys with a remedy that was false (« retention stays with
+  the env vars ») while the project reader had just accepted them and the
+  retention ladder and the provenance gate consume them — the project
+  starter's own `traces:` line made `nika arm` exit 2. Measured
+  2026-08-18. The grammar now admits the project's other rungs OPAQUE and
+  judges nothing about them (they are judged where they are owned); the
+  cadence domain's own deferred keys (`signature:` · `budget:`) stay
+  refused by name. A test derived from the project reader's closed key
+  set pins the parity: every key it admits, `nika arm` reads green.
+
 ## [0.113.0](https://github.com/supernovae-st/nika/compare/v0.112.0..v0.113.0) - 2026-08-21
 
 **The couture release.** The judge already knew; the agent can now see.

--- a/crates/nika-cadence/src/error.rs
+++ b/crates/nika-cadence/src/error.rs
@@ -37,8 +37,10 @@ pub enum CadenceErrorKind {
     Identity,
     /// `ceiling:` present but not a positive finite number.
     CeilingNonPositive,
-    /// Round-2+ key present (`traces:` · `registry:` · `signature:` ·
-    /// `budget:`) — refused by name, never ignored.
+    /// Round-2+ key of the CADENCE domain present (`signature:` ·
+    /// `budget:`) — refused by name, never ignored. The project's other
+    /// rungs (`traces:` · `registry:`) are not this crate's to judge:
+    /// admitted opaque, judged by the project reader.
     DeferredKey,
     /// The cadence carries no `TZ=` prefix (only `on-webhook` may).
     TzMissing,

--- a/crates/nika-cadence/src/parse.rs
+++ b/crates/nika-cadence/src/parse.rs
@@ -60,20 +60,10 @@ pub fn validate(registry: &ArmRegistry) -> impl Iterator<Item = CadenceError> {
             "ceiling: 0.50 — le défaut de tout run de ce projet",
         ));
     }
-    if registry.traces.is_some() {
-        faults.push(CadenceError::file(
-            CadenceErrorKind::DeferredKey,
-            "traces: · clé du round 2 — elle attend un manque mesuré",
-            "retire-la · la rétention demeure aux 3 variables d env pour l instant",
-        ));
-    }
-    if registry.registry.is_some() {
-        faults.push(CadenceError::file(
-            CadenceErrorKind::DeferredKey,
-            "registry: · clé du round 2 — elle attend un manque mesuré",
-            "retire-la · le plancher de provenance demeure par machine pour l instant",
-        ));
-    }
+    // `traces:` and `registry:` are NOT judged here — they are the project
+    // reader's rungs (`nika_vocab::project`), admitted opaque by the
+    // grammar so the two readers of one file never disagree about a key
+    // only one of them owns.
     let mut seen: Vec<&str> = Vec::new();
     for beat in registry.beats() {
         validate_beat(beat, &mut faults);

--- a/crates/nika-cadence/src/registry.rs
+++ b/crates/nika-cadence/src/registry.rs
@@ -16,8 +16,8 @@ use serde::Deserialize;
 use crate::cron::CronSpec;
 
 /// The one project file (`nika.yaml`) — round 1 carries `ceiling` +
-/// `arm:` only; `traces:`/`registry:` wait for a measured lack and are
-/// refused by name at validation.
+/// `arm:`. The project's other rungs (`traces:` · `registry:`) are
+/// admitted opaque and judged by the project reader.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
@@ -34,12 +34,21 @@ pub struct ArmRegistry {
     /// The armed beats (`arm:`).
     #[serde(default, rename = "arm")]
     beats: Vec<Beat>,
-    /// Round-2 key — presence-detected, refused by name at validation.
-    #[serde(default)]
-    pub(crate) traces: Option<serde::de::IgnoredAny>,
-    /// Round-2 key — presence-detected, refused by name at validation.
-    #[serde(default)]
-    pub(crate) registry: Option<serde::de::IgnoredAny>,
+    /// Another rung of the SAME file — `traces:` belongs to the project
+    /// reader (`nika_vocab::project` · `traces.keep`, the retention rung
+    /// `nika-dap` consumes). Admitted OPAQUE so the closed grammar accepts
+    /// the file it shares with that reader; judged THERE, never here.
+    /// (2026-08-18: refused as « round 2 » it told operators to remove a
+    /// key that ships and is consumed — the project starter's own
+    /// `traces:` line made `nika arm` refuse. The leading underscore is
+    /// the read: this field exists to be admitted, not consulted.)
+    #[serde(default, rename = "traces")]
+    _traces: Option<serde::de::IgnoredAny>,
+    /// Another rung of the SAME file — `registry:` (`registry.floor`, the
+    /// provenance GATE the registry client max-composes). Admitted opaque
+    /// · judged by the project reader.
+    #[serde(default, rename = "registry")]
+    _registry: Option<serde::de::IgnoredAny>,
 }
 
 impl ArmRegistry {

--- a/crates/nika-cadence/src/tests/mod.rs
+++ b/crates/nika-cadence/src/tests/mod.rs
@@ -912,12 +912,30 @@ arm:
             "{key} · refusé nommément, jamais ignoré"
         );
     }
-    for key in ["traces: {}", "registry: {}"] {
-        let yaml = format!("nika: proj\n{key}\n");
+}
+
+#[test]
+fn the_projects_other_rungs_are_admitted_opaque() {
+    // Measured 2026-08-18: `traces.keep` and `registry.floor` are the
+    // project reader's rungs — shipped, consumed (the retention ladder ·
+    // the provenance gate), and written by the project starter itself.
+    // Refused here as « round 2 », the grammar made `nika arm` refuse a
+    // file the project reader had just accepted, with a remedy that was
+    // false (« retention stays with the env vars »). Two readers of one
+    // file must never disagree about a key only one of them owns: the
+    // grammar ADMITS them and judges nothing about them.
+    for rung in [
+        "traces:\n  keep: 30d\n",
+        "registry:\n  floor: provenanced\n",
+    ] {
+        let yaml = format!(
+            "nika: proj\n{rung}arm:\n  - workflow: workflows/a.nika.yaml\n    \
+             cadence: on-webhook\n    plafond: 0.35\n    manqué: sauter\n"
+        );
         let faults = kinds(&yaml);
         assert!(
-            faults.contains(&CadenceErrorKind::DeferredKey),
-            "{key} · refusé nommément, jamais ignoré"
+            faults.is_empty(),
+            "{rung:?} · une clé d un autre barreau du même fichier passe sans faute ici — vu {faults:?}"
         );
     }
 }

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -352,6 +352,48 @@ mod tests {
         "    manqué: rattraper\n",
     );
 
+    /// ⭐ THE TOP-LEVEL PARITY, PINNED — measured 2026-08-18.
+    ///
+    /// Two readers parse this file: `nika_vocab::project` (first — it is
+    /// what `discover` runs) and `nika-cadence` (the grammar). A key the
+    /// project reader ADMITS must never be a key the grammar REFUSES:
+    /// `traces.keep` and `registry.floor` are shipped rungs (consumed by
+    /// the retention ladder and the provenance gate · the project starter
+    /// writes `traces:` itself), and the grammar refused them as « round
+    /// 2 » with a false remedy — a project that set its retention could
+    /// not run `nika arm` at all.
+    ///
+    /// Derived from the SSOT: every key in
+    /// [`project::TOP_LEVEL_KEYS`] rides ONE file with a valid value and
+    /// the verb must read it green. A project key added without a
+    /// snippet here fails loudly — the parity is a law, not a snapshot.
+    #[test]
+    fn every_key_the_project_reader_admits_the_verb_reads_green() {
+        let arm_block = TWO_BEATS
+            .strip_prefix("nika: proj\n")
+            .expect("TWO_BEATS opens on the project name");
+        let snippets: [(&str, &str); 5] = [
+            ("nika", "nika: proj\n"),
+            ("ceiling", "ceiling: 2.0\n"),
+            ("traces", "traces:\n  keep: 30d\n"),
+            ("registry", "registry:\n  floor: provenanced\n"),
+            ("arm", arm_block),
+        ];
+        let mut keys: Vec<&str> = snippets.iter().map(|(k, _)| *k).collect();
+        keys.sort_unstable();
+        let mut ssot: Vec<&str> = project::TOP_LEVEL_KEYS.to_vec();
+        ssot.sort_unstable();
+        assert_eq!(
+            keys, ssot,
+            "a project key without a snippet here — teach the parity its new key"
+        );
+        let body: String = snippets.iter().map(|(_, s)| *s).collect();
+        let dir = project_at("parity", &body);
+        let out = run_at(dir.path());
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(out.text.contains("2 beats"), "{}", out.text);
+    }
+
     #[test]
     fn a_project_with_no_file_says_so_without_failing() {
         let dir = tempfile::Builder::new()

--- a/docs/crate-specs/nika-cadence.md
+++ b/docs/crate-specs/nika-cadence.md
@@ -51,7 +51,12 @@ zoneless) · `dom`+`dow` restricted together refused (the Vixie OR trap)
 the DEFAULTS (law ⑥): `où: local` · `chevauchement: sauter` ·
 `après_saut: prochain-créneau` · `actif: false` requires `raison:` +
 `jusqu_au:` · round 1 refuses by name: `signature:` · `budget:` ·
-`traces:` · `registry:` · every unknown key (`deny_unknown_fields`).
+every unknown key (`deny_unknown_fields`). The project's other rungs
+(`traces:` · `registry:` — `nika_vocab::project`'s, consumed by the
+retention ladder and the provenance gate) are admitted OPAQUE and judged
+there: two readers of one file must never disagree about a key only one
+of them owns (2026-08-18 — refused here as « round 2 », the starter's
+own `traces:` line made `nika arm` refuse a shipped key).
 
 It does **not** own: filesystem access (the L4 edge reads the bytes,
 this layer reads the text — a workflow's EXISTENCE is judged there,


### PR DESCRIPTION
## Defect

`nika arm` refused any project whose `nika.yaml` set `traces.keep` or `registry.floor`. Two readers parse that file — the project reader (`nika_vocab::project` · nika · ceiling · arm · traces · registry) and the cadence grammar. The grammar refused `traces:` and `registry:` by name as « round 2 » keys, with a remedy that was false (« la rétention demeure aux 3 variables d env ») while the project reader had just accepted them, the retention ladder (`nika-dap`) and the provenance gate (`nika-registry-client`) consume them, and the project starter writes `traces:` itself.

Measured 2026-08-18 on main: `nika arm` → exit 2 · `cadence.deferred-key · traces:` + `registry:`. Shipped in v0.109.0 (0.108.0 has no `arm`).

## Mechanism

The grammar's `ArmRegistry` keeps both keys as opaque `IgnoredAny` fields (`_traces` / `_registry` — admitted, never consulted) so the closed grammar accepts the file it shares with the project reader, and `validate()` no longer emits `DeferredKey` for them: a key only one reader owns is judged by that reader. The cadence domain's own deferred keys (`signature:` · `budget:`) stay refused by name.

## Evidence

- nika-cadence unit `the_projects_other_rungs_are_admitted_opaque` (traces + registry present → zero faults)
- nika-cli `every_key_the_project_reader_admits_the_verb_reads_green` — derived from `project::TOP_LEVEL_KEYS` (a project key added without a snippet fails the test by name); one file carrying every key reads green with its two beats
- **Mutation-proved**: re-adding the traces refusal turns BOTH red (cadence 59/60 · arm 4/5)
- Differential on a project file: main build rc 2 (2 refusals) → this build rc 0 (1 beat · 3 slots)
- nika-cadence public API unchanged (`cargo public-api` diff empty)

## Deliberately unchanged

The eight entry-level cadence keys the project reader refuses first (`chevauchement` · `après_saut` · `actif` · …) — pinned by `eight_cadence_keys_are_unreachable_through_the_project_file` as an operator's arbitration (expose · remove · mark internal), not this session's.
