### PR TITLE
docs+test: drop internal branch topology, and stop naming a real private path in a fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ era of private prototypes through summer 2025 · first git commit on
 January 1, 2026 on the branch named `brouillon` · **79 versions in a
 103-day draft era** (public [crates.io trail](https://crates.io/crates/nika/versions)
 from March) · then **rewritten from scratch on April 13, 2026** — the
-Diamond era, an orphan branch, zero code inherited, the version line
+Diamond era, zero code inherited, the version line
 continuing because the language is the continuity. Every dated claim is machine-verified in the spec
 repo's [timeline](https://github.com/supernovae-st/nika-spec/blob/main/timeline/timeline.yaml),
 rendered with the forward gates at [nika.sh/timeline](https://nika.sh/timeline).

--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 155
-  aggregate_sha256: 5114765950a150e12197368e4427c3a60aa05e5cb89cbfd0a4f1afc1aa027665
+  aggregate_sha256: d91b25a987796ccc8e0ebe99fb26fd8c1b844fe67c03a1535367d47fa8d7cb56
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -237,7 +237,7 @@ patterns:
 - glob: "*"
   class: authored
   match_count: 28
-  aggregate_sha256: c3e10c2b7d1a01adcfbf445c051361bd347151b7de86fd7923183e72967f9232
+  aggregate_sha256: 344d48faf48e7d67144affb074dd893f35b81136bf8dc0d37c888225baf0f6a9
   evidence: "root prose + config surface (README · DIAMOND · LICENSE · llms.txt · Cargo.toml · deny/clippy/cliff/typos toml · lefthook.yml · flake.nix · Dockerfile) — no generation markers at file heads; CHANGELOG.md · Cargo.lock · SPEC_PIN · ROADMAP.md excepted in files:"
 - glob: "**"
   class: authored

--- a/scripts/hygiene/tests/private-leaks.test.sh
+++ b/scripts/hygiene/tests/private-leaks.test.sh
@@ -56,7 +56,11 @@ expect() { # label, expected_rc, injected_line ("" = clean tree)
 expect "clean tree is green" 0 ""
 expect "a dx/ path turns it red" 2 "see dx/journal/ for the studio chronicle"
 expect "a studio/ path turns it red" 2 "see studio/04-identity/brand/ for the palette"
-expect "a private venture pole turns it red" 2 "ventures/nika/01-product/strategy/NORTH_STAR.md"
+# A SYNTHETIC pole · the shape is what turns it red, not the document. Naming a
+# real private file here published its path in a public repo, which is the very
+# thing this gate exists to stop (measured 2026-08-20 by the monorepo's
+# vocabulary screen, whose `01-product/strategy` pattern matched this line).
+expect "a private venture pole turns it red" 2 "ventures/example/05-growth/campaign-notes.md"
 expect "a pre-migration spelling turns it red" 2 "nika/hq/strategy.md"
 expect "the PUBLIC venture tier stays green" 0 "ventures/nika/02-engineering/repos/engine/README.md"
 expect "lmstudio keeps the word boundary green" 0 "/home/u/.cache/lm-studio/models and the lmstudio/ provider"


### PR DESCRIPTION
Supersedes #1063 · same two commits, cherry-picked onto current `main` so the `estate` projection is computed on the merged tree. Zero force-push (the house remedy for a whole-tree projection: rebuild on a fresh branch, never re-resolve).

### README · one clause
`an orphan branch` goes. The timeline section is deliberate and machine-verified against the spec repo, and **every dated claim in it stays**. What leaves is a git-internal mechanic that tells a public reader nothing usable.

### Fixture · same property, no real document
`private-leaks.test.sh` proved a path under a private venture pole turns the gate red, using a **real document's path**, which published it in a public repo. The pattern is a **shape**, not a document, so the fixture is synthetic now.

A trap worth naming: a synthetic *venture name* would not have been enough, because the monorepo pattern matches `01-product/strategy` regardless of venture. The fixture moves **pole** instead. **9/9 cases still correct.**

Scrubbing beat allowlisting: the monorepo allowlist has shipped empty since it was written, and its first law is to never suppress a real occurrence.

### Why these were invisible until today
The screen that catches this class derived its scope with a regex matching only `target_path` values with **no trailing `/repo`** — true of exactly the five remote-only rows, the ones with no checkout and therefore no README. The nine repos that carry a public README all end in `/repo` and were never matched. It scanned zero and printed clean. It now scans eleven, names the one archived repo it skips, and reported two hits: this one and the spec twin (merged as nika-spec#278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)