### PR TITLE
test(cli): prove bare tty thread end to end

### DIFF
--- a/crates/nika-cli/tests/thread_pty.rs
+++ b/crates/nika-cli/tests/thread_pty.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+#![cfg(unix)]
+#![allow(clippy::disallowed_types, clippy::expect_used, clippy::panic)]
+
+//! PTY e2e — bare `nika` opens one local thread over the released workflow
+//! surfaces. This test deliberately avoids a model turn: `/list`, `/workflow`,
+//! and `/quit` prove the terminal skin without network or provider authority.
+
+use std::process::Command;
+use std::time::Duration;
+
+use expectrl::process::unix::{PtyStream, UnixProcess, WaitStatus};
+use expectrl::session::{OsSession, Session};
+use expectrl::stream::log::LogStream;
+use expectrl::{Eof, Expect};
+
+type LoggedSession = Session<UnixProcess, LogStream<PtyStream, std::io::Stderr>>;
+
+const WORKFLOW: &str = "nika: alpha\npermits: { exec: [\"echo\"] }\ntasks:\n  hello:\n    exec: { command: [\"echo\", \"hello\"] }\n";
+
+fn exit_code(session: &mut LoggedSession) -> i32 {
+    match session.get_process_mut().wait().expect("wait") {
+        WaitStatus::Exited(_, code) => code,
+        other => panic!("process did not exit cleanly: {other:?}"),
+    }
+}
+
+#[test]
+fn bare_tty_lists_and_posts_a_workflow_in_one_thread() {
+    let dir = tempfile::Builder::new()
+        .prefix("nika-thread-pty-")
+        .tempdir()
+        .expect("tmp dir");
+    std::fs::write(dir.path().join("alpha.nika.yaml"), WORKFLOW).expect("workflow");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_nika-cli"));
+    cmd.current_dir(dir.path())
+        .env("NO_COLOR", "1")
+        .env("TERM", "xterm-256color");
+    let session = OsSession::spawn(cmd).expect("pty spawn");
+    let mut session = expectrl::session::log(session, std::io::stderr()).expect("log tee");
+    session.set_expect_timeout(Some(Duration::from_secs(30)));
+
+    session.expect("nika · thread").expect("thread opens");
+    session
+        .expect("model xai/grok-4 · /help")
+        .expect("model shown");
+    session.expect("nika ›").expect("prompt");
+    session.send_line("/list").expect("list");
+    session.expect("alpha.nika.yaml").expect("workflow listed");
+    session.expect("nika ›").expect("same thread");
+    session
+        .send_line("/workflow alpha.nika.yaml")
+        .expect("post workflow");
+    session.expect("alpha · 1 task").expect("workflow card");
+    session.expect("nika ›").expect("thread remains open");
+    session.send_line("/quit").expect("quit");
+    session.expect(Eof).expect("thread closes");
+
+    assert_eq!(exit_code(&mut session), 0);
+}

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4508
+  classified_files: 4509
   file_rows: 11
   pattern_rows: 22
   by_class:
-    authored: 1566
+    authored: 1567
     authored-pin: 2
     generated: 122
     pinned-copy: 122
@@ -156,8 +156,8 @@ patterns:
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
-  match_count: 158
-  aggregate_sha256: 09237de9df3e97b0e75e2c2ac74cb7abfbcef551f80190c1627bc03916424201
+  match_count: 159
+  aggregate_sha256: ea4f285aa3acd7690bd5716858032dc21b3bab96ddc77a1a6f439fdb794e5f62
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored


### PR DESCRIPTION
## What

Lock the bare-TTY thread at the real binary + pseudo-terminal seam.

- bare binary opens `nika · thread`
- `/list` inventories the CWD
- `/workflow` posts the workflow card
- the same prompt remains alive
- `/quit` exits 0
- no model call and no network authority

## Proof

- `cargo test -p nika-cli --lib --quiet` · 274 passed
- `cargo nextest run -p nika-cli --test thread_pty` · 1 passed
- pre-push gate · 10/10 ratchets + workspace `--lib` green