### PR TITLE
fix(check): a prompt default is a consent decision, not a formatting detail

### DIFF
--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -123,6 +123,7 @@ pub struct Hint {
     /// `unwrapped-ref` · `envelope-output` · `policy-soft` · `run-clock`
     /// · `analysis` · `consent` · `digit-string-enum`
     /// · `glob-readme` · `assert-quarantine` · `jq-as-map` · `infer-as-law`
+    /// · `fail-open-consent`
     /// · `unproven-law`
     /// (additive · agents route on it; the module doc describes each).
     /// The paid-run family ([`PAID_RUN_KINDS`]) is what [`paid_ready`]
@@ -229,6 +230,15 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
         });
     }
 
+    // Whether this file can DO anything. A `default:` on a prompt that
+    // gates nothing is an unattended answer; on a prompt over an effect it
+    // is a standing decision about what happens with no human present.
+    // The same predicate the trifecta lane's ② leg reads, so the two
+    // cannot disagree about what counts as an effect.
+    let gates_an_effect = wf
+        .tasks
+        .iter()
+        .any(|t| crate::trifecta::egress_capable(&t.value.action));
     for task in &wf.tasks {
         let t = &task.value;
         let id = t.id.value.as_str();
@@ -266,7 +276,8 @@ pub(super) fn scan_hints(wf: &RawWorkflow) -> Vec<Hint> {
                 push_exec_json_capture_hint(&mut hints, t, exec);
             }
             RawAction::Invoke(a) => {
-                push_headless_prompt_hint(&mut hints, id, a);
+                push_headless_prompt_hint(&mut hints, id, a, gates_an_effect);
+                push_fail_open_consent_hint(&mut hints, id, a, gates_an_effect);
                 push_glob_readme_hint(&mut hints, id, a);
                 push_jq_as_map_hint(&mut hints, id, a);
             }
@@ -424,6 +435,7 @@ fn push_headless_prompt_hint(
     hints: &mut Vec<Hint>,
     id: &str,
     a: &nika_schema::raw::RawInvokeAction,
+    gates_an_effect: bool,
 ) {
     let nika_schema::raw::RawInvokeTarget::Tool(tool) = &a.target else {
         return;
@@ -438,6 +450,17 @@ fn push_headless_prompt_hint(
     {
         return;
     }
+    // The closing clause used to be unconditional — « declare the
+    // `default:` the unattended path should take ». Over a real effect,
+    // following that with `true` builds a workflow that answers its own
+    // gate and fires the action with nobody present. Name the safe one.
+    let close = if gates_an_effect {
+        "or declare `default: false` — this file has an effect, and a \
+         defaulted gate ANSWERS ITSELF unattended (spec 06), so `false` is \
+         the choice that refuses rather than approves"
+    } else {
+        "or declare the `default:` the unattended path should take"
+    };
     hints.push(hint(
         "headless-prompt",
         id,
@@ -446,7 +469,68 @@ fn push_headless_prompt_hint(
              agent handing it over) the run pauses at this gate awaiting a human \
              (exit 4 · the resume line taught on the frame); at a terminal it asks \
              directly. Answer it in one pass with `nika run <file> --answer \
-             {id}=<value>`, or declare the `default:` the unattended path should take"
+             {id}=<value>`, {close}"
+        ),
+    ));
+}
+
+/// The `fail-open-consent` hint: a confirm gate carrying `default: true`
+/// in a file that can DO something.
+///
+/// Spec 06 requires the engine to use `default:` unattended, so this is
+/// legal and this hint is advisory — a « continue? » whose safe answer is
+/// yes is a real thing to author. What was missing is that the checker
+/// could not TELL the two apart. Measured 2026-08-20 on 0.111.0, two
+/// files one key apart, each run with no human ·
+///
+/// ```text
+///                  check card                         run
+/// default: true    ✔ 0 hints · risk supervised   answer=true  · the effect FIRED
+/// default: false   ✔ 0 hints · risk supervised   answer=false · the effect skipped
+/// ```
+///
+/// The prompt asked « delete production? ». The cards differed by the
+/// filename and nothing else, and both called the posture supervised.
+///
+/// Hint, not refusal — the affirmative-consent lane's own precedent: it
+/// landed hint-only in 2026-07-30 and escalated to `NIKA-SEC-014` on the
+/// evidence it collected. This is that first half.
+fn push_fail_open_consent_hint(
+    hints: &mut Vec<Hint>,
+    id: &str,
+    a: &nika_schema::raw::RawInvokeAction,
+    gates_an_effect: bool,
+) {
+    if !gates_an_effect {
+        return; // nothing to auto-approve
+    }
+    let nika_schema::raw::RawInvokeTarget::Tool(tool) = &a.target else {
+        return;
+    };
+    if tool.value != "nika:prompt" {
+        return;
+    }
+    let Some(args) = a.args.as_ref().map(|args| &args.value) else {
+        return;
+    };
+    // `mode:` absent means confirm (spec 06 · the default mode).
+    let confirm = args
+        .get("mode")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(|m| m == "confirm");
+    if !confirm || args.get("default") != Some(&serde_json::Value::Bool(true)) {
+        return;
+    }
+    hints.push(hint(
+        "fail-open-consent",
+        id,
+        format!(
+            "`nika:prompt` on `{id}` carries `default: true` and this file has an \
+             effect — unattended (CI, a cron, an agent) the engine answers this gate \
+             `true` on its own (spec 06) and the effect fires with no human present. \
+             That is legal and sometimes right; it is a decision, not a formatting \
+             detail. `default: false` refuses instead, and omitting `default:` PARKS \
+             the run (exit 4) so a human decides"
         ),
     ));
 }

--- a/crates/nika-check/src/hints/tests.rs
+++ b/crates/nika-check/src/hints/tests.rs
@@ -1023,3 +1023,142 @@ fn a_const_fixture_stamps_compiled_true() {
     assert_eq!(obj.get("compiled"), Some(&serde_json::json!(true)));
     assert!(obj.get("next").is_none(), "{obj:?}");
 }
+
+// ── `default:` is a consent decision, not a formatting detail ──────────
+
+#[cfg(test)]
+mod default_is_a_consent_decision {
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    fn hints_of(yaml: &str) -> Vec<crate::hints::Hint> {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        crate::check(&wf).hints
+    }
+
+    /// A confirm gate over a real effect. The only thing that varies
+    /// across these fixtures is the `default:` line.
+    fn gate_over_an_effect(default_line: &str) -> String {
+        format!(
+            "\
+nika: t
+permits:
+  exec: [\"echo\"]
+  tools: [\"nika:prompt\"]
+tasks:
+  ask:
+    invoke:
+      tool: \"nika:prompt\"
+      args: {{ mode: \"confirm\", message: \"delete production?\"{default_line} }}
+  act:
+    with: {{ go: \"${{{{ tasks.ask.output }}}}\" }}
+    when: ${{{{ with.go == true }}}}
+    exec: {{ command: [\"echo\", \"done\"] }}
+"
+        )
+    }
+
+    /// MEASURED 2026-08-20 on the shipped 0.111.0. Two files, one key
+    /// apart, RUN unattended ·
+    ///
+    /// ```text
+    ///                  check card                          run
+    /// default: true    ✔ 0 hints · risk supervised   {"answer":true,  "did_it":"success"}
+    /// default: false   ✔ 0 hints · risk supervised   {"answer":false, "did_it":"skipped"}
+    /// ```
+    ///
+    /// The prompt asks « delete production? ». The cards differ by the
+    /// FILENAME and nothing else; one of these fires the irreversible
+    /// action with no human present, and the card calls it supervised.
+    #[test]
+    fn a_fail_open_default_over_an_effect_is_named() {
+        let hints = hints_of(&gate_over_an_effect(", default: true"));
+        let h = hints
+            .iter()
+            .find(|h| h.kind == "fail-open-consent")
+            .unwrap_or_else(|| panic!("no fail-open hint: {hints:?}"));
+        assert!(h.advice.contains("default: false"), "{}", h.advice);
+        assert!(
+            h.advice.contains('`') && h.advice.contains("ask"),
+            "{}",
+            h.advice
+        );
+    }
+
+    /// Fail-CLOSED is the shape an unattended path should declare, and it
+    /// is silent. A hint here would be noise on a correct file.
+    #[test]
+    fn a_fail_closed_default_is_silent() {
+        let hints = hints_of(&gate_over_an_effect(", default: false"));
+        assert!(
+            !hints.iter().any(|h| h.kind == "fail-open-consent"),
+            "fail-closed must not be flagged: {hints:?}"
+        );
+    }
+
+    /// With NO effect in the file there is nothing to auto-approve, so a
+    /// `default: true` is simply an unattended answer. Silence.
+    #[test]
+    fn a_fail_open_default_with_no_effect_is_silent() {
+        let hints = hints_of(
+            "\
+nika: t
+model: mock/echo
+permits: { tools: [\"nika:prompt\"] }
+tasks:
+  ask:
+    invoke:
+      tool: \"nika:prompt\"
+      args: { mode: \"confirm\", message: \"go?\", default: true }
+",
+        );
+        assert!(
+            !hints.iter().any(|h| h.kind == "fail-open-consent"),
+            "no effect, nothing to open: {hints:?}"
+        );
+    }
+
+    /// The headless advice was unconditional · « declare the `default:`
+    /// the unattended path should take ». Over a real effect, following
+    /// it with `true` builds the row above. Name the safe one.
+    #[test]
+    fn the_headless_advice_names_the_fail_closed_default_over_an_effect() {
+        let hints = hints_of(&gate_over_an_effect(""));
+        let h = hints
+            .iter()
+            .find(|h| h.kind == "headless-prompt")
+            .unwrap_or_else(|| panic!("no headless hint: {hints:?}"));
+        assert!(
+            h.advice.contains("default: false"),
+            "over an effect the advice must name the fail-closed default: {}",
+            h.advice
+        );
+    }
+
+    /// The guard · with no effect, the neutral wording is right and must
+    /// survive. Over-teaching is its own defect.
+    #[test]
+    fn the_headless_advice_stays_neutral_with_no_effect() {
+        let hints = hints_of(
+            "\
+nika: t
+model: mock/echo
+permits: { tools: [\"nika:prompt\"] }
+tasks:
+  ask:
+    invoke:
+      tool: \"nika:prompt\"
+      args: { mode: \"confirm\", message: \"go?\" }
+",
+        );
+        let h = hints
+            .iter()
+            .find(|h| h.kind == "headless-prompt")
+            .unwrap_or_else(|| panic!("no headless hint: {hints:?}"));
+        assert!(
+            !h.advice.contains("default: false"),
+            "nothing to fail closed over here: {}",
+            h.advice
+        );
+    }
+}


### PR DESCRIPTION
## The defect

Two files. One key apart. Each **run** unattended on 0.111.0. The prompt asks
*"delete production?"*.

|  | check card | unattended run |
|---|---|---|
| `default: true` | `✔ audited · 0 hints · risk supervised` | `answer=true` · **the effect FIRED** |
| `default: false` | `✔ audited · 0 hints · risk supervised` | `answer=false` · skipped |

The cards differ by **four diff lines, and all four are the filename**. One of
these workflows answers its own gate and performs the irreversible action with
no human present — and the card calls that posture **"risk supervised"**.

## Why a hint and not a finding

Spec 06 at `SPEC_PIN`: *"unattended (CI · daemon) the engine MUST use `default:`
when present"*. `default: true` is **legal**, and a `"continue?"` whose safe
answer is yes is a real thing to author. A refusal would be a normative change
owing a fixture in the spec repo, and the harvest plan marks this **"operator's
call"**.

The precedent is written inside `consent.rs`'s own module doc: that lane
*"landed 2026-07-30 as a hint-only lane and escalates here to the refusal it was
measuring."* **Hint first, escalate on evidence.** This is that first half, and
the hint becomes the surface that measures whether escalation is earned.

What was missing is not permission — it is that the checker **could not tell the
two apart, and said nothing.**

## The headless advice stops being unconditional

It closed with *"or declare the `default:` the unattended path should take"* on
every file — including files with real effects, where following it with `true`
builds the row above. That is the double-weighted class: a defect caused by the
tool's own counsel.

Over an effect it now names `default: false` and says why. With **no** effect the
neutral wording stands, because over-teaching is its own defect.

Both arms read **one** predicate, computed once from the same egress table the
trifecta lane's ② leg reads — so the two cannot disagree about what counts as an
effect.

## The sweep, and the declaration it refused

A hint never fails a file, so this moves **no exit code**. An rc sweep prints
`0 changed` here whether the hints fire or not. Card **text**, with a declared
count in both directions:

| corpus | swept | cards moved |
|---|---|---|
| vendored pack | 63 | 8 |
| spec @ `SPEC_PIN` | 50 | 7 |
| conformance @ pin | 59 | 0 |
| studio workflows | 27 | 0 |
| the measured pair | 2 | 1 |

**I first declared 0 and the sweep refused it.** Every moved card was then
qualified by *which hint kind changed* before the number was written down:

```
wording-only=15   new-fail-open-flags=0   other=0
```

All 15 are the conditional wording on files that genuinely have effects and a
headless prompt. **Zero shipped examples gain the fail-open flag** — the corpus
does not carry that shape anywhere, which is itself worth knowing.

## Mutation proof — three cuts, two landing on guards

| cut | verdict |
|---|---|
| fire regardless of effects | **guard** RED (no-effect silence) |
| treat an absent `default:` as fail-open | **guard** RED (fail-closed silence) |
| pin the advice unconditional | conditional test RED |

The guards are what keep this from becoming noise on correct files.

## Not in this PR

- **Escalating the hint to a refusal.** Operator's call, and it owes a spec
  fixture. The hint is the instrument that would justify it.
- **`GateKind`** — the sibling defect: `human_gate` collapses "not a prompt",
  "a defaulted prompt" and "a blocking gate" into one bool, so `NIKA-SEC-009`
  tells an author whose prompt is already upstream and dominating to *"place the
  blocking prompt upstream"*. Applying that fix verbatim returns the finding
  byte-identical — the G-07 shape this lane closed for **placement** and left
  open for `default:`. Written, held back so this PR carries one defect.

---

🦋 Generated with [Claude Code](https://claude.com/claude-code)
