### PR TITLE
fix(harness): harden kimi code acp readiness

### DIFF
--- a/crates/nika-harness/src/probe.rs
+++ b/crates/nika-harness/src/probe.rs
@@ -185,6 +185,14 @@ async fn probe_auth_with(
 /// a distinct authority and must not make the model seat look authenticated.
 /// Every ambiguity fails closed without reading a credential byte.
 fn provider_credential_directory_ready(path: &std::path::Path, credential_files: &[&str]) -> bool {
+    provider_credential_directory_ready_with(path, credential_files, |_| {})
+}
+
+fn provider_credential_directory_ready_with(
+    path: &std::path::Path,
+    credential_files: &[&str],
+    mut after_open: impl FnMut(&std::path::Path),
+) -> bool {
     let Some(path_witnesses) = path_component_witnesses(path) else {
         return false;
     };
@@ -195,11 +203,18 @@ fn provider_credential_directory_ready(path: &std::path::Path, credential_files:
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(_) => return false,
         };
-        if metadata.file_type().is_symlink()
-            || !metadata.is_file()
-            || metadata.len() == 0
-            || !readable_same_file(&entry_path, &metadata)
-            || !path_witnesses_unchanged(&path_witnesses)
+        if metadata.file_type().is_symlink() || !metadata.is_file() || metadata.len() == 0 {
+            continue;
+        }
+        let Some(opened) = open_witnessed_file(&entry_path, &metadata) else {
+            continue;
+        };
+        if !pathname_names_open_file(&entry_path, &opened) {
+            continue;
+        }
+        after_open(&entry_path);
+        if !path_witnesses_unchanged(&path_witnesses)
+            || !pathname_names_open_file(&entry_path, &opened)
         {
             continue;
         }
@@ -244,17 +259,35 @@ fn path_witnesses_unchanged(witnesses: &[(std::path::PathBuf, std::fs::Metadata)
     })
 }
 
-/// Open only to let the OS apply UID/ACL readability, then compare the opened
-/// object with the lstat witness. No byte is read; a pathname swap can only
-/// make the identity comparison refuse.
-fn readable_same_file(path: &std::path::Path, witnessed: &std::fs::Metadata) -> bool {
+/// Open only to let the OS apply UID/ACL readability, then retain the handle
+/// through every pathname witness. No credential byte is ever read.
+fn open_witnessed_file(
+    path: &std::path::Path,
+    witnessed: &std::fs::Metadata,
+) -> Option<std::fs::File> {
     let Ok(file) = std::fs::File::open(path) else {
-        return false;
+        return None;
     };
     let Ok(opened) = file.metadata() else {
+        return None;
+    };
+    (opened.is_file() && opened.len() > 0 && same_file_identity(witnessed, &opened)).then_some(file)
+}
+
+/// Re-lstat the live pathname and prove that it still names the held handle.
+/// This runs once immediately after open and again after directory witnesses,
+/// closing the entry-swap seam without reading credential contents.
+fn pathname_names_open_file(path: &std::path::Path, opened: &std::fs::File) -> bool {
+    let Ok(handle_metadata) = opened.metadata() else {
         return false;
     };
-    opened.is_file() && opened.len() > 0 && same_file_identity(witnessed, &opened)
+    let Ok(current) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    !current.file_type().is_symlink()
+        && current.is_file()
+        && current.len() > 0
+        && same_file_identity(&handle_metadata, &current)
 }
 
 #[cfg(unix)]
@@ -594,7 +627,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn kimi_auth_uses_its_override_and_refuses_empty_or_symlinked_stores() {
+    async fn kimi_auth_uses_its_override_and_detects_provider() {
         let root = std::fs::canonicalize(std::env::temp_dir())
             .expect("the test temp root canonicalizes")
             .join(format!("nika-kimi-auth-{}", std::process::id()));
@@ -666,6 +699,24 @@ mod tests {
             .await,
             Some(true)
         );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn kimi_auth_refuses_relative_or_symlinked_override() {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("the test temp root canonicalizes")
+            .join(format!("nika-kimi-auth-roots-{}", std::process::id()));
+        let home = root.join("home");
+        let relocated = root.join("relocated");
+        std::fs::create_dir_all(relocated.join("credentials")).expect("relocated credentials");
+        let rows = crate::registry_with(&|_| None).expect("registry loads");
+        let row = rows
+            .iter()
+            .find(|row| row.adapter.id == "kimi-code")
+            .expect("kimi row");
+        let policy = row.directory_auth.expect("secure directory policy");
 
         assert_eq!(
             probe_auth_with(
@@ -767,8 +818,41 @@ mod tests {
         std::fs::remove_file(&candidate).expect("swap candidate");
         std::os::unix::fs::symlink(&replacement, &candidate).expect("symlink replacement");
         assert!(
-            !readable_same_file(&candidate, &witnessed),
+            open_witnessed_file(&candidate, &witnessed).is_none(),
             "opening a swapped pathname must not validate a different inode"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kimi_auth_refuses_an_entry_swap_after_open_before_return() {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("the test temp root canonicalizes")
+            .join(format!(
+                "nika-kimi-auth-post-open-race-{}",
+                std::process::id()
+            ));
+        let credentials = root.join("credentials");
+        let replacement = root.join("replacement.json");
+        std::fs::create_dir_all(&credentials).expect("credential directory");
+        std::fs::write(
+            credentials.join("kimi-code.json"),
+            b"original-provider-fixture",
+        )
+        .expect("provider fixture");
+        std::fs::write(&replacement, b"replacement-provider-fixture").expect("replacement fixture");
+
+        let ready =
+            provider_credential_directory_ready_with(&credentials, &["kimi-code.json"], |entry| {
+                std::fs::remove_file(entry).expect("remove opened pathname");
+                std::os::unix::fs::symlink(&replacement, entry)
+                    .expect("replace opened pathname with symlink");
+            });
+        assert!(
+            !ready,
+            "the final pathname witness must reject a swap after File::open"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/nika-harness/src/probe.rs
+++ b/crates/nika-harness/src/probe.rs
@@ -183,27 +183,11 @@ async fn probe_auth_with(
 /// Metadata-only proof that a provider credential is present. Kimi Code stores
 /// provider seats as top-level `credentials/<name>.json`; the `mcp/` subtree is
 /// a distinct authority and must not make the model seat look authenticated.
-/// Every ambiguity fails closed without opening a credential file.
+/// Every ambiguity fails closed without reading a credential byte.
 fn provider_credential_directory_ready(path: &std::path::Path, credential_files: &[&str]) -> bool {
-    if !path.is_absolute() {
+    let Some(path_witnesses) = path_component_witnesses(path) else {
         return false;
-    }
-    let mut cursor = std::path::PathBuf::new();
-    for component in path.components() {
-        if matches!(
-            component,
-            std::path::Component::CurDir | std::path::Component::ParentDir
-        ) {
-            return false;
-        }
-        cursor.push(component.as_os_str());
-        let Ok(metadata) = std::fs::symlink_metadata(&cursor) else {
-            return false;
-        };
-        if metadata.file_type().is_symlink() {
-            return false;
-        }
-    }
+    };
     for file_name in credential_files {
         let entry_path = path.join(file_name);
         let metadata = match std::fs::symlink_metadata(&entry_path) {
@@ -215,12 +199,49 @@ fn provider_credential_directory_ready(path: &std::path::Path, credential_files:
             || !metadata.is_file()
             || metadata.len() == 0
             || !readable_same_file(&entry_path, &metadata)
+            || !path_witnesses_unchanged(&path_witnesses)
         {
             continue;
         }
         return true;
     }
     false
+}
+
+fn path_component_witnesses(
+    path: &std::path::Path,
+) -> Option<Vec<(std::path::PathBuf, std::fs::Metadata)>> {
+    if !path.is_absolute() {
+        return None;
+    }
+    let mut cursor = std::path::PathBuf::new();
+    let mut witnesses = Vec::new();
+    for component in path.components() {
+        if matches!(
+            component,
+            std::path::Component::CurDir | std::path::Component::ParentDir
+        ) {
+            return None;
+        }
+        cursor.push(component.as_os_str());
+        let Ok(metadata) = std::fs::symlink_metadata(&cursor) else {
+            return None;
+        };
+        if metadata.file_type().is_symlink() {
+            return None;
+        }
+        witnesses.push((cursor.clone(), metadata));
+    }
+    Some(witnesses)
+}
+
+fn path_witnesses_unchanged(witnesses: &[(std::path::PathBuf, std::fs::Metadata)]) -> bool {
+    witnesses.iter().all(|(path, witnessed)| {
+        let Ok(current) = std::fs::symlink_metadata(path) else {
+            return false;
+        };
+        !current.file_type().is_symlink() && same_file_identity(witnessed, &current)
+    })
 }
 
 /// Open only to let the OS apply UID/ACL readability, then compare the opened
@@ -748,6 +769,31 @@ mod tests {
         assert!(
             !readable_same_file(&candidate, &witnessed),
             "opening a swapped pathname must not validate a different inode"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kimi_auth_refuses_a_credentials_directory_swap() {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("the test temp root canonicalizes")
+            .join(format!("nika-kimi-auth-dir-race-{}", std::process::id()));
+        let credentials = root.join("credentials");
+        let original = root.join("credentials-original");
+        let replacement = root.join("credentials-replacement");
+        std::fs::create_dir_all(&credentials).expect("credential directory");
+        std::fs::create_dir_all(&replacement).expect("replacement directory");
+        std::fs::write(replacement.join("kimi-code.json"), b"replacement-fixture")
+            .expect("replacement fixture");
+        let witnesses = path_component_witnesses(&credentials).expect("component witnesses");
+
+        std::fs::rename(&credentials, &original).expect("move witnessed directory");
+        std::os::unix::fs::symlink(&replacement, &credentials).expect("replace with symlink");
+        assert!(
+            !path_witnesses_unchanged(&witnesses),
+            "a replaced credentials component must not survive its identity witness"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/nika-harness/src/probe.rs
+++ b/crates/nika-harness/src/probe.rs
@@ -1,25 +1,27 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2024-2026 SuperNovae Studio <contact@supernovae.studio>
 
-//! The adapter VERSION probe (spec §4 · the promise B3.2 owed) — the
-//! binary's identity is judged BEFORE a session, never discovered
-//! mid-run.
+//! The adapter IDENTITY probe (spec §4 · the promise B3.2 owed) — the
+//! binary's version and any registry-declared command shape are judged
+//! BEFORE a session, never discovered mid-run.
 //!
 //! Why before: an adapter outside its pin range speaks a dialect this
 //! client did not read. Learning that at `initialize` wastes a spawn
 //! and reports a protocol confusion where the truth is a VERSION
 //! mismatch. The probe runs `<command> --version`, parses the first
-//! semver-ish token out of whatever the CLI prints (every harness
-//! prints its own prose around it), and judges it against the
-//! adapter's declared range.
+//! semver-ish token out of whatever the CLI prints, and judges it
+//! against the adapter's declared range. A row whose binary name can
+//! collide then proves its exact subcommand through a bounded public
+//! help surface; version equality alone cannot admit it.
 //!
 //! What the probe is NOT: a credential read, a network call, or a
 //! session. It spawns the same confined child shape the session does
-//! (composed env · no shell · bounded output) and reads one line.
+//! (composed env · no shell · bounded output). Auth-store probes read
+//! path metadata only, never credential contents.
 
 use nika_kernel::ai::harness::HarnessError;
 
-use crate::registry::{AdapterRow, AuthProbe};
+use crate::registry::{AdapterRow, AuthProbe, DirectoryAuthProbe};
 use crate::spawn::{SpawnedHarness, compose_env};
 
 /// One adapter's probe row (P3 B6 · the doctor surface's facts) —
@@ -45,8 +47,9 @@ pub struct AdapterProbeRow {
 
 impl AdapterProbeRow {
     /// Whether the adapter can serve a session NOW (detected AND inside
-    /// the pin). Auth stays a separate column — a harness without auth
-    /// is detected-but-refusing, a truth the row keeps distinct.
+    /// the pin, with its command-shape proof satisfied when declared).
+    /// Auth stays a separate column — a harness without auth is
+    /// detected-but-refusing, a truth the row keeps distinct.
     #[must_use]
     pub fn usable(&self) -> bool {
         self.version.is_some()
@@ -102,7 +105,7 @@ async fn probe_one(row: AdapterRow) -> AdapterProbeRow {
         Ok(seen) => (seen, String::new()),
         Err(e) => (None, e.to_string()),
     };
-    let authenticated = probe_auth(&row.auth).await;
+    let authenticated = probe_auth(&row.auth, row.directory_auth).await;
     AdapterProbeRow {
         id: row.adapter.id.clone(),
         version,
@@ -114,17 +117,45 @@ async fn probe_one(row: AdapterRow) -> AdapterProbeRow {
 
 /// The auth surface probe — an exit code or a presence bit, bounded
 /// like every spawn (a hung status command is `None`, not a hang).
-async fn probe_auth(surface: &AuthProbe) -> Option<bool> {
+async fn probe_auth(
+    surface: &AuthProbe,
+    directory_auth: Option<DirectoryAuthProbe>,
+) -> Option<bool> {
     #[allow(clippy::disallowed_methods)] // the sanctioned env boundary ($HOME presence)
     let home = std::env::var_os("HOME");
-    probe_auth_with(home.as_deref(), surface).await
+    #[allow(clippy::disallowed_methods)] // sanctioned adapter-home boundary
+    let override_home = directory_auth.and_then(|probe| std::env::var_os(probe.override_env));
+    probe_auth_with(
+        home.as_deref(),
+        override_home.as_deref(),
+        surface,
+        directory_auth,
+    )
+    .await
 }
 
 /// [`probe_auth`] with the home dir injected — the pure half tests
 /// drive (writing `$HOME` would need `unsafe` under Rust 2024).
-async fn probe_auth_with(home: Option<&std::ffi::OsStr>, surface: &AuthProbe) -> Option<bool> {
+async fn probe_auth_with(
+    home: Option<&std::ffi::OsStr>,
+    override_home: Option<&std::ffi::OsStr>,
+    surface: &AuthProbe,
+    directory_auth: Option<DirectoryAuthProbe>,
+) -> Option<bool> {
     match surface {
-        AuthProbe::HomeFile(rel) => Some(std::path::Path::new(home?).join(rel).exists()),
+        AuthProbe::HomeFile(rel) => {
+            if let Some(probe) = directory_auth {
+                let path = match override_home {
+                    Some(root) => std::path::Path::new(root).join(probe.override_relative),
+                    None => match home {
+                        Some(root) => std::path::Path::new(root).join(rel),
+                        None => return Some(false),
+                    },
+                };
+                return Some(nonempty_directory_without_symlinks(&path));
+            }
+            Some(std::path::Path::new(home?).join(rel).exists())
+        }
         AuthProbe::Command { command, args } => {
             let parent: std::collections::BTreeMap<String, String> = std::env::vars().collect();
             let env = compose_env(&parent, &[]);
@@ -144,6 +175,48 @@ async fn probe_auth_with(home: Option<&std::ffi::OsStr>, surface: &AuthProbe) ->
             Some(status.success())
         }
     }
+}
+
+/// Metadata-only proof that a credentials directory is usable. Every
+/// ambiguity fails closed: relative paths, missing/unreadable entries,
+/// special files, and symlinks in either the path or its first level.
+fn nonempty_directory_without_symlinks(path: &std::path::Path) -> bool {
+    if !path.is_absolute() {
+        return false;
+    }
+    let mut cursor = std::path::PathBuf::new();
+    for component in path.components() {
+        if matches!(
+            component,
+            std::path::Component::CurDir | std::path::Component::ParentDir
+        ) {
+            return false;
+        }
+        cursor.push(component.as_os_str());
+        let Ok(metadata) = std::fs::symlink_metadata(&cursor) else {
+            return false;
+        };
+        if metadata.file_type().is_symlink() {
+            return false;
+        }
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return false;
+    };
+    let mut nonempty = false;
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return false;
+        };
+        let Ok(kind) = entry.file_type() else {
+            return false;
+        };
+        if kind.is_symlink() || (!kind.is_file() && !kind.is_dir()) {
+            return false;
+        }
+        nonempty = true;
+    }
+    nonempty
 }
 
 /// The inclusive version range an adapter is pinned to — the
@@ -335,6 +408,7 @@ mod tests {
                 .with_version_pin(VersionPin::new((1, 0), 1)),
             serves: &["mock"],
             auth: crate::registry::AuthProbe::HomeFile(".definitely-absent-nika-test"),
+            directory_auth: None,
             package: "test-only",
         };
         let out = probe_adapters_sync(vec![mk("sync-a"), mk("sync-b")]);
@@ -423,14 +497,14 @@ mod tests {
             command: "false",
             args: &[],
         };
-        assert_eq!(probe_auth(&yes).await, Some(true));
-        assert_eq!(probe_auth(&no).await, Some(false));
+        assert_eq!(probe_auth(&yes, None).await, Some(true));
+        assert_eq!(probe_auth(&no, None).await, Some(false));
         // An absent binary is unreadable, never a guess.
         let absent = AuthProbe::Command {
             command: "nika-no-such-binary- anywhere",
             args: &[],
         };
-        assert_eq!(probe_auth(&absent).await, None);
+        assert_eq!(probe_auth(&absent, None).await, None);
 
         // HomeFile: presence against the INJECTED home.
         let dir = std::env::temp_dir().join(format!("nika-auth-probe-{}", std::process::id()));
@@ -439,24 +513,119 @@ mod tests {
         let home = dir.as_os_str();
         let present = AuthProbe::HomeFile(".gemini/google_accounts.json");
         let missing = AuthProbe::HomeFile(".qwen");
-        assert_eq!(probe_auth_with(Some(home), &present).await, Some(true));
-        assert_eq!(probe_auth_with(Some(home), &missing).await, Some(false));
-        // kimi-code: the official store directory, existence only —
-        // no file is written, so no secret is ever opened.
-        std::fs::create_dir_all(dir.join(".kimi-code/credentials")).expect("kimi store");
-        let kimi = AuthProbe::HomeFile(".kimi-code/credentials");
-        assert_eq!(probe_auth_with(Some(home), &kimi).await, Some(true));
-        let kimi_absent = AuthProbe::HomeFile(".kimi-code/credentials");
-        let empty = std::env::temp_dir().join(format!("nika-auth-empty-{}", std::process::id()));
-        std::fs::create_dir_all(&empty).expect("empty home");
         assert_eq!(
-            probe_auth_with(Some(empty.as_os_str()), &kimi_absent).await,
+            probe_auth_with(Some(home), None, &present, None).await,
+            Some(true)
+        );
+        assert_eq!(
+            probe_auth_with(Some(home), None, &missing, None).await,
             Some(false)
         );
-        let _ = std::fs::remove_dir_all(&empty);
         // No home at all: unreadable, never a guess.
-        assert_eq!(probe_auth_with(None, &present).await, None);
+        assert_eq!(probe_auth_with(None, None, &present, None).await, None);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn kimi_auth_uses_its_override_and_refuses_empty_or_symlinked_stores() {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("the test temp root canonicalizes")
+            .join(format!("nika-kimi-auth-{}", std::process::id()));
+        let home = root.join("home");
+        let default_credentials = home.join(".kimi-code/credentials");
+        std::fs::create_dir_all(&default_credentials).expect("default credentials dir");
+
+        let rows = crate::registry_with(&|_| None).expect("registry loads");
+        let row = rows
+            .iter()
+            .find(|row| row.adapter.id == "kimi-code")
+            .expect("kimi row");
+        let policy = row.directory_auth.expect("secure directory policy");
+
+        assert_eq!(
+            probe_auth_with(Some(home.as_os_str()), None, &row.auth, Some(policy)).await,
+            Some(false),
+            "an empty default store is not authentication"
+        );
+        std::fs::write(default_credentials.join("account.json"), b"opaque-fixture")
+            .expect("opaque fixture");
+        assert_eq!(
+            probe_auth_with(Some(home.as_os_str()), None, &row.auth, Some(policy)).await,
+            Some(true),
+            "only metadata and non-emptiness are needed"
+        );
+
+        let relocated = root.join("relocated");
+        std::fs::create_dir_all(&relocated).expect("relocated root");
+        assert_eq!(
+            probe_auth_with(
+                Some(home.as_os_str()),
+                Some(relocated.as_os_str()),
+                &row.auth,
+                Some(policy),
+            )
+            .await,
+            Some(false),
+            "KIMI_CODE_HOME wins even when the default store is populated"
+        );
+        let relocated_credentials = relocated.join("credentials");
+        std::fs::create_dir_all(&relocated_credentials).expect("relocated credentials");
+        assert_eq!(
+            probe_auth_with(
+                Some(home.as_os_str()),
+                Some(relocated.as_os_str()),
+                &row.auth,
+                Some(policy),
+            )
+            .await,
+            Some(false),
+            "an empty relocated store is not authentication"
+        );
+        std::fs::write(
+            relocated_credentials.join("account.json"),
+            b"opaque-fixture",
+        )
+        .expect("opaque relocated fixture");
+        assert_eq!(
+            probe_auth_with(
+                Some(home.as_os_str()),
+                Some(relocated.as_os_str()),
+                &row.auth,
+                Some(policy),
+            )
+            .await,
+            Some(true)
+        );
+        assert_eq!(
+            probe_auth_with(
+                Some(home.as_os_str()),
+                Some(std::ffi::OsStr::new("relative-kimi-home")),
+                &row.auth,
+                Some(policy),
+            )
+            .await,
+            Some(false),
+            "a relative override is ambiguous"
+        );
+
+        #[cfg(unix)]
+        {
+            let linked = root.join("linked");
+            std::os::unix::fs::symlink(&relocated, &linked).expect("symlink fixture");
+            assert_eq!(
+                probe_auth_with(
+                    Some(home.as_os_str()),
+                    Some(linked.as_os_str()),
+                    &row.auth,
+                    Some(policy),
+                )
+                .await,
+                Some(false),
+                "a symlinked credentials root fails closed"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[tokio::test]
@@ -477,6 +646,7 @@ mod tests {
                 command: "true",
                 args: &[],
             },
+            directory_auth: None,
             package: "test-only",
         };
         let probed = probe_one(row).await;
@@ -495,6 +665,7 @@ mod tests {
                 .with_version_pin(VersionPin::new((1, 0), 1)),
             serves: &["mock"],
             auth: AuthProbe::HomeFile(".definitely-absent-nika-test"),
+            directory_auth: None,
             package: "test-only",
         };
         let rows = vec![mk("zzz-first"), mk("aaa-second")];

--- a/crates/nika-harness/src/probe.rs
+++ b/crates/nika-harness/src/probe.rs
@@ -152,7 +152,7 @@ async fn probe_auth_with(
                         None => return Some(false),
                     },
                 };
-                return Some(nonempty_directory_without_symlinks(&path));
+                return Some(provider_credential_directory_ready(&path));
             }
             Some(std::path::Path::new(home?).join(rel).exists())
         }
@@ -177,10 +177,11 @@ async fn probe_auth_with(
     }
 }
 
-/// Metadata-only proof that a credentials directory is usable. Every
-/// ambiguity fails closed: relative paths, missing/unreadable entries,
-/// special files, and symlinks in either the path or its first level.
-fn nonempty_directory_without_symlinks(path: &std::path::Path) -> bool {
+/// Metadata-only proof that a provider credential is present. Kimi Code stores
+/// provider seats as top-level `credentials/<name>.json`; the `mcp/` subtree is
+/// a distinct authority and must not make the model seat look authenticated.
+/// Every ambiguity fails closed without opening a credential file.
+fn provider_credential_directory_ready(path: &std::path::Path) -> bool {
     if !path.is_absolute() {
         return false;
     }
@@ -203,7 +204,6 @@ fn nonempty_directory_without_symlinks(path: &std::path::Path) -> bool {
     let Ok(entries) = std::fs::read_dir(path) else {
         return false;
     };
-    let mut nonempty = false;
     for entry in entries {
         let Ok(entry) = entry else {
             return false;
@@ -211,12 +211,40 @@ fn nonempty_directory_without_symlinks(path: &std::path::Path) -> bool {
         let Ok(kind) = entry.file_type() else {
             return false;
         };
-        if kind.is_symlink() || (!kind.is_file() && !kind.is_dir()) {
+        if kind.is_symlink() {
             return false;
         }
-        nonempty = true;
+        let entry_path = entry.path();
+        if !kind.is_file() || entry_path.extension() != Some(std::ffi::OsStr::new("json")) {
+            continue;
+        }
+        let Some(stem) = entry_path.file_stem().and_then(std::ffi::OsStr::to_str) else {
+            continue;
+        };
+        if stem.is_empty() || stem.starts_with('.') {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            return false;
+        };
+        if metadata.len() == 0 || !owner_readable(&metadata) {
+            continue;
+        }
+        return true;
     }
-    nonempty
+    false
+}
+
+#[cfg(unix)]
+fn owner_readable(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    metadata.permissions().mode() & 0o400 != 0
+}
+
+#[cfg(not(unix))]
+fn owner_readable(_metadata: &std::fs::Metadata) -> bool {
+    true
 }
 
 /// The inclusive version range an adapter is pinned to — the
@@ -552,7 +580,7 @@ mod tests {
         assert_eq!(
             probe_auth_with(Some(home.as_os_str()), None, &row.auth, Some(policy)).await,
             Some(true),
-            "only metadata and non-emptiness are needed"
+            "a non-empty top-level provider JSON is the metadata-only proxy"
         );
 
         let relocated = root.join("relocated");
@@ -596,6 +624,7 @@ mod tests {
             .await,
             Some(true)
         );
+
         assert_eq!(
             probe_auth_with(
                 Some(home.as_os_str()),
@@ -623,6 +652,53 @@ mod tests {
                 Some(false),
                 "a symlinked credentials root fails closed"
             );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn kimi_auth_refuses_noise_mcp_only_and_unreadable_credentials() {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("the test temp root canonicalizes")
+            .join(format!("nika-kimi-auth-shape-{}", std::process::id()));
+        let credentials = root.join("credentials");
+        std::fs::create_dir_all(credentials.join("mcp")).expect("credential directories");
+        std::fs::write(credentials.join(".DS_Store"), b"finder metadata").expect("metadata");
+        std::fs::write(credentials.join("README"), b"not a credential").expect("prose");
+        std::fs::write(credentials.join("mcp/server.json"), b"opaque-mcp-fixture")
+            .expect("mcp fixture");
+
+        let rows = crate::registry_with(&|_| None).expect("registry loads");
+        let row = rows
+            .iter()
+            .find(|row| row.adapter.id == "kimi-code")
+            .expect("kimi row");
+        let policy = row.directory_auth.expect("secure directory policy");
+        let probe = || probe_auth_with(None, Some(root.as_os_str()), &row.auth, Some(policy));
+        assert_eq!(
+            probe().await,
+            Some(false),
+            "filesystem noise and MCP-only credentials do not authenticate a model seat"
+        );
+
+        let credential = credentials.join("account.json");
+        std::fs::write(&credential, b"opaque-provider-fixture").expect("provider fixture");
+        assert_eq!(probe().await, Some(true));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            std::fs::set_permissions(&credential, std::fs::Permissions::from_mode(0o000))
+                .expect("make credential unreadable");
+            assert_eq!(
+                probe().await,
+                Some(false),
+                "an unreadable provider credential fails closed"
+            );
+            std::fs::set_permissions(&credential, std::fs::Permissions::from_mode(0o600))
+                .expect("restore fixture permissions");
         }
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/nika-harness/src/probe.rs
+++ b/crates/nika-harness/src/probe.rs
@@ -34,9 +34,9 @@ pub struct AdapterProbeRow {
     /// The version the probe read, inside the pin (None = binary
     /// absent or outside the pin — `note` names which).
     pub version: Option<(u32, u32)>,
-    /// The auth surface's verdict: `Some(true)` an auth exists,
-    /// `Some(false)` the surface says none, `None` the surface itself
-    /// is unreadable here (absent is honest — never a guess).
+    /// The auth surface's verdict: `Some(true)` a configured auth witness
+    /// exists, `Some(false)` the surface says none, `None` the surface itself
+    /// is unreadable here. Token validity is judged by the harness session.
     pub authenticated: Option<bool>,
     /// The install pointer (the registry row's package line).
     pub package: String,
@@ -152,7 +152,10 @@ async fn probe_auth_with(
                         None => return Some(false),
                     },
                 };
-                return Some(provider_credential_directory_ready(&path));
+                return Some(provider_credential_directory_ready(
+                    &path,
+                    probe.credential_files,
+                ));
             }
             Some(std::path::Path::new(home?).join(rel).exists())
         }
@@ -181,7 +184,7 @@ async fn probe_auth_with(
 /// provider seats as top-level `credentials/<name>.json`; the `mcp/` subtree is
 /// a distinct authority and must not make the model seat look authenticated.
 /// Every ambiguity fails closed without opening a credential file.
-fn provider_credential_directory_ready(path: &std::path::Path) -> bool {
+fn provider_credential_directory_ready(path: &std::path::Path, credential_files: &[&str]) -> bool {
     if !path.is_absolute() {
         return false;
     }
@@ -201,33 +204,15 @@ fn provider_credential_directory_ready(path: &std::path::Path) -> bool {
             return false;
         }
     }
-    let Ok(entries) = std::fs::read_dir(path) else {
-        return false;
-    };
-    for entry in entries {
-        let Ok(entry) = entry else {
-            return false;
-        };
-        let Ok(kind) = entry.file_type() else {
-            return false;
-        };
-        if kind.is_symlink() {
-            return false;
-        }
-        let entry_path = entry.path();
-        if !kind.is_file() || entry_path.extension() != Some(std::ffi::OsStr::new("json")) {
-            continue;
-        }
-        let Some(stem) = entry_path.file_stem().and_then(std::ffi::OsStr::to_str) else {
-            continue;
-        };
-        if stem.is_empty() || stem.starts_with('.') {
-            continue;
-        }
-        let Ok(metadata) = std::fs::symlink_metadata(&entry_path) else {
-            return false;
+    for file_name in credential_files {
+        let entry_path = path.join(file_name);
+        let metadata = match std::fs::symlink_metadata(&entry_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return false,
         };
         if metadata.file_type().is_symlink()
+            || !metadata.is_file()
             || metadata.len() == 0
             || !readable_same_file(&entry_path, &metadata)
         {
@@ -608,8 +593,11 @@ mod tests {
             Some(false),
             "an empty default store is not authentication"
         );
-        std::fs::write(default_credentials.join("account.json"), b"opaque-fixture")
-            .expect("opaque fixture");
+        std::fs::write(
+            default_credentials.join("kimi-code.json"),
+            b"opaque-fixture",
+        )
+        .expect("opaque fixture");
         assert_eq!(
             probe_auth_with(Some(home.as_os_str()), None, &row.auth, Some(policy)).await,
             Some(true),
@@ -643,7 +631,7 @@ mod tests {
             "an empty relocated store is not authentication"
         );
         std::fs::write(
-            relocated_credentials.join("account.json"),
+            relocated_credentials.join("kimi-code.json"),
             b"opaque-fixture",
         )
         .expect("opaque relocated fixture");
@@ -701,6 +689,11 @@ mod tests {
         std::fs::write(credentials.join("README"), b"not a credential").expect("prose");
         std::fs::write(credentials.join("mcp/server.json"), b"opaque-mcp-fixture")
             .expect("mcp fixture");
+        std::fs::write(
+            credentials.join("unrelated-provider.json"),
+            b"opaque-unrelated-fixture",
+        )
+        .expect("unrelated provider fixture");
 
         let rows = crate::registry_with(&|_| None).expect("registry loads");
         let row = rows
@@ -712,10 +705,10 @@ mod tests {
         assert_eq!(
             probe().await,
             Some(false),
-            "filesystem noise and MCP-only credentials do not authenticate a model seat"
+            "filesystem noise, MCP-only, and unrelated providers do not witness the managed seat"
         );
 
-        let credential = credentials.join("account.json");
+        let credential = credentials.join("kimi-code.json");
         std::fs::write(&credential, b"opaque-provider-fixture").expect("provider fixture");
         assert_eq!(probe().await, Some(true));
 

--- a/crates/nika-harness/src/probe.rs
+++ b/crates/nika-harness/src/probe.rs
@@ -17,7 +17,7 @@
 //! What the probe is NOT: a credential read, a network call, or a
 //! session. It spawns the same confined child shape the session does
 //! (composed env · no shell · bounded output). Auth-store probes read
-//! path metadata only, never credential contents.
+//! path metadata plus a zero-read readability handle, never credential contents.
 
 use nika_kernel::ai::harness::HarnessError;
 
@@ -224,10 +224,13 @@ fn provider_credential_directory_ready(path: &std::path::Path) -> bool {
         if stem.is_empty() || stem.starts_with('.') {
             continue;
         }
-        let Ok(metadata) = entry.metadata() else {
+        let Ok(metadata) = std::fs::symlink_metadata(&entry_path) else {
             return false;
         };
-        if metadata.len() == 0 || !owner_readable(&metadata) {
+        if metadata.file_type().is_symlink()
+            || metadata.len() == 0
+            || !readable_same_file(&entry_path, &metadata)
+        {
             continue;
         }
         return true;
@@ -235,16 +238,46 @@ fn provider_credential_directory_ready(path: &std::path::Path) -> bool {
     false
 }
 
-#[cfg(unix)]
-fn owner_readable(metadata: &std::fs::Metadata) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-
-    metadata.permissions().mode() & 0o400 != 0
+/// Open only to let the OS apply UID/ACL readability, then compare the opened
+/// object with the lstat witness. No byte is read; a pathname swap can only
+/// make the identity comparison refuse.
+fn readable_same_file(path: &std::path::Path, witnessed: &std::fs::Metadata) -> bool {
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(opened) = file.metadata() else {
+        return false;
+    };
+    opened.is_file() && opened.len() > 0 && same_file_identity(witnessed, &opened)
 }
 
-#[cfg(not(unix))]
-fn owner_readable(_metadata: &std::fs::Metadata) -> bool {
-    true
+#[cfg(unix)]
+fn same_file_identity(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn same_file_identity(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    match (
+        left.volume_serial_number(),
+        left.file_index(),
+        right.volume_serial_number(),
+        right.file_index(),
+    ) {
+        (Some(left_volume), Some(left_index), Some(right_volume), Some(right_index)) => {
+            left_volume == right_volume && left_index == right_index
+        }
+        _ => false,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_file_identity(_left: &std::fs::Metadata, _right: &std::fs::Metadata) -> bool {
+    false
 }
 
 /// The inclusive version range an adapter is pinned to — the
@@ -700,6 +733,29 @@ mod tests {
             std::fs::set_permissions(&credential, std::fs::Permissions::from_mode(0o600))
                 .expect("restore fixture permissions");
         }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kimi_auth_readability_refuses_a_path_swap_to_a_symlink() {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("the test temp root canonicalizes")
+            .join(format!("nika-kimi-auth-race-{}", std::process::id()));
+        std::fs::create_dir_all(&root).expect("fixture directory");
+        let candidate = root.join("account.json");
+        let replacement = root.join("other.json");
+        std::fs::write(&candidate, b"original-provider-fixture").expect("candidate fixture");
+        std::fs::write(&replacement, b"replacement-fixture").expect("replacement fixture");
+        let witnessed = std::fs::symlink_metadata(&candidate).expect("lstat witness");
+
+        std::fs::remove_file(&candidate).expect("swap candidate");
+        std::os::unix::fs::symlink(&replacement, &candidate).expect("symlink replacement");
+        assert!(
+            !readable_same_file(&candidate, &witnessed),
+            "opening a swapped pathname must not validate a different inode"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/nika-harness/src/registry.rs
+++ b/crates/nika-harness/src/registry.rs
@@ -55,6 +55,8 @@ pub(crate) struct DirectoryAuthProbe {
     pub(crate) override_env: &'static str,
     /// The directory below the overridden application home.
     pub(crate) override_relative: &'static str,
+    /// Exact top-level credential witnesses accepted for this seat.
+    pub(crate) credential_files: &'static [&'static str],
 }
 
 /// One shipped adapter row.
@@ -168,6 +170,7 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
             directory_auth: Some(DirectoryAuthProbe {
                 override_env: "KIMI_CODE_HOME",
                 override_relative: "credentials",
+                credential_files: &["kimi-code.json"],
             }),
             package: "kimi-code (kimi upgrade · https://moonshotai.github.io/kimi-code/)",
         },
@@ -258,6 +261,7 @@ mod tests {
             Some(DirectoryAuthProbe {
                 override_env: "KIMI_CODE_HOME",
                 override_relative: "credentials",
+                credential_files: &["kimi-code.json"],
             })
         );
         let pin = row.adapter.version_pin.as_ref().expect("pinned");

--- a/crates/nika-harness/src/registry.rs
+++ b/crates/nika-harness/src/registry.rs
@@ -162,8 +162,8 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
             serves: &["moonshot"],
             // Official store (data-locations.md): `$KIMI_CODE_HOME/credentials/`
             // (default `~/.kimi-code/credentials/`). The probe reads
-            // path metadata + directory non-emptiness only; it never
-            // opens a credential. No `login status` command exists.
+            // path metadata plus a zero-read readability handle; it
+            // never reads a credential. No `login status` command exists.
             auth: AuthProbe::HomeFile(".kimi-code/credentials"),
             directory_auth: Some(DirectoryAuthProbe {
                 override_env: "KIMI_CODE_HOME",

--- a/crates/nika-harness/src/registry.rs
+++ b/crates/nika-harness/src/registry.rs
@@ -10,7 +10,8 @@
 //! a shell line), the session argv, the version pin + the argv that
 //! makes the ADAPTER print its version (the wrapper class's lesson —
 //! `npx …` probed bare reports the wrapper, not the adapter), the
-//! provider ids it can serve, and the AUTH SURFACE — how `doctor`
+//! optional command-shape evidence needed when binary names collide,
+//! the provider ids it can serve, and the AUTH SURFACE — how `doctor`
 //! reads the auth state, which is never a credential read.
 //!
 //! The kill-switch is the operator's: `NIKA_HARNESS_DISABLE=codex-acp,…`
@@ -46,6 +47,16 @@ pub enum AuthProbe {
     HomeFile(&'static str),
 }
 
+/// Stronger metadata-only policy for an auth store directory whose
+/// application home can be relocated independently of `$HOME`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DirectoryAuthProbe {
+    /// The variable that overrides the application's default home.
+    pub(crate) override_env: &'static str,
+    /// The directory below the overridden application home.
+    pub(crate) override_relative: &'static str,
+}
+
 /// One shipped adapter row.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -56,6 +67,8 @@ pub struct AdapterRow {
     pub serves: &'static [&'static str],
     /// The auth surface (never a credential read).
     pub auth: AuthProbe,
+    /// Stronger directory semantics for auth stores that need them.
+    pub(crate) directory_auth: Option<DirectoryAuthProbe>,
     /// The install pointer the fix line names.
     pub package: &'static str,
 }
@@ -117,6 +130,7 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
                 .with_version_pin(VersionPin::new((0, 37), 0)),
             serves: &["gemini"],
             auth: AuthProbe::HomeFile(".gemini/google_accounts.json"),
+            directory_auth: None,
             package: "@google/gemini-cli (brew install gemini-cli)",
         },
         AdapterRow {
@@ -125,6 +139,7 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
                 .with_version_pin(VersionPin::new((0, 21), 0)),
             serves: &["qwen"],
             auth: AuthProbe::HomeFile(".qwen"),
+            directory_auth: None,
             package: "@qwen-code/qwen-code (npm i -g @qwen-code/qwen-code)",
         },
         AdapterRow {
@@ -134,17 +149,26 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
             // stdio."). Official Zed args are `["acp"]`. `--login` is
             // a separate option (device-code then exit) and is NOT
             // the session argv. Native CLI: `--version` works, so the
-            // probe is the flag, never a handshake.
+            // identity probe is the flag plus the ACP help shape,
+            // never a session handshake.
             adapter: HarnessAdapter::new("kimi-code", "kimi")?
                 .with_args(vec!["acp".to_owned()])
                 .with_version_pin(VersionPin::new((0, 37), 0))
+                .with_command_shape_probe(
+                    vec!["acp".to_owned(), "--help".to_owned()],
+                    "Agent Client Protocol",
+                )
                 .with_passthrough_env(vec!["KIMI_CODE_HOME".to_owned()]),
             serves: &["moonshot"],
             // Official store (data-locations.md): `$KIMI_CODE_HOME/credentials/`
-            // (default `~/.kimi-code/credentials/`). Existence only —
-            // the files are never opened. No `login status` command
-            // exists (`kimi login status` is `unknown command`).
+            // (default `~/.kimi-code/credentials/`). The probe reads
+            // path metadata + directory non-emptiness only; it never
+            // opens a credential. No `login status` command exists.
             auth: AuthProbe::HomeFile(".kimi-code/credentials"),
+            directory_auth: Some(DirectoryAuthProbe {
+                override_env: "KIMI_CODE_HOME",
+                override_relative: "credentials",
+            }),
             package: "kimi-code (kimi upgrade · https://moonshotai.github.io/kimi-code/)",
         },
         AdapterRow {
@@ -166,6 +190,7 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
                 command: "codex",
                 args: &["login", "status"],
             },
+            directory_auth: None,
             package: "@zed-industries/codex-acp@0.16.0 (npm i -g · wraps the codex CLI's own auth)",
         },
         AdapterRow {
@@ -177,6 +202,7 @@ fn rows() -> Result<Vec<AdapterRow>, HarnessError> {
                 command: "claude",
                 args: &["auth", "status"],
             },
+            directory_auth: None,
             package: "@zed-industries/claude-agent-acp@0.23.1 (npm i -g · wraps the claude CLI's own auth)",
         },
     ])
@@ -222,7 +248,18 @@ mod tests {
             !row.adapter.probe_via_handshake,
             "kimi --version works; handshake is the wrapper class"
         );
+        assert!(
+            row.adapter.command_shape_probe.is_some(),
+            "the shared binary name needs evidence beyond its version"
+        );
         assert_eq!(row.adapter.version_args, vec!["--version".to_owned()]);
+        assert_eq!(
+            row.directory_auth,
+            Some(DirectoryAuthProbe {
+                override_env: "KIMI_CODE_HOME",
+                override_relative: "credentials",
+            })
+        );
         let pin = row.adapter.version_pin.as_ref().expect("pinned");
         assert_eq!(pin.min, (0, 37), "floor is the measured ACP-native release");
         assert_eq!(pin.max_major, 0);

--- a/crates/nika-harness/src/spawn.rs
+++ b/crates/nika-harness/src/spawn.rs
@@ -21,6 +21,7 @@ use std::collections::BTreeMap;
 use std::process::Stdio;
 
 use nika_kernel::ai::harness::{AgentBackendDyn, HarnessError, HarnessEventStream, HarnessRequest};
+use tokio::io::AsyncReadExt;
 
 use crate::client::drive;
 
@@ -30,6 +31,93 @@ use crate::client::drive;
 /// unavailable — a `--version` is a millisecond operation; ten seconds
 /// is already generous for a cold npx resolve.
 const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Combined stdout + stderr retained by an identity probe. Public version and
+/// help surfaces are tiny; anything larger is ambiguity or a hostile wrapper.
+const PROBE_OUTPUT_LIMIT: usize = 64 * 1024;
+
+struct ProbeOutput {
+    status: std::process::ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+#[derive(Debug)]
+enum ProbeReadError {
+    Io(std::io::Error),
+    Overflow,
+}
+
+async fn read_probe_streams(
+    mut stdout: tokio::process::ChildStdout,
+    mut stderr: tokio::process::ChildStderr,
+) -> Result<(Vec<u8>, Vec<u8>), ProbeReadError> {
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+    let mut stdout_open = true;
+    let mut stderr_open = true;
+    let mut retained = 0_usize;
+    let mut stdout_chunk = [0_u8; 4096];
+    let mut stderr_chunk = [0_u8; 4096];
+    while stdout_open || stderr_open {
+        tokio::select! {
+            read = stdout.read(&mut stdout_chunk), if stdout_open => {
+                let count = read.map_err(ProbeReadError::Io)?;
+                if count == 0 {
+                    stdout_open = false;
+                } else {
+                    retain_probe_chunk(&mut stdout_bytes, &stdout_chunk[..count], &mut retained)?;
+                }
+            }
+            read = stderr.read(&mut stderr_chunk), if stderr_open => {
+                let count = read.map_err(ProbeReadError::Io)?;
+                if count == 0 {
+                    stderr_open = false;
+                } else {
+                    retain_probe_chunk(&mut stderr_bytes, &stderr_chunk[..count], &mut retained)?;
+                }
+            }
+        }
+    }
+    Ok((stdout_bytes, stderr_bytes))
+}
+
+fn retain_probe_chunk(
+    destination: &mut Vec<u8>,
+    chunk: &[u8],
+    retained: &mut usize,
+) -> Result<(), ProbeReadError> {
+    if chunk.len() > PROBE_OUTPUT_LIMIT.saturating_sub(*retained) {
+        return Err(ProbeReadError::Overflow);
+    }
+    destination.extend_from_slice(chunk);
+    *retained += chunk.len();
+    Ok(())
+}
+
+async fn stop_probe(child: &mut tokio::process::Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+fn take_probe_pipes(
+    child: &mut tokio::process::Child,
+    adapter_id: &str,
+    purpose: &str,
+) -> Result<(tokio::process::ChildStdout, tokio::process::ChildStderr), HarnessError> {
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| HarnessError::Unavailable {
+            reason: format!("adapter `{adapter_id}`: {purpose} has no stdout pipe"),
+        })?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| HarnessError::Unavailable {
+            reason: format!("adapter `{adapter_id}`: {purpose} has no stderr pipe"),
+        })?;
+    Ok((stdout, stderr))
+}
 
 const ENV_FLOOR: [&str; 7] = ["HOME", "PATH", "TERM", "LANG", "LC_ALL", "USER", "TMPDIR"];
 
@@ -253,6 +341,92 @@ pub struct SpawnedHarness {
 }
 
 impl SpawnedHarness {
+    async fn run_bounded_probe(
+        &self,
+        args: &[String],
+        purpose: &str,
+    ) -> Result<ProbeOutput, HarnessError> {
+        let parent: BTreeMap<String, String> = std::env::vars().collect();
+        let env = compose_env(&parent, &self.adapter.passthrough_env);
+        let command_line = format!("{} {}", self.adapter.command, args.join(" "));
+        let mut child = tokio::process::Command::new(&self.adapter.command)
+            .args(args)
+            .env_clear()
+            .envs(&env)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|error| HarnessError::Unavailable {
+                reason: format!(
+                    "adapter `{}`: cannot start {purpose} `{command_line}`: {error}",
+                    self.adapter.id
+                ),
+            })?;
+        let (stdout, stderr) = take_probe_pipes(&mut child, &self.adapter.id, purpose)?;
+        let deadline = tokio::time::Instant::now() + PROBE_TIMEOUT;
+        let captured = tokio::time::timeout_at(deadline, read_probe_streams(stdout, stderr)).await;
+        let (stdout, stderr) = match captured {
+            Err(_) => {
+                stop_probe(&mut child).await;
+                return Err(HarnessError::Unavailable {
+                    reason: format!(
+                        "adapter `{}`: {purpose} `{command_line}` did not answer in {}s",
+                        self.adapter.id,
+                        PROBE_TIMEOUT.as_secs()
+                    ),
+                });
+            }
+            Ok(Err(ProbeReadError::Overflow)) => {
+                stop_probe(&mut child).await;
+                return Err(HarnessError::Unavailable {
+                    reason: format!(
+                        "adapter `{}`: {purpose} output exceeded the {PROBE_OUTPUT_LIMIT}-byte \
+                         combined stdout/stderr limit; child terminated",
+                        self.adapter.id
+                    ),
+                });
+            }
+            Ok(Err(ProbeReadError::Io(error))) => {
+                stop_probe(&mut child).await;
+                return Err(HarnessError::Unavailable {
+                    reason: format!(
+                        "adapter `{}`: cannot read {purpose} `{command_line}`: {error}",
+                        self.adapter.id
+                    ),
+                });
+            }
+            Ok(Ok(captured)) => captured,
+        };
+        let status = match tokio::time::timeout_at(deadline, child.wait()).await {
+            Ok(Ok(status)) => status,
+            Ok(Err(error)) => {
+                return Err(HarnessError::Unavailable {
+                    reason: format!(
+                        "adapter `{}`: cannot wait for {purpose} `{command_line}`: {error}",
+                        self.adapter.id
+                    ),
+                });
+            }
+            Err(_) => {
+                stop_probe(&mut child).await;
+                return Err(HarnessError::Unavailable {
+                    reason: format!(
+                        "adapter `{}`: {purpose} `{command_line}` did not exit in {}s",
+                        self.adapter.id,
+                        PROBE_TIMEOUT.as_secs()
+                    ),
+                });
+            }
+        };
+        Ok(ProbeOutput {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+
     /// Construct (INV-019).
     #[must_use]
     pub fn new(adapter: HarnessAdapter) -> Self {
@@ -307,38 +481,9 @@ impl SpawnedHarness {
             self.probe_command_shape().await?;
             return Ok(None);
         };
-        let parent: BTreeMap<String, String> = std::env::vars().collect();
-        let env = compose_env(&parent, &self.adapter.passthrough_env);
-        let out = tokio::process::Command::new(&self.adapter.command)
-            .args(&self.adapter.version_args)
-            .env_clear()
-            .envs(&env)
-            .stdin(Stdio::null())
-            .kill_on_drop(true)
-            .output();
-        // A `--version` that never answers (a TTY prompt · a licence
-        // check on the network) hung the verb before a driver existed
-        // (review 2026-08-06): the probe is bounded like every other
-        // wait, and kill-on-drop reaps the stalled child.
-        let out = tokio::time::timeout(PROBE_TIMEOUT, out)
-            .await
-            .map_err(|_| HarnessError::Unavailable {
-                reason: format!(
-                    "adapter `{}`: `{} {}` did not answer in {}s",
-                    self.adapter.id,
-                    self.adapter.command,
-                    self.adapter.version_args.join(" "),
-                    PROBE_TIMEOUT.as_secs()
-                ),
-            })?
-            .map_err(|e| HarnessError::Unavailable {
-                reason: format!(
-                    "adapter `{}`: cannot probe `{} {}`: {e}",
-                    self.adapter.id,
-                    self.adapter.command,
-                    self.adapter.version_args.join(" ")
-                ),
-            })?;
+        let out = self
+            .run_bounded_probe(&self.adapter.version_args, "version probe")
+            .await?;
         // Some CLIs print their version on stderr — judge both, in
         // stdout-first order (never a guess about which one it is).
         let text = format!(
@@ -358,34 +503,9 @@ impl SpawnedHarness {
         let Some(probe) = &self.adapter.command_shape_probe else {
             return Ok(());
         };
-        let parent: BTreeMap<String, String> = std::env::vars().collect();
-        let env = compose_env(&parent, &self.adapter.passthrough_env);
-        let out = tokio::process::Command::new(&self.adapter.command)
-            .args(&probe.args)
-            .env_clear()
-            .envs(&env)
-            .stdin(Stdio::null())
-            .kill_on_drop(true)
-            .output();
-        let out = tokio::time::timeout(PROBE_TIMEOUT, out)
-            .await
-            .map_err(|_| HarnessError::Unavailable {
-                reason: format!(
-                    "adapter `{}`: command shape `{} {}` did not answer in {}s",
-                    self.adapter.id,
-                    self.adapter.command,
-                    probe.args.join(" "),
-                    PROBE_TIMEOUT.as_secs()
-                ),
-            })?
-            .map_err(|e| HarnessError::Unavailable {
-                reason: format!(
-                    "adapter `{}`: cannot probe command shape `{} {}`: {e}",
-                    self.adapter.id,
-                    self.adapter.command,
-                    probe.args.join(" ")
-                ),
-            })?;
+        let out = self
+            .run_bounded_probe(&probe.args, "command shape probe")
+            .await?;
         if !out.status.success() {
             return Err(HarnessError::Unavailable {
                 reason: format!(
@@ -776,6 +896,81 @@ else:
         let msg = err.to_string();
         assert!(msg.contains("kimi-code"), "{msg}");
         assert!(msg.contains("command shape"), "{msg}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn probe_capture_never_retains_past_its_combined_limit() {
+        let mut bytes = Vec::new();
+        let mut retained = 0;
+        let exact = vec![b'x'; PROBE_OUTPUT_LIMIT];
+        retain_probe_chunk(&mut bytes, &exact, &mut retained).expect("the exact cap fits");
+        let error = retain_probe_chunk(&mut bytes, b"x", &mut retained);
+        assert!(matches!(error, Err(ProbeReadError::Overflow)));
+        assert_eq!(bytes.len(), PROBE_OUTPUT_LIMIT);
+        assert_eq!(retained, PROBE_OUTPUT_LIMIT);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kimi_shape_probe_caps_infinite_output_and_reaps_the_child() {
+        let dir =
+            std::env::temp_dir().join(format!("nika-kimi-oversize-probe-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("fixture directory");
+        let script = dir.join("infinite-kimi.py");
+        let pid_file = dir.join("pid");
+        std::fs::write(
+            &script,
+            r#"import os, sys
+pid_file, args = sys.argv[1], sys.argv[2:]
+if args == ["--version"]:
+    print("0.37.2")
+elif args == ["acp", "--help"]:
+    with open(pid_file, "w") as handle:
+        handle.write(str(os.getpid()))
+    while True:
+        os.write(sys.stdout.fileno(), b"x" * 4096)
+        os.write(sys.stderr.fileno(), b"y" * 4096)
+else:
+    sys.exit(2)
+"#,
+        )
+        .expect("fixture script");
+        let script = script.to_string_lossy().into_owned();
+        let pid_file_arg = pid_file.to_string_lossy().into_owned();
+        let adapter = HarnessAdapter::new("kimi-code", "python3")
+            .expect("id is no class token")
+            .with_version_args(vec![
+                script.clone(),
+                pid_file_arg.clone(),
+                "--version".to_owned(),
+            ])
+            .with_version_pin(crate::probe::VersionPin::new((0, 37), 0))
+            .with_command_shape_probe(
+                vec![script, pid_file_arg, "acp".to_owned(), "--help".to_owned()],
+                "Agent Client Protocol",
+            );
+
+        let error = SpawnedHarness::new(adapter)
+            .probe_version()
+            .await
+            .expect_err("infinite public help must refuse at the byte cap");
+        let message = error.to_string();
+        assert!(message.contains("output exceeded"), "{message}");
+        assert!(
+            message.contains(&format!("{PROBE_OUTPUT_LIMIT}-byte")),
+            "{message}"
+        );
+        let pid = std::fs::read_to_string(&pid_file).expect("fixture published its pid");
+        let alive = tokio::process::Command::new("kill")
+            .args(["-0", pid.trim()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .expect("the process liveness probe runs");
+        assert!(!alive.success(), "the overflowing probe child was reaped");
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/nika-harness/src/spawn.rs
+++ b/crates/nika-harness/src/spawn.rs
@@ -3,8 +3,8 @@
 
 //! The confined spawn (B3.2 · spec §4) — the adapter process is engine
 //! INFRASTRUCTURE, strictly bounded: pinned binary identity · version
-//! handshake BEFORE any session · controlled argv · composed env · no
-//! shell · kill-on-drop.
+//! handshake + declared command-shape proof BEFORE any session ·
+//! controlled argv · composed env · no shell · kill-on-drop.
 //!
 //! **The ONE deliberate difference from the `nika-mcp` spawn
 //! discipline (A-3):** no env scrub of the harness's own auth store.
@@ -104,6 +104,15 @@ pub fn compose_env(
     env
 }
 
+/// One adapter-specific command-shape proof. Version equality is not
+/// enough when two unrelated packages install the same binary name and
+/// version line (the legacy `kimi-cli` / Kimi Code collision).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandShapeProbe {
+    args: Vec<String>,
+    marker: String,
+}
+
 /// One configured harness adapter — the pinned identity of a binary
 /// this machine may drive (`#[non_exhaustive]` · registry rows arrive
 /// at B6 with the probe surface).
@@ -140,6 +149,10 @@ pub struct HarnessAdapter {
     /// self-report (`agentInfo.name` + `agentInfo.version` · the
     /// protocol version). When set, this supersedes `version_args`.
     pub probe_via_handshake: bool,
+    /// An additional command-shape proof for colliding binary names.
+    /// Kept crate-private: registry rows own this evidence; local-dev
+    /// declarations remain honest without inventing a vendor dialect.
+    pub(crate) command_shape_probe: Option<CommandShapeProbe>,
 }
 
 impl HarnessAdapter {
@@ -171,6 +184,7 @@ impl HarnessAdapter {
             version_pin: None,
             version_args: vec!["--version".to_owned()],
             probe_via_handshake: false,
+            command_shape_probe: None,
         })
     }
 
@@ -212,6 +226,20 @@ impl HarnessAdapter {
     #[must_use]
     pub fn with_handshake_probe(mut self) -> Self {
         self.probe_via_handshake = true;
+        self
+    }
+
+    /// Require a successful help surface carrying a stable protocol marker.
+    #[must_use]
+    pub(crate) fn with_command_shape_probe(
+        mut self,
+        args: Vec<String>,
+        marker: impl Into<String>,
+    ) -> Self {
+        self.command_shape_probe = Some(CommandShapeProbe {
+            args,
+            marker: marker.into(),
+        });
         self
     }
 }
@@ -271,9 +299,12 @@ impl SpawnedHarness {
     /// adapter.
     pub async fn probe_version(&self) -> Result<Option<(u32, u32)>, HarnessError> {
         if self.adapter.probe_via_handshake {
-            return self.probe_handshake().await;
+            let seen = self.probe_handshake().await?;
+            self.probe_command_shape().await?;
+            return Ok(seen);
         }
         let Some(pin) = &self.adapter.version_pin else {
+            self.probe_command_shape().await?;
             return Ok(None);
         };
         let parent: BTreeMap<String, String> = std::env::vars().collect();
@@ -315,7 +346,72 @@ impl SpawnedHarness {
             String::from_utf8_lossy(&out.stdout),
             String::from_utf8_lossy(&out.stderr)
         );
-        crate::probe::judge_version(&self.adapter.id, &text, pin).map(Some)
+        let seen = crate::probe::judge_version(&self.adapter.id, &text, pin)?;
+        self.probe_command_shape().await?;
+        Ok(Some(seen))
+    }
+
+    /// Prove a registry-declared command shape after identity/version.
+    /// Output is inspected only for a public help marker and is never
+    /// copied into an error, log, or doctor row.
+    async fn probe_command_shape(&self) -> Result<(), HarnessError> {
+        let Some(probe) = &self.adapter.command_shape_probe else {
+            return Ok(());
+        };
+        let parent: BTreeMap<String, String> = std::env::vars().collect();
+        let env = compose_env(&parent, &self.adapter.passthrough_env);
+        let out = tokio::process::Command::new(&self.adapter.command)
+            .args(&probe.args)
+            .env_clear()
+            .envs(&env)
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .output();
+        let out = tokio::time::timeout(PROBE_TIMEOUT, out)
+            .await
+            .map_err(|_| HarnessError::Unavailable {
+                reason: format!(
+                    "adapter `{}`: command shape `{} {}` did not answer in {}s",
+                    self.adapter.id,
+                    self.adapter.command,
+                    probe.args.join(" "),
+                    PROBE_TIMEOUT.as_secs()
+                ),
+            })?
+            .map_err(|e| HarnessError::Unavailable {
+                reason: format!(
+                    "adapter `{}`: cannot probe command shape `{} {}`: {e}",
+                    self.adapter.id,
+                    self.adapter.command,
+                    probe.args.join(" ")
+                ),
+            })?;
+        if !out.status.success() {
+            return Err(HarnessError::Unavailable {
+                reason: format!(
+                    "adapter `{}`: command shape `{} {}` was rejected ({})",
+                    self.adapter.id,
+                    self.adapter.command,
+                    probe.args.join(" "),
+                    out.status
+                ),
+            });
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stdout.contains(&probe.marker) || stderr.contains(&probe.marker) {
+            return Ok(());
+        }
+        Err(HarnessError::Unavailable {
+            reason: format!(
+                "adapter `{}`: command shape `{} {}` did not identify `{}` support — \
+                 refusing an ambiguous binary",
+                self.adapter.id,
+                self.adapter.command,
+                probe.args.join(" "),
+                probe.marker
+            ),
+        })
     }
 
     /// The npm-wrapper class's probe (B6): spawn the SESSION argv, send
@@ -607,38 +703,79 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn kimi_code_version_probe_judges_the_bare_triple_without_launching_kimi() {
+    async fn kimi_code_shape_probe_rejects_legacy_flag_cli_and_accepts_subcommand_cli() {
         let dir = std::env::temp_dir().join(format!("nika-kimi-probe-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("dir");
         let script = dir.join("fake-kimi.py");
-        std::fs::write(&script, "print('0.37.2')\n").expect("script");
+        std::fs::write(
+            &script,
+            r#"import sys
+mode, args = sys.argv[1], sys.argv[2:]
+if args == ["--version"]:
+    print("0.37.2")
+elif mode == "legacy" and args == ["--acp"]:
+    sys.exit(0)
+elif mode == "real" and args == ["acp", "--help"]:
+    print("Run kimi-code as an Agent Client Protocol (ACP) server over stdio.")
+elif mode == "ambiguous" and args == ["acp", "--help"]:
+    print("Usage: kimi [OPTIONS] [PROMPT]")
+else:
+    print("unknown command", file=sys.stderr)
+    sys.exit(2)
+"#,
+        )
+        .expect("script");
         let path = script.to_string_lossy().into_owned();
-        let in_pin = HarnessAdapter::new("kimi-code", "python3")
-            .expect("id is no class token")
-            .with_args(vec!["acp".to_owned()])
-            .with_version_args(vec![path.clone()])
-            .with_version_pin(crate::probe::VersionPin::new((0, 37), 0));
-        assert_eq!(in_pin.args, vec!["acp".to_owned()]);
-        assert!(!in_pin.probe_via_handshake);
-        let seen = SpawnedHarness::new(in_pin)
+
+        let legacy_flag = tokio::process::Command::new("python3")
+            .args([&path, "legacy", "--acp"])
+            .status()
+            .await
+            .expect("legacy fixture runs");
+        assert!(
+            legacy_flag.success(),
+            "the fixture really supports `kimi --acp`"
+        );
+
+        let adapter = |mode: &str| {
+            HarnessAdapter::new("kimi-code", "python3")
+                .expect("id is no class token")
+                .with_args(vec![path.clone(), mode.to_owned(), "acp".to_owned()])
+                .with_version_args(vec![path.clone(), mode.to_owned(), "--version".to_owned()])
+                .with_version_pin(crate::probe::VersionPin::new((0, 37), 0))
+                .with_command_shape_probe(
+                    vec![
+                        path.clone(),
+                        mode.to_owned(),
+                        "acp".to_owned(),
+                        "--help".to_owned(),
+                    ],
+                    "Agent Client Protocol",
+                )
+        };
+
+        let seen = SpawnedHarness::new(adapter("real"))
             .probe_version()
             .await
-            .expect("in pin");
+            .expect("the Kimi Code subcommand shape is accepted");
         assert_eq!(seen, Some((0, 37)));
 
-        std::fs::write(&script, "print('0.36.0')\n").expect("old");
-        let old = HarnessAdapter::new("kimi-code", "python3")
-            .expect("id is fine")
-            .with_args(vec!["acp".to_owned()])
-            .with_version_args(vec![path])
-            .with_version_pin(crate::probe::VersionPin::new((0, 37), 0));
-        let err = SpawnedHarness::new(old)
+        let ambiguous = SpawnedHarness::new(adapter("ambiguous"))
             .probe_version()
             .await
-            .expect_err("below the floor");
+            .expect_err("a successful generic help page proves no ACP dialect");
+        assert!(
+            ambiguous.to_string().contains("did not identify"),
+            "{ambiguous}"
+        );
+
+        let err = SpawnedHarness::new(adapter("legacy"))
+            .probe_version()
+            .await
+            .expect_err("legacy kimi-cli has only the flag, never the subcommand");
         let msg = err.to_string();
         assert!(msg.contains("kimi-code"), "{msg}");
-        assert!(msg.contains("0.36"), "{msg}");
+        assert!(msg.contains("command shape"), "{msg}");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/docs/crate-specs/nika-acp.md
+++ b/docs/crate-specs/nika-acp.md
@@ -106,9 +106,10 @@ store — the harness MUST read its own credentials; scrubbing its env would
 break the whole legitimacy model. The child env is: the runner floor ∪ the
 adapter's declared passthrough ∪ nothing of nika's secrets. Documented at the
 spawn site; a negative test proves nika's own `NIKA_*_API_KEY` vars never
-cross. Auth readiness opens no credential: it reads path metadata and directory
-non-emptiness only, honors an adapter-home override (`KIMI_CODE_HOME`), and
-fails closed on absent, empty, ambiguous, unreadable, or symlinked stores.
+cross. Auth readiness opens no credential: it reads path metadata and requires a
+top-level provider shape (`credentials/<name>.json`, never the distinct `mcp/`
+subtree), honors an adapter-home override (`KIMI_CODE_HOME`), and fails closed
+on absent, empty, ambiguous, unreadable, or symlinked stores.
 
 ## 5 · The mock ACP agent (P3.3 · the load-bearing instrument)
 

--- a/docs/crate-specs/nika-acp.md
+++ b/docs/crate-specs/nika-acp.md
@@ -96,15 +96,19 @@ Lifted from `nika-mcp/src/client.rs:559-604` (the confined-spawn seam):
   a refusal is terminal · the receipt line prints once on live spawn.
 - `KillOnDrop` child · piped stdio · bounded line reads (update-overflow
   refuses, never OOMs).
-- Version handshake: binary present + `--version` inside the adapter's pin
-  range BEFORE initialize · controlled argv · no shell.
+- Identity handshake: binary present + `--version` inside the adapter's pin
+  range BEFORE initialize; a colliding binary name also proves its exact
+  session subcommand through a bounded public help marker (`kimi acp --help`,
+  not legacy `kimi --acp`) · controlled argv · no shell.
 
 **The difference (A-3):** NO `apply_env_scrub` of the harness's own auth
 store — the harness MUST read its own credentials; scrubbing its env would
 break the whole legitimacy model. The child env is: the runner floor ∪ the
 adapter's declared passthrough ∪ nothing of nika's secrets. Documented at the
 spawn site; a negative test proves nika's own `NIKA_*_API_KEY` vars never
-cross.
+cross. Auth readiness opens no credential: it reads path metadata and directory
+non-emptiness only, honors an adapter-home override (`KIMI_CODE_HOME`), and
+fails closed on absent, empty, ambiguous, unreadable, or symlinked stores.
 
 ## 5 · The mock ACP agent (P3.3 · the load-bearing instrument)
 

--- a/docs/crate-specs/nika-acp.md
+++ b/docs/crate-specs/nika-acp.md
@@ -107,10 +107,12 @@ break the whole legitimacy model. The child env is: the runner floor ∪ the
 adapter's declared passthrough ∪ nothing of nika's secrets. Documented at the
 spawn site; a negative test proves nika's own `NIKA_*_API_KEY` vars never
 cross. Auth readiness reads no credential byte: it checks path metadata, obtains
-a zero-read read-only handle so the OS applies UID/ACL policy, and requires a
-top-level provider shape (`credentials/<name>.json`, never the distinct `mcp/`
-subtree). It honors `KIMI_CODE_HOME` and fails closed on absent, empty,
-ambiguous, unreadable, swapped, or symlinked stores.
+a zero-read read-only handle so the OS applies UID/ACL policy, and requires the
+managed-seat witness `credentials/kimi-code.json` (never another provider or
+the distinct `mcp/` subtree). It honors `KIMI_CODE_HOME` and fails closed on
+absent, empty, ambiguous, unreadable, swapped, or symlinked stores. This is a
+configuration witness, not a token-validity claim: the first ACP session owns
+expiry/parse judgment and must fail without any native-provider fallback.
 
 ## 5 · The mock ACP agent (P3.3 · the load-bearing instrument)
 

--- a/docs/crate-specs/nika-acp.md
+++ b/docs/crate-specs/nika-acp.md
@@ -106,10 +106,11 @@ store — the harness MUST read its own credentials; scrubbing its env would
 break the whole legitimacy model. The child env is: the runner floor ∪ the
 adapter's declared passthrough ∪ nothing of nika's secrets. Documented at the
 spawn site; a negative test proves nika's own `NIKA_*_API_KEY` vars never
-cross. Auth readiness opens no credential: it reads path metadata and requires a
+cross. Auth readiness reads no credential byte: it checks path metadata, obtains
+a zero-read read-only handle so the OS applies UID/ACL policy, and requires a
 top-level provider shape (`credentials/<name>.json`, never the distinct `mcp/`
-subtree), honors an adapter-home override (`KIMI_CODE_HOME`), and fails closed
-on absent, empty, ambiguous, unreadable, or symlinked stores.
+subtree). It honors `KIMI_CODE_HOME` and fails closed on absent, empty,
+ambiguous, unreadable, swapped, or symlinked stores.
 
 ## 5 · The mock ACP agent (P3.3 · the load-bearing instrument)
 


### PR DESCRIPTION
## What

- admit the pinned Kimi Code CLI as a native ACP seat
- keep API keys and credential contents outside the child environment
- validate only the managed credential pathname and provider presence
- keep the credential handle alive and revalidate pathname identity after open
- bound combined version/help output to 64 KiB and a shared 10 second deadline
- kill and reap probe children on timeout, overflow, and I/O failure

## Proof

- `nika-harness`: 58/58 unit tests green
- infinite-output probe is capped and its direct child PID is reaped
- deterministic credential swap after open is refused
- clippy all-targets green
- zero production unwraps
- all functions at or below 100 lines
- full local pre-push gate and all 10 ratchets green at `b498d537`
- independent refuter found no reproducible bypass for either corrected boundary

## Residual boundary

The probe proves readiness at probe time. It does not claim perpetual pathname freshness before a later session starts, nor process-group control over arbitrary grandchildren; no reproducible bypass was found within this PR's probe boundary.

Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>
Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
