### PR TITLE
fix(estate): the manifest is proven at the tag, not at every commit

### DIFF
--- a/.github/workflows/estate.yml
+++ b/.github/workflows/estate.yml
@@ -1,14 +1,21 @@
 name: estate
 
-# E0 OBSERVATION — the estate manifest (estate.yaml · schema 2, the glob
-# estate) declares every tracked file's provenance: authored · authored-pin
-# · generated · pinned-copy · testimonial · foreign. This step only
-# OBSERVES: non-blocking (continue-on-error) · read-only permissions ·
-# it enforces nothing. Drift exits 5 (the ssot-compiler convention —
-# distinguishable from the sibling gates' exit 1 in CI logs). The heavy
+# The estate manifest (estate.yaml · schema 2, the glob estate) declares
+# every tracked file's provenance: authored · authored-pin · generated ·
+# pinned-copy · testimonial · foreign. Read-only permissions. The heavy
 # rail (diamond-ci.yml) is deliberately untouched.
 #
-# TWO JOBS, TWO POSTURES. `estate` observes and never blocks, as above.
+# SPLIT BY VERDICT (2026-08-21). COVERAGE — exit 3, a path no rule
+# classifies or a rule matching nothing — BLOCKS here. FRESHNESS — exit 5,
+# the manifest behind the tree — reports and does not block, because
+# requiring a whole-tree projection per commit makes concurrent branches
+# collide on a file neither edited, and because freshness is PROVEN at
+# tag time in release.yml, which is where a true manifest is the
+# deliverable. Until this split, the property the manifest exists to
+# guarantee had no blocking gate anywhere while the pre-commit hook
+# refused every commit over the other half.
+#
+# TWO JOBS, TWO POSTURES. `estate` blocks on coverage, as above.
 # `mirror` DOES block: it proves scripts/estate.py is byte-identical to
 # nika-estate at the rev in ESTATE_PIN. Editing a mirrored file is never an
 # observation, it is a bug, so it fails the run. That is why this workflow
@@ -35,11 +42,23 @@ jobs:
   estate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: The estate matches the tree (observation — never blocks)
-        run: python3 scripts/estate.py --check
+      # Split by verdict, and the halves land in different places.
+      #
+      # COVERAGE (exit 3 · a path no rule classifies, or a rule matching
+      # nothing) BLOCKS. It never did before: this job carried
+      # `continue-on-error: true`, so the one property the manifest exists
+      # to guarantee had no enforcing gate anywhere, while the pre-commit
+      # hook refused every commit over the other half. The refusal and the
+      # enforcement had swapped places.
+      #
+      # FRESHNESS (exit 5) is reported and does not block here. Requiring
+      # it per-commit is what made four concurrent PRs conflict on a file
+      # none of them edited (2026-08-20). It is PROVEN at tag time instead,
+      # in release.yml, which is where a true manifest is the deliverable.
+      - name: The estate covers the tree (coverage blocks · freshness reports)
+        run: bash scripts/hooks/estate-gate.sh
 
   mirror:
     name: The estate tool is the shared one

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,19 @@ jobs:
             echo "::error::release tag ${REF_NAME} does not match Cargo workspace version ${cargo_version}"
             exit 1
           fi
+      # The provenance manifest must be TRUE of the tree being released.
+      # It is not required per-commit (a whole-tree projection carried by
+      # every branch makes concurrent PRs collide on a file none of them
+      # edited), so this is the gate that owns it: the tagged tree, the
+      # one whose binaries a user will verify, must match its manifest
+      # exactly. RELEASING.md step 2 regenerates it before the tag.
+      - name: The estate manifest is true of the tagged tree
+        run: |
+          set -euo pipefail
+          if ! python3 scripts/estate.py --check; then
+            echo "::error::the estate manifest does not describe the tagged tree — run python3 scripts/estate.py --write, commit it, and re-tag"
+            exit 1
+          fi
       - name: Add the Rust target
         run: rustup target add ${{ matrix.target }}
       - name: Cache cargo

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,27 @@ without an explicit operator decision.
    Run `bash scripts/hygiene/check-all.sh` before tagging: both fire
    there, and both were earned by a release that shipped without them.
 
-3. **Tag and push.**
+3. **Regenerate the estate manifest.**
+
+   ```sh
+   python3 scripts/estate.py --write && git add estate.yaml
+   ```
+
+   The manifest is a WHOLE-TREE projection, so requiring it per-commit made
+   every pair of concurrent branches collide on a file neither had edited —
+   four pull requests, four conflicts, 2026-08-20, and `git merge-tree`
+   named the projection as the only overlap. It is therefore no longer a
+   commit-time refusal: the pre-commit hook and the `estate` CI job block
+   on COVERAGE (a path no rule classifies) and merely report FRESHNESS.
+
+   Freshness is owned HERE instead, where it is the deliverable rather
+   than a formality: `release.yml` refuses a tag whose tree does not match
+   its manifest, because that tree is the one whose binaries a user will
+   verify. Forget this step and the release stops at the guard — which is
+   the same shape as the version-match guard above, and for the same
+   reason.
+
+4. **Tag and push.**
 
    ```sh
    git tag v<NEXT> && git push origin v<NEXT>

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -78,8 +78,13 @@ pre-commit:
     # THEN stage the manifest. This hook caught that very mistake on the commit
     # that installs it, in 0.16 s.
     estate-manifest:
-      run: python3 scripts/estate.py --check
-      fail_text: 'estate.yaml diverges from the tracked tree. Run: git add <file> && python3 scripts/estate.py --write && git add estate.yaml (estate.py reads the INDEX, so stage first).'
+      # Split by verdict · a COVERAGE hole refuses, FRESHNESS does not.
+      # A whole-tree projection required at commit time makes every pair
+      # of concurrent branches collide on a file neither one edited
+      # (four PRs, four conflicts, 2026-08-20). Freshness is proven where
+      # it is the guarantee — at tag time, in release.yml.
+      run: bash scripts/hooks/estate-gate.sh
+      fail_text: 'estate: a path no rule classifies, or a rule matching nothing. Fix the glob in scripts/estate_rules.py (freshness alone no longer refuses — the tag gate owns it).'
 
     block-private-paths:
       run: bash scripts/hooks/block-private-paths.sh

--- a/scripts/hooks/estate-gate.sh
+++ b/scripts/hooks/estate-gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# The estate gate, split by what each verdict MEANS.
+#
+# WHY THIS SPLIT EXISTS · `estate.yaml` is a WHOLE-TREE projection. Any
+# commit that touches any tracked file rewrites it, so two branches that
+# share no source file still collide there. Measured 2026-08-20: four
+# pull requests, four conflicts, every one of them on this file and only
+# this file — `git merge-tree` reported nine source files with zero
+# collisions and one "changed in both", the projection. The pre-commit
+# hook REQUIRED the delta that guaranteed the collision, while the CI job
+# that would have caught real drift ran `continue-on-error: true`. The
+# refusal and the enforcement had swapped places.
+#
+# Freshness (exit 5) is therefore no longer a commit-time refusal. It is
+# enforced where it is the actual guarantee: at TAG time, in
+# `.github/workflows/release.yml`, beside the version-match guard. A
+# released artifact carries a true manifest; an intermediate commit
+# never needed to.
+#
+# Coverage (exit 3 · a path no rule classifies, or a rule matching
+# nothing) STAYS blocking, here and in CI. It is the half a stale
+# manifest cannot hide, it is author-fixable at the moment it appears,
+# and it is the reason the manifest exists at all.
+#
+# Exit: 0 the commit may proceed · 1 a coverage hole the author must fix.
+set -uo pipefail
+
+out="$(python3 scripts/estate.py --check 2>&1)"
+rc=$?
+
+case "$rc" in
+  0)
+    exit 0
+    ;;
+  5)
+    # Freshness only. Say so, do not refuse: the tag gate owns this.
+    printf 'estate: the manifest is behind the tree (freshness only).\n' >&2
+    printf '  Nothing to do — it is regenerated and PROVEN at tag time\n' >&2
+    printf '  (RELEASING.md step 2 · release.yml refuses a tag whose\n' >&2
+    printf '  manifest does not match). Run `python3 scripts/estate.py\n' >&2
+    printf '  --write` yourself only if you WANT this commit to carry it.\n' >&2
+    exit 0
+    ;;
+  3)
+    printf 'estate: COVERAGE HOLE — a path no rule classifies, or a rule\n' >&2
+    printf 'that now matches nothing. This is not freshness; the manifest\n' >&2
+    printf 'cannot describe the tree until a rule covers it.\n\n' >&2
+    printf '%s\n\n' "$out" >&2
+    printf 'Fix: add or repair the glob in scripts/estate_rules.py.\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'estate: the tool exited %s — an unrecognised verdict is not a\n' "$rc" >&2
+    printf 'pass. Refusing rather than guessing which half failed.\n\n' >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## The refusal and the enforcement had swapped places

**The pre-commit hook** refused every commit whose `estate.yaml` was behind
the tree. `estate.yaml` is a **whole-tree projection**, so any commit
touching any tracked file rewrites it — and two branches sharing no source
file still collide there.

Measured 2026-08-20: **four pull requests, four conflicts**, every one on
this file and only this file. `git merge-tree` reported nine source files
with **zero** collisions and one "changed in both": the projection.

**Meanwhile CI** carried `continue-on-error: true`, with its step named
*"observation — never blocks"*. So the property the manifest exists to
guarantee had **no enforcing gate anywhere**, while the hook refused every
commit over the other half.

## Split by what each verdict means

| verdict | where it is enforced now |
|---|---|
| **COVERAGE** (exit 3 · a path no rule classifies, or a rule matching nothing) | **blocks** in the hook **and** in CI |
| **FRESHNESS** (exit 5 · manifest behind the tree) | reported, does not refuse a commit — **proven at TAG time** |

CI **gains a blocking gate it never had**. `release.yml` now refuses a tag
whose tree does not match its manifest, beside the version-match guard and
for the same reason: the tagged tree is the one whose binaries a user
verifies. `RELEASING.md` gains the regeneration step.

## The first design was wrong, and the measurement said so

I assumed coverage was exit 3 and drift exit 5, and planned to block on 3
and warn on 5 — until a probe showed **both ordinary cases** (staged
content change, staged new file) exit **5**. That design would have made
the blocking half **decorative**: it would almost never have bitten.

Producing a real 3 needed a genuine stale rule. My first attempt at one
**crashed the tool** (`TypeError`, exit 1). The gate refused that too —
correctly, and for the wrong reason. The proof only counts because the
crash was qualified instead of read as a verdict.

## Gate proof — all four arms

```
clean tree              estate.py 0   gate 0  proceeds
staged content drift    estate.py 5   gate 0  proceeds
stale rule (coverage)   estate.py 3   gate 1  REFUSES
tool crash              estate.py 1   gate 1  refuses · fails closed
```

**The commit carrying this change passed its own new gate and carries no
`estate.yaml` delta** — the demonstration is the commit itself.

## Also corrected

The workflow's header said *"This step only OBSERVES: non-blocking
(continue-on-error) · it enforces nothing"*. It now describes what the file
does, rather than being a claim nobody tests.

---

🦋 Generated with [Claude Code](https://claude.com/claude-code)
