### PR TITLE
fix(release): wave-sweep learns the third lock · every excluded crate's own Cargo.lock

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 154
-  aggregate_sha256: 7d1be1fc48bedc0af16ac2f227dfdafcc9b469979dcb8daceabcfc15eb11f8eb
+  aggregate_sha256: 5e29a366d2b65056820dba27d1ae3d6bf4c62e5da8fcca7bb09f5796dca1c5c8
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/release/wave-sweep.sh
+++ b/scripts/release/wave-sweep.sh
@@ -68,12 +68,25 @@ run() { if [ "$DRY" = "--dry" ]; then echo "DRY · $*"; else "$@"; fi; }
 run perl -pi -e "s/^(version\s*=\s*)\"$V\"/\${1}\"$VER\"/" Cargo.toml crates/*/Cargo.toml
 run perl -pi -e "s/(version = )\"$V\"/\${1}\"$VER\"/g" crates/*/Cargo.toml
 
-# 2 · locks — never hand-edited
+# 2 · locks — never hand-edited. THREE, not two: the workspace lock, the
+#     fuzz lock, and the lock of every crate the workspace EXCLUDES but
+#     that path-depends on workspace members (today `crates/nika-acp` — its
+#     own `Cargo.lock` pins the members it builds against, so every version
+#     sweep must move it too). Measured 2026-08-18/19: the 0.109.0 release
+#     commit had to be amended after the pre-push gate rebuilt that lock,
+#     and the 0.109.1 · 0.109.2 · 0.110.0-dev sweeps each bumped it by hand
+#     — a carrier the sweep did not list is a carrier that drifts. `--offline`
+#     because a version sweep must never reach the network for a pin the
+#     tree already holds; the workspace lock above already resolved them.
 if [ "$DRY" != "--dry" ]; then
   cargo update --workspace -q
   cargo update --workspace --manifest-path fuzz/Cargo.toml -q
+  for excluded_lock in crates/*/Cargo.lock; do
+    [ -f "$excluded_lock" ] || continue
+    cargo update --workspace --offline -q --manifest-path "${excluded_lock%Cargo.lock}Cargo.toml"
+  done
 else
-  echo "DRY · cargo update --workspace (both locks)"
+  echo "DRY · cargo update --workspace (the workspace lock · the fuzz lock · every excluded crate's own lock)"
 fi
 
 # 3 · teaching comment + live status rows. The Dockerfile comment teaches


### PR DESCRIPTION
The sweep listed two locks (workspace · fuzz) and the tree carries a third: `crates/nika-acp` is EXCLUDED from the workspace and path-depends on its members, so its own `Cargo.lock` pins the versions the sweep just moved. Measured 2026-08-18/19: the 0.109.0 release commit had to be amended after the pre-push gate rebuilt that lock, and the 0.109.1 · 0.109.2 · 0.110.0-dev sweeps each bumped it by hand — a carrier the sweep does not list is a carrier that drifts. Step 2 now updates every `crates/*/Cargo.lock` it finds (`--offline` · the workspace lock already resolved the pins); the dry run names three locks. shfmt · shellcheck clean.