### PR TITLE
fix(schema): a task key from another dialect, or the wrong depth, teaches

### DIFF
--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -377,7 +377,14 @@ fn retired_key_teaching(key: &str, location: &str) -> Option<&'static str> {
         return retired::envelope(key);
     }
     if location.starts_with("task `") {
-        return retired::task(key);
+        // Three tables, one scope, tried in order of how much the author
+        // already knows. A RETIRED key was ours and moved. A FOREIGN key
+        // is another tool's word for a concept we spell differently. An
+        // ENVELOPE key is our own word at the wrong depth — the author is
+        // not wrong about the vocabulary at all, only about the column.
+        return retired::task(key)
+            .or_else(|| retired::foreign(key))
+            .or_else(|| retired::envelope_key_at_task_level(key));
     }
     None
 }
@@ -465,7 +472,7 @@ impl Cx<'_> {
                     // the set an author meets first and the one whose
                     // vocabulary they are least likely to hold; it has
                     // never taught itself, at fourteen keys or at nine.
-                    // A task's twenty keys still stay silent, which is
+                    // A task's fifteen keys still stay silent, which is
                     // the line this threshold exists to draw.
                     (known.len() <= 9).then(|| format!("the fields here: {}", known.join(" · ")))
                 };

--- a/crates/nika-schema/src/parser/retired.rs
+++ b/crates/nika-schema/src/parser/retired.rs
@@ -86,10 +86,124 @@ pub(super) fn task(key: &str) -> Option<&'static str> {
     }
 }
 
+/// Keys an author BRINGS from another tool's dialect. Nothing here was
+/// ever ours, so none of it is retired — but the author is not confused
+/// about spelling, they are confused about which language they are in,
+/// and `unknown field` answers a question they did not ask.
+///
+/// Measured 2026-08-20 · a persona wave put fifteen outside authors
+/// against 0.111.0 with only the binary, the oracle and the public docs.
+/// Two of them, independently, stopped here. One wrote `run:` inside a
+/// task and quit at that line, verbatim: « the error message does not
+/// teach you what the field should be ». The other wrote `uses:` and
+/// `needs:`, reached green only by reading a shipped example, and named
+/// the missing sentence exactly: « dependencies are inferred from data
+/// bindings, there is no `needs:` field ».
+///
+/// That sentence already EXISTS. `depends_on:` gets it one layer up as
+/// its own code (`W2DependsOnField`). `needs:` is the same concept in
+/// another spelling and reached the generic path with nothing. These
+/// arms route to the teaching that is already written; they invent no
+/// new prose.
+pub(super) fn foreign(key: &str) -> Option<&'static str> {
+    match key {
+        "needs" => Some(
+            "a dependency is not declared on the task here — DATA rides a `with:` \
+             binding and the binding IS the edge (`with: { x: \"${{ tasks.a.output }}\" }`), \
+             and pure ORDERING rides `after: { a: success }` (spec 03 §the flow · \
+             `depends_on:` is the same key under its other name)",
+        ),
+        "uses" | "steps" | "jobs" | "script" => Some(
+            "a task body is one of the four verbs — `infer:` · `exec:` · `invoke:` · \
+             `agent:` — and there is no action-reference field; a reusable unit is \
+             another workflow, called with `invoke: { workflow: ./child.nika.yaml }` \
+             (spec 14 §composition)",
+        ),
+        _ => None,
+    }
+}
+
+/// An ENVELOPE key typed one level too deep. Every one of these is valid
+/// at column 0, so the author holds the right word in the wrong place —
+/// and `unknown field` says the word is wrong, which is the one thing it
+/// is not. `run:` is the case that cost an outside author the session:
+/// it is a real envelope key, and inside a task it read as nonsense.
+pub(super) fn envelope_key_at_task_level(key: &str) -> Option<&'static str> {
+    crate::parser::TOP_LEVEL_KEYS.contains(&key).then_some(
+        "this is a workflow ENVELOPE field · it belongs at column 0 beside \
+         `tasks:`, never inside a task. A task body is one of the four verbs \
+         (`infer:` · `exec:` · `invoke:` · `agent:`) plus the task modifiers \
+         (`after` · `when` · `for_each` · `retry` · `on_error` · `timeout` · \
+         `with` · `extract` · `returns` · `lift` · `group`)",
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use crate::parser::{ParseMode, parse};
     use crate::source::FileId;
+
+    /// A key from another dialect, and our own key at the wrong depth,
+    /// both TEACH — because in neither case is the author confused about
+    /// spelling. Measured 2026-08-20: two outside authors in one persona
+    /// wave stopped at exactly these two shapes, one of them for good.
+    ///
+    /// The assertions name MECHANISMS, never whole sentences: a pin that
+    /// quotes its own prose passes on a message that has been reworded
+    /// into nonsense, which is a mirror, not a test.
+    #[test]
+    fn a_task_key_from_another_dialect_or_the_wrong_depth_teaches() {
+        let sees = |body: &str| {
+            let yaml = format!("nika: w\ntasks:\n  t:\n{body}");
+            parse(&yaml, FileId::new(0), ParseMode::Strict)
+                .expect_err("an unknown task key refuses")
+                .to_string()
+        };
+
+        // `run:` is a REAL envelope key. Inside a task it read as nonsense
+        // to the author who typed it, and the message said only "unknown".
+        let run = sees("    run:\n      x: 1\n");
+        assert!(
+            run.contains("ENVELOPE") && run.contains("column 0"),
+            "an envelope key at task level names the depth · {run}"
+        );
+        assert!(
+            run.contains("infer") && run.contains("invoke"),
+            "and names what a task body actually is · {run}"
+        );
+
+        // The GitHub Actions spelling of a concept that already has a
+        // teaching one layer up (`depends_on:` · W2DependsOnField).
+        let needs = sees("    needs: [other]\n    exec: { command: [\"true\"] }\n");
+        assert!(
+            needs.contains("with:") && needs.contains("after:"),
+            "`needs:` routes to the mechanism, both halves · {needs}"
+        );
+        assert!(
+            needs.contains("depends_on"),
+            "and names the same key under its other spelling · {needs}"
+        );
+
+        // An action reference: the shape has no counterpart, so the
+        // teaching has to name the four verbs AND where reuse lives.
+        let uses = sees("    uses: some/action@v4\n");
+        assert!(
+            uses.contains("four verbs") && uses.contains("invoke:"),
+            "`uses:` names the verb set · {uses}"
+        );
+        assert!(
+            uses.contains("workflow:"),
+            "and sends reuse to composition · {uses}"
+        );
+
+        // The silence the threshold exists to keep: a key that is nobody's
+        // envelope word and nobody's import stays a bare unknown field.
+        let noise = sees("    zzqx: 1\n    exec: { command: [\"true\"] }\n");
+        assert!(
+            !noise.contains("ENVELOPE") && !noise.contains("four verbs"),
+            "an ordinary unknown key gains no teaching · {noise}"
+        );
+    }
 
     /// EVERY key the fourteen-key era shipped teaches where its role went
     /// — not a spelling guess, not the bare set listing (that one says

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 9ac3fcba0e587bdd07e08b6a1285022dc61acc64c442ef8b327611d427bfcac5
+  aggregate_sha256: 36cefe95330f2484f131393bcff933f7fe65d634f52050bf8cb355d1b3871330
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## Two outside authors, one layer, neither confused about spelling

A persona wave ran eight outside users against 0.111.0 on 2026-08-20, each with only the binary, the oracle and the public docs.

**Persona 01** wrote a shell step inside a task and **quit at that line**. Their words:

> The error message does not teach you what the field should be. It only rejects what you tried.

The word they typed was `run:` — a **real envelope key**. So `unknown field` told them the one thing that was not true.

**Persona 02** arrived from GitHub Actions, wrote `uses:` and `needs:`, reached green only by reading a shipped example, and named the missing sentence exactly:

> dependencies are inferred from data bindings, there is no `needs:` field

## The disagreement that located it

**Persona 08** called the same code `NIKA-PARSE-005` *excellent*, with a full field inventory. Both quoted real output. The variable between them is **position**:

```
envelope : unknown field `ceiling` … — the fields here: nika · model · inputs · const · …
task     : unknown field `run` in task `greet` (strict mode)          ← nothing
```

The inventory exists. It is not emitted where authors actually err.

## The fix invents no prose

The sentence persona 02 wanted **already exists**. It rides `depends_on:` one layer up as its own code (`W2DependsOnField`). `needs:` is the same concept in another dialect and reached the generic path with nothing. These arms route to teachings that are already written.

Three tables now answer in one scope, ordered by how much the author already knows:

| table | the author is | example |
|---|---|---|
| `retired::task` | right about the word, wrong about the era | `on_finally`, `max_parallel` |
| `retired::foreign` | in the wrong language | `needs`, `uses`, `steps`, `jobs`, `script` |
| `envelope_key_at_task_level` | right about the word, wrong about the **column** | `run`, `permits`, `outputs` |

The shape follows what the module already did for the two fan-out knobs when they moved inside `for_each:`.

## What it renders now

```
unknown field `run` … — this is a workflow ENVELOPE field · it belongs at column 0
beside `tasks:`, never inside a task. A task body is one of the four verbs …

unknown field `needs` … — a dependency is not declared on the task here — DATA
rides a `with:` binding and the binding IS the edge … pure ORDERING rides
`after: { a: success }` (spec 03 §the flow · `depends_on:` is the same key under
its other name)

unknown field `uses` … — a task body is one of the four verbs … a reusable unit
is another workflow, called with `invoke: { workflow: ./child.nika.yaml }`
```

## The silence stays where it was earned

The `known.len() <= 9` threshold and its reasoning are untouched: an ordinary unknown key still gains nothing, and **the pin asserts that too**. A teaching that fires on everything teaches nothing.

## Mutation proof

```
tables unrouted → FAILED · "an envelope key at task level names the depth ·
                            unknown field `run` in task `t` (strict mode)"
restored        → ok
```

The failure message is verbatim what both authors received, which is the point.

The assertions check **mechanisms** (`with:` and `after:` both present, `ENVELOPE` and `column 0`, the verb set), never whole sentences — a pin that quotes its own prose passes on a reword into nonsense.

## Incidental

A comment claimed a task carries twenty keys. The set is fifteen: eleven modifiers plus four verbs. The threshold it justifies is unaffected either way.

## Proof

`cargo test --workspace --lib` → **5990 passed, 0 failed**.

## Method

`dx/doctrine/rules/persona-gauntlet-discipline.md` (private) carries the four laws the wave ran under. Law 4 is why this exists: where two personas contradict, the variable that differs is the defect's real boundary. Neither 01 nor 08 alone would have found it — one had the failure, the other had the counterexample.
