### PR TITLE
fix(check): explain the hint kind nika check just printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`nika explain` answers the token `nika check` printed in `[brackets]`,
+  including a hint.** A HINT row put `jq-as-map` (or `native-first/006`)
+  in the same slot as `NIKA-PARSE-019`, so the next gesture was
+  `nika explain jq-as-map` and the answer was `unknown code`. A finding
+  carries `code`; a hint carries `kind` — real in the data, invisible
+  in the render. Explain now resolves the printed identity (the kind,
+  or the numbered native-first rule) and teaches the class; MCP
+  `nika_explain` speaks the same text.
 - **`nika check` names the line of a PARSE refusal.** A CONFORM finding
   already carried a rustc-grade frame (`path:line:col` + caret). A PARSE
   finding — `NIKA-PARSE-017` duplicate key, `NIKA-PARSE-005` unknown

--- a/crates/nika-check/public-api.txt
+++ b/crates/nika-check/public-api.txt
@@ -2741,6 +2741,7 @@ pub fn nika_check::action_effect_fields(action: &nika_schema::raw::action::RawAc
 pub fn nika_check::check(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_check::CheckReport
 pub fn nika_check::check_composed(wf: &nika_schema::raw::workflow::RawWorkflow, root: &str, read: &mut dyn core::ops::function::FnMut(&str) -> core::result::Result<alloc::string::String, alloc::string::String>) -> nika_check::CheckReport
 pub fn nika_check::compiled(hints: &[nika_check::Hint]) -> bool
+pub fn nika_check::hint_help(token: &str) -> core::option::Option<&'static str>
 pub fn nika_check::infer_permits(wf: &nika_schema::raw::workflow::RawWorkflow) -> nika_check::InferredPermits
 pub fn nika_check::paid_blockers(hints: &[nika_check::Hint]) -> alloc::vec::Vec<&nika_check::Hint>
 pub fn nika_check::paid_ready(hints: &[nika_check::Hint]) -> bool

--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -1485,5 +1485,9 @@ fn hint(kind: &'static str, task: &str, advice: String) -> Hint {
         advice,
     }
 }
+
+mod catalog;
+pub use catalog::hint_help;
+
 #[cfg(test)]
 mod tests;

--- a/crates/nika-check/src/hints/catalog.rs
+++ b/crates/nika-check/src/hints/catalog.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! Teach a hint identity — the token `nika check` prints in `[brackets]`.
+//!
+//! A finding carries `code` (`NIKA-PARSE-019`). A hint carries `kind`
+//! (`jq-as-map`) and sometimes a numbered `code` (`native-first/006`).
+//! The renderer puts whichever it has in the same slot. `nika explain`
+//! used to resolve codes only, so the next gesture after a HINT row
+//! 404'd (#1038). This table is the other half of that slot.
+
+/// Teaching text for a hint identity `nika check` prints in `[brackets]`.
+/// `None` for a token that is not a hint — callers then try the error
+/// registries.
+#[must_use]
+pub fn hint_help(token: &str) -> Option<&'static str> {
+    ROWS.iter()
+        .find(|(identity, _)| *identity == token)
+        .map(|(_, help)| *help)
+}
+
+/// Closed set of identities the check renderer can put in the HINT
+/// slot (`hint.code.unwrap_or(hint.kind)`). Adding a kind or a numbered
+/// native-first rule without a row here is the defect this file exists
+/// to close.
+const ROWS: &[(&str, &str)] = &[
+    (
+        "cost",
+        "an `infer:`/`agent:` task with no token bound — add `max_tokens:` \
+         (or `max_tokens_total:`) and the cost report becomes a hard ceiling",
+    ),
+    (
+        "zero-cap",
+        "a declared `max_tokens: 0` / `max_tokens_total: 0` is arithmetically \
+         a $0 ceiling and a call no provider will honor — raise it or drop the field",
+    ),
+    (
+        "thinking-budget",
+        "a reasoning-capable model seated with `max_tokens` but no `thinking:` \
+         — the reasoning share lives inside that budget, and a heavy think ends \
+         in a paid blank (NIKA-INFER-004 at run). Declare `thinking:`",
+    ),
+    (
+        "dead-spend",
+        "a pure `infer:` whose output nobody reads — every token it spends is \
+         dead. Bind it, put it in `outputs:`, or delete the task",
+    ),
+    (
+        "typing",
+        "a task whose output is deeply referenced (`tasks.X.output.field`) \
+         but declares no `schema:` / `output:` — declare a shape and the \
+         dataflow typer starts proving those references",
+    ),
+    (
+        "permits",
+        "no `permits:` block, and the body is pure compute (F-O8 legal zero) \
+         — declare `permits: {}` to state the zero explicitly",
+    ),
+    (
+        "strictness",
+        "an object schema admitting undeclared keys — close it \
+         (`additionalProperties: false`) and the output shape is deterministic",
+    ),
+    (
+        "schema-portability",
+        "a schema keyword no provider grammar enforces — the check accepts it; \
+         constrained decoding at run will not. Prefer keywords the catalog's \
+         grammars actually apply",
+    ),
+    (
+        "redundant-gate",
+        "`after: {x: terminal}` beside a value edge to `x` changes nothing \
+         (edges compose by intersection). Tighten to `success` or drop the entry",
+    ),
+    (
+        "retry-effects",
+        "`retry:` on a task whose effects are not contracted as idempotent — \
+         a second attempt can double a write or a send. Drop retry, or make \
+         the effect safe to repeat",
+    ),
+    (
+        "secrets-store",
+        "a referenced `secrets.X` whose source is not yet runtime-resolvable \
+         — check is green, run fails NIKA-1702. Use `source: env` or \
+         `source: file` until vault resolution ships",
+    ),
+    (
+        "native-first",
+        "an `exec:` whose literal command a stdlib builtin (or an MCP tool) \
+         covers. The numbered rules `native-first/001..006` name the family \
+         (http · file · data · media · helper · utility). Advisory unless \
+         `nika check --native-strict`",
+    ),
+    (
+        "native-first/001",
+        "`exec:` of `curl`/`wget`/`xh`/`http(s)` (or an interpreter one-liner \
+         around `fetch(`/`axios`) — use `nika:fetch` (`multipart:` · \
+         `traverse:`). `nika check --native-strict` promotes this to a finding",
+    ),
+    (
+        "native-first/002",
+        "`exec:` of `cat`/`tee`/`cp`/`mv`/`mkdir`/`touch`/`head`/`tail`/`ls` \
+         — use `nika:read` / `nika:write` (`create_dirs: true`) / `nika:glob`. \
+         `nika check --native-strict` promotes this to a finding",
+    ),
+    (
+        "native-first/003",
+        "`exec:` of `jq`/`sed`/`awk` — use `nika:jq` (or an `extract:` binding) \
+         for JSON, `nika:edit` for in-place literal file edits. \
+         `nika check --native-strict` promotes this to a finding",
+    ),
+    (
+        "native-first/004",
+        "`exec:` of an image/speech provider endpoint — use \
+         `nika:image_generate` / `nika:tts_generate`. \
+         `nika check --native-strict` promotes this to a finding",
+    ),
+    (
+        "native-first/005",
+        "`exec:` of an interpreter (`node` · `python` · `sh` · …) running a \
+         script file — inventory the helper (HTTP→fetch · files→read/write · \
+         JSON→jq · a product API→MCP) and keep only a genuine subprocess. \
+         `nika check --native-strict` promotes this to a finding",
+    ),
+    (
+        "native-first/006",
+        "a utility with an exact builtin: `sleep`→`nika:wait` (`duration:`) · \
+         `date`→`nika:date` (`op:`) · `uuidgen`→`nika:uuid` · \
+         `sha256sum`→`nika:hash` (`algo:`) · `yq`→`nika:convert` · \
+         `grep`/`rg`/`ag`→`nika:grep` · `find`→`nika:glob`. Names the builtin \
+         AND its argument shape. `nika check --native-strict` promotes this \
+         to a finding",
+    ),
+    (
+        "exec-json-capture",
+        "`capture: structured` plus a binding that parses `.stdout | fromjson` \
+         and no binding reads `exit_code`/`stderr` — for a JSON-producing \
+         helper use `capture: stdout` so a non-zero exit fails as NIKA-EXEC-001 \
+         instead of becoming data",
+    ),
+    (
+        "swallowed-exit",
+        "`capture: structured` makes a non-zero exit DATA, not a failure, and \
+         nothing reads `exit_code` — a failing command here reports success. \
+         Read `exit_code` or switch capture",
+    ),
+    (
+        "unwrapped-ref",
+        "an `outputs:` value that spells a reference path without `${{ }}` \
+         rides as the literal string (the run returns the path text, not the \
+         value). Wrap it",
+    ),
+    (
+        "envelope-output",
+        "an `outputs:` binding referencing a bare `tasks.X` captures the whole \
+         envelope (status · timestamps · output), so goldens drift. Bind \
+         `tasks.X.output` for the value",
+    ),
+    (
+        "run-clock",
+        "a task `timeout:` whose time source the envelope never names — the \
+         deadline rides the ambient system clock. Declare `run: { clock: … }` \
+         to pin the choice (F-P3)",
+    ),
+    (
+        "analysis",
+        "past the analysis task cap the width/pinch/blast read and the pair \
+         scan of the write-write law are skipped (the O(n²) DoS floor) — the \
+         skip is stated, never silent",
+    ),
+    (
+        "consent",
+        "an egress-capable descendant of a confirm-mode `nika:prompt` sits \
+         behind a gate the checker cannot prove consumes the answer. The \
+         proven non-affirmative route is NIKA-SEC-014; this hint is the \
+         undecidable remainder. Teach `with: go` + `when:`",
+    ),
+    (
+        "headless-prompt",
+        "`nika:prompt` declares no `default:` — unattended (CI, an agent) \
+         there is no answer. Declare the `default:` the unattended path \
+         should take, or keep the gate attended-only",
+    ),
+    (
+        "fail-open-consent",
+        "`nika:prompt` carries `default: true` and the file has an effect — \
+         unattended, the engine answers `true` and the effect fires with no \
+         human (spec 06). `default: false` refuses; omitting `default:` parks",
+    ),
+    (
+        "digit-string-enum",
+        "a string enum of digits only — models emit JSON numbers (`3` not \
+         `\"3\"`); constrained decoding can reject the call before Nika \
+         stringifies. Prefer `type: integer` with a numeric enum. \
+         A paid-run hint: `is_clean` stays green, `paid_ready` does not",
+    ),
+    (
+        "glob-readme",
+        "`nika:glob` of a markdown pattern includes a README in the same \
+         directory — the next infer classifies the table of contents as a \
+         record. `exclude: \"**/README.md\"`. A paid-run hint: `is_clean` \
+         stays green, `paid_ready` does not",
+    ),
+    (
+        "jq-as-map",
+        "`nika:jq` binds `. as $name` then calls `map(` on the current value \
+         — after a later construct that value is often a pair, not the bound \
+         array. Write `($name | map(...))`. A paid-run hint: `is_clean` stays \
+         green, `paid_ready` does not",
+    ),
+    (
+        "infer-as-law",
+        "an `infer:` asks the model to name a belt/level/score — that is the \
+         law, not a fact. Extract integer facts, then `nika:jq` or \
+         `nika:decide`. A paid-run hint: `is_clean` stays green, `paid_ready` \
+         does not",
+    ),
+    (
+        "unproven-law",
+        "`nika:jq` / `nika:decide` scores an infer extract and no \
+         const-fixture `nika:assert` proves the law on known answers. \
+         `is_clean` does not compile the law. A paid-run hint: `paid_ready` \
+         is false until an assert pins it",
+    ),
+    (
+        "assert-quarantine",
+        "a red `nika:assert` quarantines writes to \
+         `.nika/quarantine/<trace>/` — authors hunt an empty `out/` otherwise",
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_printed_jq_as_map_slot_has_a_teaching() {
+        // #1038 · the measured case: check prints `[jq-as-map]`, explain 404'd.
+        let help = hint_help("jq-as-map").expect("jq-as-map is a printed identity");
+        assert!(help.contains("($name | map"), "{help}");
+        assert!(help.contains("paid_ready"), "{help}");
+    }
+
+    #[test]
+    fn a_numbered_native_first_rule_has_a_teaching() {
+        let help = hint_help("native-first/006").expect("006 is a printed identity");
+        assert!(help.contains("nika:wait"), "{help}");
+        assert!(help.contains("duration:"), "{help}");
+    }
+
+    #[test]
+    fn every_catalogued_identity_explains_and_unknown_stays_none() {
+        assert!(hint_help("ghost-hint").is_none());
+        assert!(hint_help("NIKA-PARSE-019").is_none());
+        for (identity, help) in ROWS {
+            assert_eq!(hint_help(identity), Some(*help), "{identity}");
+            assert!(!help.is_empty(), "{identity} must teach something");
+        }
+        let identities: Vec<&str> = ROWS.iter().map(|(id, _)| *id).collect();
+        assert!(identities.contains(&"jq-as-map"));
+        assert!(identities.contains(&"native-first/001"));
+        assert!(identities.contains(&"native-first/006"));
+        let mut sorted = identities.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), identities.len(), "duplicate hint identities");
+    }
+}

--- a/crates/nika-check/src/lib.rs
+++ b/crates/nika-check/src/lib.rs
@@ -173,7 +173,9 @@ pub use energy::{EnergyCounts, EnergyReading, EnergyTask};
 pub use exec_floor::ExecFloorFinding;
 pub use findings::UnifiedFinding;
 pub use flow::{FlowFacts, TaintTrace, action_effect_fields};
-pub use hints::{Hint, PAID_RUN_KINDS, compiled, paid_blockers, paid_ready, stamp_paid_ready};
+pub use hints::{
+    Hint, PAID_RUN_KINDS, compiled, hint_help, paid_blockers, paid_ready, stamp_paid_ready,
+};
 pub use lift::LiftFinding;
 pub use order::OrderFinding;
 pub use permit_taint::{PermitTaint, PermitTaintKind};

--- a/crates/nika-cli/src/main.rs
+++ b/crates/nika-cli/src/main.rs
@@ -162,13 +162,15 @@ enum Command {
         #[arg(long, value_enum)]
         format: Option<verbs::graph::GraphFormatArg>,
     },
-    /// Teach one error code (cause · category · fix-form) — or narrate a
-    /// workflow FILE: what it does · the waves · cost before a token is
-    /// spent · what it touches · how to run it.
+    /// Teach one error code (cause · category · fix-form), a hint kind
+    /// `nika check` printed in `[brackets]`, or narrate a workflow FILE:
+    /// what it does · the waves · cost before a token is spent · what
+    /// it touches · how to run it.
     #[command(display_order = 41)]
     Explain {
-        /// An error code (`NIKA-440` · bare `440` · `DAG-003`) or a
-        /// workflow file path (`*.nika.yaml` · `-` reads stdin).
+        /// An error code (`NIKA-440` · bare `440` · `DAG-003`), a hint
+        /// identity (`jq-as-map` · `native-first/006`), or a workflow
+        /// file path (`*.nika.yaml` · `-` reads stdin).
         code: String,
         /// File form only: emit the versioned machine projection
         /// (`explain_version: 1` · the check report's own vocabulary).

--- a/crates/nika-cli/src/verbs/explain.rs
+++ b/crates/nika-cli/src/verbs/explain.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! `nika explain NIKA-XXXX` — teach one error code (spec §2).
+//! `nika explain NIKA-XXXX` — teach one error code (spec §2), or the
+//! hint identity `nika check` printed in the same `[brackets]` slot.
 //!
 //! Two registries, ONE voice: the numeric crate registry
 //! (`nika-error::codes` · `NIKA-440`) AND the spec's conformance codes
 //! (`NIKA-DAG-002` · the canon's `error_codes` table) — every code the
 //! checker can emit gets an answer here. Retired codes (`NIKA-DAG-003` ·
 //! `NIKA-PARSE-016`) teach their retirement and point at the successor.
-//! Never invents: a code in no registry is a finding (`exit 2`), not a
-//! guess.
+//! Hint kinds (`jq-as-map` · `native-first/006`) are the other occupant
+//! of that slot (#1038) — `nika-check::hint_help` is the teaching, same
+//! text the MCP tool returns. Never invents: a token in no registry is
+//! a finding (`exit 2`), not a guess.
 
 use nika_error::codes::{code_help, lookup};
 
@@ -30,6 +33,12 @@ pub fn run(wire: &str, theme: Theme) -> VerbOutput {
     // The seam (`Theme::link` → `format::osc8`): text unchanged, escapes
     // only when the links capability resolved on.
     let docs = theme.link(DOCS_ERRORS_URL, DOCS_ERRORS_TEXT);
+    // A HINT row prints `kind` (or a numbered `code`) in the same
+    // bracketed slot as `NIKA-PARSE-019`. Resolve that token before
+    // wrapping `NIKA-` — `jq-as-map` is not `NIKA-jq-as-map` (#1038).
+    if let Some(help) = nika_check::hint_help(wire) {
+        return VerbOutput::ok(format!("{wire} · hint\n\n  {help}\n"));
+    }
     let normalized = if wire.starts_with("NIKA-") {
         wire.to_owned()
     } else {
@@ -59,7 +68,8 @@ pub fn run(wire: &str, theme: Theme) -> VerbOutput {
             "unknown code `{wire}` — the registry knows NIKA-001..NIKA-9999 \
              (allocated ranges), the spec conformance codes \
              (NIKA-DAG-* · NIKA-VAR-* · …), per-builtin NIKA-BUILTIN-<NAME>-NNN \
-             and per-provider NIKA-PROVIDER-NNN codes; see {docs}"
+             and per-provider NIKA-PROVIDER-NNN codes, and the hint kinds \
+             `nika check` prints in [brackets]; see {docs}"
         ));
     };
     // The category/severity labels are the OWNING crate's canonical
@@ -559,6 +569,34 @@ mod tests {
         let out = run("NIKA-ZZZ-999");
         assert_eq!(out.code, exit::FILE);
         assert!(out.text.contains("unknown code"));
+        assert!(
+            out.text.contains("[brackets]"),
+            "the 404 names the other occupant of the slot:\n{}",
+            out.text
+        );
+    }
+
+    #[test]
+    fn a_printed_hint_kind_teaches_instead_of_404() {
+        // #1038 · check prints `[jq-as-map]` in the code slot; explain
+        // used to wrap it as `NIKA-jq-as-map` and refuse.
+        let out = run("jq-as-map");
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(out.text.starts_with("jq-as-map · hint"), "{}", out.text);
+        assert!(out.text.contains("($name | map"), "{}", out.text);
+        assert!(out.text.contains("paid_ready"), "{}", out.text);
+    }
+
+    #[test]
+    fn a_numbered_native_first_rule_teaches() {
+        let out = run("native-first/006");
+        assert_eq!(out.code, exit::OK, "{}", out.text);
+        assert!(
+            out.text.starts_with("native-first/006 · hint"),
+            "{}",
+            out.text
+        );
+        assert!(out.text.contains("nika:wait"), "{}", out.text);
     }
 
     #[test]

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -68,7 +68,7 @@ fn display_title(name: &str) -> &'static str {
     match name {
         "nika_check" => "Audit a workflow",
         "nika_inspect" => "Project the workflow graph",
-        "nika_explain" => "Explain an error code",
+        "nika_explain" => "Explain an error code or hint",
         "nika_schema" => "The workflow JSON Schema",
         "nika_examples" => "Browse runnable examples",
         "nika_template" => "Fetch a template skeleton",
@@ -132,13 +132,13 @@ fn validate_tools() -> Value {
         },
         {
             "name": "nika_explain",
-            "description": "Teach one Nika error code — cause, category, and the fix form.",
+            "description": "Teach one Nika error code or hint identity — cause, category, and the fix form.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "code": {
                         "type": "string",
-                        "description": "A code like `NIKA-VAR-001` or the bare `440`."
+                        "description": "A code like `NIKA-VAR-001`, the bare `440`, or a hint kind `nika check` printed in [brackets] (`jq-as-map` · `native-first/006`)."
                     }
                 },
                 "required": ["code"]
@@ -686,12 +686,19 @@ fn tools_payload() -> Result<String, String> {
         .map_err(|e| format!("tools projection failed: {e}"))
 }
 
-/// `nika_explain` — teach one error code (numeric registry or spec code).
+/// `nika_explain` — teach one error code (numeric registry or spec
+/// code) or a hint identity `nika check` printed in `[brackets]`.
 fn explain(args: &Value) -> Result<String, String> {
     let code = args
         .get("code")
         .and_then(Value::as_str)
         .ok_or("missing `code` (e.g. `NIKA-VAR-001`)")?;
+    // Same slot as the CLI (#1038): a HINT row prints `jq-as-map` /
+    // `native-first/006` where a finding prints `NIKA-PARSE-019`.
+    // Resolve before wrapping `NIKA-`.
+    if let Some(help) = nika_check::hint_help(code) {
+        return Ok(format!("{code} · hint\n\n  {help}"));
+    }
     let normalized = if code.starts_with("NIKA-") {
         code.to_owned()
     } else {
@@ -730,7 +737,8 @@ fn explain(args: &Value) -> Result<String, String> {
     Err(format!(
         "unknown code `{code}` — the registry knows NIKA-001..9999, the spec \
          codes (NIKA-VAR-* · NIKA-DAG-* · …), per-builtin \
-         NIKA-BUILTIN-<NAME>-NNN and per-provider NIKA-PROVIDER-NNN codes; \
+         NIKA-BUILTIN-<NAME>-NNN and per-provider NIKA-PROVIDER-NNN codes, \
+         and the hint kinds `nika check` prints in [brackets]; \
          see docs.nika.sh/errors"
     ))
 }
@@ -1164,6 +1172,16 @@ mod tests {
     #[test]
     fn explain_an_unknown_code_is_a_tool_error() {
         assert!(execute("nika_explain", &json!({ "code": "NIKA-GHOST-999" })).is_err());
+    }
+
+    #[test]
+    fn explain_a_printed_hint_kind_teaches_like_the_cli() {
+        let out = execute("nika_explain", &json!({ "code": "jq-as-map" })).expect("hint kind");
+        assert!(out.contains("jq-as-map · hint"), "{out}");
+        assert!(out.contains("($name | map"), "{out}");
+        let numbered =
+            execute("nika_explain", &json!({ "code": "native-first/006" })).expect("006");
+        assert!(numbered.contains("nika:wait"), "{numbered}");
     }
 
     /// One voice with the CLI (gauntlet 2026-07-12): a failed run's


### PR DESCRIPTION
## Why

`nika check` prints a hint in the same `[brackets]` slot as an error code:

```
 ↳ HINT     [jq-as-map] `nika:jq` on `audit` binds `. as $name` then calls ...
```

The next gesture is `nika explain jq-as-map`. Until now that was `unknown code`. A finding carries `code`; a hint carries `kind`. Real in the data, invisible in the render (#1038).

## What

`nika-check::hint_help` is a closed table of every identity the renderer can print (`kind`, or a numbered `native-first/001..006` rule). CLI `nika explain` and MCP `nika_explain` resolve it **before** wrapping `NIKA-`. Unknown still refuses; the 404 now names the other occupant of the slot.

The secondary `jq-as-map` heuristic widening (map piped from a field access on `.`) is **not** in this PR — the issue called it not urgent on its own.

Closes #1038.