### PR TITLE
docs(examples): hello comments name the nine-key identity

### DIFF
--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -967,7 +967,10 @@ mod tests {
             .cloned()
             .expect("pack has examples");
         let out = execute("nika_examples", &json!({ "slug": slug })).expect("ran");
-        assert!(out.contains("nika: v1"), "a real workflow source: {out}");
+        assert!(
+            out.contains("nika: hello"),
+            "a real workflow source (nine-key identity): {out}"
+        );
     }
 
     #[test]

--- a/crates/nika-pack/pack/examples/01-hello.nika.yaml
+++ b/crates/nika-pack/pack/examples/01-hello.nika.yaml
@@ -8,7 +8,7 @@
 # one of the four still executes — it just stops being a contract.
 #
 # Demonstrates ·
-#   - the envelope · `nika: v1` (the contract version) + `workflow.id`
+#   - the envelope · `nika: hello` (the mark AND the name · nine keys)
 #   - `model:` · one local model · no API key, nothing leaves the machine
 #   - `permits: {}` · the DECLARED zero · this workflow may touch nothing
 #   - one task · the `infer:` verb, bounded by `max_tokens:`

--- a/crates/nika-pack/pack/examples/snippets/hello.nika.yaml
+++ b/crates/nika-pack/pack/examples/snippets/hello.nika.yaml
@@ -8,7 +8,7 @@
 # blast radius from the very first command.
 #
 # Demonstrates ·
-#   - the envelope · `nika: v1` + `workflow.id`
+#   - the envelope · `nika: hello` (the mark AND the name · nine keys)
 #   - `permits.exec` · an argv allowlist, no shell anywhere
 #   - one `exec:` task · argv form, never a shell string
 #

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 770
-  aggregate_sha256: 2f25f0691294be76bc347a5e8054d1b2855033df1258ad423c0b0ef122136856
+  aggregate_sha256: 1df0cb7f65f94fe0d2455177983f95c4b1527ce72b8273cbb1d4f2e6d3e4bbcb
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 116
-  aggregate_sha256: 889aa9d08239bd01515997bf5a31edffa84b6c339ca9452f7d40504bc1d38495
+  aggregate_sha256: ae0663ba24366a21f67f342525790ee34bf517cba405a1becbdaa5166ea8af6c
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"


### PR DESCRIPTION
The hello examples already run as nika: hello. Their headers still taught the dead pair. The mcp examples tool test asserted that dead string as proof of a real source (the same fail that keeps pack-resync #987 red). It now looks for nika: hello.

Does not touch nika-runtime, arm, or pack-resync itself — #987 gets the same test fix on its branch.