### PR TITLE
ci: the release funnel runs on every push — the gate the tag trusts has already run

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [clippy, tests, no-default-features, wasm]
+        job: [clippy, tests, no-default-features, wasm, funnel]
     env:
       JOB: ${{ matrix.job }}
     steps:
@@ -115,8 +115,8 @@ jobs:
         uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2
         with:
           tool: cargo-nextest
-      - name: Install bubblewrap (tests leg · forces the landlock jail proof to RUN not skip)
-        if: matrix.job == 'tests'
+      - name: Install bubblewrap (tests + funnel legs · the landlock jail proof RUNS · the funnel's consent leg runs a permits workflow)
+        if: matrix.job == 'tests' || matrix.job == 'funnel'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends bubblewrap

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4472
+  classified_files: 4473
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1535
+    authored: 1536
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -182,13 +182,13 @@ patterns:
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored
-  match_count: 154
-  aggregate_sha256: 7d1be1fc48bedc0af16ac2f227dfdafcc9b469979dcb8daceabcfc15eb11f8eb
+  match_count: 155
+  aggregate_sha256: 323807a90dcb9a86ef857144edc4d42a2194148a97cc59548193b412b34f53cc
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: cbb728544d431f2a7bf4238984550e89d9b46f14c48cd2c73dd3a70729349a2a
+  aggregate_sha256: 34fd472402ad1835ec61e3715f33f5a4229afd9a39d45e5de2208b0b72250378
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored

--- a/scripts/ci/check-funnel.sh
+++ b/scripts/ci/check-funnel.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# The release gate, played BEFORE the tag. `scripts/ci/funnel-e2e.sh` is the
+# stranger's first path against a built binary and the gate release.yml
+# runs on every staged tarball — nothing uploads if it fails. Until
+# 2026-08-19 it ran ONLY at tag time, so a tree could turn red for weeks
+# and nobody saw it: v0.109.0 was tagged with three fixtures still spelled
+# in the previous envelope (`nika: v1` + `workflow:`), the funnel refused
+# them at parse (NIKA-PARSE-005), and the release never published (v0.106.0
+# died the same way on 2026-07-27). Hygiene vector 50 now greps both gate
+# scripts for the dead envelope forms — the SPELLING; this leg is the
+# BEHAVIOR: it builds the same binary the release builds (`--features
+# local-infer` · the sovereign lane the funnel §8 asserts) in the dev
+# profile and plays the whole funnel on every push — wording needles, exit
+# codes, the sovereign lane, the mcp wire — so the gate the release trusts
+# is a gate that has already run, whatever moved. The funnel's consent leg
+# RUNS a `permits:` + `exec:` workflow, which the 0.109 sandbox policy
+# refuses unconfined (NIKA-1710 · what killed v0.109.1's Linux builders):
+# the CI job installs bubblewrap before this script, exactly as the
+# release builders now do.
+set -euo pipefail
+
+if grep -qE '^\s*members\s*=\s*\[\s*\]\s*$' Cargo.toml; then
+  echo "SKIP  workspace has no members yet (Phase 0)"
+  exit 0
+fi
+
+cargo build -p nika-cli --bin nika-cli --features local-infer
+bin="${CARGO_TARGET_DIR:-target}/debug/nika-cli"
+# Both tag-time gates, in the order release.yml plays them: the stranger's
+# first path, then the operator's trust path (resume · reproduce · chain
+# verify · tamper/drop · OTLP export) — v0.106.0 died on the battery the
+# way v0.109.0 died on the funnel, at the tag, unseen before it.
+bash scripts/ci/funnel-e2e.sh "$bin"
+exec bash scripts/test/trust-battery.sh "$bin"


### PR DESCRIPTION
Defect: the funnel e2e gate ran ONLY at tag time. v0.109.0 (f58a17396)
died on it — three fixtures still spelled the previous envelope and the
gate refused its own subject before any needle — six days after the
language moved, with nothing red on any push (7c60fdfa8 fixed the
fixtures and cut v0.109.1; v0.106.0 had died the same way on 2026-07-27
when the trust battery spent an exec without permits). Vector 50 now
greps both gate scripts for the dead envelope forms on every push — the
SPELLING. Nothing yet runs the funnel's BEHAVIOR before a tag: a wording
change that removes a needle, an exit code that moves, the sovereign
lane going missing, the mcp wire — all still surface at the tag.

Mechanism: a `funnel` leg joins the diamond-ci rust matrix
(`scripts/ci/check-funnel.sh`): builds `nika-cli --features local-infer`
(the same feature set release.yml ships · the sovereign lane §8 asserts)
in the dev profile and plays the whole funnel — the stranger's first path
is judged on every push, not discovered by a tag.

Evidence: `bash scripts/ci/check-funnel.sh` locally on the tagged tree
before 7c60fdfa8 → FAIL guard-dirty · consent-check · consent-run
(byte-identical to release run 32190274141); on 7c60fdfa8+ → FAILS=0,
all eight sections including the sovereign lane. Complementary to
vector 50 (spelling · instant) — this is the behavior (~1 min build on a
warm cache).

Rebased on `6cf7c902c` (v0.109.1): the fixture edits are already on main via 7c60fdfa8 · what remains is the CI leg.