### PR TITLE
fix(hygiene): the clone says when its own enforcement is not armed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,7 +18,24 @@
 # The merge result only has to be a valid EARLIER manifest, never a
 # correct one; correctness is re-established where it is the deliverable.
 #
-# The `ours` driver is registered automatically by
-# scripts/hooks/estate-gate.sh, which already runs on every commit — a
-# fix that needs a per-clone gesture is not a fix.
+# ARMING · read this before trusting the line below.
+#
+# `merge=ours` does NOTHING until `merge.ours.driver` is registered in the
+# clone's config, and git ignores an unregistered driver IN SILENCE: it falls
+# back to a plain three-way merge and hands you the meaningless conflict this
+# mark exists to prevent, naming no cause.
+#
+# scripts/hooks/estate-gate.sh registers it, but it runs from lefthook.yml,
+# which requires `lefthook install`. This file used to claim that made the
+# gesture unnecessary — « a fix that needs a per-clone gesture is not a fix ».
+# The principle is right; the claim was not reachable. Measured 2026-08-21 on
+# a working loose clone: 20 gates declared, ZERO installed, .git/hooks holding
+# only samples, and the driver absent. Git offers no way to ship config into a
+# clone, and no hook runs before the merge machinery reads this file, so a
+# clone cannot arm itself.
+#
+# The honest version of the principle: make the gesture ONE, idempotent, and
+# make its absence LOUD.
+#   arm    · bash scripts/dev/bootstrap.sh
+#   verify · bash scripts/hygiene/check-clone-armed.sh   (hygiene vector 51)
 /estate.yaml merge=ours

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# bootstrap.sh — arm THIS clone's local enforcement. One gesture, idempotent.
+#
+# WHY A GESTURE AT ALL
+# --------------------
+# `.gitattributes` carried the line « a fix that needs a per-clone gesture is
+# not a fix ». The principle is right and the claim was not reachable: git
+# offers no way to ship config into a clone, and no hook runs before the merge
+# machinery reads `.gitattributes`. A clone therefore cannot arm itself.
+#
+# What IS reachable is this: make the gesture ONE, make it idempotent, and make
+# its absence LOUD (`scripts/hygiene/check-clone-armed.sh`, vector 51). That is
+# the honest version of the principle.
+#
+# WHAT IT ARMS
+#   · merge.ours.driver=true  — without it, `/estate.yaml merge=ours` is
+#     silently ignored and you get the meaningless aggregate-hash conflict
+#   · lefthook                — the local gates declared in lefthook.yml
+#
+# Safe to re-run. Reports what it changed and what was already in place.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+armed=0
+already=0
+
+# 1 · the estate merge driver
+if [ "$(git config --get merge.ours.driver 2>/dev/null || true)" = "true" ]; then
+  echo "  = merge.ours.driver     already true"
+  already=$((already + 1))
+else
+  git config merge.ours.driver true
+  echo "  + merge.ours.driver     registered (estate.yaml keeps ONE real manifest)"
+  armed=$((armed + 1))
+fi
+
+# 2 · the local gates
+declared=$(grep -cE '^\s+run:' lefthook.yml 2>/dev/null || echo 0)
+if ! command -v lefthook >/dev/null 2>&1; then
+  echo "  ! lefthook              NOT INSTALLED — ${declared} local gates stay inert"
+  echo "                          install it, then re-run this script"
+else
+  hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
+  if { [ -n "$hooks_path" ] && [ -e "$hooks_path/pre-commit" ]; } || [ -f .git/hooks/pre-commit ]; then
+    echo "  = lefthook              already installed (${declared} gates reachable)"
+    already=$((already + 1))
+  elif lefthook install >/dev/null 2>&1; then
+    echo "  + lefthook              installed (${declared} gates now reachable)"
+    armed=$((armed + 1))
+  else
+    echo "  ! lefthook install      FAILED — ${declared} gates stay inert"
+  fi
+fi
+
+echo
+echo "armed ${armed} · already in place ${already}"
+echo "verify · bash scripts/hygiene/check-clone-armed.sh"
+echo
+echo "note · a reachable hook is not a proven run. This script registers the"
+echo "       path; only a commit proves the gate fires."

--- a/scripts/hygiene/check-all.sh
+++ b/scripts/hygiene/check-all.sh
@@ -154,6 +154,12 @@ run_check "47 version-surfaces     " "check-version-surfaces.sh"
 run_check "48 agent-plugins-1.0.0  " "check-agent-plugins.sh"
 run_check "49 hygiene-self-tests   " "check-hygiene-self-tests.sh"
 run_check "50 release-gate-envelope" "check-release-gate-envelope.sh"
+# 51 is about THIS CLONE, not the repo. Every other vector asks whether the
+# tree is right; this one asks whether the tree's local enforcement is even
+# reachable — because an unregistered `merge.ours.driver` makes `/estate.yaml
+# merge=ours` a no-op IN SILENCE, and an uninstalled lefthook makes every gate
+# above it inert with no message at all.
+run_check "51 clone-armed          " "check-clone-armed.sh"
 
 # --- Output ---
 g=0

--- a/scripts/hygiene/check-clone-armed.sh
+++ b/scripts/hygiene/check-clone-armed.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# check-clone-armed.sh — is THIS clone's local enforcement actually armed?
+#
+# WHY THIS EXISTS
+# ---------------
+# `.gitattributes` marks `/estate.yaml merge=ours` because a textual merge of
+# two aggregate manifests describes a tree that never existed. That mark only
+# does anything when `merge.ours.driver` is registered in the clone's config —
+# and git IGNORES AN UNREGISTERED DRIVER IN SILENCE. It falls back to a plain
+# three-way merge and hands you the meaningless conflict the mark exists to
+# prevent, with no message naming the cause.
+#
+# The driver is registered by `scripts/hooks/estate-gate.sh`, which runs from
+# `lefthook.yml`, which requires `lefthook install`. In a clone where that
+# gesture was never made, every local gate is inert and NOTHING says so:
+# measured 2026-08-21 on a working loose clone — 20 gates declared, zero
+# installed, `.git/hooks/` holding only samples.
+#
+# So this vector does the one thing the silent path cannot: it makes the
+# unarmed state VISIBLE, where a contributor already looks.
+#
+# WHAT IT LOOKS AT (per gate-honesty Mandate 5 — an instrument says what it
+# examined, what it skipped, and how it goes red)
+#   · merge.ours.driver in the effective git config
+#   · whether a real pre-commit hook is reachable (core.hooksPath, or a
+#     non-sample .git/hooks/pre-commit)
+# WHAT IT CANNOT SEE
+#   · whether the hook, once installed, actually FIRES. A registered path is
+#     not a proven run. That is the arming-edge limit, and it is stated rather
+#     than papered over.
+#
+# EXIT · 0 armed · 1 unarmed (yellow — local state, never a repo defect)
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+missing=()
+
+driver=$(git config --get merge.ours.driver 2>/dev/null || true)
+[ "$driver" = "true" ] || missing+=("merge.ours.driver")
+
+hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
+hook_ok=0
+if [ -n "$hooks_path" ] && [ -e "$hooks_path/pre-commit" ]; then
+  hook_ok=1
+elif [ -f .git/hooks/pre-commit ]; then
+  # a `.sample` is git's stock file; only a real one counts
+  hook_ok=1
+fi
+[ "$hook_ok" -eq 1 ] || missing+=("pre-commit hook")
+
+declared=$(grep -cE '^\s+run:' lefthook.yml 2>/dev/null || echo 0)
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo "armed · merge.ours.driver + pre-commit reachable (${declared} local gates declared · a reachable hook is not a proven run)"
+  exit 0
+fi
+
+printf 'UNARMED · %s absent — ' "$(
+  IFS=', '
+  echo "${missing[*]}"
+)"
+printf '%s local gates in lefthook.yml are inert here, and an unregistered ' "$declared"
+printf 'merge driver fails SILENTLY on estate.yaml. One gesture: bash scripts/dev/bootstrap.sh\n'
+exit 1


### PR DESCRIPTION
## What was silent

`.gitattributes` marks `/estate.yaml merge=ours` because blending two aggregate manifests describes a tree that never existed. **That mark does nothing until `merge.ours.driver` is registered**, and git ignores an unregistered driver *in silence* · it falls back to a plain three-way merge and hands you the meaningless conflict the mark exists to prevent, naming no cause.

The driver is registered by `estate-gate.sh`, which runs from `lefthook.yml`, which needs `lefthook install`.

**Measured 2026-08-21 on a working loose clone** · 20 gates declared, **zero installed**, `.git/hooks/` holding only samples, the driver absent. Every local gate was inert and nothing said so.

I met this from the wrong end: ten pull requests conflicting on that one file. I registered the driver by hand and only afterwards noticed the arming edge underneath it.

## The claim that was not reachable

The file carried « *a fix that needs a per-clone gesture is not a fix* ». The principle is right; the claim is not achievable. Git offers no way to ship config into a clone, and no hook runs before the merge machinery reads `.gitattributes`. **A clone cannot arm itself.**

The honest version: make the gesture **one**, idempotent, and its absence **loud**.

## What lands

| | |
|---|---|
| `scripts/dev/bootstrap.sh` | arms the driver + lefthook · reports what it changed versus what was already there · safe to re-run |
| hygiene **vector 51** `clone-armed` | reports an unarmed clone where a contributor already looks |
| `.gitattributes` | the stale claim replaced by the reachable one |

Vector 51 states what it examined **and what it cannot see** · *a reachable hook is not a proven run*. That is the arming-edge limit, written rather than papered over.

## Proof

**Mutation-proven on both legs.** Unsetting `merge.ours.driver` reddens it; moving the `pre-commit` hook reddens it. Each mutation was verified to have taken effect *before* its verdict was read, and both were restored.

The first commit to pass under the newly armed hooks was this one · `shfmt-engine` refused it, which is the gate proving itself.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>