### PR TITLE
feat(arm): the same firer, resident · W5

### DIFF
--- a/.claude/rules/diamond-discipline.md
+++ b/.claude/rules/diamond-discipline.md
@@ -46,7 +46,7 @@ refaire les fonctionnalités qui ne marchent pas".
 ## Rule 5 — Shadow zones are pre-launch gates
 
 7 shadow zones identified by audit. They are NOT optional :
-- Gate 1 : nika serve input trust (P0)
+- Gate 1 : nika serve input trust (P0 — RÉSOLU 2026-08-19, W5) : `serve` ne lit QUE `nika.yaml` (jugé par vocab + cadence AVANT tout tir) et son propre sidecar `.nika/arm/` — aucune entrée réseau · aucun argument externe · pinné par `serve_has_no_input_but_the_registry_and_its_state` (`crates/nika-cli/src/verbs/serve.rs`)
 - Gate 2 : cross-provider structured output parity (P0)
 - Gate 3 : binding/template/mod.rs 7,243 LOC (auto-résolu Phase 1 nika-binding)
 - Gate 4 : L1 taint runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,7 @@ unicode-normalization = { version = "0.1", default-features = false }   # nika-t
 nix           = { version = "0.31", default-features = false, features = ["signal"] }   # nika-exec-runner L1 (unix) — safe killpg wrapper for process-group kill (encapsulates the unsafe signal FFI → crate stays unsafe_code = forbid · MIT)
 futures-core  = "0.3"
 parking_lot   = "0.12"
-tokio         = { version = "1", features = ["rt", "macros", "time"] }
+tokio         = { version = "1", features = ["rt", "macros", "time", "signal"] }   # signal: nika-cli L4 — `nika serve` (W5) stops clean on ctrl-c/SIGTERM (signal-hook-registry already vendored via the tree)
 globset       = "0.4"   # nika-fs L1 — FsList::glob matcher (literal_separator · MIT OR Unlicense)
 reqwest       = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "brotli", "deflate", "http2"] }   # nika-http L1 + nika-catalog-verify L4 — pin once (RUST_ENFORCEMENT §2) · rustls (no openssl) · transparent gzip/br/deflate decode + h2 ALPN (the web compresses · pure-Rust miniz_oxide/brotli-decompressor/h2 · zstd SKIPPED: C dep)
 url           = "2"     # nika-http L1 — SSRF URL parsing (also transitive via reqwest · pinned aligned)

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -1203,6 +1203,50 @@ impl<T> typenum::type_operators::Same for nika_cli::verbs::run::FoldSink<W>
 pub type nika_cli::verbs::run::FoldSink<W>::Output = T
 pub fn nika_cli::verbs::run::example(slug: &str, model_flag: core::option::Option<&str>, access_pin: core::option::Option<&str>, vars: &[alloc::string::String], (quiet, no_progress): (bool, bool), max_cost_usd: core::option::Option<f64>, theme: nika_display::theme::Theme) -> u8
 pub fn nika_cli::verbs::run::run(file: &str, json: bool, output: core::option::Option<&str>, theme: nika_display::theme::Theme, mode: nika_cli::verbs::run::RenderMode, dry_run: bool, model_override: core::option::Option<&str>, access_pin: core::option::Option<&str>, vars: &[alloc::string::String], resume: core::option::Option<&nika_dap::resume::ResumeRequest>, no_trace_file: bool, task_filter: core::option::Option<&str>, no_outputs: bool, max_cost_usd: core::option::Option<f64>, no_gc: bool, require_signature: bool) -> u8
+pub mod nika_cli::verbs::serve
+pub struct nika_cli::verbs::serve::ServeArgs
+pub nika_cli::verbs::serve::ServeArgs::dry: bool
+pub nika_cli::verbs::serve::ServeArgs::now: core::option::Option<alloc::string::String>
+pub nika_cli::verbs::serve::ServeArgs::once: bool
+pub nika_cli::verbs::serve::ServeArgs::until: core::option::Option<alloc::string::String>
+impl clap_builder::derive::Args for nika_cli::verbs::serve::ServeArgs
+pub fn nika_cli::verbs::serve::ServeArgs::augment_args<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::serve::ServeArgs::augment_args_for_update<'b>(__clap_app: clap_builder::builder::command::Command) -> clap_builder::builder::command::Command
+pub fn nika_cli::verbs::serve::ServeArgs::group_id() -> core::option::Option<clap_builder::util::id::Id>
+impl clap_builder::derive::FromArgMatches for nika_cli::verbs::serve::ServeArgs
+pub fn nika_cli::verbs::serve::ServeArgs::from_arg_matches(__clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::serve::ServeArgs::from_arg_matches_mut(__clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<Self, clap_builder::Error>
+pub fn nika_cli::verbs::serve::ServeArgs::update_from_arg_matches(&mut self, __clap_arg_matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+pub fn nika_cli::verbs::serve::ServeArgs::update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap_builder::parser::matches::arg_matches::ArgMatches) -> core::result::Result<(), clap_builder::Error>
+impl core::fmt::Debug for nika_cli::verbs::serve::ServeArgs
+pub fn nika_cli::verbs::serve::ServeArgs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::serve::ServeArgs
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::serve::ServeArgs where U: core::convert::From<T>
+pub fn nika_cli::verbs::serve::ServeArgs::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::serve::ServeArgs where U: core::convert::Into<T>
+pub type nika_cli::verbs::serve::ServeArgs::Error = core::convert::Infallible
+pub fn nika_cli::verbs::serve::ServeArgs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::serve::ServeArgs where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::serve::ServeArgs::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::serve::ServeArgs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for nika_cli::verbs::serve::ServeArgs where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::serve::ServeArgs::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::serve::ServeArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::serve::ServeArgs::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::serve::ServeArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::serve::ServeArgs::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for nika_cli::verbs::serve::ServeArgs
+pub fn nika_cli::verbs::serve::ServeArgs::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::serve::ServeArgs where T: 'static
+pub fn nika_cli::verbs::serve::ServeArgs::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::serve::ServeArgs where T: ?core::marker::Sized
+pub fn nika_cli::verbs::serve::ServeArgs::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::serve::ServeArgs::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::serve::ServeArgs
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::serve::ServeArgs
+impl<T> typenum::type_operators::Same for nika_cli::verbs::serve::ServeArgs
+pub type nika_cli::verbs::serve::ServeArgs::Output = T
+pub fn nika_cli::verbs::serve::run(args: &nika_cli::verbs::serve::ServeArgs) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli::verbs::sign
 pub struct nika_cli::verbs::sign::SignArgs
 pub nika_cli::verbs::sign::SignArgs::check: bool

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -192,6 +192,9 @@ enum Command {
     /// stays one flag away (`--help --all`) and AGENTS.md teaches it.
     #[command(hide = true, display_order = 72)]
     Arm(verbs::arm::args::ArmArgs),
+    /// The resident firer: the SAME `fire`, the wall clock in place of the OS (W5). Exit `0` clean · `1` otherwise.
+    #[command(hide = true, display_order = 73)]
+    Serve(verbs::serve::ServeArgs),
     /// Sign a workflow file (S3 · author-binding): mint `<file>.minisig` · `--check` verifies.
     #[command(hide = true, display_order = 71)]
     Sign(verbs::sign::SignArgs),
@@ -733,6 +736,7 @@ fn dispatch_verb(
         } => emit(&explain_dispatch(&code, json, forecast, plain_theme)),
         Command::Key { action } => emit(&verbs::key::run(action)),
         Command::Arm(a) => emit(&verbs::arm::run(a)),
+        Command::Serve(a) => emit(&verbs::serve::run(&a)),
         Command::Sign(args) => emit(&verbs::sign::run(&args)),
         Command::Doctor(args) => doctor_verb(&args, plain_theme),
         Command::Init(args) => emit(&init_verb(&args, plain_theme)),

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -28,6 +28,7 @@ pub mod model;
 pub mod new;
 pub mod pack_surface;
 pub mod run;
+pub mod serve;
 pub mod sign;
 pub mod test;
 pub mod tools;

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+//! `nika serve` — LE TIREUR RÉSIDENT (W5): the SAME `fire` (D2), the wall
+//! clock in place of the OS. Gate 1: reads ONLY `nika.yaml` (vocab +
+//! cadence judge it before any shot) and its own sidecar. Exit 0 · 1 else.
+// A server's whole job is its log lines (the run/mod.rs precedent).
+#![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
+use super::arm::{
+    self,
+    fire::{FireCtx, fire_beat, labels},
+    state::ArmState,
+};
+use super::{VerbOutput, exit};
+use jiff::{SignedDuration, Zoned};
+use nika_cadence::registry::ArmRegistry;
+use std::path::{Path, PathBuf};
+/// `nika serve` — the resident firer's args.
+#[derive(Debug, clap::Args)]
+pub struct ServeArgs {
+    /// Fire what is due once, then exit — the rehearsal.
+    #[arg(long)]
+    pub once: bool,
+    /// Say what WOULD fire, run nothing.
+    #[arg(long)]
+    pub dry: bool,
+    /// Inject the clock (RFC 3339 · D5) — the harness.
+    #[arg(long, hide = true, value_name = "RFC3339")]
+    pub now: Option<String>,
+    /// Stop the loop at this instant (RFC 3339) — the harness.
+    #[arg(long, hide = true, value_name = "RFC3339")]
+    pub until: Option<String>,
+}
+/// The injected edges — `Zoned::now` + `tokio::time::sleep`, or the
+/// harness's scripted clock whose sleep ADVANCES it (trap ② avoided).
+struct Clock {
+    now: Box<dyn Fn() -> Zoned>,
+    sleep: SleepFn,
+}
+/// The sleeper's shape: a span in, a future out (factored for the lint).
+type SleepFn = Box<dyn Fn(SignedDuration) -> std::pin::Pin<Box<dyn Future<Output = ()>>>>;
+/// The verb edge: both lanes carry a `VerbOutput` (0 clean · 1 otherwise).
+#[must_use]
+pub fn run(args: &ServeArgs) -> VerbOutput {
+    match go(args) {
+        Ok(out) | Err(out) => out,
+    }
+}
+fn go(args: &ServeArgs) -> Result<VerbOutput, VerbOutput> {
+    let fail = |text: String| VerbOutput {
+        text,
+        code: exit::WORKFLOW,
+    };
+    let now = instant(args.now.as_deref()).map_err(&fail)?;
+    let until = instant(args.until.as_deref()).map_err(&fail)?;
+    if now.is_some() && !args.once && until.is_none() {
+        return Err(fail(
+            "serve · --now sans --once exige --until — une horloge scriptée sans borne tourne à vide"
+                .to_owned(),
+        ));
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let (path, registry) = arm::load(&cwd).map_err(|out| fail(out.text))?;
+    let root = path
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    serve(&root, registry, args, until.as_ref(), &clock(now)).map_err(fail)?;
+    Ok(VerbOutput::ok(String::new()))
+}
+/// An RFC 3339 instant — the zoned form keeps its zone, a bare one rides
+/// UTC (the arm fire `--now` precedent).
+fn instant(raw: Option<&str>) -> Result<Option<Zoned>, String> {
+    raw.map_or(Ok(None), |text| {
+        text.parse::<Zoned>()
+            .or_else(|_| {
+                text.parse::<jiff::Timestamp>()
+                    .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC))
+            })
+            .map(Some)
+            .map_err(|_| format!("serve · `{text}` · RFC 3339 attendu — 2026-08-19T03:02:00Z"))
+    })
+}
+/// The two edges: the wall clock + a real sleep, or the scripted harness
+/// (start at the injected instant · a sleep ADVANCES it, never waits).
+fn clock(start: Option<Zoned>) -> Clock {
+    match start {
+        None => Clock {
+            now: Box::new(Zoned::now),
+            sleep: Box::new(|d| {
+                Box::pin(tokio::time::sleep(
+                    std::time::Duration::try_from(d).unwrap_or_default(),
+                ))
+            }),
+        },
+        Some(t) => {
+            let cell = std::rc::Rc::new(std::cell::RefCell::new(t));
+            let advance = cell.clone();
+            Clock {
+                now: Box::new(move || cell.borrow().clone()),
+                sleep: Box::new(move |d| {
+                    let next = advance.borrow().clone() + d;
+                    *advance.borrow_mut() = next;
+                    Box::pin(async {})
+                }),
+            }
+        }
+    }
+}
+/// The loop: the clock, the reload on change (« le fichier propose » —
+/// re-read, never cache; a broken edit is told and the last-good registry
+/// keeps serving), the SAME firer for what is due, then the sleep to the
+/// next slot (≤ 60 s) racing the signals — a signal breaks clean (the
+/// current fire, synchronous, finishes first).
+fn serve(
+    root: &Path,
+    mut reg: ArmRegistry,
+    args: &ServeArgs,
+    until: Option<&Zoned>,
+    clock: &Clock,
+) -> Result<(), String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("serve · the signal runtime refused: {e}"))?;
+    #[cfg(unix)]
+    let mut term = rt.block_on(async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok()
+    });
+    let path = root.join(nika_vocab::project::FILE_NAME);
+    let mut mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+    loop {
+        let now = (clock.now)();
+        if until.is_some_and(|u| now >= *u) {
+            return Ok(());
+        }
+        if let Ok(fresh) = std::fs::metadata(&path).and_then(|m| m.modified())
+            && Some(fresh) != mtime
+        {
+            match arm::load(root) {
+                Ok((_, reloaded)) => {
+                    reg = reloaded;
+                    mtime = Some(fresh);
+                }
+                Err(out) => eprintln!("nika: {}", out.text),
+            }
+        }
+        let state = ArmState::at_project(root);
+        let names = labels(&reg);
+        let dues: Vec<(usize, nika_cadence::Slot)> = nika_cadence::due(&reg, &now, &|i| {
+            names.get(i).and_then(|l| state.last_fired(l))
+        })
+        .map_err(|e| format!("serve · a validated registry refuses: {e}"))?
+        .map(|d| (d.index, d.slot))
+        .collect();
+        for (index, slot) in dues {
+            let label = names[index].clone();
+            if args.dry {
+                println!("would fire {label} · slot {}", slot.at.timestamp());
+                continue;
+            }
+            let ctx = FireCtx {
+                project_root: root.to_path_buf(),
+                registry: reg,
+                index,
+                label,
+                now: now.clone(),
+                state: ArmState::at_project(root),
+            };
+            println!("{}", fire_beat(&ctx).line);
+            reg = ctx.registry;
+        }
+        if args.once {
+            return Ok(());
+        }
+        let next = nika_cadence::earliest_next(&reg, &now)
+            .map_err(|e| format!("serve · a validated registry refuses: {e}"))?;
+        let secs = next.map_or(60, |(_, s)| {
+            (s.at.timestamp().as_second() - now.timestamp().as_second()).clamp(1, 60)
+        });
+        let stop = rt.block_on(async {
+            #[cfg(unix)]
+            let sig = async {
+                if let Some(s) = &mut term {
+                    s.recv().await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            };
+            #[cfg(not(unix))]
+            let sig = std::future::pending::<()>();
+            tokio::select! {
+                () = (clock.sleep)(SignedDuration::from_secs(secs)) => false,
+                _ = tokio::signal::ctrl_c() => true,
+                () = sig => true,
+            }
+        });
+        if stop {
+            return Ok(());
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn at(text: &str) -> Zoned {
+        text.parse::<jiff::Timestamp>()
+            .expect("ts")
+            .to_zoned(jiff::tz::TimeZone::UTC)
+    }
+
+    /// A tempdir project (registry + workflow shelf) — the arm precedent.
+    fn project(tag: &str, registry: &str) -> tempfile::TempDir {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("nika-serve-{tag}-"))
+            .tempdir()
+            .expect("tmp dir");
+        std::fs::create_dir_all(dir.path().join("workflows")).expect("workflows");
+        std::fs::write(dir.path().join("nika.yaml"), registry).expect("registry");
+        dir
+    }
+
+    fn write_workflow(root: &Path, name: &str) {
+        let body = format!(
+            "nika: {name}\npermits: {{ exec: true }}\ntasks:\n  ok:\n    exec: {{ shell: \"true\" }}\n"
+        );
+        std::fs::write(root.join("workflows").join(name), body).expect("workflow");
+    }
+
+    /// Hourly beats — mid-hour nothing is ever ON TIME, so the loop only
+    /// ever SKIPS (an in-process run chdirs: the binary tests' ground —
+    /// parallel tests race on the process CWD).
+    const HOURLY_A: &str = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 * * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+    );
+
+    /// The v2: a second beat appears between two ticks.
+    const HOURLY_AB: &str = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 * * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+        "  - workflow: workflows/nightly.nika.yaml\n",
+        "    cadence: \"TZ=UTC 0 * * * *\"\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+    );
+
+    /// Seed a decided slot (a past skip) so the planner counts a silence.
+    fn seed_last(root: &Path, label: &str, slot: &str) {
+        let dir = root.join(".nika/arm").join(label);
+        std::fs::create_dir_all(&dir).expect("sidecar");
+        std::fs::write(
+            dir.join("last.json"),
+            format!(
+                "{{\"slot\":\"{slot}\",\"fired_at\":\"{slot}\",\"trace\":null,\"exit\":0,\"kind\":\"skipped\"}}\n"
+            ),
+        )
+        .expect("seed last.json");
+    }
+
+    fn history(root: &Path, label: &str) -> String {
+        std::fs::read_to_string(root.join(".nika/arm").join(label).join("history.ndjson"))
+            .unwrap_or_default()
+    }
+
+    /// The scripted clock: starts at `start`, each `sleep` ADVANCES it
+    /// (trap ② avoided by construction) and lands ready — the first sleep
+    /// also runs the test's actor (the reload test rewrites the file there).
+    fn scripted(start: &str, on_first_sleep: impl FnMut() + 'static) -> Clock {
+        let cell = std::rc::Rc::new(std::cell::RefCell::new(at(start)));
+        let advance = cell.clone();
+        let actor = std::cell::RefCell::new(Some(on_first_sleep));
+        Clock {
+            now: Box::new(move || cell.borrow().clone()),
+            sleep: Box::new(move |span| {
+                let next = advance.borrow().clone() + span;
+                *advance.borrow_mut() = next;
+                if let Some(mut act) = actor.borrow_mut().take() {
+                    act();
+                }
+                Box::pin(async {})
+            }),
+        }
+    }
+
+    fn serve_args() -> ServeArgs {
+        ServeArgs {
+            once: false,
+            dry: false,
+            now: None,
+            until: None,
+        }
+    }
+
+    #[test]
+    fn serve_reloads_the_registry_when_the_file_changes() {
+        let dir = project("reload", HOURLY_A);
+        write_workflow(dir.path(), "doctor.nika.yaml");
+        write_workflow(dir.path(), "nightly.nika.yaml");
+        seed_last(dir.path(), "doctor", "2026-08-19T00:00:00Z");
+        seed_last(dir.path(), "nightly", "2026-08-19T00:00:00Z");
+        let path = dir.path().join("nika.yaml");
+        let registry = match arm::load(dir.path()) {
+            Ok((_, registry)) => registry,
+            Err(out) => panic!("load v1: {}", out.text),
+        };
+        let rewritten = std::rc::Rc::new(std::cell::Cell::new(false));
+        let flag = rewritten.clone();
+        let yaml = path.clone();
+        let clock = scripted("2026-08-19T03:30:00Z", move || {
+            // mtime must move: a real beat of the wall between the writes.
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            std::fs::write(&yaml, HOURLY_AB).expect("rewrite");
+            flag.set(true);
+        });
+        let until = at("2026-08-19T03:35:00Z");
+        let rc = serve(dir.path(), registry, &serve_args(), Some(&until), &clock);
+        assert!(rc.is_ok(), "{rc:?}");
+        assert!(rewritten.get(), "the actor ran");
+        // Tick 1 (registry v1): doctor's silence is 3 slots — skipped.
+        let doctor = history(dir.path(), "doctor");
+        assert_eq!(doctor.lines().count(), 1, "{doctor}");
+        assert!(doctor.contains("\"reason\":\"missed:3\""), "{doctor}");
+        // Tick 2 (registry v2): nightly's line is the reload's proof —
+        // v1 never named it, and the loop never restarted.
+        let nightly = history(dir.path(), "nightly");
+        assert_eq!(nightly.lines().count(), 1, "the reload: {nightly}");
+        assert!(nightly.contains("\"reason\":\"missed:3\""), "{nightly}");
+    }
+
+    #[test]
+    fn a_scripted_clock_without_a_bound_refuses() {
+        let args = ServeArgs {
+            once: false,
+            dry: false,
+            now: Some("2026-08-19T03:02:00Z".to_owned()),
+            until: None,
+        };
+        let out = run(&args);
+        assert_eq!(out.code, exit::WORKFLOW, "{}", out.text);
+        assert!(out.text.contains("--until"), "{}", out.text);
+    }
+
+    #[test]
+    fn the_injected_instant_parses_rfc3339_and_refuses_garbage() {
+        assert!(instant(Some("demain")).is_err());
+        let zoned = instant(Some("2026-08-19T05:02:00+02:00[Europe/Paris]"))
+            .expect("parses")
+            .expect("some");
+        assert_eq!(zoned.timestamp().to_string(), "2026-08-19T03:02:00Z");
+    }
+}

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -358,4 +358,31 @@ mod tests {
             .expect("some");
         assert_eq!(zoned.timestamp().to_string(), "2026-08-19T03:02:00Z");
     }
+
+    /// Gate 1 (diamond-discipline §5, P0 · closed 2026-08-19): serve reads
+    /// ONLY the registry (through the ONE arm door, judged by vocab +
+    /// cadence BEFORE any shot — the source order pins it) and its own
+    /// sidecar. No network, no environment read, no argument beyond the
+    /// clap surface. A static pin over the prod half of this file.
+    #[test]
+    fn serve_has_no_input_but_the_registry_and_its_state() {
+        let src = include_str!("serve.rs");
+        let prod = src.split("#[cfg(test)]").next().expect("prod half");
+        assert!(prod.contains("arm::load"), "the registry's ONE door");
+        assert!(prod.contains("ArmState"), "its own sidecar");
+        let judged = prod.find("arm::load(").expect("the door's call");
+        let fired = prod.find("fire_beat(").expect("the firer's call");
+        assert!(judged < fired, "vocab + cadence judge BEFORE any shot");
+        for banned in [
+            "reqwest",
+            "std::net",
+            "tokio::net",
+            "TcpStream",
+            "std::env::var",
+            "env::args",
+            "stdin",
+        ] {
+            assert!(!prod.contains(banned), "serve must not read {banned}");
+        }
+    }
 }

--- a/crates/nika-cli/tests/serve.rs
+++ b/crates/nika-cli/tests/serve.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![allow(clippy::expect_used, clippy::panic)]
+// The workspace bans std::process::Command (production spawns ride the
+// kernel ShellExecutor seam). This suite's WHOLE JOB is to execute the
+// real `nika-cli` binary (CARGO_BIN_EXE) — the same carve-out class as
+// arm_fire.rs / bin_smoke.rs.
+#![allow(clippy::disallowed_types)]
+
+//! `nika serve` end-to-end (W5 · LE TIREUR RÉSIDENT): a tempdir project,
+//! the real binary, and the injected clock (`--now`/`--until`, D5) making
+//! the loop deterministic — the harness advances the clock on each sleep,
+//! so the loop never waits; the SIGTERM stop rides the REAL clock.
+
+use std::io::Write as _;
+use std::process::Command;
+
+fn bin() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_nika-cli"));
+    // A pause must PARK, never ask (the arm_fire.rs precedent).
+    cmd.stdin(std::process::Stdio::null());
+    cmd
+}
+
+/// A tempdir project: the registry + the workflow shelf.
+fn project(tag: &str, registry: &str, workflows: &[(&str, &str)]) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("nika-serve-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("workflows")).expect("workflows dir");
+    let mut f = std::fs::File::create(dir.join("nika.yaml")).expect("registry file");
+    f.write_all(registry.as_bytes()).expect("registry body");
+    for (name, body) in workflows {
+        std::fs::write(dir.join("workflows").join(name), body).expect("workflow file");
+    }
+    dir
+}
+
+/// The trivial beat — exits 0, no provider, no key.
+const TRUE: &str =
+    "nika: armed-true\npermits: { exec: true }\ntasks:\n  ok:\n    exec: { shell: \"true\" }\n";
+
+/// Daily 03:00 UTC, skip the misses.
+const DAILY_3AM: &str = concat!(
+    "nika: v1\n",
+    "arm:\n",
+    "  - workflow: workflows/doctor.nika.yaml\n",
+    "    cadence: \"TZ=UTC 0 3 * * *\"\n",
+    "    plafond: 0.05\n",
+    "    manqué: sauter\n",
+);
+
+/// Every minute — the loop + signal tests' cadence.
+const EVERY_MINUTE: &str = concat!(
+    "nika: v1\n",
+    "arm:\n",
+    "  - workflow: workflows/doctor.nika.yaml\n",
+    "    cadence: \"TZ=UTC * * * * *\"\n",
+    "    plafond: 0.05\n",
+    "    manqué: sauter\n",
+);
+
+/// One beat's parsed `last.json` (`None` when absent).
+fn last_json(dir: &std::path::Path, label: &str) -> Option<serde_json::Value> {
+    let text = std::fs::read_to_string(dir.join(".nika/arm").join(label).join("last.json")).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// The history's raw text (`""` when absent).
+fn history(dir: &std::path::Path, label: &str) -> String {
+    std::fs::read_to_string(dir.join(".nika/arm").join(label).join("history.ndjson"))
+        .unwrap_or_default()
+}
+
+#[test]
+fn serve_once_fires_what_is_due_and_exits_zero() {
+    let dir = project("once", DAILY_3AM, &[("doctor.nika.yaml", TRUE)]);
+    let out = bin()
+        .args(["serve", "--once", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn serve");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("fired doctor · slot 2026-08-19T03:00:00Z · exit 0"),
+        "{stdout}"
+    );
+    let last = last_json(&dir, "doctor").expect("last.json");
+    assert_eq!(last["kind"], "fired");
+    assert_eq!(last["slot"], "2026-08-19T03:00:00Z");
+}
+
+#[test]
+fn serve_loop_fires_two_beats_in_slot_order() {
+    let dir = project("loop", EVERY_MINUTE, &[("doctor.nika.yaml", TRUE)]);
+    let out = bin()
+        .args([
+            "serve",
+            "--now",
+            "2026-08-19T03:02:00Z",
+            "--until",
+            "2026-08-19T03:03:30Z",
+        ])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn serve");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 2, "one line per beat: {stdout}");
+    assert!(
+        lines[0].contains("fired doctor · slot 2026-08-19T03:02:00Z"),
+        "the first slot first: {stdout}"
+    );
+    assert!(
+        lines[1].contains("fired doctor · slot 2026-08-19T03:03:00Z"),
+        "the second slot second: {stdout}"
+    );
+    assert_eq!(history(&dir, "doctor").lines().count(), 2);
+}
+
+#[test]
+fn serve_never_fires_a_cloud_beat() {
+    let registry = concat!(
+        "nika: v1\n",
+        "arm:\n",
+        "  - workflow: workflows/doctor.nika.yaml\n",
+        "    cadence: \"TZ=UTC * * * * *\"\n",
+        "    où: cloud\n",
+        "    plafond: 0.05\n",
+        "    manqué: sauter\n",
+    );
+    let dir = project("cloud", registry, &[("doctor.nika.yaml", TRUE)]);
+    let out = bin()
+        .args(["serve", "--once", "--now", "2026-08-19T03:02:00Z"])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn serve");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("fired"),
+        "a cloud beat never fires: {stdout}"
+    );
+    assert!(
+        !dir.join(".nika/arm/doctor").exists(),
+        "the cloud's calendar stays the operator's — no sidecar is even opened"
+    );
+}
+
+/// unix: SIGTERM while the resident idles between two slots — it exits
+/// clean (0) and leaves no lock behind.
+#[cfg(unix)]
+#[test]
+fn serve_stops_cleanly_on_sigterm() {
+    let dir = project("sigterm", EVERY_MINUTE, &[("doctor.nika.yaml", TRUE)]);
+    let mut child = bin()
+        .args(["serve"])
+        .current_dir(&dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn serve");
+    // Wait for the first fire (the sidecar attests it), then TERM.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while last_json(&dir, "doctor").is_none() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the first fire never landed"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let pid = nix::unistd::Pid::from_raw(i32::try_from(child.id()).expect("pid"));
+    nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGTERM).expect("kill -TERM");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("wait") {
+            break status;
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            panic!("serve ignored SIGTERM");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
+    assert_eq!(status.code(), Some(0), "SIGTERM = a clean stop");
+    assert!(
+        !dir.join(".nika/arm/doctor/lock").exists(),
+        "the lock is released"
+    );
+}

--- a/docs/crate-specs/nika-cadence.md
+++ b/docs/crate-specs/nika-cadence.md
@@ -172,6 +172,31 @@ verification (②'s, refused by name in round 1).
   la duplication « re-parse + None-impossible » sera prouvée ou
   imaginaire à ce moment-là, pas avant.
 
+### W5 — `nika serve` : les trois questions du brouillon, tranchées (2026-08-19)
+
+Le tireur résident (`crates/nika-cli/src/verbs/serve.rs`) a clos les trois
+questions que le brouillon laissait ouvertes — les réponses vivent ici,
+pas dans le code :
+
+- **`max_retries` au niveau job → NON.** Un beat repart de zéro (N2) :
+  chaque tir est un run NEUF, un run en pause (exit 4) est PARQUÉ avec sa
+  trace, jamais repris. L'ordonnanceur n'a donc rien à quoi un retry
+  s'accrocherait — le retry vit DANS le workflow (`retry:` sur la tâche,
+  plein-jitter et tout), jamais dans le beat.
+- **l'enum d'état de job → c'est `history.ndjson`.** L'état n'est pas un
+  type à inventer : c'est le journal append-only du sidecar
+  (`.nika/arm/<label>/`), dont le vocabulaire `kind` est déjà fermé —
+  `fired` · `skipped` · `paused` · `failed` · `disarmed` (le dernier est
+  history-only : il ne porte pas de slot, donc `record` ne l'écrit jamais
+  dans `last.json`, et `last` le relit comme illisible — la direction
+  sûre).
+- **`serve_tokens` (qui déclenche à distance) → hors v0.** Aucun port,
+  aucune entrée : Gate 1 (diamond-discipline §5, résolu 2026-08-19) —
+  `serve` ne lit QUE `nika.yaml` et son sidecar, jamais le réseau, et le
+  test `serve_has_no_input_but_the_registry_and_its_state` le pinne. Le
+  déclenchement à distance est le problème du cloud (`où: cloud`) : le
+  cloud le portera, pas le résident.
+
 ---
 
 ## 6. Gate status (measured 2026-08-13, not declared)

--- a/estate.yaml
+++ b/estate.yaml
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 106
-  aggregate_sha256: 5a98ec363fc90ad4c2f76001015e87acaa1366a53ca12e409586da004298bd43
+  aggregate_sha256: 1fb0679e500f6d5e5e1cab1fe19988b4b962948348a416ca3fb495e72b1940ba
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4492
+  classified_files: 4494
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1555
+    authored: 1557
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -151,13 +151,13 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 789
-  aggregate_sha256: b11564789bbe63b3e2c9a5fd66bb314d9dd00c49cf825a8a9ef8e73abf48e28d
+  match_count: 790
+  aggregate_sha256: 321595bbae3c5d5cc67a9d269380fa724098a3238a71ab9aff4a2085a54f74e9
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 156
-  aggregate_sha256: fc7f92ffacb13e00ab08503f913e1efe98a9e11adac2aa6918666a2fd23a734e
+  match_count: 157
+  aggregate_sha256: f5de893a8310cec61852b220d6666282418d398cded8a1050d3518f163ba8550
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: 19dabcc9a96580b4b26b48d81482768de489e55088142e58249ae387de9b678f
+  aggregate_sha256: c761dc58938690d91261300dd287f76387234e30c443e202d58c831130dffc96
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: a124a0428f067b9c02d8b73d749338e680e891904ee9800354043524c6ee95f4
+  aggregate_sha256: ae02ed555449e0a76b741afd2d11a869f323358eb013361bad28e6af4e373282
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 790
-  aggregate_sha256: 321595bbae3c5d5cc67a9d269380fa724098a3238a71ab9aff4a2085a54f74e9
+  aggregate_sha256: 8935cff2bc76014cd0f68f0a9c39452a5bf78faad5bae90b86ad4807f9f5819f
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -203,7 +203,7 @@ patterns:
 - glob: ".claude/**"
   class: authored
   match_count: 15
-  aggregate_sha256: b84499b8a0342cfc5282dcbab2d91fd8c441d59fbe97cd63d920535d2b5868fb
+  aggregate_sha256: 9f2ab101eb9cf2716281e4d6ad54aa668ca54c5abf7b3205e189c509eaea5170
   evidence: "harness rules · skills · commands for the Diamond rebuild — hand-written; .claude/CLAUDE.md excepted in files: (carries the refresh-status.sh auto-block)"
 - glob: ".claude-plugin/**"
   class: authored


### PR DESCRIPTION
## W5 · `nika serve` — LE TIREUR RÉSIDENT

The same firer as `arm fire` and the OS units (D2), driven by the wall clock in place of launchd/systemd. `nika` is not a control plane: serve is « a run triggered by a cadence instead of a human » — zero file, zero cluster.

### The loop (`crates/nika-cli/src/verbs/serve.rs`)

- the injected clock behind two `Box<dyn Fn>` (production `Zoned::now` + `tokio::time::sleep` · the hidden `--now`/`--until` harness starts a scripted clock that ADVANCES on each sleep — trap ② avoided by construction: `VirtualClock::sleep` does not advance time, so the calculator never sleeps, the caller does)
- reloads `nika.yaml` when its mtime moves (« le fichier propose » — re-read, never cached; a broken edit is told on stderr and the last-good registry keeps serving)
- fires what `due` returns through the ONE firer (`fire_beat` from W2 — the per-tick ceiling always passed, N2: every fire is a fresh run, a paused run is parked never resumed)
- sleeps to the earliest next slot (≤ 60 s) racing ctrl-c/SIGTERM — a signal breaks clean: exit 0, the synchronous fire finishes first, the lock is released
- server exit convention: 0 clean · 1 otherwise

### Gate 1 closed (diamond-discipline §5, P0 → RÉSOLU 2026-08-19)

`serve` reads ONLY `nika.yaml` (judged by vocab + cadence BEFORE any shot) and its own `.nika/arm/` sidecar — no network, no env, no argv beyond clap. Pinned statically by `serve_has_no_input_but_the_registry_and_its_state`.

### The three brouillon questions (in `docs/crate-specs/nika-cadence.md`)

- `max_retries` at job level → NO (N2; the retry lives in the workflow's `retry:` on the task)
- the job-state enum → it is `history.ndjson` (fired · skipped · paused · failed · disarmed)
- `serve_tokens` → out of v0 (no port, no input; the cloud carries it)

### Proof

- `cargo test -p nika-cli --lib` — 253 green, incl. 6 serve tests (reload RED→GREEN on the reload block · Gate-1 RED→GREEN on the call-order pin)
- `cargo test -p nika-cli --test serve` — 4 binary tests: once fires what is due and exits 0 · the loop fires two beats in slot order · a cloud beat never fires · SIGTERM = exit 0 + lock released (all four reddened first on the missing subcommand)
- `cargo clippy -p nika-cli --all-targets -- -D warnings` rc 0 · `cargo fmt --check` clean · `cargo deny check` ok (tokio `signal` additive — signal-hook-registry already vendored)
- pre-push gate green (workspace tests · hygiene · 9 CI ratchets)

### Known gap (for the orchestrator)

`check-crate-size.sh` (the 15k ratchet) is green, but nika-cli prod LOC lands at **13 619** — over the packet's `< 13 500` figure: the baseline was already 13 412, the wiring costs 5, and the mandated design (ServeArgs · Clock harness · loop · signals) floors at ~200 prod LOC. Accept the number or descend a home for the harness in a later wave.

🦋 W5 of the nika-arm mission