### PR TITLE
fix(runtime): a recovered fan-out says so in its record, not only in prose

### DIFF
--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -664,7 +664,7 @@ where
         let result = fan_out::fan_out_result(
             acc.outputs,
             acc.tokens_sum,
-            acc.first_error,
+            (acc.first_error, acc.first_recovered_from),
             (acc.cost_sum, acc.unpriced),
         );
         let retries = acc.retries;

--- a/crates/nika-runtime/src/task/fan_out.rs
+++ b/crates/nika-runtime/src/task/fan_out.rs
@@ -82,6 +82,16 @@ pub(super) struct FanOutAccum {
     /// under `recover: null` and the card said `✔ 3 items · 5/5 done` —
     /// she found out by counting the trace).
     pub(super) recovered: usize,
+    /// The FIRST error an iteration was repaired from — the fan's
+    /// `recovered_from` (spec 13 §payload). Mirrors `first_error`: one
+    /// witness, kept, rather than N discarded.
+    ///
+    /// It used to be counted and dropped. `recovered_from` was
+    /// destructured, tested with `is_some()`, and thrown away for the
+    /// counter below, so the tally survived as prose in the note while
+    /// the machine-readable `cause` reported `normal` on a fan whose
+    /// iterations had died.
+    pub(super) first_recovered_from: Option<TaskErrorRecord>,
 }
 
 /// Drain the buffered iteration stream, reducing it to a [`FanOutAccum`] in
@@ -102,6 +112,7 @@ where
         cost_sum: None,
         unpriced: None,
         recovered: 0,
+        first_recovered_from: None,
     };
 
     while let Some(iter_ran) = stream.next().await {
@@ -123,8 +134,14 @@ where
                 // fallback — the ONE fact distinguishing it from a task
                 // that legitimately produced its value (a bare null
                 // count would misread honest nulls as deaths).
-                if recovered_from.is_some() {
+                if let Some(original) = recovered_from {
                     acc.recovered += 1;
+                    // The witness the fan owes its record. `first_error`
+                    // beside it keeps the first FAILURE the same way; a
+                    // fan has N originals and the payload law names one.
+                    if acc.first_recovered_from.is_none() {
+                        acc.first_recovered_from = Some(original.clone());
+                    }
                 }
                 acc.outputs.push(value);
                 if let Some(n) = tokens {
@@ -215,7 +232,7 @@ fn resolve_collection(
 pub(super) fn fan_out_result(
     outputs: Vec<Value>,
     tokens_sum: Option<i64>,
-    first_error: Option<TaskErrorRecord>,
+    (first_error, first_recovered_from): (Option<TaskErrorRecord>, Option<TaskErrorRecord>),
     spend: (Option<f64>, Option<nika_types::cost::UnpricedReason>),
 ) -> RunResult {
     let (cost_usd, cost_unpriced) = spend;
@@ -223,7 +240,11 @@ pub(super) fn fan_out_result(
         None => RunResult::Success {
             value: Value::Array(outputs),
             tokens: tokens_sum,
-            recovered_from: None,
+            // `settle` reads THIS to choose the cause: `Some` gives
+            // `success/recovered` + the payload's original error, `None`
+            // gives `success/normal`. Hardcoding `None` here is what made
+            // a fan of dead iterations report `normal`.
+            recovered_from: first_recovered_from,
             warning: None,
             // per-iteration child rows stay per-call — no aggregate row
             child: None,

--- a/crates/nika-runtime/tests/outcomes.rs
+++ b/crates/nika-runtime/tests/outcomes.rs
@@ -358,6 +358,93 @@ async fn row_success_recovered() {
     assert!(events.iter().any(|e| e.kind == EventKind::TaskRecovered));
 }
 
+/// Row 2, reached through a FAN-OUT — the same row, the other road.
+///
+/// This battery says « one test per ROW ». Row 2 is covered, and it was
+/// covered only for a bare task: a judge governs the collection it walks,
+/// not the row it names. Measured on 0.111.0, a `for_each` whose
+/// iterations recover records ·
+///
+/// ```json
+/// "note":    "for_each · 2/5 ok · 3 recovered",
+/// "outcome": {"cause":"normal","class":"success",
+///             "payload":{"attempts":1,"value":["",null,"",null,null]}}
+/// ```
+///
+/// Three of five checks died and the record says `normal`. Spec 13
+/// assigns `success` × `recovered` to exactly this, and closes the table
+/// with « Any (class, cause) pair outside this table is an engine bug,
+/// never a state ».
+///
+/// The engine KNEW · it wrote « 3 recovered » into `note`, a human string,
+/// while the machine-readable half beside it said `normal`. The
+/// per-iteration `recovered_from` was destructured, tested with
+/// `is_some()`, and dropped for a counter.
+#[tokio::test]
+async fn row_success_recovered_through_a_fan_out() {
+    let yaml = "nika: w\nconst: { items: [1, 2] }\npermits: { exec: true }\ntasks:\n  a:\n    for_each: { items: \"${{ const.items }}\", fail_fast: false }\n    on_error: { recover: \"fallback\" }\n    exec: { command: [\"boom\"] }\n";
+    // DISTINCT errors: the record claims to keep the FIRST, mirroring
+    // , and a claim nothing can tell apart is untested.
+    let shell = MockShell::new()
+        .enqueue_fail(9, "the first one")
+        .enqueue_fail(9, "the second one");
+    let (outcome, events) = run_simple(yaml, shell).await;
+    assert!(outcome.ok, "the recoveries settle the run green");
+
+    let record = &outcome.records["a"];
+    assert_eq!(record.status, TaskStatus::Success);
+    assert_eq!(
+        record.cause,
+        TerminalCause::Recovered,
+        "a fan-out whose iterations were repaired is NOT `normal` — spec 13 \
+         calls that pair an engine bug"
+    );
+    let original = record
+        .recovered_from
+        .as_ref()
+        .expect("the record keeps the original error (spec 13 §payload)");
+
+    let o = outcome_of(&events, "a");
+    judge(&o, &pack_table());
+    assert_eq!(o["cause"], "recovered");
+    assert_eq!(
+        o["payload"]["recovered_from"]["code"],
+        Value::String(original.code.clone()),
+        "the payload carries the original error, not just a tally in prose"
+    );
+    assert!(
+        original.message.contains("the first one"),
+        "the FIRST original is the witness kept, not the last: {}",
+        original.message
+    );
+    assert!(
+        events.iter().any(|e| e.kind == EventKind::TaskRecovered),
+        "the fan-out owes the same prefix frame the bare task emits"
+    );
+}
+
+/// The guard · a fan-out where NOTHING was repaired keeps `normal`. A
+/// cause that fired on every fan would be its own defect, and would make
+/// the row above meaningless.
+#[tokio::test]
+async fn a_clean_fan_out_stays_normal() {
+    let yaml = "nika: w\nconst: { items: [1, 2] }\npermits: { exec: true }\ntasks:\n  a:\n    for_each: { items: \"${{ const.items }}\" }\n    exec: { command: [\"ok\"] }\n";
+    let shell = MockShell::new().enqueue_ok("fine\n").enqueue_ok("fine\n");
+    let (outcome, events) = run_simple(yaml, shell).await;
+    assert!(outcome.ok);
+    let record = &outcome.records["a"];
+    assert_eq!(record.cause, TerminalCause::Normal);
+    assert!(record.recovered_from.is_none());
+    let o = outcome_of(&events, "a");
+    judge(&o, &pack_table());
+    assert_eq!(o["cause"], "normal");
+    assert!(o["payload"].get("recovered_from").is_none());
+    assert!(
+        !events.iter().any(|e| e.kind == EventKind::TaskRecovered),
+        "nothing was repaired, so nothing announces a repair"
+    );
+}
+
 /// Row 3 · `failure(verb_error)` — the verb refused and no retry
 /// remained (attempts = 1 when no `retry:`).
 #[tokio::test]

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,12 +152,12 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 796
-  aggregate_sha256: 994ba27f5a69dcd9ea38f3ad7b60b6c5f0703062773dff31e7c0addc4da9cc68
+  aggregate_sha256: a39e76359cbb9e1a3dfe567126e0d53979e8f562e68cf331a7b4150ec3a66539
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored
   match_count: 159
-  aggregate_sha256: ebbb6bac3299145f48d84e01c6d610f42e9ea19c1de658bd7a972927a30fd26e
+  aggregate_sha256: 68073e0c23e3fea4eb2d8c496dc1c0adf2bca8b2edda3ea4ddb2959d91f07494
   evidence: "crate-owned tests + fixtures under tests/ — written with the crate per gate discipline, no generation markers"
 - glob: "crates/**"
   class: authored


### PR DESCRIPTION
## First: the finding this started from is **stale**, and that matters

The harvest plan's sharpest line was *"a health battery whose checks all died and
got recovered is byte-for-byte indistinguishable from all-green; the string
'recover' appears ZERO times in the trace."*

Measured on **the same binary the persona wave used** (`0.111.0 · e3aaeb8d2`),
three shapes:

```
single task recovered   ✔ probe_a  exec · false · recovered   (── 1 recovered)
for_each · 3 of 5 fail  ✔ probe    for_each · 2/5 ok · 3 recovered
for_each · ALL 5 fail   ✔ probe    for_each · 0/5 ok · 5 recovered
all-green twin          ✔ probe    for_each · 5 iterations
```

Every one is distinguishable at the frame. **A wave that rebuilt from the plan
would have shipped a fix for a surface that already works.** Reproducing before
building is what caught it.

## The real defect sits next to it, and it is normative

The frame is fine. The **record** is not. Same `on_error: recover:`, two roads:

| shape | `task_recovered` event | `outcome.cause` | `recovered_from` |
|---|---|---|---|
| single task | yes | `recovered` | present (`NIKA-EXEC-001`) |
| `for_each` | **no** | **`normal`** | **absent** |

The fan-out completion event, verbatim:

```json
"note":    "for_each · 2/5 ok · 3 recovered",
"outcome": {"cause":"normal","class":"success",
            "payload":{"attempts":1,"value":["",null,"",null,null]}}
```

Spec 13 assigns `success` × `recovered` to exactly this situation, requires the
record to keep `recovered_from`, and closes its table with:

> **"Any (class, cause) pair outside this table is an engine bug, never a state."**

A run where three of five health checks died records `cause: normal`.

## The root defect, in its purest form

`crates/nika-runtime/src/task/fan_out.rs` — the error is *right there*:

```rust
ref recovered_from,          // ← destructured
...
if recovered_from.is_some() {
    acc.recovered += 1;      // ← tested, then discarded for a counter
}
```

…and the aggregate then hardcoded `recovered_from: None`.

**The engine knew.** It wrote `"3 recovered"` into `note` — a human-readable
string — while the machine-readable half beside it said `normal`.

`settle.rs:550` derives the cause from exactly that field
(`if recovered_from.is_some() { Recovered } else { Normal }`), so populating it
fixes the cause **and** the payload with **no new derivation logic**.

This is the sixth instance of the class
[`typed-fact-prose-projection`](../../dx/doctrine/rules/typed-fact-prose-projection.md)
graduated to Layer 5 today, and the first that breaks the **spec** rather than a
rendering. Loi 2 exactly: *the prose projects the type, never the reverse.* The
note stays, and now derives.

## The battery said "one test per ROW"

Row 2 (`success`/`recovered`) **was** covered — and only for a bare task. A judge
governs the collection it walks, not the row it names. The fan-out road to the
same row had no test, which is how a conformance violation lived under a battery
built to prevent one.

## Mutation proof — and the one that survived

| cut | verdict |
|---|---|
| drop the witness at the boundary | new row RED |
| never capture it | new row RED |
| keep the **LAST** original instead of the first | **SURVIVED** |

The third survived because both fixtures failed *identically*. My doc-comment
claimed "the FIRST error" and nothing could tell the difference — **an untested
claim**. The fixtures now fail differently (`"the first one"` / `"the second
one"`) and the test names which witness it expects; the mutant then dies with
the wrong message quoted back.

## Scope named, not invented

`recovered_from` is **singular** in the spec's payload table, and a fan-out has N
original errors. Making the `cause` correct is unambiguous and normative. Which
singular original a fan should carry is a **spec question**, not an
implementation one — this PR keeps the *first*, mirroring the existing
`first_error`, and says so rather than inventing a plural shape.

## Corpus

The change is inert unless an iteration recovers. The shipped `for_each` example
renders **byte-identical** on both binaries, and the guard test pins that a clean
fan keeps `cause: normal` with no frame. Every `nika-runtime` battery green
(304 lib + 18 outcomes + 15 more suites).

---

🦋 Generated with [Claude Code](https://claude.com/claude-code)
