### PR TITLE
fix(security): close remote execution prerequisites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ version = "0.113.0"
 dependencies = [
  "nika-check",
  "nika-kernel",
+ "nika-sandbox-seatbelt",
  "nika-schema",
  "nika-types",
  "proptest",
@@ -5042,9 +5043,12 @@ version = "0.113.0"
 dependencies = [
  "miette",
  "nika-error",
+ "nika-exec-runner",
  "nika-kernel",
  "nika-kernel-mock",
+ "nika-sandbox-seatbelt",
  "proptest",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
 ]

--- a/crates/nika-acp/Cargo.lock
+++ b/crates/nika-acp/Cargo.lock
@@ -842,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2181,6 +2181,7 @@ dependencies = [
  "bytes",
  "globset",
  "nika-kernel",
+ "nix",
  "tokio",
 ]
 
@@ -2422,6 +2423,7 @@ dependencies = [
 name = "nika-verb-agent"
 version = "0.113.0"
 dependencies = [
+ "bytes",
  "futures-core",
  "futures-util",
  "jsonschema",
@@ -2487,6 +2489,18 @@ dependencies = [
  "nika-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2926,7 +2940,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3144,7 +3158,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/nika-cli/src/verbs/run/mod.rs
+++ b/crates/nika-cli/src/verbs/run/mod.rs
@@ -305,7 +305,7 @@ fn run_verdict(
         };
     let file = source.logical_path();
     let source_text = source.source();
-    if require_signature && let Err(code) = require_signature_gate(file, output_json) {
+    if require_signature && let Err(code) = require_signature_gate(&source, output_json) {
         return RunVerdict::bare(code);
     }
     let (wf, report, skills) =
@@ -571,9 +571,12 @@ fn executor(output_json: bool) -> Result<tokio::runtime::Runtime, u8> {
 
 /// The `--require-signature` trust gate: verify against an enrolled key
 /// before anything executes (exit 2 FILE · already printed + enveloped).
-fn require_signature_gate(file: &str, output_json: bool) -> Result<(), u8> {
+fn require_signature_gate(source: &crate::verbs::RunSource, output_json: bool) -> Result<(), u8> {
     use crate::seal::WorkflowSig;
-    let reason = match crate::seal::check_workflow(std::path::Path::new(file)) {
+    let reason = match crate::seal::check_workflow_bytes(
+        std::path::Path::new(source.logical_path()),
+        source.source().as_bytes(),
+    ) {
         WorkflowSig::Valid(_) => return Ok(()),
         WorkflowSig::MissingSidecar => "missing sidecar — `nika sign <file>` mints one".to_owned(),
         WorkflowSig::NoEnrolledKey => "unknown key — nothing enrolled on this machine".to_owned(),

--- a/crates/nika-cli/src/verbs/run/resume_setup.rs
+++ b/crates/nika-cli/src/verbs/run/resume_setup.rs
@@ -142,23 +142,7 @@ fn load_resume_plan(
         epilogue::emit_error_envelope(&message, output_json);
         exit::ENV
     };
-    let trace_parent = trace
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty());
-    let trace_name = trace
-        .file_name()
-        .and_then(std::ffi::OsStr::to_str)
-        .ok_or_else(|| refuse(format!("--resume: invalid trace path {label}")))?;
-    let trace_dir =
-        nika_fs::OwnedDir::open(trace_parent.unwrap_or_else(|| std::path::Path::new(".")))
-            .map_err(|e| {
-                refuse(format!(
-                    "--resume: cannot open the trace directory for {label}: {e}"
-                ))
-            })?;
-    let raw = trace_dir
-        .read(trace_name)
-        .map_err(|e| refuse(format!("--resume: cannot read {label}: {e}")))?;
+    let raw = read_trace(trace, &label, output_json)?;
     // ADR-099 trust amendment — the chain verdict BEFORE the fold (own
     // fn: the 100-line wall, and the judgment belongs to itself).
     let unverified = gate_trust(&raw, &label, req.allow_unverified, output_json)?;
@@ -236,6 +220,31 @@ fn load_resume_plan(
         compat,
         unverified,
     })
+}
+
+fn read_trace(trace: &std::path::Path, label: &str, output_json: bool) -> Result<String, u8> {
+    let refuse = |message: String| {
+        eprintln!("nika run: {message}");
+        epilogue::emit_error_envelope(&message, output_json);
+        exit::ENV
+    };
+    let trace_parent = trace
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let trace_name = trace
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .ok_or_else(|| refuse(format!("--resume: invalid trace path {label}")))?;
+    let trace_dir =
+        nika_fs::OwnedDir::open(trace_parent.unwrap_or_else(|| std::path::Path::new(".")))
+            .map_err(|error| {
+                refuse(format!(
+                    "--resume: cannot open the trace directory for {label}: {error}"
+                ))
+            })?;
+    trace_dir
+        .read(trace_name)
+        .map_err(|error| refuse(format!("--resume: cannot read {label}: {error}")))
 }
 
 /// The ADR-099 trust gate — the chain verdict BEFORE the fold (the same

--- a/crates/nika-cli/src/verbs/run/resume_setup.rs
+++ b/crates/nika-cli/src/verbs/run/resume_setup.rs
@@ -142,7 +142,22 @@ fn load_resume_plan(
         epilogue::emit_error_envelope(&message, output_json);
         exit::ENV
     };
-    let raw = std::fs::read_to_string(trace)
+    let trace_parent = trace
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let trace_name = trace
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .ok_or_else(|| refuse(format!("--resume: invalid trace path {label}")))?;
+    let trace_dir =
+        nika_fs::OwnedDir::open(trace_parent.unwrap_or_else(|| std::path::Path::new(".")))
+            .map_err(|e| {
+                refuse(format!(
+                    "--resume: cannot open the trace directory for {label}: {e}"
+                ))
+            })?;
+    let raw = trace_dir
+        .read(trace_name)
         .map_err(|e| refuse(format!("--resume: cannot read {label}: {e}")))?;
     // ADR-099 trust amendment — the chain verdict BEFORE the fold (own
     // fn: the 100-line wall, and the judgment belongs to itself).
@@ -199,9 +214,25 @@ fn load_resume_plan(
         nika_dap::resume::apply_from(&mut plan, wf, from)
             .map_err(|message| refuse(format!("--resume: {message}")))?;
     }
+    let paused = fold
+        .paused
+        .map(|approval| {
+            let home = std::env::home_dir().ok_or_else(|| {
+                    refuse(
+                        "--resume: HOME is unavailable; the durable approval claim store cannot be opened"
+                            .to_owned(),
+                    )
+                })?;
+            approval.with_durable_claim_root(&home).map_err(|error| {
+                refuse(format!(
+                    "--resume: cannot open the durable approval claim store: {error}"
+                ))
+            })
+        })
+        .transpose()?;
     Ok(LoadedResume {
         plan,
-        paused: fold.paused,
+        paused,
         compat,
         unverified,
     })

--- a/crates/nika-cli/tests/resume_e2e.rs
+++ b/crates/nika-cli/tests/resume_e2e.rs
@@ -395,10 +395,7 @@ fn paused_prompt_rearms_and_an_answer_completes_the_run() {
         frame.contains("\"decision\",\"value\":\"allow\""),
         "{frame}"
     );
-    assert!(
-        frame.contains("\"source\",\"value\":\"resumed\""),
-        "{frame}"
-    );
+    assert!(frame.contains("\"source\",\"value\":\"resume\""), "{frame}");
     assert!(
         frame.contains(&format!("\"digest\",\"value\":\"{shown_digest}\"")),
         "the signed digest equals the shown digest:\n{frame}\nvs {shown_digest}"

--- a/crates/nika-cli/tests/resume_e2e.rs
+++ b/crates/nika-cli/tests/resume_e2e.rs
@@ -36,7 +36,13 @@ use std::io::Write as _;
 use std::process::Command;
 
 fn bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_nika-cli"))
+    let home = std::env::temp_dir()
+        .join("nika-resume-e2e")
+        .join(format!("home-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("isolated home");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_nika-cli"));
+    command.env("HOME", home);
+    command
 }
 
 fn fixture(name: &str, yaml: &str) -> std::path::PathBuf {
@@ -82,6 +88,38 @@ fn field_str(line: &str, key: &str) -> String {
         .find(|kv| kv["key"] == key)
         .and_then(|kv| kv["value"].as_str().map(str::to_owned))
         .unwrap_or_else(|| panic!("the frame carries {key}: {line}"))
+}
+
+fn assert_approval_replay_refused(wf: &std::path::Path, trace: &std::path::Path) {
+    let replay = bin()
+        .args([
+            "run",
+            &wf.to_string_lossy(),
+            "--resume",
+            &trace.to_string_lossy(),
+            "--answer",
+            "approve=yes",
+            "--json",
+            "--color",
+            "never",
+        ])
+        .output()
+        .expect("binary runs");
+    let stdout = String::from_utf8(replay.stdout).expect("utf8");
+    let stderr = String::from_utf8(replay.stderr).expect("utf8");
+    assert_ne!(
+        replay.status.code(),
+        Some(0),
+        "a consumed answer fails closed"
+    );
+    assert!(
+        stdout.contains("NIKA-SEC-010") && stdout.contains("approval.replayed"),
+        "the second process emits the stable refusal:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        events_for(&stdout, "task_started", "ship").is_empty(),
+        "the replay reaches no downstream effect:\n{stdout}"
+    );
 }
 
 // ─── (a) kill-midrun → resume completes the remainder ───────────────────
@@ -404,6 +442,11 @@ fn paused_prompt_rearms_and_an_answer_completes_the_run() {
         frame.contains(&format!("\"shown_hash\",\"value\":\"{shown_hash}\"")),
         "the signed content equals the shown content:\n{frame}"
     );
+
+    // The durable ticket claim is scoped by the trace/ticket digest. A
+    // second process cannot replay the same answer before TTL: the prompt
+    // effect and its downstream exec happened exactly once.
+    assert_approval_replay_refused(&wf, &trace);
 }
 
 // ─── the TEXT lane pauses too (the first-run gate · 2026-07-31) ─────────

--- a/crates/nika-dap/public-api.txt
+++ b/crates/nika-dap/public-api.txt
@@ -2785,6 +2785,7 @@ impl<T> tracing::instrument::WithSubscriber for nika_dap::sign::WorkflowSig
 impl<T> typenum::type_operators::Same for nika_dap::sign::WorkflowSig
 pub type nika_dap::sign::WorkflowSig::Output = T
 pub fn nika_dap::sign::check_workflow(path: &std::path::Path) -> nika_dap::sign::WorkflowSig
+pub fn nika_dap::sign::check_workflow_bytes(path: &std::path::Path, data: &[u8]) -> nika_dap::sign::WorkflowSig
 pub fn nika_dap::sign::sidecar_path(workflow: &std::path::Path) -> std::path::PathBuf
 pub fn nika_dap::sign::sign_workflow_with(path: &std::path::Path, sk: &minisign::secret_key::SecretKey, pk_box: &str) -> core::result::Result<alloc::string::String, alloc::string::String>
 pub mod nika_dap::stats

--- a/crates/nika-dap/src/sign.rs
+++ b/crates/nika-dap/src/sign.rs
@@ -78,15 +78,31 @@ pub fn sign_workflow_with(
 /// `sign --check` / the `--require-signature` gate (`verify_sidecar`).
 #[must_use]
 pub fn check_workflow(path: &Path) -> WorkflowSig {
-    let text = std::fs::read_to_string(sidecar_path(path)); // seam-bypass-ok: CLI reads the sidecar beside the named file
+    let text = std::fs::read_to_string(sidecar_path(path)); // seam-bypass-ok: `nika sign --check` reads the sidecar beside the named file
     let Ok(text) = text else {
         return WorkflowSig::MissingSidecar;
     };
-    let data = std::fs::read(path); // seam-bypass-ok: CLI reads the named workflow file
+    let data = std::fs::read(path); // seam-bypass-ok: `nika sign --check` reads the named workflow file
     let Ok(data) = data else {
         return WorkflowSig::Invalid(format!("cannot read {}", path.display()));
     };
     verify_sidecar(&data, &text, &enrolled_pubboxes())
+}
+
+/// Verify the sidecar beside `path` against bytes already captured by the
+/// caller. `nika run --require-signature` uses this form so the signature
+/// judges the exact execution candidate, never a second pathname read.
+#[must_use]
+pub fn check_workflow_bytes(path: &Path, data: &[u8]) -> WorkflowSig {
+    check_workflow_bytes_against(path, data, &enrolled_pubboxes())
+}
+
+fn check_workflow_bytes_against(path: &Path, data: &[u8], candidates: &[String]) -> WorkflowSig {
+    let text = std::fs::read_to_string(sidecar_path(path)); // seam-bypass-ok: CLI reads the sidecar beside the named file
+    let Ok(text) = text else {
+        return WorkflowSig::MissingSidecar;
+    };
+    verify_sidecar(data, &text, candidates)
 }
 /// The pure half of `sign --check`: 16-hex key-id match, then minisign-verify.
 fn verify_sidecar(data: &[u8], sig_text: &str, candidates: &[String]) -> WorkflowSig {
@@ -128,6 +144,7 @@ fn hex_lower(bytes: &[u8]) -> String {
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
 
     fn keypair() -> (String, minisign::SecretKey) {
         let pair = minisign::KeyPair::generate_unencrypted_keypair().expect("keypair");
@@ -181,6 +198,45 @@ mod tests {
             unreachable!("a tampered workflow must not verify")
         };
         assert!(why.contains("bad signature"), "{why}");
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the signature TOCTOU fixture uses an OS thread held at exact barriers"
+    )]
+    fn signature_gate_verifies_captured_b_not_reread_pathname_a() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (pk, sk) = keypair();
+        let wf = dir.path().join("flow.nika.yaml");
+        let captured = Arc::new(Barrier::new(2));
+        let replaced = Arc::new(Barrier::new(2));
+        std::fs::write(&wf, b"nika: B\n").expect("write B");
+
+        let reader_path = wf.clone();
+        let reader_captured = Arc::clone(&captured);
+        let reader_replaced = Arc::clone(&replaced);
+        let reader = std::thread::spawn(move || {
+            let bytes = std::fs::read(reader_path).expect("capture B");
+            reader_captured.wait();
+            reader_replaced.wait();
+            bytes
+        });
+
+        captured.wait();
+        std::fs::write(&wf, b"nika: A\n").expect("replace pathname with A");
+        sign_workflow_with(&wf, &sk, pk.trim()).expect("sign pathname A");
+        replaced.wait();
+        let bytes_b = reader.join().expect("reader");
+
+        assert!(matches!(
+            check_workflow_bytes_against(&wf, &bytes_b, &[pk.trim().to_owned()]),
+            WorkflowSig::Invalid(why) if why.contains("bad signature")
+        ));
+        assert!(matches!(
+            check_workflow_bytes_against(&wf, b"nika: A\n", &[pk.trim().to_owned()]),
+            WorkflowSig::Valid(_)
+        ));
     }
 
     /// A sidecar minted by a key this machine does not enroll names the

--- a/crates/nika-exec-runner/Cargo.toml
+++ b/crates/nika-exec-runner/Cargo.toml
@@ -39,6 +39,7 @@ tokio    = { workspace = true, features = ["process", "io-util", "sync", "time",
 # L0 leaves, downward-only. (nika-schema rides [dependencies] — the
 # sandbox_spec derivation speaks Permits in prod.)
 nika-check  = { path = "../nika-check", version = "0.113.0" }
+nika-sandbox-seatbelt = { path = "../nika-sandbox-seatbelt", version = "0.113.0" }
 
 [package.metadata.lore]
 daemon        = "timonier"

--- a/crates/nika-exec-runner/src/egress.rs
+++ b/crates/nika-exec-runner/src/egress.rs
@@ -575,6 +575,12 @@ pub(crate) fn conflicting_boundary(proxy: &EgressProxy, spec: &EgressAllowlist) 
 /// The runner-side wiring of the allowlist arm (kept here so `lib.rs` stays
 /// a lean process-lifecycle surface — this module owns the whole egress
 /// concern, proxy AND confinement hand-off).
+type AppliedSandbox = (
+    nika_kernel::ShellCommand,
+    Option<std::path::PathBuf>,
+    Option<std::sync::Arc<dyn nika_kernel::command_sandbox::CommandSandbox>>,
+);
+
 impl crate::TokioShell {
     /// Apply the injected OS sandbox to a command that requests one. No spec =
     /// unchanged (today's behavior); spec + backend = confined; spec but NO
@@ -598,11 +604,10 @@ impl crate::TokioShell {
     pub(super) fn apply_sandbox(
         &self,
         mut command: nika_kernel::ShellCommand,
-    ) -> Result<(nika_kernel::ShellCommand, Option<std::path::PathBuf>), nika_kernel::ShellError>
-    {
+    ) -> Result<AppliedSandbox, nika_kernel::ShellError> {
         use nika_kernel::{ShellError, process::NetPolicy};
         let Some(mut spec) = command.sandbox.take() else {
-            return Ok((command, None));
+            return Ok((command, None, None));
         };
         let Some(backend) = &self.sandbox else {
             return Err(ShellError::Blocked {
@@ -636,7 +641,7 @@ impl crate::TokioShell {
         let confined = backend
             .confine(&spec, command)
             .map_err(|e| crate::map_sandbox_error(&e))?;
-        Ok((confined, scratch))
+        Ok((confined, scratch, Some(std::sync::Arc::clone(backend))))
     }
 
     /// Secure the per-run loopback egress proxy for the allowlist arm:
@@ -1285,7 +1290,9 @@ mod tests {
         let _ = confined(&shell, allowlisted(&["a.test"]));
         let mut cmd = ShellCommand::new("echo");
         cmd.sandbox = Some(allowlisted(&["b.test"]));
-        let err = shell.apply_sandbox(cmd).unwrap_err();
+        let Err(err) = shell.apply_sandbox(cmd) else {
+            panic!("conflicting egress boundaries must refuse");
+        };
         assert!(
             matches!(err, ShellError::Blocked { .. }),
             "a second boundary must not widen the per-run proxy: {err}"
@@ -1336,7 +1343,7 @@ mod tests {
 
         let mut cmd = ShellCommand::new("echo");
         cmd.sandbox = Some(SandboxSpec::new());
-        let (out, scratch) = shell.apply_sandbox(cmd).expect("confined");
+        let (out, scratch, _classifier) = shell.apply_sandbox(cmd).expect("confined");
         let dir = scratch.expect("the seatbelt arm mints a scratch");
         assert!(dir.is_dir(), "the scratch exists before the spawn");
         let tmpdir = out.env.get("TMPDIR").expect("TMPDIR is set").clone();
@@ -1360,7 +1367,7 @@ mod tests {
         cmd.sandbox = Some(SandboxSpec::new());
         cmd.env
             .insert("TMPDIR".to_owned(), "/authored/tmp".to_owned());
-        let (out, scratch) = shell.apply_sandbox(cmd).expect("confined");
+        let (out, scratch, _classifier) = shell.apply_sandbox(cmd).expect("confined");
         assert_eq!(
             out.env.get("TMPDIR").map(String::as_str),
             Some("/authored/tmp"),

--- a/crates/nika-exec-runner/src/lib.rs
+++ b/crates/nika-exec-runner/src/lib.rs
@@ -229,7 +229,7 @@ impl ShellRunDyn for TokioShell {
         // the blocklist so the floor inspected the REAL command, not the
         // launcher wrapper. `scratch` is the per-spawn private TMPDIR the
         // seatbelt arm minted (issue 754) — removed when the spawn settles.
-        let (command, scratch) = self.apply_sandbox(command)?;
+        let (command, scratch, sandbox_classifier) = self.apply_sandbox(command)?;
 
         let start = Instant::now();
         let mut cmd = build_command(&command);
@@ -298,7 +298,7 @@ impl ShellRunDyn for TokioShell {
             let _ = std::fs::remove_dir_all(&dir);
         }
 
-        outcome_to_result(outcome, pid, start)
+        outcome_to_result(outcome, pid, start, sandbox_classifier.as_deref())
     }
 }
 
@@ -346,6 +346,7 @@ fn outcome_to_result(
     outcome: Outcome,
     pid: Option<u32>,
     start: Instant,
+    sandbox: Option<&dyn CommandSandbox>,
 ) -> Result<ShellResult, ShellError> {
     match outcome {
         Outcome::Cancelled => Err(ShellError::Cancelled {
@@ -353,16 +354,30 @@ fn outcome_to_result(
         }),
         Outcome::TimedOut(ms) => Err(ShellError::Timeout { duration_ms: ms }),
         Outcome::Done(Err(e)) => Err(classify_drain_error(&e)),
-        Outcome::Done(Ok((status, stdout, stderr))) => Ok(ShellResult::new(
-            status.code().unwrap_or(-1),
-            String::from_utf8_lossy(&stdout),
-            String::from_utf8_lossy(&stderr),
-            start.elapsed(),
-        )
-        // The raw octets ride alongside the lossy text projections —
-        // the `decode:` pipeline (spec 09 §decode) reads bytes, never
-        // a lossy string.
-        .with_raw(stdout, stderr)),
+        Outcome::Done(Ok((status, stdout, stderr))) => {
+            let status = status.code().unwrap_or(-1);
+            let stderr_text = String::from_utf8_lossy(&stderr);
+            let classification = sandbox.map(|backend| {
+                // The backend owns this conservative table: the runner has
+                // drained the real launcher result and keeps its classifier
+                // alive until this exact point.
+                backend.classify_outcome(status, &stderr_text)
+            });
+            let result = ShellResult::new(
+                status,
+                String::from_utf8_lossy(&stdout),
+                stderr_text,
+                start.elapsed(),
+            )
+            // The raw octets ride alongside the lossy text projections —
+            // the `decode:` pipeline (spec 09 §decode) reads bytes, never
+            // a lossy string.
+            .with_raw(stdout, stderr);
+            Ok(match classification {
+                Some(receipt) => result.with_adapter_outcome(receipt),
+                None => result,
+            })
+        }
     }
 }
 
@@ -658,6 +673,43 @@ mod tests {
             .expect("echo runs");
         assert_eq!(res.stdout.trim(), "hello");
         assert!(res.success());
+    }
+
+    /// Real macOS production path: Seatbelt wraps the command, the child
+    /// encounters an undeclared read, drains plausible structured output,
+    /// and exits in the launcher/refusal class. The runner must retain the
+    /// Seatbelt classifier until after drain so the JSON cannot become data.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn seatbelt_status_126_with_json_is_typed_authority() {
+        use nika_kernel::process::SandboxSpec;
+        use nika_sandbox_seatbelt::SeatbeltSandbox;
+
+        assert!(SeatbeltSandbox::available(), "macOS must ship sandbox-exec");
+        let denied =
+            std::env::temp_dir().join(format!("nika-w02-seatbelt-denied-{}", std::process::id()));
+        std::fs::write(&denied, b"authority boundary").expect("denied fixture");
+        let quoted = denied.to_string_lossy().replace('\'', "'\\''");
+        let line = format!(
+            "if /bin/cat '{quoted}' >/dev/null 2>&1; then exit 42; \
+             else /usr/bin/printf '{{\"ok\":true}}\\n'; exit 126; fi"
+        );
+        let mut command = ShellCommand::new(line);
+        command.shell = true;
+        command.pre_validated = true;
+        command.sandbox = Some(SandboxSpec::new());
+        let result = TokioShell::with_sandbox(Arc::new(SeatbeltSandbox::new()))
+            .run(command)
+            .await
+            .expect("the drained refusal is represented as ShellResult");
+        let _ = std::fs::remove_file(denied);
+
+        assert_eq!(result.status, 126, "the fixture reached the refusal arm");
+        assert_eq!(result.stdout.trim(), r#"{"ok":true}"#);
+        assert!(matches!(
+            result.into_process_result(),
+            Err(ShellError::Blocked { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -95,7 +95,9 @@ impl ExecutionService {
         }
     }
 
-    fn admit_snapshot(snapshot: ExecutionSnapshot) -> Result<AdmittedExecution, ExecutionError> {
+    pub(crate) fn admit_snapshot(
+        snapshot: ExecutionSnapshot,
+    ) -> Result<AdmittedExecution, ExecutionError> {
         let root = snapshot.root().to_owned();
         let root_text = snapshot
             .text(&root)

--- a/crates/nika-execution/src/service.rs
+++ b/crates/nika-execution/src/service.rs
@@ -135,7 +135,6 @@ impl Default for ExecutionService {
 }
 
 /// A checked execution world. It deliberately owns no filesystem capability.
-#[derive(Debug)]
 #[non_exhaustive]
 pub struct AdmittedExecution {
     execution_id: ExecutionId,
@@ -144,6 +143,16 @@ pub struct AdmittedExecution {
     workflow: RawWorkflow,
     check: CheckReport,
     skills: ResolvedSkills,
+}
+
+impl std::fmt::Debug for AdmittedExecution {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdmittedExecution")
+            .field("execution_id", &self.execution_id)
+            .field("trace_id", &self.trace_id)
+            .field("snapshot_digest", &self.snapshot.digest())
+            .finish_non_exhaustive()
+    }
 }
 
 impl AdmittedExecution {
@@ -185,7 +194,7 @@ impl AdmittedExecution {
 }
 
 /// Read-only execution input handed to an injected runtime runner.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 #[non_exhaustive]
 pub struct ExecutionContext<'a> {
     execution_id: ExecutionId,
@@ -194,6 +203,17 @@ pub struct ExecutionContext<'a> {
     workflow: &'a RawWorkflow,
     check: &'a CheckReport,
     skills: &'a ResolvedSkills,
+}
+
+#[allow(clippy::elidable_lifetime_names)] // Preserve the locked public trait shape.
+impl<'a> std::fmt::Debug for ExecutionContext<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecutionContext")
+            .field("execution_id", &self.execution_id)
+            .field("trace_id", &self.trace_id)
+            .field("snapshot_digest", &self.snapshot.digest())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> ExecutionContext<'a> {
@@ -235,13 +255,22 @@ impl<'a> ExecutionContext<'a> {
 }
 
 /// Typed result envelope returned by the shared execution boundary.
-#[derive(Debug)]
 #[non_exhaustive]
 pub struct ExecutionVerdict<T> {
     execution_id: ExecutionId,
     trace_id: TraceId,
     snapshot_digest: String,
     outcome: T,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for ExecutionVerdict<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecutionVerdict")
+            .field("execution_id", &self.execution_id)
+            .field("trace_id", &self.trace_id)
+            .field("snapshot_digest", &self.snapshot_digest)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T> ExecutionVerdict<T> {
@@ -344,7 +373,7 @@ fn report_findings(logical_path: &str, report: &CheckReport) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::cell::RefCell;
     use std::collections::BTreeMap;
     use std::path::Path;
 
@@ -352,13 +381,13 @@ mod tests {
     use crate::snapshot::ByteSource;
 
     struct CountingSource {
-        reads: Cell<usize>,
+        reads: RefCell<Vec<String>>,
         files: BTreeMap<String, Vec<u8>>,
     }
 
     impl ByteSource for CountingSource {
         fn read(&self, logical_path: &str, _limit: usize) -> Result<Vec<u8>, ExecutionError> {
-            self.reads.set(self.reads.get() + 1);
+            self.reads.borrow_mut().push(logical_path.to_owned());
             self.files
                 .get(logical_path)
                 .cloned()
@@ -369,31 +398,69 @@ mod tests {
     }
 
     #[test]
-    fn admission_and_execution_read_zero_sources_after_capture() {
-        let workflow = b"nika: root\npermits:\n  tools: [\"nika:jq\"]\ntasks:\n  value:\n    invoke:\n      tool: nika:jq\n      args: { input: 1, expression: \".\" }\n";
+    fn digest_check_skills_and_run_read_zero_sources_after_capture() {
+        let workflow = b"nika: root\nmodel: mock/echo\npermits:\n  fs:\n    read: [\"skills/review/SKILL.md\"]\ntasks:\n  review:\n    agent: { prompt: \"review\", skills: [\"skills/review/SKILL.md\"] }\n";
+        let skill = b"---\nname: review\ndescription: Review code.\n---\nOriginal.\n";
+        let import = b"policy-v1";
         let source = CountingSource {
-            reads: Cell::new(0),
-            files: BTreeMap::from([("root.nika.yaml".to_owned(), workflow.to_vec())]),
+            reads: RefCell::new(Vec::new()),
+            files: BTreeMap::from([
+                ("root.nika.yaml".to_owned(), workflow.to_vec()),
+                ("imports/policy.bin".to_owned(), import.to_vec()),
+                ("skills/review/SKILL.md".to_owned(), skill.to_vec()),
+            ]),
         };
         let snapshot = ExecutionSnapshot::capture_from(
             &source,
             Path::new("root.nika.yaml"),
-            std::iter::empty::<&Path>(),
+            [Path::new("imports/policy.bin")],
             SnapshotLimits::default(),
         )
         .expect("capture");
-        let reads_at_boundary = source.reads.get();
-        let admitted = ExecutionService::admit_snapshot(snapshot).expect("admit captured world");
-        assert_eq!(source.reads.get(), reads_at_boundary, "check never reopens");
-        let verdict = ExecutionService::default().execute(admitted, read_root);
-        assert_eq!(source.reads.get(), reads_at_boundary, "run never reopens");
+        let reads_at_boundary = source.reads.borrow().clone();
         assert_eq!(
-            verdict.outcome().as_deref(),
-            Some(std::str::from_utf8(workflow).expect("utf8"))
+            reads_at_boundary,
+            [
+                "root.nika.yaml",
+                "imports/policy.bin",
+                "skills/review/SKILL.md"
+            ]
+        );
+        let digest = snapshot.digest().to_owned();
+        assert_eq!(source.reads.borrow().as_slice(), reads_at_boundary);
+        let admitted = ExecutionService::admit_snapshot(snapshot).expect("admit captured world");
+        assert_eq!(
+            source.reads.borrow().as_slice(),
+            reads_at_boundary,
+            "parse, composed check, and skill resolution never reopen"
+        );
+        let verdict = ExecutionService::default().execute(admitted, read_owned_world);
+        assert_eq!(
+            source.reads.borrow().as_slice(),
+            reads_at_boundary,
+            "run never reopens"
+        );
+        assert_eq!(verdict.snapshot_digest(), digest);
+        assert_eq!(
+            verdict.outcome(),
+            &[
+                std::str::from_utf8(workflow)
+                    .expect("workflow utf8")
+                    .to_owned(),
+                std::str::from_utf8(skill).expect("skill utf8").to_owned(),
+                String::from_utf8(import.to_vec()).expect("import utf8"),
+            ]
         );
     }
 
-    fn read_root(cx: ExecutionContext<'_>) -> Option<String> {
-        cx.snapshot().text("root.nika.yaml").map(str::to_owned)
+    fn read_owned_world(cx: ExecutionContext<'_>) -> Vec<String> {
+        [
+            "root.nika.yaml",
+            "skills/review/SKILL.md",
+            "imports/policy.bin",
+        ]
+        .into_iter()
+        .filter_map(|path| cx.snapshot().text(path).map(str::to_owned))
+        .collect()
     }
 }

--- a/crates/nika-execution/src/snapshot.rs
+++ b/crates/nika-execution/src/snapshot.rs
@@ -41,13 +41,24 @@ impl SnapshotUnitKind {
 }
 
 /// One logical unit and the exact bytes admitted for execution.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct CapturedUnit {
     logical_path: String,
     kind: SnapshotUnitKind,
     bytes: Arc<[u8]>,
     digest: String,
+}
+
+impl std::fmt::Debug for CapturedUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CapturedUnit")
+            .field("logical_path", &self.logical_path)
+            .field("kind", &self.kind)
+            .field("bytes_len", &self.bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
 }
 
 impl CapturedUnit {
@@ -151,13 +162,24 @@ impl Default for SnapshotLimits {
 }
 
 /// Immutable closure of every byte the admitted program may compose from.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct ExecutionSnapshot {
     format_version: u32,
     root: String,
     units: BTreeMap<String, CapturedUnit>,
     digest: String,
+}
+
+impl std::fmt::Debug for ExecutionSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecutionSnapshot")
+            .field("format_version", &self.format_version)
+            .field("root", &self.root)
+            .field("unit_count", &self.units.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
 }
 
 impl ExecutionSnapshot {

--- a/crates/nika-execution/src/tests.rs
+++ b/crates/nika-execution/src/tests.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::sync::{Arc, Barrier};
 
 use nika_fs::OwnedDir;
 
@@ -30,6 +31,43 @@ fn project(files: &[(&str, &str)]) -> (tempfile::TempDir, OwnedDir) {
     }
     let owned = OwnedDir::open(tmp.path()).expect("owned project");
     (tmp, owned)
+}
+
+struct InterleavingSource {
+    project: OwnedDir,
+    target: &'static str,
+    captured: Arc<Barrier>,
+    replaced: Arc<Barrier>,
+}
+
+impl crate::snapshot::ByteSource for InterleavingSource {
+    fn read(&self, logical_path: &str, limit: usize) -> Result<Vec<u8>, ExecutionError> {
+        let bytes =
+            <OwnedDir as crate::snapshot::ByteSource>::read(&self.project, logical_path, limit)?;
+        if logical_path == self.target {
+            self.captured.wait();
+            self.replaced.wait();
+        }
+        Ok(bytes)
+    }
+}
+
+fn interleaving_source(
+    project: &OwnedDir,
+    target: &'static str,
+) -> (InterleavingSource, Arc<Barrier>, Arc<Barrier>) {
+    let captured = Arc::new(Barrier::new(2));
+    let replaced = Arc::new(Barrier::new(2));
+    (
+        InterleavingSource {
+            project: project.try_clone().expect("source clone"),
+            target,
+            captured: Arc::clone(&captured),
+            replaced: Arc::clone(&replaced),
+        },
+        captured,
+        replaced,
+    )
 }
 
 #[test]
@@ -129,6 +167,62 @@ fn directory_replacement_after_capture_cannot_redirect_execution() {
     )
     .expect("replacement child");
     assert_eq!(snapshot.text("world/child.nika.yaml"), Some(CHILD));
+}
+
+#[test]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "the synchronous ByteSource race needs an OS thread held at explicit barriers"
+)]
+fn root_replacement_interleaved_after_read_cannot_change_admitted_bytes() {
+    let (tmp, owned) = project(&[("root.nika.yaml", pure_root())]);
+    let (source, captured, replaced) = interleaving_source(&owned, "root.nika.yaml");
+    let root = tmp.path().join("root.nika.yaml");
+    let attacker = std::thread::spawn(move || {
+        captured.wait();
+        fs::write(root, b"nika: attacker\n").expect("replace root");
+        replaced.wait();
+    });
+    let snapshot = ExecutionSnapshot::capture_from(
+        &source,
+        Path::new("root.nika.yaml"),
+        std::iter::empty::<&Path>(),
+        SnapshotLimits::default(),
+    )
+    .expect("capture owns the already-read root");
+    attacker.join().expect("attacker");
+    assert_eq!(snapshot.text("root.nika.yaml"), Some(pure_root()));
+}
+
+#[test]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "the synchronous ByteSource race needs an OS thread held at explicit barriers"
+)]
+fn skill_registry_reload_interleaved_after_read_cannot_change_admission() {
+    const ROOT: &str = "nika: root\nmodel: mock/echo\npermits:\n  fs:\n    read: [\"skills/review/SKILL.md\"]\ntasks:\n  review:\n    agent: { prompt: \"review\", skills: [\"skills/review/SKILL.md\"] }\n";
+    const SKILL: &str = "---\nname: review\ndescription: Review code.\n---\nOriginal.\n";
+    let (tmp, owned) = project(&[("root.nika.yaml", ROOT), ("skills/review/SKILL.md", SKILL)]);
+    let (source, captured, replaced) = interleaving_source(&owned, "skills/review/SKILL.md");
+    let skill = tmp.path().join("skills/review/SKILL.md");
+    let attacker = std::thread::spawn(move || {
+        captured.wait();
+        fs::write(skill, b"attacker registry reload").expect("replace skill");
+        replaced.wait();
+    });
+    let snapshot = ExecutionSnapshot::capture_from(
+        &source,
+        Path::new("root.nika.yaml"),
+        std::iter::empty::<&Path>(),
+        SnapshotLimits::default(),
+    )
+    .expect("capture owns the already-read skill");
+    attacker.join().expect("attacker");
+    let admitted = ExecutionService::admit_snapshot(snapshot).expect("snapshot admits");
+    assert_eq!(
+        admitted.snapshot().text("skills/review/SKILL.md"),
+        Some(SKILL)
+    );
 }
 
 #[test]

--- a/crates/nika-execution/src/tests.rs
+++ b/crates/nika-execution/src/tests.rs
@@ -67,6 +67,29 @@ fn skill_mutation_after_capture_cannot_change_admitted_bytes() {
     );
 }
 
+#[test]
+fn nested_child_mutation_after_capture_cannot_change_admitted_bytes() {
+    let root = parent("nested/middle.nika.yaml");
+    let middle = "nika: middle\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  leaf:\n    invoke:\n      workflow: \"leaf.nika.yaml\"\n      args: { url: \"${{ inputs.url }}\" }\n    returns: { object: { report: string } }\noutputs:\n  report: { value: \"${{ tasks.leaf.output.report }}\", type: string }\n";
+    let (tmp, owned) = project(&[
+        ("root.nika.yaml", &root),
+        ("nested/middle.nika.yaml", middle),
+        ("nested/leaf.nika.yaml", CHILD),
+    ]);
+    let snapshot = ExecutionSnapshot::capture(
+        &owned,
+        Path::new("root.nika.yaml"),
+        SnapshotLimits::default(),
+    )
+    .expect("capture");
+    fs::write(
+        tmp.path().join("nested/leaf.nika.yaml"),
+        b"nika: attacker\n",
+    )
+    .expect("mutate nested child");
+    assert_eq!(snapshot.text("nested/leaf.nika.yaml"), Some(CHILD));
+}
+
 #[cfg(unix)]
 #[test]
 fn symlink_swap_after_capture_cannot_redirect_execution() {
@@ -85,6 +108,27 @@ fn symlink_swap_after_capture_cannot_redirect_execution() {
     fs::remove_file(tmp.path().join("child.nika.yaml")).expect("remove child");
     symlink(outside.path(), tmp.path().join("child.nika.yaml")).expect("swap");
     assert_eq!(snapshot.text("child.nika.yaml"), Some(CHILD));
+}
+
+#[test]
+fn directory_replacement_after_capture_cannot_redirect_execution() {
+    let root = parent("world/child.nika.yaml");
+    let (tmp, owned) = project(&[("root.nika.yaml", &root), ("world/child.nika.yaml", CHILD)]);
+    let snapshot = ExecutionSnapshot::capture(
+        &owned,
+        Path::new("root.nika.yaml"),
+        SnapshotLimits::default(),
+    )
+    .expect("capture");
+    fs::rename(tmp.path().join("world"), tmp.path().join("original-world"))
+        .expect("rename original directory");
+    fs::create_dir(tmp.path().join("world")).expect("replacement directory");
+    fs::write(
+        tmp.path().join("world/child.nika.yaml"),
+        b"nika: attacker\n",
+    )
+    .expect("replacement child");
+    assert_eq!(snapshot.text("world/child.nika.yaml"), Some(CHILD));
 }
 
 #[test]
@@ -235,7 +279,50 @@ fn execute_performs_zero_opens_after_admission() {
     assert_eq!(verdict.trace_id(), verdict.execution_id().into());
 }
 
+#[test]
+fn debug_surfaces_do_not_disclose_captured_or_outcome_payloads() {
+    const SECRET_SHAPED: &str = "sk-live-w02-must-never-reach-debug";
+    let root = format!("{}# {SECRET_SHAPED}\n", pure_root());
+    let (_tmp, owned) = project(&[("root.nika.yaml", &root)]);
+    let service = ExecutionService::default();
+    let admitted = service
+        .admit(&owned, Path::new("root.nika.yaml"))
+        .expect("admit");
+
+    let snapshot_debug = format!("{:?}", admitted.snapshot());
+    let unit_debug = format!(
+        "{:?}",
+        admitted
+            .snapshot()
+            .unit("root.nika.yaml")
+            .expect("root unit")
+    );
+    let admitted_debug = format!("{admitted:?}");
+    assert!(!snapshot_debug.contains(SECRET_SHAPED));
+    assert!(!unit_debug.contains(SECRET_SHAPED));
+    assert!(!admitted_debug.contains(SECRET_SHAPED));
+
+    let context_debug = service.execute(admitted, debug_execution_context);
+    assert!(!context_debug.outcome().contains(SECRET_SHAPED));
+
+    let admitted = service
+        .admit(&owned, Path::new("root.nika.yaml"))
+        .expect("readmit");
+    let verdict = service.execute(admitted, secret_shaped_outcome);
+    let verdict_debug = format!("{verdict:?}");
+    assert!(!verdict_debug.contains(SECRET_SHAPED));
+    assert_eq!(*verdict.outcome(), SECRET_SHAPED);
+}
+
 fn snapshot_digest(cx: crate::ExecutionContext<'_>) -> String {
     assert_eq!(cx.snapshot().text("root.nika.yaml"), Some(pure_root()));
     cx.snapshot().digest().to_owned()
+}
+
+fn secret_shaped_outcome(_cx: crate::ExecutionContext<'_>) -> &'static str {
+    "sk-live-w02-must-never-reach-debug"
+}
+
+fn debug_execution_context(cx: crate::ExecutionContext<'_>) -> String {
+    format!("{cx:?}")
 }

--- a/crates/nika-execution/src/tests.rs
+++ b/crates/nika-execution/src/tests.rs
@@ -70,17 +70,47 @@ fn interleaving_source(
     )
 }
 
-#[test]
-fn child_mutation_after_capture_cannot_change_admitted_bytes() {
-    let parent = parent("child.nika.yaml");
-    let (tmp, owned) = project(&[("root.nika.yaml", &parent), ("child.nika.yaml", CHILD)]);
-    let snapshot = ExecutionSnapshot::capture(
-        &owned,
-        Path::new("root.nika.yaml"),
+#[allow(
+    clippy::disallowed_methods,
+    reason = "the synchronous ByteSource race needs an OS thread held at explicit barriers"
+)]
+fn capture_while_replacing<F>(
+    project: &OwnedDir,
+    root: &Path,
+    target: &'static str,
+    replace: F,
+) -> ExecutionSnapshot
+where
+    F: FnOnce() + Send + 'static,
+{
+    let (source, captured, replaced) = interleaving_source(project, target);
+    let attacker = std::thread::spawn(move || {
+        captured.wait();
+        replace();
+        replaced.wait();
+    });
+    let snapshot = ExecutionSnapshot::capture_from(
+        &source,
+        root,
+        std::iter::empty::<&Path>(),
         SnapshotLimits::default(),
     )
-    .expect("capture");
-    fs::write(tmp.path().join("child.nika.yaml"), b"nika: replaced\n").expect("mutate");
+    .expect("capture owns the target read before replacement");
+    attacker.join().expect("attacker");
+    snapshot
+}
+
+#[test]
+fn child_replacement_interleaved_after_read_cannot_change_admitted_bytes() {
+    let parent = parent("child.nika.yaml");
+    let (tmp, owned) = project(&[("root.nika.yaml", &parent), ("child.nika.yaml", CHILD)]);
+    let child = tmp.path().join("child.nika.yaml");
+    let snapshot = capture_while_replacing(
+        &owned,
+        Path::new("root.nika.yaml"),
+        "child.nika.yaml",
+        move || fs::write(child, b"nika: replaced\n").expect("replace child"),
+    );
     assert_eq!(snapshot.text("child.nika.yaml"), Some(CHILD));
 }
 
@@ -106,7 +136,7 @@ fn skill_mutation_after_capture_cannot_change_admitted_bytes() {
 }
 
 #[test]
-fn nested_child_mutation_after_capture_cannot_change_admitted_bytes() {
+fn nested_child_replacement_interleaved_after_read_cannot_change_admitted_bytes() {
     let root = parent("nested/middle.nika.yaml");
     let middle = "nika: middle\ninputs:\n  url: { type: string, required: true }\npermits:\n  exec: [\"echo\"]\ntasks:\n  leaf:\n    invoke:\n      workflow: \"leaf.nika.yaml\"\n      args: { url: \"${{ inputs.url }}\" }\n    returns: { object: { report: string } }\noutputs:\n  report: { value: \"${{ tasks.leaf.output.report }}\", type: string }\n";
     let (tmp, owned) = project(&[
@@ -114,58 +144,56 @@ fn nested_child_mutation_after_capture_cannot_change_admitted_bytes() {
         ("nested/middle.nika.yaml", middle),
         ("nested/leaf.nika.yaml", CHILD),
     ]);
-    let snapshot = ExecutionSnapshot::capture(
+    let child = tmp.path().join("nested/leaf.nika.yaml");
+    let snapshot = capture_while_replacing(
         &owned,
         Path::new("root.nika.yaml"),
-        SnapshotLimits::default(),
-    )
-    .expect("capture");
-    fs::write(
-        tmp.path().join("nested/leaf.nika.yaml"),
-        b"nika: attacker\n",
-    )
-    .expect("mutate nested child");
+        "nested/leaf.nika.yaml",
+        move || fs::write(child, b"nika: attacker\n").expect("replace nested child"),
+    );
     assert_eq!(snapshot.text("nested/leaf.nika.yaml"), Some(CHILD));
 }
 
 #[cfg(unix)]
 #[test]
-fn symlink_swap_after_capture_cannot_redirect_execution() {
+fn symlink_swap_interleaved_after_read_cannot_redirect_execution() {
     use std::os::unix::fs::symlink;
 
     let parent = parent("child.nika.yaml");
     let (tmp, owned) = project(&[("root.nika.yaml", &parent), ("child.nika.yaml", CHILD)]);
-    let snapshot = ExecutionSnapshot::capture(
-        &owned,
-        Path::new("root.nika.yaml"),
-        SnapshotLimits::default(),
-    )
-    .expect("capture");
+    let child = tmp.path().join("child.nika.yaml");
     let outside = tempfile::NamedTempFile::new().expect("outside");
     fs::write(outside.path(), b"nika: attacker\n").expect("outside write");
-    fs::remove_file(tmp.path().join("child.nika.yaml")).expect("remove child");
-    symlink(outside.path(), tmp.path().join("child.nika.yaml")).expect("swap");
+    let outside_path = outside.path().to_owned();
+    let snapshot = capture_while_replacing(
+        &owned,
+        Path::new("root.nika.yaml"),
+        "child.nika.yaml",
+        move || {
+            fs::remove_file(&child).expect("remove child");
+            symlink(outside_path, child).expect("swap");
+        },
+    );
     assert_eq!(snapshot.text("child.nika.yaml"), Some(CHILD));
 }
 
 #[test]
-fn directory_replacement_after_capture_cannot_redirect_execution() {
+fn directory_replacement_interleaved_after_read_cannot_redirect_execution() {
     let root = parent("world/child.nika.yaml");
     let (tmp, owned) = project(&[("root.nika.yaml", &root), ("world/child.nika.yaml", CHILD)]);
-    let snapshot = ExecutionSnapshot::capture(
+    let world = tmp.path().join("world");
+    let original_world = tmp.path().join("original-world");
+    let snapshot = capture_while_replacing(
         &owned,
         Path::new("root.nika.yaml"),
-        SnapshotLimits::default(),
-    )
-    .expect("capture");
-    fs::rename(tmp.path().join("world"), tmp.path().join("original-world"))
-        .expect("rename original directory");
-    fs::create_dir(tmp.path().join("world")).expect("replacement directory");
-    fs::write(
-        tmp.path().join("world/child.nika.yaml"),
-        b"nika: attacker\n",
-    )
-    .expect("replacement child");
+        "world/child.nika.yaml",
+        move || {
+            fs::rename(&world, original_world).expect("rename original directory");
+            fs::create_dir(&world).expect("replacement directory");
+            fs::write(world.join("child.nika.yaml"), b"nika: attacker\n")
+                .expect("replacement child");
+        },
+    );
     assert_eq!(snapshot.text("world/child.nika.yaml"), Some(CHILD));
 }
 

--- a/crates/nika-fs/public-api.txt
+++ b/crates/nika-fs/public-api.txt
@@ -18,6 +18,7 @@ pub fn nika_fs::OwnedDir::read_optional(&self, name: &str) -> core::io::error::R
 pub fn nika_fs::OwnedDir::remove(&self, name: &str) -> core::io::error::Result<()>
 pub fn nika_fs::OwnedDir::try_clone(&self) -> core::io::error::Result<Self>
 pub fn nika_fs::OwnedDir::write_atomic(&self, name: &str, body: &str) -> core::io::error::Result<()>
+pub fn nika_fs::OwnedDir::write_once(&self, name: &str, body: &str) -> core::io::error::Result<()>
 impl core::fmt::Debug for nika_fs::OwnedDir
 pub fn nika_fs::OwnedDir::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<D> owo_colors::OwoColorize for nika_fs::OwnedDir

--- a/crates/nika-fs/src/owned_dir.rs
+++ b/crates/nika-fs/src/owned_dir.rs
@@ -245,6 +245,27 @@ impl OwnedDir {
         result
     }
 
+    /// Create one regular file exactly once and synchronize both the file
+    /// and its containing directory.
+    ///
+    /// This is the durable compare-and-set primitive for consumed
+    /// capabilities: concurrent callers race on `O_EXCL`, so exactly one
+    /// can publish the marker. Existing files and symlinks are refused.
+    ///
+    /// # Errors
+    /// Returns [`io::ErrorKind::AlreadyExists`] when the name was already
+    /// claimed, or another I/O error when the contained file cannot be
+    /// created, written, or synchronized safely.
+    pub fn write_once(&self, name: &str, body: &str) -> io::Result<()> {
+        let mut file = self.open_file(
+            name,
+            OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        )?;
+        file.write_all(body.as_bytes())?;
+        file.sync_all()?;
+        self.fd.sync_all()
+    }
+
     /// List child names relative to the held directory.
     ///
     /// # Errors
@@ -480,6 +501,49 @@ mod tests {
 
         std::fs::create_dir(root.path().join("arm/daily/nested")).expect("nested child");
         assert!(dir.read("nested").is_err());
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the synchronous O_EXCL race needs two OS threads at one deterministic barrier"
+    )]
+    fn write_once_is_an_atomic_single_winner() {
+        use std::sync::{Arc, Barrier};
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let owned = Arc::new(OwnedDir::open(root.path()).expect("owned"));
+        let barrier = Arc::new(Barrier::new(3));
+        let mut threads = Vec::new();
+        for body in ["first", "second"] {
+            let owned = Arc::clone(&owned);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                owned.write_once("claim", body)
+            }));
+        }
+        barrier.wait();
+        let results: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("thread"))
+            .collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| {
+                    result
+                        .as_ref()
+                        .is_err_and(|error| error.kind() == io::ErrorKind::AlreadyExists)
+                })
+                .count(),
+            1
+        );
+        assert!(matches!(
+            owned.read("claim").as_deref(),
+            Ok("first" | "second")
+        ));
     }
 
     #[test]

--- a/crates/nika-kernel-core/public-api.txt
+++ b/crates/nika-kernel-core/public-api.txt
@@ -2113,11 +2113,14 @@ pub nika_kernel_core::io::process::ShellResult::stderr_raw: core::option::Option
 pub nika_kernel_core::io::process::ShellResult::stdout: alloc::string::String
 pub nika_kernel_core::io::process::ShellResult::stdout_raw: core::option::Option<alloc::vec::Vec<u8>>
 impl nika_kernel_core::io::process::ShellResult
+pub fn nika_kernel_core::io::process::ShellResult::into_process_result(self) -> core::result::Result<Self, nika_kernel_core::io::process::ShellError>
 pub fn nika_kernel_core::io::process::ShellResult::new(status: i32, stdout: impl core::convert::Into<alloc::string::String>, stderr: impl core::convert::Into<alloc::string::String>, duration: core::time::Duration) -> Self
 pub fn nika_kernel_core::io::process::ShellResult::stderr_octets(&self) -> &[u8]
 pub fn nika_kernel_core::io::process::ShellResult::stdout_octets(&self) -> &[u8]
 pub fn nika_kernel_core::io::process::ShellResult::success(&self) -> bool
+pub fn nika_kernel_core::io::process::ShellResult::with_authority_refusal(self, reason: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn nika_kernel_core::io::process::ShellResult::with_raw(self, stdout_raw: alloc::vec::Vec<u8>, stderr_raw: alloc::vec::Vec<u8>) -> Self
+pub fn nika_kernel_core::io::process::ShellResult::with_transport_failure(self, reason: impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for nika_kernel_core::io::process::ShellResult
 pub fn nika_kernel_core::io::process::ShellResult::clone(&self) -> nika_kernel_core::io::process::ShellResult
 impl core::fmt::Debug for nika_kernel_core::io::process::ShellResult

--- a/crates/nika-kernel-core/public-api.txt
+++ b/crates/nika-kernel-core/public-api.txt
@@ -967,6 +967,7 @@ pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::fmt(&self, f: &mut co
 impl core::marker::Copy for nika_kernel_core::io::command_sandbox::NoopSandbox
 impl nika_kernel_core::io::command_sandbox::CommandSandbox for nika_kernel_core::io::command_sandbox::NoopSandbox
 pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::backend(&self) -> &'static str
+pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::classify_outcome(&self, _status: i32, _stderr: &str) -> nika_kernel_core::io::process::ShellAdapterOutcome
 pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::confine(&self, _spec: &nika_kernel_core::io::process::SandboxSpec, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellCommand, nika_kernel_core::io::command_sandbox::CommandSandboxError>
 impl<D> owo_colors::OwoColorize for nika_kernel_core::io::command_sandbox::NoopSandbox
 impl<T, U> core::convert::Into<U> for nika_kernel_core::io::command_sandbox::NoopSandbox where U: core::convert::From<T>
@@ -995,9 +996,11 @@ impl<T> nika_error::traits::AsAny for nika_kernel_core::io::command_sandbox::Noo
 pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::as_any(&self) -> &(dyn core::any::Any + 'static)
 pub trait nika_kernel_core::io::command_sandbox::CommandSandbox: core::marker::Send + core::marker::Sync
 pub fn nika_kernel_core::io::command_sandbox::CommandSandbox::backend(&self) -> &'static str
+pub fn nika_kernel_core::io::command_sandbox::CommandSandbox::classify_outcome(&self, status: i32, _stderr: &str) -> nika_kernel_core::io::process::ShellAdapterOutcome
 pub fn nika_kernel_core::io::command_sandbox::CommandSandbox::confine(&self, spec: &nika_kernel_core::io::process::SandboxSpec, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellCommand, nika_kernel_core::io::command_sandbox::CommandSandboxError>
 impl nika_kernel_core::io::command_sandbox::CommandSandbox for nika_kernel_core::io::command_sandbox::NoopSandbox
 pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::backend(&self) -> &'static str
+pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::classify_outcome(&self, _status: i32, _stderr: &str) -> nika_kernel_core::io::process::ShellAdapterOutcome
 pub fn nika_kernel_core::io::command_sandbox::NoopSandbox::confine(&self, _spec: &nika_kernel_core::io::process::SandboxSpec, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellCommand, nika_kernel_core::io::command_sandbox::CommandSandboxError>
 pub fn nika_kernel_core::io::command_sandbox::fold_sandbox_prefix(prefix: &str) -> core::option::Option<alloc::string::String>
 pub fn nika_kernel_core::io::command_sandbox::names_system_root(folded: &str, roots: &[&str]) -> bool
@@ -2062,6 +2065,41 @@ impl<T> core::convert::From<T> for nika_kernel_core::io::process::SandboxSpec
 pub fn nika_kernel_core::io::process::SandboxSpec::from(t: T) -> T
 impl<T> nika_error::traits::AsAny for nika_kernel_core::io::process::SandboxSpec where T: 'static
 pub fn nika_kernel_core::io::process::SandboxSpec::as_any(&self) -> &(dyn core::any::Any + 'static)
+#[non_exhaustive] pub struct nika_kernel_core::io::process::ShellAdapterOutcome
+impl nika_kernel_core::io::process::ShellAdapterOutcome
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::authority_refusal(reason: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::missing_terminal_receipt(adapter: &'static str) -> Self
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::process() -> Self
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::transport_failure(reason: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for nika_kernel_core::io::process::ShellAdapterOutcome
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::clone(&self) -> nika_kernel_core::io::process::ShellAdapterOutcome
+impl core::fmt::Debug for nika_kernel_core::io::process::ShellAdapterOutcome
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<D> owo_colors::OwoColorize for nika_kernel_core::io::process::ShellAdapterOutcome
+impl<T, U> core::convert::Into<U> for nika_kernel_core::io::process::ShellAdapterOutcome where U: core::convert::From<T>
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for nika_kernel_core::io::process::ShellAdapterOutcome where U: core::convert::Into<T>
+pub type nika_kernel_core::io::process::ShellAdapterOutcome::Error = core::convert::Infallible
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for nika_kernel_core::io::process::ShellAdapterOutcome where U: core::convert::TryFrom<T>
+pub type nika_kernel_core::io::process::ShellAdapterOutcome::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for nika_kernel_core::io::process::ShellAdapterOutcome where T: core::clone::Clone
+pub type nika_kernel_core::io::process::ShellAdapterOutcome::Owned = T
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::clone_into(&self, target: &mut T)
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::to_owned(&self) -> T
+impl<T> core::any::Any for nika_kernel_core::io::process::ShellAdapterOutcome where T: 'static + ?core::marker::Sized
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for nika_kernel_core::io::process::ShellAdapterOutcome where T: ?core::marker::Sized
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for nika_kernel_core::io::process::ShellAdapterOutcome where T: ?core::marker::Sized
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for nika_kernel_core::io::process::ShellAdapterOutcome where T: core::clone::Clone
+pub unsafe fn nika_kernel_core::io::process::ShellAdapterOutcome::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for nika_kernel_core::io::process::ShellAdapterOutcome
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::from(t: T) -> T
+impl<T> nika_error::traits::AsAny for nika_kernel_core::io::process::ShellAdapterOutcome where T: 'static
+pub fn nika_kernel_core::io::process::ShellAdapterOutcome::as_any(&self) -> &(dyn core::any::Any + 'static)
 #[non_exhaustive] pub struct nika_kernel_core::io::process::ShellCommand
 pub nika_kernel_core::io::process::ShellCommand::args: alloc::vec::Vec<alloc::string::String>
 pub nika_kernel_core::io::process::ShellCommand::cwd: core::option::Option<std::path::PathBuf>
@@ -2118,6 +2156,7 @@ pub fn nika_kernel_core::io::process::ShellResult::new(status: i32, stdout: impl
 pub fn nika_kernel_core::io::process::ShellResult::stderr_octets(&self) -> &[u8]
 pub fn nika_kernel_core::io::process::ShellResult::stdout_octets(&self) -> &[u8]
 pub fn nika_kernel_core::io::process::ShellResult::success(&self) -> bool
+pub fn nika_kernel_core::io::process::ShellResult::with_adapter_outcome(self, outcome: nika_kernel_core::io::process::ShellAdapterOutcome) -> Self
 pub fn nika_kernel_core::io::process::ShellResult::with_authority_refusal(self, reason: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn nika_kernel_core::io::process::ShellResult::with_raw(self, stdout_raw: alloc::vec::Vec<u8>, stderr_raw: alloc::vec::Vec<u8>) -> Self
 pub fn nika_kernel_core::io::process::ShellResult::with_transport_failure(self, reason: impl core::convert::Into<alloc::string::String>) -> Self

--- a/crates/nika-kernel-core/src/io/command_sandbox.rs
+++ b/crates/nika-kernel-core/src/io/command_sandbox.rs
@@ -25,7 +25,7 @@
 //! the wrapped form (`sandbox-exec -p … -- <real command>`) is spawned
 //! directly. Confining first would hide the real command behind the launcher.
 
-use super::process::{SandboxSpec, ShellCommand};
+use super::process::{SandboxSpec, ShellAdapterOutcome, ShellCommand};
 
 /// Confine a spawned command to an OS sandbox derived from the spec.
 ///
@@ -53,6 +53,24 @@ pub trait CommandSandbox: Send + Sync {
     /// A short, stable name of the backend (`"seatbelt"` · `"landlock"` ·
     /// `"noop"`) for diagnostics + the capability report.
     fn backend(&self) -> &'static str;
+
+    /// Classify a drained launcher result before capture policy sees it.
+    ///
+    /// A sandbox wrapper and its inner process share one OS exit-status
+    /// channel. Backends therefore own the conservative table that
+    /// distinguishes a launcher/authority refusal from a business-process
+    /// exit. Unknown backends fail closed on non-zero rather than allowing
+    /// `capture: structured` to reinterpret an unclassified refusal.
+    fn classify_outcome(&self, status: i32, _stderr: &str) -> ShellAdapterOutcome {
+        if status == 0 {
+            ShellAdapterOutcome::process()
+        } else {
+            ShellAdapterOutcome::authority_refusal(format!(
+                "unclassified `{}` sandbox outcome (status {status}) was refused",
+                self.backend()
+            ))
+        }
+    }
 }
 
 /// Errors from confining a command.
@@ -96,6 +114,13 @@ impl CommandSandbox for NoopSandbox {
 
     fn backend(&self) -> &'static str {
         "noop"
+    }
+
+    fn classify_outcome(&self, _status: i32, _stderr: &str) -> ShellAdapterOutcome {
+        // Reaching Noop is the composition layer's explicit
+        // NIKA_SANDBOX=off waiver. It has no launcher whose status could be
+        // an authority refusal, so every status is the process status.
+        ShellAdapterOutcome::process()
     }
 }
 
@@ -188,6 +213,13 @@ pub fn fold_sandbox_prefix(prefix: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::io::process::{ShellError, ShellResult};
+
+    fn apply(outcome: ShellAdapterOutcome) -> Result<ShellResult, ShellError> {
+        ShellResult::new(126, r#"{"ok":true}"#, "", std::time::Duration::ZERO)
+            .with_adapter_outcome(outcome)
+            .into_process_result()
+    }
 
     fn _assert_send_sync<T: Send + Sync>() {}
 
@@ -207,6 +239,39 @@ mod tests {
         assert_eq!(out.program, "echo");
         assert_eq!(out.args, vec!["hi".to_owned()]);
         assert_eq!(NoopSandbox.backend(), "noop");
+        assert!(
+            apply(NoopSandbox.classify_outcome(126, r#"{"ok":true}"#)).is_ok(),
+            "the explicit waiver has no launcher status to reinterpret"
+        );
+    }
+
+    #[derive(Debug)]
+    struct UnsupportedSandbox;
+
+    impl CommandSandbox for UnsupportedSandbox {
+        fn confine(
+            &self,
+            _spec: &SandboxSpec,
+            command: ShellCommand,
+        ) -> Result<ShellCommand, CommandSandboxError> {
+            Ok(command)
+        }
+
+        fn backend(&self) -> &'static str {
+            "unsupported"
+        }
+    }
+
+    #[test]
+    fn an_unknown_sandbox_adapter_fails_closed_on_nonzero() {
+        assert!(matches!(
+            apply(UnsupportedSandbox.classify_outcome(126, r#"{"ok":true}"#)),
+            Err(ShellError::Blocked { .. })
+        ));
+        let zero = ShellResult::new(0, "", "", std::time::Duration::ZERO)
+            .with_adapter_outcome(UnsupportedSandbox.classify_outcome(0, ""))
+            .into_process_result();
+        assert!(zero.is_ok());
     }
 
     #[test]

--- a/crates/nika-kernel-core/src/io/process.rs
+++ b/crates/nika-kernel-core/src/io/process.rs
@@ -211,6 +211,58 @@ enum ShellResultFailure {
     Transport(String),
 }
 
+/// Typed terminal receipt produced by a local sandbox or remote adapter.
+///
+/// Captured bytes alone never prove that a remote or wrapped process reached
+/// a business exit. Adapters must attach one of these receipts; an absent or
+/// unsupported receipt is a transport failure, never structured data.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ShellAdapterOutcome {
+    kind: ShellAdapterOutcomeKind,
+}
+
+#[derive(Debug, Clone)]
+enum ShellAdapterOutcomeKind {
+    Process,
+    Authority(String),
+    Transport(String),
+}
+
+impl ShellAdapterOutcome {
+    /// The status belongs to the authored business process.
+    #[must_use]
+    pub fn process() -> Self {
+        Self {
+            kind: ShellAdapterOutcomeKind::Process,
+        }
+    }
+
+    /// A permit, sandbox, or remote authority refused the operation.
+    #[must_use]
+    pub fn authority_refusal(reason: impl Into<String>) -> Self {
+        Self {
+            kind: ShellAdapterOutcomeKind::Authority(reason.into()),
+        }
+    }
+
+    /// The adapter did not deliver a trustworthy process outcome.
+    #[must_use]
+    pub fn transport_failure(reason: impl Into<String>) -> Self {
+        Self {
+            kind: ShellAdapterOutcomeKind::Transport(reason.into()),
+        }
+    }
+
+    /// A remote/adapter envelope carried bytes without a terminal receipt.
+    #[must_use]
+    pub fn missing_terminal_receipt(adapter: &'static str) -> Self {
+        Self::transport_failure(format!(
+            "{adapter} returned captured bytes without a terminal receipt"
+        ))
+    }
+}
+
 impl ShellResult {
     /// Create a new shell result.
     #[must_use]
@@ -259,6 +311,26 @@ impl ShellResult {
     #[must_use]
     pub fn with_transport_failure(mut self, reason: impl Into<String>) -> Self {
         self.failure = Some(ShellResultFailure::Transport(reason.into()));
+        self
+    }
+
+    /// Attach a typed adapter receipt to captured bytes.
+    ///
+    /// This is the production hand-off for both sandbox wrappers and future
+    /// remote workers. `MissingTerminalReceipt` fails closed so a remote
+    /// adapter cannot turn plausible output into a process result merely by
+    /// omitting its terminal authority receipt.
+    #[must_use]
+    pub fn with_adapter_outcome(mut self, outcome: ShellAdapterOutcome) -> Self {
+        self.failure = match outcome.kind {
+            ShellAdapterOutcomeKind::Process => self.failure,
+            ShellAdapterOutcomeKind::Authority(reason) => {
+                Some(ShellResultFailure::Authority(reason))
+            }
+            ShellAdapterOutcomeKind::Transport(reason) => {
+                Some(ShellResultFailure::Transport(reason))
+            }
+        };
         self
     }
 
@@ -422,6 +494,33 @@ mod tests {
             .with_transport_failure("remote disconnected")
             .into_process_result();
         assert!(matches!(transport, Err(ShellError::Other { .. })));
+    }
+
+    #[test]
+    fn remote_terminal_receipt_table_is_fail_closed() {
+        let process = ShellResult::new(7, r#"{"ok":true}"#, "", Duration::ZERO)
+            .with_adapter_outcome(ShellAdapterOutcome::process())
+            .into_process_result();
+        assert!(matches!(process, Ok(result) if result.status == 7));
+
+        let authority = ShellResult::new(126, r#"{"ok":true}"#, "", Duration::ZERO)
+            .with_adapter_outcome(ShellAdapterOutcome::authority_refusal(
+                "remote permit refused",
+            ))
+            .into_process_result();
+        assert!(matches!(authority, Err(ShellError::Blocked { .. })));
+
+        let disconnected = ShellResult::new(0, "partial", "", Duration::ZERO)
+            .with_adapter_outcome(ShellAdapterOutcome::transport_failure(
+                "remote stream disconnected",
+            ))
+            .into_process_result();
+        assert!(matches!(disconnected, Err(ShellError::Other { .. })));
+
+        let unsupported = ShellResult::new(0, r#"{"ok":true}"#, "", Duration::ZERO)
+            .with_adapter_outcome(ShellAdapterOutcome::missing_terminal_receipt("remote"))
+            .into_process_result();
+        assert!(matches!(unsupported, Err(ShellError::Other { .. })));
     }
 
     #[test]

--- a/crates/nika-kernel-core/src/io/process.rs
+++ b/crates/nika-kernel-core/src/io/process.rs
@@ -202,6 +202,13 @@ pub struct ShellResult {
     pub stdout_raw: Option<Vec<u8>>,
     /// The RAW captured stderr octets (see `stdout_raw`).
     pub stderr_raw: Option<Vec<u8>>,
+    failure: Option<ShellResultFailure>,
+}
+
+#[derive(Debug, Clone)]
+enum ShellResultFailure {
+    Authority(String),
+    Transport(String),
 }
 
 impl ShellResult {
@@ -220,6 +227,7 @@ impl ShellResult {
             duration,
             stdout_raw: None,
             stderr_raw: None,
+            failure: None,
         }
     }
 
@@ -230,6 +238,42 @@ impl ShellResult {
         self.stdout_raw = Some(stdout_raw);
         self.stderr_raw = Some(stderr_raw);
         self
+    }
+
+    /// Mark a captured adapter result as an authority refusal.
+    ///
+    /// Some sandbox, permit, and remote-process adapters must drain output
+    /// before they can classify the terminal status. This tag keeps that
+    /// refusal typed so `capture: structured` cannot reinterpret the drained
+    /// bytes as successful business data.
+    #[must_use]
+    pub fn with_authority_refusal(mut self, reason: impl Into<String>) -> Self {
+        self.failure = Some(ShellResultFailure::Authority(reason.into()));
+        self
+    }
+
+    /// Mark a captured adapter result as a transport failure.
+    ///
+    /// The output may have been drained for cleanup or diagnostics, but it is
+    /// never a process outcome that capture policy may declassify.
+    #[must_use]
+    pub fn with_transport_failure(mut self, reason: impl Into<String>) -> Self {
+        self.failure = Some(ShellResultFailure::Transport(reason.into()));
+        self
+    }
+
+    /// Consume the captured envelope and recover only a business-process
+    /// result. Typed authority/transport failures take precedence.
+    ///
+    /// # Errors
+    /// Returns [`ShellError::Blocked`] for an authority refusal and
+    /// [`ShellError::Other`] for a transport failure.
+    pub fn into_process_result(self) -> Result<Self, ShellError> {
+        match self.failure {
+            None => Ok(self),
+            Some(ShellResultFailure::Authority(reason)) => Err(ShellError::Blocked { reason }),
+            Some(ShellResultFailure::Transport(reason)) => Err(ShellError::Other { reason }),
+        }
     }
 
     /// The exact captured stdout octets — the recorded raw stream when
@@ -366,6 +410,18 @@ mod tests {
     fn shell_result_failure() {
         let result = ShellResult::new(1, "", "error", Duration::from_millis(50));
         assert!(!result.success());
+    }
+
+    #[test]
+    fn shell_result_typed_failures_precede_process_interpretation() {
+        let authority = ShellResult::new(126, "plausible", "", Duration::ZERO)
+            .with_authority_refusal("permit refused")
+            .into_process_result();
+        assert!(matches!(authority, Err(ShellError::Blocked { .. })));
+        let transport = ShellResult::new(1, "partial", "", Duration::ZERO)
+            .with_transport_failure("remote disconnected")
+            .into_process_result();
+        assert!(matches!(transport, Err(ShellError::Other { .. })));
     }
 
     #[test]

--- a/crates/nika-runtime/public-api.txt
+++ b/crates/nika-runtime/public-api.txt
@@ -129,14 +129,14 @@ pub nika_runtime::approval::PausedApproval::ticket: nika_runtime::approval::Appr
 pub nika_runtime::approval::PausedApproval::trace_nonce: alloc::string::String
 impl nika_runtime::approval::PausedApproval
 pub fn nika_runtime::approval::PausedApproval::new(ticket: nika_runtime::approval::ApprovalTicket, trace_nonce: alloc::string::String) -> Self
+pub fn nika_runtime::approval::PausedApproval::with_durable_claim_root(self, root: &std::path::Path) -> core::io::error::Result<Self>
 impl core::clone::Clone for nika_runtime::approval::PausedApproval
 pub fn nika_runtime::approval::PausedApproval::clone(&self) -> nika_runtime::approval::PausedApproval
 impl core::cmp::Eq for nika_runtime::approval::PausedApproval
 impl core::cmp::PartialEq for nika_runtime::approval::PausedApproval
-pub fn nika_runtime::approval::PausedApproval::eq(&self, other: &nika_runtime::approval::PausedApproval) -> bool
+pub fn nika_runtime::approval::PausedApproval::eq(&self, other: &Self) -> bool
 impl core::fmt::Debug for nika_runtime::approval::PausedApproval
 pub fn nika_runtime::approval::PausedApproval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for nika_runtime::approval::PausedApproval
 impl<D> owo_colors::OwoColorize for nika_runtime::approval::PausedApproval
 impl<Q, K> equivalent::Equivalent<K> for nika_runtime::approval::PausedApproval where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
 pub fn nika_runtime::approval::PausedApproval::equivalent(&self, key: &K) -> bool

--- a/crates/nika-runtime/src/approval.rs
+++ b/crates/nika-runtime/src/approval.rs
@@ -1,42 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! F-P4 · the human approval is a BOUNDED CAPABILITY (NEP-0013 · the 6th
-//! invariant) — the `nika:prompt` gate, ticketed.
-//!
-//! The gate today is a bare call (the `Prompter` seam in nika-builtin):
-//! nothing binds what was SHOWN to what was SIGNED, nothing bounds the
-//! prompt storm, nothing attests the decision in the journal. This
-//! module wraps the seam — never edits it, the builtin stays a pure
-//! call — with the five laws:
-//!
-//! 1. **Content-bound (WYSIWYS)** — the ticket hashes the CANONICAL
-//!    render of the shown content (mode · message · choices over the
-//!    secret-marker scope, the pause payload's own discipline) + the
-//!    action's identity + the effect classes the yes unleashes (JCS +
-//!    blake3 · never an LLM summary). A resumed `--answer` whose
-//!    recomputed hash ≠ the shown hash is refused
-//!    (`approval.content_mismatch`).
-//! 2. **Scope + TTL** — the ticket lives for THIS run (the nonce is the
-//!    `workflow_started` event id) × THIS step × THIS hash · TTL
-//!    [`APPROVAL_TTL_SECONDS`] · expired = re-prompt · a cross-run
-//!    replay is refused (the nonce names another run).
-//! 3. **Anti-fatigue + single-use** — at most
-//!    [`APPROVAL_MAX_TICKETS_PER_RUN`] tickets mint per run; the task id
-//!    binds the shown content, and a decided ticket is consumed rather
-//!    than replayed. The N+1ᵗʰ mint is the typed refusal
-//!    ([`APPROVAL_CODE`] · `approval.rate_limited`) — never a queue.
-//! 4. **Attestation** — every decision lands as a hash-chained
-//!    `approval_decided` frame (digest · shown-hash · decision · TTL ·
-//!    scope) beside the task's terminal frame; a blocking prompt that
-//!    pauses the run serializes its mint on the `workflow_paused`
-//!    frame, and the resumed run validates the `--answer` against it
-//!    BEFORE binding.
-//! 5. **Revocation** — before execution only: the pause IS the
-//!    pre-execution window (a ticket is revoked by never answering it);
-//!    the journal is append-only, nothing rewrites retroactively.
-//!
-//! The ticket attests what happened — it never promises.
+//! Human approval as a bounded capability (NEP-0013): shown content is
+//! hash-bound to one run and step, tickets expire and are single-use, each
+//! run has a mint limit, and every decision is journaled. A resumed answer is
+//! validated before binding; refusing or abandoning it grants no authority.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
@@ -50,26 +18,16 @@ use serde_json::{Value, json};
 use crate::expr::{self, Scope};
 use crate::record::TaskRecord;
 
-/// NEP-0013 law 2 — the ticket's time-to-live: the fresh-consent window
-/// (the sudo timestamp precedent). The named engine constant · v1 fixes
-/// it (a `policy:` knob is the named owe if a deployment ever proves it
-/// needs another).
+/// Fresh-consent window (NEP-0013 law 2).
 pub const APPROVAL_TTL_SECONDS: u32 = 15 * 60;
 
-/// NEP-0013 law 3 — the per-run prompt-storm bound: at most this many
-/// DISTINCT tickets mint per run. The next distinct mint is the typed
-/// refusal, never a queue.
+/// Per-run prompt-storm bound (NEP-0013 law 3).
 pub const APPROVAL_MAX_TICKETS_PER_RUN: u32 = 5;
 
-/// The wire code every approval-capability refusal speaks — the
-/// `security_error` family, the NEP-0013 row after `NIKA-SEC-009`
-/// (trifecta). Catchable by `on_error.on_codes:` like every spec-plane
-/// security stop; never transient.
+/// Wire code for non-transient approval-capability refusals.
 pub const APPROVAL_CODE: &str = "NIKA-SEC-010";
 
-/// The canonical-content recipe version (the resume `KEY_VERSION`
-/// precedent): bump on any shape change — older tickets simply mismatch
-/// and re-ask, honest, never a wrong bind.
+/// Bump when the canonical shown-content shape changes.
 const CONTENT_RECIPE_VERSION: u32 = 2;
 
 /// What a ticket resolved to (NEP-0013 law 4 · the wire vocabulary).
@@ -84,9 +42,7 @@ pub enum ApprovalDecision {
     /// The gate resolved to refuse (a confirm answered false · an
     /// engine refusal — the event's `why` names the law applied).
     Deny,
-    /// Legacy wire value from the pre-single-use implementation. New
-    /// decisions never emit it; retained so older journal readers can
-    /// still deserialize historical traces.
+    /// Legacy wire value retained for historical trace readers.
     Dedup,
 }
 
@@ -103,9 +59,7 @@ impl ApprovalDecision {
     }
 }
 
-/// One bounded-approval capability (NEP-0013 · law 1+2). Minted BEFORE
-/// the ask, inside the runtime layer — the prompter seam itself stays a
-/// pure call and never sees it.
+/// One bounded-approval capability, minted before the prompt runs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ApprovalTicket {
@@ -113,11 +67,9 @@ pub struct ApprovalTicket {
     pub content_hash: String,
     /// The run's identity — its `workflow_started` event id (law 2).
     pub run_nonce: String,
-    /// The prompt task this ticket was minted at (law 2 · the journal's
-    /// `task` on the frames it rides).
+    /// The prompt task this ticket was minted at.
     pub step: String,
-    /// Mint time — wall-clock unix ms from the run's injected clock seam
-    /// (a determinism demand resolves a deterministic clock · F-P3).
+    /// Mint time from the run's injected clock, in Unix milliseconds.
     pub minted_at_ms: i64,
     /// The TTL the mint carries ([`APPROVAL_TTL_SECONDS`] today).
     pub ttl_seconds: u32,
@@ -145,13 +97,7 @@ impl ApprovalTicket {
         }
     }
 
-    /// The ticket's own digest — JCS + blake3 over the MINT fields (the
-    /// capability's identity). The decision is excluded on purpose: the
-    /// digest names the capability, the `approval_decided` frame names
-    /// its use — so the digest the pause showed equals the digest the
-    /// answer signs. `None` only if the payload cannot canonicalize
-    /// (string/int fields by construction — the honest-absent door,
-    /// never a fabricated digest).
+    /// JCS + blake3 over the mint fields; the later decision is excluded.
     #[must_use]
     pub fn digest(&self) -> Option<String> {
         crate::resume::jcs_blake3_hex(&json!({
@@ -182,11 +128,7 @@ impl ApprovalTicket {
     }
 }
 
-/// The folded resume authority (NEP-0013 law 1+2) — what the composer
-/// reads back from a paused trace: the journaled ticket plus the run
-/// identity of the trace it came from (its `workflow_started` event id).
-/// The cross-run check is self-contained in the trace bytes: a ticket
-/// whose `run_nonce` names another run is a replay, refused.
+/// A journaled ticket folded from a paused trace with that trace's run nonce.
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct PausedApproval {
@@ -208,32 +150,18 @@ impl PausedApproval {
         }
     }
 
-    /// Bind this folded ticket to a descriptor-held, durable claim store.
-    ///
-    /// The runtime consumes the ticket through an atomic create-once marker
-    /// immediately before admitting the answer. Clones share the in-process
-    /// atomic, while independently folded CLI resumes converge on the same
-    /// ticket-digest marker below the caller's local Nika state root.
+    /// Bind the ticket to a descriptor-held, create-once claim store.
     ///
     /// # Errors
-    /// The claim directory cannot be opened or created without following a
-    /// symlink. Callers must fail closed rather than resume without it.
+    /// Returns an error when the owned claim directory cannot be opened.
     pub fn with_durable_claim_root(mut self, root: &Path) -> io::Result<Self> {
         let store = nika_fs::OwnedDir::create(root, &[".nika", "approval-claims"])?;
-        self.claim = Arc::new(ApprovalClaim {
-            consumed: AtomicBool::new(false),
-            dir: Some(store),
-        });
+        self.claim = Arc::new(ApprovalClaim::durable(store));
         Ok(self)
     }
 
     fn consume(&self) -> Result<(), ClaimError> {
-        if self
-            .claim
-            .consumed
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
+        if self.claim.consumed.swap(true, Ordering::AcqRel) {
             return Err(ClaimError::Consumed);
         }
         let Some(dir) = &self.claim.dir else {
@@ -278,6 +206,13 @@ impl ApprovalClaim {
             dir: None,
         }
     }
+
+    fn durable(dir: nika_fs::OwnedDir) -> Self {
+        Self {
+            consumed: AtomicBool::new(false),
+            dir: Some(dir),
+        }
+    }
 }
 
 enum ClaimError {
@@ -285,28 +220,19 @@ enum ClaimError {
     Unavailable,
 }
 
-/// The `approval_decided` payload, assembled at the pipeline and emitted
-/// by the settle spine (the pens stay in ONE site — the declassify
-/// precedent). `task` on the wire IS the ticket's `step` (the journal
-/// joins per-task frames on it; the dossier's scope word is `step`).
+/// Payload for the settle spine's `approval_decided` frame.
 pub(crate) struct ApprovalAttestation {
     pub task: String,
     pub mode: String,
     pub decision: &'static str,
-    /// WHO answered, honestly scoped to what this layer can know:
-    /// `resume` (a validated paused-ticket answer) · `cli` (a fresh-run
-    /// `--answer`) · `policy` (an authored `default:`) · `builtin`
-    /// (the builtin resolved an answer without claiming a human identity)
-    /// · `engine` (an engine refusal). API principal provenance is added
-    /// by the remote adapter rather than guessed at this local seam.
+    /// Provenance: `resume`, `cli`, `policy`, `builtin`, or `engine`.
     pub source: &'static str,
     pub shown_hash: String,
     pub digest: Option<String>,
     pub run_nonce: String,
     pub ttl_seconds: u32,
     pub ttl_remaining_seconds: i64,
-    /// The law applied on an engine refusal (`approval.rate_limited` ·
-    /// `approval.content_mismatch` · `approval.scope_mismatch`).
+    /// The law applied on an engine refusal.
     pub why: Option<&'static str>,
 }
 
@@ -340,12 +266,9 @@ impl ApprovalAttestation {
 pub(crate) enum Gate {
     /// Not a direct `invoke: nika:prompt` — the pipeline runs unchanged.
     NotPrompt,
-    /// Run the (possibly answer/dedup-bound) task. Boxed: the enum
-    /// stays slim on every path (the `RawTask` is the heavy arm).
+    /// Run the possibly answer-bound task.
     Run(Box<RawTask>),
-    /// The capability was refused (`NIKA-SEC-010`) — the task never
-    /// starts; the attestation rides the Finish to the settle spine.
-    /// Boxed: the happy path stays slim (the `Run` variant's size law).
+    /// Refuse before the task starts and retain the attestation.
     Refused(Box<Refusal>),
 }
 
@@ -355,21 +278,20 @@ pub(crate) struct Refusal {
     pub attestation: ApprovalAttestation,
 }
 
-/// One gated action in a prompt's unleashed closure (the content's
-/// `gated` entries).
+/// One action in a prompt's unleashed closure.
 #[derive(Debug, Clone)]
 struct GatedAction {
     task: String,
     classes: Vec<&'static str>,
 }
 
-/// The book's per-content record (the dedup state · law 3).
+/// Per-content mint state.
 struct MintedApproval {
     ticket: ApprovalTicket,
     decided: Option<(ApprovalDecision, Value)>,
 }
 
-/// The book's per-step line (the pause payload + the attestation read it).
+/// Per-step state read by pause and attestation paths.
 struct StepEntry {
     ticket: ApprovalTicket,
     mode: String,
@@ -378,13 +300,13 @@ struct StepEntry {
 
 #[derive(Default)]
 struct BookInner {
-    /// THIS run's identity (the `workflow_started` event id).
+    /// This run's `workflow_started` event id.
     nonce: String,
     /// Prompt step → its unleashed closure (computed once per run).
     gated: BTreeMap<String, Vec<GatedAction>>,
-    /// Content hash → the minted ticket + its decision (the dedup map).
+    /// Content hash → mint state.
     minted: BTreeMap<String, MintedApproval>,
-    /// Prompt step → its entry (one prompt task mints at most once a run).
+    /// Prompt step → its entry.
     steps: BTreeMap<String, StepEntry>,
     /// The anti-fatigue counter (law 3) — DISTINCT mints this run.
     mints: u32,
@@ -392,10 +314,7 @@ struct BookInner {
     paused: Option<PausedApproval>,
 }
 
-/// The per-run approval state. Shared `&self` across the wave's
-/// concurrent pipelines — a Mutex over the tiny maps is the whole story
-/// (the `RunLedger` precedent: short synchronous critical sections,
-/// never held across an await).
+/// Per-run approval state shared across concurrent task pipelines.
 pub(crate) struct ApprovalBook {
     inner: Mutex<BookInner>,
 }
@@ -415,10 +334,7 @@ impl ApprovalBook {
         }
     }
 
-    /// A poisoned lock = a sibling panicked mid-fold (test-harness
-    /// class): the maps are plain accumulators with no invariant a
-    /// partial write could break — recover and keep the law (the
-    /// `RunLedger` idiom, verbatim).
+    /// Recover the plain accumulator maps after a test-harness panic.
     fn lock(&self) -> std::sync::MutexGuard<'_, BookInner> {
         match self.inner.lock() {
             Ok(inner) => inner,
@@ -426,18 +342,14 @@ impl ApprovalBook {
         }
     }
 
-    /// Open the run: stamp the nonce + precompute every prompt's
-    /// unleashed closure (static over the workflow bytes — identical on
-    /// the paused and the resumed run, which is what makes the shown
-    /// hash recomputable at resume).
+    /// Stamp the nonce and precompute each prompt's static closure.
     pub(crate) fn begin_run(&self, wf: &RawWorkflow, nonce: String) {
         let mut inner = self.lock();
         inner.nonce = nonce;
         inner.gated = gated_closures(wf);
     }
 
-    /// Inject the composer's folded resume authority (ADR-099 rider ·
-    /// `None` on a fresh run).
+    /// Inject folded resume authority (`None` for a fresh run).
     pub(crate) fn set_paused(&self, paused: Option<PausedApproval>) {
         self.lock().paused = paused;
     }
@@ -452,9 +364,7 @@ impl ApprovalBook {
         self.lock().gated.get(step).cloned().unwrap_or_default()
     }
 
-    /// The gate's state machine (laws 1–3). `answer` is the operator's
-    /// `--answer` for this step when present. Every path either names
-    /// the ticket to run under or refuses — never a queue.
+    /// Admit or refuse this step under the ticket state machine.
     fn admit(
         &self,
         step: &str,
@@ -473,11 +383,7 @@ impl ApprovalBook {
         admit_live(&mut inner, step, mode, shown_hash, now_ms, answer, source)
     }
 
-    /// Assemble the `approval_decided` payload for a Ran task — `Some`
-    /// only when the ask RESOLVED (a success): a blocked prompt carries
-    /// its mint on the `workflow_paused` frame instead, and a failed one
-    /// attests nothing beyond its `task_failed`. Records the decision
-    /// for the run's later dedup (law 3).
+    /// Attest a resolved prompt; blocked and failed prompts attest elsewhere.
     pub(crate) fn attest_outcome(
         &self,
         task: &str,
@@ -504,8 +410,7 @@ impl ApprovalBook {
         } else {
             ApprovalDecision::Allow
         };
-        // First terminal wins. A duplicate/racing terminal can observe the
-        // settled decision, but it can never rewrite a deny into an allow.
+        // First terminal wins; a racing terminal cannot rewrite it.
         let decision = if let Some(minted) = inner.minted.get_mut(&ticket.content_hash) {
             if let Some((settled, _)) = &minted.decided {
                 *settled
@@ -531,10 +436,7 @@ impl ApprovalBook {
         };
         drop(inner);
 
-        // `false` in confirm mode is an authority denial, not successful
-        // boolean data. It settles after dispatch (the prompt did run) but
-        // before output binding and DAG admission, and bypasses `on_error`
-        // recovery so authored policy cannot convert the denial to green.
+        // A false confirmation is an authority denial, not successful data.
         if decision == ApprovalDecision::Deny
             && let crate::task::SettleAs::Ran(ran) = settle
         {
@@ -554,10 +456,7 @@ impl ApprovalBook {
     }
 }
 
-/// Law 1+2 — the resumed ticket validates BEFORE anything binds.
-/// `Some(verdict)` when a paused ticket covers this answered step
-/// (refused · re-minted · or bound against the SHOWN ticket); `None`
-/// hands the step to the live state machine. The caller holds the lock.
+/// Validate a matching paused ticket before binding its answer.
 fn admit_resumed(
     inner: &mut BookInner,
     step: &str,
@@ -567,8 +466,7 @@ fn admit_resumed(
     answer: Option<&Value>,
     source: &'static str,
 ) -> Option<Admit> {
-    // (cloned up front — the expiry path consumes the slot, so the
-    // borrow cannot live across the state machine.)
+    // Clone because the expiry path consumes the paused slot.
     let paused = inner
         .paused
         .as_ref()
@@ -613,9 +511,7 @@ fn admit_resumed(
         )));
     }
     if ticket.is_expired(now_ms) {
-        // Law 2 — expired = re-prompt: the stale answer does NOT bind;
-        // the authority is consumed and a fresh ticket mints (a
-        // non-interactive surface pauses again).
+        // Expired authority re-mints without binding the stale answer.
         inner.paused = None;
         return Some(mint(inner, step, mode, shown_hash, now_ms, None, source));
     }
@@ -645,26 +541,15 @@ fn admit_resumed(
             detail,
         )));
     }
-    // Valid — the answer binds against the SHOWN ticket. No new mint,
-    // no count: the capability was issued by the paused run.
+    // This capability was issued by the paused run, so no new mint counts.
     inner.paused = None;
-    inner.steps.insert(
-        step.to_owned(),
-        StepEntry {
-            ticket,
-            mode: mode.to_owned(),
-            source: "resume",
-        },
-    );
+    remember_step(inner, step, ticket, mode, "resume");
     Some(Admit::Run {
         bind: Some(answer.clone()),
     })
 }
 
-/// The live state machine (no resumed ticket in play): a DECIDED ticket is
-/// consumed and always re-mints; only an undecided in-flight twin can share
-/// its mint. Canonical content includes the step identity, so normal tasks
-/// cannot share that in-flight capability. The caller holds the lock.
+/// Admit a live ticket; decided tickets re-mint, in-flight twins may share.
 fn admit_live(
     inner: &mut BookInner,
     step: &str,
@@ -683,14 +568,7 @@ fn admit_live(
             inner.minted.remove(shown_hash);
             return mint(inner, step, mode, shown_hash, now_ms, answer, source);
         }
-        inner.steps.insert(
-            step.to_owned(),
-            StepEntry {
-                ticket,
-                mode: mode.to_owned(),
-                source,
-            },
-        );
+        remember_step(inner, step, ticket, mode, source);
         return Admit::Run {
             bind: answer.cloned(),
         };
@@ -698,9 +576,7 @@ fn admit_live(
     mint(inner, step, mode, shown_hash, now_ms, answer, source)
 }
 
-/// Mint a fresh ticket for a new distinct content — the N+1ᵗʰ distinct
-/// mint of the run is the typed refusal (law 3 · never a queue). The
-/// caller holds the lock.
+/// Mint a ticket or refuse the first mint above the per-run bound.
 fn mint(
     inner: &mut BookInner,
     step: &str,
@@ -742,6 +618,19 @@ fn mint(
             decided: None,
         },
     );
+    remember_step(inner, step, ticket, mode, source);
+    Admit::Run {
+        bind: answer.cloned(),
+    }
+}
+
+fn remember_step(
+    inner: &mut BookInner,
+    step: &str,
+    ticket: ApprovalTicket,
+    mode: &str,
+    source: &'static str,
+) {
     inner.steps.insert(
         step.to_owned(),
         StepEntry {
@@ -750,13 +639,9 @@ fn mint(
             source,
         },
     );
-    Admit::Run {
-        bind: answer.cloned(),
-    }
 }
 
-/// Build a refusal with its attestation (the deny event the settle
-/// spine journals before the task's failure frame).
+/// Build the deny attestation journaled before task failure.
 fn refusal(
     inner: &BookInner,
     step: &str,
@@ -793,26 +678,19 @@ pub(crate) fn is_prompt_task(task: &RawTask) -> bool {
     )
 }
 
-/// Bind an answer to a `nika:prompt` task as its `default:` (the
-/// answered branch of the stdlib contract — the builtin validates the
-/// TYPE per mode, so a bad answer fails with the same honest
-/// PROMPT-001/002 diagnostics). The gate owns every CALL (it validates
-/// the ticket BEFORE binding · NEP-0013); this is the mechanical
-/// binder — dispatch-only, never the resume identity.
+/// Bind an answer as `default:` after the gate has validated its ticket.
 pub(crate) fn prompt_task_with_default(task: &RawTask, answer: &Value) -> RawTask {
     let mut bound = task.clone();
     let RawAction::Invoke(invoke) = &mut bound.action else {
         return bound; // unreachable — the gate only calls for a prompt
     };
     if let Some(args) = invoke.args.as_mut() {
-        // Non-object args fail the builtin's own validation — never
-        // silently rewritten here.
+        // Preserve non-object args for the builtin's own validation.
         if let Value::Object(map) = &mut args.value {
             map.insert("default".to_owned(), answer.clone());
         }
     } else {
-        // No args at all (message missing → the builtin refuses
-        // loudly anyway) — still bind, one behavior.
+        // Bind even without args; the builtin still validates required fields.
         let span = task.id.span;
         invoke.args = Some(nika_schema::Spanned::new(
             serde_json::json!({ "default": answer }),
@@ -822,9 +700,7 @@ pub(crate) fn prompt_task_with_default(task: &RawTask, answer: &Value) -> RawTas
     bound
 }
 
-/// The task's coarse effect classes, sorted by name (the canonical
-/// content's `effects` · nika-cap's policy projection — one vocabulary
-/// for the shown content and the check's batch rule).
+/// The task's coarse effect classes, sorted for canonical content.
 fn effect_classes_of(task: &RawTask) -> Vec<&'static str> {
     let tool = match &task.action {
         RawAction::Invoke(invoke) => invoke.tool().map(|t| t.value.as_str()),
@@ -838,11 +714,7 @@ fn effect_classes_of(task: &RawTask) -> Vec<&'static str> {
     names
 }
 
-/// Every prompt step's unleashed closure: the descendants its yes
-/// unleashes BEFORE any other human question, with their effect classes.
-/// The walk never traverses THROUGH another `nika:prompt` — the nearest
-/// gate owns what it re-asks for (the check's batch rule reads the same
-/// closure law).
+/// Effectful descendants unleashed before another prompt boundary.
 fn gated_closures(wf: &RawWorkflow) -> BTreeMap<String, Vec<GatedAction>> {
     let mut downstream: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for task in &wf.tasks {
@@ -892,16 +764,10 @@ fn gated_closures(wf: &RawWorkflow) -> BTreeMap<String, Vec<GatedAction>> {
     out
 }
 
-/// The canonical shown content (NEP-0013 law 1): the rendered mode ·
-/// message · choices over the SECRET-MARKER scope (the pause payload's
-/// discipline — a resolved secret value never enters the hash, a render
-/// miss falls back to the raw authored text), the action's identity,
-/// its effect classes, and the unleashed closure. JCS + blake3 — never
-/// a summary, never a float (the recipe is strings/arrays/ints only).
+/// Canonical shown content over the secret-marker scope (NEP-0013 law 1).
 fn canonical_content(task: &RawTask, gated: &[GatedAction], scope: &Scope<'_>) -> (String, Value) {
     let RawAction::Invoke(invoke) = &task.action else {
-        // The gate guards this (is_prompt_task) — a non-invoke never
-        // reaches here; the fallback keeps the function total.
+        // The gate guarantees invoke; keep this helper total regardless.
         return ("confirm".to_owned(), Value::Null);
     };
     let raw = invoke
@@ -952,9 +818,7 @@ impl<S, T, H, P, D, C> crate::Runtime<S, T, H, P, D, C>
 where
     C: nika_kernel::clock::ClockDyn + Sync,
 {
-    /// The wall-clock unix ms from the run's injected clock seam (never
-    /// a direct `SystemTime` read — a determinism demand resolves a
-    /// deterministic clock · F-P3).
+    /// Unix milliseconds from the injected clock seam.
     pub(crate) fn now_unix_ms(&self) -> i64 {
         self.clock
             .system_now()
@@ -963,10 +827,7 @@ where
             .unwrap_or(0)
     }
 
-    /// The F-P4 gate, applied to every task BEFORE it runs: a direct
-    /// `invoke: nika:prompt` mints its ticket first (rate-limit + dedup
-    /// enforced · the resumed `--answer` validated against the shown
-    /// hash), everything else passes through untouched.
+    /// Apply the bounded approval gate before a prompt runs.
     pub(crate) fn approval_gate(
         &self,
         task: &RawTask,
@@ -979,13 +840,7 @@ where
             return Gate::NotPrompt;
         }
         let step = task.id.value.as_str();
-        // The content renders over the SECRET-MARKER scope — the pause
-        // payload's own discipline (never a resolved secret value in the
-        // hash · markers only — a low-entropy secret inside a hash is an
-        // oracle, the resume-identity law). The task's `with:` namespace
-        // materializes over the SAME marker scope (upstream data reaches
-        // a prompt only through `with:` · NIKA-VAR-021), so the hash
-        // binds the RESOLVED question the human actually read.
+        // Hash the resolved question, but keep secrets as markers.
         let base = Scope {
             records,
             inputs,
@@ -1003,8 +858,7 @@ where
                     with_ns.insert(key.value.clone(), v);
                     true
                 }
-                // A `with:` miss degrades to the raw authored args (the
-                // pause payload's fallback) — the hash still binds.
+                // A miss falls back to authored args; the hash still binds.
                 Err(_) => false,
             }
         });
@@ -1015,9 +869,7 @@ where
         let gated = self.approvals.gated_for(step);
         let (mode, content) = canonical_content(task, &gated, &scope);
         let Some(shown_hash) = crate::resume::jcs_blake3_hex(&content) else {
-            // Strings/arrays/ints by construction — unreachable in
-            // practice; the law stays fail-closed anyway: an unhashable
-            // ask is never an unbounded one.
+            // The content shape is canonicalizable; still fail closed.
             let inner = self.approvals.lock();
             return Gate::Refused(Box::new(refusal(
                 &inner,
@@ -1047,9 +899,7 @@ where
         ) {
             "policy"
         } else {
-            // The generic tool-result seam carries no proof that the
-            // builtin answer came from a TTY. Stay honest: never elevate an
-            // unverified automated adapter to `human` provenance.
+            // The generic tool seam cannot prove a human answered.
             "builtin"
         };
         match self

--- a/crates/nika-runtime/src/approval.rs
+++ b/crates/nika-runtime/src/approval.rs
@@ -21,10 +21,10 @@
 //!    `workflow_started` event id) × THIS step × THIS hash · TTL
 //!    [`APPROVAL_TTL_SECONDS`] · expired = re-prompt · a cross-run
 //!    replay is refused (the nonce names another run).
-//! 3. **Anti-fatigue** — at most [`APPROVAL_MAX_TICKETS_PER_RUN`]
-//!    distinct tickets mint per run; identical content dedups to ONE
-//!    ticket (the second ask is attested `dedup`, never re-questioned);
-//!    the N+1ᵗʰ distinct mint is the typed refusal
+//! 3. **Anti-fatigue + single-use** — at most
+//!    [`APPROVAL_MAX_TICKETS_PER_RUN`] tickets mint per run; the task id
+//!    binds the shown content, and a decided ticket is consumed rather
+//!    than replayed. The N+1ᵗʰ mint is the typed refusal
 //!    ([`APPROVAL_CODE`] · `approval.rate_limited`) — never a queue.
 //! 4. **Attestation** — every decision lands as a hash-chained
 //!    `approval_decided` frame (digest · shown-hash · decision · TTL ·
@@ -67,7 +67,7 @@ pub const APPROVAL_CODE: &str = "NIKA-SEC-010";
 /// The canonical-content recipe version (the resume `KEY_VERSION`
 /// precedent): bump on any shape change — older tickets simply mismatch
 /// and re-ask, honest, never a wrong bind.
-const CONTENT_RECIPE_VERSION: u32 = 1;
+const CONTENT_RECIPE_VERSION: u32 = 2;
 
 /// What a ticket resolved to (NEP-0013 law 4 · the wire vocabulary).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,8 +81,9 @@ pub enum ApprovalDecision {
     /// The gate resolved to refuse (a confirm answered false · an
     /// engine refusal — the event's `why` names the law applied).
     Deny,
-    /// An identical earlier ticket's decision replayed (the human was
-    /// NOT re-questioned · law 3).
+    /// Legacy wire value from the pre-single-use implementation. New
+    /// decisions never emit it; retained so older journal readers can
+    /// still deserialize historical traces.
     Dedup,
 }
 
@@ -212,11 +213,11 @@ pub(crate) struct ApprovalAttestation {
     pub mode: String,
     pub decision: &'static str,
     /// WHO answered, honestly scoped to what this layer can know:
-    /// `resumed` (a validated paused-ticket `--answer`) · `answer` (a
-    /// fresh-run `--answer`) · `dedup` (an in-run replay) · `builtin`
-    /// (the builtin resolved it — a TTY answer or an authored `default:`,
-    /// the seam cannot split them and never guesses) · `engine` (an
-    /// engine refusal).
+    /// `resume` (a validated paused-ticket answer) · `cli` (a fresh-run
+    /// `--answer`) · `policy` (an authored `default:`) · `builtin`
+    /// (the builtin resolved an answer without claiming a human identity)
+    /// · `engine` (an engine refusal). API principal provenance is added
+    /// by the remote adapter rather than guessed at this local seam.
     pub source: &'static str,
     pub shown_hash: String,
     pub digest: Option<String>,
@@ -292,7 +293,6 @@ struct StepEntry {
     ticket: ApprovalTicket,
     mode: String,
     source: &'static str,
-    dedup: bool,
 }
 
 #[derive(Default)]
@@ -321,7 +321,7 @@ pub(crate) struct ApprovalBook {
 
 /// The book's answer to the gate.
 enum Admit {
-    /// Run — binding this answer (a `--answer` · a dedup replay) when set.
+    /// Run — binding this answer (a validated CLI/resume answer) when set.
     Run { bind: Option<Value> },
     /// Refuse — the typed detail + the attestation.
     Refused(Refusal),
@@ -381,12 +381,15 @@ impl ApprovalBook {
         shown_hash: &str,
         now_ms: i64,
         answer: Option<&Value>,
+        source: &'static str,
     ) -> Admit {
         let mut inner = self.lock();
-        if let Some(verdict) = admit_resumed(&mut inner, step, mode, shown_hash, now_ms, answer) {
+        if let Some(verdict) =
+            admit_resumed(&mut inner, step, mode, shown_hash, now_ms, answer, source)
+        {
             return verdict;
         }
-        admit_live(&mut inner, step, mode, shown_hash, now_ms, answer)
+        admit_live(&mut inner, step, mode, shown_hash, now_ms, answer, source)
     }
 
     /// Assemble the `approval_decided` payload for a Ran task — `Some`
@@ -397,49 +400,46 @@ impl ApprovalBook {
     pub(crate) fn attest_outcome(
         &self,
         task: &str,
-        settle: &crate::task::SettleAs,
+        settle: &mut crate::task::SettleAs,
         now_ms: i64,
     ) -> Option<ApprovalAttestation> {
-        let crate::task::SettleAs::Ran(ran) = settle else {
-            return None;
-        };
-        let crate::task::RunResult::Success { value, .. } = &ran.result else {
-            return None;
+        let (value, costs) = match settle {
+            crate::task::SettleAs::Ran(ran) => match &ran.result {
+                crate::task::RunResult::Success {
+                    value,
+                    cost_usd,
+                    cost_unpriced,
+                    ..
+                } => (value.clone(), (*cost_usd, *cost_unpriced)),
+                _ => return None,
+            },
+            _ => return None,
         };
         let mut inner = self.lock();
         let entry = inner.steps.get(task)?;
-        let (ticket, mode, source, dedup) = (
-            entry.ticket.clone(),
-            entry.mode.clone(),
-            entry.source,
-            entry.dedup,
-        );
-        let decision: &'static str = if dedup {
-            ApprovalDecision::Dedup.as_str()
-        } else if mode == "confirm" && matches!(value, Value::Bool(false)) {
-            ApprovalDecision::Deny.as_str()
+        let (ticket, mode, source) = (entry.ticket.clone(), entry.mode.clone(), entry.source);
+        let proposed = if mode == "confirm" && matches!(value, Value::Bool(false)) {
+            ApprovalDecision::Deny
         } else {
-            ApprovalDecision::Allow.as_str()
+            ApprovalDecision::Allow
         };
-        if !dedup && let Some(minted) = inner.minted.get_mut(&ticket.content_hash) {
-            minted.decided = Some((
-                if decision == ApprovalDecision::Deny.as_str() {
-                    ApprovalDecision::Deny
-                } else {
-                    ApprovalDecision::Allow
-                },
-                value.clone(),
-            ));
-            minted.ticket.decision = if decision == ApprovalDecision::Deny.as_str() {
-                ApprovalDecision::Deny
+        // First terminal wins. A duplicate/racing terminal can observe the
+        // settled decision, but it can never rewrite a deny into an allow.
+        let decision = if let Some(minted) = inner.minted.get_mut(&ticket.content_hash) {
+            if let Some((settled, _)) = &minted.decided {
+                *settled
             } else {
-                ApprovalDecision::Allow
-            };
-        }
-        Some(ApprovalAttestation {
+                minted.decided = Some((proposed, value));
+                minted.ticket.decision = proposed;
+                proposed
+            }
+        } else {
+            proposed
+        };
+        let attestation = ApprovalAttestation {
             task: task.to_owned(),
             mode,
-            decision,
+            decision: decision.as_str(),
             source,
             shown_hash: ticket.content_hash.clone(),
             digest: ticket.digest(),
@@ -447,7 +447,29 @@ impl ApprovalBook {
             ttl_seconds: ticket.ttl_seconds,
             ttl_remaining_seconds: ticket.ttl_remaining_seconds(now_ms),
             why: None,
-        })
+        };
+        drop(inner);
+
+        // `false` in confirm mode is an authority denial, not successful
+        // boolean data. It settles after dispatch (the prompt did run) but
+        // before output binding and DAG admission, and bypasses `on_error`
+        // recovery so authored policy cannot convert the denial to green.
+        if decision == ApprovalDecision::Deny
+            && let crate::task::SettleAs::Ran(ran) = settle
+        {
+            ran.result = crate::task::RunResult::Failed {
+                error: crate::record::TaskErrorRecord {
+                    code: APPROVAL_CODE.to_owned(),
+                    message: format!(
+                        "task '{task}' · approval.denied — the confirmation refused authority ({APPROVAL_CODE})"
+                    ),
+                    transient: false,
+                },
+                cost_usd: costs.0,
+                cost_unpriced: costs.1,
+            };
+        }
+        Some(attestation)
     }
 }
 
@@ -462,6 +484,7 @@ fn admit_resumed(
     shown_hash: &str,
     now_ms: i64,
     answer: Option<&Value>,
+    source: &'static str,
 ) -> Option<Admit> {
     // (cloned up front — the expiry path consumes the slot, so the
     // borrow cannot live across the state machine.)
@@ -511,7 +534,7 @@ fn admit_resumed(
         // the authority is consumed and a fresh ticket mints (a
         // non-interactive surface pauses again).
         inner.paused = None;
-        return Some(mint(inner, step, mode, shown_hash, now_ms, None));
+        return Some(mint(inner, step, mode, shown_hash, now_ms, None, source));
     }
     // Valid — the answer binds against the SHOWN ticket. No new mint,
     // no count: the capability was issued by the paused run.
@@ -520,8 +543,7 @@ fn admit_resumed(
         StepEntry {
             ticket,
             mode: mode.to_owned(),
-            source: "resumed",
-            dedup: false,
+            source: "resume",
         },
     );
     Some(Admit::Run {
@@ -529,10 +551,10 @@ fn admit_resumed(
     })
 }
 
-/// The live state machine (no resumed ticket in play): dedup a DECIDED
-/// ticket for the same content (law 3 — the human is never re-questioned
-/// inside the TTL), re-mint a stale one, share an in-flight twin's, or
-/// mint a new distinct content. The caller holds the lock.
+/// The live state machine (no resumed ticket in play): a DECIDED ticket is
+/// consumed and always re-mints; only an undecided in-flight twin can share
+/// its mint. Canonical content includes the step identity, so normal tasks
+/// cannot share that in-flight capability. The caller holds the lock.
 fn admit_live(
     inner: &mut BookInner,
     step: &str,
@@ -540,56 +562,30 @@ fn admit_live(
     shown_hash: &str,
     now_ms: i64,
     answer: Option<&Value>,
+    source: &'static str,
 ) -> Admit {
-    let prior = inner.minted.get(shown_hash).map(|m| {
-        (
-            m.ticket.clone(),
-            m.decided.clone(),
-            m.ticket.is_expired(now_ms),
-        )
-    });
-    if let Some((ticket, decided, expired)) = prior {
-        match decided {
-            Some((_decision, value)) if !expired => {
-                inner.steps.insert(
-                    step.to_owned(),
-                    StepEntry {
-                        ticket,
-                        mode: mode.to_owned(),
-                        source: "dedup",
-                        dedup: true,
-                    },
-                );
-                return Admit::Run { bind: Some(value) };
-            }
-            // A decided-but-stale ticket re-mints (fresh consent) · an
-            // undecided one is an in-flight twin (same-wave fan-out):
-            // same ticket, no new mint, no count.
-            Some(_) => {
-                inner.minted.remove(shown_hash);
-                return mint(inner, step, mode, shown_hash, now_ms, answer);
-            }
-            None => {
-                inner.steps.insert(
-                    step.to_owned(),
-                    StepEntry {
-                        ticket,
-                        mode: mode.to_owned(),
-                        source: if answer.is_some() {
-                            "answer"
-                        } else {
-                            "builtin"
-                        },
-                        dedup: false,
-                    },
-                );
-                return Admit::Run {
-                    bind: answer.cloned(),
-                };
-            }
+    let prior = inner
+        .minted
+        .get(shown_hash)
+        .map(|m| (m.ticket.clone(), m.decided.clone()));
+    if let Some((ticket, decided)) = prior {
+        if decided.is_some() {
+            inner.minted.remove(shown_hash);
+            return mint(inner, step, mode, shown_hash, now_ms, answer, source);
         }
+        inner.steps.insert(
+            step.to_owned(),
+            StepEntry {
+                ticket,
+                mode: mode.to_owned(),
+                source,
+            },
+        );
+        return Admit::Run {
+            bind: answer.cloned(),
+        };
     }
-    mint(inner, step, mode, shown_hash, now_ms, answer)
+    mint(inner, step, mode, shown_hash, now_ms, answer, source)
 }
 
 /// Mint a fresh ticket for a new distinct content — the N+1ᵗʰ distinct
@@ -602,6 +598,7 @@ fn mint(
     shown_hash: &str,
     now_ms: i64,
     answer: Option<&Value>,
+    source: &'static str,
 ) -> Admit {
     if inner.mints >= APPROVAL_MAX_TICKETS_PER_RUN {
         return Admit::Refused(refusal(
@@ -640,12 +637,7 @@ fn mint(
         StepEntry {
             ticket,
             mode: mode.to_owned(),
-            source: if answer.is_some() {
-                "answer"
-            } else {
-                "builtin"
-            },
-            dedup: false,
+            source,
         },
     );
     Admit::Run {
@@ -840,6 +832,7 @@ fn canonical_content(task: &RawTask, gated: &[GatedAction], scope: &Scope<'_>) -
             "gated": gated_json,
             "message": message,
             "mode": mode,
+            "step": task.id.value,
         },
     });
     (mode, content)
@@ -931,9 +924,27 @@ where
             )));
         };
         let answer = self.prompt_answers.get(step);
+        let source = if answer.is_some() {
+            "cli"
+        } else if matches!(
+            &task.action,
+            RawAction::Invoke(invoke)
+                if invoke
+                    .args
+                    .as_ref()
+                    .and_then(|args| args.value.get("default"))
+                    .is_some()
+        ) {
+            "policy"
+        } else {
+            // The generic tool-result seam carries no proof that the
+            // builtin answer came from a TTY. Stay honest: never elevate an
+            // unverified automated adapter to `human` provenance.
+            "builtin"
+        };
         match self
             .approvals
-            .admit(step, &mode, &shown_hash, self.now_unix_ms(), answer)
+            .admit(step, &mode, &shown_hash, self.now_unix_ms(), answer, source)
         {
             Admit::Run { bind } => match bind {
                 Some(value) => Gate::Run(Box::new(prompt_task_with_default(task, &value))),

--- a/crates/nika-runtime/src/approval.rs
+++ b/crates/nika-runtime/src/approval.rs
@@ -39,7 +39,10 @@
 //! The ticket attests what happened — it never promises.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Mutex;
+use std::io;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use nika_schema::raw::{RawAction, RawTask, RawWorkflow};
 use serde_json::{Value, json};
@@ -184,13 +187,14 @@ impl ApprovalTicket {
 /// identity of the trace it came from (its `workflow_started` event id).
 /// The cross-run check is self-contained in the trace bytes: a ticket
 /// whose `run_nonce` names another run is a replay, refused.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct PausedApproval {
     /// The ticket the paused run journaled on its `workflow_paused` frame.
     pub ticket: ApprovalTicket,
     /// The run identity of the trace the ticket was folded FROM.
     pub trace_nonce: String,
+    claim: Arc<ApprovalClaim>,
 }
 
 impl PausedApproval {
@@ -200,8 +204,85 @@ impl PausedApproval {
         Self {
             ticket,
             trace_nonce,
+            claim: Arc::new(ApprovalClaim::ephemeral()),
         }
     }
+
+    /// Bind this folded ticket to a descriptor-held, durable claim store.
+    ///
+    /// The runtime consumes the ticket through an atomic create-once marker
+    /// immediately before admitting the answer. Clones share the in-process
+    /// atomic, while independently folded CLI resumes converge on the same
+    /// ticket-digest marker below the caller's local Nika state root.
+    ///
+    /// # Errors
+    /// The claim directory cannot be opened or created without following a
+    /// symlink. Callers must fail closed rather than resume without it.
+    pub fn with_durable_claim_root(mut self, root: &Path) -> io::Result<Self> {
+        let store = nika_fs::OwnedDir::create(root, &[".nika", "approval-claims"])?;
+        self.claim = Arc::new(ApprovalClaim {
+            consumed: AtomicBool::new(false),
+            dir: Some(store),
+        });
+        Ok(self)
+    }
+
+    fn consume(&self) -> Result<(), ClaimError> {
+        if self
+            .claim
+            .consumed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(ClaimError::Consumed);
+        }
+        let Some(dir) = &self.claim.dir else {
+            return Ok(());
+        };
+        let digest = self.ticket.digest().ok_or(ClaimError::Unavailable)?;
+        let name = format!(".nika-approval-{digest}.claimed");
+        match dir.write_once(&name, &format!("{digest}\n")) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Err(ClaimError::Consumed),
+            Err(_) => Err(ClaimError::Unavailable),
+        }
+    }
+}
+
+impl std::fmt::Debug for PausedApproval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PausedApproval")
+            .field("ticket", &self.ticket)
+            .field("trace_nonce", &self.trace_nonce)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for PausedApproval {
+    fn eq(&self, other: &Self) -> bool {
+        self.ticket == other.ticket && self.trace_nonce == other.trace_nonce
+    }
+}
+
+impl Eq for PausedApproval {}
+
+struct ApprovalClaim {
+    consumed: AtomicBool,
+    dir: Option<nika_fs::OwnedDir>,
+}
+
+impl ApprovalClaim {
+    fn ephemeral() -> Self {
+        Self {
+            consumed: AtomicBool::new(false),
+            dir: None,
+        }
+    }
+}
+
+enum ClaimError {
+    Consumed,
+    Unavailable,
 }
 
 /// The `approval_decided` payload, assembled at the pipeline and emitted
@@ -492,8 +573,10 @@ fn admit_resumed(
         .paused
         .as_ref()
         .filter(|p| p.ticket.step == step)
-        .map(|p| (p.ticket.clone(), p.trace_nonce.clone()));
-    let (ticket, trace_nonce) = paused?;
+        .cloned();
+    let paused = paused?;
+    let ticket = paused.ticket.clone();
+    let trace_nonce = paused.trace_nonce.clone();
     let answer = answer?;
     if ticket.run_nonce != trace_nonce {
         return Some(Admit::Refused(refusal(
@@ -536,8 +619,35 @@ fn admit_resumed(
         inner.paused = None;
         return Some(mint(inner, step, mode, shown_hash, now_ms, None, source));
     }
+    if let Err(error) = paused.consume() {
+        let (why, detail) = match error {
+            ClaimError::Consumed => (
+                "approval.replayed",
+                format!(
+                    "task '{step}' · approval.replayed — this paused approval was already consumed; a resume answer is single-use ({APPROVAL_CODE})"
+                ),
+            ),
+            ClaimError::Unavailable => (
+                "approval.claim_unavailable",
+                format!(
+                    "task '{step}' · approval.claim_unavailable — the engine could not durably consume this paused approval and refused to run ({APPROVAL_CODE})"
+                ),
+            ),
+        };
+        return Some(Admit::Refused(refusal(
+            inner,
+            step,
+            mode,
+            shown_hash,
+            ticket.digest(),
+            ticket.ttl_remaining_seconds(now_ms),
+            why,
+            detail,
+        )));
+    }
     // Valid — the answer binds against the SHOWN ticket. No new mint,
     // no count: the capability was issued by the paused run.
+    inner.paused = None;
     inner.steps.insert(
         step.to_owned(),
         StepEntry {

--- a/crates/nika-runtime/src/approval.rs
+++ b/crates/nika-runtime/src/approval.rs
@@ -390,14 +390,9 @@ impl ApprovalBook {
         settle: &mut crate::task::SettleAs,
         now_ms: i64,
     ) -> Option<ApprovalAttestation> {
-        let (value, costs) = match settle {
+        let value = match settle {
             crate::task::SettleAs::Ran(ran) => match &ran.result {
-                crate::task::RunResult::Success {
-                    value,
-                    cost_usd,
-                    cost_unpriced,
-                    ..
-                } => (value.clone(), (*cost_usd, *cost_unpriced)),
+                crate::task::RunResult::Success { value, .. } => value.clone(),
                 _ => return None,
             },
             _ => return None,
@@ -422,7 +417,7 @@ impl ApprovalBook {
         } else {
             proposed
         };
-        let attestation = ApprovalAttestation {
+        Some(ApprovalAttestation {
             task: task.to_owned(),
             mode,
             decision: decision.as_str(),
@@ -433,26 +428,7 @@ impl ApprovalBook {
             ttl_seconds: ticket.ttl_seconds,
             ttl_remaining_seconds: ticket.ttl_remaining_seconds(now_ms),
             why: None,
-        };
-        drop(inner);
-
-        // A false confirmation is an authority denial, not successful data.
-        if decision == ApprovalDecision::Deny
-            && let crate::task::SettleAs::Ran(ran) = settle
-        {
-            ran.result = crate::task::RunResult::Failed {
-                error: crate::record::TaskErrorRecord {
-                    code: APPROVAL_CODE.to_owned(),
-                    message: format!(
-                        "task '{task}' · approval.denied — the confirmation refused authority ({APPROVAL_CODE})"
-                    ),
-                    transient: false,
-                },
-                cost_usd: costs.0,
-                cost_unpriced: costs.1,
-            };
-        }
-        Some(attestation)
+        })
     }
 }
 

--- a/crates/nika-runtime/src/approval/tests.rs
+++ b/crates/nika-runtime/src/approval/tests.rs
@@ -238,7 +238,8 @@ fn the_first_terminal_decision_is_immutable() {
     assert!(matches!(
         denied,
         crate::task::SettleAs::Ran(ref ran)
-            if matches!(ran.result, crate::task::RunResult::Failed { .. })
+            if matches!(ran.result, crate::task::RunResult::Success { ref value, .. }
+                if value == &Value::Bool(false))
     ));
 
     // A duplicate/racing success cannot rewrite the already terminal deny.
@@ -250,7 +251,8 @@ fn the_first_terminal_decision_is_immutable() {
     assert!(matches!(
         late_allow,
         crate::task::SettleAs::Ran(ref ran)
-            if matches!(ran.result, crate::task::RunResult::Failed { .. })
+            if matches!(ran.result, crate::task::RunResult::Success { ref value, .. }
+                if value == &Value::Bool(true))
     ));
 }
 
@@ -833,11 +835,11 @@ async fn fixture_e_identical_prompts_require_fresh_consent() {
     );
 }
 
-/// A confirm refusal is an authority failure, not successful boolean data.
+/// A confirm refusal is successful `false` data; Deny lives in its attestation.
 /// A later identical gate reached through `terminal` must ask independently;
-/// the first denial can never be replayed as approval (or as a green task).
+/// the first denial can never be replayed as approval.
 #[tokio::test]
-async fn a_refusal_fails_the_task_and_cannot_authorize_the_next_gate() {
+async fn a_refusal_succeeds_false_and_cannot_authorize_the_next_gate() {
     const WF: &str = "nika: deny-is-terminal\npermits: { tools: [\"nika:prompt\"] }\ntasks:\n  denied:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\" }\n  independent:\n    after: { denied: terminal }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\" }\n";
     let (outcome, sink) = run_gated(
         WF,
@@ -855,16 +857,9 @@ async fn a_refusal_fails_the_task_and_cannot_authorize_the_next_gate() {
     )
     .await;
 
-    assert!(!outcome.ok, "one authority denial keeps the workflow red");
-    assert_eq!(outcome.records["denied"].status, crate::TaskStatus::Failure);
-    assert_eq!(
-        outcome.records["denied"]
-            .error
-            .as_ref()
-            .expect("typed authority failure")
-            .code,
-        APPROVAL_CODE
-    );
+    assert!(outcome.ok, "a refusal is a decision, never a task failure");
+    assert_eq!(outcome.records["denied"].status, crate::TaskStatus::Success);
+    assert_eq!(outcome.records["denied"].output, Value::Bool(false));
     assert_eq!(
         outcome.records["independent"].status,
         crate::TaskStatus::Success,

--- a/crates/nika-runtime/src/approval/tests.rs
+++ b/crates/nika-runtime/src/approval/tests.rs
@@ -42,6 +42,27 @@ fn ticket(step: &str) -> ApprovalTicket {
     )
 }
 
+fn resolved(value: Value) -> crate::task::SettleAs {
+    crate::task::SettleAs::Ran(Box::new(crate::task::RanTask {
+        decisions: Vec::new(),
+        note: "invoke · nika:prompt".to_owned(),
+        retries: Vec::new(),
+        agent_events: Vec::new(),
+        evidence: None,
+        duration_ms: 0,
+        result: crate::task::RunResult::Success {
+            value,
+            tokens: None,
+            recovered_from: None,
+            warning: None,
+            child: None,
+            cost_usd: None,
+            cost_unpriced: None,
+            model: None,
+        },
+    }))
+}
+
 #[test]
 fn the_digest_binds_the_mint_fields_and_ignores_the_decision() {
     let mut a = ticket("ask");
@@ -124,10 +145,10 @@ fn the_book_mints_counts_and_refuses_the_sixth_distinct() {
     );
     for i in 0..APPROVAL_MAX_TICKETS_PER_RUN {
         let hash = format!("{i:064x}");
-        let admit = book.admit("ask", "confirm", &hash, 0, None);
+        let admit = book.admit("ask", "confirm", &hash, 0, None, "builtin");
         assert!(matches!(admit, Admit::Run { .. }), "mint {i} runs");
     }
-    let admit = book.admit("ask", "confirm", &"f".repeat(64), 0, None);
+    let admit = book.admit("ask", "confirm", &"f".repeat(64), 0, None, "builtin");
     let Admit::Refused(r) = admit else {
         panic!("the sixth distinct mint is refused");
     };
@@ -136,12 +157,12 @@ fn the_book_mints_counts_and_refuses_the_sixth_distinct() {
     assert!(r.detail.contains(APPROVAL_CODE), "{}", r.detail);
     // A SIXTH distinct step is refused; a SIXTH mint of KNOWN content
     // still passes (the dedup path is not the storm).
-    let admit = book.admit("ask", "confirm", &format!("{:064x}", 0), 0, None);
+    let admit = book.admit("ask", "confirm", &format!("{:064x}", 0), 0, None, "builtin");
     assert!(matches!(admit, Admit::Run { .. }), "known content re-runs");
 }
 
 #[test]
-fn the_book_dedups_a_decided_ticket_and_re_mints_a_stale_one() {
+fn the_book_consumes_a_decided_ticket_instead_of_replaying_it() {
     let book = ApprovalBook::new();
     book.begin_run(
         &nika_schema::parse(
@@ -154,57 +175,83 @@ fn the_book_dedups_a_decided_ticket_and_re_mints_a_stale_one() {
     );
     let hash = "a".repeat(64);
     // Mint + decide (the attest path records the answer for dedup).
-    let Admit::Run { .. } = book.admit("one", "confirm", &hash, 0, None) else {
+    let Admit::Run { .. } = book.admit("one", "confirm", &hash, 0, None, "builtin") else {
         panic!("the first mint runs");
     };
-    let settle = crate::task::SettleAs::Ran(Box::new(crate::task::RanTask {
-        decisions: Vec::new(),
-        note: "invoke · nika:prompt".to_owned(),
-        retries: Vec::new(),
-        agent_events: Vec::new(),
-        evidence: None,
-        duration_ms: 0,
-        result: crate::task::RunResult::Success {
-            value: Value::Bool(true),
-            tokens: None,
-            recovered_from: None,
-            warning: None,
-            child: None,
-            cost_usd: None,
-            cost_unpriced: None,
-            model: None,
-        },
-    }));
+    let mut settle = resolved(Value::Bool(true));
     let att = book
-        .attest_outcome("one", &settle, 1_000)
+        .attest_outcome("one", &mut settle, 1_000)
         .expect("a resolved ask attests");
     assert_eq!(att.decision, "allow");
     assert_eq!(att.source, "builtin");
-    // The second task with IDENTICAL content dedups — the recorded
-    // answer binds, the ticket is the same, the source is `dedup`.
-    let Admit::Run { bind } = book.admit("two", "confirm", &hash, 2_000, None) else {
-        panic!("the dedup runs");
+    // A decision consumes the capability. Even if a caller presents the
+    // same content hash again inside the TTL, the recorded answer cannot
+    // bind a second task: fresh consent and a fresh ticket are required.
+    let Admit::Run { bind } = book.admit("two", "confirm", &hash, 2_000, None, "builtin") else {
+        panic!("the second ask re-mints");
     };
-    assert_eq!(bind, Some(Value::Bool(true)), "the recorded answer binds");
+    assert_eq!(bind, None, "the consumed answer never replays");
     let entry_digest = book
         .ticket_for("two")
         .and_then(|t| t.digest())
-        .expect("the dedup ticket");
-    assert_eq!(entry_digest, att.digest.clone().expect("digest"));
-    // …and its attestation says `dedup`, never `allow` twice.
+        .expect("the fresh ticket");
+    assert_ne!(entry_digest, att.digest.clone().expect("digest"));
+    // The second ask resolves independently, never as `dedup`.
     let att2 = book
-        .attest_outcome("two", &settle, 3_000)
-        .expect("the dedup attests");
-    assert_eq!(att2.decision, "dedup");
-    assert_eq!(att2.source, "dedup");
-    // A STALE decided ticket re-mints (fresh consent · it counts).
+        .attest_outcome("two", &mut settle, 3_000)
+        .expect("the fresh decision attests");
+    assert_eq!(att2.decision, "allow");
+    assert_eq!(att2.source, "builtin");
+    // A later use also re-mints (fresh consent · it counts).
     let stale_at = 1_000_000 + 901_000;
-    let Admit::Run { bind } = book.admit("three", "confirm", &hash, stale_at, None) else {
+    let Admit::Run { bind } = book.admit("three", "confirm", &hash, stale_at, None, "builtin")
+    else {
         panic!("the stale ticket re-mints");
     };
     assert_eq!(bind, None, "the stale answer never replays");
     let fresh = book.ticket_for("three").expect("the fresh ticket");
     assert_eq!(fresh.minted_at_ms, stale_at, "a NEW capability issued");
+}
+
+#[test]
+fn the_first_terminal_decision_is_immutable() {
+    let book = ApprovalBook::new();
+    book.begin_run(
+        &nika_schema::parse(
+            "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n",
+            nika_schema::FileId::new(0),
+            nika_schema::ParseMode::Strict,
+        )
+        .expect("parses"),
+        "nonce".to_owned(),
+    );
+    let hash = "e".repeat(64);
+    let Admit::Run { .. } = book.admit("ask", "confirm", &hash, 0, None, "builtin") else {
+        panic!("the ticket mints");
+    };
+
+    let mut denied = resolved(Value::Bool(false));
+    let first = book
+        .attest_outcome("ask", &mut denied, 1)
+        .expect("the refusal settles");
+    assert_eq!(first.decision, "deny");
+    assert!(matches!(
+        denied,
+        crate::task::SettleAs::Ran(ref ran)
+            if matches!(ran.result, crate::task::RunResult::Failed { .. })
+    ));
+
+    // A duplicate/racing success cannot rewrite the already terminal deny.
+    let mut late_allow = resolved(Value::Bool(true));
+    let second = book
+        .attest_outcome("ask", &mut late_allow, 2)
+        .expect("the duplicate observes the terminal");
+    assert_eq!(second.decision, "deny");
+    assert!(matches!(
+        late_allow,
+        crate::task::SettleAs::Ran(ref ran)
+            if matches!(ran.result, crate::task::RunResult::Failed { .. })
+    ));
 }
 
 #[test]
@@ -225,7 +272,14 @@ fn the_book_validates_the_resumed_ticket_laws() {
         ApprovalTicket::new(hash.clone(), "nonce-a".to_owned(), "ask".to_owned(), 0, 900),
         "nonce-else".to_owned(),
     )));
-    let admit = book.admit("ask", "confirm", &hash, 1_000, Some(&Value::Bool(true)));
+    let admit = book.admit(
+        "ask",
+        "confirm",
+        &hash,
+        1_000,
+        Some(&Value::Bool(true)),
+        "cli",
+    );
     let Admit::Refused(r) = admit else {
         panic!("a cross-run replay is refused");
     };
@@ -241,6 +295,7 @@ fn the_book_validates_the_resumed_ticket_laws() {
         &"d".repeat(64),
         1_000,
         Some(&Value::Bool(true)),
+        "cli",
     );
     let Admit::Refused(r) = admit else {
         panic!("a content mismatch is refused");
@@ -255,7 +310,14 @@ fn the_book_validates_the_resumed_ticket_laws() {
         ApprovalTicket::new(hash.clone(), "nonce-a".to_owned(), "ask".to_owned(), 0, 900),
         "nonce-a".to_owned(),
     )));
-    let admit = book.admit("ask", "confirm", &hash, 901_000, Some(&Value::Bool(true)));
+    let admit = book.admit(
+        "ask",
+        "confirm",
+        &hash,
+        901_000,
+        Some(&Value::Bool(true)),
+        "cli",
+    );
     let Admit::Run { bind } = admit else {
         panic!("the expired ticket re-mints");
     };
@@ -265,7 +327,14 @@ fn the_book_validates_the_resumed_ticket_laws() {
         ApprovalTicket::new(hash.clone(), "nonce-a".to_owned(), "ask".to_owned(), 0, 900),
         "nonce-a".to_owned(),
     )));
-    let admit = book.admit("ask", "confirm", &hash, 60_000, Some(&Value::Bool(true)));
+    let admit = book.admit(
+        "ask",
+        "confirm",
+        &hash,
+        60_000,
+        Some(&Value::Bool(true)),
+        "cli",
+    );
     let Admit::Run { bind } = admit else {
         panic!("the valid ticket binds");
     };
@@ -681,10 +750,10 @@ async fn fixture_c_an_expired_ticket_re_prompts_and_a_cross_run_replay_is_refuse
     assert_eq!(ds[0].why.as_deref(), Some("approval.scope_mismatch"));
 }
 
-// ─── (e) dedup — the same hash ×2 is ONE ticket, attested `dedup` ───
+// ─── (e) single-use — identical asks consume distinct tickets ───────
 
 #[tokio::test]
-async fn fixture_e_identical_prompts_share_one_ticket() {
+async fn fixture_e_identical_prompts_require_fresh_consent() {
     const WF: &str = "nika: dedup\npermits: { tools: [\"nika:prompt\"] }\ntasks:\n  one:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"same question?\" }\n  two:\n    after: { one: success }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"same question?\" }\n";
     let (outcome, sink) = run_gated(
         WF,
@@ -701,19 +770,106 @@ async fn fixture_e_identical_prompts_share_one_ticket() {
         },
     )
     .await;
-    assert!(outcome.ok, "the dedup run completes");
+    assert!(outcome.ok, "both independently approved asks complete");
     let ds = decisions(&sink);
     assert_eq!(ds.len(), 2, "{ds:?}");
     assert_eq!(ds[0].task, "one");
     assert_eq!(ds[0].decision, "allow");
     assert_eq!(ds[1].task, "two");
-    assert_eq!(ds[1].decision, "dedup", "the twin is attested dedup");
-    assert_eq!(ds[1].source, "dedup");
-    assert_eq!(ds[0].shown_hash, ds[1].shown_hash, "one shown hash");
-    assert_eq!(
-        ds[0].digest, ds[1].digest,
-        "one ticket digest — never re-questioned"
+    assert_eq!(ds[1].decision, "allow", "the twin was re-approved");
+    assert_eq!(ds[1].source, "builtin");
+    assert_ne!(
+        ds[0].shown_hash, ds[1].shown_hash,
+        "step identity binds the ask"
     );
+    assert_ne!(
+        ds[0].digest, ds[1].digest,
+        "a consumed ticket is single-use"
+    );
+}
+
+/// A confirm refusal is an authority failure, not successful boolean data.
+/// A later identical gate reached through `terminal` must ask independently;
+/// the first denial can never be replayed as approval (or as a green task).
+#[tokio::test]
+async fn a_refusal_fails_the_task_and_cannot_authorize_the_next_gate() {
+    const WF: &str = "nika: deny-is-terminal\npermits: { tools: [\"nika:prompt\"] }\ntasks:\n  denied:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\" }\n  independent:\n    after: { denied: terminal }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\" }\n";
+    let (outcome, sink) = run_gated(
+        WF,
+        Seams {
+            shell: vec![],
+            tool: vec![
+                ToolResult::success("tc1", "false").with_structured(Value::Bool(false)),
+                ToolResult::success("tc2", "true").with_structured(Value::Bool(true)),
+            ],
+            pause: true,
+            plan: None,
+            answers: BTreeMap::new(),
+            paused: None,
+        },
+    )
+    .await;
+
+    assert!(!outcome.ok, "one authority denial keeps the workflow red");
+    assert_eq!(outcome.records["denied"].status, crate::TaskStatus::Failure);
+    assert_eq!(
+        outcome.records["denied"]
+            .error
+            .as_ref()
+            .expect("typed authority failure")
+            .code,
+        APPROVAL_CODE
+    );
+    assert_eq!(
+        outcome.records["independent"].status,
+        crate::TaskStatus::Success,
+        "terminal reaches a new independently answered gate"
+    );
+    let ds = decisions(&sink);
+    assert_eq!(ds.len(), 2, "{ds:?}");
+    assert_eq!(ds[0].decision, "deny");
+    assert_eq!(ds[1].decision, "allow");
+    assert_ne!(ds[0].digest, ds[1].digest, "the denial was consumed");
+}
+
+#[tokio::test]
+async fn automated_answers_never_claim_human_provenance() {
+    let cases = [
+        (
+            "nika: policy\npermits: { tools: [\"nika:prompt\"] }\ntasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\", default: true }\n",
+            BTreeMap::new(),
+            "policy",
+        ),
+        (
+            "nika: cli\npermits: { tools: [\"nika:prompt\"] }\ntasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\" }\n",
+            BTreeMap::from([("ask".to_owned(), Value::Bool(true))]),
+            "cli",
+        ),
+        (
+            "nika: unverified-adapter\npermits: { tools: [\"nika:prompt\"] }\ntasks:\n  ask:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { mode: \"confirm\", message: \"ship?\" }\n",
+            BTreeMap::new(),
+            "builtin",
+        ),
+    ];
+    for (yaml, answers, expected) in cases {
+        let (outcome, sink) = run_gated(
+            yaml,
+            Seams {
+                shell: vec![],
+                tool: vec![ToolResult::success("tc", "true").with_structured(Value::Bool(true))],
+                pause: true,
+                plan: None,
+                answers,
+                paused: None,
+            },
+        )
+        .await;
+        assert!(outcome.ok, "{expected} answer completes");
+        let ds = decisions(&sink);
+        assert_eq!(ds.len(), 1, "{ds:?}");
+        assert_eq!(ds[0].source, expected);
+        assert_ne!(ds[0].source, "human", "unverified automation is not human");
+    }
 }
 
 // ─── (f) green — the honest gate, end to end, attested ──────────────
@@ -777,10 +933,7 @@ async fn fixture_f_the_honest_gate_binds_and_attests() {
     let allow = &ds[0];
     assert_eq!(allow.task, "ask");
     assert_eq!(allow.decision, "allow");
-    assert_eq!(
-        allow.source, "resumed",
-        "the authority is the paused ticket"
-    );
+    assert_eq!(allow.source, "resume", "the authority is the paused ticket");
     assert_eq!(allow.shown_hash, shown, "montré = signé");
     assert_eq!(
         allow.digest.as_deref(),

--- a/crates/nika-runtime/src/approval/tests.rs
+++ b/crates/nika-runtime/src/approval/tests.rs
@@ -345,6 +345,51 @@ fn the_book_validates_the_resumed_ticket_laws() {
 }
 
 #[test]
+fn a_paused_capability_clone_admits_exactly_one_runtime() {
+    let workflow = nika_schema::parse(
+        "nika: t\ntasks:\n  a:\n    exec: { command: [\"true\"] }\n",
+        nika_schema::FileId::new(0),
+        nika_schema::ParseMode::Strict,
+    )
+    .expect("parses");
+    let hash = "e".repeat(64);
+    let paused = PausedApproval::new(
+        ApprovalTicket::new(hash.clone(), "nonce-a".to_owned(), "ask".to_owned(), 0, 900),
+        "nonce-a".to_owned(),
+    );
+    let first = ApprovalBook::new();
+    first.begin_run(&workflow, "nonce-a".to_owned());
+    first.set_paused(Some(paused.clone()));
+    let second = ApprovalBook::new();
+    second.begin_run(&workflow, "nonce-a".to_owned());
+    second.set_paused(Some(paused));
+
+    assert!(matches!(
+        first.admit(
+            "ask",
+            "confirm",
+            &hash,
+            1_000,
+            Some(&Value::Bool(true)),
+            "cli",
+        ),
+        Admit::Run { .. }
+    ));
+    let Admit::Refused(refusal) = second.admit(
+        "ask",
+        "confirm",
+        &hash,
+        1_000,
+        Some(&Value::Bool(true)),
+        "cli",
+    ) else {
+        panic!("the cloned capability must be single-use across runtimes");
+    };
+    assert_eq!(refusal.attestation.why, Some("approval.replayed"));
+    assert!(refusal.detail.contains(APPROVAL_CODE));
+}
+
+#[test]
 fn the_closure_stops_at_the_nearest_gate() {
     let wf = nika_schema::parse(
         "nika: t\npermits: { exec: [\"echo\"], tools: [\"nika:prompt\"] }\ntasks:\n  first:\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"one?\" }\n  second:\n    after: { first: success }\n    invoke:\n      tool: \"nika:prompt\"\n      args: { message: \"two?\" }\n  act:\n    after: { second: success }\n    exec: { command: [\"echo\", \"x\"] }\n",

--- a/crates/nika-runtime/src/sandbox_select.rs
+++ b/crates/nika-runtime/src/sandbox_select.rs
@@ -189,6 +189,22 @@ mod tests {
         assert!(parse_policy_env(Some("requrie")).is_err());
     }
 
+    #[test]
+    fn noop_and_unsupported_hosts_refuse_unless_the_operator_waives() {
+        for policy in [SandboxPolicy::Auto, SandboxPolicy::Require] {
+            assert_eq!(
+                policy.judge(false, true),
+                SandboxVerdict::Refused,
+                "a permits-bearing run cannot compose a noop/unsupported backend"
+            );
+        }
+        assert_eq!(
+            SandboxPolicy::Off.judge(false, true),
+            SandboxVerdict::Waived,
+            "only the explicit, journalled off posture reaches Noop"
+        );
+    }
+
     /// The refusal names the code, the reason, and BOTH exits (#889 ·
     /// NIKA-1710).
     #[test]

--- a/crates/nika-runtime/src/task.rs
+++ b/crates/nika-runtime/src/task.rs
@@ -375,7 +375,7 @@ where
         let task = &*gated;
 
         // ── `for_each:` fan-out or the single lane ──────────────────
-        let settle = self
+        let mut settle = self
             .run_lanes(
                 task,
                 wf,
@@ -392,7 +392,7 @@ where
         // here and the settle spine journals it (`approval_decided`).
         let approval = self
             .approvals
-            .attest_outcome(&id, &settle, self.now_unix_ms());
+            .attest_outcome(&id, &mut settle, self.now_unix_ms());
         assemble_ran_finish(
             task, id, settle, resume, resume_ctx, inputs, records, integrity, approval,
         )

--- a/crates/nika-runtime/tests/exec_permits.rs
+++ b/crates/nika-runtime/tests/exec_permits.rs
@@ -14,6 +14,7 @@
 use std::sync::Arc;
 
 use nika_check::check;
+use nika_kernel::process::ShellResult;
 use nika_kernel_mock::{
     MockClock, MockProvider, MockShell, MockToolDefinitionProvider, MockToolExecutor,
 };
@@ -24,6 +25,7 @@ use nika_verb_agent::AgentVerb;
 use nika_verb_exec::ExecVerb;
 use nika_verb_infer::InferVerb;
 use nika_verb_invoke::InvokeVerb;
+use std::time::Duration;
 
 async fn run(yaml: &str, shell: MockShell) -> RunOutcome {
     let wf = parse(yaml, FileId::new(0), ParseMode::Strict).expect("fixture parses");
@@ -69,11 +71,24 @@ tasks:
   danger:
     exec:
       command: ["${{ const.prog }}", "-rf", "/tmp/x"]
+      capture: structured
 "#;
-    // The MockShell is EMPTY — the security gate must fire before any spawn
-    // (an `enqueue`-less mock would panic if `run` were ever called).
-    let outcome = run(yaml, MockShell::new()).await;
+    // Plant a plausible structured result behind the authority boundary.
+    // If capture/process output were ever allowed to outrank the permit
+    // refusal this would look like a successful task despite exit 23.
+    let shell = MockShell::new().enqueue_result(ShellResult::new(
+        23,
+        "{\"status\":\"ok\"}\n",
+        "denied by sandbox\n",
+        Duration::from_millis(1),
+    ));
+    let witness = shell.clone();
+    let outcome = run(yaml, shell).await;
     assert!(!outcome.ok, "a denied capability fails the run");
+    assert!(
+        witness.executed_commands().is_empty(),
+        "authority denial wins before plausible process/capture output"
+    );
     let rec = &outcome.records["danger"];
     assert_eq!(rec.status, TaskStatus::Failure);
     assert_eq!(

--- a/crates/nika-sandbox-landlock/public-api.txt
+++ b/crates/nika-sandbox-landlock/public-api.txt
@@ -12,6 +12,7 @@ pub fn nika_sandbox_landlock::LandlockSandbox::fmt(&self, f: &mut core::fmt::For
 impl core::marker::Copy for nika_sandbox_landlock::LandlockSandbox
 impl nika_kernel_core::io::command_sandbox::CommandSandbox for nika_sandbox_landlock::LandlockSandbox
 pub fn nika_sandbox_landlock::LandlockSandbox::backend(&self) -> &'static str
+pub fn nika_sandbox_landlock::LandlockSandbox::classify_outcome(&self, status: i32, stderr: &str) -> nika_kernel_core::io::process::ShellAdapterOutcome
 pub fn nika_sandbox_landlock::LandlockSandbox::confine(&self, spec: &nika_kernel_core::io::process::SandboxSpec, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellCommand, nika_kernel_core::io::command_sandbox::CommandSandboxError>
 impl<D> owo_colors::OwoColorize for nika_sandbox_landlock::LandlockSandbox
 impl<T, U> core::convert::Into<U> for nika_sandbox_landlock::LandlockSandbox where U: core::convert::From<T>

--- a/crates/nika-sandbox-landlock/src/lib.rs
+++ b/crates/nika-sandbox-landlock/src/lib.rs
@@ -64,7 +64,7 @@ use std::path::Path;
 use nika_kernel::command_sandbox::{
     CommandSandbox, CommandSandboxError, fold_sandbox_prefix, names_system_root,
 };
-use nika_kernel::process::{NetPolicy, SandboxSpec, ShellCommand};
+use nika_kernel::process::{NetPolicy, SandboxSpec, ShellAdapterOutcome, ShellCommand};
 
 /// The bubblewrap launcher. A fixed absolute path (not `$PATH`) so a hijacked
 /// `PATH` cannot point the sandbox at an impostor launcher.
@@ -120,6 +120,26 @@ impl CommandSandbox for LandlockSandbox {
 
     fn backend(&self) -> &'static str {
         "landlock"
+    }
+
+    fn classify_outcome(&self, status: i32, stderr: &str) -> ShellAdapterOutcome {
+        classify_terminal_outcome(status, stderr)
+    }
+}
+
+/// Bubblewrap's wrapper-status table, kept pure so every host can verify the
+/// Linux decision without pretending to execute a Linux jail locally.
+fn classify_terminal_outcome(status: i32, stderr: &str) -> ShellAdapterOutcome {
+    let launcher_diagnostic = stderr
+        .lines()
+        .map(str::trim_start)
+        .any(|line| line.starts_with("bwrap:"));
+    if status == 126 || launcher_diagnostic {
+        ShellAdapterOutcome::authority_refusal(format!(
+            "landlock/bwrap refused the confined process (status {status})"
+        ))
+    } else {
+        ShellAdapterOutcome::process()
     }
 }
 
@@ -320,6 +340,29 @@ const SYSTEM_ROOTS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn apply(outcome: ShellAdapterOutcome) -> Result<(), nika_kernel::ShellError> {
+        nika_kernel::ShellResult::new(126, r#"{"ok":true}"#, "", std::time::Duration::ZERO)
+            .with_adapter_outcome(outcome)
+            .into_process_result()
+            .map(|_| ())
+    }
+
+    #[test]
+    fn terminal_outcome_table_is_platform_independent_and_fail_closed() {
+        assert!(matches!(
+            apply(classify_terminal_outcome(126, r#"{"ok":true}"#)),
+            Err(nika_kernel::ShellError::Blocked { .. })
+        ));
+        assert!(matches!(
+            apply(classify_terminal_outcome(
+                1,
+                "bwrap: setting up uid map: Permission denied"
+            )),
+            Err(nika_kernel::ShellError::Blocked { .. })
+        ));
+        assert!(apply(classify_terminal_outcome(7, "business validation failed")).is_ok());
+    }
 
     /// The availability truth table — all four rows, platform-free.
     /// Kills Gate 5's three survivors: `-> true` (row 4 fails), `-> false`

--- a/crates/nika-sandbox-seatbelt/public-api.txt
+++ b/crates/nika-sandbox-seatbelt/public-api.txt
@@ -12,6 +12,7 @@ pub fn nika_sandbox_seatbelt::SeatbeltSandbox::fmt(&self, f: &mut core::fmt::For
 impl core::marker::Copy for nika_sandbox_seatbelt::SeatbeltSandbox
 impl nika_kernel_core::io::command_sandbox::CommandSandbox for nika_sandbox_seatbelt::SeatbeltSandbox
 pub fn nika_sandbox_seatbelt::SeatbeltSandbox::backend(&self) -> &'static str
+pub fn nika_sandbox_seatbelt::SeatbeltSandbox::classify_outcome(&self, status: i32, stderr: &str) -> nika_kernel_core::io::process::ShellAdapterOutcome
 pub fn nika_sandbox_seatbelt::SeatbeltSandbox::confine(&self, spec: &nika_kernel_core::io::process::SandboxSpec, command: nika_kernel_core::io::process::ShellCommand) -> core::result::Result<nika_kernel_core::io::process::ShellCommand, nika_kernel_core::io::command_sandbox::CommandSandboxError>
 impl<D> owo_colors::OwoColorize for nika_sandbox_seatbelt::SeatbeltSandbox
 impl<T, U> core::convert::Into<U> for nika_sandbox_seatbelt::SeatbeltSandbox where U: core::convert::From<T>

--- a/crates/nika-sandbox-seatbelt/src/lib.rs
+++ b/crates/nika-sandbox-seatbelt/src/lib.rs
@@ -73,7 +73,7 @@ use std::path::{Path, PathBuf};
 use nika_kernel::command_sandbox::{
     CommandSandbox, CommandSandboxError, fold_sandbox_prefix, names_system_root,
 };
-use nika_kernel::process::{NetPolicy, SandboxSpec, ShellCommand};
+use nika_kernel::process::{NetPolicy, SandboxSpec, ShellAdapterOutcome, ShellCommand};
 
 /// The OS-shipped Seatbelt launcher. A fixed absolute path (not `$PATH`) so a
 /// hijacked `PATH` cannot point the sandbox at an impostor launcher.
@@ -115,6 +115,29 @@ impl CommandSandbox for SeatbeltSandbox {
 
     fn backend(&self) -> &'static str {
         "seatbelt"
+    }
+
+    fn classify_outcome(&self, status: i32, stderr: &str) -> ShellAdapterOutcome {
+        classify_terminal_outcome(status, stderr)
+    }
+}
+
+/// Seatbelt's wrapper-status table. Status 126 is reserved fail-closed at
+/// this boundary because it is the launcher/exec refusal class and cannot be
+/// distinguished safely from an inner program deliberately choosing 126.
+/// A launcher diagnostic is likewise authority, regardless of its numeric
+/// status. Other non-zero statuses remain authored process outcomes.
+fn classify_terminal_outcome(status: i32, stderr: &str) -> ShellAdapterOutcome {
+    let launcher_diagnostic = stderr
+        .lines()
+        .map(str::trim_start)
+        .any(|line| line.starts_with("sandbox-exec:") || line.contains("Operation not permitted"));
+    if status == 126 || launcher_diagnostic {
+        ShellAdapterOutcome::authority_refusal(format!(
+            "seatbelt refused the confined process (status {status})"
+        ))
+    } else {
+        ShellAdapterOutcome::process()
     }
 }
 
@@ -462,6 +485,32 @@ const PROFILE_PREAMBLE: &str = r#"(version 1)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn apply(outcome: ShellAdapterOutcome) -> Result<(), nika_kernel::ShellError> {
+        nika_kernel::ShellResult::new(126, r#"{"ok":true}"#, "", std::time::Duration::ZERO)
+            .with_adapter_outcome(outcome)
+            .into_process_result()
+            .map(|_| ())
+    }
+
+    #[test]
+    fn terminal_outcome_table_keeps_authority_ahead_of_capture() {
+        assert!(matches!(
+            apply(classify_terminal_outcome(126, r#"{"ok":true}"#)),
+            Err(nika_kernel::ShellError::Blocked { .. })
+        ));
+        assert!(matches!(
+            apply(classify_terminal_outcome(
+                1,
+                "sandbox-exec: deny(1) file-read-data"
+            )),
+            Err(nika_kernel::ShellError::Blocked { .. })
+        ));
+        assert!(
+            apply(classify_terminal_outcome(7, "business validation failed")).is_ok(),
+            "an ordinary non-zero remains business data"
+        );
+    }
 
     /// The availability truth table — all four rows, platform-free.
     /// Kills Gate 5's three survivors: `-> true` (row 4 fails), `->

--- a/crates/nika-verb-exec/Cargo.toml
+++ b/crates/nika-verb-exec/Cargo.toml
@@ -19,8 +19,11 @@ miette      = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
+nika-exec-runner = { path = "../nika-exec-runner", version = "0.113.0" }
 nika-kernel-mock = { path = "../nika-kernel-mock", version = "0.113.0" }
+nika-sandbox-seatbelt = { path = "../nika-sandbox-seatbelt", version = "0.113.0" }
 proptest = { workspace = true }
+tempfile = { workspace = true }
 tokio    = { workspace = true }
 
 [package.metadata.lore]

--- a/crates/nika-verb-exec/src/lib.rs
+++ b/crates/nika-verb-exec/src/lib.rs
@@ -268,10 +268,12 @@ where
             .shell
             .run(build_command(input))
             .await
+            .and_then(ShellResult::into_process_result)
             .map_err(|source| VerbExecError::Shell { source })?;
 
-        // The capture one-obvious-way split: default modes fail on a
-        // non-zero exit; `structured` carries the exit code as data.
+        // Typed adapter refusals were consumed above, before this capture
+        // split. Only an actual business-process status can reach structured
+        // interpretation.
         if capture != CaptureMode::Structured && result.status != 0 {
             return Err(VerbExecError::non_zero(result.status, &result.stderr));
         }
@@ -541,6 +543,69 @@ mod tests {
                 exit_code: 1,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn structured_mode_cannot_declassify_a_sandbox_refusal() {
+        use nika_error::traits::NikaErrorCode as _;
+
+        let mock = MockShell::new().enqueue_result(
+            nika_kernel::process::ShellResult::new(
+                126,
+                r#"{"ok":true}"#,
+                "sandbox launcher refused authority",
+                Duration::from_millis(1),
+            )
+            .with_authority_refusal("sandbox launcher refused authority"),
+        );
+        let mut input = ExecInput::new("sandboxed-command");
+        input.capture = CaptureMode::Structured;
+        input.sandbox = Some(nika_kernel::process::SandboxSpec::new());
+        let err = verb(mock.clone())
+            .run(input)
+            .await
+            .expect_err("a sandbox refusal is authority failure, never structured success");
+        assert_eq!(
+            mock.executed_commands().len(),
+            1,
+            "the ShellResult was consumed"
+        );
+        assert_eq!(err.spec_code(), "NIKA-SEC-001");
+        assert!(matches!(
+            err,
+            VerbExecError::Shell {
+                source: nika_kernel::process::ShellError::Blocked { .. }
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn structured_mode_cannot_declassify_a_transport_failure() {
+        use nika_error::traits::NikaErrorCode as _;
+
+        let mock = MockShell::new().enqueue_result(
+            nika_kernel::process::ShellResult::new(
+                1,
+                r#"{"ok":true}"#,
+                "partial",
+                Duration::from_millis(1),
+            )
+            .with_transport_failure("remote worker disconnected"),
+        );
+        let mut input = ExecInput::new("remote-command");
+        input.capture = CaptureMode::Structured;
+        let err = verb(mock.clone())
+            .run(input)
+            .await
+            .expect_err("a transport failure is never structured success");
+        assert_eq!(mock.executed_commands().len(), 1, "the result was consumed");
+        assert_eq!(err.spec_code(), "NIKA-EXEC-002");
+        assert!(matches!(
+            err,
+            VerbExecError::Shell {
+                source: nika_kernel::process::ShellError::Other { .. }
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/nika-verb-exec/src/lib.rs
+++ b/crates/nika-verb-exec/src/lib.rs
@@ -579,6 +579,53 @@ mod tests {
         ));
     }
 
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn production_seatbelt_refusal_precedes_structured_capture() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        use nika_error::traits::NikaErrorCode as _;
+        use nika_exec_runner::TokioShell;
+        use nika_sandbox_seatbelt::SeatbeltSandbox;
+
+        assert!(SeatbeltSandbox::available(), "macOS must ship sandbox-exec");
+        let dir = tempfile::tempdir().expect("fixture dir");
+        let script = dir.path().join("refuse.sh");
+        let denied = dir.path().join("denied.txt");
+        std::fs::write(&denied, b"must stay outside the exact script grant")
+            .expect("denied fixture");
+        let quoted = denied.to_string_lossy().replace('\'', "'\\''");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif /bin/cat '{quoted}' >/dev/null 2>&1; then exit 42; \
+                 else /usr/bin/printf '{{\"ok\":true}}\\n'; exit 126; fi\n"
+            ),
+        )
+        .expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700))
+            .expect("executable script");
+
+        let shell = Arc::new(TokioShell::with_sandbox(Arc::new(SeatbeltSandbox::new())));
+        let mut input = ExecInput::argv([script.to_string_lossy().into_owned()]);
+        input.capture = CaptureMode::Structured;
+        let mut spec = nika_kernel::process::SandboxSpec::new();
+        spec.fs_read.push(script.to_string_lossy().into_owned());
+        input.sandbox = Some(spec);
+        let error = ExecVerb::new(shell)
+            .run(input)
+            .await
+            .expect_err("Seatbelt authority cannot become structured data");
+
+        assert_eq!(error.spec_code(), "NIKA-SEC-001");
+        assert!(matches!(
+            error,
+            VerbExecError::Shell {
+                source: nika_kernel::process::ShellError::Blocked { .. }
+            }
+        ));
+    }
+
     #[tokio::test]
     async fn structured_mode_cannot_declassify_a_transport_failure() {
         use nika_error::traits::NikaErrorCode as _;

--- a/docs/crate-specs/nika-execution.md
+++ b/docs/crate-specs/nika-execution.md
@@ -80,6 +80,8 @@ false.
 Inline `--lib` tests cover:
 
 - child, skill, and import mutation after capture;
+- barrier-interleaved root replacement and skill-registry reload after their
+  reads but before admission;
 - child pathname replacement with an out-of-root symlink after capture;
 - workflow cycles and normalized-path duplicates;
 - depth, unit-count, per-unit-size, and aggregate-size ceilings;
@@ -93,6 +95,36 @@ Inline `--lib` tests cover:
 
 The tests use no sleeps and inspect the bytes presented to the runner, not only
 an announced digest.
+
+## 4bis. Executable-input reader census (W02.D)
+
+This is the source-level census at `2026-08-22` for bytes that can define an
+execution. State/evidence readers in `nika-arm` are excluded: they do not parse
+workflow, child, skill, or import bytes. `follow` says whether the current read
+can follow a replaced link; `owned` says whether the exact bytes survive into
+all later phases.
+
+| reader | root | follow | owned | phase | consumer | disposition |
+|---|---|---:|---:|---|---|---|
+| `nika-execution::ByteSource for OwnedDir` | held project descriptor | no | yes | capture | `ExecutionService` check + runner | canonical; W03 carrier |
+| `nika-cli::verbs::RunSource::capture` | caller pathname/stdin | yes for file | primary only | CLI pre-check | current CLI runtime | migrate to `ExecutionService` in W04 |
+| `nika-cli::verbs::load_checked_run_source` composed reader | caller pathname | yes | no | static check | CLI checker | migrate to snapshot reader in W04 |
+| `nika-cli::verbs::resolve_workflow_skills` | workflow parent pathname | yes | no | pre-run | CLI agent skills | P0 legacy reader; remove in W04 |
+| `nika-cli::verbs::run::child_runner::load_child` | parent pathname | yes | no | dispatch | child runtime | P0 legacy reader; remove in W04 |
+| `nika-cli::verbs::run::child_runner::closure_digest` | canonicalized pathname | yes | digest only | resume-key build | CLI resume | replace with snapshot unit digests in W04 |
+| `nika-arm::RunShot` primary source | held project descriptor | no | yes | claim/firing | ARM adapter | primary safe; W04 must route its children/skills through the service |
+| `nika-cli::run::resume_setup` trace reader | held trace-parent descriptor | no | yes | pre-compose evidence fold | CLI resume | closed in W02; not executable source |
+| `nika-runtime::EnvFileSecretResolver` | authored secret pathname | yes | value only | composition | provider/tool secret namespace | separate secret-store boundary; remote disclosure is governed by W02.E/W06 |
+
+The structural gate is three-layered rather than a textual search: (1)
+`ExecutionSnapshot::capture_from` is the only `ByteSource` consumer, (2)
+`ExecutionService::admit_snapshot` is crate-private and `execute` accepts a bare
+function over `ExecutionContext` with no root or reader capability, and (3)
+`digest_check_skills_and_run_read_zero_sources_after_capture` injects a reader
+spy and proves the read count cannot change during parse, composed check, skill
+resolution, digest, or run. The committed `public-api.txt` additionally locks
+the absence of a reader/root accessor from `ExecutionContext`. Any W04 adapter
+that keeps one of the pathname readers above has not completed migration.
 
 ## 5. Admission gates
 

--- a/docs/crate-specs/nika-execution.md
+++ b/docs/crate-specs/nika-execution.md
@@ -107,13 +107,16 @@ all later phases.
 | reader | root | follow | owned | phase | consumer | disposition |
 |---|---|---:|---:|---|---|---|
 | `nika-execution::ByteSource for OwnedDir` | held project descriptor | no | yes | capture | `ExecutionService` check + runner | canonical; W03 carrier |
-| `nika-cli::verbs::RunSource::capture` | caller pathname/stdin | yes for file | primary only | CLI pre-check | current CLI runtime | migrate to `ExecutionService` in W04 |
+| `nika-cli::verbs::RunSource::capture` | caller pathname/stdin | yes for file | primary only | CLI pre-check | current CLI runtime | migrate to `ExecutionService` in W04; its owned bytes already feed the signature gate |
 | `nika-cli::verbs::load_checked_run_source` composed reader | caller pathname | yes | no | static check | CLI checker | migrate to snapshot reader in W04 |
 | `nika-cli::verbs::resolve_workflow_skills` | workflow parent pathname | yes | no | pre-run | CLI agent skills | P0 legacy reader; remove in W04 |
 | `nika-cli::verbs::run::child_runner::load_child` | parent pathname | yes | no | dispatch | child runtime | P0 legacy reader; remove in W04 |
 | `nika-cli::verbs::run::child_runner::closure_digest` | canonicalized pathname | yes | digest only | resume-key build | CLI resume | replace with snapshot unit digests in W04 |
 | `nika-arm::RunShot` primary source | held project descriptor | no | yes | claim/firing | ARM adapter | primary safe; W04 must route its children/skills through the service |
 | `nika-cli::run::resume_setup` trace reader | held trace-parent descriptor | no | yes | pre-compose evidence fold | CLI resume | closed in W02; not executable source |
+| `nika-dap::sign::check_workflow_bytes` | sidecar beside logical workflow path | yes for sidecar only | workflow yes, sidecar used once | pre-effect trust gate | `run --require-signature` | closed in W02: verifies `RunSource` bytes and never reopens the workflow pathname |
+| `nika-dap::sign::check_workflow` | workflow + adjacent sidecar pathnames | yes | no | standalone `sign --check` | signing operator | allowed non-execution reader; cannot feed `nika run` |
+| `nika-dap::sign::sign_workflow_with` | workflow + adjacent sidecar pathnames | yes | signs that read only | standalone `nika sign` | signing operator | allowed minting reader; cannot feed `nika run` |
 | `nika-runtime::EnvFileSecretResolver` | authored secret pathname | yes | value only | composition | provider/tool secret namespace | separate secret-store boundary; remote disclosure is governed by W02.E/W06 |
 
 The structural gate is three-layered rather than a textual search: (1)
@@ -123,8 +126,11 @@ function over `ExecutionContext` with no root or reader capability, and (3)
 `digest_check_skills_and_run_read_zero_sources_after_capture` injects a reader
 spy and proves the read count cannot change during parse, composed check, skill
 resolution, digest, or run. The committed `public-api.txt` additionally locks
-the absence of a reader/root accessor from `ExecutionContext`. Any W04 adapter
-that keeps one of the pathname readers above has not completed migration.
+the absence of a reader/root accessor from `ExecutionContext`. The DAP
+`signature_gate_verifies_captured_b_not_reread_pathname_a` barrier proves a
+pathname replaced with signed bytes A cannot authorize already captured bytes
+B. Any W04 adapter that keeps one of the executable pathname readers above has
+not completed migration.
 
 ## 5. Admission gates
 

--- a/docs/security/nika-serve-threat-model.md
+++ b/docs/security/nika-serve-threat-model.md
@@ -134,6 +134,30 @@ owned by the later OpenAPI carrier. Adding a route cannot weaken this table.
 - Logs identify request/job outcomes without logging credentials, raw workflow
   bytes, raw inputs, or model/tool payloads.
 
+### W02 remote-security baseline and gap register
+
+No network route may be implemented around an unresolved P0/P1 row. “Closed”
+below means the named local primitive and its test exist; it does not claim an
+HTTP surface that has not landed.
+
+| surface | severity | baseline at W02 | owner / wave |
+|---|---:|---|---|
+| trace + event secret bytes | P0 | closed: provenance-based `RedactingSink` covers raw, JSON-escaped, nested, output-side-channel, and tool/provider echo shapes | runtime; W11 reruns adversarial suite |
+| debug/error/log projection | P0 | snapshot, admitted context, and generic verdict `Debug` expose identity/digest only; HTTP error and request-log allowlists do not yet exist | Serve adapter / W06, blocking before bind |
+| provider/tool secret-shaped payload | P0 | runtime events redact known secret provenance; arbitrary raw provider/tool bodies remain unfit for remote serialization | Serve projection / W06, SSE projection / W07 |
+| prompt injection versus permits | P0 | runtime `dispatch::regate`, `permit_regate`, and adversarial F1–F4 fixtures keep model/tool text as data and re-check effect arguments | runtime / W02 closed; W11 refutes end-to-end |
+| remote workflow projection | P0 | deny-by-default: `AdmittedExecution` fields are private and its debug view has no bytes; there is no remote serializer | Serve / W06 must add an explicit field allowlist, never `Serialize` the admitted world |
+| sandbox/permit refusal under structured capture | P0 | closed: a typed authority/transport result fails before structured interpretation; business-process nonzero remains data | exec/runtime / W02 |
+| approval replay across processes | P0 | closed: ticket-digest marker is atomically create-once in local `~/.nika/approval-claims`; process clones share an atomic claim | runtime + CLI / W02 |
+| network composition | P1 | runtime maps absent/empty net grants to deny and refuses an unavailable declared sandbox; listener auth, bind acknowledgement, proxy and egress composition are still absent | Serve / W06 and VPS / W10 |
+| public health metadata | P1 | no route exists; the allowed future projection is `EngineIdentity` only | Serve / W06 |
+
+W02 therefore leaves no known P0/P1 in an existing remote adapter: there is no
+adapter yet. The future P0/P1 rows are explicit entry gates for W06/W07, not
+permission to ship a partial listener. Secret redaction is defense in depth;
+the primary remote rule is still field allowlisting, so a value that was never
+approved for projection cannot rely on a string scrubber to become safe.
+
 ### Deployment
 
 - Preferred VPS shape: loopback Serve listener behind a same-host TLS reverse
@@ -153,7 +177,9 @@ owned by the later OpenAPI carrier. Adding a route cannot weaken this table.
 - [ ] oversized, slow, invalid, and wrong-content-type bodies never execute;
 - [ ] absolute, traversal, separator-confused, extension-confused, and symlink
   workflow names refuse;
-- [ ] source replacement after capture cannot change checked/executed bytes;
+- [x] source replacement after capture cannot change checked/executed bytes
+  (`nika-execution` includes deterministic root, child, skill, symlink,
+  directory, and barrier-interleaving fixtures);
 - [ ] identical idempotent replay returns one job across restart;
 - [ ] conflicting key reuse and simultaneous duplicates refuse without a second
   effect;

--- a/docs/security/nika-serve-threat-model.md
+++ b/docs/security/nika-serve-threat-model.md
@@ -147,8 +147,10 @@ HTTP surface that has not landed.
 | provider/tool secret-shaped payload | P0 | runtime events redact known secret provenance; arbitrary raw provider/tool bodies remain unfit for remote serialization | Serve projection / W06, SSE projection / W07 |
 | prompt injection versus permits | P0 | runtime `dispatch::regate`, `permit_regate`, and adversarial F1–F4 fixtures keep model/tool text as data and re-check effect arguments | runtime / W02 closed; W11 refutes end-to-end |
 | remote workflow projection | P0 | deny-by-default: `AdmittedExecution` fields are private and its debug view has no bytes; there is no remote serializer | Serve / W06 must add an explicit field allowlist, never `Serialize` the admitted world |
-| sandbox/permit refusal under structured capture | P0 | closed: a typed authority/transport result fails before structured interpretation; business-process nonzero remains data | exec/runtime / W02 |
-| approval replay across processes | P0 | closed: ticket-digest marker is atomically create-once in local `~/.nika/approval-claims`; process clones share an atomic claim | runtime + CLI / W02 |
+| sandbox/permit refusal under structured capture | P0 | closed: the production runner retains the Seatbelt/landlock classifier through drain and attaches its typed receipt before structured interpretation; status 126 and launcher diagnostics refuse, while an unmarked business nonzero remains data | exec/runtime / W02 |
+| remote terminal classification | P0 | no remote process adapter exists; the kernel receipt table maps authority to blocked, transport to error, and missing/unsupported remote terminal receipts to fail-closed transport error | Serve worker adapter / W06 must attach a receipt on every terminal envelope |
+| approval replay across processes | P0 | closed against concurrent/repeated use: ticket-digest marker is atomically create-once in local `~/.nika/approval-claims`; process clones share an atomic claim | runtime + CLI / W02 |
+| approval marker rollback/deletion | P1 | the local marker assumes its owned state directory is not rolled back or deleted by the same OS principal; create-once does not make deletion evident | durable job ledger / W05 must bind claim state into its tamper-evident chain before W06 |
 | network composition | P1 | runtime maps absent/empty net grants to deny and refuses an unavailable declared sandbox; listener auth, bind acknowledgement, proxy and egress composition are still absent | Serve / W06 and VPS / W10 |
 | public health metadata | P1 | no route exists; the allowed future projection is `EngineIdentity` only | Serve / W06 |
 
@@ -157,6 +159,12 @@ adapter yet. The future P0/P1 rows are explicit entry gates for W06/W07, not
 permission to ship a partial listener. Secret redaction is defense in depth;
 the primary remote rule is still field allowlisting, so a value that was never
 approved for projection cannot rely on a string scrubber to become safe.
+
+The reviewer-v2 counterexamples were identified on `0d5c744c`: the production
+runner discarded the sandbox backend before constructing `ShellResult`, and
+`run --require-signature` reopened the workflow pathname after `RunSource`
+capture. The barrier regressions landed with the fixes; no historical RED test
+transcript is claimed where no such test existed on that SHA.
 
 ### Deployment
 
@@ -178,8 +186,9 @@ approved for projection cannot rely on a string scrubber to become safe.
 - [ ] absolute, traversal, separator-confused, extension-confused, and symlink
   workflow names refuse;
 - [x] source replacement after capture cannot change checked/executed bytes
-  (`nika-execution` includes deterministic root, child, skill, symlink,
-  directory, and barrier-interleaving fixtures);
+  (`nika-execution` includes deterministic barrier-interleaved root, child,
+  nested-child, skill, symlink, and directory fixtures; DAP separately binds
+  workflow signatures to captured bytes);
 - [ ] identical idempotent replay returns one job across restart;
 - [ ] conflicting key reuse and simultaneous duplicates refuse without a second
   effect;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2501,6 +2501,7 @@ dependencies = [
  "bytes",
  "globset",
  "nika-kernel",
+ "nix",
  "tokio",
 ]
 
@@ -2740,6 +2741,7 @@ dependencies = [
 name = "nika-verb-agent"
 version = "0.113.0"
 dependencies = [
+ "bytes",
  "futures-util",
  "jsonschema",
  "miette",
@@ -2804,6 +2806,18 @@ dependencies = [
  "nika-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3765,7 +3779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2c6921c8ce48fb1b052b457619d008834039d80325992ed3bc55bbe6c155ad"
 dependencies = [
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.23.1",
  "encoding_rs_io",
  "granit-parser 1.0.1",
  "miette",


### PR DESCRIPTION
## What

- make approval claims single-use across resume boundaries
- read captured workflows and traces through capability-safe handles
- preserve typed authority and transport failures through adapter outcomes
- reject unsigned captured execution before any effect
- close root, nested path, directory, and symlink replacement barriers
- keep runtime and function-size ratchets green

## Proof

- full local pre-push gate green at `3f08452`
- all workspace library tests green
- `nika-cli`: 296/296
- `nika-runtime`: 313/313
- clippy, hygiene, cargo-deny, cargo-machete green
- all 10 CI ratchets green

## Boundary

This wave closes the security prerequisites for remote execution. Durable remote receipts and marker rollback remain owned by W05/W06; this PR does not claim those later guarantees.

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>
Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
