### PR TITLE
docs(skill): nika inspect is live — strike inspect-unwired

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -53,6 +53,9 @@ four are the decisions that cost rounds when guessed instead of copied.
 | the same task for every item of a collection | `07-for-each-locales` |
 | extract facts, then score them without a second infer | `13-extract-then-law` |
 | publish or abstain from a Decision Bundle | `14-decide-publish` |
+| an agent drafts a file and checks it until valid | `15-compose-self-check` |
+| the run reads its own DAG / cost / records | `16-inspect-self` |
+| mock TTS that writes a real WAV | `17-tts-self` |
 | land a typed artifact on disk | `t1-meeting-actions` |
 | poll something, act only when a condition holds | `t1-price-watch` |
 | rows in, chart and report out, zero model calls | `t2-csv-chart-report` |
@@ -99,7 +102,7 @@ the `.nika.yaml` extension. `nika new <slug>` makes one yours;
    `--native-strict` is the run-gate bar (an `exec:` a builtin covers).
    `.paid_ready` is the paid-infer bar (`nika check --json | jq .paid_ready`).
    A green exit with leftover `infer-as-law` / `digit-string-enum` /
-   `glob-readme` / `jq-as-map` / `inspect-unwired` / `unproven-law` is
+   `glob-readme` / `jq-as-map` / `unproven-law` is
    legal, not the one-way. The MCP `nika_check` oracle fails
    `infer-as-law` and `digit-string-enum` by default.
    The exec ledger does NOT buy an exemption (measured: a `.py` wrapper
@@ -285,8 +288,8 @@ this with a paid seat.
 1. `nika check --json --native-strict` until `clean` and `paid_ready`
    are both true (zero findings, zero paid-run hints).
 2. Probe every new builtin in a one-task file on `mock/echo` *before*
-   wiring it after a paid `infer:` (`nika:inspect` is catalogued and
-   unwired — hint `inspect-unwired`).
+   wiring it after a paid `infer:` (`nika:inspect` is live — lesson
+   `16-inspect-self` asserts `available` at run start).
 3. Freeze the extract schema type. Numeric facts are `type: integer`
    with a numeric `enum`. `enum: ["0","1","3"]` is the shape models do
    not emit (JSON `3` — hint `digit-string-enum`).
@@ -334,7 +337,7 @@ or `for_each:` over items — never one giant infer. Verification is
 4. **Is every numeric enum `type: integer`?** Hint `digit-string-enum`.
 5. **Does a markdown glob include README?** Hint `glob-readme`.
 6. **Did I probe every new builtin on `mock/echo`?** One-task file,
-   then wire it. `nika:inspect` is unwired (hint `inspect-unwired`).
+   then wire it. `nika:inspect` is live (`16-inspect-self`).
 7. **Would a closer template have given this graph?** `nika new "?"`
    and `nika new "the job in plain words"`. If a skeleton is closer
    than what I wrote, start over from it.

--- a/crates/nika-pack/pack/examples/README.md
+++ b/crates/nika-pack/pack/examples/README.md
@@ -33,6 +33,7 @@
 | [`14-decide-publish`](14-decide-publish.nika.yaml) | publish or abstain | `nika:decide` over an inline Decision Bundle · `never_automatic` · assert a hand-known `human_required` fixture |
 | [`15-compose-self-check`](15-compose-self-check.nika.yaml) | the loop checks the draft | `nika:compose` on `agent.tools` (after `nika:done`) · mock/echo rehearsal · standalone invoke is `NIKA-BUILTIN-COMPOSE-001` · checking never executes |
 | [`16-inspect-self`](16-inspect-self.nika.yaml) | the run reads itself | `nika:inspect` `view: dag_info` · live cell seeded at run start · assert `available` |
+| [`17-tts-self`](17-tts-self.nika.yaml) | mock TTS, real WAV | `nika:tts_generate` `provider: mock` · bytes stay on disk · assert `audio.format == "wav"` |
 
 All **4 verbs** appear across the path; everything callable is a tool under
 `invoke:`. The per-construct index is derived from the files, never

--- a/estate.yaml
+++ b/estate.yaml
@@ -114,7 +114,7 @@ patterns:
 - glob: "crates/nika-pack/pack/**"
   class: pinned-copy
   match_count: 121
-  aggregate_sha256: d6b0d4f49b275acc0a2b2aa7d85bb659edf316e240287c651e10379288df9574
+  aggregate_sha256: 06a1840ec42c248173b7f5802e623c38e4145c4f157f75b109e6184c89fddc64
   evidence: "crates/nika-pack/src/lib.rs:16 'The snapshot under pack/ is vendored by scripts/sync-pack.sh' — a byte-copy of the spec surface, never edited here"
   derivation:
     tool: "bash scripts/sync-pack.sh <nika-spec checkout> — healed daily by .github/workflows/pack-resync.yml (branch bot/pack-resync · PR-only, the 12-gate CI judges)"
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: 54ef9e5c7a29b1b47630ccf6403dd383fdb69600e850b032584d1f5695f3dfd4
+  aggregate_sha256: 309bd36f42af445dd1ab36c5af1cbfc09b98bc040f9f27c7f6ccdecca3fd776c
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
The released 0.111.0 authoring skill still named `inspect-unwired` in three places after `#1018` made `nika:inspect` live. Marketplace #149 correctly mirrored those bytes (no hand-edit). This fixes the source.

- strike the retired hint from the leftover paid-run list
- probe step + after-valid Q6 now point at `16-inspect-self`
- numbered-path table lists `15-compose-self-check` · `16-inspect-self` · `17-tts-self`
- pack examples README gains the missing `17-tts-self` row

`the_kit_never_teaches_a_form_the_engine_refuses` green.