### PR TITLE
fix(check): parse-fatal wasm rows stay PARSE regardless of code

### DIFF
--- a/crates/nika-check-wasm/src/lib.rs
+++ b/crates/nika-check-wasm/src/lib.rs
@@ -160,10 +160,9 @@ pub fn engine_version() -> String {
 pub fn check(source: &str) -> String {
     let wf = match parse(source, FileId::new(0), ParseMode::Strict) {
         Ok(wf) => wf,
-        Err(e) => {
-            let (kind, gate) = kind_and_gate(&e);
-            return verdict(false, &[finding_row(kind, gate, source, &e)]);
-        }
+        // CLI `parse_fatal_json` always stamps PARSE, even when the
+        // spec code is not `NIKA-PARSE-*` (DAG-005 unknown predicate).
+        Err(e) => return verdict(false, &[finding_row("parse", "PARSE", source, &e)]),
     };
     match nika_check::analyze(&wf) {
         Ok(_) => verdict(true, &[]),

--- a/crates/nika-check-wasm/tests/differential.rs
+++ b/crates/nika-check-wasm/tests/differential.rs
@@ -103,7 +103,7 @@ fn leg_a_the_wasm_assembly_never_diverges_from_the_library() {
 
     for input in &inputs {
         let yaml = std::fs::read_to_string(input).expect("fixture readable");
-        let (_parse_fatal, lib) = library_errors(&yaml);
+        let (parse_fatal, lib) = library_errors(&yaml);
         let v: serde_json::Value =
             serde_json::from_str(&check(&yaml)).expect("check() emits valid JSON");
         let rows = v["findings"].as_array().expect("findings[]");
@@ -126,11 +126,14 @@ fn leg_a_the_wasm_assembly_never_diverges_from_the_library() {
                 library_row_message(err),
                 "message diverges at {at}"
             );
-            let expected_gate = if err.spec_code().to_string().starts_with("NIKA-PARSE-") {
-                "PARSE"
-            } else {
-                "CONFORM"
-            };
+            // parse() fatal → PARSE (CLI parse_fatal_json). Analyzer
+            // errors → PARSE only when the spec family is NIKA-PARSE-*.
+            let expected_gate =
+                if parse_fatal || err.spec_code().to_string().starts_with("NIKA-PARSE-") {
+                    "PARSE"
+                } else {
+                    "CONFORM"
+                };
             assert_eq!(row["gate"], expected_gate, "gate diverges at {at}");
             // the fields NO gate watched (Gate-11 correctness #2): a mutant
             // flipping severity, swapping the parse/conformance literals, or
@@ -139,7 +142,7 @@ fn leg_a_the_wasm_assembly_never_diverges_from_the_library() {
             assert_eq!(row["severity"], "error", "severity diverges at {at}");
             assert_eq!(
                 row["kind"],
-                if err.spec_code().to_string().starts_with("NIKA-PARSE-") {
+                if parse_fatal || err.spec_code().to_string().starts_with("NIKA-PARSE-") {
                     "parse"
                 } else {
                     "conformance"


### PR DESCRIPTION
## Why

#1101 made analyzer `NIKA-PARSE-*` rows wear PARSE. Wasm also applied that rule to `parse()` fatals. CLI `parse_fatal_json` always stamps PARSE, even for `NIKA-DAG-005` (unknown `after` predicate). Differential leg B went red on `016-after-unknown-predicate`.

## What

`parse()` Err → PARSE, matching the CLI. Analyzer errors still use the spec family (`NIKA-PARSE-*` → PARSE, else CONFORM).

## Proof

`NIKA_DIFF_CLI=1 cargo test -p nika-check-wasm --test differential` A+B green locally against the spec pin corpus (including `016`).

Follow-up to #1101. No tag.