### PR TITLE
fix(check): infer-permits never pastes a host-file grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,14 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`--infer-permits` no longer pastes a host-file grant.** A
+  `nika:read` of `/etc/passwd` (or `~/.ssh/…`) under an absent
+  `permits:` block printed `fs.read: ["/etc/passwd"]`; applying that
+  block greened check and run (persona 7). G-09 already withheld the
+  shovel on a *declared* boundary; the AUTH-006 companion and the
+  inferred YAML still handed it. Escaping paths (absolute · home ·
+  `..`-climb) stay a note. The printed repair is the tool conjunct
+  only.
 - **`nika check` no longer panics on a decorative verb glyph.** Copying
   `⛨permits:` / `◇infer:` from nika.sh into a file, then running the
   advertised `nika check`, dumped `annotate-snippets` (`byte index N is

--- a/crates/nika-check/src/permits_fit.rs
+++ b/crates/nika-check/src/permits_fit.rs
@@ -354,20 +354,45 @@ fn absent_effect_escape(
                 undeclared: false,
             });
         }
-        Some(BuiltinEffect::Fs { path_arg, .. }) => {
-            if judgeable_arg(consts, a, path_arg).is_none() {
+        Some(BuiltinEffect::Fs {
+            path_arg,
+            walk_root,
+            ..
+        }) => {
+            let Some(raw) = judgeable_arg(consts, a, path_arg) else {
                 escapes_tool(id, "invoke", tool, out); // the decidable conjunct
                 return;
-            }
+            };
+            let path = if walk_root {
+                nika_cap::glob_walk_root(&raw)
+            } else {
+                raw
+            };
+            // G-09 (declared boundary) already withholds the grant-this-path
+            // shovel for a workspace escape. The ABSENT-block AUTH-006
+            // companion still said « and the path to permits.fs », and
+            // `--infer-permits` wrote `/etc/passwd` into the paste block
+            // (persona 7 · 2026-08-22 · applying the printed repair
+            // greened a host-file read). The tool conjunct stays; the
+            // path never does.
+            let escaping = path_escapes_workspace(&path);
             out.push(CapabilityEscape {
                 task: id.to_owned(),
                 category: "fs",
-                detail: format!(
-                    "invoke `{tool}` with a literal path under an absent `permits:` block"
-                ),
-                fix: Some(format!(
-                    "add \"{tool}\" to permits.tools and the path to permits.fs"
-                )),
+                detail: if escaping {
+                    format!(
+                        "invoke `{tool}` with a literal path under an absent `permits:` \
+                         block — `{path}` escapes the workspace, so the repair is never \
+                         a grant of that path"
+                    )
+                } else {
+                    format!("invoke `{tool}` with a literal path under an absent `permits:` block")
+                },
+                fix: Some(if escaping {
+                    format!("add \"{tool}\" to permits.tools")
+                } else {
+                    format!("add \"{tool}\" to permits.tools and the path to permits.fs")
+                }),
                 floor: false,
                 undeclared: false,
             });
@@ -747,12 +772,18 @@ fn fs_escape(
     }
 }
 
-/// Lexically, does the path leave the workflow's root? Absolute paths
-/// and `..`-traversals that climb past the anchor do; `a/../b` does
-/// not. Purely textual (the check has no filesystem) — symlink escapes
-/// stay the runtime gate's, as the PERMITS verdict already states.
-fn path_escapes_workspace(path: &str) -> bool {
-    if path.starts_with('/') || path.starts_with('\\') {
+/// Lexically, does the path leave the workflow's root? Absolute paths,
+/// home-relative paths (`~` · `$HOME`), and `..`-traversals that climb
+/// past the anchor do; `a/../b` does not. Purely textual (the check has
+/// no filesystem) — symlink escapes stay the runtime gate's, as the
+/// PERMITS verdict already states.
+pub(super) fn path_escapes_workspace(path: &str) -> bool {
+    if path.starts_with('/')
+        || path.starts_with('\\')
+        || path.starts_with('~')
+        || path.starts_with("$HOME")
+        || path.starts_with("${HOME}")
+    {
         return true;
     }
     let mut depth: i32 = 0;

--- a/crates/nika-check/src/permits_fit/tests.rs
+++ b/crates/nika-check/src/permits_fit/tests.rs
@@ -477,6 +477,29 @@ tasks:
             e[0].fix, None,
             "no program allowlist verifies a shell string — no machine fix"
         );
+        // Persona 7 · 2026-08-22: AUTH-006 on `/etc/passwd` taught
+        // « and the path to permits.fs »; applying `--infer-permits`
+        // greened the read. The tool conjunct stays; the path never
+        // becomes a printed grant.
+        let host = "nika: w\ntasks:\n  steal:\n    invoke: { tool: \"nika:read\", args: { path: \"/etc/passwd\" } }\n";
+        let e = escapes_of(host);
+        assert!(
+            e.iter().any(|x| x.undeclared && x.category == "fs"),
+            "absent block still refuses the host-file read: {e:?}"
+        );
+        assert!(
+            e.iter().all(|x| {
+                x.fix.as_deref().is_none_or(|f| {
+                    !f.contains("/etc/passwd") && !f.contains("the path to permits.fs")
+                })
+            }),
+            "no printed repair names the host path: {e:?}"
+        );
+        assert!(
+            e.iter()
+                .any(|x| x.fix.as_deref() == Some(r#"add "nika:read" to permits.tools"#)),
+            "the tool conjunct is still the repair: {e:?}"
+        );
         // …and a COMPUTED argv head is the same cell: WHICH program runs
         // is dynamic (law 3's runtime re-gate owns the value), but the
         // category refusal is decidable at check.

--- a/crates/nika-check/src/permits_infer.rs
+++ b/crates/nika-check/src/permits_infer.rs
@@ -28,8 +28,8 @@
 use std::collections::BTreeSet;
 
 use super::permits_fit::{
-    BuiltinEffect, ConstStrings, builtin_effect, chart_vl_sibling, judgeable_arg, static_program,
-    url_host,
+    BuiltinEffect, ConstStrings, builtin_effect, chart_vl_sibling, judgeable_arg,
+    path_escapes_workspace, static_program, url_host,
 };
 use nika_schema::raw::{RawAction, RawCommand, RawExecAction, RawTask, RawWorkflow};
 use nika_schema::types::{ExecPermit, FsPermits, NetPermits, Permits};
@@ -362,45 +362,7 @@ fn collect_builtin_effect(c: &mut Collector, id: &str, a: &nika_schema::raw::Raw
                 }
             }
         }
-        Some(BuiltinEffect::Fs {
-            path_arg,
-            reads,
-            writes,
-            recursive,
-            walk_root,
-        }) => {
-            if let Some(path) = judgeable_arg(&c.consts, a, path_arg).map(|raw| {
-                // Inference must write a boundary the RUNTIME accepts · for
-                // a glob that is the walk root, never the pattern
-                // (2026-08-19).
-                if walk_root {
-                    nika_cap::glob_walk_root(&raw)
-                } else {
-                    raw
-                }
-            }) {
-                // a recursive effect (nika:grep reads descendants ·
-                // nika:image_generate writes into the dir) touches
-                // descendants too
-                let entry = if recursive {
-                    format!("{path}/**")
-                } else {
-                    path
-                };
-                if reads {
-                    c.reads.insert(entry.clone());
-                }
-                if writes {
-                    c.writes.insert(entry);
-                }
-            } else {
-                c.partial.fs = true;
-                c.notes.push(format!(
-                    "task `{id}` uses a dynamic path — `fs` cannot express 'any path'; \
-                     add the resolved path(s) before running"
-                ));
-            }
-        }
+        Some(effect @ BuiltinEffect::Fs { .. }) => collect_fs_effect(c, id, a, &effect),
         None => {}
     }
     // The chart vega sibling is a SECOND gated write — inferred alongside
@@ -408,6 +370,68 @@ fn collect_builtin_effect(c: &mut Collector, id: &str, a: &nika_schema::raw::Raw
     // its `.vl.json` would self-refuse the very workflow it came from).
     if let Some(vl) = chart_vl_sibling(a) {
         c.writes.insert(vl);
+    }
+}
+
+/// Record a builtin fs effect, or an honesty note if the path is dynamic
+/// or escapes the workspace (G-09 / persona 7 — never paste a host-file
+/// grant the author would apply verbatim).
+fn collect_fs_effect(
+    c: &mut Collector,
+    id: &str,
+    a: &nika_schema::raw::RawInvokeAction,
+    effect: &BuiltinEffect,
+) {
+    let BuiltinEffect::Fs {
+        path_arg,
+        reads,
+        writes,
+        recursive,
+        walk_root,
+    } = effect
+    else {
+        return;
+    };
+    let Some(path) = judgeable_arg(&c.consts, a, path_arg).map(|raw| {
+        // Inference must write a boundary the RUNTIME accepts · for
+        // a glob that is the walk root, never the pattern (2026-08-19).
+        if *walk_root {
+            nika_cap::glob_walk_root(&raw)
+        } else {
+            raw
+        }
+    }) else {
+        c.partial.fs = true;
+        c.notes.push(format!(
+            "task `{id}` uses a dynamic path — `fs` cannot express 'any path'; \
+             add the resolved path(s) before running"
+        ));
+        return;
+    };
+    // a recursive effect (nika:grep reads descendants ·
+    // nika:image_generate writes into the dir) touches descendants too
+    let entry = if *recursive {
+        format!("{path}/**")
+    } else {
+        path
+    };
+    if path_escapes_workspace(&entry) {
+        c.partial.fs = true;
+        c.notes.push(format!(
+            "task `{id}` reads or writes `{entry}` — that path \
+             escapes the workspace, so no `permits.fs` entry is \
+             inferred (point the task at a workspace-relative \
+             path; widening the boundary toward a host file is \
+             a deliberate operator choice, never the printed \
+             repair)"
+        ));
+        return;
+    }
+    if *reads {
+        c.reads.insert(entry.clone());
+    }
+    if *writes {
+        c.writes.insert(entry);
     }
 }
 
@@ -731,6 +755,11 @@ tasks:
             let Ok(src_wf) = parse(&yaml, FileId::new(0), ParseMode::Strict) else {
                 return Ok(());
             };
+            // Escaping paths are never inferred (persona 7 · G-09 shovel);
+            // the round-trip claim is for workspace-relative grants.
+            if path_escapes_workspace(&path) {
+                return Ok(());
+            }
             let r = infer(&src_wf);
             // the rendered block must itself parse + admit the workflow
             let (head, tail) = yaml.split_once("tasks:").expect("has tasks");
@@ -1009,6 +1038,40 @@ tasks:
             "the loopback note teaches the opt-in: {}",
             r.notes[0]
         );
+    }
+
+    #[test]
+    fn an_escaping_host_path_is_never_inferred_into_the_grants() {
+        // Persona 7 · 2026-08-22: `--infer-permits` printed
+        // `fs.read: ["/etc/passwd"]`, the author pasted it, check+run
+        // greened. Absolute / home-relative paths stay a note.
+        let r = infer_of(
+            "nika: w\ntasks:\n  a:\n    invoke: { tool: \"nika:read\", args: { path: \"/etc/passwd\" } }\n  b:\n    invoke: { tool: \"nika:read\", args: { path: \"./notes.md\" } }\n",
+        );
+        let fs = r.permits.fs.as_ref().expect("workspace path infers fs");
+        assert_eq!(fs.read, vec!["./notes.md".to_owned()]);
+        assert!(
+            !fs.read.iter().any(|p| p.contains("passwd")),
+            "host file must not be in the paste block: {:?}",
+            fs.read
+        );
+        assert!(r.partial.fs, "the escaping face is incomplete");
+        assert!(
+            r.notes
+                .iter()
+                .any(|n| n.contains("/etc/passwd") && n.contains("never the printed repair")),
+            "{:?}",
+            r.notes
+        );
+        let home = infer_of(
+            "nika: w\ntasks:\n  t:\n    invoke: { tool: \"nika:read\", args: { path: \"~/.ssh/id_rsa\" } }\n",
+        );
+        assert!(
+            home.permits.fs.as_ref().is_none_or(|f| f.read.is_empty()),
+            "home-relative secrets are not inferred: {:?}",
+            home.permits.fs
+        );
+        assert!(home.partial.fs);
     }
 
     #[test]


### PR DESCRIPTION
`nika check` AUTH-006 on a `nika:read` of `/etc/passwd` under an absent `permits:` block taught « and the path to permits.fs ». `--infer-permits` printed `fs.read: ["/etc/passwd"]`. Applying that block greened check and run (persona 7, gauntlet g2 on 81c1138f).

G-09 already withheld the shovel on a *declared* boundary. Escaping paths (absolute · home · `..`-climb) now stay a note. The printed repair is the tool conjunct only (`add "nika:read" to permits.tools`).

CLI proof on this tree:
- `nika check` → AUTH-006, fix is tool-only, no grant of `/etc/passwd`
- `nika check --infer-permits` → `tools: ["nika:read"]`, no `fs.read`

Not this PR: a hand-written host-file grant still greens (runtime always-on floor) · house `geo-probe` SEC-009 · house `nika.yaml` `nika: v1`. Do not merge #1110.

## Checklist

- [x] Conventional commit + `Co-Authored-By: Nika 🦋 <nika@supernovae.studio>`
- [x] `cargo test -p nika-check --lib` green
- [x] `cargo clippy -p nika-check --all-targets -- -D warnings` green
- [x] `cargo fmt --check` clean
- [x] 0 `.unwrap()` / `.expect()` in `src/`