### PR TITLE
feat(arm): the one firer · W2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,6 +4265,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "expectrl",
+ "insta",
  "jiff",
  "minisign",
  "nika-builtin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,6 +4299,7 @@ dependencies = [
  "nika-verb-infer",
  "nika-verb-invoke",
  "nika-vocab",
+ "nix 0.31.3",
  "proptest",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -91,6 +91,7 @@ nika-verb-agent  = { path = "../nika-verb-agent", version = "0.110.0-dev" }
 sha2           = { workspace = true }   # composition_e2e/trace_verify test-side journal chains
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
+insta    = { workspace = true }   # the arm report's snapshot (PROUVÉ · DÉCLARÉ · orphelins)
 uuid     = { workspace = true }   # test fixtures mint EventIds (the last prod use descended with the journal writer)
 expectrl = { workspace = true }   # PTY e2e · the wizard conversation is TTY-gated — unreachable
                                   # from piped harnesses by construction (tests/wizard_pty.rs · unix)

--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -26,6 +26,7 @@ nika-pack   = { path = "../nika-pack", version = "0.110.0-dev" }   # the embedde
 clap        = { workspace = true }                             # verb tree (completions + man derive later)
 clap_complete = { workspace = true }                           # `nika completions <shell>` (spec §9)
 serde_json  = { workspace = true }                             # trace NDJSON parse · --json surfaces
+nix         = { workspace = true, features = ["fs"] }          # the arm firer's lock liveness (signal 0 probe) + the stdout→stderr fold during the in-process run (unix)
 # The `nika run` composer (verbs/run/compose.rs · the verb/agent/effect
 # crates) descended to `nika_runtime::compose` 2026-07-22 (the 15k wall —
 # compute descends, render stays); what remains below is what the CLI's own

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -35,7 +35,550 @@ pub use nika_cli::verbs::trace_verify
 pub use nika_cli::verbs::welcome
 pub use nika_cli::verbs::wire
 pub mod nika_cli::verbs::arm
-pub fn nika_cli::verbs::arm::run() -> nika_cli_host::output::VerbOutput
+pub mod nika_cli::verbs::arm::args
+pub enum nika_cli::verbs::arm::args::ArmSub
+pub nika_cli::verbs::arm::args::ArmSub::Disarm
+pub nika_cli::verbs::arm::args::ArmSub::Disarm::label: alloc::string::String
+pub nika_cli::verbs::arm::args::ArmSub::Disarm::write: bool
+pub nika_cli::verbs::arm::args::ArmSub::Fire(nika_cli::verbs::arm::args::FireArgs)
+impl clap_builder::derive::FromArgMatches for nika_cli::verbs::arm::args::ArmSub
+pub fn nika_cli::verbs::arm::args::ArmSub::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::ArmSub::from_arg_matches_mut(__clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::ArmSub::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::ArmSub::update_from_arg_matches_mut<'b>(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+impl clap_builder::derive::Subcommand for nika_cli::verbs::arm::args::ArmSub
+pub fn nika_cli::verbs::arm::args::ArmSub::augment_subcommands<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::arm::args::ArmSub::augment_subcommands_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::arm::args::ArmSub::has_subcommand(__clap_name: &str) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::args::ArmSub
+pub fn nika_cli::verbs::arm::args::ArmSub::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::args::ArmSub
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::args::ArmSub where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::args::ArmSub::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::args::ArmSub where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::args::ArmSub::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::args::ArmSub::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::args::ArmSub where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::args::ArmSub::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::args::ArmSub::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::arm::args::ArmSub where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmSub::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::args::ArmSub where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmSub::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::args::ArmSub where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmSub::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::args::ArmSub
+pub fn nika_cli::verbs::arm::args::ArmSub::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::args::ArmSub where T: 'static
+pub fn nika_cli::verbs::arm::args::ArmSub::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::args::ArmSub where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmSub::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::args::ArmSub::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::args::ArmSub
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::args::ArmSub
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::args::ArmSub
+pub type nika_cli::verbs::arm::args::ArmSub::Output = T
+pub enum nika_cli::verbs::arm::args::EmitMode
+pub nika_cli::verbs::arm::args::EmitMode::System
+pub nika_cli::verbs::arm::args::EmitMode::User
+impl clap_builder::derive::ValueEnum for nika_cli::verbs::arm::args::EmitMode
+pub fn nika_cli::verbs::arm::args::EmitMode::to_possible_value<'a>(&self) -> core::option::Option<clap_builder::builder::possible_value::PossibleValue>
+pub fn nika_cli::verbs::arm::args::EmitMode::value_variants<'a>() -> &'a [Self]
+impl core::clone::Clone for nika_cli::verbs::arm::args::EmitMode
+pub fn nika_cli::verbs::arm::args::EmitMode::clone(&self) -> nika_cli::verbs::arm::args::EmitMode
+impl core::cmp::Eq for nika_cli::verbs::arm::args::EmitMode
+impl core::cmp::PartialEq for nika_cli::verbs::arm::args::EmitMode
+pub fn nika_cli::verbs::arm::args::EmitMode::eq(&self, other: &nika_cli::verbs::arm::args::EmitMode) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::args::EmitMode
+pub fn nika_cli::verbs::arm::args::EmitMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cli::verbs::arm::args::EmitMode
+impl core::marker::StructuralPartialEq for nika_cli::verbs::arm::args::EmitMode
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::args::EmitMode
+impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::arm::args::EmitMode where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitMode::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::arm::args::EmitMode where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitMode::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::args::EmitMode where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::args::EmitMode::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::args::EmitMode where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::args::EmitMode::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::args::EmitMode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::args::EmitMode where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::args::EmitMode::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::args::EmitMode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::args::EmitMode where T: core::clone::Clone
+pub type nika_cli::verbs::arm::args::EmitMode::Owned = T
+pub fn nika_cli::verbs::arm::args::EmitMode::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::args::EmitMode::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::args::EmitMode where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitMode::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::args::EmitMode where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitMode::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::args::EmitMode where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitMode::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::args::EmitMode where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::args::EmitMode::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::args::EmitMode
+pub fn nika_cli::verbs::arm::args::EmitMode::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::args::EmitMode where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::args::EmitMode::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::args::EmitMode where T: 'static
+pub fn nika_cli::verbs::arm::args::EmitMode::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_cli::verbs::arm::args::EmitMode where T: core::marker::Copy
+pub fn nika_cli::verbs::arm::args::EmitMode::as_out(&mut self) -> outref::Out<'_, T>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::args::EmitMode where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitMode::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::args::EmitMode::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::args::EmitMode
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::args::EmitMode
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::args::EmitMode
+pub type nika_cli::verbs::arm::args::EmitMode::Output = T
+pub enum nika_cli::verbs::arm::args::EmitTarget
+pub nika_cli::verbs::arm::args::EmitTarget::Launchd
+pub nika_cli::verbs::arm::args::EmitTarget::Systemd
+impl clap_builder::derive::ValueEnum for nika_cli::verbs::arm::args::EmitTarget
+pub fn nika_cli::verbs::arm::args::EmitTarget::to_possible_value<'a>(&self) -> core::option::Option<clap_builder::builder::possible_value::PossibleValue>
+pub fn nika_cli::verbs::arm::args::EmitTarget::value_variants<'a>() -> &'a [Self]
+impl core::clone::Clone for nika_cli::verbs::arm::args::EmitTarget
+pub fn nika_cli::verbs::arm::args::EmitTarget::clone(&self) -> nika_cli::verbs::arm::args::EmitTarget
+impl core::cmp::Eq for nika_cli::verbs::arm::args::EmitTarget
+impl core::cmp::PartialEq for nika_cli::verbs::arm::args::EmitTarget
+pub fn nika_cli::verbs::arm::args::EmitTarget::eq(&self, other: &nika_cli::verbs::arm::args::EmitTarget) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::args::EmitTarget
+pub fn nika_cli::verbs::arm::args::EmitTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cli::verbs::arm::args::EmitTarget
+impl core::marker::StructuralPartialEq for nika_cli::verbs::arm::args::EmitTarget
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::args::EmitTarget
+impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::arm::args::EmitTarget where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitTarget::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::arm::args::EmitTarget where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitTarget::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::args::EmitTarget where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::args::EmitTarget::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::args::EmitTarget where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::args::EmitTarget::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::args::EmitTarget::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::args::EmitTarget where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::args::EmitTarget::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::args::EmitTarget::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::args::EmitTarget where T: core::clone::Clone
+pub type nika_cli::verbs::arm::args::EmitTarget::Owned = T
+pub fn nika_cli::verbs::arm::args::EmitTarget::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::args::EmitTarget::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::args::EmitTarget where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitTarget::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::args::EmitTarget where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitTarget::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::args::EmitTarget where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitTarget::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::args::EmitTarget where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::args::EmitTarget::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::args::EmitTarget
+pub fn nika_cli::verbs::arm::args::EmitTarget::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::args::EmitTarget where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::args::EmitTarget::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::args::EmitTarget where T: 'static
+pub fn nika_cli::verbs::arm::args::EmitTarget::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_cli::verbs::arm::args::EmitTarget where T: core::marker::Copy
+pub fn nika_cli::verbs::arm::args::EmitTarget::as_out(&mut self) -> outref::Out<'_, T>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::args::EmitTarget where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::EmitTarget::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::args::EmitTarget::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::args::EmitTarget
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::args::EmitTarget
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::args::EmitTarget
+pub type nika_cli::verbs::arm::args::EmitTarget::Output = T
+pub struct nika_cli::verbs::arm::args::ArmArgs
+pub nika_cli::verbs::arm::args::ArmArgs::emit: core::option::Option<nika_cli::verbs::arm::args::EmitTarget>
+pub nika_cli::verbs::arm::args::ArmArgs::env_file: core::option::Option<std::path::PathBuf>
+pub nika_cli::verbs::arm::args::ArmArgs::mode: core::option::Option<nika_cli::verbs::arm::args::EmitMode>
+pub nika_cli::verbs::arm::args::ArmArgs::nika_bin: core::option::Option<std::path::PathBuf>
+pub nika_cli::verbs::arm::args::ArmArgs::out: core::option::Option<std::path::PathBuf>
+pub nika_cli::verbs::arm::args::ArmArgs::sub: core::option::Option<nika_cli::verbs::arm::args::ArmSub>
+pub nika_cli::verbs::arm::args::ArmArgs::write: bool
+impl clap_builder::derive::Args for nika_cli::verbs::arm::args::ArmArgs
+pub fn nika_cli::verbs::arm::args::ArmArgs::augment_args<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::arm::args::ArmArgs::augment_args_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::arm::args::ArmArgs::group_id() -> core::option::Option<clap_builder::util::id::Id>
+impl clap_builder::derive::FromArgMatches for nika_cli::verbs::arm::args::ArmArgs
+pub fn nika_cli::verbs::arm::args::ArmArgs::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::ArmArgs::from_arg_matches_mut(__clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::ArmArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::ArmArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+impl core::fmt::Debug for nika_cli::verbs::arm::args::ArmArgs
+pub fn nika_cli::verbs::arm::args::ArmArgs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::args::ArmArgs
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::args::ArmArgs where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::args::ArmArgs::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::args::ArmArgs where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::args::ArmArgs::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::args::ArmArgs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::args::ArmArgs where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::args::ArmArgs::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::args::ArmArgs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::arm::args::ArmArgs where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmArgs::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::args::ArmArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmArgs::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::args::ArmArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmArgs::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::args::ArmArgs
+pub fn nika_cli::verbs::arm::args::ArmArgs::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::args::ArmArgs where T: 'static
+pub fn nika_cli::verbs::arm::args::ArmArgs::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::args::ArmArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::ArmArgs::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::args::ArmArgs::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::args::ArmArgs
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::args::ArmArgs
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::args::ArmArgs
+pub type nika_cli::verbs::arm::args::ArmArgs::Output = T
+pub struct nika_cli::verbs::arm::args::FireArgs
+pub nika_cli::verbs::arm::args::FireArgs::label: alloc::string::String
+pub nika_cli::verbs::arm::args::FireArgs::now: core::option::Option<alloc::string::String>
+impl clap_builder::derive::Args for nika_cli::verbs::arm::args::FireArgs
+pub fn nika_cli::verbs::arm::args::FireArgs::augment_args<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::arm::args::FireArgs::augment_args_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::arm::args::FireArgs::group_id() -> core::option::Option<clap_builder::util::id::Id>
+impl clap_builder::derive::FromArgMatches for nika_cli::verbs::arm::args::FireArgs
+pub fn nika_cli::verbs::arm::args::FireArgs::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::FireArgs::from_arg_matches_mut(__clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::FireArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+pub fn nika_cli::verbs::arm::args::FireArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+impl core::fmt::Debug for nika_cli::verbs::arm::args::FireArgs
+pub fn nika_cli::verbs::arm::args::FireArgs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::args::FireArgs
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::args::FireArgs where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::args::FireArgs::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::args::FireArgs where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::args::FireArgs::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::args::FireArgs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::args::FireArgs where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::args::FireArgs::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::args::FireArgs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::arm::args::FireArgs where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::FireArgs::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::args::FireArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::FireArgs::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::args::FireArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::FireArgs::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::args::FireArgs
+pub fn nika_cli::verbs::arm::args::FireArgs::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::args::FireArgs where T: 'static
+pub fn nika_cli::verbs::arm::args::FireArgs::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::args::FireArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::args::FireArgs::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::args::FireArgs::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::args::FireArgs
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::args::FireArgs
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::args::FireArgs
+pub type nika_cli::verbs::arm::args::FireArgs::Output = T
+pub mod nika_cli::verbs::arm::fire
+pub struct nika_cli::verbs::arm::fire::FireCtx
+pub nika_cli::verbs::arm::fire::FireCtx::index: usize
+pub nika_cli::verbs::arm::fire::FireCtx::label: alloc::string::String
+pub nika_cli::verbs::arm::fire::FireCtx::now: jiff::zoned::Zoned
+pub nika_cli::verbs::arm::fire::FireCtx::project_root: std::path::PathBuf
+pub nika_cli::verbs::arm::fire::FireCtx::registry: nika_cadence::registry::ArmRegistry
+pub nika_cli::verbs::arm::fire::FireCtx::state: nika_cli::verbs::arm::state::ArmState
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::fire::FireCtx
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::fire::FireCtx where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::fire::FireCtx::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::fire::FireCtx where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::fire::FireCtx::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::fire::FireCtx::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::fire::FireCtx where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::fire::FireCtx::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::fire::FireCtx::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::arm::fire::FireCtx where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireCtx::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::fire::FireCtx where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireCtx::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::fire::FireCtx where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireCtx::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::fire::FireCtx
+pub fn nika_cli::verbs::arm::fire::FireCtx::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::fire::FireCtx where T: 'static
+pub fn nika_cli::verbs::arm::fire::FireCtx::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::fire::FireCtx where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireCtx::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::fire::FireCtx::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::fire::FireCtx
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::fire::FireCtx
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::fire::FireCtx
+pub type nika_cli::verbs::arm::fire::FireCtx::Output = T
+pub struct nika_cli::verbs::arm::fire::FireVerdict
+pub nika_cli::verbs::arm::fire::FireVerdict::code: u8
+pub nika_cli::verbs::arm::fire::FireVerdict::line: alloc::string::String
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::fire::FireVerdict
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::fire::FireVerdict where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::fire::FireVerdict::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::fire::FireVerdict where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::fire::FireVerdict::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::fire::FireVerdict::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::fire::FireVerdict where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::fire::FireVerdict::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::fire::FireVerdict::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::arm::fire::FireVerdict where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireVerdict::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::fire::FireVerdict where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireVerdict::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::fire::FireVerdict where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireVerdict::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::fire::FireVerdict
+pub fn nika_cli::verbs::arm::fire::FireVerdict::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::fire::FireVerdict where T: 'static
+pub fn nika_cli::verbs::arm::fire::FireVerdict::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::fire::FireVerdict where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::fire::FireVerdict::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::fire::FireVerdict::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::fire::FireVerdict
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::fire::FireVerdict
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::fire::FireVerdict
+pub type nika_cli::verbs::arm::fire::FireVerdict::Output = T
+pub fn nika_cli::verbs::arm::fire::fire_beat(ctx: &nika_cli::verbs::arm::fire::FireCtx) -> nika_cli::verbs::arm::fire::FireVerdict
+pub fn nika_cli::verbs::arm::fire::labels(registry: &nika_cadence::registry::ArmRegistry) -> alloc::vec::Vec<alloc::string::String>
+pub fn nika_cli::verbs::arm::fire::run(fire: &nika_cli::verbs::arm::args::FireArgs) -> nika_cli_host::output::VerbOutput
+pub mod nika_cli::verbs::arm::state
+pub enum nika_cli::verbs::arm::state::FireKind
+pub nika_cli::verbs::arm::state::FireKind::Failed
+pub nika_cli::verbs::arm::state::FireKind::Fired
+pub nika_cli::verbs::arm::state::FireKind::Paused
+pub nika_cli::verbs::arm::state::FireKind::Skipped
+impl nika_cli::verbs::arm::state::FireKind
+pub const fn nika_cli::verbs::arm::state::FireKind::as_str(self) -> &'static str
+impl core::clone::Clone for nika_cli::verbs::arm::state::FireKind
+pub fn nika_cli::verbs::arm::state::FireKind::clone(&self) -> nika_cli::verbs::arm::state::FireKind
+impl core::cmp::Eq for nika_cli::verbs::arm::state::FireKind
+impl core::cmp::PartialEq for nika_cli::verbs::arm::state::FireKind
+pub fn nika_cli::verbs::arm::state::FireKind::eq(&self, other: &nika_cli::verbs::arm::state::FireKind) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::state::FireKind
+pub fn nika_cli::verbs::arm::state::FireKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cli::verbs::arm::state::FireKind
+impl core::marker::StructuralPartialEq for nika_cli::verbs::arm::state::FireKind
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::FireKind
+impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::arm::state::FireKind where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::FireKind::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::arm::state::FireKind where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::FireKind::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::FireKind where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::FireKind::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::FireKind where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::FireKind::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::FireKind::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::FireKind where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::FireKind::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::FireKind::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::FireKind where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::FireKind::Owned = T
+pub fn nika_cli::verbs::arm::state::FireKind::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::FireKind::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::FireKind where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::FireKind::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::FireKind where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::FireKind::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::FireKind where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::FireKind::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::FireKind where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::FireKind::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::FireKind
+pub fn nika_cli::verbs::arm::state::FireKind::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::FireKind where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::FireKind::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::FireKind where T: 'static
+pub fn nika_cli::verbs::arm::state::FireKind::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_cli::verbs::arm::state::FireKind where T: core::marker::Copy
+pub fn nika_cli::verbs::arm::state::FireKind::as_out(&mut self) -> outref::Out<'_, T>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::FireKind where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::FireKind::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::FireKind::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::FireKind
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::FireKind
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::FireKind
+pub type nika_cli::verbs::arm::state::FireKind::Output = T
+pub enum nika_cli::verbs::arm::state::LockOutcome
+pub nika_cli::verbs::arm::state::LockOutcome::Acquired
+pub nika_cli::verbs::arm::state::LockOutcome::HeldAlive
+pub nika_cli::verbs::arm::state::LockOutcome::HeldAlive::pid: u32
+pub nika_cli::verbs::arm::state::LockOutcome::StaleTaken
+pub nika_cli::verbs::arm::state::LockOutcome::StaleTaken::old_pid: core::option::Option<u32>
+impl core::clone::Clone for nika_cli::verbs::arm::state::LockOutcome
+pub fn nika_cli::verbs::arm::state::LockOutcome::clone(&self) -> nika_cli::verbs::arm::state::LockOutcome
+impl core::cmp::Eq for nika_cli::verbs::arm::state::LockOutcome
+impl core::cmp::PartialEq for nika_cli::verbs::arm::state::LockOutcome
+pub fn nika_cli::verbs::arm::state::LockOutcome::eq(&self, other: &nika_cli::verbs::arm::state::LockOutcome) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::state::LockOutcome
+pub fn nika_cli::verbs::arm::state::LockOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cli::verbs::arm::state::LockOutcome
+impl core::marker::StructuralPartialEq for nika_cli::verbs::arm::state::LockOutcome
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::LockOutcome
+impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::arm::state::LockOutcome where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LockOutcome::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::arm::state::LockOutcome where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LockOutcome::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::LockOutcome where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::LockOutcome::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::LockOutcome where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::LockOutcome::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::LockOutcome::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::LockOutcome where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::LockOutcome::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::LockOutcome::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::LockOutcome where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::LockOutcome::Owned = T
+pub fn nika_cli::verbs::arm::state::LockOutcome::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::LockOutcome::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::LockOutcome where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LockOutcome::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::LockOutcome where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LockOutcome::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::LockOutcome where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LockOutcome::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::LockOutcome where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::LockOutcome::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::LockOutcome
+pub fn nika_cli::verbs::arm::state::LockOutcome::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::LockOutcome where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::LockOutcome::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::LockOutcome where T: 'static
+pub fn nika_cli::verbs::arm::state::LockOutcome::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_cli::verbs::arm::state::LockOutcome where T: core::marker::Copy
+pub fn nika_cli::verbs::arm::state::LockOutcome::as_out(&mut self) -> outref::Out<'_, T>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::LockOutcome where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LockOutcome::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::LockOutcome::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::LockOutcome
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::LockOutcome
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::LockOutcome
+pub type nika_cli::verbs::arm::state::LockOutcome::Output = T
+pub struct nika_cli::verbs::arm::state::ArmState
+impl nika_cli::verbs::arm::state::ArmState
+pub fn nika_cli::verbs::arm::state::ArmState::at_project(project_dir: &std::path::Path) -> Self
+pub fn nika_cli::verbs::arm::state::ArmState::last(&self, label: &str) -> core::option::Option<nika_cli::verbs::arm::state::LastRecord>
+pub fn nika_cli::verbs::arm::state::ArmState::last_fired(&self, label: &str) -> core::option::Option<jiff::zoned::Zoned>
+pub fn nika_cli::verbs::arm::state::ArmState::orphans(&self, known: &[alloc::string::String]) -> alloc::vec::Vec<alloc::string::String>
+pub fn nika_cli::verbs::arm::state::ArmState::record(&self, label: &str, entry: &nika_cli::verbs::arm::state::HistoryEntry) -> core::io::error::Result<()>
+pub fn nika_cli::verbs::arm::state::ArmState::release(&self, label: &str) -> core::io::error::Result<()>
+pub fn nika_cli::verbs::arm::state::ArmState::root(&self) -> &std::path::Path
+pub fn nika_cli::verbs::arm::state::ArmState::tallies(&self, label: &str) -> core::option::Option<(usize, usize)>
+pub fn nika_cli::verbs::arm::state::ArmState::try_lock(&self, label: &str, pid: u32, now: &jiff::zoned::Zoned) -> core::io::error::Result<nika_cli::verbs::arm::state::LockOutcome>
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::ArmState
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::ArmState where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::ArmState::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::ArmState where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::ArmState::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::ArmState::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::ArmState where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::ArmState::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::ArmState::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::arm::state::ArmState where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::ArmState::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::ArmState where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::ArmState::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::ArmState where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::ArmState::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::ArmState
+pub fn nika_cli::verbs::arm::state::ArmState::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::ArmState where T: 'static
+pub fn nika_cli::verbs::arm::state::ArmState::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::ArmState where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::ArmState::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::ArmState::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::ArmState
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::ArmState
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::ArmState
+pub type nika_cli::verbs::arm::state::ArmState::Output = T
+pub struct nika_cli::verbs::arm::state::HistoryEntry
+pub nika_cli::verbs::arm::state::HistoryEntry::decided_at: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::HistoryEntry::exit: core::option::Option<u8>
+pub nika_cli::verbs::arm::state::HistoryEntry::kind: nika_cli::verbs::arm::state::FireKind
+pub nika_cli::verbs::arm::state::HistoryEntry::reason: core::option::Option<alloc::string::String>
+pub nika_cli::verbs::arm::state::HistoryEntry::slot: core::option::Option<jiff::timestamp::Timestamp>
+pub nika_cli::verbs::arm::state::HistoryEntry::slots: core::option::Option<u32>
+pub nika_cli::verbs::arm::state::HistoryEntry::trace: core::option::Option<alloc::string::String>
+impl core::clone::Clone for nika_cli::verbs::arm::state::HistoryEntry
+pub fn nika_cli::verbs::arm::state::HistoryEntry::clone(&self) -> nika_cli::verbs::arm::state::HistoryEntry
+impl core::fmt::Debug for nika_cli::verbs::arm::state::HistoryEntry
+pub fn nika_cli::verbs::arm::state::HistoryEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::HistoryEntry
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::HistoryEntry where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::HistoryEntry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::HistoryEntry where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::HistoryEntry::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::HistoryEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::HistoryEntry where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::HistoryEntry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::HistoryEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::HistoryEntry where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::HistoryEntry::Owned = T
+pub fn nika_cli::verbs::arm::state::HistoryEntry::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::HistoryEntry::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::HistoryEntry where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::HistoryEntry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::HistoryEntry where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::HistoryEntry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::HistoryEntry where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::HistoryEntry::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::HistoryEntry where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::HistoryEntry::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::HistoryEntry
+pub fn nika_cli::verbs::arm::state::HistoryEntry::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::HistoryEntry where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::HistoryEntry::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::HistoryEntry where T: 'static
+pub fn nika_cli::verbs::arm::state::HistoryEntry::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::HistoryEntry where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::HistoryEntry::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::HistoryEntry::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::HistoryEntry
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::HistoryEntry
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::HistoryEntry
+pub type nika_cli::verbs::arm::state::HistoryEntry::Output = T
+pub struct nika_cli::verbs::arm::state::LastRecord
+pub nika_cli::verbs::arm::state::LastRecord::exit: core::option::Option<u8>
+pub nika_cli::verbs::arm::state::LastRecord::fired_at: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::LastRecord::kind: nika_cli::verbs::arm::state::FireKind
+pub nika_cli::verbs::arm::state::LastRecord::slot: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::LastRecord::trace: core::option::Option<alloc::string::String>
+impl core::clone::Clone for nika_cli::verbs::arm::state::LastRecord
+pub fn nika_cli::verbs::arm::state::LastRecord::clone(&self) -> nika_cli::verbs::arm::state::LastRecord
+impl core::fmt::Debug for nika_cli::verbs::arm::state::LastRecord
+pub fn nika_cli::verbs::arm::state::LastRecord::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::LastRecord
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::LastRecord where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::LastRecord::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::LastRecord where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::LastRecord::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::LastRecord::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::LastRecord where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::LastRecord::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::LastRecord::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::LastRecord where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::LastRecord::Owned = T
+pub fn nika_cli::verbs::arm::state::LastRecord::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::LastRecord::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::LastRecord where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LastRecord::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::LastRecord where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LastRecord::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::LastRecord where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LastRecord::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::LastRecord where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::LastRecord::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::LastRecord
+pub fn nika_cli::verbs::arm::state::LastRecord::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::LastRecord where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::LastRecord::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::LastRecord where T: 'static
+pub fn nika_cli::verbs::arm::state::LastRecord::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::LastRecord where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::LastRecord::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::LastRecord::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::LastRecord
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::LastRecord
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::LastRecord
+pub type nika_cli::verbs::arm::state::LastRecord::Output = T
+pub fn nika_cli::verbs::arm::run(args: nika_cli::verbs::arm::args::ArmArgs) -> nika_cli_host::output::VerbOutput
 pub fn nika_cli::verbs::arm::run_at(start: &std::path::Path) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli::verbs::catalog
 pub fn nika_cli::verbs::catalog::run(json: bool, theme: nika_display::theme::Theme) -> nika_cli_host::output::VerbOutput

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -191,7 +191,7 @@ enum Command {
     /// day-one craft verbs, and arming a project is not day one. It
     /// stays one flag away (`--help --all`) and AGENTS.md teaches it.
     #[command(hide = true, display_order = 72)]
-    Arm,
+    Arm(verbs::arm::args::ArmArgs),
     /// Sign a workflow file (S3 · author-binding): mint `<file>.minisig` · `--check` verifies.
     #[command(hide = true, display_order = 71)]
     Sign(verbs::sign::SignArgs),
@@ -732,7 +732,7 @@ fn dispatch_verb(
             forecast,
         } => emit(&explain_dispatch(&code, json, forecast, plain_theme)),
         Command::Key { action } => emit(&verbs::key::run(action)),
-        Command::Arm => emit(&verbs::arm::run()),
+        Command::Arm(a) => emit(&verbs::arm::run(a)),
         Command::Sign(args) => emit(&verbs::sign::run(&args)),
         Command::Doctor(args) => doctor_verb(&args, plain_theme),
         Command::Init(args) => emit(&init_verb(&args, plain_theme)),

--- a/crates/nika-cli/src/verbs/arm/args.rs
+++ b/crates/nika-cli/src/verbs/arm/args.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `nika arm` clap surface — the arg types the bin's `Command`
+//! enum carries (the `CheckArgs` precedent at the 1500-line cap: the
+//! bin composes, the verb owns its arg types).
+//!
+//! `emit` · `write` · `out` · `mode` · `env_file` · `nika_bin` are the
+//! W3 (OS-unit emission) surface, DECLARED now so the clap tree freezes
+//! once: passing one in W2 refuses honestly rather than silently doing
+//! nothing.
+
+use std::path::PathBuf;
+
+/// `nika arm` — bare (no subcommand, no flag) it READS the registry
+/// and reports (the file proposes, the machine disposes). The
+/// subcommands are the machine's edge: `fire` is the one firer (D2 —
+/// the OS units and `serve` both end here), `disarm` teaches the N4
+/// gesture.
+#[derive(Debug, clap::Args)]
+pub struct ArmArgs {
+    /// The machine edge (`fire` · `disarm`) — absent: the read-only
+    /// arming report.
+    #[command(subcommand)]
+    pub sub: Option<ArmSub>,
+    /// Emit the OS unit that fires the beats (`launchd` · `systemd`)
+    /// instead of reading the registry — the W3 wave.
+    #[arg(long, value_enum, value_name = "OS")]
+    pub emit: Option<EmitTarget>,
+    /// With `--emit`: write the unit file instead of printing it.
+    #[arg(long)]
+    pub write: bool,
+    /// With `--emit --write`: the directory the unit writes to.
+    #[arg(long, value_name = "DIR")]
+    pub out: Option<PathBuf>,
+    /// With `--emit`: the scope the unit installs at.
+    #[arg(long, value_enum, value_name = "SCOPE")]
+    pub mode: Option<EmitMode>,
+    /// With `--emit`: the env file the unit loads (provider keys live
+    /// there, never in the unit).
+    #[arg(long, value_name = "FILE")]
+    pub env_file: Option<PathBuf>,
+    /// With `--emit`: the nika binary the unit invokes.
+    #[arg(long, value_name = "BIN")]
+    pub nika_bin: Option<PathBuf>,
+}
+
+/// The machine edge under `nika arm`.
+#[derive(Debug, clap::Subcommand)]
+pub enum ArmSub {
+    /// Fire ONE beat now, if it is due — the one firer (D2): on-time
+    /// window · miss policy · overlap lock · per-tick ceiling · the
+    /// firing record. Prints exactly one stdout line, always (D8).
+    Fire(FireArgs),
+    /// Teach the disarm gesture (law N4 — removing the line does NOT
+    /// disarm; `actif: false` + `raison:` + `jusqu_au:` does).
+    Disarm {
+        /// The beat label (the workflow file radical).
+        label: String,
+        /// Also tear the OS unit down — the W3 wave.
+        #[arg(long)]
+        write: bool,
+    },
+}
+
+/// `nika arm fire <label>` — the firer's args.
+#[derive(Debug, clap::Args)]
+pub struct FireArgs {
+    /// The beat label — the workflow file radical
+    /// (`workflows/doctor.nika.yaml` → `doctor`; a radical collision in
+    /// file order takes `-2`, `-3`).
+    pub label: String,
+    /// Inject the decision instant (RFC 3339) instead of reading the
+    /// wall clock — the clock is the verb's edge (D5), so a replay and
+    /// a test are deterministic.
+    #[arg(long, hide = true, value_name = "RFC3339")]
+    pub now: Option<String>,
+}
+
+/// The OS an emitted unit targets — the W3 surface, declared now.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum EmitTarget {
+    /// macOS launchd user agent (`~/Library/LaunchAgents/nika.arm.<radical>.plist`).
+    Launchd,
+    /// A systemd user timer + service pair.
+    Systemd,
+}
+
+/// The scope an emitted unit installs at — the W3 surface, declared now.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum EmitMode {
+    /// The operator's own agent (the default posture).
+    User,
+    /// A system-wide daemon.
+    System,
+}

--- a/crates/nika-cli/src/verbs/arm/fire.rs
+++ b/crates/nika-cli/src/verbs/arm/fire.rs
@@ -551,6 +551,8 @@ fn run_and_record(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdic
     let workflow = beat.map_or_else(String::new, |b| b.workflow.clone());
     let before = trace_set(&ctx.project_root);
     let Ok(_room) = enter_room(&ctx.project_root) else {
+        // The lock we hold never outlives a door we cannot walk through.
+        let _ = ctx.state.release(&ctx.label);
         return FireVerdict {
             line: format!("failed {} · cannot enter the project root", ctx.label),
             code: exit::ENV,

--- a/crates/nika-cli/src/verbs/arm/fire.rs
+++ b/crates/nika-cli/src/verbs/arm/fire.rs
@@ -1,0 +1,986 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `nika arm fire <label>` — LE TIREUR · the one firer (D2).
+//!
+//! ONE function applies the on-time window, the miss policy, the
+//! overlap lock, the per-tick ceiling and the record — the OS units
+//! (W3) and `serve` (W5) both end here, so the law lives exactly once.
+//! The beat to fire is the workflow file's radical (D4 —
+//! `workflows/doctor.nika.yaml` → `doctor`; a collision takes `-2`,
+//! `-3` in file order), the firing state is the sidecar of
+//! [`state`](super::state) (D3), and the clock is injected at the
+//! verb's edge (D5 — `--now`, hidden): the pure decision never reads
+//! one, never sleeps, and a replay is deterministic.
+//!
+//! The stdout contract (D8): a decision prints EXACTLY ONE line —
+//! `fired …` · `skipped …` · `paused …` · `failed …`. The in-process
+//! run's own fold is turned onto stderr for its duration, so the
+//! machine surface stays byte-pure (the launchd/serve log captures
+//! both). Two honest exceptions: a registry REFUSAL (exit 2) teaches
+//! multi-line, the same voice `nika arm` uses today; and a run that
+//! dies ENVIRONMENT (rc 3) rides the bin's env-to-stderr law.
+//!
+//! Law 4 (N2) binds the pause: every fire is a FRESH run — a paused
+//! run is PARKED with its trace (`paused … · trace …`), never resumed,
+//! never answered by the firer.
+
+use std::path::{Path, PathBuf};
+
+use jiff::{Timestamp, Zoned};
+use nika_cadence::registry::{AfterSkip, ArmRegistry, Beat, Cadence, Locus, MissPolicy, Overlap};
+use nika_vocab::project;
+
+use super::args::FireArgs;
+use super::state::{ArmState, FireKind, HistoryEntry, LockOutcome};
+use crate::verbs::run::RenderMode;
+use crate::verbs::{self, VerbOutput, exit};
+
+/// The poll quantum while a queued tick (`chevauchement: file`) waits
+/// for the running one to release the lock.
+const POLL_MS: i64 = 1_000;
+
+/// The firer's context (D2) — everything the decision needs, injected.
+/// `serve` (②) builds the same one; the verb below only parses args.
+pub struct FireCtx {
+    /// The project root (the directory holding `nika.yaml`).
+    pub project_root: PathBuf,
+    /// The parsed + validated registry.
+    pub registry: ArmRegistry,
+    /// The beat's position in the registry (label resolution is the
+    /// caller's — [`labels`]).
+    pub index: usize,
+    /// The beat's label (the workflow file radical, D4).
+    pub label: String,
+    /// The decision instant — injected (D5); the pure code never reads
+    /// a clock.
+    pub now: Zoned,
+    /// The firing sidecar (D3).
+    pub state: ArmState,
+}
+
+/// What a fire leaves: the ONE stdout line (D8) + the process exit.
+pub struct FireVerdict {
+    /// The single line — `fired …` · `skipped …` · `paused …` ·
+    /// `failed …`.
+    pub line: String,
+    /// `0` fired/skipped · `2` a refusal · the run's rc (1·2·3·4) when
+    /// the run went.
+    pub code: u8,
+}
+
+/// The pure decision — the file's own truth, the v0 refusals, the
+/// clock's verdict — GIVEN the beat, the injected instant and the last
+/// decided slot. Locking and running are the impure halves
+/// ([`fire_beat`]).
+enum Decision {
+    /// A policy said no. `slot` Some ⇒ the decision consumes the slot
+    /// (last.json moves); `journal` false ⇒ nothing changed, nothing is
+    /// written (a duplicate tick is not a decision).
+    Skip {
+        /// The full one-line report (D8).
+        line: String,
+        /// The machine token (`missed:2` · `overlap` · `cloud` · …).
+        reason: String,
+        /// The slot the decision covers.
+        slot: Option<Zoned>,
+        /// Journal the decision (history · maybe last.json).
+        journal: bool,
+    },
+    /// v0 refuses with teaching, naming the version it arrives with.
+    Refuse {
+        /// The teaching line (exit 2).
+        line: String,
+    },
+    /// Fire the slot — `slots` Some(n) is `rattraper-une-fois`: ONE run
+    /// answers for the whole silence.
+    Fire {
+        /// The slot to fire.
+        slot: Zoned,
+        /// The silence's count for `rattraper-une-fois`.
+        slots: Option<u32>,
+    },
+}
+
+/// `nika arm fire <label>` — the verb edge: discover, parse, judge the
+/// label, inject the clock (D5), then the one firer. The report's CWD
+/// door and refusal voice, unchanged.
+#[must_use]
+pub fn run(fire: &FireArgs) -> VerbOutput {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let found = match project::discover(&cwd) {
+        Ok(found) => found,
+        Err(e) => return VerbOutput::file(format!("PROJECT ✗  {e}")),
+    };
+    let Some((path, _project)) = found else {
+        return VerbOutput::file(
+            "nothing armed — this project has no `nika.yaml`\n  \
+             fix: `nika init --project-file` lays a commented starter"
+                .to_owned(),
+        );
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) => return VerbOutput::env(format!("cannot read {}: {e}", path.display())),
+    };
+    let registry = match nika_cadence::parse_registry(&text) {
+        Ok(registry) => registry,
+        Err(e) => return VerbOutput::file(format!("ARM ✗  {e}")),
+    };
+    let faults: Vec<String> = nika_cadence::validate(&registry)
+        .map(|e| format!("  {e}"))
+        .collect();
+    if !faults.is_empty() {
+        return VerbOutput::file(format!(
+            "ARM ✗  {} in {}\n{}",
+            crate::text::count(faults.len(), "refusal"),
+            path.display(),
+            faults.join("\n")
+        ));
+    }
+    let labels = labels(&registry);
+    let Some(index) = labels.iter().position(|l| l == &fire.label) else {
+        return VerbOutput::file(format!(
+            "arm fire: unknown beat `{}` — this project arms: {}",
+            fire.label,
+            labels.join(" · ")
+        ));
+    };
+    let now = match parse_now(fire.now.as_deref()) {
+        Ok(now) => now,
+        Err(line) => return VerbOutput::file(line),
+    };
+    let root = path
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let ctx = FireCtx {
+        state: ArmState::at_project(&root),
+        project_root: root,
+        registry,
+        index,
+        label: fire.label.clone(),
+        now,
+    };
+    let verdict = fire_beat(&ctx);
+    VerbOutput {
+        text: verdict.line,
+        code: verdict.code,
+    }
+}
+
+/// The beat labels, in file order (D4): the workflow file's radical —
+/// `workflows/doctor.nika.yaml` → `doctor` — a collision taking `-2`,
+/// `-3`. The OS unit names itself `nika.arm.<radical>` from this list.
+#[must_use]
+pub fn labels(registry: &ArmRegistry) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for beat in registry.beats() {
+        let radical = radical_of(&beat.workflow);
+        let mut candidate = radical.clone();
+        let mut n = 1u32;
+        // Uniqueness is the law (`doctor-2.nika.yaml` arming next to
+        // two `doctor` must never hand two beats one label).
+        while out.contains(&candidate) {
+            n += 1;
+            candidate = format!("{radical}-{n}");
+        }
+        out.push(candidate);
+    }
+    out
+}
+
+/// The radical of a workflow path: the basename minus the `.nika.yaml`
+/// the grammar guarantees (a bare `*.yaml` loses its last extension).
+fn radical_of(workflow: &str) -> String {
+    let base = workflow.rsplit('/').next().unwrap_or(workflow);
+    if let Some(radical) = base.strip_suffix(".nika.yaml") {
+        return radical.to_owned();
+    }
+    base.rsplit_once('.')
+        .map_or_else(|| base.to_owned(), |(stem, _)| stem.to_owned())
+}
+
+/// The decision instant: the hidden `--now` (RFC 3339) or the wall
+/// clock — the ONE clock read of the verb (D5). A bare RFC 3339 instant
+/// lands on UTC; jiff's zoned form (`…+02:00[Europe/Paris]`) keeps its
+/// zone. Comparisons ride the instant either way.
+fn parse_now(raw: Option<&str>) -> Result<Zoned, String> {
+    match raw {
+        None => Ok(Zoned::now()),
+        Some(text) => text
+            .parse::<Zoned>()
+            .or_else(|_| {
+                text.parse::<Timestamp>()
+                    .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC))
+            })
+            .map_err(|_| {
+                format!("arm fire: --now `{text}` · RFC 3339 attendu — 2026-08-19T03:02:00Z")
+            }),
+    }
+}
+
+/// The decision, pure — every branch pinned by the unit tests below.
+/// Order matters: the file's own truth first (inactive · cloud ·
+/// expired), then the v0 refusals (they teach even when the beat would
+/// be due), then the clock's verdict.
+fn decide(
+    registry: &ArmRegistry,
+    index: usize,
+    label: &str,
+    now: &Zoned,
+    last: Option<&Zoned>,
+) -> Decision {
+    let Some(beat) = registry.beats().nth(index) else {
+        return Decision::Refuse {
+            line: "arm fire · engine fault: the label resolved past the registry".to_owned(),
+        };
+    };
+    if !beat.is_active() {
+        let why = beat.raison.as_deref().unwrap_or("sans raison");
+        return Decision::Skip {
+            line: format!("skipped {label} · inactive — {why}"),
+            reason: "inactive".to_owned(),
+            slot: None,
+            journal: true,
+        };
+    }
+    if beat.locus() == Locus::Cloud {
+        return Decision::Skip {
+            line: format!(
+                "skipped {label} · cloud — le cloud exécute, le calendrier demeure au registre"
+            ),
+            reason: "cloud".to_owned(),
+            slot: None,
+            journal: true,
+        };
+    }
+    if let Some(expired) = expiry_passed(beat, now) {
+        return Decision::Skip {
+            line: format!("skipped {label} · expired · jusqu_au {expired}"),
+            reason: "expired".to_owned(),
+            slot: None,
+            journal: true,
+        };
+    }
+    if let Some(line) = v0_refusal(beat) {
+        return Decision::Refuse { line };
+    }
+    let cadence = match Cadence::parse(&beat.cadence) {
+        Ok(cadence) => cadence,
+        // validate ran first — a cadence that fails here is an ENGINE
+        // fault, said as such (the two-readers law).
+        Err(e) => {
+            return Decision::Refuse {
+                line: format!("arm fire · engine fault: a validated cadence refuses — {e}"),
+            };
+        }
+    };
+    if matches!(cadence, Cadence::Webhook) {
+        return Decision::Skip {
+            line: format!(
+                "skipped {label} · webhook — le beat tire à l'événement, jamais à l'horloge"
+            ),
+            reason: "webhook".to_owned(),
+            slot: None,
+            journal: true,
+        };
+    }
+    decide_by_clock(registry, index, label, now, last, &cadence, beat)
+}
+
+/// The clock half of the decision: the planner's silence over
+/// `(last, now]`, the on-time window, the miss policy.
+fn decide_by_clock(
+    registry: &ArmRegistry,
+    index: usize,
+    label: &str,
+    now: &Zoned,
+    last: Option<&Zoned>,
+    cadence: &Cadence,
+    beat: &Beat,
+) -> Decision {
+    let last_owned = last.cloned();
+    // A named binding: the planner borrows the callback for the call.
+    let last_of = move |i: usize| {
+        if i == index { last_owned.clone() } else { None }
+    };
+    let dues = match nika_cadence::due(registry, now, &last_of) {
+        Ok(dues) => dues,
+        // validate ran first — same engine-fault voice as the cadence.
+        Err(e) => {
+            return Decision::Refuse {
+                line: format!("arm fire · engine fault: a validated registry refuses — {e}"),
+            };
+        }
+    };
+    match dues.into_iter().find(|d| d.index == index) {
+        Some(due) => match (due.kind, beat.manque) {
+            (nika_cadence::DueKind::OnTime, _) => Decision::Fire {
+                slot: due.slot.at,
+                slots: None,
+            },
+            (nika_cadence::DueKind::Missed { slots }, Some(MissPolicy::Sauter)) => Decision::Skip {
+                line: format!(
+                    "skipped {label} · missed:{slots} · slot {}",
+                    due.slot.at.timestamp()
+                ),
+                reason: format!("missed:{slots}"),
+                slot: Some(due.slot.at),
+                journal: true,
+            },
+            (nika_cadence::DueKind::Missed { slots }, Some(MissPolicy::RattraperUneFois)) => {
+                Decision::Fire {
+                    slot: due.slot.at,
+                    slots: Some(slots),
+                }
+            }
+            // `rattraper` is a v0 refusal upstream and a missing
+            // `manqué:` never passes validate — an arrival here is an
+            // engine fault, said as such, never an approximation.
+            _ => Decision::Refuse {
+                line: "arm fire · engine fault: manqué: policy escaped validation".to_owned(),
+            },
+        },
+        // Not due: either this slot was already DECIDED (a duplicate
+        // tick changes nothing — and journals nothing), or there is no
+        // state and the planner invents no backlog (N2).
+        None => match (last, cadence.prev_before(now)) {
+            (Some(fired), Some(prev)) if prev.at == *fired => Decision::Skip {
+                line: format!("skipped {label} · already · slot {}", prev.at.timestamp()),
+                reason: "already".to_owned(),
+                slot: None,
+                journal: false,
+            },
+            _ => Decision::Skip {
+                line: format!(
+                    "skipped {label} · not-due — hors fenêtre, et N2 n'invente pas d'arriéré"
+                ),
+                reason: "not-due".to_owned(),
+                slot: None,
+                journal: false,
+            },
+        },
+    }
+}
+
+/// The v0 refusals (D6) — each names the version it arrives with. A
+/// policy the firer cannot honor must REFUSE, never approximate.
+fn v0_refusal(beat: &Beat) -> Option<String> {
+    let w = beat.workflow.as_str();
+    if beat.chevauchement == Some(Overlap::Remplacer) {
+        return Some(format!(
+            "arm fire {w} · chevauchement: remplacer — arrive avec serve v0.2 · aujourd'hui: sauter (le défaut) ou file"
+        ));
+    }
+    if beat.apres_saut == Some(AfterSkip::ACompletion) {
+        return Some(format!(
+            "arm fire {w} · après_saut: à-complétion — arrive avec serve v0.2 · aujourd'hui: prochain-créneau (le défaut)"
+        ));
+    }
+    if beat.manque == Some(MissPolicy::Rattraper) {
+        return Some(format!(
+            "arm fire {w} · manqué: rattraper — arrive avec serve v0.2 · aujourd'hui: rattraper-une-fois ou sauter"
+        ));
+    }
+    if beat.decalage.is_some() {
+        return Some(format!(
+            "arm fire {w} · décalage: — arrive avec serve v0.2 · aujourd'hui le créneau tire à l'instant dit"
+        ));
+    }
+    None
+}
+
+/// `jusqu_au` strictly before the decision instant's own date ⇒ the
+/// suspension is over. v0 judges on the instant's civil date (a bare
+/// `--now` rides UTC) — the zone-exact expiry lands with serve.
+fn expiry_passed(beat: &Beat, now: &Zoned) -> Option<String> {
+    let raw = beat.jusqu_au.as_deref()?;
+    let date = raw.parse::<jiff::civil::Date>().ok()?;
+    (date < now.date()).then(|| raw.to_owned())
+}
+
+/// The one firer (D2): decide, then act — journal the skip, or lock
+/// (law ⑥) and run. Always the ONE line (D8).
+#[must_use]
+pub fn fire_beat(ctx: &FireCtx) -> FireVerdict {
+    let last = ctx.state.last_fired(&ctx.label);
+    match decide(
+        &ctx.registry,
+        ctx.index,
+        &ctx.label,
+        &ctx.now,
+        last.as_ref(),
+    ) {
+        Decision::Refuse { line } => FireVerdict {
+            line,
+            code: exit::FILE,
+        },
+        Decision::Skip {
+            line,
+            reason,
+            slot,
+            journal,
+        } => {
+            if journal {
+                let verdict = write_record(
+                    ctx,
+                    &HistoryEntry {
+                        slot: slot.as_ref().map(Zoned::timestamp),
+                        decided_at: ctx.now.timestamp(),
+                        kind: FireKind::Skipped,
+                        reason: Some(reason),
+                        trace: None,
+                        exit: Some(exit::OK),
+                        slots: None,
+                    },
+                );
+                if let Some(verdict) = verdict {
+                    return verdict;
+                }
+            }
+            FireVerdict {
+                line,
+                code: exit::OK,
+            }
+        }
+        Decision::Fire { slot, slots } => fire_slot(ctx, &slot, slots),
+    }
+}
+
+/// The lock, then the shot.
+fn fire_slot(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdict {
+    match ctx.state.try_lock(&ctx.label, std::process::id(), &ctx.now) {
+        Err(e) => FireVerdict {
+            line: format!("failed {} · the lock refused: {e}", ctx.label),
+            code: exit::ENV,
+        },
+        Ok(LockOutcome::HeldAlive { pid }) => match beat_of(ctx).map(Beat::overlap) {
+            Some(Overlap::Sauter) => say_after_journal(
+                ctx,
+                FireKind::Skipped,
+                Some("overlap".to_owned()),
+                slot,
+                None,
+                None,
+                exit::OK,
+                format!(
+                    "skipped {} · overlap · pid {pid} tient le créneau",
+                    ctx.label
+                ),
+            ),
+            Some(Overlap::File) => poll_queue(ctx, slot, slots, pid),
+            // `remplacer` is a v0 refusal upstream — an arrival here is
+            // an engine fault, said as such, never an approximation.
+            _ => FireVerdict {
+                line: format!(
+                    "failed {} · engine fault: remplacer reached the lock",
+                    ctx.label
+                ),
+                code: exit::FILE,
+            },
+        },
+        Ok(LockOutcome::Acquired | LockOutcome::StaleTaken { .. }) => {
+            run_and_record(ctx, slot, slots)
+        }
+    }
+}
+
+/// `chevauchement: file` — poll the lock each second until the running
+/// tick releases it, or until the beat's NEXT slot (firing the old one
+/// past it would double the new one).
+fn poll_queue(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>, holder: u32) -> FireVerdict {
+    let budget_ms = beat_of(ctx)
+        .and_then(|b| Cadence::parse(&b.cadence).ok())
+        .and_then(|c| c.next_after(&ctx.now))
+        .map_or(0, |next| {
+            next.at.timestamp().as_millisecond() - ctx.now.timestamp().as_millisecond()
+        });
+    let mut waited_ms = 0i64;
+    loop {
+        if waited_ms >= budget_ms {
+            return say_after_journal(
+                ctx,
+                FireKind::Skipped,
+                Some("overlap-timeout".to_owned()),
+                slot,
+                None,
+                None,
+                exit::OK,
+                format!(
+                    "skipped {} · overlap-timeout · pid {holder} a tenu jusqu'au créneau suivant",
+                    ctx.label
+                ),
+            );
+        }
+        let step = (budget_ms - waited_ms).min(POLL_MS);
+        std::thread::sleep(std::time::Duration::from_millis(
+            u64::try_from(step).unwrap_or(0),
+        ));
+        waited_ms += step;
+        match ctx.state.try_lock(&ctx.label, std::process::id(), &ctx.now) {
+            Ok(LockOutcome::Acquired | LockOutcome::StaleTaken { .. }) => {
+                return run_and_record(ctx, slot, slots);
+            }
+            Ok(LockOutcome::HeldAlive { .. }) => {}
+            Err(e) => {
+                return FireVerdict {
+                    line: format!("failed {} · the lock refused: {e}", ctx.label),
+                    code: exit::ENV,
+                };
+            }
+        }
+    }
+}
+
+/// The shot: enter the project (traces and workflow-relative paths
+/// resolve at the root), turn stdout onto stderr for the run's
+/// duration (D8), run IN-PROCESS with the `nika run` CLI defaults —
+/// the per-tick ceiling ALWAYS set (law 7) — then record, release, and
+/// say the ONE line.
+fn run_and_record(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdict {
+    let beat = beat_of(ctx);
+    let Some(plafond) = beat.and_then(|b| b.plafond) else {
+        return FireVerdict {
+            line: format!(
+                "failed {} · engine fault: plafond absent après validation — à reporter avec le fichier",
+                ctx.label
+            ),
+            code: exit::FILE,
+        };
+    };
+    let workflow = beat.map_or_else(String::new, |b| b.workflow.clone());
+    let before = trace_set(&ctx.project_root);
+    let Ok(_room) = enter_room(&ctx.project_root) else {
+        return FireVerdict {
+            line: format!("failed {} · cannot enter the project root", ctx.label),
+            code: exit::ENV,
+        };
+    };
+    let code = run_quietly(|| {
+        verbs::run::run(
+            &workflow,
+            false, // json
+            None,  // output
+            crate::Theme::new(false, true, false),
+            RenderMode::Plain, // the piped `nika run` defaults
+            false,             // dry_run
+            None,              // model_override
+            None,              // access_pin
+            &[],               // vars
+            None,              // resume — NEVER (law 4 · N2)
+            false,             // no_trace_file — the trace is load-bearing
+            None,              // task_filter
+            false,             // no_outputs
+            Some(plafond),     // the per-tick ceiling, ALWAYS (law 7)
+            false,             // no_gc
+            false,             // require_signature — ② (serve) verifies
+        )
+    });
+    let trace = new_trace(&ctx.project_root, &before);
+    let _ = ctx.state.release(&ctx.label);
+    let (kind, line) = verdict_line(ctx, slot, slots, code, trace.as_deref());
+    say_after_journal(ctx, kind, None, slot, slots, trace, code, line)
+}
+
+/// The line + the kind for a run that went (rc 0 · 1 · 2 · 3 · 4).
+fn verdict_line(
+    ctx: &FireCtx,
+    slot: &Zoned,
+    slots: Option<u32>,
+    code: u8,
+    trace: Option<&str>,
+) -> (FireKind, String) {
+    let label = ctx.label.as_str();
+    let slot_rfc = slot.timestamp().to_string();
+    let catchup = slots.map_or(String::new(), |n| format!(" · rattrapage ×{n}"));
+    let via_trace = trace.map_or(String::new(), |t| format!(" · trace {t}"));
+    match code {
+        exit::OK => (
+            FireKind::Fired,
+            format!("fired {label} · slot {slot_rfc}{catchup} · exit 0{via_trace}"),
+        ),
+        exit::PAUSED => (
+            FireKind::Paused,
+            format!(
+                "paused {label} · slot {slot_rfc}{via_trace} — garé (N2: jamais repris, jamais répondu)"
+            ),
+        ),
+        _ => (
+            FireKind::Failed,
+            format!("failed {label} · slot {slot_rfc} · exit {code}{via_trace}"),
+        ),
+    }
+}
+
+/// Journal the decision, then the line. A fire without its record is a
+/// fire that re-fires — a record failure is said, never swallowed.
+#[allow(clippy::too_many_arguments)] // the decision's full facts
+fn say_after_journal(
+    ctx: &FireCtx,
+    kind: FireKind,
+    reason: Option<String>,
+    slot: &Zoned,
+    slots: Option<u32>,
+    trace: Option<String>,
+    code: u8,
+    line: String,
+) -> FireVerdict {
+    let entry = HistoryEntry {
+        slot: Some(slot.timestamp()),
+        decided_at: ctx.now.timestamp(),
+        kind,
+        reason,
+        trace,
+        exit: Some(code),
+        slots,
+    };
+    if let Some(verdict) = write_record(ctx, &entry) {
+        return verdict;
+    }
+    FireVerdict { line, code }
+}
+
+/// The record write — `Some(verdict)` when it failed (the failure
+/// line REPLACES the decision's: an unrecorded fire re-fires).
+fn write_record(ctx: &FireCtx, entry: &HistoryEntry) -> Option<FireVerdict> {
+    ctx.state
+        .record(&ctx.label, entry)
+        .err()
+        .map(|e| FireVerdict {
+            line: format!("failed {} · the record refused: {e}", ctx.label),
+            code: exit::ENV,
+        })
+}
+
+/// The beat at the context's index (validated: always present).
+fn beat_of(ctx: &FireCtx) -> Option<&Beat> {
+    ctx.registry.beats().nth(ctx.index)
+}
+
+/// The trace files present under the project (`.nika/traces/*.ndjson`).
+fn trace_set(root: &Path) -> Vec<String> {
+    let dir = root.join(nika_dap::store::TRACE_DIR);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.ends_with(".ndjson"))
+        .collect()
+}
+
+/// The trace THIS run wrote: the `.ndjson` present now that was not
+/// there before (several = the alphabetically last — the freshest
+/// timestamp wins the name).
+fn new_trace(root: &Path, before: &[String]) -> Option<String> {
+    let mut fresh: Vec<String> = trace_set(root)
+        .into_iter()
+        .filter(|n| !before.contains(n))
+        .collect();
+    fresh.sort_unstable();
+    fresh
+        .last()
+        .map(|name| format!("{}/{name}", nika_dap::store::TRACE_DIR))
+}
+
+/// Enter the project root for the run's duration — the fold's trace
+/// sink (`.nika/traces/`) and the workflow's relative paths read the
+/// CWD (the `try` verb's rehearsal-room precedent).
+struct RoomGuard(Option<PathBuf>);
+
+impl Drop for RoomGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.0 {
+            let _ = std::env::set_current_dir(previous);
+        }
+    }
+}
+
+fn enter_room(root: &Path) -> std::io::Result<RoomGuard> {
+    let previous = std::env::current_dir().ok();
+    std::env::set_current_dir(root)?;
+    Ok(RoomGuard(previous))
+}
+
+/// Turn stdout onto stderr for the run's duration — D8's one-line
+/// machine surface stays byte-pure while the fold narrates to the log
+/// (nix's `dup2_stdout` pair; restored on drop, panic included).
+#[cfg(unix)]
+struct StdoutGuard {
+    saved: std::os::fd::OwnedFd,
+}
+
+#[cfg(unix)]
+impl StdoutGuard {
+    fn enter() -> std::io::Result<Self> {
+        use std::io::Write as _;
+        std::io::stdout().flush()?;
+        let saved = nix::unistd::dup(std::io::stdout())?;
+        nix::unistd::dup2_stdout(std::io::stderr())?;
+        Ok(Self { saved })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for StdoutGuard {
+    fn drop(&mut self) {
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        let _ = nix::unistd::dup2_stdout(&self.saved);
+    }
+}
+
+/// The run behind the stdout guard (unix) — a guard failure degrades
+/// to the unguarded run (the line still prints; the fold may precede
+/// it), never blocks the shot.
+#[cfg(unix)]
+fn run_quietly(f: impl FnOnce() -> u8) -> u8 {
+    match StdoutGuard::enter() {
+        Ok(_guard) => f(),
+        Err(_) => f(),
+    }
+}
+
+/// No fd surface off-unix: the run speaks (the ship targets are unix).
+#[cfg(not(unix))]
+fn run_quietly(f: impl FnOnce() -> u8) -> u8 {
+    f()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// A one-beat registry (validated green) — the `decide` fixture.
+    fn registry_with(body: &str) -> ArmRegistry {
+        let text = format!(
+            "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
+        );
+        let registry = nika_cadence::parse_registry(&text).expect("parse");
+        assert!(
+            nika_cadence::validate(&registry).next().is_none(),
+            "the fixture must be lawful"
+        );
+        registry
+    }
+
+    const BASE: &str = "    manqué: sauter\n";
+
+    fn at(text: &str) -> Zoned {
+        text.parse::<Timestamp>()
+            .expect("ts")
+            .to_zoned(jiff::tz::TimeZone::UTC)
+    }
+
+    fn decide_base(now: &Zoned, last: Option<&Zoned>) -> Decision {
+        let registry = registry_with(BASE);
+        decide(&registry, 0, "doctor", now, last)
+    }
+
+    /// On time, never fired: the window alone decides (N2) — FIRE.
+    #[test]
+    fn an_on_time_slot_without_state_fires() {
+        match decide_base(&at("2026-08-19T03:02:00Z"), None) {
+            Decision::Fire { slot, slots } => {
+                assert_eq!(slot.timestamp().to_string(), "2026-08-19T03:00:00Z");
+                assert_eq!(slots, None);
+            }
+            _ => panic!("on-time without state fires"),
+        }
+    }
+
+    /// Never fired and the window long gone: no state invents no
+    /// backlog (N2) — skipped, journaled NOWHERE.
+    #[test]
+    fn a_first_contact_beyond_the_window_skips_without_a_record() {
+        match decide_base(&at("2026-08-19T10:00:00Z"), None) {
+            Decision::Skip {
+                reason, journal, ..
+            } => {
+                assert_eq!(reason, "not-due");
+                assert!(!journal, "N2 writes nothing");
+            }
+            _ => panic!("hors fenêtre sans état saute"),
+        }
+    }
+
+    /// The slot already DECIDED: a duplicate tick is a no-op.
+    #[test]
+    fn an_already_decided_slot_skips_without_a_record() {
+        let fired = at("2026-08-19T03:00:00Z");
+        match decide_base(&at("2026-08-19T03:01:00Z"), Some(&fired)) {
+            Decision::Skip {
+                reason, journal, ..
+            } => {
+                assert_eq!(reason, "already");
+                assert!(!journal);
+            }
+            _ => panic!("déjà décidé saute"),
+        }
+    }
+
+    /// A missed slot under `manqué: sauter`: skipped, journaled WITH
+    /// the slot (a skip consumes it).
+    #[test]
+    fn a_missed_slot_under_sauter_is_journaled_and_consumed() {
+        let fired = at("2026-08-18T03:00:00Z");
+        match decide_base(&at("2026-08-19T10:00:00Z"), Some(&fired)) {
+            Decision::Skip {
+                reason,
+                slot,
+                journal,
+                line,
+            } => {
+                assert_eq!(reason, "missed:1");
+                assert!(journal);
+                assert_eq!(
+                    slot.expect("the consumed slot").timestamp().to_string(),
+                    "2026-08-19T03:00:00Z"
+                );
+                assert!(line.starts_with("skipped doctor · missed:1"), "{line}");
+            }
+            _ => panic!("un créneau raté saute"),
+        }
+    }
+
+    /// `rattraper-une-fois`: ONE fire answers for the whole silence.
+    #[test]
+    fn rattraper_une_fois_fires_once_for_the_whole_silence() {
+        let registry = registry_with("    manqué: rattraper-une-fois\n");
+        let fired = at("2026-08-17T03:00:00Z");
+        match decide(
+            &registry,
+            0,
+            "doctor",
+            &at("2026-08-19T03:02:00Z"),
+            Some(&fired),
+        ) {
+            Decision::Fire { slot, slots } => {
+                assert_eq!(slot.timestamp().to_string(), "2026-08-19T03:00:00Z");
+                assert_eq!(slots, Some(2), "the 18th AND the 19th");
+            }
+            _ => panic!("un seul tir pour tout le silence"),
+        }
+    }
+
+    /// The file's own truth, judged before the clock.
+    #[test]
+    fn inactive_cloud_and_expired_beats_skip_with_their_reason() {
+        let registry = registry_with(concat!(
+            "    manqué: sauter\n",
+            "    actif: false\n",
+            "    raison: \"pause estivale\"\n",
+            "    jusqu_au: \"2099-12-31\"\n",
+        ));
+        match decide(&registry, 0, "doctor", &at("2026-08-19T03:02:00Z"), None) {
+            Decision::Skip { reason, line, .. } => {
+                assert_eq!(reason, "inactive");
+                assert!(line.contains("pause estivale"), "{line}");
+            }
+            _ => panic!("un beat inactif saute"),
+        }
+
+        let registry = registry_with("    manqué: sauter\n    où: cloud\n");
+        match decide(&registry, 0, "doctor", &at("2026-08-19T03:02:00Z"), None) {
+            Decision::Skip { reason, .. } => assert_eq!(reason, "cloud"),
+            _ => panic!("un beat cloud saute"),
+        }
+
+        let registry = registry_with("    manqué: sauter\n    jusqu_au: \"2026-01-01\"\n");
+        match decide(&registry, 0, "doctor", &at("2026-08-19T03:02:00Z"), None) {
+            Decision::Skip { reason, .. } => assert_eq!(reason, "expired"),
+            _ => panic!("un beat expiré saute"),
+        }
+    }
+
+    /// A webhook beat fires on its event, never on the clock.
+    #[test]
+    fn a_webhook_beat_skips_the_clock() {
+        let text = concat!(
+            "nika: v1\n",
+            "arm:\n",
+            "  - workflow: workflows/doctor.nika.yaml\n",
+            "    cadence: \"on-webhook\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+        );
+        let registry = nika_cadence::parse_registry(text).expect("parse");
+        match decide(&registry, 0, "doctor", &at("2026-08-19T03:02:00Z"), None) {
+            Decision::Skip { reason, .. } => assert_eq!(reason, "webhook"),
+            _ => panic!("un webhook saute l'horloge"),
+        }
+    }
+
+    /// The v0 refusals (D6) — each names the version it arrives with.
+    #[test]
+    fn the_v0_unsupported_policies_refuse_with_teaching() {
+        for (extra, named) in [
+            ("    chevauchement: remplacer\n", "chevauchement: remplacer"),
+            (
+                "    chevauchement: sauter\n    après_saut: à-complétion\n",
+                "après_saut: à-complétion",
+            ),
+            ("    décalage: hash\n", "décalage:"),
+        ] {
+            let registry = registry_with(&format!("    manqué: sauter\n{extra}"));
+            match decide(&registry, 0, "doctor", &at("2026-08-19T03:02:00Z"), None) {
+                Decision::Refuse { line } => {
+                    assert!(line.contains(named), "{line}");
+                    assert!(line.contains("serve v0.2"), "names the version: {line}");
+                }
+                _ => panic!("{named} doit refuser"),
+            }
+        }
+        let registry = registry_with("    manqué: rattraper\n");
+        match decide(&registry, 0, "doctor", &at("2026-08-19T03:02:00Z"), None) {
+            Decision::Refuse { line } => {
+                assert!(line.contains("manqué: rattraper"), "{line}");
+                assert!(line.contains("serve v0.2"), "{line}");
+            }
+            _ => panic!("rattraper doit refuser"),
+        }
+    }
+
+    /// D4: the label is the workflow file's radical; a collision takes
+    /// `-2`, `-3` in file order.
+    #[test]
+    fn labels_are_the_radicals_with_collision_suffixes() {
+        let text = concat!(
+            "nika: v1\n",
+            "arm:\n",
+            "  - workflow: a/doctor.nika.yaml\n",
+            "    cadence: \"TZ=UTC 0 3 * * *\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "  - workflow: b/doctor.nika.yaml\n",
+            "    cadence: \"TZ=UTC 0 4 * * *\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "  - workflow: c/doctor.nika.yaml\n",
+            "    cadence: \"TZ=UTC 0 5 * * *\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "  - workflow: nightly.nika.yaml\n",
+            "    cadence: \"TZ=UTC 0 6 * * *\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+        );
+        let registry = nika_cadence::parse_registry(text).expect("parse");
+        assert_eq!(
+            labels(&registry),
+            vec!["doctor", "doctor-2", "doctor-3", "nightly"]
+        );
+    }
+
+    /// `--now`: bare RFC 3339 lands on UTC; garbage teaches.
+    #[test]
+    fn the_injected_clock_parses_rfc3339_and_refuses_garbage() {
+        let now = parse_now(Some("2026-08-19T03:02:00Z")).expect("parses");
+        assert_eq!(now.timestamp().to_string(), "2026-08-19T03:02:00Z");
+        let zoned = parse_now(Some("2026-08-19T05:02:00+02:00[Europe/Paris]")).expect("parses");
+        assert_eq!(zoned.timestamp().to_string(), "2026-08-19T03:02:00Z");
+        assert!(parse_now(Some("demain")).is_err());
+    }
+}

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -47,18 +47,62 @@ use nika_vocab::project;
 
 use super::VerbOutput;
 
+pub mod args;
+
 /// How many upcoming slots each beat shows.
 const SLOTS_SHOWN: usize = 3;
 
-/// `nika arm` — the read-only arming report.
-///
-/// The CWD door. Discovery walks up from the invocation directory,
-/// git-style — the same calm fallback the ceiling ladder takes when the
-/// CWD is unresolvable (a broken CWD must never block a read).
+/// `nika arm` — the verb. Bare (no subcommand, no flag) it is the
+/// read-only arming report below; the subcommands are the machine's
+/// edge, and the `--emit` family is the W3 wave's — declared on the
+/// clap tree now, refused honestly until it lands.
 #[must_use]
-pub fn run() -> VerbOutput {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    run_at(&cwd)
+pub fn run(args: args::ArmArgs) -> VerbOutput {
+    use args::ArmSub;
+    match args.sub {
+        Some(ArmSub::Fire(_)) => VerbOutput::file(
+            "arm fire · le tireur arrive avec la vague W2 de cette branche".to_owned(),
+        ),
+        Some(ArmSub::Disarm { label, write }) => disarm(&label, write),
+        None if emits_requested(&args) => VerbOutput::file(
+            "arm --emit · the OS units arrive with the W3 wave — today the verb READS".to_owned(),
+        ),
+        None => {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            run_at(&cwd)
+        }
+    }
+}
+
+/// Any `--emit`-family flag set? Those flags only make sense WITH the
+/// emission the W3 wave lands — set today, they refuse rather than
+/// silently report (a flag that does nothing is a lie).
+fn emits_requested(args: &args::ArmArgs) -> bool {
+    args.emit.is_some()
+        || args.write
+        || args.out.is_some()
+        || args.mode.is_some()
+        || args.env_file.is_some()
+        || args.nika_bin.is_some()
+}
+
+/// `arm disarm <label>` — the N4 teaching. Removing the line does NOT
+/// disarm (the state would go ORPHAN, and the machine keeps its
+/// record); the gesture is a suspension the file re-reads.
+#[must_use]
+fn disarm(label: &str, write: bool) -> VerbOutput {
+    if write {
+        return VerbOutput::file(
+            "arm disarm --write · the OS-unit teardown arrives with the W3 wave".to_owned(),
+        );
+    }
+    VerbOutput::ok(format!(
+        "disarm `{label}` — law N4: removing the line does NOT disarm\n  \
+         the gesture, in nika.yaml, on the beat's entry:\n  \
+         · actif: false   — the declared intention\n  \
+         · raison: \"…\"    — why it sleeps (a suspension is told)\n  \
+         · jusqu_au: YYYY-MM-DD — when it wakes or is deleted"
+    ))
 }
 
 /// The report at an explicit root — the tempdir-injectable half
@@ -214,6 +258,58 @@ mod tests {
         let out = run_at(dir.path());
         assert_eq!(out.code, exit::OK, "{}", out.text);
         assert!(out.text.contains("nothing armed"), "{}", out.text);
+    }
+
+    /// The bare dispatch: no subcommand, no flag → the report. The
+    /// report half itself is pinned by the `run_at` tests (the
+    /// refactor's zero-behavior-change claim); the CWD door is covered
+    /// end-to-end by the binary tests (`tests/arm_fire.rs`), never by
+    /// moving the test process's own CWD (parallel tests race on it).
+    /// The declared-but-unlanded surfaces refuse honestly — a flag that
+    /// would silently do nothing is a lie.
+    #[test]
+    fn the_w2_and_w3_surfaces_refuse_by_name_until_they_land() {
+        let base = crate::verbs::arm::args::ArmArgs {
+            sub: None,
+            emit: Some(crate::verbs::arm::args::EmitTarget::Launchd),
+            write: false,
+            out: None,
+            mode: None,
+            env_file: None,
+            nika_bin: None,
+        };
+        let out = run(base);
+        assert_eq!(out.code, exit::FILE, "--emit refuses: {}", out.text);
+        assert!(out.text.contains("W3"), "names the wave: {}", out.text);
+
+        let fire = crate::verbs::arm::args::ArmArgs {
+            sub: Some(crate::verbs::arm::args::ArmSub::Fire(
+                crate::verbs::arm::args::FireArgs {
+                    label: "doctor".to_owned(),
+                    now: None,
+                },
+            )),
+            emit: None,
+            write: false,
+            out: None,
+            mode: None,
+            env_file: None,
+            nika_bin: None,
+        };
+        let out = run(fire);
+        assert_eq!(out.code, exit::FILE, "fire refuses pre-W2: {}", out.text);
+        assert!(out.text.contains("W2"), "names the wave: {}", out.text);
+    }
+
+    #[test]
+    fn disarm_teaches_the_n4_gesture_and_refuses_the_unit_teardown() {
+        let teach = disarm("doctor", false);
+        assert_eq!(teach.code, exit::OK, "{}", teach.text);
+        assert!(teach.text.contains("actif: false"), "{}", teach.text);
+        assert!(teach.text.contains("jusqu_au"), "{}", teach.text);
+        let teardown = disarm("doctor", true);
+        assert_eq!(teardown.code, exit::FILE, "{}", teardown.text);
+        assert!(teardown.text.contains("W3"), "{}", teardown.text);
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -48,6 +48,7 @@ use nika_vocab::project;
 use super::VerbOutput;
 
 pub mod args;
+pub mod state;
 
 /// How many upcoming slots each beat shows.
 const SLOTS_SHOWN: usize = 3;

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -48,6 +48,7 @@ use nika_vocab::project;
 use super::VerbOutput;
 
 pub mod args;
+pub mod fire;
 pub mod state;
 
 /// How many upcoming slots each beat shows.
@@ -61,9 +62,7 @@ const SLOTS_SHOWN: usize = 3;
 pub fn run(args: args::ArmArgs) -> VerbOutput {
     use args::ArmSub;
     match args.sub {
-        Some(ArmSub::Fire(_)) => VerbOutput::file(
-            "arm fire · le tireur arrive avec la vague W2 de cette branche".to_owned(),
-        ),
+        Some(ArmSub::Fire(f)) => fire::run(&f),
         Some(ArmSub::Disarm { label, write }) => disarm(&label, write),
         None if emits_requested(&args) => VerbOutput::file(
             "arm --emit · the OS units arrive with the W3 wave — today the verb READS".to_owned(),
@@ -266,10 +265,10 @@ mod tests {
     /// refactor's zero-behavior-change claim); the CWD door is covered
     /// end-to-end by the binary tests (`tests/arm_fire.rs`), never by
     /// moving the test process's own CWD (parallel tests race on it).
-    /// The declared-but-unlanded surfaces refuse honestly — a flag that
-    /// would silently do nothing is a lie.
+    /// The declared-but-unlanded W3 surface refuses honestly — a flag
+    /// that would silently do nothing is a lie.
     #[test]
-    fn the_w2_and_w3_surfaces_refuse_by_name_until_they_land() {
+    fn the_w3_surface_refuses_by_name_until_it_lands() {
         let base = crate::verbs::arm::args::ArmArgs {
             sub: None,
             emit: Some(crate::verbs::arm::args::EmitTarget::Launchd),
@@ -282,24 +281,6 @@ mod tests {
         let out = run(base);
         assert_eq!(out.code, exit::FILE, "--emit refuses: {}", out.text);
         assert!(out.text.contains("W3"), "names the wave: {}", out.text);
-
-        let fire = crate::verbs::arm::args::ArmArgs {
-            sub: Some(crate::verbs::arm::args::ArmSub::Fire(
-                crate::verbs::arm::args::FireArgs {
-                    label: "doctor".to_owned(),
-                    now: None,
-                },
-            )),
-            emit: None,
-            write: false,
-            out: None,
-            mode: None,
-            env_file: None,
-            nika_bin: None,
-        };
-        let out = run(fire);
-        assert_eq!(out.code, exit::FILE, "fire refuses pre-W2: {}", out.text);
-        assert!(out.text.contains("W2"), "names the wave: {}", out.text);
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -161,6 +161,11 @@ pub fn run_at(start: &std::path::Path) -> VerbOutput {
 }
 
 /// The green report — one block per beat, and the next slots for each.
+///
+/// The block also tells PROUVÉ from DÉCLARÉ (law N3's honesty: the
+/// registry DECLARES, only the sidecar PROVES the machine fired), and
+/// after the beats the ORPHELINS — the sidecar directories no registry
+/// entry names (law N4: reported, NEVER erased).
 fn report(registry: &nika_cadence::registry::ArmRegistry, path: &std::path::Path) -> VerbOutput {
     use std::fmt::Write as _;
 
@@ -171,6 +176,12 @@ fn report(registry: &nika_cadence::registry::ArmRegistry, path: &std::path::Path
         ));
     }
 
+    let root = path.parent().map_or_else(
+        || std::path::PathBuf::from("."),
+        std::path::Path::to_path_buf,
+    );
+    let sidecar = state::ArmState::at_project(&root);
+    let labels = fire::labels(registry);
     let now = jiff::Zoned::now();
     let mut out = String::new();
     let _ = writeln!(
@@ -180,13 +191,19 @@ fn report(registry: &nika_cadence::registry::ArmRegistry, path: &std::path::Path
         path.display()
     );
 
-    for beat in registry.beats() {
+    for (index, beat) in registry.beats().enumerate() {
         let state = if beat.is_active() { "armed" } else { "idle " };
         let _ = writeln!(
             out,
             "\n  [{state}] {} · {}",
             beat.workflow,
             beat.cadence.trim()
+        );
+        proof_line(
+            &sidecar,
+            labels.get(index).map_or("?", String::as_str),
+            beat,
+            &mut out,
         );
         // An inactive beat is REPORTED, never COMPUTED — asking a
         // disarmed beat for its next slot would print a date nobody
@@ -213,12 +230,55 @@ fn report(registry: &nika_cadence::registry::ArmRegistry, path: &std::path::Path
             }
         }
     }
+
+    let orphans = sidecar.orphans(&labels);
+    if !orphans.is_empty() {
+        let _ = writeln!(out, "\norphelins (N4 — rapportés, JAMAIS effacés):");
+        for name in orphans {
+            let _ = writeln!(out, "  · {name} — .nika/arm/{name}/");
+        }
+    }
+
     let _ = write!(
         out,
         "\nnothing was scheduled — `nika arm` READS the file. \
          The machine that fires them is the arming edge."
     );
     VerbOutput::ok(out)
+}
+
+/// The proof line of one beat: `✓ PROUVÉ` when the sidecar attests the
+/// machine fired (last.json), `DÉCLARÉ` when only the registry speaks.
+/// The history's tallies (`x sauts / y tirs`) and the declared
+/// `tolérance: m/k` ride the same line when they exist; `par:` is
+/// shown for what it is — déclaré, non vérifié (N3).
+fn proof_line(sidecar: &state::ArmState, label: &str, beat: &nika_cadence::Beat, out: &mut String) {
+    use std::fmt::Write as _;
+
+    let mut line = match sidecar.last(label) {
+        Some(last) => format!(
+            "✓ PROUVÉ · {} · {} · slot {}",
+            last.kind.as_str(),
+            last.fired_at,
+            last.slot
+        ),
+        None => "· DÉCLARÉ — le registre le dit, la machine ne l'a jamais tiré".to_owned(),
+    };
+    if let Some((skips, fires)) = sidecar.tallies(label) {
+        let _ = write!(
+            line,
+            " · {} / {}",
+            crate::text::count(skips, "saut"),
+            crate::text::count(fires, "tir")
+        );
+    }
+    if let Some(tol) = &beat.tolerance {
+        let _ = write!(line, " · tolérance {tol}");
+    }
+    let _ = writeln!(out, "         {line}");
+    if let Some(par) = &beat.par {
+        let _ = writeln!(out, "         par: {par} — déclaré · non vérifié");
+    }
 }
 
 #[cfg(test)]
@@ -292,6 +352,75 @@ mod tests {
         let teardown = disarm("doctor", true);
         assert_eq!(teardown.code, exit::FILE, "{}", teardown.text);
         assert!(teardown.text.contains("W3"), "{}", teardown.text);
+    }
+
+    /// The report tells PROUVÉ from DÉCLARÉ and names the ORPHELINS —
+    /// the three states in one tempdir, snapshotted. The beats sleep
+    /// (`actif: false`): an idle beat is REPORTED, never computed, so
+    /// the text is deterministic (no next-slot line rides the clock).
+    #[test]
+    fn the_report_tells_proven_from_declared_and_names_the_orphans() {
+        let body = concat!(
+            "nika: v1\n",
+            "arm:\n",
+            "  - workflow: workflows/prouve.nika.yaml\n",
+            "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
+            "    plafond: 0.25\n",
+            "    manqué: sauter\n",
+            "    actif: false\n",
+            "    raison: \"pause estivale\"\n",
+            "    jusqu_au: \"2099-12-31\"\n",
+            "    tolérance: \"3/4\"\n",
+            "    par: \"thibaut\"\n",
+            "  - workflow: workflows/declare.nika.yaml\n",
+            "    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n",
+            "    plafond: 1.0\n",
+            "    manqué: rattraper-une-fois\n",
+            "    actif: false\n",
+            "    raison: \"en sommeil\"\n",
+            "    jusqu_au: \"2099-12-31\"\n",
+        );
+        let dir = project_at("proof", body);
+        let sidecar = state::ArmState::at_project(dir.path());
+        // prouve: the machine fired twice, skipped once — the sidecar
+        // attests (last.json + the history's tallies).
+        let fired = state::HistoryEntry {
+            slot: Some("2026-08-18T07:07:00Z".parse().expect("ts")),
+            decided_at: "2026-08-18T07:07:04Z".parse().expect("ts"),
+            kind: state::FireKind::Fired,
+            reason: None,
+            trace: Some(".nika/traces/2026-08-18T07-07-04Z_cafe.ndjson".to_owned()),
+            exit: Some(0),
+            slots: None,
+        };
+        sidecar.record("prouve", &fired).expect("record");
+        sidecar.record("prouve", &fired).expect("record");
+        let mut skipped = fired.clone();
+        skipped.kind = state::FireKind::Skipped;
+        skipped.reason = Some("missed:1".to_owned());
+        skipped.trace = None;
+        sidecar.record("prouve", &skipped).expect("record");
+        // ghost: a sidecar the registry no longer names (N4).
+        sidecar.record("ghost", &fired).expect("record");
+        // The order is the LAST decision's: re-fire so last.json says fired.
+        sidecar.record("prouve", &fired).expect("record");
+
+        let out = run_at(dir.path());
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(out.text.contains("✓ PROUVÉ"), "{}", out.text);
+        assert!(out.text.contains("DÉCLARÉ"), "{}", out.text);
+        assert!(
+            out.text.contains("· ghost — .nika/arm/ghost/"),
+            "{}",
+            out.text
+        );
+        // The tmpdir path is the only non-deterministic byte (insta's
+        // `filters` feature is not in the workspace set — a replace is
+        // the same redaction, zero new feature).
+        let shown = out
+            .text
+            .replace(&dir.path().to_string_lossy().into_owned(), "[PROJET]");
+        insta::assert_snapshot!(shown);
     }
 
     #[test]

--- a/crates/nika-cli/src/verbs/arm/snapshots/nika_cli__verbs__arm__tests__the_report_tells_proven_from_declared_and_names_the_orphans.snap
+++ b/crates/nika-cli/src/verbs/arm/snapshots/nika_cli__verbs__arm__tests__the_report_tells_proven_from_declared_and_names_the_orphans.snap
@@ -1,0 +1,17 @@
+---
+source: crates/nika-cli/src/verbs/arm/mod.rs
+expression: shown
+---
+2 beats in [PROJET]/nika.yaml
+
+  [idle ] workflows/prouve.nika.yaml · TZ=Europe/Paris lundi 9h07
+         ✓ PROUVÉ · fired · 2026-08-18T07:07:04Z · slot 2026-08-18T07:07:00Z · 1 saut / 3 tirs · tolérance 3/4
+         par: thibaut — déclaré · non vérifié
+
+  [idle ] workflows/declare.nika.yaml · TZ=Europe/Paris 0 3 * * *
+         · DÉCLARÉ — le registre le dit, la machine ne l'a jamais tiré
+
+orphelins (N4 — rapportés, JAMAIS effacés):
+  · ghost — .nika/arm/ghost/
+
+nothing was scheduled — `nika arm` READS the file. The machine that fires them is the arming edge.

--- a/crates/nika-cli/src/verbs/arm/state.rs
+++ b/crates/nika-cli/src/verbs/arm/state.rs
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The firing sidecar (D3) — the state the FILE never carries:
+//!
+//! ```text
+//! .nika/arm/<label>/lock           { "pid": u32, "started_at": RFC3339 }
+//! .nika/arm/<label>/last.json      { "slot": RFC3339, "fired_at": RFC3339,
+//!                                    "trace": path|null, "exit": u8,
+//!                                    "kind": "fired|skipped|paused|failed" }
+//! .nika/arm/<label>/history.ndjson one line per decision · append-only
+//! ```
+//!
+//! It lives NEXT TO the traces, at the root of the project that arms
+//! the beats (the directory holding `nika.yaml`) — never in the YAML
+//! (what changes by itself is never written in what a human re-reads).
+//!
+//! The lock's owner must be ALIVE to hold: a lock whose pid answers
+//! signal 0 is a running tick (law ⑥ governs it); a dead pid's lock is
+//! a crash remnant, taken over. The takeover assumes ONE firer per beat
+//! (D2 — launchd today, `serve` at ②): two racers re-reading the same
+//! stale lock resolve through the atomic `create_new`, the loser
+//! re-judges the winner's live pid.
+//!
+//! N2 rides the read half: a missing OR corrupt `last.json` reads as
+//! « never fired » — the planner then owes the on-time window alone and
+//! invents no backlog, which is the safe failure direction (at most one
+//! on-time re-fire, never a catch-up storm).
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use jiff::{Timestamp, Zoned};
+
+/// The sidecar root below a project directory (D3 — next to the traces).
+const ARM_DIR: &str = ".nika/arm";
+
+/// The firing state, rooted at `<project>/.nika/arm`.
+pub struct ArmState {
+    root: PathBuf,
+}
+
+/// What a lock attempt found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockOutcome {
+    /// No live owner — the lock is ours.
+    Acquired,
+    /// A LIVE process holds it (signal 0 answered) — law ⑥ governs.
+    HeldAlive {
+        /// The holding process.
+        pid: u32,
+    },
+    /// The holder's pid is dead (a crash remnant) — taken over.
+    StaleTaken {
+        /// The dead pid, when the remnant parsed.
+        old_pid: Option<u32>,
+    },
+}
+
+/// The decision kinds — the `kind:` vocabulary of `last.json` and
+/// `history.ndjson`, and the firer's one-line prefixes (D8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FireKind {
+    /// The run went and exited clean.
+    Fired,
+    /// A policy said no (missed · overlap · already · inactive · …).
+    Skipped,
+    /// A human gate paused the run — PARKED with its trace (law N2:
+    /// never resumed, never answered by the firer).
+    Paused,
+    /// The run went and failed (or refused its own file).
+    Failed,
+}
+
+impl FireKind {
+    /// The wire word (JSON + the one-line prefix).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Fired => "fired",
+            Self::Skipped => "skipped",
+            Self::Paused => "paused",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// One decision, journaled. `slot` is `None` only for the pre-slot
+/// skips (inactive · cloud · expired · webhook) — those journal the
+/// decision but leave `last.json` untouched (its `slot` is not
+/// nullable). `slots` carries the silence's count when
+/// `rattraper-une-fois` fires ONE run for n slots.
+#[derive(Debug, Clone)]
+pub struct HistoryEntry {
+    /// The slot decided (the absolute instant — zone-free on the wire).
+    pub slot: Option<Timestamp>,
+    /// The decision instant (the injected clock — D5).
+    pub decided_at: Timestamp,
+    /// What was decided.
+    pub kind: FireKind,
+    /// The skip's reason (`missed:3` · `overlap` · `cloud` · …).
+    pub reason: Option<String>,
+    /// The run's trace path, repo-relative (`fired` · `paused` · `failed`).
+    pub trace: Option<String>,
+    /// The run's exit code (`fired` 0 · `failed` 1|2|3 · `paused` 4).
+    pub exit: Option<u8>,
+    /// `rattraper-une-fois`: how many slots the one fire answers for.
+    pub slots: Option<u32>,
+}
+
+/// The parsed `last.json` — the report (PROUVE) and the planner read it.
+#[derive(Debug, Clone)]
+pub struct LastRecord {
+    /// The last DECIDED slot (a skip consumes its slot too).
+    pub slot: Timestamp,
+    /// The decision instant.
+    pub fired_at: Timestamp,
+    /// The run's trace path when the decision ran something.
+    pub trace: Option<String>,
+    /// The run's exit code when it ran.
+    pub exit: Option<u8>,
+    /// The decision kind.
+    pub kind: FireKind,
+}
+
+impl ArmState {
+    /// The sidecar of the project rooted at `project_dir` (D3).
+    #[must_use]
+    pub fn at_project(project_dir: &Path) -> Self {
+        Self {
+            root: project_dir.join(ARM_DIR),
+        }
+    }
+
+    /// The sidecar root (the report's orphan walk reads it).
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// The last DECIDED slot as the planner's `last_fired` — strictly
+    /// after it, a slot is due again. A skip/park consumes its slot:
+    /// « fired » here means « decided ». Missing or corrupt state reads
+    /// as never-fired (N2 — the on-time window alone then decides).
+    #[must_use]
+    pub fn last_fired(&self, label: &str) -> Option<Zoned> {
+        self.last(label)
+            .map(|r| r.slot.to_zoned(jiff::tz::TimeZone::UTC))
+    }
+
+    /// The parsed `last.json` of one beat — `None` when absent or
+    /// unreadable (N2's safe direction, see the module doc).
+    #[must_use]
+    pub fn last(&self, label: &str) -> Option<LastRecord> {
+        let text = std::fs::read_to_string(self.root.join(label).join("last.json")).ok()?;
+        let doc: serde_json::Value = serde_json::from_str(&text).ok()?;
+        let slot: Timestamp = doc.get("slot")?.as_str()?.parse().ok()?;
+        let fired_at: Timestamp = doc.get("fired_at")?.as_str()?.parse().ok()?;
+        let kind = match doc.get("kind")?.as_str()? {
+            "fired" => FireKind::Fired,
+            "skipped" => FireKind::Skipped,
+            "paused" => FireKind::Paused,
+            "failed" => FireKind::Failed,
+            _ => return None,
+        };
+        Some(LastRecord {
+            slot,
+            fired_at,
+            trace: doc
+                .get("trace")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+            exit: doc
+                .get("exit")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|e| u8::try_from(e).ok()),
+            kind,
+        })
+    }
+
+    /// The history's skip/fire tallies (`x sauts / y tirs`) — `None`
+    /// when no history exists at all (the report then says nothing).
+    #[must_use]
+    pub fn tallies(&self, label: &str) -> Option<(usize, usize)> {
+        let text = std::fs::read_to_string(self.root.join(label).join("history.ndjson")).ok()?;
+        let mut skips = 0usize;
+        let mut fires = 0usize;
+        for line in text.lines() {
+            let Ok(doc) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            match doc.get("kind").and_then(serde_json::Value::as_str) {
+                Some("skipped") => skips += 1,
+                Some("fired") => fires += 1,
+                _ => {}
+            }
+        }
+        Some((skips, fires))
+    }
+
+    /// The sidecar directories that name NO known label (law N4:
+    /// reported, NEVER erased). `known` carries the registry's labels.
+    #[must_use]
+    pub fn orphans(&self, known: &[String]) -> Vec<String> {
+        let Ok(entries) = std::fs::read_dir(&self.root) else {
+            return Vec::new();
+        };
+        let mut out: Vec<String> = entries
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|name| !known.contains(name))
+            .collect();
+        out.sort_unstable();
+        out
+    }
+
+    /// Try the beat's lock. A live holder answers signal 0 — `HeldAlive`
+    /// (law ⑥ then governs: sauter · file). A dead holder's file is a
+    /// crash remnant — taken over (`StaleTaken`). No file: `Acquired`.
+    ///
+    /// # Errors
+    /// I/O on the sidecar directory (unwritable project, …).
+    pub fn try_lock(&self, label: &str, pid: u32, now: &Zoned) -> io::Result<LockOutcome> {
+        const MAX_PASSES: u32 = 8;
+        let dir = self.dir(label)?;
+        let lock = dir.join("lock");
+        let body = format!("{{\"pid\":{pid},\"started_at\":\"{}\"}}\n", now.timestamp());
+        // The remnant WE removed on the way in, if any (Some(None) =
+        // the remnant was unparseable) — it rides the StaleTaken
+        // verdict once the atomic create lands.
+        let mut removed: Option<Option<u32>> = None;
+        let mut passes = 0u32;
+        loop {
+            passes += 1;
+            if passes > MAX_PASSES {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "arm lock: contended past the pass bound",
+                ));
+            }
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock)
+            {
+                Ok(mut f) => {
+                    use std::io::Write as _;
+                    f.write_all(body.as_bytes())?;
+                    return Ok(match removed {
+                        Some(old_pid) => LockOutcome::StaleTaken { old_pid },
+                        None => LockOutcome::Acquired,
+                    });
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(e) => return Err(e),
+            }
+            let old_pid = std::fs::read_to_string(&lock)
+                .ok()
+                .and_then(|text| lock_pid(&text));
+            if let Some(old) = old_pid
+                && owner_alive(old)
+            {
+                return Ok(LockOutcome::HeldAlive { pid: old });
+            }
+            // The holder is dead (or the file unparseable — either way
+            // no LIVE owner is proven): remove the remnant, then the
+            // atomic create decides between us and a racer — a racer's
+            // win shows up as a live pid on the next pass.
+            match std::fs::remove_file(&lock) {
+                Ok(()) => removed = Some(old_pid),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Release the beat's lock. Idempotent: an absent lock is released.
+    ///
+    /// # Errors
+    /// I/O other than `NotFound`.
+    pub fn release(&self, label: &str) -> io::Result<()> {
+        match std::fs::remove_file(self.root.join(label).join("lock")) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Journal one decision: append the history line, and when the
+    /// decision bears a slot, refresh `last.json` (both writes atomic —
+    /// tmp + rename for the rewrite, `O_APPEND` for the journal).
+    ///
+    /// # Errors
+    /// I/O on the sidecar (the firer fails the decision loudly then —
+    /// a fire without its record is a fire that re-fires).
+    pub fn record(&self, label: &str, entry: &HistoryEntry) -> io::Result<()> {
+        let dir = self.dir(label)?;
+        let line = history_line(entry);
+        append_line(&dir.join("history.ndjson"), &line)?;
+        if entry.slot.is_some() {
+            write_atomic(&dir.join("last.json"), &last_json(entry))?;
+        }
+        Ok(())
+    }
+
+    /// The beat's directory, created on demand.
+    fn dir(&self, label: &str) -> io::Result<PathBuf> {
+        let dir = self.root.join(label);
+        std::fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+}
+
+/// The `last.json` document — the locked shape (D3).
+fn last_json(entry: &HistoryEntry) -> String {
+    let slot = entry.slot.map_or(String::new(), |s| s.to_string());
+    let trace = entry
+        .trace
+        .as_deref()
+        .map_or("null".to_owned(), |t| format!("\"{t}\""));
+    let exit = entry.exit.unwrap_or(0);
+    format!(
+        "{{\"slot\":\"{slot}\",\"fired_at\":\"{}\",\"trace\":{trace},\"exit\":{exit},\"kind\":\"{}\"}}\n",
+        entry.decided_at,
+        entry.kind.as_str()
+    )
+}
+
+/// One history line — the same fields, plus the skip's reason and the
+/// catch-up count when they exist.
+fn history_line(entry: &HistoryEntry) -> String {
+    let slot = entry.slot.map_or("null".to_owned(), |s| format!("\"{s}\""));
+    let reason = entry
+        .reason
+        .as_deref()
+        .map_or("null".to_owned(), |r| format!("\"{r}\""));
+    let trace = entry
+        .trace
+        .as_deref()
+        .map_or("null".to_owned(), |t| format!("\"{t}\""));
+    let exit = entry.exit.map_or("null".to_owned(), |e| e.to_string());
+    let slots = entry.slots.map_or("null".to_owned(), |s| s.to_string());
+    format!(
+        "{{\"slot\":{slot},\"decided_at\":\"{}\",\"kind\":\"{}\",\"reason\":{reason},\"trace\":{trace},\"exit\":{exit},\"slots\":{slots}}}",
+        entry.decided_at,
+        entry.kind.as_str()
+    )
+}
+
+/// The pid out of a lock file — `None` when the file does not parse
+/// (an unparseable lock proves no live owner: taken over as stale).
+fn lock_pid(text: &str) -> Option<u32> {
+    let doc: serde_json::Value = serde_json::from_str(text).ok()?;
+    doc.get("pid")?.as_u64().and_then(|p| u32::try_from(p).ok())
+}
+
+/// Does a process with this pid exist? Signal 0 probes without
+/// delivering. `EPERM` is an owner too — a process we may not signal is
+/// still a LIVE holder (stealing its lock would double-fire).
+#[cfg(unix)]
+fn owner_alive(pid: u32) -> bool {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    let pid = Pid::from_raw(i32::try_from(pid).unwrap_or(-1));
+    // Ok = the process answered · EPERM = a process exists we may not
+    // signal — both are a LIVE holder; ESRCH (and the rest) = dead.
+    matches!(kill(pid, None), Ok(()) | Err(nix::errno::Errno::EPERM))
+}
+
+/// The non-unix fallback: no signal surface, so every holder reads
+/// alive — the conservative direction (never steal, never double-fire).
+#[cfg(not(unix))]
+fn owner_alive(_pid: u32) -> bool {
+    true
+}
+
+/// Rewrite a file atomically: write a sibling tmp, rename it over.
+fn write_atomic(path: &Path, body: &str) -> io::Result<()> {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("state");
+    let tmp = path.with_file_name(format!("{name}.tmp-{}", std::process::id()));
+    std::fs::write(&tmp, body)?;
+    std::fs::rename(&tmp, path)
+}
+
+/// One line onto the journal (`O_APPEND` — several firers never tear a
+/// line, each append landing whole).
+fn append_line(path: &Path, line: &str) -> io::Result<()> {
+    use std::io::Write as _;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    f.write_all(line.as_bytes())?;
+    f.write_all(b"\n")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn state(tag: &str) -> (tempfile::TempDir, ArmState) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("nika-arm-state-{tag}-"))
+            .tempdir()
+            .expect("tmp dir");
+        let state = ArmState::at_project(dir.path());
+        (dir, state)
+    }
+
+    fn at(text: &str) -> Zoned {
+        text.parse::<Timestamp>()
+            .expect("ts")
+            .to_zoned(jiff::tz::TimeZone::UTC)
+    }
+
+    fn entry(kind: FireKind) -> HistoryEntry {
+        HistoryEntry {
+            slot: Some("2026-08-19T03:00:00Z".parse::<Timestamp>().expect("ts")),
+            decided_at: "2026-08-19T03:02:00Z".parse::<Timestamp>().expect("ts"),
+            kind,
+            reason: None,
+            trace: None,
+            exit: Some(0),
+            slots: None,
+        }
+    }
+
+    /// (a) No state reads as never-fired (N2); the recorded slot reads
+    /// back as the planner's `last_fired`.
+    #[test]
+    fn last_fired_is_none_then_the_recorded_slot() {
+        let (_dir, state) = state("last");
+        assert!(state.last_fired("doctor").is_none(), "N2: no state");
+        state
+            .record("doctor", &entry(FireKind::Fired))
+            .expect("record");
+        let fired = state.last_fired("doctor").expect("the recorded slot");
+        let expected: Timestamp = "2026-08-19T03:00:00Z".parse().expect("ts");
+        assert_eq!(fired.timestamp(), expected);
+    }
+
+    /// (b) A lock whose pid is THIS process is a LIVE holder.
+    #[test]
+    fn a_lock_held_by_a_living_owner_refuses_the_takeover() {
+        let (_dir, state) = state("live");
+        let now = at("2026-08-19T03:02:00Z");
+        let me = std::process::id();
+        let first = state.try_lock("doctor", me, &now).expect("lock");
+        assert_eq!(first, LockOutcome::Acquired);
+        let second = state
+            .try_lock("doctor", me.wrapping_add(1), &now)
+            .expect("re-lock");
+        assert_eq!(second, LockOutcome::HeldAlive { pid: me });
+        state.release("doctor").expect("release");
+    }
+
+    /// (c) A lock whose pid cannot exist (999999 dies past macOS's and
+    /// Linux's `pid_max`) is a crash remnant — taken over.
+    #[test]
+    fn a_dead_owner_s_lock_is_taken_over() {
+        let (_dir, state) = state("stale");
+        let now = at("2026-08-19T03:02:00Z");
+        let dir = state.root().join("doctor");
+        std::fs::create_dir_all(&dir).expect("dir");
+        std::fs::write(
+            dir.join("lock"),
+            "{\"pid\":999999,\"started_at\":\"2026-08-19T03:00:00Z\"}\n",
+        )
+        .expect("remnant");
+        let outcome = state
+            .try_lock("doctor", std::process::id(), &now)
+            .expect("lock");
+        assert_eq!(
+            outcome,
+            LockOutcome::StaleTaken {
+                old_pid: Some(999_999)
+            }
+        );
+        // The takeover rewrote the file with OUR live pid.
+        let body = std::fs::read_to_string(dir.join("lock")).expect("lock body");
+        assert!(body.contains(&std::process::id().to_string()), "{body}");
+        state.release("doctor").expect("release");
+    }
+
+    /// An unparseable lock proves no live owner — stale, taken over.
+    #[test]
+    fn a_corrupt_lock_is_taken_over() {
+        let (_dir, state) = state("corrupt");
+        let now = at("2026-08-19T03:02:00Z");
+        let dir = state.root().join("doctor");
+        std::fs::create_dir_all(&dir).expect("dir");
+        std::fs::write(dir.join("lock"), "not json\n").expect("remnant");
+        let outcome = state
+            .try_lock("doctor", std::process::id(), &now)
+            .expect("lock");
+        assert!(
+            matches!(outcome, LockOutcome::StaleTaken { .. }),
+            "{outcome:?}"
+        );
+        state.release("doctor").expect("release");
+    }
+
+    /// (d) Two decisions = two history lines, append-only.
+    #[test]
+    fn two_records_append_two_history_lines() {
+        let (_dir, state) = state("hist");
+        let mut skipped = entry(FireKind::Skipped);
+        skipped.reason = Some("missed:1".to_owned());
+        state
+            .record("doctor", &entry(FireKind::Fired))
+            .expect("one");
+        state.record("doctor", &skipped).expect("two");
+        let text =
+            std::fs::read_to_string(state.root().join("doctor/history.ndjson")).expect("history");
+        assert_eq!(text.lines().count(), 2, "{text}");
+        assert!(text.contains("\"kind\":\"fired\""), "{text}");
+        assert!(text.contains("\"reason\":\"missed:1\""), "{text}");
+        // The tallies the report prints ride the same journal.
+        assert_eq!(state.tallies("doctor"), Some((1, 1)));
+        // … and last.json carries the LAST decision.
+        let last = state.last("doctor").expect("last.json");
+        assert_eq!(last.kind, FireKind::Skipped);
+    }
+
+    /// The orphan walk names sidecar dirs no registry knows — N4:
+    /// reported, never erased.
+    #[test]
+    fn a_sidecar_dir_without_a_registry_entry_is_an_orphan() {
+        let (_dir, state) = state("orphan");
+        state
+            .record("doctor", &entry(FireKind::Fired))
+            .expect("rec");
+        state.record("ghost", &entry(FireKind::Fired)).expect("rec");
+        let orphans = state.orphans(&["doctor".to_owned()]);
+        assert_eq!(orphans, vec!["ghost".to_owned()]);
+        // … and the orphan's record DEMEURE (the walk never writes).
+        assert!(state.root().join("ghost/last.json").exists());
+    }
+
+    /// Release is idempotent — an absent lock is released.
+    #[test]
+    fn release_without_a_lock_is_ok() {
+        let (_dir, state) = state("rel");
+        state.release("doctor").expect("idempotent");
+    }
+}

--- a/crates/nika-cli/tests/arm_fire.rs
+++ b/crates/nika-cli/tests/arm_fire.rs
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// The workspace bans std::process::Command (production spawns ride the
+// kernel ShellExecutor seam). This suite's WHOLE JOB is to execute the
+// real `nika-cli` binary (CARGO_BIN_EXE) — the same carve-out class as
+// ascii_contract.rs / bin_smoke.rs.
+#![allow(clippy::disallowed_types)]
+
+//! `nika arm fire <label>` end-to-end (W2 · LE TIREUR): a tempdir
+//! project (a `nika.yaml` registry + a `workflows/` shelf), the real
+//! binary, and the injected clock (`--now`, D5) making every branch
+//! deterministic. D8 is pinned on EVERY branch: exactly one stdout
+//! line, whatever happened.
+//!
+//! The workflows are `exec: { shell: "true" }` (exit 0, zero provider,
+//! zero Keychain) and a default-less `nika:prompt` gate for the pause
+//! (stdin is /dev/null — the terminal ask never fires, the run parks).
+
+use std::io::Write as _;
+use std::process::Command;
+
+fn bin() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_nika-cli"));
+    // A pause must PARK, never ask (the TTY ask would block a developer
+    // machine): stdin stays closed, so the gate goes durable.
+    cmd.stdin(std::process::Stdio::null());
+    cmd
+}
+
+/// A tempdir project: the registry + the workflow shelf.
+fn project(tag: &str, registry: &str, workflows: &[(&str, &str)]) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("nika-arm-fire-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("workflows")).expect("workflows dir");
+    let mut f = std::fs::File::create(dir.join("nika.yaml")).expect("registry file");
+    f.write_all(registry.as_bytes()).expect("registry body");
+    for (name, body) in workflows {
+        std::fs::write(dir.join("workflows").join(name), body).expect("workflow file");
+    }
+    dir
+}
+
+/// The trivial beat — exits 0, no provider, no key.
+const TRUE: &str =
+    "nika: armed-true\npermits: { exec: true }\ntasks:\n  ok:\n    exec: { shell: \"true\" }\n";
+
+/// The gated beat — a default-less `nika:prompt` pauses a
+/// non-interactive run (exit 4).
+const GATED: &str = r#"
+nika: armed-gate
+permits: { tools: ["nika:prompt"] }
+tasks:
+  approve:
+    invoke:
+      tool: "nika:prompt"
+      args: { mode: "input", message: "ship it?" }
+"#;
+
+/// Daily 03:00 UTC, skip the misses.
+const DAILY_3AM: &str = concat!(
+    "nika: v1\n",
+    "arm:\n",
+    "  - workflow: workflows/doctor.nika.yaml\n",
+    "    cadence: \"TZ=UTC 0 3 * * *\"\n",
+    "    plafond: 0.05\n",
+    "    manqué: sauter\n",
+);
+
+/// One beat's parsed `last.json` (`None` when absent).
+fn last_json(dir: &std::path::Path, label: &str) -> Option<serde_json::Value> {
+    let text = std::fs::read_to_string(dir.join(".nika/arm").join(label).join("last.json")).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// The history's raw text (`""` when absent).
+fn history(dir: &std::path::Path, label: &str) -> String {
+    std::fs::read_to_string(dir.join(".nika/arm").join(label).join("history.ndjson"))
+        .unwrap_or_default()
+}
+
+/// A pre-seeded last.json (a beat that fired a past slot).
+fn seed_last(dir: &std::path::Path, label: &str, slot: &str) {
+    let dir = dir.join(".nika/arm").join(label);
+    std::fs::create_dir_all(&dir).expect("sidecar dir");
+    std::fs::write(
+        dir.join("last.json"),
+        format!(
+            "{{\"slot\":\"{slot}\",\"fired_at\":\"{slot}\",\"trace\":null,\"exit\":0,\"kind\":\"fired\"}}\n"
+        ),
+    )
+    .expect("seed last.json");
+}
+
+/// A lock held by a LIVE owner (this test process).
+fn seed_lock(dir: &std::path::Path, label: &str) {
+    let dir = dir.join(".nika/arm").join(label);
+    std::fs::create_dir_all(&dir).expect("sidecar dir");
+    std::fs::write(
+        dir.join("lock"),
+        format!(
+            "{{\"pid\":{},\"started_at\":\"2026-08-19T03:00:00Z\"}}\n",
+            std::process::id()
+        ),
+    )
+    .expect("seed lock");
+}
+
+/// The traces under the project.
+fn traces(dir: &std::path::Path) -> Vec<String> {
+    let path = dir.join(".nika/traces");
+    let Ok(entries) = std::fs::read_dir(&path) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.ends_with(".ndjson"))
+        .collect()
+}
+
+/// D8: stdout is EXACTLY one line, always.
+fn assert_one_line(what: &std::process::Output) -> String {
+    let stdout = String::from_utf8_lossy(&what.stdout);
+    assert_eq!(
+        stdout.lines().count(),
+        1,
+        "D8 — exactly one stdout line, got: «{stdout}» (stderr: {})",
+        String::from_utf8_lossy(&what.stderr)
+    );
+    stdout.lines().next().expect("the one line").to_owned()
+}
+
+#[test]
+fn fire_runs_a_due_beat_and_records_it() {
+    let dir = project("due", DAILY_3AM, &[("doctor.nika.yaml", TRUE)]);
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let line = assert_one_line(&out);
+    assert!(
+        line.starts_with("fired doctor · slot 2026-08-19T03:00:00Z · exit 0 · trace .nika/traces/"),
+        "{line}"
+    );
+    // The record: last.json fired · exit 0 · the slot — and the trace
+    // the line cites really exists (law: every fire leaves one).
+    let last = last_json(&dir, "doctor").expect("last.json");
+    assert_eq!(last["kind"], "fired");
+    assert_eq!(last["exit"], 0);
+    assert_eq!(last["slot"], "2026-08-19T03:00:00Z");
+    let trace = last["trace"].as_str().expect("a trace path");
+    assert!(dir.join(trace).exists(), "{trace}");
+    assert_eq!(history(&dir, "doctor").lines().count(), 1);
+    assert_eq!(traces(&dir).len(), 1, "one fresh run = one trace (N2)");
+}
+
+#[test]
+fn fire_skips_a_missed_slot_when_manque_is_sauter() {
+    let dir = project("missed", DAILY_3AM, &[("doctor.nika.yaml", TRUE)]);
+    seed_last(&dir, "doctor", "2026-08-18T03:00:00Z");
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T10:00:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(0));
+    let line = assert_one_line(&out);
+    assert!(
+        line.starts_with("skipped doctor · missed:1 · slot 2026-08-19T03:00:00Z"),
+        "{line}"
+    );
+    // The skip CONSUMES the slot: last.json moves to it, kind skipped.
+    let last = last_json(&dir, "doctor").expect("last.json");
+    assert_eq!(last["kind"], "skipped");
+    assert_eq!(last["slot"], "2026-08-19T03:00:00Z");
+    assert_eq!(history(&dir, "doctor").lines().count(), 1);
+    // … and nothing ran (no trace, the workflow never went).
+    assert!(traces(&dir).is_empty());
+}
+
+#[test]
+fn fire_refuses_an_unknown_label_and_names_the_known_ones() {
+    let registry = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 3 * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+        "  - workflow: workflows/nightly.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 4 * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+    );
+    let dir = project(
+        "unknown",
+        registry,
+        &[("doctor.nika.yaml", TRUE), ("nightly.nika.yaml", TRUE)],
+    );
+    let out = bin()
+        .args(["arm", "fire", "bogus", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(2));
+    let line = assert_one_line(&out);
+    assert!(line.contains("unknown beat `bogus`"), "{line}");
+    assert!(line.contains("doctor"), "the known labels: {line}");
+    assert!(line.contains("nightly"), "the known labels: {line}");
+}
+
+#[test]
+fn fire_skips_when_the_lock_is_held_by_a_living_owner() {
+    let dir = project("locked", DAILY_3AM, &[("doctor.nika.yaml", TRUE)]);
+    seed_lock(&dir, "doctor");
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(0));
+    let line = assert_one_line(&out);
+    assert!(
+        line.starts_with("skipped doctor · overlap · pid "),
+        "{line}"
+    );
+    let last = last_json(&dir, "doctor").expect("last.json");
+    assert_eq!(last["kind"], "skipped");
+    // Law ⑥ sauter: the running tick keeps its lock, nothing ran.
+    assert!(dir.join(".nika/arm/doctor/lock").exists());
+    assert!(traces(&dir).is_empty());
+}
+
+#[test]
+fn fire_with_file_policy_times_out_at_the_next_slot() {
+    let registry = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC * * * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+        "    chevauchement: file\n",
+    );
+    let dir = project("queue", registry, &[("doctor.nika.yaml", TRUE)]);
+    seed_lock(&dir, "doctor");
+    // 03:02:59.9 — the 03:02 slot is 59.9s old (on time), the next one
+    // lands in 100ms: the queue waits the 100ms, then gives up.
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:59.900Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(0));
+    let line = assert_one_line(&out);
+    assert!(
+        line.starts_with("skipped doctor · overlap-timeout"),
+        "{line}"
+    );
+    assert!(traces(&dir).is_empty(), "the queue never ran");
+}
+
+#[test]
+fn fire_prints_exactly_one_stdout_line() {
+    // The cheap branches, each pinning D8 (the run-bearing branches
+    // assert the same in their own tests).
+    let dir = project("oneline", DAILY_3AM, &[("doctor.nika.yaml", TRUE)]);
+
+    // not-due: no state, the window long gone (N2 invents no backlog).
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T10:00:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(0));
+    let line = assert_one_line(&out);
+    assert!(line.starts_with("skipped doctor · not-due"), "{line}");
+    assert!(last_json(&dir, "doctor").is_none(), "N2 writes nothing");
+
+    // refusal: a bad --now teaches, one line, exit 2.
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "demain"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(2));
+    assert_one_line(&out);
+}
+
+#[test]
+fn fire_refuses_the_v0_unsupported_policies_with_teaching() {
+    let registry = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 3 * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+        "    chevauchement: remplacer\n",
+    );
+    let dir = project("refuse", registry, &[("doctor.nika.yaml", TRUE)]);
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(2));
+    let line = assert_one_line(&out);
+    assert!(line.contains("chevauchement: remplacer"), "{line}");
+    assert!(line.contains("serve v0.2"), "names the version: {line}");
+    assert!(traces(&dir).is_empty(), "a refusal never runs");
+}
+
+#[test]
+fn a_paused_run_is_parked_never_answered() {
+    let dir = project("paused", DAILY_3AM, &[("doctor.nika.yaml", GATED)]);
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "the gate parks the run · stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let line = assert_one_line(&out);
+    assert!(
+        line.starts_with("paused doctor · slot 2026-08-19T03:00:00Z"),
+        "{line}"
+    );
+    assert!(
+        line.contains("trace .nika/traces/"),
+        "the trace is cited: {line}"
+    );
+    assert!(line.contains("garé"), "parked, never resumed: {line}");
+    // Law 4 (N2): the park is recorded with its trace — and nothing
+    // answered the gate (the run went ONCE, exit 4).
+    let last = last_json(&dir, "doctor").expect("last.json");
+    assert_eq!(last["kind"], "paused");
+    assert_eq!(last["exit"], 4);
+    let trace = last["trace"].as_str().expect("the parked trace");
+    let body = std::fs::read_to_string(dir.join(trace)).expect("trace body");
+    assert!(body.contains("workflow_paused"), "the pause is journaled");
+}
+
+#[test]
+fn rattraper_une_fois_fires_one_run_for_the_whole_silence() {
+    let registry = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 3 * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: rattraper-une-fois\n",
+    );
+    let dir = project("catchup", registry, &[("doctor.nika.yaml", TRUE)]);
+    seed_last(&dir, "doctor", "2026-08-17T03:00:00Z");
+    let out = bin()
+        .args(["arm", "fire", "doctor", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn fire");
+    assert_eq!(out.status.code(), Some(0));
+    let line = assert_one_line(&out);
+    assert!(
+        line.starts_with("fired doctor · slot 2026-08-19T03:00:00Z · rattrapage ×2"),
+        "{line}"
+    );
+    let hist = history(&dir, "doctor");
+    assert!(hist.contains("\"slots\":2"), "the silence's count: {hist}");
+    let last = last_json(&dir, "doctor").expect("last.json");
+    assert_eq!(last["kind"], "fired");
+    assert_eq!(last["slot"], "2026-08-19T03:00:00Z");
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4479
+  classified_files: 4480
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1542
+    authored: 1543
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: a96e9a7ca8bf919b58e7fdd33b4380d9da3c27cfc7ed34545911989b18a1eba8
+  sha256: d636dacbbd56b1979afb8d92f667ac87f79bc434cad64e9137f71952688c914b
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 777
-  aggregate_sha256: 0c59c83148d50d5ea40c6f0084c0468f4ab4df3b13d47228e57828f09a98027c
+  match_count: 778
+  aggregate_sha256: bbc08c1e2cc309be6591d490feb5ab0cafeef9d73991fcaee4827952c57c5ffb
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 139
-  aggregate_sha256: 8568adc840c7ef2888db4f7b153b6c9e02dcad05468346500dbccb63b67752c8
+  aggregate_sha256: 71c21b51cb1a6ac706459bb0f58edb9ea99bd7bab56aaf72e19239ff0a5f1c42
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: d7593d3293e5cd6c2c2092b1216a05e3ff4d0a9e9fbf7016975a76c30369f497
+  aggregate_sha256: c23a0383e1a3db84b3d9c6e28f6c68c07d19471013eb99b23c4ff3292d58ce81
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4476
+  classified_files: 4477
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1539
+    authored: 1540
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -48,7 +48,7 @@ files:
   note: "generated with a human gate — the maintainer may amend the section at PR review"
 - path: "Cargo.lock"
   class: generated
-  sha256: 27da5d5d952d80366cd2d3f52e699efe6cc553423aa5820314ac87d980a50971
+  sha256: a96e9a7ca8bf919b58e7fdd33b4380d9da3c27cfc7ed34545911989b18a1eba8
   evidence: "cargo's resolver writes it; no human edits a lockfile"
   derivation:
     tool: "cargo (dependency resolution against Cargo.toml + crates/*/Cargo.toml)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 775
-  aggregate_sha256: ae817939128626bd25f228129bcc9d4b61a783078728e64b3223cf29692e2011
+  match_count: 776
+  aggregate_sha256: b79d367aa18f331b6fb6fe2a2f1832410c56ee8759e9a04939901cab2369b939
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -162,7 +162,7 @@ patterns:
 - glob: "crates/**"
   class: authored
   match_count: 139
-  aggregate_sha256: 819e38985237d9fb1eaceac7a05624b245bb02f4545ea276ef8342cbebf263e3
+  aggregate_sha256: 8568adc840c7ef2888db4f7b153b6c9e02dcad05468346500dbccb63b67752c8
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4475
+  classified_files: 4476
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1538
+    authored: 1539
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 774
-  aggregate_sha256: 693b19c26173680f0eb95a52153eae2488cac67ef5212ca01e07c142ea6effe7
+  match_count: 775
+  aggregate_sha256: ae817939128626bd25f228129bcc9d4b61a783078728e64b3223cf29692e2011
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4477
+  classified_files: 4479
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1540
+    authored: 1542
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,13 +151,13 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 776
-  aggregate_sha256: b79d367aa18f331b6fb6fe2a2f1832410c56ee8759e9a04939901cab2369b939
+  match_count: 777
+  aggregate_sha256: 0c59c83148d50d5ea40c6f0084c0468f4ab4df3b13d47228e57828f09a98027c
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 154
-  aggregate_sha256: 396ffe947d35b038b7a10a66f5d2cf024dbed9df3edb27fe27a5844947c8504f
+  match_count: 155
+  aggregate_sha256: d5e7df3eba3c6307ba69bd391a4089b02737df812378eec01ecfd6bcd5deca5c
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 778
-  aggregate_sha256: bbc08c1e2cc309be6591d490feb5ab0cafeef9d73991fcaee4827952c57c5ffb
+  aggregate_sha256: 5c257268932cae61c194e6570363deb75588aa3a2fe483fbd60336ad1c52abb1
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
# W2 · `nika arm fire <label>` — LE TIREUR

The second wave of the ARM+SERVE arc (W1 = #993). `nika arm` stops being a
read-only report: the verb grows the one firer, its sidecar, and a report
that tells proven from declared.

## What lands

- **Task 2.0** — `verbs/arm.rs` becomes `verbs/arm/{mod,args,fire,state}.rs`
  (zero behavior change; the clap tree freezes once: `ArmArgs` · `ArmSub` ·
  `FireArgs` · the W3 `--emit` enums are declared and refuse by name until
  their wave). `main.rs` changes at exactly the two named spots. The command
  stays `hide = true`.
- **Task 2.1** — `state.rs`: the firing sidecar (D3) —
  `.nika/arm/<label>/{lock,last.json,history.ndjson}` at the project root,
  never in the YAML. The lock's owner must answer signal 0 to hold (EPERM is
  alive too); a dead pid's remnant is taken over through the atomic
  `create_new`. Missing or corrupt state reads as never-fired — N2's safe
  direction.
- **Task 2.2** — `fire.rs`: **the one firer (D2)**. One function applies the
  on-time window (`ON_TIME_WINDOW`), the miss policy (`manqué:`), the overlap
  lock (`chevauchement:` sauter · file with poll-until-next-slot), the
  per-tick ceiling (`max_cost_usd = Some(plafond)` ALWAYS, law 7) and the
  record. The beat label is the workflow file's radical (D4, collisions take
  `-2`, `-3`). The clock is injected (`--now`, hidden — D5); the pure
  `decide` is unit-pinned per branch. v0 refuses `remplacer` ·
  `à-complétion` · `rattraper` · `décalage:` by name, each naming **serve
  v0.2** (D6). The run goes **in-process** with the `nika run` CLI defaults;
  its fold is turned onto stderr for the duration so the decision prints
  **exactly one stdout line** (D8: `fired …` · `skipped …` · `paused …` ·
  `failed …`). A paused run is parked with its trace — never resumed, never
  answered (law 4 · N2).
- **Task 2.3** — the report says `✓ PROUVÉ` (the sidecar attests) vs
  `DÉCLARÉ` (the registry alone speaks), shows `par:` as « déclaré · non
  vérifié » (N3), tallies `x sauts / y tirs · tolérance m/k` from the
  history, and names the **orphelins** (sidecar dirs no registry entry
  names — N4: reported, NEVER erased). Pinned by an insta snapshot.

## Test surface

- 24 lib tests under `verbs::arm` (report · state · decide branches ·
  labels · clock parse · snapshot).
- 9 binary end-to-end tests (`tests/arm_fire.rs`, the
  `CARGO_BIN_EXE_nika-cli` pattern): due beat fires + records · missed slot
  under `sauter` skips and consumes · unknown label names the known ones ·
  live-owner lock skips (overlap) · `file` policy polls and times out at the
  next slot · D8 one-line on every branch · v0 refusal teaches v0.2 · a
  paused run parks (exit 4, trace cited) · `rattraper-une-fois` fires once
  for the whole silence.

## Honest edges (named, not hidden)

- A run dying ENVIRONMENT (rc 3) rides the bin's env-to-stderr law — D8's
  one-stdout-line binds the decision codes (0 · 1 · 2 · 4).
- `jusqu_au` expiry is judged on the decision instant's civil date; the
  zone-exact expiry lands with serve.
- The `enter_room`-failure release path is a defensive two-liner, untested
  (no deterministic trigger).
- Local runs of the integration suite never touched Keychain (exec/prompt
  workflows resolve no provider); CI's nextest leg covers them on Linux.

## Verification

`cargo fmt --check` · `cargo clippy -p nika-cli --all-targets -- -D warnings`
· `cargo test -p nika-cli --lib` (246 green) ·
`cargo test -p nika-cli --test arm_fire` (9 green) · crate size 13 049 prod
LOC (< 13 500) · `fire.rs` 986 lines · typos clean.
