### PR TITLE
fix(authoring): keep local guidance honest

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -115,7 +115,8 @@ the `.nika.yaml` extension. `nika new <slug>` makes one yours;
 5. Repeat 3–4 until clean. **Never hand a file to the human that does
    not pass `nika check --native-strict` AND `paid_ready: true`.**
    `--native-strict` is the run-gate bar (an `exec:` a builtin covers).
-   `.paid_ready` is the paid-infer bar (`nika check --json | jq .paid_ready`).
+   `.paid_ready` is the paid-infer bar
+   (`nika check --json <file> | jq .paid_ready`).
    A green exit with leftover `infer-as-law` / `digit-string-enum` /
    `glob-readme` / `jq-as-map` / `unproven-law` is
    legal, not the one-way. The MCP `nika_check` oracle fails

--- a/crates/nika-cli/src/agent_kit/tests.rs
+++ b/crates/nika-cli/src/agent_kit/tests.rs
@@ -182,3 +182,19 @@ fn authoring_names_the_served_cel_callables() {
         "the retired one-function claim returned"
     );
 }
+
+/// The paid-readiness probe must name the workflow it audits. Without a
+/// path, `nika check --json` may fall back to directory discovery and emit a
+/// human diagnostic instead of the JSON the pipe expects.
+#[test]
+fn authoring_paid_ready_probe_names_the_workflow() {
+    let skill = read("skills/nika-authoring/SKILL.md");
+    assert!(
+        skill.contains("`nika check --json <file> | jq .paid_ready`"),
+        "the paid-readiness probe must pass the workflow path"
+    );
+    assert!(
+        !skill.contains("`nika check --json | jq .paid_ready`"),
+        "the pathless paid-readiness probe returned"
+    );
+}

--- a/crates/nika-cli/src/verbs/list.rs
+++ b/crates/nika-cli/src/verbs/list.rs
@@ -61,4 +61,14 @@ mod tests {
         assert_eq!(out.code, crate::verbs::exit::ENV);
         assert!(out.text.contains("scan incomplete"), "{}", out.text);
     }
+
+    #[test]
+    fn an_empty_directory_is_a_successful_empty_list() {
+        let dir = tempfile::tempdir().expect("scratch");
+
+        let out = run(dir.path());
+
+        assert_eq!(out.code, crate::verbs::exit::OK);
+        assert!(out.text.is_empty(), "script output must stay empty");
+    }
 }

--- a/crates/nika-cli/src/verbs/session.rs
+++ b/crates/nika-cli/src/verbs/session.rs
@@ -137,6 +137,14 @@ fn show<W: Write>(output: &mut W, value: &VerbOutput) -> std::io::Result<()> {
     Ok(())
 }
 
+fn show_list<W: Write>(output: &mut W, value: &VerbOutput) -> std::io::Result<()> {
+    if value.code == exit::OK && value.text.is_empty() {
+        writeln!(output, "no workflows below here · create one: nika new")
+    } else {
+        show(output, value)
+    }
+}
+
 fn finish_turn<W: Write>(output: &mut W, turn: &Turn) -> std::io::Result<()> {
     if turn.interrupted {
         writeln!(output, "interrupted · thread stays open")
@@ -170,7 +178,7 @@ fn drive<R: BufRead, W: Write, T: ThreadRuntime>(
         match message.split_once(' ') {
             _ if matches!(message, "/quit" | "/exit") => return Ok(exit::OK),
             _ if message == "/help" => write!(output, "{HELP}")?,
-            _ if message == "/list" => show(output, &runtime.list())?,
+            _ if message == "/list" => show_list(output, &runtime.list())?,
             Some(("/model", model)) if model.contains('/') => {
                 model.trim().clone_into(&mut thread.model);
                 writeln!(output, "model {}", thread.model)?;
@@ -226,6 +234,7 @@ mod tests {
         posted: Vec<String>,
         runs: Vec<String>,
         interrupt_first: bool,
+        empty_list: bool,
     }
 
     impl ThreadRuntime for FakeRuntime {
@@ -249,7 +258,11 @@ mod tests {
         }
 
         fn list(&mut self) -> VerbOutput {
-            VerbOutput::ok("a.nika.yaml\nnested/b.nika.yaml\n".to_owned())
+            if self.empty_list {
+                VerbOutput::ok(String::new())
+            } else {
+                VerbOutput::ok("a.nika.yaml\nnested/b.nika.yaml\n".to_owned())
+            }
         }
     }
 
@@ -302,5 +315,25 @@ mod tests {
         assert_eq!(runtime.prompts[0].1, "xai/grok-4");
         assert!(shown.contains("interrupted · thread stays open"));
         assert!(shown.contains("answer-2"));
+    }
+
+    #[test]
+    fn empty_list_in_thread_teaches_creation() {
+        let mut input = Cursor::new(b"/list\n/quit\n");
+        let mut output = Vec::new();
+        let mut runtime = FakeRuntime {
+            empty_list: true,
+            ..FakeRuntime::default()
+        };
+
+        let code = drive(&mut input, &mut output, plain(), &mut runtime).expect("thread");
+        let shown = String::from_utf8(output).expect("utf8");
+
+        assert_eq!(code, exit::OK);
+        assert!(
+            shown.contains("no workflows below here · create one: nika new"),
+            "{shown}"
+        );
+        assert_eq!(shown.matches("nika ›").count(), 2, "{shown}");
     }
 }

--- a/crates/nika-onboard/src/guided.rs
+++ b/crates/nika-onboard/src/guided.rs
@@ -33,7 +33,7 @@ use std::path::Path;
 
 use nika_display::theme::{Role, Theme};
 
-use crate::intent::RoutingOutcome;
+use crate::intent::{IntentContract, RoutingOutcome};
 use crate::{Audit, Outcome, codes};
 
 /// Emit a value as a SAFE YAML scalar. A plain token (`provider/model`,
@@ -155,10 +155,14 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
     if let Some(body) = nika_pack::example(template) {
         return write_example(template, body, dest, force);
     }
-    let (name, body, routed) = match nika_pack::template(template) {
-        Some(body) => (template.to_owned(), body, false),
+    let (name, body, contract) = match nika_pack::template(template) {
+        Some(body) => (template.to_owned(), body, None),
         None => match crate::intent::route(template) {
-            RoutingOutcome::Routed { template: name, .. } => {
+            RoutingOutcome::Routed {
+                template: name,
+                contract,
+                ..
+            } => {
                 // route returns names from the WHOLE catalog (G-16: the
                 // 26 human-worded jobs used to be invisible to the one
                 // surface that takes human words) — a routed EXAMPLE
@@ -166,7 +170,7 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
                 // the shared materializer), a routed skeleton
                 // instantiates.
                 if let Some(body) = nika_pack::example(&name) {
-                    return with_cadence_note(write_example(&name, body, dest, force), template);
+                    return with_cadence_note(write_example(&name, body, dest, force), &contract);
                 }
                 // A skeleton name — the lookup is total for the template
                 // set; an empty body would be a pack bug surfaced as the
@@ -174,7 +178,7 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
                 let Some(body) = nika_pack::template(&name) else {
                     return unknown(template);
                 };
-                (name, body, true)
+                (name, body, Some(contract))
             }
             RoutingOutcome::NeedsClarification { candidates, .. } => {
                 return clarify(template, &candidates);
@@ -211,6 +215,7 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
             code: codes::ENV,
         };
     }
+    let routed = contract.is_some();
     let routing = if routed { "routed intent → " } else { "" };
     // A ROUTED file is a draft by construction (P0-10): the intent was
     // interpreted, not understood — the message says « draft », never
@@ -230,8 +235,8 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
         text,
         code: codes::OK,
     };
-    if routed {
-        with_cadence_note(out, template)
+    if let Some(contract) = contract {
+        with_cadence_note(out, &contract)
     } else {
         out
     }
@@ -242,34 +247,19 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
 /// a deployed schedule is cron/CI territory, never a YAML side
 /// effect). Half of « Chaque lundi, analyser les tickets » used to
 /// vanish without a word (gauntlet 08-01, Camille) — routing keeps
-/// its focus on the work, and the dropped half is now NAMED. Lexicon
-/// over parsing: a bounded FR/EN keyword sweep, no date grammar.
-fn with_cadence_note(mut out: Outcome, intent: &str) -> Outcome {
+/// its focus on the work, and the dropped half is now NAMED. The
+/// already-extracted contract is the single cadence decision; this
+/// display must not run a second, broader lexicon over the utterance.
+fn with_cadence_note(mut out: Outcome, contract: &IntentContract) -> Outcome {
     if out.code != codes::OK {
         return out;
     }
-    let lower = intent.to_lowercase();
-    let hit = [
-        "chaque ",
-        "tous les ",
-        "toutes les ",
-        "every ",
-        "each ",
-        "daily",
-        "weekly",
-        "monthly",
-        "hebdomadaire",
-        "quotidien",
-    ]
-    .into_iter()
-    .find(|k| lower.contains(k));
-    if let Some(keyword) = hit {
-        // Quote from the lowercased copy: `to_lowercase` may shift
-        // byte offsets (Unicode), so indexing the original with a
-        // `lower` offset could split a char boundary — the workspace
-        // forbids that panic class.
-        let start = lower.find(keyword).unwrap_or(0);
-        let clause: String = lower[start..].chars().take(24).collect();
+    if let Some(cadence) = contract
+        .constraints
+        .iter()
+        .find_map(|constraint| constraint.strip_prefix("cadence:"))
+    {
+        let clause: String = cadence.chars().take(24).collect();
         let clause = clause.trim_end();
         let _ = write!(
             out.text,

--- a/crates/nika-onboard/src/guided.rs
+++ b/crates/nika-onboard/src/guided.rs
@@ -69,6 +69,14 @@ fn shell_quote(path: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+fn routing_prefix(contract: Option<&IntentContract>) -> &'static str {
+    if contract.is_some() {
+        "routed intent → "
+    } else {
+        ""
+    }
+}
+
 /// `nika new` — resolve the missing `--from` per clig.dev: a terminal
 /// gets the guided flow (prompt for the missing argument) · a pipe/CI
 /// fails fast naming the flag (never REQUIRE interactivity).
@@ -215,12 +223,11 @@ pub fn run(template: &str, dest: Option<&str>, force: bool) -> Outcome {
             code: codes::ENV,
         };
     }
-    let routed = contract.is_some();
-    let routing = if routed { "routed intent → " } else { "" };
+    let routing = routing_prefix(contract.as_ref());
     // A ROUTED file is a draft by construction (P0-10): the intent was
     // interpreted, not understood — the message says « draft », never
     // « ready », and hands over to `nika check` before any run.
-    let text = if routed {
+    let text = if contract.is_some() {
         format!(
             "{dest} ← {routing}template `{name}` — a DRAFT scaffold · fill the `# SLOT:` lines, then `nika check {q}` before any run",
             q = shell_quote(dest)

--- a/crates/nika-onboard/src/guided/tests.rs
+++ b/crates/nika-onboard/src/guided/tests.rs
@@ -208,6 +208,11 @@ fn parallel_intent_routes_to_fanout() {
         "{}",
         out.text
     );
+    assert!(
+        !out.text.contains("is a schedule"),
+        "per-item fan-out must not be described as cadence: {}",
+        out.text
+    );
     // Own-corpus by construction: the instantiated file IS the
     // embedded template verbatim.
     let written = std::fs::read_to_string(&d).expect("file written");

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: d460e87def5255a30ec901bf42bfbbe916ed383905508f0e53e51d9e5f7020f6
+  aggregate_sha256: 8633f86a9c841c4faea2e8d14540f42513e45b98e63ab6d5630dd4c5c58b005e
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 697836eb7ca3bb72738041be28947a8113d32bace449626089c9e1cf2c6fa1ec
+  aggregate_sha256: d460e87def5255a30ec901bf42bfbbe916ed383905508f0e53e51d9e5f7020f6
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 9a8cdac7b5dd6df4b8070704a4c87fe9d7c66842e599ab099af4d5baf3a4ccff
+  aggregate_sha256: 697836eb7ca3bb72738041be28947a8113d32bace449626089c9e1cf2c6fa1ec
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 9bc563760b05cc4a252f6891d26590fa0583d350a630a90d28f0ce000770f9ae
+  aggregate_sha256: 9a8cdac7b5dd6df4b8070704a4c87fe9d7c66842e599ab099af4d5baf3a4ccff
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: 748432409ea9301717c227023ed2f2efe3bbca46900c6bc48a0bd2f5296ab166
+  aggregate_sha256: 66bf9d27fa4f319c55310fb7b2ed5bc59bc0c6a161e0d02b057961b7b2065c49
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored


### PR DESCRIPTION
## What

- pass `<file>` to the taught paid-readiness JSON probe
- derive cadence feedback from the routed intent contract instead of a second broader lexicon
- keep `nika list` silent for scripts while teaching creation when `/list` is empty in the thread
- keep guided routing within the 100-line ratchet

## TDD receipts

- paid-readiness ratchet: red then green
- `every item` fan-out: red then green; `every Friday` remains positive
- empty thread `/list`: red transcript then green with creation hint

## Gates

- `cargo test -p nika-onboard --lib --quiet` — 112 passed, 1 ignored
- `cargo test -p nika-cli --lib --quiet` — 279 passed
- `cargo deny check` — advisories/bans/licenses/sources ok
- manual binary TTY and `nika try 01-hello` green
- pre-push: 10/10 ratchets, clippy workspace and workspace lib tests green