### PR TITLE
fix(check): a non-array constant fails for_each at check, not at dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`for_each` over a constant that is not an array is refused at check, not
+  at dispatch.** `const: { items: "x" }` with `for_each: ${{ const.items }}`
+  audited clean, then died at the run with `NIKA-VAR-006` — a linter's answer,
+  not a verifier's, and exactly the gap ADR-092 exists to close. The static
+  lane already caught a *typed* non-array var but exempted every untyped one,
+  on the rationale that « a `--var` override could pass an array ». That rule
+  is inputs-only: `--var` sets an `inputs:` value and refuses unknown keys, and
+  spec 01 §const is normative — a constant is « immutable across the run and
+  never caller-supplied ». An untyped constant's literal IS its run value, so
+  a non-array can never become one. Untyped entries are legal in `const:`
+  alone, arrays and typed declarations are untouched, and all 59 shipped
+  templates and examples still audit clean.
 - **`nika explain` answers the token `nika check` printed in `[brackets]`,
   including a hint.** A HINT row put `jq-as-map` (or `native-first/006`)
   in the same slot as `NIKA-PARSE-019`, so the next gesture was

--- a/crates/nika-check/src/schema_lint.rs
+++ b/crates/nika-check/src/schema_lint.rs
@@ -326,7 +326,7 @@ fn finding(task: &str, path: &str, detail: String) -> SchemaLintFinding {
 }
 
 /// A short JSON kind name for diagnostics.
-fn kind(v: &Value) -> &'static str {
+pub(crate) fn kind(v: &Value) -> &'static str {
     match v {
         Value::Null => "null",
         Value::Bool(_) => "a boolean",

--- a/crates/nika-check/src/schema_typing.rs
+++ b/crates/nika-check/src/schema_typing.rs
@@ -160,8 +160,34 @@ fn scan_for_each_sources(wf: &RawWorkflow, findings: &mut Vec<SchemaTypeFinding>
             "inputs" => &wf.inputs,
             _ => &wf.consts,
         };
-        let declared = block.iter().find(|(n, _)| n.value == name);
-        let Some((_, VarDecl::Typed { r#type, .. })) = declared else {
+        let Some((_, decl)) = block.iter().find(|(n, _)| n.value == name) else {
+            continue;
+        };
+        // An UNTYPED entry is legal in `const:` alone (the parser refuses
+        // one for `inputs:`), and spec 01 §const is normative: a constant
+        // is « immutable across the run and never caller-supplied ». The
+        // `--var` override that spares an untyped input therefore cannot
+        // reach it — the literal IS the run value, so a non-array can
+        // never become an array. Without this arm the run refuses what
+        // the check just cleared (NIKA-VAR-006 at dispatch), which is the
+        // linter-not-verifier gap ADR-092 exists to close.
+        if let VarDecl::Untyped(literal) = decl
+            && authority == "const"
+            && !literal.is_array()
+        {
+            findings.push(SchemaTypeFinding {
+                site: task.value.id.value.clone(),
+                reference: format!("for_each: {{ items: \"${{{{ {authority}.{name} }}}}\" }}"),
+                target: format!("{authority}.{name}"),
+                detail: format!(
+                    "`const.{name}` is {} — `for_each` needs an array (a constant is \
+                     never caller-supplied · the run rejects it · NIKA-VAR-006)",
+                    crate::schema_lint::kind(literal)
+                ),
+            });
+            continue;
+        }
+        let VarDecl::Typed { r#type, .. } = decl else {
             continue;
         };
         let Ok(declared_type) = parse_type(&r#type.value, &type_names, &name) else {
@@ -547,6 +573,34 @@ mod tests {
     }
 
     #[test]
+    fn for_each_over_an_untyped_non_array_const_is_caught_before_run() {
+        // A constant is baked into the file: spec 01 §const is normative —
+        // « immutable across the run and never caller-supplied ». The
+        // `--var` override that spares an UNTYPED entry reaches `inputs:`
+        // only (and an untyped entry is legal in `const:` alone), so an
+        // untyped constant's literal IS its run value. A non-array can
+        // therefore never become one: the run refuses it (NIKA-VAR-006)
+        // and the check must say so first, or `nika check` is a linter.
+        for literal in [
+            "\"not-an-array\"",
+            "3",
+            "true",
+            // Missing `type:` → a bare literal OBJECT constant, per the
+            // spec 01 discriminator (BOTH keys make a typed constant).
+            "{ value: [\"x\"] }",
+        ] {
+            let f = findings_of(&for_each_wf("const", literal));
+            assert_eq!(f.len(), 1, "literal {literal} flagged: {f:?}");
+            assert!(f[0].detail.contains("for_each"), "{:?}", f[0]);
+        }
+        // An array literal is exactly what `for_each` wants.
+        assert!(
+            findings_of(&for_each_wf("const", "[\"x\", \"y\"]")).is_empty(),
+            "an array constant is the legal case"
+        );
+    }
+
+    #[test]
     fn for_each_over_a_typed_non_array_var_is_caught_before_run() {
         // The runtime refuses a non-array for_each collection (NIKA-VAR-006);
         // a var DECLARED type:string can NEVER be an array, so the check
@@ -585,9 +639,19 @@ mod tests {
 
     #[test]
     fn for_each_over_a_valid_or_unknown_source_is_never_flagged() {
-        // Zero false positives: a typed ARRAY var, an UNTYPED var (a --var
-        // override could pass an array), an inline list, and a `tasks.*`
-        // source are all left alone.
+        // Zero false positives: a typed ARRAY var, an untyped literal that
+        // IS an array, an inline list, and a `tasks.*` source are all left
+        // alone.
+        //
+        // The « an UNTYPED var (a --var override could pass an array) »
+        // exemption that once covered `const: xs: "hello"` here was an
+        // inputs-only rule generalised one authority too far: `--var` sets
+        // an `inputs:` value and refuses unknown keys, and spec 01 §const
+        // is normative — a constant is « immutable across the run and
+        // never caller-supplied ». The run proved it, refusing at dispatch
+        // (NIKA-VAR-006) a workflow this check had just cleared. That case
+        // is now asserted flagged in
+        // `for_each_over_an_untyped_non_array_const_is_caught_before_run`.
         assert!(
             findings_of(&for_each_wf(
                 "inputs",
@@ -596,7 +660,6 @@ mod tests {
             .is_empty()
         );
         assert!(findings_of(&for_each_wf("const", "[\"a\", \"b\"]")).is_empty()); // untyped literal array
-        assert!(findings_of(&for_each_wf("const", "\"hello\"")).is_empty()); // untyped literal string
         // An inline list literal source never resolves to a bare authority ref.
         let inline = "nika: w\nmodel: mock/echo\ntasks:\n  fan:\n    \
                       for_each: { items: [1, 2, 3] }\n    with: { it: \"${{ item }}\" }\n    \

--- a/crates/nika-runtime/tests/properties.rs
+++ b/crates/nika-runtime/tests/properties.rs
@@ -18,7 +18,10 @@
 //! Every task is `infer` over the mock/echo provider (echo = pure
 //! function of the prompt · no mock queues ⇒ no dequeue-order coupling
 //! under concurrency) · runtime failures are injected via `for_each`
-//! over a scalar var (statically clean · NIKA-VAR-006 at run time).
+//! over a task output that is a scalar (statically clean · NIKA-VAR-006 at
+//! run time). The collection rides `scalar_src`, not a `const:`: a constant
+//! is never caller-supplied, so its literal IS its run value and the check
+//! now refuses a non-array one outright.
 
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -43,7 +46,7 @@ enum Kind {
     /// Explicit `when:` over publish=no — always skipped (the gate
     /// REPLACES the default · evaluated even over dead deps).
     Gated,
-    /// `for_each` over a scalar var — statically clean · fails at run
+    /// `for_each` over a scalar TASK OUTPUT — statically clean · fails at run
     /// time (`NIKA-VAR-006` · `FailedBeforeStart` · cascades).
     Fails,
     /// `agent:` over the echo provider (one text turn · no tools) —
@@ -85,7 +88,8 @@ fn dag_strategy() -> impl Strategy<Value = Vec<TaskSpec>> {
 fn yaml_of(specs: &[TaskSpec]) -> String {
     use std::fmt::Write as _;
     let mut y = String::from(
-        "nika: prop\nmodel: mock/echo\nconst:\n  publish: \"no\"\n  scalar: \"not a list\"\ntasks:\n",
+        "nika: prop\nmodel: mock/echo\nconst:\n  publish: \"no\"\ntasks:\n  \
+         scalar_src:\n    infer: { prompt: \"not a list\" }\n",
     );
     for (i, spec) in specs.iter().enumerate() {
         let _ = writeln!(y, "  t{i}:");
@@ -109,7 +113,11 @@ fn yaml_of(specs: &[TaskSpec]) -> String {
                 let _ = writeln!(y, "    infer: {{ prompt: \"gated {i}\" }}");
             }
             Kind::Fails => {
-                let _ = writeln!(y, "    for_each: {{ items: \"${{{{ const.scalar }}}}\" }}");
+                let _ = writeln!(
+                    y,
+                    "    with: {{ src: \"${{{{ tasks.scalar_src.output }}}}\" }}"
+                );
+                let _ = writeln!(y, "    for_each: {{ items: \"${{{{ with.src }}}}\" }}");
                 let _ = writeln!(y, "    infer: {{ prompt: \"iter ${{{{ item }}}}\" }}");
             }
             Kind::Normal => {
@@ -210,7 +218,13 @@ proptest! {
     #[test]
     fn random_dags_uphold_the_determinism_theorems(specs in dag_strategy()) {
         let yaml = yaml_of(&specs);
-        let n = specs.len();
+        // The generated ids are `t0..t{specs.len()}`; the workflow also
+        // carries `scalar_src`, the fixed preamble task whose scalar
+        // output a `Fails` lane fans over. It is a real task with a real
+        // record, so WHOLE-WORKFLOW counts include it while the per-id
+        // sweeps below stay over the generated ids alone.
+        let generated = specs.len();
+        let n = generated + 1;
         // Identical queued turns ⇒ dequeue order is inconsequential ·
         // a generous count covers the live agents (dead ones never draw).
         let agents = specs.iter().filter(|s| matches!(s.kind, Kind::Agent)).count();
@@ -235,7 +249,7 @@ proptest! {
             matches!(last, EventKind::WorkflowCompleted | EventKind::WorkflowFailed),
             "stream ends on the terminal frame"
         );
-        for i in 0..n {
+        for i in 0..generated {
             let id = format!("t{i}");
             let terminals = events_a
                 .iter()

--- a/crates/nika-runtime/tests/spec_v2.rs
+++ b/crates/nika-runtime/tests/spec_v2.rs
@@ -956,6 +956,16 @@ tasks:
 
 /// An empty collection skips the task (spec 03) · a non-array
 /// collection fails it loudly (`NIKA-VAR-006` class).
+///
+/// The bad lane sources from a TASK OUTPUT, not a `const:`. Defence in
+/// depth is the point: the runtime owns this refusal on its own, and the
+/// fixture must stay clean for `run_to_events` to reach the run at all.
+/// A `const:` scalar no longer survives the ladder — the check refuses it
+/// statically now (a constant is never caller-supplied, so its literal IS
+/// its run value), and that static arm is covered in
+/// `nika-check`'s `for_each_over_an_untyped_non_array_const_is_caught_before_run`.
+/// A `tasks.*` source is left alone there by construction, so it is the
+/// honest way to hand the runtime a non-array at dispatch.
 #[tokio::test]
 async fn for_each_empty_skips_and_non_array_fails() {
     let yaml = r#"
@@ -963,18 +973,20 @@ nika: fan-edges
 permits: { exec: true }
 const:
   none: []
-  scalar: "not a list"
 tasks:
+  emit_scalar:
+    exec: { command: ["echo", "not a list"] }
   empty_lane:
     for_each: { items: "${{ const.none }}" }
     exec: { command: ["never", "${{ item }}"] }
   bad_lane:
-    for_each: { items: "${{ const.scalar }}" }
+    with: { items: "${{ tasks.emit_scalar.output }}" }
+    for_each: { items: "${{ with.items }}" }
     exec: { command: ["never", "${{ item }}"] }
 "#;
     let (outcome, events) = run_to_events(
         yaml,
-        MockShell::new(),
+        MockShell::new().enqueue_ok("not a list"),
         MockToolExecutor::new(),
         MockProvider::new("mock"),
         RuntimeConfig::default(),
@@ -1109,19 +1121,24 @@ tasks:
         .code
         .clone();
 
-    // Shape 2 · the expression-type class (non-array for_each).
+    // Shape 2 · the expression-type class (non-array for_each). The
+    // collection rides a TASK OUTPUT: a `const:` scalar is now refused
+    // statically (a constant is never caller-supplied, so its literal IS
+    // its run value) and would never reach the run this shape pins.
     let var_yaml = r#"
 nika: pin-var
 permits: { exec: true }
-const: { scalar: "not a list" }
 tasks:
+  emit_scalar:
+    exec: { command: ["echo", "not a list"] }
   bad:
-    for_each: { items: "${{ const.scalar }}" }
+    with: { items: "${{ tasks.emit_scalar.output }}" }
+    for_each: { items: "${{ with.items }}" }
     exec: { command: ["never", "${{ item }}"] }
 "#;
     let (outcome2, _) = run_to_events(
         var_yaml,
-        MockShell::new(),
+        MockShell::new().enqueue_ok("not a list"),
         MockToolExecutor::new(),
         MockProvider::new("mock"),
         RuntimeConfig::default(),

--- a/docs/adr/adr-092-nika-check-program-analysis-ladder.md
+++ b/docs/adr/adr-092-nika-check-program-analysis-ladder.md
@@ -142,7 +142,8 @@ design, not a leak; the model response is not a verbatim echo).
   `additionalProperties: true` honored as opaque · typo'd fields caught with zero tokens)
 - `crates/nika-tmpl/src/expression/refs.rs` -- `walk_chains` shared chain-flattening
   core (`expr_refs` + `task_output_paths` consume one walker — no drift)
-- `crates/nika-check/src/analyzer/dag.rs:104` -- `topo_waves`, reused for the fixpoint order
+- `crates/nika-check-analyzer/src/dag.rs:235` -- `topo_waves`, reused for the fixpoint
+  order (ex `crates/nika-check/src/analyzer/dag.rs` -- the analyzer became its own crate)
 - `crates/nika-tmpl/src/expression/refs.rs` -- `expr_refs`/`NamespaceRef`, the taint extractor
 - `crates/nika-types/src/suggest.rs` -- deterministic did-you-mean core (moved out of `check/` when the analyzer adopted it)
   (Damerau-Levenshtein · rustc threshold · lexicographic tie-break — the diagnostic


### PR DESCRIPTION
## Why

`nika check` cleared this, and the run refused it:

```yaml
const:
  items: "not-an-array"
tasks:
  process:
    for_each: { items: "${{ const.items }}" }
```

```
$ nika check   → rc=0   ✔ audited · 1 task · 1 wave · 0 hints
$ nika run     → rc=1   ✖ NIKA-VAR-006 · for_each collection must be an array · got string
```

The value is a literal in the file. The checker had everything it needed and
stayed silent — a linter's answer, not a verifier's, and the exact gap
ADR-092 exists to close.

## What

The static lane (`schema_typing::scan_for_each_sources`) already caught a
**typed** non-array var, but exempted every untyped one on this rationale:

> an UNTYPED var (a `--var` override could pass an array)

That rule is **inputs-only**, and it had been generalised one authority too far:

- `--var` is documented as "Set a workflow `inputs:` value … Unknown keys refused"
- spec 01 §const is normative: a constant is "immutable across the run and
  **never caller-supplied**"
- an untyped entry is legal in `const:` alone (the parser refuses one for `inputs:`)

So an untyped constant's literal **is** its run value. Verified a const
carrying a template string is not expanded either (the run says `got string`,
and the check flags the referenced input as never referenced), so the string
case is provable too.

## Scope · zero false positives

Only an untyped `const:` whose literal is not an array. Array literals, typed
declarations, `tasks.*` sources, inline lists and transformed expressions are
untouched. The diagnostic reuses the existing kind vocabulary rather than
adding a second one.

The prior test asserted the cleared case stays silent, on that same
inputs-only rationale. The run refuting it is the arbiter, so the assertion
moved to the flagged side with the reason recorded in place.

## Proof

| check | result |
|---|---|
| `cargo test --workspace --lib` | **6254 passed, 0 failed** |
| `cargo clippy --workspace --all-targets -- -D warnings` | **0** |
| `scripts/ci/check-crate-size.sh` | **rc=0** (nika-check 14457/15000) |
| `scripts/ci/check-layering.sh` | **rc=0** |
| all 59 shipped pack templates + examples | **still audit clean** |
| the three gap cases (string · object · template-string const) | **now refused at check** |

RED before GREEN: the new test failed with `flagged: []` before the fix.

Also folds in a docs fix hygiene vector 20 was flagging: ADR-092's evidence
row cited `crates/nika-check/src/analyzer/dag.rs:104`, but the analyzer became
its own crate and the symbol now lives at
`crates/nika-check-analyzer/src/dag.rs:235`. Vector 20 goes YELLOW to GREEN
(199 evidence paths verified).

Found by running the `nika-bug-hunter` methodology against the current tree.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>