### PR TITLE
fix(check): lock the plan projection API

### DIFF
--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -58,6 +58,8 @@ pub fn nika_check::permits_fit::CapabilityEscape::__clone_box(&self, _: dyn_clon
 impl<T> nika_error::traits::AsAny for nika_check::permits_fit::CapabilityEscape where T: 'static
 pub fn nika_check::permits_fit::CapabilityEscape::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub fn nika_check::permits_fit::scan_escapes(wf: &nika_schema::raw::workflow::RawWorkflow) -> alloc::vec::Vec<nika_check::permits_fit::CapabilityEscape>
+pub mod nika_check::plan
+pub fn nika_check::plan::payload(file: &str, wf: &nika_schema::raw::workflow::RawWorkflow, report: &nika_check::CheckReport) -> serde_json::value::Value
 pub mod nika_check::trifecta
 pub fn nika_check::trifecta::scan_trifecta(wf: &nika_schema::raw::workflow::RawWorkflow, edges: &[nika_check_analyzer::edges::Edge], topo_waves: &[alloc::vec::Vec<usize>]) -> nika_cap::trifecta::TrifectaVerdict
 #[non_exhaustive] pub enum nika_check::DataClassification

--- a/estate.yaml
+++ b/estate.yaml
@@ -140,7 +140,7 @@ patterns:
 - glob: "crates/*/public-api.txt"
   class: generated
   match_count: 66
-  aggregate_sha256: 27f548ba816f782040a4cd3ed32e89e1bb9f57997fce851a982e01f6aa2e6481
+  aggregate_sha256: d0ab514d88d281daeb5d53ace3440a596bf75fcd637caee87d4797f777812761
   evidence: ".github/workflows/public-api.yml 'diff each covered lib crate' byte-compares each snapshot against cargo public-api output; macOS renders differently, so snapshots regenerate FROM THE UBUNTU ARTIFACT (workflow comment)"
   derivation:
     tool: "cargo public-api -p <crate> --omit auto-trait-impls > crates/<crate>/public-api.txt (DEFAULT features · the CI job shape — all-features drags platform deps into the render · cargo-public-api 0.51.0 pinned · the public-api-actual CI artifact stays the judge)"


### PR DESCRIPTION
Follow-up to #1099. Auto-merge completed just before its final snapshot push, so `main` contains the additive `nika_check::plan` surface but not its generated public-API lock.

This regenerates `crates/nika-check/public-api.txt` with the prescribed `cargo public-api` command and resynchronizes `estate.yaml`. No runtime source changes.

Proof: all 10 ratchets and the full pre-push library gate pass.