### PR TITLE
fix(authoring): the fan-out block teaches its own nesting

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -248,13 +248,39 @@ and a `default:`.
 | `with:` | the DATA edge — bind another task's output, body reads `${{ with.alias }}` |
 | `after:` | the CONTROL edge — `success` · `failure` · `skipped` · `terminal` · `unwind` |
 | `when:` | a CEL boolean gate · closed callables: `size()` · `has()` · `.size()` · `.contains()` · `.startsWith()` · `.endsWith()` |
-| `for_each:` | fan out over a collection · the body reads the current element as `${{ item }}` and its position as `${{ index }}` (loop-scoped locals, NOT a fourth value authority · `item.field` reaches into an object element) · the task's `.output` is the ARRAY of per-iteration outputs, in input order · `max_parallel:` caps concurrency (1 = sequential) · `fail_fast:` aborts on the first error (default true) |
+| `for_each:` | fan out over a collection · a BLOCK, never a scalar — `items:` carries the collection and is required, `max_parallel:` caps concurrency (1 = sequential), `fail_fast:` aborts on the first error (default true), and all three live INSIDE the block · a bare `for_each: <expr>` refuses `NIKA-PARSE-019`, and `max_parallel:`/`fail_fast:` at task level are retired spellings · `items:` reads a prior task through `with:` like every other reference · the body reads the current element as `${{ item }}` and its position as `${{ index }}` (loop-scoped locals, NOT a fourth value authority · `item.field` reaches into an object element) · the task's `.output` is the ARRAY of per-iteration outputs, in input order |
 | `retry:` | `max_attempts` · `backoff_ms` · `backoff_strategy` · `backoff_max_ms` · `jitter` · `on_codes` — transient failures only; a wrong prompt never heals by retry |
 | `on_error:` | exactly ONE action — `recover:` · `skip:` (preserves the original error at `tasks.X.error`) — with an optional `on_codes:` filter · the default (no `on_error:`) IS failure, and there is no keyword for saying so (`fail_workflow:` is dead · a YAML comment says it) |
 | `extract:` | named jq bindings → `${{ tasks.X.<name> }}` |
 | `returns:` | the task's output contract — exclusive with a verb-level `schema:` (`NIKA-TYPE-003`) |
 | `timeout:` | a quoted Go duration |
 | `lift:` | the ONE authored door, a list · each entry opens exactly one named law with a non-empty `because:` (check-visible · receipt-recorded) · `{law: taint, from: <binding>, because: "…"}` raises ONE binding through the permit-parameterization taint — never a permit bypass, the value is still matched against the declared boundary · `{law: data-as-code, because: "…"}` declares a `nika:fetch` payload code-bearing but never loaded — lifts that sink law ONLY, never the net boundary (`from:` is forbidden here) · a lift that would not have fired refuses `NIKA-AUTH-011` · `declassify:` and `inert:` are dead spellings of the same door |
+
+One shape a table cannot carry, because its whole defect is nesting:
+
+```yaml
+nika: fan-out-shape
+const:
+  targets: ["alpha", "beta"]
+permits:
+  tools: [nika:log]
+tasks:
+  each:
+    for_each:
+      items: ${{ const.targets }}   # REQUIRED · the collection
+      max_parallel: 4               # inside the block · at task level it is refused
+      fail_fast: true               # inside the block · this is the default
+    invoke:
+      tool: nika:log
+      args:
+        message: "${{ item }} at ${{ index }}"
+outputs:
+  lines: .each
+```
+
+Checked and RUN against the shipped binary before it was written here ·
+`clean` · `compiled` · `paid_ready` · zero hints · prints `alpha at 0`
+then `beta at 1`. An example that only checks is half an example.
 
 ## The one way (take the default, and the checker goes quiet)
 

--- a/estate.yaml
+++ b/estate.yaml
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: 0acf5d7fbb549cb8fa928b14e6cad8b9c9986dc45e0371516a8d03601da314d8
+  aggregate_sha256: adf9b34160ec5775394d7e78a920168972721a779b24c1f9f2c8d6d7f155d66a
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
## The row named three keys and never said where they live

```
| `for_each:` | fan out over a collection · … `max_parallel:` caps concurrency
  (1 = sequential) · `fail_fast:` aborts on the first error (default true) |
```

Everything in that sentence is true. Nothing in it says the three keys sit **inside** a block. And the shape is exactly what the retired spellings got wrong:

- a bare `for_each: <expr>` refuses `NIKA-PARSE-019`
- `max_parallel:` / `fail_fast:` at task level are frozen forms the kit's own `check-dead-forms.py` bans

So every way of guessing from that row lands on a refusal.

## I am the evidence

I read this row, wrote the flat form, and the parse refused. Then I wrote the knobs at task level and a pre-commit hook caught that too. Two refusals from one row in one sitting, before I had any reason to suspect the row.

## The pin was already here, armed, with nothing to look at

`the_kit_never_teaches_a_form_the_engine_refuses` walks every fence in the kit, selects the complete workflows, parses them strict and audits them clean. Its own comment says why the loop has been idle:

> the kit prints no complete workflow today, so the loop had no subject either way — but it was ARMED

**This example is its first subject.**

## Mutation proof

A pin with no subject is decoration, so the example was reverted to the flat form:

```
FAILED · skills/nika-authoring/SKILL.md: a taught workflow does not PARSE:
         `for_each` must be a block with `items:`
FAILED · init:.agents/skills/nika-authoring/SKILL.md: (same)
```

Two surfaces at once — the plugin skill and the copy `init` writes. Restoring returns green.

## The example was run, not only checked

```
clean · compiled · paid_ready · zero hints
alpha at 0
beta at 1
```

An example that only checks is half an example: this repo has spent the week on files that check green and die at run.

## Proof

`cargo test --workspace --lib` → **5989 passed, 0 failed**.

## Method

`dx/doctrine/rules/persona-gauntlet-discipline.md` (private) carries the four laws the wave ran under. A separate persona in the same wave reached the fan-out shape in **one attempt with zero guessing** — through `nika new '?'` → `nika new fanout`, whose generated template teaches the whole construct in its own header comments. That contrast is the finding: the binary teaches this well, and the skill did not.
