### PR TITLE
fix(cli): check names the ancestor project ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Changed
 
+- **`nika check` names the ancestor `nika.yaml` spend cap.** `nika run`
+  already filled `--max-cost-usd` from that file; check printed « no
+  total ceiling » and advised adding the flag, on a tree that already
+  had one (issue 1050). The COST line still prices the workflow; a
+  `BUDGET` footnote (and a presence-gated `run_budget` object on
+  `--json`) now says the number and `nika.yaml:line`. `--max-cost-usd`
+  still wins. `run --dry-run` and `--help` stay silent — this is the
+  surface that contradicted the file.
 - **A piped `nika try` / `nika run` no longer waits on the macOS keychain
   after a green card.** The card printed, then `SecKeychainFindGenericPassword`
   blocked the main thread: a pipe cannot complete an ACL prompt. The

--- a/crates/nika-cli/src/verbs/check/budget.rs
+++ b/crates/nika-cli/src/verbs/check/budget.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The ancestor `nika.yaml` `ceiling:` on `nika check`.
+//!
+//! `nika run` already walks up from CWD and fills `--max-cost-usd` from
+//! that file (the ladder in `run::ceiling`). `nika check` priced the
+//! workflow in isolation and printed « no total ceiling » / « cap it on
+//! the run with --max-cost-usd » while the same tree already carried a
+//! spend cap. The value is recorded in the post-run trace; this module
+//! puts the same number on the pre-run surface, with its provenance
+//! (#1050).
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use crate::display::theme::{Role, Theme};
+
+/// A project-file ceiling that `nika run` from this CWD would honour.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct AmbientCeiling {
+    pub usd: f64,
+    pub path: PathBuf,
+    pub line: Option<usize>,
+}
+
+/// Walk from `start` the same way `run::ceiling::ladder` does.
+#[must_use]
+pub(super) fn at(start: &Path) -> Option<AmbientCeiling> {
+    let (path, project) = nika_vocab::project::discover(start).ok().flatten()?;
+    let usd = project.ceiling?;
+    let line = ceiling_line(&path);
+    Some(AmbientCeiling { usd, path, line })
+}
+
+/// The CWD door — identical start to `nika run` with no flag.
+#[must_use]
+pub(super) fn from_cwd() -> Option<AmbientCeiling> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    at(&cwd)
+}
+
+/// Human footnote. Presence-gated: silence when no file governs spend.
+pub(super) fn footnote(text: &mut String, theme: Theme) {
+    let Some(c) = from_cwd() else {
+        return;
+    };
+    let where_ = provenance(&c);
+    let _ = writeln!(
+        text,
+        " {} {}   ${} ← {where_} · the run's spend cap when `--max-cost-usd` is omitted",
+        theme.paint(Role::Accent, "↳"),
+        theme.paint(Role::Strong, "BUDGET"),
+        nika_display::vocab::usd(c.usd),
+    );
+}
+
+/// Presence-gated `--json` object. `clean` does not read it.
+pub(super) fn stamp_json(obj: &mut serde_json::Map<String, serde_json::Value>) {
+    let Some(c) = from_cwd() else {
+        return;
+    };
+    let mut v = serde_json::json!({
+        "max_cost_usd": c.usd,
+        "source": c.path.display().to_string(),
+        "via": "project",
+    });
+    if let Some(line) = c.line
+        && let Some(o) = v.as_object_mut()
+    {
+        o.insert("line".to_owned(), serde_json::json!(line));
+    }
+    obj.insert("run_budget".to_owned(), v);
+}
+
+fn provenance(c: &AmbientCeiling) -> String {
+    let name = c
+        .path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("nika.yaml");
+    match c.line {
+        Some(line) => format!("{name}:{line}"),
+        None => name.to_owned(),
+    }
+}
+
+/// 1-based line of the `ceiling:` key. Best-effort: the parser keeps
+/// spans only on refusals, so a green file is re-read here.
+fn ceiling_line(path: &Path) -> Option<usize> {
+    let text = std::fs::read_to_string(path).ok()?;
+    text.lines().enumerate().find_map(|(i, raw)| {
+        let t = raw.trim_start();
+        t.starts_with("ceiling:").then_some(i + 1)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `set_current_dir` is process-global — one lock for every test
+    /// in this module that chdirs.
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn fresh(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("nika-check-budget-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        dir
+    }
+
+    #[test]
+    fn an_ancestor_ceiling_is_the_ambient_budget() {
+        let root = fresh("ancestor");
+        let child = root.join("sub");
+        std::fs::create_dir_all(&child).expect("mkdir");
+        std::fs::write(root.join("nika.yaml"), "nika: proj\nceiling: 0.01\n").expect("seed");
+        let c = at(&child).expect("walks up");
+        assert_eq!(c.usd.to_bits(), 0.01f64.to_bits());
+        assert_eq!(c.line, Some(2));
+        assert!(c.path.ends_with("nika.yaml"), "{:?}", c.path);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_file_without_ceiling_is_silence() {
+        let dir = fresh("none");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\n").expect("seed");
+        assert!(at(&dir).is_none(), "no ceiling → check stays silent");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_boundary_file_stops_the_walk() {
+        // Same shape as the engine's own nika.yaml: a name and nothing
+        // else, so a tempdir nested under /tmp cannot pick up a stray
+        // ancestor ceiling.
+        let dir = fresh("boundary");
+        std::fs::write(dir.join("nika.yaml"), "nika: boundary\n").expect("seed");
+        assert!(at(&dir).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_nearest_file_wins() {
+        let root = fresh("nearest");
+        let child = root.join("sub");
+        std::fs::create_dir_all(&child).expect("mkdir");
+        std::fs::write(root.join("nika.yaml"), "nika: root\nceiling: 9.99\n").expect("root");
+        std::fs::write(child.join("nika.yaml"), "nika: leaf\nceiling: 0.25\n").expect("leaf");
+        let c = at(&child).expect("leaf");
+        assert_eq!(
+            c.usd.to_bits(),
+            0.25f64.to_bits(),
+            "the first file on the walk governs"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn footnote_names_the_file_and_the_dollars() {
+        let _lock = CWD_LOCK.lock().expect("cwd lock");
+        let dir = fresh("footnote");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 0.01\n").expect("seed");
+        let prev = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&dir).expect("chdir");
+        let mut text = String::new();
+        footnote(&mut text, Theme::new(false, true, false));
+        let _ = std::env::set_current_dir(prev);
+        assert!(
+            text.contains("BUDGET") && text.contains("0.0100") && text.contains("nika.yaml:2"),
+            "{text}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_run_names_the_ancestor_ceiling() {
+        let _lock = CWD_LOCK.lock().expect("cwd lock");
+        let dir = fresh("run");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 0.01\n").expect("seed");
+        std::fs::write(
+            dir.join("wf.nika.yaml"),
+            "nika: wf\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 10, model: \"mock/echo\" }\n",
+        )
+        .expect("wf");
+        let prev = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&dir).expect("chdir");
+        let out = crate::verbs::check::run(
+            "wf.nika.yaml",
+            false,
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let json = crate::verbs::check::run(
+            "wf.nika.yaml",
+            true,
+            false,
+            None,
+            Theme::new(false, true, false),
+        );
+        let _ = std::env::set_current_dir(&prev);
+        assert!(
+            out.text.contains("BUDGET")
+                && out.text.contains("0.0100")
+                && out.text.contains("nika.yaml:2"),
+            "{}",
+            out.text
+        );
+        let v: serde_json::Value = serde_json::from_str(&json.text).expect("json");
+        assert_eq!(v["run_budget"]["max_cost_usd"], 0.01, "{v}");
+        assert_eq!(v["run_budget"]["line"], 2, "{v}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn json_is_presence_gated_and_carries_provenance() {
+        let _lock = CWD_LOCK.lock().expect("cwd lock");
+        let dir = fresh("json");
+        std::fs::write(dir.join("nika.yaml"), "nika: proj\nceiling: 0.01\n").expect("seed");
+        let prev = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&dir).expect("chdir");
+        let mut obj = serde_json::Map::new();
+        stamp_json(&mut obj);
+        let _ = std::env::set_current_dir(&prev);
+        let v = obj.get("run_budget").expect("present");
+        assert_eq!(v["max_cost_usd"], 0.01);
+        assert_eq!(v["via"], "project");
+        assert_eq!(v["line"], 2);
+        assert!(
+            v["source"]
+                .as_str()
+                .is_some_and(|s| s.ends_with("nika.yaml")),
+            "{v}"
+        );
+        let empty = fresh("json-empty");
+        std::fs::write(empty.join("nika.yaml"), "nika: boundary\n").expect("boundary");
+        std::env::set_current_dir(&empty).expect("chdir empty");
+        let mut silent = serde_json::Map::new();
+        stamp_json(&mut silent);
+        let _ = std::env::set_current_dir(prev);
+        assert!(silent.is_empty(), "{silent:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&empty);
+    }
+}

--- a/crates/nika-cli/src/verbs/check/mod.rs
+++ b/crates/nika-cli/src/verbs/check/mod.rs
@@ -175,6 +175,7 @@ use nika_schema::raw::RawWorkflow;
 use crate::display::theme::{Role, Theme};
 use crate::verbs::{RunSource, VerbOutput, load_checked, load_checked_run_source};
 
+mod budget;
 mod drift;
 pub(crate) mod energy;
 pub(crate) mod models_rung;
@@ -421,6 +422,7 @@ pub(crate) fn run_source_with_profile(
         grade,
     );
     naming_note(&mut text, theme, path, &wf);
+    budget::footnote(&mut text, theme);
     // The `--ascii` byte contract (P1 · audit UX 2026-07-30): the finished
     // report folds through the ONE enforcement seam — the glyph twins stay
     // the primary mechanism, this fold is what makes the emitted bytes
@@ -594,6 +596,7 @@ fn json_verdict(
             );
         }
         skills.extend_check_json(obj);
+        budget::stamp_json(obj);
         obj.insert(
             "pricing".to_owned(),
             pricing_section(report, model_findings),


### PR DESCRIPTION
`nika run` already filled `--max-cost-usd` from an ancestor `nika.yaml`. `nika check` priced the workflow in isolation and printed « no total ceiling », then advised adding the flag, on a tree that already had one (#1050).

This is the **check** surface (the one that contradicted the file):

- human: `↳ BUDGET   $0.0100 ← nika.yaml:2 · the run's spend cap when --max-cost-usd is omitted`
- `--json`: presence-gated `run_budget` `{ max_cost_usd, source, via: project, line }`
- same walk as `run::ceiling` (CWD, first file wins, no file = silence)
- `--max-cost-usd` still wins at run time

Not this PR: `run --dry-run` and `--help` still do not name the file. Issue 1050 stays open for those surfaces.

Tests: 7 in `check/budget.rs`, including a `nika check` round-trip that chdirs.

Refs #1050