### PR TITLE
fix(check): parse-family findings wear the parse gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **A `NIKA-PARSE-*` finding is a PARSE row, including when the analyzer
+  emitted it.** Missing `nika:` / `tasks:` no longer wear the CONFORM
+  ladder on `nika check`, `--json` `findings[]`, wasm, or MCP — the spec
+  family is the gate the agent explains from.
+
 - **`--fix` cannot rewrite a digest-pinned registry cache, a symlink into
   that cache, stdin, or a device/FIFO.** The footer teaches a copy into the
   workspace; a project path that merely looks like `.nika/registry` stays a

--- a/crates/nika-check-wasm/src/lib.rs
+++ b/crates/nika-check-wasm/src/lib.rs
@@ -35,6 +35,14 @@
 use nika_schema::{FileId, ParseMode, SchemaError, parse};
 use wasm_bindgen::prelude::*;
 
+fn kind_and_gate(e: &SchemaError) -> (&'static str, &'static str) {
+    if e.spec_code().to_string().starts_with("NIKA-PARSE-") {
+        ("parse", "PARSE")
+    } else {
+        ("conformance", "CONFORM")
+    }
+}
+
 /// One finding, in the report's own row shape (`findings[]` of
 /// `nika check --json`): kind · gate · severity · message · code ·
 /// `docs_url` · span. The row is assembled from the error's OWN
@@ -152,14 +160,20 @@ pub fn engine_version() -> String {
 pub fn check(source: &str) -> String {
     let wf = match parse(source, FileId::new(0), ParseMode::Strict) {
         Ok(wf) => wf,
-        Err(e) => return verdict(false, &[finding_row("parse", "PARSE", source, &e)]),
+        Err(e) => {
+            let (kind, gate) = kind_and_gate(&e);
+            return verdict(false, &[finding_row(kind, gate, source, &e)]);
+        }
     };
     match nika_check::analyze(&wf) {
         Ok(_) => verdict(true, &[]),
         Err(errors) => {
             let rows: Vec<serde_json::Value> = errors
                 .iter()
-                .map(|e| finding_row("conformance", "CONFORM", source, e))
+                .map(|e| {
+                    let (kind, gate) = kind_and_gate(e);
+                    finding_row(kind, gate, source, e)
+                })
                 .collect();
             verdict(false, &rows)
         }
@@ -311,6 +325,15 @@ mod tests {
             message.contains("→ nika explain") && message.contains(code),
             "PARSE message must project SchemaDiagnostic, not SchemaError Display: {message}"
         );
+    }
+
+    #[test]
+    fn an_analyzer_parse_code_wears_the_parse_gate() {
+        let v: serde_json::Value = serde_json::from_str(&check("nika: w\n")).unwrap();
+        let row = &v["findings"][0];
+        assert_eq!(row["gate"], "PARSE");
+        assert_eq!(row["kind"], "parse");
+        assert_eq!(row["code"], "NIKA-PARSE-002");
     }
 
     #[test]

--- a/crates/nika-check-wasm/tests/differential.rs
+++ b/crates/nika-check-wasm/tests/differential.rs
@@ -103,7 +103,7 @@ fn leg_a_the_wasm_assembly_never_diverges_from_the_library() {
 
     for input in &inputs {
         let yaml = std::fs::read_to_string(input).expect("fixture readable");
-        let (parse_fatal, lib) = library_errors(&yaml);
+        let (_parse_fatal, lib) = library_errors(&yaml);
         let v: serde_json::Value =
             serde_json::from_str(&check(&yaml)).expect("check() emits valid JSON");
         let rows = v["findings"].as_array().expect("findings[]");
@@ -126,7 +126,11 @@ fn leg_a_the_wasm_assembly_never_diverges_from_the_library() {
                 library_row_message(err),
                 "message diverges at {at}"
             );
-            let expected_gate = if parse_fatal { "PARSE" } else { "CONFORM" };
+            let expected_gate = if err.spec_code().to_string().starts_with("NIKA-PARSE-") {
+                "PARSE"
+            } else {
+                "CONFORM"
+            };
             assert_eq!(row["gate"], expected_gate, "gate diverges at {at}");
             // the fields NO gate watched (Gate-11 correctness #2): a mutant
             // flipping severity, swapping the parse/conformance literals, or
@@ -135,7 +139,11 @@ fn leg_a_the_wasm_assembly_never_diverges_from_the_library() {
             assert_eq!(row["severity"], "error", "severity diverges at {at}");
             assert_eq!(
                 row["kind"],
-                if parse_fatal { "parse" } else { "conformance" },
+                if err.spec_code().to_string().starts_with("NIKA-PARSE-") {
+                    "parse"
+                } else {
+                    "conformance"
+                },
                 "kind diverges at {at}"
             );
             assert_eq!(

--- a/crates/nika-check/src/findings.rs
+++ b/crates/nika-check/src/findings.rs
@@ -182,6 +182,18 @@ fn conform_row_message(c: &super::ConformanceViolation) -> String {
     format!("{} · → nika explain {}", c.message, c.code)
 }
 
+/// The spec family is the ladder keyword. Envelope refusals are
+/// `NIKA-PARSE-*` even when the analyzer (not `parse()`) emits them —
+/// a `CONFORM` row for a parse code is a second well the agent cannot
+/// explain from.
+fn kind_and_gate(code: &str) -> (&'static str, &'static str) {
+    if code.starts_with("NIKA-PARSE-") {
+        ("parse", "PARSE")
+    } else {
+        ("conformance", "CONFORM")
+    }
+}
+
 /// Fold every class into the one list — conformance first (the ladder's
 /// own order), then the analysis classes in render order.
 pub(super) fn collect(report: &CheckReport) -> Vec<UnifiedFinding> {
@@ -190,7 +202,9 @@ pub(super) fn collect(report: &CheckReport) -> Vec<UnifiedFinding> {
         // Same well as `SchemaDiagnostic` Display minus `[CODE] ` — wasm
         // `check()` and CLI `--json` PARSE already project this; the
         // human CONFORM row keeps `c.message` and its own `fix:` line.
-        let mut f = UnifiedFinding::new("conformance", "CONFORM", conform_row_message(c));
+        // Gate follows the spec family (`NIKA-PARSE-*` → PARSE).
+        let (kind, gate) = kind_and_gate(&c.code);
+        let mut f = UnifiedFinding::new(kind, gate, conform_row_message(c));
         f.code = Some(c.code.clone());
         f.docs_url = Some(c.docs_url.clone());
         f.span = c.span;
@@ -492,6 +506,12 @@ mod tests {
     #[test]
     fn each_dirty_class_lands_in_findings_with_its_gate() {
         let cases: Vec<(&str, &str, &str)> = vec![
+            (
+                // parse family, analyzer-emitted: `nika:` without `tasks:`
+                "nika: w\n",
+                "parse",
+                "PARSE",
+            ),
             (
                 // conformance: unresolved reference
                 "nika: w\ntasks:\n  a:\n    infer: { prompt: \"${{ tasks.ghost.output }}\", max_tokens: 9 }\n",

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -54,11 +54,18 @@ pub fn mark(theme: Theme, ok: bool) -> String {
 /// when the finding carries a span (rustc-grade caret · the CONFORM row
 /// above stays grep-stable).
 fn conformance_row(out: &mut String, c: &ConformanceViolation, source: &str, path: &str, t: Theme) {
+    // Spec family owns the ladder keyword: `NIKA-PARSE-*` is PARSE even
+    // when the analyzer (not `parse()`) emitted the row.
+    let gate = if c.code.starts_with("NIKA-PARSE-") {
+        "PARSE"
+    } else {
+        "CONFORM"
+    };
     let _ = writeln!(
         out,
         " {} {}  [{}] {}",
         mark(t, false),
-        t.paint(Role::Strong, "CONFORM"),
+        t.paint(Role::Strong, gate),
         c.code,
         c.message
     );

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -1032,6 +1032,12 @@ mod tests {
             2,
             "empty source refuses both envelope fields: {payload:#}"
         );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f["gate"] == "PARSE" && f["kind"] == "parse"),
+            "PARSE codes must not wear the CONFORM ladder: {payload:#}"
+        );
         assert_eq!(
             payload["next_actions"].as_array().map(Vec::len),
             Some(1),


### PR DESCRIPTION
## Why

Envelope refusals are `NIKA-PARSE-*` even when the analyzer (not `parse()`) emits them. The JSON `findings[]` fold and the human ladder still printed `CONFORM`. An agent looking at the gate explained the wrong well.

## What

The spec family is the ladder keyword: `NIKA-PARSE-*` → PARSE on `nika check`, `--json` findings, wasm, and MCP. Other conformance codes stay CONFORM.

## Proof

- `nika-check` findings fold + dirty-class fixture `nika: w` without `tasks:`
- wasm unit + differential expected gate follows the code, not which function returned it
- MCP empty-source rows assert `gate: PARSE`

No tag. Follow-up to #1095 couture.