### PR TITLE
feat(agent): spill oversized tool results to the blob store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Added
 
+- **Tool-result spill in the `agent:` loop (opt-in seam).** Past 16 KiB a
+  tool result's full text leaves the conversation for the blob store —
+  the content hash IS the locator — and the model keeps a 2 KiB preview
+  plus the pointer, so the context window stops re-paying bytes it cannot
+  use. Nothing is discarded, and a store refusal keeps the full text:
+  the spill is an optimization of the model's reading, never a gate on
+  the data. Seat it with `AgentVerb::with_spill`; without the seam the
+  loop is byte-unchanged.
 - **`nika check` judges a project file as a project.** It applied the nine-key
   WORKFLOW envelope to every document, so a project file came back
   `NIKA-PARSE-002 missing required envelope field: tasks` — on a file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5002,6 +5002,7 @@ dependencies = [
 name = "nika-verb-agent"
 version = "0.113.0"
 dependencies = [
+ "bytes",
  "futures-core",
  "futures-util",
  "jsonschema",

--- a/crates/nika-verb-agent/Cargo.toml
+++ b/crates/nika-verb-agent/Cargo.toml
@@ -22,6 +22,7 @@ nika-check       = { path = "../nika-check", version = "0.113.0" }        # agen
 nika-catalog     = { path = "../nika-catalog", version = "0.113.0", features = ["pricing"] } # find_pricing_for — the priced-ness the unmetered gate reads (R3-F1)
 jsonschema       = { workspace = true }                                   # final-message `schema:` validation (NIKA_464)
 serde_json       = { workspace = true }
+bytes            = { workspace = true }                                   # blob put for the spill seam (spill.rs)
 thiserror        = { workspace = true }
 miette           = { workspace = true }
 tokio            = { workspace = true }                                   # spawn_blocking — agent:compose's sync check off the async executor (ADR-096)

--- a/crates/nika-verb-agent/public-api.txt
+++ b/crates/nika-verb-agent/public-api.txt
@@ -906,6 +906,7 @@ pub fn nika_verb_agent::AgentVerb<P, T, D>::new(provider: alloc::sync::Arc<P>, i
 pub fn nika_verb_agent::AgentVerb<P, T, D>::with_config(self, config: nika_verb_agent::config::AgentConfig) -> Self
 pub fn nika_verb_agent::AgentVerb<P, T, D>::with_observer(self, observer: alloc::sync::Arc<dyn nika_verb_agent::observe::AgentObserver>) -> Self
 pub fn nika_verb_agent::AgentVerb<P, T, D>::with_schema_retry_budget(self, budget: u8) -> Self
+pub fn nika_verb_agent::AgentVerb<P, T, D>::with_spill<S>(self, store: alloc::sync::Arc<S>) -> Self where S: nika_kernel_core::io::blob::BlobStoreDyn + core::marker::Sync + 'static
 impl<P, T, D> core::fmt::Debug for nika_verb_agent::AgentVerb<P, T, D>
 pub fn nika_verb_agent::AgentVerb<P, T, D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_verb_agent::AgentVerb<P, T, D>

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -99,6 +99,7 @@ mod intrinsic;
 mod io;
 mod router;
 mod shape;
+mod spill;
 
 use std::sync::Arc;
 
@@ -107,6 +108,7 @@ use nika_kernel::ai::provider::{
     ResponseFormat, Role, TokenUsage, ToolDef,
 };
 use nika_kernel::ai::tool_defs::ToolDefinitionProviderDyn;
+use nika_kernel::blob::BlobStoreDyn;
 use nika_kernel::runtime::agent::AgentStopReason;
 use nika_types::blame::BlamePolarity;
 use nika_types::cost::SpendOnFailure;
@@ -169,6 +171,10 @@ pub struct AgentVerb<P, T, D> {
     // embedder signature (Runtime::new already carries the verb generics);
     // the observer is telemetry, never on the data path's hot types.
     observer: Arc<dyn AgentObserver>,
+    // The spill store: OPTIONAL, and `dyn` for the same reason as the
+    // observer. Absent, the loop feeds every result back byte-identical
+    // (the pre-spill behavior is the default — feature-defaults law).
+    spill: Option<Arc<dyn spill::SpillStoreDyn>>,
     // The harness seat (P3 B4): delegates to the user's own harness —
     // same dyn-seam rationale as the observer.
     #[cfg(feature = "access-harness")]
@@ -202,6 +208,7 @@ impl<P, T, D> AgentVerb<P, T, D> {
             config: AgentConfig::new(),
             schema_retry_budget: DEFAULT_SCHEMA_RETRY_BUDGET,
             observer: Arc::new(NoopObserver),
+            spill: None,
             #[cfg(feature = "access-harness")]
             harness: None,
         }
@@ -232,6 +239,19 @@ impl<P, T, D> AgentVerb<P, T, D> {
     #[must_use]
     pub fn with_config(mut self, config: AgentConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Seat the spill store: tool results past the threshold leave the
+    /// conversation for the store (a bounded preview + the blob locator
+    /// stay). Without it the loop is byte-unchanged — the seam is
+    /// optional, the default is the pre-spill behavior.
+    #[must_use]
+    pub fn with_spill<S>(mut self, store: Arc<S>) -> Self
+    where
+        S: BlobStoreDyn + Sync + 'static,
+    {
+        self.spill = Some(store);
         self
     }
 
@@ -706,6 +726,12 @@ where
         // verbatim · a trailing text block after tool results is the
         // documented-legal shape on every wire).
         let mut content = batch.results;
+        // Oversized outputs leave the conversation for the spill store —
+        // the preview + locator stay, the bytes stay addressable. Never a
+        // loss: a store refusal keeps the full text (see spill.rs).
+        if let Some(store) = &self.spill {
+            spill::spill_tool_results(&mut content, store).await;
+        }
         match guard.observe_turn(batch.signature, batch.all_errors) {
             GuardVerdict::Proceed => {}
             GuardVerdict::Nudge(reason, period) => {
@@ -1392,3 +1418,5 @@ fn is_clean_tool_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_spill;

--- a/crates/nika-verb-agent/src/spill.rs
+++ b/crates/nika-verb-agent/src/spill.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Tool-result spill — oversized outputs leave the CONVERSATION, never
+//! the record.
+//!
+//! The `ReAct` loop feeds every tool result back to the model verbatim
+//! (ADR-096). That is the right default — the model repairs from what it
+//! sees — until one result is a 2 MiB HTML page: the window fills with
+//! bytes the model needed one line of, and every later turn re-pays them.
+//!
+//! The spill inverts the placement: past [`SPILL_THRESHOLD_BYTES`], the
+//! full text goes to the blob store (content-addressed — the hash IS the
+//! locator) and the conversation keeps a bounded preview plus the pointer.
+//! Nothing is discarded: the bytes stay addressable for the run's record
+//! and for the human — the loop just stops re-reading what it cannot use.
+//!
+//! ⚠️ A spill failure NEVER loses content: if the store refuses, the
+//! original text rides the conversation exactly as it did before this
+//! seam existed. The spill is an optimization of the model's reading,
+//! not a gate on the data.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use nika_kernel::ai::provider::ContentBlock;
+use nika_kernel::blob::{BlobError, BlobMetadata, BlobStoreDyn};
+
+/// The kernel's `BlobStoreDyn` keeps `impl Future` returns — statically
+/// dispatched, NOT object-safe. The loop needs the store OPTIONAL, and an
+/// optional generic would infect every embedder signature (the rationale
+/// the observer seam already lives by) — so the spill goes through this
+/// object-safe bridge over the same kernel trait.
+pub(crate) trait SpillStoreDyn: Send + Sync {
+    /// Store bytes, returning the content-addressed metadata (the hash
+    /// is the locator), boxed so the trait stays dyn-compatible.
+    fn put(
+        &self,
+        data: bytes::Bytes,
+        mime_type: &'static str,
+    ) -> Pin<Box<dyn Future<Output = Result<BlobMetadata, BlobError>> + Send + '_>>;
+}
+
+impl<T: BlobStoreDyn + Sync> SpillStoreDyn for T {
+    fn put(
+        &self,
+        data: bytes::Bytes,
+        mime_type: &'static str,
+    ) -> Pin<Box<dyn Future<Output = Result<BlobMetadata, BlobError>> + Send + '_>> {
+        Box::pin(async move { self.put(data, mime_type).await })
+    }
+}
+
+/// Above this many bytes a tool result spills. Sixteen KiB: ordinary
+/// outputs (a file read, a fetch, a page of search hits) stay inline and
+/// the loop is byte-unchanged for them; past it the per-turn re-read cost
+/// dominates whatever the model could still learn from the middle of the
+/// blob. Not configurable on purpose: it is a property of the loop, not
+/// of a workflow (a workflow that needs its outputs whole narrows the
+/// query, it does not tune the reader).
+pub(crate) const SPILL_THRESHOLD_BYTES: usize = 16 * 1024;
+
+/// How much of a spilled result stays in the conversation. Two KiB holds
+/// the head of almost any payload — enough for the model to recognize
+/// what it got and to decide whether a narrower re-query is worth it.
+pub(crate) const SPILL_PREVIEW_BYTES: usize = 2 * 1024;
+
+/// Rewrite oversized tool results in place: full text to the store,
+/// preview + locator into the conversation. Results under the threshold,
+/// and every result when the store fails, pass through byte-identical.
+pub(crate) async fn spill_tool_results(
+    content: &mut [ContentBlock],
+    store: &Arc<dyn SpillStoreDyn>,
+) {
+    for block in content.iter_mut() {
+        let ContentBlock::ToolResult { content, .. } = block else {
+            continue;
+        };
+        if content.len() <= SPILL_THRESHOLD_BYTES {
+            continue;
+        }
+        let Ok(meta) = store
+            .put(
+                bytes::Bytes::copy_from_slice(content.as_bytes()),
+                "text/plain",
+            )
+            .await
+        else {
+            continue; // never a loss: the full text stays (see module doc)
+        };
+        let total = content.len();
+        let mut end = SPILL_PREVIEW_BYTES.min(total);
+        while !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        *content = format!(
+            "{}\n[… spilled · {total} bytes · the full output is kept as blob `{}` · the preview above is the first {end} bytes · narrow the query if you need a later part]",
+            &content[..end],
+            meta.hash,
+        );
+    }
+}

--- a/crates/nika-verb-agent/src/tests_spill.rs
+++ b/crates/nika-verb-agent/src/tests_spill.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Spill seam tests (`spill.rs`) — split from `tests.rs` under the
+//! 1500-LOC file cap · same `super::*` semantics.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use nika_kernel::ai::provider::{InferResponse, StopReason, TokenUsage, ToolDef};
+use nika_kernel::blob::{BlobError, BlobMetadata, BlobStoreDyn};
+use nika_kernel::runtime::tool_executor::ToolResult;
+use nika_kernel_mock::{MockProvider, MockToolDefinitionProvider, MockToolExecutor};
+
+use super::*;
+
+/// Past the 16 KiB spill threshold.
+const BIG: usize = 20 * 1024;
+
+/// An in-memory spill store for these tests — `BlobStoreDyn`-native.
+/// (`MockBlob` predates the Dyn variant and implements only the base
+/// trait; a thin in-crate store keeps the test honest without touching
+/// another crate's public surface.)
+#[derive(Clone, Default)]
+struct SpillMem {
+    blobs: Arc<RwLock<BTreeMap<String, bytes::Bytes>>>,
+    next: Arc<AtomicU64>,
+}
+
+impl SpillMem {
+    // no .expect() here: to the hygiene ratchet these helpers are
+    // production code, and a poisoned lock answers « empty » — the
+    // assertion downstream says why.
+    fn len(&self) -> usize {
+        match self.blobs.read() {
+            Ok(g) => g.len(),
+            Err(_) => 0,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn get(&self, hash: &str) -> Option<bytes::Bytes> {
+        match self.blobs.read() {
+            Ok(g) => g.get(hash).cloned(),
+            Err(_) => None,
+        }
+    }
+}
+
+impl BlobStoreDyn for SpillMem {
+    fn put(
+        &self,
+        data: bytes::Bytes,
+        mime_type: &str,
+    ) -> impl std::future::Future<Output = Result<BlobMetadata, BlobError>> + Send {
+        let n = self.next.fetch_add(1, Ordering::SeqCst) + 1;
+        let hash = format!("mock-{n:08x}");
+        let meta = BlobMetadata::new(&hash, mime_type, data.len() as u64);
+        match self.blobs.write() {
+            Ok(mut g) => {
+                g.insert(hash, data);
+                std::future::ready(Ok(meta))
+            }
+            Err(_) => std::future::ready(Err(BlobError::Io {
+                reason: "lock poisoned".to_owned(),
+            })),
+        }
+    }
+
+    fn get(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<bytes::Bytes, BlobError>> + Send {
+        let found = match self.blobs.read() {
+            Ok(g) => g.get(hash).cloned(),
+            Err(_) => None,
+        };
+        let hash = hash.to_owned();
+        std::future::ready(found.ok_or(BlobError::NotFound { hash }))
+    }
+
+    fn exists(&self, hash: &str) -> impl std::future::Future<Output = bool> + Send {
+        let there = match self.blobs.read() {
+            Ok(g) => g.contains_key(hash),
+            Err(_) => false,
+        };
+        std::future::ready(there)
+    }
+
+    fn stat(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<BlobMetadata, BlobError>> + Send {
+        let found = match self.blobs.read() {
+            Ok(g) => g
+                .get(hash)
+                .map(|b| BlobMetadata::new(hash, "text/plain", b.len() as u64)),
+            Err(_) => None,
+        };
+        let hash = hash.to_owned();
+        std::future::ready(found.ok_or(BlobError::NotFound { hash }))
+    }
+
+    fn delete(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<(), BlobError>> + Send {
+        let gone = match self.blobs.write() {
+            Ok(mut g) => g.remove(hash),
+            Err(_) => None,
+        };
+        let hash = hash.to_owned();
+        std::future::ready(gone.map(|_| ()).ok_or(BlobError::NotFound { hash }))
+    }
+}
+
+/// A store that always refuses — the «never a loss» path's witness.
+struct FailingBlob;
+
+impl BlobStoreDyn for FailingBlob {
+    fn put(
+        &self,
+        _data: bytes::Bytes,
+        _mime_type: &str,
+    ) -> impl std::future::Future<Output = Result<BlobMetadata, BlobError>> + Send {
+        std::future::ready(Err(BlobError::Io {
+            reason: "test disk full".to_owned(),
+        }))
+    }
+
+    fn get(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<bytes::Bytes, BlobError>> + Send {
+        std::future::ready(Err(BlobError::NotFound {
+            hash: hash.to_owned(),
+        }))
+    }
+
+    fn exists(&self, _hash: &str) -> impl std::future::Future<Output = bool> + Send {
+        std::future::ready(false)
+    }
+
+    fn stat(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<BlobMetadata, BlobError>> + Send {
+        std::future::ready(Err(BlobError::NotFound {
+            hash: hash.to_owned(),
+        }))
+    }
+
+    fn delete(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<(), BlobError>> + Send {
+        std::future::ready(Err(BlobError::NotFound {
+            hash: hash.to_owned(),
+        }))
+    }
+}
+
+fn text_response(text: &str) -> InferResponse {
+    InferResponse::new(
+        vec![ContentBlock::Text {
+            text: text.to_owned(),
+        }],
+        TokenUsage::default(),
+        StopReason::EndTurn,
+    )
+}
+
+fn tool_use_response(id: &str, name: &str) -> InferResponse {
+    InferResponse::new(
+        vec![
+            ContentBlock::Text {
+                text: format!("calling {name}"),
+            },
+            ContentBlock::ToolUse {
+                id: id.to_owned(),
+                name: name.to_owned(),
+                input: serde_json::json!({}),
+            },
+        ],
+        TokenUsage::default(),
+        StopReason::ToolUse,
+    )
+}
+
+fn def(name: &str) -> ToolDef {
+    ToolDef::new(name, format!("{name} description"), serde_json::json!({}))
+}
+
+/// The rig with the spill store seated — `rig()`'s shape plus the seam.
+fn spill_rig(
+    provider: MockProvider,
+    tools: MockToolExecutor,
+) -> (
+    Arc<MockProvider>,
+    Arc<SpillMem>,
+    AgentVerb<MockProvider, MockToolExecutor, MockToolDefinitionProvider>,
+) {
+    let provider = Arc::new(provider);
+    let blob = Arc::new(SpillMem::default());
+    let verb = AgentVerb::new(
+        Arc::clone(&provider),
+        Arc::new(InvokeVerb::new(Arc::new(tools))),
+        Arc::new(MockToolDefinitionProvider::with_defs(vec![def(
+            "nika:read",
+        )])),
+        "mock/agent",
+    )
+    .with_spill(Arc::clone(&blob));
+    (provider, blob, verb)
+}
+
+/// What the model was fed back through tool results at one request.
+fn fed_results(provider: &MockProvider, request: usize) -> String {
+    provider.captured_requests()[request]
+        .messages
+        .iter()
+        .flat_map(|m| m.content.iter())
+        .filter_map(|b| match b {
+            ContentBlock::ToolResult { content, .. } => Some(content.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn oversized_result_spills_with_locator_and_the_bytes_survive() {
+    let big = "x".repeat(BIG);
+    let (provider, blob, verb) = spill_rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response("call-1", "nika:read"))
+            .enqueue_response(text_response("got the head")),
+        MockToolExecutor::new().enqueue_ok(ToolResult::success("call-1", big.clone())),
+    );
+    let mut input = AgentInput::new("read the big file");
+    input.tools = vec!["nika:read".to_owned()];
+    let out = verb.run(input).await.expect("completes");
+    assert_eq!(out.turns, 2);
+
+    // The record kept the bytes, content-addressed.
+    assert_eq!(blob.len(), 1, "one spill, one blob");
+    let hash = "mock-00000001";
+    let back = blob.get(hash).expect("the locator resolves");
+    assert_eq!(back.as_ref(), big.as_bytes(), "the store holds every byte");
+
+    // What the model reads instead: a bounded preview + the pointer.
+    let fed = fed_results(&provider, 1);
+    assert!(
+        fed.contains("[… spilled ·"),
+        "the marker says what happened · {fed}"
+    );
+    assert!(fed.contains(hash), "the locator rides · {fed}");
+    assert!(fed.contains(&BIG.to_string()), "the total size rides");
+    assert!(
+        !fed.contains(&"x".repeat(4 * 1024)),
+        "the body left the conversation"
+    );
+}
+
+#[tokio::test]
+async fn ordinary_result_never_spills() {
+    let (provider, blob, verb) = spill_rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response("call-1", "nika:read"))
+            .enqueue_response(text_response("done")),
+        MockToolExecutor::new().enqueue_ok(ToolResult::success("call-1", "hello from notes")),
+    );
+    let mut input = AgentInput::new("read my notes");
+    input.tools = vec!["nika:read".to_owned()];
+    verb.run(input).await.expect("completes");
+
+    assert!(blob.is_empty(), "nothing reaches the store");
+    assert_eq!(fed_results(&provider, 1), "hello from notes");
+}
+
+#[tokio::test]
+async fn without_the_seam_an_oversized_result_rides_byte_identical() {
+    // The default (no `with_spill`) is the pre-spill behavior: the loop
+    // feeds everything back, however big — the seam is opt-in.
+    let big = "x".repeat(BIG);
+    let provider = Arc::new(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response("call-1", "nika:read"))
+            .enqueue_response(text_response("done")),
+    );
+    let verb = AgentVerb::new(
+        Arc::clone(&provider),
+        Arc::new(InvokeVerb::new(Arc::new(
+            MockToolExecutor::new().enqueue_ok(ToolResult::success("call-1", big.clone())),
+        ))),
+        Arc::new(MockToolDefinitionProvider::with_defs(vec![def(
+            "nika:read",
+        )])),
+        "mock/agent",
+    );
+    let mut input = AgentInput::new("read the big file");
+    input.tools = vec!["nika:read".to_owned()];
+    verb.run(input).await.expect("completes");
+
+    let fed = fed_results(&provider, 1);
+    assert!(fed.contains(&big), "no store, no spill, no loss");
+}
+
+#[tokio::test]
+async fn a_store_refusal_never_loses_the_result() {
+    let big = "x".repeat(BIG);
+    let provider = Arc::new(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response("call-1", "nika:read"))
+            .enqueue_response(text_response("done")),
+    );
+    let verb = AgentVerb::new(
+        Arc::clone(&provider),
+        Arc::new(InvokeVerb::new(Arc::new(
+            MockToolExecutor::new().enqueue_ok(ToolResult::success("call-1", big.clone())),
+        ))),
+        Arc::new(MockToolDefinitionProvider::with_defs(vec![def(
+            "nika:read",
+        )])),
+        "mock/agent",
+    )
+    .with_spill(Arc::new(FailingBlob));
+    let mut input = AgentInput::new("read the big file");
+    input.tools = vec!["nika:read".to_owned()];
+    verb.run(input).await.expect("completes");
+
+    let fed = fed_results(&provider, 1);
+    assert!(
+        fed.contains(&big),
+        "a store refusal is not a reason to lose the output"
+    );
+}
+
+#[tokio::test]
+async fn the_preview_never_splits_a_char_boundary() {
+    // « é » is two bytes: a naive byte cut of the preview lands mid-char.
+    let big = "é".repeat(BIG);
+    let (provider, blob, verb) = spill_rig(
+        MockProvider::new("mock")
+            .enqueue_response(tool_use_response("call-1", "nika:read"))
+            .enqueue_response(text_response("done")),
+        MockToolExecutor::new().enqueue_ok(ToolResult::success("call-1", big)),
+    );
+    let mut input = AgentInput::new("lire le gros fichier");
+    input.tools = vec!["nika:read".to_owned()];
+    verb.run(input).await.expect("completes");
+
+    let fed = fed_results(&provider, 1);
+    assert!(fed.contains("[… spilled ·"));
+    assert!(blob.len() == 1);
+}


### PR DESCRIPTION
## What

An opt-in **spill seam** for the `agent:` loop: past 16 KiB, a tool result's full text leaves the conversation for the blob store — the content hash IS the locator — and the model keeps a 2 KiB preview plus the pointer.

## Why

The ReAct loop feeds every tool result back verbatim. One 2 MiB HTML page fills the window with bytes the model needed one line of, and every later turn re-pays them. The trace does not carry tool outputs (`tool_invoked` records `turn · tool · error` only), so the blob store becomes the one durable copy — which is why a store refusal keeps the full text inline: the spill optimizes the model's *reading*, it never gates the data.

## How

- `crates/nika-verb-agent/src/spill.rs` — the threshold (16 KiB), the boundary-safe preview (2 KiB), the marker, and `SpillStoreDyn`: an object-safe bridge over the kernel's `BlobStoreDyn` (its `impl Future` returns are statically dispatched by design, so the loop's optional seam boxes them — same `dyn` rationale as the observer seam).
- `AgentVerb::with_spill(store)` — opt-in; without it the loop is byte-unchanged.
- One hook in `dispatch_turn`, before the results message is pushed.

## Tests (`--lib`, 5 new)

- oversized result → preview + locator in the conversation, every byte retrievable from the store by hash
- ordinary result → never spills
- no seam → byte-identical passthrough (default behavior preserved)
- store refusal → the full text survives inline
- UTF-8: the preview never splits a char boundary

## Deliberately NOT in this PR

- Production wiring: the composer (`nika-runtime/src/compose.rs`) does not seat a store yet — the root decision (`.nika/spill/` global vs per-run) lands with the native session work.
- In-loop read-back (a `nika:spill` intrinsic): the model narrows its query instead; read-back is a follow-up.
