### PR TITLE
fix(authoring): keep intent and thread guidance exact

### DIFF
--- a/.agents/plugins/nika/skills/nika-authoring/SKILL.md
+++ b/.agents/plugins/nika/skills/nika-authoring/SKILL.md
@@ -147,7 +147,7 @@ the `.nika.yaml` extension. `nika new <slug>` makes one yours;
    four-tier ladder and reports the highest tier honestly attained —
    chain OK · **SEALED** (the run signature verifies against a custody
    key) · **ANCHORED** (the detached transparency-log sidecar verifies
-   fully offline) · **REPLAYED** (`--replay` compares a fresh run;
+   fully offline) · **REPLAYED** (`--replay <fresh-trace>` compares a fresh run;
    verify never re-executes). `nika trace show <trace>` reads the card;
    `nika trace evidence <trace>` exports the pack an auditor reads without
    trusting you. Cite the trace, never a memory of the run.

--- a/crates/nika-cli/src/agent_kit/tests.rs
+++ b/crates/nika-cli/src/agent_kit/tests.rs
@@ -198,3 +198,18 @@ fn authoring_paid_ready_probe_names_the_workflow() {
         "the pathless paid-readiness probe returned"
     );
 }
+
+/// Replay verification compares two journals, so the authoring map must name
+/// the fresh trace path that the CLI requires instead of presenting a switch.
+#[test]
+fn authoring_replay_names_the_fresh_trace() {
+    let skill = read("skills/nika-authoring/SKILL.md");
+    assert!(
+        skill.contains("`--replay <fresh-trace>`"),
+        "replay verification must name its fresh trace"
+    );
+    assert!(
+        !skill.contains("`--replay` compares"),
+        "the pathless replay form returned"
+    );
+}

--- a/crates/nika-cli/src/verbs/session.rs
+++ b/crates/nika-cli/src/verbs/session.rs
@@ -188,6 +188,7 @@ fn drive<R: BufRead, W: Write, T: ThreadRuntime>(
             Some(("/workflow", path)) if !path.trim().is_empty() => {
                 show(output, &runtime.post(path.trim(), theme))?;
             }
+            _ if message == "/run" => writeln!(output, "use /run <path>")?,
             Some(("/run", path)) if !path.trim().is_empty() => {
                 finish_turn(output, &runtime.run_workflow(path.trim(), theme))?;
             }
@@ -335,5 +336,20 @@ mod tests {
             "{shown}"
         );
         assert_eq!(shown.matches("nika ›").count(), 2, "{shown}");
+    }
+
+    #[test]
+    fn bare_run_teaches_its_path_without_dispatching() {
+        let mut input = Cursor::new(b"/run\n/quit\n");
+        let mut output = Vec::new();
+        let mut runtime = FakeRuntime::default();
+
+        let code = drive(&mut input, &mut output, plain(), &mut runtime).expect("thread");
+        let shown = String::from_utf8(output).expect("utf8");
+
+        assert_eq!(code, exit::OK);
+        assert!(shown.contains("use /run <path>"), "{shown}");
+        assert!(!shown.contains("unknown thread command"), "{shown}");
+        assert!(runtime.runs.is_empty());
     }
 }

--- a/crates/nika-onboard/src/intent.rs
+++ b/crates/nika-onboard/src/intent.rs
@@ -76,7 +76,7 @@ pub(crate) const ALIASES: &[(&str, &[&str])] = &[
     ("build", &["exec"]),
     ("test", &["exec", "verify"]),
     ("deploy", &["ship", "act", "exec"]),
-    ("release", &["ship", "act"]),
+    ("release", &["ship", "act", "changelog"]),
     ("parallel", &["for_each", "fan", "merge"]),
     ("concurrent", &["for_each", "fan"]),
     ("batch", &["for_each", "items"]),
@@ -1179,6 +1179,18 @@ mod calibration_probe {
 #[cfg(test)]
 mod catalog_routing_laws {
     use super::*;
+
+    #[test]
+    fn release_notes_intent_leads_the_named_job() {
+        match route("write release notes from git commits") {
+            RoutingOutcome::Routed { template, .. } => assert_eq!(template, "release-notes"),
+            RoutingOutcome::NeedsClarification { candidates, .. } => assert_eq!(
+                candidates.first().map(String::as_str),
+                Some("release-notes"),
+                "the named job must lead the clarify list: {candidates:?}"
+            ),
+        }
+    }
 
     /// THE LAW (RAMS-1 · G-16 · entry-doors probes 2026-07-31): the
     /// three probes that each failed on the skeleton-only corpus (« 3

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: f7ec2e14e508991355cecc8ec05525ac45143c7a2ee5f596fcd71aef2f0487e9
+  aggregate_sha256: cf2d1ef4d8c50200ebb50c0464dd5f7d9d67444d3013716d28c149da3649b8ad
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
@@ -198,7 +198,7 @@ patterns:
 - glob: ".agents/**"
   class: authored
   match_count: 32
-  aggregate_sha256: 66bf9d27fa4f319c55310fb7b2ed5bc59bc0c6a161e0d02b057961b7b2065c49
+  aggregate_sha256: 0acf5d7fbb549cb8fa928b14e6cad8b9c9986dc45e0371516a8d03601da314d8
   evidence: "the agent-plugin pack SOURCE (marketplace.json · plugin manifests · skills · rules · hooks) — authored here, mirrored downstream into supernovae-st/nika-plugins (its plugins/ is a byte-pinned copy healed on releases)"
 - glob: ".claude/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 8633f86a9c841c4faea2e8d14540f42513e45b98e63ab6d5630dd4c5c58b005e
+  aggregate_sha256: 002ef00ebada449ffba5eb63351c4b7550e7b4f942610e1f322445dce8e019a9
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 002ef00ebada449ffba5eb63351c4b7550e7b4f942610e1f322445dce8e019a9
+  aggregate_sha256: f7ec2e14e508991355cecc8ec05525ac45143c7a2ee5f596fcd71aef2f0487e9
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Three measured authoring quick wins: release-notes intent now leads the named canonical job, the interactive thread teaches the required path for a bare `/run`, and the authoring kit names the required fresh trace for `--replay`. TDD ratchets cover every boundary. Local gates: `nika-onboard` and `nika-cli` lib suites green, clippy all-targets green, cargo-deny green, built-binary intent/PTY/list/check/try smokes green, and the full pre-push gate passed all 10 ratchets plus workspace `--lib`.