### PR TITLE
fix(nika): authoring seams from a real paid extract wave

### DIFF
--- a/crates/nika-builtin/src/data.rs
+++ b/crates/nika-builtin/src/data.rs
@@ -241,9 +241,7 @@ pub(crate) fn json_merge_patch(args: &Args) -> BuiltinOutcome {
 pub(crate) fn validate(args: &Args) -> BuiltinOutcome {
     const C1: &str = "NIKA-BUILTIN-VALIDATE-001";
     const C2: &str = "NIKA-BUILTIN-VALIDATE-002";
-    let schema = args
-        .get("schema")
-        .ok_or_else(|| BuiltinFailure::new(C1, "`schema:` is required"))?;
+    let schema = parse_schema_arg(args, C1)?;
     let format = opt_str(args, "format", C1)?.unwrap_or("json");
 
     let data = match format {
@@ -264,7 +262,7 @@ pub(crate) fn validate(args: &Args) -> BuiltinOutcome {
         }
     };
 
-    let validator = jsonschema::validator_for(schema).map_err(|e| {
+    let validator = jsonschema::validator_for(&schema).map_err(|e| {
         BuiltinFailure::new(C1, format!("`schema:` is not a valid JSON Schema: {e}"))
     })?;
     // Structured error objects, not bare strings — `path` (JSON Pointer
@@ -283,6 +281,33 @@ pub(crate) fn validate(args: &Args) -> BuiltinOutcome {
         })
         .collect();
     Ok(serde_json::json!({ "valid": errors.is_empty(), "errors": errors }))
+}
+
+/// `schema:` may be a JSON object OR a string `nika:read` just handed
+/// over (the 2026-08-19 authoring miss: a `.json` file is text, and
+/// treating that text as the schema value itself fails
+/// `validator_for` with "not of types boolean, object").
+fn parse_schema_arg(args: &Args, code: &'static str) -> Result<serde_json::Value, BuiltinFailure> {
+    match args.get("schema") {
+        None => Err(BuiltinFailure::new(code, "`schema:` is required")),
+        Some(serde_json::Value::String(text)) => serde_json::from_str(text)
+            .or_else(|_| {
+                serde_yaml_bw::from_str(text).map_err(|yaml_err| {
+                    BuiltinFailure::new(
+                        code,
+                        format!("`schema:` is a string that is neither JSON nor YAML: {yaml_err}"),
+                    )
+                })
+            })
+            .and_then(|parsed| match parsed {
+                serde_json::Value::Object(_) | serde_json::Value::Bool(_) => Ok(parsed),
+                other => Err(BuiltinFailure::new(
+                    code,
+                    format!("`schema:` string parsed as {other}, not a JSON Schema object/boolean"),
+                )),
+            }),
+        Some(value) => Ok(value.clone()),
+    }
 }
 
 // ─── nika:convert · universal multi-format conversion ───────────────────
@@ -517,10 +542,28 @@ fn emit_csv(
 
 // ─── nika:hash · content hashing ────────────────────────────────────────
 
+/// Bytes under `content:`. A string is hashed as-is (the receipt of
+/// prose). Any other JSON value is hashed as compact JSON — the 2026-08-19
+/// miss was interpolating a task's object output and getting
+/// `content: (string) is required` instead of a digest.
+fn content_bytes(args: &Args, code: &'static str) -> Result<String, BuiltinFailure> {
+    match args.get("content") {
+        None | Some(serde_json::Value::Null) => {
+            Err(BuiltinFailure::new(code, "`content:` is required"))
+        }
+        Some(serde_json::Value::String(text)) => Ok(text.clone()),
+        Some(serde_json::Value::Number(n)) => Ok(n.to_string()),
+        Some(serde_json::Value::Bool(flag)) => Ok(flag.to_string()),
+        Some(other) => serde_json::to_string(other).map_err(|e| {
+            BuiltinFailure::new(code, format!("`content:` could not be serialized: {e}"))
+        }),
+    }
+}
+
 /// Hash `content:` (blake3 default · sha256/sha512). md5/sha1 refused.
 pub(crate) fn hash(args: &Args) -> BuiltinOutcome {
     const C: &str = "NIKA-BUILTIN-HASH-001";
-    let content = req_str(args, "content", C)?;
+    let content = content_bytes(args, C)?;
     let algo = opt_str(args, "algo", C)?.unwrap_or("blake3");
     let encoding = opt_str(args, "encoding", C)?.unwrap_or("hex");
 

--- a/crates/nika-builtin/src/data/tests.rs
+++ b/crates/nika-builtin/src/data/tests.rs
@@ -687,6 +687,46 @@ fn hash_blake3_default_and_rejects_broken() {
 }
 
 #[test]
+fn hash_accepts_structured_content_without_a_tojson_prepass() {
+    // Empirical 2026-08-19: interpolating a roster object into
+    // `content:` used to refuse HASH-001 "`content:` (string) is required".
+    let from_object = hash(&args(serde_json::json!({
+        "content": [{"stem": "ada", "level": "gold"}]
+    })))
+    .expect("object content hashes");
+    let via_json = hash(&args(serde_json::json!({
+        "content": "[{\"level\":\"gold\",\"stem\":\"ada\"}]"
+    })));
+    // Compact serde_json key order is insertion order — the digest is
+    // defined, not compared to a hand-typed string here. A number is
+    // hashed as its decimal digits (same as a string of those digits).
+    assert_eq!(from_object.as_str().expect("hex").len(), 64);
+    let as_number = hash(&args(serde_json::json!({ "content": 3 }))).expect("n");
+    let as_text = hash(&args(serde_json::json!({ "content": "3" }))).expect("s");
+    assert_eq!(as_number, as_text);
+    assert!(via_json.is_ok(), "string content still works: {via_json:?}");
+}
+
+#[test]
+fn validate_parses_a_json_string_schema_from_nika_read() {
+    let schema = "{\n  \"type\": \"object\",\n  \"required\": [\"name\"]\n}\n";
+    let out = validate(&args(serde_json::json!({
+        "data": {"name": "ada"},
+        "schema": schema
+    })))
+    .expect("string schema is a schema");
+    assert_eq!(out["valid"], true);
+    let garbage = validate(&args(serde_json::json!({
+        "data": {},
+        "schema": "not a schema at all"
+    })));
+    assert!(
+        matches!(&garbage, Err(f) if f.code == "NIKA-BUILTIN-VALIDATE-001"),
+        "garbage string schema is VALIDATE-001: {garbage:?}"
+    );
+}
+
+#[test]
 fn base64_encoder_matches_known_vectors() {
     assert_eq!(base64_encode(b""), "");
     assert_eq!(base64_encode(b"f"), "Zg==");

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -87,6 +87,14 @@
 //!   rides the ambient system clock (the honest status quo · WARN-dur,
 //!   NEVER a refusal — the existing corpus cannot turn red overnight);
 //!   declare `run: { clock: … }` to pin the choice (F-P3).
+//! - **markdown glob eats README** (`glob-readme`) — `nika:glob` of
+//!   `*.md` without excluding README: the next infer classifies the
+//!   table of contents as a record.
+//! - **bare `map(` after `. as $`** (`jq-as-map`) — `nika:jq` binds
+//!   `. as $c` then `map(`s the *current* value (often a pair). Write
+//!   `($c | map(...))`.
+//! - **assert after a write** (`assert-quarantine`) — a red
+//!   `nika:assert` quarantines `out/` to `.nika/quarantine/<trace>/`.
 
 use std::collections::BTreeSet;
 
@@ -106,8 +114,9 @@ pub struct Hint {
     /// `secrets-store` · `native-first` ·
     /// `exec-json-capture` ·
     /// `unwrapped-ref` · `envelope-output` · `policy-soft` · `run-clock`
-    /// · `analysis` · `consent` (additive · agents route on it; the
-    /// module doc describes each).
+    /// · `analysis` · `consent` · `digit-string-enum` · `inspect-unwired`
+    /// · `glob-readme` · `assert-quarantine` · `jq-as-map`
+    /// (additive · agents route on it; the module doc describes each).
     /// `parallel-writers` is RETIRED (F-P15 · promoted to the
     /// NIKA-SEC-012 finding — an error owns its repair, never a hint).
     /// `exec-floor` is RETIRED (#605 · promoted to the NIKA-SEC-001
@@ -169,11 +178,17 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
                 }
                 push_strictness_hint(&mut hints, id, a.schema.as_ref().map(|s| &s.value));
                 push_portability_hint(&mut hints, id, a.schema.as_ref().map(|s| &s.value));
+                push_digit_enum_hint(&mut hints, id, a.schema.as_ref().map(|s| &s.value));
             }
             RawAction::Exec(exec) => {
                 push_exec_json_capture_hint(&mut hints, t, exec);
             }
-            RawAction::Invoke(a) => push_headless_prompt_hint(&mut hints, id, a),
+            RawAction::Invoke(a) => {
+                push_headless_prompt_hint(&mut hints, id, a);
+                push_inspect_unwired_hint(&mut hints, id, a);
+                push_glob_readme_hint(&mut hints, id, a);
+                push_jq_as_map_hint(&mut hints, id, a);
+            }
             #[allow(
                 clippy::unreachable,
                 reason = "non_exhaustive future variant — enum and checker ship together; fail loud beats silently-wrong output"
@@ -192,6 +207,7 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
     push_unwrapped_output_ref_hints(&mut hints, wf);
     push_swallowed_exit_hints(&mut hints, wf);
     push_run_clock_hint(&mut hints, wf);
+    push_assert_quarantine_hint(&mut hints, wf);
     hints
 }
 
@@ -260,6 +276,7 @@ fn push_infer_hints(
     }
     push_strictness_hint(hints, id, a.schema.as_ref().map(|s| &s.value));
     push_portability_hint(hints, id, a.schema.as_ref().map(|s| &s.value));
+    push_digit_enum_hint(hints, id, a.schema.as_ref().map(|s| &s.value));
 }
 
 /// The deadline-vs-undeclared-clock hint (F-P3 finding (b)): a task
@@ -839,6 +856,210 @@ fn collect_grammar_blind(node: &serde_json::Value, out: &mut BTreeSet<&'static s
         out.extend(obj.contains_key("not").then_some("not"));
         out.extend(cond.then_some("if/then/else"));
         for_each_subschema(obj, &mut |kid| collect_grammar_blind(kid, out));
+    }
+}
+
+/// String `enum` of digits only (`"0"|"1"|"3"`). Models emit JSON
+/// numbers; provider grammars may reject the call before Nika coerce
+/// stringifies. Prefer `type: integer`.
+fn push_digit_enum_hint(hints: &mut Vec<Hint>, id: &str, schema: Option<&serde_json::Value>) {
+    let mut paths = Vec::new();
+    if let Some(node) = schema {
+        collect_digit_string_enums(node, "", &mut paths);
+    }
+    if paths.is_empty() {
+        return;
+    }
+    let list = paths.join("` · `");
+    hints.push(hint(
+        "digit-string-enum",
+        id,
+        format!(
+            "`{id}` declares a string enum of digits only at `{list}` — models emit JSON numbers \
+             (`3` not `\"3\"`); constrained decoding can reject the call before Nika's coerce \
+             stringifies. Prefer `type: integer` with a numeric enum"
+        ),
+    ));
+}
+
+fn collect_digit_string_enums(node: &serde_json::Value, path: &str, out: &mut Vec<String>) {
+    let Some(obj) = node.as_object().filter(|o| !o.contains_key("$ref")) else {
+        return;
+    };
+    let types: Vec<&str> = match obj.get("type") {
+        Some(serde_json::Value::String(t)) => vec![t.as_str()],
+        Some(serde_json::Value::Array(list)) => list.iter().filter_map(|t| t.as_str()).collect(),
+        _ => Vec::new(),
+    };
+    let string_only = types == ["string"];
+    if string_only
+        && let Some(variants) = obj.get("enum").and_then(serde_json::Value::as_array)
+        && !variants.is_empty()
+        && variants.iter().all(|v| {
+            v.as_str().is_some_and(|s| {
+                !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit() || b == b'-')
+            })
+        })
+    {
+        out.push(if path.is_empty() {
+            "/".to_owned()
+        } else {
+            path.to_owned()
+        });
+    }
+    if let Some(props) = obj.get("properties").and_then(serde_json::Value::as_object) {
+        for (key, child) in props {
+            collect_digit_string_enums(child, &format!("{path}/properties/{key}"), out);
+        }
+    }
+    if let Some(items) = obj.get("items") {
+        collect_digit_string_enums(items, &format!("{path}/items"), out);
+    }
+}
+
+/// `nika:inspect` is catalogued but the runtime injects a `NoWorkflow`
+/// today — every view returns `available: false`. Say so at check time
+/// instead of letting an author discover it after a paid infer wave.
+fn push_inspect_unwired_hint(
+    hints: &mut Vec<Hint>,
+    id: &str,
+    a: &nika_schema::raw::RawInvokeAction,
+) {
+    let Some(tool) = a.tool() else {
+        return;
+    };
+    if tool.value != "nika:inspect" {
+        return;
+    }
+    hints.push(hint(
+        "inspect-unwired",
+        id,
+        format!(
+            "`nika:inspect` on `{id}` has no live run context in this engine — every view \
+             returns `available: false`. Read cost/DAG from `nika trace show` until the \
+             runtime injects WorkflowIntrospect (ADR-088 wiring gap)"
+        ),
+    ));
+}
+
+/// A markdown glob that will also match a README sitting in the same
+/// tree. Authors then spend a paid infer wave classifying the README.
+fn push_glob_readme_hint(hints: &mut Vec<Hint>, id: &str, a: &nika_schema::raw::RawInvokeAction) {
+    let Some(tool) = a.tool() else {
+        return;
+    };
+    if tool.value != "nika:glob" {
+        return;
+    }
+    let Some(args) = a.args.as_ref() else {
+        return;
+    };
+    let Some(pattern) = args.value.get("pattern").and_then(|v| v.as_str()) else {
+        return;
+    };
+    if pattern.contains("${{") {
+        return;
+    }
+    let md_glob = std::path::Path::new(pattern)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+    if !md_glob {
+        return;
+    }
+    let excluded = match args.value.get("exclude") {
+        Some(serde_json::Value::String(s)) => s.to_ascii_lowercase().contains("readme"),
+        Some(serde_json::Value::Array(list)) => list.iter().any(|v| {
+            v.as_str()
+                .is_some_and(|s| s.to_ascii_lowercase().contains("readme"))
+        }),
+        _ => false,
+    };
+    if excluded {
+        return;
+    }
+    hints.push(hint(
+        "glob-readme",
+        id,
+        format!(
+            "`nika:glob` on `{id}` matches `{pattern}` — that set includes a README \
+             sitting in the same directory. Pin the notes (`exclude: \"**/README.md\"` \
+             or glob a folder that has no README) before a paid infer classifies the \
+             table of contents as a record"
+        ),
+    ));
+}
+
+/// `. as $c` then a bare `map(` maps the CURRENT value (often a pair),
+/// not `$c`. The jury-jq class: `($c | map(...))`.
+fn push_jq_as_map_hint(hints: &mut Vec<Hint>, id: &str, a: &nika_schema::raw::RawInvokeAction) {
+    let Some(tool) = a.tool() else {
+        return;
+    };
+    if tool.value != "nika:jq" {
+        return;
+    }
+    let Some(expr) = a
+        .args
+        .as_ref()
+        .and_then(|args| args.value.get("expression"))
+        .and_then(|v| v.as_str())
+    else {
+        return;
+    };
+    if !expr.contains(". as $") {
+        return;
+    }
+    let bare_map = expr.lines().any(|line| {
+        let t = line.trim();
+        t.starts_with("map(") || t.starts_with("| map(")
+    });
+    if !bare_map {
+        return;
+    }
+    hints.push(hint(
+        "jq-as-map",
+        id,
+        format!(
+            "`nika:jq` on `{id}` binds `. as $name` then calls `map(` on the current \
+             value — after a later construct the current value is often a pair, not \
+             the bound array. Write `($name | map(...))`"
+        ),
+    ));
+}
+
+/// A failed last `nika:assert` quarantines writes to
+/// `.nika/quarantine/<trace>/`. Say so when the DAG both writes and
+/// asserts — authors hunt an empty `out/` otherwise.
+fn push_assert_quarantine_hint(hints: &mut Vec<Hint>, wf: &RawWorkflow) {
+    let mut asserts = Vec::new();
+    let mut writes = false;
+    for task in &wf.tasks {
+        let RawAction::Invoke(a) = &task.value.action else {
+            continue;
+        };
+        let Some(tool) = a.tool() else {
+            continue;
+        };
+        match tool.value.as_str() {
+            "nika:assert" => asserts.push(task.value.id.value.as_str()),
+            "nika:write" | "nika:edit" | "nika:chart" | "nika:emit" => writes = true,
+            _ => {}
+        }
+    }
+    if !writes {
+        return;
+    }
+    for id in asserts {
+        hints.push(hint(
+            "assert-quarantine",
+            id,
+            format!(
+                "`nika:assert` on `{id}` shares the DAG with a write — a red assert \
+                 moves `out/` into `.nika/quarantine/<trace>/`. Look there before \
+                 assuming the write never happened; keep the assert off the last \
+                 wave if you need the artifacts from a red run"
+            ),
+        ));
     }
 }
 

--- a/crates/nika-check/src/hints/tests.rs
+++ b/crates/nika-check/src/hints/tests.rs
@@ -793,3 +793,86 @@ fn the_run_clock_hint_counts_every_deadline_once() {
     assert_eq!(hits.len(), 1, "one deduped row: {hits:?}");
     assert!(hits[0].advice.contains("2 task(s)"), "{}", hits[0].advice);
 }
+
+#[test]
+fn digit_string_enum_is_hinted_words_are_silent() {
+    let h = hints_of(
+        "nika: w\nmodel: mock/echo\ntasks:\n  t:\n    infer:\n      prompt: x\n      max_tokens: 10\n      schema:\n        type: object\n        properties:\n          n: { type: string, enum: [\"0\", \"1\", \"3\"] }\noutputs:\n  r: ${{ tasks.t.output }}\n",
+    );
+    let hit = h
+        .iter()
+        .find(|x| x.kind == "digit-string-enum")
+        .expect("digit-string-enum");
+    assert_eq!(hit.task, "t");
+    assert!(hit.advice.contains("integer"), "{}", hit.advice);
+
+    let words = hints_of(
+        "nika: w\nmodel: mock/echo\ntasks:\n  t:\n    infer:\n      prompt: x\n      max_tokens: 10\n      schema:\n        type: object\n        properties:\n          n: { type: string, enum: [none, S, M] }\noutputs:\n  r: ${{ tasks.t.output }}\n",
+    );
+    assert!(
+        !words.iter().any(|x| x.kind == "digit-string-enum"),
+        "{words:?}"
+    );
+}
+
+#[test]
+fn inspect_invoke_is_hinted_as_unwired() {
+    let h = hints_of(
+        "nika: w\npermits: { tools: [\"nika:inspect\"] }\ntasks:\n  look:\n    invoke: { tool: \"nika:inspect\", args: { view: cost } }\n",
+    );
+    let hit = h
+        .iter()
+        .find(|x| x.kind == "inspect-unwired")
+        .expect("inspect-unwired");
+    assert_eq!(hit.task, "look");
+    assert!(hit.advice.contains("available: false"), "{}", hit.advice);
+}
+
+#[test]
+fn markdown_glob_without_readme_exclude_is_hinted() {
+    let h = hints_of(
+        "nika: w\npermits: { tools: [\"nika:glob\"], fs: { read: [\"held\"] } }\ntasks:\n  find:\n    invoke: { tool: \"nika:glob\", args: { pattern: \"held/*.md\" } }\n",
+    );
+    let hit = h
+        .iter()
+        .find(|x| x.kind == "glob-readme")
+        .expect("glob-readme");
+    assert_eq!(hit.task, "find");
+    assert!(hit.advice.contains("README"), "{}", hit.advice);
+
+    let excluded = hints_of(
+        "nika: w\npermits: { tools: [\"nika:glob\"], fs: { read: [\"held\"] } }\ntasks:\n  find:\n    invoke: { tool: \"nika:glob\", args: { pattern: \"held/*.md\", exclude: \"**/README.md\" } }\n",
+    );
+    assert!(
+        !excluded.iter().any(|x| x.kind == "glob-readme"),
+        "{excluded:?}"
+    );
+}
+
+#[test]
+fn jq_as_then_bare_map_is_hinted() {
+    let h = hints_of(
+        "nika: w\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  score:\n    invoke:\n      tool: nika:jq\n      args:\n        input: []\n        expression: |\n          . as $c\n          | map(.n)\n",
+    );
+    let hit = h.iter().find(|x| x.kind == "jq-as-map").expect("jq-as-map");
+    assert_eq!(hit.task, "score");
+    assert!(hit.advice.contains("$name | map"), "{}", hit.advice);
+
+    let ok = hints_of(
+        "nika: w\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  score:\n    invoke:\n      tool: nika:jq\n      args:\n        input: []\n        expression: |\n          . as $c\n          | ($c | map(.n))\n",
+    );
+    assert!(!ok.iter().any(|x| x.kind == "jq-as-map"), "{ok:?}");
+}
+
+#[test]
+fn assert_after_a_write_names_the_quarantine() {
+    let h = hints_of(
+        "nika: w\npermits: { tools: [\"nika:write\", \"nika:assert\"], fs: { write: [\"out\"] } }\ntasks:\n  save:\n    invoke: { tool: \"nika:write\", args: { path: out/a.md, content: \"x\" } }\n  gate:\n    invoke: { tool: \"nika:assert\", args: { that: true } }\n",
+    );
+    let hit = h
+        .iter()
+        .find(|x| x.kind == "assert-quarantine")
+        .expect("assert-quarantine");
+    assert_eq!(hit.task, "gate");
+    assert!(hit.advice.contains("quarantine"), "{}", hit.advice);
+}

--- a/crates/nika-pack/pack/examples/CONVENTIONS.md
+++ b/crates/nika-pack/pack/examples/CONVENTIONS.md
@@ -395,6 +395,32 @@ not verbs.
 (`create_dirs: true`); `jq` is `nika:jq`. The checker says so
 (`native-first/001`, `/002`) and it is right.
 
+## §9 · Authoring seams (paid-run class · 2026-08-19)
+
+Measured on a real OpenAI `nika run` of a 40+ task extract → jq law →
+builtins workflow. The engine now hints or accepts these; do not rediscover
+them with tokens.
+
+1. **Integer facts, not digit strings.** `enum: ["0","1","3"]` — models emit
+   JSON `3`. Prefer `type: integer`. Hint `digit-string-enum`.
+2. **Probe a new builtin with `mock/echo` first.** `nika:inspect` is
+   catalogued and unwired (`available: false`). Hint `inspect-unwired`.
+3. **`nika:hash` accepts an object.** Do not pre-`tojson` a roster.
+   `nika:validate` parses a string schema from `nika:read`.
+4. **Pin the glob.** `held/*.md` includes `README.md`. `exclude:
+   "**/README.md"`. Hint `glob-readme`.
+5. **jq `. as $c` then `($c | map(...))`.** A bare `map(` after `. as $c`
+   maps the current value (often a pair). Hint `jq-as-map`.
+6. **A red last `nika:assert` quarantines `out/`.** Look in
+   `.nika/quarantine/<trace>/`. Hint `assert-quarantine`.
+7. **`--resume` on a `for_each` infer whose prompt uses `item.field`
+   now cache-hits** when the collection and definition are unchanged.
+   The skip is the *whole fan*, not one item.
+
+Order that is cheaper: `nika check --native-strict` → one-task mock
+probe of every new builtin → freeze the extract schema type → then
+wire paid infer.
+
 ---
 
 ## §9 · The one honest red · NIKA-SEC-009

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -229,7 +229,7 @@ JSON diff · returns **RFC 6902** JSON Patch. (jq can't diff.) Throws · `NIKA-B
 invoke: { tool: "nika:validate", args: { data: { ... }, schema: { type: object, ... }, format: json } }
 # format: json (default · validate a value) | yaml (parse a YAML string first, then validate)
 ```
-Validate data against a **JSON Schema** · returns `{ valid: bool, errors: [...] }`. Invalid DATA is a **report, never a task failure** (gate on `.valid` downstream · or `nika:assert` it). Merges the former `json_verify` + `yaml_validate` (`format:` arg · one validator). Throws · `NIKA-BUILTIN-VALIDATE-001` (the `schema:` itself is not a valid JSON Schema · `validation_error`) · `-002` (`format: yaml` and the string does not parse as YAML).
+Validate data against a **JSON Schema** · returns `{ valid: bool, errors: [...] }`. Invalid DATA is a **report, never a task failure** (gate on `.valid` downstream · or `nika:assert` it). Merges the former `json_verify` + `yaml_validate` (`format:` arg · one validator). `schema:` accepts a JSON object **or a string** (`nika:read` of a `.json`/`.yaml` file) — the string is parsed as JSON first, then YAML. Throws · `NIKA-BUILTIN-VALIDATE-001` (the `schema:` itself is not a valid JSON Schema · `validation_error`) · `-002` (`format: yaml` and the string does not parse as YAML).
 
 ### `nika:json_merge_patch`
 ```yaml
@@ -300,7 +300,7 @@ so `op:` exposes it through the builtin that already owns the digest.
 
 | Arg | Ops | Notes |
 |---|---|---|
-| `content` | all | required · the bytes under the operation |
+| `content` | all | required · a string is hashed as-is; any other JSON value is hashed as compact JSON (no `nika:jq tojson` pre-pass) |
 | `algo` | `hash` | `blake3` (default) · `sha256` · `sha512` |
 | `encoding` | `hash` · `sign` | `hex` (default) · `base64` — the output encoding |
 | `key` | `sign` | required · the Ed25519 private key · **MUST be a `${{ secrets.X }}` reference** |

--- a/crates/nika-pack/pack/templates/fanout.nika.yaml
+++ b/crates/nika-pack/pack/templates/fanout.nika.yaml
@@ -18,6 +18,9 @@
 #     `for_each.fail_fast: false`
 #   - `on_error: recover: null` + a null-aware fan-in · a failed item becomes a
 #     hole at its index, order is preserved, the batch survives
+#   - pin the glob · `*.md` also matches README.md (hint `glob-readme`)
+#   - `--resume` cache-hits the whole fan when items + definition match,
+#     including prompts that read `item.field`
 #
 # Needs · nothing. Scaffolds and runs green in an empty directory — an empty
 #   discovery skips the fan-out and the fan-in still returns a value.

--- a/crates/nika-runtime/src/resume.rs
+++ b/crates/nika-runtime/src/resume.rs
@@ -35,11 +35,12 @@
 //!   JCS alone serializes numbers as ES6 doubles, which collapses
 //!   distinct int64s beyond 2^53 · the CEL `numeric_cmp` bug class).
 //! - **Fail-closed eligibility**: any form this recipe cannot serialize
-//!   (`#[non_exhaustive]` future variants) or render (deep `item.`
-//!   navigation under the fan-out placeholder), and any payload that
-//!   would carry a resolved secret VALUE (leaked through an upstream
-//!   record), yields NO stamp — the task simply never skips. Honest
-//!   degradation, never a wrong skip, never an error.
+//!   (`#[non_exhaustive]` future variants) or render (a missing upstream
+//!   · a secret leak), yields NO stamp — the task simply never skips.
+//!   Honest degradation, never a wrong skip, never an error. A `for_each`
+//!   body that navigates `item.field` IS eligible: the resolved collection
+//!   carries every per-item value, and the stand-in is shaped from that
+//!   collection so field navigation renders to a marker (never a miss).
 
 use std::collections::BTreeMap;
 
@@ -123,6 +124,70 @@ fn secret_marker(name: &str, source: &str, key: &str) -> Value {
 /// per-item data participates through the resolved collection itself.
 fn item_marker() -> Value {
     Value::String(format!("{MARK}nika:item{MARK}"))
+}
+
+/// A walkable stand-in for `item` during a *task-level* fan-out stamp.
+///
+/// The collection itself is the input identity. This object only has to
+/// satisfy `item.field` / nested navigation so a prompt like
+/// `${{ item.stem }}` does not fail eligibility (the string marker
+/// cannot — CEL's `.field` on a string is `NIKA-VAR-001`). Leaves are
+/// the same marker; keys are the union of every element's shape.
+fn item_stand_in(items: &Value) -> Value {
+    match items {
+        Value::Array(arr) => {
+            let mut shape = Value::Null;
+            for el in arr {
+                shape = merge_item_shape(&shape, el);
+            }
+            mask_item_leaves(&shape)
+        }
+        other => mask_item_leaves(other),
+    }
+}
+
+/// Union of two JSON shapes (objects merge keys · arrays pad to max
+/// length · a container wins over a scalar · first non-null scalar
+/// keeps). Used only to make the stand-in navigable.
+fn merge_item_shape(acc: &Value, next: &Value) -> Value {
+    match (acc, next) {
+        (Value::Null, v) => v.clone(),
+        (Value::Object(a), Value::Object(b)) => {
+            let mut out = a.clone();
+            for (k, bv) in b {
+                let existing = out.get(k).cloned().unwrap_or(Value::Null);
+                out.insert(k.clone(), merge_item_shape(&existing, bv));
+            }
+            Value::Object(out)
+        }
+        (Value::Array(a), Value::Array(b)) => {
+            let n = a.len().max(b.len());
+            let mut out = Vec::with_capacity(n);
+            for i in 0..n {
+                let av = a.get(i).unwrap_or(&Value::Null);
+                let bv = b.get(i).unwrap_or(&Value::Null);
+                out.push(merge_item_shape(av, bv));
+            }
+            Value::Array(out)
+        }
+        (Value::Object(_) | Value::Array(_), _) => acc.clone(),
+        (_, Value::Object(_) | Value::Array(_)) => next.clone(),
+        _ => acc.clone(),
+    }
+}
+
+/// Replace every leaf with [`item_marker`] so rendered action text never
+/// carries a real item value (those already ride in `items`).
+fn mask_item_leaves(v: &Value) -> Value {
+    match v {
+        Value::Object(m) if !m.is_empty() => Value::Object(
+            m.iter()
+                .map(|(k, child)| (k.clone(), mask_item_leaves(child)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.iter().map(mask_item_leaves).collect()),
+        _ => item_marker(),
+    }
 }
 
 /// One task's resume identity — the typed key payload (ADR-099 · brief
@@ -632,8 +697,9 @@ fn raw_with_object(with: &[(Spanned<String>, Spanned<Value>)]) -> Value {
 /// the action fields + the `with:` namespace rendered over the run
 /// scope (secrets bound as markers), plus the resolved `for_each`
 /// collection. `None` = a reference does not render here (the task
-/// then runs live and surfaces its real error, or — fan-out deep
-/// `item.` navigation — is simply not resume-eligible).
+/// then runs live and surfaces its real error). A fan-out body's
+/// `item.field` navigation is eligible: the stand-in is shaped from
+/// the collection so the render cannot miss on a real key.
 fn input_value(
     task: &RawTask,
     records: &BTreeMap<String, TaskRecord>,
@@ -661,12 +727,12 @@ fn input_value(
         }
         Some(_) => return None,
     };
-    // Fan-out renders bind `item`/`index` to fixed placeholders: the real
-    // data already rides in `items`; a template the placeholder cannot
-    // satisfy (deep `item.field`) fails the render → not eligible.
-    let item_stand_in = item_marker();
+    // Fan-out renders bind `item`/`index` to a *shaped* stand-in: real
+    // values already ride in `items`; field navigation resolves to the
+    // marker so `${{ item.stem }}` stays stamp-eligible.
+    let stand_in = item_stand_in(&items);
     let (item, index) = if task.for_each.is_some() {
-        (Some(&item_stand_in), Some(0))
+        (Some(&stand_in), Some(0))
     } else {
         (None, None)
     };

--- a/crates/nika-runtime/src/resume/tests.rs
+++ b/crates/nika-runtime/src/resume/tests.rs
@@ -428,10 +428,11 @@ mod unit {
     }
 
     /// The fan-out collection participates in the input hash (a changed
-    /// item set re-runs); deep `item.` navigation under the placeholder
-    /// is not resume-eligible (fail-closed, never a wrong skip).
+    /// item set re-runs). Deep `item.field` navigation is eligible: the
+    /// stand-in is shaped from the collection so the render cannot miss,
+    /// and the real values ride in `items` (never a wrong skip).
     #[test]
-    fn fan_out_collection_participates_and_deep_item_nav_is_ineligible() {
+    fn fan_out_collection_participates_and_deep_item_nav_is_eligible() {
         const SHALLOW: &str = "nika: t\nconst:\n  urls: [\"a\", \"b\"]\ntasks:\n  fan:\n    for_each: { items: \"${{ const.urls }}\" }\n    exec: { command: [\"echo\", \"${{ item }}\"] }\n";
         const DEEP: &str = "nika: t\nconst:\n  rows: [{ url: \"a\" }]\ntasks:\n  fan:\n    for_each: { items: \"${{ const.rows }}\" }\n    exec: { command: [\"echo\", \"${{ item.url }}\"] }\n";
         let records = BTreeMap::new();
@@ -441,10 +442,19 @@ mod unit {
         let b = stamp_const_of(SHALLOW, &records, &ac).expect("shallow item is eligible");
         assert_ne!(a.input_hash, b.input_hash, "the item set is an input");
 
-        let rows = BTreeMap::from([("rows".to_owned(), json!([{ "url": "a" }]))]);
-        assert!(
-            stamp_const_of(DEEP, &records, &rows).is_none(),
-            "deep item navigation cannot key deterministically → never skips"
+        let rows_a = BTreeMap::from([("rows".to_owned(), json!([{ "url": "a" }]))]);
+        let rows_b = BTreeMap::from([("rows".to_owned(), json!([{ "url": "b" }]))]);
+        let deep_a = stamp_const_of(DEEP, &records, &rows_a).expect("item.field is eligible");
+        let deep_a2 = stamp_const_of(DEEP, &records, &rows_a).expect("stable");
+        let deep_b = stamp_const_of(DEEP, &records, &rows_b).expect("item.field is eligible");
+        assert_eq!(deep_a, deep_a2, "same collection → same stamp");
+        assert_eq!(
+            deep_a.def_hash, deep_b.def_hash,
+            "the task text is unchanged"
+        );
+        assert_ne!(
+            deep_a.input_hash, deep_b.input_hash,
+            "a changed item field re-keys the fan"
         );
     }
 
@@ -870,6 +880,63 @@ mod trace_carry {
             rerun.cache_hits.is_empty(),
             "hash mismatch → re-run, never skip"
         );
+    }
+
+    /// A `for_each` body that navigates `item.field` stamps and
+    /// cache-hits on `--resume` — the paid-replay class (a prompt of
+    /// `${{ item.stem }}` used to drop the key, so a later `--from`
+    /// downstream re-ran every infer). The collection is the identity.
+    #[tokio::test]
+    async fn for_each_item_field_resume_cache_hits() {
+        const FAN: &str = "nika: fan\nconst:\n  rows:\n    - { url: a }\n    - { url: b }\npermits: { exec: [\"echo\"] }\ntasks:\n  fan:\n    for_each: { items: \"${{ const.rows }}\" }\n    exec: { command: [\"echo\", \"${{ item.url }}\"] }\n  after:\n    with: { prev: \"${{ tasks.fan.output }}\" }\n    exec: { command: [\"echo\", \"done\"] }\n";
+        let (first, sink) = run_yaml(
+            FAN,
+            MockShell::new()
+                .enqueue_ok("a\n")
+                .enqueue_ok("b\n")
+                .enqueue_ok("done\n"),
+            None,
+        )
+        .await;
+        assert!(first.ok, "fresh fan run");
+        assert!(first.cache_hits.is_empty());
+        let completed = sink
+            .events()
+            .iter()
+            .find(|e| e.kind == EventKind::TaskCompleted && str_field(e, "task") == Some("fan"))
+            .expect("fan completed");
+        let def = str_field(completed, crate::resume::fields::DEF_HASH)
+            .expect("item.field fan stamps def_hash");
+        let input = str_field(completed, crate::resume::fields::INPUT_HASH)
+            .expect("item.field fan stamps input_hash");
+        let plan = crate::resume::ResumePlan::from([(
+            "fan".to_owned(),
+            crate::resume::PriorSuccess::new(
+                def.to_owned(),
+                input.to_owned(),
+                serde_json::from_str(
+                    str_field(completed, crate::resume::fields::OUTPUT).expect("output"),
+                )
+                .expect("output parses"),
+            ),
+        )]);
+        let (resumed, sink) =
+            run_yaml(FAN, MockShell::new().enqueue_ok("done\n"), Some(plan)).await;
+        assert!(resumed.ok);
+        assert_eq!(
+            resumed.cache_hits,
+            vec!["fan".to_owned()],
+            "the item.field fan reuses the prior wave"
+        );
+        let kinds: Vec<_> = sink
+            .events()
+            .iter()
+            .filter(|e| str_field(e, "task") == Some("fan"))
+            .map(|e| e.kind)
+            .collect();
+        assert!(kinds.contains(&EventKind::TaskCacheHit));
+        assert!(!kinds.contains(&EventKind::TaskStarted));
+        assert_eq!(resumed.records["fan"].output, first.records["fan"].output);
     }
 
     /// `referenced_upstreams` sees BOTH edge kinds — the boundary

--- a/crates/nika-verb-infer/src/coerce.rs
+++ b/crates/nika-verb-infer/src/coerce.rs
@@ -36,11 +36,19 @@ fn coerce_node(value: &Value, schema: &Value) -> Value {
     let Some(node) = schema.as_object() else {
         return value.clone();
     };
-    if ["$ref", "anyOf", "oneOf", "allOf"]
-        .iter()
-        .any(|k| node.contains_key(*k))
-    {
+    if node.contains_key("$ref") || node.contains_key("oneOf") || node.contains_key("allOf") {
         return value.clone();
+    }
+    // A scalar `anyOf` (integer | string, optionally with enums) is the
+    // same as `type: [integer, string]` — flattening it lets number→string
+    // and string→integer fire. A nested/object anyOf stays fenced (no
+    // resolver, never a guess). Empirical 2026-08-19: authors wrote
+    // anyOf to accept `3` and `"3"` and the fence disabled EVERY coerce.
+    if node.contains_key("anyOf") {
+        return match flatten_scalar_any_of(node) {
+            Some(flat) => coerce_node(value, &flat),
+            None => value.clone(),
+        };
     }
     let types = declared_types(node);
 
@@ -134,6 +142,65 @@ fn enum_snap(text: &str, node: &serde_json::Map<String, Value>) -> Option<Value>
         return None;
     }
     Some(Value::String(first.to_owned()))
+}
+
+/// Collapse `anyOf: [{type: integer, enum: [...]}, {type: string, enum: [...]}]`
+/// into one scalar node. `None` if any branch is composite or `$ref`.
+fn flatten_scalar_any_of(node: &serde_json::Map<String, Value>) -> Option<Value> {
+    let branches = node.get("anyOf")?.as_array()?;
+    if branches.is_empty() {
+        return None;
+    }
+    let mut types = Vec::new();
+    let mut enums = Vec::new();
+    let mut saw_enum = false;
+    for branch in branches {
+        let obj = branch.as_object()?;
+        if obj.keys().any(|k| {
+            matches!(
+                k.as_str(),
+                "$ref" | "anyOf" | "oneOf" | "allOf" | "properties" | "items"
+            )
+        }) {
+            return None;
+        }
+        match obj.get("type") {
+            Some(Value::String(t)) if is_scalar_type(t) => types.push(t.clone()),
+            Some(Value::Array(list)) => {
+                for t in list {
+                    let name = t.as_str()?;
+                    if !is_scalar_type(name) {
+                        return None;
+                    }
+                    types.push(name.to_owned());
+                }
+            }
+            _ => return None,
+        }
+        if let Some(variants) = obj.get("enum").and_then(Value::as_array) {
+            saw_enum = true;
+            enums.extend(variants.iter().cloned());
+        }
+    }
+    types.sort();
+    types.dedup();
+    let mut flat = serde_json::Map::new();
+    flat.insert(
+        "type".into(),
+        if types.len() == 1 {
+            Value::String(types.remove(0))
+        } else {
+            Value::Array(types.into_iter().map(Value::String).collect())
+        },
+    );
+    if saw_enum {
+        flat.insert("enum".into(), Value::Array(enums));
+    }
+    Some(Value::Object(flat))
+}
+
+fn is_scalar_type(name: &str) -> bool {
+    matches!(name, "string" | "integer" | "number" | "boolean" | "null")
 }
 
 /// The `type:` names a node declares (scalar or union form).
@@ -253,14 +320,45 @@ mod tests {
     #[test]
     fn composition_and_ref_nodes_stay_untouched() {
         let schema = json!({"type": "object", "properties": {
-            "a": {"anyOf": [{"type": "integer"}]},
+            "a": {"anyOf": [{"type": "object", "properties": {"k": {"type": "integer"}}}]},
             "b": {"$ref": "#/$defs/X"}
         }});
         let input = json!({"a": "1", "b": "2"});
         assert_eq!(
             coerce_toward(&input, &schema),
             input,
-            "no resolver, no guess"
+            "no resolver, no guess on composite anyOf or $ref"
+        );
+    }
+
+    #[test]
+    fn scalar_any_of_integer_parses_a_digit_string() {
+        let schema = json!({"type": "object", "properties": {
+            "n": {"anyOf": [{"type": "integer"}]}
+        }});
+        let out = coerce_toward(&json!({"n": "3"}), &schema);
+        assert_eq!(out["n"], 3, "scalar anyOf no longer fences integer coerce");
+    }
+
+    #[test]
+    fn scalar_any_of_integer_or_string_coerces_both_ways() {
+        let schema = json!({"type": "object", "properties": {
+            "n": {"anyOf": [
+                {"type": "integer", "enum": [-1, 0, 1, 3]},
+                {"type": "string", "enum": ["-1", "0", "1", "3"]}
+            ]}
+        }});
+        let from_text = coerce_toward(&json!({"n": "3"}), &schema);
+        assert!(
+            from_text["n"] == json!(3) || from_text["n"] == json!("3"),
+            "string digit matches a branch: {}",
+            from_text["n"]
+        );
+        let from_num = coerce_toward(&json!({"n": 3}), &schema);
+        assert!(
+            from_num["n"] == json!(3) || from_num["n"] == json!("3"),
+            "number 3 matches a branch: {}",
+            from_num["n"]
         );
     }
 

--- a/docs/findings/2026-08-19-authoring-seams.md
+++ b/docs/findings/2026-08-19-authoring-seams.md
@@ -1,0 +1,76 @@
+# Authoring seams · 2026-08-19
+
+Empirical class from a real OpenAI `nika run` of a 40+ task workflow
+(structured extract → jq law → builtins). No product names. The
+failures are engine/authoring seams, not domain bugs.
+
+## What burned tokens
+
+1. **String enum of digits.** `type: string, enum: ["0","1","3"]`.
+   Models emit JSON `3`. Provider constrained decoding can reject the
+   call *before* Nika's coerce stringifies. The task errors, `on_error:
+   recover` swallows it, the scorer sees `null` → the wrong default.
+   Prefer `type: integer`. `nika check` now hints `digit-string-enum`.
+2. **`anyOf` fence vs coerce.** Authors wrote `anyOf: [integer, string]`
+   to accept both forms. Coerce treated any `anyOf` as opaque and
+   skipped *every* repair on that node. Scalar anyOf now flattens.
+3. **`nika:hash` `content:` string-only.** Interpolating a task object
+   (a roster) refused `content: (string) is required`. Hash now
+   serializes non-strings as compact JSON. Strings stay raw.
+4. **`nika:validate` `schema:` from `nika:read`.** A `.json` file is a
+   string. `validator_for` then said the schema "is not of types
+   boolean, object". String schemas are parsed as JSON, then YAML.
+5. **`nika:inspect` is catalogued, unwired.** Every view returns
+   `{ available: false }` (ADR-088: dispatcher composed before the
+   run, no `WorkflowIntrospect`). `nika check` now hints
+   `inspect-unwired`. Read the trace for cost/DAG.
+6. **`--resume` + `for_each` infer.** A body that navigates
+   `item.field` (`item.stem` · `item.text`) used to drop the stamp
+   (`None` — the string stand-in cannot satisfy CEL `.field`). A later
+   `--from <downstream>` then re-ran the whole paid infer wave. The
+   collection is now the input identity; the stand-in is *shaped* from
+   it so `item.field` stays eligible. Resume still skips the **whole
+   fan** (one task), not a single iteration — a mid-wave crash still
+   replays every item (ADR-099 per-iteration remains open).
+7. **A failed last assert quarantines writes.** `out/` artifacts from
+   a red `nika:assert` land in `.nika/quarantine/<trace>/`. Look there
+   before assuming the write never happened. `nika check` hints
+   `assert-quarantine`.
+8. **A markdown glob eats README.** `held/*.md` also matches
+   `held/README.md`. The extract infer then classifies the table of
+   contents. `nika check` hints `glob-readme` unless `exclude`
+   mentions README.
+9. **jq `. as $c` then bare `map(`.** After `. as $c`, `map(...)`
+   maps the *current* value (often a `[cards, receipt]` pair), not
+   `$c`. Write `($c | map(...))`. `nika check` hints `jq-as-map`.
+
+## Authoring order that would have been cheaper
+
+1. Check `--native-strict`.
+2. Probe every new builtin with `mock/echo` (one-task file) *before*
+   wiring it after a paid infer.
+3. Fix the extract schema type (integer vs string) before adding
+   retry passes, anyOf, or more infer.
+4. Never put a README in the input glob (`exclude: "**/README.md"`).
+5. After a file change, `--resume` now cache-hits a `for_each` infer
+   whose *collection and definition* did not change (including
+   `item.field` prompts). A definition edit of the infer itself still
+   re-runs — that is the law.
+
+## Shipped in this arc
+
+- `nika-builtin` · hash accepts structured `content:` · validate
+  parses string schemas
+- `nika-verb-infer` · scalar `anyOf` flattens into coerce
+- `nika-check` · hints `digit-string-enum` · `inspect-unwired` ·
+  `glob-readme` · `jq-as-map` · `assert-quarantine`
+- `nika-runtime` · `for_each` + `item.field` is resume-eligible
+  (collection is the input identity · shaped stand-in)
+
+## Still open
+
+- Per-*iteration* resume keys (ADR-099: a mid-wave crash still
+  replays every item; the task-level stamp only skips the whole fan)
+- Runtime injection of `WorkflowIntrospect` into `nika:inspect`
+- Check-time type of `nika:hash` `content:` when the binding is an
+  object-shaped task output (the runtime now accepts it)

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4494
+  classified_files: 4495
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1557
+    authored: 1558
     authored-pin: 2
     generated: 122
     pinned-copy: 117
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 116
-  aggregate_sha256: 182f41db66cbee95baa893891b595b02070a3b3472cf502c95f957451500ac34
+  aggregate_sha256: d8c58622e7998e06c7c62df3614b26824e0322d7ad797bf71a142ecbb95b99a0
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 790
-  aggregate_sha256: 0ffec5ddf8a7011110140d280d9b966222a553ce96ce530c493a2cb3dc28e982
+  aggregate_sha256: e011557d19f6691f20154e52647b16fd0094d56466bfb0cfcb7257104ca73e36
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -177,8 +177,8 @@ patterns:
   evidence: "per-decision records authored at decision time (scripts/adr/new.sh scaffolds · adr-seal-check hook seals); index.toml excepted in files:"
 - glob: "docs/**"
   class: authored
-  match_count: 106
-  aggregate_sha256: 1fb0679e500f6d5e5e1cab1fe19988b4b962948348a416ca3fb495e72b1940ba
+  match_count: 107
+  aggregate_sha256: 1c8d11a64fce9d96e42584c92d0315b1ba7d8c61fdedf4e5e1efeff80b62ee51
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored


### PR DESCRIPTION
## Why

A real OpenAI `nika run` of a 40+ task extract → jq law → builtins workflow burned tokens on engine/authoring seams, not domain bugs.

Signed replacement of #1011 (that branch missed DCO `Signed-off-by`).

## What

- `nika:hash` accepts structured `content:`; `nika:validate` parses a string schema from `nika:read`
- scalar `anyOf` flattens so coerce can repair
- `for_each` + `item.field` is resume-eligible (collection is the input identity). `--resume` cache-hits the whole fan when items + definition match
- `nika check` hints: `digit-string-enum`, `inspect-unwired`, `glob-readme`, `jq-as-map`, `assert-quarantine`

## Still open

Per-iteration resume (ADR-099): a mid-wave crash still replays every item.

Finding: `docs/findings/2026-08-19-authoring-seams.md`