### PR TITLE
fix(estate): the manifest stops conflicting, because a merged one is a lie

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# estate.yaml is a GENERATED whole-tree projection. It carries 22
+# aggregate sha256 lines, one per glob, and EACH is rewritten by any
+# change to any file inside that glob. Two branches that share no source
+# file therefore rewrite the same lines, which is why every pair of
+# concurrent pull requests collided here — four of them on 2026-08-20,
+# with `git merge-tree` reporting nine source files at zero collisions
+# and this one file as the only overlap.
+#
+# A textual merge of two aggregate hashes is not merely awkward, it is
+# MEANINGLESS: the blend describes a tree that never existed. `merge=ours`
+# keeps one real previous manifest instead of inventing a false one.
+#
+# That is safe because the two properties were split (2026-08-21):
+#   COVERAGE  recomputed fresh, BLOCKS in CI — a stale manifest cannot
+#             hide a path no rule classifies.
+#   FRESHNESS proven at TAG time — release.yml refuses a tag whose tree
+#             does not match its manifest.
+# The merge result only has to be a valid EARLIER manifest, never a
+# correct one; correctness is re-established where it is the deliverable.
+#
+# The `ours` driver is registered automatically by
+# scripts/hooks/estate-gate.sh, which already runs on every commit — a
+# fix that needs a per-clone gesture is not a fix.
+/estate.yaml merge=ours

--- a/scripts/hooks/estate-gate.sh
+++ b/scripts/hooks/estate-gate.sh
@@ -25,6 +25,15 @@
 # Exit: 0 the commit may proceed · 1 a coverage hole the author must fix.
 set -uo pipefail
 
+# Self-installing. `.gitattributes` marks estate.yaml `merge=ours`, and
+# that attribute is inert unless a driver by that name exists in git
+# config. Registering it HERE — on a hook that already runs on every
+# commit — means no clone, and no new contributor, has to remember a
+# setup step. A fix that needs a gesture each time is not a fix.
+if [ "$(git config --get merge.ours.driver 2>/dev/null)" != "true" ]; then
+  git config merge.ours.driver true 2>/dev/null || true
+fi
+
 out="$(python3 scripts/estate.py --check 2>&1)"
 rc=$?
 


### PR DESCRIPTION
## Why the file conflicts, structurally

`estate.yaml` carries **22 aggregate sha256 lines**, one per glob, and each
is rewritten by *any* change to *any* file inside that glob. Two branches
that share **no source file** therefore rewrite the same lines.

Four pull requests, four conflicts, 2026-08-20. `git merge-tree` reported
**nine source files at zero collisions** and this one file as the only
overlap.

## A merged manifest is a lie

Blending two aggregate hashes does not produce a compromise — it produces
**a description of a tree that never existed**. So `.gitattributes` marks
the file `merge=ours`: keep one real earlier manifest rather than invent a
false one.

## Safe only because the properties were split

| property | where it lives now |
|---|---|
| **COVERAGE** | recomputed fresh, **blocks in CI** — a stale manifest cannot hide an unclassified path |
| **FRESHNESS** | **proven at tag time** — `release.yml` refuses a tag whose tree does not match |

The merge result only has to be **a valid earlier manifest**, never a
correct one. Correctness is re-established where it is the deliverable.

## Self-installing, because the alternative does not work

The `ours` driver is registered by `scripts/hooks/estate-gate.sh`, which
already runs on every commit. No clone, no new contributor, no CI job has
to remember a setup step — **a fix that needs a gesture each time is not a
fix**, which is the lesson the keychain prompt taught the same day.

## Proof — and the control arrived by accident

The first run of the proof **stashed the attribute before branching**, so
it tested the fix *absent from the tree*. That failure is exactly the
negative control the proof needed:

```
base WITHOUT .gitattributes   merge rc 1   1 CONFLICT   estate.yaml unmerged
base WITH    .gitattributes   merge rc 0   0 CONFLICT   nothing unmerged
```

Both branches genuinely fight over the file — `git diff --name-only zz_a
zz_b` names `estate.yaml` in both arms.

---

🦋 Generated with [Claude Code](https://claude.com/claude-code)
