### PR TITLE
fix(check): a map piped from a field is not jq-as-map

### DIFF
--- a/crates/nika-check/src/hints.rs
+++ b/crates/nika-check/src/hints.rs
@@ -1138,37 +1138,6 @@ fn push_glob_readme_hint(hints: &mut Vec<Hint>, id: &str, a: &nika_schema::raw::
     ));
 }
 
-/// `. as $c` then a bare `map(` maps the CURRENT value (often a pair),
-/// not `$c`. The jury-jq class: `($c | map(...))`.
-fn push_jq_as_map_hint(hints: &mut Vec<Hint>, id: &str, a: &nika_schema::raw::RawInvokeAction) {
-    let Some(tool) = a.tool() else {
-        return;
-    };
-    if tool.value != "nika:jq" {
-        return;
-    }
-    let Some(expr) = a
-        .args
-        .as_ref()
-        .and_then(|args| args.value.get("expression"))
-        .and_then(|v| v.as_str())
-    else {
-        return;
-    };
-    if !jq_maps_the_current_after_bind(expr) {
-        return;
-    }
-    hints.push(hint(
-        "jq-as-map",
-        id,
-        format!(
-            "`nika:jq` on `{id}` binds `. as $name` then calls `map(` on the current \
-             value — after a later construct the current value is often a pair, not \
-             the bound array. Write `($name | map(...))`"
-        ),
-    ));
-}
-
 /// A failed last `nika:assert` quarantines writes to
 /// `.nika/quarantine/<trace>/`. Say so when the DAG both writes and
 /// asserts — authors hunt an empty `out/` otherwise.
@@ -1254,66 +1223,6 @@ fn asks_model_to_name_the_law(text: &str) -> bool {
             && !clause.contains("don't")
             && !clause.contains("not ")
     })
-}
-
-/// `. as $c | map(...)` maps the *current* value. `($c | map(...))` is
-/// the one-way. A one-liner used to slip past the line-start detector.
-fn jq_maps_the_current_after_bind(expr: &str) -> bool {
-    // The DOT binding is what puts the current value in question, so it stays
-    // the trigger: no `. as $name`, no hint.
-    if bound_jq_names(expr).is_empty() || !expr.contains("map(") {
-        return false;
-    }
-    // But ANY bound name names its input out loud. A law that walks several
-    // bindings (`($entries | map(...)) as $rows | ($rows | map(...))`) already
-    // does exactly what the advice prescribes, and stripping only the
-    // dot-bound name reported it as a defect (measured 2026-08-19).
-    let mut rest = squash_ws(expr);
-    for name in &all_bound_jq_names(expr) {
-        rest = rest.replace(&format!("(${name} | map("), "");
-        rest = rest.replace(&format!("(${name}|map("), "");
-    }
-    rest.contains("map(")
-}
-
-/// Every `as $NAME` binding, dot-bound or not. A `map(` piped from one of
-/// them is explicit; only a BARE `map(` rides the current value.
-fn all_bound_jq_names(expr: &str) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut rest = expr;
-    while let Some(i) = rest.find(" as $") {
-        let after = &rest[i + 5..];
-        let name: String = after
-            .chars()
-            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
-            .collect();
-        if name.is_empty() {
-            rest = after;
-            continue;
-        }
-        names.push(name.clone());
-        rest = after.get(name.len()..).unwrap_or("");
-    }
-    names
-}
-
-fn bound_jq_names(expr: &str) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut rest = expr;
-    while let Some(i) = rest.find(". as $") {
-        let after = &rest[i + 6..];
-        let name: String = after
-            .chars()
-            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
-            .collect();
-        if name.is_empty() {
-            rest = after;
-            continue;
-        }
-        names.push(name.clone());
-        rest = after.get(name.len()..).unwrap_or("");
-    }
-    names
 }
 
 /// `infer` → `nika:jq`/`nika:decide` with no const-fixture assert.
@@ -1460,24 +1369,7 @@ fn value_mentions_tasks(v: &serde_json::Value, ids: &BTreeSet<&str>) -> bool {
         .any(|id| ids.contains(id.as_str()))
 }
 
-fn squash_ws(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut gap = false;
-    for c in s.chars() {
-        if c.is_whitespace() {
-            gap = true;
-        } else {
-            if gap && !out.is_empty() {
-                out.push(' ');
-            }
-            gap = false;
-            out.push(c);
-        }
-    }
-    out
-}
-
-fn hint(kind: &'static str, task: &str, advice: String) -> Hint {
+pub(super) fn hint(kind: &'static str, task: &str, advice: String) -> Hint {
     Hint {
         kind,
         code: None,
@@ -1487,7 +1379,9 @@ fn hint(kind: &'static str, task: &str, advice: String) -> Hint {
 }
 
 mod catalog;
+mod jq_as_map;
 pub use catalog::hint_help;
+use jq_as_map::push_jq_as_map_hint;
 
 #[cfg(test)]
 mod tests;

--- a/crates/nika-check/src/hints/jq_as_map.rs
+++ b/crates/nika-check/src/hints/jq_as_map.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! `jq-as-map` — `. as $c` then a bare `map(` maps the CURRENT value.
+//!
+//! Split from `hints.rs` at the 1500-LOC ceiling so the field-pipe
+//! admission (issue 1038 remainder) has somewhere to live.
+
+use super::{Hint, hint};
+use nika_schema::raw::RawInvokeAction;
+
+/// `. as $c` then a bare `map(` maps the CURRENT value (often a pair),
+/// not `$c`. The jury-jq class: `($c | map(...))`.
+pub(super) fn push_jq_as_map_hint(hints: &mut Vec<Hint>, id: &str, a: &RawInvokeAction) {
+    let Some(tool) = a.tool() else {
+        return;
+    };
+    if tool.value != "nika:jq" {
+        return;
+    }
+    let Some(expr) = a
+        .args
+        .as_ref()
+        .and_then(|args| args.value.get("expression"))
+        .and_then(|v| v.as_str())
+    else {
+        return;
+    };
+    if !jq_maps_the_current_after_bind(expr) {
+        return;
+    }
+    hints.push(hint(
+        "jq-as-map",
+        id,
+        format!(
+            "`nika:jq` on `{id}` binds `. as $name` then calls `map(` on the current \
+             value — after a later construct the current value is often a pair, not \
+             the bound array. Write `($name | map(...))`"
+        ),
+    ));
+}
+
+/// `. as $c | map(...)` maps the *current* value. `($c | map(...))` is
+/// the one-way. A one-liner used to slip past the line-start detector.
+fn jq_maps_the_current_after_bind(expr: &str) -> bool {
+    // The DOT binding is what puts the current value in question, so it stays
+    // the trigger: no `. as $name`, no hint.
+    if bound_jq_names(expr).is_empty() || !expr.contains("map(") {
+        return false;
+    }
+    // ANY bound name names its input out loud. A law that walks several
+    // bindings (`($entries | map(...)) as $rows | ($rows | map(...))`) already
+    // does exactly what the advice prescribes, and stripping only the
+    // dot-bound name reported it as a defect (measured 2026-08-19).
+    let mut rest = squash_ws(expr);
+    for name in &all_bound_jq_names(expr) {
+        rest = rest.replace(&format!("(${name} | map("), "");
+        rest = rest.replace(&format!("(${name}|map("), "");
+    }
+    // A map piped from a field access on the current value (`.paths | map(`)
+    // re-navigates, so map receives that array — the same class as a map
+    // piped from a bound name (issue 1038 remainder).
+    rest = erase_field_piped_maps(&rest);
+    rest.contains("map(")
+}
+
+/// Drop `.IDENT | map(` / `(.IDENT | map(` so a remaining `map(` is bare.
+fn erase_field_piped_maps(s: &str) -> String {
+    let mut rest = s.to_owned();
+    while let Some((start, end)) = find_field_piped_map(&rest) {
+        rest.replace_range(start..end, "");
+    }
+    rest
+}
+
+fn find_field_piped_map(s: &str) -> Option<(usize, usize)> {
+    let mut i = 0usize;
+    while i < s.len() {
+        let rest = &s[i..];
+        let paren = rest.starts_with('(');
+        let body = if paren { &rest[1..] } else { rest };
+        if let Some(after_dot) = body.strip_prefix('.') {
+            let name_len = after_dot
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .count();
+            if name_len > 0 {
+                let after_name = &after_dot[name_len..];
+                let tail = if after_name.starts_with(" | map(") {
+                    " | map(".len()
+                } else if after_name.starts_with("|map(") {
+                    "|map(".len()
+                } else {
+                    0
+                };
+                if tail > 0 {
+                    let consumed = usize::from(paren) + 1 + name_len + tail;
+                    return Some((i, i + consumed));
+                }
+            }
+        }
+        i += s[i..].chars().next()?.len_utf8();
+    }
+    None
+}
+
+/// Every `as $NAME` binding, dot-bound or not. A `map(` piped from one of
+/// them is explicit; only a BARE `map(` rides the current value.
+fn all_bound_jq_names(expr: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = expr;
+    while let Some(at) = rest.find(" as $") {
+        let after = &rest[at + 5..];
+        let name: String = after
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            rest = after;
+            continue;
+        }
+        let skip = name.len();
+        names.push(name);
+        rest = after.get(skip..).unwrap_or("");
+    }
+    names
+}
+
+fn bound_jq_names(expr: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = expr;
+    while let Some(at) = rest.find(". as $") {
+        let after = &rest[at + 6..];
+        let name: String = after
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            rest = after;
+            continue;
+        }
+        let skip = name.len();
+        names.push(name);
+        rest = after.get(skip..).unwrap_or("");
+    }
+    names
+}
+
+fn squash_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut gap = false;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            gap = true;
+        } else {
+            if gap && !out.is_empty() {
+                out.push(' ');
+            }
+            gap = false;
+            out.push(c);
+        }
+    }
+    out
+}

--- a/crates/nika-check/src/hints/tests.rs
+++ b/crates/nika-check/src/hints/tests.rs
@@ -919,6 +919,43 @@ fn jq_as_map_admits_a_map_from_any_bound_name() {
     );
 }
 
+/// Issue 1038 remainder · five probes against 0.111.0. A map piped from
+/// a field access on the current value (`.paths | map(`) is as explicit
+/// as one piped from a bound name. Only that shape still fired.
+#[test]
+fn jq_as_map_admits_a_map_piped_from_a_field() {
+    let cases: &[(&str, bool)] = &[
+        (
+            ".paths as $p | ($p | map(. as $r | ($r | length)) | length)",
+            false,
+        ),
+        (
+            ".paths as $p | (.[0] | . as $ex | ($p | map(length) | length))",
+            false,
+        ),
+        (". as $d | (.paths | map(length) | length)", false),
+        (
+            ".paths as $p | [ $p[] | . as $x | ($p | map(length)) ] | length",
+            false,
+        ),
+        (
+            ".paths as $p | [ $p[] | . as $x | ($x | length) ] | length",
+            false,
+        ),
+    ];
+    for (expr, want_hint) in cases {
+        let yaml = format!(
+            "nika: w\npermits: {{ tools: [\"nika:jq\"] }}\ntasks:\n  score:\n    invoke: {{ tool: nika:jq, args: {{ input: [], expression: {expr:?} }} }}\n"
+        );
+        let h = hints_of(&yaml);
+        let fired = h.iter().any(|x| x.kind == "jq-as-map");
+        assert_eq!(
+            fired, *want_hint,
+            "shape `{expr}` want_hint={want_hint} hints={h:?}"
+        );
+    }
+}
+
 #[test]
 fn assert_after_a_write_names_the_quarantine() {
     let h = hints_of(


### PR DESCRIPTION
## Why

Issue 1038's secondary: `. as $d | (.paths | map(length) | length)` is safe (the current value is re-navigated) but still fired `jq-as-map`, which blocks `paid_ready`. Pull request 1024 admitted `($name | map(`; a map piped from a field is the same class.

`hints.rs` was on the 1500-line wall, so the detector moved to `hints/jq_as_map.rs` first.

## Test

The five-shape table from the issue, in `jq_as_map_admits_a_map_piped_from_a_field`. RED on the field-pipe row before the admission; GREEN after. Bare `map(` after a binding still hints.

`cargo test -p nika-check --lib` 542 passed.
