### PR TITLE
feat(pack): compose self-check lesson and leftover dialect

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -601,8 +601,8 @@ Per D-2026-05-22-N18.)
 **Event subsystem, artifact modes, output modes, templatable fields**:
 - Artifact modes: `overwrite | append | unique | fail`, with optional `manifest: true` → `artifacts.json` index
 - Output modes: `text | json | yaml | markdown | binary`
-- 65 typed fields accept `{{...}}` templates (type-coerced after resolution, NIKA-041 on error)
-- Endpoints config in `nika.toml` `[endpoints.<name>]` for self-hosted LLMs + `model: <endpoint>/<name>` slash syntax
+- 65 typed fields accept `${{ }}` CEL (type-coerced after resolution, NIKA-041 on error)
+- Self-hosted LLMs use `model: <provider>/<name>` slash syntax · the provider base URL is operator/engine config, not the project file (`nika.yaml` carries `ceiling` · `arm` · `traces` · `registry`)
 - `nika:decode` builtin: base64 → CAS blob (for APIs returning inline images)
 - `nika:import` builtin: file → CAS blob
 

--- a/crates/nika-cli/src/verbs/examples.rs
+++ b/crates/nika-cli/src/verbs/examples.rs
@@ -533,18 +533,13 @@ mod tests {
 
     /// The coverage ratchet, builtins leg — the same gate the kit has
     /// (`the_kit_never_teaches_a_form_the_engine_refuses`), pointed the
-    /// other way: the corpus must SHOW what the engine ships. Four ride a
+    /// other way: the corpus must SHOW what the engine ships. Two ride a
     /// named debt; a new builtin cannot join silently, and a debt paid
     /// by a new lesson must be struck from the list in the same arc.
     #[test]
     fn every_builtin_is_shown_or_carries_a_named_debt() {
         // Each entry: why the gap is tolerated TODAY + the showcase owed.
         const OWED: &[(&str, &str)] = &[
-            (
-                "compose",
-                "the agent loop's self-verification intrinsic (ADR-096) — owes \
-                 the lesson where a loop checks the workflow it just wrote",
-            ),
             (
                 "inspect",
                 "cost · records · dag_info · threads behind one door (ADR-088) \

--- a/crates/nika-pack/pack/QUICKSTART.md
+++ b/crates/nika-pack/pack/QUICKSTART.md
@@ -202,7 +202,12 @@ The cheapest authoring order, measured on a 40+ task paid extract run:
    [`13-extract-then-law`](./examples/13-extract-then-law.nika.yaml).
    Prove the law on const fixtures (`unproven-law`). The named bundle
    is [`14-decide-publish`](./examples/14-decide-publish.nika.yaml).
-5. **Pin the glob** (`exclude: "**/README.md"`) before a fan-out infer
+5. **An agent that drafts a workflow checks it in the loop.** Grant
+   `nika:compose` on `agent.tools` after `nika:done`. Iterate on the
+   check JSON until `valid`. Never a standalone `invoke:`
+   (`NIKA-BUILTIN-COMPOSE-001`). Checking never executes. Shape:
+   [`15-compose-self-check`](./examples/15-compose-self-check.nika.yaml).
+6. **Pin the glob** (`exclude: "**/README.md"`) before a fan-out infer
    classifies the table of contents.
 
 Then, and only then, swap `model:` to a paid seat.

--- a/crates/nika-pack/pack/canon.yaml
+++ b/crates/nika-pack/pack/canon.yaml
@@ -7,7 +7,7 @@
 #   sealed outcome_class enum) · the 15 ledger sections (canon/EXCEPTIONS.md ·
 #   SSOT-1 §18) stay AUTHORED and are carried verbatim — editing those is legal.
 # regenerate: python3 scripts/ssot-compiler.py --emit-canon
-# body-sha256: e37589b28d142270ec5f0f374148d546dfa804444af0e4068c6b14f27694af21
+# body-sha256: 655188ecf8f7b0436c681a10e056af6b709f46fa37c93c4b92daeadc5145d98c
 #   (digest of every byte below the end-of-header line · detached self-hash per PAA-006)
 # ---- end generated header (SSOT-1 §21-23 · the canon flip · C0)
 # nika canonical registry · the single source of truth for Nika canonical facts
@@ -302,7 +302,7 @@ error_codes:
     - { code: NIKA-PARSE-001, category: parse_error, transient: "false", failure: "the YAML itself does not parse (syntax error)" }
     - { code: NIKA-PARSE-002, category: validation_error, transient: "false", failure: "missing envelope field (nika: / non-empty tasks:)" }
     - { code: NIKA-PARSE-003, category: parse_error, transient: "false", failure: "nika: is not a kebab-case id (^[a-z][a-z0-9-]*$)" }
-    - { code: NIKA-PARSE-004, category: validation_error, transient: "false", failure: "workflow: id violates ^[a-z][a-z0-9-]*$" }
+    - { code: NIKA-PARSE-004, category: validation_error, transient: "false", failure: "RESERVED · retired with the nine-key envelope · the id moved onto nika: (NIKA-PARSE-003 judges it)" }
     - { code: NIKA-PARSE-005, category: validation_error, transient: "false", failure: "unknown field — strict mode rejects anything outside the closed v1 set" }
     - { code: NIKA-PARSE-006, category: validation_error, transient: "false", failure: "task id violates ^[a-z][a-z0-9_]*$ (snake_case · CEL-safe · no hyphens)" }
     - { code: NIKA-PARSE-007, category: validation_error, transient: "false", failure: "duplicate task id within the workflow" }

--- a/crates/nika-pack/pack/examples/01-hello.nika.yaml
+++ b/crates/nika-pack/pack/examples/01-hello.nika.yaml
@@ -8,7 +8,7 @@
 # one of the four still executes — it just stops being a contract.
 #
 # Demonstrates ·
-#   - the envelope · `nika: hello` (the mark AND the name · nine keys)
+#   - the envelope · `nika: <id>` · the mark AND the file's name (no version typed)
 #   - `model:` · one local model · no API key, nothing leaves the machine
 #   - `permits: {}` · the DECLARED zero · this workflow may touch nothing
 #   - one task · the `infer:` verb, bounded by `max_tokens:`

--- a/crates/nika-pack/pack/examples/15-compose-self-check.nika.yaml
+++ b/crates/nika-pack/pack/examples/15-compose-self-check.nika.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
+#
+# 15 · Compose self-check — the loop checks the draft, never runs it.
+#
+# 10 taught parent→child composition (`invoke: { workflow: }`). This
+# file is the other compose: `nika:compose` inside an `agent:` whitelist
+# (ADR-096). The model drafts a nine-key workflow as YAML, gets the
+# full `nika check` verdict back as JSON, repairs until `valid`, then
+# calls `nika:done`. Checking never executes the draft (« generation
+# is not permission »).
+#
+# Demonstrates ·
+#   - `nika:compose` is loop-only · a standalone `invoke:` is
+#     `NIKA-BUILTIN-COMPOSE-001`
+#   - `tools: [nika:done, nika:compose]` · `nika:done` FIRST so
+#     `--model mock/echo` closes at turn one (same law as 06)
+#   - PURE permits · those two tools · no fs / net / exec
+#   - the draft is an artifact + its certificate, not a child run
+#
+# Do not confuse with [`10-compose-pipeline`](10-compose-pipeline.nika.yaml).
+# Do not write a follow-up that *calls* the unwired introspection
+# builtin (`inspect-unwired` · `paid_ready: false`).
+#
+# Run · nika try 15-compose-self-check
+#   (offline · mock/echo · zero keys)
+
+nika: compose-self-check
+
+model: mock/echo
+
+permits:
+  tools: ["nika:done", "nika:compose"]
+
+tasks:
+  draft:
+    agent:
+      tools:
+        # `nika:done` first is deliberate: a real model ignores order,
+        # but the offline rehearsal (`--model mock/echo`) invokes the
+        # first granted tool. Done-first closes the loop at turn one.
+        # A synthesized `nika:compose` with an empty `workflow_yaml`
+        # would still return a check JSON, but the mock has nothing to
+        # draft — finish, do not pretend.
+        - "nika:done"
+        - "nika:compose"
+      max_turns: 8
+      max_tokens_total: 8000
+      system: |
+        You draft Nika workflows. The language is the nine-key envelope
+        (`nika: <kebab-id>` plus model, inputs, const, secrets, permits,
+        run, tasks, outputs). Four verbs: infer, exec, invoke, agent.
+        Interpolation is CEL in the dollar-double-brace form (lesson 01).
+        Fetch is the tool `nika:fetch` under invoke.
+
+        After each draft, call nika:compose with workflow_yaml set to
+        the complete YAML. Repair from the JSON verdict until valid is
+        true. Then call nika:done. Checking never runs the draft.
+      prompt: |
+        Draft the smallest complete nine-key hello: one infer that
+        says hello in one short sentence, model mock/echo, permits {}.
+        Check it with nika:compose until valid. Then nika:done.
+        Do not execute the draft.
+
+outputs:
+  draft: ${{ tasks.draft.output }}

--- a/crates/nika-pack/pack/examples/CONVENTIONS.md
+++ b/crates/nika-pack/pack/examples/CONVENTIONS.md
@@ -429,6 +429,11 @@ The named bundle is [`14-decide-publish`](14-decide-publish.nika.yaml).
    `nika:decide` without a const-fixture `nika:assert` is hint
    `unproven-law` · `paid_ready: false`. Shape: lesson 13 `prove` +
    lesson 14.
+10. **`nika:compose` is loop-only.** Grant it on `agent.tools` after
+    `nika:done`. The model drafts YAML, gets the full `nika check`
+    JSON, iterates until `valid`. A standalone `invoke:` is
+    `NIKA-BUILTIN-COMPOSE-001`. Checking never executes the draft.
+    Shape: lesson 15. Parent→child calls stay lesson 10.
 
 Order that is cheaper: `nika check --json --native-strict` until
 `paid_ready: true` → one-task mock probe of every new builtin → freeze

--- a/crates/nika-pack/pack/examples/README.md
+++ b/crates/nika-pack/pack/examples/README.md
@@ -31,6 +31,7 @@
 | [`12-failure-routing`](12-failure-routing.nika.yaml) | routing failure | the `failure` edge predicate — a strictly-failure arm that settles `⊘` on green runs |
 | [`13-extract-then-law`](13-extract-then-law.nika.yaml) | facts, then the law | `infer.schema:` as `type: integer` + numeric `enum` · `for_each` over `item.field` · `nika:jq` scores · const-fixture `nika:assert` (hint `unproven-law`) · the model never names the level |
 | [`14-decide-publish`](14-decide-publish.nika.yaml) | publish or abstain | `nika:decide` over an inline Decision Bundle · `never_automatic` · assert a hand-known `human_required` fixture |
+| [`15-compose-self-check`](15-compose-self-check.nika.yaml) | the loop checks the draft | `nika:compose` on `agent.tools` (after `nika:done`) · mock/echo rehearsal · standalone invoke is `NIKA-BUILTIN-COMPOSE-001` · checking never executes |
 
 All **4 verbs** appear across the path; everything callable is a tool under
 `invoke:`. The per-construct index is derived from the files, never

--- a/crates/nika-pack/pack/examples/config-drift-sentinel.nika.yaml
+++ b/crates/nika-pack/pack/examples/config-drift-sentinel.nika.yaml
@@ -134,8 +134,8 @@ tasks:
   # Provenance over the exact response bytes, taken BEFORE the parse: two
   # different JSON texts that mean the same thing hash differently, and that
   # is the point — this attests the artifact, not the interpretation.
-  # `nika:hash` accepts an object (compact JSON) — do not pre-`tojson` —
-  # but that would fingerprint the parse. Hash the raw string here.
+  # `nika:hash` requires `content:` to be a string; handing it the parsed
+  # object fails `NIKA-BUILTIN-HASH-001` at run while `check` stays green.
   fingerprint:
     with:
       raw: ${{ tasks.live_raw.output }}

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -4,7 +4,7 @@
 # Consumers · the reference engine embeds this pack (nika try ·
 # nika spec) · docs + website render projections of the same files.
 pack_version: 0.1.0-draft
-workflow_count: 50
+workflow_count: 51
 foundation:
   - file: examples/01-hello.nika.yaml
     sha256_16: ca6fd74b9c22772a
@@ -36,6 +36,8 @@ foundation:
     sha256_16: 92274753edd5335a
   - file: examples/14-decide-publish.nika.yaml
     sha256_16: 807fe9415700b263
+  - file: examples/15-compose-self-check.nika.yaml
+    sha256_16: 246260ab82f062ea
 templates:
   - file: templates/agent-loop.nika.yaml
     sha256_16: 97cca73d639c1537
@@ -73,7 +75,7 @@ showcase:
   - file: examples/config-drift-sentinel.nika.yaml
     name: config-drift-sentinel
     constructs: [local_model, on_error, outputs, retry, secrets, typed_inputs, when, with]
-    sha256_16: a96790d56290cc71
+    sha256_16: d2fb87f81941bd90
   - file: examples/contract-guard.nika.yaml
     name: contract-guard
     constructs: [local_model, outputs, schema, typed_inputs, with]

--- a/crates/nika-pack/pack/examples/snippets/hello.nika.yaml
+++ b/crates/nika-pack/pack/examples/snippets/hello.nika.yaml
@@ -8,7 +8,7 @@
 # blast radius from the very first command.
 #
 # Demonstrates ·
-#   - the envelope · `nika: hello` (the mark AND the name · nine keys)
+#   - the envelope · `nika: <id>` · the mark AND the file's name
 #   - `permits.exec` · an argv allowlist, no shell anywhere
 #   - one `exec:` task · argv form, never a shell string
 #

--- a/crates/nika-pack/pack/spec/02-verbs.md
+++ b/crates/nika-pack/pack/spec/02-verbs.md
@@ -354,7 +354,12 @@ drafting**: pass a `workflow_yaml` string, get the full `nika check` verdict
 back (conformance + secret-flow + permits + the termination/cost certificate)
 as the tool result. It **never executes** the draft: verification yields an
 artifact + its certificate, and running it stays a separate, gated decision.
-See [stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) §`nika:compose`.
+The teaching shape is
+[`examples/15-compose-self-check.nika.yaml`](../examples/15-compose-self-check.nika.yaml)
+(`nika:done` first so `mock/echo` closes at turn one). See
+[stdlib/builtins-v0.1.md](../stdlib/builtins-v0.1.md) §`nika:compose`.
+Do not confuse this loop intrinsic with parent→child composition
+(`invoke: { workflow: }` · [14](./14-composition.md) · lesson 10).
 
 **Termination outcomes (normative)** ·
 

--- a/crates/nika-pack/pack/spec/05-errors.md
+++ b/crates/nika-pack/pack/spec/05-errors.md
@@ -127,7 +127,7 @@ these from this file alone.
 | `NIKA-PARSE-001` | the YAML itself does not parse (syntax error) | `parse_error` | false |
 | `NIKA-PARSE-002` | missing envelope field (`nika:` · a non-empty `tasks:`) — a file with no `nika:` key is not a nika file; `workflow:` no longer exists to be missing ([01 §envelope](./01-envelope.md)) | `validation_error` | false |
 | `NIKA-PARSE-003` | `nika:` is not a kebab-case id (`^[a-z][a-z0-9-]*$`) — the key carries the file's NAME, not a version; the version slot is gone forever and losslessly (there is no `nika: v2`, ever · [01 §nika](./01-envelope.md)) | `parse_error` | false |
-| `NIKA-PARSE-004` | `workflow:` id violates `^[a-z][a-z0-9-]*$` | `validation_error` | false |
+| `NIKA-PARSE-004` | RESERVED — retired with the nine-key envelope (2026-08-12): the id moved onto `nika:` and `NIKA-PARSE-003` judges it; the number is never reused | `validation_error` | false |
 | `NIKA-PARSE-005` | unknown field — strict mode rejects anything outside the closed v1 set | `validation_error` | false |
 | `NIKA-PARSE-006` | task id violates `^[a-z][a-z0-9_]*$` (snake_case · CEL-safe · no hyphens) | `validation_error` | false |
 | `NIKA-PARSE-007` | duplicate task id within the workflow | `validation_error` | false |

--- a/crates/nika-pack/pack/spec/10-authority.md
+++ b/crates/nika-pack/pack/spec/10-authority.md
@@ -234,7 +234,8 @@ and anything derived from them are untrusted, with monotone propagation
 > authority died with the envelope nuke. A `${{ config.X }}` read refuses
 > `NIKA-VALUES-003` — it never reaches a taint judgment. A deployment knob
 > is an `inputs:` entry with `required: false` and a `default:`, untrusted
-> as `inputs.*`.
+> as `inputs.*` ([04 §namespaces](./04-variables.md#the-5-namespaces) ·
+> [01 §inputs](./01-envelope.md#inputs--optional--typed-workflow-inputs)).
 
 Two rules bind
 untrusted values under a `permits:` block (NEP-0004 · LAW-AUTH-0325):

--- a/crates/nika-pack/pack/spec/14-composition.md
+++ b/crates/nika-pack/pack/spec/14-composition.md
@@ -15,6 +15,10 @@
 > receipts · semantic resume · and reference-model parity. Until that
 > whole receipt exists, « proven » is not a word this contract lets an
 > implementation use.
+>
+> This chapter is **parent→child** composition (`invoke: { workflow: }`
+> · lesson 10). The agent loop's self-check builtin `nika:compose` is a
+> different door (ADR-096 · loop-only · lesson 15). Do not fuse them.
 
 ---
 

--- a/crates/nika-pack/pack/spec/16-projections.md
+++ b/crates/nika-pack/pack/spec/16-projections.md
@@ -41,10 +41,11 @@ semantic_document = (
 
 - **`semantic_document_format: 1`** — the surface names its **own**
   version, independent of the nested `graph.graph_format`. Until now the
-  document versioned itself *implicitly* through `graph.graph_format: 2`;
-  a projection that will grow additive fields (holes · actions ·
-  capabilities · §the additive arc) needs a version of its own so a
-  consumer can reason about the *surface* without unwrapping the graph.
+  document versioned itself *implicitly* through the nested graph's
+  format integer; a projection that will grow additive fields (holes ·
+  actions · capabilities · §the additive arc) needs a version of its own
+  so a consumer can reason about the *surface* without unwrapping the
+  graph.
 - **`graph`** is the canonical projection of [03](./03-dag.md) *verbatim*
   (`graph_format: 3` · the derived edges · the reference identity). The
   semantic document never re-derives it — it carries it.

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -410,8 +410,10 @@ Send notifications · `channel:` enum (`webhook`/`slack`/`email`/`discord`/`sms`
 ```yaml
 agent:
   prompt: "Draft a workflow, then check it before you finish."
-  tools: ["nika:compose"]            # the agent grants itself the self-check
+  tools: ["nika:done", "nika:compose"]   # done first · mock/echo closes at turn one
 ```
+The teaching shape is
+[`examples/15-compose-self-check.nika.yaml`](../examples/15-compose-self-check.nika.yaml).
 The agent loop's self-verification intrinsic · the model passes a workflow
 YAML draft it wrote, and gets the FULL `nika check` verdict back as JSON:
 conformance violations (with codes + repair hints), secret-flow findings,

--- a/docs/findings/2026-08-19-authoring-depth-mega-plan.md
+++ b/docs/findings/2026-08-19-authoring-depth-mega-plan.md
@@ -57,10 +57,13 @@ Small. Same four verbs. No new builtin.
 
 Refuse · promoting `unproven-law` to a finding · growing `LAW_PHRASES`.
 
-## Wave 2 · leftover dialect (same session if Wave 1 is green)
+## Wave 2 · leftover dialect (SHIPPED this wave)
 
 Grep-and-kill on **teaching** surfaces (pack · spec examples ·
-guides · SKILL · QUICKSTART). Not a grammar change.
+guides · SKILL · QUICKSTART). Not a grammar change. Live leftover
+was `ROADMAP.md` teaching `nika.toml` + `{{...}}` · now `nika.yaml`
++ `${{ }}`. Detector tests may keep a dead form as the input that
+must hint. Prose and runnable examples must not teach it.
 
 | Dead form | Live form |
 |---|---|
@@ -71,15 +74,14 @@ guides · SKILL · QUICKSTART). Not a grammar change.
 | 5-verb lists | 4 verbs · fetch is a tool |
 | `config:` / `vars:` / `env:` envelope | `inputs:` / `const:` / `secrets:` |
 
-Detector tests may keep a dead form as the **input that must hint**.
-Prose and runnable examples must not teach it.
+## Wave 3 · compose lesson (SHIPPED this wave)
 
-## Wave 3 · compose lesson (after Wave 1)
-
-`nika:compose` is still OWED. It is **loop-served only** (standalone
-`invoke` → `NIKA-BUILTIN-COMPOSE-001`). The lesson is an `agent:`
-whitelist that drafts a child workflow and iterates on the check
-JSON until `valid` — AlphaCodium's tests-first compile, as a file.
+`nika:compose` is **loop-served only** (standalone `invoke` →
+`NIKA-BUILTIN-COMPOSE-001`). Lesson
+`15-compose-self-check.nika.yaml` is an `agent:` whitelist
+(`nika:done` first, then `nika:compose`) that drafts a nine-key
+hello and iterates on the check JSON until `valid`. Mock/echo
+closes at turn one. OWED `compose` struck.
 
 Do **not** fake it with a standalone invoke. Do **not** execute the
 draft inside the same run ("generation is not permission").
@@ -115,8 +117,8 @@ authoring train.
 | RLM (2512.24601) | Nika already | What's missing |
 |---|---|---|
 | file = environment | the `.nika.yaml` *is* the scratchpad | agents write once and hope |
-| recursion | `for_each` · `invoke: { workflow: }` | compose lesson (Wave 3) |
-| verification | jq / decide / assert | `unproven-law` (this ship) + `compiled`/`next` (Wave 1) |
+| recursion | `for_each` · `invoke: { workflow: }` · lesson 15 `nika:compose` | inspect wiring (Wave 4) |
+| verification | jq / decide / assert · `compiled`/`next` | agents still write once and hope — the loop is the product |
 
 The loop we want: write → `nika check --json` → if `next`, repair
 that one task → re-check → handoff only when `paid_ready`.

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,14 +18,14 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4499
+  classified_files: 4500
   file_rows: 11
   pattern_rows: 22
   by_class:
     authored: 1560
     authored-pin: 2
     generated: 122
-    pinned-copy: 119
+    pinned-copy: 120
     testimonial: 2696
     foreign: 0
   unverified-default: 7
@@ -62,7 +62,7 @@ files:
   evidence: "its own header: 'Bump deliberately: edit this' · the rev the shared estate tool is mirrored from, and the INPUT the mirror gate compares against"
 - path: "ROADMAP.md"
   class: authored
-  sha256: 2c35bf28f7b61237cfee04e577525193023a3143ef45b8a12118e9dd6eefc1aa
+  sha256: f1b7308d7c1b2bf456f660a788ee9cfb6133c241ad2510b4c955bff7ac348c88
   evidence: "hand-written roadmap prose (real-semver ladder · layer plan)"
   note: "ROADMAP.md:98 carries the same refresh-status.sh AUTO-GENERATED status block — a tool-maintained block inside an authored file"
 - path: "SPEC_PIN"
@@ -113,8 +113,8 @@ files:
 patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
-  match_count: 118
-  aggregate_sha256: d0aeb8c6ca93ea05ce288f68cf80df6b6d34aff081f9433bd9810acf7979ac73
+  match_count: 119
+  aggregate_sha256: 285f5f9fdcd2eb07a27ff70aae52f5af83a12f0a36812df24937e3ba25fb2f64
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 790
-  aggregate_sha256: 58be3e9bada0c9f1161ad73c7bd1bce754d1f9c0e7dbac9e39b396c6d8e0ef96
+  aggregate_sha256: 1e0f631b6691d4e1ac31d3b54c954eec071060916ea51830ac84b800312a3436
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 109
-  aggregate_sha256: 47743dd209e736ec6ac416783a02e47d4160a6506fe074b4a77f2dc832d8328e
+  aggregate_sha256: 95fa27fe7dd8e5de2ac4e9cae3c8d4ec0aee378ccbdfb8630f6d52b9035f538e
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored


### PR DESCRIPTION
## What
Wave 2 leftover + Wave 3 compose lesson.

- Lesson `15-compose-self-check` · `nika:compose` after `nika:done` inside an `agent:` whitelist
- OWED `compose` struck · `inspect` and `tts_generate` stay named debts
- ROADMAP no longer teaches `nika.toml` or bare-brace `{{...}}` templates
- Pack vendored from spec `48daa3d` (also picks up PARSE-004 reserved + a few teaching comments already on spec main)

Checking never executes the draft. No 5th verb. No `v0.111.0` tag from this branch.

## Verify (local)
- `cargo test -p nika-cli --lib -- every_builtin` green
- `cargo test -p nika-pack --test pack_integrity` green
- `cargo test -p nika-check --lib -- hints` green
- `nika check` / `nika run --model mock/echo` on lesson 15 green
- MCP `nika_check` clean