### PR TITLE
fix(check): a PARSE refusal names the line the parser already held

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`nika check` names the line of a PARSE refusal.** A CONFORM finding
+  already carried a rustc-grade frame (`path:line:col` + caret). A PARSE
+  finding — `NIKA-PARSE-017` duplicate key, `NIKA-PARSE-005` unknown
+  field, any span the parser held — printed the code and left the author
+  to find the site. Duplicate keys are the worst of that class: the
+  message says `"a" appears twice`, so grepping `a:` returns both, and
+  neither is wrong on its own. The colliding key's span was in the
+  loader's hand and discarded (`span: None`). It now rides the same
+  frame CONFORM uses, under the same `PARSE ✗` first line.
 - **`nika arm` no longer refuses a project that sets its retention or its
   provenance floor.** Two readers parse `nika.yaml` — the project reader
   (`ceiling` · `traces.keep` · `registry.floor` · `arm`) and the cadence

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -478,13 +478,17 @@ fn naming_note(text: &mut String, theme: Theme, path: &str, wf: &nika_schema::ra
 /// `--json` parse-fatal verdict: one findings row, `parse_fatal: true`.
 fn parse_fatal_json(out: &VerbOutput) -> VerbOutput {
     let text = out.text.trim();
-    // The plain voice is `PARSE ✗  [NIKA-…] message` — recover the code;
-    // an env-class refusal (unreadable file) has no code and stays codeless.
-    let code = text
+    // The plain voice is `PARSE ✗  [NIKA-…] message` on the FIRST line;
+    // a span-carrying refusal (#1075) appends a rustc-grade frame under
+    // it. Scrape the diagnostic line only — the frame is human, not
+    // the finding's message.
+    // An env-class refusal (unreadable file) has no code and stays codeless.
+    let line = text.lines().next().unwrap_or(text);
+    let code = line
         .split_once('[')
         .and_then(|(_, rest)| rest.split_once(']'))
         .map(|(code, _)| code.to_owned());
-    let message = text.split_once("] ").map_or(text, |(_, m)| m).to_owned();
+    let message = line.split_once("] ").map_or(line, |(_, m)| m).to_owned();
     let mut finding = serde_json::json!({
         "kind": "parse",
         "gate": "PARSE",

--- a/crates/nika-cli/src/verbs/mod.rs
+++ b/crates/nika-cli/src/verbs/mod.rs
@@ -82,7 +82,7 @@ pub(crate) fn load_checked_run_source(
     source: &RunSource,
 ) -> Result<(RawWorkflow, CheckReport), VerbOutput> {
     let wf = nika_schema::parse(source.source(), FileId::new(0), ParseMode::Strict)
-        .map_err(|error| schema_refusal(&error))?;
+        .map_err(|error| schema_refusal(&error, source))?;
     // The composed lane (spec 14): child targets resolve against the
     // file the operator named; the fs edge is the skills reader's twin.
     let mut report = nika_check::check_composed(&wf, source.logical_path(), &mut |p| {
@@ -94,8 +94,26 @@ pub(crate) fn load_checked_run_source(
 
 /// The single CLI sink for every schema-facing refusal, whether acquisition
 /// rejected the encoding or the parser rejected the decoded workflow.
-fn schema_refusal(error: &SchemaError) -> VerbOutput {
-    VerbOutput::file(format!("PARSE ✗  {}", error.diagnostic()))
+///
+/// When the error carries a span, the same rustc-grade frame CONFORM
+/// findings already print rides under the PARSE line — the parser had
+/// the site; dropping it made PARSE look vaguer than CONFORM (#1075).
+fn schema_refusal(error: &SchemaError, source: &RunSource) -> VerbOutput {
+    let mut text = format!("PARSE ✗  {}", error.diagnostic());
+    if let Some(span) = error.span() {
+        let frame = crate::display::snippet::paint_span(
+            source.source(),
+            source.logical_path(),
+            nika_check::ByteSpan::new(span.start.0, span.end.0),
+            crate::display::theme::Theme::new(false, true, false),
+        );
+        let frame = frame.trim_end();
+        if !frame.is_empty() {
+            text.push('\n');
+            text.push_str(frame);
+        }
+    }
+    VerbOutput::file(text)
 }
 
 /// Stamp the judged-vs-booted binding (F-P2): the report records the
@@ -340,9 +358,76 @@ mod tests {
             .expect_err("a task with two verbs must fail to parse");
         std::fs::remove_file(&path).ok();
         assert_eq!(err.code, exit::FILE, "{}", err.text);
+        let first = err.text.lines().next().expect("a diagnostic line");
         assert_eq!(
-            err.text,
+            first,
             "PARSE ✗  [NIKA-PARSE-009] task `a` has multiple verbs (infer, exec) — exactly one required · → nika explain NIKA-PARSE-009"
+        );
+        let stem = path.file_name().expect("name").to_string_lossy();
+        assert!(
+            err.text.contains(&format!("{stem}:")),
+            "a span-carrying PARSE names the task site:\n{}",
+            err.text
+        );
+    }
+
+    /// #1075 · a PARSE finding that the parser located must name the
+    /// site. Duplicate keys are the worst of the class: the message
+    /// says `"a" appears twice`, so grepping `a:` returns both, and
+    /// neither is wrong on its own. The colliding key is the one the
+    /// author can delete.
+    #[test]
+    fn parse_fatal_duplicate_key_names_the_colliding_site() {
+        let path = std::env::temp_dir().join(format!("nika-dup-{}.nika.yaml", std::process::id(),));
+        std::fs::write(
+            &path,
+            "nika: dup\ntasks:\n  a:\n    exec: { command: [true] }\n  a:\n    exec: { command: [true] }\n",
+        )
+        .expect("fixture written");
+        let display = path.to_str().expect("utf-8 tmp path");
+        let err = load_checked(display).expect_err("duplicate task key must fail to parse");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(err.code, exit::FILE, "{}", err.text);
+        assert!(
+            err.text.starts_with(
+                "PARSE ✗  [NIKA-PARSE-017] duplicate key: \"a\" appears twice in the same mapping"
+            ),
+            "the diagnostic line stays grep-stable:\n{}",
+            err.text
+        );
+        let stem = path.file_name().expect("name").to_string_lossy();
+        assert!(
+            err.text.contains(&format!("{stem}:")),
+            "the colliding site is named as path:line:\n{}",
+            err.text
+        );
+    }
+
+    /// #1075 · PARSE-005 already carries a span on the error. The
+    /// parse-fatal sink used to drop it, so the most common newcomer
+    /// typo (`temperture`) named the field and not the line.
+    #[test]
+    fn parse_fatal_unknown_field_names_the_key() {
+        let path = std::env::temp_dir().join(format!("nika-unk-{}.nika.yaml", std::process::id(),));
+        std::fs::write(
+            &path,
+            "nika: x\ntasks:\n  t:\n    infer:\n      prompt: hi\n      temperture: 0.1\n",
+        )
+        .expect("fixture written");
+        let display = path.to_str().expect("utf-8 tmp path");
+        let err = load_checked(display).expect_err("unknown field must fail to parse");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(err.code, exit::FILE, "{}", err.text);
+        assert!(
+            err.text.contains("[NIKA-PARSE-005]"),
+            "coded:\n{}",
+            err.text
+        );
+        let stem = path.file_name().expect("name").to_string_lossy();
+        assert!(
+            err.text.contains(&format!("{stem}:")),
+            "the unknown key is named as path:line:\n{}",
+            err.text
         );
     }
 

--- a/crates/nika-schema/src/parser/mod.rs
+++ b/crates/nika-schema/src/parser/mod.rs
@@ -93,6 +93,14 @@ pub fn parse(yaml: &str, file_id: FileId, mode: ParseMode) -> Result<RawWorkflow
     // indentation level, so BOTH bounds must precede it.
     check_source_bounds(yaml)?;
 
+    // Char-to-byte translation table: marked-yaml reports character
+    // (code-point) indices, but `ByteOffset` — and every miette
+    // `SourceSpan` downstream — wants byte offsets. Built BEFORE the
+    // loader so a DuplicateKey (which the loader reports with both
+    // keys' spans) can keep the colliding site instead of discarding
+    // it (#1075). Precompute once per parse so each span lookup is O(1).
+    let char_to_byte = CharToByte::new(yaml)?;
+
     // YAML 1.2 forbids duplicate mapping keys from silently last-winning
     // — `error_on_duplicate_keys` turns them into loud errors (covers
     // vars/env/secrets/outputs/with/output duplicate-key detection).
@@ -108,7 +116,10 @@ pub fn parse(yaml: &str, file_id: FileId, mode: ParseMode) -> Result<RawWorkflow
                     "\"{}\" appears twice in the same mapping",
                     inner.key.as_str()
                 ),
-                span: None,
+                // The colliding key (not the first, which was legal
+                // until this one arrived) — grepping the name returns
+                // both sites; the span names the one to delete.
+                span: yaml_span_to_span(file_id, inner.key.span(), &char_to_byte),
             },
             // Pre-parse cause lint (the copy-fidelity class · #323): a weak
             // copier de-comments the editor modeline and YAML reads the bare
@@ -132,12 +143,6 @@ pub fn parse(yaml: &str, file_id: FileId, mode: ParseMode) -> Result<RawWorkflow
                 },
             },
         })?;
-
-    // Char-to-byte translation table: marked-yaml reports character
-    // (code-point) indices, but `ByteOffset` — and every miette
-    // `SourceSpan` downstream — wants byte offsets. Precompute once
-    // per parse so each span lookup is O(1).
-    let char_to_byte = CharToByte::new(yaml)?;
 
     let mapping = node.as_mapping().ok_or_else(|| SchemaError::Validation {
         message: "workflow root must be a YAML mapping".to_owned(),
@@ -996,8 +1001,22 @@ tasks:
     #[test]
     fn duplicate_top_level_keys_error() {
         // YAML 1.2 · duplicate keys never silently last-win.
-        let err = parse_strict("nika: first\nnika: second\n").expect_err("dup");
-        assert!(matches!(err, SchemaError::DuplicateKey { .. }), "{err:?}");
+        // The second site is the one the author can act on — the first is
+        // legal until the collision arrives. A span-less PARSE finding
+        // (#1075) left both keys looking equally wrong, and the layer
+        // that knew the answer discarded it.
+        let yaml = "nika: first\nnika: second\n";
+        let err = parse_strict(yaml).expect_err("dup");
+        let SchemaError::DuplicateKey { message, span } = err else {
+            panic!("expected DuplicateKey, got {err:?}");
+        };
+        assert!(message.contains("\"nika\" appears twice"), "{message}");
+        let span = span.expect("the colliding key carries a span");
+        let second = yaml.rfind("nika:").expect("second key");
+        assert_eq!(
+            span.start.0 as usize, second,
+            "span starts on the colliding key, not the first"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

A CONFORM finding already painted `path:line:col` + a caret. A PARSE finding printed the code and left the author to find the site. Duplicate keys are the worst of that class: the message says `"a" appears twice`, so grepping `a:` returns both, and neither is wrong on its own.

Measured on 0.111.0 from the outside-user surface (`#1075`). Two drops, one class:

1. The YAML loader handed both keys' spans. The parser stored `span: None`.
2. The parse-fatal CLI sink rendered `error.diagnostic()` (code + message) and never asked `error.span()`. `NIKA-PARSE-005` already carried a span and still printed nowhere.

## What

- DuplicateKey keeps the **colliding** key's span (the first was legal until this one arrived). `CharToByte` is built before the loader so the span can be translated.
- `schema_refusal` paints the same rustc-grade frame CONFORM uses, under the same `PARSE ✗` first line.
- `--json` still scrapes the diagnostic line only; the frame is human.

Closes #1075.