### PR TITLE
feat(project): the manifest names itself, and the retired tag refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 ---
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — the project file names itself (`nika.yaml`).** `nika:` carried a
+  frozen `v1` tag while a workflow's `nika:` names the file: one key, two
+  grammars, and every surface reading both had to know a special rule. It now
+  carries the project's kebab-case **name**, the same grammar the workflow
+  envelope gives its own `nika:`. The reasoning is this repo's own, written
+  when the workflow envelope was nuked — a field with one legal value is not a
+  version, so nothing is traded away, and the project gains a name it never
+  had. The retired tag refuses **here and nowhere else**: a pre-nuke workflow
+  carried a `workflow:` block beside its `nika: v1` and still refuses on that
+  key, so `v1` stays free to be an ordinary workflow name; a pre-nuke project
+  file had no companion key, so without a refusal the same bytes would quietly
+  stop meaning « schema v1 » and start meaning « a project named v1 ». Only a
+  whole marker qualifies — `vault`, `v2ray` and `v1-migration` stay names.
+  Migration is one line: `nika: v1` → `nika: <your-project-name>`.
+
+### Added
+
+- **`nika check` judges a project file as a project.** It applied the nine-key
+  WORKFLOW envelope to every document, so a project file came back
+  `NIKA-PARSE-002 missing required envelope field: tasks` — on a file
+  `nika init --project-file` had just written — and following that finding's
+  own advice converted a correct project file into a broken workflow. The
+  discriminant is the spec's, normative and covering every document
+  (`01-envelope` §The type discriminant): a `tasks:` key means WORKFLOW, its
+  absence means PROJECT. Deliberately not the filename, so it still holds for
+  a registry blob, an HTTP body or a fence pasted into a chat. A project now
+  audits in its own vocabulary — exit 0 clean, 2 on a finding — and says what
+  it governs rather than a count it never stated.
+- **`nika check` notes a file whose name and filename have drifted apart.**
+  Copy `foo.nika.yaml` to `bar.nika.yaml`, forget the header, and every trace
+  and journal event keeps saying `foo`. It is a NOTE and never a finding:
+  divergence is usually deliberate (an ordering prefix such as `01-hello` is
+  stripped before comparing), and the exit code is untouched. The filename is
+  a location `git mv` may change; the name is an identity that rides traces.
+
 ## [0.113.0](https://github.com/supernovae-st/nika/compare/v0.112.0..v0.113.0) - 2026-08-21
 
 **The couture release.** The judge already knew; the agent can now see.

--- a/crates/nika-arm/src/fire.rs
+++ b/crates/nika-arm/src/fire.rs
@@ -849,7 +849,7 @@ mod tests {
     /// A one-beat registry (validated green) — the `decide` fixture.
     fn registry_with(body: &str) -> ArmRegistry {
         let text = format!(
-            "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
+            "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
         );
         let registry = nika_cadence::parse_registry(&text).expect("parse");
         assert!(
@@ -968,7 +968,7 @@ mod tests {
     #[test]
     fn labels_are_the_radicals_with_collision_suffixes() {
         let text = concat!(
-            "nika: v1\n",
+            "nika: proj\n",
             "arm:\n",
             "  - workflow: a/doctor.nika.yaml\n",
             "    cadence: \"TZ=UTC 0 3 * * *\"\n",

--- a/crates/nika-arm/src/fire/firer_tests.rs
+++ b/crates/nika-arm/src/fire/firer_tests.rs
@@ -22,7 +22,7 @@ type RegistryFixture = (String, ArmRegistry);
 /// suite rides, with the overlap policy as the variable.
 fn registry_with(body: &str) -> RegistryFixture {
     let source = format!(
-        "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
+        "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
     );
     let registry = nika_cadence::parse_registry(&source).expect("parse");
     assert!(
@@ -34,7 +34,7 @@ fn registry_with(body: &str) -> RegistryFixture {
 
 fn minutely_registry(body: &str) -> RegistryFixture {
     let source = format!(
-        "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC * * * * *\"\n    plafond: 0.25\n{body}"
+        "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC * * * * *\"\n    plafond: 0.25\n{body}"
     );
     let registry = nika_cadence::parse_registry(&source).expect("parse");
     assert!(nika_cadence::validate(&registry).next().is_none());

--- a/crates/nika-cadence/public-api.txt
+++ b/crates/nika-cadence/public-api.txt
@@ -403,13 +403,13 @@ pub nika_cadence::error::CadenceErrorKind::FieldCount
 pub nika_cadence::error::CadenceErrorKind::FieldRange
 pub nika_cadence::error::CadenceErrorKind::FieldSyntax
 pub nika_cadence::error::CadenceErrorKind::Grammar
+pub nika_cadence::error::CadenceErrorKind::Identity
 pub nika_cadence::error::CadenceErrorKind::ManqueMissing
 pub nika_cadence::error::CadenceErrorKind::PhraseSyntax
 pub nika_cadence::error::CadenceErrorKind::PlafondMissing
 pub nika_cadence::error::CadenceErrorKind::PlafondNonPositive
 pub nika_cadence::error::CadenceErrorKind::SuspensionSansEcheance
 pub nika_cadence::error::CadenceErrorKind::SuspensionSansRaison
-pub nika_cadence::error::CadenceErrorKind::TagFrozen
 pub nika_cadence::error::CadenceErrorKind::ToleranceSyntaxe
 pub nika_cadence::error::CadenceErrorKind::TzMissing
 pub nika_cadence::error::CadenceErrorKind::TzUnknown
@@ -1542,9 +1542,10 @@ pub type nika_cadence::registry::Overlap::Output = T
 pub nika_cadence::registry::ArmRegistry::ceiling: core::option::Option<f64>
 pub nika_cadence::registry::ArmRegistry::nika: alloc::string::String
 impl nika_cadence::registry::ArmRegistry
-pub const nika_cadence::registry::ArmRegistry::SCHEMA: &'static str
 pub fn nika_cadence::registry::ArmRegistry::beat_count(&self) -> usize
 pub fn nika_cadence::registry::ArmRegistry::beats(&self) -> impl core::iter::traits::iterator::Iterator<Item = &nika_cadence::registry::Beat>
+pub fn nika_cadence::registry::ArmRegistry::is_kebab_id(s: &str) -> bool
+pub fn nika_cadence::registry::ArmRegistry::is_retired_tag(s: &str) -> bool
 impl core::fmt::Debug for nika_cadence::registry::ArmRegistry
 pub fn nika_cadence::registry::ArmRegistry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'de> serde_core::de::Deserialize<'de> for nika_cadence::registry::ArmRegistry
@@ -1760,13 +1761,13 @@ pub nika_cadence::CadenceErrorKind::FieldCount
 pub nika_cadence::CadenceErrorKind::FieldRange
 pub nika_cadence::CadenceErrorKind::FieldSyntax
 pub nika_cadence::CadenceErrorKind::Grammar
+pub nika_cadence::CadenceErrorKind::Identity
 pub nika_cadence::CadenceErrorKind::ManqueMissing
 pub nika_cadence::CadenceErrorKind::PhraseSyntax
 pub nika_cadence::CadenceErrorKind::PlafondMissing
 pub nika_cadence::CadenceErrorKind::PlafondNonPositive
 pub nika_cadence::CadenceErrorKind::SuspensionSansEcheance
 pub nika_cadence::CadenceErrorKind::SuspensionSansRaison
-pub nika_cadence::CadenceErrorKind::TagFrozen
 pub nika_cadence::CadenceErrorKind::ToleranceSyntaxe
 pub nika_cadence::CadenceErrorKind::TzMissing
 pub nika_cadence::CadenceErrorKind::TzUnknown
@@ -2363,9 +2364,10 @@ pub type nika_cadence::firing::ArmGeneration::Output = T
 pub nika_cadence::ArmRegistry::ceiling: core::option::Option<f64>
 pub nika_cadence::ArmRegistry::nika: alloc::string::String
 impl nika_cadence::registry::ArmRegistry
-pub const nika_cadence::registry::ArmRegistry::SCHEMA: &'static str
 pub fn nika_cadence::registry::ArmRegistry::beat_count(&self) -> usize
 pub fn nika_cadence::registry::ArmRegistry::beats(&self) -> impl core::iter::traits::iterator::Iterator<Item = &nika_cadence::registry::Beat>
+pub fn nika_cadence::registry::ArmRegistry::is_kebab_id(s: &str) -> bool
+pub fn nika_cadence::registry::ArmRegistry::is_retired_tag(s: &str) -> bool
 impl core::fmt::Debug for nika_cadence::registry::ArmRegistry
 pub fn nika_cadence::registry::ArmRegistry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'de> serde_core::de::Deserialize<'de> for nika_cadence::registry::ArmRegistry

--- a/crates/nika-cadence/src/error.rs
+++ b/crates/nika-cadence/src/error.rs
@@ -32,8 +32,9 @@ pub enum CadenceErrorKind {
     /// The YAML itself does not parse, or a key is unknown (closed
     /// grammar).
     Grammar,
-    /// `nika:` is not the frozen `v1` tag.
-    TagFrozen,
+    /// `nika:` is absent, not a kebab-case name, or is the retired
+    /// schema tag.
+    Identity,
     /// `ceiling:` present but not a positive finite number.
     CeilingNonPositive,
     /// Round-2+ key present (`traces:` · `registry:` · `signature:` ·
@@ -90,7 +91,7 @@ impl CadenceErrorKind {
     pub const fn spec_code(self) -> &'static str {
         match self {
             Self::Grammar => "cadence.grammar",
-            Self::TagFrozen => "cadence.tag-frozen",
+            Self::Identity => "cadence.identity",
             Self::CeilingNonPositive => "cadence.ceiling-non-positive",
             Self::DeferredKey => "cadence.deferred-key",
             Self::TzMissing => "cadence.tz-missing",

--- a/crates/nika-cadence/src/parse.rs
+++ b/crates/nika-cadence/src/parse.rs
@@ -35,11 +35,20 @@ pub fn parse_registry(text: &str) -> Result<ArmRegistry, CadenceError> {
 /// (FCI-014: an iterator, not a Vec.)
 pub fn validate(registry: &ArmRegistry) -> impl Iterator<Item = CadenceError> {
     let mut faults = Vec::new();
-    if registry.nika != ArmRegistry::SCHEMA {
+    if ArmRegistry::is_retired_tag(&registry.nika) {
         faults.push(CadenceError::file(
-            CadenceErrorKind::TagFrozen,
-            format!("nika: {} · le tag est gelé à `v1`", registry.nika),
-            "le tag de l enveloppe projet est `nika: v1` — le toucher est le geste le plus lourd du projet",
+            CadenceErrorKind::Identity,
+            format!("nika: {} · c est l ancien tag de schéma, pas un nom de projet", registry.nika),
+            "le tag est devenu le NOM du projet (`nika: mon-projet`) — la version vit sur la ligne `$schema`",
+        ));
+    } else if !ArmRegistry::is_kebab_id(&registry.nika) {
+        faults.push(CadenceError::file(
+            CadenceErrorKind::Identity,
+            format!(
+                "nika: {} · un nom de projet est en kebab-case (`^[a-z][a-z0-9-]*$`)",
+                registry.nika
+            ),
+            "nomme le projet (`nika: mon-projet`) — la même grammaire que le `nika:` d un workflow",
         ));
     }
     if let Some(ceiling) = registry.ceiling

--- a/crates/nika-cadence/src/parse.rs
+++ b/crates/nika-cadence/src/parse.rs
@@ -39,7 +39,7 @@ pub fn validate(registry: &ArmRegistry) -> impl Iterator<Item = CadenceError> {
         faults.push(CadenceError::file(
             CadenceErrorKind::Identity,
             format!("nika: {} · c est l ancien tag de schéma, pas un nom de projet", registry.nika),
-            "le tag est devenu le NOM du projet (`nika: mon-projet`) — la version vit sur la ligne `$schema`",
+            "le tag est devenu le NOM du projet (`nika: mon-projet`) — la version vit désormais dans la ligne `$schema`",
         ));
     } else if !ArmRegistry::is_kebab_id(&registry.nika) {
         faults.push(CadenceError::file(

--- a/crates/nika-cadence/src/registry.rs
+++ b/crates/nika-cadence/src/registry.rs
@@ -3,8 +3,9 @@
 
 //! The registry types — the parsed shape of `nika.yaml`.
 //!
-//! Discipline (the forward-compat invariants): the wire tag is `nika:
-//! v1`, frozen (FCI-003) · public-field structs are `#[non_exhaustive]`
+//! Discipline (the forward-compat invariants): `nika:` carries the
+//! project's kebab-case NAME, the same grammar the workflow envelope
+//! gives its own `nika:` · public-field structs are `#[non_exhaustive]`
 //! (FCI-016) · no `HashMap` anywhere — the workspace lint
 //! `iter_over_hash_type = "deny"` guards a future signature's
 //! determinism, and this crate simply holds no maps · no `Vec` in
@@ -21,8 +22,10 @@ use crate::cron::CronSpec;
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct ArmRegistry {
-    /// The schema tag — frozen at `v1` (the same freeze law as the
-    /// workflow envelope: touching it is the project's heaviest move).
+    /// The project's NAME, kebab-case — the same grammar the workflow
+    /// envelope gives its own `nika:`. It replaced a frozen `v1` tag: a
+    /// field with one legal value is not a version, and the version now
+    /// rides the `$schema` URL where an editor already reads it.
     pub nika: String,
     /// The project-wide run ceiling (USD) — a default every beat's
     /// `plafond` may exceed EXPLICITLY: the hierarchy stays visible.
@@ -40,8 +43,26 @@ pub struct ArmRegistry {
 }
 
 impl ArmRegistry {
-    /// The wire tag this parser accepts — frozen forever (FCI-003).
-    pub const SCHEMA: &'static str = "v1";
+    /// `^[a-z][a-z0-9-]*$` — the name shape, shared with the workflow
+    /// envelope and with `nika_vocab::project`.
+    #[must_use]
+    pub fn is_kebab_id(s: &str) -> bool {
+        s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+            && s.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    }
+
+    /// A retired schema tag (`^v[0-9]+$`). It refuses in a PROJECT file
+    /// and nowhere else: a pre-nuke workflow carried `workflow:` beside
+    /// its `nika: v1` and refuses on that key, while a project file had
+    /// no companion — the same bytes would quietly stop meaning « schema
+    /// v1 » and start meaning « a project named v1 ». Only the WHOLE
+    /// marker: `vault` · `v2ray` · `v1-migration` stay ordinary names.
+    #[must_use]
+    pub fn is_retired_tag(s: &str) -> bool {
+        s.strip_prefix('v')
+            .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()))
+    }
 
     /// The armed beats, in file order.
     pub fn beats(&self) -> impl Iterator<Item = &Beat> {

--- a/crates/nika-cadence/src/tests/emit.rs
+++ b/crates/nika-cadence/src/tests/emit.rs
@@ -60,7 +60,7 @@ fn ctx_with_env() -> EmitCtx {
 /// Two Paris beats: the readable weekly (one dict) and a cron monthly
 /// with two minutes (two dicts).
 const TWO_BEATS: &str = concat!(
-    "nika: v1\n",
+    "nika: proj\n",
     "arm:\n",
     "  - workflow: workflows/weekly.nika.yaml\n",
     "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
@@ -227,7 +227,7 @@ fn a_beat_in_another_zone_refuses_on_launchd_and_rides_systemd() {
     // differs is refused, naming both zones. systemd carries the zone,
     // so the same beat renders there.
     let reg = registry(concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=Asia/Tokyo 0 3 * * *\"\n",
@@ -252,7 +252,7 @@ fn a_beat_in_another_zone_refuses_on_launchd_and_rides_systemd() {
 #[test]
 fn a_webhook_beat_refuses_the_clock_surfaces() {
     let reg = registry(concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/hook.nika.yaml\n",
         "    cadence: \"on-webhook\"\n",
@@ -274,7 +274,7 @@ fn a_webhook_beat_refuses_the_clock_surfaces() {
 fn past_the_interval_budget_the_render_refuses_with_the_count() {
     // 30 minutes × 12 heures × 2 jours = 720 dicts — au-delà du budget.
     let reg = registry(concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/dense.nika.yaml\n",
         "    cadence: \"TZ=Europe/Paris */2 */2 1,15 * *\"\n",
@@ -302,7 +302,7 @@ fn the_v0_unsupported_policies_refuse_with_their_version() {
         ("    décalage: hash\n", "décalage:"),
     ] {
         let reg = registry(&format!(
-            "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n    plafond: 0.25\n    manqué: sauter\n{extra}"
+            "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n    plafond: 0.25\n    manqué: sauter\n{extra}"
         ));
         let refusal =
             emit::render(&reg, &ctx(), Target::Launchd, Mode::PerBeat).expect_err("D6 refuse");
@@ -320,7 +320,7 @@ fn the_v0_unsupported_policies_refuse_with_their_version() {
         }
     }
     let reg = registry(concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n",
@@ -345,7 +345,7 @@ fn deux_beats_meme_workflow_rendent_deux_labels() {
     // Two DIFFERENT paths, one radical: the second takes `-2` (D4), and
     // each gets its own unit file.
     let reg = registry(concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: a/doctor.nika.yaml\n",
         "    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n",
@@ -369,7 +369,7 @@ fn deux_beats_meme_workflow_rendent_deux_labels() {
 #[test]
 fn suspended_and_cloud_beats_emit_nothing() {
     let reg = registry(concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/local.nika.yaml\n",
         "    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n",
@@ -422,7 +422,7 @@ fn check_budget(cadence_text: &str) {
     let cadence = Cadence::parse(cadence_text).expect("le corpus se parse");
     let expected = expected_dicts(&cadence);
     let reg = registry(&format!(
-        "nika: v1\narm:\n  - workflow: w.nika.yaml\n    cadence: \"{cadence_text}\"\n    plafond: 0.25\n    manqué: sauter\n"
+        "nika: proj\narm:\n  - workflow: w.nika.yaml\n    cadence: \"{cadence_text}\"\n    plafond: 0.25\n    manqué: sauter\n"
     ));
     let ctx = EmitCtx::new(
         PathBuf::from("/usr/local/bin/nika"),

--- a/crates/nika-cadence/src/tests/mod.rs
+++ b/crates/nika-cadence/src/tests/mod.rs
@@ -33,8 +33,8 @@ use proptest::prelude::*;
 
 use crate::next::next_slots;
 use crate::{
-    AfterSkip, ArmRegistry, Cadence, CadenceErrorKind, Locus, MissPolicy, Overlap, Shift,
-    parse_registry, validate,
+    AfterSkip, Cadence, CadenceErrorKind, Locus, MissPolicy, Overlap, Shift, parse_registry,
+    validate,
 };
 
 /// A literal instant (UTC) — the calculator's only input.
@@ -75,7 +75,7 @@ fn kinds(yaml: &str) -> Vec<CadenceErrorKind> {
 }
 
 const HEALTHY: &str = "
-nika: v1
+nika: proj
 ceiling: 0.50
 arm:
   - workflow: workflows/geo-probe.nika.yaml
@@ -85,6 +85,33 @@ arm:
 ";
 
 // ── parse · the two forms, the zone inside ─────────────────────────
+
+/// The retired schema tag refuses in a project file — the second
+/// parser of `nika.yaml` must agree with the first, or the same bytes
+/// get two verdicts depending on which door read them.
+#[test]
+fn le_tag_de_schema_retire_est_refuse() {
+    let reg =
+        parse_registry("nika: v1\nceiling: 0.50\n").expect("la grammaire accepte, la loi refuse");
+    let faults: Vec<_> = validate(&reg).collect();
+    assert!(
+        faults
+            .iter()
+            .any(|f| f.kind() == CadenceErrorKind::Identity),
+        "un tag retire doit refuser ici aussi · {faults:?}"
+    );
+    // Le marqueur ENTIER seulement.
+    for name in ["vault", "v2ray", "v1-migration"] {
+        let reg = parse_registry(&format!("nika: {name}\n")).expect("un nom ordinaire");
+        let faults: Vec<_> = validate(&reg).collect();
+        assert!(
+            !faults
+                .iter()
+                .any(|f| f.kind() == CadenceErrorKind::Identity),
+            "{name} est un nom ordinaire · {faults:?}"
+        );
+    }
+}
 
 #[test]
 fn parse_cron_with_zone_inside() {
@@ -342,7 +369,7 @@ fn every_refusal_class_carries_its_own_distinct_slug() {
     use CadenceErrorKind as K;
     let all = [
         K::Grammar,
-        K::TagFrozen,
+        K::Identity,
         K::CeilingNonPositive,
         K::DeferredKey,
         K::TzMissing,
@@ -369,7 +396,7 @@ fn every_refusal_class_carries_its_own_distinct_slug() {
         #[allow(clippy::match_same_arms)]
         match k {
             K::Grammar
-            | K::TagFrozen
+            | K::Identity
             | K::CeilingNonPositive
             | K::DeferredKey
             | K::TzMissing
@@ -426,7 +453,7 @@ fn the_ceiling_guard_refuses_zero_negative_infinite_and_nan() {
     for value in ["0", "0.0", "-1.0", ".inf", "-.inf", ".nan"] {
         let yaml = format!(
             "
-nika: v1
+nika: proj
 ceiling: 0.50
 arm:
   - workflow: workflows/geo-probe.nika.yaml
@@ -747,7 +774,7 @@ fn a_healthy_registry_validates_clean() {
         0,
         "aucun refus pour un fichier sain"
     );
-    assert_eq!(reg.nika, ArmRegistry::SCHEMA);
+    assert_eq!(reg.nika, "proj");
     assert_eq!(reg.beat_count(), 1);
     let beat = reg.beats().next().expect("un beat");
     assert_eq!(beat.locus(), Locus::Local, "défaut sûr · loi ⑥");
@@ -765,7 +792,7 @@ fn a_healthy_registry_validates_clean() {
 fn manque_and_plafond_are_required_without_default() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -786,7 +813,7 @@ arm:
 fn a_suspension_tells_its_reason_and_its_expiry() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -801,7 +828,7 @@ arm:
 
     let clean = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -820,7 +847,7 @@ arm:
 
     let bad_date = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -838,7 +865,7 @@ arm:
 fn apres_saut_only_rides_a_sauter_overlap() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -852,7 +879,7 @@ arm:
 
     let clean = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -870,7 +897,7 @@ fn round_two_keys_are_refused_by_name() {
     for key in ["signature: \"ed25519:abc\"", "budget: 10.0"] {
         let yaml = format!(
             "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -886,7 +913,7 @@ arm:
         );
     }
     for key in ["traces: {}", "registry: {}"] {
-        let yaml = format!("nika: v1\n{key}\n");
+        let yaml = format!("nika: proj\n{key}\n");
         let faults = kinds(&yaml);
         assert!(
             faults.contains(&CadenceErrorKind::DeferredKey),
@@ -899,7 +926,7 @@ arm:
 fn a_workflow_armed_twice_is_a_refusal() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -917,16 +944,16 @@ arm:
 #[test]
 fn the_envelope_tag_is_frozen() {
     let faults = kinds("nika: v2\n");
-    assert!(faults.contains(&CadenceErrorKind::TagFrozen));
+    assert!(faults.contains(&CadenceErrorKind::Identity));
 }
 
 #[test]
 fn an_unknown_key_dies_at_parse() {
-    let err = parse_registry("nika: v1\nfoo: bar\n").expect_err("clé inconnue");
+    let err = parse_registry("nika: proj\nfoo: bar\n").expect_err("clé inconnue");
     assert_eq!(err.kind(), CadenceErrorKind::Grammar);
     let err = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -943,7 +970,7 @@ arm:
 fn tolerance_is_the_m_over_k_firm_form() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -959,7 +986,7 @@ arm:
 
     let clean = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -975,7 +1002,7 @@ arm:
 fn only_hash_jitter_exists() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: on-webhook
@@ -990,7 +1017,7 @@ arm:
 #[test]
 fn a_ceiling_is_a_positive_finite_number() {
     for ceiling in ["0", "-2"] {
-        let faults = kinds(&format!("nika: v1\nceiling: {ceiling}\n"));
+        let faults = kinds(&format!("nika: proj\nceiling: {ceiling}\n"));
         assert!(faults.contains(&CadenceErrorKind::CeilingNonPositive));
     }
 }
@@ -999,7 +1026,7 @@ fn a_ceiling_is_a_positive_finite_number() {
 fn the_workflow_path_names_a_nika_yaml() {
     let faults = kinds(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: README.md
     cadence: on-webhook
@@ -1016,7 +1043,7 @@ fn the_span_survives_the_law_pass() {
     // authored text keeps its byte span THROUGH validate().
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: TZ=UTC 61 9 * * 1
@@ -1080,7 +1107,7 @@ fn the_workflow_path_is_relative_to_the_registry() {
     ] {
         let yaml = format!(
             "
-nika: v1
+nika: proj
 arm:
   - workflow: {path}
     cadence: on-webhook
@@ -1138,7 +1165,7 @@ arm:
 fn the_workflow_remedy_is_itself_a_legal_path() {
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: /absolu/interdit.nika.yaml
     cadence: on-webhook
@@ -1159,7 +1186,7 @@ arm:
         .expect("le remède montre un chemin");
     let yaml = format!(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: {montre}
     cadence: on-webhook

--- a/crates/nika-cadence/src/tests/planner.rs
+++ b/crates/nika-cadence/src/tests/planner.rs
@@ -129,7 +129,7 @@ fn prev_before_crosses_a_month_and_a_year_backwards() {
 // ── due · the pure planner, the clock handed in ─────────────────────
 
 const DUE_DAILY: &str = "
-nika: v1
+nika: proj
 ceiling: 0.50
 arm:
   - workflow: workflows/nightly.nika.yaml
@@ -169,7 +169,7 @@ fn due_a_missed_slot_says_how_many() {
 fn due_an_idle_or_cloud_beat_is_never_due() {
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/suspended.nika.yaml
     cadence: TZ=Europe/Paris 0 3 * * *
@@ -203,7 +203,7 @@ arm:
 fn earliest_next_is_the_soonest_of_the_armed_beats() {
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/weekly.nika.yaml
     cadence: TZ=Europe/Paris lundi 9h07
@@ -233,7 +233,7 @@ fn earliest_next_a_tie_keeps_the_first_beat() {
     // comparaison du meilleur.
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/a.nika.yaml
     cadence: TZ=Europe/Paris 0 3 * * *
@@ -351,7 +351,7 @@ fn due_the_gap_fire_is_due_like_any_other() {
 fn a_webhook_beat_is_never_due_nor_next() {
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/hooked.nika.yaml
     cadence: on-webhook
@@ -372,7 +372,7 @@ fn due_a_cadence_that_breaks_the_law_refuses_the_plan() {
     // REFUSE le plan entier, il ne saute pas le beat en silence.
     let reg = parse_registry(
         "
-nika: v1
+nika: proj
 arm:
   - workflow: workflows/nightly.nika.yaml
     cadence: 0 3 * * *

--- a/crates/nika-cadence/src/tests/tick.rs
+++ b/crates/nika-cadence/src/tests/tick.rs
@@ -26,7 +26,7 @@ fn at(text: &str) -> Zoned {
 
 fn registry_with(body: &str) -> ArmRegistry {
     let text = format!(
-        "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
+        "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ=UTC 0 3 * * *\"\n    plafond: 0.25\n{body}"
     );
     let registry = crate::parse_registry(&text).expect("parse");
     assert!(
@@ -189,7 +189,7 @@ fn expiry_is_strictly_before_the_decision_date() {
 #[test]
 fn a_webhook_beat_skips_the_clock() {
     let text = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"on-webhook\"\n",

--- a/crates/nika-cli/src/verbs/arm/mod.rs
+++ b/crates/nika-cli/src/verbs/arm/mod.rs
@@ -340,7 +340,7 @@ mod tests {
     }
 
     const TWO_BEATS: &str = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/weekly.nika.yaml\n",
         "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn the_report_tells_proven_from_declared_and_names_the_orphans() {
         let body = concat!(
-            "nika: v1\n",
+            "nika: proj\n",
             "arm:\n",
             "  - workflow: workflows/prouve.nika.yaml\n",
             "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     fn the_report_refuses_tampered_or_truncated_history_loudly() {
         let body = concat!(
-            "nika: v1\n",
+            "nika: proj\n",
             "arm:\n",
             "  - workflow: workflows/doctor.nika.yaml\n",
             "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -531,7 +531,7 @@ mod tests {
     #[test]
     fn the_report_surfaces_the_folded_ambiguous_claim() {
         let body = concat!(
-            "nika: v1\n",
+            "nika: proj\n",
             "arm:\n",
             "  - workflow: workflows/doctor.nika.yaml\n",
             "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -597,7 +597,7 @@ mod tests {
         let dir = project_at(
             "nolaw",
             concat!(
-                "nika: v1\n",
+                "nika: proj\n",
                 "arm:\n",
                 "  - workflow: w.nika.yaml\n",
                 "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",
@@ -638,7 +638,7 @@ mod tests {
     #[test]
     fn every_cadence_key_is_reachable_through_the_project_file() {
         let body = concat!(
-            "nika: v1\n",
+            "nika: proj\n",
             "arm:\n",
             "  - workflow: w.nika.yaml\n",
             "    cadence: \"TZ=Europe/Paris lundi 9h07\"\n",

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -178,6 +178,7 @@ use crate::verbs::{RunSource, VerbOutput, load_checked, load_checked_run_source}
 mod drift;
 pub(crate) mod energy;
 pub(crate) mod models_rung;
+mod project;
 use models_rung::{ModelFinding, ModelsAudit, pricing_section, unresolvable_models};
 
 use nika_display::check_render::render;
@@ -263,6 +264,42 @@ fn strict_footers(
     }
 }
 
+/// How many `native-first` hints survive — the count `--native-strict`
+/// folds into the verdict, and the only hint family that ever does.
+fn native_hint_count(report: &CheckReport) -> usize {
+    report
+        .hints
+        .iter()
+        .filter(|h| h.kind == "native-first")
+        .count()
+}
+
+/// The project-file route, taken BEFORE the workflow envelope is applied.
+///
+/// The envelope cannot describe a project file — it refuses `ceiling:` as
+/// an unknown field and demands a `tasks:` map, which is the destructive
+/// advice this route exists to end. The discriminant is the spec's
+/// (`01-envelope` §The type discriminant): a `tasks:` key means WORKFLOW,
+/// its absence means PROJECT, at full coverage and independent of the
+/// filename.
+fn project_route(path: &str, json: bool) -> Option<VerbOutput> {
+    let yaml = read_source(path)?;
+    nika_vocab::project::is_project_document(&yaml).then(|| project::judge(path, &yaml, json))
+}
+
+/// Read the document once for the discriminant.
+///
+/// `-` (stdin) is deliberately NOT routed: stdin can be consumed only
+/// once, and silently swallowing it here would break the workflow lane
+/// that owns it. A project file piped on stdin still meets the workflow
+/// envelope — a known edge, named rather than half-handled.
+fn read_source(path: &str) -> Option<String> {
+    if path == "-" {
+        return None;
+    }
+    std::fs::read_to_string(path).ok()
+}
+
 /// Like [`run`], with an explicit readiness profile.
 #[must_use]
 pub fn run_with_profile(
@@ -291,6 +328,9 @@ fn run_target_with_profile(
     model_override: Option<&str>,
     theme: Theme,
 ) -> VerbOutput {
+    if let Some(out) = project_route(&target.path, json) {
+        return out;
+    }
     let source = match RunSource::capture_with_repair_target(&target.path, target.repair_target) {
         Ok(source) => source,
         Err(out) if json => return parse_fatal_json(&out),
@@ -317,11 +357,7 @@ pub(crate) fn run_source_with_profile(
     // The declared-vs-used drift family (NIKA-DRIFT-001 · drift.rs) —
     // advisory in both projections, never an exit-code input.
     let drift_hints = drift::scan(&wf);
-    let native_hints = report
-        .hints
-        .iter()
-        .filter(|h| h.kind == "native-first")
-        .count();
+    let native_hints = native_hint_count(&report);
     // The MODELS rung (#320): the ladder validated TOOLS but not MODELS —
     // the exact asymmetry a hallucinating agent hits. A `model:` this
     // binary cannot resolve is a FINDING (exit 2), never a green audit.
@@ -384,6 +420,7 @@ pub(crate) fn run_source_with_profile(
         profile == Profile::Operational && clean && !profile_clean,
         grade,
     );
+    naming_note(&mut text, theme, path, &wf);
     // The `--ascii` byte contract (P1 · audit UX 2026-07-30): the finished
     // report folds through the ONE enforcement seam — the glyph twins stay
     // the primary mechanism, this fold is what makes the emitted bytes
@@ -393,6 +430,49 @@ pub(crate) fn run_source_with_profile(
     } else {
         VerbOutput::file(nika_display::vocab::sober(theme, &text))
     }
+}
+
+/// The accidental-rename note (INFO, never a refusal).
+///
+/// Copy `foo.nika.yaml` to `bar.nika.yaml`, forget the header, and every
+/// trace keeps saying `foo`: the file moved, its identity did not.
+///
+/// A NOTE because divergence is usually deliberate — the spec's own
+/// example is `deploy.nika.yaml` carrying `nika: deploy-to-prod`, and a
+/// numbered path puts curriculum order in the filename. So an ordering
+/// prefix is stripped before comparing; a different WORD is the
+/// accidental shape. The filename is a location `git mv` may change, the
+/// name is an identity that rides traces — renaming one must never
+/// silently re-identify the other.
+fn naming_note(text: &mut String, theme: Theme, path: &str, wf: &nika_schema::raw::RawWorkflow) {
+    let Some(name) = wf.workflow.as_ref().map(|n| n.value.as_str()) else {
+        return;
+    };
+    let Some(stem) = std::path::Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .and_then(|f| {
+            f.strip_suffix(".nika.yaml")
+                .or_else(|| f.strip_suffix(".nika.yml"))
+        })
+    else {
+        return;
+    };
+    // An ordering prefix (`01-`, `02_`) is a deliberate convention.
+    let bare = stem
+        .find(|c: char| !c.is_ascii_digit())
+        .filter(|&i| i > 0 && matches!(stem.as_bytes()[i], b'-' | b'_'))
+        .map_or(stem, |i| &stem[i + 1..]);
+    if bare == name {
+        return;
+    }
+    let _ = write!(
+        text,
+        "\n {} the file is `{stem}` and its name is `{name}` — traces, journal \
+         events and errors will all say `{name}`. Deliberate is fine; a \
+         forgotten header after a copy is not.\n",
+        theme.paint(Role::Dim, "note ·")
+    );
 }
 
 /// `--json` parse-fatal verdict: one findings row, `parse_fatal: true`.

--- a/crates/nika-cli/src/verbs/check/project.rs
+++ b/crates/nika-cli/src/verbs/check/project.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The project-file lane of `nika check`.
+//!
+//! `check` used to apply the nine-key WORKFLOW envelope to every document,
+//! so a project file came back `NIKA-PARSE-002 missing … tasks` — on a file
+//! `nika init --project-file` had just written — and obeying that finding
+//! converts a correct project file into a broken workflow.
+//!
+//! The discriminant lives in [`nika_vocab::project`], beside the grammar it
+//! describes; this module is only the verdict a human reads.
+
+use nika_cli_host::output::VerbOutput;
+use nika_vocab::project;
+
+/// Judge a project document with the grammar that governs it.
+///
+/// Exit codes match the workflow lane (0 clean · 2 findings); the text
+/// is [`nika_display::project_render`]'s.
+#[must_use]
+pub(super) fn judge(path: &str, yaml: &str, json: bool) -> VerbOutput {
+    match project::parse(yaml) {
+        Ok(parsed) => {
+            let name = parsed.name.as_deref().unwrap_or("<unnamed>");
+            if json {
+                return VerbOutput::ok(format!(
+                    "{{\"report_version\":1,\"file\":{path:?},\"kind\":\"project\",\
+                     \"clean\":true,\"name\":{name:?},\"findings\":[]}}"
+                ));
+            }
+            let governs = nika_display::project_render::governs(
+                parsed.ceiling,
+                parsed.traces.is_some(),
+                parsed.registry.is_some(),
+                parsed.arm().len(),
+            );
+            VerbOutput::ok(nika_display::project_render::verdict(path, name, &governs))
+        }
+        Err(err) => {
+            let slug = err.kind().spec_code();
+            if json {
+                let detail = err.detail();
+                return VerbOutput {
+                    text: format!(
+                        "{{\"report_version\":1,\"file\":{path:?},\"kind\":\"project\",\
+                         \"clean\":false,\"findings\":[{{\"code\":{slug:?},\
+                         \"message\":{detail:?}}}]}}"
+                    ),
+                    code: nika_cli_host::output::exit::FILE,
+                };
+            }
+            VerbOutput::file(nika_display::project_render::refusal(
+                path,
+                err.line(),
+                slug,
+                err.detail(),
+                err.remedy(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_valid_project_is_green_and_says_what_it_governs() {
+        let out = judge("nika.yaml", "nika: my-project\nceiling: 0.50\n", false);
+        assert_eq!(out.code, nika_cli_host::output::exit::OK, "{}", out.text);
+        assert!(out.text.contains("my-project"), "{}", out.text);
+        assert!(out.text.contains("ceiling $0.50"), "{}", out.text);
+    }
+
+    #[test]
+    fn a_bare_project_says_it_governs_nothing() {
+        let out = judge("nika.yaml", "nika: my-project\n", false);
+        assert_eq!(out.code, nika_cli_host::output::exit::OK, "{}", out.text);
+        assert!(out.text.contains("governs nothing"), "{}", out.text);
+    }
+
+    #[test]
+    fn a_broken_project_refuses_in_its_own_vocabulary() {
+        let out = judge("nika.yaml", "nika: my-project\nceling: 0.50\n", false);
+        assert_eq!(out.code, nika_cli_host::output::exit::FILE, "{}", out.text);
+        assert!(out.text.contains("project."), "{}", out.text);
+        assert!(
+            !out.text.contains("tasks"),
+            "a project refusal must never demand `tasks:`: {}",
+            out.text
+        );
+    }
+}

--- a/crates/nika-cli/src/verbs/check/project.rs
+++ b/crates/nika-cli/src/verbs/check/project.rs
@@ -24,10 +24,8 @@ pub(super) fn judge(path: &str, yaml: &str, json: bool) -> VerbOutput {
         Ok(parsed) => {
             let name = parsed.name.as_deref().unwrap_or("<unnamed>");
             if json {
-                return VerbOutput::ok(format!(
-                    "{{\"report_version\":1,\"file\":{path:?},\"kind\":\"project\",\
-                     \"clean\":true,\"name\":{name:?},\"findings\":[]}}"
-                ));
+                let text = nika_display::project_render::json(path, true, Some(name), "", "");
+                return VerbOutput::ok(text);
             }
             let governs = nika_display::project_render::governs(
                 parsed.ceiling,
@@ -40,13 +38,10 @@ pub(super) fn judge(path: &str, yaml: &str, json: bool) -> VerbOutput {
         Err(err) => {
             let slug = err.kind().spec_code();
             if json {
-                let detail = err.detail();
+                let text =
+                    nika_display::project_render::json(path, false, None, slug, err.detail());
                 return VerbOutput {
-                    text: format!(
-                        "{{\"report_version\":1,\"file\":{path:?},\"kind\":\"project\",\
-                         \"clean\":false,\"findings\":[{{\"code\":{slug:?},\
-                         \"message\":{detail:?}}}]}}"
-                    ),
+                    text,
                     code: nika_cli_host::output::exit::FILE,
                 };
             }

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -1417,3 +1417,35 @@ fn the_long_version_keeps_the_bare_version_first() {
         assert_eq!(long, format!("{} ({sha})", identity.engine_version()));
     }
 }
+
+/// The naming note fires on the ACCIDENT and stays silent on the
+/// deliberate — and it never touches the verdict.
+///
+/// The accidental shape is a copy: `bar.nika.yaml` still carrying
+/// `nika: foo`, so every trace and journal event says `foo` while the
+/// file says `bar`. The deliberate shapes are the ordering prefix (the
+/// numbered teaching path) and plain agreement — 62 of this house's 80
+/// workflow files agree, and all 18 divergences are the prefix.
+#[test]
+fn the_naming_note_fires_on_a_copy_and_not_on_an_ordering_prefix() {
+    let wf = parse_wf(
+        "nika: foo\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n",
+    );
+    let theme = Theme::new(false, true, false);
+
+    let mut accident = String::new();
+    naming_note(&mut accident, theme, "bar.nika.yaml", &wf);
+    assert!(accident.contains("`bar`"), "the file: {accident}");
+    assert!(accident.contains("`foo`"), "the name: {accident}");
+
+    for deliberate in ["01-foo.nika.yaml", "17_foo.nika.yaml", "foo.nika.yaml"] {
+        let mut out = String::new();
+        naming_note(&mut out, theme, deliberate, &wf);
+        assert!(out.is_empty(), "{deliberate} must stay silent: {out}");
+    }
+
+    // A path that is not a workflow filename at all says nothing.
+    let mut other = String::new();
+    naming_note(&mut other, theme, "-", &wf);
+    assert!(other.is_empty(), "stdin has no stem: {other}");
+}

--- a/crates/nika-cli/src/verbs/init.rs
+++ b/crates/nika-cli/src/verbs/init.rs
@@ -267,8 +267,12 @@ mod tests {
         );
         let laid = std::fs::read_to_string(tmp.join("nika.yaml")).expect("written");
         assert!(
-            laid.starts_with("# nika.yaml — the project file"),
+            laid.contains("# nika.yaml — the project file"),
             "the starter, verbatim: {laid}"
+        );
+        assert!(
+            laid.contains("\nnika: my-project\n"),
+            "the starter teaches the NAME — the version rides the $schema line: {laid}"
         );
 
         // A second run: the skip law (adds-only) — the receipt says so.

--- a/crates/nika-cli/src/verbs/list.rs
+++ b/crates/nika-cli/src/verbs/list.rs
@@ -44,7 +44,7 @@ mod tests {
         std::fs::create_dir_all(dir.path().join(".git")).expect("hidden");
         std::fs::write(dir.path().join("z.nika.yaml"), "nika: z\n").expect("workflow");
         std::fs::write(dir.path().join("nested/a.nika.yml"), "nika: a\n").expect("nested workflow");
-        std::fs::write(dir.path().join("nika.yaml"), "nika: v1\n").expect("project file");
+        std::fs::write(dir.path().join("nika.yaml"), "nika: proj\n").expect("project file");
         std::fs::write(dir.path().join(".git/hidden.nika.yaml"), "nika: hidden\n")
             .expect("hidden workflow");
 

--- a/crates/nika-cli/src/verbs/run/ceiling.rs
+++ b/crates/nika-cli/src/verbs/run/ceiling.rs
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn flag_beats_file_beats_default() {
         let dir = fresh_dir("ladder");
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\nceiling: 0.50\n").expect("seed");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 0.50\n").expect("seed");
 
         assert_eq!(
             ladder(Some(1.25), &dir).expect("ok"),
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn a_broken_file_refuses_flag_or_no_flag() {
         let dir = fresh_dir("broken");
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\nceling: 0.50\n").expect("typo");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceling: 0.50\n").expect("typo");
         let err = ladder(None, &dir).unwrap_err();
         assert_eq!(
             err.kind(),

--- a/crates/nika-cli/src/verbs/serve.rs
+++ b/crates/nika-cli/src/verbs/serve.rs
@@ -423,7 +423,7 @@ mod tests {
     /// ever SKIPS (an in-process run chdirs: the binary tests' ground —
     /// parallel tests race on the process CWD).
     const HOURLY_A: &str = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC 0 * * * *\"\n",
@@ -433,7 +433,7 @@ mod tests {
 
     /// The v2: a second beat appears between two ticks.
     const HOURLY_AB: &str = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC 0 * * * *\"\n",
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     fn a_queued_beat_waits_without_blocking_the_other_beats() {
         let registry_text = concat!(
-            "nika: v1\n",
+            "nika: proj\n",
             "arm:\n",
             "  - workflow: workflows/doctor.nika.yaml\n",
             "    cadence: \"TZ=UTC 0 * * * *\"\n",

--- a/crates/nika-cli/tests/arm_emit.rs
+++ b/crates/nika-cli/tests/arm_emit.rs
@@ -62,7 +62,7 @@ fn home(dir: &Path) -> PathBuf {
 /// A one-beat registry in the machine's zone.
 fn registry_in(zone: &str) -> String {
     format!(
-        "nika: v1\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ={zone} 0 3 * * *\"\n    plafond: 0.05\n    manqué: sauter\n"
+        "nika: proj\narm:\n  - workflow: workflows/doctor.nika.yaml\n    cadence: \"TZ={zone} 0 3 * * *\"\n    plafond: 0.05\n    manqué: sauter\n"
     )
 }
 

--- a/crates/nika-cli/tests/arm_fire.rs
+++ b/crates/nika-cli/tests/arm_fire.rs
@@ -109,7 +109,7 @@ tasks:
 
 /// Daily 03:00 UTC, skip the misses.
 const DAILY_3AM: &str = concat!(
-    "nika: v1\n",
+    "nika: proj\n",
     "arm:\n",
     "  - workflow: workflows/doctor.nika.yaml\n",
     "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -446,7 +446,7 @@ fn fire_resolves_relative_skills_from_the_declared_workflow_path() {
 #[test]
 fn concurrent_labels_record_their_own_exact_trace_paths() {
     let registry = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/alpha.nika.yaml\n",
         "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -524,7 +524,7 @@ fn fire_skips_a_missed_slot_when_manque_is_sauter() {
 #[test]
 fn fire_refuses_an_unknown_label_and_names_the_known_ones() {
     let registry = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -581,7 +581,7 @@ fn fire_skips_when_the_lock_is_held_by_a_living_owner() {
 #[test]
 fn fire_with_file_policy_times_out_at_the_next_slot() {
     let registry = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC * * * * *\"\n",
@@ -641,7 +641,7 @@ fn fire_prints_exactly_one_stdout_line() {
 #[test]
 fn fire_refuses_the_v0_unsupported_policies_with_teaching() {
     let registry = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -699,7 +699,7 @@ fn a_paused_run_is_parked_never_answered() {
 #[test]
 fn rattraper_une_fois_fires_one_run_for_the_whole_silence() {
     let registry = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC 0 3 * * *\"\n",

--- a/crates/nika-cli/tests/serve.rs
+++ b/crates/nika-cli/tests/serve.rs
@@ -41,7 +41,7 @@ const TRUE: &str =
 
 /// Daily 03:00 UTC, skip the misses.
 const DAILY_3AM: &str = concat!(
-    "nika: v1\n",
+    "nika: proj\n",
     "arm:\n",
     "  - workflow: workflows/doctor.nika.yaml\n",
     "    cadence: \"TZ=UTC 0 3 * * *\"\n",
@@ -51,7 +51,7 @@ const DAILY_3AM: &str = concat!(
 
 /// Every minute — the loop + signal tests' cadence.
 const EVERY_MINUTE: &str = concat!(
-    "nika: v1\n",
+    "nika: proj\n",
     "arm:\n",
     "  - workflow: workflows/doctor.nika.yaml\n",
     "    cadence: \"TZ=UTC * * * * *\"\n",
@@ -133,7 +133,7 @@ fn serve_loop_fires_two_beats_in_slot_order() {
 #[test]
 fn serve_never_fires_a_cloud_beat() {
     let registry = concat!(
-        "nika: v1\n",
+        "nika: proj\n",
         "arm:\n",
         "  - workflow: workflows/doctor.nika.yaml\n",
         "    cadence: \"TZ=UTC * * * * *\"\n",

--- a/crates/nika-cli/tests/verbs_static.rs
+++ b/crates/nika-cli/tests/verbs_static.rs
@@ -341,10 +341,26 @@ fn check_json_conformance_carries_severity_and_docs_url() {
 
 #[test]
 fn check_parse_error_is_a_file_finding_exit_2() {
-    let path = fixture_path("check-parse.nika.yaml", "nika: v1\nworkflow: [broken");
+    // `tasks:` is the spec's type discriminant: without it this document
+    // is a PROJECT, and the project grammar would own the refusal. The
+    // PARSE lane is the workflow envelope's.
+    let path = fixture_path("check-parse.nika.yaml", "nika: broken\ntasks: [broken");
     let out = check::run(&path, false, false, None, PLAIN);
     assert_eq!(out.code, exit::FILE);
     assert!(out.text.contains("PARSE"), "{}", out.text);
+}
+
+#[test]
+fn a_document_without_tasks_is_judged_as_a_project() {
+    let path = fixture_path("as-project.nika.yaml", "nika: my-project\nceiling: 0.50\n");
+    let out = check::run(&path, false, false, None, PLAIN);
+    assert_eq!(out.code, exit::OK, "{}", out.text);
+    assert!(out.text.contains("PROJECT"), "{}", out.text);
+    assert!(
+        !out.text.contains("PARSE") && !out.text.contains("missing required"),
+        "a project audit must never demand a workflow envelope: {}",
+        out.text
+    );
 }
 
 #[test]

--- a/crates/nika-dap/src/retention.rs
+++ b/crates/nika-dap/src/retention.rs
@@ -637,7 +637,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("nika-retproj-{}", std::process::id()));
         std::fs::remove_dir_all(&dir).ok();
         std::fs::create_dir_all(&dir).expect("mkdir");
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\ntraces:\n  keep: 45d\n").expect("seed");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\ntraces:\n  keep: 45d\n").expect("seed");
 
         // Env unset → the file rung governs the age cap.
         let (cfg, notes) = RetentionConfig::layered_at(None, None, None, &dir);
@@ -660,7 +660,7 @@ mod tests {
 
         // A BROKEN file → the default PLUS a loud note (fail-open,
         // never silent — the same error closes the budget gate).
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\ntraces:\n  keep: soon\n").expect("bad");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\ntraces:\n  keep: soon\n").expect("bad");
         let (cfg, notes) = RetentionConfig::layered_at(None, None, None, &dir);
         assert_eq!(
             cfg.max_age,

--- a/crates/nika-display/public-api.txt
+++ b/crates/nika-display/public-api.txt
@@ -468,6 +468,11 @@ pub fn nika_display::fruit::last_said(view: &nika_display::state::RunView) -> co
 pub fn nika_display::fruit::rehearsal(view: &nika_display::state::RunView) -> bool
 pub fn nika_display::fruit::rehearsal_note(view: &nika_display::state::RunView) -> core::option::Option<&'static str>
 pub fn nika_display::fruit::written_files(view: &nika_display::state::RunView) -> alloc::vec::Vec<nika_display::fruit::WroteFile>
+pub mod nika_display::project_render
+pub fn nika_display::project_render::governs(ceiling: core::option::Option<f64>, traces: bool, registry: bool, beats: usize) -> alloc::string::String
+pub fn nika_display::project_render::json(path: &str, clean: bool, name: core::option::Option<&str>, code: &str, message: &str) -> alloc::string::String
+pub fn nika_display::project_render::refusal(path: &str, line: core::option::Option<usize>, slug: &str, detail: &str, remedy: &str) -> alloc::string::String
+pub fn nika_display::project_render::verdict(path: &str, name: &str, governs: &str) -> alloc::string::String
 pub mod nika_display::render
 pub fn nika_display::render::frame(view: &nika_display::state::RunView, theme: &nika_display::theme::Theme, tick: usize) -> alloc::vec::Vec<alloc::string::String>
 pub fn nika_display::render::frame_with_outputs(view: &nika_display::state::RunView, theme: &nika_display::theme::Theme, tick: usize) -> alloc::vec::Vec<alloc::string::String>

--- a/crates/nika-display/src/lib.rs
+++ b/crates/nika-display/src/lib.rs
@@ -31,6 +31,7 @@ pub mod demo;
 pub mod flow;
 pub mod format;
 pub mod fruit;
+pub mod project_render;
 pub mod render;
 pub mod shape;
 pub mod snippet;

--- a/crates/nika-display/src/project_render.rs
+++ b/crates/nika-display/src/project_render.rs
@@ -58,6 +58,22 @@ pub fn governs(ceiling: Option<f64>, traces: bool, registry: bool, beats: usize)
     }
 }
 
+/// The machine verdict · `report_version: 1`, the same envelope the
+/// workflow lane's `--json` speaks, with `kind: "project"` naming which
+/// grammar judged it.
+#[must_use]
+pub fn json(path: &str, clean: bool, name: Option<&str>, code: &str, message: &str) -> String {
+    let head = format!("{{\"report_version\":1,\"file\":{path:?},\"kind\":\"project\"");
+    if clean {
+        let name = name.unwrap_or("<unnamed>");
+        format!("{head},\"clean\":true,\"name\":{name:?},\"findings\":[]}}")
+    } else {
+        format!(
+            "{head},\"clean\":false,\"findings\":[{{\"code\":{code:?},\"message\":{message:?}}}]}}"
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +95,29 @@ mod tests {
     #[test]
     fn one_beat_is_singular() {
         assert!(governs(None, false, false, 1).contains("1 beat armed"));
+    }
+
+    #[test]
+    fn the_machine_verdict_is_parseable_json_both_ways() {
+        // A `--json` surface that emits something a parser chokes on is
+        // worse than no `--json`: an agent cannot tell it from a crash.
+        for wire in [
+            json("nika.yaml", true, Some("my-project"), "", ""),
+            json(
+                "nika.yaml",
+                false,
+                None,
+                "project.unknown-key",
+                "unknown field `celing`",
+            ),
+        ] {
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(&wire);
+            assert!(parsed.is_ok(), "not JSON · {wire}");
+            let v = parsed.unwrap_or_default();
+            assert_eq!(v["report_version"], 1, "{wire}");
+            assert_eq!(v["kind"], "project", "{wire}");
+            assert!(v["findings"].is_array(), "{wire}");
+        }
     }
 
     #[test]

--- a/crates/nika-display/src/project_render.rs
+++ b/crates/nika-display/src/project_render.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The project-file verdict `nika check` prints.
+//!
+//! Renders from PRIMITIVES, never from `nika-vocab`'s types: this crate
+//! renders and owes no dependency on the grammar it renders. The caller
+//! reads the parsed project and hands over the pieces.
+
+/// The green verdict, and why this document was judged as a project.
+#[must_use]
+pub fn verdict(path: &str, name: &str, governs: &str) -> String {
+    format!(
+        "nika check · {path}\n \
+         ✔ PROJECT  {name} · {governs}\n   \
+         the type discriminant is `tasks:` — this document declares none, \
+         so it is judged as a project, never as a workflow\n"
+    )
+}
+
+/// A refusal in the project grammar's own vocabulary — never the
+/// workflow envelope's, which would demand a `tasks:` map this file must
+/// not grow.
+#[must_use]
+pub fn refusal(path: &str, line: Option<usize>, slug: &str, detail: &str, remedy: &str) -> String {
+    let at = line.map_or_else(String::new, |l| format!(":{l}"));
+    format!(
+        "nika check · {path}\n \
+         ✖ PROJECT  {path}{at} · {slug} · {detail}\n   fix: {remedy}\n"
+    )
+}
+
+/// What the file governs, named from what it actually declared.
+///
+/// A project that governs nothing says so, rather than rendering an
+/// empty list that reads like a measurement.
+#[must_use]
+pub fn governs(ceiling: Option<f64>, traces: bool, registry: bool, beats: usize) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(c) = ceiling {
+        parts.push(format!("ceiling ${c:.2}"));
+    }
+    if traces {
+        parts.push("trace retention".to_owned());
+    }
+    if registry {
+        parts.push("a registry floor".to_owned());
+    }
+    match beats {
+        0 => {}
+        1 => parts.push("1 beat armed".to_owned()),
+        n => parts.push(format!("{n} beats armed")),
+    }
+    if parts.is_empty() {
+        "governs nothing (every knob falls to its built-in default)".to_owned()
+    } else {
+        parts.join(" · ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_project_that_declares_nothing_says_so() {
+        assert!(governs(None, false, false, 0).contains("governs nothing"));
+    }
+
+    #[test]
+    fn every_declared_knob_is_named_once() {
+        let g = governs(Some(0.5), true, true, 3);
+        assert!(g.contains("ceiling $0.50"), "{g}");
+        assert!(g.contains("trace retention"), "{g}");
+        assert!(g.contains("a registry floor"), "{g}");
+        assert!(g.contains("3 beats armed"), "{g}");
+    }
+
+    #[test]
+    fn one_beat_is_singular() {
+        assert!(governs(None, false, false, 1).contains("1 beat armed"));
+    }
+
+    #[test]
+    fn a_refusal_never_demands_tasks() {
+        let r = refusal("nika.yaml", Some(2), "project.unknown-key", "d", "r");
+        assert!(!r.contains("tasks"), "{r}");
+        assert!(r.contains("nika.yaml:2"), "{r}");
+    }
+}

--- a/crates/nika-onboard/src/project_file.rs
+++ b/crates/nika-onboard/src/project_file.rs
@@ -100,12 +100,12 @@ mod tests {
         assert_eq!(laid, STARTER, "the grammar's own starter, verbatim");
 
         // A hand-written file is never touched without --force.
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\nceiling: 9.99\n").expect("seed");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 9.99\n").expect("seed");
         let (_, outcome) = ensure(d, false);
         assert!(matches!(outcome, Outcome::Skipped), "existing = skip");
         assert_eq!(
             std::fs::read_to_string(dir.join("nika.yaml")).expect("read"),
-            "nika: v1\nceiling: 9.99\n",
+            "nika: proj\nceiling: 9.99\n",
             "the human's bytes survive"
         );
 
@@ -128,7 +128,21 @@ mod tests {
         let parsed = nika_vocab::project::discover(&dir)
             .expect("the laid file parses")
             .map(|(_path, project)| project);
-        assert_eq!(parsed, Some(nika_vocab::project::Project::default()));
+        let parsed = parsed.expect("the laid file is discovered");
+        assert_eq!(
+            parsed.name.as_deref(),
+            Some("my-project"),
+            "the starter lays a NAME — the version rides the $schema line"
+        );
+        // `Project` is `#[non_exhaustive]` (FCI-016), so a sibling crate
+        // compares the knobs rather than rebuilding the struct.
+        assert!(
+            parsed.ceiling.is_none()
+                && parsed.traces.is_none()
+                && parsed.registry.is_none()
+                && parsed.arm().is_empty(),
+            "every other starter line is a commented example: {parsed:?}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/nika-onboard/src/wizard.rs
+++ b/crates/nika-onboard/src/wizard.rs
@@ -956,13 +956,22 @@ mod tests {
         );
         let laid = std::fs::read_to_string(dir.join("nika.yaml")).expect("written");
         assert!(
-            laid.starts_with("# nika.yaml — the project file"),
+            laid.starts_with("# nika.yaml — the project file")
+                && laid.contains("\nnika: my-project\n"),
             "the grammar's starter, verbatim: {laid}"
         );
-        // …and what was laid parses back to the defaults (never a
-        // silently-governing file).
+        // …and what was laid governs nothing but its own name (never a
+        // silently-governing file). `Project` is `#[non_exhaustive]`, so
+        // a sibling crate reads the knobs instead of rebuilding it.
         let parsed = nika_vocab::project::parse(&laid).expect("the laid starter parses");
-        assert_eq!(parsed, nika_vocab::project::Project::default());
+        assert_eq!(parsed.name.as_deref(), Some("my-project"));
+        assert!(
+            parsed.ceiling.is_none()
+                && parsed.traces.is_none()
+                && parsed.registry.is_none()
+                && parsed.arm().is_empty(),
+            "the starter governs nothing: {parsed:?}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -1002,7 +1011,7 @@ mod tests {
         // Skip — the human's bytes win over the offer.
         let dir = fresh_dir("offer-exists");
         let d = dir.to_str().expect("utf8");
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\nceiling: 9.99\n").expect("seed");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 9.99\n").expect("seed");
         let mut input = std::io::Cursor::new(b"5\n\n\ny\n".to_vec());
         let mut out = Vec::new();
         let v = wizard_io(
@@ -1022,7 +1031,7 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(dir.join("nika.yaml")).expect("read"),
-            "nika: v1\nceiling: 9.99\n",
+            "nika: proj\nceiling: 9.99\n",
             "the human's bytes survive the offer"
         );
         std::fs::remove_dir_all(&dir).ok();
@@ -1030,7 +1039,7 @@ mod tests {
         // Force — the founding law's one override.
         let dir = fresh_dir("offer-force");
         let d = dir.to_str().expect("utf8");
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\nceiling: 9.99\n").expect("seed");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 9.99\n").expect("seed");
         let mut input = std::io::Cursor::new(b"5\n\n\ny\n".to_vec());
         let mut out = Vec::new();
         let v = wizard_io(
@@ -1047,7 +1056,8 @@ mod tests {
         assert!(shown.contains("created nika.yaml"), "{shown}");
         let laid = std::fs::read_to_string(dir.join("nika.yaml")).expect("read");
         assert!(
-            laid.starts_with("# nika.yaml — the project file"),
+            laid.contains("# nika.yaml — the project file")
+                && laid.contains("\nnika: my-project\n"),
             "the starter replaced the seed: {laid}"
         );
         std::fs::remove_dir_all(&dir).ok();

--- a/crates/nika-registry-client/src/tier.rs
+++ b/crates/nika-registry-client/src/tier.rs
@@ -260,7 +260,7 @@ mod tests {
         let dir = fresh_dir("max");
         std::fs::write(
             dir.join("nika.yaml"),
-            "nika: v1\nregistry:\n  floor: provenanced\n",
+            "nika: proj\nregistry:\n  floor: provenanced\n",
         )
         .expect("seed");
 
@@ -302,7 +302,7 @@ mod tests {
         .expect("absence never refuses");
         assert_eq!(policy.floor, ProvenanceTier::Provenanced);
 
-        std::fs::write(dir.join("nika.yaml"), "nika: v1\nceiling: 0.50\n").expect("seed");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 0.50\n").expect("seed");
         let policy = Policy {
             floor: ProvenanceTier::Unprovenanced,
         }
@@ -319,7 +319,7 @@ mod tests {
         let dir = fresh_dir("broken");
         std::fs::write(
             dir.join("nika.yaml"),
-            "nika: v1\nregistry:\n  floor: bogus\n",
+            "nika: proj\nregistry:\n  floor: bogus\n",
         )
         .expect("bad");
         let err = Policy {

--- a/crates/nika-vocab/public-api.txt
+++ b/crates/nika-vocab/public-api.txt
@@ -566,7 +566,7 @@ pub fn nika_vocab::project::MissPolicy::from(t: T) -> T
 #[non_exhaustive] pub enum nika_vocab::project::ProjectErrorKind
 pub nika_vocab::project::ProjectErrorKind::BadValue
 pub nika_vocab::project::ProjectErrorKind::Grammar
-pub nika_vocab::project::ProjectErrorKind::TagFrozen
+pub nika_vocab::project::ProjectErrorKind::Identity
 pub nika_vocab::project::ProjectErrorKind::UnknownKey
 pub nika_vocab::project::ProjectErrorKind::Unreadable
 impl nika_vocab::project::ProjectErrorKind
@@ -700,6 +700,7 @@ impl<T> core::convert::From<T> for nika_vocab::project::ArmEntry
 pub fn nika_vocab::project::ArmEntry::from(t: T) -> T
 #[non_exhaustive] pub struct nika_vocab::project::Project
 pub nika_vocab::project::Project::ceiling: core::option::Option<f64>
+pub nika_vocab::project::Project::name: core::option::Option<alloc::string::String>
 pub nika_vocab::project::Project::registry: core::option::Option<nika_vocab::project::RegistryPolicy>
 pub nika_vocab::project::Project::traces: core::option::Option<nika_vocab::project::TracesPolicy>
 impl nika_vocab::project::Project
@@ -850,11 +851,12 @@ pub unsafe fn nika_vocab::project::TracesPolicy::clone_to_uninit(&self, dest: *m
 impl<T> core::convert::From<T> for nika_vocab::project::TracesPolicy
 pub fn nika_vocab::project::TracesPolicy::from(t: T) -> T
 pub const nika_vocab::project::FILE_NAME: &str
-pub const nika_vocab::project::SCHEMA: &str
 pub const nika_vocab::project::STARTER: &str
 pub const nika_vocab::project::TOP_LEVEL_KEYS: &[&str]
 pub fn nika_vocab::project::discover(start: &std::path::Path) -> core::result::Result<core::option::Option<(std::path::PathBuf, nika_vocab::project::Project)>, nika_vocab::project::ProjectError>
 pub fn nika_vocab::project::discover_from_cwd() -> core::result::Result<core::option::Option<(std::path::PathBuf, nika_vocab::project::Project)>, nika_vocab::project::ProjectError>
+pub fn nika_vocab::project::is_kebab_id(s: &str) -> bool
+pub fn nika_vocab::project::is_project_document(yaml: &str) -> bool
 pub fn nika_vocab::project::parse(text: &str) -> core::result::Result<nika_vocab::project::Project, nika_vocab::project::ProjectError>
 pub mod nika_vocab::registry_ref
 #[non_exhaustive] pub enum nika_vocab::registry_ref::RefDefect

--- a/crates/nika-vocab/src/project.rs
+++ b/crates/nika-vocab/src/project.rs
@@ -49,9 +49,15 @@ pub use parse::parse;
 /// The one file name, at the discovered root.
 pub const FILE_NAME: &str = "nika.yaml";
 
-/// The frozen schema tag (FCI-003 — touching it is the project's
-/// heaviest move, the same freeze law as the workflow envelope).
-pub const SCHEMA: &str = "v1";
+/// `^[a-z][a-z0-9-]*$` — the kebab-case resource-name shape, the SAME
+/// rule the workflow envelope applies to its own `nika:` (spec 01
+/// §`nika`). One grammar for the key across both artifact classes.
+#[must_use]
+pub fn is_kebab_id(s: &str) -> bool {
+    s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
 
 /// The closed top-level key set (D-2026-08-11-N5, verbatim) — public
 /// so consumers DERIVE from it instead of retyping it (the
@@ -67,7 +73,7 @@ pub const TOP_LEVEL_KEYS: &[&str] = &["nika", "ceiling", "arm", "traces", "regis
 pub const STARTER: &str = "\
 # nika.yaml — the project file (OPTIONAL · an absent key is its built-in default).
 # Ladder per key: the invocation flag / env var wins · then this file · then the default.
-nika: v1
+nika: my-project
 
 # ceiling: 0.50     # default max-cost-usd for runs of this project · --max-cost-usd always wins
 
@@ -81,6 +87,18 @@ nika: v1
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
 pub struct Project {
+    /// `nika:` — the project's NAME, kebab-case. Same grammar as a
+    /// workflow's `nika:`: the key declares « this is a Nika file », the
+    /// value names it. `None` only for a file that declares nothing (a
+    /// comments-only or `{}` mapping governs nothing, so it owes no
+    /// name); any file that carries a key carries this one.
+    ///
+    /// It replaced a frozen `v1` tag. The reasoning is the workflow
+    /// envelope's, verbatim: a field with ONE legal value is not a
+    /// version, so nothing was traded away — and the version marker the
+    /// tag pretended to be now lives where it can be fetched and where
+    /// an editor already reads it, the `$schema` URL.
+    pub name: Option<String>,
     /// `ceiling:` — the default per-run spend ceiling (USD). The flag
     /// wins; this only fills a flag-less invocation.
     pub ceiling: Option<f64>,
@@ -307,8 +325,9 @@ pub enum ProjectErrorKind {
     Grammar,
     /// The file exists but cannot be read (permissions · a directory).
     Unreadable,
-    /// `nika:` is absent or is not the frozen `v1` tag.
-    TagFrozen,
+    /// `nika:` is absent, or carries something that is not a
+    /// kebab-case name.
+    Identity,
     /// A key outside the closed set — top-level, `traces:`,
     /// `registry:`, or an `arm:` entry. Never a silent drop.
     UnknownKey,
@@ -324,7 +343,7 @@ impl ProjectErrorKind {
         match self {
             Self::Grammar => "project.grammar",
             Self::Unreadable => "project.unreadable",
-            Self::TagFrozen => "project.tag-frozen",
+            Self::Identity => "project.identity",
             Self::UnknownKey => "project.unknown-key",
             Self::BadValue => "project.bad-value",
         }

--- a/crates/nika-vocab/src/project.rs
+++ b/crates/nika-vocab/src/project.rs
@@ -59,6 +59,43 @@ pub fn is_kebab_id(s: &str) -> bool {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
 }
 
+/// The envelope line's own indentation, when the document opens on one.
+fn envelope_indent(yaml: &str) -> Option<&str> {
+    for line in yaml.lines() {
+        let stripped = line.trim_start();
+        if stripped.is_empty() || stripped.starts_with('#') {
+            continue;
+        }
+        let indent = &line[..line.len() - stripped.len()];
+        return stripped
+            .strip_prefix("nika:")
+            .filter(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace))
+            .map(|_| indent);
+    }
+    None
+}
+
+/// Does this document declare itself a PROJECT rather than a workflow?
+///
+/// The spec's discriminant (`01-envelope` §The type discriminant),
+/// normative and covering every document · a `tasks:` key means WORKFLOW,
+/// its absence means PROJECT. Deliberately NOT the filename: a document
+/// arrives as a registry blob, an HTTP body, a stdin pipe or a chat
+/// paste, and the bytes must still say what they are. Anchored to the
+/// envelope's own indent, so a nested `tasks:` never qualifies; a
+/// document with no `nika:` envelope is not a nika file and returns
+/// false, leaving the workflow envelope's `NIKA-PARSE-002` to own it.
+#[must_use]
+pub fn is_project_document(yaml: &str) -> bool {
+    let Some(indent) = envelope_indent(yaml) else {
+        return false;
+    };
+    !yaml.lines().any(|line| {
+        line.strip_prefix(indent)
+            .is_some_and(|rest| rest.starts_with("tasks:") && !rest.starts_with("tasks::"))
+    })
+}
+
 /// The closed top-level key set (D-2026-08-11-N5, verbatim) — public
 /// so consumers DERIVE from it instead of retyping it (the
 /// `nika_schema::parser::TOP_LEVEL_KEYS` precedent: a mirror validated

--- a/crates/nika-vocab/src/project/parse.rs
+++ b/crates/nika-vocab/src/project/parse.rs
@@ -17,7 +17,7 @@ use marked_yaml::{LoadError, LoaderOptions, Node, Span as YamlSpan, parse_yaml_w
 
 use super::{
     ArmEntry, ArmLocus, MissPolicy, Project, ProjectError, ProjectErrorKind, ProvenanceFloor,
-    RegistryPolicy, SCHEMA, TOP_LEVEL_KEYS, TracesPolicy,
+    RegistryPolicy, TOP_LEVEL_KEYS, TracesPolicy, is_kebab_id,
 };
 use std::time::Duration;
 
@@ -68,8 +68,8 @@ pub fn parse(text: &str) -> Result<Project, ProjectError> {
         }
         return Err(ProjectError::at(
             ProjectErrorKind::Grammar,
-            "the top level must be a mapping (`nika: v1` opens the file)",
-            "open with `nika: v1` — the frozen tag, then the keys you govern",
+            "the top level must be a mapping (`nika: <name>` opens the file)",
+            "open with `nika: <name>` — the project's kebab-case name, then the keys you govern",
             line_of(node.span()),
         ));
     };
@@ -88,7 +88,7 @@ pub fn parse(text: &str) -> Result<Project, ProjectError> {
         match name {
             "nika" => {
                 seen_tag = true;
-                check_tag(value)?;
+                project.name = Some(parse_name(value)?);
             }
             "ceiling" => project.ceiling = Some(usd(value, "ceiling")?),
             "traces" => project.traces = Some(parse_traces(value)?),
@@ -99,9 +99,9 @@ pub fn parse(text: &str) -> Result<Project, ProjectError> {
     }
     if !seen_tag {
         return Err(ProjectError::at(
-            ProjectErrorKind::TagFrozen,
-            "`nika:` absent — the file opens on its frozen tag",
-            "open with `nika: v1` (the tag is frozen forever — the heaviest move in the project)",
+            ProjectErrorKind::Identity,
+            "`nika:` absent — a file that governs keys must name itself",
+            "open with `nika: <name>` (kebab-case · the same grammar a workflow's `nika:` uses)",
             Some(1),
         ));
     }
@@ -109,18 +109,49 @@ pub fn parse(text: &str) -> Result<Project, ProjectError> {
     Ok(project)
 }
 
-/// The `nika:` envelope tag — frozen at `v1` (FCI-003).
-fn check_tag(value: &Node) -> Result<(), ProjectError> {
-    let tag = scalar(value, "nika")?.as_str();
-    if tag != SCHEMA {
+/// The `nika:` value — the project's NAME, kebab-case.
+///
+/// It held the literal `v1` until this file learned the workflow
+/// envelope's own lesson: a field with ONE legal value is not a version.
+/// The slot now carries the project's most necessary field instead, in
+/// the SAME grammar the workflow uses, so `nika:` means one thing across
+/// both artifact classes. The version marker moved to the `$schema` URL,
+/// where an editor already reads it and a fetch can resolve it.
+fn parse_name(value: &Node) -> Result<String, ProjectError> {
+    let name = scalar(value, "nika")?.as_str();
+    // The reinterpretation guard, and it belongs HERE and not in the
+    // workflow envelope. A pre-nuke WORKFLOW always carried a
+    // `workflow:` block beside its `nika: v1`, so the dead form refuses
+    // on that key and `v1` is free to be an ordinary workflow name. A
+    // pre-nuke PROJECT file had no such companion: `nika: v1` +
+    // `ceiling:` + `arm:` is well-formed under BOTH readings, so the
+    // same bytes would silently stop meaning « schema v1 » and start
+    // meaning « a project named v1 ». Nothing else can catch that, so a
+    // retired marker refuses here — a reserved word must refuse, never
+    // glide. `vault` · `v2ray` · `v1-migration` are ordinary names: the
+    // rule is the WHOLE marker, never a prefix.
+    if name
+        .strip_prefix('v')
+        .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()))
+    {
         return Err(ProjectError::at(
-            ProjectErrorKind::TagFrozen,
-            format!("`nika: {tag}` — the tag is frozen at `{SCHEMA}`"),
-            "the tag is `nika: v1` — touching it is the project's heaviest move",
+            ProjectErrorKind::Identity,
+            format!("`nika: {name}` — that is the retired schema tag, not a project name"),
+            "the tag became the project's NAME (`nika: my-project`); the version moved to the \
+             `$schema` line, where an editor reads it and a fetch resolves it",
             line_of(value.span()),
         ));
     }
-    Ok(())
+    if !is_kebab_id(name) {
+        return Err(ProjectError::at(
+            ProjectErrorKind::Identity,
+            format!("`nika: {name}` — a project name is kebab-case (`^[a-z][a-z0-9-]*$`)"),
+            "name the project (`nika: my-project`) — the version lives on the `$schema` \
+             line, never in the body",
+            line_of(value.span()),
+        ));
+    }
+    Ok(name.to_owned())
 }
 
 /// `traces:` — a mapping over the closed set; `keep` is REQUIRED

--- a/crates/nika-vocab/src/project/tests.rs
+++ b/crates/nika-vocab/src/project/tests.rs
@@ -12,8 +12,7 @@
 #![allow(clippy::float_cmp)]
 
 use super::{
-    ArmLocus, MissPolicy, Project, ProjectErrorKind, ProvenanceFloor, SCHEMA, STARTER, discover,
-    parse,
+    ArmLocus, MissPolicy, Project, ProjectErrorKind, ProvenanceFloor, STARTER, discover, parse,
 };
 use proptest::strategy::Strategy as _;
 use std::time::Duration;
@@ -21,7 +20,7 @@ use std::time::Duration;
 /// The ratified example, VERBATIM (D-2026-08-11-N5) — comments and
 /// all. If this drifts, the decision and the parser drift together.
 const CANONICAL: &str = r#"
-nika: v1
+nika: proj
 
 ceiling: 0.50          # default max-cost-usd · the per-invocation --max-cost-usd flag ALWAYS wins
 
@@ -70,13 +69,26 @@ fn the_canonical_example_parses_verbatim() {
     assert_eq!(beat.manque, MissPolicy::RattraperUneFois);
 }
 
-/// Absent = defaults, zero ceremony: the bare tag, an empty file, and
-/// a comments-only file all parse to the SAME default — and the
+/// Absent = defaults, zero ceremony: a name and nothing else, an empty
+/// file, and a comments-only file all govern the SAME nothing — and the
 /// wizard's starter is one of them (the example cannot drift).
+///
+/// The NAME is the one field a named file carries that an empty one
+/// cannot: a file that declares nothing owes no name, so `default()`
+/// leaves it `None` and the knobs are what this test compares.
 #[test]
 fn absence_is_the_default() {
     let default = Project::default();
-    assert_eq!(parse("nika: v1\n").expect("bare tag"), default);
+    let named = parse("nika: proj\n").expect("bare name");
+    assert_eq!(named.name.as_deref(), Some("proj"));
+    assert_eq!(
+        Project {
+            name: None,
+            ..named
+        },
+        default,
+        "a name governs nothing else"
+    );
     assert_eq!(parse("").expect("empty"), default);
     assert_eq!(parse("   \n  \n").expect("whitespace"), default);
     assert_eq!(
@@ -84,10 +96,19 @@ fn absence_is_the_default() {
         default,
         "a file that declares nothing governs nothing"
     );
+    let starter = parse(STARTER).expect("the wizard's starter parses");
     assert_eq!(
-        parse(STARTER).expect("the wizard's starter parses"),
+        starter.name.as_deref(),
+        Some("my-project"),
+        "the starter teaches the name, so the example cannot drift from the law"
+    );
+    assert_eq!(
+        Project {
+            name: None,
+            ..starter
+        },
         default,
-        "the starter is all-commented examples — absence IS the defaults"
+        "every other starter line is a commented example — absence IS the defaults"
     );
 }
 
@@ -96,19 +117,19 @@ fn absence_is_the_default() {
 #[test]
 fn unknown_keys_refuse_by_name_with_their_line() {
     // Top level — the typo'd `celing` sits on line 3.
-    let err = parse("nika: v1\nceiling: 0.50\nceling: 0.25\n").unwrap_err();
+    let err = parse("nika: proj\nceiling: 0.50\nceling: 0.25\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
     assert_eq!(err.line(), Some(3), "the key's own line: {err}");
     assert!(err.detail().contains("celing"), "the key is named: {err}");
     assert!(err.remedy().contains("ceiling"), "the set is taught: {err}");
 
     // `traces:` level.
-    let err = parse("nika: v1\ntraces:\n  keep: 30d\n  budget: 1\n").unwrap_err();
+    let err = parse("nika: proj\ntraces:\n  keep: 30d\n  budget: 1\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
     assert_eq!(err.line(), Some(4));
 
     // `registry:` level.
-    let err = parse("nika: v1\nregistry:\n  flor: provenanced\n").unwrap_err();
+    let err = parse("nika: proj\nregistry:\n  flor: provenanced\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
     assert_eq!(err.line(), Some(3));
 
@@ -121,28 +142,54 @@ fn unknown_keys_refuse_by_name_with_their_line() {
 /// operator is never pointed at nothing.
 #[test]
 fn malformed_yaml_refuses_with_a_line() {
-    let err = parse("nika: v1\nceiling: [0.50\n").unwrap_err();
+    let err = parse("nika: proj\nceiling: [0.50\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::Grammar);
     assert!(err.line().is_some(), "a line rides the refusal: {err}");
     // A duplicate key is YAML-loud too (never last-wins).
-    let err = parse("nika: v1\nnika: v1\n").unwrap_err();
+    let err = parse("nika: proj\nnika: proj\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::Grammar, "{err}");
     // A bare scalar at the top is not a project file.
     let err = parse("just a string\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::Grammar);
 }
 
-/// The tag is frozen: absent or non-`v1` refuses by name.
+/// `nika:` names the project: absent, or a value that is not a
+/// kebab-case name, refuses by name.
 #[test]
-fn the_tag_is_frozen() {
+fn the_project_names_itself() {
     let err = parse("ceiling: 0.50\n").unwrap_err();
-    assert_eq!(err.kind(), ProjectErrorKind::TagFrozen, "{err}");
-    let err = parse("nika: v2\n").unwrap_err();
-    assert_eq!(err.kind(), ProjectErrorKind::TagFrozen, "{err}");
-    assert_eq!(
-        parse(&format!("nika: {SCHEMA}\n")).expect("v1"),
-        Project::default()
-    );
+    assert_eq!(err.kind(), ProjectErrorKind::Identity, "{err}");
+    for bad in ["Not_Kebab", "1leading-digit", "", "-leading-dash"] {
+        let err = parse(&format!("nika: {bad}\n")).unwrap_err();
+        assert_eq!(err.kind(), ProjectErrorKind::Identity, "{bad}: {err}");
+    }
+    let p = parse("nika: my-project\n").expect("a name parses");
+    assert_eq!(p.name.as_deref(), Some("my-project"));
+}
+
+/// The retired schema tag refuses HERE, where a workflow lets it pass.
+///
+/// The asymmetry is the point: a pre-nuke workflow carried `workflow:`
+/// beside its `nika: proj` and refuses on that key, so `v1` is free to be
+/// an ordinary workflow NAME. A pre-nuke project file had no companion
+/// key — `nika: proj` + `ceiling:` is well-formed under both readings —
+/// so only a refusal here keeps the same bytes from quietly changing
+/// meaning.
+#[test]
+fn the_retired_schema_tag_refuses_in_a_project_file() {
+    for marker in ["v1", "v2", "v999"] {
+        let err = parse(&format!("nika: {marker}\nceiling: 0.50\n")).unwrap_err();
+        assert_eq!(err.kind(), ProjectErrorKind::Identity, "{marker}: {err}");
+        assert!(
+            err.to_string().contains("retired schema tag"),
+            "the refusal must NAME the reinterpretation: {err}"
+        );
+    }
+    // Only the WHOLE marker. These are ordinary names and stay legal.
+    for name in ["vault", "v2ray", "v1-migration", "victor"] {
+        let p = parse(&format!("nika: {name}\n")).expect("an ordinary name");
+        assert_eq!(p.name.as_deref(), Some(name));
+    }
 }
 
 /// `ceiling:` — a positive finite number, unquoted. The flag-side
@@ -151,7 +198,7 @@ fn the_tag_is_frozen() {
 #[test]
 fn ceiling_values_are_lawful_money() {
     assert_eq!(
-        parse("nika: v1\nceiling: 0.50\n").expect("ok").ceiling,
+        parse("nika: proj\nceiling: 0.50\n").expect("ok").ceiling,
         Some(0.5)
     );
     for bad in [
@@ -160,7 +207,7 @@ fn ceiling_values_are_lawful_money() {
         "ceiling: \"0.50\"",
         "ceiling: soon",
     ] {
-        let err = parse(&format!("nika: v1\n{bad}\n")).unwrap_err();
+        let err = parse(&format!("nika: proj\n{bad}\n")).unwrap_err();
         assert_eq!(err.kind(), ProjectErrorKind::BadValue, "{bad}: {err}");
     }
 }
@@ -169,16 +216,16 @@ fn ceiling_values_are_lawful_money() {
 /// govern nothing.
 #[test]
 fn traces_keep_is_days_grained() {
-    let p = parse("nika: v1\ntraces:\n  keep: 45d\n").expect("ok");
+    let p = parse("nika: proj\ntraces:\n  keep: 45d\n").expect("ok");
     assert_eq!(
         p.traces.map(|t| t.keep),
         Some(Duration::from_secs(45 * 86_400))
     );
     for bad in ["keep: 30", "keep: 30h", "keep: soon", "keep: -1d"] {
-        let err = parse(&format!("nika: v1\ntraces:\n  {bad}\n")).unwrap_err();
+        let err = parse(&format!("nika: proj\ntraces:\n  {bad}\n")).unwrap_err();
         assert_eq!(err.kind(), ProjectErrorKind::BadValue, "{bad}: {err}");
     }
-    let err = parse("nika: v1\ntraces:\n").unwrap_err();
+    let err = parse("nika: proj\ntraces:\n").unwrap_err();
     assert_eq!(
         err.kind(),
         ProjectErrorKind::BadValue,
@@ -191,12 +238,12 @@ fn traces_keep_is_days_grained() {
 #[test]
 fn registry_floor_is_the_closed_ladder() {
     for tier in ProvenanceFloor::ALL {
-        let p = parse(&format!("nika: v1\nregistry:\n  floor: {tier}\n")).expect("tier parses");
+        let p = parse(&format!("nika: proj\nregistry:\n  floor: {tier}\n")).expect("tier parses");
         assert_eq!(p.registry.map(|r| r.floor), Some(tier));
     }
-    let err = parse("nika: v1\nregistry:\n  floor: bogus\n").unwrap_err();
+    let err = parse("nika: proj\nregistry:\n  floor: bogus\n").unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::BadValue, "{err}");
-    let err = parse("nika: v1\nregistry:\n").unwrap_err();
+    let err = parse("nika: proj\nregistry:\n").unwrap_err();
     assert_eq!(
         err.kind(),
         ProjectErrorKind::BadValue,
@@ -222,7 +269,7 @@ fn the_floor_spellings_round_trip() {
 /// for the cadence arc to consume.
 #[test]
 fn arm_entries_validate_their_shape() {
-    let ok = "nika: v1\narm:\n  - workflow: workflows/w.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 9 * * 1\"\n    plafond: 0.35\n    manqué: rattraper\n  - workflow: workflows/v.nika.yaml\n    cadence: on-webhook\n    où: cloud\n    plafond: 2.00\n    manqué: rattraper-une-fois\n";
+    let ok = "nika: proj\narm:\n  - workflow: workflows/w.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 9 * * 1\"\n    plafond: 0.35\n    manqué: rattraper\n  - workflow: workflows/v.nika.yaml\n    cadence: on-webhook\n    où: cloud\n    plafond: 2.00\n    manqué: rattraper-une-fois\n";
     let p = parse(ok).expect("two beats parse");
     assert_eq!(p.arm().len(), 2);
     assert_eq!(
@@ -253,7 +300,7 @@ fn arm_entries_validate_their_shape() {
         ),
     ];
     for (entry, missing_key) in cases {
-        let err = parse(&format!("nika: v1\narm:\n  - {entry}\n")).unwrap_err();
+        let err = parse(&format!("nika: proj\narm:\n  - {entry}\n")).unwrap_err();
         assert_eq!(
             err.kind(),
             ProjectErrorKind::BadValue,
@@ -266,7 +313,7 @@ fn arm_entries_validate_their_shape() {
     }
 
     // The shape laws — each broken entry against one full document.
-    let base = "nika: v1\narm:\n  - workflow: w.nika.yaml\n    cadence: \"lundi 9h00\"\n    plafond: 1.0\n    manqué: sauter\n";
+    let base = "nika: proj\narm:\n  - workflow: w.nika.yaml\n    cadence: \"lundi 9h00\"\n    plafond: 1.0\n    manqué: sauter\n";
     let bad_docs = [
         base.replace("workflow: w.nika.yaml", "workflow: w.yaml"), // not *.nika.yaml
         base.replace("workflow: w.nika.yaml", "workflow: ''"),     // empty path
@@ -282,8 +329,8 @@ fn arm_entries_validate_their_shape() {
     }
     // `arm:` that is not a sequence, an entry that is not a mapping.
     for doc in [
-        "nika: v1\narm: yes\n",
-        "nika: v1\narm:\n  - just-a-string\n",
+        "nika: proj\narm: yes\n",
+        "nika: proj\narm:\n  - just-a-string\n",
     ] {
         let err = parse(doc).unwrap_err();
         assert_eq!(err.kind(), ProjectErrorKind::BadValue, "{doc}: {err}");
@@ -301,7 +348,7 @@ fn arm_entries_validate_their_shape() {
 /// parseurs, jamais en désaccord).
 #[test]
 fn the_thirteen_beat_keys_are_reachable_through_the_project_file() {
-    let src = "nika: v1\nceiling: 0.50\narm:\n  - workflow: t.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n    plafond: 0.10\n    manqué: sauter\n    chevauchement: file\n    après_saut: prochain-créneau\n    actif: false\n    raison: pause estivale\n    jusqu_au: 2026-09-01\n    tolérance: 3/4\n    décalage: hash\n    par: thibaut\n    où: local\n";
+    let src = "nika: proj\nceiling: 0.50\narm:\n  - workflow: t.nika.yaml\n    cadence: \"TZ=Europe/Paris 0 3 * * *\"\n    plafond: 0.10\n    manqué: sauter\n    chevauchement: file\n    après_saut: prochain-créneau\n    actif: false\n    raison: pause estivale\n    jusqu_au: 2026-09-01\n    tolérance: 3/4\n    décalage: hash\n    par: thibaut\n    où: local\n";
     let project = parse(src).expect("13 keys are the shape · none is unknown");
     assert_eq!(project.arm().len(), 1);
     let beat = &project.arm()[0];
@@ -336,7 +383,7 @@ fn the_thirteen_beat_keys_are_reachable_through_the_project_file() {
 #[test]
 fn a_fourteenth_key_still_refuses_by_name() {
     let err = parse(
-        "nika: v1\narm:\n  - workflow: w.nika.yaml\n    cadence: \"lundi 9h00\"\n    plafond: 1.00\n    manqué: sauter\n    quatorze: true\n",
+        "nika: proj\narm:\n  - workflow: w.nika.yaml\n    cadence: \"lundi 9h00\"\n    plafond: 1.00\n    manqué: sauter\n    quatorze: true\n",
     )
     .unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
@@ -354,7 +401,7 @@ fn a_fourteenth_key_still_refuses_by_name() {
 #[test]
 fn discovery_walks_up_first_found_governs() {
     let root = fresh_dir("walk");
-    std::fs::write(root.join("nika.yaml"), "nika: v1\nceiling: 0.50\n").expect("seed");
+    std::fs::write(root.join("nika.yaml"), "nika: proj\nceiling: 0.50\n").expect("seed");
     let nested = root.join("a/b/c");
     std::fs::create_dir_all(&nested).expect("mkdir");
     let (path, project) = discover(&nested)
@@ -368,7 +415,7 @@ fn discovery_walks_up_first_found_governs() {
     assert_eq!(project.ceiling, Some(0.5));
 
     // A closer file shadows the root's (git's exact law).
-    std::fs::write(root.join("a/b/nika.yaml"), "nika: v1\nceiling: 0.25\n").expect("seed2");
+    std::fs::write(root.join("a/b/nika.yaml"), "nika: proj\nceiling: 0.25\n").expect("seed2");
     let (path, project) = discover(&nested).expect("ok").expect("found");
     assert_eq!(path, root.join("a/b/nika.yaml"));
     assert_eq!(project.ceiling, Some(0.25));
@@ -397,7 +444,7 @@ fn an_unreadable_file_is_not_absent() {
 #[test]
 fn discovery_errors_speak_path_and_line() {
     let dir = fresh_dir("speak");
-    std::fs::write(dir.join("nika.yaml"), "nika: v1\nunknown: 1\n").expect("seed");
+    std::fs::write(dir.join("nika.yaml"), "nika: proj\nunknown: 1\n").expect("seed");
     let err = discover(&dir).unwrap_err();
     assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
     let shown = format!("{err}");
@@ -434,7 +481,7 @@ proptest::proptest! {
         ),
     ) {
         use std::fmt::Write as _;
-        let mut doc = format!("nika: v1\nceiling: {ceiling}\ntraces:\n  keep: {days}d\nregistry:\n  floor: {tier}\n");
+        let mut doc = format!("nika: proj\nceiling: {ceiling}\ntraces:\n  keep: {days}d\nregistry:\n  floor: {tier}\n");
         if !beats.is_empty() {
             doc.push_str("arm:\n");
             for (slug, ou, manque, plafond) in &beats {
@@ -468,7 +515,7 @@ proptest::proptest! {
                 !super::TOP_LEVEL_KEYS.contains(&k.as_str())
             }),
     ) {
-        let doc = format!("nika: v1\n{key}: 1\n");
+        let doc = format!("nika: proj\n{key}: 1\n");
         let err = parse(&doc).unwrap_err();
         proptest::prop_assert_eq!(err.kind(), ProjectErrorKind::UnknownKey);
         proptest::prop_assert_eq!(err.line(), Some(2));

--- a/crates/nika-vocab/src/project/tests.rs
+++ b/crates/nika-vocab/src/project/tests.rs
@@ -521,3 +521,26 @@ proptest::proptest! {
         proptest::prop_assert_eq!(err.line(), Some(2));
     }
 }
+
+/// The type discriminant is `tasks:`, never the filename — the spec's
+/// rule, and the reason it survives a registry blob, an HTTP body, a
+/// stdin pipe or a chat paste, where `.nika.yaml` is gone.
+#[test]
+fn the_type_discriminant_is_tasks_never_the_filename() {
+    use super::is_project_document as is_project;
+    assert!(is_project("nika: my-project\nceiling: 0.50\n"));
+    assert!(is_project("nika: my-project\n"));
+    assert!(!is_project("nika: wf\ntasks:\n  a:\n    exec: {}\n"));
+    // Comments and blank lines precede the envelope.
+    assert!(is_project("# a comment\n\n# another\nnika: my-project\n"));
+    // A nested `tasks:` is not the envelope's own.
+    assert!(is_project("nika: p\nregistry:\n  tasks: nope\n"));
+    // An indented envelope anchors its own `tasks:`.
+    assert!(is_project("  nika: p\n  ceiling: 0.50\n"));
+    assert!(!is_project(
+        "  nika: wf\n  tasks:\n    a:\n      exec: {}\n"
+    ));
+    // No envelope at all is not a nika file — the workflow lane owns it.
+    assert!(!is_project("ceiling: 0.50\n"));
+    assert!(!is_project("name: something\ntasks: []\n"));
+}

--- a/nika.yaml
+++ b/nika.yaml
@@ -1,0 +1,11 @@
+# nika.yaml — this repository, named.
+#
+# It governs nothing: no ceiling, no retention, no armed beat. It exists
+# because `project::discover` walks UP from the invocation directory,
+# git-style, and a checkout nested inside a larger tree would otherwise
+# answer with THAT tree's project file — including in the test suite,
+# which must never read the developer's home directory.
+#
+# So this is the boundary as much as the name. Whoever nests this
+# checkout, the engine's own runs and tests stop here.
+nika: nika-engine


### PR DESCRIPTION
`nika.yaml` opened on a frozen `v1` tag while a workflow's `nika:` names the
file. One key, two grammars — and every surface reading both had to know a
special rule. The docs' own fence sweep did not, and judged a manifest with the
nine-key workflow envelope ([nika-docs#134](https://github.com/supernovae-st/nika-docs/pull/134)).

## What changes

`nika:` now carries the project's kebab-case **name**, the same grammar the
workflow envelope gives its own `nika:`. The **kind** comes from the filename —
`nika.yaml` never matches a `*.nika.yaml` glob, so every file-based sweep in the
house was already correct. The **version** leaves the body.

The reasoning is this repo's own, written above `parse_nika_id` when the
workflow envelope was nuked:

> `v1` was the only legal value for the entire lifetime of the contract […]
> **A field with one legal value is not a version**, so nothing was traded away.

It also gives the project a name it never had, which every projection currently
infers from the directory.

## The asymmetry is the point

The retired tag refuses **in a project file and nowhere else**:

| | pre-nuke shape | caught by |
|---|---|---|
| **workflow** | `nika: v1` **+ `workflow:`** | ✅ the `workflow:` key already refuses |
| **manifest** | `nika: v1` + `ceiling:` | ❌ **nothing** — well-formed under *both* readings |

So `v1` stays free to be an ordinary workflow name — `the_dead_version_literals_are_now_ordinary_names` is **untouched** and still asserts exactly that. In a manifest, without a refusal, the same bytes would quietly stop meaning « schema v1 » and start meaning « a project named v1 ».

Only a **whole** marker qualifies (`^v[0-9]+$`). `vault`, `v2ray`, `v1-migration` stay ordinary names — pinned by test on both doors.

## Both doors move together

`nika.yaml` has two parsers — the spanned one in `nika-vocab` and the serde one
in `nika-cadence`. They move in the same commit, or the same bytes get two
verdicts depending on which door read them.

## Gates

`cargo fmt` clean · `clippy --workspace --all-targets -D warnings` clean ·
**65 lib suites green, zero failures** · full pre-push gate green (539s).

35 fixtures were reclassified **contextually** (whichever family's key appears
first after the marker), so workflow fixtures kept `nika: v1` on purpose. One
escaped the classifier and the compiler caught it: a fixture whose next key was
`celing:` — the very typo that test verifies.

## Two owes named rather than half-done

1. **The `$schema` line is NOT in the starter.** `nika.sh/spec/v1/project.schema.json` currently **404s**, and a starter teaching a dead URL is worse than one teaching nothing. The design still sends the version there; the line lands with the published schema.
2. **Five `nika-cli` tests read the developer's real project file** through `discover_from_cwd`. A unit test must never depend on what sits above its checkout — the refusal only surfaced it. The injectable half already exists (`ladder(flag, start)`); threading a root through `run()` is a separate change.

The second commit is the interim: this repo now names itself and **ends the
walk** there. Legitimate, not a workaround — it is the first real manifest
written in the grammar this repo defines.

## One unrelated commit

`chore(deny): scope the arrayref yank` is **cherry-pickable out**. `arrayref 0.3.9`
was yanked upstream (no advisory, no vulnerability) and the pre-push gate refuses
*every* push in the repo until answered. No in-tree move exists — `blake3 1.8.6`
pins it and has published nothing newer. The exception is scoped to the exact
crate and version rather than flipping `yanked` to warn, so any other yank still
refuses.

## ⚠️ Sequencing — do not migrate the ecosystem before release

The engine ships first. Migrating a root `nika.yaml` now would make the
**released** binary refuse it — and on at least one machine that would break a
daily armed `doctor` beat. Root manifests, the docs page, and emitted OS units
migrate **after** this lands in a release.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>