### PR TITLE
fix(check): jq-as-map admits a map piped from any bound name

### DIFF
--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -1167,16 +1167,42 @@ fn asks_model_to_name_the_law(text: &str) -> bool {
 /// `. as $c | map(...)` maps the *current* value. `($c | map(...))` is
 /// the one-way. A one-liner used to slip past the line-start detector.
 fn jq_maps_the_current_after_bind(expr: &str) -> bool {
-    let names = bound_jq_names(expr);
-    if names.is_empty() || !expr.contains("map(") {
+    // The DOT binding is what puts the current value in question, so it stays
+    // the trigger: no `. as $name`, no hint.
+    if bound_jq_names(expr).is_empty() || !expr.contains("map(") {
         return false;
     }
+    // But ANY bound name names its input out loud. A law that walks several
+    // bindings (`($entries | map(...)) as $rows | ($rows | map(...))`) already
+    // does exactly what the advice prescribes, and stripping only the
+    // dot-bound name reported it as a defect (measured 2026-08-19).
     let mut rest = squash_ws(expr);
-    for name in &names {
+    for name in &all_bound_jq_names(expr) {
         rest = rest.replace(&format!("(${name} | map("), "");
         rest = rest.replace(&format!("(${name}|map("), "");
     }
     rest.contains("map(")
+}
+
+/// Every `as $NAME` binding, dot-bound or not. A `map(` piped from one of
+/// them is explicit; only a BARE `map(` rides the current value.
+fn all_bound_jq_names(expr: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = expr;
+    while let Some(i) = rest.find(" as $") {
+        let after = &rest[i + 5..];
+        let name: String = after
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            rest = after;
+            continue;
+        }
+        names.push(name.clone());
+        rest = after.get(name.len()..).unwrap_or("");
+    }
+    names
 }
 
 fn bound_jq_names(expr: &str) -> Vec<String> {

--- a/crates/nika-check/src/hints/tests.rs
+++ b/crates/nika-check/src/hints/tests.rs
@@ -886,6 +886,40 @@ fn jq_as_then_bare_map_is_hinted() {
 }
 
 #[test]
+fn jq_as_map_admits_a_map_from_any_bound_name() {
+    // A map piped from a SECOND bound name is exactly as explicit as one
+    // piped from the dot-bound name: the current value is never in question,
+    // and the hint's own advice (`($name | map(...))`) is satisfied. Measured
+    // 2026-08-19 on four one-task probes; this shape was the false positive.
+    let chained = hints_of(
+        "nika: w\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  score:\n    invoke:\n      tool: nika:jq\n      args:\n        input: []\n        expression: |\n          . as $c\n          | ($c | map(.n)) as $d\n          | ($d | map(. + 1))\n",
+    );
+    assert!(
+        !chained.iter().any(|x| x.kind == "jq-as-map"),
+        "a map piped from a bound name is explicit: {chained:?}"
+    );
+
+    // A law that walks several bound names is the common shape of a ledger.
+    let ledger = hints_of(
+        "nika: w\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  score:\n    invoke:\n      tool: nika:jq\n      args:\n        input: []\n        expression: |\n          . as $c\n          | ($c.legs | to_entries) as $entries\n          | ($entries | map({name: .key})) as $rows\n          | ($rows | map(select(.name != null)) | length)\n",
+    );
+    assert!(
+        !ledger.iter().any(|x| x.kind == "jq-as-map"),
+        "a multi-name law is explicit throughout: {ledger:?}"
+    );
+
+    // The real defect still fires: a bare map( inside a later construct maps
+    // whatever the current value happens to be, which is the whole warning.
+    let bare = hints_of(
+        "nika: w\npermits: { tools: [\"nika:jq\"] }\ntasks:\n  score:\n    invoke:\n      tool: nika:jq\n      args:\n        input: []\n        expression: |\n          . as $c\n          | { out: (map(.n)) }\n",
+    );
+    assert!(
+        bare.iter().any(|x| x.kind == "jq-as-map"),
+        "a bare map after a binding must still hint: {bare:?}"
+    );
+}
+
+#[test]
 fn assert_after_a_write_names_the_quarantine() {
     let h = hints_of(
         "nika: w\npermits: { tools: [\"nika:write\", \"nika:assert\"], fs: { write: [\"out\"] } }\ntasks:\n  save:\n    invoke: { tool: \"nika:write\", args: { path: out/a.md, content: \"x\" } }\n  gate:\n    invoke: { tool: \"nika:assert\", args: { that: true } }\n",

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 792
-  aggregate_sha256: 04320e76978f382a27366996b992016e9deccf5c2283d28e47e7a9f29707e8ea
+  aggregate_sha256: 91bb42d8186d7c314f7abc7f28c55adeeed69b4d2417449b077514109cc89775
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## What

`jq-as-map` reports a law that already obeys its own advice.

The hint exists to catch a bare `map(` after a dot binding, where the current value is often a pair rather than the bound array. Its advice tells the author to write the explicit form, a map piped from a bound name. A law that follows that advice through more than one binding was reported anyway.

The stripper only removed pipes from names bound by `.`, so a law that binds `$entries`, maps them into `$rows`, then maps `$rows` again still had a visible `map(` left over and the predicate returned true.

## The measurement

Four one-task probes on the installed 0.111.0, before the change:

| shape | verdict |
|---|---|
| dot binding, map piped from the dot-bound name | clean |
| dot binding, map piped from a **second** bound name | **fires** · the false positive |
| no binding at all, bare map | clean |
| dot binding, bare map inside a later construct | fires · the real defect |

The probes are kept at `ventures/nika/02-engineering/architecture/research/pre1-gate/probes/seatbelt-judge/rjq-{a,b,c,d}.nika.yaml` in the private monorepo.

## The change

The trigger is untouched: no `. as $name`, no hint. Only the strip list widens, from dot-bound names to every `as $name` binding. A map piped from any bound name names its input out loud; only a bare `map(` rides whatever the current value happens to be.

## Proof

Tests first. The new case failed on the false positive before the change and passes after; the existing bare-map test is unchanged and still passes. `cargo test --workspace --lib` is green (98 passed in the touched crate's suite, 0 failed overall), and `cargo clippy -p nika-check --all-targets -- -D warnings` is clean.

## Where it came from

Found while repairing the studio's own ledgers, where a judge that walks several bound names is the normal shape. The workaround at the time was to drop the head binding, which is a worse law for a lint's convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
