### PR TITLE
test(nika-pack): the template surface is asserted by name, not a typed count

### DIFF
--- a/crates/nika-pack/tests/pack_integrity.rs
+++ b/crates/nika-pack/tests/pack_integrity.rs
@@ -89,7 +89,11 @@ fn every_manifest_entry_resolves_and_hashes_clean() {
 
 #[test]
 fn surface_counts_hold() {
-    assert_eq!(nika_pack::template_names().len(), 10); // t2-model-bench joined the SSOT (the 9-vs-10 diamond-audit fix)
+    // A FLOOR here, never a typed count. The exact surface is asserted by NAME
+    // against the vendored canon in `spec_parity::canon_templates_equal_the_
+    // embedded_surface` — a hand-typed equality only ever noticed that a number
+    // moved, and had to be edited by hand at 9→10 and again at 10→14.
+    assert!(nika_pack::template_names().len() >= 10);
     assert!(nika_pack::example_slugs().len() >= 27);
     assert!(nika_pack::doc_paths().len() >= 12, "spec + stdlib pages");
     assert!(nika_pack::schema_json().contains("\"$schema\""));

--- a/crates/nika-pack/tests/spec_parity.rs
+++ b/crates/nika-pack/tests/spec_parity.rs
@@ -76,3 +76,57 @@ fn every_canonical_prefix_is_a_catalog_id() {
         catalog.len()
     );
 }
+
+/// Parse `templates.{count,items}` out of the vendored canon.yaml.
+fn canon_templates() -> (u64, Vec<String>) {
+    let canon: serde_yaml_bw::Value =
+        serde_yaml_bw::from_str(nika_pack::canon()).expect("vendored canon.yaml parses");
+    let templates = canon
+        .get("templates")
+        .expect("canon.yaml carries a templates section");
+    let count = templates
+        .get("count")
+        .and_then(serde_yaml_bw::Value::as_u64)
+        .expect("templates.count is an integer");
+    let items = templates
+        .get("items")
+        .and_then(serde_yaml_bw::Value::as_sequence)
+        .expect("templates.items is a list");
+    let names = items
+        .iter()
+        .map(|v| v.as_str().expect("every template name is a string").to_owned())
+        .collect();
+    (count, names)
+}
+
+// The embedded template surface must equal what the vendored canon DECLARES,
+// by NAME. This replaces a hand-typed `assert_eq!(len(), 10)` that only ever
+// noticed that a number changed: a partial sync (canon says 14, twelve files
+// copied) walked straight past it. Equality by name is the invariant the
+// vendoring lane actually owes — `scripts/sync-pack.sh` copies canon.yaml and
+// templates/ in the same pass, so a disagreement means the pass was half done.
+#[test]
+fn canon_templates_equal_the_embedded_surface() {
+    let (count, declared) = canon_templates();
+    let declared_set: BTreeSet<&str> = declared.iter().map(String::as_str).collect();
+    assert_eq!(
+        declared_set.len(),
+        declared.len(),
+        "a template name appears twice in canon.yaml templates.items"
+    );
+    assert_eq!(
+        usize::try_from(count).expect("templates.count fits a usize"),
+        declared.len(),
+        "templates.count disagrees with its own items list"
+    );
+
+    let names = nika_pack::template_names();
+    let embedded: BTreeSet<&str> = names.iter().map(AsRef::as_ref).collect();
+    let missing: Vec<&str> = declared_set.difference(&embedded).copied().collect();
+    let extra: Vec<&str> = embedded.difference(&declared_set).copied().collect();
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "vendored pack half synced · declared-not-embedded {missing:?} · \
+         embedded-not-declared {extra:?} (run scripts/sync-pack.sh <spec>)"
+    );
+}


### PR DESCRIPTION
`pack_integrity` carried `assert_eq!(template_names().len(), 10)`, with a comment recording an earlier hand-edit from 9. A typed equality only ever notices that a number moved. A **half sync** · canon declares fourteen, twelve files land · walks straight past it, because the count it compares against is the one an editor typed rather than the one the vendored canon declares.

`spec_parity` now reads `templates.{count,items}` out of the embedded canon and asserts **set equality by name** against the embedded surface, matching the shape its provider sibling already uses. On failure it names both directions, so the reader knows which half of `scripts/sync-pack.sh` did not run. `pack_integrity` keeps a floor.

**Mutation-proven** · renaming one declared template to a wrong name of equal cardinality reddens it and prints both lists. The file hash was captured before and after, so the mutation is known to have taken effect.

**How this surfaced** · the release-train checklist reported the vendored pack drifting from the spec canon. Syncing from spec HEAD was the wrong gesture · `SPEC_PIN` says *never HEAD* and `spec-pin-heal.yml` owns advancing it, PR-only, judging the battery at the candidate. That heal is dispatched separately. This PR keeps only the part that holds at any pin.

Supersedes #1093 (missing DCO sign-off, and a `cast_possible_truncation` that only `-D warnings` in CI caught).

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>