### PR TITLE
fix(check): the exec fit judges the script its interpreter must open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,23 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`nika check` now judges the script an `exec:` interpreter must open.**
+  The runtime jails every `exec:` child to the declared `permits.fs` set, so
+  `exec: ["bash", "leg.sh"]` with no `fs.read` grant could never open its
+  own script — measured on seatbelt, the leg exits **126** with empty
+  stdout. The audit was ✔ on all fourteen lanes and the run rendered it
+  `✔ leg` with rc 0: a leg that did nothing, reported as a success. The
+  `exec:` fit lane gained an fs arm beside its net arm (which shipped
+  2026-07-29 for the same sentence one boundary over), so the escape is a
+  `NIKA-SEC-004` finding at check with the one-line repair. The claim is
+  narrow on purpose — only a literal argv whose program is an interpreter,
+  on its script positional, through a literal `cwd:`; everything else stays
+  the runtime's verdict, and the verdict models the jail (which binds a
+  grant's literal prefix and never globs) rather than the stricter lexical
+  walk. `--infer-permits` learned the same fact in the same change, so the
+  boundary it writes cannot self-refuse the workflow it came from. Swept
+  over the shipped corpus: 63 of 63 unchanged.
+
 - **The `nika-error` crate-spec band table matches the one-voice
   registry.** It still read `330-379 Binding/template · 380-429 Provider`
   while the registry moved Provider to 330-379 (2026-05-11) and reserves

--- a/crates/nika-cap/public-api.txt
+++ b/crates/nika-cap/public-api.txt
@@ -459,6 +459,7 @@ pub fn nika_cap::Permits::new() -> Self
 impl nika_cap::Permits
 pub fn nika_cap::Permits::allows_host(&self, host: &str) -> bool
 pub fn nika_cap::Permits::allows_path(&self, path: &str, write: bool) -> bool
+pub fn nika_cap::Permits::jail_admits_read(&self, path: &str) -> bool
 impl nika_cap::Permits
 pub fn nika_cap::Permits::intersect(&self, other: &Self) -> Self
 pub fn nika_cap::Permits::union(&self, other: &Self) -> Self

--- a/crates/nika-cap/src/fit.rs
+++ b/crates/nika-cap/src/fit.rs
@@ -37,6 +37,46 @@ impl Permits {
             globs.iter().any(|g| path_glob_matches(g, path))
         })
     }
+
+    /// Whether the OS jail derived from this boundary would let a
+    /// SUBPROCESS open `path` for reading.
+    ///
+    /// This is NOT [`Self::allows_path`]. The jail does not glob: the
+    /// launchers take each grant's LITERAL PREFIX — everything before the
+    /// first `*`/`?`/`[`, trimmed back to a directory boundary — and bind
+    /// that subtree (`nika-sandbox-*::grant_subpath`). So the jail admits
+    /// strictly MORE than the lexical walk, and the difference is
+    /// measured, not assumed (2026-08-20, seatbelt, `nika 0.111.0`):
+    ///
+    /// ```text
+    /// permits.fs.read      script            run    allows_path
+    /// ───────────────      ──────            ───    ───────────
+    /// []                   leg.sh            126    no
+    /// ["leg.sh"]           leg.sh              0    yes
+    /// ["data/**"]          leg.sh            126    no
+    /// ["sub"]              sub/leg.sh          0    NO   ← binds the subtree
+    /// ["sub/inn*"]         sub/leg.sh          0    NO   ← prefix is `sub`
+    /// ```
+    ///
+    /// The looser reading is the one an exec claim must be judged against:
+    /// a checker using the stricter one would redden files the run
+    /// executes happily. The builtin fs gate keeps `allows_path` — its own
+    /// runtime seam enforces that stricter reading, and check refuses
+    /// before a run exists — so the two readings of one grant are a live
+    /// divergence in the authored vocabulary. Naming both here is what
+    /// keeps it from being rediscovered a fourth time.
+    ///
+    /// A grant with no literal prefix (`*` · `**/x`) grants nothing, the
+    /// same `Ok(None)` skip the launchers make. A prefix the launcher
+    /// REFUSES outright (a bare system root) is admitted here: that spawn
+    /// fails loudly with a profile error, which is not the silent class
+    /// this predicate exists to catch.
+    #[must_use]
+    pub fn jail_admits_read(&self, path: &str) -> bool {
+        self.fs
+            .as_ref()
+            .is_some_and(|fs| fs.read.iter().any(|g| bound_subtree_admits(g, path)))
+    }
 }
 
 /// Gitignore-style path glob match · supports a trailing `/**` (any
@@ -60,6 +100,44 @@ pub(crate) fn path_glob_matches(glob: &str, path: &str) -> bool {
         return false;
     }
     glob_admits(&glob, &path)
+}
+
+/// Does the subtree the JAIL binds for `glob` contain `path`?
+///
+/// The launchers do not glob — they bind `glob`'s literal prefix and let
+/// the kernel admit everything under it (`grant_subpath` · `literal_prefix`
+/// in `nika-sandbox-landlock` and its seatbelt sibling). This models that,
+/// lexically, both sides folded. An empty prefix grants nothing, matching
+/// the launchers' `Ok(None)` skip.
+///
+/// NOTE · this is a THIRD copy of the prefix rule (the two launchers carry
+/// byte-identical siblings, so the unification is a named follow-on, not a
+/// regression introduced here). The rule is four lines and pinned by this
+/// module's tests against the launchers' own examples.
+fn bound_subtree_admits(glob: &str, path: &str) -> bool {
+    let cut = glob.find(['*', '?', '[']).unwrap_or(glob.len());
+    let head = &glob[..cut];
+    let prefix = match head.rfind('/') {
+        Some(slash) if cut < glob.len() => &head[..slash],
+        _ => head,
+    };
+    if prefix.is_empty() {
+        return false; // no literal prefix — the launchers skip the grant
+    }
+    let path = lexically_normalize(path);
+    let prefix = lexically_normalize(prefix);
+    if prefix.is_empty() {
+        return false;
+    }
+    // An escaping path must never be admitted by an in-tree grant — the
+    // same guard `path_glob_matches` states, for the same reason.
+    if path.starts_with("..") && !prefix.starts_with("..") {
+        return false;
+    }
+    path == prefix
+        || path
+            .strip_prefix(&prefix)
+            .is_some_and(|tail| tail.starts_with('/'))
 }
 
 /// Whether one path SEGMENT matches one glob segment. `*` matches any run of
@@ -234,6 +312,82 @@ mod tests {
         assert!(p.allows_host("api.github.com"));
         assert!(p.allows_host("github.com"), "*.x matches the bare apex");
         assert!(!p.allows_host("evil.com"));
+    }
+
+    /// The jail binds a grant's LITERAL PREFIX and lets the kernel admit
+    /// the subtree — it never globs. Pinned against the launchers' own
+    /// documented examples (`nika-sandbox-landlock::literal_prefix`:
+    /// `./output/**` → `./output` · `/data/lo*` → `/data` · `/data/x.txt`
+    /// → itself · `**/y` → empty), so a drift on either side shows here.
+    ///
+    /// MEASURED 2026-08-20 on seatbelt · `permits.fs.read: ["sub"]` with
+    /// `["bash","sub/leg.sh"]` exits 0 and prints the script's output.
+    #[test]
+    fn the_jail_binds_a_literal_prefix_where_the_lexical_walk_globs() {
+        let grant = |g: &str| {
+            let mut p = Permits::new();
+            p.fs = Some(FsPermits {
+                read: vec![g.into()],
+                write: vec![],
+            });
+            p
+        };
+
+        // a bare directory · the row that reddened three studio workflows
+        let p = grant("sub");
+        assert!(
+            p.jail_admits_read("sub/leg.sh"),
+            "the jail binds the subtree"
+        );
+        assert!(
+            !p.allows_path("sub/leg.sh", false),
+            "the lexical walk still refuses — the divergence is the point"
+        );
+        assert!(p.jail_admits_read("sub"));
+        assert!(!p.jail_admits_read("other/leg.sh"));
+        assert!(
+            !p.jail_admits_read("subterfuge/leg.sh"),
+            "prefix, not segment"
+        );
+
+        // a MID-PATH glob · the prefix is `data`, so the whole tree is bound
+        let p = grant("data/lo*");
+        assert!(
+            p.jail_admits_read("data/other.txt"),
+            "the launcher binds `data`, not the pattern"
+        );
+        assert!(!p.jail_admits_read("elsewhere/lo.txt"));
+
+        // `**` and an exact file behave as the launcher documents
+        assert!(grant("./output/**").jail_admits_read("output/a/b.txt"));
+        assert!(grant("data/x.txt").jail_admits_read("data/x.txt"));
+        assert!(!grant("data/x.txt").jail_admits_read("data/y.txt"));
+
+        // no literal prefix · the launchers skip the grant, so it grants
+        // nothing here either
+        assert!(!grant("*").jail_admits_read("anything"));
+        assert!(!grant("**/y").jail_admits_read("a/y"));
+    }
+
+    /// A grant is not a licence to climb out of it, on either reading.
+    #[test]
+    fn the_jail_reading_still_refuses_an_escape() {
+        let mut p = Permits::new();
+        p.fs = Some(FsPermits {
+            read: vec!["sub".into(), "data/**".into()],
+            write: vec![],
+        });
+        assert!(!p.jail_admits_read("sub/../secret"));
+        assert!(!p.jail_admits_read("../secret"));
+        assert!(!p.jail_admits_read("leg.sh"), "granted something, not this");
+        assert!(p.jail_admits_read("data/a/b.txt"), "the subtree is bound");
+    }
+
+    /// An omitted `fs:` block is zero authority on this reading too — the
+    /// jail with no grants opens nothing.
+    #[test]
+    fn no_fs_block_admits_no_read_in_the_jail() {
+        assert!(!Permits::new().jail_admits_read("anything"));
     }
 
     #[test]

--- a/crates/nika-check/src/permits_fit.rs
+++ b/crates/nika-check/src/permits_fit.rs
@@ -23,7 +23,7 @@
 //!   unlisted host). A path/host built from a `${{ }}` value is dynamic and
 //!   stays the runtime `NIKA-SEC-004` check.
 
-use nika_schema::raw::{RawAction, RawCommand, RawInvokeAction, RawWorkflow};
+use nika_schema::raw::{RawAction, RawCommand, RawExecAction, RawInvokeAction, RawWorkflow};
 use nika_schema::types::{ExecPermit, Permits};
 // The `*.`-subdomain allowlist glob lives in `nika_types::net` — the SINGLE
 // canonical matcher shared with the runtime http effect (`nika-http`) so the
@@ -171,7 +171,7 @@ fn check_action(
     }
     let Some(permits) = permits else { return };
     match action {
-        RawAction::Exec(a) => check_exec(id, &a.command, permits, out),
+        RawAction::Exec(a) => check_exec(id, a, permits, out),
         RawAction::Invoke(a) => {
             let Some(tool) = a.tool() else {
                 // A `workflow:` call is not a tool grant — its authority
@@ -385,7 +385,13 @@ fn absent_effect_escape(
 /// sits in the body, whatever the command form — law 3's runtime deferral
 /// owns the dynamic VALUE cases (which program · which host), never the
 /// category question, which ∅ decides.
-fn check_exec(id: &str, command: &RawCommand, permits: &Permits, out: &mut Vec<CapabilityEscape>) {
+fn check_exec(
+    id: &str,
+    action: &RawExecAction,
+    permits: &Permits,
+    out: &mut Vec<CapabilityEscape>,
+) {
+    let command = &action.command;
     if !permits.allows_exec() {
         // NEP-0003 law 1 · the category refusal is statically decidable
         // under the zero boundary (∅ grants nothing — the run is refused
@@ -456,6 +462,108 @@ fn check_exec(id: &str, command: &RawCommand, permits: &Permits, out: &mut Vec<C
         }
     }
     check_exec_net(id, command, permits, out);
+    check_exec_fs(id, action, permits, out);
+}
+
+/// The fs arm of the exec fit — the twin of [`check_exec_net`], written
+/// for the same sentence one boundary over.
+///
+/// The runtime jails every `exec:` child to the DECLARED `permits.fs` set
+/// (`nika-exec-runner::sandbox_spec::spec_of` copies `fs.read` straight
+/// into the sandbox spec). So an interpreter invoked on a script the jail
+/// does not admit cannot OPEN its own script. Measured 2026-08-20 on
+/// seatbelt, every row of this table by running it:
+///
+/// ```text
+/// permits.fs.read   argv                       cwd:    run     check was
+/// ───────────────   ────                       ────    ───     ─────────
+/// []                ["bash","leg.sh"]          —       126     ✔ green
+/// ["leg.sh"]        ["bash","leg.sh"]          —         0     ✔ green
+/// ["data/**"]       ["bash","leg.sh"]          —       126     ✔ green
+/// ["sub"]           ["bash","sub/leg.sh"]      —         0     ✔ green
+/// ["sub/**"]        ["bash","inner.sh"]        sub       0     ✔ green
+/// ["sub/inn*"]      ["bash","sub/leg.sh"]      —         0     ✔ green
+/// ```
+///
+/// Three of those six audited ✔ on all fourteen lanes and then RAN as
+/// `✔ leg` with rc 0 while the leg had exited **126** with empty stdout —
+/// a success rendered over a script that never opened. That is the class
+/// this arm closes, and the last three rows are why it is careful.
+///
+/// The verdict is [`Permits::jail_admits_read`], NOT `allows_path`: the
+/// jail hands a bare directory grant to the launcher as a bind subpath, so
+/// it opens the subtree (row 4), and an arm judging by the stricter
+/// lexical walk would redden files the run executes. See that method for
+/// the divergence in full.
+///
+/// SCOPE — the decidable sub-question, and the ones it deliberately leaves
+/// (a waiver that does not name its decidable half is a defect):
+///
+/// - **DECIDED** · a literal argv whose program is an INTERPRETER, on its
+///   script positional, resolved through a literal `cwd:`. That the
+///   interpreter must read that exact path is a property of the
+///   interpreter, not a guess about the program's semantics —
+///   [`nika_types::exec::interpreter_script_operand`] walks the same table
+///   the exec floor walks, so the two cannot drift.
+/// - **LEFT** · every other argv operand. Whether `cat x` reads `x`, or
+///   `rm -f x` writes it, or `docker ps --format {{.Names}}` names a path
+///   at all, is the PROGRAM's semantics — a per-program effect table the
+///   checker does not have and would be wrong about. Those stay the
+///   runtime jail's verdict, exactly as the PERMITS panel says.
+/// - **LEFT** · a templated `cwd:`. The script's resolved identity is not
+///   knowable, so no claim holds. An earlier draft of this arm ignored
+///   `cwd:` and reddened all seven tasks of a real workflow whose every
+///   `exec:` runs a script relative to a computed working directory.
+/// - **LEFT** · the shell form, per this lane's standing scope law: the
+///   runtime judges an interpolated string, so no positional claim holds.
+/// - **LEFT** · a `${{ }}` program or operand — the run re-judges the
+///   resolved argv.
+fn check_exec_fs(
+    id: &str,
+    action: &RawExecAction,
+    permits: &Permits,
+    out: &mut Vec<CapabilityEscape>,
+) {
+    let RawCommand::Argv(parts) = &action.command else {
+        return; // the shell form makes no positional claim
+    };
+    let mut elements = parts.iter().map(|p| p.value.as_str());
+    let Some(program) = elements.next() else {
+        return;
+    };
+    let args: Vec<&str> = elements.collect();
+    if program.contains("${{") || args.iter().any(|a| a.contains("${{")) {
+        return; // the resolved argv is the RUN's verdict
+    }
+    let Some(script) = nika_types::exec::interpreter_script_operand(program, &args) else {
+        return; // not an interpreter · inline eval · no path named
+    };
+    let cwd = action.cwd.as_ref().map(|c| c.value.as_str());
+    let Some(resolved) = resolve_against_cwd(script, cwd) else {
+        return; // a computed cwd makes the script's identity unknowable
+    };
+    if permits.jail_admits_read(&resolved) {
+        return;
+    }
+    out.push(fs_escape(id, program, &resolved, "fs.read", permits, false));
+}
+
+/// Where the interpreter will look for its script. An ABSOLUTE script
+/// ignores `cwd:` (it is already an identity); a relative one is opened
+/// relative to the subprocess's working directory, so a declared `cwd:`
+/// re-anchors it — while the BOUNDARY stays anchored at the run root
+/// (`sandbox_spec`'s own law: « a task-level `cwd:` does not re-anchor the
+/// boundary »). `None` means the answer is not statically knowable.
+pub(super) fn resolve_against_cwd(script: &str, cwd: Option<&str>) -> Option<String> {
+    if script.starts_with('/') || script.starts_with('~') {
+        return Some(script.to_owned());
+    }
+    match cwd {
+        None => Some(script.to_owned()),
+        Some(c) if c.contains("${{") => None,
+        Some(c) if c == "." || c == "./" => Some(script.to_owned()),
+        Some(c) => Some(format!("{}/{script}", c.trim_end_matches('/'))),
+    }
 }
 
 /// The net arm of the exec fit (the 2026-07-29 audit · run 5 · D1): an

--- a/crates/nika-check/src/permits_fit/tests.rs
+++ b/crates/nika-check/src/permits_fit/tests.rs
@@ -17,6 +17,248 @@ mod fit {
         scan_escapes(&parse(yaml, FileId::new(0), ParseMode::Strict).expect("parse"))
     }
 
+    // ── the fs arm of the exec fit (2026-08-20 · the gauntlet's D2) ──
+
+    /// MEASURED 2026-08-20 on nika 0.111.0, both directions, before the
+    /// arm existed · `["bash","leg.sh"]` under `exec: [bash]` with no
+    /// `fs.read` audited ✔ on all fourteen lanes and printed « risk
+    /// supervised », then RAN as `✔ leg`, rc 0 — while the leg had exited
+    /// **126** with empty stdout, because the sandbox derives its read set
+    /// from `permits.fs.read` and bash could never open the script. Adding
+    /// `fs.read: ["leg.sh"]` and changing nothing else returned exit 0 and
+    /// the script's output. One grant, byte-identical check verdict.
+    ///
+    /// The net twin of this arm shipped 2026-07-29 for exactly the same
+    /// sentence (`exec: ["curl", …]` outside `permits.net.http` passed
+    /// check clean and died at the OS sandbox). The fs half was never
+    /// written; this is it.
+    #[test]
+    fn an_interpreter_script_outside_fs_read_escapes_the_boundary() {
+        let escapes = escapes_of(
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"leg.sh\"] }
+",
+        );
+        let fs: Vec<_> = escapes.iter().filter(|e| e.category == "fs").collect();
+        assert_eq!(fs.len(), 1, "one fs escape expected, got {escapes:?}");
+        assert!(
+            fs[0].detail.contains("leg.sh") && fs[0].detail.contains("permits.fs.read"),
+            "the witness must name the script and the grant: {}",
+            fs[0].detail
+        );
+        assert_eq!(fs[0].task, "leg");
+    }
+
+    /// The grant that makes the run work must make the check green — the
+    /// asymmetry the whole arm exists to remove.
+    #[test]
+    fn the_grant_that_makes_the_run_work_makes_the_check_green() {
+        let escapes = escapes_of(
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"leg.sh\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"leg.sh\"] }
+",
+        );
+        assert!(
+            !escapes.iter().any(|e| e.category == "fs"),
+            "a granted script must not escape: {escapes:?}"
+        );
+    }
+
+    /// The silences where a GRANT covers the script. Each row was RUN;
+    /// each exits 0. A finding here would be the cancelled kind, since it
+    /// would redden a file the run executes.
+    #[test]
+    fn the_exec_fs_arm_is_silent_where_the_jail_admits_the_script() {
+        for yaml in [
+            // a globbed subtree
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"scripts/**\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"scripts/deploy.sh\"] }
+",
+            // a BARE directory · the launcher binds it as a subpath
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"sub\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"sub/leg.sh\"] }
+",
+            // a MID-PATH glob · the bound prefix is `sub`, not the pattern
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"sub/inn*\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"sub/leg.sh\"] }
+",
+            // a `cwd:` re-anchors the interpreter's lookup
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"sub/**\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"inner.sh\"], cwd: \"sub\" }
+",
+        ] {
+            let escapes = escapes_of(yaml);
+            assert!(
+                !escapes.iter().any(|e| e.category == "fs"),
+                "silence expected for\n{yaml}\ngot {escapes:?}"
+            );
+        }
+    }
+
+    /// The silences where the checker cannot DECIDE. Not one of these is
+    /// safe by inspection: each is a question whose answer belongs to the
+    /// run, and a claim here would be a guess wearing a code.
+    #[test]
+    fn the_exec_fs_arm_claims_nothing_it_cannot_decide() {
+        for yaml in [
+            // not an interpreter · the positional is the program's own business
+            "\
+nika: t
+permits:
+  exec: [\"echo\"]
+tasks:
+  leg:
+    exec: { command: [\"echo\", \"hello.txt\"] }
+",
+            // a templated operand · the run re-judges the resolved argv
+            "\
+nika: t
+inputs:
+  which: { type: string }
+permits:
+  exec: [\"bash\"]
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"${{ inputs.which }}\"] }
+",
+            // `-m module` · resolved by the interpreter, not opened by name
+            "\
+nika: t
+permits:
+  exec: [\"python3\"]
+tasks:
+  leg:
+    exec: { command: [\"python3\", \"-m\", \"unittest\"] }
+",
+            // a COMPUTED cwd · the script's identity is unknowable
+            "\
+nika: t
+const:
+  where: \"sub\"
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"sub/**\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"inner.sh\"], cwd: \"${{ const.where }}\" }
+",
+            // the shell form · judged as an interpolated string at run,
+            // never positionally (this lane's standing scope law). MEASURED
+            // exit 126 all the same — a named gap, not an assumed one.
+            "\
+nika: t
+permits:
+  exec: true
+tasks:
+  leg:
+    exec: { shell: \"bash leg.sh\" }
+",
+        ] {
+            let escapes = escapes_of(yaml);
+            assert!(
+                !escapes.iter().any(|e| e.category == "fs"),
+                "silence expected for\n{yaml}\ngot {escapes:?}"
+            );
+        }
+    }
+
+    /// A boundary that grants SOMETHING but not this — measured 126. The
+    /// arm must keep its teeth once it learned to be careful.
+    #[test]
+    fn a_grant_that_does_not_cover_the_script_still_escapes() {
+        let escapes = escapes_of(
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+  fs: { read: [\"data/**\"] }
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"leg.sh\"] }
+",
+        );
+        assert_eq!(
+            escapes.iter().filter(|e| e.category == "fs").count(),
+            1,
+            "a non-covering grant must not buy silence: {escapes:?}"
+        );
+    }
+
+    /// Mootness, the same law the net arm states: where the FORM is
+    /// already refused, the fs question never arises. A task that cannot
+    /// spawn at all must not also be told its script is unreadable — it
+    /// has one defect, and one repair.
+    #[test]
+    fn a_refused_exec_form_asks_no_further_fs_question() {
+        // zero authority · the category itself escapes
+        let escapes = escapes_of(
+            "\
+nika: t
+permits: {}
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"leg.sh\"] }
+",
+        );
+        assert_eq!(
+            escapes.iter().filter(|e| e.task == "leg").count(),
+            1,
+            "one defect, one finding: {escapes:?}"
+        );
+        assert_eq!(escapes[0].category, "exec");
+
+        // a shell line under a program allowlist · refused by form
+        let escapes = escapes_of(
+            "\
+nika: t
+permits:
+  exec: [\"bash\"]
+tasks:
+  leg:
+    exec: { shell: \"bash leg.sh\" }
+",
+        );
+        assert!(
+            !escapes.iter().any(|e| e.category == "fs"),
+            "a refused form asks no fs question: {escapes:?}"
+        );
+    }
+
     #[test]
     fn a_globs_walk_root_is_the_read_bound_the_run_needs() {
         // A glob OPENS the directory its pattern roots at. `pattern ⊆

--- a/crates/nika-check/src/permits_infer.rs
+++ b/crates/nika-check/src/permits_infer.rs
@@ -31,7 +31,7 @@ use super::permits_fit::{
     BuiltinEffect, ConstStrings, builtin_effect, chart_vl_sibling, judgeable_arg, static_program,
     url_host,
 };
-use nika_schema::raw::{RawAction, RawCommand, RawTask, RawWorkflow};
+use nika_schema::raw::{RawAction, RawCommand, RawExecAction, RawTask, RawWorkflow};
 use nika_schema::types::{ExecPermit, FsPermits, NetPermits, Permits};
 
 /// The inferred boundary plus the honesty notes (effects too dynamic to
@@ -153,6 +153,27 @@ pub(crate) fn task_permits(task: &RawTask) -> Vec<String> {
     out
 }
 
+/// The read an argv-form `exec:` needs for its own script — `None` when
+/// the program is not an interpreter, the argv evals, the argv is
+/// templated, or a computed `cwd:` makes the path unknowable.
+///
+/// The SAME resolution the fit lane judges with
+/// ([`super::permits_fit::resolve_against_cwd`]), so an inferred boundary
+/// and the finding that would refuse it cannot disagree.
+fn interpreter_script_read(a: &RawExecAction) -> Option<String> {
+    let RawCommand::Argv(parts) = &a.command else {
+        return None;
+    };
+    let mut elements = parts.iter().map(|p| p.value.as_str());
+    let program = elements.next()?;
+    let args: Vec<&str> = elements.collect();
+    if program.contains("${{") || args.iter().any(|s| s.contains("${{")) {
+        return None;
+    }
+    let script = nika_types::exec::interpreter_script_operand(program, &args)?;
+    super::permits_fit::resolve_against_cwd(script, a.cwd.as_ref().map(|c| c.value.as_str()))
+}
+
 /// Fold one action (a task's main verb OR an `on_finally` cleanup verb)
 /// into the inference state.
 fn collect_action(c: &mut Collector, id: &str, action: &RawAction) {
@@ -164,6 +185,16 @@ fn collect_action(c: &mut Collector, id: &str, action: &RawAction) {
                 RawCommand::Argv(_) => {
                     if let Some(p) = static_program(&a.command) {
                         c.programs.insert(p.to_owned());
+                        // An interpreter must OPEN its script before it
+                        // runs a line, and the jail admits only what the
+                        // boundary declares — so a block that grants the
+                        // program and not the script would self-refuse the
+                        // very workflow it came from (the vega-sibling law
+                        // below, one boundary over). Measured 2026-08-20:
+                        // without the read the leg exits 126, empty.
+                        if let Some(read) = interpreter_script_read(a) {
+                            c.reads.insert(read);
+                        }
                     } else {
                         c.exec_dynamic = true;
                         c.notes.push(format!(
@@ -402,6 +433,98 @@ mod tests {
     use nika_schema::parser::{ParseMode, parse};
     use nika_schema::source::FileId;
     use proptest::prelude::*;
+
+    /// The round trip that keeps the tool's own advice honest: a boundary
+    /// this module WRITES must satisfy the lane that judges it. An
+    /// interpreter needs its script readable, so a block granting the
+    /// program and not the script would self-refuse the very workflow it
+    /// came from — the chart/tts sibling law, one boundary over.
+    ///
+    /// MEASURED 2026-08-20 · without the read the leg exits 126, empty
+    /// stdout, and the run still renders it as a completed task.
+    #[test]
+    fn an_inferred_boundary_grants_the_script_its_interpreter_opens() {
+        let wf = parse(
+            "\
+nika: t
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"scripts/deploy.sh\"] }
+",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("parses");
+        let inferred = infer(&wf);
+        let fs = inferred.permits.fs.as_ref().expect("an fs block");
+        assert!(
+            fs.read.iter().any(|r| r == "scripts/deploy.sh"),
+            "the script must be granted: {:?}",
+            fs.read
+        );
+        // and the boundary it wrote must survive the lane that judges it
+        assert!(
+            inferred.permits.jail_admits_read("scripts/deploy.sh"),
+            "an inferred boundary must not self-refuse"
+        );
+    }
+
+    /// A `cwd:` re-anchors the script; a COMPUTED one makes it unknowable,
+    /// and a guess there would write a grant the author never meant.
+    #[test]
+    fn the_inferred_script_read_follows_a_literal_cwd_and_stops_at_a_computed_one() {
+        let literal = parse(
+            "\
+nika: t
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"inner.sh\"], cwd: \"sub\" }
+",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("parses");
+        let fs = infer(&literal).permits.fs.expect("an fs block");
+        assert!(fs.read.iter().any(|r| r == "sub/inner.sh"), "{:?}", fs.read);
+
+        let computed = parse(
+            "\
+nika: t
+const:
+  where: \"sub\"
+tasks:
+  leg:
+    exec: { command: [\"bash\", \"inner.sh\"], cwd: \"${{ const.where }}\" }
+",
+            FileId::new(0),
+            ParseMode::Strict,
+        )
+        .expect("parses");
+        let reads = infer(&computed)
+            .permits
+            .fs
+            .map(|f| f.read)
+            .unwrap_or_default();
+        assert!(
+            reads.is_empty(),
+            "a computed cwd must pin nothing: {reads:?}"
+        );
+    }
+
+    /// The silences · a non-interpreter positional is the program's own
+    /// business, and inline eval opens no file.
+    #[test]
+    fn the_inferred_script_read_claims_nothing_it_cannot_know() {
+        for yaml in [
+            "nika: t\ntasks:\n  t:\n    exec: { command: [\"echo\", \"hi.txt\"] }\n",
+            "nika: t\ntasks:\n  t:\n    exec: { command: [\"python3\", \"-m\", \"unittest\"] }\n",
+            "nika: t\ntasks:\n  t:\n    exec: { shell: \"bash leg.sh\" }\n",
+        ] {
+            let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+            let reads = infer(&wf).permits.fs.map(|f| f.read).unwrap_or_default();
+            assert!(reads.is_empty(), "silence expected for {yaml}: {reads:?}");
+        }
+    }
 
     /// The inference covers chart + tts (they were invisible — the
     /// boundary it wrote refused the very run it came from) and the

--- a/crates/nika-exec-runner/src/sandbox_spec.rs
+++ b/crates/nika-exec-runner/src/sandbox_spec.rs
@@ -275,6 +275,99 @@ mod tests {
         std::fs::canonicalize(&base).expect("canonical scratch root")
     }
 
+    // ── check ≡ run on the exec fs bound (the 2026-08-20 D2 harvest) ──
+
+    /// The fs twin of `blocklist::tests::check_and_run_agree_on_the_argv_floor`.
+    ///
+    /// MEASURED on 0.111.0 before this arm existed · `["bash","leg.sh"]`
+    /// under `exec: [bash]` and no `fs.read` audited ✔ on all fourteen
+    /// lanes, then ran as `✔ leg` with rc 0 — while the leg had exited
+    /// **126**, empty stdout, because `spec_of` below copies `fs.read`
+    /// into the jail and bash could never open its own script. Granting
+    /// `fs.read: ["leg.sh"]` and changing nothing else returned exit 0.
+    ///
+    /// Both big pipelines are pinned to ONE reference semantics —
+    /// `Permits::jail_admits_read(script)` — exactly as
+    /// `nika-runtime`'s `boundary_differential` pins the exec CATEGORY to
+    /// `allows_program`:
+    ///
+    /// * **static leg** · `nika_check::check` raises an `fs` escape on the
+    ///   task ⟺ the reference REFUSES the script.
+    /// * **derivation leg** · the jail `spec_of` hands the OS admits the
+    ///   script ⟺ the reference ADMITS it. This is the leg that earns its
+    ///   keep: `spec_of` re-anchors every grant against the run root, so a
+    ///   fold that mangled a glob would open a hole no static lane can see.
+    ///
+    /// Composed · check-flags ⟺ reference-refuses ⟺ jail-refuses.
+    #[test]
+    fn check_and_run_agree_on_the_exec_script_read_bound() {
+        // (grants, script, the reference verdict — admitted?)
+        let cases: &[(&[&str], &str, bool)] = &[
+            (&[], "leg.sh", false),                         // the measured repro
+            (&["leg.sh"], "leg.sh", true),                  // the one grant that fixes it
+            (&["scripts/**"], "scripts/deploy.sh", true),   // a globbed subtree
+            (&["scripts/**"], "other/deploy.sh", false),    // a NEIGHBOURING tree
+            (&["sub"], "sub/leg.sh", true),                 // a BARE dir binds its subtree
+            (&["sub"], "other/leg.sh", false),              // and only its own
+            (&["./scripts/**"], "scripts/deploy.sh", true), // `./` folds on both sides
+            (&["data/**"], "leg.sh", false),                // granted, but not this
+        ];
+        let root = Path::new("/repo");
+        for (grants, script, admitted) in cases {
+            let p = permits(grants, &[], &[]);
+
+            // the reference
+            assert_eq!(
+                p.jail_admits_read(script),
+                *admitted,
+                "reference verdict for {script:?} under {grants:?}"
+            );
+
+            // static leg · the `nika check` finding
+            let list = grants
+                .iter()
+                .map(|g| format!("\"{g}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let yaml = format!(
+                "nika: w\npermits:\n  exec: [\"bash\"]\n  fs: {{ read: [{list}] }}\n\
+                 tasks:\n  t:\n    exec: {{ command: [\"bash\", \"{script}\"] }}\n"
+            );
+            let wf = nika_schema::parser::parse(
+                &yaml,
+                nika_schema::source::FileId::new(0),
+                nika_schema::parser::ParseMode::Strict,
+            )
+            .expect("fixture parses");
+            let report = nika_check::check(&wf);
+            let static_flags = report
+                .capability_escapes
+                .iter()
+                .any(|e| e.category == "fs" && e.task == "t");
+            assert_eq!(
+                static_flags, !*admitted,
+                "static check verdict for {script:?} under {grants:?}"
+            );
+
+            // derivation leg · what the jail would admit
+            let spec = spec_of(&p, root).expect("no symlink on the judged prefixes");
+            let mut jail = Permits::new();
+            jail.fs = Some(nika_schema::types::FsPermits::new(spec.fs_read, vec![]));
+            let jail_admits = jail.jail_admits_read(&absolutize(root, script));
+            assert_eq!(
+                jail_admits, *admitted,
+                "the jail must admit exactly what the reference admits — \
+                 {script:?} under {grants:?}"
+            );
+
+            // the law
+            assert_eq!(
+                static_flags, !jail_admits,
+                "check ≡ run on the exec fs bound — {script:?} under {grants:?}"
+            );
+        }
+    }
+
     #[test]
     fn relative_globs_anchor_at_the_run_root() {
         let spec = spec_of(

--- a/crates/nika-types/public-api.txt
+++ b/crates/nika-types/public-api.txt
@@ -1003,8 +1003,43 @@ impl<T> core::clone::CloneToUninit for nika_types::exec::ArgvFloorRefusal where 
 pub unsafe fn nika_types::exec::ArgvFloorRefusal::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for nika_types::exec::ArgvFloorRefusal
 pub fn nika_types::exec::ArgvFloorRefusal::from(t: T) -> T
+#[non_exhaustive] pub enum nika_types::exec::InterpreterTarget<'a>
+pub nika_types::exec::InterpreterTarget::Eval
+pub nika_types::exec::InterpreterTarget::Script(&'a str)
+impl<'a> core::clone::Clone for nika_types::exec::InterpreterTarget<'a>
+pub fn nika_types::exec::InterpreterTarget<'a>::clone(&self) -> nika_types::exec::InterpreterTarget<'a>
+impl<'a> core::cmp::Eq for nika_types::exec::InterpreterTarget<'a>
+impl<'a> core::cmp::PartialEq for nika_types::exec::InterpreterTarget<'a>
+pub fn nika_types::exec::InterpreterTarget<'a>::eq(&self, other: &nika_types::exec::InterpreterTarget<'a>) -> bool
+impl<'a> core::fmt::Debug for nika_types::exec::InterpreterTarget<'a>
+pub fn nika_types::exec::InterpreterTarget<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for nika_types::exec::InterpreterTarget<'a>
+impl<'a> core::marker::StructuralPartialEq for nika_types::exec::InterpreterTarget<'a>
+impl<T, U> core::convert::Into<U> for nika_types::exec::InterpreterTarget<'a> where U: core::convert::From<T>
+pub fn nika_types::exec::InterpreterTarget<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_types::exec::InterpreterTarget<'a> where U: core::convert::Into<T>
+pub type nika_types::exec::InterpreterTarget<'a>::Error = core::convert::Infallible
+pub fn nika_types::exec::InterpreterTarget<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_types::exec::InterpreterTarget<'a> where U: core::convert::TryFrom<T>
+pub type nika_types::exec::InterpreterTarget<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_types::exec::InterpreterTarget<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_types::exec::InterpreterTarget<'a> where T: core::clone::Clone
+pub type nika_types::exec::InterpreterTarget<'a>::Owned = T
+pub fn nika_types::exec::InterpreterTarget<'a>::clone_into(&self, target: &mut T)
+pub fn nika_types::exec::InterpreterTarget<'a>::to_owned(&self) -> T
+impl<T> core::any::Any for nika_types::exec::InterpreterTarget<'a> where T: 'static + ?core::marker::Sized
+pub fn nika_types::exec::InterpreterTarget<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_types::exec::InterpreterTarget<'a> where T: ?core::marker::Sized
+pub fn nika_types::exec::InterpreterTarget<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_types::exec::InterpreterTarget<'a> where T: ?core::marker::Sized
+pub fn nika_types::exec::InterpreterTarget<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_types::exec::InterpreterTarget<'a> where T: core::clone::Clone
+pub unsafe fn nika_types::exec::InterpreterTarget<'a>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_types::exec::InterpreterTarget<'a>
+pub fn nika_types::exec::InterpreterTarget<'a>::from(t: T) -> T
 pub fn nika_types::exec::argv_floor_refusal<S: core::convert::AsRef<str>>(program: &str, args: &[S]) -> core::option::Option<nika_types::exec::ArgvFloorRefusal>
 pub fn nika_types::exec::argv_program_refusal(program: &str) -> core::option::Option<nika_types::exec::ArgvFloorRefusal>
+pub fn nika_types::exec::interpreter_script_operand<'a>(program: &str, args: &[&'a str]) -> core::option::Option<&'a str>
 pub fn nika_types::exec::normalize_for_blocklist(s: &str) -> alloc::string::String
 pub mod nika_types::extract
 #[non_exhaustive] pub enum nika_types::extract::ExtractMode

--- a/crates/nika-types/src/exec.rs
+++ b/crates/nika-types/src/exec.rs
@@ -173,14 +173,47 @@ fn eval_spec(base: &str) -> Option<EvalSpec> {
 /// module handoff (`python -m <module>` — the flags after it are the
 /// MODULE's, so `python3 -m unittest discover -p test_*.py` stays allowed).
 fn interpreter_eval_requested(base: &str, args: &[&str]) -> bool {
-    let Some(spec) = eval_spec(base) else {
-        return false;
-    };
+    matches!(
+        interpreter_target(base, args),
+        Some(InterpreterTarget::Eval)
+    )
+}
+
+/// What an argv-form interpreter invocation asks the interpreter to DO —
+/// the structural fact the eval walk below has always computed on its way
+/// to a verdict, published instead of flattened.
+///
+/// The walk that proves "this is not inline eval" has, at that exact
+/// moment, its hand on the script the interpreter will OPEN. Returning a
+/// `bool` threw that away, and the fs boundary never learned of the file:
+/// a `["bash","leg.sh"]` under an empty `permits.fs.read` audited green and
+/// died 126 at the sandbox, reported as a success (measured 2026-08-20).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InterpreterTarget<'a> {
+    /// An eval flag or subcommand — the code IS the argv. The floor refuses
+    /// it ([`ArgvFloorRefusal::InterpreterEval`]); no file is opened.
+    Eval,
+    /// A script FILE. The interpreter must read it before it runs a line,
+    /// so the sandbox's `fs.read` set has to admit it.
+    Script(&'a str),
+}
+
+/// Walk one interpreter's OWN argv (everything before the script
+/// positional, `--`, or `-m <module>`) and name what it targets.
+///
+/// `None` is the honest silence — not an interpreter, or the target is not
+/// a path the interpreter opens BY NAME (`-` reads stdin · `-m` resolves a
+/// module · `--` hands off without the walk having proven which element is
+/// the script · an argv that ends on flags). A caller may claim nothing
+/// there, which is what keeps the fs arm from reddening a correct file.
+fn interpreter_target<'a>(base: &str, args: &[&'a str]) -> Option<InterpreterTarget<'a>> {
+    let spec = eval_spec(base)?;
     let mut i = 0;
     while i < args.len() {
         let arg = args[i];
         if arg == "--" || Some(arg) == spec.module_flag {
-            return false; // `--` / `-m <module>`: the rest is not the interpreter's
+            return None; // `--` / `-m <module>`: the rest is not the interpreter's
         }
         if spec.value_flags.contains(&arg) {
             i += 2; // the flag's operand is a value, not an option
@@ -188,23 +221,46 @@ fn interpreter_eval_requested(base: &str, args: &[&str]) -> bool {
         }
         if arg.starts_with("--") {
             if spec.long_flags.contains(&arg) {
-                return true;
+                return Some(InterpreterTarget::Eval);
             }
         } else if let Some(bundle) = arg.strip_prefix('-') {
             if bundle.is_empty() {
-                return false; // `-` (stdin handoff): the rest is the script's
+                return None; // `-` (stdin handoff): the rest is the script's
             }
             if bundle.chars().any(|c| spec.short_letters.contains(&c)) {
-                return true;
+                return Some(InterpreterTarget::Eval);
             }
+        } else if spec.eval_subcommands.contains(&arg) {
+            // First positional · an eval subcommand (`deno eval <code>`).
+            return Some(InterpreterTarget::Eval);
         } else {
-            // First positional: an eval subcommand, else the script file —
-            // everything after it belongs to the script.
-            return spec.eval_subcommands.contains(&arg);
+            // First positional · the script file. Everything after it
+            // belongs to the script, so the interpreter's walk ends here.
+            return Some(InterpreterTarget::Script(arg));
         }
         i += 1;
     }
-    false
+    None
+}
+
+/// The script FILE an argv-form interpreter invocation must OPEN and READ
+/// before it can run a line.
+///
+/// The fs half of the exec floor's `check ≡ run` pair, and the twin of
+/// [`argv_floor_refusal`]: that one names an argv the run refuses at the
+/// BLOCKLIST, this one names the read the run needs from the SANDBOX. Both
+/// walk the same interpreter table, so neither can drift from the other.
+///
+/// `None` is a claim of nothing — the program is not an interpreter, the
+/// argv evals instead of opening a file, or the script is not named as a
+/// path (`-` · `-m` · `--` · flags only). Callers MUST treat `None` as
+/// silence, never as "no read needed".
+#[must_use]
+pub fn interpreter_script_operand<'a>(program: &str, args: &[&'a str]) -> Option<&'a str> {
+    match interpreter_target(&program_basename(program), args) {
+        Some(InterpreterTarget::Script(path)) => Some(path),
+        Some(InterpreterTarget::Eval) | None => None,
+    }
 }
 
 /// The normalized lowercase BASENAME of an argv program — NFKC + zero-width
@@ -329,6 +385,53 @@ mod tests {
 
     fn allowed(program: &str, args: &[&str]) -> bool {
         argv_floor_refusal(program, args).is_none()
+    }
+
+    // ── the script operand · the fact the eval walk already computes ──
+
+    /// The interpreter's script positional is the file the RUN must open.
+    /// Today `interpreter_eval_requested` finds it and throws it away, so
+    /// the fs boundary never learns of it and a sandboxed run dies 126 on
+    /// a file `nika check` called green.
+    #[test]
+    fn the_interpreter_script_operand_is_the_file_the_run_must_open() {
+        assert_eq!(
+            interpreter_script_operand("bash", &["leg.sh"]),
+            Some("leg.sh")
+        );
+        assert_eq!(
+            interpreter_script_operand("/bin/sh", &["-e", "deploy.sh"]),
+            Some("deploy.sh")
+        );
+        assert_eq!(
+            interpreter_script_operand("python3", &["-X", "faulthandler", "app.py"]),
+            Some("app.py")
+        );
+        assert_eq!(
+            interpreter_script_operand("node", &["tools/build.js", "--watch"]),
+            Some("tools/build.js")
+        );
+    }
+
+    /// The silences, each for its own reason — a claim here would redden a
+    /// file the run admits.
+    #[test]
+    fn the_script_operand_stays_silent_where_no_file_is_opened_by_name() {
+        // inline eval · the code is the argv, there is no file
+        assert_eq!(interpreter_script_operand("bash", &["-c", "echo hi"]), None);
+        // not an interpreter · positional semantics are the program's own
+        assert_eq!(interpreter_script_operand("echo", &["hi.txt"]), None);
+        // `-m module` · the interpreter resolves a module, not a named path
+        assert_eq!(
+            interpreter_script_operand("python3", &["-m", "unittest"]),
+            None
+        );
+        // `-` · the script arrives on stdin
+        assert_eq!(interpreter_script_operand("sh", &["-", "arg"]), None);
+        // `--` · conservative silence rather than a positional guess
+        assert_eq!(interpreter_script_operand("bash", &["--", "leg.sh"]), None);
+        // no positional at all
+        assert_eq!(interpreter_script_operand("bash", &[]), None);
     }
 
     // ── the program-identity floor (exact basename · no substrings) ──


### PR DESCRIPTION
## The defect

`nika check` had a **net** arm on `exec:` — shipped 2026-07-29 for the sentence
*"`exec: ["curl", …]` outside `permits.net.http` passed check clean and died
only at the OS sandbox — check-green, run-refused on a statically decidable
class."* It had **no fs arm at all**.

The runtime jails every `exec:` child to the declared boundary:
`sandbox_spec::spec_of` copies `permits.fs.read` straight into the sandbox
spec. So an interpreter invoked on a script no grant admits cannot open its own
script. Measured on seatbelt at 0.111.0 — every row by running it, not by
reading the code:

| `permits.fs.read` | argv | `cwd:` | run | check said |
|---|---|---|---|---|
| `[]` | `["bash","leg.sh"]` | — | **126** | ✔ green · rc 0 |
| `["leg.sh"]` | `["bash","leg.sh"]` | — | 0 | ✔ green · rc 0 |
| `["data/**"]` | `["bash","leg.sh"]` | — | **126** | ✔ green · rc 0 |
| `["sub"]` | `["bash","sub/leg.sh"]` | — | 0 | ✔ green · rc 0 |
| `["sub/**"]` | `["bash","inner.sh"]` | `sub` | 0 | ✔ green · rc 0 |
| `["sub/inn*"]` | `["bash","sub/leg.sh"]` | — | 0 | ✔ green · rc 0 |

Rows 1 and 3 exit **126 with empty stdout**. The audit was ✔ on all fourteen
lanes and printed « risk supervised »; the run then rendered `✔ leg` and
returned rc 0. **A leg that did nothing, reported as a success.**

## The root defect, in the code

`nika_types::exec::interpreter_eval_requested` walks an interpreter's own argv
to decide eval-vs-file. At the exact moment it proves "not inline eval" it has
its hand on the script:

```rust
} else {
    // First positional: an eval subcommand, else the script file —
    // everything after it belongs to the script.
    return spec.eval_subcommands.contains(&arg);
}
```

…and returns a `bool`. A structural fact computed, then flattened, and lost at
the boundary. It now returns `InterpreterTarget::{Eval, Script(path)}`, and
`interpreter_eval_requested` is a `matches!` over it — the exec floor's
behaviour is preserved *by construction*, and its 17 tests still pass unchanged.

## The verdict is the jail's, not `allows_path`'s — and that took two corrections

**The jail does not glob.** The launchers take each grant's *literal prefix* —
everything before the first `*`/`?`/`[`, trimmed back to a directory boundary —
and bind that subtree (`nika-sandbox-*::grant_subpath` · `literal_prefix`). So:

```
permits.fs.read: ["sub"]      ·  nika:read  "sub/leg.sh"  → check REFUSES SEC-004
permits.fs.read: ["sub"]      ·  bash       "sub/leg.sh"  → run  exit 0
permits.fs.read: ["sub/inn*"] ·  bash       "sub/leg.sh"  → run  exit 0   ← !
```

That last row does not match the pattern at all. The jail binds `sub/` and the
kernel admits everything beneath it.

My first draft judged by `allows_path` and reddened **five studio workflows**.
The second understood bare directories but still refused a mid-path glob the
run admits. **Each correction came from running the case, not from reading the
code.** `jail_admits_read` now models the launcher, pinned against the
launcher's own documented examples so a drift on either side shows up as a
failing test.

The divergence between the two readings is **pre-existing** — it reddens
builtin reads on the *shipped* binary today, with none of this branch in the
tree — and is **named in both predicates and left for its own change**: it is a
verdict over the whole builtin fs lane, which is not this PR's defect.

## Scope — decided, and deliberately left

A waiver that does not name its decidable half is a defect, so:

- **DECIDED** · a literal argv whose program is an interpreter, on its script
  positional, resolved through a literal `cwd:`. That the interpreter must read
  that exact path is a property of the *interpreter*, and the predicate walks
  the same table the exec floor walks, so the two cannot drift.
- **LEFT** · every other argv operand. Whether `cat x` reads `x`, `rm -f x`
  writes it, or `docker ps --format {{.Names}}` names a path at all is the
  *program's* semantics — a per-program effect table the checker does not have
  and would be wrong about.
- **LEFT** · a computed `cwd:` — the script's identity is not knowable.
- **LEFT** · the shell form (this lane's standing scope law) and a templated
  program or operand (the run re-judges the resolved argv).

## The sweep — before pushing, because an unmeasured verdict change is a guess

- **shipped corpus · 63 files swept, 63 unchanged, 0 reddened.**
- The first draft reddened **five studio workflows**. That is how rows 4, 5 and
  6 were found. The draft was wrong, not the files — every cause is fixed and
  pinned as a silence test, each carrying the exit code that was measured.

## The other half: `--infer-permits` learned the same fact

The inferrer recorded the *program* and never the *script*. After this arm it
would have written:

```yaml
permits:
  exec: [bash]      # and nothing else
```

…a boundary refused by the very lane that judges it. That is the
**self-refusing class** the chart/tts sibling law already names one boundary
over (*"an exact-path boundary that admits the svg but not its `.vl.json`
would self-refuse the very workflow it came from"*). A finding caused by the
tool's own advice counts double, so both sides now share **one** resolution
(`resolve_against_cwd`) — an inferred block and the finding that would refuse
it cannot disagree.

## Mutation proof — four cuts, one per leg

| cut | breaks | verdict |
|---|---|---|
| unwire `check_exec_fs` | the static leg | unit RED + parity RED |
| `Script(arg)` → `Script("MUTANT2")` | the predicate | unit RED + parity RED |
| `spec_of` drops one grant | the jail derivation | parity RED, on its own message |
| drop the inferred read | the round trip | both inferrer tests RED |

All four restored; all green after.

## What this leaves behind

- `check_and_run_agree_on_the_exec_script_read_bound`, beside the argv-floor
  parity test it is modelled on. Both pipelines pinned to one reference
  semantics, the way `boundary_differential` pins the exec category.
- Isolated unit tests for `jail_admits_read` in `nika-cap`, including the
  divergence from `allows_path` — so it cannot be rediscovered a fourth time.
- Silence tests for each measured row the run admits, and a teeth test for the
  row it kills.

## Named follow-ons (not in this PR)

1. **A conformance fixture for the shape.** `nika-cli/tests/check_run_equivalence.rs`
   already asserts *judged = executed = attested* over the conformance corpus.
   The class escaped it because no fixture carries the shape — the corpus, not
   the oracle, had the hole. The fixture belongs in `nika-spec`.
2. **The bare-directory divergence** between `allows_path` and the jail.
3. **The shell form.** `shell: "bash leg.sh"` under `exec: true` with no
   `fs.read` was RUN for this PR and exits **126** with empty stdout, exactly
   like the argv twin — so the class extends there. This arm stays silent by
   design (the lane's standing scope law: the runtime judges an interpolated
   string, so no positional claim holds), and the silence is now a measured
   gap rather than an assumed one.
4. **One prefix rule, three copies.** `literal_prefix` already exists twice
   (landlock + seatbelt, documented as byte-identical); `bound_subtree_admits`
   is the third. Unifying them in `nika-cap` is the right change and is not
   this one — the rule is four lines and pinned here against their examples.

---

🦋 Generated with [Claude Code](https://claude.com/claude-code)
