### PR TITLE
feat(arm): the file proposes, the machine fires · W1

### DIFF
--- a/crates/nika-cadence/public-api.txt
+++ b/crates/nika-cadence/public-api.txt
@@ -47,7 +47,7 @@ impl<const LO: u8, const HI: u8> nika_cadence::cron::Field<LO, HI>
 pub fn nika_cadence::cron::Field<LO, HI>::contains(&self, v: u8) -> bool
 pub fn nika_cadence::cron::Field<LO, HI>::is_empty(&self) -> bool
 pub fn nika_cadence::cron::Field<LO, HI>::is_full(&self) -> bool
-pub fn nika_cadence::cron::Field<LO, HI>::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = u8>
+pub fn nika_cadence::cron::Field<LO, HI>::iter(&self) -> impl core::iter::traits::double_ended::DoubleEndedIterator<Item = u8>
 pub fn nika_cadence::cron::Field<LO, HI>::len(&self) -> u32
 pub fn nika_cadence::cron::Field<LO, HI>::single(&self) -> core::option::Option<u8>
 impl<const LO: u8, const HI: u8> core::clone::Clone for nika_cadence::cron::Field<LO, HI>
@@ -85,6 +85,81 @@ impl<T> core::clone::CloneToUninit for nika_cadence::cron::Field<LO, HI> where T
 pub unsafe fn nika_cadence::cron::Field<LO, HI>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_cadence::cron::Field<LO, HI>
 pub fn nika_cadence::cron::Field<LO, HI>::from(t: T) -> T
+pub mod nika_cadence::due
+#[non_exhaustive] pub enum nika_cadence::due::DueKind
+pub nika_cadence::due::DueKind::Missed
+pub nika_cadence::due::DueKind::Missed::slots: u32
+pub nika_cadence::due::DueKind::OnTime
+impl core::clone::Clone for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::clone(&self) -> nika_cadence::due::DueKind
+impl core::cmp::Eq for nika_cadence::due::DueKind
+impl core::cmp::PartialEq for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::eq(&self, other: &nika_cadence::due::DueKind) -> bool
+impl core::fmt::Debug for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cadence::due::DueKind
+impl core::marker::StructuralPartialEq for nika_cadence::due::DueKind
+impl<Q, K> equivalent::Equivalent<K> for nika_cadence::due::DueKind where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cadence::due::DueKind where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cadence::due::DueKind where U: core::convert::From<T>
+pub fn nika_cadence::due::DueKind::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cadence::due::DueKind where U: core::convert::Into<T>
+pub type nika_cadence::due::DueKind::Error = core::convert::Infallible
+pub fn nika_cadence::due::DueKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cadence::due::DueKind where U: core::convert::TryFrom<T>
+pub type nika_cadence::due::DueKind::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cadence::due::DueKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cadence::due::DueKind where T: core::clone::Clone
+pub type nika_cadence::due::DueKind::Owned = T
+pub fn nika_cadence::due::DueKind::clone_into(&self, target: &mut T)
+pub fn nika_cadence::due::DueKind::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cadence::due::DueKind where T: 'static + ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cadence::due::DueKind where T: ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cadence::due::DueKind where T: ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cadence::due::DueKind where T: core::clone::Clone
+pub unsafe fn nika_cadence::due::DueKind::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::from(t: T) -> T
+#[non_exhaustive] pub struct nika_cadence::due::Due<'a>
+pub nika_cadence::due::Due::beat: &'a nika_cadence::registry::Beat
+pub nika_cadence::due::Due::index: usize
+pub nika_cadence::due::Due::kind: nika_cadence::due::DueKind
+pub nika_cadence::due::Due::slot: nika_cadence::next::Slot
+impl<'a> core::clone::Clone for nika_cadence::due::Due<'a>
+pub fn nika_cadence::due::Due<'a>::clone(&self) -> nika_cadence::due::Due<'a>
+impl<'a> core::fmt::Debug for nika_cadence::due::Due<'a>
+pub fn nika_cadence::due::Due<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, U> core::convert::Into<U> for nika_cadence::due::Due<'a> where U: core::convert::From<T>
+pub fn nika_cadence::due::Due<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cadence::due::Due<'a> where U: core::convert::Into<T>
+pub type nika_cadence::due::Due<'a>::Error = core::convert::Infallible
+pub fn nika_cadence::due::Due<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cadence::due::Due<'a> where U: core::convert::TryFrom<T>
+pub type nika_cadence::due::Due<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cadence::due::Due<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cadence::due::Due<'a> where T: core::clone::Clone
+pub type nika_cadence::due::Due<'a>::Owned = T
+pub fn nika_cadence::due::Due<'a>::clone_into(&self, target: &mut T)
+pub fn nika_cadence::due::Due<'a>::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cadence::due::Due<'a> where T: 'static + ?core::marker::Sized
+pub fn nika_cadence::due::Due<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cadence::due::Due<'a> where T: ?core::marker::Sized
+pub fn nika_cadence::due::Due<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cadence::due::Due<'a> where T: ?core::marker::Sized
+pub fn nika_cadence::due::Due<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cadence::due::Due<'a> where T: core::clone::Clone
+pub unsafe fn nika_cadence::due::Due<'a>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cadence::due::Due<'a>
+pub fn nika_cadence::due::Due<'a>::from(t: T) -> T
+pub const nika_cadence::due::MISSED_SLOTS_CAP: usize
+pub const nika_cadence::due::ON_TIME_WINDOW: jiff::signed_duration::SignedDuration
+pub fn nika_cadence::due::due<'a>(reg: &'a nika_cadence::registry::ArmRegistry, now: &jiff::zoned::Zoned, last_fired: &dyn core::ops::function::Fn(usize) -> core::option::Option<jiff::zoned::Zoned>) -> core::result::Result<impl core::iter::traits::iterator::Iterator<Item = nika_cadence::due::Due<'a>>, nika_cadence::error::CadenceError>
+pub fn nika_cadence::due::earliest_next(reg: &nika_cadence::registry::ArmRegistry, now: &jiff::zoned::Zoned) -> core::result::Result<core::option::Option<(usize, nika_cadence::next::Slot)>, nika_cadence::error::CadenceError>
 pub mod nika_cadence::error
 #[non_exhaustive] pub enum nika_cadence::error::CadenceErrorKind
 pub nika_cadence::error::CadenceErrorKind::ApresSautMisplaced
@@ -330,6 +405,7 @@ impl nika_cadence::registry::Cadence
 pub fn nika_cadence::registry::Cadence::describe(&self) -> alloc::string::String
 impl nika_cadence::registry::Cadence
 pub fn nika_cadence::registry::Cadence::next_after(&self, from: &jiff::zoned::Zoned) -> core::option::Option<nika_cadence::next::Slot>
+pub fn nika_cadence::registry::Cadence::prev_before(&self, from: &jiff::zoned::Zoned) -> core::option::Option<nika_cadence::next::Slot>
 impl nika_cadence::registry::Cadence
 pub fn nika_cadence::registry::Cadence::parse(raw: &str) -> core::result::Result<Self, nika_cadence::error::CadenceError>
 impl core::clone::Clone for nika_cadence::registry::Cadence
@@ -609,6 +685,7 @@ impl nika_cadence::registry::Cadence
 pub fn nika_cadence::registry::Cadence::describe(&self) -> alloc::string::String
 impl nika_cadence::registry::Cadence
 pub fn nika_cadence::registry::Cadence::next_after(&self, from: &jiff::zoned::Zoned) -> core::option::Option<nika_cadence::next::Slot>
+pub fn nika_cadence::registry::Cadence::prev_before(&self, from: &jiff::zoned::Zoned) -> core::option::Option<nika_cadence::next::Slot>
 impl nika_cadence::registry::Cadence
 pub fn nika_cadence::registry::Cadence::parse(raw: &str) -> core::result::Result<Self, nika_cadence::error::CadenceError>
 impl core::clone::Clone for nika_cadence::registry::Cadence
@@ -706,6 +783,45 @@ impl<T> core::clone::CloneToUninit for nika_cadence::error::CadenceErrorKind whe
 pub unsafe fn nika_cadence::error::CadenceErrorKind::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_cadence::error::CadenceErrorKind
 pub fn nika_cadence::error::CadenceErrorKind::from(t: T) -> T
+#[non_exhaustive] pub enum nika_cadence::DueKind
+pub nika_cadence::DueKind::Missed
+pub nika_cadence::DueKind::Missed::slots: u32
+pub nika_cadence::DueKind::OnTime
+impl core::clone::Clone for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::clone(&self) -> nika_cadence::due::DueKind
+impl core::cmp::Eq for nika_cadence::due::DueKind
+impl core::cmp::PartialEq for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::eq(&self, other: &nika_cadence::due::DueKind) -> bool
+impl core::fmt::Debug for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cadence::due::DueKind
+impl core::marker::StructuralPartialEq for nika_cadence::due::DueKind
+impl<Q, K> equivalent::Equivalent<K> for nika_cadence::due::DueKind where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cadence::due::DueKind where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cadence::due::DueKind where U: core::convert::From<T>
+pub fn nika_cadence::due::DueKind::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cadence::due::DueKind where U: core::convert::Into<T>
+pub type nika_cadence::due::DueKind::Error = core::convert::Infallible
+pub fn nika_cadence::due::DueKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cadence::due::DueKind where U: core::convert::TryFrom<T>
+pub type nika_cadence::due::DueKind::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cadence::due::DueKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cadence::due::DueKind where T: core::clone::Clone
+pub type nika_cadence::due::DueKind::Owned = T
+pub fn nika_cadence::due::DueKind::clone_into(&self, target: &mut T)
+pub fn nika_cadence::due::DueKind::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cadence::due::DueKind where T: 'static + ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cadence::due::DueKind where T: ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cadence::due::DueKind where T: ?core::marker::Sized
+pub fn nika_cadence::due::DueKind::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cadence::due::DueKind where T: core::clone::Clone
+pub unsafe fn nika_cadence::due::DueKind::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cadence::due::DueKind
+pub fn nika_cadence::due::DueKind::from(t: T) -> T
 #[non_exhaustive] pub enum nika_cadence::Locus
 pub nika_cadence::Locus::Cloud
 pub nika_cadence::Locus::Local
@@ -1029,12 +1145,43 @@ impl<T> core::clone::CloneToUninit for nika_cadence::cron::CronSpec where T: cor
 pub unsafe fn nika_cadence::cron::CronSpec::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_cadence::cron::CronSpec
 pub fn nika_cadence::cron::CronSpec::from(t: T) -> T
+#[non_exhaustive] pub struct nika_cadence::Due<'a>
+pub nika_cadence::Due::beat: &'a nika_cadence::registry::Beat
+pub nika_cadence::Due::index: usize
+pub nika_cadence::Due::kind: nika_cadence::due::DueKind
+pub nika_cadence::Due::slot: nika_cadence::next::Slot
+impl<'a> core::clone::Clone for nika_cadence::due::Due<'a>
+pub fn nika_cadence::due::Due<'a>::clone(&self) -> nika_cadence::due::Due<'a>
+impl<'a> core::fmt::Debug for nika_cadence::due::Due<'a>
+pub fn nika_cadence::due::Due<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T, U> core::convert::Into<U> for nika_cadence::due::Due<'a> where U: core::convert::From<T>
+pub fn nika_cadence::due::Due<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cadence::due::Due<'a> where U: core::convert::Into<T>
+pub type nika_cadence::due::Due<'a>::Error = core::convert::Infallible
+pub fn nika_cadence::due::Due<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cadence::due::Due<'a> where U: core::convert::TryFrom<T>
+pub type nika_cadence::due::Due<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cadence::due::Due<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cadence::due::Due<'a> where T: core::clone::Clone
+pub type nika_cadence::due::Due<'a>::Owned = T
+pub fn nika_cadence::due::Due<'a>::clone_into(&self, target: &mut T)
+pub fn nika_cadence::due::Due<'a>::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cadence::due::Due<'a> where T: 'static + ?core::marker::Sized
+pub fn nika_cadence::due::Due<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cadence::due::Due<'a> where T: ?core::marker::Sized
+pub fn nika_cadence::due::Due<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cadence::due::Due<'a> where T: ?core::marker::Sized
+pub fn nika_cadence::due::Due<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cadence::due::Due<'a> where T: core::clone::Clone
+pub unsafe fn nika_cadence::due::Due<'a>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cadence::due::Due<'a>
+pub fn nika_cadence::due::Due<'a>::from(t: T) -> T
 pub struct nika_cadence::Field<const LO: u8, const HI: u8>
 impl<const LO: u8, const HI: u8> nika_cadence::cron::Field<LO, HI>
 pub fn nika_cadence::cron::Field<LO, HI>::contains(&self, v: u8) -> bool
 pub fn nika_cadence::cron::Field<LO, HI>::is_empty(&self) -> bool
 pub fn nika_cadence::cron::Field<LO, HI>::is_full(&self) -> bool
-pub fn nika_cadence::cron::Field<LO, HI>::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = u8>
+pub fn nika_cadence::cron::Field<LO, HI>::iter(&self) -> impl core::iter::traits::double_ended::DoubleEndedIterator<Item = u8>
 pub fn nika_cadence::cron::Field<LO, HI>::len(&self) -> u32
 pub fn nika_cadence::cron::Field<LO, HI>::single(&self) -> core::option::Option<u8>
 impl<const LO: u8, const HI: u8> core::clone::Clone for nika_cadence::cron::Field<LO, HI>
@@ -1110,6 +1257,10 @@ impl<T> core::clone::CloneToUninit for nika_cadence::next::Slot where T: core::c
 pub unsafe fn nika_cadence::next::Slot::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_cadence::next::Slot
 pub fn nika_cadence::next::Slot::from(t: T) -> T
+pub const nika_cadence::MISSED_SLOTS_CAP: usize
+pub const nika_cadence::ON_TIME_WINDOW: jiff::signed_duration::SignedDuration
+pub fn nika_cadence::due<'a>(reg: &'a nika_cadence::registry::ArmRegistry, now: &jiff::zoned::Zoned, last_fired: &dyn core::ops::function::Fn(usize) -> core::option::Option<jiff::zoned::Zoned>) -> core::result::Result<impl core::iter::traits::iterator::Iterator<Item = nika_cadence::due::Due<'a>>, nika_cadence::error::CadenceError>
+pub fn nika_cadence::earliest_next(reg: &nika_cadence::registry::ArmRegistry, now: &jiff::zoned::Zoned) -> core::result::Result<core::option::Option<(usize, nika_cadence::next::Slot)>, nika_cadence::error::CadenceError>
 pub fn nika_cadence::next_slots(cadence: &nika_cadence::registry::Cadence, from: &jiff::zoned::Zoned, count: usize) -> impl core::iter::traits::iterator::Iterator<Item = nika_cadence::next::Slot>
 pub fn nika_cadence::parse_registry(text: &str) -> core::result::Result<nika_cadence::registry::ArmRegistry, nika_cadence::error::CadenceError>
 pub fn nika_cadence::validate(registry: &nika_cadence::registry::ArmRegistry) -> impl core::iter::traits::iterator::Iterator<Item = nika_cadence::error::CadenceError>

--- a/crates/nika-cadence/src/cron.rs
+++ b/crates/nika-cadence/src/cron.rs
@@ -86,7 +86,10 @@ impl<const LO: u8, const HI: u8> Field<LO, HI> {
     }
 
     /// The values, ascending (FCI-014 — an iterator, never a Vec).
-    pub fn iter(&self) -> impl Iterator<Item = u8> {
+    /// Double-ended by construction (a filtered inclusive range), so the
+    /// backwards walk of `CronSpec::prev_before` rides `.rev()`.
+    #[must_use]
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = u8> {
         (LO..=HI).filter(move |v| self.contains(*v))
     }
 

--- a/crates/nika-cadence/src/due.rs
+++ b/crates/nika-cadence/src/due.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `due` — the pure planner both firing edges read (`fire` at W2,
+//! `serve` at W5): GIVEN the registry, the wall clock handed in (an L4
+//! act — this crate never reads one, trap ①), and the firing state as
+//! a CALLBACK, answer « what is due now? » and « what fires next? ».
+//!
+//! The firing state is the one thing this crate must never own (N2 —
+//! no resume: the crate computes slots, never carries run state), so
+//! `last_fired` arrives as a function over the beat index and the pure
+//! code never opens a store.
+//!
+//! The law:
+//!
+//! - only ACTIVE, LOCAL beats are ever due — a suspended beat is told
+//!   and bounded (`actif: false` carries `raison:` + `jusqu_au:`), and
+//!   a cloud beat's calendar stays the operator's;
+//! - a beat is due when a slot should have fired in `(last_fired,
+//!   now]` — strictly after the last fire (an already-fired slot never
+//!   re-fires), at or before now (a slot AT now has just passed). The
+//!   window is read over the FIRE set (`next_slots`), never the
+//!   existing-civil set: the gap's advanced fire is a fire like any
+//!   other, and a planner that skipped it would drop a missed slot
+//!   into a hole;
+//! - the KIND: `OnTime` when the due slot is the ONLY one of the
+//!   silence and within [`ON_TIME_WINDOW`] of now — `Missed { slots }`
+//!   otherwise, counting the whole silence, saturated at
+//!   [`MISSED_SLOTS_CAP`];
+//! - NEVER fired (no state) is the on-time window only: N2 — a beat
+//!   starts from ZERO, and a planner without state invents no backlog.
+
+use jiff::Zoned;
+
+use crate::error::CadenceError;
+use crate::next::{Slot, next_slots};
+use crate::registry::{ArmRegistry, Beat, Cadence, Locus};
+
+/// The on-time grace: a slot fired within five minutes of its instant
+/// is ON TIME, not missed. A `SignedDuration`, not a `Span`: the window
+/// is absolute time (five minutes is five minutes, whatever the
+/// calendar says) — and `Span`'s builders are not `const` in jiff 0.2.
+pub const ON_TIME_WINDOW: jiff::SignedDuration = jiff::SignedDuration::from_mins(5);
+
+/// The missed-slot count saturates here: a silence longer than ten
+/// thousand slots is an OUTAGE, and the exact figure teaches nothing
+/// the cap does not (the `tolérance:` (m,k)-firm law's own read:
+/// « beyond, it's an outage, not a skip »).
+pub const MISSED_SLOTS_CAP: usize = 10_000;
+
+/// What « due » means for one beat.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DueKind {
+    /// The slot is the silence's only one and within
+    /// [`ON_TIME_WINDOW`] of now — fire it now.
+    OnTime,
+    /// The silence outgrew the window — the `manqué:` policy governs
+    /// what happens; `slots` counts it (the due slot included),
+    /// saturated at [`MISSED_SLOTS_CAP`].
+    Missed {
+        /// How many slots the silence covers, capped.
+        slots: u32,
+    },
+}
+
+/// One beat due: its index in the registry, the beat, the slot that
+/// fell due, and the kind.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Due<'a> {
+    /// The beat's position in the registry (the firing state keys on it).
+    pub index: usize,
+    /// The beat itself.
+    pub beat: &'a Beat,
+    /// The most recent slot of the silence — the one to fire.
+    pub slot: Slot,
+    /// On time or missed (and how many).
+    pub kind: DueKind,
+}
+
+/// Active · local beats whose previous slot falls in `(last_fired,
+/// now]`, in registry order. `last_fired(index)` comes from the firing
+/// state — the pure code never reads it. (FCI-014: an iterator, not a
+/// Vec — the walk itself is eager so a broken cadence refuses the whole
+/// plan instead of surfacing mid-iteration.)
+///
+/// # Errors
+/// A [`CadenceError`] when a beat's cadence expression does not parse —
+/// a registry that bypassed `validate` refuses the whole plan rather
+/// than skipping one beat in silence.
+pub fn due<'a>(
+    reg: &'a ArmRegistry,
+    now: &Zoned,
+    last_fired: &dyn Fn(usize) -> Option<Zoned>,
+) -> Result<impl Iterator<Item = Due<'a>>, CadenceError> {
+    let mut out = Vec::new();
+    for (index, beat) in reg.beats().enumerate() {
+        if !beat.is_active() || beat.locus() != Locus::Local {
+            continue;
+        }
+        let cadence = Cadence::parse(&beat.cadence)?;
+        match last_fired(index) {
+            None => {
+                // N2: no state, no invented backlog — the on-time
+                // window alone decides.
+                let Some(slot) = cadence.prev_before(now) else {
+                    continue;
+                };
+                if within_window(now, &slot) {
+                    out.push(Due {
+                        index,
+                        beat,
+                        slot,
+                        kind: DueKind::OnTime,
+                    });
+                }
+            }
+            Some(fired) => {
+                let Some((slot, slots)) = silence(&cadence, &fired, now) else {
+                    continue;
+                };
+                let kind = if slots == 1 && within_window(now, &slot) {
+                    DueKind::OnTime
+                } else {
+                    DueKind::Missed { slots }
+                };
+                out.push(Due {
+                    index,
+                    beat,
+                    slot,
+                    kind,
+                });
+            }
+        }
+    }
+    Ok(out.into_iter())
+}
+
+/// The earliest next slot among active · local beats — `None` means
+/// nothing armed (or only webhooks, which carry no calendar). The
+/// firing edge sleeps until then, never longer (trap ②: the caller
+/// sleeps, never the calculator).
+///
+/// # Errors
+/// As [`due`]: a cadence that will not parse refuses the whole answer.
+pub fn earliest_next(
+    reg: &ArmRegistry,
+    now: &Zoned,
+) -> Result<Option<(usize, Slot)>, CadenceError> {
+    let mut best: Option<(usize, Slot)> = None;
+    for (index, beat) in reg.beats().enumerate() {
+        if !beat.is_active() || beat.locus() != Locus::Local {
+            continue;
+        }
+        let cadence = Cadence::parse(&beat.cadence)?;
+        let Some(slot) = cadence.next_after(now) else {
+            continue;
+        };
+        if best.as_ref().is_none_or(|(_, held)| slot.at < held.at) {
+            best = Some((index, slot));
+        }
+    }
+    Ok(best)
+}
+
+/// The silence between the last fire and now, over the FIRE set: the
+/// most recent slot owed (the one to fire) and how many the silence
+/// covers, saturated at [`MISSED_SLOTS_CAP`]. `None` — not due — when
+/// no slot falls in `(fired, now]` (already fired · a state ahead of
+/// the clock).
+fn silence(cadence: &Cadence, fired: &Zoned, now: &Zoned) -> Option<(Slot, u32)> {
+    let mut slots = next_slots(cadence, fired, MISSED_SLOTS_CAP).take_while(|s| s.at <= *now);
+    let mut last = slots.next()?;
+    let mut count = 1u32;
+    for slot in slots {
+        last = slot;
+        count += 1;
+    }
+    Some((last, count))
+}
+
+/// Within the on-time grace: the slot's instant is at most
+/// [`ON_TIME_WINDOW`] older than `now` (a slot AT now has age zero —
+/// it has just passed). Read on epoch seconds: both instants are
+/// absolute, whatever zone they ride.
+fn within_window(now: &Zoned, slot: &Slot) -> bool {
+    let age = now.timestamp().as_second() - slot.at.timestamp().as_second();
+    (0..=ON_TIME_WINDOW.as_secs()).contains(&age)
+}

--- a/crates/nika-cadence/src/lib.rs
+++ b/crates/nika-cadence/src/lib.rs
@@ -4,11 +4,13 @@
 //! `nika-cadence` — L0 · PUR · zéro I/O · zéro async.
 //!
 //! The grammar of the arming registry (the `arm:` block of `nika.yaml`,
-//! D-2026-08-10-N3) and the pure next-slot calculator. Two L4 consumers
-//! will read this registry (`nika arm` today · `nika serve` at ②), so
-//! the shared logic lives at L0 — never in a CLI crate (the layering
-//! precedent: `nika-check`'s Cargo.toml · "THREE L0 consumers make any
-//! higher layer an upward-dep violation").
+//! D-2026-08-10-N3), the pure slot calculator (`next_after` ·
+//! `prev_before` — the half-open interval `(prev, next]` a beat is due
+//! in), and the pure planner (`due` · `earliest_next`) the firing edges
+//! read. Two L4 consumers read this registry (`nika arm` today ·
+//! `nika serve` at ②), so the shared logic lives at L0 — never in a CLI
+//! crate (the layering precedent: `nika-check`'s Cargo.toml · "THREE L0
+//! consumers make any higher layer an upward-dep violation").
 //!
 //! The four locks (D-2026-08-11-N1→N4 · one law at four moments: THE
 //! FILE PROPOSES, THE MACHINE DISPOSES):
@@ -64,6 +66,7 @@
 #![forbid(unsafe_code)]
 
 pub mod cron;
+pub mod due;
 pub mod error;
 pub mod next;
 pub mod parse;
@@ -71,6 +74,7 @@ pub mod phrase;
 pub mod registry;
 
 pub use cron::{CronSpec, Field};
+pub use due::{Due, DueKind, MISSED_SLOTS_CAP, ON_TIME_WINDOW, due, earliest_next};
 pub use error::{CadenceError, CadenceErrorKind};
 pub use next::{Shift, Slot, next_slots};
 pub use parse::{parse_registry, validate};

--- a/crates/nika-cadence/src/lib.rs
+++ b/crates/nika-cadence/src/lib.rs
@@ -81,10 +81,4 @@ pub use parse::{parse_registry, validate};
 pub use registry::{AfterSkip, ArmRegistry, Beat, Cadence, Locus, MissPolicy, Overlap};
 
 #[cfg(test)]
-#[allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::panic,
-    clippy::unreachable
-)]
 mod tests;

--- a/crates/nika-cadence/src/next.rs
+++ b/crates/nika-cadence/src/next.rs
@@ -134,6 +134,28 @@ impl Cadence {
             }
         }
     }
+
+    /// The last slot at or before `from` — the mirror of
+    /// [`next_after`](Self::next_after): strictly-after there,
+    /// at-or-before here, so the two bound the half-open interval
+    /// `(prev, next]` a beat is due in. `None` for a webhook (no
+    /// calendar) or when no slot exists within the 366-day walk.
+    ///
+    /// The N1 law in mirror: a slot that never EXISTED (a spring gap) is
+    /// never returned — it fired at the first valid instant AFTER, and
+    /// `next_after` carries that one. A slot that exists twice (an
+    /// autumn fold) fired at its FIRST occurrence — the mirror hands
+    /// that one back, never the second.
+    #[must_use]
+    pub fn prev_before(&self, from: &jiff::Zoned) -> Option<Slot> {
+        match self {
+            Self::Webhook => None,
+            Self::Cron { tz, spec } => {
+                let zone = bundled_tz(tz)?;
+                spec.prev_before(&zone, from)
+            }
+        }
+    }
 }
 
 impl CronSpec {
@@ -189,6 +211,49 @@ impl CronSpec {
                 }
             }
             day = day.tomorrow().ok()?;
+        }
+        None
+    }
+
+    /// Day-by-day BACKWARDS over a 366-day window — the recent past a
+    /// planner asks about (« quel créneau vient de passer ? »), never an
+    /// archaeology: a 29 February three years back answers `None`, and
+    /// the walk still ends rather than spinning, which is what the bound
+    /// is for. Hours and minutes descend inside matching days, in the
+    /// BEAT's zone, so the first candidate at or before `from` IS the
+    /// answer.
+    pub(crate) fn prev_before(&self, tz: &TimeZone, from: &jiff::Zoned) -> Option<Slot> {
+        let from_local = from.with_time_zone(tz.clone());
+        let mut day = from_local.date();
+        for _ in 0..366 {
+            if self.covers(day) {
+                for hour in self.hours().iter().rev() {
+                    for minute in self.minutes().iter().rev() {
+                        // Same per-candidate discipline as the forward
+                        // walk: a failed conversion skips the candidate,
+                        // it never kills the beat.
+                        let (Ok(h), Ok(m)) = (i8::try_from(hour), i8::try_from(minute)) else {
+                            continue;
+                        };
+                        let civil = day.to_datetime(jiff::civil::time(h, m, 0, 0));
+                        let Some(candidate) = resolve(civil, tz) else {
+                            continue;
+                        };
+                        // N1 in mirror: the ADVANCED slot never existed —
+                        // it fired at the first valid instant AFTER, which
+                        // `next_after` already carries. The mirror skips
+                        // it rather than hand back a slot that was never
+                        // a fire of its own.
+                        if candidate.shift == Shift::AdvancedFirstValid {
+                            continue;
+                        }
+                        if &candidate.at <= from {
+                            return Some(candidate);
+                        }
+                    }
+                }
+            }
+            day = day.yesterday().ok()?;
         }
         None
     }

--- a/crates/nika-cadence/src/tests.rs
+++ b/crates/nika-cadence/src/tests.rs
@@ -29,6 +29,17 @@ fn at(ts: &str) -> Zoned {
         .to_zoned(TimeZone::UTC)
 }
 
+/// A literal instant INSIDE a beat's zone — resolved from the EMBEDDED
+/// tzdb (trap ③ binds the tests too: never the host's zoneinfo).
+fn zoned(text: &str) -> Zoned {
+    let (civil, zone) = text.split_once('[').expect("civil[fuseau]");
+    let zone = zone.strip_suffix(']').expect("le crochet fermant");
+    let civil: jiff::civil::DateTime = civil.parse().expect("civil ISO");
+    civil
+        .to_zoned(crate::next::bundled_tz(zone).expect("fuseau embarqué"))
+        .expect("un instant qui existe")
+}
+
 /// The instant a candidate landed on, as a UTC string.
 fn utc(z: &Zoned) -> String {
     z.timestamp().to_string()
@@ -636,6 +647,111 @@ fn a_webhook_has_no_calendar() {
     assert_eq!(cadence.next_after(&at("2026-08-11T00:00:00Z")), None);
 }
 
+// ── prev_before · the mirror, literal instants ───────────────────────
+
+#[test]
+fn prev_before_is_the_mirror_of_next_after() {
+    // At-or-before, contre strictly-after: les deux bornent l'intervalle
+    // « (prev, next] ». À 10h00, le créneau qui vient de passer est 03h00.
+    let cad = Cadence::parse("TZ=Europe/Paris 0 3 * * *").expect("cadence");
+    let from = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("a slot exists before");
+    assert_eq!(prev.civil.to_string(), "2026-08-18T03:00:00");
+    let back = cad
+        .next_after(
+            &prev
+                .at
+                .checked_sub(jiff::Span::new().seconds(1))
+                .expect("span"),
+        )
+        .expect("next");
+    assert_eq!(back.at, prev.at, "next_after(prev − 1s) retombe sur prev");
+}
+
+#[test]
+fn prev_before_at_the_slot_returns_the_slot_itself() {
+    // Inclusive: un créneau À l'instant demandé vient de passer — il est dû.
+    let cad = Cadence::parse("TZ=Europe/Paris 0 3 * * *").expect("cadence");
+    let from = zoned("2026-08-18T03:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("le créneau même");
+    assert_eq!(prev.civil.to_string(), "2026-08-18T03:00:00");
+}
+
+#[test]
+fn prev_before_walks_the_dst_gap_backwards() {
+    // N1 miroir · 2026-03-29, Paris avance 02:00 → 03:00: le 02:30 du 29
+    // n'a JAMAIS existé — il a tiré à 03:00 (le premier instant valide
+    // APRÈS), et ce tir-là appartient à next_after. Le miroir le saute
+    // et rend le 28.
+    let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
+    let from = zoned("2026-03-29T12:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("slot");
+    assert_eq!(prev.civil.to_string(), "2026-03-28T02:30:00");
+    assert_eq!(prev.shift, Shift::Exact);
+}
+
+#[test]
+fn prev_before_walks_the_dst_fold_backwards() {
+    // N1 miroir · 2026-10-25, Paris recule 03:00 → 02:00: 02:30 existe
+    // DEUX fois, le beat a tiré à la PREMIÈRE (00:30 UTC). Le miroir la
+    // rend — jamais la seconde occurrence, jamais deux fois.
+    let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
+    let from = zoned("2026-10-25T12:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("slot");
+    assert_eq!(prev.civil.to_string(), "2026-10-25T02:30:00");
+    assert_eq!(
+        utc(&prev.at),
+        "2026-10-25T00:30:00Z",
+        "la première occurrence"
+    );
+    assert_eq!(prev.shift, Shift::FoldedFirst, "le repli est DÉCLARÉ");
+    // …et le créneau d'avant est la VEILLE, pas la seconde occurrence.
+    let before = cad
+        .prev_before(
+            &prev
+                .at
+                .checked_sub(jiff::Span::new().seconds(1))
+                .expect("span"),
+        )
+        .expect("la veille");
+    assert_eq!(before.civil.to_string(), "2026-10-24T02:30:00");
+}
+
+#[test]
+fn prev_before_beyond_366_days_is_none() {
+    // La borne: 366 jours — le passé récent du planificateur, jamais une
+    // archéologie. Le 29 février 2024 est hors de portée en août 2026.
+    let cad = Cadence::parse("TZ=Europe/Paris 0 9 29 2 *").expect("cadence");
+    assert_eq!(cad.prev_before(&at("2026-08-18T00:00:00Z")), None);
+    // …mais dans la fenêtre, il répond.
+    let prev = cad
+        .prev_before(&at("2024-03-01T00:00:00Z"))
+        .expect("le 29 février, cette année-là");
+    assert_eq!(prev.civil.to_string(), "2024-02-29T09:00:00");
+}
+
+#[test]
+fn prev_before_a_webhook_has_no_calendar() {
+    assert_eq!(
+        Cadence::Webhook.prev_before(&at("2026-08-11T00:00:00Z")),
+        None
+    );
+}
+
+#[test]
+fn prev_before_crosses_a_month_and_a_year_backwards() {
+    let cad = Cadence::parse("TZ=Europe/Paris 0 9 1 * *").expect("cadence");
+    let prev = cad
+        .prev_before(&at("2026-08-15T00:00:00Z"))
+        .expect("le 1er du mois d'avant");
+    assert_eq!(utc(&prev.at), "2026-08-01T07:00:00Z");
+    let jan = Cadence::parse("TZ=UTC 0 0 1 1 *").expect("cadence");
+    let prev = jan
+        .prev_before(&at("2026-06-15T00:00:00Z"))
+        .expect("le nouvel an");
+    assert_eq!(utc(&prev.at), "2026-01-01T00:00:00Z");
+}
+
 // ── describe · display normalizes to the readable form ─────────────
 
 #[test]
@@ -1209,5 +1325,45 @@ proptest! {
             .expect("un beat quotidien a toujours un prochain créneau");
         prop_assert!(next.at.timestamp() > from_ts, "strictement après");
         prop_assert!(next.at.timestamp().as_second() - secs <= 86_400, "au plus un jour");
+    }
+
+    #[test]
+    fn prev_before_and_next_after_are_mutual_inverses(secs in 0i64..=4_102_444_800) {
+        // La loi miroir, tout instant, toute cadence du corpus:
+        // prev_before(next_after(t) + 1s) == next_after(t). Exception
+        // DÉCLARÉE: le créneau AVANCÉ (gap DST) n'a jamais existé — il
+        // n'appartient pas à prev_before; la loi devient « le miroir rend
+        // l'existant d'avant, dont next_after retombe sur l'avancé ».
+        let corpus = [
+            "TZ=UTC 30 4 * * *",
+            "TZ=Europe/Paris 0 3 * * *",
+            "TZ=Europe/Paris 30 2 * * *", // traverse le gap ET le fold 2026
+            "TZ=Europe/Paris lundi 9h07",
+            "TZ=America/New_York 15 9 * * 1-5",
+        ];
+        let from = Timestamp::from_second(secs)
+            .expect("instant")
+            .to_zoned(TimeZone::UTC);
+        for expr in corpus {
+            let cad = Cadence::parse(expr).expect("cadence");
+            let next = cad.next_after(&from).expect("un prochain créneau");
+            let just_after = next
+                .at
+                .checked_add(jiff::Span::new().seconds(1))
+                .expect("+1s");
+            let prev = cad.prev_before(&just_after).expect("le miroir répond");
+            if next.shift == Shift::AdvancedFirstValid {
+                prop_assert!(prev.at < next.at, "{} · l'avancé n'est jamais RENDU", expr);
+                let round = cad.next_after(&prev.at).expect("next depuis l'existant");
+                prop_assert_eq!(
+                    &round.at,
+                    &next.at,
+                    "{} · next_after de l'existant retombe sur l'avancé",
+                    expr
+                );
+            } else {
+                prop_assert_eq!(&prev.at, &next.at, "{} · le miroir exact", expr);
+            }
+        }
     }
 }

--- a/crates/nika-cadence/src/tests.rs
+++ b/crates/nika-cadence/src/tests.rs
@@ -16,6 +16,7 @@ use jiff::Zoned;
 use jiff::tz::TimeZone;
 use proptest::prelude::*;
 
+use crate::due::{DueKind, MISSED_SLOTS_CAP, due, earliest_next};
 use crate::next::next_slots;
 use crate::{
     AfterSkip, ArmRegistry, Cadence, CadenceErrorKind, Locus, MissPolicy, Overlap, Shift,
@@ -750,6 +751,244 @@ fn prev_before_crosses_a_month_and_a_year_backwards() {
         .prev_before(&at("2026-06-15T00:00:00Z"))
         .expect("le nouvel an");
     assert_eq!(utc(&prev.at), "2026-01-01T00:00:00Z");
+}
+
+// ── due · the pure planner, the clock handed in ─────────────────────
+
+const DUE_DAILY: &str = "
+nika: v1
+ceiling: 0.50
+arm:
+  - workflow: workflows/nightly.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+";
+
+#[test]
+fn due_an_on_time_slot_is_due_once() {
+    // 03:02, jamais tiré · le créneau de 03:00 est dû, À L'HEURE.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].index, 0);
+    assert_eq!(plan[0].kind, DueKind::OnTime);
+    assert_eq!(plan[0].slot.civil.to_string(), "2026-08-18T03:00:00");
+    assert_eq!(plan[0].beat.workflow, "workflows/nightly.nika.yaml");
+}
+
+#[test]
+fn due_a_missed_slot_says_how_many() {
+    // 10:00, dernier tir hier 03:00 · le créneau du jour est dû, RATÉ,
+    // et le silence compte UN créneau.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let fired = zoned("2026-08-17T03:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].kind, DueKind::Missed { slots: 1 });
+}
+
+#[test]
+fn due_an_idle_or_cloud_beat_is_never_due() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/suspended.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+    actif: false
+    raison: pause estivale
+    jusqu_au: 2026-09-01
+  - workflow: workflows/cloud.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+    où: cloud
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert!(
+        plan.is_empty(),
+        "ni le suspendu ni le cloud ne sont dus ICI: {plan:?}"
+    );
+    assert_eq!(
+        earliest_next(&reg, &now).expect("le prochain"),
+        None,
+        "rien d'armé ne tire ici"
+    );
+}
+
+#[test]
+fn earliest_next_is_the_soonest_of_the_armed_beats() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/weekly.nika.yaml
+    cadence: TZ=Europe/Paris lundi 9h07
+    plafond: 0.25
+    manqué: sauter
+  - workflow: workflows/nightly.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: rattraper
+",
+    )
+    .expect("registre");
+    // Mardi 10:00 Paris: l'hebdo vise lundi prochain, le quotidien demain.
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let (index, slot) = earliest_next(&reg, &now)
+        .expect("le plan")
+        .expect("un prochain créneau");
+    assert_eq!(index, 1, "le quotidien tire avant l'hebdo");
+    assert_eq!(slot.civil.to_string(), "2026-08-19T03:00:00");
+}
+
+#[test]
+fn due_an_already_fired_slot_is_not_due_again() {
+    // La borne STRICTE: last_fired == le créneau → déjà tiré, jamais deux fois.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let fired = zoned("2026-08-18T03:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert!(plan.is_empty(), "un créneau tiré ne se retire pas");
+}
+
+#[test]
+fn due_never_fired_and_outside_the_window_invents_no_backlog() {
+    // N2: pas d'état, pas de rattrapage inventé — seule la fenêtre compte.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert!(plan.is_empty(), "jamais tiré + hors fenêtre = pas dû");
+}
+
+#[test]
+fn the_on_time_window_is_five_minutes_to_the_second() {
+    // La borne de la fenêtre, des deux côtés: 03:05:00 pile est ON TIME,
+    // 03:05:01 est MISSED.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let fired = zoned("2026-08-17T03:00:00[Europe/Paris]");
+    let state = |_: usize| Some(fired.clone());
+    let edge = zoned("2026-08-18T03:05:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &edge, &state).expect("le plan").collect();
+    assert_eq!(
+        plan[0].kind,
+        DueKind::OnTime,
+        "à cinq minutes pile, à l'heure"
+    );
+    let late = zoned("2026-08-18T03:05:01[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &late, &state).expect("le plan").collect();
+    assert_eq!(
+        plan[0].kind,
+        DueKind::Missed { slots: 1 },
+        "une seconde plus tard, raté"
+    );
+}
+
+#[test]
+fn due_counts_every_slot_of_the_silence() {
+    // Deux jours de silence sur un beat quotidien = DEUX créneaux dus.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let fired = zoned("2026-08-16T03:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert_eq!(plan[0].kind, DueKind::Missed { slots: 2 }, "le 17 ET le 18");
+}
+
+#[test]
+fn the_missed_count_saturates_at_the_cap() {
+    // Au-delà de dix mille créneaux le compte dit le cap: un silence
+    // plus long est une panne, pas un chiffre.
+    let hourly = DUE_DAILY.replace("0 3 * * *", "0 * * * *");
+    let reg = parse_registry(&hourly).expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let fired = zoned("2025-06-26T00:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    #[allow(clippy::cast_possible_truncation)]
+    let cap = MISSED_SLOTS_CAP as u32;
+    assert_eq!(plan[0].kind, DueKind::Missed { slots: cap });
+}
+
+#[test]
+fn due_the_gap_fire_is_due_like_any_other() {
+    // Le créneau du gap a tiré à 03:00 CEST le 29 mars — un beat dont le
+    // dernier tir est la veille le doit À L'HEURE à 03:02. La vue du
+    // planificateur est le FEU (next_after porte l'avancé), pas le civil
+    // existant — sinon ce tir manqué tomberait dans un trou.
+    let gap = DUE_DAILY.replace("0 3 * * *", "30 2 * * *");
+    let reg = parse_registry(&gap).expect("registre");
+    let fired = zoned("2026-03-28T02:30:00[Europe/Paris]");
+    let now = zoned("2026-03-29T03:02:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert_eq!(plan.len(), 1, "le tir avancé du gap est dû");
+    assert_eq!(plan[0].kind, DueKind::OnTime);
+    assert_eq!(
+        plan[0].slot.shift,
+        Shift::AdvancedFirstValid,
+        "le créneau dû DÉCLARE son déplacement"
+    );
+}
+
+#[test]
+fn a_webhook_beat_is_never_due_nor_next() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/hooked.nika.yaml
+    cadence: on-webhook
+    plafond: 0.10
+    manqué: sauter
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert!(plan.is_empty(), "un webhook n'a pas de calendrier");
+    assert_eq!(earliest_next(&reg, &now).expect("le prochain"), None);
+}
+
+#[test]
+fn due_a_cadence_that_breaks_the_law_refuses_the_plan() {
+    // Un registre qui a contourné validate (TZ absente) — le planificateur
+    // REFUSE le plan entier, il ne saute pas le beat en silence.
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/nightly.nika.yaml
+    cadence: 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let err = due(&reg, &now, &|_| None)
+        .map(Iterator::count)
+        .expect_err("le refus");
+    assert_eq!(err.kind(), CadenceErrorKind::TzMissing);
+    let err = earliest_next(&reg, &now)
+        .map(|slot| slot.map(|_| ()))
+        .expect_err("le refus");
+    assert_eq!(err.kind(), CadenceErrorKind::TzMissing);
 }
 
 // ── describe · display normalizes to the readable form ─────────────

--- a/crates/nika-cadence/src/tests/mod.rs
+++ b/crates/nika-cadence/src/tests/mod.rs
@@ -10,13 +10,18 @@
 //!   displaced or merged slot is DECLARED ([`Slot::shift`]).
 //! - **the dispatcher (later, L4)** — that is where `VirtualClock`
 //!   will live, never here.
+//!
+//! Split 2026-08-19 (the 1,500-line file cap): the mirror
+//! (`prev_before`) and the planner (`due`) pins live in
+//! [`mod@planner`].
+
+mod planner;
 
 use jiff::Timestamp;
 use jiff::Zoned;
 use jiff::tz::TimeZone;
 use proptest::prelude::*;
 
-use crate::due::{DueKind, MISSED_SLOTS_CAP, due, earliest_next};
 use crate::next::next_slots;
 use crate::{
     AfterSkip, ArmRegistry, Cadence, CadenceErrorKind, Locus, MissPolicy, Overlap, Shift,
@@ -648,349 +653,6 @@ fn a_webhook_has_no_calendar() {
     assert_eq!(cadence.next_after(&at("2026-08-11T00:00:00Z")), None);
 }
 
-// ── prev_before · the mirror, literal instants ───────────────────────
-
-#[test]
-fn prev_before_is_the_mirror_of_next_after() {
-    // At-or-before, contre strictly-after: les deux bornent l'intervalle
-    // « (prev, next] ». À 10h00, le créneau qui vient de passer est 03h00.
-    let cad = Cadence::parse("TZ=Europe/Paris 0 3 * * *").expect("cadence");
-    let from = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let prev = cad.prev_before(&from).expect("a slot exists before");
-    assert_eq!(prev.civil.to_string(), "2026-08-18T03:00:00");
-    let back = cad
-        .next_after(
-            &prev
-                .at
-                .checked_sub(jiff::Span::new().seconds(1))
-                .expect("span"),
-        )
-        .expect("next");
-    assert_eq!(back.at, prev.at, "next_after(prev − 1s) retombe sur prev");
-}
-
-#[test]
-fn prev_before_at_the_slot_returns_the_slot_itself() {
-    // Inclusive: un créneau À l'instant demandé vient de passer — il est dû.
-    let cad = Cadence::parse("TZ=Europe/Paris 0 3 * * *").expect("cadence");
-    let from = zoned("2026-08-18T03:00:00[Europe/Paris]");
-    let prev = cad.prev_before(&from).expect("le créneau même");
-    assert_eq!(prev.civil.to_string(), "2026-08-18T03:00:00");
-}
-
-#[test]
-fn prev_before_walks_the_dst_gap_backwards() {
-    // N1 miroir · 2026-03-29, Paris avance 02:00 → 03:00: le 02:30 du 29
-    // n'a JAMAIS existé — il a tiré à 03:00 (le premier instant valide
-    // APRÈS), et ce tir-là appartient à next_after. Le miroir le saute
-    // et rend le 28.
-    let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
-    let from = zoned("2026-03-29T12:00:00[Europe/Paris]");
-    let prev = cad.prev_before(&from).expect("slot");
-    assert_eq!(prev.civil.to_string(), "2026-03-28T02:30:00");
-    assert_eq!(prev.shift, Shift::Exact);
-}
-
-#[test]
-fn prev_before_walks_the_dst_fold_backwards() {
-    // N1 miroir · 2026-10-25, Paris recule 03:00 → 02:00: 02:30 existe
-    // DEUX fois, le beat a tiré à la PREMIÈRE (00:30 UTC). Le miroir la
-    // rend — jamais la seconde occurrence, jamais deux fois.
-    let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
-    let from = zoned("2026-10-25T12:00:00[Europe/Paris]");
-    let prev = cad.prev_before(&from).expect("slot");
-    assert_eq!(prev.civil.to_string(), "2026-10-25T02:30:00");
-    assert_eq!(
-        utc(&prev.at),
-        "2026-10-25T00:30:00Z",
-        "la première occurrence"
-    );
-    assert_eq!(prev.shift, Shift::FoldedFirst, "le repli est DÉCLARÉ");
-    // …et le créneau d'avant est la VEILLE, pas la seconde occurrence.
-    let before = cad
-        .prev_before(
-            &prev
-                .at
-                .checked_sub(jiff::Span::new().seconds(1))
-                .expect("span"),
-        )
-        .expect("la veille");
-    assert_eq!(before.civil.to_string(), "2026-10-24T02:30:00");
-}
-
-#[test]
-fn prev_before_beyond_366_days_is_none() {
-    // La borne: 366 jours — le passé récent du planificateur, jamais une
-    // archéologie. Le 29 février 2024 est hors de portée en août 2026.
-    let cad = Cadence::parse("TZ=Europe/Paris 0 9 29 2 *").expect("cadence");
-    assert_eq!(cad.prev_before(&at("2026-08-18T00:00:00Z")), None);
-    // …mais dans la fenêtre, il répond.
-    let prev = cad
-        .prev_before(&at("2024-03-01T00:00:00Z"))
-        .expect("le 29 février, cette année-là");
-    assert_eq!(prev.civil.to_string(), "2024-02-29T09:00:00");
-}
-
-#[test]
-fn prev_before_a_webhook_has_no_calendar() {
-    assert_eq!(
-        Cadence::Webhook.prev_before(&at("2026-08-11T00:00:00Z")),
-        None
-    );
-}
-
-#[test]
-fn prev_before_crosses_a_month_and_a_year_backwards() {
-    let cad = Cadence::parse("TZ=Europe/Paris 0 9 1 * *").expect("cadence");
-    let prev = cad
-        .prev_before(&at("2026-08-15T00:00:00Z"))
-        .expect("le 1er du mois d'avant");
-    assert_eq!(utc(&prev.at), "2026-08-01T07:00:00Z");
-    let jan = Cadence::parse("TZ=UTC 0 0 1 1 *").expect("cadence");
-    let prev = jan
-        .prev_before(&at("2026-06-15T00:00:00Z"))
-        .expect("le nouvel an");
-    assert_eq!(utc(&prev.at), "2026-01-01T00:00:00Z");
-}
-
-// ── due · the pure planner, the clock handed in ─────────────────────
-
-const DUE_DAILY: &str = "
-nika: v1
-ceiling: 0.50
-arm:
-  - workflow: workflows/nightly.nika.yaml
-    cadence: TZ=Europe/Paris 0 3 * * *
-    plafond: 0.10
-    manqué: sauter
-";
-
-#[test]
-fn due_an_on_time_slot_is_due_once() {
-    // 03:02, jamais tiré · le créneau de 03:00 est dû, À L'HEURE.
-    let reg = parse_registry(DUE_DAILY).expect("registre");
-    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
-    assert_eq!(plan.len(), 1);
-    assert_eq!(plan[0].index, 0);
-    assert_eq!(plan[0].kind, DueKind::OnTime);
-    assert_eq!(plan[0].slot.civil.to_string(), "2026-08-18T03:00:00");
-    assert_eq!(plan[0].beat.workflow, "workflows/nightly.nika.yaml");
-}
-
-#[test]
-fn due_a_missed_slot_says_how_many() {
-    // 10:00, dernier tir hier 03:00 · le créneau du jour est dû, RATÉ,
-    // et le silence compte UN créneau.
-    let reg = parse_registry(DUE_DAILY).expect("registre");
-    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let fired = zoned("2026-08-17T03:00:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
-        .expect("le plan")
-        .collect();
-    assert_eq!(plan.len(), 1);
-    assert_eq!(plan[0].kind, DueKind::Missed { slots: 1 });
-}
-
-#[test]
-fn due_an_idle_or_cloud_beat_is_never_due() {
-    let reg = parse_registry(
-        "
-nika: v1
-arm:
-  - workflow: workflows/suspended.nika.yaml
-    cadence: TZ=Europe/Paris 0 3 * * *
-    plafond: 0.10
-    manqué: sauter
-    actif: false
-    raison: pause estivale
-    jusqu_au: 2026-09-01
-  - workflow: workflows/cloud.nika.yaml
-    cadence: TZ=Europe/Paris 0 3 * * *
-    plafond: 0.10
-    manqué: sauter
-    où: cloud
-",
-    )
-    .expect("registre");
-    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
-    assert!(
-        plan.is_empty(),
-        "ni le suspendu ni le cloud ne sont dus ICI: {plan:?}"
-    );
-    assert_eq!(
-        earliest_next(&reg, &now).expect("le prochain"),
-        None,
-        "rien d'armé ne tire ici"
-    );
-}
-
-#[test]
-fn earliest_next_is_the_soonest_of_the_armed_beats() {
-    let reg = parse_registry(
-        "
-nika: v1
-arm:
-  - workflow: workflows/weekly.nika.yaml
-    cadence: TZ=Europe/Paris lundi 9h07
-    plafond: 0.25
-    manqué: sauter
-  - workflow: workflows/nightly.nika.yaml
-    cadence: TZ=Europe/Paris 0 3 * * *
-    plafond: 0.10
-    manqué: rattraper
-",
-    )
-    .expect("registre");
-    // Mardi 10:00 Paris: l'hebdo vise lundi prochain, le quotidien demain.
-    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let (index, slot) = earliest_next(&reg, &now)
-        .expect("le plan")
-        .expect("un prochain créneau");
-    assert_eq!(index, 1, "le quotidien tire avant l'hebdo");
-    assert_eq!(slot.civil.to_string(), "2026-08-19T03:00:00");
-}
-
-#[test]
-fn due_an_already_fired_slot_is_not_due_again() {
-    // La borne STRICTE: last_fired == le créneau → déjà tiré, jamais deux fois.
-    let reg = parse_registry(DUE_DAILY).expect("registre");
-    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
-    let fired = zoned("2026-08-18T03:00:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
-        .expect("le plan")
-        .collect();
-    assert!(plan.is_empty(), "un créneau tiré ne se retire pas");
-}
-
-#[test]
-fn due_never_fired_and_outside_the_window_invents_no_backlog() {
-    // N2: pas d'état, pas de rattrapage inventé — seule la fenêtre compte.
-    let reg = parse_registry(DUE_DAILY).expect("registre");
-    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
-    assert!(plan.is_empty(), "jamais tiré + hors fenêtre = pas dû");
-}
-
-#[test]
-fn the_on_time_window_is_five_minutes_to_the_second() {
-    // La borne de la fenêtre, des deux côtés: 03:05:00 pile est ON TIME,
-    // 03:05:01 est MISSED.
-    let reg = parse_registry(DUE_DAILY).expect("registre");
-    let fired = zoned("2026-08-17T03:00:00[Europe/Paris]");
-    let state = |_: usize| Some(fired.clone());
-    let edge = zoned("2026-08-18T03:05:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &edge, &state).expect("le plan").collect();
-    assert_eq!(
-        plan[0].kind,
-        DueKind::OnTime,
-        "à cinq minutes pile, à l'heure"
-    );
-    let late = zoned("2026-08-18T03:05:01[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &late, &state).expect("le plan").collect();
-    assert_eq!(
-        plan[0].kind,
-        DueKind::Missed { slots: 1 },
-        "une seconde plus tard, raté"
-    );
-}
-
-#[test]
-fn due_counts_every_slot_of_the_silence() {
-    // Deux jours de silence sur un beat quotidien = DEUX créneaux dus.
-    let reg = parse_registry(DUE_DAILY).expect("registre");
-    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let fired = zoned("2026-08-16T03:00:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
-        .expect("le plan")
-        .collect();
-    assert_eq!(plan[0].kind, DueKind::Missed { slots: 2 }, "le 17 ET le 18");
-}
-
-#[test]
-fn the_missed_count_saturates_at_the_cap() {
-    // Au-delà de dix mille créneaux le compte dit le cap: un silence
-    // plus long est une panne, pas un chiffre.
-    let hourly = DUE_DAILY.replace("0 3 * * *", "0 * * * *");
-    let reg = parse_registry(&hourly).expect("registre");
-    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
-    let fired = zoned("2025-06-26T00:00:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
-        .expect("le plan")
-        .collect();
-    #[allow(clippy::cast_possible_truncation)]
-    let cap = MISSED_SLOTS_CAP as u32;
-    assert_eq!(plan[0].kind, DueKind::Missed { slots: cap });
-}
-
-#[test]
-fn due_the_gap_fire_is_due_like_any_other() {
-    // Le créneau du gap a tiré à 03:00 CEST le 29 mars — un beat dont le
-    // dernier tir est la veille le doit À L'HEURE à 03:02. La vue du
-    // planificateur est le FEU (next_after porte l'avancé), pas le civil
-    // existant — sinon ce tir manqué tomberait dans un trou.
-    let gap = DUE_DAILY.replace("0 3 * * *", "30 2 * * *");
-    let reg = parse_registry(&gap).expect("registre");
-    let fired = zoned("2026-03-28T02:30:00[Europe/Paris]");
-    let now = zoned("2026-03-29T03:02:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
-        .expect("le plan")
-        .collect();
-    assert_eq!(plan.len(), 1, "le tir avancé du gap est dû");
-    assert_eq!(plan[0].kind, DueKind::OnTime);
-    assert_eq!(
-        plan[0].slot.shift,
-        Shift::AdvancedFirstValid,
-        "le créneau dû DÉCLARE son déplacement"
-    );
-}
-
-#[test]
-fn a_webhook_beat_is_never_due_nor_next() {
-    let reg = parse_registry(
-        "
-nika: v1
-arm:
-  - workflow: workflows/hooked.nika.yaml
-    cadence: on-webhook
-    plafond: 0.10
-    manqué: sauter
-",
-    )
-    .expect("registre");
-    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
-    assert!(plan.is_empty(), "un webhook n'a pas de calendrier");
-    assert_eq!(earliest_next(&reg, &now).expect("le prochain"), None);
-}
-
-#[test]
-fn due_a_cadence_that_breaks_the_law_refuses_the_plan() {
-    // Un registre qui a contourné validate (TZ absente) — le planificateur
-    // REFUSE le plan entier, il ne saute pas le beat en silence.
-    let reg = parse_registry(
-        "
-nika: v1
-arm:
-  - workflow: workflows/nightly.nika.yaml
-    cadence: 0 3 * * *
-    plafond: 0.10
-    manqué: sauter
-",
-    )
-    .expect("registre");
-    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
-    let err = due(&reg, &now, &|_| None)
-        .map(Iterator::count)
-        .expect_err("le refus");
-    assert_eq!(err.kind(), CadenceErrorKind::TzMissing);
-    let err = earliest_next(&reg, &now)
-        .map(|slot| slot.map(|_| ()))
-        .expect_err("le refus");
-    assert_eq!(err.kind(), CadenceErrorKind::TzMissing);
-}
-
 // ── describe · display normalizes to the readable form ─────────────
 
 #[test]
@@ -1517,13 +1179,15 @@ fn no_zone_ever_resolves_from_the_host() {
     let dir = env!("CARGO_MANIFEST_DIR");
     for file in [
         "cron.rs",
+        "due.rs",
         "error.rs",
         "lib.rs",
         "next.rs",
         "parse.rs",
         "phrase.rs",
         "registry.rs",
-        "tests.rs",
+        "tests/mod.rs",
+        "tests/planner.rs",
     ] {
         let text = std::fs::read_to_string(format!("{dir}/src/{file}")).expect("la source se lit");
         for (n, line) in text.lines().enumerate() {
@@ -1564,45 +1228,5 @@ proptest! {
             .expect("un beat quotidien a toujours un prochain créneau");
         prop_assert!(next.at.timestamp() > from_ts, "strictement après");
         prop_assert!(next.at.timestamp().as_second() - secs <= 86_400, "au plus un jour");
-    }
-
-    #[test]
-    fn prev_before_and_next_after_are_mutual_inverses(secs in 0i64..=4_102_444_800) {
-        // La loi miroir, tout instant, toute cadence du corpus:
-        // prev_before(next_after(t) + 1s) == next_after(t). Exception
-        // DÉCLARÉE: le créneau AVANCÉ (gap DST) n'a jamais existé — il
-        // n'appartient pas à prev_before; la loi devient « le miroir rend
-        // l'existant d'avant, dont next_after retombe sur l'avancé ».
-        let corpus = [
-            "TZ=UTC 30 4 * * *",
-            "TZ=Europe/Paris 0 3 * * *",
-            "TZ=Europe/Paris 30 2 * * *", // traverse le gap ET le fold 2026
-            "TZ=Europe/Paris lundi 9h07",
-            "TZ=America/New_York 15 9 * * 1-5",
-        ];
-        let from = Timestamp::from_second(secs)
-            .expect("instant")
-            .to_zoned(TimeZone::UTC);
-        for expr in corpus {
-            let cad = Cadence::parse(expr).expect("cadence");
-            let next = cad.next_after(&from).expect("un prochain créneau");
-            let just_after = next
-                .at
-                .checked_add(jiff::Span::new().seconds(1))
-                .expect("+1s");
-            let prev = cad.prev_before(&just_after).expect("le miroir répond");
-            if next.shift == Shift::AdvancedFirstValid {
-                prop_assert!(prev.at < next.at, "{} · l'avancé n'est jamais RENDU", expr);
-                let round = cad.next_after(&prev.at).expect("next depuis l'existant");
-                prop_assert_eq!(
-                    &round.at,
-                    &next.at,
-                    "{} · next_after de l'existant retombe sur l'avancé",
-                    expr
-                );
-            } else {
-                prop_assert_eq!(&prev.at, &next.at, "{} · le miroir exact", expr);
-            }
-        }
     }
 }

--- a/crates/nika-cadence/src/tests/mod.rs
+++ b/crates/nika-cadence/src/tests/mod.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::unreachable
+)]
 
 //! Two families, never confused (§2sexies):
 //!

--- a/crates/nika-cadence/src/tests/mod.rs
+++ b/crates/nika-cadence/src/tests/mod.rs
@@ -576,6 +576,24 @@ fn dst_gap_at_the_boundary_also_fires_at_first_valid() {
 }
 
 #[test]
+fn the_widest_gap_the_tzdb_remembers_still_lands() {
+    // Apia skipped a whole DAY (2011-12-30, the dateline jump) — the
+    // widest gap there is, 24 h, and the reason resolve() steps up to
+    // 26 h of minutes. A midnight slot on the 30th never existed: it
+    // fires at the first valid instant, 00:00 on the 31st (+14:00).
+    // The resolve() comment claimed this probe without a test; here it
+    // is, and it kills the `26 * 60` → `26 + 60` survivor (86 minutes
+    // of stepping never reaches the 31st).
+    let cad = Cadence::parse("TZ=Pacific/Apia 0 0 * * *").expect("cadence");
+    let slot = cad
+        .next_after(&at("2011-12-29T12:00:00Z"))
+        .expect("le lendemain existe");
+    assert_eq!(utc(&slot.at), "2011-12-30T10:00:00Z", "00:00 +14:00");
+    assert_eq!(slot.shift, Shift::AdvancedFirstValid);
+    assert_eq!(slot.civil.to_string(), "2011-12-30T00:00:00");
+}
+
+#[test]
 fn dst_fold_fires_once_at_the_first_occurrence() {
     // N1 · 2026-10-25, Paris falls 03:00 → 02:00: 02:30 exists TWICE.
     // The beat fires at the first occurrence (CEST), declares the fold,

--- a/crates/nika-cadence/src/tests/planner.rs
+++ b/crates/nika-cadence/src/tests/planner.rs
@@ -220,6 +220,34 @@ arm:
 }
 
 #[test]
+fn earliest_next_a_tie_keeps_the_first_beat() {
+    // Deux beats, même cadence, même prochain créneau — le PREMIER du
+    // registre garde l'égalité (un dernier qui l'emporterait rendrait
+    // l'ordre du fichier mensonger). Tue le mutant `< → <=` sur la
+    // comparaison du meilleur.
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/a.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+  - workflow: workflows/b.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.20
+    manqué: sauter
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let (index, _) = earliest_next(&reg, &now)
+        .expect("le plan")
+        .expect("un prochain créneau");
+    assert_eq!(index, 0, "l'égalité garde le premier du registre");
+}
+
+#[test]
 fn due_an_already_fired_slot_is_not_due_again() {
     // La borne STRICTE: last_fired == le créneau → déjà tiré, jamais deux fois.
     let reg = parse_registry(DUE_DAILY).expect("registre");

--- a/crates/nika-cadence/src/tests/planner.rs
+++ b/crates/nika-cadence/src/tests/planner.rs
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The W1 surface, pinned: `prev_before` (the mirror — at-or-before,
+//! the gap never returned, the fold's FIRST occurrence, the 366-day
+//! bound) and `due` (the pure planner — the clock and the firing state
+//! handed in, never read). Same law as the parent module: literal
+//! `Zoned` instants, zero clock to drive (trap ①).
+
+use jiff::Timestamp;
+use jiff::tz::TimeZone;
+use proptest::prelude::*;
+
+use super::{at, utc, zoned};
+use crate::due::{DueKind, MISSED_SLOTS_CAP, due, earliest_next};
+use crate::{Cadence, CadenceErrorKind, Shift, parse_registry};
+
+// ── prev_before · the mirror, literal instants ───────────────────────
+
+#[test]
+fn prev_before_is_the_mirror_of_next_after() {
+    // At-or-before, contre strictly-after: les deux bornent l'intervalle
+    // « (prev, next] ». À 10h00, le créneau qui vient de passer est 03h00.
+    let cad = Cadence::parse("TZ=Europe/Paris 0 3 * * *").expect("cadence");
+    let from = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("a slot exists before");
+    assert_eq!(prev.civil.to_string(), "2026-08-18T03:00:00");
+    let back = cad
+        .next_after(
+            &prev
+                .at
+                .checked_sub(jiff::Span::new().seconds(1))
+                .expect("span"),
+        )
+        .expect("next");
+    assert_eq!(back.at, prev.at, "next_after(prev − 1s) retombe sur prev");
+}
+
+#[test]
+fn prev_before_at_the_slot_returns_the_slot_itself() {
+    // Inclusive: un créneau À l'instant demandé vient de passer — il est dû.
+    let cad = Cadence::parse("TZ=Europe/Paris 0 3 * * *").expect("cadence");
+    let from = zoned("2026-08-18T03:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("le créneau même");
+    assert_eq!(prev.civil.to_string(), "2026-08-18T03:00:00");
+}
+
+#[test]
+fn prev_before_walks_the_dst_gap_backwards() {
+    // N1 miroir · 2026-03-29, Paris avance 02:00 → 03:00: le 02:30 du 29
+    // n'a JAMAIS existé — il a tiré à 03:00 (le premier instant valide
+    // APRÈS), et ce tir-là appartient à next_after. Le miroir le saute
+    // et rend le 28.
+    let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
+    let from = zoned("2026-03-29T12:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("slot");
+    assert_eq!(prev.civil.to_string(), "2026-03-28T02:30:00");
+    assert_eq!(prev.shift, Shift::Exact);
+}
+
+#[test]
+fn prev_before_walks_the_dst_fold_backwards() {
+    // N1 miroir · 2026-10-25, Paris recule 03:00 → 02:00: 02:30 existe
+    // DEUX fois, le beat a tiré à la PREMIÈRE (00:30 UTC). Le miroir la
+    // rend — jamais la seconde occurrence, jamais deux fois.
+    let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
+    let from = zoned("2026-10-25T12:00:00[Europe/Paris]");
+    let prev = cad.prev_before(&from).expect("slot");
+    assert_eq!(prev.civil.to_string(), "2026-10-25T02:30:00");
+    assert_eq!(
+        utc(&prev.at),
+        "2026-10-25T00:30:00Z",
+        "la première occurrence"
+    );
+    assert_eq!(prev.shift, Shift::FoldedFirst, "le repli est DÉCLARÉ");
+    // …et le créneau d'avant est la VEILLE, pas la seconde occurrence.
+    let before = cad
+        .prev_before(
+            &prev
+                .at
+                .checked_sub(jiff::Span::new().seconds(1))
+                .expect("span"),
+        )
+        .expect("la veille");
+    assert_eq!(before.civil.to_string(), "2026-10-24T02:30:00");
+}
+
+#[test]
+fn prev_before_beyond_366_days_is_none() {
+    // La borne: 366 jours — le passé récent du planificateur, jamais une
+    // archéologie. Le 29 février 2024 est hors de portée en août 2026.
+    let cad = Cadence::parse("TZ=Europe/Paris 0 9 29 2 *").expect("cadence");
+    assert_eq!(cad.prev_before(&at("2026-08-18T00:00:00Z")), None);
+    // …mais dans la fenêtre, il répond.
+    let prev = cad
+        .prev_before(&at("2024-03-01T00:00:00Z"))
+        .expect("le 29 février, cette année-là");
+    assert_eq!(prev.civil.to_string(), "2024-02-29T09:00:00");
+}
+
+#[test]
+fn prev_before_a_webhook_has_no_calendar() {
+    assert_eq!(
+        Cadence::Webhook.prev_before(&at("2026-08-11T00:00:00Z")),
+        None
+    );
+}
+
+#[test]
+fn prev_before_crosses_a_month_and_a_year_backwards() {
+    let cad = Cadence::parse("TZ=Europe/Paris 0 9 1 * *").expect("cadence");
+    let prev = cad
+        .prev_before(&at("2026-08-15T00:00:00Z"))
+        .expect("le 1er du mois d'avant");
+    assert_eq!(utc(&prev.at), "2026-08-01T07:00:00Z");
+    let jan = Cadence::parse("TZ=UTC 0 0 1 1 *").expect("cadence");
+    let prev = jan
+        .prev_before(&at("2026-06-15T00:00:00Z"))
+        .expect("le nouvel an");
+    assert_eq!(utc(&prev.at), "2026-01-01T00:00:00Z");
+}
+
+// ── due · the pure planner, the clock handed in ─────────────────────
+
+const DUE_DAILY: &str = "
+nika: v1
+ceiling: 0.50
+arm:
+  - workflow: workflows/nightly.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+";
+
+#[test]
+fn due_an_on_time_slot_is_due_once() {
+    // 03:02, jamais tiré · le créneau de 03:00 est dû, À L'HEURE.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].index, 0);
+    assert_eq!(plan[0].kind, DueKind::OnTime);
+    assert_eq!(plan[0].slot.civil.to_string(), "2026-08-18T03:00:00");
+    assert_eq!(plan[0].beat.workflow, "workflows/nightly.nika.yaml");
+}
+
+#[test]
+fn due_a_missed_slot_says_how_many() {
+    // 10:00, dernier tir hier 03:00 · le créneau du jour est dû, RATÉ,
+    // et le silence compte UN créneau.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let fired = zoned("2026-08-17T03:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].kind, DueKind::Missed { slots: 1 });
+}
+
+#[test]
+fn due_an_idle_or_cloud_beat_is_never_due() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/suspended.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+    actif: false
+    raison: pause estivale
+    jusqu_au: 2026-09-01
+  - workflow: workflows/cloud.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+    où: cloud
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert!(
+        plan.is_empty(),
+        "ni le suspendu ni le cloud ne sont dus ICI: {plan:?}"
+    );
+    assert_eq!(
+        earliest_next(&reg, &now).expect("le prochain"),
+        None,
+        "rien d'armé ne tire ici"
+    );
+}
+
+#[test]
+fn earliest_next_is_the_soonest_of_the_armed_beats() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/weekly.nika.yaml
+    cadence: TZ=Europe/Paris lundi 9h07
+    plafond: 0.25
+    manqué: sauter
+  - workflow: workflows/nightly.nika.yaml
+    cadence: TZ=Europe/Paris 0 3 * * *
+    plafond: 0.10
+    manqué: rattraper
+",
+    )
+    .expect("registre");
+    // Mardi 10:00 Paris: l'hebdo vise lundi prochain, le quotidien demain.
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let (index, slot) = earliest_next(&reg, &now)
+        .expect("le plan")
+        .expect("un prochain créneau");
+    assert_eq!(index, 1, "le quotidien tire avant l'hebdo");
+    assert_eq!(slot.civil.to_string(), "2026-08-19T03:00:00");
+}
+
+#[test]
+fn due_an_already_fired_slot_is_not_due_again() {
+    // La borne STRICTE: last_fired == le créneau → déjà tiré, jamais deux fois.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let fired = zoned("2026-08-18T03:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert!(plan.is_empty(), "un créneau tiré ne se retire pas");
+}
+
+#[test]
+fn due_never_fired_and_outside_the_window_invents_no_backlog() {
+    // N2: pas d'état, pas de rattrapage inventé — seule la fenêtre compte.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert!(plan.is_empty(), "jamais tiré + hors fenêtre = pas dû");
+}
+
+#[test]
+fn the_on_time_window_is_five_minutes_to_the_second() {
+    // La borne de la fenêtre, des deux côtés: 03:05:00 pile est ON TIME,
+    // 03:05:01 est MISSED.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let fired = zoned("2026-08-17T03:00:00[Europe/Paris]");
+    let state = |_: usize| Some(fired.clone());
+    let edge = zoned("2026-08-18T03:05:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &edge, &state).expect("le plan").collect();
+    assert_eq!(
+        plan[0].kind,
+        DueKind::OnTime,
+        "à cinq minutes pile, à l'heure"
+    );
+    let late = zoned("2026-08-18T03:05:01[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &late, &state).expect("le plan").collect();
+    assert_eq!(
+        plan[0].kind,
+        DueKind::Missed { slots: 1 },
+        "une seconde plus tard, raté"
+    );
+}
+
+#[test]
+fn due_counts_every_slot_of_the_silence() {
+    // Deux jours de silence sur un beat quotidien = DEUX créneaux dus.
+    let reg = parse_registry(DUE_DAILY).expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let fired = zoned("2026-08-16T03:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert_eq!(plan[0].kind, DueKind::Missed { slots: 2 }, "le 17 ET le 18");
+}
+
+#[test]
+fn the_missed_count_saturates_at_the_cap() {
+    // Au-delà de dix mille créneaux le compte dit le cap: un silence
+    // plus long est une panne, pas un chiffre.
+    let hourly = DUE_DAILY.replace("0 3 * * *", "0 * * * *");
+    let reg = parse_registry(&hourly).expect("registre");
+    let now = zoned("2026-08-18T03:02:00[Europe/Paris]");
+    let fired = zoned("2025-06-26T00:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    #[allow(clippy::cast_possible_truncation)]
+    let cap = MISSED_SLOTS_CAP as u32;
+    assert_eq!(plan[0].kind, DueKind::Missed { slots: cap });
+}
+
+#[test]
+fn due_the_gap_fire_is_due_like_any_other() {
+    // Le créneau du gap a tiré à 03:00 CEST le 29 mars — un beat dont le
+    // dernier tir est la veille le doit À L'HEURE à 03:02. La vue du
+    // planificateur est le FEU (next_after porte l'avancé), pas le civil
+    // existant — sinon ce tir manqué tomberait dans un trou.
+    let gap = DUE_DAILY.replace("0 3 * * *", "30 2 * * *");
+    let reg = parse_registry(&gap).expect("registre");
+    let fired = zoned("2026-03-28T02:30:00[Europe/Paris]");
+    let now = zoned("2026-03-29T03:02:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| Some(fired.clone()))
+        .expect("le plan")
+        .collect();
+    assert_eq!(plan.len(), 1, "le tir avancé du gap est dû");
+    assert_eq!(plan[0].kind, DueKind::OnTime);
+    assert_eq!(
+        plan[0].slot.shift,
+        Shift::AdvancedFirstValid,
+        "le créneau dû DÉCLARE son déplacement"
+    );
+}
+
+#[test]
+fn a_webhook_beat_is_never_due_nor_next() {
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/hooked.nika.yaml
+    cadence: on-webhook
+    plafond: 0.10
+    manqué: sauter
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let plan: Vec<_> = due(&reg, &now, &|_| None).expect("le plan").collect();
+    assert!(plan.is_empty(), "un webhook n'a pas de calendrier");
+    assert_eq!(earliest_next(&reg, &now).expect("le prochain"), None);
+}
+
+#[test]
+fn due_a_cadence_that_breaks_the_law_refuses_the_plan() {
+    // Un registre qui a contourné validate (TZ absente) — le planificateur
+    // REFUSE le plan entier, il ne saute pas le beat en silence.
+    let reg = parse_registry(
+        "
+nika: v1
+arm:
+  - workflow: workflows/nightly.nika.yaml
+    cadence: 0 3 * * *
+    plafond: 0.10
+    manqué: sauter
+",
+    )
+    .expect("registre");
+    let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
+    let err = due(&reg, &now, &|_| None)
+        .map(Iterator::count)
+        .expect_err("le refus");
+    assert_eq!(err.kind(), CadenceErrorKind::TzMissing);
+    let err = earliest_next(&reg, &now)
+        .map(|slot| slot.map(|_| ()))
+        .expect_err("le refus");
+    assert_eq!(err.kind(), CadenceErrorKind::TzMissing);
+}
+
+// ── proptest · the inverse law, the gap's exception declared ────────
+
+proptest! {
+    #[test]
+    fn prev_before_and_next_after_are_mutual_inverses(secs in 0i64..=4_102_444_800) {
+        // La loi miroir, tout instant, toute cadence du corpus:
+        // prev_before(next_after(t) + 1s) == next_after(t). Exception
+        // DÉCLARÉE: le créneau AVANCÉ (gap DST) n'a jamais existé — il
+        // n'appartient pas à prev_before; la loi devient « le miroir rend
+        // l'existant d'avant, dont next_after retombe sur l'avancé ».
+        let corpus = [
+            "TZ=UTC 30 4 * * *",
+            "TZ=Europe/Paris 0 3 * * *",
+            "TZ=Europe/Paris 30 2 * * *", // traverse le gap ET le fold 2026
+            "TZ=Europe/Paris lundi 9h07",
+            "TZ=America/New_York 15 9 * * 1-5",
+        ];
+        let from = Timestamp::from_second(secs)
+            .expect("instant")
+            .to_zoned(TimeZone::UTC);
+        for expr in corpus {
+            let cad = Cadence::parse(expr).expect("cadence");
+            let next = cad.next_after(&from).expect("un prochain créneau");
+            let just_after = next
+                .at
+                .checked_add(jiff::Span::new().seconds(1))
+                .expect("+1s");
+            let prev = cad.prev_before(&just_after).expect("le miroir répond");
+            if next.shift == Shift::AdvancedFirstValid {
+                prop_assert!(prev.at < next.at, "{} · l'avancé n'est jamais RENDU", expr);
+                let round = cad.next_after(&prev.at).expect("next depuis l'existant");
+                prop_assert_eq!(
+                    &round.at,
+                    &next.at,
+                    "{} · next_after de l'existant retombe sur l'avancé",
+                    expr
+                );
+            } else {
+                prop_assert_eq!(&prev.at, &next.at, "{} · le miroir exact", expr);
+            }
+        }
+    }
+}

--- a/crates/nika-cadence/src/tests/planner.rs
+++ b/crates/nika-cadence/src/tests/planner.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::unreachable
+)]
 
 //! The W1 surface, pinned: `prev_before` (the mirror — at-or-before,
 //! the gap never returned, the fold's FIRST occurrence, the 366-day

--- a/crates/nika-cadence/src/tests/planner.rs
+++ b/crates/nika-cadence/src/tests/planner.rs
@@ -39,7 +39,7 @@ fn prev_before_is_the_mirror_of_next_after() {
                 .expect("span"),
         )
         .expect("next");
-    assert_eq!(back.at, prev.at, "next_after(prev − 1s) retombe sur prev");
+    assert_eq!(back.at, prev.at, "next_after(prev − 1s) retombe dessus");
 }
 
 #[test]
@@ -53,8 +53,8 @@ fn prev_before_at_the_slot_returns_the_slot_itself() {
 
 #[test]
 fn prev_before_walks_the_dst_gap_backwards() {
-    // N1 miroir · 2026-03-29, Paris avance 02:00 → 03:00: le 02:30 du 29
-    // n'a JAMAIS existé — il a tiré à 03:00 (le premier instant valide
+    // N1 miroir · 2026-03-29, Paris saute 02:00 → 03:00: le 02:30 du 29
+    // n'a JAMAIS existé — il a tiré à 03:00 (le premier instant licite
     // APRÈS), et ce tir-là appartient à next_after. Le miroir le saute
     // et rend le 28.
     let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
@@ -68,7 +68,7 @@ fn prev_before_walks_the_dst_gap_backwards() {
 fn prev_before_walks_the_dst_fold_backwards() {
     // N1 miroir · 2026-10-25, Paris recule 03:00 → 02:00: 02:30 existe
     // DEUX fois, le beat a tiré à la PREMIÈRE (00:30 UTC). Le miroir la
-    // rend — jamais la seconde occurrence, jamais deux fois.
+    // rend — jamais la 2e occurrence, jamais deux fois.
     let cad = Cadence::parse("TZ=Europe/Paris 30 2 * * *").expect("cadence");
     let from = zoned("2026-10-25T12:00:00[Europe/Paris]");
     let prev = cad.prev_before(&from).expect("slot");
@@ -79,7 +79,7 @@ fn prev_before_walks_the_dst_fold_backwards() {
         "la première occurrence"
     );
     assert_eq!(prev.shift, Shift::FoldedFirst, "le repli est DÉCLARÉ");
-    // …et le créneau d'avant est la VEILLE, pas la seconde occurrence.
+    // …et le créneau d'avant est la VEILLE, pas la 2e occurrence.
     let before = cad
         .prev_before(
             &prev
@@ -229,7 +229,7 @@ arm:
 fn earliest_next_a_tie_keeps_the_first_beat() {
     // Deux beats, même cadence, même prochain créneau — le PREMIER du
     // registre garde l'égalité (un dernier qui l'emporterait rendrait
-    // l'ordre du fichier mensonger). Tue le mutant `< → <=` sur la
+    // l'ordre du fichier mensonger). Tue le mutant `< → <=` dans la
     // comparaison du meilleur.
     let reg = parse_registry(
         "
@@ -293,13 +293,13 @@ fn the_on_time_window_is_five_minutes_to_the_second() {
     assert_eq!(
         plan[0].kind,
         DueKind::Missed { slots: 1 },
-        "une seconde plus tard, raté"
+        "03:05:01 — une respiration de trop, raté"
     );
 }
 
 #[test]
 fn due_counts_every_slot_of_the_silence() {
-    // Deux jours de silence sur un beat quotidien = DEUX créneaux dus.
+    // Deux jours de silence pour un beat quotidien = DEUX créneaux dus.
     let reg = parse_registry(DUE_DAILY).expect("registre");
     let now = zoned("2026-08-18T10:00:00[Europe/Paris]");
     let fired = zoned("2026-08-16T03:00:00[Europe/Paris]");
@@ -330,7 +330,7 @@ fn due_the_gap_fire_is_due_like_any_other() {
     // Le créneau du gap a tiré à 03:00 CEST le 29 mars — un beat dont le
     // dernier tir est la veille le doit À L'HEURE à 03:02. La vue du
     // planificateur est le FEU (next_after porte l'avancé), pas le civil
-    // existant — sinon ce tir manqué tomberait dans un trou.
+    // qui existe — sinon ce tir manqué tomberait dans un trou.
     let gap = DUE_DAILY.replace("0 3 * * *", "30 2 * * *");
     let reg = parse_registry(&gap).expect("registre");
     let fired = zoned("2026-03-28T02:30:00[Europe/Paris]");
@@ -401,7 +401,7 @@ proptest! {
         // prev_before(next_after(t) + 1s) == next_after(t). Exception
         // DÉCLARÉE: le créneau AVANCÉ (gap DST) n'a jamais existé — il
         // n'appartient pas à prev_before; la loi devient « le miroir rend
-        // l'existant d'avant, dont next_after retombe sur l'avancé ».
+        // le réel d'avant, dont next_after retombe dessus ».
         let corpus = [
             "TZ=UTC 30 4 * * *",
             "TZ=Europe/Paris 0 3 * * *",
@@ -422,11 +422,11 @@ proptest! {
             let prev = cad.prev_before(&just_after).expect("le miroir répond");
             if next.shift == Shift::AdvancedFirstValid {
                 prop_assert!(prev.at < next.at, "{} · l'avancé n'est jamais RENDU", expr);
-                let round = cad.next_after(&prev.at).expect("next depuis l'existant");
+                let round = cad.next_after(&prev.at).expect("next depuis le réel");
                 prop_assert_eq!(
                     &round.at,
                     &next.at,
-                    "{} · next_after de l'existant retombe sur l'avancé",
+                    "{} · next_after du réel retombe dessus",
                     expr
                 );
             } else {

--- a/crates/nika-cli/src/verbs/arm.rs
+++ b/crates/nika-cli/src/verbs/arm.rs
@@ -18,16 +18,22 @@
 //! the text, convert `&[ArmEntry] → Vec<Beat>`, or make cadence a pure
 //! calculator. Writing the verb answered it:
 //!
-//! **The conversion is REFUTED.** `Beat` carries `chevauchement:` and
-//! `après_saut:` — two policies `ArmEntry` does not have. Converting
-//! would drop them silently, which is the worst of the three.
+//! **The conversion is REFUTED.** `Beat` judges the VALUES of the
+//! cadence grammar's thirteen keys; `ArmEntry` carries eight of them
+//! VERBATIM (vocab judges the shape, cadence the law — law 8, deux
+//! parseurs jamais en désaccord). Converting one type into the other
+//! would duplicate the value judgments silently, which is the worst of
+//! the three.
 //!
 //! So the two parsers stay, and they are NOT duplicates: `nika-vocab`
 //! judges the project file's SHAPE (so a broken `arm:` refuses before
 //! any spend, alongside `ceiling:` and `registry:`), `nika-cadence`
 //! owns the cadence GRAMMAR and its policies. What they must never do
 //! is DISAGREE about the same bytes — so this verb checks that they
-//! counted the same beats, and refuses loudly if they did not.
+//! counted the same beats, and refuses loudly if they did not. (Until
+//! 2026-08-19 the vocab set was five keys and cadence's eight others
+//! were unreachable through the file — the divergence the flipped test
+//! below now pins CLOSED.)
 //!
 //! And the walk is not duplicated either: [`project::discover`] hands
 //! back the PATH it found, so the cadence parser reads the file the
@@ -250,64 +256,72 @@ mod tests {
         assert_ne!(out.code, exit::OK, "a lawless registry must refuse");
     }
 
-    /// ⭐ THE DIVERGENCE, PINNED — measured 2026-08-15.
+    /// ⭐ THE DIVERGENCE, CLOSED — measured 2026-08-15, fixed 2026-08-19.
     ///
     /// `nika-cadence::Beat` defines THIRTEEN keys; `nika_vocab::ArmEntry`
-    /// accepts FIVE. And `nika_vocab` runs FIRST (it is what `discover`
-    /// parses), so the other eight are UNREACHABLE through the project
-    /// file: the cadence grammar defines them, validates them, and no
-    /// author can ever write one.
+    /// used to accept FIVE, and `nika_vocab` runs FIRST (it is what
+    /// `discover` parses), so the other eight were UNREACHABLE through
+    /// the project file: the cadence grammar defined them, validated
+    /// them, and no author could write one (measured again 2026-08-18:
+    /// a file carrying `chevauchement:` cost `nika arm` exit 2 and
+    /// `nika run` exit 3, `project.unknown-key`).
     ///
-    /// Among the unreachable: `actif:` — the disarm switch that law N4
-    /// says is the ONLY way to disarm (« removing a line does NOT
+    /// The close keeps the two parsers on their own planes (law 8 —
+    /// deux parseurs, jamais en désaccord): vocab judges the SHAPE and
+    /// carries the cadence arc's eight keys VERBATIM (`actif` alone is
+    /// shape-judged, a bool); the VALUES' law stays cadence's. A
+    /// `chevauchement: nimporte` passes vocab and is refused by
+    /// cadence — the agreement is on the key SET, never on the
+    /// semantics.
+    ///
+    /// Among the newly reachable: `actif:` — the disarm switch that law
+    /// N4 says is the ONLY way to disarm (« removing a line does NOT
     /// disarm ») — and `chevauchement:`/`après_saut:`, the whole of law
-    /// ⑥. The overlap policy this verb reports is a policy nobody can
-    /// set.
+    /// ⑥. The overlap policy this verb reports is a policy an author
+    /// can now set.
     ///
-    /// This test does not FIX the gap (widening `ArmEntry` means
-    /// duplicating cadence's enums at L0, narrowing `Beat` means
-    /// deleting a grammar its crate was built for — an operator's
-    /// arbitration, not a session's). It makes the gap VISIBLE, so
-    /// closing it either way is a deliberate act and not a surprise.
+    /// This test pins the fixed state: the thirteen keys written
+    /// together pass BOTH readers — the report is green, one beat, and
+    /// (suspended as it is) it is REPORTED, never computed.
     #[test]
-    fn eight_cadence_keys_are_unreachable_through_the_project_file() {
-        const CADENCE_ONLY: &[&str] = &[
-            "chevauchement: sauter",
-            "après_saut: prochain-créneau",
-            "actif: false",
-            "raison: \"pause\"",
-            "jusqu_au: \"2026-12-31\"",
-            "tolérance: \"5m\"",
-            "décalage: \"1m\"",
-            "par: \"thibaut\"",
-        ];
-        for key in CADENCE_ONLY {
-            let body = format!(
-                concat!(
-                    "nika: v1\n",
-                    "arm:\n",
-                    "  - workflow: w.nika.yaml\n",
-                    "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
-                    "    plafond: 0.25\n",
-                    "    manqué: sauter\n",
-                    "    {}\n",
-                ),
-                key
-            );
-            // The cadence grammar KNOWS it …
-            assert!(
-                nika_cadence::parse::parse_registry(&body).is_ok(),
-                "cadence must accept `{key}` — it is in its closed set"
-            );
-            // … and the project shape refuses it first.
-            let dir = project_at("gap", &body);
-            let out = run_at(dir.path());
-            assert_ne!(
-                out.code,
-                exit::OK,
-                "`{key}` reaches the cadence grammar today — the gap closed, \
-                 update this pin (and say which way it closed)"
-            );
-        }
+    fn every_cadence_key_is_reachable_through_the_project_file() {
+        let body = concat!(
+            "nika: v1\n",
+            "arm:\n",
+            "  - workflow: w.nika.yaml\n",
+            "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
+            "    où: local\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "    chevauchement: sauter\n",
+            "    après_saut: prochain-créneau\n",
+            "    actif: false\n",
+            "    raison: \"pause estivale\"\n",
+            "    jusqu_au: \"2026-12-31\"\n",
+            "    tolérance: \"3/4\"\n",
+            "    décalage: hash\n",
+            "    par: \"thibaut\"\n",
+        );
+        // The cadence grammar knows all thirteen …
+        assert!(
+            nika_cadence::parse::parse_registry(body).is_ok(),
+            "cadence accepts its own closed set"
+        );
+        // … and so does the project shape, FIRST — the whole file is
+        // lawful to both readers, and the verb's report is green.
+        let dir = project_at("closed", body);
+        let out = run_at(dir.path());
+        assert_eq!(
+            out.code,
+            exit::OK,
+            "the thirteen keys pass both readers: {}",
+            out.text
+        );
+        assert!(out.text.contains("1 beat"), "{}", out.text);
+        assert!(
+            out.text.contains("[idle ]"),
+            "actif: false is REPORTED, never computed: {}",
+            out.text
+        );
     }
 }

--- a/crates/nika-vocab/public-api.txt
+++ b/crates/nika-vocab/public-api.txt
@@ -656,10 +656,18 @@ pub unsafe fn nika_vocab::project::ProvenanceFloor::clone_to_uninit(&self, dest:
 impl<T> core::convert::From<T> for nika_vocab::project::ProvenanceFloor
 pub fn nika_vocab::project::ProvenanceFloor::from(t: T) -> T
 #[non_exhaustive] pub struct nika_vocab::project::ArmEntry
+pub nika_vocab::project::ArmEntry::actif: core::option::Option<bool>
+pub nika_vocab::project::ArmEntry::apres_saut: core::option::Option<alloc::string::String>
 pub nika_vocab::project::ArmEntry::cadence: alloc::string::String
+pub nika_vocab::project::ArmEntry::chevauchement: core::option::Option<alloc::string::String>
+pub nika_vocab::project::ArmEntry::decalage: core::option::Option<alloc::string::String>
+pub nika_vocab::project::ArmEntry::jusqu_au: core::option::Option<alloc::string::String>
 pub nika_vocab::project::ArmEntry::manque: nika_vocab::project::MissPolicy
 pub nika_vocab::project::ArmEntry::ou: core::option::Option<nika_vocab::project::ArmLocus>
+pub nika_vocab::project::ArmEntry::par: core::option::Option<alloc::string::String>
 pub nika_vocab::project::ArmEntry::plafond: f64
+pub nika_vocab::project::ArmEntry::raison: core::option::Option<alloc::string::String>
+pub nika_vocab::project::ArmEntry::tolerance: core::option::Option<alloc::string::String>
 pub nika_vocab::project::ArmEntry::workflow: alloc::string::String
 impl core::clone::Clone for nika_vocab::project::ArmEntry
 pub fn nika_vocab::project::ArmEntry::clone(&self) -> nika_vocab::project::ArmEntry

--- a/crates/nika-vocab/src/project.rs
+++ b/crates/nika-vocab/src/project.rs
@@ -24,9 +24,11 @@
 //!   never lower the operator's — the only non-downgrade read).
 //! - `arm:` — parsed + shape-validated ONLY. The cadence/arm RUNTIME
 //!   is another arc (`crates/nika-cadence` owns the law pass); this
-//!   module validates the entry shape against the locked vocabulary
-//!   and exposes the entries so that arc can consume them later. The
-//!   French keys are the registry's own (`où` · `plafond` · `manqué`).
+//!   module validates the entry shape against the registry's THIRTEEN
+//!   keys and exposes the entries so that arc can consume them later.
+//!   Five are judged here (`workflow` · `cadence` · `où` · `plafond` ·
+//!   `manqué`); the cadence arc's eight ride verbatim, their values
+//!   judged THERE (law 8 — deux parseurs, jamais en désaccord).
 //!
 //! NO `seat`, NO `profile`, NO permits here — the portability test
 //! (D-2026-08-10-N2) rejected them; the file carries exactly five
@@ -178,6 +180,13 @@ impl std::fmt::Display for ProvenanceFloor {
 /// REQUIRED in the file (the pay law · the run-missed law — a default
 /// would either spend what nobody asked for or lose a deliverable in
 /// silence); the parser refuses their absence by name.
+///
+/// The cadence arc's eight further keys ride VERBATIM
+/// (`Option<String>` — only `actif` is judged, a bool: the same
+/// non-coercion shape law as `ceiling:`). Their VALUES are never
+/// judged here: the grammar lives in `nika-cadence` (law 8 — deux
+/// parseurs, jamais en désaccord), so a `chevauchement: nimporte`
+/// passes this gate and is refused by the cadence one.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct ArmEntry {
@@ -195,6 +204,29 @@ pub struct ArmEntry {
     pub plafond: f64,
     /// `manqué:` — what « missed » means, REQUIRED, no default.
     pub manque: MissPolicy,
+    /// `chevauchement:` — the overlap policy, verbatim (the closed
+    /// enum is the cadence arc's law).
+    pub chevauchement: Option<String>,
+    /// `après_saut:` — the after-skip policy, verbatim (same law).
+    pub apres_saut: Option<String>,
+    /// `actif:` — the declared INTENTION (`false` = suspended). The
+    /// one judged shape among the eight: a bool, unquoted.
+    pub actif: Option<bool>,
+    /// `raison:` — why the beat is suspended, verbatim (REQUIRED when
+    /// `actif: false` — the cadence arc's law, not this gate's).
+    pub raison: Option<String>,
+    /// `jusqu_au:` — the suspension expiry, verbatim (the ISO-date law
+    /// is the cadence arc's).
+    pub jusqu_au: Option<String>,
+    /// `tolérance:` — the (m,k)-firm form, verbatim (the `m/k` law is
+    /// the cadence arc's).
+    pub tolerance: Option<String>,
+    /// `décalage:` — the jitter form, verbatim (only `hash` exists —
+    /// the cadence arc's law).
+    pub decalage: Option<String>,
+    /// `par:` — DECLARES the human (N3 — proves NOTHING: the machine's
+    /// key is what authorizes).
+    pub par: Option<String>,
 }
 
 /// `où:` — the deployment locus (`local | cloud`). Mirrors the

--- a/crates/nika-vocab/src/project/parse.rs
+++ b/crates/nika-vocab/src/project/parse.rs
@@ -25,9 +25,24 @@ use std::time::Duration;
 const TRACES_KEYS: &[&str] = &["keep"];
 /// The closed `registry:` key set.
 const REGISTRY_KEYS: &[&str] = &["floor"];
-/// The closed `arm:` entry key set (the locked example vocabulary —
-/// the cadence arc's wider law pass owns anything beyond it).
-const ARM_ENTRY_KEYS: &[&str] = &["workflow", "cadence", "où", "plafond", "manqué"];
+/// The closed `arm:` entry key set — the registry's THIRTEEN keys
+/// (the cadence arc's `Beat` defines them; this gate accepts them all
+/// and judges only the five that are its own).
+const ARM_ENTRY_KEYS: &[&str] = &[
+    "workflow",
+    "cadence",
+    "où",
+    "plafond",
+    "manqué",
+    "chevauchement",
+    "après_saut",
+    "actif",
+    "raison",
+    "jusqu_au",
+    "tolérance",
+    "décalage",
+    "par",
+];
 
 /// Parse the project file text (syntax + shape laws — no I/O, no
 /// cross-reference). An EMPTY (or whitespace-only) text is an empty
@@ -199,7 +214,10 @@ fn parse_arm(value: &Node) -> Result<Vec<ArmEntry>, ProjectError> {
 
 /// One `arm:` entry. `plafond` and `manqué` are REQUIRED (the pay law
 /// · the run-missed law — a default for either is a silent spend or a
-/// silent loss); the parser refuses their absence by name.
+/// silent loss); the parser refuses their absence by name. The cadence
+/// arc's eight further keys are read WITHOUT their values judged
+/// (verbatim — only `actif` is shape-judged, a bool); a value outside
+/// the cadence law passes here and is refused THERE.
 fn parse_arm_entry(node: &Node) -> Result<ArmEntry, ProjectError> {
     let Node::Mapping(mapping) = node else {
         return Err(wrong_shape("an arm entry", "a mapping", node));
@@ -209,6 +227,14 @@ fn parse_arm_entry(node: &Node) -> Result<ArmEntry, ProjectError> {
     let mut ou = None;
     let mut plafond = None;
     let mut manque = None;
+    let mut chevauchement = None;
+    let mut apres_saut = None;
+    let mut actif = None;
+    let mut raison = None;
+    let mut jusqu_au = None;
+    let mut tolerance = None;
+    let mut decalage = None;
+    let mut par = None;
     for (key, value) in mapping.iter() {
         let name = key.as_str();
         match name {
@@ -217,6 +243,14 @@ fn parse_arm_entry(node: &Node) -> Result<ArmEntry, ProjectError> {
             "où" => ou = Some(locus(value)?),
             "plafond" => plafond = Some(usd(value, "plafond")?),
             "manqué" => manque = Some(miss_policy(value)?),
+            "chevauchement" => chevauchement = Some(verbatim(value, name)?),
+            "après_saut" => apres_saut = Some(verbatim(value, name)?),
+            "actif" => actif = Some(switch(value)?),
+            "raison" => raison = Some(verbatim(value, name)?),
+            "jusqu_au" => jusqu_au = Some(verbatim(value, name)?),
+            "tolérance" => tolerance = Some(verbatim(value, name)?),
+            "décalage" => decalage = Some(verbatim(value, name)?),
+            "par" => par = Some(verbatim(value, name)?),
             _ => return Err(unknown_key(name, ARM_ENTRY_KEYS, key.span())),
         }
     }
@@ -258,6 +292,14 @@ fn parse_arm_entry(node: &Node) -> Result<ArmEntry, ProjectError> {
                 "manqué: rattraper · rattraper-une-fois · sauter",
             )
         })?,
+        chevauchement,
+        apres_saut,
+        actif,
+        raison,
+        jusqu_au,
+        tolerance,
+        decalage,
+        par,
     })
 }
 
@@ -312,6 +354,28 @@ fn miss_policy(value: &Node) -> Result<MissPolicy, ProjectError> {
             ProjectErrorKind::BadValue,
             format!("`manqué: {raw}` — unknown missed-run policy"),
             "manqué: rattraper · rattraper-une-fois · sauter",
+            line_of(value.span()),
+        )
+    })
+}
+
+/// One of the cadence arc's own keys — a scalar, stored VERBATIM. The
+/// value's LAW (the closed enums · the ISO date · the `m/k` form) is
+/// the cadence arc's: deux parseurs, jamais en désaccord — each judges
+/// its own plane, and this plane is the SHAPE.
+fn verbatim(value: &Node, key: &str) -> Result<String, ProjectError> {
+    Ok(scalar(value, key)?.as_str().to_owned())
+}
+
+/// `actif:` — a bool, the one judged shape among the cadence arc's
+/// eight. A quoted `"false"` refuses, the same non-coercion law as
+/// `ceiling:` (a string that silently became a switch is the lie class).
+fn switch(value: &Node) -> Result<bool, ProjectError> {
+    scalar(value, "actif")?.as_bool().ok_or_else(|| {
+        ProjectError::at(
+            ProjectErrorKind::BadValue,
+            "`actif:` must be a bool (`true` · `false`, unquoted)",
+            "actif: false — the suspension itself is told by `raison:` + `jusqu_au:` (the cadence arc's law)",
             line_of(value.span()),
         )
     })

--- a/crates/nika-vocab/src/project/tests.rs
+++ b/crates/nika-vocab/src/project/tests.rs
@@ -112,16 +112,9 @@ fn unknown_keys_refuse_by_name_with_their_line() {
     assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
     assert_eq!(err.line(), Some(3));
 
-    // An `arm:` entry — the cadence arc's wider vocabulary
-    // (`chevauchement` and friends) is NOT this file's: refused by
-    // name until the arc widens the set.
-    let err = parse(
-        "nika: v1\narm:\n  - workflow: w.nika.yaml\n    cadence: \"lundi 9h00\"\n    plafond: 1.00\n    manqué: sauter\n    chevauchement: sauter\n",
-    )
-    .unwrap_err();
-    assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
-    assert_eq!(err.line(), Some(7));
-    assert!(err.detail().contains("chevauchement"), "{err}");
+    // The `arm:` entry level is pinned by
+    // `a_fourteenth_key_still_refuses_by_name` — since 2026-08-19 the
+    // cadence arc's full thirteen-key vocabulary IS this file's.
 }
 
 /// Malformed YAML refuses with the grammar's name AND a line — the
@@ -295,6 +288,64 @@ fn arm_entries_validate_their_shape() {
         let err = parse(doc).unwrap_err();
         assert_eq!(err.kind(), ProjectErrorKind::BadValue, "{doc}: {err}");
     }
+}
+
+/// The cadence arc's THIRTEEN keys all pass the shape gate — measured
+/// 2026-08-18, eight of them were refused as unknown (`project.unknown-key`,
+/// `nika arm` exit 2 · `nika run` exit 3) while the cadence grammar
+/// defined and validated them. The grammar lives in `nika-cadence`
+/// (`registry.rs`); this file judges the SHAPE only, so a project file
+/// carrying the thirteen keys must refuse NEITHER `nika arm` NOR
+/// `nika run` — and a value outside cadence's law (`chevauchement:
+/// nimporte`) still passes HERE and is refused THERE (law 8 — deux
+/// parseurs, jamais en désaccord).
+#[test]
+fn the_thirteen_beat_keys_are_reachable_through_the_project_file() {
+    let src = "nika: v1\nceiling: 0.50\narm:\n  - workflow: t.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n    plafond: 0.10\n    manqué: sauter\n    chevauchement: file\n    après_saut: prochain-créneau\n    actif: false\n    raison: pause estivale\n    jusqu_au: 2026-09-01\n    tolérance: 3/4\n    décalage: hash\n    par: thibaut\n    où: local\n";
+    let project = parse(src).expect("13 keys are the shape · none is unknown");
+    assert_eq!(project.arm().len(), 1);
+    let beat = &project.arm()[0];
+    assert_eq!(beat.actif, Some(false), "the one judged shape: a bool");
+    assert_eq!(beat.chevauchement.as_deref(), Some("file"));
+    assert_eq!(beat.apres_saut.as_deref(), Some("prochain-créneau"));
+    assert_eq!(beat.raison.as_deref(), Some("pause estivale"));
+    assert_eq!(beat.jusqu_au.as_deref(), Some("2026-09-01"));
+    assert_eq!(beat.tolerance.as_deref(), Some("3/4"));
+    assert_eq!(beat.decalage.as_deref(), Some("hash"));
+    assert_eq!(beat.par.as_deref(), Some("thibaut"));
+
+    // A value outside cadence's law passes THIS gate untouched — the
+    // grammar refuses it downstream, never here (law 8).
+    let nimporte = src.replace("chevauchement: file", "chevauchement: nimporte");
+    assert_eq!(
+        parse(&nimporte).expect("shape ok").arm()[0]
+            .chevauchement
+            .as_deref(),
+        Some("nimporte"),
+        "vocab judges the shape, cadence the grammar"
+    );
+    // …but `actif:` non-bool IS a shape refusal here.
+    let quoted = src.replace("actif: false", "actif: \"false\"");
+    let err = parse(&quoted).unwrap_err();
+    assert_eq!(err.kind(), ProjectErrorKind::BadValue, "{err}");
+}
+
+/// The closed set still bites: a FOURTEENTH key, outside the thirteen,
+/// refuses by name with its line — widening the grammar never meant
+/// opening it.
+#[test]
+fn a_fourteenth_key_still_refuses_by_name() {
+    let err = parse(
+        "nika: v1\narm:\n  - workflow: w.nika.yaml\n    cadence: \"lundi 9h00\"\n    plafond: 1.00\n    manqué: sauter\n    quatorze: true\n",
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
+    assert_eq!(err.line(), Some(7));
+    assert!(err.detail().contains("quatorze"), "{err}");
+    assert!(
+        err.remedy().contains("chevauchement"),
+        "the remedy now names the thirteen: {err}"
+    );
 }
 
 /// Discovery walks UP from a nested dir, the first file found

--- a/docs/crate-specs/nika-cadence.md
+++ b/docs/crate-specs/nika-cadence.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| Status | **CANDIDATE** — Gate 1 (this document) authored 2026-08-11. Crafted shim-standalone (50 tests today, 45 at authoring · clippy 0 `-D warnings` · rustfmt clean) · committed with the temporary `[workspace]` shim (`92a0f8497`), then the four pre-freeze corrections of plan §2unvicies (the bitset's ONE encoding · `Slot` declares the DST shift · the field count is the type · the error span). The two items this row used to name (the allowlist row, the shim removal) are BOTH DONE; the row described work already shipped. Remaining before admission, measured 2026-08-13: the Gate 11 P1 below, and Gate 5 at 88 percent against a 90 floor. |
+| Status | **CANDIDATE** — Gate 1 (this document) authored 2026-08-11. Crafted shim-standalone (50 tests today, 45 at authoring · clippy 0 `-D warnings` · rustfmt clean) · committed with the temporary `[workspace]` shim (`92a0f8497`), then the four pre-freeze corrections of plan §2unvicies (the bitset's ONE encoding · `Slot` declares the DST shift · the field count is the type · the error span). The two items this row used to name (the allowlist row, the shim removal) are BOTH DONE; the row described work already shipped. Remaining before admission, measured 2026-08-13: the Gate 11 P1 below, and Gate 5 at 88 percent against a 90 floor. **W1, measured 2026-08-19**: 79 tests green (`cargo test -p nika-cadence --lib`) · `Cadence::prev_before` (the mirror, 366-day bound) · the `due` planner (`due` · `earliest_next` · `DueKind` · `ON_TIME_WINDOW`) — the pure half the `fire`/`serve` edges read; `emit` lands in W3 (planned, see §3). Gate 5 re-run this wave; the floor holds ≥90. |
 | Layer | L0 — pure, zero I/O, zero async |
 | Design | The arming-registry grammar (the `arm:` block of `nika.yaml`, D-2026-08-10-N3) + the pure next-slot calculator. Hand-counted 5-field cron (zero cron library — the count is validated BEFORE field semantics, scar #6) · IANA zones resolved from the EMBEDDED tzdb only (`jiff-tzdb`, never the host's zoneinfo) · two cadence forms (cron + readable `lundi 9h07`), display normalizing to the readable one. |
 | LOC budget | ≤2,000 src prod (post-corrections 1,467 prod + 753 cfg(test)) · ≤15,000 hard cap |
@@ -70,8 +70,11 @@ time — the caller sleeps, never the calculator) · host zone resolution
   out slices or iterators) · `#[non_exhaustive]` on public-field
   structs (FCI-016) · wire tag frozen at `nika: v1` (FCI-003) <!-- stale-ok: the PROJECT file (nika.yaml) · the engine still freezes v1 here while spec 01 says nika: <name> · engine work owed -->
 - the day walk happens in the BEAT's zone — a Monday slot is Monday in
-  Paris, whatever zone `from` rides · horizon 1,500 days (a 29 February
-  is never further than 4 years)
+  Paris, whatever zone `from` rides · horizon 3,000 days forward (a
+  century year is leap only when divisible by 400: from 2096-03-01 the
+  next 29 February is 2,920 days out — the 1,500-day horizon died on
+  that, §6.2) · 366 days backward (`prev_before`: the recent past a
+  planner asks about, never an archaeology)
 
 ## 3. Public surface
 
@@ -82,20 +85,42 @@ is the TYPE — `parse_cron_fields(&[&str; 5])`, scar #6 is the
 compiler's) · `Cadence::next_after(&Zoned) -> Option<Slot>` where
 `Slot { at, civil, shift }` DECLARES the DST displacement
 (`Shift::{Exact, AdvancedFirstValid, FoldedFirst}` — N1 at the type
-level; a merged slot says so) · `Cadence::describe() -> String` (the
+level; a merged slot says so) · `Cadence::prev_before(&Zoned) ->
+Option<Slot>` (W1 — the mirror: strictly-after there, at-or-before
+here, the two bound the half-open interval `(prev, next]` a beat is
+due in; 366-day walk; the gap's advanced slot is never RETURNED —
+`next_after` carries it) · `Cadence::describe() -> String` (the
 readable form wins, full fields print `*` — the bitset's one
-encoding) · `phrase::next_slots(&Cadence, &Zoned, usize) -> impl
+encoding) · `next::next_slots(&Cadence, &Zoned, usize) -> impl
 Iterator<Item = Slot>` · `ArmRegistry::{SCHEMA, beats, beat_count}` ·
 `Beat::{locus, overlap, after_skip, is_active}` · `CronSpec` field
 accessors handing out `Field<LO, HI>` (the bitset: `contains` ·
-`iter` · `single` · `is_full` · 8 bytes · `Copy` · zero alloc) ·
+`iter` — double-ended since W1, the backwards walk rides `.rev()` —
+`single` · `is_full` · 8 bytes · `Copy` · zero alloc) ·
 `CadenceError{kind, detail, remedy, on, span}` (the span paints the
 faulty byte, the `CelError` precedent) + `CadenceErrorKind::
 spec_code()`.
 
+**W1 — the pure planner (`due` module), the half both firing edges
+read** (`fire` at W2 · `serve` at W5): `due(&ArmRegistry, &Zoned, &dyn
+Fn(usize) -> Option<Zoned>) -> Result<impl Iterator<Item = Due>,
+CadenceError>` — active · local beats whose previous slot falls in
+`(last_fired, now]`, the firing state arriving as a CALLBACK (N2: the
+crate computes slots, never carries run state) · `earliest_next(
+&ArmRegistry, &Zoned) -> Result<Option<(usize, Slot)>, CadenceError>`
+— what the edge sleeps until · `Due { index, beat, slot, kind }` ·
+`DueKind::{OnTime, Missed { slots }}` (the silence counted whole over
+the FIRE set — the gap's advanced fire included — saturated at
+`MISSED_SLOTS_CAP` = 10,000) · `ON_TIME_WINDOW` = 5 minutes (a
+`SignedDuration`: absolute time, and `Span`'s builders are not `const`
+in jiff 0.2). **Planned, not landed**: `emit` (the launchd/systemd
+projection) is W3's — this crate stays the pure half; the OS
+rendering lands with its own spec amendment.
+
 ## 4. Tests
 
-50 today, 45 at authoring (the four pre-freeze corrections added five that
+79 today (W1, 2026-08-19 — 50 before the wave; the planner and the
+mirror added the rest), 45 at authoring (the four pre-freeze corrections added five that
 were described in prose here without being recounted): parse (both forms ·
 TZ-less refused · 6 fields refused
 by the TYPE · out-of-range · Vixie OR judged on the sets (`1-31` dom is
@@ -105,13 +130,24 @@ every day) · unknown zone · 7-is-dimanche · spans pin the faulty token)
 fires 03:00 CEST with `Shift::AdvancedFirstValid`, the 2026-10-25 fold
 fires once with `Shift::FoldedFirst`, and the gap-day merge
 `0,30 2,3 * * *` is visible in the returned slots — 4 civil slots, 2
-fires, the absorbing fire declared) · the two-encodings regression
+fires, the absorbing fire declared) · **the mirror (W1)**: at-or-before
+· the slot at the instant itself · gap walked backwards (the advanced
+slot is never returned) · fold walked backwards (the first occurrence,
+then the EVE — never the second) · the 366-day bound (a 29 February
+three years back is `None`) · month/year crossing backwards · **the
+planner (W1)**: on-time due once · missed with the silence counted ·
+idle/cloud never due · already-fired never re-due · never-fired invents
+no backlog (N2) · the 5-minute window to the second · the 10,000 cap ·
+the gap fire due like any other (the fire-set read) · a law-breaking
+cadence refuses the whole plan · the two-encodings regression
 (`describe("* * * * *")` stays 5 fields, not 244 chars) · validate
 (every law, every refusal teaching its fix) · the embedded tzdb proven
 twice (behavioral Paris offsets + a static source guard: no non-comment
 line may name the host-preferring resolvers) · proptest (parse never
 panics · law pass never panics · a daily slot is strictly later and
-within a day). Mutation floor: run `check-mutation-floor.sh` at
+within a day · **the inverse law (W1)**: `prev_before(next_after(t) +
+1s) == next_after(t)` over the corpus, the gap slot's exception
+declared). Mutation floor: run `check-mutation-floor.sh` at
 admission.
 
 ## 5. Non-goals / guards

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 772
-  aggregate_sha256: ff711a35de26b038df77f6561b579c8f2fcaeccce9fe0d0f5aa5b7d6687d13d4
+  aggregate_sha256: 33e636a9b0fa6dcc821b2e38d64fea71ca97f881093dfc4dddb06f44a5b877f1
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4471
+  classified_files: 4472
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1534
+    authored: 1535
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 771
-  aggregate_sha256: 030ac51ab8b0c2101e3fd26b9c4291d3bdc64b9fa862ea81c0c8ec3e3fa7c4aa
+  match_count: 772
+  aggregate_sha256: ff711a35de26b038df77f6561b579c8f2fcaeccce9fe0d0f5aa5b7d6687d13d4
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 106
-  aggregate_sha256: 28bb4d9773bc6004fde0426350553a4332903d536d16cf5d51ca67f0279bf9de
+  aggregate_sha256: 5a98ec363fc90ad4c2f76001015e87acaa1366a53ca12e409586da004298bd43
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: bf11e999b2702682cfcacb213a6333703d52ced6af06aeae840ff08d41f92c3e
+  aggregate_sha256: b2ea6cab5d6c53780910df9896db5ca38f5cb5983a9fc795f795ea40a4150e16
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 106
-  aggregate_sha256: a1f0bf5a1caed2eaf600c59c2400b41f885fb5089c070d4c02f2c407eb176bcf
+  aggregate_sha256: 28bb4d9773bc6004fde0426350553a4332903d536d16cf5d51ca67f0279bf9de
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4470
+  classified_files: 4471
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1533
+    authored: 1534
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 770
-  aggregate_sha256: 481a583329251ee9bda0c3f5160c9f8fcf39a60e699ec09b23466a4abb6461fe
+  match_count: 771
+  aggregate_sha256: 030ac51ab8b0c2101e3fd26b9c4291d3bdc64b9fa862ea81c0c8ec3e3fa7c4aa
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 772
-  aggregate_sha256: 33e636a9b0fa6dcc821b2e38d64fea71ca97f881093dfc4dddb06f44a5b877f1
+  aggregate_sha256: 575d90ea926bbacb0a2ed8269b54b2043388e68acf30b47c536b8f5576539d5f
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 770
-  aggregate_sha256: 1df0cb7f65f94fe0d2455177983f95c4b1527ce72b8273cbb1d4f2e6d3e4bbcb
+  aggregate_sha256: 955e54bbc041774d937b9a75347680fef0ee17bfe9c1d08e9c2615ea69d8b195
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 770
-  aggregate_sha256: 955e54bbc041774d937b9a75347680fef0ee17bfe9c1d08e9c2615ea69d8b195
+  aggregate_sha256: 481a583329251ee9bda0c3f5160c9f8fcf39a60e699ec09b23466a4abb6461fe
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 772
-  aggregate_sha256: 575d90ea926bbacb0a2ed8269b54b2043388e68acf30b47c536b8f5576539d5f
+  aggregate_sha256: 18e6754d78e955dd2eeb3157e717cc8fc72698350248c0d400f12067a88237b5
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## W1 · LA GRAMMAIRE S'OUVRE

The first wave of the ARM + SERVE arc: the project file's `arm:` block becomes fully writable, and `nika-cadence` gains the pure halves the firing edges (`fire` at W2 · `serve` at W5) will read.

### What ships

- **vocab accepts the thirteen beat keys (FORM only).** `nika_vocab::ArmEntry` carried 5 of the 13 keys `nika_cadence::Beat` defines, and vocab runs BEFORE cadence — so `chevauchement:`, `après_saut:`, `actif:`, `raison:`, `jusqu_au:`, `tolérance:`, `décalage:`, `par:` were unreachable through `nika.yaml` (measured 2026-08-18: `nika arm` exit 2 · `nika run` exit 3 · `project.unknown-key`). The eight keys now ride VERBATIM (`Option<String>`; only `actif` is shape-judged, a bool — the non-coercion law, same as `ceiling:`). Law 8 holds: deux parseurs, jamais en désaccord — vocab judges the shape, cadence the grammar; a `chevauchement: nimporte` passes vocab and is refused by cadence. A fourteenth key still refuses by name with its line. The pinned divergence test in `crates/nika-cli/src/verbs/arm.rs` flips to `every_cadence_key_is_reachable_through_the_project_file`.
- **`Cadence::prev_before`** — the mirror of `next_after`: strictly-after there, at-or-before here, so the two bound the half-open interval `(prev, next]` a beat is due in. Day walk backwards in the beat's zone (hours · minutes descending on the same bitsets — `Field::iter` is double-ended by construction), 366-day bound. The N1 law in mirror: a slot that never existed (spring gap) is never returned — `next_after` carries it; a fold hands back its FIRST occurrence. Proptest pins the inverse law over the corpus, with the gap slot's exception declared.
- **`due` — the pure planner.** `due(&ArmRegistry, &Zoned, &dyn Fn(usize) -> Option<Zoned>)` and `earliest_next(...)`. Active · local beats whose previous slot falls in `(last_fired, now]`, read over the FIRE set (`next_slots`) so the gap's advanced fire is a fire like any other. `DueKind::{OnTime, Missed { slots }}` with `ON_TIME_WINDOW` = 5 min (`SignedDuration` — `Span`'s builders are not `const` in jiff 0.2) and the silence count saturated at `MISSED_SLOTS_CAP` = 10 000. Never-fired invents no backlog (N2).
- **The crate-spec tells today's truth** (81 tests, the horizon fix in §2, the W1 surface in §3, `emit` named as W3-planned) and the two `public-api.txt` snapshots regenerate (the diffs are exactly the W1 additions).

### Measured

- Probe replay (fresh tempdir, debug binary): `nika arm` **0** (1 beat) · `nika run t.nika.yaml` **0** · `nika run t2.nika.yaml` **0** — the `0/0/0` (was 2/3 on the unknown key).
- `cargo test -p nika-vocab --lib`: **98** green · `-p nika-cadence --lib`: **81** green · `-p nika-cli --lib`: **226** green.
- clippy `-D warnings` on the three crates · `cargo fmt --check` workspace · crate-size OK · loc-limits OK (the test module split at the 1,500 cap: `tests/mod.rs` + `tests/planner.rs`).
- **Gate 5** (`check-mutation-floor.sh nika-cadence`, floor 90): **93 percent killed (226/241 viable)** — the wave did not lower it. Two killer tests added (the Apia 24 h gap pins the 26 h stepping bound · the earliest_next tie keeps the first beat); the two new-code survivors from the first pass were re-proven caught by hand-mutation. Remaining survivors are the documented pre-existing `cron.rs` class (§6.5).
- CI repairs along the way: `Signed-off-by` trailers added across the series (the gate's prescribed `git rebase --signoff`), and the planner pins' French reworded per the typos.toml law (rewrite, never allowlist).

Draft — W2 (`nika arm fire` + state + report) and W3 (`emit` launchd/systemd) land on top.
