### PR TITLE
test(hygiene): the comment stops quoting the token it explains

### DIFF
--- a/estate.yaml
+++ b/estate.yaml
@@ -183,7 +183,7 @@ patterns:
 - glob: "scripts/**"
   class: authored
   match_count: 156
-  aggregate_sha256: dff48ba6eb32abc12ecc520e955df3cc031c12364a1622c014ff54e723ef8f09
+  aggregate_sha256: 5357323fac217ba8cd2e7ef01f8f01c4ff03757b9e54ad74eaf654ccccd9a139
   evidence: "hand-written gates · hooks · hygiene vectors · media lanes; the ratchet baselines (scripts/ci/*-baseline.txt · scripts/hygiene/baselines/) are hand-kept monotonic floors ('Never remove a line by hand')"
 - glob: ".github/workflows/**"
   class: authored

--- a/scripts/hygiene/tests/private-leaks.test.sh
+++ b/scripts/hygiene/tests/private-leaks.test.sh
@@ -59,7 +59,11 @@ expect "a studio/ path turns it red" 2 "see studio/04-identity/brand/ for the pa
 # A SYNTHETIC pole · the shape is what turns it red, not the document. Naming a
 # real private file here published its path in a public repo, which is the very
 # thing this gate exists to stop (measured 2026-08-20 by the monorepo's
-# vocabulary screen, whose `01-product/strategy` pattern matched this line).
+# vocabulary screen, whose private-PM-pole pattern matched the old line).
+#
+# That screen then matched THIS comment, because the first draft quoted the
+# offending token while explaining it. An explanation of a screened string is
+# not exempt from the screen · describe the pattern, never reproduce it.
 expect "a private venture pole turns it red" 2 "ventures/example/05-growth/campaign-notes.md"
 expect "a pre-migration spelling turns it red" 2 "nika/hq/strategy.md"
 expect "the PUBLIC venture tier stays green" 0 "ventures/nika/02-engineering/repos/engine/README.md"


### PR DESCRIPTION
A one-line rewording, and a small law worth the PR.

#1082 replaced a real private path in this fixture with a synthetic one, and **explained why in a comment that quoted the offending pattern verbatim**. The monorepo's vocabulary screen then matched the explanation, so the gate stayed **red on the very commit that closed it** — and the reported line was mine.

> An explanation of a screened string is not exempt from the screen. **Describe the pattern, never reproduce it.**

No scanner distinguishes a use from a mention; that is structural, not an implementation weakness. The comment now names the pattern instead of spelling it, and records the trap for the next reader.

**9/9 cases still correct.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)