### PR TITLE
fix(cap): a glob declares its walk root, so check stops greening a file the run kills

### DIFF
--- a/crates/nika-cap/public-api.txt
+++ b/crates/nika-cap/public-api.txt
@@ -11,6 +11,7 @@ pub nika_cap::BuiltinEffect::Fs
 pub nika_cap::BuiltinEffect::Fs::path_arg: &'static str
 pub nika_cap::BuiltinEffect::Fs::reads: bool
 pub nika_cap::BuiltinEffect::Fs::recursive: bool
+pub nika_cap::BuiltinEffect::Fs::walk_root: bool
 pub nika_cap::BuiltinEffect::Fs::writes: bool
 pub nika_cap::BuiltinEffect::Net
 pub nika_cap::BuiltinEffect::Net::url_arg: &'static str
@@ -662,6 +663,7 @@ pub fn nika_cap::code_bearing_path_class(path: &str) -> core::option::Option<(&'
 pub fn nika_cap::compose_child_env(lookup: impl core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>, passthrough: &[alloc::string::String], authored: &alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>
 pub fn nika_cap::glob_admits(glob: &str, path: &str) -> bool
 pub fn nika_cap::glob_matches(glob: &str, value: &str) -> bool
+pub fn nika_cap::glob_walk_root(pattern: &str) -> alloc::string::String
 pub fn nika_cap::invoke_tool_is_ingress(tool_id: &str, mcp_content_trusted: bool) -> bool
 pub fn nika_cap::is_dangerous_env_name(name: &str) -> bool
 pub fn nika_cap::is_pure_internal(tool: &str) -> bool

--- a/crates/nika-cap/src/effect.rs
+++ b/crates/nika-cap/src/effect.rs
@@ -21,9 +21,17 @@
 /// classification table both the escape checker and capability inference
 /// read, so verification and inference cannot drift.
 ///
-/// `nika:glob` is deliberately ABSENT: its arg is itself a glob `pattern:`,
-/// and glob-pattern ⊆ permits-glob inclusion is not soundly decidable
-/// statically — the runtime `NIKA-SEC-004` owns it.
+/// `nika:glob` carries a `pattern:`, not a path, so it declares
+/// `walk_root: true`. The undecidable half stays unjudged — glob-pattern ⊆
+/// permits-glob inclusion is NOT soundly decidable, and no code here tries.
+/// The decidable half is the WALK ROOT: the literal prefix before the first
+/// metacharacter is the directory the runtime must OPEN, and it refuses on
+/// exactly that (`NIKA-SEC-004`). Naming only the undecidable question was
+/// the defect (AGENTS.md · a waiver must name the decidable sub-question it
+/// rejects): spec 05 already states the read set models "`nika:glob`'s
+/// literal walk root", the drift scan already derived it, and the runtime
+/// already gated it — this table was the one place that did not, so a
+/// workflow could pass `check` and die at run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinEffect {
     /// An HTTP egress whose host comes from a literal URL-shaped arg.
@@ -45,6 +53,11 @@ pub enum BuiltinEffect {
         /// reader · `nika:image_generate` lands files INSIDE the dir) —
         /// inference grants `<path>/**`, not just the path.
         recursive: bool,
+        /// The arg carries a glob PATTERN, not a path: the effective path is
+        /// [`glob_walk_root`] of it — the directory the runtime opens. Every
+        /// consumer must derive it; reading the arg verbatim would ask the
+        /// undecidable pattern ⊆ permits question instead.
+        walk_root: bool,
     },
 }
 
@@ -136,18 +149,21 @@ pub fn builtin_effect(tool: &str, args: Option<&serde_json::Value>) -> Option<Bu
             reads: true,
             writes: false,
             recursive: false,
+            walk_root: false,
         }),
         "nika:grep" => Some(BuiltinEffect::Fs {
             path_arg: "path",
             reads: true,
             writes: false,
             recursive: true,
+            walk_root: false,
         }),
         "nika:write" => Some(BuiltinEffect::Fs {
             path_arg: "path",
             reads: false,
             writes: true,
             recursive: false,
+            walk_root: false,
         }),
         // in-place find/replace reads the bytes, then rewrites the path
         "nika:edit" => Some(BuiltinEffect::Fs {
@@ -155,6 +171,7 @@ pub fn builtin_effect(tool: &str, args: Option<&serde_json::Value>) -> Option<Bu
             reads: true,
             writes: true,
             recursive: false,
+            walk_root: false,
         }),
         // Media generators: assets (+ manifest) land INSIDE a literal
         // `output_dir:` — a recursive write (stdlib §Media · provider
@@ -165,6 +182,7 @@ pub fn builtin_effect(tool: &str, args: Option<&serde_json::Value>) -> Option<Bu
             reads: false,
             writes: true,
             recursive: true,
+            walk_root: false,
         }),
         // Single-artifact writers: the WRITE side (`out:`) is the
         // statically-checkable effect. image_fx's `input:` read is
@@ -178,6 +196,7 @@ pub fn builtin_effect(tool: &str, args: Option<&serde_json::Value>) -> Option<Bu
             reads: false,
             writes: true,
             recursive: false,
+            walk_root: false,
         }),
         // decide is pure compute (spec 11 §nika:decide); its ONE
         // statically-visible effect is a literal string `bundle:` — a path
@@ -189,8 +208,43 @@ pub fn builtin_effect(tool: &str, args: Option<&serde_json::Value>) -> Option<Bu
             reads: true,
             writes: false,
             recursive: false,
+            walk_root: false,
+        }),
+        // The walk root, never the pattern — see the type's doc. The entry is
+        // UNCONDITIONAL like its `nika:read` siblings: whether the arg is
+        // literal is the CONSUMER's question, and each already asks it. Making
+        // the entry itself conditional made a dynamic pattern vanish from the
+        // table, which silently un-poisoned the drift scan's read set.
+        "nika:glob" => Some(BuiltinEffect::Fs {
+            path_arg: "pattern",
+            reads: true,
+            writes: false,
+            // a pattern descends: the grant inference owes `<root>/**`
+            recursive: true,
+            walk_root: true,
         }),
         _ => None,
+    }
+}
+
+/// The directory a glob PATTERN opens: the literal prefix before the first
+/// metacharacter. The ONE definition — the checker, the capability
+/// inference, the drift scan and the runtime all read this, so check, infer
+/// and run cannot disagree about what a glob touches.
+#[must_use]
+pub fn glob_walk_root(pattern: &str) -> String {
+    if !pattern.starts_with('/') {
+        let p = pattern.strip_prefix("./").unwrap_or(pattern);
+        let first_meta = p.find(['*', '?', '[']).unwrap_or(p.len());
+        return match p[..first_meta].rfind('/') {
+            None => ".".to_owned(),
+            Some(i) => format!("./{}", &p[..i]),
+        };
+    }
+    let first_meta = pattern.find(['*', '?', '[']).unwrap_or(pattern.len());
+    match pattern[..first_meta].rfind('/') {
+        None | Some(0) => "/".to_owned(),
+        Some(i) => pattern[..i].to_owned(),
     }
 }
 
@@ -359,6 +413,52 @@ mod tests {
     }
 
     #[test]
+    fn the_walk_root_is_the_literal_prefix_before_the_first_metacharacter() {
+        // The ONE definition · the checker, the inference, the drift scan and
+        // the runtime all read it, so a glob cannot mean one thing to the
+        // audit and another to the run.
+        for (pattern, root) in [
+            ("config/env/*.yaml", "./config/env"),
+            ("./config/env/*.yaml", "./config/env"),
+            ("reports/**/*summary*", "./reports"),
+            ("a/b/c.md", "./a/b"),   // no metacharacter · the parent
+            ("*.md", "."),           // root-level pattern
+            ("/etc/*.conf", "/etc"), // absolute
+            ("/*.conf", "/"),        // absolute at the root
+        ] {
+            assert_eq!(glob_walk_root(pattern), root, "walk root of {pattern}");
+        }
+    }
+
+    #[test]
+    fn a_glob_declares_its_walk_root_not_its_pattern() {
+        // The table entry that was missing until 2026-08-19 · without it a
+        // workflow passed `check` and died at run on NIKA-SEC-004.
+        let args = json!({ "pattern": "config/env/*.yaml" });
+        assert_eq!(
+            builtin_effect("nika:glob", Some(&args)),
+            Some(BuiltinEffect::Fs {
+                path_arg: "pattern",
+                reads: true,
+                writes: false,
+                recursive: true,
+                walk_root: true,
+            })
+        );
+        // A templated pattern still DECLARES the effect · the consumers ask
+        // whether the arg is literal (and a dynamic one poisons their sets).
+        // Hiding the effect here is what un-poisoned the drift read set.
+        let templated = json!({ "pattern": "${{ inputs.d }}/*.yaml" });
+        assert!(matches!(
+            builtin_effect("nika:glob", Some(&templated)),
+            Some(BuiltinEffect::Fs {
+                walk_root: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn decide_is_a_read_only_on_the_literal_path_form() {
         // Literal string bundle → a declared fs.read on `bundle:`.
         let path_form = json!({ "bundle": "./triage.bundle.json", "evidence": {} });
@@ -369,6 +469,7 @@ mod tests {
                 reads: true,
                 writes: false,
                 recursive: false,
+                walk_root: false,
             })
         );
         // Inline object bundle → pure compute, no filesystem at all.
@@ -496,6 +597,7 @@ mod tests {
                     reads,
                     writes,
                     recursive,
+                    walk_root: _,
                 }) => {
                     assert_eq!(path_arg, "output_dir", "{tool} writes into output_dir");
                     assert!(writes, "{tool} is a write");
@@ -512,6 +614,7 @@ mod tests {
                     reads,
                     writes,
                     recursive,
+                    walk_root: _,
                 }) => {
                     assert_eq!(path_arg, "out", "{tool} writes a single artifact to out");
                     assert!(writes, "{tool} is a write");

--- a/crates/nika-cap/src/lib.rs
+++ b/crates/nika-cap/src/lib.rs
@@ -46,7 +46,7 @@ mod witness;
 // shape.rs; the coarse policy table (EffectClass) lives beside it.
 pub use effect::{
     BuiltinEffect, PURE_INTERNAL_TOOLS, builtin_effect, builtin_egresses, chart_vl_sibling,
-    is_pure_internal, is_pure_internal_call,
+    glob_walk_root, is_pure_internal, is_pure_internal_call,
 };
 pub use env::{
     DANGEROUS_ENV_VARS, RUNNER_FLOOR_ENV_VARS, compose_child_env, is_dangerous_env_name,

--- a/crates/nika-check/src/data_journey.rs
+++ b/crates/nika-check/src/data_journey.rs
@@ -298,8 +298,15 @@ fn collect_action_effects(
                     reads,
                     writes,
                     recursive,
+                    walk_root,
                 }) => {
-                    if let Some(path) = judgeable_arg(consts, a, path_arg) {
+                    if let Some(path) = judgeable_arg(consts, a, path_arg).map(|raw| {
+                        if walk_root {
+                            nika_cap::glob_walk_root(&raw)
+                        } else {
+                            raw
+                        }
+                    }) {
                         let entry = if recursive {
                             format!("{path}/**")
                         } else {

--- a/crates/nika-check/src/permits_fit.rs
+++ b/crates/nika-check/src/permits_fit.rs
@@ -550,10 +550,19 @@ fn check_builtin_effect(
             path_arg,
             reads,
             writes,
+            walk_root,
             ..
         }) => {
-            let Some(path) = judgeable_arg(consts, a, path_arg) else {
+            let Some(raw) = judgeable_arg(consts, a, path_arg) else {
                 return;
+            };
+            // A glob's arg is a PATTERN · the path the runtime opens is its
+            // walk root. Judging the pattern itself would ask the undecidable
+            // question the table's doc rejects.
+            let path = if walk_root {
+                nika_cap::glob_walk_root(&raw)
+            } else {
+                raw
             };
             for (active, dir_writes, cat) in [(reads, false, "fs.read"), (writes, true, "fs.write")]
             {

--- a/crates/nika-check/src/permits_fit/tests.rs
+++ b/crates/nika-check/src/permits_fit/tests.rs
@@ -18,6 +18,46 @@ mod fit {
     }
 
     #[test]
+    fn a_globs_walk_root_is_the_read_bound_the_run_needs() {
+        // A glob OPENS the directory its pattern roots at. `pattern ⊆
+        // permits-glob` is undecidable and stays unjudged — but the WALK ROOT
+        // is a literal prefix, the runtime gates it (NIKA-SEC-004), the spec
+        // already says the fs read set models it (05-errors · NIKA-DRIFT-001
+        // « the fs read set DOES model the two decidable runtime gates ·
+        // nika:glob's literal walk root »), and the drift scan already derives
+        // it. Only the ONE effect table was missing the entry, so `check`
+        // shipped green on a file the run kills. Measured 2026-08-19 on a
+        // workflow in the wild: a bound written `<dir>/*.yaml` beside a glob
+        // on the same pattern · check GREEN, then run NIKA-SEC-004 on `<dir>`.
+        let refused = escapes_of(
+            "nika: w\npermits:\n  fs: { read: [\"config/env/*.yaml\"] }\n  tools: [\"nika:glob\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:glob\", args: { pattern: \"config/env/*.yaml\" } }\n",
+        );
+        assert!(
+            !refused.is_empty(),
+            "the walk root ./config/env sits outside the declared bound: {refused:?}"
+        );
+
+        // The bound that DOES cover the walk root stays silent.
+        let covered = escapes_of(
+            "nika: w\npermits:\n  fs: { read: [\"config/env/**\"] }\n  tools: [\"nika:glob\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:glob\", args: { pattern: \"config/env/*.yaml\" } }\n",
+        );
+        assert!(
+            covered.is_empty(),
+            "a bound covering the walk root must stay silent: {covered:?}"
+        );
+
+        // A COMPUTED pattern has no literal walk root · the run owns it, and
+        // the checker must not invent a red it cannot prove.
+        let templated = escapes_of(
+            "nika: w\ninputs: { d: { type: string, default: \"x\" } }\npermits:\n  fs: { read: [\"config/env/**\"] }\n  tools: [\"nika:glob\"]\ntasks:\n  a:\n    invoke: { tool: \"nika:glob\", args: { pattern: \"${{ inputs.d }}/*.yaml\" } }\n",
+        );
+        assert!(
+            templated.is_empty(),
+            "a computed pattern is the RUN's verdict, never a static red: {templated:?}"
+        );
+    }
+
+    #[test]
     fn url_host_matches_the_shared_parity_vectors() {
         // The static extractor (`url_host`) MUST agree with the runtime
         // (`nika-http`'s `host_of`) on every shared vector — the no-drift

--- a/crates/nika-check/src/permits_infer.rs
+++ b/crates/nika-check/src/permits_infer.rs
@@ -271,7 +271,16 @@ fn collect_builtin_effect(c: &mut Collector, id: &str, a: &nika_schema::raw::Raw
             reads,
             writes,
             recursive,
-        }) => match judgeable_arg(&c.consts, a, path_arg) {
+            walk_root,
+        }) => match judgeable_arg(&c.consts, a, path_arg).map(|raw| {
+            // Inference must write a boundary the RUNTIME accepts · for a
+            // glob that is the walk root, never the pattern (2026-08-19).
+            if walk_root {
+                nika_cap::glob_walk_root(&raw)
+            } else {
+                raw
+            }
+        }) {
             Some(path) => {
                 // a recursive effect (nika:grep reads descendants ·
                 // nika:image_generate writes into the dir) touches

--- a/crates/nika-dap/src/drift.rs
+++ b/crates/nika-dap/src/drift.rs
@@ -343,9 +343,21 @@ impl BodyUsage {
                         path_arg,
                         reads,
                         writes,
+                        walk_root,
                         ..
                     }) => {
-                        let path = literal_arg(a, path_arg);
+                        // A glob offers its WALK ROOT · the ONE definition
+                        // lives in nika-cap beside the effect table, so this
+                        // scan, the checker, the inference and the runtime
+                        // cannot disagree (the hand-synced second copy that
+                        // used to live here is gone · 2026-08-19).
+                        let path = literal_arg(a, path_arg).map(|raw| {
+                            if walk_root {
+                                nika_cap::glob_walk_root(&raw)
+                            } else {
+                                raw
+                            }
+                        });
                         if reads {
                             offer(&mut self.reads, path.clone());
                         }
@@ -363,7 +375,6 @@ impl BodyUsage {
                     }
                     None => {}
                 }
-                self.eat_glob_walk_root(a);
                 self.eat_multipart_parts(a);
             }
             RawAction::Agent(a) => {
@@ -397,23 +408,6 @@ impl BodyUsage {
                 offer(&mut self.hosts, None);
             }
         }
-    }
-
-    /// `nika:glob` walks the literal directory prefix of its `pattern:` —
-    /// the runtime gate fences THAT root (`builtin_effect` declines the
-    /// glob ⊆ glob question, but the root is decidable). A literal pattern
-    /// contributes its walk root as a read; a `${{ }}` one poisons the set.
-    fn eat_glob_walk_root(&mut self, a: &RawInvokeAction) {
-        let Some(tool) = a.tool() else {
-            return;
-        };
-        if tool.value != "nika:glob" {
-            return;
-        }
-        offer(
-            &mut self.reads,
-            literal_arg(a, "pattern").map(|p| glob_walk_root(&p)),
-        );
     }
 
     /// A `nika:fetch` `multipart:` file part's `path` is fs.read-gated at
@@ -629,27 +623,6 @@ fn url_host(raw: &str) -> Option<String> {
         url::Host::Domain(d) => Some(d.trim_end_matches('.').to_owned()),
         url::Host::Ipv4(a) => Some(a.to_string()),
         url::Host::Ipv6(a) => Some(a.to_string()),
-    }
-}
-
-/// The directory a `nika:glob` pattern walks FROM — the runtime boundary's
-/// own split (nika-builtin's private `glob_walk_root`, restated here like
-/// `url_host` above): the longest literal directory prefix, `.` when the
-/// pattern has none, `/` for a root-relative one. Both copies must agree
-/// with the gate, or the hint would order a removal the gate requires.
-fn glob_walk_root(pattern: &str) -> String {
-    if !pattern.starts_with('/') {
-        let p = pattern.strip_prefix("./").unwrap_or(pattern);
-        let first_meta = p.find(['*', '?', '[']).unwrap_or(p.len());
-        return match p[..first_meta].rfind('/') {
-            None => ".".to_owned(),
-            Some(i) => format!("./{}", &p[..i]),
-        };
-    }
-    let first_meta = pattern.find(['*', '?', '[']).unwrap_or(pattern.len());
-    match pattern[..first_meta].rfind('/') {
-        None | Some(0) => "/".to_owned(),
-        Some(i) => pattern[..i].to_owned(),
     }
 }
 

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -1206,7 +1206,9 @@ tasks:
 async fn builtin_invoke_array_output_lets_for_each_iterate() {
     let yaml = r#"
 nika: glob-fanout
-permits: { tools: ["nika:glob", "nika:read"] }
+# The glob OPENS ./docs · a bound covering the walk root is what the run needs,
+# and since 2026-08-20 the audit says so too (the effect table gained the entry).
+permits: { tools: ["nika:glob", "nika:read"], fs: { read: ["./docs/**"] } }
 tasks:
   files:
     invoke:

--- a/estate.yaml
+++ b/estate.yaml
@@ -157,7 +157,7 @@ patterns:
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 159
-  aggregate_sha256: ea4f285aa3acd7690bd5716858032dc21b3bab96ddc77a1a6f439fdb794e5f62
+  aggregate_sha256: ebbb6bac3299145f48d84e01c6d610f42e9ea19c1de658bd7a972927a30fd26e
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: 77e58f3d5f30191e2e1552b2b3c9911618e6ebb99586c211665cc4af51d8ce75
+  aggregate_sha256: 55536bc829dccb1f90987bfcaf90c130c92ed65ba2456c7d24e51ee53bbc947b
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: cf2d1ef4d8c50200ebb50c0464dd5f7d9d67444d3013716d28c149da3649b8ad
+  aggregate_sha256: 3769f5294724876db728a0c1c1f77e91a797244bf00ee3b28f971347b627d474
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## The waiver answered the wrong question

`nika:glob` was deliberately absent from the effect table, behind this:

> `nika:glob` is deliberately ABSENT: its arg is itself a glob `pattern:`, and glob-pattern ⊆ permits-glob inclusion is not soundly decidable statically — the runtime `NIKA-SEC-004` owns it.

The first half is true and nothing here challenges it. But the run never asks pattern inclusion. It asks whether it may **open the directory the pattern walks from**, and that prefix is a literal. `AGENTS.md` makes an undecidability waiver a reviewable defect unless it names the decidable sub-question it rejects; this one named only the undecidable half.

## Everything else already agreed

| surface | what it already said |
|---|---|
| spec 05 (`NIKA-DRIFT-001`) | *"the fs read set DOES model the two decidable runtime gates (`nika:glob`'s literal walk root · …)"* |
| `nika-dap/src/drift.rs` | had its own `glob_walk_root` + `eat_glob_walk_root`, doc: *"`nika:glob`'s walk root IS an fs read"* |
| the runtime | refuses on exactly that root |
| **the effect table** | **no entry** |

One table, read by both the escape checker and the capability inference, was the only place that disagreed. So a workflow passed the audit and died at run.

## Measured

A real workflow, twice, on 2026-08-19: a bound written `<dir>/*.yaml` beside a glob on that same pattern. The bound covers the files; the walk opens the directory.

```
shipped 0.111.0 →  {"clean": true, "findings": []}
this branch     →  NIKA-SEC-004 · `nika:glob` path `./<dir>` is outside
                   permits.fs.read (task `state_sources`)
                   — fix: add "./<dir>" to permits.fs.read
```

## One definition now

`glob_walk_root` moves into `nika-cap` beside the table (L0, downward). The drift scan's hand-synced second copy is deleted, and its own doc comment had already written the epitaph:

> both copies must agree with the gate, or the hint would order a removal the gate requires

Which is what it did: `drift.rs` derived the walk root, compared it to the declared bound, and told authors to **delete the grant the run needs**. Its test passes unchanged with the local copy gone.

Capability inference derives the root too, so `--infer-permits` now writes a boundary the runtime accepts.

## A wrong turn worth recording

My first attempt made the entry conditional on a literal pattern. That silently **un-poisoned the drift read set**: a dynamic pattern vanished from the table entirely instead of reaching the consumer that pokes it, and `dynamic_glob_pattern_poisons_the_read_set` went red. The entry is unconditional, like its `nika:read` siblings — whether an arg is literal is the consumer's question, and each already asks it.

## Proof

Tests first, red before and green after. Four new: the walk root across seven shapes (relative, `./`-prefixed, no metacharacter, root-level, absolute, absolute-at-root), the table entry itself including the templated case, and the `NIKA-SEC-004` judgement with a covering bound staying silent and a computed pattern staying silent.

`cargo test --workspace --lib` → **5986 passed, 0 failed**. `cargo clippy -p nika-cap -p nika-check -p nika-dap --all-targets -- -D warnings` → clean.

## Scope

No new finding code, no new gate, no new dependency, no new crate. One table entry, one function moved down a layer, one duplicate deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
