### PR TITLE
feat(runtime): inject LiveInspect so nika:inspect is live

### DIFF
--- a/crates/nika-builtin/src/lib.rs
+++ b/crates/nika-builtin/src/lib.rs
@@ -47,6 +47,7 @@ pub mod image;
 pub mod image_fx;
 pub mod inspect;
 pub(crate) mod judged_fs;
+pub mod live;
 pub(crate) mod media;
 pub mod net;
 pub(crate) mod net_payload;
@@ -68,6 +69,7 @@ use nika_kernel::runtime::tool_executor::{
 
 pub use defs::{TOOLS_EXPORT_VERSION, tool_defs, tools_json};
 pub use image::ImageKeys;
+pub use live::LiveInspect;
 pub use permits::FsBoundary;
 pub use tts::TtsKeys;
 
@@ -187,21 +189,9 @@ impl Emitter for NullEmitter {
 /// Answers `nika:inspect`'s 4 views from live run state. The L3 engine
 /// implements it per-run; [`NoWorkflow`] is the no-run-context stand-in.
 ///
-/// # The wiring gap (F3 · why production injects [`NoWorkflow`] today)
-///
-/// A real impl needs the run's LIVE DAG (the check report's waves + the
-/// task graph), the settling `records` map, and the running cost total —
-/// all of which exist only INSIDE `nika_runtime::Runtime::run` (the
-/// `records` map is built there; cost rides the per-task token counts).
-/// The `BuiltinDispatcher` that serves `nika:inspect`, however, is
-/// composed BEFORE the run and shared (`Arc`) across every concurrent
-/// task — it holds no handle to that live state. Closing the gap means
-/// either (a) the dispatcher holding an `Arc<Mutex<RunState>>` the
-/// runtime updates as it executes (a new runtime-introspection surface),
-/// or (b) the runtime owning the dispatcher and re-injecting a per-run
-/// `WorkflowIntrospect` — both are a real subsystem, not a builtin patch.
-/// Until then [`NoWorkflow`] returns an explicit `available: false` so the
-/// builtin never serves zeros that look like a real empty run.
+/// Production injects [`LiveInspect`] (an `Arc` shared with the
+/// dispatcher, written as tasks settle). [`NoWorkflow`] remains the
+/// no-run-context stand-in for isolated dispatcher tests.
 pub trait WorkflowIntrospect: Send + Sync {
     /// `view: cost` → `{ total_usd, by_task, by_provider }`.
     fn cost(&self) -> serde_json::Value;
@@ -218,9 +208,8 @@ pub trait WorkflowIntrospect: Send + Sync {
 /// like a real (empty) run (`{ nodes: [], … }` is indistinguishable from a
 /// genuine empty DAG — the F3 misleading-empty footgun). The `view:`
 /// argument is still validated by the builtin; this seam only supplies the
-/// answer. The composition root injects a real [`WorkflowIntrospect`] once
-/// the runtime exposes its live DAG/records/cost (see the type doc).
-/// Construct via [`Default`].
+/// answer. Production injects [`LiveInspect`]; isolated tests keep this
+/// stand-in. Construct via [`Default`].
 #[derive(Debug, Clone, Copy, Default)]
 #[non_exhaustive]
 pub struct NoWorkflow;

--- a/crates/nika-builtin/src/live.rs
+++ b/crates/nika-builtin/src/live.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Live [`WorkflowIntrospect`] — the cell the runtime writes as tasks
+//! settle. Injected at composition (`Arc` shared with the dispatcher).
+//! Every view is `available: true` once the DAG is seeded; zeros are
+//! never served as a stand-in for « no run » (that remains [`crate::NoWorkflow`]).
+
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use crate::WorkflowIntrospect;
+
+/// One settled task as `view: records` wants it.
+#[derive(Clone, Debug)]
+struct TaskSnap {
+    status: String,
+    duration_ms: Option<u64>,
+}
+
+/// The snapshot the lock guards.
+#[derive(Clone, Debug, Default)]
+struct Snap {
+    seeded: bool,
+    nodes: Vec<String>,
+    edges: Vec<(String, String)>,
+    waves: Vec<Vec<String>>,
+    tasks: BTreeMap<String, TaskSnap>,
+    spent_usd: f64,
+    any_priced: bool,
+    by_source: BTreeMap<String, f64>,
+}
+
+/// Shared live-run introspection. `Send + Sync`. Poison recovers.
+#[derive(Debug, Default)]
+pub struct LiveInspect {
+    inner: RwLock<Snap>,
+}
+
+impl LiveInspect {
+    /// Empty cell — views stay `available: false` until [`Self::seed_dag`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn read(&self) -> Snap {
+        self.inner
+            .read()
+            .map_or_else(|e| e.into_inner().clone(), |g| g.clone())
+    }
+
+    fn write<R>(&self, f: impl FnOnce(&mut Snap) -> R) -> R {
+        let mut g = self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        f(&mut g)
+    }
+
+    /// Seed the static DAG (call once at run start, before any task).
+    pub fn seed_dag(
+        &self,
+        nodes: Vec<String>,
+        edges: Vec<(String, String)>,
+        waves: Vec<Vec<String>>,
+    ) {
+        self.write(|s| {
+            s.seeded = true;
+            s.nodes = nodes;
+            s.edges = edges;
+            s.waves = waves;
+        });
+    }
+
+    /// Replace the settled-task map (call after each wave merge).
+    pub fn replace_records(&self, rows: impl IntoIterator<Item = (String, String, Option<u64>)>) {
+        self.write(|s| {
+            s.tasks = rows
+                .into_iter()
+                .map(|(id, status, duration_ms)| {
+                    (
+                        id,
+                        TaskSnap {
+                            status,
+                            duration_ms,
+                        },
+                    )
+                })
+                .collect();
+        });
+    }
+
+    /// Copy the ledger fold (spent · priced? · by attribution key).
+    pub fn set_spend(&self, spent_usd: f64, any_priced: bool, by_source: BTreeMap<String, f64>) {
+        self.write(|s| {
+            s.spent_usd = spent_usd;
+            s.any_priced = any_priced;
+            s.by_source = by_source;
+        });
+    }
+}
+
+impl WorkflowIntrospect for LiveInspect {
+    fn cost(&self) -> serde_json::Value {
+        let s = self.read();
+        if !s.seeded {
+            return no_run("cost");
+        }
+        serde_json::json!({
+            "available": true,
+            "view": "cost",
+            "total_usd": if s.any_priced { s.spent_usd } else { 0.0 },
+            "metered": s.any_priced,
+            "by_task": {},
+            "by_provider": s.by_source,
+        })
+    }
+
+    fn records(&self) -> serde_json::Value {
+        let s = self.read();
+        if !s.seeded {
+            return no_run("records");
+        }
+        let tasks: Vec<serde_json::Value> = s
+            .tasks
+            .iter()
+            .map(|(id, t)| {
+                serde_json::json!({
+                    "id": id,
+                    "status": t.status,
+                    "duration_ms": t.duration_ms,
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "available": true,
+            "view": "records",
+            "tasks": tasks,
+        })
+    }
+
+    fn dag_info(&self) -> serde_json::Value {
+        let s = self.read();
+        if !s.seeded {
+            return no_run("dag_info");
+        }
+        let edges: Vec<serde_json::Value> = s
+            .edges
+            .iter()
+            .map(|(from, to)| serde_json::json!({ "from": from, "to": to }))
+            .collect();
+        serde_json::json!({
+            "available": true,
+            "view": "dag_info",
+            "nodes": s.nodes,
+            "edges": edges,
+            "waves": s.waves,
+        })
+    }
+
+    fn threads(&self) -> serde_json::Value {
+        let s = self.read();
+        if !s.seeded {
+            return no_run("threads");
+        }
+        let completed = s.tasks.len();
+        let total = s.nodes.len();
+        let remaining = total.saturating_sub(completed);
+        let (active, queued) = if remaining == 0 {
+            (0, 0)
+        } else {
+            (1, remaining.saturating_sub(1))
+        };
+        serde_json::json!({
+            "available": true,
+            "view": "threads",
+            "active": active,
+            "queued": queued,
+            "completed": completed,
+        })
+    }
+}
+
+fn no_run(view: &str) -> serde_json::Value {
+    serde_json::json!({
+        "available": false,
+        "view": view,
+        "reason": "nika:inspect has no live run context here — the DAG was not seeded",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unseeded_is_honestly_unavailable() {
+        let cell = LiveInspect::new();
+        for view in [cell.cost(), cell.records(), cell.dag_info(), cell.threads()] {
+            assert_eq!(view["available"], false);
+        }
+    }
+
+    #[test]
+    fn seeded_dag_is_available_and_names_its_nodes() {
+        let cell = LiveInspect::new();
+        cell.seed_dag(
+            vec!["look".into(), "done".into()],
+            vec![("look".into(), "done".into())],
+            vec![vec!["look".into()], vec!["done".into()]],
+        );
+        let dag = cell.dag_info();
+        assert_eq!(dag["available"], true);
+        assert_eq!(dag["nodes"][0], "look");
+        assert_eq!(dag["waves"].as_array().map(Vec::len), Some(2));
+        cell.replace_records([("look".into(), "success".into(), Some(3))]);
+        let rec = cell.records();
+        assert_eq!(rec["tasks"][0]["id"], "look");
+        assert_eq!(rec["tasks"][0]["duration_ms"], 3);
+        let th = cell.threads();
+        assert_eq!(th["completed"], 1);
+        assert_eq!(th["active"], 1);
+    }
+}

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -121,7 +121,7 @@ pub struct Hint {
     /// `secrets-store` · `native-first` ·
     /// `exec-json-capture` ·
     /// `unwrapped-ref` · `envelope-output` · `policy-soft` · `run-clock`
-    /// · `analysis` · `consent` · `digit-string-enum` · `inspect-unwired`
+    /// · `analysis` · `consent` · `digit-string-enum`
     /// · `glob-readme` · `assert-quarantine` · `jq-as-map` · `infer-as-law`
     /// · `unproven-law`
     /// (additive · agents route on it; the module doc describes each).
@@ -143,7 +143,6 @@ pub struct Hint {
 pub const PAID_RUN_KINDS: &[&str] = &[
     "digit-string-enum",
     "glob-readme",
-    "inspect-unwired",
     "jq-as-map",
     "infer-as-law",
     "unproven-law",
@@ -268,7 +267,6 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
             }
             RawAction::Invoke(a) => {
                 push_headless_prompt_hint(&mut hints, id, a);
-                push_inspect_unwired_hint(&mut hints, id, a);
                 push_glob_readme_hint(&mut hints, id, a);
                 push_jq_as_map_hint(&mut hints, id, a);
             }
@@ -999,31 +997,6 @@ fn collect_digit_string_enums(node: &serde_json::Value, path: &str, out: &mut Ve
     if let Some(items) = obj.get("items") {
         collect_digit_string_enums(items, &format!("{path}/items"), out);
     }
-}
-
-/// `nika:inspect` is catalogued but the runtime injects a `NoWorkflow`
-/// today — every view returns `available: false`. Say so at check time
-/// instead of letting an author discover it after a paid infer wave.
-fn push_inspect_unwired_hint(
-    hints: &mut Vec<Hint>,
-    id: &str,
-    a: &nika_schema::raw::RawInvokeAction,
-) {
-    let Some(tool) = a.tool() else {
-        return;
-    };
-    if tool.value != "nika:inspect" {
-        return;
-    }
-    hints.push(hint(
-        "inspect-unwired",
-        id,
-        format!(
-            "`nika:inspect` on `{id}` has no live run context in this engine — every view \
-             returns `available: false`. Read cost/DAG from `nika trace show` until the \
-             runtime injects WorkflowIntrospect (ADR-088 wiring gap)"
-        ),
-    ));
 }
 
 /// A markdown glob that will also match a README sitting in the same

--- a/crates/nika-check/src/hints/tests.rs
+++ b/crates/nika-check/src/hints/tests.rs
@@ -830,16 +830,15 @@ fn hash_of_an_object_task_output_does_not_hint_tojson() {
 }
 
 #[test]
-fn inspect_invoke_is_hinted_as_unwired() {
+fn inspect_invoke_is_not_hinted_as_unwired() {
+    // LiveInspect is injected at composition — check stays silent.
     let h = hints_of(
         "nika: w\npermits: { tools: [\"nika:inspect\"] }\ntasks:\n  look:\n    invoke: { tool: \"nika:inspect\", args: { view: cost } }\n",
     );
-    let hit = h
-        .iter()
-        .find(|x| x.kind == "inspect-unwired")
-        .expect("inspect-unwired");
-    assert_eq!(hit.task, "look");
-    assert!(hit.advice.contains("available: false"), "{}", hit.advice);
+    assert!(
+        !h.iter().any(|x| x.kind == "inspect-unwired"),
+        "inspect is wired: {h:?}"
+    );
 }
 
 #[test]

--- a/crates/nika-cli/src/verbs/examples.rs
+++ b/crates/nika-cli/src/verbs/examples.rs
@@ -533,23 +533,16 @@ mod tests {
 
     /// The coverage ratchet, builtins leg — the same gate the kit has
     /// (`the_kit_never_teaches_a_form_the_engine_refuses`), pointed the
-    /// other way: the corpus must SHOW what the engine ships. Two ride a
+    /// other way: the corpus must SHOW what the engine ships. One rides a
     /// named debt; a new builtin cannot join silently, and a debt paid
     /// by a new lesson must be struck from the list in the same arc.
     #[test]
     fn every_builtin_is_shown_or_carries_a_named_debt() {
         // Each entry: why the gap is tolerated TODAY + the showcase owed.
-        const OWED: &[(&str, &str)] = &[
-            (
-                "inspect",
-                "cost · records · dag_info · threads behind one door (ADR-088) \
-                 — owes the lesson where a run reads itself",
-            ),
-            (
-                "tts_generate",
-                "the audio graduate — a showcase gap, not a logic gap",
-            ),
-        ];
+        const OWED: &[(&str, &str)] = &[(
+            "tts_generate",
+            "the audio graduate — a showcase gap, not a logic gap",
+        )];
         let mut bodies = String::new();
         for slug in nika_pack::example_slugs() {
             bodies.push_str(nika_pack::example(&slug).unwrap_or_default());

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -278,7 +278,7 @@ fn native_first_verdict(
 /// `infer-as-law` and `digit-string-enum` burned the 2026-08-19 wave.
 /// The rest of [`nika_check::PAID_RUN_KINDS`] still ride `.paid_ready`
 /// (JSON) and the explain panel — they are not fail-set members
-/// (`inspect-unwired` is a wiring gap · `glob-readme` has no FS ·
+/// (`glob-readme` has no FS ·
 /// `jq-as-map` is a style ratchet). This oracle is what an agent reads
 /// before handing a file to a human.
 fn paid_ready_verdict(

--- a/crates/nika-pack/pack/examples/15-compose-self-check.nika.yaml
+++ b/crates/nika-pack/pack/examples/15-compose-self-check.nika.yaml
@@ -19,8 +19,8 @@
 #   - the draft is an artifact + its certificate, not a child run
 #
 # Do not confuse with [`10-compose-pipeline`](10-compose-pipeline.nika.yaml).
-# Do not write a follow-up that *calls* the unwired introspection
-# builtin (`inspect-unwired` · `paid_ready: false`).
+# Next door · [`16-inspect-self`](16-inspect-self.nika.yaml) is the run
+# reading its own DAG.
 #
 # Run · nika try 15-compose-self-check
 #   (offline · mock/echo · zero keys)

--- a/crates/nika-pack/pack/examples/16-inspect-self.nika.yaml
+++ b/crates/nika-pack/pack/examples/16-inspect-self.nika.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
+#
+# 16 · Inspect self — the run reads its own DAG.
+#
+# `nika:inspect` is the one introspection door (ADR-088 · four views).
+# The runtime injects a live cell at composition and writes it as
+# tasks settle. This file is the first task of a two-task DAG: look
+# at `dag_info` before anything has settled, then assert the cell
+# is available (the DAG was seeded at run start).
+#
+# Demonstrates ·
+#   - `invoke: { tool: nika:inspect, args: { view: dag_info } }`
+#   - `available: true` · nodes + waves from the check report
+#   - PURE permits · inspect + assert
+#   - const-fixture assert so `unproven-law` stays silent
+#
+# Other views · `cost` · `records` · `threads` (advisory).
+#
+# Run · nika try 16-inspect-self
+#   (offline · mock/echo · zero keys)
+
+nika: inspect-self
+
+model: mock/echo
+
+permits:
+  tools: ["nika:inspect", "nika:assert"]
+
+tasks:
+  look:
+    invoke:
+      tool: nika:inspect
+      args:
+        view: dag_info
+  compiled:
+    with:
+      shot: ${{ tasks.look.output }}
+    invoke:
+      tool: nika:assert
+      args:
+        condition: ${{ with.shot.available }}
+        message: "inspect must have live run context (DAG seeded at start)"
+
+outputs:
+  dag: ${{ tasks.look.output }}

--- a/crates/nika-pack/pack/examples/CONVENTIONS.md
+++ b/crates/nika-pack/pack/examples/CONVENTIONS.md
@@ -413,7 +413,7 @@ The named bundle is [`14-decide-publish`](14-decide-publish.nika.yaml).
    until the paid-run family is gone. The MCP `nika_check` oracle fails
    `infer-as-law` and `digit-string-enum` by default.
 3. **Probe a new builtin with `mock/echo` first.** `nika:inspect` is
-   catalogued and unwired (`available: false`). Hint `inspect-unwired`.
+   live (`available: true` once the DAG is seeded). Shape: lesson 16.
 4. **`nika:hash` accepts an object.** Do not pre-`tojson` a roster.
    `nika:validate` parses a string schema from `nika:read`.
 5. **Pin the glob.** `held/*.md` includes `README.md`. `exclude:

--- a/crates/nika-pack/pack/examples/README.md
+++ b/crates/nika-pack/pack/examples/README.md
@@ -32,6 +32,7 @@
 | [`13-extract-then-law`](13-extract-then-law.nika.yaml) | facts, then the law | `infer.schema:` as `type: integer` + numeric `enum` · `for_each` over `item.field` · `nika:jq` scores · const-fixture `nika:assert` (hint `unproven-law`) · the model never names the level |
 | [`14-decide-publish`](14-decide-publish.nika.yaml) | publish or abstain | `nika:decide` over an inline Decision Bundle · `never_automatic` · assert a hand-known `human_required` fixture |
 | [`15-compose-self-check`](15-compose-self-check.nika.yaml) | the loop checks the draft | `nika:compose` on `agent.tools` (after `nika:done`) · mock/echo rehearsal · standalone invoke is `NIKA-BUILTIN-COMPOSE-001` · checking never executes |
+| [`16-inspect-self`](16-inspect-self.nika.yaml) | the run reads itself | `nika:inspect` `view: dag_info` · live cell seeded at run start · assert `available` |
 
 All **4 verbs** appear across the path; everything callable is a tool under
 `invoke:`. The per-construct index is derived from the files, never

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -4,7 +4,7 @@
 # Consumers · the reference engine embeds this pack (nika try ·
 # nika spec) · docs + website render projections of the same files.
 pack_version: 0.1.0-draft
-workflow_count: 51
+workflow_count: 52
 foundation:
   - file: examples/01-hello.nika.yaml
     sha256_16: ca6fd74b9c22772a
@@ -38,6 +38,8 @@ foundation:
     sha256_16: 807fe9415700b263
   - file: examples/15-compose-self-check.nika.yaml
     sha256_16: 246260ab82f062ea
+  - file: examples/16-inspect-self.nika.yaml
+    sha256_16: 17acfa8335f711fc
 templates:
   - file: templates/agent-loop.nika.yaml
     sha256_16: 97cca73d639c1537

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -446,12 +446,12 @@ Replaces · 4 legacy introspection builtins (`nika:cost` · `nika:records` · `n
 
 Throws · `NIKA-BUILTIN-INSPECT-001` if `view:` value not in the canonical enum.
 
-**Reference-engine honesty (ADR-088 wiring gap).** The builtin is
-catalogued; the runtime still injects a `NoWorkflow` today, so every
-view returns `{ available: false }`. The checker hints `inspect-unwired`.
-Read cost/DAG from `nika trace show` until `WorkflowIntrospect` is
-injected. Probe any new builtin with `mock/echo` *before* wiring it
-after a paid infer.
+The reference engine injects a live cell at composition and writes it
+as tasks settle. `available: true` once the DAG is seeded at run start.
+The teaching shape is
+[`examples/16-inspect-self.nika.yaml`](../examples/16-inspect-self.nika.yaml).
+Probe any new builtin with `mock/echo` *before* wiring it after a paid
+infer.
 
 ---
 

--- a/crates/nika-runtime/src/compose.rs
+++ b/crates/nika-runtime/src/compose.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use crate::simulated::{SimulatedDispatcher, SimulatedShell};
 use crate::{Runtime, RuntimeConfig, SecretResolveError, WorkflowSecretResolver};
 use nika_builtin::{
-    BuiltinDispatcher, Emitter, FsBoundary, ImageKeys, NoWorkflow, NonInteractive, TtsKeys,
+    BuiltinDispatcher, Emitter, FsBoundary, ImageKeys, LiveInspect, NonInteractive, TtsKeys,
 };
 use nika_clock::DeclaredClock;
 use nika_exec_runner::TokioShell;
@@ -146,7 +146,7 @@ type ProdDispatcher = BuiltinDispatcher<
     DeclaredClock,
     StderrEmitter,
     NonInteractive,
-    NoWorkflow,
+    LiveInspect,
 >;
 
 /// The fully-resolved production runtime spelling (tames the 6 generics
@@ -816,20 +816,18 @@ pub fn production_runtime(
     let provider_http = Arc::new(provider_http()?);
     let config = config_from_env();
 
-    // The builtin tool plane (invoke + the agent's tools) over real
-    // effects · shared by InvokeVerb and the agent's tool-defs seam. The
-    // file builtins enforce the declared permits.fs boundary (NIKA-SEC-004).
+    // Builtin plane over real effects · InvokeVerb + agent tools.
+    // File builtins enforce permits.fs (NIKA-SEC-004). Same Arc as runtime.
+    let inspect = Arc::new(LiveInspect::new());
     let dispatcher: Arc<ProdDispatcher> = Arc::new(
         BuiltinDispatcher::new(
             Arc::new(TokioFs),
             Arc::clone(&http),
             Arc::new(seams.clock.clone()),
-            // log/emit → stderr (observable · NOT a silent no-op). The
-            // `run --json` event-stream integration is the deeper wiring
-            // documented on this fn.
+            // log/emit → stderr (observable · NOT a silent no-op).
             Arc::new(StderrEmitter),
             Arc::new(NonInteractive::default()),
-            Arc::new(NoWorkflow::default()),
+            Arc::clone(&inspect),
         )
         .with_fs_boundary(caps.fs)
         // The IMAGE PLANE (`nika:image_generate`): provider calls ride the
@@ -879,6 +877,7 @@ pub fn production_runtime(
             .with_sandbox_policy(policy.as_str())
             .with_sandbox_waived(verdict == crate::sandbox_select::SandboxVerdict::Waived),
     )
+    .with_inspect(inspect)
     .with_access_probes(access_probes)
     .with_harness_seat_id(crate::harness_seat::declared_id())
     // Resolve `secrets:` from env/file at run start (MINOR-B · the sanctioned
@@ -965,9 +964,8 @@ pub fn simulated_runtime(
     let provider_http = Arc::new(provider_http()?);
     let config = config_from_env();
 
-    // The REAL builtin plane (pure + read tools delegate to it) — the
-    // declared permits.fs boundary enforced exactly as production — then
-    // the simulated gate over it.
+    // Real builtin plane (permits.fs as production) then the simulated gate.
+    let inspect = Arc::new(LiveInspect::new());
     let dispatcher = Arc::new(SimulatedDispatcher::new(Arc::new(
         BuiltinDispatcher::new(
             Arc::new(TokioFs),
@@ -975,7 +973,7 @@ pub fn simulated_runtime(
             Arc::new(seams.clock.clone()),
             Arc::new(StderrEmitter),
             Arc::new(NonInteractive::default()),
-            Arc::new(NoWorkflow::default()),
+            Arc::clone(&inspect),
         )
         .with_fs_boundary(caps.fs),
     )));
@@ -1004,6 +1002,7 @@ pub fn simulated_runtime(
             .with_sandbox_root(std::env::current_dir().unwrap_or_default())
             .with_sandbox_backend("simulated"),
     )
+    .with_inspect(inspect)
     // The SAME secrets boundary as production (env/file at run start ·
     // fail-closed on a miss) — reading the operator's own store is not an
     // external effect, and ${{ secrets.X }} templates resolve identically.

--- a/crates/nika-runtime/src/lib.rs
+++ b/crates/nika-runtime/src/lib.rs
@@ -258,6 +258,8 @@ pub struct Runtime<S, T, H, P, D, C> {
     /// `harness_seat` so the trace names the execution override beside
     /// the resolver's plan. `None` without a declaration.
     harness_seat_id: Option<String>,
+    /// Live `nika:inspect` cell (ADR-088). Shared with the dispatcher.
+    inspect: Option<Arc<nika_builtin::LiveInspect>>,
     /// The run's SOURCE identity — sha256 hex over the exact bytes the
     /// operator ran (computed by the composer that read the file; the
     /// runtime never re-reads). Stamped on `workflow_started` so every
@@ -367,7 +369,58 @@ impl<S, T, H, P, D, C> Runtime<S, T, H, P, D, C> {
             access_probes: Vec::new(),
             boot_access_fields: Vec::new(),
             harness_seat_id: None,
+            inspect: None,
         }
+    }
+
+    /// Inject the live inspect cell (same `Arc` the dispatcher holds).
+    #[must_use]
+    pub fn with_inspect(mut self, cell: Arc<nika_builtin::LiveInspect>) -> Self {
+        self.inspect = Some(cell);
+        self
+    }
+
+    /// Seed the static DAG before any task runs.
+    fn seed_inspect(&self, wf: &nika_schema::raw::RawWorkflow, report: &nika_check::CheckReport) {
+        let Some(cell) = &self.inspect else {
+            return;
+        };
+        let nodes: Vec<String> = wf.tasks.iter().map(|t| t.value.id.value.clone()).collect();
+        let edges: Vec<(String, String)> = wf
+            .tasks
+            .iter()
+            .flat_map(|t| {
+                let to = t.value.id.value.clone();
+                t.value
+                    .after
+                    .iter()
+                    .map(move |(from, _)| (from.value.clone(), to.clone()))
+            })
+            .collect();
+        let waves: Vec<Vec<String>> = report
+            .waves
+            .iter()
+            .map(|w| {
+                w.iter()
+                    .filter_map(|&i| wf.tasks.get(i).map(|t| t.value.id.value.clone()))
+                    .collect()
+            })
+            .collect();
+        cell.seed_dag(nodes, edges, waves);
+    }
+
+    /// Mirror settled records + spend after each wave merge.
+    fn publish_inspect(&self, records: &BTreeMap<String, TaskRecord>, ledger: &ledger::RunLedger) {
+        let Some(cell) = &self.inspect else {
+            return;
+        };
+        cell.replace_records(
+            records
+                .iter()
+                .map(|(id, r)| (id.clone(), r.status.as_str().to_owned(), r.duration_ms)),
+        );
+        let snap = ledger.snapshot();
+        cell.set_spend(snap.spent_usd, snap.any_priced, snap.by_source);
     }
 
     /// Declare the composer's `--model` override (#409): it joins the
@@ -786,6 +839,7 @@ where
         // once per run and nothing a task's `returns:` can look up.
         let types = std::collections::BTreeMap::new();
         self.emit_run_prologue(wf, &workflow_name, stamper, sink);
+        self.seed_inspect(wf, report);
 
         let mut records: BTreeMap<String, TaskRecord> = BTreeMap::new();
         let mut ok = true;
@@ -897,6 +951,7 @@ where
         *records = frozen;
         let (wave_records, paused) = streamed?;
         records.extend(wave_records);
+        self.publish_inspect(records, run_ledger);
 
         if let Some(p) = paused {
             emit_paused(workflow_name, &p, stamper, sink);

--- a/docs/findings/2026-08-19-authoring-depth-mega-plan.md
+++ b/docs/findings/2026-08-19-authoring-depth-mega-plan.md
@@ -86,22 +86,13 @@ closes at turn one. OWED `compose` struck.
 Do **not** fake it with a standalone invoke. Do **not** execute the
 draft inside the same run ("generation is not permission").
 
-## Wave 4 · inspect (gated on runtime)
+## Wave 4 · inspect (SHIPPED this wave)
 
-`nika:inspect` is catalogued. The runtime still injects `NoWorkflow`
-→ every view `{ available: false }` → hint `inspect-unwired` →
-`paid_ready: false`. A lesson that *calls* inspect cannot be
-paid_ready today.
-
-Until `WorkflowIntrospect` is injected (ADR-088):
-
-- keep `inspect` on OWED
-- keep the hint
-- teach `nika trace show` as the live cost/DAG door
-- do not write `15-inspect-self`
-
-Wiring inspect is a **runtime** batch (~crate wall). Not this
-authoring train.
+`LiveInspect` is injected at composition (same `Arc` the dispatcher
+holds). The runtime seeds the DAG at run start and mirrors records +
+spend after each wave. Hint `inspect-unwired` retired. Lesson
+`16-inspect-self` asserts `available`. OWED `inspect` struck.
+`NoWorkflow` stays for isolated dispatcher tests.
 
 ## Wave 5 · still open, not this authoring train
 
@@ -117,7 +108,7 @@ authoring train.
 | RLM (2512.24601) | Nika already | What's missing |
 |---|---|---|
 | file = environment | the `.nika.yaml` *is* the scratchpad | agents write once and hope |
-| recursion | `for_each` · `invoke: { workflow: }` · lesson 15 `nika:compose` | inspect wiring (Wave 4) |
+| recursion | `for_each` · `invoke: { workflow: }` · lesson 15 `nika:compose` · lesson 16 `nika:inspect` | per-iteration resume (ADR-099) |
 | verification | jq / decide / assert · `compiled`/`next` | agents still write once and hope — the loop is the product |
 
 The loop we want: write → `nika check --json` → if `next`, repair

--- a/docs/findings/2026-08-19-authoring-seams.md
+++ b/docs/findings/2026-08-19-authoring-seams.md
@@ -20,10 +20,10 @@ failures are engine/authoring seams, not domain bugs.
 4. **`nika:validate` `schema:` from `nika:read`.** A `.json` file is a
    string. `validator_for` then said the schema "is not of types
    boolean, object". String schemas are parsed as JSON, then YAML.
-5. **`nika:inspect` is catalogued, unwired.** Every view returns
-   `{ available: false }` (ADR-088: dispatcher composed before the
-   run, no `WorkflowIntrospect`). `nika check` now hints
-   `inspect-unwired`. Read the trace for cost/DAG.
+5. **`nika:inspect` was catalogued, unwired.** Every view used to
+   return `{ available: false }` (ADR-088: dispatcher composed
+   before the run). Live as of this wave (`LiveInspect` seeded at
+   run start). The `inspect-unwired` hint is retired.
 6. **`--resume` + `for_each` infer.** A body that navigates
    `item.field` (`item.stem` · `item.text`) used to drop the stamp
    (`None` — the string stand-in cannot satisfy CEL `.field`). A later
@@ -62,8 +62,8 @@ failures are engine/authoring seams, not domain bugs.
 - `nika-builtin` · hash accepts structured `content:` · validate
   parses string schemas
 - `nika-verb-infer` · scalar `anyOf` flattens into coerce
-- `nika-check` · hints `digit-string-enum` · `inspect-unwired` ·
-  `glob-readme` · `jq-as-map` · `assert-quarantine`
+- `nika-check` · hints `digit-string-enum` · `glob-readme` ·
+  `jq-as-map` · `assert-quarantine` · `inspect-unwired` retired
 - `nika-runtime` · `for_each` + `item.field` is resume-eligible
   (collection is the input identity · shaped stand-in)
 
@@ -72,21 +72,17 @@ failures are engine/authoring seams, not domain bugs.
 - `nika-builtin` ToolDef · `nika:hash` `content:` is no longer
   `type: string`. An object-shaped task output hashes as compact JSON;
   check/tools no longer teach `| tojson`.
-- `nika:inspect` still returns `{ available: false }`. Wiring is not a
-  builtin-only injection (see next patch).
+- `nika:inspect` is live (`LiveInspect` · seeded at run start).
 
 ## Still open
 
 - Per-*iteration* resume keys (ADR-099: a mid-wave crash still
   replays every item; the task-level stamp only skips the whole fan)
-- Runtime injection of `WorkflowIntrospect` into `nika:inspect`
+- ~~Runtime injection of `WorkflowIntrospect` into `nika:inspect`~~ shipped
 
-## Next patch · WorkflowIntrospect
+## Next patch · WorkflowIntrospect — SHIPPED
 
-`BuiltinDispatcher` is composed once before `Runtime::run` and shared
-(`Arc`) across concurrent tasks. Live DAG, settling `records`, and
-running cost exist only inside the settle pass. Next honest patch:
-a `RunState` cell (`Arc<Mutex<…>>` or `RwLock`) the runtime writes as
-tasks settle, inject that as `W: WorkflowIntrospect` at composition,
-drop `NoWorkflow` from `ProdDispatcher`, retire `inspect-unwired`.
+`LiveInspect` (`Arc<RwLock<Snap>>`) is injected at composition.
+The runtime seeds the DAG at run start and mirrors records + spend
+after each wave. `NoWorkflow` stays for isolated dispatcher tests.
 Do not re-compose the dispatcher mid-run and do not serve zeros.

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,14 +18,14 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4501
+  classified_files: 4503
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1561
+    authored: 1562
     authored-pin: 2
     generated: 122
-    pinned-copy: 120
+    pinned-copy: 121
     testimonial: 2696
     foreign: 0
   unverified-default: 7
@@ -113,8 +113,8 @@ files:
 patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
-  match_count: 119
-  aggregate_sha256: 285f5f9fdcd2eb07a27ff70aae52f5af83a12f0a36812df24937e3ba25fb2f64
+  match_count: 120
+  aggregate_sha256: db4febad548640a631b90a03b77e28222a8817824084dc4c7f7165793a587fe1
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 791
-  aggregate_sha256: 5ef765b6a5d2187bd04fa8f487e156c42d3b1b9323af36a34663970e9ca9740c
+  match_count: 792
+  aggregate_sha256: 69345bf564be59b869fb938b2e596b9b5cf5348f802355ee80dbe730821d6166
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 109
-  aggregate_sha256: 1fe039641bda5057cd75b10188797e448d49b5900ecbc0d97c11aa37553d67ff
+  aggregate_sha256: c5261d98d219c717a0fd9af0def0854e3e585789f56111e295078701253cc68e
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored


### PR DESCRIPTION
## Why

`nika:inspect` was catalogued and every view returned `available: false`.
The dispatcher was composed before the run and held `NoWorkflow`.
Authors discovered the gap after a paid infer wave.

## What

- `LiveInspect` (`Arc<RwLock<Snap>>`) is the same cell the dispatcher and the runtime share
- DAG seeded at run start — first-task inspect is `available: true`
- records + spend mirrored after each wave merge
- hint `inspect-unwired` retired from `PAID_RUN_KINDS`
- lesson `16-inspect-self` asserts available (mock/echo)
- `NoWorkflow` stays for isolated dispatcher tests
- OWED `inspect` struck; `tts_generate` remains

Pairs with spec #275 and docs #132 (merged).

## Proof

- `cargo test -p nika-builtin --lib -- live`
- `cargo test -p nika-check --lib -- inspect_invoke_is_not_hinted`
- `cargo test -p nika-cli --lib -- every_builtin`
- `cargo test -p nika-pack --test pack_integrity`
- crate-size: nika-runtime 14942/15000
- compose.rs 1497/1500
- e2e: `{"available":true,"nodes":["look","compiled"],"waves":[["look"],["compiled"]]}`