### PR TITLE
ci: apt gets a deadline · a mirror stall is a five-minute red, not a six-hour hang

### DIFF
--- a/.github/workflows/diamond-ci.yml
+++ b/.github/workflows/diamond-ci.yml
@@ -118,8 +118,13 @@ jobs:
       - name: Install bubblewrap (tests + funnel legs · the landlock jail proof RUNS · the funnel's consent leg runs a permits workflow)
         if: matrix.job == 'tests' || matrix.job == 'funnel'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap
+          # apt has no deadline of its own: measured 2026-08-19 (02:54Z→~03:20Z),
+          # every job entering this step hung on a mirror stall and the 6-hour job
+          # timeout was the only exit — every open PR froze behind it. A 30 s socket
+          # timeout + 3 retries cover the transient half; the 5-minute hard deadline
+          # turns the rest into a clean red the operator can re-run.
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends bubblewrap
           # ubuntu-24.04's AppArmor bwrap profile grants userns creation but
           # denies CAP_NET_ADMIN inside it, so bwrap dies bringing up loopback
           # in the unshared netns ("loopback: Failed RTM_NEWADDR: Operation
@@ -176,8 +181,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux desktop deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          # apt has no deadline of its own: measured 2026-08-19 (02:54Z→~03:20Z),
+          # every job entering this step hung on a mirror stall and the 6-hour job
+          # timeout was the only exit — every open PR froze behind it. A 30 s socket
+          # timeout + 3 retries cover the transient half; the hard deadline (5 min ·
+          # 10 for the desktop deps) turns the rest into a clean red to re-run.
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo timeout 600 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev libdbus-1-dev libudev-dev \
             libx11-dev libxi-dev libxtst-dev libpipewire-0.3-dev \
             libegl1-mesa-dev libgl1-mesa-dev libgbm-dev pkg-config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,13 @@ jobs:
         # keep unprivileged userns open (the tests-leg recipe, proven daily).
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap
+          # apt has no deadline of its own: measured 2026-08-19 (02:54Z→~03:20Z),
+          # every job entering this step hung on a mirror stall and the 6-hour job
+          # timeout was the only exit — every open PR froze behind it. A 30 s socket
+          # timeout + 3 retries cover the transient half; the 5-minute hard deadline
+          # turns the rest into a clean red the operator can re-run.
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo timeout 300 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends bubblewrap
           sudo apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict 2>/dev/null || true
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true  # absent on ubuntu-22.04
       - name: Funnel e2e (gate before upload)

--- a/estate.yaml
+++ b/estate.yaml
@@ -188,7 +188,7 @@ patterns:
 - glob: ".github/workflows/**"
   class: authored
   match_count: 22
-  aggregate_sha256: 34fd472402ad1835ec61e3715f33f5a4229afd9a39d45e5de2208b0b72250378
+  aggregate_sha256: cf1d816997a66cf427b5a9b5b8c8d9654e86f3a341b25d6baab26e0b8fd4f85e
   evidence: "hand-written CI rails, comments narrate design decisions; the heal lanes here rewrite OTHER files (spec-pin-heal.yml → SPEC_PIN · pack-resync.yml → the pack · changelog-cliff.yml → CHANGELOG.md), nothing rewrites the workflows themselves"
 - glob: ".github/**"
   class: authored


### PR DESCRIPTION
ci: apt gets a deadline · a mirror stall is a five-minute red, not a six-hour hang

Defect: `sudo apt-get update` has no deadline of its own. Measured
2026-08-19 · from 02:54Z every Diamond CI job that entered the
bubblewrap step hung there (fix/codegen-mutation-gaps `rust (tests)`
since 02:54:13Z · two dependabot `rust (tests)` since ~02:56Z · #999
`rust (funnel)` since 02:59Z) while the main run of 02:52Z had cleared
the same step in 72 s · a runner-side apt/mirror stall, the 6-hour job
timeout the only exit · every open PR froze behind a step that installs
one package. The re-run of the failed job needed a cancel + a rerun,
and a cancel + rerun-failed dropped the head SHA's `rust (tests)` check
run (the required context) · the PR read BLOCKED with nothing red.

Mechanism: the three apt sites (diamond-ci tests+funnel legs ·
diamond-ci hack desktop deps · release Linux builders) run under
`timeout 300` (600 for the desktop deps) with `-o Acquire::Retries=3
-o Acquire::http::Timeout=30` · a stalled socket is dropped after 30 s
and retried three times (the transient half) · the hard deadline turns
the rest into a clean red the operator can re-run · the step's own
comment carries the measurement.

Evidence: actionlint clean on both workflows · byte-identical outside
the three `run:` blocks · the AppArmor lines and the `if:` guards
untouched · the recipe on green mirrors is unchanged (`timeout` wraps,
it never alters apt's arguments beyond the two Acquire knobs).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
