### PR TITLE
fix(check): a slash hint id teaches instead of looking like a path

### DIFF
--- a/crates/nika-cli/src/verbs/explain_file.rs
+++ b/crates/nika-cli/src/verbs/explain_file.rs
@@ -37,9 +37,12 @@ use nika_dap::store::{TraceState, fold_facts};
 
 /// Route `explain`'s positional: an existing path or a path-shaped string
 /// (`/` · `.yaml`/`.yml` · `-`) narrates the FILE; everything else teaches
-/// the CODE (`NIKA-440` · `DAG-003` · bare `440`). A file literally named
-/// like a code still routes as a file when it exists on disk — the
-/// pathological tie goes to the thing that provably exists.
+/// the CODE (`NIKA-440` · `DAG-003` · bare `440`). Hint identities that
+/// themselves contain a slash (`native-first/006` · the token `nika check`
+/// prints in `[brackets]`) are CODE, not a path — unless a file of that
+/// name actually exists on disk. A file literally named like a code still
+/// routes as a file when it exists — the pathological tie goes to the
+/// thing that provably exists.
 #[must_use]
 pub fn dispatch(
     query: &str,
@@ -50,11 +53,14 @@ pub fn dispatch(
     let yaml_ext = Path::new(query)
         .extension()
         .is_some_and(|e| e.eq_ignore_ascii_case("yaml") || e.eq_ignore_ascii_case("yml"));
-    let file_shaped = query == "-"
-        || query.contains('/')
-        || query.contains('\\')
-        || yaml_ext
-        || Path::new(query).exists();
+    let exists = Path::new(query).exists();
+    let slash = query.contains('/') || query.contains('\\');
+    // A slash used to mean FILE unconditionally, so `nika explain
+    // native-first/006` (the taught next-gesture after a HINT row) 404'd
+    // as a missing path. Known hint identities keep the code form; a
+    // file that actually exists still wins the tie.
+    let file_shaped =
+        query == "-" || yaml_ext || exists || (slash && nika_check::hint_help(query).is_none());
     if file_shaped {
         return run(query, json, forecast);
     }

--- a/crates/nika-cli/src/verbs/explain_file/tests.rs
+++ b/crates/nika-cli/src/verbs/explain_file/tests.rs
@@ -712,3 +712,61 @@ fn a_clean_latest_run_keeps_the_naked_cta_and_no_rail() {
     std::fs::remove_file(&path).ok();
     let _ = std::fs::remove_dir_all(dir);
 }
+
+fn plain_theme() -> crate::display::theme::Theme {
+    crate::display::theme::Theme::new(false, true, false)
+}
+
+/// #1106 taught `nika explain native-first/006` (the token check prints
+/// in `[brackets]`). The library `explain::run` already answers. The CLI
+/// dispatch used to treat any `/` as a file path, so the taught form
+/// 404'd as `cannot read native-first/006`. A test on `dispatch` is the
+/// one that would have caught it — `explain::run` alone is blind to the
+/// router.
+#[test]
+fn a_numbered_native_first_hint_is_not_a_file_path() {
+    let out = dispatch("native-first/006", false, false, plain_theme());
+    assert_eq!(out.code, exit::OK, "{}", out.text);
+    assert!(
+        out.text.starts_with("native-first/006 · hint"),
+        "slash-containing hint ids teach, they are not paths:\n{}",
+        out.text
+    );
+    assert!(out.text.contains("nika:wait"), "{}", out.text);
+    assert!(
+        !out.text.contains("cannot read"),
+        "must not fall through to the file form:\n{}",
+        out.text
+    );
+}
+
+#[test]
+fn every_numbered_native_first_rule_teaches_through_dispatch() {
+    for n in 1..=6 {
+        let id = format!("native-first/{n:03}");
+        let out = dispatch(&id, false, false, plain_theme());
+        assert_eq!(out.code, exit::OK, "{id} → {}", out.text);
+        assert!(
+            out.text.starts_with(&format!("{id} · hint")),
+            "{id} must teach:\n{}",
+            out.text
+        );
+    }
+}
+
+#[test]
+fn jq_as_map_still_teaches_through_dispatch() {
+    let out = dispatch("jq-as-map", false, false, plain_theme());
+    assert_eq!(out.code, exit::OK, "{}", out.text);
+    assert!(out.text.starts_with("jq-as-map · hint"), "{}", out.text);
+}
+
+#[test]
+fn an_existing_yaml_path_still_narrates_as_a_file() {
+    let path = tmp("still-a-file", DIAMOND);
+    let out = dispatch(path.to_str().expect("utf8"), false, false, plain_theme());
+    std::fs::remove_file(&path).ok();
+    assert_eq!(out.code, exit::OK, "{}", out.text);
+    assert!(out.text.contains("brief-factory"), "{}", out.text);
+    assert!(out.text.contains("the story"), "{}", out.text);
+}


### PR DESCRIPTION
## Why

`nika check` prints `HINT [native-first/006]`. The next gesture the help and CHANGELOG teach is `nika explain native-first/006`. On `main` that command 404s as a missing file (`cannot read native-first/006`) because the CLI dispatcher treated any `/` as a path. The library `explain::run` already taught the token; the router never reached it. A test on `explain::run` could not have caught this. A test on `dispatch` does.

Measured on `nika 0.113.0 (50761a054)` before the fix: rc=3. After: rc=0, first line `native-first/006 · hint`. `jq-as-map` and a real yaml path still go to their own forms.

## Test

`cargo test -p nika-cli --lib verbs::explain` — 36 passed, including `a_numbered_native_first_hint_is_not_a_file_path` (red before the router change).

A finding is closed when a test would have caught it.

## Not in this PR

Post-run stall (`nika try` / `nika run` print the card then never exit under a pipe). House `dx/workflows` identity `nika: v1` at repo root. Tag `v0.114.0` refused until those are named green.
