### PR TITLE
fix(display): a recovered run is not a green tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **A recovered run is no longer a green tick at a glance.** `--quiet`
+  and the shareable card titled `✔` / `✓` on a run that repaired a
+  task (`task_recovered` then Ok). Exit 0 is still correct — recovered
+  is a success cause. The headline and the card title now carry the
+  warn mark; the storyboard already named `N recovered` (persona 14).
+  `trace ls` still says `completed` (no new `TraceState` this cut).
 - **`--infer-permits` no longer pastes a host-file grant.** A
   `nika:read` of `/etc/passwd` (or `~/.ssh/…`) under an absent
   `permits:` block printed `fs.read: ["/etc/passwd"]`; applying that

--- a/crates/nika-display/src/demo.rs
+++ b/crates/nika-display/src/demo.rs
@@ -162,6 +162,34 @@ pub fn failure() -> Vec<Event> {
     events
 }
 
+/// A completed run that repaired a task (`task_recovered` then Ok).
+/// Persona 14 · gauntlet g2: the first glance (`--quiet` headline · the
+/// shareable card title) must not look like an unblemished success.
+#[must_use]
+pub fn recovered() -> Vec<Event> {
+    vec![
+        at(100, 0, EventKind::WorkflowStarted).with_field(s("workflow", "recovered")),
+        at(101, 10, EventKind::TaskScheduled).with_field(s("task", "risky")),
+        at(102, 11, EventKind::TaskScheduled).with_field(s("task", "greet")),
+        at(103, 20, EventKind::TaskStarted)
+            .with_field(s("task", "risky"))
+            .with_field(s("note", "invoke · nika:assert")),
+        at(104, 25, EventKind::TaskRecovered)
+            .with_field(s("task", "risky"))
+            .with_field(s("note", "on_error recover")),
+        at(105, 30, EventKind::TaskCompleted)
+            .with_field(s("task", "risky"))
+            .with_field(s("note", "recovered")),
+        at(106, 40, EventKind::TaskStarted)
+            .with_field(s("task", "greet"))
+            .with_field(s("note", "infer · mock/echo")),
+        at(107, 80, EventKind::TaskCompleted)
+            .with_field(s("task", "greet"))
+            .with_field(s("note", "mocked")),
+        at(108, 90, EventKind::WorkflowCompleted).with_field(s("workflow", "recovered")),
+    ]
+}
+
 /// The paused storyboard (ADR-099 rider · ends `workflow_paused`): the
 /// run parked at a human gate — no verdict, the gate row left awaiting.
 #[must_use]
@@ -183,7 +211,9 @@ mod tests {
         assert_eq!(success(), success());
         assert_eq!(failure(), failure());
         assert_eq!(paused(), paused());
+        assert_eq!(recovered(), recovered());
         assert_ne!(success(), failure());
+        assert_ne!(success(), recovered());
     }
 
     #[test]

--- a/crates/nika-display/src/flow.rs
+++ b/crates/nika-display/src/flow.rs
@@ -302,11 +302,13 @@ pub fn verdict_card(view: &RunView, theme: &Theme, notes: &[String]) -> Vec<Stri
     } else {
         ('╭', '╮', '╰', '╯', '─', '│')
     };
-    let mark_raw = match (ok, theme.ascii) {
-        (true, false) => "✓",
-        (true, true) => "OK",
-        (false, false) => "✖",
-        (false, true) => "X",
+    let mark_raw = match (ok, crate::fruit::recovered_ok(view), theme.ascii) {
+        (true, true, false) => "⚠",
+        (true, true, true) => "!",
+        (true, false, false) => "✓",
+        (true, false, true) => "OK",
+        (false, _, false) => "✖",
+        (false, _, true) => "X",
     };
     let title_raw = format!("{h} nika {mark_raw} {} ", view.workflow);
 
@@ -740,6 +742,34 @@ mod tests {
                 "unicode {glyph} leaked into --ascii: {ascii:?}"
             );
         }
+    }
+
+    /// Persona 14 · gauntlet g2: the shareable card titled `nika ✓`
+    /// on a recovered run. Exit 0 stays; the title mark does not.
+    #[test]
+    fn verdict_card_recovered_is_not_a_green_tick() {
+        let mut view = RunView::new();
+        for e in demo::recovered() {
+            view.apply(&e);
+        }
+        let uni = verdict_card(&view, &PLAIN, &[]);
+        assert!(
+            uni[0].contains("nika ⚠ recovered"),
+            "recovered title is not a green tick: {uni:?}"
+        );
+        assert!(
+            !uni[0].contains('✓'),
+            "recovered title keeps no tick: {uni:?}"
+        );
+        let ascii = verdict_card(&view, &ASCII, &[]);
+        assert!(
+            ascii[0].contains("nika ! recovered"),
+            "ascii twin: {ascii:?}"
+        );
+        assert!(
+            !ascii[0].contains("OK"),
+            "ascii recovered is not OK: {ascii:?}"
+        );
     }
 
     /// Verdict-count discipline (cargo school): `0 retries` renders

--- a/crates/nika-display/src/fruit.rs
+++ b/crates/nika-display/src/fruit.rs
@@ -114,6 +114,15 @@ pub fn last_said(view: &RunView) -> Option<(&str, &str)> {
     })
 }
 
+/// A completed run that repaired at least one task. Exit 0 is still
+/// correct (recovered is a success cause); the first-glance glyph is
+/// not. Persona 14 · gauntlet g2 on 81c1138f: `--quiet` printed `✔`
+/// and `trace ls` said `completed`.
+#[must_use]
+pub fn recovered_ok(view: &RunView) -> bool {
+    view.verdict == Some(true) && view.recovered_count() > 0
+}
+
 /// Every model the stream named is a mock — the run was a REHEARSAL and
 /// the closing surface must say so (Zoe and Ben read the echo as the
 /// product). `false` when no model spoke at all (nothing to announce).
@@ -533,6 +542,26 @@ mod tests {
             &[("task", "solo"), ("output", "\"hi\"")],
         ));
         assert_eq!(inputs_all_recovered(&bare), None);
+    }
+
+    #[test]
+    fn recovered_ok_is_completed_with_a_repair() {
+        let mut view = RunView::new();
+        for e in demo::recovered() {
+            view.apply(&e);
+        }
+        assert_eq!(view.verdict, Some(true));
+        assert!(recovered_ok(&view));
+        let mut clean = RunView::new();
+        for e in demo::success() {
+            clean.apply(&e);
+        }
+        assert!(!recovered_ok(&clean));
+        let mut failed = RunView::new();
+        for e in demo::failure() {
+            failed.apply(&e);
+        }
+        assert!(!recovered_ok(&failed));
     }
 
     /// The caution set: ask-back fires with the task named · an empty

--- a/crates/nika-display/src/render.rs
+++ b/crates/nika-display/src/render.rs
@@ -601,6 +601,11 @@ fn duration_cell(theme: &Theme, time: Option<&str>, time_w: usize) -> String {
 pub fn verdict_frame(view: &RunView, theme: &Theme) -> Vec<String> {
     let mut lines = Vec::with_capacity(4);
     let glyph = match view.verdict {
+        Some(true) if crate::fruit::recovered_ok(view) => {
+            // Recovered is a success cause (exit 0) but not an unblemished
+            // tick — persona 14 grepped the quiet headline and saw ✔.
+            theme.paint(Role::Warn, if theme.ascii { "! " } else { "⚠ " })
+        }
         Some(true) => theme.glyph(TaskState::Ok, 0),
         Some(false) => theme.glyph(TaskState::Failed, 0),
         None => theme.glyph(TaskState::Pending, 0),

--- a/crates/nika-display/src/render_tests.rs
+++ b/crates/nika-display/src/render_tests.rs
@@ -379,6 +379,32 @@ fn verdict_frame_ascii_theme() {
     assert!(lines[0].starts_with("  ok veille-news · "), "{}", lines[0]);
 }
 
+/// Persona 14 · gauntlet g2: `--quiet` on a recovered run printed `✔`
+/// (exit 0, which is correct) so the first glance looked like success.
+#[test]
+fn verdict_frame_recovered_is_not_a_green_tick() {
+    let view = fold(&demo::recovered());
+    assert_eq!(view.verdict, Some(true));
+    assert!(crate::fruit::recovered_ok(&view));
+    let uni = verdict_frame(&view, &UNICODE);
+    assert!(
+        uni[0].starts_with("  ⚠  recovered ·"),
+        "quiet headline names the repair: {}",
+        uni[0]
+    );
+    assert!(
+        !uni[0].contains('✔'),
+        "a recovered success is not a green tick: {}",
+        uni[0]
+    );
+    let ascii = verdict_frame(&view, &ASCII);
+    assert!(
+        ascii[0].starts_with("  !  recovered ·"),
+        "ascii twin: {}",
+        ascii[0]
+    );
+}
+
 /// The verdict line carries elapsed time as SECONDS (`ms / 1000`): a
 /// mutated divisor (`* 1000` → `4_700_000s` · `% 1000` → `700s`) renders a
 /// wildly wrong duration, so the exact `4.7s` pins the conversion.


### PR DESCRIPTION
`--quiet` on a `task_recovered`-then-Ok run printed a green tick (persona 14, gauntlet g2 on 81c1138f). Exit 0 is still correct: recovered is a success cause. The quiet headline and the shareable card title now carry the warn mark. The storyboard already named `N recovered`.

CLI proof on this tree:
```
  ⚠  recovered · 2 tasks · 0.0s · ≥ $0.00 (1 unpriced)
  ⚠ 1 of 1 inputs recovered · the model answered from fallbacks
```
rc=0.

Not this PR: `trace ls` still says `completed` (no new `TraceState`) · P4 blast radius on the default check card · runtime always-on host-file floor · house `geo-probe` SEC-009 · house `nika.yaml` `nika: v1`. Do not merge #1110.

## Checklist

- [x] Conventional commit + `Co-Authored-By: Nika 🦋 <nika@supernovae.studio>`
- [x] `cargo test -p nika-display --lib` green (146)
- [x] `cargo clippy -p nika-display --all-targets -- -D warnings` green
- [x] `cargo fmt --check` clean
- [x] 0 `.unwrap()` / `.expect()` in `src/`