### PR TITLE
feat(pack): tts-self lesson pays the last showcase debt

### DIFF
--- a/crates/nika-cli/src/verbs/examples.rs
+++ b/crates/nika-cli/src/verbs/examples.rs
@@ -539,10 +539,7 @@ mod tests {
     #[test]
     fn every_builtin_is_shown_or_carries_a_named_debt() {
         // Each entry: why the gap is tolerated TODAY + the showcase owed.
-        const OWED: &[(&str, &str)] = &[(
-            "tts_generate",
-            "the audio graduate — a showcase gap, not a logic gap",
-        )];
+        const OWED: &[(&str, &str)] = &[];
         let mut bodies = String::new();
         for slug in nika_pack::example_slugs() {
             bodies.push_str(nika_pack::example(&slug).unwrap_or_default());

--- a/crates/nika-pack/pack/examples/16-inspect-self.nika.yaml
+++ b/crates/nika-pack/pack/examples/16-inspect-self.nika.yaml
@@ -17,6 +17,9 @@
 #
 # Other views · `cost` · `records` · `threads` (advisory).
 #
+# Next door · [`17-tts-self`](17-tts-self.nika.yaml) is the last
+# named showcase — mock TTS, a real WAV on disk.
+#
 # Run · nika try 16-inspect-self
 #   (offline · mock/echo · zero keys)
 

--- a/crates/nika-pack/pack/examples/17-tts-self.nika.yaml
+++ b/crates/nika-pack/pack/examples/17-tts-self.nika.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
+#
+# 17 · TTS self — the last named showcase debt.
+#
+# `nika:tts_generate` is the audio graduate (stdlib §Audio). The mock
+# provider writes a REAL deterministic WAV, zero network, zero keys —
+# the same honesty as `nika:image_generate` `provider: mock` (og-images).
+# Audio bytes never ride outputs: path + sha256 + duration_ms do.
+#
+# Demonstrates ·
+#   - `invoke: { tool: nika:tts_generate, args: { provider: mock } }`
+#   - `permits.fs.write` covering a DIRECTORY-writing builtin (`**`)
+#   - const-fixture assert on the mock contract (provider + wav)
+#   - flip ONE line to `local` / `openai` / `elevenlabs` for paid audio
+#
+# Run · nika try 17-tts-self
+#   (offline · mock WAV · zero keys)
+
+nika: tts-self
+
+model: mock/echo
+
+permits:
+  tools: ["nika:tts_generate", "nika:assert"]
+  fs:
+    write: ["out/speech/**"]
+
+tasks:
+  speak:
+    invoke:
+      tool: nika:tts_generate
+      args:
+        provider: mock
+        text: "hello"
+        output_dir: out/speech
+        metadata: { page_slug: "hello" }
+  compiled:
+    with:
+      shot: ${{ tasks.speak.output }}
+    invoke:
+      tool: nika:assert
+      args:
+        condition: ${{ with.shot.provider == "mock" && with.shot.audio.format == "wav" }}
+        message: "mock TTS must land a real WAV (bytes stay on disk)"
+
+outputs:
+  audio: ${{ tasks.speak.output.audio }}
+  manifest: ${{ tasks.speak.output.manifest_path }}

--- a/crates/nika-pack/pack/examples/CONVENTIONS.md
+++ b/crates/nika-pack/pack/examples/CONVENTIONS.md
@@ -414,6 +414,8 @@ The named bundle is [`14-decide-publish`](14-decide-publish.nika.yaml).
    `infer-as-law` and `digit-string-enum` by default.
 3. **Probe a new builtin with `mock/echo` first.** `nika:inspect` is
    live (`available: true` once the DAG is seeded). Shape: lesson 16.
+   Media: `nika:tts_generate` `provider: mock` writes a real WAV
+   offline. Shape: lesson 17.
 4. **`nika:hash` accepts an object.** Do not pre-`tojson` a roster.
    `nika:validate` parses a string schema from `nika:read`.
 5. **Pin the glob.** `held/*.md` includes `README.md`. `exclude:

--- a/crates/nika-pack/pack/examples/manifest.yaml
+++ b/crates/nika-pack/pack/examples/manifest.yaml
@@ -4,7 +4,7 @@
 # Consumers · the reference engine embeds this pack (nika try ·
 # nika spec) · docs + website render projections of the same files.
 pack_version: 0.1.0-draft
-workflow_count: 52
+workflow_count: 53
 foundation:
   - file: examples/01-hello.nika.yaml
     sha256_16: ca6fd74b9c22772a
@@ -40,6 +40,8 @@ foundation:
     sha256_16: 246260ab82f062ea
   - file: examples/16-inspect-self.nika.yaml
     sha256_16: 17acfa8335f711fc
+  - file: examples/17-tts-self.nika.yaml
+    sha256_16: 37d15028add0d76f
 templates:
   - file: templates/agent-loop.nika.yaml
     sha256_16: 97cca73d639c1537

--- a/crates/nika-pack/pack/stdlib/builtins-v0.1.md
+++ b/crates/nika-pack/pack/stdlib/builtins-v0.1.md
@@ -731,6 +731,9 @@ narrate:
         output_dir: "./assets/audio"
 ```
 
+Teaching shape · [`17-tts-self`](../examples/17-tts-self.nika.yaml)
+(`provider: mock` · a real WAV · offline).
+
 The image family's contract, applied to audio: ONE audio file lands under
 `output_dir:` (permit-gated per final path BEFORE I/O · atomic write ·
 content-hash-named `{stem}-{provider}-{model}-{sha8}.{ext}` so identical

--- a/docs/findings/2026-08-19-authoring-depth-mega-plan.md
+++ b/docs/findings/2026-08-19-authoring-depth-mega-plan.md
@@ -94,14 +94,18 @@ spend after each wave. Hint `inspect-unwired` retired. Lesson
 `16-inspect-self` asserts `available`. OWED `inspect` struck.
 `NoWorkflow` stays for isolated dispatcher tests.
 
-## Wave 5 · still open, not this authoring train
+## Wave 5 · tag (SHIPPED) + leftover
+
+`v0.111.0` is tagged (`25f502adb`). Lesson
+`17-tts-self` pays the last named showcase
+debt (`provider: mock` · real WAV). OWED empty.
+
+Still later ·
 
 | Item | Why later |
 |---|---|
 | per-iteration `for_each` resume | runtime · ~15k wall |
-| `tts_generate` showcase | audio graduate · not a logic gap |
 | NEP-0021 | still gated |
-| tag `v0.111.0` | release train after merge to `main` |
 
 ## RLM mapping (why this order)
 

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,14 +18,14 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4503
+  classified_files: 4504
   file_rows: 11
   pattern_rows: 22
   by_class:
     authored: 1562
     authored-pin: 2
     generated: 122
-    pinned-copy: 121
+    pinned-copy: 122
     testimonial: 2696
     foreign: 0
   unverified-default: 7
@@ -113,8 +113,8 @@ files:
 patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
-  match_count: 120
-  aggregate_sha256: db4febad548640a631b90a03b77e28222a8817824084dc4c7f7165793a587fe1
+  match_count: 121
+  aggregate_sha256: d6b0d4f49b275acc0a2b2aa7d85bb659edf316e240287c651e10379288df9574
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 792
-  aggregate_sha256: 69345bf564be59b869fb938b2e596b9b5cf5348f802355ee80dbe730821d6166
+  aggregate_sha256: 0669cff6fc7dbb123446c1c5c4dd1488972e7db5761f6fafde56395fe97a1afc
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -178,7 +178,7 @@ patterns:
 - glob: "docs/**"
   class: authored
   match_count: 109
-  aggregate_sha256: c5261d98d219c717a0fd9af0def0854e3e585789f56111e295078701253cc68e
+  aggregate_sha256: 16c36f7d2e34bd1c69a49ca5df5ee7f5cb3a62394487e7d17df09012dae898fc
   evidence: "crate-specs · architecture prose · perf notes — no generation markers at file heads"
 - glob: "scripts/**"
   class: authored


### PR DESCRIPTION
## Why

`every_builtin` named `tts_generate` as the last showcase debt. The
mock provider already writes a real WAV offline.

## What

- Pack lesson `17-tts-self` (spec 73a03dd)
- OWED list is empty
- Mega-plan: v0.111.0 tagged, tts debt paid

Proven locally: `clean` · `compiled` · `paid_ready`, WAV 13k on disk.

Pairs with spec #276 and docs #133.