### PR TITLE
fix(nika-check): name mcp secret flows

### DIFF
--- a/crates/nika-check/src/data_journey.rs
+++ b/crates/nika-check/src/data_journey.rs
@@ -723,7 +723,7 @@ outputs:
             .iter()
             .find(|s| s.name == "api_token")
             .expect("the used secret is named");
-        assert_eq!(secret.tasks, ["search"], "{secret:?}");
+        assert_eq!(secret.tasks, ["search"]);
         assert_eq!(
             secret.flows_to,
             ["mcp:service/search"],

--- a/crates/nika-check/src/data_journey.rs
+++ b/crates/nika-check/src/data_journey.rs
@@ -7,8 +7,8 @@
 //! models · the IFC taint facts): the journey names the CLASSES, never
 //! the values (law 13 — no secret value, no file content, ever).
 //!
-//! The closure proof is « aucun sink cloud sensible sans reçu/consentement
-//! visible »: a secret reaching a cloud destination is NAMED on the
+//! The closure proof is « aucun sink externe sensible sans reçu/consentement
+//! visible »: a secret reaching an external destination is NAMED on the
 //! journey (advisory — the blocking refusal for the unsanctioned case
 //! already lives in the IFC leak lane; a sanctioned egress stays a flow
 //! the operator must SEE, receipt-side).
@@ -31,7 +31,7 @@ use super::walk::static_literal_of;
 /// author cannot talk their way down a class). Conservative by law:
 /// `internal` by default, `sensitive` when declared secrets are used or
 /// a PII-shaped path is declared, `regulated` when a secret reaches a
-/// cloud destination. Never an over-claim: an unknown shape stays DOWN.
+/// external destination. Never an over-claim: an unknown shape stays DOWN.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -42,7 +42,7 @@ pub enum DataClassification {
     /// A declared secret is used, or a declared path names a
     /// personal-data class (customers · patients · …).
     Sensitive,
-    /// A secret reaches a cloud destination — the receipt law applies.
+    /// A secret reaches an external destination — the receipt law applies.
     Regulated,
 }
 
@@ -115,7 +115,7 @@ pub struct ModelEndpoint {
 }
 
 /// One declared secret the workflow USES — the NAME only (law 13),
-/// the tasks touching it, the cloud destinations it reaches, and the
+/// the tasks touching it, the external destinations it reaches, and the
 /// author's declared clearances (the `egress:` receipts).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
@@ -124,8 +124,8 @@ pub struct SecretUse {
     pub name: String,
     /// The effect tasks referencing it (directly or through the taint).
     pub tasks: Vec<String>,
-    /// The cloud destinations the secret reaches (a provider id · a
-    /// public host) — the rows the JOURNEY rung warns on.
+    /// The external destinations the secret reaches (a provider id · a
+    /// public host · an MCP tool id) — the rows the JOURNEY rung warns on.
     pub flows_to: Vec<String>,
     /// The author's declared clearances (`egress.to:` tokens).
     pub consents: Vec<String>,
@@ -165,7 +165,8 @@ pub struct DataJourney {
     pub classification: DataClassification,
     /// Where data is READ (declared static `fs.read` effects).
     pub sources: Vec<JourneyEndpoint>,
-    /// Where data GOES (`fs.write` · `exec` programs · `net.http` hosts).
+    /// Where data GOES (`fs.write` · `exec` programs · `net.http` hosts ·
+    /// `mcp.tool` ids).
     pub destinations: Vec<JourneyEndpoint>,
     /// The model endpoint each infer/agent task resolves to.
     pub model_endpoints: Vec<ModelEndpoint>,
@@ -199,24 +200,25 @@ pub(crate) fn collect(wf: &RawWorkflow, flow: &FlowFacts) -> DataJourney {
     // (kind, target) → tasks — the endpoint tables, BTree-ordered.
     let mut endpoints: BTreeMap<(&'static str, String), BTreeSet<String>> = BTreeMap::new();
     let mut model_endpoints = Vec::new();
-    // task → the cloud destinations it reaches (provider ids · public hosts).
-    let mut task_cloud: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    // task → the external destinations it reaches (provider ids · public
+    // hosts · MCP tool ids).
+    let mut task_external: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     // secret name → the tasks using it.
     let mut secret_tasks: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
 
     for (idx, task) in wf.tasks.iter().enumerate() {
         let t = &task.value;
         let id = t.id.value.clone();
-        let mut cloud = BTreeSet::new();
-        collect_action_effects(&consts, &id, &t.action, &mut endpoints, &mut cloud);
+        let mut external = BTreeSet::new();
+        collect_action_effects(&consts, &id, &t.action, &mut endpoints, &mut external);
         if let Some(ep) = model_endpoint_of(wf, t, envelope.as_deref()) {
             if ep.locus == EndpointLocus::Cloud {
-                cloud.insert(ep.provider.clone());
+                external.insert(ep.provider.clone());
             }
             model_endpoints.push(ep);
         }
-        if !cloud.is_empty() {
-            task_cloud.insert(id.clone(), cloud);
+        if !external.is_empty() {
+            task_external.insert(id.clone(), external);
         }
         for name in secret_names_of_task(idx, t, flow, &declared) {
             secret_tasks.entry(name).or_default().insert(id.clone());
@@ -224,7 +226,7 @@ pub(crate) fn collect(wf: &RawWorkflow, flow: &FlowFacts) -> DataJourney {
     }
 
     let sources = endpoints_of(&endpoints, "fs.read");
-    let destinations: Vec<JourneyEndpoint> = ["fs.write", "net.http", "exec"]
+    let destinations: Vec<JourneyEndpoint> = ["fs.write", "net.http", "mcp.tool", "exec"]
         .into_iter()
         .flat_map(|kind| endpoints_of(&endpoints, kind))
         .collect();
@@ -233,7 +235,7 @@ pub(crate) fn collect(wf: &RawWorkflow, flow: &FlowFacts) -> DataJourney {
         .filter(|d| d.kind == "fs.write")
         .map(|d| d.target.clone())
         .collect();
-    let secrets_used = secret_uses(wf, secret_tasks, &task_cloud);
+    let secrets_used = secret_uses(wf, secret_tasks, &task_external);
     let consents = consents_of(wf);
     let trace_retention = retention_facts(&model_endpoints);
     let classification = classify(&sources, &writes, &secrets_used);
@@ -259,7 +261,7 @@ fn collect_action_effects(
     id: &str,
     action: &RawAction,
     endpoints: &mut BTreeMap<(&'static str, String), BTreeSet<String>>,
-    cloud: &mut BTreeSet<String>,
+    external: &mut BTreeSet<String>,
 ) {
     let mut touch = |kind: &'static str, target: String| {
         endpoints
@@ -276,8 +278,17 @@ fn collect_action_effects(
             }
         }
         RawAction::Invoke(a) => {
-            if !matches!(a.target, RawInvokeTarget::Tool(_)) {
+            let RawInvokeTarget::Tool(tool) = &a.target else {
                 return; // a child workflow's boundary: the composition lane's
+            };
+            // MCP is an open namespace, so check cannot derive the remote
+            // host or deployment locus. It CAN still name the exact external
+            // effect the author chose. Omitting it made a sanctioned secret
+            // flow disappear from both the JSON and human journey.
+            if tool.value.starts_with("mcp:") {
+                touch("mcp.tool", tool.value.clone());
+                external.insert(tool.value.clone());
+                return;
             }
             match builtin_effect(a) {
                 Some(BuiltinEffect::Net { url_arg }) => {
@@ -288,7 +299,7 @@ fn collect_action_effects(
                         // A floor-blocked literal (loopback · private) is not
                         // a cloud sink — data to it stays off the wire.
                         if !nika_types::net::host_is_blocked(&host) {
-                            cloud.insert(host.clone());
+                            external.insert(host.clone());
                         }
                         touch("net.http", host);
                     }
@@ -446,19 +457,19 @@ fn endpoints_of(
         .collect()
 }
 
-/// The used secrets with their cloud flows — a secret's `flows_to` is
-/// the union of the cloud destinations of every task touching it.
+/// The used secrets with their external flows — a secret's `flows_to` is
+/// the union of the external destinations of every task touching it.
 fn secret_uses(
     wf: &RawWorkflow,
     secret_tasks: BTreeMap<String, BTreeSet<String>>,
-    task_cloud: &BTreeMap<String, BTreeSet<String>>,
+    task_external: &BTreeMap<String, BTreeSet<String>>,
 ) -> Vec<SecretUse> {
     secret_tasks
         .into_iter()
         .map(|(name, tasks)| {
             let flows_to: BTreeSet<String> = tasks
                 .iter()
-                .filter_map(|t| task_cloud.get(t))
+                .filter_map(|t| task_external.get(t))
                 .flatten()
                 .cloned()
                 .collect();
@@ -515,7 +526,7 @@ fn retention_facts(endpoints: &[ModelEndpoint]) -> Vec<RetentionFact> {
 }
 
 /// The derived class — conservative: `regulated` needs a secret reaching
-/// a cloud sink, `sensitive` needs a used secret or a PII-shaped
+/// an external sink, `sensitive` needs a used secret or a PII-shaped
 /// declared path, everything else stays `internal`.
 fn classify(
     sources: &[JourneyEndpoint],
@@ -671,6 +682,54 @@ tasks:
             "no cloud endpoint → no retention fact: {:?}",
             j.trace_retention
         );
+    }
+
+    /// An MCP tool is an external effect even when its transport and
+    /// deployment locus are discovered only at run time. The journey must
+    /// name that boundary: otherwise a sanctioned secret flow disappears
+    /// from both the human and JSON audit surfaces.
+    #[test]
+    fn an_mcp_sink_and_its_secret_flow_are_named() {
+        let j = journey_of(
+            r#"
+nika: mcp-journey
+secrets:
+  api_token:
+    source: env
+    key: SERVICE_API_TOKEN
+    egress:
+      - { to: "mcp:service/search" }
+      - { to: outputs }
+permits:
+  tools: ["mcp:service/search"]
+tasks:
+  search:
+    invoke:
+      tool: "mcp:service/search"
+      args: { token: "${{ secrets.api_token }}", query: "nika" }
+outputs:
+  result: "${{ tasks.search.output }}"
+"#,
+        );
+        assert!(
+            j.destinations.iter().any(|d| {
+                d.kind == "mcp.tool" && d.target == "mcp:service/search" && d.tasks == ["search"]
+            }),
+            "the MCP sink is a named destination: {:?}",
+            j.destinations
+        );
+        let secret = j
+            .secrets_used
+            .iter()
+            .find(|s| s.name == "api_token")
+            .expect("the used secret is named");
+        assert_eq!(secret.tasks, ["search"], "{secret:?}");
+        assert_eq!(
+            secret.flows_to,
+            ["mcp:service/search"],
+            "the sanctioned external flow stays visible"
+        );
+        assert_eq!(j.classification, DataClassification::Regulated);
     }
 
     /// Law 13: the journey names CLASSES, never values. A canary value

--- a/crates/nika-display/src/check_journey.rs
+++ b/crates/nika-display/src/check_journey.rs
@@ -3,7 +3,7 @@
 
 //! The JOURNEY rung of `nika check` — the data voyage made readable
 //! (P0-18 · CORE-18): class + counts, the named secret flows, and one
-//! dim disclosure row per cloud endpoint (locus · retention ·
+//! dim disclosure row per external endpoint (locus · retention ·
 //! training in the provider's own sourced words). Split from
 //! `check_render.rs` at the 1500-line file wall — same seams, no
 //! behavior change.
@@ -15,13 +15,32 @@ use nika_check::CheckReport;
 use crate::check_render::mark;
 use crate::theme::{Role, Theme};
 
+/// The SECRETS headline names observed flows without re-judging consent.
+/// Findings own that verdict; JOURNEY owns the complete visible projection.
+pub(crate) fn secret_flow_summary(report: &CheckReport) -> String {
+    let declared_flows = report
+        .data_journey
+        .secrets_used
+        .iter()
+        .map(|secret| secret.flows_to.len())
+        .sum::<usize>();
+    if declared_flows == 0 {
+        "no declared secret reaches an effect · model echo untracked".to_owned()
+    } else {
+        format!(
+            "{} shown in JOURNEY · consent findings above · model echo untracked",
+            crate::vocab::count(declared_flows, "declared-secret flow")
+        )
+    }
+}
+
 /// JOURNEY rung (P0-18 · audit UX 2026-07-30) — the data voyage made
 /// visible BEFORE the run: the derived class and the counts, then one ⚠
-/// row per secret reaching a cloud destination, NAMED. Advisory by
+/// row per secret reaching an external destination, NAMED. Advisory by
 /// design — the blocking refusal of an UNSANCTIONED flow lives in the
 /// SECRETS lane (the IFC leak finding); a sanctioned flow still has to
-/// be SEEN, which is the receipt law the row carries (« read it before
-/// the run »). Names and classes only — never a value (law 13).
+/// be SEEN, so the row asks the operator to review consent before the
+/// run. Names and classes only — never a value (law 13).
 pub(crate) fn journey_rung(out: &mut String, report: &CheckReport, t: Theme) {
     let j = &report.data_journey;
     let flows: Vec<(&str, &str)> = j
@@ -68,7 +87,7 @@ pub(crate) fn journey_rung(out: &mut String, report: &CheckReport, t: Theme) {
             t.paint(Role::Strong, "JOURNEY"),
             t.paint(
                 Role::Dim,
-                &format!("{summary} · no secret reaches a cloud destination")
+                &format!("{summary} · no secret reaches an external destination")
             )
         );
         for row in &cloud_rows {
@@ -95,7 +114,7 @@ pub(crate) fn journey_rung(out: &mut String, report: &CheckReport, t: Theme) {
     for (name, dest) in flows {
         let _ = writeln!(
             out,
-            " {} {} secret `{name}` flows to {dest} · the receipt names this flow — read it before the run",
+            " {} {} secret `{name}` flows to {dest} · review consent before the run",
             t.paint(Role::Warn, if t.ascii { "!" } else { "⚠" }),
             t.paint(Role::Strong, "JOURNEY"),
         );

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -178,12 +178,13 @@ fn narrowed_rungs(out: &mut String, report: &CheckReport, t: Theme) {
     // `✔ SECRETS no information-flow escapes · 0 hints`. The carve-out is
     // a deliberate soundness trade; the UNIVERSAL sentence over it was
     // not.
+    let secrets_claim = crate::check_journey::secret_flow_summary(report);
     section_or_skip(
         out,
         report,
         t,
         "SECRETS",
-        "no declared secret reaches an effect · model echo untracked",
+        &secrets_claim,
         secret_rows(report),
     );
     section_list(

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -34,14 +34,14 @@ mod journey_rung_tests {
             .expect("the JOURNEY rung renders");
         assert!(line.contains("internal"), "the class: {line}");
         assert!(
-            line.contains("no secret reaches a cloud destination"),
+            line.contains("no secret reaches an external destination"),
             "the honest closure: {line}"
         );
     }
 
     /// A secret flowing to a cloud endpoint is NAMED on an explicit ⚠
     /// row — advisory (the sanctioned egress stays clean; the SECRETS
-    /// lane owns the unsanctioned refusal), with the receipt law riding.
+    /// lane owns the unsanctioned refusal), with the consent review riding.
     #[test]
     fn a_secret_reaching_a_cloud_endpoint_is_named_with_the_receipt_law() {
         let out = console(
@@ -71,8 +71,8 @@ mod journey_rung_tests {
         );
         assert!(row.contains('⚠'), "advisory warn mark: {row}");
         assert!(
-            row.contains("read it before the run"),
-            "the receipt law rides: {row}"
+            row.contains("review consent before the run"),
+            "the review law rides: {row}"
         );
         // Advisory, never a finding: the sanctioned workflow's verdict
         // stays green and no ✖ rides the JOURNEY rung.
@@ -82,6 +82,89 @@ mod journey_rung_tests {
             "no blocking row on the rung:\n{out}"
         );
         assert!(out.contains("audited"), "the verdict stays clean:\n{out}");
+    }
+
+    /// A sanctioned MCP egress is not a leak, but it is still an effect.
+    /// Both SECRETS and JOURNEY must say so before suggesting a run.
+    #[test]
+    fn a_sanctioned_mcp_secret_flow_is_visible_on_both_rungs() {
+        let out = console(
+            r#"
+nika: mcp-secret
+secrets:
+  api_token:
+    source: env
+    key: SERVICE_API_TOKEN
+    egress:
+      - { to: "mcp:service/search" }
+      - { to: outputs }
+permits:
+  tools: ["mcp:service/search"]
+tasks:
+  search:
+    invoke:
+      tool: "mcp:service/search"
+      args: { token: "${{ secrets.api_token }}", query: "nika" }
+outputs:
+  result: "${{ tasks.search.output }}"
+"#,
+        );
+        let secrets = out
+            .lines()
+            .find(|line| line.contains("SECRETS"))
+            .expect("the SECRETS rung renders");
+        assert!(
+            secrets.contains("1 declared-secret flow")
+                && !secrets.contains("no declared secret reaches"),
+            "the clean rung names the observed flow without overstating consent: {secrets}"
+        );
+        let journey = out
+            .lines()
+            .find(|line| line.contains("JOURNEY") && line.contains("flows to"))
+            .expect("the MCP flow row renders");
+        assert!(
+            journey.contains("secret `api_token` flows to mcp:service/search"),
+            "the exact external sink rides the journey: {journey}"
+        );
+    }
+
+    /// The journey observes every direct flow, while the IFC finding lane
+    /// judges consent. The summary must never promote observed flows to
+    /// sanctioned ones on its own.
+    #[test]
+    fn multiple_mcp_secret_flows_do_not_overstate_consent() {
+        let out = console(
+            r#"
+nika: mcp-two-secrets
+secrets:
+  a_cleared:
+    source: env
+    key: CLEARED
+    egress: [{ to: "mcp:service/send" }]
+  z_uncleared: { source: env, key: UNCLEARED }
+permits:
+  tools: ["mcp:service/send"]
+tasks:
+  send:
+    invoke:
+      tool: "mcp:service/send"
+      args:
+        payload: "${{ secrets.a_cleared }}:${{ secrets.z_uncleared }}"
+"#,
+        );
+        let secrets = out
+            .lines()
+            .find(|line| line.contains("SECRETS"))
+            .expect("the SECRETS rung renders");
+        assert!(
+            secrets.contains("2 declared-secret flows") && !secrets.contains("sanctioned"),
+            "an observation is not a consent verdict: {secrets}"
+        );
+        assert!(
+            out.contains("secret `a_cleared` flows to mcp:service/send")
+                && out.contains("secret `z_uncleared` flows to mcp:service/send"),
+            "both direct flows remain visible:\n{out}"
+        );
     }
 
     /// The local→cloud flip is READABLE on the human surface (gauntlet

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -115,8 +115,7 @@ outputs:
             .expect("the SECRETS rung renders");
         assert!(
             secrets.contains("1 declared-secret flow")
-                && !secrets.contains("no declared secret reaches"),
-            "the clean rung names the observed flow without overstating consent: {secrets}"
+                && !secrets.contains("no declared secret reaches")
         );
         let journey = out
             .lines()
@@ -156,10 +155,7 @@ tasks:
             .lines()
             .find(|line| line.contains("SECRETS"))
             .expect("the SECRETS rung renders");
-        assert!(
-            secrets.contains("2 declared-secret flows") && !secrets.contains("sanctioned"),
-            "an observation is not a consent verdict: {secrets}"
-        );
+        assert!(secrets.contains("2 declared-secret flows") && !secrets.contains("sanctioned"));
         assert!(
             out.contains("secret `a_cleared` flows to mcp:service/send")
                 && out.contains("secret `z_uncleared` flows to mcp:service/send"),

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: a3550064e9f52fe908fd02748bad6b65110fe0dae69ec76eded5c5f0fa5b213b
+  aggregate_sha256: 2bd67e3ff7b51f8ef90e8682f3b05c54c56d0bc493c912c745573ceb98a2ac22
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 795
-  aggregate_sha256: 3769f5294724876db728a0c1c1f77e91a797244bf00ee3b28f971347b627d474
+  aggregate_sha256: a3550064e9f52fe908fd02748bad6b65110fe0dae69ec76eded5c5f0fa5b213b
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## Outcome

Make `nika check` name MCP tool boundaries and every observed declared-secret flow in both its JSON data journey and human audit.

Before, a sanctioned `FIRECRAWL_TOKEN -> mcp:firecrawl/scrape` flow disappeared behind `0 destinations` and `no declared secret reaches an effect`. After, the audit names one `mcp.tool` destination and prints the exact flow before a run.

## Truth boundary

This projection observes flows; it does not re-judge consent. The SECRETS summary says `declared-secret flow`, never `sanctioned`, and directs the operator to the finding lane. A two-secret adversarial fixture proves both flows remain visible without promoting either one.

External MCP examples are intentionally not added here. The production runtime currently has no MCP `tools/call` dispatcher, so publishing one as runnable would violate the example corpus contract. That runtime integration, executable-readiness gate, configured-tool oracle, and only then the public examples belong to the next scoped lane.

## Measured

- `cargo test -p nika-check -p nika-display --lib --quiet` — 500 + 127 passed
- `cargo test -p nika-cli --lib --quiet` — 281 passed
- `cargo clippy -p nika-check -p nika-display --all-targets -- -D warnings` — green
- `bash scripts/ci/check-loc-limits.sh` — green, `check_render.rs` 1489/1500 LOC
- `bash scripts/hooks/run-ci-ratchets.sh` — 10/10 passed
- pre-push gate — workspace lib tests + workspace clippy + hygiene, green

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
