### PR TITLE
fix(display): check names the declared blast radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@ Legacy `main` is frozen at v0.79.3. Diamond starts at v0.80.0.
 
 ### Fixed
 
+- **`nika check`'s audited line names the declared blast radius.** The
+  default card said `permits declared`; the grants themselves lived
+  behind `--infer-permits` and `--json` (persona 4). Cost was already
+  on the card. The cell now lists the exec / tools / fs / net / env
+  grants (an explicit empty block is `{}`, absent is still `none`).
 - **A recovered run is no longer a green tick at a glance.** `--quiet`
   and the shareable card titled `✔` / `✓` on a run that repaired a
   task (`task_recovered` then Ok). Exit 0 is still correct — recovered

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ nika check brief.nika.yaml
  ✔ PERMITS  literal + const: args fit the boundary · computed + symlinks at run
  ✔ TRIFECTA no lethal trifecta over the declared permits: without a human gate
  ✔ JOURNEY  internal · 1 source · 0 destinations · 2 model endpoints · no secret reaches a cloud destination
- ⚠ audited · 2 tasks · 2 waves · permits declared · est unbounded · 1 uncapped task · 0 hints · risk unbounded
+ ⚠ audited · 2 tasks · 2 waves · permits tools:nika:read · est unbounded · 1 uncapped task · 0 hints · risk unbounded
 
 $ nika run brief.nika.yaml
   🦋 nika · daily-brief · 2 tasks

--- a/crates/nika-check/src/effective.rs
+++ b/crates/nika-check/src/effective.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 
 use super::permits_infer;
 use nika_schema::raw::RawWorkflow;
-use nika_schema::types::Permits;
+use nika_schema::types::{ExecPermit, Permits};
 
 /// Where the effective boundary comes from. `lowercase` on the wire.
 /// Additive: `report_version` stays 1.
@@ -63,6 +63,59 @@ pub struct EffectivePermits {
     /// of the derivation are INCOMPLETE. When any is set, `needed` is a
     /// FLOOR and no consumer may present it as the tightest boundary.
     pub partial: crate::permits_infer::PartialFaces,
+}
+
+impl EffectivePermits {
+    /// Compact grant list for a first-glance card. Absent is `none`;
+    /// an explicit empty block is `{}` (the legal zero). Persona 4 ·
+    /// gauntlet g2: the default card said `declared` while `--json`
+    /// already named the grants.
+    #[must_use]
+    pub fn glance(&self) -> String {
+        match self.declared.as_ref() {
+            None => "none".to_owned(),
+            Some(p) => format_grants(p),
+        }
+    }
+}
+
+fn format_grants(p: &Permits) -> String {
+    let mut cells = Vec::new();
+    match &p.exec {
+        Some(ExecPermit::Any) => cells.push("exec:any".to_owned()),
+        Some(ExecPermit::Programs(ps)) if !ps.is_empty() => {
+            cells.push(format!("exec:{}", ps.join(",")));
+        }
+        _ => {}
+    }
+    if let Some(tools) = &p.tools
+        && !tools.is_empty()
+    {
+        cells.push(format!("tools:{}", tools.join(",")));
+    }
+    if let Some(fs) = &p.fs {
+        if !fs.read.is_empty() {
+            cells.push(format!("read:{}", fs.read.join(",")));
+        }
+        if !fs.write.is_empty() {
+            cells.push(format!("write:{}", fs.write.join(",")));
+        }
+    }
+    if let Some(net) = &p.net
+        && !net.http.is_empty()
+    {
+        cells.push(format!("http:{}", net.http.join(",")));
+    }
+    if let Some(env) = &p.env
+        && !env.is_empty()
+    {
+        cells.push(format!("env:{}", env.join(",")));
+    }
+    if cells.is_empty() {
+        "{}".to_owned()
+    } else {
+        cells.join(" ")
+    }
 }
 
 /// State the affirmative contract for one workflow (total — a

--- a/crates/nika-cli/src/verbs/check/tests.rs
+++ b/crates/nika-cli/src/verbs/check/tests.rs
@@ -1008,7 +1008,7 @@ fn clean_verdict_is_the_audited_card_line() {
     let text = checked_text("audited-card.nika.yaml", yaml, false);
     assert!(
             text.contains(
-                "✔ audited · 2 tasks · 2 waves · permits declared · est out ≤$0.0000 · 0 hints · risk supervised"
+                "✔ audited · 2 tasks · 2 waves · permits exec:echo · est out ≤$0.0000 · 0 hints · risk supervised"
             ),
             "the audited card line: {text}"
         );

--- a/crates/nika-display/src/check_render.rs
+++ b/crates/nika-display/src/check_render.rs
@@ -566,18 +566,14 @@ fn unbounded_census(report: &CheckReport) -> String {
 /// Supervised earn the green mark.
 fn audited_line(
     report: &CheckReport,
-    wf: &RawWorkflow,
+    _wf: &RawWorkflow,
     distinct_hints: usize,
     hint_sites: usize,
     grade: nika_check::RiskGrade,
     t: Theme,
 ) -> String {
     let tasks: usize = report.waves.iter().map(Vec::len).sum();
-    let permits = if wf.permits.is_some() {
-        "declared"
-    } else {
-        "none"
-    };
+    let permits = permits_glance::permits_glance(report);
     // The green mark is EARNED, never defaulted: grade ≥ High (glob
     // grants · true wildcards · uncapped spend) renders the warn mark
     // and Role::Warn — the audit completed, the readiness did not.
@@ -1465,6 +1461,7 @@ fn loopback_declassification_lines(out: &mut String, wf: &RawWorkflow, t: Theme)
     }
 }
 mod footer;
+mod permits_glance;
 use footer::hints_and_verdict;
 
 #[cfg(test)]

--- a/crates/nika-display/src/check_render/permits_glance.rs
+++ b/crates/nika-display/src/check_render/permits_glance.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
+
+//! The audited-line permits cell — the declared blast radius at a
+//! glance (persona 4 · gauntlet g2). `--json` and `--infer-permits`
+//! already named the grants; the default card said `declared`.
+
+use nika_check::CheckReport;
+use nika_schema::types::{ExecPermit, Permits};
+
+/// Compact grant list for the audited card. Absent is `none`; an
+/// explicit empty block is `{}` (the legal zero, not the undeclared
+/// one). Cells join on spaces so the outer ` · ` separators stay one
+/// field.
+#[must_use]
+pub(super) fn permits_glance(report: &CheckReport) -> String {
+    match report.permits.declared.as_ref() {
+        None => "none".to_owned(),
+        Some(p) => format_grants(p),
+    }
+}
+
+fn format_grants(p: &Permits) -> String {
+    let mut cells = Vec::new();
+    match &p.exec {
+        Some(ExecPermit::Any) => cells.push("exec:any".to_owned()),
+        Some(ExecPermit::Programs(ps)) if !ps.is_empty() => {
+            cells.push(format!("exec:{}", ps.join(",")));
+        }
+        _ => {}
+    }
+    if let Some(tools) = &p.tools
+        && !tools.is_empty()
+    {
+        cells.push(format!("tools:{}", tools.join(",")));
+    }
+    if let Some(fs) = &p.fs {
+        if !fs.read.is_empty() {
+            cells.push(format!("read:{}", fs.read.join(",")));
+        }
+        if !fs.write.is_empty() {
+            cells.push(format!("write:{}", fs.write.join(",")));
+        }
+    }
+    if let Some(net) = &p.net
+        && !net.http.is_empty()
+    {
+        cells.push(format!("http:{}", net.http.join(",")));
+    }
+    if let Some(env) = &p.env
+        && !env.is_empty()
+    {
+        cells.push(format!("env:{}", env.join(",")));
+    }
+    if cells.is_empty() {
+        "{}".to_owned()
+    } else {
+        cells.join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    fn glance_of(yaml: &str) -> String {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        permits_glance(&nika_check::check(&wf))
+    }
+
+    #[test]
+    fn absent_is_none() {
+        assert_eq!(
+            glance_of("nika: w\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 1 }\n"),
+            "none"
+        );
+    }
+
+    #[test]
+    fn empty_block_is_the_legal_zero() {
+        assert_eq!(
+            glance_of(
+                "nika: w\npermits: {}\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 1 }\n"
+            ),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn declared_grants_are_named() {
+        let g = glance_of(
+            "nika: w\npermits:\n  exec: [\"docker\"]\n  tools: [\"nika:write\"]\n  fs:\n    write: [\"./docker-health.md\"]\ntasks:\n  t:\n    exec: { command: [\"docker\", \"ps\"] }\n",
+        );
+        assert!(g.contains("exec:docker"), "{g}");
+        assert!(g.contains("tools:nika:write"), "{g}");
+        assert!(g.contains("write:./docker-health.md"), "{g}");
+        assert!(!g.contains("declared"), "{g}");
+    }
+}

--- a/crates/nika-display/src/check_render/permits_glance.rs
+++ b/crates/nika-display/src/check_render/permits_glance.rs
@@ -6,57 +6,13 @@
 //! already named the grants; the default card said `declared`.
 
 use nika_check::CheckReport;
-use nika_schema::types::{ExecPermit, Permits};
 
-/// Compact grant list for the audited card. Absent is `none`; an
-/// explicit empty block is `{}` (the legal zero, not the undeclared
-/// one). Cells join on spaces so the outer ` · ` separators stay one
-/// field.
+/// Compact grant list for the audited card. Delegates to
+/// [`nika_check::EffectivePermits::glance`] so MCP and the CLI card
+/// cannot drift.
 #[must_use]
 pub(super) fn permits_glance(report: &CheckReport) -> String {
-    match report.permits.declared.as_ref() {
-        None => "none".to_owned(),
-        Some(p) => format_grants(p),
-    }
-}
-
-fn format_grants(p: &Permits) -> String {
-    let mut cells = Vec::new();
-    match &p.exec {
-        Some(ExecPermit::Any) => cells.push("exec:any".to_owned()),
-        Some(ExecPermit::Programs(ps)) if !ps.is_empty() => {
-            cells.push(format!("exec:{}", ps.join(",")));
-        }
-        _ => {}
-    }
-    if let Some(tools) = &p.tools
-        && !tools.is_empty()
-    {
-        cells.push(format!("tools:{}", tools.join(",")));
-    }
-    if let Some(fs) = &p.fs {
-        if !fs.read.is_empty() {
-            cells.push(format!("read:{}", fs.read.join(",")));
-        }
-        if !fs.write.is_empty() {
-            cells.push(format!("write:{}", fs.write.join(",")));
-        }
-    }
-    if let Some(net) = &p.net
-        && !net.http.is_empty()
-    {
-        cells.push(format!("http:{}", net.http.join(",")));
-    }
-    if let Some(env) = &p.env
-        && !env.is_empty()
-    {
-        cells.push(format!("env:{}", env.join(",")));
-    }
-    if cells.is_empty() {
-        "{}".to_owned()
-    } else {
-        cells.join(" ")
-    }
+    report.permits.glance()
 }
 
 #[cfg(test)]

--- a/crates/nika-display/src/check_render/tests.rs
+++ b/crates/nika-display/src/check_render/tests.rs
@@ -625,6 +625,62 @@ mod models_rung_liveness_tests {
 /// program reaching for the ambient environment printed
 /// `✖ CONFORM [NIKA-VAR-005]` and, three rows later, « pure compute » about
 /// the same body.
+mod audited_line_names_the_blast_radius {
+    use super::super::*;
+    use nika_schema::parser::{ParseMode, parse};
+    use nika_schema::source::FileId;
+
+    fn console(yaml: &str) -> String {
+        let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("parses");
+        let report = nika_check::check(&wf);
+        render(
+            &report,
+            &wf,
+            yaml,
+            "w.nika.yaml",
+            RepairTarget::WorkspaceFile,
+            Theme::new(false, false, false),
+            &ModelsAudit::new(Vec::new(), 0, 0),
+            &nika_schema::ResolvedSkills::default(),
+            &[],
+            true,
+        )
+    }
+
+    /// Persona 4 · gauntlet g2: cost was on the default card, the named
+    /// blast radius lived behind `--infer-permits` / `--json`.
+    #[test]
+    fn the_audited_line_names_the_declared_grants() {
+        let out = console(
+            "nika: w\npermits:\n  exec: [\"docker\"]\n  tools: [\"nika:write\"]\n  fs:\n    write: [\"./out.md\"]\ntasks:\n  t:\n    exec: { command: [\"docker\", \"ps\"] }\n",
+        );
+        let line = out
+            .lines()
+            .find(|l| l.contains("audited"))
+            .expect("audited card");
+        assert!(
+            line.contains("permits exec:docker tools:nika:write write:./out.md"),
+            "named radius on the default card: {line}"
+        );
+        assert!(
+            !line.contains("permits declared"),
+            "the opaque word is gone: {line}"
+        );
+    }
+
+    #[test]
+    fn absent_permits_still_say_none() {
+        let out = console(
+            "nika: w\nmodel: mock/echo\ntasks:\n  t:\n    infer: { prompt: hi, max_tokens: 1 }\n",
+        );
+        let line = out
+            .lines()
+            .find(|l| l.contains("audited"))
+            .expect("audited card");
+        assert!(line.contains("permits none"), "{line}");
+    }
+}
+
 mod permits_panel_under_red_conformance {
     use nika_schema::parser::{ParseMode, parse};
     use nika_schema::source::FileId;

--- a/crates/nika-mcp/src/tools.rs
+++ b/crates/nika-mcp/src/tools.rs
@@ -386,8 +386,10 @@ fn affirmative_contract(report: &nika_check::CheckReport) -> String {
     // render as a declared boundary, because that sentence is the one a
     // reviewer trusts. Naming the variant beats inventing a reading.
     let boundary = match report.permits.source {
-        nika_check::PermitsSource::Declared => "permits declared",
-        nika_check::PermitsSource::Absent => "no permits declared (zero authority)",
+        nika_check::PermitsSource::Declared => {
+            format!("permits {}", report.permits.glance())
+        }
+        nika_check::PermitsSource::Absent => "no permits declared (zero authority)".to_owned(),
         ref other => {
             return format!(
                 "  boundary source `{other:?}` is newer than this renderer — \
@@ -904,7 +906,7 @@ mod tests {
         for fact in [
             "task(s)",
             "wave(s)",
-            "permits declared",
+            "permits tools:nika:write write:./out.md",
             "est out",
             "destination(s)",
             "data ",


### PR DESCRIPTION
`nika check`'s audited line said `permits declared`. The grants themselves lived behind `--infer-permits` and `--json` (persona 4, gauntlet g2). Cost was already on the card.

CLI proof:
```
⚠ audited · 4 tasks · 3 waves · permits exec:docker tools:nika:write write:./docker-health.md · …
```

`EffectivePermits::glance` is the shared cell (CLI card · MCP green answer · tests). An explicit empty block is `{}`; absent is still `none`.

Not this PR: handwritten host-file grant still greens (runtime floor) · `trace ls` still `completed` on recovered · house `geo-probe` SEC-009 · house `nika.yaml` `nika: v1`. Do not merge #1110.

## Checklist

- [x] Conventional commit + `Co-Authored-By: Nika 🦋 <nika@supernovae.studio>`
- [x] `cargo test -p nika-display --lib` + CLI/MCP glance tests green
- [x] `cargo clippy` on touched crates `-D warnings` green
- [x] `cargo fmt --check` clean
- [x] 0 `.unwrap()` / `.expect()` in `src/`