### PR TITLE
fix(dap): a stripped chain header is a BREAK, not a pre-0.96 era

### DIFF
--- a/crates/nika-dap/src/chain.rs
+++ b/crates/nika-dap/src/chain.rs
@@ -109,6 +109,18 @@ const LIFECYCLE_TERMINAL: &[&str] = &[
 /// `serde_json` sees it.
 pub const MAX_LINE_BYTES: usize = crate::bounded::MAX_ARTIFACT_BYTES;
 
+/// Does ANY of these lines carry a `chain` field? The pre-0.96 era is
+/// defined by their total absence, so one chained line refutes it — and
+/// refuting it is what separates an old journal from a stripped header.
+fn any_line_is_chained(lines: &[(usize, &str)]) -> bool {
+    lines.iter().any(|&(_, l)| {
+        serde_json::from_str::<serde_json::Value>(l)
+            .ok()
+            .and_then(|v| v.get("chain").and_then(|c| c.as_str()).map(str::to_owned))
+            .is_some()
+    })
+}
+
 /// The pure walk — recompute the chain over exact line bytes. Line
 /// numbers are FILE lines (blanks skipped, never renumbered — the
 /// recover path counts the same way), each line parses exactly once,
@@ -151,10 +163,15 @@ pub fn walk(raw: &str) -> Verdict {
             return Verdict::Unreadable { line: lineno + 1 };
         };
         let Some(recorded) = value.get("chain").and_then(|c| c.as_str()) else {
-            // The FIRST line decides the era: no chain there = a
-            // pre-chain journal. A chain that starts and then STOPS is
-            // a break, not an era.
-            if pos == 0 {
+            // The first line proposes the era; the REST of the file
+            // decides it. A pre-0.96 journal carries zero chained
+            // lines, so a chainless first line above chained ones is a
+            // STRIPPED HEADER, not an era — and that question is
+            // decidable from the bytes in hand. Answering it from line
+            // 0 alone renders a tampered trace as "nothing to verify,
+            // nothing to distrust", which is the one thing a proof
+            // layer may never say about a file that was edited.
+            if pos == 0 && !any_line_is_chained(&numbered[1..]) {
                 return Verdict::Unchained;
             }
             return Verdict::Broken {
@@ -276,6 +293,47 @@ mod tests {
     fn a_pre_chain_journal_is_unchained_not_broken() {
         let raw = format!("{}\n", ev("workflow_started"));
         assert!(matches!(walk(&raw), Verdict::Unchained));
+    }
+
+    /// A STRIPPED HEADER is not a pre-chain era, and the difference is
+    /// decidable from the file itself: a real pre-0.96 journal carries
+    /// ZERO chained lines, while this one carries every line but the
+    /// first. Deciding the era from line 0 alone resolves the ambiguity
+    /// toward the reassuring reading and renders a TAMPERED trace as
+    /// "nothing to verify, nothing to distrust".
+    #[test]
+    fn a_stripped_header_is_broken_not_a_pre_chain_era() {
+        let raw = chained(&[
+            ev("workflow_started"),
+            ev("task_completed"),
+            ev("workflow_completed"),
+        ]);
+        let mut lines: Vec<String> = raw.lines().map(str::to_owned).collect();
+        // Rename the genesis line's `chain` key — the exact shape an
+        // attacker reaches for to buy a benign verdict.
+        lines[0] = lines[0].replacen("\"chain\"", "\"chbin\"", 1);
+        let tampered = format!("{}\n", lines.join("\n"));
+        assert!(
+            matches!(walk(&tampered), Verdict::Broken { line: 1, .. }),
+            "a header stripped from a chained file is a BREAK, not an era"
+        );
+    }
+
+    /// The other direction, so the fix cannot be bought by calling
+    /// everything broken: a genuine pre-chain journal has no chained
+    /// line anywhere and must stay `Unchained`.
+    #[test]
+    fn a_genuine_pre_chain_journal_with_many_lines_stays_unchained() {
+        let raw = format!(
+            "{}\n{}\n{}\n",
+            ev("workflow_started"),
+            ev("task_completed"),
+            ev("workflow_completed")
+        );
+        assert!(
+            matches!(walk(&raw), Verdict::Unchained),
+            "no line carries a chain · this really is the pre-0.96 era"
+        );
     }
 
     #[test]

--- a/estate.yaml
+++ b/estate.yaml
@@ -152,7 +152,7 @@ patterns:
 - glob: "crates/**/src/**"
   class: authored
   match_count: 796
-  aggregate_sha256: 63269984054c0cd0e130a51454d8cf95d1efa84a8f8b574a6ef782665ebeec4a
+  aggregate_sha256: e7091cc687852c026982d21c4b8b39d13d232cff7ea66f3c03cd0e0d64a8a5bc
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
## "Nothing to distrust" — about a file that was edited

Rename the `chain` key on the **first line** of a fresh, fully-chained
trace. `nika trace verify` answers:

```
unchained — <file> predates the chain (pre-0.96 journal):
            nothing to verify, nothing to distrust
```

The file has six lines. **Five of them still carry a chain.** A genuine
pre-0.96 journal carries **zero**.

## The rule, and the case its own comment did not cover

```rust
let Some(recorded) = value.get("chain")… else {
    // The FIRST line decides the era: no chain there = a
    // pre-chain journal. A chain that starts and then STOPS is
    // a break, not an era.
    if pos == 0 { return Verdict::Unchained; }
    return Verdict::Broken { … };
};
```

*starts-then-stops* → covered, correctly, as a break.
*never-starts-then-starts* → not considered — and that is precisely the
shape of a header someone removed.

## The discarded question was decidable

"Is this the pre-chain era?" is answerable from the bytes already in
hand: **does any line carry a chain?** One chained line refutes the era.

Resolving that ambiguity toward the reassuring reading, silently, is the
indecidability waiver `AGENTS.md` refuses without naming what it skips.
So the first line now *proposes* the era, and the rest of the file
*decides* it.

## Nothing new was invented

`Verdict::Broken` already said the right thing. The walk was simply
routing this case away from it:

```
BROKEN at line 1 — recorded chain (absent) · computed 7466341540fd02fc
  every line from here on is unverified (edited, inserted, dropped or reordered)
```

## Mutation proof — both directions fix the width

| cut | verdict |
|---|---|
| restore the line-0 rule | the new row **RED** |
| make the era unreachable (`if false`) | **3 EXISTING rows RED** |

The second matters as much: a real pre-chain journal must keep its
honest, quiet verdict. A fix wide enough to call every old journal
"broken" would be the cancelled kind of change.

## Sweep

| | |
|---|---|
| traces in tree + this session's live ones | **3 swept, 0 changed** |
| synthetic genuine pre-chain journal | **byte-identical** on both binaries |
| the tampered trace | `unchained` → `BROKEN at line 1` |

## How it was found

While mutation-proving an **unrelated** gate row — not while looking for
it. The first mutation attempt changed nothing at all, and a `diff`
before the verdict is the only reason this was not published as "tamper
goes undetected" on a file that had never been tampered with.

---

🦋 Generated with [Claude Code](https://claude.com/claude-code)
