### PR TITLE
fix(reference): make dry-run and AUTH advice tell the truth

### DIFF
--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -142,6 +142,7 @@ mod order;
 mod permit_taint;
 pub mod permits_fit;
 mod permits_infer;
+pub mod plan;
 mod reach;
 mod requirements;
 mod risk;

--- a/crates/nika-check/src/permit_taint.rs
+++ b/crates/nika-check/src/permit_taint.rs
@@ -30,8 +30,9 @@
 //!   informational « deferred re-gates » listing (a SHOULD) is a declared
 //!   v1 gap — the hint rail would fire on every ordinary
 //!   `${{ tasks.x.output }}` workflow.
-//! - **Law 5 (`declassify:`)** — a task-level entry raises its `from:`
-//!   binding to trusted HERE (the static twin never re-gates it); the
+//! - **Law 5 (`lift: [{law: taint, …}]`)** — a task-level entry raises
+//!   its `from:` binding to trusted HERE (the static twin never re-gates
+//!   it); the
 //!   value is still matched like a literal everywhere else (never a
 //!   permit bypass) and the run receipt records the event.
 //! - **F-P5 ([`PermitTaintKind::NetWildcard`] · `NIKA-AUTH-010`)** — a
@@ -484,7 +485,11 @@ fn regate_finding(
             paths.join(" , "),
         ),
         fix: Some(format!(
-            "{repair} · or declare declassify: on the task (the only door)"
+            "{repair} · or open the door on the task: \
+             `lift: [{{law: taint, from: {binding}, because: …}}]`",
+            binding = paths
+                .first()
+                .map_or("<the untrusted binding>", String::as_str),
         )),
     }
 }
@@ -524,7 +529,7 @@ fn resolve_untrusted(
         };
         let binding = format!("{root}.{name}");
         if declassified.contains(&binding.as_str()) {
-            return None; // the declassify: door — trusted HERE (law 5)
+            return None; // the `lift:` taint door — trusted HERE (law 5)
         }
         let default = string_default(wf, root, name)?;
         resolved.push_str(&template[cursor..island.start]);
@@ -855,6 +860,49 @@ tasks:
         );
     }
 
+    /// The remedy a finding teaches must PARSE. NIKA-AUTH-008's fix line
+    /// named `declassify:` long after that key merged into `lift:`
+    /// (2026-08-11) — so the message that exists to teach the repair
+    /// taught a spelling the same binary refuses at NIKA-PARSE-005, while
+    /// the parse error three feet away named `lift:` correctly.
+    ///
+    /// This does not compare strings: it takes the door the fix names,
+    /// writes a workflow that uses it, and requires strict-mode parse. A
+    /// future rename breaks the test at the rename, not at the next
+    /// person who follows the advice.
+    #[test]
+    fn the_regate_fix_teaches_a_door_that_parses() {
+        let y = r#"nika: t
+permits:
+  fs: { read: ["datasets/**"] }
+  tools: ["nika:read"]
+inputs:
+  p: { type: string, required: false, default: "../../etc/passwd" }
+tasks:
+  load:
+    invoke:
+      tool: nika:read
+      args: { path: "${{ inputs.p }}" }
+"#;
+        let taints = taints_of(y);
+        let fix = taints[0].fix.clone().expect("law 2 carries a repair");
+        assert!(
+            fix.contains("lift:") && !fix.contains("declassify"),
+            "the fix must name the door this binary accepts: {fix}"
+        );
+        // It also names the binding at fault, not a placeholder.
+        assert!(fix.contains("inputs.p"), "{fix}");
+        // And the door it names is one the parser admits.
+        let repaired = format!(
+            "{y}    lift:\n      - law: taint\n        from: inputs.p\n        \
+             because: \"the operator vouched for it\"\n"
+        );
+        assert!(
+            parse(&repaired, FileId::new(0), ParseMode::Strict).is_ok(),
+            "the taught remedy must parse in strict mode"
+        );
+    }
+
     #[test]
     fn fixture_008_untrusted_exec_reentry_flag_is_refused() {
         let y = r#"nika: t
@@ -983,7 +1031,7 @@ tasks:
     }
 
     #[test]
-    fn fixture_011_declassify_declared_opens_the_door() {
+    fn fixture_011_a_declared_lift_opens_the_door() {
         let y = r#"nika: t
 permits:
   fs: { read: ["datasets/**", "vendor/**"] }

--- a/crates/nika-check/src/plan.rs
+++ b/crates/nika-check/src/plan.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The versioned, effect-free run-plan projection.
+
+use nika_schema::raw::RawWorkflow;
+
+use crate::CheckReport;
+
+/// Project the checked workflow into the machine-readable dry-run contract.
+#[must_use]
+pub fn payload(file: &str, wf: &RawWorkflow, report: &CheckReport) -> serde_json::Value {
+    let ids: Vec<&str> = wf.tasks.iter().map(|t| t.value.id.value.as_str()).collect();
+    let waves: Vec<Vec<&str>> = report
+        .waves
+        .iter()
+        .map(|wave| {
+            wave.iter()
+                .filter_map(|&index| ids.get(index).copied())
+                .collect()
+        })
+        .collect();
+    let tasks: Vec<serde_json::Value> = wf
+        .tasks
+        .iter()
+        .map(|task| {
+            serde_json::json!({
+                "id": task.value.id.value,
+                "verb": task.value.action.verb(),
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "plan_version": 1,
+        "workflow": wf.workflow.as_ref().map(|name| name.value.as_str()),
+        "file": file,
+        "dry_run": true,
+        "effects_executed": false,
+        "waves": waves,
+        "tasks": tasks,
+        "cost": report.cost,
+        "permits": report.permits,
+        "requirements": report.requirements,
+    })
+}

--- a/crates/nika-cli/src/verbs/check/models_rung.rs
+++ b/crates/nika-cli/src/verbs/check/models_rung.rs
@@ -137,7 +137,7 @@ fn rejection_rows(rejected: &[AccessRejection]) -> Vec<serde_json::Value> {
 /// provider set, [`nika_providers::CANONICAL_IDS`]) — never the vendor
 /// catalog, which advertises providers this binary cannot drive (the
 /// azure class: cataloged, unresolvable, green until the run died).
-pub(super) fn unresolvable_models(
+pub(crate) fn unresolvable_models(
     report: &nika_check::CheckReport,
     wf: &nika_schema::raw::RawWorkflow,
 ) -> ModelsAudit {

--- a/crates/nika-cli/src/verbs/inspect.rs
+++ b/crates/nika-cli/src/verbs/inspect.rs
@@ -54,10 +54,19 @@ const ASCII_GLYPHS: Glyphs = Glyphs {
 /// verb identity rides the tokens-SSOT glyph chips, chrome stays dim.
 #[must_use]
 pub fn run(path: &str, theme: Theme) -> VerbOutput {
-    let (wf, report) = match load_checked(path) {
-        Ok(pair) => pair,
-        Err(out) => return out,
-    };
+    match load_checked(path) {
+        Ok((wf, report)) => render_pair(&wf, &report, theme),
+        Err(out) => out,
+    }
+}
+
+/// Render a checked pair without re-reading the file. This keeps the human
+/// dry-run card on the same model-overridden pair as its JSON twin (#1051).
+pub(crate) fn render_pair(
+    wf: &nika_schema::raw::RawWorkflow,
+    report: &nika_check::CheckReport,
+    theme: Theme,
+) -> VerbOutput {
     if !report.conformance.is_empty() {
         let mut text = String::from("cannot inspect: no valid DAG order while conformance fails\n");
         for c in &report.conformance {
@@ -65,7 +74,7 @@ pub fn run(path: &str, theme: Theme) -> VerbOutput {
         }
         return VerbOutput::file(text);
     }
-    let doc = project(&wf, &report);
+    let doc = project(wf, report);
 
     let ceiling = if report.cost.tasks.is_empty() {
         // One voice with the COST rung (`check/render.rs`), narrowed for
@@ -97,7 +106,7 @@ pub fn run(path: &str, theme: Theme) -> VerbOutput {
     // The NEP-0018 §4 aggregate — energy beside cost, same honesty
     // markers, computed by the SAME classification the check ladder's
     // ENERGY rung renders (one classifier · two surfaces).
-    let energy = crate::verbs::check::energy::inspect_fragment(&report, theme.ascii)
+    let energy = crate::verbs::check::energy::inspect_fragment(report, theme.ascii)
         .map(|f| format!(" · {f}"))
         .unwrap_or_default();
 

--- a/crates/nika-cli/src/verbs/run/dry_run.rs
+++ b/crates/nika-cli/src/verbs/run/dry_run.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The `--dry-run` lane: model swap, refusal, then one honest preview.
+
+use nika_check::CheckReport;
+use nika_schema::raw::RawWorkflow;
+
+use super::{RunVerdict, exit};
+use crate::Theme;
+
+/// Apply `--model` and re-check the envelope the preview will describe.
+pub(super) fn swap(
+    wf: &RawWorkflow,
+    model: &str,
+) -> Result<(RawWorkflow, CheckReport), Box<CheckReport>> {
+    let swapped = crate::verbs::with_model_override(wf, model);
+    let mut report = nika_check::check(&swapped);
+    crate::verbs::stamp_judged_semantic(&swapped, &mut report);
+    let models = crate::verbs::check::models_rung::unresolvable_models(&report, &swapped);
+    if report.is_clean() && models.findings.is_empty() {
+        Ok((swapped, report))
+    } else {
+        Err(Box::new(report))
+    }
+}
+
+/// Preview the overridden pair, or emit the same refusal as `nika check`.
+#[allow(clippy::fn_params_excessive_bools)]
+pub(super) fn lane(
+    file: &str,
+    wf: &RawWorkflow,
+    report: &CheckReport,
+    model_override: Option<&str>,
+    json: bool,
+    theme: Theme,
+    output_json: bool,
+) -> RunVerdict {
+    if let Some(model) = model_override {
+        if let Ok((wf, report)) = swap(wf, model) {
+            return RunVerdict::bare(verdict(file, &wf, &report, json, theme));
+        }
+        let out = crate::verbs::check::run(file, json, false, Some(model), theme);
+        super::epilogue::emit_diagnostic(&out.text, output_json);
+        return RunVerdict::bare(out.code);
+    }
+    RunVerdict::bare(verdict(file, wf, report, json, theme))
+}
+
+fn verdict(file: &str, wf: &RawWorkflow, report: &CheckReport, json: bool, theme: Theme) -> u8 {
+    if json {
+        println!("{:#}", nika_check::plan::payload(file, wf, report));
+    } else {
+        let plan = crate::verbs::inspect::render_pair(wf, report, theme);
+        if !plan.text.is_empty() {
+            println!("{}", plan.text.trim_end());
+        }
+        println!("\n  dry-run · plan only · no effects executed");
+    }
+    exit::OK
+}

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -49,6 +49,7 @@ use sink::{TraceNote, TraceSurface, surface_trace};
 
 mod budget;
 mod ceiling;
+mod dry_run;
 mod epilogue;
 mod provenance;
 pub use provenance::run_with_repair_target;
@@ -317,7 +318,7 @@ fn run_verdict(
         Err(code) => return RunVerdict::bare(code),
     };
     if dry_run {
-        return RunVerdict::bare(dry_run_verdict(file, &wf, &report, json, theme));
+        return dry_run::lane(file, &wf, &report, model_override, json, theme, output_json);
     }
     if let Err(code) = budget::preflight(&wf, &report, model_override, max_cost_usd, output_json) {
         return RunVerdict::bare(code);
@@ -613,85 +614,6 @@ fn output_mode(output: Option<&str>) -> Result<bool, u8> {
             Err(exit::ENV)
         }
     }
-}
-
-/// `--dry-run` (spec §10 · "plan only · zero effects"): the audit passed —
-/// render the static plan (the same anatomy `nika inspect` renders) without
-/// composing any production seam. No fs, no http, no subprocess, no
-/// provider call — the run is never reached.
-fn render_dry_run(file: &str, theme: Theme) -> u8 {
-    let plan = crate::verbs::inspect::run(file, theme);
-    if !plan.text.is_empty() {
-        println!("{}", plan.text.trim_end());
-    }
-    println!("\n  dry-run · plan only · no effects executed");
-    exit::OK
-}
-
-/// The dry-run fork: the human preview, or the #332 machine plan.
-fn dry_run_verdict(
-    file: &str,
-    wf: &RawWorkflow,
-    report: &nika_check::CheckReport,
-    json: bool,
-    theme: Theme,
-) -> u8 {
-    if json {
-        dry_run_json(file, wf, report)
-    } else {
-        render_dry_run(file, theme)
-    }
-}
-
-/// `--dry-run --json` (#332): ONE versioned plan object on stdout — what
-/// the run WOULD do, projected from the SAME report the audit already
-/// computed (waves resolved to task ids · per-task verb/model · the cost
-/// ceiling · the affirmative permits · the caller requirements). CI and
-/// PR renderers read this instead of composing `check --json` +
-/// `explain --json` and reconstructing the plan client-side.
-/// `plan_version` follows the check-report discipline: additive keys
-/// never bump it.
-fn dry_run_json(file: &str, wf: &RawWorkflow, report: &nika_check::CheckReport) -> u8 {
-    println!("{:#}", dry_run_payload(file, wf, report));
-    exit::OK
-}
-
-/// The pure projection behind [`dry_run_json`] (unit-pinned): waves
-/// resolved from indices to task ids, one `{id, verb}` row per task,
-/// and the report's own cost/permits/requirements objects verbatim.
-fn dry_run_payload(
-    file: &str,
-    wf: &RawWorkflow,
-    report: &nika_check::CheckReport,
-) -> serde_json::Value {
-    let ids: Vec<&str> = wf.tasks.iter().map(|t| t.value.id.value.as_str()).collect();
-    let waves: Vec<Vec<&str>> = report
-        .waves
-        .iter()
-        .map(|w| w.iter().filter_map(|&i| ids.get(i).copied()).collect())
-        .collect();
-    let tasks: Vec<serde_json::Value> = wf
-        .tasks
-        .iter()
-        .map(|t| {
-            serde_json::json!({
-                "id": t.value.id.value,
-                "verb": t.value.action.verb(),
-            })
-        })
-        .collect();
-    serde_json::json!({
-        "plan_version": 1,
-        "workflow": wf.workflow.as_ref().map(|w| w.value.as_str()),
-        "file": file,
-        "dry_run": true,
-        "effects_executed": false,
-        "waves": waves,
-        "tasks": tasks,
-        "cost": report.cost,
-        "permits": report.permits,
-        "requirements": report.requirements,
-    })
 }
 
 /// Compose the production runtime for one run — extracted so `run` stays

--- a/crates/nika-cli/src/verbs/run/tests.rs
+++ b/crates/nika-cli/src/verbs/run/tests.rs
@@ -9,8 +9,9 @@
 
 use std::collections::BTreeMap;
 
+use super::dry_run::swap as dry_run_swap;
 use super::sink::TraceSurface;
-use super::{RenderMode, capture_mock_outputs, dry_run_payload, exit, run, surfaced_trace};
+use super::{RenderMode, capture_mock_outputs, exit, run, surfaced_trace};
 use crate::Theme;
 use serde_json::json;
 
@@ -70,7 +71,7 @@ fn dry_run_payload_projects_the_versioned_plan() {
     )
     .expect("fixture parses");
     let report = nika_check::check(&wf);
-    let p = dry_run_payload("demo.nika.yaml", &wf, &report);
+    let p = nika_check::plan::payload("demo.nika.yaml", &wf, &report);
     assert_eq!(p["plan_version"], 1);
     assert_eq!(p["workflow"], "demo");
     assert_eq!(p["waves"], json!([["a"], ["b"]]));
@@ -559,4 +560,61 @@ fn require_signature_refuses_unsigned_before_execution() {
         false, // unsigned-tolerant default
     );
     assert_eq!(planned, exit::OK, "the workflow itself is runnable");
+}
+
+/// A `.nika.yaml` naming a local seat, so the swap is VISIBLE: whatever
+/// the plan prints, it cannot have come from both models.
+#[cfg(test)]
+fn ollama_fixture() -> (nika_schema::raw::RawWorkflow, nika_check::CheckReport) {
+    let yaml = "nika: hello-ai\nmodel: ollama/llama3.2:3b\npermits: {}\ntasks:\n  greet:\n    infer: { prompt: \"Say hello.\", max_tokens: 64 }\n";
+    let wf = nika_schema::parse(
+        yaml,
+        nika_schema::source::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("fixture parses");
+    let report = nika_check::check(&wf);
+    (wf, report)
+}
+
+/// #1051 · the preview prices and NAMES the model the run would use.
+///
+/// Before the fix this asserted `ollama/llama3.2:3b` — the plan card and
+/// the `plan_version: 1` object both carried the file's model while the
+/// run would have used the flag's. Reproduced against the published
+/// 0.111.0 on `nika new snippets/hello-ai`, unedited.
+#[test]
+fn dry_run_plan_names_the_overridden_model() {
+    let (wf, _) = ollama_fixture();
+    let (wf, report) = dry_run_swap(&wf, "mock/echo").expect("mock/echo resolves in this binary");
+    let p = nika_check::plan::payload("hello-ai.nika.yaml", &wf, &report);
+    let model = p["cost"]["tasks"][0]["model"]
+        .as_str()
+        .expect("the plan prices one task");
+    assert_eq!(
+        model, "mock/echo",
+        "the preview must price the model the RUN will use, not the file's"
+    );
+}
+
+/// #1051, second half · the preview REFUSES a model this binary cannot
+/// resolve, where before it printed a green plan at exit 0 — the only one
+/// of `check` / `run` / `run --dry-run` that could not see the flag.
+#[test]
+fn dry_run_refuses_a_model_that_does_not_resolve() {
+    let (wf, _) = ollama_fixture();
+    let refused = dry_run_swap(&wf, "nonexistent/model");
+    assert!(
+        refused.is_err(),
+        "a swap to an unresolvable provider must not render a plan"
+    );
+}
+
+/// The unflagged preview keeps the file's own seat — the swap is a
+/// transform the lane applies only when asked, never a normalisation.
+#[test]
+fn dry_run_without_the_flag_keeps_the_files_model() {
+    let (wf, report) = ollama_fixture();
+    let p = nika_check::plan::payload("hello-ai.nika.yaml", &wf, &report);
+    assert_eq!(p["cost"]["tasks"][0]["model"], "ollama/llama3.2:3b");
 }

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4586
+  classified_files: 4587
   file_rows: 11
   pattern_rows: 23
   by_class:
-    authored: 1622
+    authored: 1623
     authored-pin: 2
     generated: 122
     pinned-copy: 135
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 811
-  aggregate_sha256: 75b483af2193ad1acbd06cf40839b55a9bbff3a8f9f390a0a52a3248903de6ab
+  match_count: 812
+  aggregate_sha256: d5ae0196b9b5deb276ce33eef05ff022cf48fe90bf9eade688be2ccd450c7b4c
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored

--- a/estate.yaml
+++ b/estate.yaml
@@ -18,11 +18,11 @@ classes:
   testimonial: "captured evidence — fixtures, corpora, traces, receipts: proves behavior; neither shipped source nor regenerable output"
   foreign: "pointer to a third-party sovereign source"
 summary:
-  classified_files: 4587
+  classified_files: 4588
   file_rows: 11
   pattern_rows: 23
   by_class:
-    authored: 1623
+    authored: 1624
     authored-pin: 2
     generated: 122
     pinned-copy: 135
@@ -151,8 +151,8 @@ patterns:
     - "cargo-public-api 0.51.0"
 - glob: "crates/**/src/**"
   class: authored
-  match_count: 812
-  aggregate_sha256: d5ae0196b9b5deb276ce33eef05ff022cf48fe90bf9eade688be2ccd450c7b4c
+  match_count: 813
+  aggregate_sha256: 9e0c8fd58cbdf5e0a3698275b68970629349b9ad25bdb6457cfb6a278f6962d8
   evidence: "the code — SPDX AGPL-3.0-or-later headers · 12-gate admission (ADR-003) · zero-unwrap discipline; spot-checked file heads carry no generation marker (grep hits for 'generated' are prose mentions, not markers)"
 - glob: "crates/**/tests/**"
   class: authored


### PR DESCRIPTION
Replaces #1083 with its two functional commits replayed on current `main`; the unsigned merge commit and stale estate are intentionally excluded.

- `run --dry-run --model` now checks, prices, and renders the effective model on both the human card and `plan_version: 1` JSON.
- The plan projection lives in `nika-check`, the SSOT for the static report, keeping `nika-cli` below its 15k production-LOC wall.
- NIKA-AUTH-008 now teaches the accepted `lift:` door and names the tainted binding.

Proof: `cargo test -p nika-cli --lib` (340/340), `cargo test -p nika-check --lib` (536/536), all 10 pre-push ratchets, estate and clippy green.

Closes #1051
Closes #1073