### PR TITLE
fix(nika-display): the ORDER and LIFT findings render in the human lane

### DIFF
--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -285,6 +285,108 @@ fn checked_text(name: &str, yaml: &str, ascii: bool) -> String {
     run(path.to_str().expect("utf8 path"), false, false, None, theme).text
 }
 
+/// The one-voice guard · every wire code the `--json` lane stamps in
+/// `findings[]` must appear in the human lane's text for the SAME file.
+/// A finding the wire carries and the terminal hides is the
+/// mute-diagnostic class (`✖ findings above` pointing at nothing) — the
+/// operator who cannot query JSON is the one who gets no reason.
+/// Returns the human text so the caller can assert its rows too.
+fn assert_every_wire_code_renders(name: &str, yaml: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("nika-cli-onevoice-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("tmp dir");
+    let path = dir.join(name);
+    std::fs::write(&path, yaml).expect("fixture body");
+    let path = path.to_str().expect("utf8 path");
+    let theme = Theme::new(false, true, false);
+    let machine = run(path, true, false, None, theme).text;
+    let human = run(path, false, false, None, theme).text;
+    let payload: serde_json::Value = serde_json::from_str(&machine).expect("json lane parses");
+    let codes: Vec<String> = payload["findings"]
+        .as_array()
+        .expect("findings[] is an array")
+        .iter()
+        .filter_map(|f| f["code"].as_str().map(str::to_owned))
+        .collect();
+    assert!(
+        !codes.is_empty(),
+        "the fixture must carry at least one wire code: {machine}"
+    );
+    for code in &codes {
+        assert!(
+            human.contains(code.as_str()),
+            "the wire stamps {code} and the human lane never prints it (mute diagnostic): {human}"
+        );
+    }
+    human
+}
+
+/// The order law (spec 10 · NIKA-SEC-015) refused in the wire and said
+/// NOTHING in the human lane — measured 2026-08-19 on the published
+/// 0.109.2: a beat workflow whose `exec: sleep 3` etiquette gap sat one
+/// `after:` control edge downstream of a `nika:fetch` exited rc=2 with
+/// every row green and `✖ findings above` pointing at nothing;
+/// `check_render.rs` read no `order_findings`. Now an ORDER row, always
+/// present like WRITES (a universal static law reads as one), carries
+/// the code and the route.
+#[test]
+fn order_law_renders_its_row_in_the_human_lane() {
+    const GAP_AFTER_FETCH: &str = "nika: beat\npermits:\n  exec: [\"sleep\"]\n  tools: [\"nika:fetch\"]\n  net:\n    http: [\"export.arxiv.org\"]\ntasks:\n  pull:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://export.arxiv.org/api/query?search_query=nika\", mode: text } }\n  gap:\n    after: { pull: success }\n    exec: { command: [\"sleep\", \"3\"] }\n";
+    // The same file with the gap BESIDE the fetch (no path from a
+    // net-effecting task to the shell) · the row is green and says what
+    // it looked at — the repair the finding teaches, rendered.
+    const GAP_BESIDE_FETCH: &str = "nika: beat\npermits:\n  exec: [\"sleep\"]\n  tools: [\"nika:fetch\"]\n  net:\n    http: [\"export.arxiv.org\"]\ntasks:\n  pull:\n    invoke: { tool: \"nika:fetch\", args: { url: \"https://export.arxiv.org/api/query?search_query=nika\", mode: text } }\n  gap:\n    exec: { command: [\"sleep\", \"3\"] }\n";
+    let text = assert_every_wire_code_renders("order-gap-after-fetch.nika.yaml", GAP_AFTER_FETCH);
+    let row = text
+        .lines()
+        .find(|l| l.contains("ORDER"))
+        .unwrap_or("<ORDER row absent from the report>");
+    assert!(
+        row.contains("[NIKA-SEC-015]") && row.contains("`gap`") && row.contains("`pull`"),
+        "the ORDER row names the code, the sink and the source: `{row}` in: {text}"
+    );
+    assert!(
+        !row.contains("✔"),
+        "a refused route is never a green row: {row}"
+    );
+
+    let text = checked_text("order-gap-beside-fetch.nika.yaml", GAP_BESIDE_FETCH, true);
+    let row = text
+        .lines()
+        .find(|l| l.contains("ORDER"))
+        .unwrap_or("<ORDER row absent from the report>");
+    assert!(
+        row.contains("no exec: sits downstream of a net-effecting task"),
+        "the universal law renders its green like WRITES does: `{row}` in: {text}"
+    );
+}
+
+/// The authored doors rule 6 (spec 10 · NIKA-AUTH-011) had the same gap:
+/// the wire stamped the code, the human lane had no LIFT row to print it
+/// in. The row renders only when a task declares `lift:` — a file with
+/// no door renders unchanged.
+#[test]
+fn idle_door_renders_its_row_in_the_human_lane_and_a_doorless_file_has_no_row() {
+    // `inputs.p` is declared and lifted, but the task never reads it ·
+    // the door guards an empty room.
+    const IDLE_DOOR: &str = "nika: doors\ninputs:\n  p: { type: string, default: \"x\" }\npermits:\n  exec: [\"echo\"]\ntasks:\n  say:\n    lift:\n      - { law: taint, from: inputs.p, because: \"reviewed 2026-08-19\" }\n    exec: { command: [\"echo\", \"hello\"] }\n";
+    const NO_DOOR: &str = "nika: plain\npermits:\n  exec: [\"echo\"]\ntasks:\n  say:\n    exec: { command: [\"echo\", \"hello\"] }\n";
+    let text = assert_every_wire_code_renders("lift-idle-door.nika.yaml", IDLE_DOOR);
+    let row = text
+        .lines()
+        .find(|l| l.contains("LIFT"))
+        .unwrap_or("<LIFT row absent from the report>");
+    assert!(
+        row.contains("[NIKA-AUTH-011]") && row.contains("`say`") && row.contains("fix:"),
+        "the LIFT row names the code, the task and the repair: `{row}` in: {text}"
+    );
+
+    let text = checked_text("lift-no-door.nika.yaml", NO_DOOR, true);
+    assert!(
+        !text.lines().any(|l| l.contains("LIFT")),
+        "a file with no authored door renders no LIFT row: {text}"
+    );
+}
+
 /// Same fixture plumbing, full `VerbOutput` (exit-code assertions) —
 /// the `--native-strict` posture tests read `.code`.
 fn checked_output(name: &str, yaml: &str, native_strict: bool) -> VerbOutput {
@@ -952,7 +1054,7 @@ fn dag_gated_lanes_announce_the_skip_instead_of_a_verdict() {
         "{LEAK}  ghost:\n    with: {{ z: \"${{{{ tasks.nope.output }}}}\" }}\n    exec: {{ command: [\"curl\", \"${{{{ with.z }}}}\"] }}\n"
     );
     let text = checked_text("lanes-skip.nika.yaml", &broken, false);
-    for lane in ["SECRETS", "GATES", "TRIFECTA"] {
+    for lane in ["SECRETS", "GATES", "TRIFECTA", "ORDER"] {
         // The placeholder makes ONE assert cover both failure shapes:
         // the lane vanished, or it printed a verdict it never computed.
         let line = text

--- a/crates/nika-display/src/check_laws.rs
+++ b/crates/nika-display/src/check_laws.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ORDER and LIFT rungs of `nika check` — the two spec-10 laws whose
+//! findings the wire stamped (`NIKA-SEC-015` · `NIKA-AUTH-011`) and the
+//! human lane never printed (measured 2026-08-19 on the published
+//! 0.109.2 · every row green · `✖ findings above` pointing at nothing).
+//! Split from `check_render.rs` at the 1500-line file wall, the JOURNEY
+//! precedent — same seams, the section helpers stay where they were.
+
+use nika_check::CheckReport;
+use nika_schema::raw::RawWorkflow;
+
+use crate::check_render::{section_list, section_or_skip};
+use crate::theme::Theme;
+
+/// ORDER rung (spec 10 · the unconditional order law · NIKA-SEC-015) ·
+/// always present, like WRITES — a universal static law reads as one.
+/// DAG-gated at the source (`lib.rs` runs `scan_order` only while
+/// conformance is clean), so the SKIP is announced, never a verdict the
+/// lane did not compute.
+///
+/// Measured 2026-08-19 on the published 0.109.2 · a beat workflow whose
+/// `exec: sleep 3` etiquette gap sat one `after:` edge downstream of a
+/// `nika:fetch` exited rc=2 with EVERY row green and `✖ findings above`
+/// pointing at nothing — only `--json` carried the finding, because this
+/// file read no `order_findings`. The mute-diagnostic class the PERMITS
+/// panel names, one lane over: a law that refuses in the wire and says
+/// nothing in the human lane is a law the operator cannot repair.
+pub(crate) fn order_rung(out: &mut String, report: &CheckReport, t: Theme) {
+    section_or_skip(
+        out,
+        report,
+        t,
+        "ORDER",
+        "no exec: sits downstream of a net-effecting task · unauthored content never reaches a shell",
+        report
+            .order_findings
+            .iter()
+            .map(|f| format!("[{}] {}", nika_check::OrderFinding::WIRE_CODE, f.detail))
+            .collect(),
+    );
+}
+
+/// LIFT rung (spec 10 rule 6 · the authored doors · NIKA-AUTH-011) ·
+/// only when a task declares `lift:` — a file with no door renders
+/// unchanged. Not DAG-gated at the source (`scan_idle_doors` reads the
+/// tasks, not the order), so a plain section: green when every door
+/// guards a law that fires, one code-first row per idle door. Same
+/// 2026-08-19 gap as ORDER: the wire stamped `NIKA-AUTH-011`, the human
+/// lane had no row to print it in.
+pub(crate) fn lift_rung(out: &mut String, report: &CheckReport, wf: &RawWorkflow, t: Theme) {
+    if !wf.tasks.iter().any(|task| !task.value.lift.is_empty()) {
+        return;
+    }
+    section_list(
+        out,
+        t,
+        "LIFT",
+        "every authored door guards a law that fires · a taint entry's binding reaches the task · a data-as-code entry meets a code-bearing fetch",
+        report
+            .lift_findings
+            .iter()
+            .map(|f| {
+                format!(
+                    "[{}] {} · fix: {}",
+                    nika_check::LiftFinding::WIRE_CODE,
+                    f.detail,
+                    f.fix
+                )
+            })
+            .collect(),
+    );
+}

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -144,9 +144,11 @@ pub fn render(
     );
     writes_rung(&mut out, report, t);
     exec_rung(&mut out, report, t);
+    crate::check_laws::order_rung(&mut out, report, t);
     permits(&mut out, report, wf, t);
     trifecta_rung(&mut out, report, wf, t);
     consent_rung(&mut out, report, t);
+    crate::check_laws::lift_rung(&mut out, report, wf, t);
     crate::check_journey::journey_rung(&mut out, report, t);
     run_rung(&mut out, report, wf, t);
     hints_and_verdict(&mut out, report, wf, t, drift_hints, verdict);
@@ -750,7 +752,7 @@ fn secret_rows(report: &CheckReport) -> Vec<String> {
 /// name that does not exist and the same leak reports
 /// `✔ SECRETS no information-flow escapes`. The green did not mean the
 /// leak was gone. It meant nobody looked.
-fn section_or_skip(
+pub(crate) fn section_or_skip(
     out: &mut String,
     report: &CheckReport,
     t: Theme,
@@ -775,7 +777,13 @@ fn section_or_skip(
     );
 }
 
-fn section_list(out: &mut String, t: Theme, label: &str, ok_msg: &str, rows: Vec<String>) {
+pub(crate) fn section_list(
+    out: &mut String,
+    t: Theme,
+    label: &str,
+    ok_msg: &str,
+    rows: Vec<String>,
+) {
     // Pad BEFORE painting — ANSI escapes break `{:<8}` width arithmetic
     // (the format pads bytes, not display columns).
     let padded = format!("{label:<8}");

--- a/crates/nika-display/src/lib.rs
+++ b/crates/nika-display/src/lib.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod check_journey;
+mod check_laws;
 mod check_models;
 pub mod check_render;
 pub mod chrome;

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4474
+  classified_files: 4475
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1537
+    authored: 1538
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 773
-  aggregate_sha256: 8c554135d456c3d25b9566943bf7138e4b1bded6eae96078397a124392c445d8
+  match_count: 774
+  aggregate_sha256: 693b19c26173680f0eb95a52153eae2488cac67ef5212ca01e07c142ea6effe7
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
fix(nika-display): the ORDER and LIFT findings render in the human lane

Defect: `nika check` refused a file in the wire and said nothing in the
terminal. Measured 2026-08-19 on the published 0.109.2 · a beat workflow
whose `exec: sleep 3` etiquette gap sat one `after:` control edge
downstream of a `nika:fetch` exited rc=2 with EVERY row green and
`✖ findings above` pointing at nothing · `--json` carried
`NIKA-SEC-015` (the order law · spec 10 · unconditional). The same gap
held for `NIKA-AUTH-011` (the authored doors · rule 6): `findings[]`
stamped both codes, `check_render.rs` read neither `order_findings` nor
`lift_findings`. The mute-diagnostic class the PERMITS panel names in
its own comment, one lane over · a law that refuses in the wire and
stays silent in the human lane is a law the operator cannot repair.

Mechanism: two rungs in `check_laws.rs` (split out at the 1500-line
file wall of `check_render.rs` · the JOURNEY precedent · the section
helpers stay where they were). ORDER is always present, like WRITES · a universal
static law reads as one · `section_or_skip` because the source is
DAG-gated (`lib.rs` runs `scan_order` only while conformance is clean),
so a broken DAG announces the SKIP, never a verdict the lane did not
compute · one code-first row per refused route, the detail carrying the
path. LIFT renders only when a task declares `lift:` (a doorless file
renders unchanged) · plain `section_list` because `scan_idle_doors`
reads the tasks, not the order · green names what it looked at, each
idle door prints its code, its detail and its fix.

Evidence: 3 tests · the order row on a gap-after-fetch fixture (code,
sink, source · never a green glyph) and the green row on the same file
with the gap beside the fetch · the LIFT row on an idle taint door and
no LIFT row on a doorless file · ORDER joins the DAG-gated skip loop ·
plus a one-voice guard `assert_every_wire_code_renders` (every code
`--json` stamps must appear in the human text of the same file) that
the two fixtures ride · nika-cli 228/228 · verbs_static 22/22 ·
nika-display 125/125 · clippy -D warnings clean · fmt clean · the live
binary renders both shapes on `dx/workflows/sota-radar-beat.nika.yaml`
(before the monorepo fix · `✖ ORDER [NIKA-SEC-015] … arxiv_relevance →
etiquette_gap` · after · `✔ ORDER`).

Honest limit: the guard covers the fixtures it is handed · a future
lane with no fixture and no row would slip it · the structural twin (a
walk of the whole check-reject corpus through the same guard) is a
follow-up.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
