### PR TITLE
feat(arm): the lock outlives the shot · W5-bis

### DIFF
--- a/crates/nika-cli/Cargo.toml
+++ b/crates/nika-cli/Cargo.toml
@@ -41,7 +41,7 @@ nika-providers   = { path = "../nika-providers", version = "0.111.0-dev" }     #
 nika-builtin     = { path = "../nika-builtin", version = "0.111.0-dev" }       # tool_defs/tools_json — the tools + welcome surfaces
 nika-http        = { path = "../nika-http", version = "0.111.0-dev" }          # ReqwestHttp — the registry + trace-anchor clients (notify descended to nika-cli-host · ADR-111)
 # keyring + minisign moved out with the trust plane (nika-dap::seal/sign host the custody + primitives now).
-# sha2 pruned 2026-07-22 — zero `sha2::` use in src/ (the trust plane's descent took the last one).
+sha2           = { workspace = true }                              # the arm ledger's hash chain + the slot identity (W5-bis · the source-identity convention)
 nika-catalog     = { path = "../nika-catalog", version = "0.111.0-dev", features = ["providers", "pricing"] }  # env_var ladder + the rates the preflight shows
 nika-lsp         = { path = "../nika-lsp", version = "0.111.0-dev" }           # `nika lsp` — the language server (stdio · drives the editor extension)
 nika-display     = { path = "../nika-display", version = "0.111.0-dev" } # the run-comprehension surface (descended 2026-07-10 · re-exported at display::)
@@ -88,7 +88,6 @@ nika-verb-infer  = { path = "../nika-verb-infer", version = "0.111.0-dev" }
 nika-verb-exec   = { path = "../nika-verb-exec", version = "0.111.0-dev" }
 nika-verb-invoke = { path = "../nika-verb-invoke", version = "0.111.0-dev" }
 nika-verb-agent  = { path = "../nika-verb-agent", version = "0.111.0-dev" }
-sha2           = { workspace = true }   # composition_e2e/trace_verify test-side journal chains
 proptest = { workspace = true }   # Gate 6 · the fold's order-independence property (tests/fold_property.rs)
 tempfile = { workspace = true }   # trace-file sink fixtures (`.nika/traces/` journal · sink.rs tests)
 insta    = { workspace = true }   # the arm report's snapshot (PROUVÉ · DÉCLARÉ · orphelins)

--- a/crates/nika-cli/public-api.txt
+++ b/crates/nika-cli/public-api.txt
@@ -281,6 +281,7 @@ pub struct nika_cli::verbs::arm::fire::FireCtx
 pub nika_cli::verbs::arm::fire::FireCtx::index: usize
 pub nika_cli::verbs::arm::fire::FireCtx::label: alloc::string::String
 pub nika_cli::verbs::arm::fire::FireCtx::now: jiff::zoned::Zoned
+pub nika_cli::verbs::arm::fire::FireCtx::pid: u32
 pub nika_cli::verbs::arm::fire::FireCtx::project_root: std::path::PathBuf
 pub nika_cli::verbs::arm::fire::FireCtx::registry: nika_cadence::registry::ArmRegistry
 pub nika_cli::verbs::arm::fire::FireCtx::state: nika_cli::verbs::arm::state::ArmState
@@ -461,11 +462,13 @@ pub fn nika_cli::verbs::arm::state::ArmState::at_project(project_dir: &std::path
 pub fn nika_cli::verbs::arm::state::ArmState::last(&self, label: &str) -> core::option::Option<nika_cli::verbs::arm::state::LastRecord>
 pub fn nika_cli::verbs::arm::state::ArmState::last_fired(&self, label: &str) -> core::option::Option<jiff::zoned::Zoned>
 pub fn nika_cli::verbs::arm::state::ArmState::orphans(&self, known: &[alloc::string::String]) -> alloc::vec::Vec<alloc::string::String>
-pub fn nika_cli::verbs::arm::state::ArmState::record(&self, label: &str, entry: &nika_cli::verbs::arm::state::HistoryEntry) -> core::io::error::Result<()>
+pub fn nika_cli::verbs::arm::state::ArmState::record(&self, label: &str, entry: &nika_cli::verbs::arm::state::HistoryEntry) -> core::io::error::Result<nika_cli::verbs::arm::state::RecordOutcome>
+pub fn nika_cli::verbs::arm::state::ArmState::record_claim(&self, label: &str, claim: &nika_cli::verbs::arm::state::Claim) -> core::io::error::Result<nika_cli::verbs::arm::state::RecordOutcome>
 pub fn nika_cli::verbs::arm::state::ArmState::release(&self, label: &str) -> core::io::error::Result<()>
 pub fn nika_cli::verbs::arm::state::ArmState::root(&self) -> &std::path::Path
 pub fn nika_cli::verbs::arm::state::ArmState::tallies(&self, label: &str) -> core::option::Option<(usize, usize)>
 pub fn nika_cli::verbs::arm::state::ArmState::try_lock(&self, label: &str, pid: u32, now: &jiff::zoned::Zoned) -> core::io::error::Result<nika_cli::verbs::arm::state::LockOutcome>
+pub fn nika_cli::verbs::arm::state::ArmState::unsettled(&self, label: &str) -> alloc::vec::Vec<nika_cli::verbs::arm::state::Unsettled>
 impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::ArmState
 impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::ArmState where U: core::convert::From<T>
 pub fn nika_cli::verbs::arm::state::ArmState::into(self) -> U
@@ -492,12 +495,56 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::ArmStat
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::ArmState
 impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::ArmState
 pub type nika_cli::verbs::arm::state::ArmState::Output = T
+pub struct nika_cli::verbs::arm::state::Claim
+pub nika_cli::verbs::arm::state::Claim::deadline: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::Claim::decided_at: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::Claim::slot_id: alloc::string::String
+impl core::clone::Clone for nika_cli::verbs::arm::state::Claim
+pub fn nika_cli::verbs::arm::state::Claim::clone(&self) -> nika_cli::verbs::arm::state::Claim
+impl core::fmt::Debug for nika_cli::verbs::arm::state::Claim
+pub fn nika_cli::verbs::arm::state::Claim::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::Claim
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::Claim where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::Claim::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::Claim where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::Claim::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::Claim::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::Claim where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::Claim::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::Claim::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::Claim where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::Claim::Owned = T
+pub fn nika_cli::verbs::arm::state::Claim::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::Claim::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::Claim where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Claim::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::Claim where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Claim::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::Claim where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Claim::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::Claim where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::Claim::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::Claim
+pub fn nika_cli::verbs::arm::state::Claim::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::Claim where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::Claim::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::Claim where T: 'static
+pub fn nika_cli::verbs::arm::state::Claim::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::Claim where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Claim::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::Claim::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::Claim
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::Claim
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::Claim
+pub type nika_cli::verbs::arm::state::Claim::Output = T
 pub struct nika_cli::verbs::arm::state::HistoryEntry
 pub nika_cli::verbs::arm::state::HistoryEntry::decided_at: jiff::timestamp::Timestamp
 pub nika_cli::verbs::arm::state::HistoryEntry::exit: core::option::Option<u8>
+pub nika_cli::verbs::arm::state::HistoryEntry::fencing: core::option::Option<u64>
 pub nika_cli::verbs::arm::state::HistoryEntry::kind: nika_cli::verbs::arm::state::FireKind
 pub nika_cli::verbs::arm::state::HistoryEntry::reason: core::option::Option<alloc::string::String>
 pub nika_cli::verbs::arm::state::HistoryEntry::slot: core::option::Option<jiff::timestamp::Timestamp>
+pub nika_cli::verbs::arm::state::HistoryEntry::slot_id: core::option::Option<alloc::string::String>
 pub nika_cli::verbs::arm::state::HistoryEntry::slots: core::option::Option<u32>
 pub nika_cli::verbs::arm::state::HistoryEntry::trace: core::option::Option<alloc::string::String>
 impl core::clone::Clone for nika_cli::verbs::arm::state::HistoryEntry
@@ -582,6 +629,110 @@ impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::LastRec
 impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::LastRecord
 impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::LastRecord
 pub type nika_cli::verbs::arm::state::LastRecord::Output = T
+pub struct nika_cli::verbs::arm::state::RecordOutcome
+pub nika_cli::verbs::arm::state::RecordOutcome::repaired: u64
+pub nika_cli::verbs::arm::state::RecordOutcome::seq: u64
+impl core::clone::Clone for nika_cli::verbs::arm::state::RecordOutcome
+pub fn nika_cli::verbs::arm::state::RecordOutcome::clone(&self) -> nika_cli::verbs::arm::state::RecordOutcome
+impl core::cmp::Eq for nika_cli::verbs::arm::state::RecordOutcome
+impl core::cmp::PartialEq for nika_cli::verbs::arm::state::RecordOutcome
+pub fn nika_cli::verbs::arm::state::RecordOutcome::eq(&self, other: &nika_cli::verbs::arm::state::RecordOutcome) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::state::RecordOutcome
+pub fn nika_cli::verbs::arm::state::RecordOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for nika_cli::verbs::arm::state::RecordOutcome
+impl core::marker::StructuralPartialEq for nika_cli::verbs::arm::state::RecordOutcome
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::RecordOutcome
+impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::arm::state::RecordOutcome where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::RecordOutcome::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::arm::state::RecordOutcome where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::RecordOutcome::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::RecordOutcome where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::RecordOutcome::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::RecordOutcome where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::RecordOutcome::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::RecordOutcome::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::RecordOutcome where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::RecordOutcome::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::RecordOutcome::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::RecordOutcome where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::RecordOutcome::Owned = T
+pub fn nika_cli::verbs::arm::state::RecordOutcome::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::RecordOutcome::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::RecordOutcome where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::RecordOutcome::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::RecordOutcome where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::RecordOutcome::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::RecordOutcome where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::RecordOutcome::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::RecordOutcome where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::RecordOutcome::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::RecordOutcome
+pub fn nika_cli::verbs::arm::state::RecordOutcome::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::RecordOutcome where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::RecordOutcome::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::RecordOutcome where T: 'static
+pub fn nika_cli::verbs::arm::state::RecordOutcome::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> outref::AsOut<T> for nika_cli::verbs::arm::state::RecordOutcome where T: core::marker::Copy
+pub fn nika_cli::verbs::arm::state::RecordOutcome::as_out(&mut self) -> outref::Out<'_, T>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::RecordOutcome where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::RecordOutcome::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::RecordOutcome::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::RecordOutcome
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::RecordOutcome
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::RecordOutcome
+pub type nika_cli::verbs::arm::state::RecordOutcome::Output = T
+pub struct nika_cli::verbs::arm::state::Unsettled
+pub nika_cli::verbs::arm::state::Unsettled::claimed_at: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::Unsettled::deadline: jiff::timestamp::Timestamp
+pub nika_cli::verbs::arm::state::Unsettled::seq: u64
+pub nika_cli::verbs::arm::state::Unsettled::slot_id: alloc::string::String
+impl core::clone::Clone for nika_cli::verbs::arm::state::Unsettled
+pub fn nika_cli::verbs::arm::state::Unsettled::clone(&self) -> nika_cli::verbs::arm::state::Unsettled
+impl core::cmp::Eq for nika_cli::verbs::arm::state::Unsettled
+impl core::cmp::PartialEq for nika_cli::verbs::arm::state::Unsettled
+pub fn nika_cli::verbs::arm::state::Unsettled::eq(&self, other: &nika_cli::verbs::arm::state::Unsettled) -> bool
+impl core::fmt::Debug for nika_cli::verbs::arm::state::Unsettled
+pub fn nika_cli::verbs::arm::state::Unsettled::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for nika_cli::verbs::arm::state::Unsettled
+impl<D> owo_colors::OwoColorize for nika_cli::verbs::arm::state::Unsettled
+impl<Q, K> equivalent::Equivalent<K> for nika_cli::verbs::arm::state::Unsettled where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Unsettled::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for nika_cli::verbs::arm::state::Unsettled where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Unsettled::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for nika_cli::verbs::arm::state::Unsettled where U: core::convert::From<T>
+pub fn nika_cli::verbs::arm::state::Unsettled::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_cli::verbs::arm::state::Unsettled where U: core::convert::Into<T>
+pub type nika_cli::verbs::arm::state::Unsettled::Error = core::convert::Infallible
+pub fn nika_cli::verbs::arm::state::Unsettled::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_cli::verbs::arm::state::Unsettled where U: core::convert::TryFrom<T>
+pub type nika_cli::verbs::arm::state::Unsettled::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_cli::verbs::arm::state::Unsettled::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_cli::verbs::arm::state::Unsettled where T: core::clone::Clone
+pub type nika_cli::verbs::arm::state::Unsettled::Owned = T
+pub fn nika_cli::verbs::arm::state::Unsettled::clone_into(&self, target: &mut T)
+pub fn nika_cli::verbs::arm::state::Unsettled::to_owned(&self) -> T
+impl<T> core::any::Any for nika_cli::verbs::arm::state::Unsettled where T: 'static + ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Unsettled::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_cli::verbs::arm::state::Unsettled where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Unsettled::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_cli::verbs::arm::state::Unsettled where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Unsettled::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_cli::verbs::arm::state::Unsettled where T: core::clone::Clone
+pub unsafe fn nika_cli::verbs::arm::state::Unsettled::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_cli::verbs::arm::state::Unsettled
+pub fn nika_cli::verbs::arm::state::Unsettled::from(t: T) -> T
+impl<T> dyn_clone::DynClone for nika_cli::verbs::arm::state::Unsettled where T: core::clone::Clone
+pub fn nika_cli::verbs::arm::state::Unsettled::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
+impl<T> nika_error::traits::AsAny for nika_cli::verbs::arm::state::Unsettled where T: 'static
+pub fn nika_cli::verbs::arm::state::Unsettled::as_any(&self) -> &(dyn core::any::Any + 'static)
+impl<T> tower_http::follow_redirect::policy::PolicyExt for nika_cli::verbs::arm::state::Unsettled where T: ?core::marker::Sized
+pub fn nika_cli::verbs::arm::state::Unsettled::and<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn nika_cli::verbs::arm::state::Unsettled::or<P, B, E>(self, other: P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for nika_cli::verbs::arm::state::Unsettled
+impl<T> tracing::instrument::WithSubscriber for nika_cli::verbs::arm::state::Unsettled
+impl<T> typenum::type_operators::Same for nika_cli::verbs::arm::state::Unsettled
+pub type nika_cli::verbs::arm::state::Unsettled::Output = T
+pub fn nika_cli::verbs::arm::state::slot_id(workflow: &str, cadence: &str, slot: &jiff::zoned::Zoned) -> alloc::string::String
 pub fn nika_cli::verbs::arm::run(args: nika_cli::verbs::arm::args::ArmArgs) -> nika_cli_host::output::VerbOutput
 pub fn nika_cli::verbs::arm::run_at(start: &std::path::Path) -> nika_cli_host::output::VerbOutput
 pub mod nika_cli::verbs::catalog

--- a/crates/nika-cli/src/verbs/arm/emit.rs
+++ b/crates/nika-cli/src/verbs/arm/emit.rs
@@ -361,9 +361,11 @@ fn journal_disarm(label: &str) -> String {
         trace: None,
         exit: None,
         slots: None,
+        slot_id: None,
+        fencing: None,
     };
     match state.record(label, &entry) {
-        Ok(()) => format!("· journalé: disarmed dans .nika/arm/{label}/history.ndjson\n"),
+        Ok(_) => format!("· journalé: disarmed dans .nika/arm/{label}/history.ndjson\n"),
         Err(e) => format!("· historique NON journalé ({e}) — l'unité, elle, est retirée\n"),
     }
 }

--- a/crates/nika-cli/src/verbs/arm/fire.rs
+++ b/crates/nika-cli/src/verbs/arm/fire.rs
@@ -13,6 +13,18 @@
 //! verb's edge (D5 — `--now`, hidden): the pure decision never reads
 //! one, never sleeps, and a replay is deterministic.
 //!
+//! The order law (W5-bis): the per-beat lock is taken BEFORE the
+//! decision and held until AFTER the receipt append. Under the lock
+//! the firer reads the state, decides, appends `claimed` (+ fsync),
+//! runs, appends the receipt (+ fsync · last.json · watermark), and
+//! only then releases. After ANY wait (`chevauchement: file`) the
+//! state is re-read and re-decided — the pre-wait slot is stale by
+//! law. Ledger appends made WITHOUT the beat lock (the overlap-skip
+//! path) are serialized by the inner ledger lock. What this buys is
+//! AT-LEAST-ONCE: a crash between the claim and its receipt leaves a
+//! visible orphan (`ArmState::unsettled`), never a silent double-fire;
+//! exactly-once is never claimed.
+//!
 //! The stdout contract (D8): a decision prints EXACTLY ONE line —
 //! `fired …` · `skipped …` · `paused …` · `failed …`. The in-process
 //! run's own fold is turned onto stderr for its duration, so the
@@ -26,19 +38,29 @@
 //! never answered by the firer.
 
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
-use jiff::{Timestamp, Zoned};
+use jiff::{SignedDuration, Timestamp, Zoned};
 use nika_cadence::registry::{AfterSkip, ArmRegistry, Beat, Cadence, Locus, MissPolicy, Overlap};
 use nika_vocab::project;
 
 use super::args::FireArgs;
-use super::state::{ArmState, FireKind, HistoryEntry, LockOutcome};
+use super::state::{ArmState, Claim, FireKind, HistoryEntry, LockOutcome, slot_id};
 use crate::verbs::run::RenderMode;
 use crate::verbs::{self, VerbOutput, exit};
+
+#[cfg(test)]
+mod firer_tests;
 
 /// The poll quantum while a queued tick (`chevauchement: file`) waits
 /// for the running one to release the lock.
 const POLL_MS: i64 = 1_000;
+
+/// The claim deadline's fallback when the cadence names no next slot
+/// after now: the v0 crash-detector (a claim past its deadline without
+/// a receipt is an orphan — the sweep that re-arms it is W8's). 24h
+/// bounds even the weirdest lawful cadence's gap.
+const CLAIM_DEADLINE_FALLBACK: SignedDuration = SignedDuration::from_hours(24);
 
 /// The firer's context (D2) — everything the decision needs, injected.
 /// `serve` (②) builds the same one; the verb below only parses args.
@@ -57,7 +79,53 @@ pub struct FireCtx {
     pub now: Zoned,
     /// The firing sidecar (D3).
     pub state: ArmState,
+    /// The firer's own pid, written into the locks it takes (the edges
+    /// pass `std::process::id()`; a test can lend a child's).
+    pub pid: u32,
+    /// The sleep seam — the queue's wait (`chevauchement: file`) rides
+    /// it: the OS firer sleeps, `serve` races the signals, the harness
+    /// advances its scripted clock. D5's twin: the firer never sleeps
+    /// uninjected.
+    pub(crate) wait: WaitSeam,
+    /// The run seam — the real in-process run by default ([`prod_run`]);
+    /// the tests stub it, W10's sim will mock it here.
+    pub(crate) run: RunSeam,
 }
+
+/// What a wait returned: the span elapsed whole, or a signal broke it
+/// (the firer then skips `serve-stop` — never runs, never blocks).
+pub(crate) enum Wait {
+    /// The full span elapsed.
+    Elapsed,
+    /// A stop signal broke the wait (serve's ctrl-c / SIGTERM).
+    Interrupted,
+}
+
+/// The wait seam's shape: a span in, the outcome out.
+pub(crate) type WaitSeam = Box<dyn Fn(SignedDuration) -> Wait>;
+
+/// The shot the run seam takes — the workflow and its per-tick ceiling
+/// (law 7), the project root to enter.
+pub(crate) struct RunShot {
+    /// The project root (traces and workflow-relative paths resolve here).
+    pub root: PathBuf,
+    /// The workflow path, registry-verbatim.
+    pub workflow: String,
+    /// The per-tick ceiling in USD — ALWAYS set (law 7).
+    pub plafond: f64,
+}
+
+/// What a run left behind.
+pub(crate) struct RunUpshot {
+    /// The run's exit code (0 · 1 · 2 · 3 · 4).
+    pub code: u8,
+    /// The trace the run wrote (repo-relative), when one landed.
+    pub trace: Option<String>,
+}
+
+/// The run seam's shape — an `Rc`: `serve` shares ONE seam across the
+/// tick's beats.
+pub(crate) type RunSeam = Rc<dyn Fn(&RunShot) -> RunUpshot>;
 
 /// What a fire leaves: the ONE stdout line (D8) + the process exit.
 pub struct FireVerdict {
@@ -160,6 +228,9 @@ pub fn run(fire: &FireArgs) -> VerbOutput {
         index,
         label: fire.label.clone(),
         now,
+        pid: std::process::id(),
+        wait: Box::new(os_wait),
+        run: Rc::new(prod_run),
     };
     let verdict = fire_beat(&ctx);
     VerbOutput {
@@ -377,10 +448,27 @@ fn expiry_passed(beat: &Beat, now: &Zoned) -> Option<String> {
     (date < now.date()).then(|| raw.to_owned())
 }
 
-/// The one firer (D2): decide, then act — journal the skip, or lock
-/// (law ⑥) and run. Always the ONE line (D8).
+/// The one firer (D2), the order law made code (W5-bis): the beat's
+/// lock is taken BEFORE the decision and held until AFTER the receipt
+/// append; after any wait the state is re-read and re-decided. Always
+/// the ONE line (D8).
 #[must_use]
 pub fn fire_beat(ctx: &FireCtx) -> FireVerdict {
+    match ctx.state.try_lock(&ctx.label, ctx.pid, &ctx.now) {
+        Err(e) => FireVerdict {
+            line: format!("failed {} · the lock refused: {e}", ctx.label),
+            code: exit::ENV,
+        },
+        Ok(LockOutcome::HeldAlive { pid }) => overlap_held(ctx, pid),
+        Ok(LockOutcome::Acquired | LockOutcome::StaleTaken { .. }) => decide_locked(ctx),
+    }
+}
+
+/// The acquired path: the lock is OURS — the decision happens under it
+/// (the law), and the release rides the guard on EVERY exit, engine
+/// fault and record refusal included.
+fn decide_locked(ctx: &FireCtx) -> FireVerdict {
+    let _lock = HeldBeatLock(ctx);
     let last = ctx.state.last_fired(&ctx.label);
     match decide(
         &ctx.registry,
@@ -398,57 +486,55 @@ pub fn fire_beat(ctx: &FireCtx) -> FireVerdict {
             reason,
             slot,
             journal,
-        } => {
-            if journal {
-                let verdict = write_record(
-                    ctx,
-                    &HistoryEntry {
-                        slot: slot.as_ref().map(Zoned::timestamp),
-                        decided_at: ctx.now.timestamp(),
-                        kind: FireKind::Skipped,
-                        reason: Some(reason),
-                        trace: None,
-                        exit: Some(exit::OK),
-                        slots: None,
-                    },
-                );
-                if let Some(verdict) = verdict {
-                    return verdict;
-                }
-            }
-            FireVerdict {
-                line,
-                code: exit::OK,
-            }
-        }
-        Decision::Fire { slot, slots } => fire_slot(ctx, &slot, slots),
+        } => act_on_skip(ctx, line, reason, slot.as_ref(), journal),
+        Decision::Fire { slot, slots } => claim_run_receipt(ctx, &slot, slots),
     }
 }
 
-/// The lock, then the shot.
-fn fire_slot(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdict {
-    match ctx.state.try_lock(&ctx.label, std::process::id(), &ctx.now) {
-        Err(e) => FireVerdict {
-            line: format!("failed {} · the lock refused: {e}", ctx.label),
-            code: exit::ENV,
+/// The lock is another LIVE firer's — law ⑥ governs. The decision
+/// below is an unlocked PEEK, advisory only: it says whether this tick
+/// had a slot to fire and which one a skip covers. A run can only ever
+/// come from a decision made UNDER the lock (the re-decision law) —
+/// the peek alone never runs.
+fn overlap_held(ctx: &FireCtx, holder: u32) -> FireVerdict {
+    let last = ctx.state.last_fired(&ctx.label);
+    match decide(
+        &ctx.registry,
+        ctx.index,
+        &ctx.label,
+        &ctx.now,
+        last.as_ref(),
+    ) {
+        // The tick had nothing to fire — the held lock is not ours to
+        // judge: the decision's own line, journaled as it would be
+        // under the lock (the inner ledger lock alone serializes the
+        // append).
+        Decision::Refuse { line } => FireVerdict {
+            line,
+            code: exit::FILE,
         },
-        Ok(LockOutcome::HeldAlive { pid }) => match beat_of(ctx).map(Beat::overlap) {
-            Some(Overlap::Sauter) => say_after_journal(
+        Decision::Skip {
+            line,
+            reason,
+            slot,
+            journal,
+        } => act_on_skip(ctx, line, reason, slot.as_ref(), journal),
+        Decision::Fire { slot, .. } => match beat_of(ctx).map(Beat::overlap) {
+            Some(Overlap::Sauter) => act_on_skip(
                 ctx,
-                FireKind::Skipped,
-                Some("overlap".to_owned()),
-                slot,
-                None,
-                None,
-                exit::OK,
                 format!(
-                    "skipped {} · overlap · pid {pid} tient le créneau",
-                    ctx.label
+                    "skipped {} · overlap · pid {holder} tient le créneau · slot {}",
+                    ctx.label,
+                    slot.timestamp()
                 ),
+                "overlap".to_owned(),
+                Some(&slot),
+                true,
             ),
-            Some(Overlap::File) => poll_queue(ctx, slot, slots, pid),
-            // `remplacer` is a v0 refusal upstream — an arrival here is
-            // an engine fault, said as such, never an approximation.
+            Some(Overlap::File) => wait_turn(ctx, &slot, holder),
+            // `remplacer` is a v0 refusal upstream (the peek refuses
+            // before the clock) — an arrival here is an engine fault,
+            // said as such, never an approximation.
             _ => FireVerdict {
                 line: format!(
                     "failed {} · engine fault: remplacer reached the lock",
@@ -457,47 +543,59 @@ fn fire_slot(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdict {
                 code: exit::FILE,
             },
         },
-        Ok(LockOutcome::Acquired | LockOutcome::StaleTaken { .. }) => {
-            run_and_record(ctx, slot, slots)
-        }
     }
 }
 
-/// `chevauchement: file` — poll the lock each second until the running
-/// tick releases it, or until the beat's NEXT slot (firing the old one
-/// past it would double the new one).
-fn poll_queue(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>, holder: u32) -> FireVerdict {
-    let budget_ms = beat_of(ctx)
-        .and_then(|b| Cadence::parse(&b.cadence).ok())
-        .and_then(|c| c.next_after(&ctx.now))
-        .map_or(0, |next| {
-            next.at.timestamp().as_millisecond() - ctx.now.timestamp().as_millisecond()
-        });
+/// `chevauchement: file` — a BOUNDED in-memory wait, never a durable
+/// queue: the wait seam carries each quantum (the OS firer sleeps,
+/// `serve` races its signals, the harness advances its clock) until
+/// the running tick releases the lock or the beat's NEXT slot ends the
+/// budget (firing the old one past it would double the new one). On
+/// acquisition the state is RE-READ and RE-DECIDED — the pre-wait slot
+/// is stale by law.
+fn wait_turn(ctx: &FireCtx, slot: &Zoned, holder: u32) -> FireVerdict {
+    let budget_ms = next_slot(ctx).map_or(0, |next| {
+        next.timestamp().as_millisecond() - ctx.now.timestamp().as_millisecond()
+    });
     let mut waited_ms = 0i64;
     loop {
         if waited_ms >= budget_ms {
-            return say_after_journal(
+            return act_on_skip(
                 ctx,
-                FireKind::Skipped,
-                Some("overlap-timeout".to_owned()),
-                slot,
-                None,
-                None,
-                exit::OK,
                 format!(
-                    "skipped {} · overlap-timeout · pid {holder} a tenu jusqu'au créneau suivant",
-                    ctx.label
+                    "skipped {} · overlap-timeout · pid {holder} a tenu jusqu'au créneau suivant · slot {}",
+                    ctx.label,
+                    slot.timestamp()
                 ),
+                "overlap-timeout".to_owned(),
+                Some(slot),
+                true,
             );
         }
         let step = (budget_ms - waited_ms).min(POLL_MS);
-        std::thread::sleep(std::time::Duration::from_millis(
-            u64::try_from(step).unwrap_or(0),
-        ));
-        waited_ms += step;
-        match ctx.state.try_lock(&ctx.label, std::process::id(), &ctx.now) {
+        match (ctx.wait)(SignedDuration::from_millis(step)) {
+            // A signal broke the wait (serve is stopping): the tick is
+            // abandoned — journaled with its slot, never run.
+            Wait::Interrupted => {
+                return act_on_skip(
+                    ctx,
+                    format!(
+                        "skipped {} · serve-stop · slot {}",
+                        ctx.label,
+                        slot.timestamp()
+                    ),
+                    "serve-stop".to_owned(),
+                    Some(slot),
+                    true,
+                );
+            }
+            Wait::Elapsed => waited_ms += step,
+        }
+        match ctx.state.try_lock(&ctx.label, ctx.pid, &ctx.now) {
             Ok(LockOutcome::Acquired | LockOutcome::StaleTaken { .. }) => {
-                return run_and_record(ctx, slot, slots);
+                // The re-decision law: the state may have changed under
+                // the wait — decide again, under the lock.
+                return decide_locked(ctx);
             }
             Ok(LockOutcome::HeldAlive { .. }) => {}
             Err(e) => {
@@ -510,14 +608,60 @@ fn poll_queue(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>, holder: u32) -> F
     }
 }
 
-/// The shot: enter the project (traces and workflow-relative paths
-/// resolve at the root), turn stdout onto stderr for the run's
-/// duration (D8), run IN-PROCESS with the `nika run` CLI defaults —
-/// the per-tick ceiling ALWAYS set (law 7) — then record, release, and
-/// say the ONE line.
-fn run_and_record(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdict {
-    let beat = beat_of(ctx);
-    let Some(plafond) = beat.and_then(|b| b.plafond) else {
+/// Act on a Skip decision: journal it when it bears one (the inner
+/// ledger lock serializes the append; the caller's beat lock, when it
+/// holds one, outlives this), then the ONE line — the ledger's repair
+/// count riding it when the chain had to be healed (D8 stays one line).
+fn act_on_skip(
+    ctx: &FireCtx,
+    line: String,
+    reason: String,
+    slot: Option<&Zoned>,
+    journal: bool,
+) -> FireVerdict {
+    if !journal {
+        return FireVerdict {
+            line,
+            code: exit::OK,
+        };
+    }
+    let entry = HistoryEntry {
+        slot: slot.map(Zoned::timestamp),
+        decided_at: ctx.now.timestamp(),
+        kind: FireKind::Skipped,
+        reason: Some(reason),
+        trace: None,
+        exit: Some(exit::OK),
+        slots: None,
+        slot_id: slot.and_then(|s| slot_id_of(ctx, s)),
+        fencing: None,
+    };
+    match ctx.state.record(&ctx.label, &entry) {
+        Ok(outcome) => FireVerdict {
+            line: with_repair(line, outcome.repaired),
+            code: exit::OK,
+        },
+        Err(e) => record_refused(ctx, &e),
+    }
+}
+
+/// The Fire branch, under the lock — the order law made code: the
+/// CLAIM is appended + fsync'd BEFORE the run (a crash after it leaves
+/// a visible orphan — the v0 crash-detector's whole point), the
+/// receipt (+ fsync · last.json · watermark) lands AFTER, the release
+/// comes last of all (the caller's guard). The receipt fences the
+/// claim's seq — that link is what makes an orphan unambiguous.
+fn claim_run_receipt(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdict {
+    let Some(beat) = beat_of(ctx) else {
+        return FireVerdict {
+            line: format!(
+                "failed {} · engine fault: the label resolved past the registry",
+                ctx.label
+            ),
+            code: exit::FILE,
+        };
+    };
+    let Some(plafond) = beat.plafond else {
         return FireVerdict {
             line: format!(
                 "failed {} · engine fault: plafond absent après validation — à reporter avec le fichier",
@@ -526,40 +670,146 @@ fn run_and_record(ctx: &FireCtx, slot: &Zoned, slots: Option<u32>) -> FireVerdic
             code: exit::FILE,
         };
     };
-    let workflow = beat.map_or_else(String::new, |b| b.workflow.clone());
-    let before = trace_set(&ctx.project_root);
-    let Ok(_room) = enter_room(&ctx.project_root) else {
-        // The lock we hold never outlives a door we cannot walk through.
-        let _ = ctx.state.release(&ctx.label);
-        return FireVerdict {
-            line: format!("failed {} · cannot enter the project root", ctx.label),
+    let claim = Claim {
+        slot_id: slot_id(&beat.workflow, &beat.cadence, slot),
+        deadline: next_slot(ctx).map_or_else(
+            || {
+                ctx.now
+                    .timestamp()
+                    .checked_add(CLAIM_DEADLINE_FALLBACK)
+                    .unwrap_or_else(|_| ctx.now.timestamp())
+            },
+            |next| next.timestamp(),
+        ),
+        decided_at: ctx.now.timestamp(),
+    };
+    let mut repaired = 0u64;
+    let fencing = match ctx.state.record_claim(&ctx.label, &claim) {
+        Ok(outcome) => {
+            repaired += outcome.repaired;
+            outcome.seq
+        }
+        Err(e) => return record_refused(ctx, &e),
+    };
+    let upshot = (ctx.run)(&RunShot {
+        root: ctx.project_root.clone(),
+        workflow: beat.workflow.clone(),
+        plafond,
+    });
+    let (kind, line) = verdict_line(ctx, slot, slots, upshot.code, upshot.trace.as_deref());
+    let receipt = HistoryEntry {
+        slot: Some(slot.timestamp()),
+        decided_at: ctx.now.timestamp(),
+        kind,
+        reason: None,
+        trace: upshot.trace,
+        exit: Some(upshot.code),
+        slots,
+        slot_id: Some(claim.slot_id),
+        fencing: Some(fencing),
+    };
+    match ctx.state.record(&ctx.label, &receipt) {
+        Ok(outcome) => repaired += outcome.repaired,
+        Err(e) => return record_refused(ctx, &e),
+    }
+    FireVerdict {
+        line: with_repair(line, repaired),
+        code: upshot.code,
+    }
+}
+
+/// The held beat lock, released on EVERY exit of the scope that took
+/// it — a leaked lock would brick the beat until the pid dies.
+struct HeldBeatLock<'a>(&'a FireCtx);
+
+impl Drop for HeldBeatLock<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.state.release(&self.0.label);
+    }
+}
+
+/// The beat's next theoretical slot after the decision instant — the
+/// queue's budget AND the claim's deadline ride the same planner door.
+fn next_slot(ctx: &FireCtx) -> Option<Zoned> {
+    beat_of(ctx)
+        .and_then(|b| Cadence::parse(&b.cadence).ok())
+        .and_then(|c| c.next_after(&ctx.now))
+        .map(|s| s.at)
+}
+
+/// The slot's canonical identity, computed from the beat's own
+/// declaration (the path + the cadence, VERBATIM — never the label).
+fn slot_id_of(ctx: &FireCtx, slot: &Zoned) -> Option<String> {
+    let beat = beat_of(ctx)?;
+    Some(slot_id(&beat.workflow, &beat.cadence, slot))
+}
+
+/// The repair suffix — the ledger's self-healing is SAID on the
+/// decision line (D8 stays one line).
+fn with_repair(line: String, repaired: u64) -> String {
+    if repaired == 0 {
+        line
+    } else {
+        format!("{line} · ledger réparé (-{repaired})")
+    }
+}
+
+/// The record's refusal: the failure line REPLACES the decision's (a
+/// fire without its record is a fire that re-fires) — exit ENV, and
+/// the caller's guard still releases the lock.
+fn record_refused(ctx: &FireCtx, e: &std::io::Error) -> FireVerdict {
+    FireVerdict {
+        line: format!("failed {} · the record refused: {e}", ctx.label),
+        code: exit::ENV,
+    }
+}
+
+/// The real shot: enter the project (traces and workflow-relative
+/// paths resolve at the root), turn stdout onto stderr for the run's
+/// duration (D8), run IN-PROCESS with the `nika run` CLI defaults —
+/// the per-tick ceiling ALWAYS set (law 7). A room the firer cannot
+/// enter is a run that failed before starting: exit ENV, journaled as
+/// such by the caller — the claim still gets its receipt, no orphan.
+pub(crate) fn prod_run(shot: &RunShot) -> RunUpshot {
+    let before = trace_set(&shot.root);
+    let Ok(_room) = enter_room(&shot.root) else {
+        return RunUpshot {
             code: exit::ENV,
+            trace: None,
         };
     };
     let code = run_quietly(|| {
         verbs::run::run(
-            &workflow,
+            &shot.workflow,
             false, // json
             None,  // output
             crate::Theme::new(false, true, false),
-            RenderMode::Plain, // the piped `nika run` defaults
-            false,             // dry_run
-            None,              // model_override
-            None,              // access_pin
-            &[],               // vars
-            None,              // resume — NEVER (law 4 · N2)
-            false,             // no_trace_file — the trace is load-bearing
-            None,              // task_filter
-            false,             // no_outputs
-            Some(plafond),     // the per-tick ceiling, ALWAYS (law 7)
-            false,             // no_gc
-            false,             // require_signature — ② (serve) verifies
+            RenderMode::Plain,  // the piped `nika run` defaults
+            false,              // dry_run
+            None,               // model_override
+            None,               // access_pin
+            &[],                // vars
+            None,               // resume — NEVER (law 4 · N2)
+            false,              // no_trace_file — the trace is load-bearing
+            None,               // task_filter
+            false,              // no_outputs
+            Some(shot.plafond), // the per-tick ceiling, ALWAYS (law 7)
+            false,              // no_gc
+            false,              // require_signature — ② (serve) verifies
         )
     });
-    let trace = new_trace(&ctx.project_root, &before);
-    let _ = ctx.state.release(&ctx.label);
-    let (kind, line) = verdict_line(ctx, slot, slots, code, trace.as_deref());
-    say_after_journal(ctx, kind, None, slot, slots, trace, code, line)
+    RunUpshot {
+        code,
+        trace: new_trace(&shot.root, &before),
+    }
+}
+
+/// The OS firer's wait: the process sleeps the span, whole — its stop
+/// is the OS unit's own kill, no signal is scrutinized here (②'s
+/// signal-aware seam is serve's).
+fn os_wait(span: SignedDuration) -> Wait {
+    std::thread::sleep(std::time::Duration::try_from(span).unwrap_or_default());
+    Wait::Elapsed
 }
 
 /// The line + the kind for a run that went (rc 0 · 1 · 2 · 3 · 4).
@@ -590,46 +840,6 @@ fn verdict_line(
             format!("failed {label} · slot {slot_rfc} · exit {code}{via_trace}"),
         ),
     }
-}
-
-/// Journal the decision, then the line. A fire without its record is a
-/// fire that re-fires — a record failure is said, never swallowed.
-#[allow(clippy::too_many_arguments)] // the decision's full facts
-fn say_after_journal(
-    ctx: &FireCtx,
-    kind: FireKind,
-    reason: Option<String>,
-    slot: &Zoned,
-    slots: Option<u32>,
-    trace: Option<String>,
-    code: u8,
-    line: String,
-) -> FireVerdict {
-    let entry = HistoryEntry {
-        slot: Some(slot.timestamp()),
-        decided_at: ctx.now.timestamp(),
-        kind,
-        reason,
-        trace,
-        exit: Some(code),
-        slots,
-    };
-    if let Some(verdict) = write_record(ctx, &entry) {
-        return verdict;
-    }
-    FireVerdict { line, code }
-}
-
-/// The record write — `Some(verdict)` when it failed (the failure
-/// line REPLACES the decision's: an unrecorded fire re-fires).
-fn write_record(ctx: &FireCtx, entry: &HistoryEntry) -> Option<FireVerdict> {
-    ctx.state
-        .record(&ctx.label, entry)
-        .err()
-        .map(|e| FireVerdict {
-            line: format!("failed {} · the record refused: {e}", ctx.label),
-            code: exit::ENV,
-        })
 }
 
 /// The beat at the context's index (validated: always present).

--- a/crates/nika-cli/src/verbs/arm/fire/firer_tests.rs
+++ b/crates/nika-cli/src/verbs/arm/fire/firer_tests.rs
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The W5-bis firer law, pinned end to end: the lock outlives the shot
+//! (the order law), the claim is appended + fsync'd BEFORE the run and
+//! the receipt settles it by fencing, the queue re-decides after ANY
+//! wait, an interrupted wait skips `serve-stop`, and a healed ledger
+//! says so on the ONE line. Every test drives [`fire_beat`] with the
+//! seams injected — the run seam is ALWAYS a stub here (the real
+//! in-process run chdirs, and parallel tests race on the process CWD;
+//! the binary tests under `tests/` own that ground).
+// The workspace bans std::process::Command (production spawns ride the
+// kernel ShellExecutor seam). These tests' OTHER firer is a real live
+// `sleep` child — the lock-liveness law needs a pid that answers
+// signal 0, and no kernel seam lends « a borrowed live pid ».
+#![allow(clippy::disallowed_types)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::cell::{Cell, RefCell};
+use std::path::Path;
+use std::rc::Rc;
+
+use jiff::Timestamp;
+
+use super::*;
+
+/// A one-beat registry (validated green) — the same shape the decide
+/// suite rides, with the overlap policy as the variable.
+fn registry_with(body: &str) -> ArmRegistry {
+    let text = format!(
+        "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
+    );
+    let registry = nika_cadence::parse_registry(&text).expect("parse");
+    assert!(
+        nika_cadence::validate(&registry).next().is_none(),
+        "the fixture must be lawful"
+    );
+    registry
+}
+
+/// `manqué: sauter`, the safe default overlap.
+const SAUTER: &str = "    manqué: sauter\n";
+/// The bounded in-memory queue.
+const FILE: &str = "    manqué: sauter\n    chevauchement: file\n";
+
+fn at(text: &str) -> Zoned {
+    text.parse::<Timestamp>()
+        .expect("ts")
+        .to_zoned(jiff::tz::TimeZone::UTC)
+}
+
+fn ts(text: &str) -> Timestamp {
+    text.parse::<Timestamp>().expect("ts")
+}
+
+/// A tempdir project root — the impure firer's ground.
+fn project(tag: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("nika-arm-firer-{tag}-"))
+        .tempdir()
+        .expect("tmp dir")
+}
+
+/// A live `sleep` child — the OTHER firer (its pid answers signal 0,
+/// so its lock reads `HeldAlive`). Killed + reaped on drop; [`die`](Self::die)
+/// for the mid-test completion (a zombie still answers the probe).
+struct LiveChild(std::process::Child);
+
+impl LiveChild {
+    fn spawn() -> Self {
+        Self(
+            std::process::Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("a sleep child"),
+        )
+    }
+
+    fn pid(&self) -> u32 {
+        self.0.id()
+    }
+
+    /// Kill + reap NOW — a zombie still answers signal 0.
+    fn die(mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+impl Drop for LiveChild {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// The firer's context with every seam injected: the pid is the test
+/// process's own, the wait is scripted by the test, the run is a stub.
+fn ctx(root: &Path, registry: ArmRegistry, now: &str, wait: WaitSeam, run: RunSeam) -> FireCtx {
+    FireCtx {
+        project_root: root.to_path_buf(),
+        registry,
+        index: 0,
+        label: "doctor".to_owned(),
+        now: at(now),
+        state: ArmState::at_project(root),
+        pid: std::process::id(),
+        wait,
+        run,
+    }
+}
+
+/// A run stub that counts its calls and exits clean.
+fn run_counter() -> (Rc<Cell<u32>>, RunSeam) {
+    let count = Rc::new(Cell::new(0u32));
+    let seen = Rc::clone(&count);
+    let seam: RunSeam = Rc::new(move |_: &RunShot| {
+        seen.set(seen.get() + 1);
+        RunUpshot {
+            code: exit::OK,
+            trace: None,
+        }
+    });
+    (count, seam)
+}
+
+/// The wait that elapses at once (no signal, no scripted clock).
+fn instant_wait() -> WaitSeam {
+    Box::new(|_| Wait::Elapsed)
+}
+
+/// One beat's ledger text (`""` when absent).
+fn history(root: &Path, label: &str) -> String {
+    std::fs::read_to_string(root.join(".nika/arm").join(label).join("history.ndjson"))
+        .unwrap_or_default()
+}
+
+/// R1 · deux processus, un run — a LIVE other firer holds the lock:
+/// the due tick skips `overlap` WITH the slot (D8's consistency), the
+/// run seam is never called, and the ledger gains exactly ONE chained
+/// line (kind skipped · reason overlap · the slot's identity).
+#[test]
+fn two_firers_one_run() {
+    let dir = project("two-firers");
+    let sidecar = ArmState::at_project(dir.path());
+    let holder = LiveChild::spawn();
+    let now = at("2026-08-19T03:02:00Z");
+    // The other firer's lock — its pid lives, the lock is its run's.
+    assert_eq!(
+        sidecar
+            .try_lock("doctor", holder.pid(), &now)
+            .expect("lock"),
+        LockOutcome::Acquired
+    );
+    let (runs, run) = run_counter();
+    let ctx = ctx(
+        dir.path(),
+        registry_with(SAUTER),
+        "2026-08-19T03:02:00Z",
+        instant_wait(),
+        run,
+    );
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+    assert!(
+        verdict.line.starts_with(&format!(
+            "skipped doctor · overlap · pid {} tient le créneau",
+            holder.pid()
+        )),
+        "{}",
+        verdict.line
+    );
+    assert!(
+        verdict.line.ends_with("· slot 2026-08-19T03:00:00Z"),
+        "the slot rides the line (D8): {}",
+        verdict.line
+    );
+    assert_eq!(runs.get(), 0, "the run seam NEVER fired");
+    let text = history(dir.path(), "doctor");
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 1, "exactly one chained line: {text}");
+    let doc: serde_json::Value = serde_json::from_str(lines[0]).expect("json");
+    assert_eq!(doc["schema"], "nika/arm-event@1", "{text}");
+    assert_eq!(doc["kind"], "skipped", "{text}");
+    assert_eq!(doc["payload"]["reason"], "overlap", "{text}");
+    assert_eq!(doc["seq"], 1, "the genesis line: {text}");
+    assert!(doc["prev_hash"].is_null(), "the genesis line: {text}");
+    assert!(
+        doc["slot_id"].is_string(),
+        "a slot-bearing skip carries the slot identity: {text}"
+    );
+    // The holder's lock is untouched — law ⑥ sauter.
+    assert!(dir.path().join(".nika/arm/doctor/lock").exists());
+}
+
+/// R2 · the order law: under the lock, the claim lands BEFORE the run
+/// (the stub sees it as the chain's last line, the lock file ours),
+/// the receipt lands AFTER — seq + 1, fencing the claim's seq, the
+/// same slot identity — and the release comes last of all.
+#[test]
+fn the_claim_precedes_the_run_and_the_receipt_settles_it() {
+    let dir = project("ordering");
+    let root = dir.path().to_path_buf();
+    let during = move |shot: &RunShot| {
+        // DURING the run: the chain's last line is the claim …
+        let text = std::fs::read_to_string(root.join(".nika/arm/doctor/history.ndjson"))
+            .expect("the claim lands BEFORE the run");
+        let last_line = text.lines().last().expect("one line");
+        let doc: serde_json::Value = serde_json::from_str(last_line).expect("json");
+        assert_eq!(doc["kind"], "claimed", "{text}");
+        assert_eq!(
+            doc["payload"]["fencing"], doc["seq"],
+            "the claim fences its own seq: {text}"
+        );
+        assert_eq!(doc["payload"]["attempt"], 1, "one attempt — v0: {text}");
+        assert_eq!(
+            doc["payload"]["deadline"], "2026-08-20T03:00:00Z",
+            "the deadline is the beat's next theoretical slot: {text}"
+        );
+        // … and the beat lock is OURS, carrying the context's pid.
+        let lock = std::fs::read_to_string(root.join(".nika/arm/doctor/lock"))
+            .expect("the lock outlives the shot");
+        assert!(
+            lock.contains(&format!("\"pid\":{}", std::process::id())),
+            "the lock carries OUR pid: {lock}"
+        );
+        assert_eq!(shot.workflow, "workflows/doctor.nika.yaml");
+        RunUpshot {
+            code: exit::OK,
+            trace: None,
+        }
+    };
+    let ctx = ctx(
+        dir.path(),
+        registry_with(SAUTER),
+        "2026-08-19T03:02:00Z",
+        instant_wait(),
+        Rc::new(during),
+    );
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+    assert!(
+        verdict
+            .line
+            .starts_with("fired doctor · slot 2026-08-19T03:00:00Z · exit 0"),
+        "{}",
+        verdict.line
+    );
+    // AFTER: the receipt settles the claim …
+    let text = history(dir.path(), "doctor");
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 2, "the claim, then the receipt: {text}");
+    let claim: serde_json::Value = serde_json::from_str(lines[0]).expect("claim json");
+    let receipt: serde_json::Value = serde_json::from_str(lines[1]).expect("receipt json");
+    assert_eq!(claim["kind"], "claimed");
+    assert_eq!(receipt["kind"], "fired");
+    assert_eq!(
+        receipt["seq"].as_u64(),
+        claim["seq"].as_u64().map(|seq| seq + 1),
+        "the receipt follows the claim"
+    );
+    assert_eq!(
+        receipt["payload"]["fencing"], claim["seq"],
+        "the receipt fences the claim's seq"
+    );
+    assert_eq!(
+        receipt["slot_id"], claim["slot_id"],
+        "the same slot identity"
+    );
+    // … the release came last: no lock outlives the verdict …
+    assert!(!dir.path().join(".nika/arm/doctor/lock").exists());
+    assert!(!dir.path().join(".nika/arm/doctor/ledger.lock").exists());
+    // … and the projections moved: last.json fired, the watermark = the
+    // decided instant.
+    let last =
+        std::fs::read_to_string(dir.path().join(".nika/arm/doctor/last.json")).expect("last.json");
+    assert!(last.contains("\"kind\":\"fired\""), "{last}");
+    let watermark =
+        std::fs::read_to_string(dir.path().join(".nika/arm/doctor/watermark")).expect("watermark");
+    assert_eq!(watermark, "2026-08-19T03:02:00Z\n");
+}
+
+/// R3 · a record that cannot land is said LOUDLY: the failure line
+/// REPLACES the decision's (exit ENV), nothing ran, and the lock is
+/// STILL released — the read-only ledger refuses the claim's append.
+#[cfg(unix)]
+#[test]
+fn a_refused_record_fails_loudly_and_still_releases() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = project("readonly");
+    let sidecar = dir.path().join(".nika/arm/doctor");
+    std::fs::create_dir_all(&sidecar).expect("sidecar");
+    let ledger = sidecar.join("history.ndjson");
+    std::fs::write(&ledger, "").expect("the ledger shell");
+    std::fs::set_permissions(&ledger, std::fs::Permissions::from_mode(0o444))
+        .expect("read-only ledger");
+    let (runs, run) = run_counter();
+    let ctx = ctx(
+        dir.path(),
+        registry_with(SAUTER),
+        "2026-08-19T03:02:00Z",
+        instant_wait(),
+        run,
+    );
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::ENV, "{}", verdict.line);
+    assert!(
+        verdict
+            .line
+            .starts_with("failed doctor · the record refused:"),
+        "the failure line replaces the decision's: {}",
+        verdict.line
+    );
+    assert_eq!(runs.get(), 0, "the claim never landed — nothing ran");
+    assert!(
+        !sidecar.join("lock").exists(),
+        "the release happens on the failure path too"
+    );
+    assert!(!sidecar.join("watermark").exists());
+}
+
+/// R6 · `chevauchement: file` RE-DECIDES after the wait: the holder's
+/// fire completed while we queued (its receipt + last.json landed), so
+/// the freshly-taken lock must NOT fire the pre-wait slot — the
+/// re-decision reads `already` and nothing runs.
+#[test]
+fn the_queue_redecides_after_the_wait() {
+    let dir = project("redecide");
+    let sidecar = ArmState::at_project(dir.path());
+    let holder = LiveChild::spawn();
+    let now = at("2026-08-19T03:02:00Z");
+    assert_eq!(
+        sidecar
+            .try_lock("doctor", holder.pid(), &now)
+            .expect("lock"),
+        LockOutcome::Acquired
+    );
+    // The wait's first beat: the holder's fire COMPLETES (its receipt +
+    // last.json land, the chain grows) and its process dies.
+    let root = dir.path().to_path_buf();
+    let holder = RefCell::new(Some(holder));
+    let wait: WaitSeam = Box::new(move |_| {
+        if let Some(child) = holder.borrow_mut().take() {
+            ArmState::at_project(&root)
+                .record(
+                    "doctor",
+                    &HistoryEntry {
+                        slot: Some(ts("2026-08-19T03:00:00Z")),
+                        decided_at: ts("2026-08-19T03:02:10Z"),
+                        kind: FireKind::Fired,
+                        reason: None,
+                        trace: None,
+                        exit: Some(0),
+                        slots: None,
+                        slot_id: Some(slot_id(
+                            "workflows/doctor.nika.yaml",
+                            "TZ=UTC 0 3 * * *",
+                            &at("2026-08-19T03:00:00Z"),
+                        )),
+                        fencing: None,
+                    },
+                )
+                .expect("the holder's receipt");
+            child.die();
+        }
+        Wait::Elapsed
+    });
+    let (runs, run) = run_counter();
+    let ctx = ctx(
+        dir.path(),
+        registry_with(FILE),
+        "2026-08-19T03:02:00Z",
+        wait,
+        run,
+    );
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+    assert!(
+        verdict
+            .line
+            .starts_with("skipped doctor · already · slot 2026-08-19T03:00:00Z"),
+        "the re-decision sees the holder's completed slot: {}",
+        verdict.line
+    );
+    assert_eq!(runs.get(), 0, "the pre-wait slot must NOT fire twice");
+    // The chain carries ONLY the holder's receipt — an `already`
+    // re-decision journals nothing.
+    let text = history(dir.path(), "doctor");
+    assert_eq!(text.lines().count(), 1, "{text}");
+    assert!(text.contains("\"kind\":\"fired\""), "{text}");
+    // The lock we briefly took is released.
+    assert!(!dir.path().join(".nika/arm/doctor/lock").exists());
+}
+
+/// R7 (the unit half) · a wait broken by a signal: `serve-stop`,
+/// journaled WITH the slot, no run, and the verdict comes back at
+/// once — the budget is not burned waiting.
+#[test]
+fn an_interrupted_wait_skips_serve_stop() {
+    let dir = project("interrupted");
+    let sidecar = ArmState::at_project(dir.path());
+    let holder = LiveChild::spawn();
+    let now = at("2026-08-19T03:02:00Z");
+    assert_eq!(
+        sidecar
+            .try_lock("doctor", holder.pid(), &now)
+            .expect("lock"),
+        LockOutcome::Acquired
+    );
+    let (runs, run) = run_counter();
+    let ctx = ctx(
+        dir.path(),
+        registry_with(FILE),
+        "2026-08-19T03:02:00Z",
+        Box::new(|_| Wait::Interrupted),
+        run,
+    );
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+    assert_eq!(
+        verdict.line,
+        "skipped doctor · serve-stop · slot 2026-08-19T03:00:00Z"
+    );
+    assert_eq!(runs.get(), 0, "a stopped firer never runs");
+    let text = history(dir.path(), "doctor");
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 1, "{text}");
+    let doc: serde_json::Value = serde_json::from_str(lines[0]).expect("json");
+    assert_eq!(doc["kind"], "skipped");
+    assert_eq!(doc["payload"]["reason"], "serve-stop");
+    assert!(doc["slot_id"].is_string(), "{text}");
+    // The abandoned tick consumed its slot: last.json moved.
+    let last =
+        std::fs::read_to_string(dir.path().join(".nika/arm/doctor/last.json")).expect("last.json");
+    assert!(last.contains("\"kind\":\"skipped\""), "{last}");
+    // The holder's lock is not ours to touch.
+    assert!(dir.path().join(".nika/arm/doctor/lock").exists());
+}
+
+/// A healed ledger says so ON the decision line — ` · ledger
+/// réparé (-n)` names the truncated tail (D8 stays ONE line).
+#[test]
+fn a_repaired_ledger_tail_rides_the_decision_line() {
+    let dir = project("repair");
+    let sidecar = ArmState::at_project(dir.path());
+    // Three clean decisions against a past slot, then one byte of
+    // tamper inside line 2 (its seq no longer continues the chain).
+    let seed = HistoryEntry {
+        slot: Some(ts("2026-08-18T03:00:00Z")),
+        decided_at: ts("2026-08-18T03:01:00Z"),
+        kind: FireKind::Skipped,
+        reason: Some("overlap".to_owned()),
+        trace: None,
+        exit: Some(0),
+        slots: None,
+        slot_id: None,
+        fencing: None,
+    };
+    for _ in 0..3 {
+        sidecar.record("doctor", &seed).expect("record");
+    }
+    let ledger = dir.path().join(".nika/arm/doctor/history.ndjson");
+    let text = std::fs::read_to_string(&ledger).expect("ledger");
+    assert_eq!(text.lines().count(), 3, "{text}");
+    std::fs::write(&ledger, text.replacen("\"seq\":2", "\"seq\":9", 1)).expect("tamper");
+    let (runs, run) = run_counter();
+    let ctx = ctx(
+        dir.path(),
+        registry_with(SAUTER),
+        "2026-08-19T10:00:00Z",
+        instant_wait(),
+        run,
+    );
+    let verdict = fire_beat(&ctx);
+    assert_eq!(verdict.code, exit::OK, "{}", verdict.line);
+    assert!(
+        verdict
+            .line
+            .starts_with("skipped doctor · missed:1 · slot 2026-08-19T03:00:00Z"),
+        "{}",
+        verdict.line
+    );
+    assert!(
+        verdict.line.ends_with(" · ledger réparé (-2)"),
+        "the repair rides the one line: {}",
+        verdict.line
+    );
+    assert_eq!(runs.get(), 0);
+    // The chain healed: the tampered tail is gone, the append continued
+    // at seq 2 linked to line 1's hash.
+    let healed = std::fs::read_to_string(&ledger).expect("ledger");
+    assert_eq!(healed.lines().count(), 2, "{healed}");
+    let second: serde_json::Value =
+        serde_json::from_str(healed.lines().nth(1).expect("line 2")).expect("json");
+    assert_eq!(second["seq"], 2, "{healed}");
+    assert_eq!(second["kind"], "skipped", "{healed}");
+    assert_eq!(second["payload"]["reason"], "missed:1", "{healed}");
+}

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -398,6 +398,8 @@ mod tests {
             trace: Some(".nika/traces/2026-08-18T07-07-04Z_cafe.ndjson".to_owned()),
             exit: Some(0),
             slots: None,
+            slot_id: None,
+            fencing: None,
         };
         sidecar.record("prouve", &fired).expect("record");
         sidecar.record("prouve", &fired).expect("record");

--- a/crates/nika-cli/src/verbs/arm/state.rs
+++ b/crates/nika-cli/src/verbs/arm/state.rs
@@ -1,40 +1,77 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The firing sidecar (D3) — the state the FILE never carries:
+//! The firing sidecar (D3) · the state the FILE never carries:
 //!
 //! ```text
-//! .nika/arm/<label>/lock           { "pid": u32, "started_at": RFC3339 }
-//! .nika/arm/<label>/last.json      { "slot": RFC3339, "fired_at": RFC3339,
-//!                                    "trace": path|null, "exit": u8,
-//!                                    "kind": "fired|skipped|paused|failed" }
-//! .nika/arm/<label>/history.ndjson one line per decision · append-only
-//!                                    (kind carries « disarmed » too — W3)
+//! .nika/arm/<label>/lock               the beat lock { "pid": u32, "started_at": RFC3339 }
+//! .nika/arm/<label>/ledger.lock        the inner ledger lock · serializes verify + append
+//!                                      + fsync between processes when the beat lock is
+//!                                      NOT held (the overlap-skip path) · never held
+//!                                      across a run
+//! .nika/arm/<label>/last.json          the PROJECTION { "slot", "fired_at", "trace",
+//!                                      "exit", "kind": "fired|skipped|paused|failed" }
+//! .nika/arm/<label>/watermark          the last DECIDED instant (RFC 3339 + newline) ·
+//!                                      the restart reconciliation floor
+//! .nika/arm/<label>/history.ndjson     the versioned ledger (nika/arm-event@1) · one
+//!                                      line per event, hash-chained: v · seq · ts ·
+//!                                      kind · slot_id · payload · prev_hash · hash
+//!                                      (kind carries « claimed » · « rotated » ·
+//!                                      « disarmed » too)
+//! .nika/arm/<label>/history-w2.ndjson  a pre-ledger journal, rotated aside on the
+//!                                      first versioned append, kept FOREVER (N4)
 //! ```
 //!
 //! It lives NEXT TO the traces, at the root of the project that arms
-//! the beats (the directory holding `nika.yaml`) — never in the YAML
+//! the beats (the directory holding `nika.yaml`) · never in the YAML
 //! (what changes by itself is never written in what a human re-reads).
 //!
 //! The lock's owner must be ALIVE to hold: a lock whose pid answers
 //! signal 0 is a running tick (law ⑥ governs it); a dead pid's lock is
 //! a crash remnant, taken over. The takeover assumes ONE firer per beat
-//! (D2 — launchd today, `serve` at ②): two racers re-reading the same
+//! (D2 · launchd today, `serve` at ②): two racers re-reading the same
 //! stale lock resolve through the atomic `create_new`, the loser
 //! re-judges the winner's live pid.
 //!
 //! N2 rides the read half: a missing OR corrupt `last.json` reads as
-//! « never fired » — the planner then owes the on-time window alone and
+//! « never fired » · the planner then owes the on-time window alone and
 //! invents no backlog, which is the safe failure direction (at most one
 //! on-time re-fire, never a catch-up storm).
+//!
+//! The ledger law (W5-bis): every append verifies the chain first (seq
+//! continuity from 1 · `prev_hash` linkage · every hash recomputed over
+//! the exact bytes) and CUTS an invalid tail · a valid line is never
+//! rewritten. The append lands fsync'd, then `last.json`, then the
+//! watermark · a crash between the append and the watermark is a redo,
+//! the safe direction. Lock order, pinned: beat lock → ledger lock,
+//! NEVER the inverse; the ledger lock is never held across a run.
 
 use std::io;
 use std::path::{Path, PathBuf};
 
 use jiff::{Timestamp, Zoned};
 
-/// The sidecar root below a project directory (D3 — next to the traces).
+/// The sidecar root below a project directory (D3 · next to the traces).
 const ARM_DIR: &str = ".nika/arm";
+
+/// The beat lock's file name (law ⑥).
+const BEAT_LOCK: &str = "lock";
+
+/// The inner ledger lock's file name · see the module doc for the
+/// lock-ordering law.
+const LEDGER_LOCK: &str = "ledger.lock";
+
+/// The versioned ledger's file name.
+const HISTORY: &str = "history.ndjson";
+
+/// The ledger line's schema tag (versioned from day one · FCI-003).
+const LEDGER_SCHEMA: &str = "nika/arm-event@1";
+
+/// The ledger-lock wait: 100 × 5 ms — an eternity against a
+/// microseconds-long critical section, finite against a wedged holder
+/// (the record then refuses LOUDLY; an eternal block never happens).
+const LEDGER_LOCK_PASSES: u32 = 100;
+const LEDGER_LOCK_NAP: std::time::Duration = std::time::Duration::from_millis(5);
 
 /// The firing state, rooted at `<project>/.nika/arm`.
 pub struct ArmState {
@@ -96,7 +133,9 @@ impl FireKind {
 /// skips (inactive · cloud · expired · webhook) — those journal the
 /// decision but leave `last.json` untouched (its `slot` is not
 /// nullable). `slots` carries the silence's count when
-/// `rattraper-une-fois` fires ONE run for n slots.
+/// `rattraper-une-fois` fires ONE run for n slots. On the ledger the
+/// fields ride the `payload` object and `decided_at` is promoted to
+/// the envelope's `ts`.
 #[derive(Debug, Clone)]
 pub struct HistoryEntry {
     /// The slot decided (the absolute instant — zone-free on the wire).
@@ -113,6 +152,68 @@ pub struct HistoryEntry {
     pub exit: Option<u8>,
     /// `rattraper-une-fois`: how many slots the one fire answers for.
     pub slots: Option<u32>,
+    /// The slot's canonical identity ([`slot_id`]) — `None` for the
+    /// pre-slot skips.
+    pub slot_id: Option<String>,
+    /// A receipt pins the claim it settles (the claim's seq) — `None`
+    /// on every line that follows no claim.
+    pub fencing: Option<u64>,
+}
+
+/// The durable claim (W5-bis): appended + fsync'd BEFORE the run — a
+/// crash between the claim and its receipt leaves a VISIBLE orphan
+/// ([`ArmState::unsettled`]), never a silent double-fire. The
+/// guarantee is at-least-once, never exactly-once.
+#[derive(Debug, Clone)]
+pub struct Claim {
+    /// The slot's canonical identity ([`slot_id`]).
+    pub slot_id: String,
+    /// The crash-detector deadline — the beat's next theoretical slot
+    /// (the sweep that reads it is W8's).
+    pub deadline: Timestamp,
+    /// The decision instant (the envelope's `ts`).
+    pub decided_at: Timestamp,
+}
+
+/// What an append landed: the line's seq (a claim's fencing token) and
+/// the invalid-tail count the append cut first (0 = a clean chain).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordOutcome {
+    /// The appended line's seq (1-based, chain-continuous).
+    pub seq: u64,
+    /// How many invalid tail lines the append cut before landing.
+    pub repaired: u64,
+}
+
+/// A claim no receipt settled — the crash detector's output (W5-bis
+/// detects; the sweep is W8's). In the single-firer world an orphan is
+/// unambiguous: its holder is this process's dead ancestor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unsettled {
+    /// The claim's seq (= its fencing token).
+    pub seq: u64,
+    /// The claimed slot's canonical identity.
+    pub slot_id: String,
+    /// The deadline the claim declared.
+    pub deadline: Timestamp,
+    /// The claim's instant.
+    pub claimed_at: Timestamp,
+}
+
+/// The slot's canonical identity (W5-bis · the dedup unit): sha256 hex
+/// over the domain-separated canonical string — the workflow path
+/// VERBATIM, the cadence string VERBATIM, the slot's instant as UTC
+/// RFC 3339. NEVER the positional label (a `-2`/`-3` permutes at
+/// insertion). Derivable before any write, stable across restarts.
+#[must_use]
+pub fn slot_id(workflow: &str, cadence: &str, slot: &Zoned) -> String {
+    sha256_hex(
+        format!(
+            "nika/arm-slot@1\n{workflow}\n{cadence}\n{}",
+            slot.timestamp()
+        )
+        .as_bytes(),
+    )
 }
 
 /// The parsed `last.json` — the report (PROUVE) and the planner read it.
@@ -185,21 +286,44 @@ impl ArmState {
         })
     }
 
-    /// The history's skip/fire tallies (`x sauts / y tirs`) — `None`
-    /// when no history exists at all (the report then says nothing).
+    /// The history's skip/fire tallies (`x sauts / y tirs`) — over the
+    /// versioned ledger AND every rotated W2-era journal (both carry a
+    /// top-level `kind`). `None` when no journal exists at all (the
+    /// report then says nothing).
     #[must_use]
     pub fn tallies(&self, label: &str) -> Option<(usize, usize)> {
-        let text = std::fs::read_to_string(self.root.join(label).join("history.ndjson")).ok()?;
+        let dir = self.root.join(label);
+        let mut journals: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .ok()?
+            .filter_map(std::result::Result::ok)
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n == HISTORY || n.starts_with("history-w2"))
+            })
+            .collect();
+        if journals.is_empty() {
+            return None;
+        }
+        // The walk is unordered — sort for a deterministic read (the
+        // count itself is order-free).
+        journals.sort_unstable();
         let mut skips = 0usize;
         let mut fires = 0usize;
-        for line in text.lines() {
-            let Ok(doc) = serde_json::from_str::<serde_json::Value>(line) else {
+        for journal in journals {
+            let Ok(text) = std::fs::read_to_string(&journal) else {
                 continue;
             };
-            match doc.get("kind").and_then(serde_json::Value::as_str) {
-                Some("skipped") => skips += 1,
-                Some("fired") => fires += 1,
-                _ => {}
+            for line in text.lines() {
+                let Ok(doc) = serde_json::from_str::<serde_json::Value>(line) else {
+                    continue;
+                };
+                match doc.get("kind").and_then(serde_json::Value::as_str) {
+                    Some("skipped") => skips += 1,
+                    Some("fired") => fires += 1,
+                    _ => {}
+                }
             }
         }
         Some((skips, fires))
@@ -229,57 +353,8 @@ impl ArmState {
     /// # Errors
     /// I/O on the sidecar directory (unwritable project, …).
     pub fn try_lock(&self, label: &str, pid: u32, now: &Zoned) -> io::Result<LockOutcome> {
-        const MAX_PASSES: u32 = 8;
         let dir = self.dir(label)?;
-        let lock = dir.join("lock");
-        let body = format!("{{\"pid\":{pid},\"started_at\":\"{}\"}}\n", now.timestamp());
-        // The remnant WE removed on the way in, if any (Some(None) =
-        // the remnant was unparseable) — it rides the StaleTaken
-        // verdict once the atomic create lands.
-        let mut removed: Option<Option<u32>> = None;
-        let mut passes = 0u32;
-        loop {
-            passes += 1;
-            if passes > MAX_PASSES {
-                return Err(io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "arm lock: contended past the pass bound",
-                ));
-            }
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&lock)
-            {
-                Ok(mut f) => {
-                    use std::io::Write as _;
-                    f.write_all(body.as_bytes())?;
-                    return Ok(match removed {
-                        Some(old_pid) => LockOutcome::StaleTaken { old_pid },
-                        None => LockOutcome::Acquired,
-                    });
-                }
-                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
-                Err(e) => return Err(e),
-            }
-            let old_pid = std::fs::read_to_string(&lock)
-                .ok()
-                .and_then(|text| lock_pid(&text));
-            if let Some(old) = old_pid
-                && owner_alive(old)
-            {
-                return Ok(LockOutcome::HeldAlive { pid: old });
-            }
-            // The holder is dead (or the file unparseable — either way
-            // no LIVE owner is proven): remove the remnant, then the
-            // atomic create decides between us and a racer — a racer's
-            // win shows up as a live pid on the next pass.
-            match std::fs::remove_file(&lock) {
-                Ok(()) => removed = Some(old_pid),
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e),
-            }
-        }
+        try_named_lock(&dir, BEAT_LOCK, pid, now)
     }
 
     /// Release the beat's lock. Idempotent: an absent lock is released.
@@ -287,28 +362,173 @@ impl ArmState {
     /// # Errors
     /// I/O other than `NotFound`.
     pub fn release(&self, label: &str) -> io::Result<()> {
-        match std::fs::remove_file(self.root.join(label).join("lock")) {
+        self.release_named(label, BEAT_LOCK)
+    }
+
+    /// Release one lock file by name. Idempotent.
+    fn release_named(&self, label: &str, name: &str) -> io::Result<()> {
+        match std::fs::remove_file(self.root.join(label).join(name)) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e),
         }
     }
 
-    /// Journal one decision: append the history line, and when the
-    /// decision bears a slot, refresh `last.json` (both writes atomic —
-    /// tmp + rename for the rewrite, `O_APPEND` for the journal).
+    /// Take the inner ledger lock — held ONLY for verify + append +
+    /// fsync + the projections, NEVER across a run (lock order: beat
+    /// lock → ledger lock, never the inverse). A live holder is waited
+    /// out (the critical section is microseconds); past the bound the
+    /// record refuses loudly rather than block forever. A dead holder's
+    /// file is a crash remnant, taken over — the beat lock's mechanics.
+    fn ledger_guard(&self, dir: &Path, label: &str, now: &Zoned) -> io::Result<LedgerGuard<'_>> {
+        let pid = std::process::id();
+        for _ in 0..LEDGER_LOCK_PASSES {
+            match try_named_lock(dir, LEDGER_LOCK, pid, now)? {
+                LockOutcome::Acquired | LockOutcome::StaleTaken { .. } => {
+                    return Ok(LedgerGuard {
+                        state: self,
+                        label: label.to_owned(),
+                    });
+                }
+                LockOutcome::HeldAlive { .. } => std::thread::sleep(LEDGER_LOCK_NAP),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "arm ledger lock: a live holder outlived the wait bound",
+        ))
+    }
+
+    /// Journal one decision on the versioned ledger: take the ledger
+    /// lock, verify the chain (cutting an invalid tail — a valid line
+    /// is NEVER rewritten), append + fsync the line, then the
+    /// projections (`last.json` when the decision bears a slot, then
+    /// the watermark — AFTER the append, each fsync'd: a crash between
+    /// the two loses the watermark, never the decision, and a redo is
+    /// the safe direction).
     ///
     /// # Errors
     /// I/O on the sidecar (the firer fails the decision loudly then —
     /// a fire without its record is a fire that re-fires).
-    pub fn record(&self, label: &str, entry: &HistoryEntry) -> io::Result<()> {
+    pub fn record(&self, label: &str, entry: &HistoryEntry) -> io::Result<RecordOutcome> {
         let dir = self.dir(label)?;
-        let line = history_line(entry);
-        append_line(&dir.join("history.ndjson"), &line)?;
+        let now = entry.decided_at.to_zoned(jiff::tz::TimeZone::UTC);
+        let _ledger = self.ledger_guard(&dir, label, &now)?;
+        let head = chain_head(&dir, &entry.decided_at)?;
+        let seq = head.seq + 1;
+        let (line, _) = ledger_line(
+            seq,
+            entry.decided_at,
+            entry.kind.as_str(),
+            entry.slot_id.as_deref(),
+            &decision_payload(entry),
+            head.prev_hash.as_deref(),
+        );
+        append_line(&dir.join(HISTORY), &line)?;
         if entry.slot.is_some() {
             write_atomic(&dir.join("last.json"), &last_json(entry))?;
         }
-        Ok(())
+        write_atomic(&dir.join("watermark"), &format!("{}\n", entry.decided_at))?;
+        Ok(RecordOutcome {
+            seq,
+            repaired: head.repaired,
+        })
+    }
+
+    /// Append the durable CLAIM (+ fsync) — the run follows, the
+    /// receipt settles. Neither `last.json` nor the watermark moves:
+    /// nothing is DECIDED about the slot until the receipt lands.
+    ///
+    /// # Errors
+    /// As [`record`](Self::record) — a claim that cannot land refuses
+    /// the run loudly (an unclaimed run would be an invisible orphan).
+    pub fn record_claim(&self, label: &str, claim: &Claim) -> io::Result<RecordOutcome> {
+        let dir = self.dir(label)?;
+        let now = claim.decided_at.to_zoned(jiff::tz::TimeZone::UTC);
+        let _ledger = self.ledger_guard(&dir, label, &now)?;
+        let head = chain_head(&dir, &claim.decided_at)?;
+        let seq = head.seq + 1;
+        // The fencing token IS the line's own seq (Kleppmann): the
+        // receipt settles the claim by naming it.
+        let payload = format!(
+            "{{\"attempt\":1,\"deadline\":\"{}\",\"fencing\":{seq}}}",
+            claim.deadline
+        );
+        let (line, _) = ledger_line(
+            seq,
+            claim.decided_at,
+            "claimed",
+            Some(&claim.slot_id),
+            &payload,
+            head.prev_hash.as_deref(),
+        );
+        append_line(&dir.join(HISTORY), &line)?;
+        Ok(RecordOutcome {
+            seq,
+            repaired: head.repaired,
+        })
+    }
+
+    /// The claims no receipt settled — the crash detector (W5-bis
+    /// detects; the sweep is W8's). A claim is settled by a LATER line
+    /// carrying the same `slot_id` and `payload.fencing` == the claim's
+    /// seq. Detection only: read-only and best-effort (a line that does
+    /// not parse simply settles nothing and claims nothing).
+    #[must_use]
+    pub fn unsettled(&self, label: &str) -> Vec<Unsettled> {
+        let Ok(text) = std::fs::read_to_string(self.root.join(label).join(HISTORY)) else {
+            return Vec::new();
+        };
+        let mut claims: Vec<(usize, Unsettled)> = Vec::new();
+        let mut receipts: Vec<(usize, String, u64)> = Vec::new();
+        for (position, line) in text.lines().enumerate() {
+            let Ok(doc) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            if doc.get("kind").and_then(serde_json::Value::as_str) == Some("claimed") {
+                let (Some(seq), Some(identity), Some(deadline), Some(claimed_at)) = (
+                    doc.get("seq").and_then(serde_json::Value::as_u64),
+                    doc.get("slot_id").and_then(serde_json::Value::as_str),
+                    doc.get("payload")
+                        .and_then(|p| p.get("deadline"))
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(|d| d.parse::<Timestamp>().ok()),
+                    doc.get("ts")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(|t| t.parse::<Timestamp>().ok()),
+                ) else {
+                    continue;
+                };
+                claims.push((
+                    position,
+                    Unsettled {
+                        seq,
+                        slot_id: identity.to_owned(),
+                        deadline,
+                        claimed_at,
+                    },
+                ));
+                continue;
+            }
+            let receipt = (
+                doc.get("slot_id").and_then(serde_json::Value::as_str),
+                doc.get("payload")
+                    .and_then(|p| p.get("fencing"))
+                    .and_then(serde_json::Value::as_u64),
+            );
+            if let (Some(identity), Some(fencing)) = receipt {
+                receipts.push((position, identity.to_owned(), fencing));
+            }
+        }
+        claims
+            .into_iter()
+            .filter(|(position, claim)| {
+                !receipts.iter().any(|(later, identity, fencing)| {
+                    later > position && *identity == claim.slot_id && *fencing == claim.seq
+                })
+            })
+            .map(|(_, claim)| claim)
+            .collect()
     }
 
     /// The beat's directory, created on demand.
@@ -334,25 +554,280 @@ fn last_json(entry: &HistoryEntry) -> String {
     )
 }
 
-/// One history line — the same fields, plus the skip's reason and the
-/// catch-up count when they exist.
-fn history_line(entry: &HistoryEntry) -> String {
+/// The five decision kinds' payload — the W2 fields verbatim
+/// (`decided_at` is promoted to the envelope's `ts`), plus `fencing`
+/// when the line is a receipt settling a claim.
+fn decision_payload(entry: &HistoryEntry) -> String {
     let slot = entry.slot.map_or("null".to_owned(), |s| format!("\"{s}\""));
-    let reason = entry
-        .reason
-        .as_deref()
-        .map_or("null".to_owned(), |r| format!("\"{r}\""));
-    let trace = entry
-        .trace
-        .as_deref()
-        .map_or("null".to_owned(), |t| format!("\"{t}\""));
+    let reason = entry.reason.as_deref().map_or("null".to_owned(), json_str);
+    let trace = entry.trace.as_deref().map_or("null".to_owned(), json_str);
     let exit = entry.exit.map_or("null".to_owned(), |e| e.to_string());
     let slots = entry.slots.map_or("null".to_owned(), |s| s.to_string());
+    let fencing = entry.fencing.map_or("null".to_owned(), |f| f.to_string());
     format!(
-        "{{\"slot\":{slot},\"decided_at\":\"{}\",\"kind\":\"{}\",\"reason\":{reason},\"trace\":{trace},\"exit\":{exit},\"slots\":{slots}}}",
-        entry.decided_at,
-        entry.kind.as_str()
+        "{{\"slot\":{slot},\"reason\":{reason},\"trace\":{trace},\"exit\":{exit},\"slots\":{slots},\"fencing\":{fencing}}}"
     )
+}
+
+/// A JSON string literal. The machine tokens never need the escapes,
+/// but a free-text field (a trace path) must never break the line's
+/// parse: the hash covers the bytes, the READER needs them valid.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for ch in raw.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if c.is_control() => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "\\u{:04x}", u32::from(c));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// One ledger line, and its hash. The byte shape is LAW (the hash
+/// covers these exact bytes), so the construction is manual and the
+/// field order fixed: `schema · v · seq · ts · kind · slot_id ·
+/// payload · prev_hash · hash`. The hash is sha256 over the `prev_hash`
+/// rendered as JSON (`null` at the genesis) + `\n` + the line's exact
+/// bytes up to the hash field.
+fn ledger_line(
+    seq: u64,
+    ts: Timestamp,
+    kind: &str,
+    slot_id: Option<&str>,
+    payload: &str,
+    prev_hash: Option<&str>,
+) -> (String, String) {
+    let kind_json = json_str(kind);
+    let slot_json = slot_id.map_or("null".to_owned(), json_str);
+    let prev_json = prev_hash.map_or("null".to_owned(), json_str);
+    let prefix = format!(
+        "{{\"schema\":\"{LEDGER_SCHEMA}\",\"v\":1,\"seq\":{seq},\"ts\":\"{ts}\",\"kind\":{kind_json},\"slot_id\":{slot_json},\"payload\":{payload},\"prev_hash\":{prev_json}"
+    );
+    let hash = sha256_hex(format!("{prev_json}\n{prefix}").as_bytes());
+    (format!("{prefix},\"hash\":\"{hash}\"}}"), hash)
+}
+
+/// The chain's head for the next append.
+struct ChainHead {
+    /// The last valid line's seq (0 = the chain is empty).
+    seq: u64,
+    /// The last valid line's hash (`None` at the genesis).
+    prev_hash: Option<String>,
+    /// How many invalid tail lines the walk cut (0 = a clean chain).
+    repaired: u64,
+}
+
+/// Verify the chain and answer the head: seq continuity from 1,
+/// `prev_hash` linkage, every hash recomputed over the exact bytes. An
+/// invalid TAIL is truncated to the last valid line (the valid
+/// prefix's bytes survive verbatim — `write_atomic`), the count riding
+/// back in `repaired`. A pre-ledger journal (its first line carries no
+/// `schema`) is ROTATED aside first — kept forever (N4) — and the
+/// fresh chain opens with a `rotated` line naming it.
+fn chain_head(dir: &Path, now: &Timestamp) -> io::Result<ChainHead> {
+    let path = dir.join(HISTORY);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e),
+    };
+    let lines: Vec<&str> = text.lines().collect();
+    if let Some(first) = lines.first() {
+        let versioned = serde_json::from_str::<serde_json::Value>(first)
+            .ok()
+            .and_then(|doc| {
+                doc.get("schema")
+                    .and_then(|s| s.as_str())
+                    .map(str::to_owned)
+            })
+            .is_some_and(|s| s == LEDGER_SCHEMA);
+        if !versioned {
+            return rotate_legacy(dir, &path, lines.len(), now);
+        }
+    }
+    let mut seq = 0u64;
+    let mut prev_hash: Option<String> = None;
+    let mut valid = 0usize;
+    for line in &lines {
+        match verify_line(line, seq + 1, prev_hash.as_deref()) {
+            Some(hash) => {
+                seq += 1;
+                prev_hash = Some(hash);
+                valid += 1;
+            }
+            None => break,
+        }
+    }
+    let repaired = u64::try_from(lines.len() - valid).unwrap_or(u64::MAX);
+    if repaired > 0 {
+        let mut prefix = lines[..valid].join("\n");
+        if valid > 0 {
+            prefix.push('\n');
+        }
+        write_atomic(&path, &prefix)?;
+    }
+    Ok(ChainHead {
+        seq,
+        prev_hash,
+        repaired,
+    })
+}
+
+/// The chain check for one line: schema · version · seq continuity ·
+/// prev linkage · the hash recomputed over the exact bytes. Returns
+/// the line's OWN hash when valid (the next line's expected prev).
+fn verify_line(line: &str, expected_seq: u64, expected_prev: Option<&str>) -> Option<String> {
+    let doc: serde_json::Value = serde_json::from_str(line).ok()?;
+    if doc.get("schema")?.as_str()? != LEDGER_SCHEMA {
+        return None;
+    }
+    if doc.get("v")?.as_u64()? != 1 {
+        return None;
+    }
+    if doc.get("seq")?.as_u64()? != expected_seq {
+        return None;
+    }
+    if doc.get("ts")?.as_str()?.parse::<Timestamp>().is_err() {
+        return None;
+    }
+    doc.get("kind")?.as_str()?;
+    doc.get("payload")?.as_object()?;
+    if !matches!(
+        doc.get("slot_id")?,
+        serde_json::Value::Null | serde_json::Value::String(_)
+    ) {
+        return None;
+    }
+    let (prev_json, linked) = match doc.get("prev_hash")? {
+        serde_json::Value::Null => ("null".to_owned(), expected_prev.is_none()),
+        serde_json::Value::String(s) => (json_str(s), expected_prev == Some(s.as_str())),
+        _ => return None,
+    };
+    if !linked {
+        return None;
+    }
+    let hash = doc.get("hash")?.as_str()?;
+    let cut = line.rfind(",\"hash\":\"")?;
+    let prefix = &line[..cut];
+    (sha256_hex(format!("{prev_json}\n{prefix}").as_bytes()) == hash).then(|| hash.to_owned())
+}
+
+/// The pre-ledger journal's rotation (N4 — kept FOREVER): renamed
+/// aside (`history-w2.ndjson`, then `-2`, `-3`… on a collision), the
+/// rename fsync'd, and a fresh chain opened with the `rotated` line
+/// naming the archive and its line count.
+fn rotate_legacy(
+    dir: &Path,
+    path: &Path,
+    legacy_lines: usize,
+    now: &Timestamp,
+) -> io::Result<ChainHead> {
+    let mut name = "history-w2.ndjson".to_owned();
+    let mut n = 2u32;
+    while dir.join(&name).exists() {
+        name = format!("history-w2-{n}.ndjson");
+        n += 1;
+    }
+    std::fs::rename(path, dir.join(&name))?;
+    sync_parent(&dir.join(&name))?;
+    let payload = format!("{{\"from\":{},\"lines\":{legacy_lines}}}", json_str(&name));
+    let (line, hash) = ledger_line(1, *now, "rotated", None, &payload, None);
+    append_line(path, &line)?;
+    Ok(ChainHead {
+        seq: 1,
+        prev_hash: Some(hash),
+        repaired: 0,
+    })
+}
+
+/// sha256 hex over the exact bytes — the chain's and the slot
+/// identity's one primitive (the source-identity convention).
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::Digest as _;
+    let digest = sha2::Sha256::digest(bytes);
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// The ledger lock, RAII: released when the critical section ends,
+/// error paths included.
+struct LedgerGuard<'a> {
+    state: &'a ArmState,
+    label: String,
+}
+
+impl Drop for LedgerGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.state.release_named(&self.label, LEDGER_LOCK);
+    }
+}
+
+/// The lock attempt's core, shared by the beat lock and the inner
+/// ledger lock: the atomic `create_new` decides between racers, a live
+/// holder answers signal 0, a dead one's file is a crash remnant
+/// (taken over).
+fn try_named_lock(dir: &Path, name: &str, pid: u32, now: &Zoned) -> io::Result<LockOutcome> {
+    const MAX_PASSES: u32 = 8;
+    let lock = dir.join(name);
+    let body = format!("{{\"pid\":{pid},\"started_at\":\"{}\"}}\n", now.timestamp());
+    // The remnant WE removed on the way in, if any (Some(None) =
+    // the remnant was unparseable) — it rides the StaleTaken
+    // verdict once the atomic create lands.
+    let mut removed: Option<Option<u32>> = None;
+    let mut passes = 0u32;
+    loop {
+        passes += 1;
+        if passes > MAX_PASSES {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "arm lock: contended past the pass bound",
+            ));
+        }
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock)
+        {
+            Ok(mut f) => {
+                use std::io::Write as _;
+                f.write_all(body.as_bytes())?;
+                return Ok(match removed {
+                    Some(old_pid) => LockOutcome::StaleTaken { old_pid },
+                    None => LockOutcome::Acquired,
+                });
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(e),
+        }
+        let old_pid = std::fs::read_to_string(&lock)
+            .ok()
+            .and_then(|text| lock_pid(&text));
+        if let Some(old) = old_pid
+            && owner_alive(old)
+        {
+            return Ok(LockOutcome::HeldAlive { pid: old });
+        }
+        // The holder is dead (or the file unparseable — either way
+        // no LIVE owner is proven): remove the remnant, then the
+        // atomic create decides between us and a racer — a racer's
+        // win shows up as a live pid on the next pass.
+        match std::fs::remove_file(&lock) {
+            Ok(()) => removed = Some(old_pid),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 /// The pid out of a lock file — `None` when the file does not parse
@@ -382,16 +857,43 @@ fn owner_alive(_pid: u32) -> bool {
     true
 }
 
-/// Rewrite a file atomically: write a sibling tmp, rename it over.
+/// Rewrite a file atomically AND durably: write a sibling tmp, fsync
+/// it, rename it over, then fsync the parent directory — a rename's
+/// durability is the DIRECTORY's, not the file's.
 fn write_atomic(path: &Path, body: &str) -> io::Result<()> {
+    use std::io::Write as _;
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("state");
     let tmp = path.with_file_name(format!("{name}.tmp-{}", std::process::id()));
-    std::fs::write(&tmp, body)?;
-    std::fs::rename(&tmp, path)
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(body.as_bytes())?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    sync_parent(path)
 }
 
-/// One line onto the journal (`O_APPEND` — several firers never tear a
-/// line, each append landing whole).
+/// fsync the directory holding `path` — the rename's durability lives
+/// there.
+#[cfg(unix)]
+fn sync_parent(path: &Path) -> io::Result<()> {
+    match path.parent() {
+        Some(dir) => std::fs::File::open(dir)?.sync_all(),
+        None => Ok(()),
+    }
+}
+
+/// No portable directory-fsync off unix: the rename stays atomic, the
+/// crash-durability degrades to the filesystem's default (the ship
+/// targets are unix — the conservative no-op is SAID, not hidden).
+#[cfg(not(unix))]
+fn sync_parent(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// One line onto the ledger (`O_APPEND` — several firers never tear a
+/// line, each append landing whole), fsync'd BEFORE the caller's next
+/// act: the ledger append precedes the stdout line, durability first.
 fn append_line(path: &Path, line: &str) -> io::Result<()> {
     use std::io::Write as _;
     let mut f = std::fs::OpenOptions::new()
@@ -399,7 +901,8 @@ fn append_line(path: &Path, line: &str) -> io::Result<()> {
         .append(true)
         .open(path)?;
     f.write_all(line.as_bytes())?;
-    f.write_all(b"\n")
+    f.write_all(b"\n")?;
+    f.sync_all()
 }
 
 #[cfg(test)]
@@ -424,14 +927,20 @@ mod tests {
 
     fn entry(kind: FireKind) -> HistoryEntry {
         HistoryEntry {
-            slot: Some("2026-08-19T03:00:00Z".parse::<Timestamp>().expect("ts")),
-            decided_at: "2026-08-19T03:02:00Z".parse::<Timestamp>().expect("ts"),
+            slot: Some(ts("2026-08-19T03:00:00Z")),
+            decided_at: ts("2026-08-19T03:02:00Z"),
             kind,
             reason: None,
             trace: None,
             exit: Some(0),
             slots: None,
+            slot_id: None,
+            fencing: None,
         }
+    }
+
+    fn ts(text: &str) -> Timestamp {
+        text.parse::<Timestamp>().expect("ts")
     }
 
     /// (a) No state reads as never-fired (N2); the recorded slot reads
@@ -551,5 +1060,278 @@ mod tests {
     fn release_without_a_lock_is_ok() {
         let (_dir, state) = state("rel");
         state.release("doctor").expect("idempotent");
+    }
+
+    /// Restore a directory's mode on drop — the tempdir cleanup needs
+    /// the write bit back, panic or not.
+    #[cfg(unix)]
+    struct ModeGuard(PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for ModeGuard {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt as _;
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    /// The watermark IS the decided instant, durable — and a sidecar
+    /// that refuses the write fails the record LOUDLY (a fire without
+    /// its record is a fire that re-fires: the error propagates, the
+    /// firer's line says it, exit ENV).
+    #[cfg(unix)]
+    #[test]
+    fn the_watermark_tracks_the_decision_and_a_readonly_sidecar_fails_loudly() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let (dir, state) = state("watermark");
+        let outcome = state
+            .record("doctor", &entry(FireKind::Fired))
+            .expect("record");
+        assert_eq!(outcome.seq, 1, "the genesis line");
+        assert_eq!(outcome.repaired, 0, "a clean append");
+        let sidecar = dir.path().join(".nika/arm/doctor");
+        let text = std::fs::read_to_string(sidecar.join("watermark")).expect("watermark");
+        assert_eq!(text, "2026-08-19T03:02:00Z\n");
+        assert!(
+            text.trim().parse::<Timestamp>().is_ok(),
+            "the watermark parses as RFC 3339: {text}"
+        );
+        // A read-only sidecar: the record REFUSES — loudly.
+        std::fs::set_permissions(&sidecar, std::fs::Permissions::from_mode(0o555))
+            .expect("chmod 555");
+        let _restore = ModeGuard(sidecar);
+        assert!(
+            state.record("doctor", &entry(FireKind::Fired)).is_err(),
+            "a read-only sidecar refuses the record"
+        );
+    }
+
+    /// R4 · an orphan claim is VISIBLE; the matching receipt (same slot
+    /// identity, fencing = the claim's seq) settles it.
+    #[test]
+    fn an_orphan_claim_is_visible_until_its_receipt_lands() {
+        let (_dir, state) = state("unsettled");
+        let identity = slot_id(
+            "workflows/doctor.nika.yaml",
+            "TZ=UTC 0 3 * * *",
+            &at("2026-08-19T03:00:00Z"),
+        );
+        let claim = Claim {
+            slot_id: identity.clone(),
+            deadline: ts("2026-08-20T03:00:00Z"),
+            decided_at: ts("2026-08-19T03:02:00Z"),
+        };
+        let claimed = state.record_claim("doctor", &claim).expect("claim");
+        assert_eq!(claimed.seq, 1);
+        let orphans = state.unsettled("doctor");
+        assert_eq!(orphans.len(), 1, "the orphan is visible: {orphans:?}");
+        assert_eq!(orphans[0].seq, 1);
+        assert_eq!(orphans[0].slot_id, identity);
+        assert_eq!(orphans[0].deadline, ts("2026-08-20T03:00:00Z"));
+        // The receipt settles it — the same slot identity, fencing the
+        // claim's seq.
+        let mut receipt = entry(FireKind::Fired);
+        receipt.slot_id = Some(identity);
+        receipt.fencing = Some(claimed.seq);
+        state.record("doctor", &receipt).expect("receipt");
+        assert!(
+            state.unsettled("doctor").is_empty(),
+            "settled by the receipt"
+        );
+    }
+
+    /// R5 · the slot identity's known vector: the domain-separated
+    /// canonical string, hashed — derivable before any write, stable
+    /// across restarts, NEVER the positional label. The test hashes the
+    /// bytes ITSELF (never through the implementation's own helper).
+    #[test]
+    fn the_slot_id_is_the_canonical_hash() {
+        use sha2::Digest as _;
+        let expected = format!(
+            "{:x}",
+            sha2::Sha256::digest(
+                b"nika/arm-slot@1\nworkflows/doctor.nika.yaml\nTZ=UTC 0 3 * * *\n2026-08-19T03:00:00Z"
+            )
+        );
+        assert_eq!(
+            slot_id(
+                "workflows/doctor.nika.yaml",
+                "TZ=UTC 0 3 * * *",
+                &at("2026-08-19T03:00:00Z")
+            ),
+            expected
+        );
+        // The INSTANT is the identity — a zoned view of the same
+        // instant hashes identically (UTC on the wire).
+        let paris: Zoned = "2026-08-19T05:00:00+02:00[Europe/Paris]"
+            .parse()
+            .expect("zoned");
+        assert_eq!(
+            slot_id("workflows/doctor.nika.yaml", "TZ=UTC 0 3 * * *", &paris),
+            expected
+        );
+    }
+
+    /// R5 · the versioned envelope: every field present, the fixed byte
+    /// order, `decided_at` promoted to the envelope's `ts`, the genesis
+    /// linkage — and the hash recomputed INDEPENDENTLY over the line's
+    /// own bytes. A second record links to the first's hash and the
+    /// chain verifies clean (no repair reported).
+    #[test]
+    fn the_envelope_is_versioned_and_the_chain_verifies() {
+        use sha2::Digest as _;
+        let (dir, state) = state("envelope");
+        state
+            .record("doctor", &entry(FireKind::Fired))
+            .expect("record");
+        let text = std::fs::read_to_string(dir.path().join(".nika/arm/doctor/history.ndjson"))
+            .expect("ledger");
+        let line = text.lines().next().expect("one line");
+        let doc: serde_json::Value = serde_json::from_str(line).expect("json");
+        for field in [
+            "schema",
+            "v",
+            "seq",
+            "ts",
+            "kind",
+            "slot_id",
+            "payload",
+            "prev_hash",
+            "hash",
+        ] {
+            assert!(doc.get(field).is_some(), "missing {field}: {line}");
+        }
+        assert_eq!(doc["schema"], "nika/arm-event@1");
+        assert_eq!(doc["v"], 1);
+        assert_eq!(doc["seq"], 1);
+        assert_eq!(doc["ts"], "2026-08-19T03:02:00Z");
+        assert_eq!(doc["kind"], "fired");
+        assert!(doc["prev_hash"].is_null(), "the genesis line");
+        // The payload keeps the W2 fields; `decided_at` moved up.
+        assert_eq!(doc["payload"]["slot"], "2026-08-19T03:00:00Z");
+        assert!(doc["payload"].get("decided_at").is_none(), "{line}");
+        // The hash, recomputed by the test itself: prev-as-JSON + \n +
+        // the line's exact bytes up to the hash field.
+        let prefix = &line[..line.rfind(",\"hash\":\"").expect("the hash field")];
+        let expected = format!(
+            "{:x}",
+            sha2::Sha256::digest(format!("null\n{prefix}").as_bytes())
+        );
+        assert_eq!(doc["hash"], expected, "{line}");
+        // A second line links to the first's hash — and its own append
+        // reports a chain that verified clean.
+        let mut second = entry(FireKind::Skipped);
+        second.reason = Some("missed:1".to_owned());
+        let outcome = state.record("doctor", &second).expect("record");
+        assert_eq!(outcome.seq, 2);
+        assert_eq!(outcome.repaired, 0, "the chain verified clean");
+        let text = std::fs::read_to_string(dir.path().join(".nika/arm/doctor/history.ndjson"))
+            .expect("ledger");
+        let follow: serde_json::Value =
+            serde_json::from_str(text.lines().nth(1).expect("line 2")).expect("json");
+        assert_eq!(follow["prev_hash"], doc["hash"], "linked to its parent");
+    }
+
+    /// R5 · one tampered byte inside line 2 of 3: the next append CUTS
+    /// the tail from the first bad line (lines 2 AND 3), lands at seq 2
+    /// linked to line 1's hash, says how much it cut — and the valid
+    /// prefix's bytes survive VERBATIM (never rewritten).
+    #[test]
+    fn a_tampered_line_truncates_the_tail() {
+        let (dir, state) = state("tamper");
+        for kind in [FireKind::Fired, FireKind::Skipped, FireKind::Fired] {
+            state.record("doctor", &entry(kind)).expect("record");
+        }
+        let ledger = dir.path().join(".nika/arm/doctor/history.ndjson");
+        let original = std::fs::read_to_string(&ledger).expect("ledger");
+        let first: serde_json::Value =
+            serde_json::from_str(original.lines().next().expect("line 1")).expect("json");
+        let first_hash = first["hash"].as_str().expect("hash").to_owned();
+        std::fs::write(&ledger, original.replacen("\"seq\":2", "\"seq\":9", 1)).expect("tamper");
+        let outcome = state
+            .record("doctor", &entry(FireKind::Skipped))
+            .expect("record");
+        assert_eq!(outcome.repaired, 2, "the tail from the first bad line");
+        assert_eq!(outcome.seq, 2, "the append continues the valid chain");
+        let healed = std::fs::read_to_string(&ledger).expect("ledger");
+        assert_eq!(healed.lines().count(), 2, "{healed}");
+        assert_eq!(
+            healed.lines().next(),
+            original.lines().next(),
+            "line 1's bytes are verbatim — valid lines are never rewritten"
+        );
+        let second: serde_json::Value =
+            serde_json::from_str(healed.lines().nth(1).expect("line 2")).expect("json");
+        assert_eq!(
+            second["prev_hash"], first_hash,
+            "linked to the last VALID line"
+        );
+        // … and the chain verifies clean from here.
+        let outcome = state
+            .record("doctor", &entry(FireKind::Skipped))
+            .expect("record");
+        assert_eq!(outcome.repaired, 0, "{healed}");
+        assert_eq!(outcome.seq, 3);
+    }
+
+    /// R5 · two swapped lines break the seq continuity — verification
+    /// fails at the first swapped position and the append repairs from
+    /// there.
+    #[test]
+    fn swapped_lines_fail_the_continuity() {
+        let (dir, state) = state("swapped");
+        for _ in 0..3 {
+            state
+                .record("doctor", &entry(FireKind::Skipped))
+                .expect("record");
+        }
+        let ledger = dir.path().join(".nika/arm/doctor/history.ndjson");
+        let original = std::fs::read_to_string(&ledger).expect("ledger");
+        let lines: Vec<&str> = original.lines().collect();
+        assert_eq!(lines.len(), 3);
+        let swapped = format!("{}\n{}\n{}\n", lines[0], lines[2], lines[1]);
+        std::fs::write(&ledger, swapped).expect("swap");
+        let outcome = state
+            .record("doctor", &entry(FireKind::Skipped))
+            .expect("record");
+        assert_eq!(outcome.repaired, 2, "the swap fails at position 2");
+        assert_eq!(outcome.seq, 2);
+        let healed = std::fs::read_to_string(&ledger).expect("ledger");
+        assert_eq!(healed.lines().count(), 2, "{healed}");
+    }
+
+    /// R5 · a W2-era journal (no `schema` on its first line) is kept
+    /// FOREVER under a rotated name (N4); the fresh chain opens with a
+    /// `rotated` line naming it; the tallies read BOTH files.
+    #[test]
+    fn a_legacy_journal_rotates_and_the_tallies_read_both() {
+        let (dir, state) = state("rotate");
+        let sidecar = dir.path().join(".nika/arm/doctor");
+        std::fs::create_dir_all(&sidecar).expect("sidecar");
+        let legacy = concat!(
+            "{\"slot\":\"2026-08-18T03:00:00Z\",\"decided_at\":\"2026-08-18T03:02:00Z\",\"kind\":\"fired\",\"reason\":null,\"trace\":null,\"exit\":0,\"slots\":null}\n",
+            "{\"slot\":\"2026-08-19T03:00:00Z\",\"decided_at\":\"2026-08-19T03:02:00Z\",\"kind\":\"skipped\",\"reason\":\"missed:1\",\"trace\":null,\"exit\":0,\"slots\":null}\n",
+        );
+        std::fs::write(sidecar.join("history.ndjson"), legacy).expect("legacy");
+        let mut skipped = entry(FireKind::Skipped);
+        skipped.reason = Some("overlap".to_owned());
+        let outcome = state.record("doctor", &skipped).expect("record");
+        assert_eq!(outcome.seq, 2, "the rotated line opened the chain at 1");
+        assert_eq!(outcome.repaired, 0);
+        // The legacy bytes moved VERBATIM, kept forever (N4).
+        let rotated = std::fs::read_to_string(sidecar.join("history-w2.ndjson")).expect("rotated");
+        assert_eq!(rotated, legacy, "the legacy journal is kept verbatim");
+        let text = std::fs::read_to_string(sidecar.join("history.ndjson")).expect("ledger");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "{text}");
+        let first: serde_json::Value = serde_json::from_str(lines[0]).expect("json");
+        assert_eq!(first["kind"], "rotated", "{text}");
+        assert_eq!(first["payload"]["from"], "history-w2.ndjson", "{text}");
+        assert_eq!(first["payload"]["lines"], 2, "{text}");
+        assert!(first["prev_hash"].is_null(), "the fresh chain's genesis");
+        let second: serde_json::Value = serde_json::from_str(lines[1]).expect("json");
+        assert_eq!(second["prev_hash"], first["hash"], "linked to the rotation");
+        // The tallies scan BOTH files: legacy fired + skipped, new skipped.
+        assert_eq!(state.tallies("doctor"), Some((2, 1)));
     }
 }

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::disallowed_macros, clippy::print_stdout, clippy::print_stderr)]
 use super::arm::{
     self,
-    fire::{FireCtx, fire_beat, labels},
+    fire::{FireCtx, RunSeam, Wait, WaitSeam, fire_beat, labels},
     state::ArmState,
 };
 use super::{VerbOutput, exit};
@@ -32,12 +32,21 @@ pub struct ServeArgs {
 }
 /// The injected edges — `Zoned::now` + `tokio::time::sleep`, or the
 /// harness's scripted clock whose sleep ADVANCES it (trap ② avoided).
+/// The scripted cell is shared with the overlap-wait seam: a
+/// `chevauchement: file` wait advances the SAME clock, never the wall.
 struct Clock {
     now: Box<dyn Fn() -> Zoned>,
     sleep: SleepFn,
+    scripted: Option<std::rc::Rc<std::cell::RefCell<Zoned>>>,
 }
 /// The sleeper's shape: a span in, a future out (factored for the lint).
 type SleepFn = Box<dyn Fn(SignedDuration) -> std::pin::Pin<Box<dyn Future<Output = ()>>>>;
+/// The shared SIGTERM stream cell (W5-bis) — the overlap wait and the
+/// between-fires race take turns owning the receiver: the stream is
+/// TAKEN out of the cell for the await and put back after, so no
+/// `RefCell` borrow ever lives across an await point.
+#[cfg(unix)]
+type TermCell = std::rc::Rc<std::cell::RefCell<Option<tokio::signal::unix::Signal>>>;
 /// The verb edge: both lanes carry a `VerbOutput` (0 clean · 1 otherwise).
 #[must_use]
 pub fn run(args: &ServeArgs) -> VerbOutput {
@@ -63,7 +72,8 @@ fn go(args: &ServeArgs) -> Result<VerbOutput, VerbOutput> {
     let root = path
         .parent()
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-    serve(&root, registry, args, until.as_ref(), &clock(now)).map_err(fail)?;
+    let run: RunSeam = std::rc::Rc::new(arm::fire::prod_run);
+    serve(&root, registry, args, until.as_ref(), &clock(now), &run).map_err(fail)?;
     Ok(VerbOutput::ok(String::new()))
 }
 /// An RFC 3339 instant — the zoned form keeps its zone, a bare one rides
@@ -90,10 +100,12 @@ fn clock(start: Option<Zoned>) -> Clock {
                     std::time::Duration::try_from(d).unwrap_or_default(),
                 ))
             }),
+            scripted: None,
         },
         Some(t) => {
             let cell = std::rc::Rc::new(std::cell::RefCell::new(t));
             let advance = cell.clone();
+            let shared = cell.clone();
             Clock {
                 now: Box::new(move || cell.borrow().clone()),
                 sleep: Box::new(move |d| {
@@ -101,30 +113,220 @@ fn clock(start: Option<Zoned>) -> Clock {
                     *advance.borrow_mut() = next;
                     Box::pin(async {})
                 }),
+                scripted: Some(shared),
             }
         }
     }
+}
+/// The prod half of the overlap wait: the span races ctrl-c/SIGTERM on
+/// the runtime — a heard signal sets the stop flag the loop checks
+/// after each fire, and the wait answers `Interrupted`. The SIGTERM
+/// receiver is taken out of its cell for the await and put back after
+/// (never a `RefCell` borrow held across an await point).
+#[cfg(unix)]
+fn prod_wait(
+    rt: &std::rc::Rc<tokio::runtime::Runtime>,
+    stop: &std::rc::Rc<std::cell::Cell<bool>>,
+    term: &TermCell,
+) -> WaitSeam {
+    let rt = std::rc::Rc::clone(rt);
+    let stop = std::rc::Rc::clone(stop);
+    let term = std::rc::Rc::clone(term);
+    Box::new(move |span| {
+        let heard = rt.block_on(async {
+            let span = std::time::Duration::try_from(span).unwrap_or_default();
+            let mut stream = term.borrow_mut().take();
+            let sig = async {
+                if let Some(s) = stream.as_mut() {
+                    s.recv().await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            };
+            let heard = tokio::select! {
+                () = tokio::time::sleep(span) => false,
+                _ = tokio::signal::ctrl_c() => true,
+                () = sig => true,
+            };
+            *term.borrow_mut() = stream;
+            heard
+        });
+        if heard {
+            stop.set(true);
+            Wait::Interrupted
+        } else {
+            Wait::Elapsed
+        }
+    })
+}
+/// The non-unix wait: no SIGTERM surface — the span races ctrl-c alone.
+#[cfg(not(unix))]
+fn prod_wait(
+    rt: &std::rc::Rc<tokio::runtime::Runtime>,
+    stop: &std::rc::Rc<std::cell::Cell<bool>>,
+) -> WaitSeam {
+    let rt = std::rc::Rc::clone(rt);
+    let stop = std::rc::Rc::clone(stop);
+    Box::new(move |span| {
+        let heard = rt.block_on(async {
+            let span = std::time::Duration::try_from(span).unwrap_or_default();
+            tokio::select! {
+                () = tokio::time::sleep(span) => false,
+                _ = tokio::signal::ctrl_c() => true,
+            }
+        });
+        if heard {
+            stop.set(true);
+            Wait::Interrupted
+        } else {
+            Wait::Elapsed
+        }
+    })
+}
+/// The reload on change (« le fichier propose »): a fresher file is
+/// re-read — a broken edit is told and the last-good registry keeps
+/// serving (the stale mtime is kept, so the next tick retries).
+fn reload_on_change(
+    root: &Path,
+    path: &Path,
+    reg: ArmRegistry,
+    mtime: Option<std::time::SystemTime>,
+) -> (ArmRegistry, Option<std::time::SystemTime>) {
+    let Ok(fresh) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+        return (reg, mtime);
+    };
+    if Some(fresh) == mtime {
+        return (reg, mtime);
+    }
+    match arm::load(root) {
+        Ok((_, reloaded)) => (reloaded, Some(fresh)),
+        Err(out) => {
+            eprintln!("nika: {}", out.text);
+            (reg, mtime)
+        }
+    }
+}
+/// One due beat through the one firer: the line prints (D8), the
+/// registry comes back (a reload may have swapped it), and `true` says
+/// a signal broke the beat's overlap wait — the caller stops the loop.
+#[allow(clippy::too_many_arguments)] // the fire's full facts
+fn fire_due(
+    root: &Path,
+    reg: ArmRegistry,
+    index: usize,
+    label: String,
+    now: &Zoned,
+    wait: WaitSeam,
+    run: &RunSeam,
+    stop: &std::rc::Rc<std::cell::Cell<bool>>,
+) -> (ArmRegistry, bool) {
+    let ctx = FireCtx {
+        project_root: root.to_path_buf(),
+        registry: reg,
+        index,
+        label,
+        now: now.clone(),
+        state: ArmState::at_project(root),
+        pid: std::process::id(),
+        wait,
+        run: std::rc::Rc::clone(run),
+    };
+    println!("{}", fire_beat(&ctx).line);
+    (ctx.registry, stop.get())
+}
+/// The between-fires wait: the span to the next slot races ctrl-c/
+/// SIGTERM on the runtime — `true` says a signal was heard and the
+/// loop stops clean. The SIGTERM receiver is taken out of its cell for
+/// the await and put back after (never a `RefCell` borrow across it).
+#[cfg(unix)]
+fn race_sleep_or_signal(
+    rt: &std::rc::Rc<tokio::runtime::Runtime>,
+    clock: &Clock,
+    term: &TermCell,
+    secs: i64,
+) -> bool {
+    rt.block_on(async {
+        let mut stream = term.borrow_mut().take();
+        let sig = async {
+            if let Some(s) = stream.as_mut() {
+                s.recv().await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
+        let heard = tokio::select! {
+            () = (clock.sleep)(SignedDuration::from_secs(secs)) => false,
+            _ = tokio::signal::ctrl_c() => true,
+            () = sig => true,
+        };
+        *term.borrow_mut() = stream;
+        heard
+    })
+}
+/// The non-unix between-fires wait: no SIGTERM surface — ctrl-c alone.
+#[cfg(not(unix))]
+fn race_sleep_or_signal(
+    rt: &std::rc::Rc<tokio::runtime::Runtime>,
+    clock: &Clock,
+    secs: i64,
+) -> bool {
+    rt.block_on(async {
+        tokio::select! {
+            () = (clock.sleep)(SignedDuration::from_secs(secs)) => false,
+            _ = tokio::signal::ctrl_c() => true,
+        }
+    })
 }
 /// The loop: the clock, the reload on change (« le fichier propose » —
 /// re-read, never cache; a broken edit is told and the last-good registry
 /// keeps serving), the SAME firer for what is due, then the sleep to the
 /// next slot (≤ 60 s) racing the signals — a signal breaks clean (the
-/// current fire, synchronous, finishes first).
+/// current fire, synchronous, finishes first). A `chevauchement: file`
+/// wait rides the wait seam (W5-bis): the scripted clock advances, or
+/// the span races ctrl-c/SIGTERM on the runtime — the loop's thread
+/// never blocks, and a broken wait sets the stop flag the loop checks
+/// after each fire.
 fn serve(
     root: &Path,
     mut reg: ArmRegistry,
     args: &ServeArgs,
     until: Option<&Zoned>,
     clock: &Clock,
+    run: &RunSeam,
 ) -> Result<(), String> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| format!("serve · the signal runtime refused: {e}"))?;
+    let rt = std::rc::Rc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("serve · the signal runtime refused: {e}"))?,
+    );
     #[cfg(unix)]
-    let mut term = rt.block_on(async {
+    let term: TermCell = std::rc::Rc::new(std::cell::RefCell::new(rt.block_on(async {
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok()
-    });
+    })));
+    // Set when a signal broke an overlap wait — the loop stops after
+    // the current beat's line (a beat mid-run still finishes first).
+    let stop = std::rc::Rc::new(std::cell::Cell::new(false));
+    // The overlap-wait seam, per lane: the harness advances the scripted
+    // clock (the wait is instant, the loop never blocks); prod races the
+    // span against the signals on the runtime.
+    let make_wait = || -> WaitSeam {
+        if let Some(cell) = clock.scripted.clone() {
+            return Box::new(move |span| {
+                let next = cell.borrow().clone() + span;
+                *cell.borrow_mut() = next;
+                Wait::Elapsed
+            });
+        }
+        #[cfg(unix)]
+        {
+            prod_wait(&rt, &stop, &term)
+        }
+        #[cfg(not(unix))]
+        {
+            prod_wait(&rt, &stop)
+        }
+    };
     let path = root.join(nika_vocab::project::FILE_NAME);
     let mut mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
     loop {
@@ -132,17 +334,9 @@ fn serve(
         if until.is_some_and(|u| now >= *u) {
             return Ok(());
         }
-        if let Ok(fresh) = std::fs::metadata(&path).and_then(|m| m.modified())
-            && Some(fresh) != mtime
-        {
-            match arm::load(root) {
-                Ok((_, reloaded)) => {
-                    reg = reloaded;
-                    mtime = Some(fresh);
-                }
-                Err(out) => eprintln!("nika: {}", out.text),
-            }
-        }
+        let (reloaded, fresh_mtime) = reload_on_change(root, &path, reg, mtime);
+        reg = reloaded;
+        mtime = fresh_mtime;
         let state = ArmState::at_project(root);
         let names = labels(&reg);
         let dues: Vec<(usize, nika_cadence::Slot)> = nika_cadence::due(&reg, &now, &|i| {
@@ -157,16 +351,12 @@ fn serve(
                 println!("would fire {label} · slot {}", slot.at.timestamp());
                 continue;
             }
-            let ctx = FireCtx {
-                project_root: root.to_path_buf(),
-                registry: reg,
-                index,
-                label,
-                now: now.clone(),
-                state: ArmState::at_project(root),
-            };
-            println!("{}", fire_beat(&ctx).line);
-            reg = ctx.registry;
+            let (returned, broken) =
+                fire_due(root, reg, index, label, &now, make_wait(), run, &stop);
+            reg = returned;
+            if broken {
+                return Ok(());
+            }
         }
         if args.once {
             return Ok(());
@@ -176,24 +366,11 @@ fn serve(
         let secs = next.map_or(60, |(_, s)| {
             (s.at.timestamp().as_second() - now.timestamp().as_second()).clamp(1, 60)
         });
-        let stop = rt.block_on(async {
-            #[cfg(unix)]
-            let sig = async {
-                if let Some(s) = &mut term {
-                    s.recv().await;
-                } else {
-                    std::future::pending::<()>().await;
-                }
-            };
-            #[cfg(not(unix))]
-            let sig = std::future::pending::<()>();
-            tokio::select! {
-                () = (clock.sleep)(SignedDuration::from_secs(secs)) => false,
-                _ = tokio::signal::ctrl_c() => true,
-                () = sig => true,
-            }
-        });
-        if stop {
+        #[cfg(unix)]
+        let heard = race_sleep_or_signal(&rt, clock, &term, secs);
+        #[cfg(not(unix))]
+        let heard = race_sleep_or_signal(&rt, clock, secs);
+        if heard {
             return Ok(());
         }
     }
@@ -203,6 +380,7 @@ fn serve(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use crate::verbs::arm::fire::{RunShot, RunUpshot};
 
     fn at(text: &str) -> Zoned {
         text.parse::<jiff::Timestamp>()
@@ -278,6 +456,7 @@ mod tests {
     fn scripted(start: &str, on_first_sleep: impl FnMut() + 'static) -> Clock {
         let cell = std::rc::Rc::new(std::cell::RefCell::new(at(start)));
         let advance = cell.clone();
+        let shared = cell.clone();
         let actor = std::cell::RefCell::new(Some(on_first_sleep));
         Clock {
             now: Box::new(move || cell.borrow().clone()),
@@ -289,6 +468,7 @@ mod tests {
                 }
                 Box::pin(async {})
             }),
+            scripted: Some(shared),
         }
     }
 
@@ -299,6 +479,130 @@ mod tests {
             now: None,
             until: None,
         }
+    }
+
+    /// The run seam that must NEVER fire — the skip-only ticks (the
+    /// reload + refusal tests) prove their point by never calling it.
+    fn never_run() -> RunSeam {
+        std::rc::Rc::new(|_| panic!("this tick runs nothing"))
+    }
+
+    /// A run stub that counts its shots (the real in-process run
+    /// chdirs — parallel tests race on the process CWD, so the seam is
+    /// stubbed; the binary tests own the real ground).
+    fn stub_run() -> (std::rc::Rc<std::cell::Cell<u32>>, RunSeam) {
+        let count = std::rc::Rc::new(std::cell::Cell::new(0u32));
+        let seen = std::rc::Rc::clone(&count);
+        let seam: RunSeam = std::rc::Rc::new(move |_: &RunShot| {
+            seen.set(seen.get() + 1);
+            RunUpshot {
+                code: exit::OK,
+                trace: None,
+            }
+        });
+        (count, seam)
+    }
+
+    // The workspace bans std::process::Command (production spawns ride
+    // the kernel ShellExecutor seam). This test's OTHER FIRER is a real
+    // live `sleep` child — the lock-liveness law needs a pid that
+    // answers signal 0, and no kernel seam lends « a borrowed live pid ».
+    /// A live `sleep` child — the other firer holding a beat's lock.
+    /// Killed + reaped on drop.
+    struct LiveChild(std::process::Child);
+
+    impl LiveChild {
+        fn spawn() -> Self {
+            #[allow(clippy::disallowed_types)]
+            let child = std::process::Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("a sleep child");
+            Self(child)
+        }
+
+        fn pid(&self) -> u32 {
+            self.0.id()
+        }
+    }
+
+    impl Drop for LiveChild {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    /// R7 · `chevauchement: file` under serve: the bounded wait rides
+    /// the wait seam (the scripted clock advances — the loop's thread
+    /// never blocks), the held beat ends `overlap-timeout`, and the
+    /// OTHER beat's due slot still fires on the same tick.
+    #[test]
+    fn a_queued_beat_waits_without_blocking_the_other_beats() {
+        let registry_text = concat!(
+            "nika: v1\n",
+            "arm:\n",
+            "  - workflow: workflows/doctor.nika.yaml\n",
+            "    cadence: \"TZ=UTC 0 * * * *\"\n",
+            "    plafond: 0.05\n",
+            "    manqué: sauter\n",
+            "    chevauchement: file\n",
+            "  - workflow: workflows/nightly.nika.yaml\n",
+            "    cadence: \"TZ=UTC 0 * * * *\"\n",
+            "    plafond: 0.05\n",
+            "    manqué: sauter\n",
+        );
+        let dir = project("queue", registry_text);
+        write_workflow(dir.path(), "doctor.nika.yaml");
+        write_workflow(dir.path(), "nightly.nika.yaml");
+        // Both beats' last DECIDED slot is 03:00 — at 04:02 both are ON
+        // TIME for the 04:00 slot.
+        seed_last(dir.path(), "doctor", "2026-08-19T03:00:00Z");
+        seed_last(dir.path(), "nightly", "2026-08-19T03:00:00Z");
+        // doctor's lock: a LIVE other firer, held for the whole test.
+        let holder = LiveChild::spawn();
+        let sidecar = dir.path().join(".nika/arm/doctor");
+        std::fs::create_dir_all(&sidecar).expect("sidecar");
+        std::fs::write(
+            sidecar.join("lock"),
+            format!(
+                "{{\"pid\":{},\"started_at\":\"2026-08-19T04:00:00Z\"}}\n",
+                holder.pid()
+            ),
+        )
+        .expect("the holder's lock");
+        let registry = match arm::load(dir.path()) {
+            Ok((_, registry)) => registry,
+            Err(out) => panic!("load: {}", out.text),
+        };
+        let (runs, seam) = stub_run();
+        let clock = scripted("2026-08-19T04:02:00Z", || {});
+        let until = at("2026-08-19T04:10:00Z");
+        let rc = serve(
+            dir.path(),
+            registry,
+            &serve_args(),
+            Some(&until),
+            &clock,
+            &seam,
+        );
+        assert!(rc.is_ok(), "{rc:?}");
+        // doctor: the wait burned the SCRIPTED clock, bounded by the
+        // next slot — ONE chained line, overlap-timeout.
+        let doctor = history(dir.path(), "doctor");
+        assert_eq!(doctor.lines().count(), 1, "{doctor}");
+        assert!(
+            doctor.contains("\"reason\":\"overlap-timeout\""),
+            "{doctor}"
+        );
+        // nightly: its due slot STILL fired on the same tick — the loop
+        // never blocked on doctor's wait (claim + receipt, the stub went
+        // exactly once).
+        let nightly = history(dir.path(), "nightly");
+        assert_eq!(nightly.lines().count(), 2, "claim + receipt: {nightly}");
+        assert!(nightly.contains("\"kind\":\"claimed\""), "{nightly}");
+        assert!(nightly.contains("\"kind\":\"fired\""), "{nightly}");
+        assert_eq!(runs.get(), 1, "exactly one run went");
     }
 
     #[test]
@@ -323,7 +627,14 @@ mod tests {
             flag.set(true);
         });
         let until = at("2026-08-19T03:35:00Z");
-        let rc = serve(dir.path(), registry, &serve_args(), Some(&until), &clock);
+        let rc = serve(
+            dir.path(),
+            registry,
+            &serve_args(),
+            Some(&until),
+            &clock,
+            &never_run(),
+        );
         assert!(rc.is_ok(), "{rc:?}");
         assert!(rewritten.get(), "the actor ran");
         // Tick 1 (registry v1): doctor's silence is 3 slots — skipped.

--- a/crates/nika-cli/tests/arm_fire.rs
+++ b/crates/nika-cli/tests/arm_fire.rs
@@ -158,7 +158,21 @@ fn fire_runs_a_due_beat_and_records_it() {
     assert_eq!(last["slot"], "2026-08-19T03:00:00Z");
     let trace = last["trace"].as_str().expect("a trace path");
     assert!(dir.join(trace).exists(), "{trace}");
-    assert_eq!(history(&dir, "doctor").lines().count(), 1);
+    // The ledger (W5-bis): the claim precedes the run, the receipt
+    // settles it by fencing.
+    let hist = history(&dir, "doctor");
+    let lines: Vec<&str> = hist.lines().collect();
+    assert_eq!(lines.len(), 2, "the claim, then the receipt: {hist}");
+    let claim: serde_json::Value = serde_json::from_str(lines[0]).expect("claim json");
+    let receipt: serde_json::Value = serde_json::from_str(lines[1]).expect("receipt json");
+    assert_eq!(claim["kind"], "claimed", "{hist}");
+    assert_eq!(claim["payload"]["fencing"], claim["seq"], "{hist}");
+    assert_eq!(receipt["kind"], "fired", "{hist}");
+    assert_eq!(
+        receipt["payload"]["fencing"], claim["seq"],
+        "the receipt fences the claim's seq: {hist}"
+    );
+    assert_eq!(receipt["slot_id"], claim["slot_id"], "{hist}");
     assert_eq!(traces(&dir).len(), 1, "one fresh run = one trace (N2)");
 }
 
@@ -232,6 +246,10 @@ fn fire_skips_when_the_lock_is_held_by_a_living_owner() {
         line.starts_with("skipped doctor · overlap · pid "),
         "{line}"
     );
+    assert!(
+        line.ends_with("· slot 2026-08-19T03:00:00Z"),
+        "the slot rides the line (D8's consistency): {line}"
+    );
     let last = last_json(&dir, "doctor").expect("last.json");
     assert_eq!(last["kind"], "skipped");
     // Law ⑥ sauter: the running tick keeps its lock, nothing ran.
@@ -264,6 +282,10 @@ fn fire_with_file_policy_times_out_at_the_next_slot() {
     assert!(
         line.starts_with("skipped doctor · overlap-timeout"),
         "{line}"
+    );
+    assert!(
+        line.ends_with("· slot 2026-08-19T03:02:00Z"),
+        "the slot rides the line (D8's consistency): {line}"
     );
     assert!(traces(&dir).is_empty(), "the queue never ran");
 }

--- a/crates/nika-cli/tests/serve.rs
+++ b/crates/nika-cli/tests/serve.rs
@@ -126,7 +126,8 @@ fn serve_loop_fires_two_beats_in_slot_order() {
         lines[1].contains("fired doctor · slot 2026-08-19T03:03:00Z"),
         "the second slot second: {stdout}"
     );
-    assert_eq!(history(&dir, "doctor").lines().count(), 2);
+    // Two fires, two lines each (W5-bis): the claim, then the receipt.
+    assert_eq!(history(&dir, "doctor").lines().count(), 4);
 }
 
 #[test]

--- a/docs/crate-specs/nika-cadence.md
+++ b/docs/crate-specs/nika-cadence.md
@@ -184,12 +184,17 @@ pas dans le code :
   s'accrocherait — le retry vit DANS le workflow (`retry:` sur la tâche,
   plein-jitter et tout), jamais dans le beat.
 - **l'enum d'état de job → c'est `history.ndjson`.** L'état n'est pas un
-  type à inventer : c'est le journal append-only du sidecar
-  (`.nika/arm/<label>/`), dont le vocabulaire `kind` est déjà fermé —
-  `fired` · `skipped` · `paused` · `failed` · `disarmed` (le dernier est
-  history-only : il ne porte pas de slot, donc `record` ne l'écrit jamais
-  dans `last.json`, et `last` le relit comme illisible — la direction
-  sûre).
+  type à inventer : c'est le journal du sidecar (`.nika/arm/<label>/`) —
+  devenu le ledger versionné `nika/arm-event@1` (W5-bis · chaîne sha256
+  vérifiée à chaque append, queue invalide coupée, journal W2 roté sans
+  effacement, chaque append fsync'd). Le vocabulaire `kind` des DÉCISIONS
+  est fermé — `fired` · `skipped` · `paused` · `failed` · `disarmed` (le
+  dernier est history-only : il ne porte pas de slot, donc `record` ne
+  l'écrit jamais dans `last.json`, et `last` le relit comme illisible —
+  la direction sûre) — et deux lignes STRUCTURELLES le complètent :
+  `claimed` (le claim durable, fsync'd AVANT le run · son receipt le
+  settle par fencing) et `rotated` (la preuve d'archive d'un journal
+  d'avant le ledger).
 - **`serve_tokens` (qui déclenche à distance) → hors v0.** Aucun port,
   aucune entrée : Gate 1 (diamond-discipline §5, résolu 2026-08-19) —
   `serve` ne lit QUE `nika.yaml` et son sidecar, jamais le réseau, et le

--- a/estate.yaml
+++ b/estate.yaml
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 109
-  aggregate_sha256: 95fa27fe7dd8e5de2ac4e9cae3c8d4ec0aee378ccbdfb8630f6d52b9035f538e
+  aggregate_sha256: 1fe039641bda5057cd75b10188797e448d49b5900ecbc0d97c11aa37553d67ff
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4500
+  classified_files: 4501
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1560
+    authored: 1561
     authored-pin: 2
     generated: 122
     pinned-copy: 120
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: 169d8f11511b35c759894dd8fdaff3dc2ad900da3f8662fb753143583c43a930
+  aggregate_sha256: ac25fa5bfd8056de9b9cc9089d53e2e72aca03507be96e9d0b11b87dd21268f1
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"
@@ -151,18 +151,18 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 790
-  aggregate_sha256: 1e0f631b6691d4e1ac31d3b54c954eec071060916ea51830ac84b800312a3436
+  match_count: 791
+  aggregate_sha256: 5ef765b6a5d2187bd04fa8f487e156c42d3b1b9323af36a34663970e9ca9740c
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 157
-  aggregate_sha256: f5de893a8310cec61852b220d6666282418d398cded8a1050d3518f163ba8550
+  aggregate_sha256: f7e4d48fbf01c832d4192d26dd0aa6d3ebcbf53f5739eb513bd023f6ee945471
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored
   match_count: 139
-  aggregate_sha256: 0b96cf8acb1e288a09724de63783a7c870cb8e330749c1933201cafa6b48fb1d
+  aggregate_sha256: e82818c7ed5025452a6cb86eebf9fdd1ac2c6b51c636f2eee7c64e661a52d151
   evidence: "the remaining crate surface — Cargo.toml manifests · build.rs · benches · READMEs · hand-curated data catalogs (llm-providers · mcp-servers · embeddings · model-capabilities, probed daily by catalog-verify.yml); the pricing snapshot is excepted in files:"
   note: "crates/nika-pack/scripts/sync-pack.sh is a DIVERGENT older duplicate of scripts/sync-pack.sh — the pack-resync.yml lane runs the root one"
 - glob: "fuzz/**"


### PR DESCRIPTION
## W5-bis · the lock outlives the shot

The follow-up the W5 review promised: close the double-fire window proven in W2's firer, and lay the durable-ledger foundations the next waves (W7 ledger · W8 bounded attempts) build on.

### The bugs (proven on main, now pinned by failing-first tests)

1. **The decision read `last_fired` BEFORE the lock** — two firers could both decide Fire on the same slot.
2. **The lock was released BEFORE the record** — a second firer acquiring in the gap read stale state and double-fired. (`run_and_record`'s docstring said "record, release" and did the opposite.)
3. **`chevauchement: file` fired the pre-wait slot without re-deciding** after the wait.
4. **The queue's `std::thread::sleep` blocked `serve`'s current-thread runtime** — ctrl-c/SIGTERM unscrutinized for the whole wait (up to the next slot: 24h on a daily beat).

### The order law (now the module doc's first paragraph)

The per-beat lock is taken **before** the decision and held until **after** the receipt append: `lock → decide → claimed (+fsync) → run → receipt (+fsync · last.json · watermark) → release → the ONE line`. After ANY wait, the state is re-read and re-decided. The release rides a RAII guard on every path, record-refusals included.

### The versioned ledger · `nika/arm-event@1`

- Every line: `{schema, v, seq, ts, kind, slot_id, payload, prev_hash, hash}` — sha256 over the exact bytes, verified on every append. An invalid tail is **cut** (never rewritten); the repair count rides the decision line (`· ledger réparé (-n)`).
- W2-era journals are **rotated aside** (`history-w2.ndjson`, kept forever, N4) and the fresh chain opens with a `rotated` line. `tallies()` reads both.
- Durability: `O_APPEND` + fsync for the ledger; tmp + fsync + rename + **parent-dir fsync** for `last.json` and the new per-beat `watermark` (written after the append — a crash between the two is a redo, the safe direction).
- `slot_id = sha256("nika/arm-slot@1" · workflow path verbatim · cadence verbatim · slot instant UTC)` — never the positional label.
- **The claim**: `claimed{attempt, deadline, fencing}` is appended + fsync'd **before** the run; the receipt settles it by naming the claim's seq. A crash between the two leaves a **visible orphan** (`ArmState::unsettled()`) — detection here, the re-arming sweep is W8's.
- The inner **ledger lock** serializes appends made without the beat lock (the overlap-skip path) — lock order pinned: beat → ledger, never the inverse.
- The overlap wait is a **seam**: the OS firer sleeps; `serve` races the span against ctrl-c/SIGTERM (a broken wait skips `serve-stop` and the loop stops clean); the harness advances its scripted clock. The run is a seam too (W10's sim will mock it here).

### Honest guarantees

At-least-once delivery · effectively-once when the workflow's effects are idempotent · **exactly-once is never claimed**. `Ambiguous`-class crashes are visible orphans, not silent gaps.

### Tests (RED first, then green)

- `two_firers_one_run` — a real live `sleep` child holds the lock: the due tick skips, the run seam is never called, one chained line.
- `the_claim_precedes_the_run_and_the_receipt_settles_it` — asserted **during** the run (the claim is the chain's last line, the lock is ours) and after (receipt seq+1, fences the claim, locks released, watermark landed).
- `a_refused_record_fails_loudly_and_still_releases` — read-only ledger: the failure line replaces the decision's, nothing runs, the lock still releases.
- `the_queue_redecides_after_the_wait` — the holder completes mid-wait; the waiter re-decides `already` and never runs.
- `an_interrupted_wait_skips_serve_stop` — a broken wait skips, journaled with its slot.
- Chain: tamper → tail cut · swap → continuity fails · legacy → rotated, tallies read both · `slot_id` known-vector.
- `serve`: a queued beat waits without blocking the other beats (scripted clock).
- The `tests/` integration suites are **strengthened**, not widened-past: a fire is now 2 lines (claim + receipt fencing it) · overlap lines carry the slot.

### Gates

`cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test --workspace --lib` (all green) · `scripts/hygiene/check-all.sh` (38 green · 8 yellow · 0 red) · `public-api.txt` resynced (the zvariant baseline lines preserved as CI renders them).
