### PR TITLE
fix(runtime): route harness seats through access plans

### DIFF
--- a/crates/nika-runtime/src/dispatch.rs
+++ b/crates/nika-runtime/src/dispatch.rs
@@ -791,29 +791,31 @@ where
             Ok(v) => v,
             Err(err) => return Dispatched::template_err("agent · ?", &err),
         };
-        // `skills:` — the composer-resolved Agent Skill texts join the
-        // system context as ONE `## Skills` section (spec 02 §agent skills).
+        // `skills:` join the system context as one `## Skills` section.
         if !action.skills.is_empty() {
             match self.skill_docs(action) {
                 Ok(docs) => input.system = Some(system_with_skills(input.system.take(), &docs)),
                 Err(refused) => return *refused,
             }
         }
-        // `model:` — the SAME render seam as infer's (#824 · one law).
         input.model = match render_opt(action.model.as_ref(), scope) {
             Ok(v) => v,
             Err(err) => return Dispatched::template_err("agent · ?", &err),
         };
+        let model = self.agent.effective_model(&input);
+        let candidates =
+            nika_providers::candidates_for(&self.access_probes, nika_providers::provider_of(model));
+        input.access_plan =
+            nika_providers::resolve_access(model, &candidates, None, self.access_pin.as_deref())
+                .ok();
         input.tools = action.tools.iter().map(|t| t.value.clone()).collect();
         Self::bridge_inputs(&mut input, scope, ctx);
         input.max_turns = action.max_turns.as_ref().map(|t| t.value);
         input.max_tokens_total = action.max_tokens_total.as_ref().map(|t| t.value);
         input.temperature = temp_f32(action.temperature.as_ref());
         input.schema = task_schema(action.schema.as_ref(), contract);
-        // The buffer is the CALLER's (per task-attempt-loop · still
-        // per-dispatch-isolated since a wave's tasks each own one):
-        // owning it here would put it inside the timeout-cancellable
-        // region and lose a timed-out attempt's telemetry (review F1).
+        // The caller owns the per-task buffer outside the cancellable
+        // region, preserving a timed-out attempt's telemetry (review F1).
         let ran = self.agent.run_observed(input, agent_buffer).await;
         match ran {
             Ok(out) => {
@@ -853,7 +855,7 @@ where
                     tokens,
                     None,
                     cost_usd,
-                    out.model_resolved.clone(),
+                    out.receipt_source.or_else(|| out.model_resolved.clone()),
                     llm_unpriced,
                 )
             }

--- a/crates/nika-runtime/src/emit_task.rs
+++ b/crates/nika-runtime/src/emit_task.rs
@@ -75,46 +75,50 @@ pub(crate) fn emit_completed(
     if let Some(n) = tokens {
         fields.push(("tokens", i(n)));
     }
-    // Real spend rides next to the tokens it prices · absent = unpriced
-    // (mock · local) — the render layer already treats absent as honest.
+    // Real spend rides beside its tokens; absent stays honestly unpriced.
     if let Some(c) = cost_usd {
         fields.push(("cost_usd", FieldValue::Float(c)));
     }
-    // …and WHY it is absent (or partial), when it is — `unknown` is
-    // never masked: `local_model` · `mock_provider` ·
-    // `missing_catalog_price` · `provider_did_not_report_usage`.
+    // WHY spend is absent/partial; `unknown` is never masked (`local_model` ·
+    // `mock_provider` · `missing_catalog_price` · `provider_did_not_report_usage`).
     if let Some(reason) = cost_unpriced {
         fields.push(("cost_unpriced", s(reason.as_str())));
     }
-    // D-2026-08-04-N1 · the access facts — structured provenance for
-    // infer/agent terminals (`model` = the resolved provider/name ·
-    // `provider` = its prefix · `access` = HOW it was reached ·
-    // `billing` = the economic lane). Additive fields; the note keeps
-    // its historical `infer · <model>` form, now a render, not a
-    // carrier — readers of pre-access traces still parse it.
+    // D-2026-08-04-N1 · access provenance; receipt suffix stays internal.
     if let Some(m) = model {
+        let (m, billing, adapter) = m
+            .split_once('\u{1e}')
+            .and_then(|(model, receipt)| {
+                receipt
+                    .split_once('\u{1f}')
+                    .map(|(billing, adapter)| (model, Some(billing), Some(adapter)))
+            })
+            .unwrap_or((m, None, None));
         fields.push(("model", s(m)));
         if let Some((provider, _)) = m.split_once('/') {
             fields.push(("provider", s(provider)));
-            let access = nika_providers::profile::access_class_for(provider);
+            let access = adapter.map_or_else(
+                || nika_providers::profile::access_class_for(provider),
+                |_| nika_types::access::AccessClass::Harness,
+            );
             fields.push(("access", s(access.as_str())));
-            fields.push(("billing", s(access.default_billing().as_str())));
+            fields.push((
+                "billing",
+                s(billing.unwrap_or_else(|| access.default_billing().as_str())),
+            ));
+            if let Some(adapter) = adapter {
+                fields.push(("adapter", s(adapter)));
+            }
         }
     } else if cost_unpriced == Some(nika_types::cost::UnpricedReason::SubscriptionQuota) {
-        // P3 B7 · the harness row: the task ran on the operator's own
-        // harness (the SubscriptionQuota arm in dispatch is only ever
-        // set there), so the receipt says so — `access: harness`, and
-        // the billing lane stays `unknown` until an adapter's own
-        // surface attests included/extra usage (P5). Never a fake $0.
+        // P3 B7 · legacy harness receipt, never fake $0 before attestation.
         fields.push(("access", s("harness")));
         fields.push((
             "billing",
             s(nika_types::access::BillingClass::Unknown.as_str()),
         ));
     }
-    // OBS-E · a non-fatal diagnostic rides the success frame as a
-    // `warning` field (the reasoning-model blank-answer footgun) · the
-    // task still completes.
+    // OBS-E · a non-fatal `warning` rides success; the task still completes.
     if let Some(msg) = warning {
         fields.push(("warning", s(msg)));
     }

--- a/crates/nika-runtime/src/harness_seat.rs
+++ b/crates/nika-runtime/src/harness_seat.rs
@@ -1,14 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The composer's seat line (P3 B4.5). Everything else lives with its
-//! owner — `nika-harness` reads the declaration, `nika-verb-agent`
-//! builds and takes the seat — because this crate sits at its 15k wall
-//! and every line here is rent.
+//! Composer-owned harness availability/probes; the verb owns routing.
 
-/// The seat a machine offers: the declared harness under the feature,
-/// a zero-sized witness without it (the composer reads the same in
-/// both builds).
+/// Declared harness, or a zero-sized feature-off witness.
 #[cfg(feature = "access-harness")]
 pub(crate) type Seat = Option<nika_verb_agent::harness_path::HarnessSeat>;
 /// The feature-off twin.
@@ -33,23 +28,22 @@ pub(crate) fn seat_from_env() -> Result<Seat, nika_kernel::HttpError> {
     let Some(b) = nika_harness::seat_from_env().map_err(wrap)? else {
         return Ok(None);
     };
+    let id = nika_harness::declared_adapter_id()
+        .ok_or_else(|| wrap("adapter built without a declared id".to_owned()))?;
     nika_verb_agent::harness_path::HarnessSeat::from_backend(std::sync::Arc::new(b))
+        .map(|seat| seat.with_access_id(id))
         .map(Some)
         .map_err(wrap)
 }
 
-/// The feature-off twin — the `Result` is shared on purpose so the
-/// composer's one `seat_from_env()?` line is identical in both builds.
+/// Feature-off twin with the same composer-facing `Result` shape.
 #[expect(clippy::unnecessary_wraps, reason = "the ON arm fails · shared shape")]
 #[cfg(not(feature = "access-harness"))]
 pub(crate) const fn seat_from_env() -> Result<Seat, nika_kernel::HttpError> {
     Ok(Seat)
 }
 
-/// The declared adapter id for the boot-manifest `harness_seat` stamp
-/// (B6): the trace names the execution override beside the resolver's
-/// plan. `None` in both builds when nothing is declared — and always
-/// without the feature (no seat exists to name).
+/// Declared adapter id for the boot-manifest `harness_seat` stamp (B6).
 #[cfg(feature = "access-harness")]
 pub(crate) fn declared_id() -> Option<String> {
     nika_harness::declared_adapter_id()
@@ -59,4 +53,150 @@ pub(crate) fn declared_id() -> Option<String> {
 #[cfg(not(feature = "access-harness"))]
 pub(crate) const fn declared_id() -> Option<String> {
     None
+}
+
+#[cfg(all(test, feature = "access-harness"))]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use nika_kernel::ai::harness::{
+        DynAgentBackend, HarnessError, HarnessEvent, HarnessEventStream, HarnessOutcome,
+        HarnessRequest,
+    };
+    use nika_kernel_mock::{
+        MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
+    };
+    use nika_providers::probe::{ExecutionLocus, ProviderProbe, ProviderReadiness};
+    use nika_types::access::AccessClass;
+    use nika_verb_agent::{AgentVerb, harness_path::HarnessSeat};
+    use nika_verb_exec::ExecVerb;
+    use nika_verb_infer::InferVerb;
+    use nika_verb_invoke::InvokeVerb;
+
+    use crate::{DeterministicStamper, EventKind, Runtime, RuntimeConfig, VecSink};
+
+    struct CompletedBackend;
+
+    impl DynAgentBackend for CompletedBackend {
+        fn run_agent_boxed(
+            &self,
+            _request: HarnessRequest,
+        ) -> Pin<Box<dyn Future<Output = Result<HarnessEventStream, HarnessError>> + Send + '_>>
+        {
+            Box::pin(async {
+                let event = HarnessEvent::Completed {
+                    outcome: Box::new(HarnessOutcome::new("harness route")),
+                };
+                Ok(Box::pin(futures_util::stream::iter([Ok(event)])) as HarnessEventStream)
+            })
+        }
+    }
+
+    fn probe(id: &str, class: AccessClass, serves: &[&str]) -> ProviderProbe {
+        ProviderProbe::new(
+            id,
+            false,
+            true,
+            "",
+            false,
+            ProviderReadiness::new(
+                true,
+                true,
+                None,
+                None,
+                false,
+                ExecutionLocus::Loopback,
+                class,
+            ),
+            "",
+        )
+        .with_serves(serves.iter().map(|s| (*s).to_owned()).collect())
+    }
+
+    fn field(event: &nika_event::Event, key: &str) -> Option<String> {
+        event
+            .fields
+            .iter()
+            .find(|field| field.key == key)
+            .and_then(|field| match &field.value {
+                crate::FieldValue::String(value) => Some(value.clone()),
+                _ => None,
+            })
+    }
+
+    #[tokio::test]
+    async fn each_model_executes_its_planned_access_and_receipts_the_harness_adapter()
+    -> Result<(), String> {
+        let provider = Arc::new(MockProvider::new("mock").enqueue_text("native route"));
+        let tools = Arc::new(MockToolExecutor::new());
+        let invoke = Arc::new(InvokeVerb::new(Arc::clone(&tools)));
+        let seat =
+            HarnessSeat::new(Arc::new(CompletedBackend), "/tmp").with_access_id("claude-agent-acp");
+        let runtime = Runtime::new(
+            ExecVerb::new(Arc::new(MockShell::new())),
+            Arc::clone(&invoke),
+            InferVerb::new(
+                Arc::new(nika_providers::ProviderRegistry::without_http(
+                    nika_providers::ProvidersConfig::new(),
+                )),
+                "openai/gpt-5",
+            ),
+            AgentVerb::new(
+                Arc::clone(&provider),
+                invoke,
+                Arc::new(MockToolDefinitionProvider::new()),
+                "openai/gpt-5",
+            )
+            .with_harness_seat(seat),
+            MockClock::new(),
+            RuntimeConfig::default(),
+        )
+        .with_access_probes(vec![
+            probe("openai", AccessClass::Api, &[]),
+            probe("claude-agent-acp", AccessClass::Harness, &["anthropic"]),
+        ]);
+        let wf = nika_schema::parse(
+            "nika: access-route\ntasks:\n  api:\n    agent: { model: openai/gpt-5, prompt: native }\n  harness:\n    agent: { model: anthropic/claude-sonnet-4-6, prompt: delegated }\n",
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .map_err(|err| err.to_string())?;
+        let report = nika_check::check(&wf);
+        assert!(report.is_clean(), "fixture checks clean: {report:?}");
+        let mut stamper = DeterministicStamper::new();
+        let mut sink = VecSink::new();
+        let outcome = runtime
+            .run(&wf, &report, &mut stamper, &mut sink)
+            .await
+            .map_err(|err| err.to_string())?;
+        assert!(outcome.ok);
+        assert_eq!(provider.captured_requests().len(), 1, "only api is native");
+
+        let completed = |task: &str| {
+            sink.events().iter().find(|event| {
+                event.kind == EventKind::TaskCompleted
+                    && field(event, "task").as_deref() == Some(task)
+            })
+        };
+        let api = completed("api").ok_or_else(|| "api task did not complete".to_owned())?;
+        assert_eq!(field(api, "access").as_deref(), Some("api"));
+        assert_eq!(field(api, "billing").as_deref(), Some("api_metered"));
+        assert!(field(api, "adapter").is_none());
+
+        let harness =
+            completed("harness").ok_or_else(|| "harness task did not complete".to_owned())?;
+        assert_eq!(
+            field(harness, "model").as_deref(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(field(harness, "provider").as_deref(), Some("anthropic"));
+        assert_eq!(field(harness, "access").as_deref(), Some("harness"));
+        assert_eq!(field(harness, "billing").as_deref(), Some("unknown"));
+        assert_eq!(
+            field(harness, "adapter").as_deref(),
+            Some("claude-agent-acp")
+        );
+        Ok(())
+    }
 }

--- a/crates/nika-verb-agent/public-api.txt
+++ b/crates/nika-verb-agent/public-api.txt
@@ -821,6 +821,7 @@ pub fn nika_verb_agent::config::AgentConfig::__clone_box(&self, _: dyn_clone::se
 impl<T> nika_error::traits::AsAny for nika_verb_agent::config::AgentConfig where T: 'static
 pub fn nika_verb_agent::config::AgentConfig::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_verb_agent::AgentInput
+pub nika_verb_agent::AgentInput::access_plan: core::option::Option<nika_types::access::AccessPlan>
 pub nika_verb_agent::AgentInput::gate_answer: core::option::Option<serde_json::value::Value>
 pub nika_verb_agent::AgentInput::max_tokens_total: core::option::Option<u64>
 pub nika_verb_agent::AgentInput::max_turns: core::option::Option<u32>
@@ -865,8 +866,11 @@ pub fn nika_verb_agent::AgentInput::__clone_box(&self, _: dyn_clone::sealed::Pri
 impl<T> nika_error::traits::AsAny for nika_verb_agent::AgentInput where T: 'static
 pub fn nika_verb_agent::AgentInput::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_verb_agent::AgentOutput
+pub nika_verb_agent::AgentOutput::access_plan: core::option::Option<nika_types::access::AccessPlan>
+pub nika_verb_agent::AgentOutput::adapter: core::option::Option<alloc::string::String>
 pub nika_verb_agent::AgentOutput::model_resolved: core::option::Option<alloc::string::String>
 pub nika_verb_agent::AgentOutput::output: nika_verb_agent::AgentValue
+pub nika_verb_agent::AgentOutput::receipt_source: core::option::Option<alloc::string::String>
 pub nika_verb_agent::AgentOutput::stop_reason: nika_kernel_runtime::agent::AgentStopReason
 pub nika_verb_agent::AgentOutput::tools_cost_usd: core::option::Option<f64>
 pub nika_verb_agent::AgentOutput::total_tokens: u64
@@ -902,6 +906,7 @@ impl<P, T, D> nika_verb_agent::AgentVerb<P, T, D> where P: nika_kernel_ai::provi
 pub async fn nika_verb_agent::AgentVerb<P, T, D>::run(&self, input: nika_verb_agent::AgentInput) -> core::result::Result<nika_verb_agent::AgentOutput, nika_verb_agent::errors::VerbAgentError>
 pub async fn nika_verb_agent::AgentVerb<P, T, D>::run_observed(&self, input: nika_verb_agent::AgentInput, observer: &dyn nika_verb_agent::observe::AgentObserver) -> core::result::Result<nika_verb_agent::AgentOutput, nika_verb_agent::errors::VerbAgentError>
 impl<P, T, D> nika_verb_agent::AgentVerb<P, T, D>
+pub fn nika_verb_agent::AgentVerb<P, T, D>::effective_model<'a>(&'a self, input: &'a nika_verb_agent::AgentInput) -> &'a str
 pub fn nika_verb_agent::AgentVerb<P, T, D>::new(provider: alloc::sync::Arc<P>, invoke: alloc::sync::Arc<nika_verb_invoke::InvokeVerb<T>>, tool_defs: alloc::sync::Arc<D>, default_model: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn nika_verb_agent::AgentVerb<P, T, D>::with_config(self, config: nika_verb_agent::config::AgentConfig) -> Self
 pub fn nika_verb_agent::AgentVerb<P, T, D>::with_observer(self, observer: alloc::sync::Arc<dyn nika_verb_agent::observe::AgentObserver>) -> Self

--- a/crates/nika-verb-agent/src/harness_path.rs
+++ b/crates/nika-verb-agent/src/harness_path.rs
@@ -2,14 +2,15 @@
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
 //! The EXTERNAL execution path (D-2026-08-04-N1 · P3 B4 · feature
-//! `access-harness`, default OFF) — the `agent:` task delegated to the
-//! user's own authenticated harness through the kernel's
-//! [`DynAgentBackend`] seam.
+//! `access-harness`, default OFF) — an `agent:` task whose access plan
+//! selects a harness adapter is delegated to the user's own
+//! authenticated harness through the kernel's [`DynAgentBackend`] seam.
 //!
 //! The native loop is untouched: without the feature this module does
-//! not compile; with it but no seat configured, `run` still takes the
-//! native loop. What this path never does (B4 honesty · refusals with
-//! witnesses, not silent degradation):
+//! not compile; API/local plans and calls without a plan stay native.
+//! A harness plan executes only the seat whose id it names. What this
+//! path never does (B4 honesty · refusals with witnesses, not silent
+//! degradation):
 //!
 //! - a task `schema:` refuses — structured output on a harness is P4's
 //!   capability attestation, never assumed;
@@ -47,11 +48,15 @@ pub struct HarnessSeat {
     /// The session's working directory (absolute · the composer's
     /// sandbox root in production).
     pub cwd: std::path::PathBuf,
+    /// The resolver-visible adapter id. An unnamed seat is never
+    /// executable from an [`nika_types::access::AccessPlan`].
+    access_id: Option<String>,
 }
 
 impl std::fmt::Debug for HarnessSeat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HarnessSeat")
+            .field("access_id", &self.access_id)
             .field("cwd", &self.cwd)
             .finish_non_exhaustive()
     }
@@ -75,7 +80,21 @@ impl HarnessSeat {
         Self {
             backend,
             cwd: cwd.into(),
+            access_id: None,
         }
+    }
+
+    /// Name this seat with the adapter id the access resolver emits.
+    #[must_use]
+    pub fn with_access_id(mut self, id: impl Into<String>) -> Self {
+        self.access_id = Some(id.into());
+        self
+    }
+
+    /// The resolver-visible adapter id, when this seat is named.
+    #[must_use]
+    pub fn access_id(&self) -> Option<&str> {
+        self.access_id.as_deref()
     }
 }
 
@@ -326,6 +345,7 @@ mod tests {
     /// verdicts are recorded by the reply closures the tape carries).
     struct TapeBackend {
         tape: Mutex<Vec<HarnessEvent>>,
+        runs: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     struct TapeStream {
@@ -349,6 +369,7 @@ mod tests {
             _request: HarnessRequest,
         ) -> Pin<Box<dyn Future<Output = Result<HarnessEventStream, HarnessError>> + Send + '_>>
         {
+            self.runs.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let tape = std::mem::take(&mut *self.tape.lock().expect("tape lock"));
             Box::pin(async move { Ok(Box::pin(TapeStream { tape }) as HarnessEventStream) })
         }
@@ -367,10 +388,65 @@ mod tests {
     }
 
     fn seat_with(tape: Vec<HarnessEvent>) -> HarnessSeat {
+        seat_with_id(tape, "test-harness").0
+    }
+
+    fn seat_with_id(
+        tape: Vec<HarnessEvent>,
+        id: &str,
+    ) -> (HarnessSeat, Arc<std::sync::atomic::AtomicUsize>) {
+        let runs = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let backend = TapeBackend {
             tape: Mutex::new(tape),
+            runs: Arc::clone(&runs),
         };
-        HarnessSeat::new(Arc::new(backend), "/tmp")
+        (
+            HarnessSeat::new(Arc::new(backend), "/tmp").with_access_id(id),
+            runs,
+        )
+    }
+
+    fn plan(
+        model: &str,
+        access: &str,
+        chosen: nika_types::access::AccessClass,
+    ) -> nika_types::access::AccessPlan {
+        nika_types::access::AccessPlan::new(
+            model,
+            model
+                .split_once('/')
+                .map_or(model, |(provider, _)| provider),
+            access,
+            chosen,
+            chosen.default_billing(),
+            false,
+            Vec::new(),
+        )
+    }
+
+    fn verb_with(
+        seat: HarnessSeat,
+        provider: nika_kernel_mock::MockProvider,
+    ) -> (
+        crate::AgentVerb<
+            nika_kernel_mock::MockProvider,
+            nika_kernel_mock::MockToolExecutor,
+            nika_kernel_mock::MockToolDefinitionProvider,
+        >,
+        Arc<nika_kernel_mock::MockProvider>,
+    ) {
+        let provider = Arc::new(provider);
+        let invoke = Arc::new(nika_verb_invoke::InvokeVerb::new(Arc::new(
+            nika_kernel_mock::MockToolExecutor::new(),
+        )));
+        let verb = crate::AgentVerb::new(
+            Arc::clone(&provider),
+            invoke,
+            Arc::new(nika_kernel_mock::MockToolDefinitionProvider::new()),
+            "openai/gpt-5",
+        )
+        .with_harness_seat(seat);
+        (verb, provider)
     }
 
     /// The witness label names WHAT was judged (mutation-killers for
@@ -704,6 +780,64 @@ mod tests {
             .expect("completes");
         assert_eq!(out.total_tokens, 140);
         assert_eq!(out.usage.input_tokens, 100);
+    }
+
+    #[tokio::test]
+    async fn an_api_plan_stays_native_even_when_a_seat_is_declared() {
+        let (seat, runs) = seat_with_id(vec![completed("wrong route")], "claude-agent-acp");
+        let (verb, provider) = verb_with(
+            seat,
+            nika_kernel_mock::MockProvider::new("mock").enqueue_text("native route"),
+        );
+        let mut input = AgentInput::new("route me");
+        input.access_plan = Some(plan(
+            "openai/gpt-5",
+            "openai",
+            nika_types::access::AccessClass::Api,
+        ));
+
+        let out = verb.run(input).await.expect("the native provider runs");
+        assert_eq!(out.output, AgentValue::Text("native route".to_owned()));
+        assert_eq!(provider.captured_requests().len(), 1);
+        assert_eq!(runs.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn a_harness_plan_refuses_a_different_seat_before_any_effect() {
+        let (seat, runs) = seat_with_id(vec![completed("must not run")], "claude-agent-acp");
+        let (verb, provider) = verb_with(
+            seat,
+            nika_kernel_mock::MockProvider::new("mock").enqueue_text("must not run"),
+        );
+        let mut input = AgentInput::new("route me");
+        input.access_plan = Some(plan(
+            "openai/gpt-5",
+            "codex-acp",
+            nika_types::access::AccessClass::Harness,
+        ));
+
+        let err = verb.run(input).await.expect_err("seat ids must match");
+        assert!(err.to_string().contains("codex-acp"), "{err}");
+        assert!(err.to_string().contains("claude-agent-acp"), "{err}");
+        assert!(provider.captured_requests().is_empty());
+        assert_eq!(runs.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn no_plan_never_promotes_the_declared_seat() {
+        let (seat, runs) = seat_with_id(vec![completed("wrong route")], "claude-agent-acp");
+        let (verb, provider) = verb_with(
+            seat,
+            nika_kernel_mock::MockProvider::new("mock").enqueue_text("native route"),
+        );
+
+        let out = verb
+            .run(AgentInput::new("route me"))
+            .await
+            .expect("absence of a plan keeps the native path");
+        assert_eq!(out.output, AgentValue::Text("native route".to_owned()));
+        assert_eq!(provider.captured_requests().len(), 1);
+        assert_eq!(runs.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 }
 

--- a/crates/nika-verb-agent/src/io.rs
+++ b/crates/nika-verb-agent/src/io.rs
@@ -40,6 +40,10 @@ pub struct AgentInput {
     /// (P3 B5) — the harness gate's human verdict. `None` on a fresh
     /// run (an out-of-grants ask then pauses for the operator).
     pub gate_answer: Option<serde_json::Value>,
+    /// The resolver's admission-time route for the effective model.
+    /// `None` never authorizes a harness seat: the native loop keeps
+    /// the task unless a named harness plan matches a named seat.
+    pub access_plan: Option<nika_types::access::AccessPlan>,
 }
 
 impl AgentInput {
@@ -57,6 +61,7 @@ impl AgentInput {
             schema: None,
             permits: None,
             gate_answer: None,
+            access_plan: None,
         }
     }
 }
@@ -115,6 +120,13 @@ pub struct AgentOutput {
     /// The model the loop resolved and ran (`provider/name`) — the
     /// pricing/attribution key. `None` on harness-built outputs.
     pub model_resolved: Option<String>,
+    /// The access plan that actually governed this execution.
+    pub access_plan: Option<nika_types::access::AccessPlan>,
+    /// The harness adapter that executed the task. `None` on the native
+    /// provider loop (including when a seat was merely declared).
+    pub adapter: Option<String>,
+    /// Opaque event bridge carrying the harness plan's receipt fields.
+    pub receipt_source: Option<String>,
 }
 
 impl AgentOutput {
@@ -135,6 +147,9 @@ impl AgentOutput {
             tools_cost_usd: None,
             usage: TokenUsage::default(),
             model_resolved: None,
+            access_plan: None,
+            adapter: None,
+            receipt_source: None,
         }
     }
 

--- a/crates/nika-verb-agent/src/lib.rs
+++ b/crates/nika-verb-agent/src/lib.rs
@@ -175,8 +175,8 @@ pub struct AgentVerb<P, T, D> {
     // observer. Absent, the loop feeds every result back byte-identical
     // (the pre-spill behavior is the default — feature-defaults law).
     spill: Option<Arc<dyn spill::SpillStoreDyn>>,
-    // The harness seat (P3 B4): delegates to the user's own harness —
-    // same dyn-seam rationale as the observer.
+    // The harness seat (P3 B4): available to an AccessPlan naming its
+    // adapter — same dyn-seam rationale as the observer.
     #[cfg(feature = "access-harness")]
     harness: Option<harness_path::HarnessSeat>,
 }
@@ -214,9 +214,9 @@ impl<P, T, D> AgentVerb<P, T, D> {
         }
     }
 
-    /// Seat the harness backend (P3 B4): every run then delegates to
-    /// the user's own harness (one verb instance per access plan · the
-    /// resolver never re-selects).
+    /// Make a harness backend available (P3 B4). Only a harness
+    /// [`nika_types::access::AccessPlan`] naming this seat delegates;
+    /// API/local plans and calls without a plan remain native.
     #[cfg(feature = "access-harness")]
     #[must_use]
     pub fn with_harness_seat(mut self, seat: harness_path::HarnessSeat) -> Self {
@@ -224,8 +224,8 @@ impl<P, T, D> AgentVerb<P, T, D> {
         self
     }
 
-    /// Seat an OPTIONAL harness — the composer's shape (a machine that
-    /// declares none keeps the native loop).
+    /// Make an OPTIONAL harness available — the composer's shape. A
+    /// machine that declares none can execute only native plans.
     #[cfg(feature = "access-harness")]
     #[must_use]
     pub fn seated(self, seat: Option<harness_path::HarnessSeat>) -> Self {
@@ -233,6 +233,13 @@ impl<P, T, D> AgentVerb<P, T, D> {
             Some(seat) => self.with_harness_seat(seat),
             None => self,
         }
+    }
+
+    /// The model this call will execute after the task override falls
+    /// back to the verb's composed default.
+    #[must_use]
+    pub fn effective_model<'a>(&'a self, input: &'a AgentInput) -> &'a str {
+        input.model.as_deref().unwrap_or(&self.default_model)
     }
 
     /// Override the intelligence-layer tuning (ADR-096).
@@ -325,12 +332,62 @@ where
         input: AgentInput,
         observer: &dyn AgentObserver,
     ) -> Result<AgentOutput, VerbAgentError> {
-        // The harness seat wins when configured (P3 B4) — the native
-        // loop's arm/whitelist/budget machinery governs the native
-        // path only; the harness boundary is the permission bridge.
+        let access_plan = input.access_plan.clone();
+        // A harness plan names the ONLY seat allowed to execute. A
+        // globally declared seat is availability, never authority: API,
+        // local and absent plans stay on the native loop.
         #[cfg(feature = "access-harness")]
-        if let Some(seat) = &self.harness {
-            return harness_path::run_on_harness(seat, input, observer).await;
+        if let Some(plan) = access_plan
+            .as_ref()
+            .filter(|plan| plan.chosen == nika_types::access::AccessClass::Harness)
+        {
+            let seat = self
+                .harness
+                .as_ref()
+                .ok_or_else(|| VerbAgentError::InvalidParam {
+                    param: "access",
+                    detail: format!(
+                        "AccessPlan chose harness adapter `{}` but no harness seat is available",
+                        plan.access
+                    ),
+                })?;
+            let seated = seat.access_id().unwrap_or("<unnamed>");
+            if seated != plan.access {
+                return Err(VerbAgentError::InvalidParam {
+                    param: "access",
+                    detail: format!(
+                        "AccessPlan chose harness adapter `{}` but the available seat is `{seated}`",
+                        plan.access
+                    ),
+                });
+            }
+            let adapter = seated.to_owned();
+            let receipt_source = format!(
+                "{}\u{1e}{}\u{1f}{seated}",
+                plan.model,
+                plan.billing.as_str()
+            );
+            return harness_path::run_on_harness(seat, input, observer)
+                .await
+                .map(|mut output| {
+                    output.access_plan = access_plan;
+                    output.adapter = Some(adapter);
+                    output.receipt_source = Some(receipt_source);
+                    output
+                });
+        }
+        #[cfg(not(feature = "access-harness"))]
+        if let Some(plan) = access_plan
+            .as_ref()
+            .filter(|plan| plan.chosen == nika_types::access::AccessClass::Harness)
+        {
+            return Err(VerbAgentError::InvalidParam {
+                param: "access",
+                detail: format!(
+                    "AccessPlan chose harness adapter `{}` but harness access is not compiled in",
+                    plan.access
+                ),
+            });
         }
         // arm_run failures precede any billed call — no spend to decorate.
         let (whitelist, defs, model, budget) = self.arm_run(&input).await?;
@@ -349,7 +406,11 @@ where
                 &mut tools_cost_usd,
             )
             .await;
-        out.map_err(|e| {
+        out.map(|mut output| {
+            output.access_plan = access_plan;
+            output
+        })
+        .map_err(|e| {
             e.with_spend(SpendOnFailure::new(
                 usage_total,
                 (tools_cost_usd > 0.0).then_some(tools_cost_usd),


### PR DESCRIPTION
## Summary

- resolve an access plan for each agent call's effective model before dispatch
- execute a harness only when the plan names the exact declared seat; keep API and unplanned calls native
- carry the executed model, provider, access, billing, and adapter into task receipts

## Verification

- `cargo test -p nika-verb-agent -p nika-runtime --features access-harness --lib --quiet`
- `cargo test -p nika-verb-agent -p nika-runtime --lib --quiet`
- `cargo clippy -p nika-verb-agent -p nika-runtime --features access-harness --all-targets -- -D warnings`
- `cargo public-api -p nika-verb-agent --omit auto-trait-impls` matches the checked-in baseline
- function-length and crate-size ratchets pass
- full pre-push gate passes, including all workspace library tests and all 10 CI ratchets
