### PR TITLE
fix: LOT 3 task-body rungs + the sweep's third lock

### DIFF
--- a/crates/nika-cli-host/src/fix_ladder.rs
+++ b/crates/nika-cli-host/src/fix_ladder.rs
@@ -154,6 +154,24 @@ pub fn apply_dead_form_arm(
         } if (field == "workflow" || field == "description") && location.contains("envelope") => {
             Some(apply_identity(source, repairs, stop_notes))
         }
+        // LOT 3 · the task-body rungs (2026-08-11's sweep inside a task):
+        // `output:` → `extract:` (R3) · `on_error.fail_workflow: true`
+        // deleted (R4) · task-level `max_parallel`/`fail_fast` INTO the
+        // `for_each:` block (R2) · `declassify:`/`inert:` → one `lift:`
+        // (R5). Equivalence-or-stop like every rung: `fail_workflow: false`,
+        // knobs with no fan-out, a flow-style for_each, a declassify that
+        // does not lift to `trusted` — each STOPS with its note.
+        SchemaError::UnknownField {
+            field, location, ..
+        } if (location.starts_with("task `")
+            && matches!(
+                field.as_str(),
+                "output" | "declassify" | "inert" | "max_parallel" | "fail_fast"
+            ))
+            || (location == "`on_error:`" && field == "fail_workflow") =>
+        {
+            Some(apply_lot3(source, repairs, stop_notes))
+        }
         // W2 « the flow » dead form (PARSE-024) — the equivalence-or-
         // stop migration (spec 03 §depends_on): data → with: bindings ·
         // provably-strict control → after: {d: success} · every
@@ -252,6 +270,41 @@ fn apply_identity(
             false
         }
         nika_migrate::IdentityOutcome::Clean => false,
+    }
+}
+
+/// The LOT 3 task-body arm — R2 · R3 · R4 · R5 in one pass. `true` =
+/// applied (the round restarts) · `false` = STOP (each note names the
+/// case) or Clean.
+fn apply_lot3(source: &mut String, repairs: &mut Vec<Repair>, stop_notes: &mut StopNotes) -> bool {
+    match nika_migrate::lot3(source) {
+        nika_migrate::Lot3Outcome::Changed {
+            source: migrated,
+            applied,
+        } => {
+            *source = migrated;
+            for rung in applied {
+                let (from, to) = match rung {
+                    "r3-extract" => ("output:", "extract:"),
+                    "r4-fail-workflow" => {
+                        ("on_error.fail_workflow: true", "the default IS the failure")
+                    }
+                    "r2-for-each" => (
+                        "task-level max_parallel / fail_fast",
+                        "inside the for_each: block",
+                    ),
+                    "r5-lift" => ("declassify: / inert:", "lift: [{law, from?, because}]"),
+                    _ => ("a retired task form", "its nine-key shape"),
+                };
+                repairs.push(Repair::applied(from, to, rung));
+            }
+            true
+        }
+        nika_migrate::Lot3Outcome::Stop(notes) => {
+            stop_notes.0 = notes;
+            false
+        }
+        nika_migrate::Lot3Outcome::Clean => false,
     }
 }
 

--- a/crates/nika-cli/src/verbs/fix.rs
+++ b/crates/nika-cli/src/verbs/fix.rs
@@ -594,6 +594,56 @@ mod tests {
     }
 
     #[test]
+    fn lot3_migrates_the_task_body_and_converges_green() {
+        // A 0.108.0 task body: `output:` (→ extract), a knob outside its
+        // for_each (→ inside), the dead on_error mode (→ deleted) — one
+        // --fix, three rungs, green.
+        let dir = std::env::temp_dir().join(format!("nika-fix-lot3-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let path = dir.join("task-body.nika.yaml");
+        std::fs::write(
+            &path,
+            "nika: lot-three\nmodel: mock/echo\npermits:\n  exec: [echo]\ntasks:\n  fan:\n    for_each: ${{ const.items }}\n    max_parallel: 2\n    exec: { command: [echo, \"${{ item }}\"], capture: structured }\n    output:\n      line: \".stdout\"\n    on_error: { fail_workflow: true }\nconst:\n  items: [\"a\", \"b\"]\n",
+        )
+        .expect("write fixture");
+        let out = run(
+            path.to_str().expect("utf8 path"),
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let healed = std::fs::read_to_string(&path).expect("re-read");
+        assert!(
+            healed.contains(
+                "    for_each:\n      items: ${{ const.items }}\n      max_parallel: 2\n"
+            ),
+            "{healed}"
+        );
+        assert!(
+            healed.contains("    extract:\n      line: \".stdout\"\n"),
+            "{healed}"
+        );
+        assert!(
+            !healed.contains("on_error") && !healed.contains("output:"),
+            "{healed}"
+        );
+        assert!(
+            out.text.contains("r3-extract")
+                && out.text.contains("r2-for-each")
+                && out.text.contains("r4-fail-workflow"),
+            "{}",
+            out.text
+        );
+        assert_eq!(
+            out.code,
+            exit::OK,
+            "clean after the task-body rungs: {}",
+            out.text
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
     fn identity_stops_and_leaves_the_file_untouched_when_two_names_compete() {
         let dir =
             std::env::temp_dir().join(format!("nika-fix-identity-stop-{}", std::process::id()));

--- a/crates/nika-migrate/public-api.txt
+++ b/crates/nika-migrate/public-api.txt
@@ -79,6 +79,42 @@ impl<T> core::clone::CloneToUninit for nika_migrate::IdentityOutcome where T: co
 pub unsafe fn nika_migrate::IdentityOutcome::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_migrate::IdentityOutcome
 pub fn nika_migrate::IdentityOutcome::from(t: T) -> T
+pub enum nika_migrate::Lot3Outcome
+pub nika_migrate::Lot3Outcome::Changed
+pub nika_migrate::Lot3Outcome::Changed::applied: alloc::vec::Vec<&'static str>
+pub nika_migrate::Lot3Outcome::Changed::source: alloc::string::String
+pub nika_migrate::Lot3Outcome::Clean
+pub nika_migrate::Lot3Outcome::Stop(alloc::vec::Vec<alloc::string::String>)
+impl core::clone::Clone for nika_migrate::Lot3Outcome
+pub fn nika_migrate::Lot3Outcome::clone(&self) -> nika_migrate::Lot3Outcome
+impl core::cmp::Eq for nika_migrate::Lot3Outcome
+impl core::cmp::PartialEq for nika_migrate::Lot3Outcome
+pub fn nika_migrate::Lot3Outcome::eq(&self, other: &nika_migrate::Lot3Outcome) -> bool
+impl core::fmt::Debug for nika_migrate::Lot3Outcome
+pub fn nika_migrate::Lot3Outcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_migrate::Lot3Outcome
+impl<T, U> core::convert::Into<U> for nika_migrate::Lot3Outcome where U: core::convert::From<T>
+pub fn nika_migrate::Lot3Outcome::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_migrate::Lot3Outcome where U: core::convert::Into<T>
+pub type nika_migrate::Lot3Outcome::Error = core::convert::Infallible
+pub fn nika_migrate::Lot3Outcome::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_migrate::Lot3Outcome where U: core::convert::TryFrom<T>
+pub type nika_migrate::Lot3Outcome::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_migrate::Lot3Outcome::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_migrate::Lot3Outcome where T: core::clone::Clone
+pub type nika_migrate::Lot3Outcome::Owned = T
+pub fn nika_migrate::Lot3Outcome::clone_into(&self, target: &mut T)
+pub fn nika_migrate::Lot3Outcome::to_owned(&self) -> T
+impl<T> core::any::Any for nika_migrate::Lot3Outcome where T: 'static + ?core::marker::Sized
+pub fn nika_migrate::Lot3Outcome::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_migrate::Lot3Outcome where T: ?core::marker::Sized
+pub fn nika_migrate::Lot3Outcome::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_migrate::Lot3Outcome where T: ?core::marker::Sized
+pub fn nika_migrate::Lot3Outcome::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_migrate::Lot3Outcome where T: core::clone::Clone
+pub unsafe fn nika_migrate::Lot3Outcome::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_migrate::Lot3Outcome
+pub fn nika_migrate::Lot3Outcome::from(t: T) -> T
 pub enum nika_migrate::W2Outcome
 pub nika_migrate::W2Outcome::Changed(alloc::string::String)
 pub nika_migrate::W2Outcome::Stop(alloc::vec::Vec<alloc::string::String>)
@@ -101,6 +137,7 @@ pub fn nika_migrate::W2Outcome::from(t: T) -> T
 pub fn nika_migrate::d1(source: &str) -> nika_migrate::D1Outcome
 pub fn nika_migrate::esplit(source: &str) -> nika_migrate::EsplitOutcome
 pub fn nika_migrate::identity(source: &str) -> nika_migrate::IdentityOutcome
+pub fn nika_migrate::lot3(source: &str) -> nika_migrate::Lot3Outcome
 pub fn nika_migrate::predicates(source: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_migrate::w1(source: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_migrate::w2(source: &str) -> nika_migrate::W2Outcome

--- a/crates/nika-migrate/src/lib.rs
+++ b/crates/nika-migrate/src/lib.rs
@@ -60,12 +60,14 @@
 mod d1;
 mod esplit;
 mod identity;
+mod lot3;
 mod predicates;
 pub mod repair;
 
 pub use d1::{D1Outcome, d1};
 pub use esplit::{EsplitOutcome, esplit};
 pub use identity::{IdentityOutcome, identity};
+pub use lot3::{Lot3Outcome, lot3};
 pub use predicates::predicates;
 
 /// Apply the W1 migration. `Some(new)` when the document changed,

--- a/crates/nika-migrate/src/lot3.rs
+++ b/crates/nika-migrate/src/lot3.rs
@@ -1,0 +1,674 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! LOT 3 · the task-body rungs (R2 · R3 · R4 · R5) — the forms the
+//! nine-key sweep of 2026-08-11 retired INSIDE a task, one rung each,
+//! all line-based and structure-aware like [`super::identity()`] (the R1 rung):
+//!
+//! - **R3** `output:` → `extract:` (same shape · the truthful word)
+//! - **R4** `on_error: { fail_workflow: true }` → the key is DELETED (the
+//!   default IS the failure · an `on_error:` left empty is deleted with it)
+//!   · `fail_workflow: false` is NOT mechanical (it meant « do not fail the
+//!   workflow » · `recover` or `skip`? · only the author knows) → STOP
+//! - **R2** task-level `max_parallel:` / `fail_fast:` → INSIDE the
+//!   `for_each:` block · a scalar `for_each: <expr>` becomes the block
+//!   `for_each:` + `items: <expr>` first · a task carrying the knobs with no
+//!   `for_each:` at all → STOP (they have no meaning without it)
+//! - **R5** `declassify:` (a `{from, to: trusted, because}` list) and
+//!   `inert: <reason>` → ONE `lift:` list · `{law: taint, from, because}`
+//!   per declassify entry · `{law: data-as-code, because}` for the inert
+//!   reason · a declassify entry whose `to:` is not `trusted`, or one
+//!   missing `from`/`because`, → STOP
+//!
+//! Only lines at the TASK-BODY indent are touched (a task id sits at
+//! indent N under a top-level `tasks:`; its body keys at N+2), so an
+//! `output:` inside `args:` or a `with:` island is never renamed. Every
+//! other line is byte-identical; a document with none of the forms is
+//! [`Lot3Outcome::Clean`] (idempotent by contract).
+
+/// The outcome of one LOT 3 pass over one document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Lot3Outcome {
+    /// Mechanically migrated · `applied` names the rungs that fired.
+    Changed {
+        source: String,
+        applied: Vec<&'static str>,
+    },
+    /// Nothing to migrate.
+    Clean,
+    /// Ambiguous or non-mechanical — each diagnostic names the case.
+    Stop(Vec<String>),
+}
+
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// The key of a `key:` / `key: value` line, when it is one.
+fn key_of(line: &str) -> Option<&str> {
+    let t = line.trim_start();
+    if t.starts_with('#') || t.starts_with('-') {
+        return None;
+    }
+    let colon = t.find(':')?;
+    let key = &t[..colon];
+    let rest = &t[colon + 1..];
+    if key.is_empty() || key.contains(' ') || key.contains('"') || key.contains('\'') {
+        return None;
+    }
+    if !(rest.is_empty() || rest.starts_with(' ') || rest.starts_with('{') || rest.starts_with('['))
+    {
+        return None;
+    }
+    Some(key)
+}
+
+/// The value text after `key:` (trimmed · trailing comment kept out).
+fn value_of(line: &str) -> String {
+    let t = line.trim_start();
+    let colon = t.find(':').unwrap_or(0);
+    let rest = t[colon + 1..].trim();
+    // a `# comment` after a scalar is not the value
+    let mut depth_q = false;
+    let mut out = String::new();
+    for c in rest.chars() {
+        if c == '"' || c == '\'' {
+            depth_q = !depth_q;
+        }
+        if c == '#' && !depth_q && (out.is_empty() || out.ends_with(' ')) {
+            break;
+        }
+        out.push(c);
+    }
+    out.trim().to_owned()
+}
+
+/// The [start, end) line span of one task's body under a top-level
+/// `tasks:` map · `(task_start, body_indent, body_end)`.
+struct TaskSpan {
+    header: usize,
+    body_indent: usize,
+    end: usize,
+}
+
+/// Locate every task body in the document.
+fn task_spans(lines: &[&str]) -> Vec<TaskSpan> {
+    let mut spans = Vec::new();
+    // the top-level `tasks:` line
+    let Some(tasks_idx) = lines
+        .iter()
+        .position(|l| indent_of(l) == 0 && key_of(l) == Some("tasks"))
+    else {
+        return spans;
+    };
+    // the tasks block ends at the next top-level key
+    let mut block_end = tasks_idx + 1;
+    while block_end < lines.len() {
+        let l = lines[block_end];
+        if !l.trim().is_empty() && indent_of(l) == 0 {
+            break;
+        }
+        block_end += 1;
+    }
+    // task ids · the first indent level inside the block
+    let id_indent = lines[tasks_idx + 1..block_end]
+        .iter()
+        .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))
+        .map(|l| indent_of(l))
+        .min()
+        .unwrap_or(2);
+    let mut i = tasks_idx + 1;
+    while i < block_end {
+        let l = lines[i];
+        if !l.trim().is_empty() && indent_of(l) == id_indent && key_of(l).is_some() {
+            // body = lines until the next id-indent key
+            let mut j = i + 1;
+            while j < block_end {
+                let m = lines[j];
+                if !m.trim().is_empty() && indent_of(m) <= id_indent {
+                    break;
+                }
+                j += 1;
+            }
+            let body_indent = lines[i + 1..j]
+                .iter()
+                .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))
+                .map(|l| indent_of(l))
+                .min()
+                .unwrap_or(id_indent + 2);
+            spans.push(TaskSpan {
+                header: i,
+                body_indent,
+                end: j,
+            });
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    spans
+}
+
+/// The [start, end) of a nested block whose header sits at `header`
+/// (deeper-indented lines · blank lines inside allowed).
+fn nested_end(lines: &[&str], header: usize, limit: usize) -> usize {
+    let base = indent_of(lines[header]);
+    let mut j = header + 1;
+    while j < limit {
+        let l = lines[j];
+        if l.trim().is_empty() || indent_of(l) > base {
+            j += 1;
+        } else {
+            break;
+        }
+    }
+    while j > header + 1 && lines[j - 1].trim().is_empty() {
+        j -= 1;
+    }
+    j
+}
+
+/// One parsed `declassify:` entry.
+struct Declassify {
+    from: String,
+    because: String,
+}
+
+/// Parse a `declassify:` block (list of `{from, to, because}` mappings ·
+/// block or flow items) · `Err(note)` on anything non-mechanical.
+fn parse_declassify(lines: &[&str], header: usize, end: usize) -> Result<Vec<Declassify>, String> {
+    let mut out = Vec::new();
+    let mut cur: Option<(Option<String>, Option<String>, Option<String>)> = None; // from · to · because
+    let flush = |cur: &mut Option<(Option<String>, Option<String>, Option<String>)>,
+                 out: &mut Vec<Declassify>|
+     -> Result<(), String> {
+        if let Some((from, to, because)) = cur.take() {
+            let from =
+                from.ok_or("a `declassify` entry without `from:` — migrate to `lift:` by hand")?;
+            let because = because
+                .ok_or("a `declassify` entry without `because:` — migrate to `lift:` by hand")?;
+            if to.as_deref() != Some("trusted") {
+                return Err(format!(
+                    "`declassify` entry `{from}` lifts to `{}` — only `to: trusted` maps to `lift: {{law: taint}}` · migrate by hand",
+                    to.unwrap_or_default()
+                ));
+            }
+            out.push(Declassify { from, because });
+        }
+        Ok(())
+    };
+    // flow form on the header line · `declassify: [{…}]`
+    let header_value = value_of(lines[header]);
+    if header_value.starts_with('[') {
+        return Err("a flow-style `declassify: [...]` — migrate to `lift:` by hand".to_owned());
+    }
+    for raw in &lines[header + 1..end] {
+        let t = raw.trim();
+        if t.is_empty() || t.starts_with('#') {
+            continue;
+        }
+        let item = t.strip_prefix('-').map(str::trim);
+        let (is_new, body) = match item {
+            Some(b) => (true, b),
+            None => (false, t),
+        };
+        if is_new {
+            flush(&mut cur, &mut out)?;
+            cur = Some((None, None, None));
+        }
+        let Some(slot) = cur.as_mut() else {
+            return Err(
+                "`declassify:` carries a line outside any `- ` entry — migrate by hand".to_owned(),
+            );
+        };
+        // flow mapping item `- { from: x, to: trusted, because: y }`
+        if body.starts_with('{') {
+            let inner = body.trim_start_matches('{').trim_end_matches('}');
+            for part in inner.split(',') {
+                let Some((k, v)) = part.split_once(':') else {
+                    continue;
+                };
+                assign(slot, k.trim(), unquote(v.trim()))?;
+            }
+            continue;
+        }
+        let Some((k, v)) = body.split_once(':') else {
+            return Err(format!(
+                "`declassify` line `{body}` is not `key: value` — migrate by hand"
+            ));
+        };
+        assign(slot, k.trim(), unquote(v.trim()))?;
+    }
+    flush(&mut cur, &mut out)?;
+    Ok(out)
+}
+
+fn assign(
+    slot: &mut (Option<String>, Option<String>, Option<String>),
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    match key {
+        "from" => slot.0 = Some(value.to_owned()),
+        "to" => slot.1 = Some(value.to_owned()),
+        "because" => slot.2 = Some(value.to_owned()),
+        other => {
+            return Err(format!(
+                "`declassify` entry carries `{other}:` — `lift:` knows `law`, `from`, `because` · migrate by hand"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn unquote(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Quote a `because:` for YAML (double quotes · inner quotes escaped).
+fn yaml_str(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// The per-line edit plan one pass accumulates · applied at the end.
+#[derive(Default)]
+struct Edits {
+    replace: Vec<(usize, String)>,
+    delete: Vec<usize>,
+    insert_after: Vec<(usize, Vec<String>)>,
+    applied: Vec<&'static str>,
+    notes: Vec<String>,
+}
+
+impl Edits {
+    fn fired(&mut self, rung: &'static str) {
+        if !self.applied.contains(&rung) {
+            self.applied.push(rung);
+        }
+    }
+    fn is_empty(&self) -> bool {
+        self.replace.is_empty() && self.delete.is_empty() && self.insert_after.is_empty()
+    }
+    /// Rebuild the document · byte-identical outside the touched lines. An
+    /// insertion attached to a deleted line is still honoured.
+    fn render(&self, lines: &[&str]) -> String {
+        let mut out: Vec<String> = Vec::with_capacity(lines.len() + 8);
+        for (idx, line) in lines.iter().enumerate() {
+            if !self.delete.contains(&idx) {
+                match self.replace.iter().find(|(r, _)| *r == idx) {
+                    Some((_, text)) => out.push(text.clone()),
+                    None => out.push((*line).to_owned()),
+                }
+            }
+            for (after, block) in &self.insert_after {
+                if *after == idx {
+                    out.extend(block.iter().cloned());
+                }
+            }
+        }
+        out.join("\n")
+    }
+}
+
+/// What one task body carries for the rungs that need the whole body
+/// (R2 needs `for_each` AND the knobs · R5 gathers every door).
+#[derive(Default)]
+struct TaskFacts {
+    for_each_header: Option<usize>,
+    for_each_scalar: Option<String>,
+    for_each_flow: bool,
+    knobs: Vec<(usize, String, String)>,
+    lift_entries: Vec<String>,
+    lift_anchor: Option<usize>,
+}
+
+/// R4 · the flow form `on_error: { fail_workflow: true[, on_codes: …] }`.
+fn r4_flow(idx: usize, line: &str, pad: &str, task: &str, edits: &mut Edits) {
+    let v = value_of(line);
+    if !v.contains("fail_workflow") {
+        return;
+    }
+    let inner = v.trim_start_matches('{').trim_end_matches('}');
+    let mut kept: Vec<&str> = Vec::new();
+    for part in inner.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        if let Some((k, val)) = part.split_once(':')
+            && k.trim() == "fail_workflow"
+        {
+            if val.trim() != "true" {
+                edits.notes.push(format!(
+                    "task `{task}`: `on_error: {{ fail_workflow: false }}` meant « do not fail the workflow » — `recover` or `skip`? only the author knows · migrate by hand"
+                ));
+                return;
+            }
+            continue;
+        }
+        kept.push(part);
+    }
+    if kept.is_empty() {
+        edits.delete.push(idx);
+    } else {
+        edits
+            .replace
+            .push((idx, format!("{pad}on_error: {{ {} }}", kept.join(", "))));
+    }
+    edits.fired("r4-fail-workflow");
+}
+
+/// R4 · the block form · the `fail_workflow:` line is deleted (and the
+/// `on_error:` header with it when nothing else remains).
+fn r4_block(lines: &[&str], idx: usize, end: usize, task: &str, edits: &mut Edits) {
+    let mut fw_line: Option<usize> = None;
+    let mut others = 0usize;
+    for (k, m) in lines[idx + 1..end].iter().enumerate() {
+        if m.trim().is_empty() || m.trim_start().starts_with('#') {
+            continue;
+        }
+        match key_of(m) {
+            Some("fail_workflow") => {
+                if value_of(m) != "true" {
+                    edits.notes.push(format!(
+                        "task `{task}`: `on_error.fail_workflow: false` meant « do not fail the workflow » — `recover` or `skip`? only the author knows · migrate by hand"
+                    ));
+                    return;
+                }
+                fw_line = Some(idx + 1 + k);
+            }
+            Some(_) => others += 1,
+            None => {}
+        }
+    }
+    if let Some(fw) = fw_line {
+        edits.delete.push(fw);
+        if others == 0 {
+            edits.delete.push(idx);
+        }
+        edits.fired("r4-fail-workflow");
+    }
+}
+
+/// One task body · the line-local rungs fire as they are met, the
+/// body-wide facts (R2 · R5) are gathered for the settle step.
+fn migrate_task(lines: &[&str], span: &TaskSpan, edits: &mut Edits) {
+    let task = key_of(lines[span.header]).unwrap_or("?").to_owned();
+    let pad = " ".repeat(span.body_indent);
+    let inner = " ".repeat(span.body_indent + 2);
+    let mut facts = TaskFacts::default();
+    for i in span.header + 1..span.end {
+        let l = lines[i];
+        if l.trim().is_empty() || indent_of(l) != span.body_indent {
+            continue;
+        }
+        match key_of(l) {
+            Some("output") => {
+                edits
+                    .replace
+                    .push((i, l.replacen("output:", "extract:", 1)));
+                edits.fired("r3-extract");
+            }
+            Some("on_error") => {
+                if value_of(l).starts_with('{') {
+                    r4_flow(i, l, &pad, &task, edits);
+                } else {
+                    r4_block(lines, i, nested_end(lines, i, span.end), &task, edits);
+                }
+            }
+            Some("for_each") => {
+                facts.for_each_header = Some(i);
+                let v = value_of(l);
+                if v.starts_with('{') {
+                    facts.for_each_flow = true;
+                } else if !v.is_empty() {
+                    facts.for_each_scalar = Some(v);
+                }
+            }
+            Some(k @ ("max_parallel" | "fail_fast")) => {
+                facts.knobs.push((i, k.to_owned(), value_of(l)));
+            }
+            Some("declassify") => {
+                let end = nested_end(lines, i, span.end);
+                match parse_declassify(lines, i, end) {
+                    Ok(entries) => {
+                        for e in entries {
+                            facts.lift_entries.push(format!(
+                                "{inner}- {{ law: taint, from: {}, because: {} }}",
+                                e.from,
+                                yaml_str(&e.because)
+                            ));
+                        }
+                        edits.delete.extend(i..end);
+                        facts.lift_anchor.get_or_insert(i);
+                    }
+                    Err(note) => edits.notes.push(format!("task `{task}`: {note}")),
+                }
+            }
+            Some("inert") => {
+                let v = value_of(l);
+                if v.is_empty() || v.starts_with('|') || v.starts_with('>') {
+                    edits.notes.push(format!(
+                        "task `{task}`: `inert:` with a block-scalar reason — migrate to `lift: [{{law: data-as-code, because}}]` by hand"
+                    ));
+                } else {
+                    facts.lift_entries.push(format!(
+                        "{inner}- {{ law: data-as-code, because: {} }}",
+                        yaml_str(unquote(&v))
+                    ));
+                    edits.delete.push(i);
+                    facts.lift_anchor.get_or_insert(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    settle_task(span, &task, &pad, &inner, facts, edits);
+}
+
+/// The body-wide rungs · R5 lands the `lift:` list where the first door
+/// stood · R2 moves the knobs into `for_each:` (or STOPS).
+fn settle_task(
+    span: &TaskSpan,
+    task: &str,
+    pad: &str,
+    inner: &str,
+    mut facts: TaskFacts,
+    edits: &mut Edits,
+) {
+    if !facts.lift_entries.is_empty() {
+        let anchor = facts.lift_anchor.unwrap_or(span.header);
+        let mut block = vec![format!("{pad}lift:")];
+        block.append(&mut facts.lift_entries);
+        edits.insert_after.push((anchor.saturating_sub(1), block));
+        edits.fired("r5-lift");
+    }
+    if facts.knobs.is_empty() {
+        return;
+    }
+    let names = facts
+        .knobs
+        .iter()
+        .map(|k| k.1.as_str())
+        .collect::<Vec<_>>()
+        .join("` / `");
+    match facts.for_each_header {
+        None => edits.notes.push(format!(
+            "task `{task}`: `{names}` has no meaning without `for_each:` — the task carries no fan-out · remove or restructure by hand"
+        )),
+        Some(_) if facts.for_each_flow => edits.notes.push(format!(
+            "task `{task}`: a flow-style `for_each: {{...}}` — `{names}` moves inside it by hand"
+        )),
+        Some(fe) => {
+            let mut block: Vec<String> = Vec::new();
+            if let Some(items) = facts.for_each_scalar.take() {
+                edits.replace.push((fe, format!("{pad}for_each:")));
+                block.push(format!("{inner}items: {items}"));
+            }
+            for (idx, key, val) in &facts.knobs {
+                block.push(format!("{inner}{key}: {val}"));
+                edits.delete.push(*idx);
+            }
+            edits.insert_after.push((fe, block));
+            edits.fired("r2-for-each");
+        }
+    }
+}
+
+/// The LOT 3 task-body migration. See the module doc for the contract.
+#[must_use]
+pub fn lot3(source: &str) -> Lot3Outcome {
+    let lines: Vec<&str> = source.split('\n').collect();
+    let spans = task_spans(&lines);
+    if spans.is_empty() {
+        return Lot3Outcome::Clean;
+    }
+    let mut edits = Edits::default();
+    for span in &spans {
+        migrate_task(&lines, span, &mut edits);
+    }
+    if !edits.notes.is_empty() {
+        return Lot3Outcome::Stop(edits.notes);
+    }
+    if edits.is_empty() {
+        return Lot3Outcome::Clean;
+    }
+    Lot3Outcome::Changed {
+        source: edits.render(&lines),
+        applied: edits.applied,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn changed(src: &str) -> (String, Vec<&'static str>) {
+        match lot3(src) {
+            Lot3Outcome::Changed { source, applied } => (source, applied),
+            other => panic!("expected Changed · got {other:?}"),
+        }
+    }
+
+    fn stop(src: &str) -> Vec<String> {
+        match lot3(src) {
+            Lot3Outcome::Stop(n) => n,
+            other => panic!("expected Stop · got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn r3_output_becomes_extract_at_the_task_body_only() {
+        let src = "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    output:\n      x: \".x\"\n  b:\n    invoke:\n      tool: nika:jq\n      args:\n        output: keep-me\n";
+        let (out, applied) = changed(src);
+        assert!(out.contains("    extract:\n      x: \".x\"\n"), "{out}");
+        assert!(
+            out.contains("        output: keep-me\n"),
+            "an args key is not the task key · {out}"
+        );
+        assert_eq!(applied, vec!["r3-extract"]);
+        assert_eq!(lot3(&out), Lot3Outcome::Clean, "idempotent");
+    }
+
+    #[test]
+    fn r4_fail_workflow_true_is_deleted_flow_and_block() {
+        let flow = "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    on_error: { fail_workflow: true }\n";
+        let (out, applied) = changed(flow);
+        assert!(!out.contains("on_error"), "{out}");
+        assert_eq!(applied, vec!["r4-fail-workflow"]);
+        let block = "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    on_error:\n      fail_workflow: true\n      on_codes: [NIKA-EXEC-001]\n";
+        let (out, _) = changed(block);
+        assert!(
+            out.contains("    on_error:\n      on_codes: [NIKA-EXEC-001]\n"),
+            "the other key survives · {out}"
+        );
+        assert!(!out.contains("fail_workflow"), "{out}");
+    }
+
+    #[test]
+    fn r4_fail_workflow_false_stops() {
+        let notes = stop(
+            "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    on_error: { fail_workflow: false }\n",
+        );
+        assert!(notes[0].contains("only the author knows"), "{notes:?}");
+    }
+
+    #[test]
+    fn r2_knobs_move_inside_the_for_each_block_and_a_scalar_becomes_items() {
+        let src = "nika: t\ntasks:\n  fan:\n    for_each: ${{ inputs.items }}\n    max_parallel: 4\n    fail_fast: false\n    exec: { command: [\"true\"] }\n";
+        let (out, applied) = changed(src);
+        assert_eq!(
+            out,
+            "nika: t\ntasks:\n  fan:\n    for_each:\n      items: ${{ inputs.items }}\n      max_parallel: 4\n      fail_fast: false\n    exec: { command: [\"true\"] }\n"
+        );
+        assert_eq!(applied, vec!["r2-for-each"]);
+        let block = "nika: t\ntasks:\n  fan:\n    for_each:\n      items: ${{ inputs.items }}\n    max_parallel: 2\n    exec: { command: [\"true\"] }\n";
+        let (out, _) = changed(block);
+        assert!(
+            out.contains(
+                "    for_each:\n      max_parallel: 2\n      items: ${{ inputs.items }}\n"
+            ),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn r2_knobs_without_for_each_stop() {
+        let notes =
+            stop("nika: t\ntasks:\n  a:\n    max_parallel: 4\n    exec: { command: [\"true\"] }\n");
+        assert!(
+            notes[0].contains("no meaning without `for_each:`"),
+            "{notes:?}"
+        );
+    }
+
+    #[test]
+    fn r5_declassify_and_inert_become_one_lift_list() {
+        let src = "nika: t\ntasks:\n  load:\n    invoke:\n      tool: nika:read\n      args: { path: \"${{ inputs.p }}\" }\n    declassify:\n      - from: inputs.p\n        to: trusted\n        because: \"the bound confines it\"\n    inert: \"the value is data\"\n";
+        let (out, applied) = changed(src);
+        assert!(
+            out.contains("    lift:\n      - { law: taint, from: inputs.p, because: \"the bound confines it\" }\n      - { law: data-as-code, because: \"the value is data\" }\n"),
+            "{out}"
+        );
+        assert!(
+            !out.contains("declassify") && !out.contains("inert:"),
+            "{out}"
+        );
+        assert_eq!(applied, vec!["r5-lift"]);
+        assert_eq!(lot3(&out), Lot3Outcome::Clean, "idempotent");
+    }
+
+    #[test]
+    fn r5_declassify_to_something_else_stops() {
+        let notes = stop(
+            "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    declassify:\n      - { from: inputs.p, to: public, because: x }\n",
+        );
+        assert!(notes[0].contains("only `to: trusted`"), "{notes:?}");
+    }
+
+    #[test]
+    fn a_nine_key_task_body_is_clean() {
+        let src = "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n    extract:\n      x: \".x\"\n    lift:\n      - { law: data-as-code, because: \"x\" }\n";
+        assert_eq!(lot3(src), Lot3Outcome::Clean);
+        assert_eq!(lot3("nika: t\n"), Lot3Outcome::Clean, "no tasks at all");
+    }
+
+    #[test]
+    fn several_rungs_fire_in_one_pass_and_report_each() {
+        let src = "nika: t\ntasks:\n  a:\n    for_each: ${{ inputs.items }}\n    max_parallel: 3\n    exec: { command: [\"true\"] }\n    output:\n      x: \".x\"\n    on_error: { fail_workflow: true }\n";
+        let (out, applied) = changed(src);
+        assert!(
+            out.contains("      max_parallel: 3\n")
+                && out.contains("    extract:\n")
+                && !out.contains("on_error"),
+            "{out}"
+        );
+        assert_eq!(
+            applied,
+            vec!["r3-extract", "r4-fail-workflow", "r2-for-each"]
+        );
+    }
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 155
-  aggregate_sha256: 323807a90dcb9a86ef857144edc4d42a2194148a97cc59548193b412b34f53cc
+  aggregate_sha256: ca0d413c2f2d1c91982afbe095d53275f1d0b0b668064c6127c3646745bf6b3f
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4473
+  classified_files: 4474
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1536
+    authored: 1537
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: b2ea6cab5d6c53780910df9896db5ca38f5cb5983a9fc795f795ea40a4150e16
+  aggregate_sha256: d7593d3293e5cd6c2c2092b1216a05e3ff4d0a9e9fbf7016975a76c30369f497
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 772
-  aggregate_sha256: 18e6754d78e955dd2eeb3157e717cc8fc72698350248c0d400f12067a88237b5
+  match_count: 773
+  aggregate_sha256: 8c554135d456c3d25b9566943bf7138e4b1bded6eae96078397a124392c445d8
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/scripts/release/wave-sweep.sh
+++ b/scripts/release/wave-sweep.sh
@@ -68,12 +68,25 @@ run() { if [ "$DRY" = "--dry" ]; then echo "DRY · $*"; else "$@"; fi; }
 run perl -pi -e "s/^(version\s*=\s*)\"$V\"/\${1}\"$VER\"/" Cargo.toml crates/*/Cargo.toml
 run perl -pi -e "s/(version = )\"$V\"/\${1}\"$VER\"/g" crates/*/Cargo.toml
 
-# 2 · locks — never hand-edited
+# 2 · locks — never hand-edited. THREE, not two: the workspace lock, the
+#     fuzz lock, and the lock of every crate the workspace EXCLUDES but
+#     that path-depends on workspace members (today `crates/nika-acp` — its
+#     own `Cargo.lock` pins the members it builds against, so every version
+#     sweep must move it too). Measured 2026-08-18/19: the 0.109.0 release
+#     commit had to be amended after the pre-push gate rebuilt that lock,
+#     and the 0.109.1 · 0.109.2 · 0.110.0-dev sweeps each bumped it by hand
+#     — a carrier the sweep did not list is a carrier that drifts. `--offline`
+#     because a version sweep must never reach the network for a pin the
+#     tree already holds; the workspace lock above already resolved them.
 if [ "$DRY" != "--dry" ]; then
   cargo update --workspace -q
   cargo update --workspace --manifest-path fuzz/Cargo.toml -q
+  for excluded_lock in crates/*/Cargo.lock; do
+    [ -f "$excluded_lock" ] || continue
+    cargo update --workspace --offline -q --manifest-path "${excluded_lock%Cargo.lock}Cargo.toml"
+  done
 else
-  echo "DRY · cargo update --workspace (both locks)"
+  echo "DRY · cargo update --workspace (the workspace lock · the fuzz lock · every excluded crate's own lock)"
 fi
 
 # 3 · teaching comment + live status rows. The Dockerfile comment teaches


### PR DESCRIPTION
Two commits ride ONE branch because `estate.yaml` — the whole-tree fingerprint every tree-changing commit regenerates — re-conflicts every open PR each time one merges (#998 went DIRTY under #997). One branch · one gate · one CI · one merge · zero force-push. Each commit keeps its own body.

## 1 · `feat(nika-migrate)` · the task-body rungs · extract · fail_workflow · for_each · lift (LOT 3 · R2-R5)

After R1 (the identity · shipped in 0.109.2) `nika check --fix` still left the four task-body forms the 2026-08-11 sweep retired to the hand: `output:` (→ `extract:`), `on_error: { fail_workflow: true }` (the mode that only ever spelled the default), task-level `max_parallel:` / `fail_fast:` (they live INSIDE `for_each:` now), and the two authored doors `declassify:` / `inert:` (merged into ONE `lift:` list). The census of 2026-08-13 counted 130 `output:` sites, 17 `fail_workflow`, 59+43 knobs, 6+3+3 doors.

`nika_migrate::lot3` — one line-based, structure-aware pass over every task body (a task id at indent N under the top-level `tasks:` · its body keys at N+2 · nothing deeper is touched, so an `output:` inside `args:` or a `with:` island is never renamed):
- **R3** `output:` → `extract:` at the body indent
- **R4** `fail_workflow: true` deleted in the flow and the block form (an `on_error:` left empty goes with it · `on_codes` survives) · `false` STOPS (recover or skip · only the author knows)
- **R2** the knobs move under `for_each:` · a scalar `for_each: <expr>` becomes the block with `items: <expr>` first · knobs with no `for_each:` STOP · a flow-style `for_each: {…}` STOPS
- **R5** `declassify: [{from, to: trusted, because}]` → `lift: [{law: taint, from, because}]` · `inert: <reason>` → `{law: data-as-code, because}` · both into ONE `lift:` where the first door stood · other `to:`, missing `from`/`because`, flow-style list, block-scalar reason → STOP

Byte-identical outside the touched lines · a nine-key body is `Clean` (idempotent). The ladder gains the arm on `UnknownField { output | declassify | inert | max_parallel | fail_fast, task }` and on `UnknownField { fail_workflow, on_error }`; every rung reports its own row, inside #971's transaction. Evidence · 9 unit tests · two hand mutations RED (body-indent guard dropped → the `args` `output` renamed → red · `to: trusted` guard dropped → red) · 1 fix-loop integration test (three rungs, one `--fix`, green) · nika-migrate 84/84 · nika-cli fix 18/18 · clippy `-D warnings` clean · rustdoc private-items clean (vector 28) · functions ≤100 LOC · public API snapshot regenerated. Deliberately unchanged · `config:` → `inputs:` (R6 · a classification) · `on_finally:` → an unwind task (R7 · a restructuring).

## 2 · `fix(release)` · wave-sweep learns the third lock · every excluded crate's own Cargo.lock

The sweep listed two locks (workspace · fuzz) and the tree carries a third: `crates/nika-acp` is EXCLUDED from the workspace and path-depends on its members, so its own `Cargo.lock` pins the versions the sweep just moved. Measured 2026-08-18/19: the 0.109.0 release commit had to be amended after the pre-push gate rebuilt that lock, and the 0.109.1 · 0.109.2 · 0.110.0-dev sweeps each bumped it by hand — a carrier the sweep does not list is a carrier that drifts. Step 2 now updates every `crates/*/Cargo.lock` it finds (`--offline` · the workspace lock already resolved the pins); the dry run names three locks. shfmt · shellcheck clean.
