### PR TITLE
test(cli): cover list binary end to end

### DIFF
--- a/crates/nika-cli/tests/bin_smoke.rs
+++ b/crates/nika-cli/tests/bin_smoke.rs
@@ -88,6 +88,34 @@ fn check_valid_exits_zero() {
 }
 
 #[test]
+fn list_prints_exactly_the_two_workflows_below_cwd() {
+    let dir = workspace_tmp_dir("nika-bin-list-two");
+    std::fs::create_dir_all(dir.join("nested")).expect("nested dir");
+    write_fixture(&dir, "alpha.nika.yaml", "nika: alpha\n");
+    write_fixture(&dir.join("nested"), "beta.nika.yml", "nika: beta\n");
+    write_fixture(&dir, "nika.yaml", "nika: v1\n");
+
+    let out = bin()
+        .arg("list")
+        .current_dir(&dir)
+        .output()
+        .expect("binary runs");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "the workflow inventory exits 0 · stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "alpha.nika.yaml\nnested/beta.nika.yml\n"
+    );
+    assert!(out.stderr.is_empty(), "list stderr must stay empty");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn run_clean_workflow_exits_zero() {
     // The `run` verb — the most-used one — had ZERO binary-contract
     // coverage. A clean workflow runs through the L3 runtime and exits 0.

--- a/estate.yaml
+++ b/estate.yaml
@@ -157,7 +157,7 @@ patterns:
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 158
-  aggregate_sha256: bb13a678bf7482abf777107d1f1f1edebcfd829a90daf66f6dec26b35bd66ee0
+  aggregate_sha256: 09237de9df3e97b0e75e2c2ac74cb7abfbcef551f80190c1627bc03916424201
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored


### PR DESCRIPTION
## What

Lock the released `nika list` contract at the real binary seam.

- create exactly two workflows below CWD
- keep project `nika.yaml` excluded
- assert byte-for-byte stable relative output
- regenerate `estate.yaml` from the staged index

## Proof

- `cargo test -p nika-cli --lib --quiet` · 274 passed
- `cargo nextest run -p nika-cli --test bin_smoke -E "test(list_prints_exactly_the_two_workflows_below_cwd)"` · 1 passed
- pre-push gate · 10/10 ratchets + workspace `--lib` green