### PR TITLE
fix(authoring): make discovery precede creation

### DIFF
--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -5,6 +5,11 @@ Versions move together across all manifests (the mirror gate pins it).
 
 ## Unreleased
 
+Authoring now reads the workspace before creating another file:
+`nika list` discovers local candidates, then `explain` · `inspect` · `check`
+establish what each one does and whether it is clean. The skill states the
+boundary explicitly: listing is discovery, never certification.
+
 The authoring skill teaches the door the engine has: `lift:` (one
 construct, two laws · `law: taint` with `from:` · `law: data-as-code`).
 Its live yaml fences are complete nine-key files (`nika: <id>` ·

--- a/.agents/plugins/nika/CHANGELOG.md
+++ b/.agents/plugins/nika/CHANGELOG.md
@@ -10,6 +10,9 @@ Authoring now reads the workspace before creating another file:
 establish what each one does and whether it is clean. The skill states the
 boundary explicitly: listing is discovery, never certification.
 
+The `when:` map now names the full closed CEL callable set instead of
+incorrectly teaching `size()` as the only function.
+
 The authoring skill teaches the door the engine has: `lift:` (one
 construct, two laws · `law: taint` with `from:` · `law: data-as-code`).
 Its live yaml fences are complete nine-key files (`nika: <id>` ·

--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -9,11 +9,26 @@ Nika turns repeatable AI work into files: one `.nika.yaml`, four verbs,
 audited **before** it runs. You author the file; `nika check` is the
 oracle; the human runs it.
 
-## Read two examples before you write (measured: 8 rounds → 0)
+## Read the workspace, then two examples before you write
 
 **This file is the map. The examples are the territory.** A map this
 detailed is exactly why authors skip the ground, and the ground is where
 the shapes live. Nothing below replaces reading two real files.
+
+Join the workspace before adding to it. A local workflow may already own
+the job, its conventions and its permits boundary:
+
+```
+nika list                       # workflows below this directory
+nika explain <candidate>        # waves · cost · touches · run line
+nika inspect <candidate>        # tasks · verbs · graph anatomy
+nika check <candidate>          # the oracle: clean or an exact repair
+```
+
+`nika list` lists candidates; it does not certify them. Reuse or extend a
+matching local file only after `nika check` is clean. If nothing local fits,
+continue to the embedded shelf; even when one does, the two canonical reads
+below remain the cheapest shape check before a structural edit.
 
 The cost of skipping it was measured on 2026-07-28. Six authors each
 wrote one workflow from a real intention with this skill loaded and

--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -246,7 +246,7 @@ and a `default:`.
 |---|---|
 | `with:` | the DATA edge — bind another task's output, body reads `${{ with.alias }}` |
 | `after:` | the CONTROL edge — `success` · `failure` · `skipped` · `terminal` · `unwind` |
-| `when:` | a CEL boolean gate (`size()` is the only function) |
+| `when:` | a CEL boolean gate · closed callables: `size()` · `has()` · `.size()` · `.contains()` · `.startsWith()` · `.endsWith()` |
 | `for_each:` | fan out over a collection · the body reads the current element as `${{ item }}` and its position as `${{ index }}` (loop-scoped locals, NOT a fourth value authority · `item.field` reaches into an object element) · the task's `.output` is the ARRAY of per-iteration outputs, in input order · `max_parallel:` caps concurrency (1 = sequential) · `fail_fast:` aborts on the first error (default true) |
 | `retry:` | `max_attempts` · `backoff_ms` · `backoff_strategy` · `backoff_max_ms` · `jitter` · `on_codes` — transient failures only; a wrong prompt never heals by retry |
 | `on_error:` | exactly ONE action — `recover:` · `skip:` (preserves the original error at `tasks.X.error`) — with an optional `on_codes:` filter · the default (no `on_error:`) IS failure, and there is no keyword for saying so (`fail_workflow:` is dead · a YAML comment says it) |

--- a/crates/nika-cli/src/agent_kit/tests.rs
+++ b/crates/nika-cli/src/agent_kit/tests.rs
@@ -158,3 +158,27 @@ fn authoring_reads_local_workflows_before_creating_another() {
         "list must never be mistaken for the oracle"
     );
 }
+
+/// The authoring map must describe the callable set the CEL evaluator
+/// actually serves. A smaller remembered subset makes valid conditions look
+/// forbidden and sends authors toward unnecessary glue.
+#[test]
+fn authoring_names_the_served_cel_callables() {
+    let skill = read("skills/nika-authoring/SKILL.md");
+    for callable in [
+        "size()",
+        "has()",
+        ".contains()",
+        ".startsWith()",
+        ".endsWith()",
+    ] {
+        assert!(
+            skill.contains(callable),
+            "CEL callable `{callable}` missing"
+        );
+    }
+    assert!(
+        !skill.contains("size()` is the only function"),
+        "the retired one-function claim returned"
+    );
+}

--- a/crates/nika-cli/src/agent_kit/tests.rs
+++ b/crates/nika-cli/src/agent_kit/tests.rs
@@ -136,3 +136,25 @@ fn the_oracle_gains_no_run_tool_and_the_gate_stays_human() {
         "the delegation rule must ban the spontaneous run"
     );
 }
+
+/// An author joins the workspace that already exists before reaching for
+/// the embedded shelf. Discovery is not validation: the skill must keep
+/// `nika check` as the oracle after it names a local candidate.
+#[test]
+fn authoring_reads_local_workflows_before_creating_another() {
+    let skill = read("skills/nika-authoring/SKILL.md");
+    let list = skill.find("nika list").expect("local discovery is taught");
+    let explain = skill[list..]
+        .find("nika explain")
+        .map(|offset| list + offset)
+        .expect("the local candidate is narrated");
+    let shelf = skill
+        .find("nika try")
+        .expect("the embedded shelf stays taught");
+    assert!(list < explain, "discovery comes before narration");
+    assert!(explain < shelf, "the workspace is read before the shelf");
+    assert!(
+        skill.contains("lists candidates; it does not certify them"),
+        "list must never be mistaken for the oracle"
+    );
+}

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -263,8 +263,9 @@ enum Command {
     Try(try_args::TryArgs),
     /// The ONE creation door: describe the job in plain words (routes),
     /// or name a slug/skeleton (takes it, ingredients included) — the
-    /// destination derives from the slug. Bare `nika new` on a terminal
-    /// is the guided flow; `nika new '?'` lists the skeleton set.
+    /// destination derives from the slug. Plain words route across jobs,
+    /// lessons and skeletons. Bare `nika new` on a terminal is the guided
+    /// flow; `nika new '?'` lists the skeleton set.
     #[command(display_order = 11)]
     New {
         /// Plain-words intent, an example slug, or a skeleton name

--- a/crates/nika-onboard/src/guided.rs
+++ b/crates/nika-onboard/src/guided.rs
@@ -453,7 +453,7 @@ fn discovery() -> Outcome {
         "\n\nexamples work here too (complete lessons · verbatim) ·\n  nika new 01-hello my-hello.nika.yaml    # any slug from `nika try`",
     );
     text.push_str(
-        "\n\ntry ·\n  nika new chain my-first.nika.yaml\n  nika new \"describe the job in plain words\" my.nika.yaml   # routes to the closest skeleton\n  nika new                                                          # guided (terminal only)",
+        "\n\ntry ·\n  nika new chain my-first.nika.yaml\n  nika new \"describe the job in plain words\" my.nika.yaml   # routes across jobs · lessons · skeletons\n  nika new                                                          # guided (terminal only)",
     );
     Outcome {
         text,

--- a/crates/nika-onboard/src/guided/tests.rs
+++ b/crates/nika-onboard/src/guided/tests.rs
@@ -160,6 +160,17 @@ fn discovery_query_lists_the_set_without_a_dest() {
     let out = run("?", None, false);
     assert_eq!(out.code, codes::OK, "{}", out.text);
     assert!(out.text.contains("embedded set:"), "{}", out.text);
+    assert!(
+        out.text
+            .contains("routes across jobs · lessons · skeletons"),
+        "the discovery surface must name the whole intent-routing corpus: {}",
+        out.text
+    );
+    assert!(
+        !out.text.contains("closest skeleton"),
+        "the router is broader than the skeleton set: {}",
+        out.text
+    );
     for name in nika_pack::template_names() {
         assert!(out.text.contains(&name), "lists `{name}`: {}", out.text);
     }

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 90c135951649a5ea3425c8ff7807096d6ac646639ae1302ca56082e594086724
+  aggregate_sha256: 9bc563760b05cc4a252f6891d26590fa0583d350a630a90d28f0ce000770f9ae
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: 7b2332bd4ca64f17633aed8feec3a600a3537a5c5cbbe24f6778e66cace18772
+  aggregate_sha256: 748432409ea9301717c227023ed2f2efe3bbca46900c6bc48a0bd2f5296ab166
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: e985c21ac39ca1316343cb9e94c30e38dac5cf79fc93d596f7be953a906e2ec0
+  aggregate_sha256: 90c135951649a5ea3425c8ff7807096d6ac646639ae1302ca56082e594086724
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: ee9acc0cdb7374f683e48098411086cc749ce788f530d7721cc334f97f2c0ff5
+  aggregate_sha256: 7b2332bd4ca64f17633aed8feec3a600a3537a5c5cbbe24f6778e66cace18772
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 0d3788ca6e830a51a813fd8f063fe4962d336ebc863b08fae9c3dbdde821cd1a
+  aggregate_sha256: e985c21ac39ca1316343cb9e94c30e38dac5cf79fc93d596f7be953a906e2ec0
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## What

- name the full plain-intent router: jobs, lessons, then skeletons
- teach `list → explain → inspect → check` before creating another workflow
- replace the stale CEL size-only claim with the full callable set

## Proof

- `cargo deny check`
- `cargo test -p nika-onboard --lib --quiet` (112 passed, 1 ignored)
- `cargo test -p nika-cli --lib --quiet` (276 passed)
- pre-push gate: 10/10 CI ratchets; workspace lib suite green
- manual TTY: `/list`, `/workflow a.nika.yaml`, `/quit`
- oracle: native-strict clean before spend
- `nika try 01-hello` green on `mock/echo`