### PR TITLE
ci(release): the Linux builders carry the jail the funnel's consent leg runs under

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,23 @@ jobs:
           tarball="nika-${ASSET_NAME}-${version}.tar.gz"
           tar -czf "${tarball}" -C "${stage}" nika completions
           shasum -a 256 "${tarball}" | tee "${tarball}.sha256"
+      # The funnel's consent leg RUNS a workflow that declares `permits:` with
+      # an `exec:` child. Since 0.109 (#889 · the sandbox policy) the engine
+      # refuses to start such a run unconfined (NIKA-1710 · exit 3) — the
+      # right answer for a user, and exactly what killed v0.109.1's two Linux
+      # builders (run 32193107899): the runner had no bubblewrap, so the
+      # « pause on the human gate » leg (want exit 4) never got past the
+      # jail check. The gate plays the stranger's path on a machine that
+      # HAS the jail — the install the diamond-ci tests leg makes; the
+      # AppArmor detour is 24.04-only (the arm64 runner) and a no-op on 22.04.
+      - name: Install bubblewrap (Linux · the jail the funnel's consent leg runs under)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap
+          sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict 2>/dev/null || true
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
       - name: Funnel e2e (gate before upload)
         # The stranger's first path, played against the TARBALL that is
         # about to ship (untarred into a clean HOME · offline · content

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 3d2af58a164d3b4148a7816dff6ab430edba73adc47e473a3664df13cd96e2be
+  aggregate_sha256: d04c10d06ff7bf2f764e4033bc476bab9f9c95c95e7d38d863cdac9706064df5
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
Defect: v0.109.1 (6cf7c902c) died on its release gate again — this time
on the two Linux builders only (run 32193107899 · macos green):
`FAIL [consent-run] exit=3 want=4` · `NIKA-1710 · this workflow
declares permits: and no OS sandbox backend can confine them on this
host`. The funnel's consent-pause fixture declares `permits:` with an
`exec:` child, and since 0.109 (#889 · the sandbox policy) the engine
refuses to START such a run unconfined — the right answer for a user,
and the second tag-time-only gate class in one night: the fixtures had
just been fixed (7c60fdfa8), the machine underneath had never been.
The ubuntu release runners ship without bubblewrap.

Mechanism: one step before the funnel on Linux — install bubblewrap
(the same install the diamond-ci tests leg makes so the landlock proof
RUNS), with the 24.04 AppArmor detour (a no-op on the 22.04 x64
runner). The gate now plays the stranger's path on a machine that has
the jail; the consent leg pauses on the human gate (exit 4) instead of
refusing at the door (exit 3). macOS is unchanged (seatbelt is native).

Evidence: the failure line and the exit code from run 32193107899; the
diamond-ci tests leg has run the same install on every push since #889
(the jail proof requires it); locally the funnel passes on macOS
(seatbelt) — the Linux path is proven by the next tag's run, which is
the only place the release funnel plays (the CI leg in #985 adds the
same install for ubuntu-latest and plays it on every push).

**P0 · v0.109.1's release run (32193107899) is red on both Linux builders on this alone** (macOS green). After merge: the re-cut is the operator's ceremony (`wave-sweep.sh 0.109.2` + tag) — a pushed tag is never moved.